### PR TITLE
fix(passthrough): swallow flush replay errors; map Anthropic overloaded_error to 529 (#29187)

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1993,10 +1993,24 @@ class Logging(LiteLLMLoggingBaseClass):
         3. Log the complete streaming response (trigger success handler)
         This is used for passthrough endpoints
         """
-        complete_streaming_response = self._flush_passthrough_collected_chunks_helper(
-            raw_bytes=raw_bytes,
-            provider_config=provider_config,
-        )
+        try:
+            complete_streaming_response = (
+                self._flush_passthrough_collected_chunks_helper(
+                    raw_bytes=raw_bytes,
+                    provider_config=provider_config,
+                )
+            )
+        except Exception as e:
+            # The flush is a logging/spend-tracking path. Provider errors
+            # surfaced inside buffered chunks (e.g. mid-stream `overloaded_error`
+            # for Anthropic / Bedrock) must not become unhandled exceptions —
+            # the upstream stream is already closed and the client response is
+            # done by the time we get here.
+            verbose_logger.warning(
+                "flush_passthrough_collected_chunks: skipping success-logging — "
+                f"provider config raised during chunk replay: {type(e).__name__}: {e}"
+            )
+            return
 
         if complete_streaming_response is not None:
             self.success_handler(result=complete_streaming_response)
@@ -2007,10 +2021,23 @@ class Logging(LiteLLMLoggingBaseClass):
         raw_bytes: List[bytes],
         provider_config: "BasePassthroughConfig",
     ):
-        complete_streaming_response = self._flush_passthrough_collected_chunks_helper(
-            raw_bytes=raw_bytes,
-            provider_config=provider_config,
-        )
+        try:
+            complete_streaming_response = (
+                self._flush_passthrough_collected_chunks_helper(
+                    raw_bytes=raw_bytes,
+                    provider_config=provider_config,
+                )
+            )
+        except Exception as e:
+            # See `flush_passthrough_collected_chunks` above — the flush is a
+            # logging/spend-tracking task scheduled via `asyncio.create_task`,
+            # so a bare raise here surfaces as `Task exception was never
+            # retrieved` and gives users no signal about the real cause.
+            verbose_logger.warning(
+                "async_flush_passthrough_collected_chunks: skipping success-logging — "
+                f"provider config raised during chunk replay: {type(e).__name__}: {e}"
+            )
+            return
 
         if complete_streaming_response is not None:
             await self.async_success_handler(result=complete_streaming_response)

--- a/litellm/llms/anthropic/chat/handler.py
+++ b/litellm/llms/anthropic/chat/handler.py
@@ -1018,12 +1018,20 @@ class ModelResponseIterator:
             elif type_chunk == "error":
                 """
                 {"type":"error","error":{"details":null,"type":"api_error","message":"Internal server error"}      }
+
+                Anthropic does not return an HTTP status code in the in-stream
+                error event. Use `error.type` to pick a sensible default so
+                clients can distinguish retryable conditions: `overloaded_error`
+                is 529 per Anthropic's public conventions, everything else
+                stays 500.
                 """
                 _error_dict = chunk.get("error", {}) or {}
                 message = _error_dict.get("message", None) or str(chunk)
+                _error_type = _error_dict.get("type", "") or ""
+                _status_code = 529 if _error_type == "overloaded_error" else 500
                 raise AnthropicError(
                     message=message,
-                    status_code=500,  # it looks like Anthropic API does not return a status code in the chunk error - default to 500
+                    status_code=_status_code,
                 )
 
             text, tool_use = self._handle_json_mode_chunk(text=text, tool_use=tool_use)


### PR DESCRIPTION
## Summary

Closes #29187.

Two small, scoped changes that together turn the Bedrock-passthrough
"client sees `Internal server error`, no signal to retry" failure into a
proper 529 surfacing path, and stop the
`Task exception was never retrieved` log spam during Anthropic
overloads.

### 1. `litellm_core_utils/litellm_logging.py` — wrap flush replay in `try/except`

`flush_passthrough_collected_chunks` and its async sibling are scheduled
via `asyncio.create_task` in the `finally` block from PR #26719 (v1.84.0
onwards). They replay the buffered stream through the provider config
purely for spend-tracking / success-logging — the client HTTP response is
already fully closed by the time we get here.

If the buffered stream contains a mid-stream error event (Anthropic's
`overloaded_error` is the visible one for Claude Code via Bedrock,
covered in the issue), the provider config raises during chunk replay,
the unhandled exception escapes the async task, and the user sees:

```
Task exception was never retrieved
future: <Task ... exception=AnthropicError('Overloaded')>
```

…while the real surfacing path (the actual HTTP response) is already
gone. Wrapping the replay in `try/except` logs it as a warning, skips
the success handler (no spend to track for a failed call anyway), and
lets the asyncio task complete cleanly. This is symmetric across the
sync (`flush_passthrough_collected_chunks`) and async
(`async_flush_passthrough_collected_chunks`) paths.

### 2. `llms/anthropic/chat/handler.py` — pick status from `error.type`

`ModelResponseIterator.chunk_parser`'s `type == "error"` branch
hard-coded `status_code=500` for every in-stream error event, with a
comment noting Anthropic doesn't return an HTTP status in the chunk.

Anthropic's public convention is **529 for `overloaded_error`** (their
own SDK / docs use this code for the "API temporarily overloaded" case).
Mapping `error.type == "overloaded_error"` → 529 lets retry middleware
and observers distinguish a transient/retryable overload from a generic
500 server error. Any other `error.type` keeps the existing 500 default.

## Test plan

- [x] Static reasoning against the failing trace in #29187:
  - the `AnthropicError('Overloaded')` raised at
    `anthropic/chat/handler.py:851` is now wrapped at the
    `litellm_logging.py:1996` / `2010` callsites — no more
    `Task exception was never retrieved`.
  - the same code path, when surfaced via the normal (non-passthrough)
    streaming path, now propagates as a 529 rather than a 500 — clients
    can choose to retry.
- [x] `python -m py_compile` both files.
- [x] Behavioral non-regression: when `complete_streaming_response is
      None` (existing path) or replay succeeds, control flow is
      unchanged — `success_handler` / `async_success_handler` is still
      invoked exactly as before.
- [x] Black-style formatting preserved (multi-line tuple-assign matches
      neighboring style in the file).

## Out of scope

- The related `anthropic_messages` route mid-stream fallback (#24004)
  and `/v1/messages` `async_sse_wrapper` error handling (#24609) are
  separate surfacing paths; this PR only addresses the bedrock
  passthrough flush path called out in #29187 (root + secondary
  finding).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
