### PR TITLE
fix(ui): show newest session logs first

### DIFF
--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -3356,7 +3356,7 @@ async def ui_view_session_spend_logs(
                 session_id, status, mcp_namespaced_tool_name, agent_id
             FROM "LiteLLM_SpendLogs"
             WHERE session_id = $1
-            ORDER BY "startTime" ASC
+            ORDER BY "startTime" DESC
             LIMIT $2 OFFSET $3
         """
         result = await prisma_client.db.query_raw(

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
@@ -1313,9 +1313,9 @@ async def test_ui_view_session_spend_logs_pagination(client, monkeypatch):
             # Endpoint uses raw SQL for pagination - verify params
             assert session_id == "session-123"
             assert page_size == 1
-            assert skip == 0  # page=1, page_size=1
+            assert skip == 1  # page=2, page_size=1
             assert 'ORDER BY "startTime" DESC' in sql_query
-            return [mock_spend_logs[1]]
+            return [mock_spend_logs[0]]
 
     class MockPrismaClient:
         def __init__(self):
@@ -1327,18 +1327,18 @@ async def test_ui_view_session_spend_logs_pagination(client, monkeypatch):
 
     response = client.get(
         "/spend/logs/session/ui",
-        params={"session_id": "session-123", "page": 1, "page_size": 1},
+        params={"session_id": "session-123", "page": 2, "page_size": 1},
         headers={"Authorization": "Bearer sk-test"},
     )
 
     assert response.status_code == 200
     data = response.json()
     assert data["total"] == 2
-    assert data["page"] == 1
+    assert data["page"] == 2
     assert data["page_size"] == 1
     assert data["total_pages"] == 2
     assert len(data["data"]) == 1
-    assert data["data"][0]["request_id"] == "req2"
+    assert data["data"][0]["request_id"] == "req1"
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
@@ -1313,7 +1313,8 @@ async def test_ui_view_session_spend_logs_pagination(client, monkeypatch):
             # Endpoint uses raw SQL for pagination - verify params
             assert session_id == "session-123"
             assert page_size == 1
-            assert skip == 1  # page=2, page_size=1
+            assert skip == 0  # page=1, page_size=1
+            assert 'ORDER BY "startTime" DESC' in sql_query
             return [mock_spend_logs[1]]
 
     class MockPrismaClient:
@@ -1326,14 +1327,14 @@ async def test_ui_view_session_spend_logs_pagination(client, monkeypatch):
 
     response = client.get(
         "/spend/logs/session/ui",
-        params={"session_id": "session-123", "page": 2, "page_size": 1},
+        params={"session_id": "session-123", "page": 1, "page_size": 1},
         headers={"Authorization": "Bearer sk-test"},
     )
 
     assert response.status_code == 200
     data = response.json()
     assert data["total"] == 2
-    assert data["page"] == 2
+    assert data["page"] == 1
     assert data["page_size"] == 1
     assert data["total_pages"] == 2
     assert len(data["data"]) == 1


### PR DESCRIPTION
﻿## What changed

- Return session-expanded request logs newest first in `/spend/logs/session/ui`.
- Update the UI spend-log regression test to assert the session endpoint uses `ORDER BY "startTime" DESC` and shows the newest request on the first page.

## To verify

- `python -m py_compile litellm\proxy\spend_tracking\spend_management_endpoints.py tests\test_litellm\proxy\spend_tracking\test_spend_management_endpoints.py`
- `python -m ruff check litellm\proxy\spend_tracking\spend_management_endpoints.py tests\test_litellm\proxy\spend_tracking\test_spend_management_endpoints.py`
- `python -m pytest tests\test_litellm\proxy\spend_tracking\test_spend_management_endpoints.py -k "session_spend_logs_pagination" -q --basetemp .tmp\pytest`

Fixes #29153
