### PR TITLE
fix(prometheus): rate-limit gauges drop the emit when value is 0

### DIFF
--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -2691,7 +2691,7 @@ class PrometheusLogger(CustomLogger):
                 label_context=label_context,
             )
 
-            if remaining_requests:
+            if remaining_requests is not None:
                 """
                 "model_group",
                 "api_provider",
@@ -2705,7 +2705,7 @@ class PrometheusLogger(CustomLogger):
                 )
                 self.litellm_remaining_requests_metric.labels(**_labels).set(remaining_requests)
 
-            if remaining_tokens:
+            if remaining_tokens is not None:
                 _labels = prometheus_label_factory(
                     supported_enum_labels=self.get_labels_for_metric(metric_name="litellm_remaining_tokens_metric"),
                     enum_values=enum_values,

--- a/tests/test_litellm/integrations/test_prometheus_remaining_tokens_router_fallback.py
+++ b/tests/test_litellm/integrations/test_prometheus_remaining_tokens_router_fallback.py
@@ -296,3 +296,46 @@ class TestRouterFallbackDefensivePaths:
             )
 
         prometheus_logger.litellm_remaining_tokens_metric.labels.assert_not_called()
+
+
+class TestProviderHeaderPathEmitsZero:
+    """The sibling path to the router fallback above.
+
+    When a provider does return `x-ratelimit-remaining-*`, the fallback
+    short-circuits and `set_llm_deployment_success_metrics` owns the emit. That
+    branch used to be guarded by `if remaining_requests:`, so a reported `0`
+    was dropped and the gauge kept serving its previous value: a dashboard
+    reading headroom while the quota was gone.
+    """
+
+    def test_should_emit_both_gauges_when_provider_reports_zero(self, prometheus_logger):
+        payload = _build_payload(
+            custom_llm_provider="openai",
+            additional_headers={
+                "x_ratelimit_remaining_requests": 0,
+                "x_ratelimit_remaining_tokens": 0,
+            },
+        )
+
+        prometheus_logger.litellm_remaining_requests_metric = MagicMock()
+        prometheus_logger.litellm_remaining_tokens_metric = MagicMock()
+        prometheus_logger.litellm_deployment_success_responses = MagicMock()
+        prometheus_logger.litellm_deployment_total_requests = MagicMock()
+        prometheus_logger.litellm_deployment_latency_per_output_token = MagicMock()
+        prometheus_logger.litellm_overhead_latency_metric = MagicMock()
+        prometheus_logger.set_deployment_healthy = MagicMock()
+
+        prometheus_logger.set_llm_deployment_success_metrics(
+            request_kwargs={
+                "model": "gpt-5-nano",
+                "litellm_params": {"custom_llm_provider": "openai"},
+                "standard_logging_object": payload,
+            },
+            start_time=None,
+            end_time=None,
+            enum_values=_enum_values(),
+            output_tokens=10,
+        )
+
+        prometheus_logger.litellm_remaining_requests_metric.labels().set.assert_called_once_with(0)
+        prometheus_logger.litellm_remaining_tokens_metric.labels().set.assert_called_once_with(0)


### PR DESCRIPTION
## TLDR

Problem this solves:

- a remaining count of `0` never reaches `litellm_remaining_requests_metric` or `litellm_remaining_tokens_metric`, because both emits sit behind a truthy check
- gauges hold their last value forever, so when a quota runs out the metric keeps reporting headroom instead of zero

How it solves it:

- both guards become `is not None`
- adds a regression test that fails before the change and passes after

Two code paths feed these gauges and they hand off to each other. `_async_set_router_remaining_metrics` bails out when `additional_headers` already carries a value, leaving the emit to `set_llm_deployment_success_metrics`, which is exactly where a `0` gets dropped. So the value has no way through

The same file already does this correctly for the same two variables, a couple hundred lines up in `_async_set_router_remaining_metrics` and again in the per-key remaining metrics. I read this as an oversight rather than a deliberate choice

Targets `main` again after the staging branch reset. The bug is still on `main` at `prometheus.py:3084` and `:3098`

## Relevant issues

Part of #34704

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Current validation and review status

The head remains `6a7260bcac`. Coverage is passing, but required CI is not fully green and the Greptile 5/5 comment references an earlier commit

The `proxy-behavior` failure is reproduced in the [main-branch run at 30f33a949b](https://github.com/BerriAI/litellm/actions/runs/34737619378): `test_join_binds_the_membership_to_the_requested_team` awaits a `MagicMock` and fails with the same TypeError (847 passed, 1 failed). The remaining failed checks are CodeQL Actions analysis and a Codecov upload job whose log is unavailable. These are not counted as passing checks

## Screenshots / Proof of Fix

Reproducing this needs a remaining count of exactly `0`, which normally means burning a real quota down to nothing. There is a cheaper way in: set `rpm` on the deployment and litellm's own accounting produces the number, so the second request reports `0` without touching provider limits

```yaml
model_list:
  - model_name: zero-remaining-demo
    litellm_params:
      model: openai/gpt-5-nano
      api_key: sk-not-used-mock-only
      mock_response: "hi"
      rpm: 2

litellm_settings:
  callbacks: ["prometheus"]

general_settings:
  master_key: sk-1234
```

A note on `mock_response`: it only stands in for the completion body. The remaining count comes from litellm's rpm accounting, travels through `standard_logging_payload`, and lands in the same `set_llm_deployment_success_metrics` branch a provider header would, so the path under test is the real one. I kept the run free because nothing about the LLM's answer affects this code. Happy to redo it against a live provider if you want that on the record

```bash
for i in 1 2; do
  curl -s -D - -o /dev/null http://localhost:4000/v1/chat/completions \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"model":"zero-remaining-demo","messages":[{"role":"user","content":"hi"}],"max_tokens":1}' \
    | grep -i "^x-ratelimit-remaining-requests"
done

curl -sL -H "Authorization: Bearer sk-1234" http://localhost:4000/metrics \
  | grep "^litellm_remaining_requests_metric{"
```

Before, on `litellm_internal_staging`. The response says zero left, the gauge still says one:

```
request 1 -> HTTP/1.1 200 OK x-ratelimit-remaining-requests: 1
request 2 -> HTTP/1.1 200 OK x-ratelimit-remaining-requests: 0

litellm_remaining_requests_metric{api_base="",api_key_alias="None",api_provider="openai",hashed_api_key="litellm_proxy_master_key",litellm_model_name="gpt-5-nano",model_group="zero-remaining-demo",model_id="4d4b7229..."} 1.0
```

After, same commands on this branch:

```
request 1 -> HTTP/1.1 200 OK x-ratelimit-remaining-requests: 1
request 2 -> HTTP/1.1 200 OK x-ratelimit-remaining-requests: 0

litellm_remaining_requests_metric{api_base="",api_key_alias="None",api_provider="openai",hashed_api_key="litellm_proxy_master_key",litellm_model_name="gpt-5-nano",model_group="zero-remaining-demo",model_id="4d4b7229..."} 0.0
```

That stale `1.0` is the part that bothers me. A missing series is at least visibly missing. This one sits on a dashboard looking fine while the quota is gone, and any alert on `litellm_remaining_requests_metric == 0` stays quiet

## Type

🐛 Bug Fix

## Changes

Two guards in `set_llm_deployment_success_metrics`:

```python
-            if remaining_requests:
+            if remaining_requests is not None:
...
-            if remaining_tokens:
+            if remaining_tokens is not None:
```

Plus one regression test in `tests/test_litellm/integrations/test_prometheus_remaining_tokens_router_fallback.py` that feeds `0` for both headers and asserts the gauges get set to `0`. On the old code it fails with `Expected 'set' to be called once. Called 0 times.`

I originally put that test under `tests/enterprise/`, which was a mistake: no workflow references that path, so the test never ran in CI and codecov correctly reported `0.00%` of the diff covered. It now lives next to the router-fallback tests for the same two gauges, which is where the contrast belongs anyway. That file documents LIT-2719, where these gauges went missing for providers that send no rate-limit headers; this change covers the opposite path, where the header arrives and says zero

## QA runbook

1. start a proxy with the config above
2. send two chat completions to `zero-remaining-demo`; the second response header should read `x-ratelimit-remaining-requests: 0`
3. `curl -sL -H "Authorization: Bearer sk-1234" http://localhost:4000/metrics | grep "^litellm_remaining_requests_metric{"` should show `0.0`
4. on unpatched code the same series shows `1.0`

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


