### PR TITLE
Show recent session logs first in the UI drawer

### DIFF
--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -3359,7 +3359,7 @@ async def ui_view_session_spend_logs(
                 session_id, status, mcp_namespaced_tool_name, agent_id
             FROM "LiteLLM_SpendLogs"
             WHERE session_id = $1
-            ORDER BY "startTime" ASC
+            ORDER BY "startTime" DESC
             LIMIT $2 OFFSET $3
         """
         result = await prisma_client.db.query_raw(

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
@@ -1311,6 +1311,7 @@ async def test_ui_view_session_spend_logs_pagination(client, monkeypatch):
 
         async def query_raw(self, sql_query, session_id, page_size, skip):
             # Endpoint uses raw SQL for pagination - verify params
+            assert 'ORDER BY "startTime" DESC' in sql_query
             assert session_id == "session-123"
             assert page_size == 1
             assert skip == 1  # page=2, page_size=1


### PR DESCRIPTION
## Summary
- fetch the newest session spend logs first for the UI session drawer
- keep the existing frontend chronological ordering for the returned page
- add a regression assertion for the session logs SQL ordering

## Why
The session drawer currently calls `/spend/logs/session/ui` without pagination controls, while the endpoint returns the first 50 rows ordered oldest-first. For sessions with more than 50 requests, recent requests are unreachable from the UI.

## Validation
- `uv run --extra proxy python -m pytest tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py::test_ui_view_session_spend_logs_pagination -q`
- `uv run ruff check litellm/proxy/spend_tracking/spend_management_endpoints.py tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py`
- `git diff --check`

Fixes #29153