### PR TITLE
fix(bedrock-invoke): retain clear_tool_uses_20250919 context_management edits + emit context-management-2025-06-27 beta (LIT-3393)

### DIFF
--- a/litellm/anthropic_beta_headers_config.json
+++ b/litellm/anthropic_beta_headers_config.json
@@ -102,7 +102,7 @@
     "computer-use-2025-01-24": "computer-use-2025-01-24",
     "computer-use-2025-11-24": "computer-use-2025-11-24",
     "context-1m-2025-08-07": "context-1m-2025-08-07",
-    "context-management-2025-06-27": null,
+    "context-management-2025-06-27": "context-management-2025-06-27",
     "effort-2025-11-24": "effort-2025-11-24",
     "fast-mode-2026-02-01": null,
     "files-api-2025-04-14": null,

--- a/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
+++ b/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
@@ -409,24 +409,43 @@ class AmazonAnthropicClaudeMessagesConfig(
             if self._supports_tool_search_on_bedrock(model):
                 beta_set.add("tool-search-tool-2025-10-19")
 
+    # Bedrock-InvokeModel-supported ``context_management.edits`` types and the
+    # ``anthropic-beta`` header that each one requires. ``clear_thinking_20251015``
+    # is intentionally absent — it is LiteLLM-internal, consumed via
+    # ``_ensure_thinking_for_clear_thinking_context_management``, and forwarding
+    # the raw edit trips Bedrock's
+    # ``"context_management: Extra inputs are not permitted"`` 400.
+    #
+    # Bedrock InvokeModel DOES support ``clear_tool_uses_20250919`` under the
+    # ``context-management-2025-06-27`` beta. AWS docs:
+    # https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-messages-tool-use.md
+    _BEDROCK_INVOKE_SUPPORTED_CONTEXT_MANAGEMENT_EDITS: Dict[str, str] = {
+        "compact_20260112": "compact-2026-01-12",
+        "clear_tool_uses_20250919": "context-management-2025-06-27",
+    }
+
     @staticmethod
     def _filter_context_management_for_bedrock_invoke(
         anthropic_messages_request: Dict,
         beta_set: set,
     ) -> None:
         """
-        Bedrock InvokeModel accepts ``context_management`` only when it carries
-        ``compact_20260112`` edits paired with the ``compact-2026-01-12``
-        anthropic-beta header. Other edit types (notably ``clear_thinking_20251015``,
-        which Claude Code sends on every request) are LiteLLM-internal and would
-        cause Bedrock to 400 with ``"context_management: Extra inputs are not
-        permitted"``.
+        Filter ``context_management.edits`` to the subset that Bedrock InvokeModel
+        accepts and add the matching ``anthropic-beta`` header for each surviving
+        edit type.
 
-        Filter the edits list to the supported subset, add the beta header when
-        compact edits remain, and drop ``context_management`` entirely when no
-        supported edits are left so the safety-net allowlist can pass it through.
+        - ``compact_20260112`` -> ``compact-2026-01-12``
+        - ``clear_tool_uses_20250919`` -> ``context-management-2025-06-27``
 
-        Ref: https://github.com/BerriAI/litellm/issues/27532
+        Other edit types (notably ``clear_thinking_20251015``, which Claude Code
+        sends on every request) are LiteLLM-internal: thinking is injected
+        separately via ``_ensure_thinking_for_clear_thinking_context_management``,
+        and forwarding the raw edit would trip Bedrock's
+        ``"context_management: Extra inputs are not permitted"`` 400.
+
+        Refs:
+          * https://github.com/BerriAI/litellm/issues/27532
+          * https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-messages-tool-use.md
         """
         cm = anthropic_messages_request.get("context_management")
         if not isinstance(cm, dict):
@@ -436,19 +455,31 @@ class AmazonAnthropicClaudeMessagesConfig(
             anthropic_messages_request.pop("context_management", None)
             return
 
-        compact_edits = [
-            e
-            for e in edits
-            if isinstance(e, dict) and e.get("type") == "compact_20260112"
-        ]
-        if compact_edits:
-            beta_set.add("compact-2026-01-12")
-            anthropic_messages_request["context_management"] = {
-                **cm,
-                "edits": compact_edits,
-            }
-        else:
+        supported = (
+            AmazonAnthropicClaudeMessagesConfig
+            ._BEDROCK_INVOKE_SUPPORTED_CONTEXT_MANAGEMENT_EDITS
+        )
+
+        retained_edits: List[Dict] = []
+        for edit in edits:
+            if not isinstance(edit, dict):
+                continue
+            if edit.get("type") in supported:
+                retained_edits.append(edit)
+
+        if not retained_edits:
             anthropic_messages_request.pop("context_management", None)
+            return
+
+        for edit in retained_edits:
+            mapped = supported.get(edit.get("type"))
+            if mapped:
+                beta_set.add(mapped)
+
+        anthropic_messages_request["context_management"] = {
+            **cm,
+            "edits": retained_edits,
+        }
 
     def _convert_output_format_to_inline_schema(
         self,

--- a/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
+++ b/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
@@ -463,17 +463,14 @@ class AmazonAnthropicClaudeMessagesConfig(
         for edit in edits:
             if not isinstance(edit, dict):
                 continue
-            if edit.get("type") in supported:
+            edit_type = edit.get("type")
+            if isinstance(edit_type, str) and edit_type in supported:
                 retained_edits.append(edit)
+                beta_set.add(supported[edit_type])
 
         if not retained_edits:
             anthropic_messages_request.pop("context_management", None)
             return
-
-        for edit in retained_edits:
-            mapped = supported.get(edit.get("type"))
-            if mapped:
-                beta_set.add(mapped)
 
         anthropic_messages_request["context_management"] = {
             **cm,

--- a/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
+++ b/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
@@ -456,8 +456,7 @@ class AmazonAnthropicClaudeMessagesConfig(
             return
 
         supported = (
-            AmazonAnthropicClaudeMessagesConfig
-            ._BEDROCK_INVOKE_SUPPORTED_CONTEXT_MANAGEMENT_EDITS
+            AmazonAnthropicClaudeMessagesConfig._BEDROCK_INVOKE_SUPPORTED_CONTEXT_MANAGEMENT_EDITS
         )
 
         retained_edits: List[Dict] = []

--- a/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
+++ b/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
@@ -1497,3 +1497,169 @@ async def test_unified_bedrock_messages_sse_usage_and_cost_claude_sonnet_46():
         custom_llm_provider="bedrock",
     )
     assert cost == pytest.approx(0.052150725, rel=0, abs=1e-9)
+
+
+def test_bedrock_messages_preserves_clear_tool_uses_context_management_and_adds_beta(monkeypatch):
+    """
+    LIT-3393: Bedrock InvokeModel supports automatic tool-call clearing via
+    ``clear_tool_uses_20250919`` under the ``context-management-2025-06-27``
+    beta. Before the LIT-3393 fix, the transformation stripped this edit (only
+    ``compact_20260112`` survived) AND the beta was filtered out by
+    ``filter_and_transform_beta_headers`` for ``bedrock``, producing a Bedrock
+    400 ``"context_management: Extra inputs are not permitted"``.
+
+    Post-fix, the edit must reach the body and the beta must reach
+    ``anthropic_beta``.
+
+    AWS docs ("Automatic tool call clearing (Beta)"):
+    https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-messages-tool-use.md
+    """
+    from litellm.types.router import GenericLiteLLMParams
+    from litellm.anthropic_beta_headers_manager import (
+        reload_beta_headers_config,
+    )
+    monkeypatch.setenv("LITELLM_LOCAL_ANTHROPIC_BETA_HEADERS", "True")
+    reload_beta_headers_config()
+
+
+    cfg = AmazonAnthropicClaudeMessagesConfig()
+    messages = [{"role": "user", "content": [{"type": "text", "text": "Hi"}]}]
+    optional_params = {
+        "max_tokens": 4096,
+        "context_management": {
+            "edits": [{"type": "clear_tool_uses_20250919"}]
+        },
+    }
+
+    result = cfg.transform_anthropic_messages_request(
+        model="anthropic.claude-haiku-4-5-20251001-v1:0",
+        messages=messages,
+        anthropic_messages_optional_request_params=optional_params,
+        litellm_params=GenericLiteLLMParams(),
+        headers={},
+    )
+
+    assert result.get("context_management") == {
+        "edits": [{"type": "clear_tool_uses_20250919"}]
+    }, "clear_tool_uses_20250919 edit must reach Bedrock InvokeModel body"
+    assert "context-management-2025-06-27" in result.get("anthropic_beta", []), (
+        "context-management-2025-06-27 beta must reach the InvokeModel body so "
+        "the tool-call-clearing edit is accepted"
+    )
+
+
+def test_bedrock_messages_preserves_mixed_compact_and_clear_tool_uses_edits(monkeypatch):
+    """
+    LIT-3393: a request mixing ``compact_20260112`` and
+    ``clear_tool_uses_20250919`` must keep BOTH edits and emit BOTH
+    anthropic-beta values (``compact-2026-01-12`` + ``context-management-2025-06-27``).
+    """
+    from litellm.types.router import GenericLiteLLMParams
+    from litellm.anthropic_beta_headers_manager import (
+        reload_beta_headers_config,
+    )
+    monkeypatch.setenv("LITELLM_LOCAL_ANTHROPIC_BETA_HEADERS", "True")
+    reload_beta_headers_config()
+
+
+    cfg = AmazonAnthropicClaudeMessagesConfig()
+    messages = [{"role": "user", "content": [{"type": "text", "text": "Hi"}]}]
+    optional_params = {
+        "max_tokens": 4096,
+        "context_management": {
+            "edits": [
+                {"type": "compact_20260112"},
+                {"type": "clear_tool_uses_20250919"},
+            ]
+        },
+    }
+
+    result = cfg.transform_anthropic_messages_request(
+        model="anthropic.claude-sonnet-4-6-20250929-v1:0",
+        messages=messages,
+        anthropic_messages_optional_request_params=optional_params,
+        litellm_params=GenericLiteLLMParams(),
+        headers={},
+    )
+
+    cm = result.get("context_management")
+    assert cm is not None
+    edit_types = sorted(e.get("type") for e in cm["edits"])
+    assert edit_types == ["clear_tool_uses_20250919", "compact_20260112"]
+
+    betas = result.get("anthropic_beta", [])
+    assert "compact-2026-01-12" in betas
+    assert "context-management-2025-06-27" in betas
+
+
+def test_bedrock_messages_filters_clear_thinking_keeps_clear_tool_uses(monkeypatch):
+    """
+    LIT-3393: ``clear_thinking_20251015`` remains LiteLLM-internal (consumed via
+    thinking-injection) and MUST be stripped from the body, while
+    ``clear_tool_uses_20250919`` (officially supported on Bedrock InvokeModel)
+    survives in the same request.
+    """
+    from litellm.types.router import GenericLiteLLMParams
+    from litellm.anthropic_beta_headers_manager import (
+        reload_beta_headers_config,
+    )
+    monkeypatch.setenv("LITELLM_LOCAL_ANTHROPIC_BETA_HEADERS", "True")
+    reload_beta_headers_config()
+
+
+    cfg = AmazonAnthropicClaudeMessagesConfig()
+    messages = [{"role": "user", "content": [{"type": "text", "text": "Hi"}]}]
+    optional_params = {
+        "max_tokens": 4096,
+        "context_management": {
+            "edits": [
+                {"type": "clear_thinking_20251015", "keep": "all"},
+                {"type": "clear_tool_uses_20250919"},
+            ]
+        },
+    }
+
+    result = cfg.transform_anthropic_messages_request(
+        model="anthropic.claude-opus-4-7",
+        messages=messages,
+        anthropic_messages_optional_request_params=optional_params,
+        litellm_params=GenericLiteLLMParams(),
+        headers={},
+    )
+
+    cm = result.get("context_management")
+    assert cm is not None
+    assert [e.get("type") for e in cm["edits"]] == [
+        "clear_tool_uses_20250919"
+    ], "clear_thinking_20251015 must still be stripped (LiteLLM-internal)"
+
+    betas = result.get("anthropic_beta", [])
+    assert "context-management-2025-06-27" in betas
+    # ``compact-2026-01-12`` was not requested.
+    assert "compact-2026-01-12" not in betas
+
+
+def test_filter_and_transform_beta_headers_passes_context_management_for_bedrock():
+    """
+    LIT-3393: ``anthropic_beta_headers_config.json`` previously mapped
+    ``bedrock.context-management-2025-06-27`` to ``null``, so
+    ``filter_and_transform_beta_headers`` dropped the header even when the
+    transformation tried to set it. This regression guard locks the mapping in
+    place.
+    """
+    from litellm.anthropic_beta_headers_manager import filter_and_transform_beta_headers
+
+    out = filter_and_transform_beta_headers(
+        ["context-management-2025-06-27"],
+        provider="bedrock",
+    )
+    assert out == ["context-management-2025-06-27"]
+
+    # Bedrock_converse genuinely lacks it per AWS docs; this guard prevents an
+    # accidental flip there.
+    out_converse = filter_and_transform_beta_headers(
+        ["context-management-2025-06-27"],
+        provider="bedrock_converse",
+    )
+    assert out_converse == []
+

--- a/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
+++ b/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
@@ -1639,27 +1639,42 @@ def test_bedrock_messages_filters_clear_thinking_keeps_clear_tool_uses(monkeypat
     assert "compact-2026-01-12" not in betas
 
 
-def test_filter_and_transform_beta_headers_passes_context_management_for_bedrock():
+def test_filter_and_transform_beta_headers_passes_context_management_for_bedrock(
+    monkeypatch,
+):
     """
     LIT-3393: ``anthropic_beta_headers_config.json`` previously mapped
     ``bedrock.context-management-2025-06-27`` to ``null``, so
     ``filter_and_transform_beta_headers`` dropped the header even when the
-    transformation tried to set it. This regression guard locks the mapping in
-    place.
+    transformation tried to set it. This regression guard locks the bundled
+    mapping in place.
+
+    Pinned to the bundled local config via ``LITELLM_LOCAL_ANTHROPIC_BETA_HEADERS``
+    so the assertion is not subject to whatever the upstream remote currently
+    serves or what previous tests left in the module cache.
     """
-    from litellm.anthropic_beta_headers_manager import filter_and_transform_beta_headers
-
-    out = filter_and_transform_beta_headers(
-        ["context-management-2025-06-27"],
-        provider="bedrock",
+    from litellm.anthropic_beta_headers_manager import (
+        filter_and_transform_beta_headers,
+        reload_beta_headers_config,
     )
-    assert out == ["context-management-2025-06-27"]
 
-    # Bedrock_converse genuinely lacks it per AWS docs; this guard prevents an
-    # accidental flip there.
-    out_converse = filter_and_transform_beta_headers(
-        ["context-management-2025-06-27"],
-        provider="bedrock_converse",
-    )
-    assert out_converse == []
+    monkeypatch.setenv("LITELLM_LOCAL_ANTHROPIC_BETA_HEADERS", "True")
+    reload_beta_headers_config()
+    try:
+        out = filter_and_transform_beta_headers(
+            ["context-management-2025-06-27"],
+            provider="bedrock",
+        )
+        assert out == ["context-management-2025-06-27"]
+
+        # Bedrock_converse genuinely lacks it per AWS docs; this guard prevents
+        # an accidental flip there.
+        out_converse = filter_and_transform_beta_headers(
+            ["context-management-2025-06-27"],
+            provider="bedrock_converse",
+        )
+        assert out_converse == []
+    finally:
+        monkeypatch.delenv("LITELLM_LOCAL_ANTHROPIC_BETA_HEADERS", raising=False)
+        reload_beta_headers_config()
 


### PR DESCRIPTION
## What

LIT-3393. `/v1/messages` -> `bedrock/invoke/...` requests that carry `context_management.edits = [{type: "clear_tool_uses_20250919"}]` were silently transformed in a way that triggered a Bedrock 400:

```
context_management: Extra inputs are not permitted
```

Bedrock InvokeModel actually [supports automatic tool-call clearing](https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-messages-tool-use.md) (`clear_tool_uses_20250919`) under the `context-management-2025-06-27` beta on Claude Haiku 4.5, Sonnet 4/4.5 and Opus 4/4.1/4.5/4.7. We were stripping it.

Two compounding bugs caused the strip:

1. **`litellm/anthropic_beta_headers_config.json`** mapped `bedrock.context-management-2025-06-27 -> null`, so `filter_and_transform_beta_headers(..., provider="bedrock")` dropped the beta header even when the transformation tried to add it. (Per AWS docs, `bedrock_converse` genuinely lacks the beta — `bedrock_converse` mapping stays `null`.)
2. **`_filter_context_management_for_bedrock_invoke`** kept only `compact_20260112` edits and popped the rest, including the customer's `clear_tool_uses_20250919`.

`clear_thinking_20251015` remains LiteLLM-internal (it is consumed via `_ensure_thinking_for_clear_thinking_context_management` thinking injection) — keeping its strip behavior intact.

Sister to the compaction fix (#27532).

## Changes

- `litellm/anthropic_beta_headers_config.json`: `bedrock.context-management-2025-06-27 -> "context-management-2025-06-27"`. `bedrock_converse` left `null`.
- `litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py`: rewrote `_filter_context_management_for_bedrock_invoke` around a small allowlist of Bedrock-InvokeModel-supported edits:

  ```
  _BEDROCK_INVOKE_SUPPORTED_CONTEXT_MANAGEMENT_EDITS = {
      "compact_20260112":         "compact-2026-01-12",
      "clear_tool_uses_20250919": "context-management-2025-06-27",
  }
  ```

  Walks `cm["edits"]`, keeps each supported edit and adds its matching beta to `beta_set`. Drops `context_management` entirely when nothing survives.
- 4 new tests in `test_anthropic_claude3_transformation.py`:
  - `test_bedrock_messages_preserves_clear_tool_uses_context_management_and_adds_beta`
  - `test_bedrock_messages_preserves_mixed_compact_and_clear_tool_uses_edits`
  - `test_bedrock_messages_filters_clear_thinking_keeps_clear_tool_uses` (clear_thinking still stripped)
  - `test_filter_and_transform_beta_headers_passes_context_management_for_bedrock` (locks the JSON mapping in place; pins to local config via `LITELLM_LOCAL_ANTHROPIC_BETA_HEADERS=True` so it is not subject to the upstream remote)

### Note on the push path

Branch was created via `POST /git/refs` and files written via `PUT /repos/{owner}/{repo}/contents/{path}` (one commit per file) — the agent's GitHub token lacks `repo + workflow` scopes for `git push`. Reviewers will see 3 commits where one would normally exist.

## Evidence

Real runtime evidence — driving `AmazonAnthropicClaudeMessagesConfig.transform_anthropic_messages_request` in subprocesses pointed at the **before** tree (`litellm_oss_agent_shin_daily_branch` HEAD `1fe911d`) and the **after** tree (this branch). The output is the actual InvokeModel request body that LiteLLM would sign and POST to Bedrock for `model="anthropic.claude-haiku-4-5-20251001-v1:0"`. No live AWS call needed — the bug is entirely in request construction.

Repro script: `/tmp/runtime_repro2.py` in the agent sandbox.

```
========== clear_tool_uses only ==========
--- BEFORE (daily branch HEAD) ---
{
  "context_management": "<MISSING>",
  "anthropic_beta": "<MISSING>"
}
--- AFTER (with LIT-3393 fix) ---
{
  "context_management": {
    "edits": [
      {
        "type": "clear_tool_uses_20250919"
      }
    ]
  },
  "anthropic_beta": [
    "context-management-2025-06-27"
  ]
}

========== compact + clear_tool_uses (mixed) ==========
--- BEFORE (daily branch HEAD) ---
{
  "context_management": {
    "edits": [
      {
        "type": "compact_20260112"
      }
    ]
  },
  "anthropic_beta": [
    "compact-2026-01-12"
  ]
}
--- AFTER (with LIT-3393 fix) ---
{
  "context_management": {
    "edits": [
      {
        "type": "compact_20260112"
      },
      {
        "type": "clear_tool_uses_20250919"
      }
    ]
  },
  "anthropic_beta": [
    "compact-2026-01-12",
    "context-management-2025-06-27"
  ]
}

========== clear_thinking still stripped (LiteLLM-internal) ==========
--- BEFORE (daily branch HEAD) ---
{
  "context_management": "<MISSING>",
  "anthropic_beta": "<MISSING>"
}
--- AFTER (with LIT-3393 fix) ---
{
  "context_management": {
    "edits": [
      {
        "type": "clear_tool_uses_20250919"
      }
    ]
  },
  "anthropic_beta": [
    "context-management-2025-06-27"
  ]
}
```

Note in the third case: BEFORE strips both `clear_thinking_20251015` AND `clear_tool_uses_20250919` (i.e. the whole `context_management` payload) and emits no beta. AFTER retains the supported `clear_tool_uses_20250919` and its beta while still stripping the LiteLLM-internal `clear_thinking_20251015`.

### Unit tests

```
$ python3 -m pytest tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
============================== 45 passed in 1.78s ==============================

$ python3 -m pytest tests/test_litellm/test_anthropic_beta_headers_filtering.py
======================== 19 passed, 3 warnings in 0.93s ========================
```

## Relevant tickets / refs

- LIT-3393
- Github issue: BerriAI/litellm#27532
- AWS docs: https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-messages-tool-use.md

## Session

https://litellm-agent-platform.onrender.com/sessions/9c1ef9c0-e731-43ff-bc0b-54a47ff9d778


### Verification

- **GitHub Actions:** 44/44 green at HEAD `536c441` (lint ✅, code-quality ✅, secret-scan ✅, semgrep ✅, build-ui ✅, validate-model-prices-json ✅, unit-test ✅, test ✅, test-server-root-path (/api/v1) ✅, test-server-root-path (/llmproxy) ✅, integrations ✅, core-utils ✅, responses-caching-types ✅, Vertex AI ✅, All Other Providers ✅, proxy-* suites ✅, enterprise-routing ✅, auth-and-jwt ✅, key-generation ✅, documentation ✅, Codecov ✅, etc.).
- **Greptile:** 4/5 on `6aca3d1` — *"The transformation logic and JSON config change are correct and well-tested."* The one P2 nit (regression-guard test missing the `LITELLM_LOCAL_ANTHROPIC_BETA_HEADERS=True` + `reload_beta_headers_config()` pin used by its three siblings) was addressed in `33882ec`; verified the test now passes in isolation.
- **Veria AI - PR Review:** ✅ success on `536c441`.
- **mergeable_state:** mergeable=True (Codecov pending uploads register as "unstable" but mergeable).
- **Base branch:** `litellm_oss_agent_shin_daily_branch` (per Shin fork policy).
