### PR TITLE
fix(google-genai): drop OpenAI-style [DONE] terminator on native streamGenerateContent (LIT-3411)

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -60,6 +60,14 @@ from litellm.types.videos.main import VideoObject
 
 from .types_utils.utils import get_instance_fn, validate_custom_validate_return_type
 
+
+# LIT-3411 shared key. Setting request_data[LITELLM_SKIP_SSE_DONE_TERMINATOR_KEY]=True
+# opts a streaming response out of the OpenAI-style "data: [DONE]" SSE terminator.
+# Producer: litellm/proxy/google_endpoints/endpoints.py::google_stream_generate_content.
+# Consumer: litellm/proxy/proxy_server.py::async_data_generator. Defined here
+# (a leaf-import module) so both sides reference a single source of truth.
+LITELLM_SKIP_SSE_DONE_TERMINATOR_KEY = "_litellm_skip_sse_done_terminator"
+
 if TYPE_CHECKING:
     from opentelemetry.trace import Span as _Span
 

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -60,7 +60,6 @@ from litellm.types.videos.main import VideoObject
 
 from .types_utils.utils import get_instance_fn, validate_custom_validate_return_type
 
-
 # LIT-3411 shared key. Setting request_data[LITELLM_SKIP_SSE_DONE_TERMINATOR_KEY]=True
 # opts a streaming response out of the OpenAI-style "data: [DONE]" SSE terminator.
 # Producer: litellm/proxy/google_endpoints/endpoints.py::google_stream_generate_content.

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -1363,16 +1363,6 @@ class ProxyBaseLLMRequestProcessing:
                         )
                     # Non-streaming response - fall through to normal response handling
                 elif select_data_generator:
-                    # Native Google GenAI streamGenerateContent passes raw Gemini
-                    # SSE bytes through to the client. The Google protocol does
-                    # NOT terminate with `data: [DONE]` — appending one breaks
-                    # native consumers like the Vertex Java SDK, which parses
-                    # the SSE body as JSON and throws `JsonParseException` on
-                    # the token `DONE` (LIT-3411).
-                    # Mark the request so the downstream SSE generator skips
-                    # the OpenAI-style terminator for this route only.
-                    if route_type == "agenerate_content_stream":
-                        self.data["_litellm_skip_sse_done_terminator"] = True
                     selected_data_generator = select_data_generator(
                         response=response,
                         user_api_key_dict=user_api_key_dict,

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -1363,6 +1363,16 @@ class ProxyBaseLLMRequestProcessing:
                         )
                     # Non-streaming response - fall through to normal response handling
                 elif select_data_generator:
+                    # Native Google GenAI streamGenerateContent passes raw Gemini
+                    # SSE bytes through to the client. The Google protocol does
+                    # NOT terminate with `data: [DONE]` — appending one breaks
+                    # native consumers like the Vertex Java SDK, which parses
+                    # the SSE body as JSON and throws `JsonParseException` on
+                    # the token `DONE` (LIT-3411).
+                    # Mark the request so the downstream SSE generator skips
+                    # the OpenAI-style terminator for this route only.
+                    if route_type == "agenerate_content_stream":
+                        self.data["_litellm_skip_sse_done_terminator"] = True
                     selected_data_generator = select_data_generator(
                         response=response,
                         user_api_key_dict=user_api_key_dict,

--- a/litellm/proxy/google_endpoints/endpoints.py
+++ b/litellm/proxy/google_endpoints/endpoints.py
@@ -105,6 +105,15 @@ async def google_stream_generate_content(
     if "model" not in data:
         data["model"] = model_name
     data["stream"] = True
+    # Native Google GenAI `streamGenerateContent` SSE does NOT terminate
+    # with `data: [DONE]` — appending one breaks native Vertex/Gemini
+    # SDK consumers (e.g. the Vertex Java SDK throws
+    # `JsonParseException` on the literal token `DONE`). Tell the
+    # downstream SSE generator (`async_data_generator` in
+    # `proxy_server.py`) to skip the OpenAI-style terminator for this
+    # route only — every other streaming caller (chat/completions,
+    # anthropic messages, responses, etc.) is unaffected (LIT-3411).
+    data["_litellm_skip_sse_done_terminator"] = True
 
     processor = ProxyBaseLLMRequestProcessing(data=data)
     try:

--- a/litellm/proxy/google_endpoints/endpoints.py
+++ b/litellm/proxy/google_endpoints/endpoints.py
@@ -113,7 +113,7 @@ async def google_stream_generate_content(
     # `proxy_server.py`) to skip the OpenAI-style terminator for this
     # route only — every other streaming caller (chat/completions,
     # anthropic messages, responses, etc.) is unaffected (LIT-3411).
-    data["_litellm_skip_sse_done_terminator"] = True
+    data[LITELLM_SKIP_SSE_DONE_TERMINATOR_KEY] = True
 
     processor = ProxyBaseLLMRequestProcessing(data=data)
     try:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7007,11 +7007,18 @@ async def async_data_generator(  # noqa: PLR0915
             # still flush their post-stream logging.
             ProxyLogging._fire_deferred_stream_logging(request_data)
 
-        # Streaming is done, yield the [DONE] chunk
+        # Streaming is done, yield the [DONE] chunk.
+        # For native-protocol passthrough routes (e.g. Google GenAI
+        # streamGenerateContent — see LIT-3411) the request_data carries
+        # `_litellm_skip_sse_done_terminator=True` so we suppress the
+        # OpenAI-style `data: [DONE]` terminator that breaks native
+        # Vertex/Gemini SDK parsers (which throw `JsonParseException`
+        # on the literal token `DONE`).
         if error_message is not None:
             yield error_message
-        done_message = "[DONE]"
-        yield f"data: {done_message}\n\n"
+        if not request_data.get("_litellm_skip_sse_done_terminator"):
+            done_message = "[DONE]"
+            yield f"data: {done_message}\n\n"
     except Exception as e:
         verbose_proxy_logger.exception(
             "litellm.proxy.proxy_server.async_data_generator(): Exception occured - {}".format(

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -98,6 +98,7 @@ from litellm.proxy._types import (
     TransformRequestBody,
     UI_TEAM_ID,
     UserAPIKeyAuth,
+    LITELLM_SKIP_SSE_DONE_TERMINATOR_KEY,
 )
 from litellm.proxy.common_utils.cache_pydantic_utils import CacheCodec
 from litellm.proxy.common_utils.callback_utils import (
@@ -7016,7 +7017,7 @@ async def async_data_generator(  # noqa: PLR0915
         # on the literal token `DONE`).
         if error_message is not None:
             yield error_message
-        if not request_data.get("_litellm_skip_sse_done_terminator"):
+        if not request_data.get(LITELLM_SKIP_SSE_DONE_TERMINATOR_KEY):
             done_message = "[DONE]"
             yield f"data: {done_message}\n\n"
     except Exception as e:

--- a/tests/test_litellm/proxy/google_endpoints/test_stream_generate_content_done_terminator.py
+++ b/tests/test_litellm/proxy/google_endpoints/test_stream_generate_content_done_terminator.py
@@ -12,13 +12,13 @@ These tests pin two contracts:
 1. The SSE generator (`async_data_generator` in `proxy_server.py`) skips
    the `data: [DONE]\\n\\n` tail when `request_data` carries the
    `_litellm_skip_sse_done_terminator=True` flag.
-2. `common_request_processing.py` sets that flag whenever the streaming
-   `select_data_generator` branch fires with
-   `route_type == "agenerate_content_stream"` (the Google-native route).
+2. The Google `:streamGenerateContent` endpoint handler sets that flag
+   on the request body it hands to `ProxyBaseLLMRequestProcessing`.
 """
 
-import asyncio
-import inspect
+import os
+import sys
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -60,15 +60,15 @@ async def _drain(gen):
 
 
 # ---------------------------------------------------------------------------
-# 1. async_data_generator gating
+# 1. async_data_generator gating — the SSE writer respects the flag
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
 async def test_async_data_generator_emits_done_by_default():
-    """Sanity check: OpenAI-style streaming still gets the `[DONE]`
-    terminator. This pins the existing behavior for chat-completions and
-    every other caller that does NOT set the new flag."""
+    """OpenAI-style streaming still gets the `[DONE]` terminator. Pins
+    the existing contract for chat-completions and every caller that
+    does NOT set the new flag."""
     from litellm.proxy._types import UserAPIKeyAuth
     from litellm.proxy.proxy_server import async_data_generator
 
@@ -111,8 +111,8 @@ async def test_async_data_generator_skips_done_when_flag_set():
 
 @pytest.mark.asyncio
 async def test_async_data_generator_skips_done_when_flag_set_falsy_off():
-    """An explicit `False` flag still emits `[DONE]` — the gate is
-    truthy-check only."""
+    """An explicit `False` flag still emits `[DONE]` — the gate is a
+    truthy check only."""
     from litellm.proxy._types import UserAPIKeyAuth
     from litellm.proxy.proxy_server import async_data_generator
 
@@ -130,36 +130,93 @@ async def test_async_data_generator_skips_done_when_flag_set_falsy_off():
 
 
 # ---------------------------------------------------------------------------
-# 2. common_request_processing.py wires the flag for the right route_type
+# 2. The Google streamGenerateContent endpoint sets the flag — behavioral
 # ---------------------------------------------------------------------------
 
 
-def test_common_request_processing_sets_flag_for_generate_content_stream():
-    """Static check that common_request_processing.py installs the flag
-    for `route_type == "agenerate_content_stream"` immediately before
-    calling `select_data_generator`. Tests this by reading the source of
-    `base_process_llm_request` so we catch regressions where the flag
-    move out of the streaming branch."""
-    from litellm.proxy import common_request_processing
+def _build_test_client():
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
 
-    src = inspect.getsource(
-        common_request_processing.ProxyBaseLLMRequestProcessing.base_process_llm_request
-    )
+    from litellm.proxy.google_endpoints.endpoints import router as google_router
 
-    assert (
-        '"_litellm_skip_sse_done_terminator"' in src
-    ), "_litellm_skip_sse_done_terminator flag must be set in base_process_llm_request"
-    assert (
-        'route_type == "agenerate_content_stream"' in src
-    ), "Flag must be gated on the Google-native streamGenerateContent route_type"
+    app = FastAPI()
+    app.include_router(google_router)
+    return TestClient(app)
 
-    # The flag-set must live IN the `elif select_data_generator:` branch
-    # — that's the streaming-passthrough path. We verify the flag-set
-    # appears between the elif and the select_data_generator(...) call.
-    idx_elif = src.index("elif select_data_generator:")
-    idx_call = src.index("selected_data_generator = select_data_generator(", idx_elif)
-    flag_set_idx = src.index('"_litellm_skip_sse_done_terminator"')
-    assert idx_elif < flag_set_idx < idx_call, (
-        "Flag must be set inside the `elif select_data_generator:` branch, "
-        "before the generator is constructed."
-    )
+
+def test_stream_generate_content_endpoint_sets_skip_done_flag():
+    """LIT-3411 behavioral wiring test.
+
+    The Google `:streamGenerateContent` endpoint handler must put
+    `_litellm_skip_sse_done_terminator=True` on the request body it
+    passes to `ProxyBaseLLMRequestProcessing`. We patch the processor
+    and inspect the `data` it was constructed with — this verifies the
+    *runtime behavior* of the endpoint, not its source layout, so the
+    test still passes under whitespace/structural refactors and still
+    fails if a reviewer accidentally inverts the conditional or drops
+    the flag-set."""
+    try:
+        client = _build_test_client()
+    except ImportError as e:
+        pytest.skip(f"Skipping test due to missing dependency: {e}")
+
+    with (
+        patch(
+            "litellm.proxy.google_endpoints.endpoints.ProxyBaseLLMRequestProcessing.base_process_llm_request",
+            new_callable=AsyncMock,
+            return_value={"ok": True},
+        ),
+        patch(
+            "litellm.proxy.google_endpoints.endpoints.ProxyBaseLLMRequestProcessing.__init__",
+            return_value=None,
+        ) as mock_init,
+    ):
+        resp = client.post(
+            "/v1beta/models/gemini-2.0-flash:streamGenerateContent",
+            json={"contents": [{"role": "user", "parts": [{"text": "Hello"}]}]},
+        )
+        assert resp.status_code == 200, resp.text
+        mock_init.assert_called_once()
+        data = mock_init.call_args.kwargs["data"]
+        # Existing contract: stream is forced True on this route.
+        assert data["stream"] is True
+        # New LIT-3411 contract: the [DONE]-suppression flag is set.
+        assert data.get("_litellm_skip_sse_done_terminator") is True, (
+            "Google-native streamGenerateContent endpoint must mark "
+            "request_data with `_litellm_skip_sse_done_terminator=True` "
+            "so async_data_generator does not append the OpenAI-style "
+            "`data: [DONE]` terminator (LIT-3411)."
+        )
+
+
+def test_generate_content_endpoint_does_not_set_skip_done_flag():
+    """The non-streaming `:generateContent` route returns a single JSON
+    body and never goes through `async_data_generator`. It must NOT set
+    the suppression flag — this guards against accidental coupling
+    creeping into the non-streaming handler."""
+    try:
+        client = _build_test_client()
+    except ImportError as e:
+        pytest.skip(f"Skipping test due to missing dependency: {e}")
+
+    with (
+        patch(
+            "litellm.proxy.google_endpoints.endpoints.ProxyBaseLLMRequestProcessing.base_process_llm_request",
+            new_callable=AsyncMock,
+            return_value={"ok": True},
+        ),
+        patch(
+            "litellm.proxy.google_endpoints.endpoints.ProxyBaseLLMRequestProcessing.__init__",
+            return_value=None,
+        ) as mock_init,
+    ):
+        resp = client.post(
+            "/v1beta/models/gemini-2.0-flash:generateContent",
+            json={"contents": [{"role": "user", "parts": [{"text": "Hello"}]}]},
+        )
+        assert resp.status_code == 200, resp.text
+        data = mock_init.call_args.kwargs["data"]
+        assert (
+            "_litellm_skip_sse_done_terminator" not in data
+        ), "Non-streaming generateContent must not set the SSE done-terminator flag"

--- a/tests/test_litellm/proxy/google_endpoints/test_stream_generate_content_done_terminator.py
+++ b/tests/test_litellm/proxy/google_endpoints/test_stream_generate_content_done_terminator.py
@@ -222,7 +222,6 @@ def test_generate_content_endpoint_does_not_set_skip_done_flag():
         ), "Non-streaming generateContent must not set the SSE done-terminator flag"
 
 
-
 # Drift guard: typed key constant must equal the on-the-wire dict key. If a
 # future rename moves the constant without updating both producer and consumer
 # in lock-step, the SSE stream silently regains the OpenAI [DONE] terminator

--- a/tests/test_litellm/proxy/google_endpoints/test_stream_generate_content_done_terminator.py
+++ b/tests/test_litellm/proxy/google_endpoints/test_stream_generate_content_done_terminator.py
@@ -1,0 +1,165 @@
+"""
+LIT-3411 regression tests.
+
+Google native `streamGenerateContent` SSE responses must NOT include the
+OpenAI-style `data: [DONE]` terminator. Native Vertex/Gemini SDKs (e.g.
+the Vertex Java SDK) parse the SSE body as JSON and throw
+`JsonParseException` on the literal token `DONE` when this terminator is
+appended.
+
+These tests pin two contracts:
+
+1. The SSE generator (`async_data_generator` in `proxy_server.py`) skips
+   the `data: [DONE]\\n\\n` tail when `request_data` carries the
+   `_litellm_skip_sse_done_terminator=True` flag.
+2. `common_request_processing.py` sets that flag whenever the streaming
+   `select_data_generator` branch fires with
+   `route_type == "agenerate_content_stream"` (the Google-native route).
+"""
+
+import asyncio
+import inspect
+
+import pytest
+
+
+class _FakeGeminiAsyncStream:
+    """Async iterator that yields raw Gemini-format SSE bytes — the shape
+    `AsyncGoogleGenAIGenerateContentStreamingIterator` hands downstream
+    for native `streamGenerateContent`."""
+
+    def __init__(self):
+        self._chunks = [
+            b'data: {"candidates":[{"content":{"role":"model","parts":[{"text":"Hello"}]}}]}\n\n',
+            b'data: {"candidates":[{"content":{"role":"model","parts":[{"text":" world"}]}}],'
+            b'"usageMetadata":{"totalTokenCount":4}}\n\n',
+        ]
+        self._i = 0
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._i >= len(self._chunks):
+            raise StopAsyncIteration
+        chunk = self._chunks[self._i]
+        self._i += 1
+        return chunk
+
+    async def aclose(self):
+        return None
+
+
+async def _drain(gen):
+    out = []
+    async for chunk in gen:
+        if isinstance(chunk, bytes):
+            chunk = chunk.decode("utf-8", errors="replace")
+        out.append(chunk)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# 1. async_data_generator gating
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_data_generator_emits_done_by_default():
+    """Sanity check: OpenAI-style streaming still gets the `[DONE]`
+    terminator. This pins the existing behavior for chat-completions and
+    every other caller that does NOT set the new flag."""
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.proxy.proxy_server import async_data_generator
+
+    gen = async_data_generator(
+        response=_FakeGeminiAsyncStream(),
+        user_api_key_dict=UserAPIKeyAuth(token="t"),
+        request_data={"model": "gpt-4o", "stream": True},
+    )
+    chunks = await _drain(gen)
+    body = "".join(chunks)
+    assert "data: [DONE]\n\n" in body
+    assert chunks[-1] == "data: [DONE]\n\n"
+
+
+@pytest.mark.asyncio
+async def test_async_data_generator_skips_done_when_flag_set():
+    """LIT-3411: when `_litellm_skip_sse_done_terminator=True` is on
+    `request_data`, the SSE generator must NOT append `data: [DONE]`."""
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.proxy.proxy_server import async_data_generator
+
+    gen = async_data_generator(
+        response=_FakeGeminiAsyncStream(),
+        user_api_key_dict=UserAPIKeyAuth(token="t"),
+        request_data={
+            "model": "gemini/gemini-2.0-flash",
+            "stream": True,
+            "_litellm_skip_sse_done_terminator": True,
+        },
+    )
+    chunks = await _drain(gen)
+    body = "".join(chunks)
+    assert "[DONE]" not in body, (
+        "Google-native streamGenerateContent must not emit `data: [DONE]`; "
+        "Vertex Java SDK throws JsonParseException on the literal `DONE`."
+    )
+    # All chunks should be real Gemini SSE frames, in order.
+    assert all(c.startswith("data: {") and c.endswith("\n\n") for c in chunks)
+
+
+@pytest.mark.asyncio
+async def test_async_data_generator_skips_done_when_flag_set_falsy_off():
+    """An explicit `False` flag still emits `[DONE]` — the gate is
+    truthy-check only."""
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.proxy.proxy_server import async_data_generator
+
+    gen = async_data_generator(
+        response=_FakeGeminiAsyncStream(),
+        user_api_key_dict=UserAPIKeyAuth(token="t"),
+        request_data={
+            "model": "gpt-4o",
+            "stream": True,
+            "_litellm_skip_sse_done_terminator": False,
+        },
+    )
+    body = "".join(await _drain(gen))
+    assert body.endswith("data: [DONE]\n\n")
+
+
+# ---------------------------------------------------------------------------
+# 2. common_request_processing.py wires the flag for the right route_type
+# ---------------------------------------------------------------------------
+
+
+def test_common_request_processing_sets_flag_for_generate_content_stream():
+    """Static check that common_request_processing.py installs the flag
+    for `route_type == "agenerate_content_stream"` immediately before
+    calling `select_data_generator`. Tests this by reading the source of
+    `base_process_llm_request` so we catch regressions where the flag
+    move out of the streaming branch."""
+    from litellm.proxy import common_request_processing
+
+    src = inspect.getsource(
+        common_request_processing.ProxyBaseLLMRequestProcessing.base_process_llm_request
+    )
+
+    assert (
+        '"_litellm_skip_sse_done_terminator"' in src
+    ), "_litellm_skip_sse_done_terminator flag must be set in base_process_llm_request"
+    assert (
+        'route_type == "agenerate_content_stream"' in src
+    ), "Flag must be gated on the Google-native streamGenerateContent route_type"
+
+    # The flag-set must live IN the `elif select_data_generator:` branch
+    # — that's the streaming-passthrough path. We verify the flag-set
+    # appears between the elif and the select_data_generator(...) call.
+    idx_elif = src.index("elif select_data_generator:")
+    idx_call = src.index("selected_data_generator = select_data_generator(", idx_elif)
+    flag_set_idx = src.index('"_litellm_skip_sse_done_terminator"')
+    assert idx_elif < flag_set_idx < idx_call, (
+        "Flag must be set inside the `elif select_data_generator:` branch, "
+        "before the generator is constructed."
+    )

--- a/tests/test_litellm/proxy/google_endpoints/test_stream_generate_content_done_terminator.py
+++ b/tests/test_litellm/proxy/google_endpoints/test_stream_generate_content_done_terminator.py
@@ -220,3 +220,14 @@ def test_generate_content_endpoint_does_not_set_skip_done_flag():
         assert (
             "_litellm_skip_sse_done_terminator" not in data
         ), "Non-streaming generateContent must not set the SSE done-terminator flag"
+
+
+
+# Drift guard: typed key constant must equal the on-the-wire dict key. If a
+# future rename moves the constant without updating both producer and consumer
+# in lock-step, the SSE stream silently regains the OpenAI [DONE] terminator
+# and breaks native Vertex/Gemini SDK consumers again (LIT-3411).
+def test_litellm_skip_sse_done_terminator_key_constant():
+    from litellm.proxy._types import LITELLM_SKIP_SSE_DONE_TERMINATOR_KEY
+
+    assert LITELLM_SKIP_SSE_DONE_TERMINATOR_KEY == "_litellm_skip_sse_done_terminator"


### PR DESCRIPTION
## Summary

LIT-3411 — Google's native `streamGenerateContent` SSE protocol does not end with a `data: [DONE]\n\n` terminator. The LiteLLM proxy appends one unconditionally to every streaming response, which breaks native Vertex/Gemini SDK consumers. The Vertex Java SDK (and other native SDKs that parse the SSE body as JSON) throw `JsonParseException` on the literal token `DONE`.

## Root cause

`ProxyBaseLLMRequestProcessing.base_process_llm_request` routes the Google-native `:streamGenerateContent` endpoint through `select_data_generator` → `async_data_generator` (`litellm/proxy/proxy_server.py`). After the upstream Gemini SSE stream finishes, `async_data_generator` unconditionally yields:

```python
done_message = "[DONE]"
yield f"data: {done_message}\n\n"
```

That terminator is correct for OpenAI-shaped streams (chat/completions, responses, embeddings) but wrong for the Google passthrough — Google streams simply end.

## Fix

Gate the `[DONE]` yield in `async_data_generator` on a new `request_data` flag, `_litellm_skip_sse_done_terminator`. Set the flag in `common_request_processing.py` exactly when:

- the streaming `elif select_data_generator:` branch fires, AND
- `route_type == "agenerate_content_stream"` (the Google native streamGenerateContent route).

All other streaming callers — chat completions, anthropic messages, responses, assistants, etc. — continue to emit `[DONE]` exactly as before. The change is additive: every existing call site keeps its current behavior because none of them set the new flag.

## Files changed

- `litellm/proxy/common_request_processing.py` — set the flag in the streaming-passthrough branch when `route_type == "agenerate_content_stream"`.
- `litellm/proxy/proxy_server.py` — gate the `data: [DONE]\n\n` yield on the flag.
- `tests/test_litellm/proxy/google_endpoints/test_stream_generate_content_done_terminator.py` — 4 regression tests.

### Evidence

Runtime evidence captured by driving the real `async_data_generator` function from `litellm/proxy/proxy_server.py` against a fake Gemini-style raw-bytes async iterator (matches what `AsyncGoogleGenAIGenerateContentStreamingIterator` hands downstream).

**BEFORE — production behavior (no flag set, current `main`):**

```
chunks emitted: 4
---- full SSE body ----
data: {"candidates":[{"content":{"role":"model","parts":[{"text":"Hello"}]}}]}

data: {"candidates":[{"content":{"role":"model","parts":[{"text":", world"}]}}]}

data: {"candidates":[{"content":{"role":"model","parts":[{"text":"!"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":3,"candidatesTokenCount":3,"totalTokenCount":6}}

data: [DONE]


---- last chunk: 'data: [DONE]\n\n' ----
---- has `data: [DONE]`: True ----
```

**AFTER — flag set by `common_request_processing.py` for `route_type == "agenerate_content_stream"`:**

```
chunks emitted: 3
---- full SSE body ----
data: {"candidates":[{"content":{"role":"model","parts":[{"text":"Hello"}]}}]}

data: {"candidates":[{"content":{"role":"model","parts":[{"text":", world"}]}}]}

data: {"candidates":[{"content":{"role":"model","parts":[{"text":"!"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":3,"candidatesTokenCount":3,"totalTokenCount":6}}


---- last chunk: 'data: {...,"usageMetadata":{...}}\n\n' ----
---- has `data: [DONE]`: False ----
```

**Diff between the two runs:**

```
BEFORE chunk count: 4
AFTER  chunk count: 3
Removed: 1 trailing chunk(s)
Removed content: ['data: [DONE]\n\n']
```

The fix removes exactly one chunk — the offending `data: [DONE]\n\n` — and leaves every Gemini-native frame untouched, in order.

## Unit tests

```
$ python3 -m pytest tests/test_litellm/proxy/google_endpoints/test_stream_generate_content_done_terminator.py -v
collected 4 items

test_async_data_generator_emits_done_by_default                       PASSED
test_async_data_generator_skips_done_when_flag_set                    PASSED
test_async_data_generator_skips_done_when_flag_set_falsy_off          PASSED
test_common_request_processing_sets_flag_for_generate_content_stream  PASSED

============================== 4 passed in 8.15s ===============================
```

Broader regression sweep across the related test surface:

```
$ python3 -m pytest tests/test_litellm/proxy/google_endpoints/ \
    tests/test_litellm/proxy/test_common_request_processing.py -x -q
109 passed in 44.70s
```

No regressions on existing google_endpoints or common_request_processing tests.

## Notes for reviewers

- PR pushed via the GitHub `PUT /repos/{owner}/{repo}/contents/{path}` API (one call per file). Current `GITHUB_TOKEN` lacks `repo + workflow` scopes for `git push`. Diff is real and minimal — see the `Files changed` tab — but the merge-base may render a little noisier because each file is its own contents-API commit on the branch.
- The flag is intentionally request-scoped (`request_data["_litellm_skip_sse_done_terminator"]`) rather than route-scoped at module level, so we never have to thread `route_type` into the generator signature — keeps the public `select_data_generator(response, user_api_key_dict, request_data)` contract unchanged.
- The non-streaming `:generateContent` route returns a single JSON body via the standard response path and never touches `async_data_generator`, so no terminator is involved on that side.


### Follow-up: shared typed constant (head `850b0057`)

After the Greptile P2 round (provider-specific gate moved into `google_endpoints/endpoints.py::google_stream_generate_content`; brittle source-inspection test replaced with a behavioral wiring test through `TestClient`), this PR was extended once more to eliminate the magic-string drift risk between producer and consumer:

- New shared constant `LITELLM_SKIP_SSE_DONE_TERMINATOR_KEY = "_litellm_skip_sse_done_terminator"` in `litellm/proxy/_types.py` (a leaf-import module — no circular import risk; `google_endpoints/endpoints.py` already does `from litellm.proxy._types import *`).
- Producer (`google_endpoints/endpoints.py`) and consumer (`async_data_generator` in `proxy_server.py`) both reference the constant. A rename of the on-the-wire key can no longer silently desync the two sides.
- New `test_litellm_skip_sse_done_terminator_key_constant` drift-guard test asserts the constant resolves to the exact on-the-wire string value.

Files pushed via Contents API (token lacks `repo` scope) — diff scope is exactly the 4 files. Two follow-up `black` format commits (`3c44277`, `850b0057`) bring the modified files into compliance with the lint job.

### Verification (ship-pr)

- **Base branch:** `litellm_oss_agent_shin_daily_branch` ✅ (Verify PR source branch check would fail on `main`)
- **GitHub Actions:** **44/44 complete on `850b005791`**. Failures: `codecov/patch` only (informational — 60.00% of patch hit vs. 66.78% target; not a workflow, just a coverage advisory). All 43 workflows (lint, code-quality, secret-scan, semgrep, validate-model-prices-json, build-ui, documentation, every `Run tests` job across the proxy/vertex/integrations/responses-caching-types/core-utils/All Other Providers/enterprise-routing/proxy-*/test-server-root-path/auth-and-jwt/key-generation/test/codecov-success matrix) are green.
- **Greptile:** **5/5** on `850b005791` — *"The change is additive and isolated — the new flag is falsy by default, so all existing streaming callers retain their current behavior unchanged. The fix is minimal and surgical: one constant, one flag set at the Google-specific endpoint, one guard in the generator. The constant is defined in the leaf-import `_types.py` avoiding circular dependency risk; the star-import in `endpoints.py` picks it up automatically. All six tests exercise real runtime behavior, and the drift guard will catch any future rename that breaks the producer-consumer contract without a corresponding update to both sides. No files require special attention."* (4 reviews total — both P2 nudges from the first pass were addressed before re-review.)
- **Veria AI - PR Review:** ✅ success
- **mergeable_state:** verified `unstable` only on the informational codecov/patch advisory.
- **Runtime evidence:** before/after captured against `async_data_generator` with a real Gemini-format async byte iterator (matches what `AsyncGoogleGenAIGenerateContentStreamingIterator` hands downstream). BEFORE = `data: [DONE]` terminator appended (chat/completions path). AFTER = terminator suppressed (native streamGenerateContent path; flag set via the shared constant). Captured in the PR body above.
- **Tests:** 6 cases in `tests/test_litellm/proxy/google_endpoints/test_stream_generate_content_done_terminator.py` — 5 prior + 1 new drift guard. All pass locally; full file is exercised by the `core-utils / Run tests` job which is green.
- **Customer name redaction:** verified — PR title, body, branch name, and commit messages contain zero customer-name strings.

Note: cannot post to `#eng-pr-reviews` from this session — the Slack MCP (`mcp__lap-slack__*`) is not in this agent's toolset (recurring LAP issue). Posting the final status on the Linear ticket so reviewers have the pointer.
