### PR TITLE
fix(mcp): inline $ref in OpenAPI-registered MCP tool schemas

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -640,8 +640,11 @@ class MCPServerManager:
                         operation.get("description", f"{method.upper()} {path}"),
                     )
 
-                    # Build input schema using imported function
-                    input_schema = build_input_schema(resolved_operation)
+                    # Build input schema using imported function.
+                    # Pass spec so $ref pointers in the request body /
+                    # parameter schemas are inlined before the tool is
+                    # registered with the LLM-facing registry.
+                    input_schema = build_input_schema(resolved_operation, spec=spec)
 
                     # Create tool function with headers using imported function
                     tool_func = create_tool_function(

--- a/litellm/proxy/_experimental/mcp_server/openapi_to_mcp_generator.py
+++ b/litellm/proxy/_experimental/mcp_server/openapi_to_mcp_generator.py
@@ -233,6 +233,97 @@ def resolve_operation_params(
     return result
 
 
+def _lookup_ref(ref: str, spec: Optional[Dict[str, Any]]) -> Optional[Any]:
+    """Resolve a local JSON-Pointer ``$ref`` against the OpenAPI spec root.
+
+    Supports OpenAPI 3.x (``#/components/schemas/...``) and Swagger 2.0
+    (``#/definitions/...``) refs, plus any other in-document JSON Pointer.
+
+    Returns ``None`` for external refs (``http(s)://...``, file URIs), unknown
+    targets, or when ``spec`` is None.  Callers preserve the original ``$ref``
+    node in that case so the schema is at worst no worse than today.
+    """
+    if not spec or not isinstance(ref, str) or not ref.startswith("#/"):
+        return None
+    cur: Any = spec
+    for raw_part in ref[2:].split("/"):
+        # JSON Pointer unescape (RFC 6901): "~1" -> "/", "~0" -> "~"
+        part = raw_part.replace("~1", "/").replace("~0", "~")
+        if isinstance(cur, dict) and part in cur:
+            cur = cur[part]
+        elif isinstance(cur, list):
+            try:
+                cur = cur[int(part)]
+            except (ValueError, IndexError):
+                return None
+        else:
+            return None
+    return cur
+
+
+def _inline_schema_refs(
+    schema: Any,
+    spec: Optional[Dict[str, Any]],
+    _visiting: Optional[frozenset] = None,
+) -> Any:
+    """Recursively inline local JSON Schema ``$ref`` nodes against ``spec``.
+
+    LLM providers (Anthropic, Bedrock, Fireworks, Gemini, ...) reject tool
+    ``input_schema`` documents that contain unresolved ``$ref`` pointers - they
+    do not run a JSON-Schema resolver. When LiteLLM registers MCP tools from an
+    OpenAPI spec, the request-body and parameter schemas commonly use
+    ``$ref: "#/components/schemas/X"`` (Google Workspace ``Presentations`` /
+    ``Sheets``, GitHub REST, etc.). Without inlining, those refs reach the
+    provider and the tool call 400s with "Invalid tool schema, $ref is not
+    supported" or "PointerToNowhere".
+
+    Behaviour:
+
+    * Walks ``dict`` / ``list`` nodes and replaces ``{"$ref": "#/..."}`` with
+      the resolved subtree.
+    * Sibling fields next to a ``$ref`` (e.g. ``description``, ``nullable``)
+      are preserved by merging them into the resolved subtree - sibling values
+      win over the referenced target so descriptions next to a ``$ref`` are not
+      lost (this matches OpenAPI 3.1 ``$ref`` sibling semantics).
+    * Cycle-safe: a ``$ref`` already on the resolution stack is left in place
+      rather than expanded infinitely. The on-disk schema still has the cycle
+      defined, so downstream consumers that *do* support ``$ref`` can still
+      follow it.
+    * Returns the input unchanged when ``spec`` is ``None`` (zero-cost no-op
+      for legacy callers).
+    """
+    if spec is None:
+        return schema
+    if isinstance(schema, list):
+        return [_inline_schema_refs(item, spec, _visiting) for item in schema]
+    if not isinstance(schema, dict):
+        return schema
+
+    ref = schema.get("$ref")
+    if isinstance(ref, str) and ref.startswith("#/"):
+        visiting = _visiting or frozenset()
+        if ref in visiting:
+            # Cycle: leave the original $ref so callers do not blow the stack.
+            return schema
+        target = _lookup_ref(ref, spec)
+        if target is None:
+            # Unresolvable - leave $ref intact; this is the legacy behaviour
+            # and keeps the bug from getting silently *worse*.
+            return schema
+        resolved = _inline_schema_refs(target, spec, visiting | {ref})
+        if isinstance(resolved, dict):
+            merged = dict(resolved)
+            for k, v in schema.items():
+                if k == "$ref":
+                    continue
+                # Sibling wins, matching OpenAPI 3.1 ``$ref`` overlay semantics.
+                merged[k] = v
+            return merged
+        return resolved
+
+    return {k: _inline_schema_refs(v, spec, _visiting) for k, v in schema.items()}
+
+
 def extract_parameters(operation: Dict[str, Any]) -> tuple:
     """Extract parameter names from OpenAPI operation."""
     path_params = []
@@ -259,10 +350,25 @@ def extract_parameters(operation: Dict[str, Any]) -> tuple:
     return path_params, query_params, body_params
 
 
-def build_input_schema(operation: Dict[str, Any]) -> Dict[str, Any]:
-    """Build MCP input schema from OpenAPI operation."""
-    properties = {}
-    required = []
+def build_input_schema(
+    operation: Dict[str, Any],
+    spec: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Build MCP input schema from an OpenAPI operation.
+
+    When ``spec`` is provided, local ``$ref`` pointers inside parameter
+    schemas and the JSON request body schema are inlined via
+    :func:`_inline_schema_refs`. LLM providers do not resolve ``$ref`` in
+    tool schemas and reject any unresolved pointer, so leaving refs in
+    place (the legacy behaviour) breaks OpenAPI-registered MCP tools that
+    use ``#/components/schemas/...`` (Google Workspace ``Presentations`` /
+    ``Sheets`` create calls, GitHub REST, etc.).
+
+    ``spec`` defaults to ``None`` so existing call sites that build a
+    schema from a free-standing operation continue to behave as before.
+    """
+    properties: Dict[str, Any] = {}
+    required: List[str] = []
 
     # Process parameters
     if "parameters" in operation:
@@ -270,7 +376,13 @@ def build_input_schema(operation: Dict[str, Any]) -> Dict[str, Any]:
             if "name" not in param:
                 continue
             param_name = param["name"]
-            param_schema = param.get("schema", {})
+            # Inline refs inside the per-parameter schema before reading
+            # ``type`` so e.g. ``{"$ref": "#/components/schemas/Cursor"}``
+            # resolves to its actual primitive type instead of silently
+            # falling back to ``"string"``.
+            param_schema = _inline_schema_refs(param.get("schema", {}), spec)
+            if not isinstance(param_schema, dict):
+                param_schema = {}
             param_type = param_schema.get("type", "string")
 
             properties[param_name] = {
@@ -289,11 +401,25 @@ def build_input_schema(operation: Dict[str, Any]) -> Dict[str, Any]:
         # Try to get JSON schema
         if "application/json" in content:
             schema = content["application/json"].get("schema", {})
-            properties["body"] = {
+            # Recursively inline ``$ref`` so the body schema is fully
+            # self-contained for downstream LLM providers.
+            schema = _inline_schema_refs(schema, spec)
+            if not isinstance(schema, dict):
+                schema = {}
+
+            body: Dict[str, Any] = {
                 "type": "object",
                 "description": request_body.get("description", "Request body"),
                 "properties": schema.get("properties", {}),
             }
+            # Propagate a body-level ``required`` list when the resolved
+            # schema declares one (common with ``#/components/schemas/...``
+            # request bodies). Without this we drop hard requirements like
+            # "title" on Google Workspace create calls.
+            body_required = schema.get("required")
+            if isinstance(body_required, list) and body_required:
+                body["required"] = body_required
+            properties["body"] = body
             if request_body.get("required", False):
                 required.append("body")
 
@@ -499,8 +625,10 @@ def register_tools_from_openapi(spec: Dict[str, Any], base_url: str):
                     "summary", operation.get("description", f"{method.upper()} {path}")
                 )
 
-                # Build input schema
-                input_schema = build_input_schema(operation)
+                # Build input schema. Pass the spec so $refs in the
+                # operation's request body / parameter schemas get inlined
+                # before we register the tool with the LLM-facing registry.
+                input_schema = build_input_schema(operation, spec=spec)
 
                 # Create tool function
                 tool_func = create_tool_function(path, method, operation, base_url)

--- a/litellm/proxy/_experimental/mcp_server/openapi_to_mcp_generator.py
+++ b/litellm/proxy/_experimental/mcp_server/openapi_to_mcp_generator.py
@@ -319,6 +319,14 @@ def _inline_schema_refs(
                 # Sibling wins, matching OpenAPI 3.1 ``$ref`` overlay semantics.
                 merged[k] = v
             return merged
+        # The resolved target is not a JSON Schema object (e.g. the spec
+        # points ``$ref`` at a list or scalar - technically malformed under
+        # JSON Schema). If the original ``$ref`` node carried sibling
+        # fields (``description``, ``nullable``, ...), they would be lost
+        # if we returned the bare resolved value. Preserve the source node
+        # in that case so no per-use-site context is dropped silently.
+        if any(k != "$ref" for k in schema):
+            return schema
         return resolved
 
     return {k: _inline_schema_refs(v, spec, _visiting) for k, v in schema.items()}

--- a/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
@@ -1085,7 +1085,7 @@ if MCP_AVAILABLE:
                     used_names.add(op_id)
                     summary = operation.get("summary", "")
                     description = operation.get("description", summary)
-                    input_schema = build_input_schema(resolved_op)
+                    input_schema = build_input_schema(resolved_op, spec=spec)
                     tools.append(
                         {
                             "name": op_id,

--- a/tests/code_coverage_tests/recursive_detector.py
+++ b/tests/code_coverage_tests/recursive_detector.py
@@ -50,6 +50,7 @@ IGNORE_FUNCTIONS = [
     "_resolve",  # OCI: $ref resolver bounded by `resolving_stack` cycle guard.
     "resolve_oci_schema_anyof",  # OCI: bounded by JSON-schema tree depth (no cycles possible in well-formed input).
     "sanitize_oci_schema",  # OCI: bounded by JSON-schema tree depth.
+    "_inline_schema_refs",  # MCP/OpenAPI: $ref resolver bounded by `_visiting` cycle guard; inlines schemas for LLM providers that do not resolve $ref.
 ]
 
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_openapi_to_mcp_generator.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_openapi_to_mcp_generator.py
@@ -1346,6 +1346,31 @@ class TestInlineSchemaRefs:
         result = _inline_schema_refs({"$ref": "#/definitions/Foo"}, spec)
         assert result == {"type": "integer"}
 
+    def test_non_dict_target_preserves_siblings(self):
+        # JSON Schema $ref should point to a schema *object*. If the spec
+        # is malformed and points at a list/scalar, sibling fields next to
+        # the $ref must not be silently dropped: keep the original node so
+        # the caller can still see the per-use-site overrides.
+        spec = {
+            "components": {
+                "schemas": {
+                    "ListNotObject": ["this", "is", "not", "a", "valid", "schema"],
+                    "ScalarThing": "scalar",
+                }
+            }
+        }
+        # With siblings: preserve everything intact.
+        with_siblings = {
+            "$ref": "#/components/schemas/ListNotObject",
+            "description": "sibling description",
+        }
+        assert _inline_schema_refs(with_siblings, spec) == with_siblings
+        # Without siblings: legacy behaviour - return the resolved target.
+        bare_ref_list = {"$ref": "#/components/schemas/ListNotObject"}
+        assert _inline_schema_refs(bare_ref_list, spec) == ["this", "is", "not", "a", "valid", "schema"]
+        bare_ref_scalar = {"$ref": "#/components/schemas/ScalarThing"}
+        assert _inline_schema_refs(bare_ref_scalar, spec) == "scalar"
+
     def test_preserves_non_dict_non_list_inputs(self):
         assert _inline_schema_refs("string-value", {"components": {}}) == "string-value"
         assert _inline_schema_refs(42, {"components": {}}) == 42

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_openapi_to_mcp_generator.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_openapi_to_mcp_generator.py
@@ -15,6 +15,8 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from litellm.proxy._experimental.mcp_server.openapi_to_mcp_generator import (
+    _inline_schema_refs,
+    _lookup_ref,
     _request_auth_header,
     _request_extra_headers,
     _resolve_param_list,
@@ -1207,3 +1209,286 @@ class TestRequestExtraHeaders:
             call_args = async_client.get.call_args
             headers_sent = call_args[1]["headers"]
             assert "X-TOKEN" not in headers_sent
+
+
+class TestLookupRef:
+    """Cover :func:`_lookup_ref` JSON Pointer resolution."""
+
+    def test_resolves_components_schemas(self):
+        spec = {"components": {"schemas": {"Foo": {"type": "object"}}}}
+        assert _lookup_ref("#/components/schemas/Foo", spec) == {"type": "object"}
+
+    def test_resolves_swagger_definitions(self):
+        spec = {"definitions": {"Foo": {"type": "integer"}}}
+        assert _lookup_ref("#/definitions/Foo", spec) == {"type": "integer"}
+
+    def test_returns_none_for_external_ref(self):
+        spec = {"components": {"schemas": {"Foo": {"type": "object"}}}}
+        assert _lookup_ref("https://example.com/schema.json", spec) is None
+
+    def test_returns_none_for_missing_target(self):
+        spec = {"components": {"schemas": {}}}
+        assert _lookup_ref("#/components/schemas/Missing", spec) is None
+
+    def test_returns_none_for_none_spec(self):
+        assert _lookup_ref("#/components/schemas/Foo", None) is None
+
+    def test_json_pointer_unescape(self):
+        # RFC 6901: "~1" -> "/", "~0" -> "~"
+        spec = {"weird/key": {"foo~bar": "value"}}
+        assert _lookup_ref("#/weird~1key/foo~0bar", spec) == "value"
+
+    def test_walks_list_indices(self):
+        spec = {"items": [{"a": 1}, {"a": 2}]}
+        assert _lookup_ref("#/items/1/a", spec) == 2
+
+    def test_invalid_list_index_returns_none(self):
+        spec = {"items": [{"a": 1}]}
+        assert _lookup_ref("#/items/notanindex/a", spec) is None
+        assert _lookup_ref("#/items/99/a", spec) is None
+
+
+class TestInlineSchemaRefs:
+    """Cover :func:`_inline_schema_refs` recursive ``$ref`` expansion."""
+
+    def test_returns_input_when_spec_is_none(self):
+        schema = {"$ref": "#/components/schemas/Foo"}
+        assert _inline_schema_refs(schema, None) is schema
+
+    def test_inlines_top_level_ref(self):
+        spec = {
+            "components": {
+                "schemas": {"Foo": {"type": "object", "properties": {"x": {"type": "integer"}}}}
+            }
+        }
+        result = _inline_schema_refs({"$ref": "#/components/schemas/Foo"}, spec)
+        assert result == {"type": "object", "properties": {"x": {"type": "integer"}}}
+
+    def test_inlines_nested_property_ref(self):
+        spec = {
+            "components": {
+                "schemas": {
+                    "Outer": {
+                        "type": "object",
+                        "properties": {"inner": {"$ref": "#/components/schemas/Inner"}},
+                    },
+                    "Inner": {"type": "string", "format": "uuid"},
+                }
+            }
+        }
+        result = _inline_schema_refs({"$ref": "#/components/schemas/Outer"}, spec)
+        assert result["properties"]["inner"] == {"type": "string", "format": "uuid"}
+
+    def test_inlines_array_items_ref(self):
+        spec = {
+            "components": {
+                "schemas": {"Item": {"type": "object", "properties": {"id": {"type": "string"}}}}
+            }
+        }
+        schema = {"type": "array", "items": {"$ref": "#/components/schemas/Item"}}
+        result = _inline_schema_refs(schema, spec)
+        assert result["items"] == {"type": "object", "properties": {"id": {"type": "string"}}}
+
+    def test_sibling_fields_preserved_and_win(self):
+        # OpenAPI 3.1 sibling overlay: siblings to $ref win over the resolved
+        # target. We expose this via merge precedence.
+        spec = {
+            "components": {
+                "schemas": {"Foo": {"type": "string", "description": "from-ref"}}
+            }
+        }
+        schema = {
+            "$ref": "#/components/schemas/Foo",
+            "description": "sibling-wins",
+            "nullable": True,
+        }
+        result = _inline_schema_refs(schema, spec)
+        assert result["type"] == "string"
+        assert result["description"] == "sibling-wins"
+        assert result["nullable"] is True
+
+    def test_cycle_is_left_in_place(self):
+        # ``Node -> next: Node``. We must not recurse infinitely.
+        spec = {
+            "components": {
+                "schemas": {
+                    "Node": {
+                        "type": "object",
+                        "properties": {
+                            "value": {"type": "string"},
+                            "next": {"$ref": "#/components/schemas/Node"},
+                        },
+                    }
+                }
+            }
+        }
+        result = _inline_schema_refs({"$ref": "#/components/schemas/Node"}, spec)
+        assert result["type"] == "object"
+        # The cycle is preserved as a $ref instead of expanding forever.
+        assert result["properties"]["next"] == {"$ref": "#/components/schemas/Node"}
+
+    def test_unresolvable_ref_is_preserved(self):
+        spec = {"components": {"schemas": {}}}
+        schema = {"$ref": "#/components/schemas/Missing"}
+        result = _inline_schema_refs(schema, spec)
+        # Don't drop the ref - leave it so the legacy behaviour is preserved
+        # and the user can see what was unresolvable.
+        assert result == {"$ref": "#/components/schemas/Missing"}
+
+    def test_external_ref_is_preserved(self):
+        spec = {"components": {"schemas": {}}}
+        schema = {"$ref": "https://example.com/schema.json#/Foo"}
+        result = _inline_schema_refs(schema, spec)
+        assert result == {"$ref": "https://example.com/schema.json#/Foo"}
+
+    def test_swagger_definitions_path(self):
+        spec = {"definitions": {"Foo": {"type": "integer"}}}
+        result = _inline_schema_refs({"$ref": "#/definitions/Foo"}, spec)
+        assert result == {"type": "integer"}
+
+    def test_preserves_non_dict_non_list_inputs(self):
+        assert _inline_schema_refs("string-value", {"components": {}}) == "string-value"
+        assert _inline_schema_refs(42, {"components": {}}) == 42
+        assert _inline_schema_refs(None, {"components": {}}) is None
+
+
+class TestBuildInputSchemaWithRefs:
+    """End-to-end behaviour of :func:`build_input_schema` when ``spec`` is provided."""
+
+    def _spec(self):
+        return {
+            "components": {
+                "schemas": {
+                    "Presentation": {
+                        "type": "object",
+                        "required": ["title"],
+                        "properties": {
+                            "title": {"type": "string"},
+                            "page_size": {"$ref": "#/components/schemas/Size"},
+                            "slides": {
+                                "type": "array",
+                                "items": {"$ref": "#/components/schemas/Slide"},
+                            },
+                        },
+                    },
+                    "Size": {
+                        "type": "object",
+                        "properties": {
+                            "width": {"type": "number"},
+                            "height": {"type": "number"},
+                        },
+                    },
+                    "Slide": {
+                        "type": "object",
+                        "properties": {"object_id": {"type": "string"}},
+                    },
+                }
+            }
+        }
+
+    def test_legacy_no_spec_drops_top_level_ref(self):
+        # Pre-fix behaviour: properties is silently empty. We keep the test
+        # so any future change to the no-spec path is intentional.
+        op = {
+            "requestBody": {
+                "content": {
+                    "application/json": {
+                        "schema": {"$ref": "#/components/schemas/Presentation"}
+                    }
+                }
+            }
+        }
+        schema = build_input_schema(op)
+        assert schema["properties"]["body"]["properties"] == {}
+        assert "required" not in schema["properties"]["body"]
+
+    def test_top_level_request_body_ref_is_inlined(self):
+        op = {
+            "requestBody": {
+                "required": True,
+                "content": {
+                    "application/json": {
+                        "schema": {"$ref": "#/components/schemas/Presentation"}
+                    }
+                },
+            }
+        }
+        schema = build_input_schema(op, spec=self._spec())
+        body = schema["properties"]["body"]
+        # Top-level $ref expanded to its target's properties.
+        assert set(body["properties"].keys()) == {"title", "page_size", "slides"}
+        # Nested $ref expanded too.
+        assert body["properties"]["page_size"]["properties"]["width"] == {"type": "number"}
+        # array items $ref expanded.
+        assert (
+            body["properties"]["slides"]["items"]["properties"]["object_id"]
+            == {"type": "string"}
+        )
+        # The target's ``required`` list propagates to the body schema so
+        # downstream LLMs see the hard requirement.
+        assert body["required"] == ["title"]
+        assert schema["required"] == ["body"]
+
+    def test_nested_property_ref_inlined_when_top_level_inline(self):
+        op = {
+            "requestBody": {
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "page_size": {"$ref": "#/components/schemas/Size"}
+                            },
+                        }
+                    }
+                }
+            }
+        }
+        schema = build_input_schema(op, spec=self._spec())
+        assert (
+            schema["properties"]["body"]["properties"]["page_size"]["properties"]["width"]
+            == {"type": "number"}
+        )
+
+    def test_parameter_ref_resolves_to_actual_type(self):
+        # Pre-fix: $ref under a query parameter's ``schema`` was forwarded as
+        # ``{"$ref": "..."}`` and ``param_schema.get("type", "string")`` fell
+        # back to "string", masking the real type.
+        spec = {
+            "components": {
+                "schemas": {"PageNumber": {"type": "integer", "minimum": 1}}
+            }
+        }
+        op = {
+            "parameters": [
+                {
+                    "name": "page",
+                    "in": "query",
+                    "required": True,
+                    "schema": {"$ref": "#/components/schemas/PageNumber"},
+                }
+            ]
+        }
+        schema = build_input_schema(op, spec=spec)
+        assert schema["properties"]["page"]["type"] == "integer"
+        assert schema["required"] == ["page"]
+
+    def test_unresolved_request_body_ref_does_not_crash(self):
+        # When spec is provided but the ref points to nothing, the body
+        # remains structurally intact (no crash, no exception).
+        spec = {"components": {"schemas": {}}}
+        op = {
+            "requestBody": {
+                "content": {
+                    "application/json": {
+                        "schema": {"$ref": "#/components/schemas/Missing"}
+                    }
+                }
+            }
+        }
+        schema = build_input_schema(op, spec=spec)
+        body = schema["properties"]["body"]
+        assert body["type"] == "object"
+        # No ``required`` added since the unresolved target carries no info.
+        assert "required" not in body
+


### PR DESCRIPTION
## Summary

Fixes **LIT-3141** ([Handle unresolved `$ref` in OpenAPI request bodies](https://linear.app/litellm-ai/issue/LIT-3141)).
Related issue: [BerriAI/litellm#26692](https://github.com/BerriAI/litellm/issues/26692).

### Root cause

`litellm.proxy._experimental.mcp_server.openapi_to_mcp_generator.build_input_schema` did not resolve JSON-Schema `$ref` pointers in request-body or parameter schemas before registering the MCP tool. LLM providers (Anthropic, Bedrock, Fireworks, Gemini, ...) do **not** run a `$ref` resolver on the tool `input_schema` they receive and reject any unresolved pointer — so:

- A top-level `requestBody.content."application/json".schema = {"$ref": "#/components/schemas/Foo"}` resulted in `body.properties == {}` and `body.required` was discarded entirely (the tool was unusable).
- A nested `$ref` (`properties.x = {"$ref": "..."}` or `items = {"$ref": "..."}`) was forwarded literally and the provider 400'd with `Invalid tool schema, $ref is not supported` (Anthropic) or `PointerToNowhere` (Fireworks).
- A query/path parameter with `schema: {$ref}` silently fell through `param_schema.get("type", "string")` and the actual type (e.g. `integer`) was lost.

This blocks any MCP server registered from an OpenAPI spec whose request bodies reference `#/components/schemas/...` — Google Workspace `Presentations` / `Sheets` create calls, GitHub REST, etc.

### Fix

`litellm/proxy/_experimental/mcp_server/openapi_to_mcp_generator.py`:

- New `_lookup_ref(ref, spec)` resolves local JSON Pointers (`#/components/schemas/...`, `#/definitions/...`, arbitrary paths). RFC 6901 escape semantics. External refs (`http(s)://`) and unknown targets return `None` (caller leaves `$ref` in place).
- New `_inline_schema_refs(schema, spec)` recursively walks `dict`/`list` nodes and inlines every local `$ref`. Sibling fields next to a `$ref` win over the resolved target (matches OpenAPI 3.1 sibling-overlay semantics). Cycle-safe — a `$ref` already on the resolution stack is left in place rather than expanded infinitely. **No-op when `spec=None`** so legacy callers are unchanged.
- `build_input_schema(operation, spec=None)` now runs each `parameter.schema` and `requestBody.content.application/json.schema` through `_inline_schema_refs` before building the MCP input schema, and propagates the resolved body schema's `required` list (which used to be discarded silently).

Threaded through the three call sites that already had `spec` in scope:
- `register_tools_from_openapi` (same file)
- `_preview_openapi_tools` in `rest_endpoints.py` (dashboard preview)
- `MCPServerManager._register_openapi_tools` in `mcp_server_manager.py`

23 new unit tests cover JSON Pointer resolution (incl. RFC 6901 unescape, list indices, external refs), sibling overlay, cycles, unresolvable refs, Swagger 2.0 `#/definitions/`, parameter-level `$ref`, and the full request-body inlining path from the ticket.

### Evidence

End-to-end registry capture (single python program). Same call into `register_tools_from_openapi(spec)`; the only difference is whether `build_input_schema` receives the `spec` argument. The dict shown is what `global_mcp_tool_registry` stores and ships to the LLM provider at tool-call time:

```text
======== LEGACY (pre-fix path) ========
tool: createpresentation
{
  "type": "object",
  "properties": {
    "body": {
      "type": "object",
      "description": "Request body",
      "properties": {}
    }
  },
  "required": [
    "body"
  ]
}

======== FIXED (spec passed through) ========
tool: createpresentation
{
  "type": "object",
  "properties": {
    "body": {
      "type": "object",
      "description": "Request body",
      "properties": {
        "title": {
          "type": "string"
        },
        "pageSize": {
          "type": "object",
          "properties": {
            "width": {
              "type": "number"
            },
            "height": {
              "type": "number"
            }
          }
        }
      },
      "required": [
        "title"
      ]
    }
  },
  "required": [
    "body"
  ]
}
```

Per-operation `build_input_schema` BEFORE (legacy, `spec=None`) vs. AFTER (`spec` passed through) on a Google-Workspace-shaped spec (top-level `$ref`, nested `$ref`, array `items.$ref`, deeply-nested `$ref` chains, and a parameter `$ref`):

```text
### tool: createPresentation  (POST /presentations)
-- BEFORE (legacy, no spec resolution) --
{
  "type": "object",
  "properties": {
    "body": {
      "type": "object",
      "description": "Request body",
      "properties": {}
    }
  },
  "required": [
    "body"
  ]
}
-- AFTER (with $ref inlining) --
{
  "type": "object",
  "properties": {
    "body": {
      "type": "object",
      "description": "Request body",
      "properties": {
        "title": {
          "type": "string",
          "description": "Presentation title"
        },
        "pageSize": {
          "type": "object",
          "properties": {
            "width": {
              "type": "object",
              "properties": {
                "magnitude": {
                  "type": "number"
                },
                "unit": {
                  "type": "string",
                  "enum": [
                    "EMU",
                    "PT"
                  ]
                }
              }
            },
            "height": {
              "type": "object",
              "properties": {
                "magnitude": {
                  "type": "number"
                },
                "unit": {
                  "type": "string",
                  "enum": [
                    "EMU",
                    "PT"
                  ]
                }
              }
            }
          }
        },
        "slides": {
          "type": "array",
          "items": {
            "type": "object",
            "properties": {
              "objectId": {
                "type": "string"
              }
            }
          }
        },
        "locale": {
          "type": "string"
        }
      },
      "required": [
        "title"
      ]
    }
  },
  "required": [
    "body"
  ]
}

### tool: createSheet  (POST /spreadsheets/{sheetId}/sheets)
-- BEFORE (legacy, no spec resolution) --
{
  "type": "object",
  "properties": {
    "body": {
      "type": "object",
      "description": "Request body",
      "properties": {
        "sheet": {
          "$ref": "#/components/schemas/Sheet"
        }
      }
    }
  },
  "required": [
    "body"
  ]
}
-- AFTER (with $ref inlining) --
{
  "type": "object",
  "properties": {
    "body": {
      "type": "object",
      "description": "Request body",
      "properties": {
        "sheet": {
          "type": "object",
          "properties": {
            "title": {
              "type": "string"
            },
            "properties": {
              "type": "object",
              "properties": {
                "rowCount": {
                  "type": "integer"
                },
                "columnCount": {
                  "type": "integer"
                }
              }
            }
          }
        }
      }
    }
  },
  "required": [
    "body"
  ]
}

### tool: listFolders  (GET /folders)
-- BEFORE (legacy, no spec resolution) --
{
  "type": "object",
  "properties": {
    "pageToken": {
      "type": "string",
      "description": "page cursor"
    }
  },
  "required": []
}
-- AFTER (with $ref inlining) --
{
  "type": "object",
  "properties": {
    "pageToken": {
      "type": "string",
      "description": "page cursor"
    }
  },
  "required": []
}
```

### Unit tests

```
$ pytest tests/test_litellm/proxy/_experimental/mcp_server/test_openapi_to_mcp_generator.py
80 passed in 10.91s
```

(57 pre-existing + 23 added by this PR.)

### Push-mechanism note

Pushed with the GitHub contents API (one call per file) because the agent's `GITHUB_TOKEN` lacks `repo`/`workflow` scope — `git push` returns "Password authentication is not supported". Diff is identical to what `git push` would produce; just four sequential per-file commits in the merge-base view instead of one squashed commit.

### Session

https://litellm-agent-platform.onrender.com/sessions/93c84e0b-2c13-4b28-8c5b-bc5d72b73243

### Verification (ship-pr)

- **Base branch**: `litellm_oss_agent_shin_daily_branch` (✅ — passes the "Verify PR source branch" check; never targets `main`).
- **Greptile**: **5/5** ("Safe to merge — the core logic is well-implemented and backward-compatible, with no regressions to existing call sites.").
- **Veria AI - PR Review**: ✅ success.
- **GitHub Actions**: **43/44 green**, 0 functional failures (only `codecov/patch` is red — the inline Codecov bot report explicitly states "All modified and coverable lines are covered by tests"; the patch-coverage check is comparing against a project-level threshold and is not a required check on this repo).
- **Mergeable**: `true` (`mergeable_state` shows `unstable` only because of the non-required `codecov/patch`).
- **Customer-name scan**: clean. The only provider names in the body are LLM provider names (Anthropic, Bedrock, Fireworks, Gemini), which are the subject of the bug — not customer names.
- **Unit tests**: 81/81 pass in the target file (`tests/test_litellm/proxy/_experimental/mcp_server/test_openapi_to_mcp_generator.py`); 57 pre-existing + 24 new (23 originally documented + `test_non_dict_target_preserves_siblings` added after Greptile P2 feedback).
- **Recursive-detector**: `_inline_schema_refs` is allowlisted in `tests/code_coverage_tests/recursive_detector.py` with a rationale comment (bounded by `_visiting` cycle guard, same pattern as the existing OCI `_resolve`).
