### PR TITLE
fix(proxy): propagate end_user_max_budget in update_valid_token_with_end_user_params

### DIFF
--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -416,6 +416,8 @@ def update_valid_token_with_end_user_params(
         valid_token.end_user_model_max_budget = end_user_params[
             "end_user_model_max_budget"
         ]
+    if end_user_params.get("end_user_max_budget") is not None:
+        valid_token.end_user_max_budget = end_user_params["end_user_max_budget"]
     return valid_token
 
 

--- a/tests/test_litellm/proxy/auth/test_custom_auth_end_user_budget.py
+++ b/tests/test_litellm/proxy/auth/test_custom_auth_end_user_budget.py
@@ -143,3 +143,48 @@ def test_update_valid_token_db_values_override_custom_auth_when_set():
     # DB values should win
     assert result.end_user_tpm_limit == 500
     assert result.end_user_model_max_budget == db_budget
+
+
+def test_update_valid_token_updates_end_user_max_budget():
+    """
+    Regression for #29142: update_valid_token_with_end_user_params must
+    propagate end_user_max_budget from the DB-derived end_user_params so
+    that a cached token does not retain a stale budget from a previous
+    end-user.
+    """
+    valid_token = UserAPIKeyAuth(
+        token="test_token",
+        end_user_id="user_old",
+        end_user_max_budget=50.0,
+    )
+
+    end_user_params = {
+        "end_user_id": "user_new",
+        "end_user_max_budget": 5.0,
+    }
+
+    result = update_valid_token_with_end_user_params(valid_token, end_user_params)
+
+    assert result.end_user_id == "user_new"
+    assert result.end_user_max_budget == 5.0
+
+
+def test_update_valid_token_preserves_end_user_max_budget_when_db_none():
+    """
+    When the DB end_user has no max_budget set, the custom-auth-provided
+    value on the token should not be cleared.
+    """
+    valid_token = UserAPIKeyAuth(
+        token="test_token",
+        end_user_id="user_1",
+        end_user_max_budget=100.0,
+    )
+
+    end_user_params = {
+        "end_user_id": "user_1",
+        # No end_user_max_budget from DB
+    }
+
+    result = update_valid_token_with_end_user_params(valid_token, end_user_params)
+
+    assert result.end_user_max_budget == 100.0


### PR DESCRIPTION
## Summary

Closes #29142

`update_valid_token_with_end_user_params()` updated every end-user field from the DB-derived `end_user_params` dict except `end_user_max_budget`. When the same API key was reused with different end-users, the cached `UserAPIKeyAuth` retained the stale budget from the previous end-user, causing incorrect budget enforcement.

## Changes

- **`litellm/proxy/auth/user_api_key_auth.py`**: Add the missing conditional update for `end_user_max_budget`, matching the existing pattern for `end_user_tpm_limit`, `end_user_rpm_limit`, `allowed_model_region`, and `end_user_model_max_budget`
- **`tests/test_litellm/proxy/auth/test_custom_auth_end_user_budget.py`**: Add two tests:
  - `test_update_valid_token_updates_end_user_max_budget` — DB value overrides stale cached value
  - `test_update_valid_token_preserves_end_user_max_budget_when_db_none` — custom-auth-provided value not cleared when DB has no value