### PR TITLE
fix(bedrock): drop unsupported numeric schema bounds

### DIFF
--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -840,6 +840,7 @@ class AmazonConverseConfig(BaseConfig):
         }
         """
         if json_schema is not None:
+            json_schema = AnthropicConfig.filter_anthropic_output_schema(json_schema)
             json_schema = AmazonConverseConfig._add_additional_properties_to_schema(
                 json_schema
             )

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -3218,6 +3218,39 @@ def test_create_output_config_for_response_format():
     assert parsed_schema == expected
 
 
+def test_create_output_config_drops_unsupported_numeric_schema_bounds():
+    """Bedrock rejects minimum/maximum in outputConfig.format.schema."""
+    config = AmazonConverseConfig()
+
+    schema = {
+        "type": "object",
+        "properties": {
+            "score": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "description": "A score between zero and one",
+            },
+        },
+        "required": ["score"],
+        "additionalProperties": False,
+    }
+
+    output_config = config._create_output_config_for_response_format(
+        json_schema=schema,
+        name="ScoreResult",
+    )
+
+    parsed_schema = json.loads(
+        output_config["textFormat"]["structure"]["jsonSchema"]["schema"]
+    )
+    score_schema = parsed_schema["properties"]["score"]
+    assert "minimum" not in score_schema
+    assert "maximum" not in score_schema
+    assert "minimum value: 0" in score_schema["description"]
+    assert "maximum value: 1" in score_schema["description"]
+
+
 def test_translate_response_format_native_output_config():
     """For supported models, _translate_response_format_param should produce outputConfig."""
     old_env = os.environ.get("LITELLM_LOCAL_MODEL_COST_MAP")


### PR DESCRIPTION
﻿## Summary
- sanitize Bedrock native structured-output JSON schemas with the existing Anthropic schema filter before building `outputConfig`
- keep numeric bounds such as `minimum`/`maximum` out of `outputConfig.textFormat.structure.jsonSchema.schema`
- preserve the removed constraints in the field description, matching the existing Anthropic structured-output behavior

Fixes #29168

## To verify
- `python -m py_compile litellm\llms\bedrock\chat\converse_transformation.py tests\test_litellm\llms\bedrock\chat\test_converse_transformation.py`
- `python -m pytest tests\test_litellm\llms\bedrock\chat\test_converse_transformation.py -k "create_output_config" -q --basetemp .tmp\pytest`
- `python -m ruff check litellm\llms\bedrock\chat\converse_transformation.py`
- `git diff --check`
