### PR TITLE
feat(team): enforce team-level model_max_budget with key precedence (LIT-2768)

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1811,6 +1811,9 @@ class TeamBase(LiteLLMPydanticObjectBase):
     budget_limits: Optional[List[BudgetLimitEntry]] = (
         None  # multiple concurrent budget windows
     )
+    model_max_budget: Optional[dict] = (
+        None  # team-level per-model max budgets; keys' own model_max_budget take precedence (LIT-2768)
+    )
 
     models: list = []
     blocked: bool = False
@@ -1893,6 +1896,7 @@ class UpdateTeamRequest(LiteLLMPydanticObjectBase):
     blocked: Optional[bool] = None
     budget_duration: Optional[str] = None
     tags: Optional[list] = None
+    model_max_budget: Optional[dict] = None  # team-level per-model max budgets (LIT-2768)
     model_aliases: Optional[dict] = None
     guardrails: Optional[List[str]] = None
     policies: Optional[List[str]] = None
@@ -2626,6 +2630,7 @@ class LiteLLM_VerificationTokenView(LiteLLM_VerificationToken):
     team_blocked: bool = False
     soft_budget: Optional[float] = None
     team_model_aliases: Optional[Dict] = None
+    team_model_max_budget: Optional[dict] = None
     team_member: Optional[Member] = None
     team_metadata: Optional[Dict] = None
     team_object_permission_id: Optional[str] = None

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1896,7 +1896,9 @@ class UpdateTeamRequest(LiteLLMPydanticObjectBase):
     blocked: Optional[bool] = None
     budget_duration: Optional[str] = None
     tags: Optional[list] = None
-    model_max_budget: Optional[dict] = None  # team-level per-model max budgets (LIT-2768)
+    model_max_budget: Optional[dict] = (
+        None  # team-level per-model max budgets (LIT-2768)
+    )
     model_aliases: Optional[dict] = None
     guardrails: Optional[List[str]] = None
     policies: Optional[List[str]] = None

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -1618,6 +1618,7 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
                                 team_id=valid_token.team_id,
                                 team_model_max_budget=team_mmb,
                                 model=model_name,
+                                key_model_max_budget=valid_token.model_max_budget,
                             )
 
             # Check 6: Additional Common Checks across jwt + key auth
@@ -2655,6 +2656,7 @@ async def _run_post_custom_auth_checks(
                 team_id=valid_token.team_id,
                 team_model_max_budget=team_mmb,
                 model=model_name,
+                key_model_max_budget=valid_token.model_max_budget,
             )
 
     # team / user / end_user / project context objects are fetched by

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -1604,6 +1604,22 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
                                 model=model_name,
                             )
 
+                    # Check 5c. Team-level model max budget (LIT-2768)
+                    team_mmb = valid_token.team_model_max_budget
+                    if (
+                        team_mmb is not None
+                        and isinstance(team_mmb, dict)
+                        and len(team_mmb) > 0
+                        and current_models
+                        and valid_token.team_id is not None
+                    ):
+                        for model_name in current_models:
+                            await model_max_budget_limiter.is_team_within_model_budget(
+                                team_id=valid_token.team_id,
+                                team_model_max_budget=team_mmb,
+                                model=model_name,
+                            )
+
             # Check 6: Additional Common Checks across jwt + key auth
             if valid_token.team_id is not None:
                 try:
@@ -2622,6 +2638,22 @@ async def _run_post_custom_auth_checks(
             await model_max_budget_limiter.is_end_user_within_model_budget(
                 end_user_id=valid_token.end_user_id,
                 end_user_model_max_budget=end_user_mmb,
+                model=model_name,
+            )
+
+    # 5. Check team-level model_max_budget (LIT-2768)
+    team_mmb = valid_token.team_model_max_budget
+    if (
+        team_mmb is not None
+        and isinstance(team_mmb, dict)
+        and len(team_mmb) > 0
+        and current_models
+        and valid_token.team_id is not None
+    ):
+        for model_name in current_models:
+            await model_max_budget_limiter.is_team_within_model_budget(
+                team_id=valid_token.team_id,
+                team_model_max_budget=team_mmb,
                 model=model_name,
             )
 

--- a/litellm/proxy/hooks/model_max_budget_limiter.py
+++ b/litellm/proxy/hooks/model_max_budget_limiter.py
@@ -140,7 +140,6 @@ class _PROXY_VirtualKeyModelMaxBudgetLimiter(RouterBudgetLimiting):
 
         return True
 
-
     async def is_team_within_model_budget(
         self,
         team_id: str,
@@ -335,14 +334,18 @@ class _PROXY_VirtualKeyModelMaxBudgetLimiter(RouterBudgetLimiting):
             "user_api_key_team_id", None
         )
         if (
-            user_api_key_model_max_budget is None
-            or len(user_api_key_model_max_budget) == 0
-        ) and (
-            user_api_key_end_user_model_max_budget is None
-            or len(user_api_key_end_user_model_max_budget) == 0
-        ) and (
-            user_api_key_team_model_max_budget is None
-            or len(user_api_key_team_model_max_budget) == 0
+            (
+                user_api_key_model_max_budget is None
+                or len(user_api_key_model_max_budget) == 0
+            )
+            and (
+                user_api_key_end_user_model_max_budget is None
+                or len(user_api_key_end_user_model_max_budget) == 0
+            )
+            and (
+                user_api_key_team_model_max_budget is None
+                or len(user_api_key_team_model_max_budget) == 0
+            )
         ):
             verbose_proxy_logger.debug(
                 "Not running _PROXY_VirtualKeyModelMaxBudgetLimiter.async_log_success_event because user_api_key_model_max_budget, user_api_key_end_user_model_max_budget, and user_api_key_team_model_max_budget are None or empty."
@@ -427,7 +430,9 @@ class _PROXY_VirtualKeyModelMaxBudgetLimiter(RouterBudgetLimiting):
             )
             if key_budget_config is not None and key_budget_config.budget_duration:
                 team_spend_key = f"{TEAM_MODEL_SPEND_CACHE_KEY_PREFIX}:{user_api_key_team_id}:{model}:{key_budget_config.budget_duration}"
-                team_start_time_key = f"team_model_budget_start_time:{user_api_key_team_id}"
+                team_start_time_key = (
+                    f"team_model_budget_start_time:{user_api_key_team_id}"
+                )
                 await self._increment_spend_for_key(
                     budget_config=key_budget_config,
                     spend_key=team_spend_key,

--- a/litellm/proxy/hooks/model_max_budget_limiter.py
+++ b/litellm/proxy/hooks/model_max_budget_limiter.py
@@ -140,6 +140,26 @@ class _PROXY_VirtualKeyModelMaxBudgetLimiter(RouterBudgetLimiting):
 
         return True
 
+    def _key_already_covers_model(
+        self,
+        user_api_key_model_max_budget: Optional[dict],
+        model: str,
+    ) -> bool:
+        """Return True iff the requesting key has its own model_max_budget
+        entry for ``model`` (matching by exact name or by the
+        ``{provider}/{model}`` normalization)."""
+        if not user_api_key_model_max_budget:
+            return False
+        key_internal: GenericBudgetConfigType = {}
+        for _model, _budget_info in user_api_key_model_max_budget.items():
+            key_internal[_model] = BudgetConfig(**_budget_info)
+        return (
+            self._get_request_model_budget_config(
+                model=model, internal_model_max_budget=key_internal
+            )
+            is not None
+        )
+
     async def is_team_within_model_budget(
         self,
         team_id: str,
@@ -164,20 +184,11 @@ class _PROXY_VirtualKeyModelMaxBudgetLimiter(RouterBudgetLimiting):
         # Key precedence: if the requesting key already declares a budget
         # for `model` (or its `{provider}/{model}` form), the team default
         # is irrelevant for this (key, model) pair.
-        if key_model_max_budget:
-            key_internal: GenericBudgetConfigType = {}
-            for _model, _budget_info in key_model_max_budget.items():
-                key_internal[_model] = BudgetConfig(**_budget_info)
-            if (
-                self._get_request_model_budget_config(
-                    model=model, internal_model_max_budget=key_internal
-                )
-                is not None
-            ):
-                verbose_proxy_logger.debug(
-                    f"Team check skipped for model={model}: key has own model_max_budget entry"
-                )
-                return True
+        if self._key_already_covers_model(key_model_max_budget, model):
+            verbose_proxy_logger.debug(
+                f"Team check skipped for model={model}: key has own model_max_budget entry"
+            )
+            return True
 
         internal_model_max_budget: GenericBudgetConfigType = {}
 
@@ -449,22 +460,7 @@ class _PROXY_VirtualKeyModelMaxBudgetLimiter(RouterBudgetLimiting):
             # is_team_within_model_budget). Otherwise a key with its own
             # private cap would still drive the shared team counter and
             # block siblings unnecessarily.
-            _key_covers_model = False
-            if (
-                user_api_key_model_max_budget is not None
-                and len(user_api_key_model_max_budget) > 0
-            ):
-                key_internal_for_model: GenericBudgetConfigType = {}
-                for _model, _budget_info in user_api_key_model_max_budget.items():
-                    key_internal_for_model[_model] = BudgetConfig(**_budget_info)
-                _key_covers_model = (
-                    self._get_request_model_budget_config(
-                        model=model, internal_model_max_budget=key_internal_for_model
-                    )
-                    is not None
-                )
-
-            if not _key_covers_model:
+            if not self._key_already_covers_model(user_api_key_model_max_budget, model):
                 internal_model_max_budget: GenericBudgetConfigType = {}
                 for _model, _budget_info in user_api_key_team_model_max_budget.items():
                     internal_model_max_budget[_model] = BudgetConfig(**_budget_info)

--- a/litellm/proxy/hooks/model_max_budget_limiter.py
+++ b/litellm/proxy/hooks/model_max_budget_limiter.py
@@ -16,6 +16,7 @@ from litellm.types.utils import (
 
 VIRTUAL_KEY_SPEND_CACHE_KEY_PREFIX = "virtual_key_spend"
 END_USER_SPEND_CACHE_KEY_PREFIX = "end_user_model_spend"
+TEAM_MODEL_SPEND_CACHE_KEY_PREFIX = "team_model_spend"
 
 
 class _PROXY_VirtualKeyModelMaxBudgetLimiter(RouterBudgetLimiting):
@@ -139,6 +140,91 @@ class _PROXY_VirtualKeyModelMaxBudgetLimiter(RouterBudgetLimiting):
 
         return True
 
+
+    async def is_team_within_model_budget(
+        self,
+        team_id: str,
+        team_model_max_budget: dict,
+        model: str,
+    ) -> bool:
+        """
+        Check if a team is within the team-level model budget.
+
+        Team-level model budgets are shared by every key on the team. A
+        key-level ``model_max_budget`` for the same model still takes
+        precedence (enforced by :meth:`is_key_within_model_budget` running
+        first); the team budget here acts as the default cap when the key
+        does not declare its own entry for ``model``.
+
+        Raises:
+            BudgetExceededError: If the team has exceeded the model budget.
+        """
+        internal_model_max_budget: GenericBudgetConfigType = {}
+
+        for _model, _budget_info in team_model_max_budget.items():
+            internal_model_max_budget[_model] = BudgetConfig(**_budget_info)
+
+        verbose_proxy_logger.debug(
+            "team internal_model_max_budget %s",
+            json.dumps(internal_model_max_budget, indent=4, default=str),
+        )
+
+        _current_model_budget_info = self._get_request_model_budget_config(
+            model=model, internal_model_max_budget=internal_model_max_budget
+        )
+        if _current_model_budget_info is None:
+            verbose_proxy_logger.debug(
+                f"Model {model} not found in team_model_max_budget"
+            )
+            return True
+
+        if (
+            _current_model_budget_info.max_budget
+            and _current_model_budget_info.max_budget > 0
+        ):
+            _current_spend = await self._get_team_spend_for_model(
+                team_id=team_id,
+                model=model,
+                key_budget_config=_current_model_budget_info,
+            )
+            if (
+                _current_spend is not None
+                and _current_model_budget_info.max_budget is not None
+                and _current_spend > _current_model_budget_info.max_budget
+            ):
+                raise litellm.BudgetExceededError(
+                    message=f"LiteLLM Team: {team_id}, exceeded budget for model={model}",
+                    current_cost=_current_spend,
+                    max_budget=_current_model_budget_info.max_budget,
+                )
+
+        return True
+
+    async def _get_team_spend_for_model(
+        self,
+        team_id: str,
+        model: str,
+        key_budget_config: BudgetConfig,
+    ) -> Optional[float]:
+        """
+        Get the current spend for a team for a model.
+
+        Lookup model in this order:
+            1. model: directly look up ``model``
+            2. If 1 does not exist, check if passed as ``{custom_llm_provider}/model``
+        """
+        team_model_spend_cache_key = f"{TEAM_MODEL_SPEND_CACHE_KEY_PREFIX}:{team_id}:{model}:{key_budget_config.budget_duration}"
+        _current_spend = await self.dual_cache.async_get_cache(
+            key=team_model_spend_cache_key,
+        )
+
+        if _current_spend is None:
+            team_model_spend_cache_key = f"{TEAM_MODEL_SPEND_CACHE_KEY_PREFIX}:{team_id}:{self._get_model_without_custom_llm_provider(model)}:{key_budget_config.budget_duration}"
+            _current_spend = await self.dual_cache.async_get_cache(
+                key=team_model_spend_cache_key,
+            )
+        return _current_spend
+
     async def _get_end_user_spend_for_model(
         self,
         end_user_id: str,
@@ -242,15 +328,24 @@ class _PROXY_VirtualKeyModelMaxBudgetLimiter(RouterBudgetLimiting):
         user_api_key_end_user_model_max_budget: Optional[dict] = _metadata.get(
             "user_api_key_end_user_model_max_budget", None
         )
+        user_api_key_team_model_max_budget: Optional[dict] = _metadata.get(
+            "user_api_key_team_model_max_budget", None
+        )
+        user_api_key_team_id: Optional[str] = _metadata.get(
+            "user_api_key_team_id", None
+        )
         if (
             user_api_key_model_max_budget is None
             or len(user_api_key_model_max_budget) == 0
         ) and (
             user_api_key_end_user_model_max_budget is None
             or len(user_api_key_end_user_model_max_budget) == 0
+        ) and (
+            user_api_key_team_model_max_budget is None
+            or len(user_api_key_team_model_max_budget) == 0
         ):
             verbose_proxy_logger.debug(
-                "Not running _PROXY_VirtualKeyModelMaxBudgetLimiter.async_log_success_event because user_api_key_model_max_budget and user_api_key_end_user_model_max_budget are None or empty."
+                "Not running _PROXY_VirtualKeyModelMaxBudgetLimiter.async_log_success_event because user_api_key_model_max_budget, user_api_key_end_user_model_max_budget, and user_api_key_team_model_max_budget are None or empty."
             )
             return
 
@@ -316,6 +411,27 @@ class _PROXY_VirtualKeyModelMaxBudgetLimiter(RouterBudgetLimiting):
                     budget_config=key_budget_config,
                     spend_key=end_user_spend_key,
                     start_time_key=end_user_start_time_key,
+                    response_cost=response_cost,
+                )
+
+        if (
+            user_api_key_team_id is not None
+            and user_api_key_team_model_max_budget is not None
+            and len(user_api_key_team_model_max_budget) > 0
+        ):
+            internal_model_max_budget: GenericBudgetConfigType = {}
+            for _model, _budget_info in user_api_key_team_model_max_budget.items():
+                internal_model_max_budget[_model] = BudgetConfig(**_budget_info)
+            key_budget_config = self._get_request_model_budget_config(
+                model=model, internal_model_max_budget=internal_model_max_budget
+            )
+            if key_budget_config is not None and key_budget_config.budget_duration:
+                team_spend_key = f"{TEAM_MODEL_SPEND_CACHE_KEY_PREFIX}:{user_api_key_team_id}:{model}:{key_budget_config.budget_duration}"
+                team_start_time_key = f"team_model_budget_start_time:{user_api_key_team_id}"
+                await self._increment_spend_for_key(
+                    budget_config=key_budget_config,
+                    spend_key=team_spend_key,
+                    start_time_key=team_start_time_key,
                     response_cost=response_cost,
                 )
 

--- a/litellm/proxy/hooks/model_max_budget_limiter.py
+++ b/litellm/proxy/hooks/model_max_budget_limiter.py
@@ -145,19 +145,40 @@ class _PROXY_VirtualKeyModelMaxBudgetLimiter(RouterBudgetLimiting):
         team_id: str,
         team_model_max_budget: dict,
         model: str,
+        key_model_max_budget: Optional[dict] = None,
     ) -> bool:
         """
         Check if a team is within the team-level model budget.
 
-        Team-level model budgets are shared by every key on the team. A
-        key-level ``model_max_budget`` for the same model still takes
-        precedence (enforced by :meth:`is_key_within_model_budget` running
-        first); the team budget here acts as the default cap when the key
-        does not declare its own entry for ``model``.
+        Team-level model budgets are shared by every key on the team and act
+        as the **default cap** when the requesting key does not declare its
+        own entry for ``model``. A key-level ``model_max_budget`` entry that
+        covers ``model`` takes precedence and short-circuits the team check
+        — :meth:`is_key_within_model_budget` runs first in the auth path,
+        and this method additionally no-ops here so the team counter is not
+        consulted for keys that have their own per-model cap.
 
         Raises:
             BudgetExceededError: If the team has exceeded the model budget.
         """
+        # Key precedence: if the requesting key already declares a budget
+        # for `model` (or its `{provider}/{model}` form), the team default
+        # is irrelevant for this (key, model) pair.
+        if key_model_max_budget:
+            key_internal: GenericBudgetConfigType = {}
+            for _model, _budget_info in key_model_max_budget.items():
+                key_internal[_model] = BudgetConfig(**_budget_info)
+            if (
+                self._get_request_model_budget_config(
+                    model=model, internal_model_max_budget=key_internal
+                )
+                is not None
+            ):
+                verbose_proxy_logger.debug(
+                    f"Team check skipped for model={model}: key has own model_max_budget entry"
+                )
+                return True
+
         internal_model_max_budget: GenericBudgetConfigType = {}
 
         for _model, _budget_info in team_model_max_budget.items():
@@ -422,23 +443,45 @@ class _PROXY_VirtualKeyModelMaxBudgetLimiter(RouterBudgetLimiting):
             and user_api_key_team_model_max_budget is not None
             and len(user_api_key_team_model_max_budget) > 0
         ):
-            internal_model_max_budget: GenericBudgetConfigType = {}
-            for _model, _budget_info in user_api_key_team_model_max_budget.items():
-                internal_model_max_budget[_model] = BudgetConfig(**_budget_info)
-            key_budget_config = self._get_request_model_budget_config(
-                model=model, internal_model_max_budget=internal_model_max_budget
-            )
-            if key_budget_config is not None and key_budget_config.budget_duration:
-                team_spend_key = f"{TEAM_MODEL_SPEND_CACHE_KEY_PREFIX}:{user_api_key_team_id}:{model}:{key_budget_config.budget_duration}"
-                team_start_time_key = (
-                    f"team_model_budget_start_time:{user_api_key_team_id}"
+            # Key precedence: if the requesting key already has its own
+            # model_max_budget entry for this model, the team counter must
+            # NOT be incremented (mirror of the precedence rule applied in
+            # is_team_within_model_budget). Otherwise a key with its own
+            # private cap would still drive the shared team counter and
+            # block siblings unnecessarily.
+            _key_covers_model = False
+            if (
+                user_api_key_model_max_budget is not None
+                and len(user_api_key_model_max_budget) > 0
+            ):
+                key_internal_for_model: GenericBudgetConfigType = {}
+                for _model, _budget_info in user_api_key_model_max_budget.items():
+                    key_internal_for_model[_model] = BudgetConfig(**_budget_info)
+                _key_covers_model = (
+                    self._get_request_model_budget_config(
+                        model=model, internal_model_max_budget=key_internal_for_model
+                    )
+                    is not None
                 )
-                await self._increment_spend_for_key(
-                    budget_config=key_budget_config,
-                    spend_key=team_spend_key,
-                    start_time_key=team_start_time_key,
-                    response_cost=response_cost,
+
+            if not _key_covers_model:
+                internal_model_max_budget: GenericBudgetConfigType = {}
+                for _model, _budget_info in user_api_key_team_model_max_budget.items():
+                    internal_model_max_budget[_model] = BudgetConfig(**_budget_info)
+                key_budget_config = self._get_request_model_budget_config(
+                    model=model, internal_model_max_budget=internal_model_max_budget
                 )
+                if key_budget_config is not None and key_budget_config.budget_duration:
+                    team_spend_key = f"{TEAM_MODEL_SPEND_CACHE_KEY_PREFIX}:{user_api_key_team_id}:{model}:{key_budget_config.budget_duration}"
+                    team_start_time_key = (
+                        f"team_model_budget_start_time:{user_api_key_team_id}"
+                    )
+                    await self._increment_spend_for_key(
+                        budget_config=key_budget_config,
+                        spend_key=team_spend_key,
+                        start_time_key=team_start_time_key,
+                        response_cost=response_cost,
+                    )
 
         if self.dual_cache.redis_cache is not None:
             await self._push_in_memory_increments_to_redis()

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -1630,6 +1630,9 @@ async def add_litellm_data_to_request(  # noqa: PLR0915
     data[_metadata_variable_name][
         "user_api_key_end_user_model_max_budget"
     ] = user_api_key_dict.end_user_model_max_budget
+    data[_metadata_variable_name][
+        "user_api_key_team_model_max_budget"
+    ] = user_api_key_dict.team_model_max_budget
 
     # User spend, budget - used by prometheus.py
     # Follow same pattern as team and API key budgets

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -843,6 +843,7 @@ async def new_team(  # noqa: PLR0915
     - tpm_limit_type: Optional[Literal["guaranteed_throughput", "best_effort_throughput"]] - The type of TPM limit enforcement. Use "guaranteed_throughput" to raise an error if overallocating TPM, or "best_effort_throughput" for best effort enforcement.
     - max_budget: Optional[float] - The maximum budget allocated to the team - all keys for this team_id will have at max this max_budget
     - soft_budget: Optional[float] - The soft budget threshold for the team. If max_budget is set, soft_budget must be strictly lower than max_budget. Can be set independently if max_budget is not set.
+    - model_max_budget: Optional[Dict[str, BudgetConfig]] - Per-model max budgets shared by every key on the team. Each entry is `{"<model>": {"budget_limit": <float>, "time_period": "1d"|"7d"|...}}`. Key-level `model_max_budget` entries take precedence for matching models; team-level entries act as the default cap for keys that do not declare their own.
     - budget_duration: Optional[str] - The duration of the budget for the team. Doc [here](https://docs.litellm.ai/docs/proxy/team_budgets)
     - models: Optional[list] - A list of models associated with the team - all keys for this team_id will have at most, these models. If empty, assumes all models are allowed.
     - blocked: bool - Flag indicating if the team is blocked or not - will stop all calls from keys with this team_id.
@@ -1540,6 +1541,7 @@ async def update_team(  # noqa: PLR0915
     - rpm_limit: Optional[int] - The RPM (Requests Per Minute) limit for this team - all keys associated with this team_id will have at max this RPM limit
     - max_budget: Optional[float] - The maximum budget allocated to the team - all keys for this team_id will have at max this max_budget
     - soft_budget: Optional[float] - The soft budget threshold for the team. If max_budget is set (either in the request or existing), soft_budget must be strictly lower than max_budget. Can be set independently if max_budget is not set.
+    - model_max_budget: Optional[Dict[str, BudgetConfig]] - Per-model max budgets shared by every key on the team. Each entry is `{"<model>": {"budget_limit": <float>, "time_period": "1d"|"7d"|...}}`. Key-level `model_max_budget` entries take precedence for matching models; team-level entries act as the default cap for keys that do not declare their own.
     - budget_duration: Optional[str] - The duration of the budget for the team. Doc [here](https://docs.litellm.ai/docs/proxy/team_budgets)
     - models: Optional[list] - A list of models associated with the team - all keys for this team_id will have at most, these models. If empty, assumes all models are allowed.
     - prompts: Optional[List[str]] - List of prompts that the team is allowed to use.

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -3467,6 +3467,7 @@ class PrismaClient:
                             t.models AS team_models,
                             t.metadata AS team_metadata,
                             t.blocked AS team_blocked,
+                            t.model_max_budget AS team_model_max_budget,
                             t.team_alias AS team_alias,
                             t.metadata AS team_metadata,
                             t.members_with_roles AS team_members_with_roles,

--- a/tests/proxy_unit_tests/test_unit_test_max_model_budget_limiter.py
+++ b/tests/proxy_unit_tests/test_unit_test_max_model_budget_limiter.py
@@ -423,7 +423,9 @@ async def test_async_log_success_event_pushes_redis_increments_when_redis_config
     _push_in_memory_increments_to_redis when Redis is wired so other workers see spend.
     """
     dual_cache = DualCache()
-    dual_cache.redis_cache = object()  # truthy placeholder; push only checks is not None
+    dual_cache.redis_cache = (
+        object()
+    )  # truthy placeholder; push only checks is not None
     limiter = _PROXY_VirtualKeyModelMaxBudgetLimiter(dual_cache=dual_cache)
     model = "gpt-4"
     kwargs = {
@@ -471,7 +473,9 @@ async def test_async_log_success_event_skips_redis_push_without_redis(budget_lim
             },
         },
     }
-    with patch.object(budget_limiter, "_increment_spend_for_key", new_callable=AsyncMock):
+    with patch.object(
+        budget_limiter, "_increment_spend_for_key", new_callable=AsyncMock
+    ):
         with patch.object(
             budget_limiter,
             "_push_in_memory_increments_to_redis",
@@ -485,6 +489,7 @@ async def test_async_log_success_event_skips_redis_push_without_redis(budget_lim
 
 # === Team-level model_max_budget tests (LIT-2768) ===
 
+
 @pytest.mark.asyncio
 async def test_is_team_within_model_budget_under(budget_limiter):
     """Team budget enforcement returns True when current spend is below budget."""
@@ -495,7 +500,9 @@ async def test_is_team_within_model_budget_under(budget_limiter):
     ):
         ok = await budget_limiter.is_team_within_model_budget(
             team_id="team-1",
-            team_model_max_budget={"gpt-4": {"budget_limit": 100.0, "time_period": "1d"}},
+            team_model_max_budget={
+                "gpt-4": {"budget_limit": 100.0, "time_period": "1d"}
+            },
             model="gpt-4",
         )
     assert ok is True
@@ -555,14 +562,18 @@ async def test_team_spend_cache_key_uses_team_prefix(budget_limiter):
         captured["key"] = key
         return 0.0
 
-    with patch.object(budget_limiter.dual_cache, "async_get_cache", side_effect=fake_get):
+    with patch.object(
+        budget_limiter.dual_cache, "async_get_cache", side_effect=fake_get
+    ):
         await budget_limiter._get_team_spend_for_model(
             team_id="team-xyz",
             model="gpt-4",
             key_budget_config=budget_cfg,
         )
 
-    assert captured["key"].startswith(TEAM_MODEL_SPEND_CACHE_KEY_PREFIX + ":team-xyz:gpt-4:")
+    assert captured["key"].startswith(
+        TEAM_MODEL_SPEND_CACHE_KEY_PREFIX + ":team-xyz:gpt-4:"
+    )
 
 
 @pytest.mark.asyncio
@@ -594,13 +605,19 @@ async def test_async_log_success_event_increments_team_spend(budget_limiter):
         },
     }
 
-    with patch.object(budget_limiter, "_increment_spend_for_key", side_effect=fake_increment):
+    with patch.object(
+        budget_limiter, "_increment_spend_for_key", side_effect=fake_increment
+    ):
         await budget_limiter.async_log_success_event(kwargs, None, 0, 0)
 
     matching_keys = [
-        k for k in incremented if k.startswith(TEAM_MODEL_SPEND_CACHE_KEY_PREFIX + ":team-tracking:")
+        k
+        for k in incremented
+        if k.startswith(TEAM_MODEL_SPEND_CACHE_KEY_PREFIX + ":team-tracking:")
     ]
-    assert matching_keys, f"Expected team-tracked spend key, got {list(incremented.keys())}"
+    assert (
+        matching_keys
+    ), f"Expected team-tracked spend key, got {list(incremented.keys())}"
     assert incremented[matching_keys[0]] == 7.5
 
 
@@ -633,9 +650,131 @@ async def test_async_log_success_event_skips_team_when_team_id_missing(budget_li
         },
     }
 
-    with patch.object(budget_limiter, "_increment_spend_for_key", side_effect=fake_increment):
+    with patch.object(
+        budget_limiter, "_increment_spend_for_key", side_effect=fake_increment
+    ):
         await budget_limiter.async_log_success_event(kwargs, None, 0, 0)
 
-    assert not any(
-        k.startswith(TEAM_MODEL_SPEND_CACHE_KEY_PREFIX) for k in incremented
+    assert not any(k.startswith(TEAM_MODEL_SPEND_CACHE_KEY_PREFIX) for k in incremented)
+
+
+# === Key precedence tests (LIT-2768 — addresses Greptile review) ===
+
+
+@pytest.mark.asyncio
+async def test_team_check_skipped_when_key_covers_model(budget_limiter):
+    """When the requesting key has its own model_max_budget entry for the
+    model, the team check must short-circuit before touching the team
+    counter — otherwise a sibling key on the same team can be denied
+    because of an unrelated key's spend."""
+    with patch.object(
+        budget_limiter,
+        "_get_team_spend_for_model",
+        AsyncMock(return_value=10_000.0),  # team well over budget
+    ) as mock_team_spend:
+        ok = await budget_limiter.is_team_within_model_budget(
+            team_id="team-1",
+            team_model_max_budget={
+                "gpt-4": {"budget_limit": 100.0, "time_period": "1d"}
+            },
+            model="gpt-4",
+            key_model_max_budget={"gpt-4": {"budget_limit": 50.0, "time_period": "1d"}},
+        )
+    assert ok is True
+    mock_team_spend.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_team_check_runs_when_key_has_different_model(budget_limiter):
+    """If the key has its own budget for a DIFFERENT model, the team
+    check still applies to the model being requested."""
+    with patch.object(
+        budget_limiter,
+        "_get_team_spend_for_model",
+        AsyncMock(return_value=10.0),  # team well under budget
+    ) as mock_team_spend:
+        ok = await budget_limiter.is_team_within_model_budget(
+            team_id="team-1",
+            team_model_max_budget={
+                "gpt-4": {"budget_limit": 100.0, "time_period": "1d"}
+            },
+            model="gpt-4",
+            key_model_max_budget={
+                "claude-3": {"budget_limit": 50.0, "time_period": "1d"}
+            },
+        )
+    assert ok is True
+    mock_team_spend.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_team_check_skipped_for_provider_prefixed_match(budget_limiter):
+    """Key precedence holds when the key's entry matches via the
+    `_get_model_without_custom_llm_provider` normalization, mirroring
+    is_key_within_model_budget."""
+    with patch.object(
+        budget_limiter,
+        "_get_team_spend_for_model",
+        AsyncMock(return_value=10_000.0),
+    ) as mock_team_spend:
+        ok = await budget_limiter.is_team_within_model_budget(
+            team_id="team-1",
+            team_model_max_budget={
+                "gpt-4": {"budget_limit": 100.0, "time_period": "1d"}
+            },
+            model="openai/gpt-4",
+            key_model_max_budget={"gpt-4": {"budget_limit": 50.0, "time_period": "1d"}},
+        )
+    assert ok is True
+    mock_team_spend.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_async_log_success_event_skips_team_increment_when_key_covers_model(
+    budget_limiter,
+):
+    """Team counter must NOT be incremented for models where the key has
+    its own model_max_budget entry — otherwise the team counter is driven
+    by keys with private caps, blocking sibling keys."""
+    from litellm.proxy.hooks.model_max_budget_limiter import (
+        TEAM_MODEL_SPEND_CACHE_KEY_PREFIX,
+        VIRTUAL_KEY_SPEND_CACHE_KEY_PREFIX,
     )
+
+    incremented = {}
+
+    async def fake_increment(budget_config, spend_key, start_time_key, response_cost):
+        incremented[spend_key] = response_cost
+
+    kwargs = {
+        "standard_logging_object": {
+            "response_cost": 5.0,
+            "model_group": "gpt-4",
+            "model": "openai/gpt-4",
+            "metadata": {"user_api_key_hash": "hash-1"},
+        },
+        "litellm_params": {
+            "metadata": {
+                "user_api_key_team_id": "team-1",
+                "user_api_key_team_model_max_budget": {
+                    "gpt-4": {"budget_limit": 100.0, "time_period": "1d"}
+                },
+                "user_api_key_model_max_budget": {
+                    "gpt-4": {"budget_limit": 50.0, "time_period": "1d"}
+                },
+            }
+        },
+    }
+    with patch.object(
+        budget_limiter, "_increment_spend_for_key", side_effect=fake_increment
+    ):
+        await budget_limiter.async_log_success_event(kwargs, None, 0, 0)
+
+    team_keys = [
+        k for k in incremented if k.startswith(TEAM_MODEL_SPEND_CACHE_KEY_PREFIX)
+    ]
+    key_keys = [
+        k for k in incremented if k.startswith(VIRTUAL_KEY_SPEND_CACHE_KEY_PREFIX)
+    ]
+    assert not team_keys, f"Unexpected team-spend writes: {team_keys}"
+    assert key_keys, "Key-spend should still be tracked"

--- a/tests/proxy_unit_tests/test_unit_test_max_model_budget_limiter.py
+++ b/tests/proxy_unit_tests/test_unit_test_max_model_budget_limiter.py
@@ -481,3 +481,161 @@ async def test_async_log_success_event_skips_redis_push_without_redis(budget_lim
                 kwargs, response_obj=None, start_time=None, end_time=None
             )
             mock_push.assert_not_awaited()
+
+
+# === Team-level model_max_budget tests (LIT-2768) ===
+
+@pytest.mark.asyncio
+async def test_is_team_within_model_budget_under(budget_limiter):
+    """Team budget enforcement returns True when current spend is below budget."""
+    with patch.object(
+        budget_limiter,
+        "_get_team_spend_for_model",
+        AsyncMock(return_value=10.0),
+    ):
+        ok = await budget_limiter.is_team_within_model_budget(
+            team_id="team-1",
+            team_model_max_budget={"gpt-4": {"budget_limit": 100.0, "time_period": "1d"}},
+            model="gpt-4",
+        )
+    assert ok is True
+
+
+@pytest.mark.asyncio
+async def test_is_team_within_model_budget_exceeded_raises(budget_limiter):
+    """Team budget exceeded raises BudgetExceededError naming the team_id."""
+    with patch.object(
+        budget_limiter,
+        "_get_team_spend_for_model",
+        AsyncMock(return_value=150.0),
+    ):
+        with pytest.raises(litellm.BudgetExceededError) as exc_info:
+            await budget_limiter.is_team_within_model_budget(
+                team_id="team-finance",
+                team_model_max_budget={
+                    "gpt-4": {"budget_limit": 100.0, "time_period": "1d"}
+                },
+                model="gpt-4",
+            )
+    assert "team-finance" in str(exc_info.value)
+    assert "gpt-4" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_is_team_within_model_budget_model_not_configured(budget_limiter):
+    """Models absent from team_model_max_budget are allowed without spend lookup."""
+    with patch.object(
+        budget_limiter,
+        "_get_team_spend_for_model",
+        AsyncMock(return_value=999.0),
+    ) as mock_get_spend:
+        ok = await budget_limiter.is_team_within_model_budget(
+            team_id="team-1",
+            team_model_max_budget={
+                "gpt-4": {"budget_limit": 100.0, "time_period": "1d"}
+            },
+            model="claude-3",
+        )
+    assert ok is True
+    mock_get_spend.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_team_spend_cache_key_uses_team_prefix(budget_limiter):
+    """Team spend cache key must include team_id prefix and time period, not the key hash."""
+    from litellm.proxy.hooks.model_max_budget_limiter import (
+        TEAM_MODEL_SPEND_CACHE_KEY_PREFIX,
+    )
+    from litellm.types.utils import BudgetConfig
+
+    budget_cfg = BudgetConfig(budget_limit=10.0, budget_duration="1d")
+    captured = {}
+
+    async def fake_get(key):
+        captured["key"] = key
+        return 0.0
+
+    with patch.object(budget_limiter.dual_cache, "async_get_cache", side_effect=fake_get):
+        await budget_limiter._get_team_spend_for_model(
+            team_id="team-xyz",
+            model="gpt-4",
+            key_budget_config=budget_cfg,
+        )
+
+    assert captured["key"].startswith(TEAM_MODEL_SPEND_CACHE_KEY_PREFIX + ":team-xyz:gpt-4:")
+
+
+@pytest.mark.asyncio
+async def test_async_log_success_event_increments_team_spend(budget_limiter):
+    """Spend tracking writes to the team-level cache key when team_model_max_budget is present."""
+    from litellm.proxy.hooks.model_max_budget_limiter import (
+        TEAM_MODEL_SPEND_CACHE_KEY_PREFIX,
+    )
+
+    incremented = {}
+
+    async def fake_increment(budget_config, spend_key, start_time_key, response_cost):
+        incremented[spend_key] = response_cost
+
+    kwargs = {
+        "standard_logging_object": {
+            "response_cost": 7.5,
+            "model_group": "gpt-4",
+            "model": "openai/gpt-4",
+            "metadata": {"user_api_key_hash": "hash-1"},
+        },
+        "litellm_params": {
+            "metadata": {
+                "user_api_key_team_id": "team-tracking",
+                "user_api_key_team_model_max_budget": {
+                    "gpt-4": {"budget_limit": 100.0, "time_period": "1d"}
+                },
+            }
+        },
+    }
+
+    with patch.object(budget_limiter, "_increment_spend_for_key", side_effect=fake_increment):
+        await budget_limiter.async_log_success_event(kwargs, None, 0, 0)
+
+    matching_keys = [
+        k for k in incremented if k.startswith(TEAM_MODEL_SPEND_CACHE_KEY_PREFIX + ":team-tracking:")
+    ]
+    assert matching_keys, f"Expected team-tracked spend key, got {list(incremented.keys())}"
+    assert incremented[matching_keys[0]] == 7.5
+
+
+@pytest.mark.asyncio
+async def test_async_log_success_event_skips_team_when_team_id_missing(budget_limiter):
+    """No team_id → team-level spend tracking is a no-op even if team_model_max_budget is set."""
+    from litellm.proxy.hooks.model_max_budget_limiter import (
+        TEAM_MODEL_SPEND_CACHE_KEY_PREFIX,
+    )
+
+    incremented = {}
+
+    async def fake_increment(budget_config, spend_key, start_time_key, response_cost):
+        incremented[spend_key] = response_cost
+
+    kwargs = {
+        "standard_logging_object": {
+            "response_cost": 3.0,
+            "model_group": "gpt-4",
+            "model": "openai/gpt-4",
+            "metadata": {"user_api_key_hash": "hash-1"},
+        },
+        "litellm_params": {
+            "metadata": {
+                # team_id intentionally absent
+                "user_api_key_team_model_max_budget": {
+                    "gpt-4": {"budget_limit": 100.0, "time_period": "1d"}
+                },
+            }
+        },
+    }
+
+    with patch.object(budget_limiter, "_increment_spend_for_key", side_effect=fake_increment):
+        await budget_limiter.async_log_success_event(kwargs, None, 0, 0)
+
+    assert not any(
+        k.startswith(TEAM_MODEL_SPEND_CACHE_KEY_PREFIX) for k in incremented
+    )


### PR DESCRIPTION
## Linear ticket

Resolves LIT-2768

## Why

`LiteLLM_TeamTable.model_max_budget` already exists in the Prisma schema (`Json @default("{}")`) but no code path on `main` reads it. As a result, setting a team-level per-model max budget — directly in the DB, or via any future field — is silently ignored.

A customer asked to set model max budgets at the team level so every key in the team inherits the budget by default while still allowing per-key overrides. Today they have to copy the same `model_max_budget` onto every key the team mints, with no shared counter.

## What changed

1. **Schema-visible field** — `model_max_budget: Optional[dict]` is now declared on `TeamBase` (inherited by `NewTeamRequest` and `LiteLLM_TeamTable`) and on `UpdateTeamRequest`. Docstrings on `new_team` + `update_team` document it. `/team/new` and `/team/update` already accepted unknown fields; this exposes the field on the request models so it is documented and validated.
2. **Hydration into auth** — the existing combined-view SQL hydration (`PrismaClient.get_data(table_name="combined_view")`) now selects `t.model_max_budget AS team_model_max_budget` alongside the other `t.*` columns. The value flows onto `LiteLLM_VerificationTokenView` → `UserAPIKeyAuth.team_model_max_budget`.
3. **Enforcement** — `_PROXY_VirtualKeyModelMaxBudgetLimiter.is_team_within_model_budget` mirrors the key-level method but reads the team value, looks up spend under a team-scoped cache key (`team_model_spend:{team_id}:{model}:{period}`), and raises `BudgetExceededError` when exceeded. `user_api_key_auth.py` calls it after the existing key + end-user model_max_budget checks at both auth wrappers (centralized common-check path + legacy path).
4. **Spend tracking** — `async_log_success_event` also increments the team-scoped counter so all keys on a team share one running total per (model, period).
5. **Key precedence (Greptile feedback)** — new `_key_already_covers_model` helper. When the requesting key already declares its own `model_max_budget` entry for the request model (exact name OR `{provider}/{model}` normalized), the team check short-circuits without touching the team counter, and the post-call hook skips the team-spend increment for that (key, model) pair. The same helper is used by both the pre-call check and the post-call increment so the precedence rule stays in lock-step.
6. **Pre-call surfacing** — `litellm_pre_call_utils.py` forwards `user_api_key_team_model_max_budget` into request metadata so the post-call hook has what it needs without re-reading auth state.

### Precedence summary

Key-level `is_key_within_model_budget` runs first in the auth path. If it rejects, the team check never runs. If it passes:
- Key with its own `model_max_budget[model]` entry → team check short-circuits; team counter is NOT consulted or incremented for that (key, model) pair.
- Key with no `model_max_budget[model]` entry → team check enforces the team cap as the default; team counter is incremented.

## Files

| File | Diff |
|---|---|
| `litellm/proxy/_types.py` | +5 |
| `litellm/proxy/auth/user_api_key_auth.py` | +34 |
| `litellm/proxy/hooks/model_max_budget_limiter.py` | +148 −1 |
| `litellm/proxy/litellm_pre_call_utils.py` | +3 |
| `litellm/proxy/management_endpoints/team_endpoints.py` | +2 |
| `litellm/proxy/utils.py` | +1 |
| `tests/proxy_unit_tests/test_unit_test_max_model_budget_limiter.py` | +319 |

## Tests

```
$ python3 -m pytest tests/proxy_unit_tests/test_unit_test_max_model_budget_limiter.py -q
.......................                                                  [100%]
23 passed in 0.66s

$ python3 -m pytest tests/test_litellm/proxy/hooks/test_max_budget_limiter.py -q
......                                                                   [100%]
6 passed in 7.72s

$ python3 -m pytest tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py -q
140 passed in 10.83s
```

Ten new unit tests in `test_unit_test_max_model_budget_limiter.py` cover:

1. under-budget pass-through
2. exceeded-budget raises with team_id + model in the message
3. model-not-configured short-circuits without spend lookup
4. team-scoped cache key shape (`team_model_spend:{team_id}:{model}:{period}`)
5. spend-increment writes to the team key
6. no-op when `team_id` is absent from metadata
7. **(precedence)** team check skipped when key covers exact model name
8. **(precedence)** team check runs when key budget targets a DIFFERENT model
9. **(precedence)** team check skipped via provider-prefixed normalization (`openai/gpt-4` vs `gpt-4`)
10. **(precedence)** team counter NOT incremented in post-call hook when key covers the model

### Evidence

Before — clean `litellm_oss_agent_shin_daily_branch` HEAD `1fe911d`:

```
BEFORE: error: 'UserAPIKeyAuth' object has no attribute 'team_model_max_budget'
BEFORE: hasattr UserAPIKeyAuth().team_model_max_budget: False
BEFORE: NewTeamRequest.model_max_budget on declared fields: False
BEFORE: limiter.is_team_within_model_budget exists: False
BEFORE: SQL query selects t.model_max_budget AS team_model_max_budget: False
```

After — this branch:

```
AFTER: UserAPIKeyAuth().team_model_max_budget default: None
AFTER: model_max_budget declared on NewTeamRequest: True
AFTER: model_max_budget declared on UpdateTeamRequest: True
AFTER: limiter.is_team_within_model_budget exists: True
AFTER: SQL query selects t.model_max_budget AS team_model_max_budget: True
```

End-to-end limiter behavior — real `DualCache`, no mocks of the limiter logic:

```
Round 1 — $80 call from key1 (member of team-finops):
  team_model_spend:team-finops:gpt-4o:1d = 80.0

Round 2 — pre-call check from key2 at $80 / $100:
  ✓ PASS (under budget)

Round 3 — $30 call from key2 pushes shared counter to $110:
  team_model_spend:team-finops:gpt-4o:1d = 110.0

Round 4 — pre-call check from key3 at $110 / $100:
  ✓ Rejected: BudgetExceededError: LiteLLM Team: team-finops, exceeded budget for model=gpt-4o

Round 5 — request for claude-3 (no team cap configured):
  ✓ Allowed

Round 6 — single shared counter across keys, not per key:
  ✓ team_model_spend:team-finops:gpt-4o:1d = 110.0 (one shared key, not three)
```

### Note on push path

The branch was pushed via `PUT /repos/{owner}/{repo}/contents/{path}` (one call per file) because the current `GITHUB_TOKEN` lacks the `repo`/`workflow` scopes required for `git push`. Reviewers should expect the merge-base diff to look slightly noisier than a single squashed commit; the actual file contents are identical to what `git push` would have produced.

## Session

https://litellm-agent-platform.onrender.com/sessions/93c84e0b-2c13-4b28-8c5b-bc5d72b73243

### Verification (ship-pr)

- **Greptile**: 5/5 — "Safe to merge; the new enforcement path is well-isolated, key-precedence logic is correct and covered by tests, and no auth bypass has been introduced." (Latest review on commit `ae296f7`)
- **GitHub Actions**: 42/44 green on head `ae296f7`. The one failure is `codecov/patch` (informational coverage threshold; the 10 new unit tests cover all four enforcement code paths and the precedence helper, but the change is split across hooks + auth so line-coverage % falls short of the global gate). `Veria AI - PR Review` was still running at submit time.
- **Unit tests**: 23/23 in `test_unit_test_max_model_budget_limiter.py` (13 existing + 10 new), 6/6 in `test_max_budget_limiter.py`, 140/140 in `test_team_endpoints.py`.
- **Lint / black / ruff**: clean.
- **Doc check**: `model_max_budget` documented in both `new_team` and `update_team` docstrings (the original miss caught by `test_api_docs.py` on the first CI run is fixed in this branch).
