### PR TITLE
fix(team-byok): preserve team_public_model_name on dashboard PATCH resend (LIT-2682)

### DIFF
--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -463,8 +463,22 @@ def _get_public_model_name(
     patch_data: updateDeployment,
     db_model: Deployment,
 ) -> str:
-    """Determine the public model name from patch or existing model."""
-    if patch_data.model_name:
+    """Determine the public model name from patch or existing model.
+
+    Precedence (highest first):
+    1. ``patch_data.model_info.team_public_model_name`` -- explicit signal.
+    2. ``patch_data.model_name`` -- only when it differs from
+       ``db_model.model_name`` (genuine top-level rename).
+    3. ``db_model.model_info.team_public_model_name`` -- existing alias.
+    4. ``db_model.model_name`` -- legacy-row fallback.
+    """
+    if (
+        patch_data.model_info is not None
+        and patch_data.model_info.team_public_model_name
+    ):
+        return patch_data.model_info.team_public_model_name
+
+    if patch_data.model_name and patch_data.model_name != db_model.model_name:
         return patch_data.model_name
 
     if db_model.model_info and db_model.model_info.team_public_model_name:

--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -1130,6 +1130,161 @@ class TestTeamModelUpdate:
             assert "403" in str(exc_info.value)
 
 
+
+class TestGetPublicModelName:
+    """Regression for LIT-2682.
+
+    The Admin UI PATCH `/model/{id}/update` payload re-sends the
+    generated internal `model_name` verbatim while keeping the intended
+    team-facing alias in `model_info.team_public_model_name`.
+
+    `_get_public_model_name` must:
+    * prefer the explicit `patch_data.model_info.team_public_model_name`;
+    * only honor `patch_data.model_name` as a rename when it differs from
+      `db_model.model_name`;
+    * fall through to the existing `db_model.model_info.team_public_model_name`;
+    * and finally to `db_model.model_name` for legacy rows.
+    """
+
+    def _make_db_model(self):
+        from litellm.types.router import ModelInfo
+        return Deployment(
+            model_name="model_name_test-team_abc123",
+            litellm_params=LiteLLM_Params(
+                model="azure/gpt-5.2-low-rpm-testing"
+            ),
+            model_info=ModelInfo(
+                team_id="test-team",
+                team_public_model_name="gpt-5.2-low-rpm-testing",
+            ),
+        )
+
+    def test_explicit_team_public_model_name_wins(self):
+        """Explicit `model_info.team_public_model_name` is the source of truth."""
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _get_public_model_name,
+        )
+        from litellm.types.router import ModelInfo
+
+        db_model = self._make_db_model()
+        patch_data = updateDeployment(
+            model_name="model_name_test-team_abc123",
+            model_info=ModelInfo(
+                team_id="test-team",
+                team_public_model_name="gpt-5.2-low-rpm-testing",
+            ),
+        )
+        assert (
+            _get_public_model_name(patch_data=patch_data, db_model=db_model)
+            == "gpt-5.2-low-rpm-testing"
+        )
+
+    def test_dashboard_resend_preserves_existing_public_name(self):
+        """Dashboard resend (no team_public_model_name in patch.model_info,
+        and patch.model_name == db_model.model_name) must NOT clobber the
+        existing public name.
+        """
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _get_public_model_name,
+        )
+        from litellm.types.router import ModelInfo
+
+        db_model = self._make_db_model()
+        patch_data = updateDeployment(
+            model_name="model_name_test-team_abc123",
+            model_info=ModelInfo(team_id="test-team"),
+        )
+        assert (
+            _get_public_model_name(patch_data=patch_data, db_model=db_model)
+            == "gpt-5.2-low-rpm-testing"
+        )
+
+    def test_genuine_top_level_rename_is_honored(self):
+        """A real rename via top-level `model_name` (no
+        team_public_model_name in patch) must still be honored.
+        """
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _get_public_model_name,
+        )
+        from litellm.types.router import ModelInfo
+
+        db_model = self._make_db_model()
+        patch_data = updateDeployment(
+            model_name="gpt-5.2-renamed",
+            model_info=ModelInfo(team_id="test-team"),
+        )
+        assert (
+            _get_public_model_name(patch_data=patch_data, db_model=db_model)
+            == "gpt-5.2-renamed"
+        )
+
+    def test_explicit_team_public_model_name_beats_top_level_rename(self):
+        """If both signals are present, the explicit
+        `model_info.team_public_model_name` wins. This avoids ambiguous
+        intent — the dashboard's "rename" UI lives behind the explicit
+        field, the top-level `model_name` is the internal handle.
+        """
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _get_public_model_name,
+        )
+        from litellm.types.router import ModelInfo
+
+        db_model = self._make_db_model()
+        patch_data = updateDeployment(
+            model_name="gpt-5.2-via-top-level",
+            model_info=ModelInfo(
+                team_id="test-team",
+                team_public_model_name="gpt-5.2-via-model-info",
+            ),
+        )
+        assert (
+            _get_public_model_name(patch_data=patch_data, db_model=db_model)
+            == "gpt-5.2-via-model-info"
+        )
+
+    def test_legacy_row_falls_back_to_db_model_name(self):
+        """Legacy `LiteLLM_ProxyModelTable` rows that pre-date team-scoped
+        public names have no `model_info.team_public_model_name`. With an
+        empty patch we fall back to the existing `db_model.model_name`.
+        """
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _get_public_model_name,
+        )
+
+        db_model = Deployment(
+            model_name="legacy-public-name",
+            litellm_params=LiteLLM_Params(model="azure/x"),
+        )
+        patch_data = updateDeployment()
+        assert (
+            _get_public_model_name(patch_data=patch_data, db_model=db_model)
+            == "legacy-public-name"
+        )
+
+    def test_empty_string_team_public_model_name_does_not_match(self):
+        """An empty-string `team_public_model_name` (treated as falsy by
+        the precedence rules) falls through to the next layer.
+        """
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _get_public_model_name,
+        )
+        from litellm.types.router import ModelInfo
+
+        db_model = self._make_db_model()
+        patch_data = updateDeployment(
+            model_name="model_name_test-team_abc123",
+            model_info=ModelInfo(team_id="test-team", team_public_model_name=""),
+        )
+        # patch_data.model_info.team_public_model_name is empty (falsy);
+        # patch_data.model_name equals db_model.model_name; existing public
+        # name must be preserved.
+        assert (
+            _get_public_model_name(patch_data=patch_data, db_model=db_model)
+            == "gpt-5.2-low-rpm-testing"
+        )
+
+
+
 class TestModelInfoEndpoint:
     """Test the model_info endpoint for retrieving individual model information"""
 


### PR DESCRIPTION
## Resolves LIT-2682

## Summary

When the Admin UI re-saves a team-scoped BYOK model, the PATCH `/model/{id}/update` payload contains:

- top-level `model_name` = the generated internal handle (`model_name_<team_id>_<uuid>`) — re-sent verbatim by the dashboard;
- `model_info.team_public_model_name` = the intended team-facing alias.

The old `_get_public_model_name` (in `litellm/proxy/management_endpoints/model_management_endpoints.py`) returned `patch_data.model_name` first, treating the dashboard's resend as a rename. The resolved public name was then stamped back into `model_info.team_public_model_name` and persisted, **overwriting the alias with the internal handle** and breaking the corresponding team-ACL entry that referenced the previous public name.

## Fix

Tighter precedence for `_get_public_model_name`:

1. `patch_data.model_info.team_public_model_name` — explicit caller signal (the dashboard always sends this on team-scoped edits).
2. `patch_data.model_name` — only when it differs from `db_model.model_name` (a genuine top-level rename).
3. `db_model.model_info.team_public_model_name` — existing alias.
4. `db_model.model_name` — legacy-row fallback.

Single-site change in one helper; team-rename + non-team-update paths are unaffected.

### Evidence

End-to-end repro that drives the production `_get_public_model_name` + `update_db_model` chain — exactly the bytes the PATCH endpoint persists to `LiteLLM_ProxyModelTable.model_info`. The proxy could not be brought up in the sandbox (the harness sets `HTTPS_PROXY` that intercepts the Prisma engine's loopback HTTP, yielding `502: vault upstream`), so evidence is via direct invocation of the two production functions on real `Deployment` / `updateDeployment` shapes, with `encrypt_value_helper` patched to identity for readability — no other mocking. Repro script: [`/tmp/repro.py` (gist below)](#repro-script).

**Before (current `litellm_oss_agent_shin_daily_branch` at `1fe911d`):**

```
==== BEFORE FIX (main / daily branch as of 1fe911d) ====
_get_public_model_name() returned: 'model_name_team-blue_a1b2c3d4-uuid'
Persisted row (the bytes written into LiteLLM_ProxyModelTable.model_info):
{
  "model_name": "model_name_team-blue_a1b2c3d4-uuid",
  "model_info.team_public_model_name": "model_name_team-blue_a1b2c3d4-uuid",
  "model_info.team_id": "team-blue"
}
```

`team_public_model_name` has been silently rewritten to the internal handle — same symptom the customer report described.

**After (this PR):**

```
==== AFTER  FIX (this PR) ====
_get_public_model_name() returned: 'gpt-5.2-low-rpm-testing'
Persisted row (the bytes written into LiteLLM_ProxyModelTable.model_info):
{
  "model_name": "model_name_team-blue_a1b2c3d4-uuid",
  "model_info.team_public_model_name": "gpt-5.2-low-rpm-testing",
  "model_info.team_id": "team-blue"
}
```

The explicit `team_public_model_name` survives the dashboard resend; team ACLs remain valid.

#### Unit tests

Six new tests in `tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py::TestGetPublicModelName` cover every branch of the new precedence:

```
tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py::TestGetPublicModelName::test_dashboard_resend_preserves_existing_public_name PASSED
tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py::TestGetPublicModelName::test_empty_string_team_public_model_name_does_not_match PASSED
tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py::TestGetPublicModelName::test_explicit_team_public_model_name_beats_top_level_rename PASSED
tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py::TestGetPublicModelName::test_explicit_team_public_model_name_wins PASSED
tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py::TestGetPublicModelName::test_genuine_top_level_rename_is_honored PASSED
tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py::TestGetPublicModelName::test_legacy_row_falls_back_to_db_model_name PASSED

============================== 6 passed in 8.27s ===============================
```

The full file's existing 41 tests also pass (47 total, no regressions).

## Notes

- Pushed via `PUT /repos/{owner}/{repo}/contents/{path}` (current `GITHUB_TOKEN` lacks `repo` scope for `git push`). Expect a noisier merge-base diff than from a normal `git push`.
- Targets `litellm_oss_agent_shin_daily_branch` per fork policy.

## Session

https://litellm-agent-platform.onrender.com/sessions/02b352ff-2152-4770-ab7c-7a3e697c226c


---

### Verification (ship-pr)

- **PR:** #29212 — `fix/lit-2682-team-public-model-name-precedence` -> `litellm_oss_agent_shin_daily_branch`
- **Greptile:** **5/5** — "Safe to merge — the change is confined to a single helper, non-team models are unaffected, and all new tests pass on real production function shapes." (first Greptile pass scored 4/5 with no P1/P2 findings; second pass on the same commit upgraded to 5/5)
- **Veria AI - PR Review:** still `in_progress` after >25 min (no other checks pending — Veria-side flake, has been observed in earlier sessions on similarly small PRs). No security finding emitted.
- **GitHub Actions:** **43/43 non-Veria checks success**, 0 failures. `mergeable_state: clean` aside from the Veria in-progress.
- **mergeable:** `true`
- **Base branch:** `litellm_oss_agent_shin_daily_branch` ✅ (per fork policy)
- **CLA:** signed
- **Unit tests:** all 6 new `TestGetPublicModelName` tests pass; the full class (47 tests) is green — no regressions.
- **Evidence:** before/after JSON of the persisted `LiteLLM_ProxyModelTable.model_info` row in the PR body shows the explicit `team_public_model_name` survives the dashboard PATCH resend.
- **Customer name leak:** none. Title/body/comments contain no customer identifiers.
