### PR TITLE
feat(spend): caller-scoped /key /user /team /org /spend/report endpoints (LIT-2401)

### DIFF
--- a/backend/routes/allowlist.py
+++ b/backend/routes/allowlist.py
@@ -18,6 +18,7 @@ BACKEND_PATH_PREFIXES: tuple[str, ...] = (
     "/team/",
     "/v2/team/",
     "/organization/",
+    "/org/",  # caller-scoped /org/spend/report etc. (LIT-2401)
     "/customer/",
     "/end_user/",
     "/sso/",

--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -1321,14 +1321,25 @@ async def get_global_spend_report(
 # ============================================================================
 
 
+# Hard allowlist of every column ``_build_spend_by_model_sql`` is allowed to
+# splice into its f-string. Adding a column here is intentional and reviewable.
+_SPEND_REPORT_FILTER_COLUMNS = frozenset({"api_key", "user", "team_id"})
+
+
 def _build_spend_by_model_sql(filter_column: str, filter_param_index: int) -> str:
     """
     Build a parameterized SQL that returns spend grouped by api_key, with a
     per-model breakdown, optionally filtered by a single scope column.
 
-    ``filter_column`` must be a trusted, hard-coded column name (never user
-    input). ``filter_param_index`` is 1-based.
+    ``filter_column`` MUST be one of ``_SPEND_REPORT_FILTER_COLUMNS`` - it is
+    f-string-interpolated into the query, so callers must never pass user
+    input directly. ``filter_param_index`` is 1-based.
     """
+    if filter_column not in _SPEND_REPORT_FILTER_COLUMNS:
+        raise ValueError(
+            f"Unsupported filter_column: {filter_column!r}. "
+            f"Allowed: {sorted(_SPEND_REPORT_FILTER_COLUMNS)}"
+        )
     return f"""
         WITH SpendByModelApiKey AS (
             SELECT
@@ -1570,8 +1581,10 @@ async def get_key_spend_report(
     except HTTPException:
         raise
     except Exception as e:
+        # Unexpected fault below the HTTP-level checks (database driver, SQL
+        # error, serialisation, ...) is a server-side fault, not a bad request.
         raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail={"error": str(e)},
         )
 
@@ -1635,8 +1648,10 @@ async def get_user_spend_report(
     except HTTPException:
         raise
     except Exception as e:
+        # Unexpected fault below the HTTP-level checks (database driver, SQL
+        # error, serialisation, ...) is a server-side fault, not a bad request.
         raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail={"error": str(e)},
         )
 
@@ -1697,8 +1712,10 @@ async def get_team_spend_report(
     except HTTPException:
         raise
     except Exception as e:
+        # Unexpected fault below the HTTP-level checks (database driver, SQL
+        # error, serialisation, ...) is a server-side fault, not a bad request.
         raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail={"error": str(e)},
         )
 
@@ -1800,8 +1817,10 @@ async def get_org_spend_report(
     except HTTPException:
         raise
     except Exception as e:
+        # Unexpected fault below the HTTP-level checks (database driver, SQL
+        # error, serialisation, ...) is a server-side fault, not a bad request.
         raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail={"error": str(e)},
         )
 

--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -1310,6 +1310,508 @@ async def get_global_spend_report(
         )
 
 
+
+
+# ============================================================================
+# LIT-2401: Caller-scoped /spend/report variants.
+#
+# ``/global/spend/report`` returns spend across the whole proxy. The four
+# endpoints below mirror its response shape but auto-scope to the caller's
+# identity (api_key, user_id, team_id, org_id), so non-admin callers can view
+# their own slice without depending on admin-only paths. Proxy admins may
+# still pass an override query param to inspect any scope.
+# ============================================================================
+
+
+def _build_spend_by_model_sql(filter_column: str, filter_param_index: int) -> str:
+    """
+    Build a parameterized SQL that returns spend grouped by api_key, with a
+    per-model breakdown, optionally filtered by a single scope column.
+
+    ``filter_column`` must be a trusted, hard-coded column name (never user
+    input). ``filter_param_index`` is 1-based.
+    """
+    return f"""
+        WITH SpendByModelApiKey AS (
+            SELECT
+                sl.api_key,
+                sl.model,
+                SUM(sl.spend) AS model_cost,
+                SUM(sl.prompt_tokens) AS model_input_tokens,
+                SUM(sl.completion_tokens) AS model_output_tokens
+            FROM
+                "LiteLLM_SpendLogs" sl
+            WHERE
+                sl."startTime" >= ($1::timestamptz AT TIME ZONE 'UTC')
+                AND sl."startTime" <  (($2::timestamptz + INTERVAL '1 day') AT TIME ZONE 'UTC')
+                AND sl.{filter_column} = ${filter_param_index}
+            GROUP BY
+                sl.api_key,
+                sl.model
+        )
+        SELECT
+            api_key,
+            SUM(model_cost) AS total_cost,
+            SUM(model_input_tokens) AS total_input_tokens,
+            SUM(model_output_tokens) AS total_output_tokens,
+            jsonb_agg(jsonb_build_object(
+                'model', model,
+                'total_cost', model_cost,
+                'total_input_tokens', model_input_tokens,
+                'total_output_tokens', model_output_tokens
+            )) AS model_details
+        FROM
+            SpendByModelApiKey
+        GROUP BY
+            api_key
+        ORDER BY
+            total_cost DESC;
+    """
+
+
+def _parse_spend_report_date_range(start_date, end_date):
+    if start_date is None or end_date is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"error": "Please provide start_date and end_date"},
+        )
+    start_date_obj = datetime.strptime(start_date, "%Y-%m-%d").replace(
+        tzinfo=timezone.utc
+    )
+    end_date_obj = datetime.strptime(end_date, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+    return start_date_obj, end_date_obj
+
+
+def _resolve_api_key_scope(
+    user_api_key_dict: UserAPIKeyAuth, api_key: Optional[str]
+) -> str:
+    """
+    Return the hashed api_key the caller is authorized to query spend for.
+
+    - Proxy admins may pass any ``api_key`` (or omit for their own key).
+    - Non-admins may only query their own api_key.
+    """
+    is_admin = _is_admin_view_safe(user_api_key_dict=user_api_key_dict)
+    if api_key:
+        if api_key.startswith("sk-"):
+            api_key = hash_token(token=api_key)
+        if not is_admin and api_key != user_api_key_dict.api_key:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail={
+                    "error": "Not authorized to view spend for a different api_key."
+                },
+            )
+        return api_key
+    if user_api_key_dict.api_key is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"error": "No api_key associated with caller; pass ?api_key=..."},
+        )
+    return user_api_key_dict.api_key
+
+
+def _resolve_user_scope(
+    user_api_key_dict: UserAPIKeyAuth, internal_user_id: Optional[str]
+) -> str:
+    """
+    Return the internal_user_id the caller is authorized to query spend for.
+
+    - Proxy admins may pass any ``internal_user_id`` (or omit for their own).
+    - All other callers may only query their own user_id.
+    """
+    is_admin = _is_admin_view_safe(user_api_key_dict=user_api_key_dict)
+    if internal_user_id:
+        if not is_admin and internal_user_id != user_api_key_dict.user_id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail={
+                    "error": "Not authorized to view spend for a different user_id."
+                },
+            )
+        return internal_user_id
+    if user_api_key_dict.user_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "error": "No user_id associated with caller; pass ?internal_user_id=..."
+            },
+        )
+    return user_api_key_dict.user_id
+
+
+def _resolve_team_scope(
+    user_api_key_dict: UserAPIKeyAuth, team_id: Optional[str]
+) -> str:
+    """
+    Return the team_id the caller is authorized to query spend for.
+
+    - Proxy admins may pass any ``team_id`` (or omit for their key's team).
+    - Non-admins may only query the team their key currently belongs to.
+    """
+    is_admin = _is_admin_view_safe(user_api_key_dict=user_api_key_dict)
+    if team_id:
+        if not is_admin and team_id != user_api_key_dict.team_id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail={
+                    "error": "Not authorized to view spend for a different team_id."
+                },
+            )
+        return team_id
+    if user_api_key_dict.team_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"error": "No team_id associated with caller; pass ?team_id=..."},
+        )
+    return user_api_key_dict.team_id
+
+
+async def _resolve_org_scope(
+    user_api_key_dict: UserAPIKeyAuth,
+    organization_id: Optional[str],
+    prisma_client,
+) -> List[str]:
+    """
+    Return the list of team_ids that make up the organization the caller is
+    authorized to query spend for.
+
+    - Proxy admins may pass any ``organization_id`` (or omit for their own).
+    - Org admins may only query their own ``organization_id``.
+    - All other callers are denied.
+    """
+    is_admin = _is_admin_view_safe(user_api_key_dict=user_api_key_dict)
+    is_org_admin = user_api_key_dict.user_role == LitellmUserRoles.ORG_ADMIN
+    if not is_admin and not is_org_admin:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "error": "Only proxy or organization admins may call /org/spend/report."
+            },
+        )
+    target_org = organization_id or user_api_key_dict.org_id
+    if not target_org:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "error": "No organization_id resolved for caller; pass ?organization_id=..."
+            },
+        )
+    if (
+        not is_admin
+        and is_org_admin
+        and target_org != user_api_key_dict.org_id
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "error": "Not authorized to view spend for a different organization_id."
+            },
+        )
+    teams = await prisma_client.db.litellm_teamtable.find_many(
+        where={"organization_id": target_org}
+    )
+    return [t.team_id for t in (teams or [])]
+
+
+@router.get(
+    "/key/spend/report",
+    tags=["Budget & Spend Tracking"],
+    dependencies=[Depends(user_api_key_auth)],
+    responses={200: {"model": List[LiteLLM_SpendLogs]}},
+)
+async def get_key_spend_report(
+    start_date: Optional[str] = fastapi.Query(
+        default=None, description="Start date (YYYY-MM-DD) inclusive."
+    ),
+    end_date: Optional[str] = fastapi.Query(
+        default=None, description="End date (YYYY-MM-DD) inclusive."
+    ),
+    api_key: Optional[str] = fastapi.Query(
+        default=None,
+        description=(
+            "Override the queried api_key. Proxy admins only - non-admin callers "
+            "are auto-scoped to their own key."
+        ),
+    ),
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+):
+    """
+    Spend report scoped to a single api_key.
+
+    Returns the same shape as ``/global/spend/report?api_key=...`` - one row
+    per api_key with a per-model breakdown - but auto-scopes to the caller's
+    own api_key when no override is supplied. Non-admin callers may not pass
+    an ``api_key`` that does not match their own.
+    """
+    from litellm.proxy.proxy_server import premium_user, prisma_client
+
+    if prisma_client is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail={"error": "Database not connected."},
+        )
+    if premium_user is not True:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "error": "/spend/report endpoint "
+                + CommonProxyErrors.not_premium_user.value
+            },
+        )
+    try:
+        start_date_obj, end_date_obj = _parse_spend_report_date_range(
+            start_date, end_date
+        )
+        resolved_api_key = _resolve_api_key_scope(
+            user_api_key_dict=user_api_key_dict, api_key=api_key
+        )
+        sql_query = _build_spend_by_model_sql(
+            filter_column="api_key", filter_param_index=3
+        )
+        db_response = await prisma_client.db.query_raw(
+            sql_query, start_date_obj, end_date_obj, resolved_api_key
+        )
+        return db_response or []
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"error": str(e)},
+        )
+
+
+@router.get(
+    "/user/spend/report",
+    tags=["Budget & Spend Tracking"],
+    dependencies=[Depends(user_api_key_auth)],
+    responses={200: {"model": List[LiteLLM_SpendLogs]}},
+)
+async def get_user_spend_report(
+    start_date: Optional[str] = fastapi.Query(default=None),
+    end_date: Optional[str] = fastapi.Query(default=None),
+    internal_user_id: Optional[str] = fastapi.Query(
+        default=None,
+        description=(
+            "Override the queried internal_user_id. Proxy admins only - "
+            "non-admin callers are auto-scoped to their own user_id."
+        ),
+    ),
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+):
+    """
+    Spend report scoped to a single internal_user_id.
+
+    Returns the same shape as ``/global/spend/report?internal_user_id=...`` -
+    one row per api_key used by the user with a per-model breakdown - but
+    auto-scopes to the caller's own ``user_id`` when no override is supplied.
+    """
+    from litellm.proxy.proxy_server import premium_user, prisma_client
+
+    if prisma_client is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail={"error": "Database not connected."},
+        )
+    if premium_user is not True:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "error": "/spend/report endpoint "
+                + CommonProxyErrors.not_premium_user.value
+            },
+        )
+    try:
+        start_date_obj, end_date_obj = _parse_spend_report_date_range(
+            start_date, end_date
+        )
+        resolved_user_id = _resolve_user_scope(
+            user_api_key_dict=user_api_key_dict, internal_user_id=internal_user_id
+        )
+        # The LiteLLM_SpendLogs schema uses the column name ``user`` (legacy).
+        # The existing /global/spend/report query references it as ``sl.user``.
+        sql_query = _build_spend_by_model_sql(
+            filter_column="user", filter_param_index=3
+        )
+        db_response = await prisma_client.db.query_raw(
+            sql_query, start_date_obj, end_date_obj, resolved_user_id
+        )
+        return db_response or []
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"error": str(e)},
+        )
+
+
+@router.get(
+    "/team/spend/report",
+    tags=["Budget & Spend Tracking"],
+    dependencies=[Depends(user_api_key_auth)],
+    responses={200: {"model": List[LiteLLM_SpendLogs]}},
+)
+async def get_team_spend_report(
+    start_date: Optional[str] = fastapi.Query(default=None),
+    end_date: Optional[str] = fastapi.Query(default=None),
+    team_id: Optional[str] = fastapi.Query(
+        default=None,
+        description=(
+            "Override the queried team_id. Proxy admins only - non-admin "
+            "callers are auto-scoped to the team_id on their key."
+        ),
+    ),
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+):
+    """
+    Spend report scoped to a single team_id.
+
+    One row per api_key used by the team with a per-model breakdown.
+    Auto-scopes to the caller's key.team_id when no override is supplied.
+    """
+    from litellm.proxy.proxy_server import premium_user, prisma_client
+
+    if prisma_client is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail={"error": "Database not connected."},
+        )
+    if premium_user is not True:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "error": "/spend/report endpoint "
+                + CommonProxyErrors.not_premium_user.value
+            },
+        )
+    try:
+        start_date_obj, end_date_obj = _parse_spend_report_date_range(
+            start_date, end_date
+        )
+        resolved_team_id = _resolve_team_scope(
+            user_api_key_dict=user_api_key_dict, team_id=team_id
+        )
+        sql_query = _build_spend_by_model_sql(
+            filter_column="team_id", filter_param_index=3
+        )
+        db_response = await prisma_client.db.query_raw(
+            sql_query, start_date_obj, end_date_obj, resolved_team_id
+        )
+        return db_response or []
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"error": str(e)},
+        )
+
+
+@router.get(
+    "/org/spend/report",
+    tags=["Budget & Spend Tracking"],
+    dependencies=[Depends(user_api_key_auth)],
+    responses={200: {"model": List[LiteLLM_SpendLogs]}},
+)
+async def get_org_spend_report(
+    start_date: Optional[str] = fastapi.Query(default=None),
+    end_date: Optional[str] = fastapi.Query(default=None),
+    organization_id: Optional[str] = fastapi.Query(
+        default=None,
+        description=(
+            "Override the queried organization_id. Proxy admins only - "
+            "org admins are auto-scoped to their own organization."
+        ),
+    ),
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+):
+    """
+    Spend report scoped to a single organization (all of its teams).
+
+    One row per api_key used by any team in the org, with a per-model
+    breakdown. Auto-scopes to the caller's ``org_id`` when no override is
+    supplied. Returns ``[]`` if the org has no teams.
+    """
+    from litellm.proxy.proxy_server import premium_user, prisma_client
+
+    if prisma_client is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail={"error": "Database not connected."},
+        )
+    if premium_user is not True:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "error": "/spend/report endpoint "
+                + CommonProxyErrors.not_premium_user.value
+            },
+        )
+    try:
+        start_date_obj, end_date_obj = _parse_spend_report_date_range(
+            start_date, end_date
+        )
+        team_ids = await _resolve_org_scope(
+            user_api_key_dict=user_api_key_dict,
+            organization_id=organization_id,
+            prisma_client=prisma_client,
+        )
+        if not team_ids:
+            return []
+        sql_query = """
+            WITH SpendByModelApiKey AS (
+                SELECT
+                    sl.api_key,
+                    sl.team_id,
+                    sl.model,
+                    SUM(sl.spend) AS model_cost,
+                    SUM(sl.prompt_tokens) AS model_input_tokens,
+                    SUM(sl.completion_tokens) AS model_output_tokens
+                FROM
+                    "LiteLLM_SpendLogs" sl
+                WHERE
+                    sl."startTime" >= ($1::timestamptz AT TIME ZONE 'UTC')
+                    AND sl."startTime" <  (($2::timestamptz + INTERVAL '1 day') AT TIME ZONE 'UTC')
+                    AND sl.team_id = ANY($3::text[])
+                GROUP BY
+                    sl.api_key,
+                    sl.team_id,
+                    sl.model
+            )
+            SELECT
+                api_key,
+                SUM(model_cost) AS total_cost,
+                SUM(model_input_tokens) AS total_input_tokens,
+                SUM(model_output_tokens) AS total_output_tokens,
+                jsonb_agg(jsonb_build_object(
+                    'team_id', team_id,
+                    'model', model,
+                    'total_cost', model_cost,
+                    'total_input_tokens', model_input_tokens,
+                    'total_output_tokens', model_output_tokens
+                )) AS model_details
+            FROM
+                SpendByModelApiKey
+            GROUP BY
+                api_key
+            ORDER BY
+                total_cost DESC;
+        """
+        db_response = await prisma_client.db.query_raw(
+            sql_query, start_date_obj, end_date_obj, team_ids
+        )
+        return db_response or []
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"error": str(e)},
+        )
+
+
 @router.get(
     "/global/spend/all_tag_names",
     tags=["Budget & Spend Tracking"],

--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -1310,8 +1310,6 @@ async def get_global_spend_report(
         )
 
 
-
-
 # ============================================================================
 # LIT-2401: Caller-scoped /spend/report variants.
 #
@@ -1497,11 +1495,7 @@ async def _resolve_org_scope(
                 "error": "No organization_id resolved for caller; pass ?organization_id=..."
             },
         )
-    if (
-        not is_admin
-        and is_org_admin
-        and target_org != user_api_key_dict.org_id
-    ):
+    if not is_admin and is_org_admin and target_org != user_api_key_dict.org_id:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail={

--- a/tests/test_litellm/proxy/spend_tracking/test_scoped_spend_report.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_scoped_spend_report.py
@@ -341,3 +341,27 @@ async def test_key_spend_report_missing_dates_400(monkeypatch):
             user_api_key_dict=_admin(),
         )
     assert ei.value.status_code == 400
+
+
+def test_build_spend_by_model_sql_rejects_unknown_column():
+    """Future-proofing: any column outside the allowlist must raise ValueError."""
+    for bad in ("evil; DROP TABLE", "metadata", ""):
+        with pytest.raises(ValueError):
+            sme._build_spend_by_model_sql(filter_column=bad, filter_param_index=3)
+
+
+@pytest.mark.asyncio
+async def test_key_spend_report_db_failure_returns_500(monkeypatch):
+    """A non-HTTPException from prisma_client must surface as HTTP 500."""
+    pc = MagicMock()
+    pc.db.query_raw = AsyncMock(side_effect=RuntimeError("connection refused"))
+    monkeypatch.setattr(ps, "prisma_client", pc, raising=False)
+    monkeypatch.setattr(ps, "premium_user", True, raising=False)
+    with pytest.raises(HTTPException) as ei:
+        await sme.get_key_spend_report(
+            start_date="2026-05-01",
+            end_date="2026-05-28",
+            api_key=None,
+            user_api_key_dict=_admin(),
+        )
+    assert ei.value.status_code == 500

--- a/tests/test_litellm/proxy/spend_tracking/test_scoped_spend_report.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_scoped_spend_report.py
@@ -1,4 +1,5 @@
 """Tests for caller-scoped /spend/report endpoints (LIT-2401)."""
+
 import datetime
 import os
 import sys
@@ -47,7 +48,9 @@ def _org_admin():
 
 def test_resolve_api_key_defaults_to_caller():
     auth = _internal_user()
-    assert sme._resolve_api_key_scope(user_api_key_dict=auth, api_key=None) == auth.api_key
+    assert (
+        sme._resolve_api_key_scope(user_api_key_dict=auth, api_key=None) == auth.api_key
+    )
 
 
 def test_resolve_api_key_non_admin_override_forbidden():
@@ -234,11 +237,11 @@ async def test_key_spend_report_calls_query_with_resolved_hash(monkeypatch):
         user_api_key_dict=auth,
     )
     assert out == [{"api_key": "h", "total_cost": 1.0}]
-    args, _ = pc.db.query_raw.await_args
-    sql, sd, ed, k = args[0], args[1], args[2], args[3]
+    args, _kw = pc.db.query_raw.await_args
+    sql, _sd, _ed, k = args[0], args[1], args[2], args[3]
     assert "sl.api_key = $3" in sql
     assert k == auth.api_key
-    assert isinstance(sd, datetime.datetime) and sd.tzinfo == timezone.utc
+    assert isinstance(_sd, datetime.datetime) and _sd.tzinfo == timezone.utc
 
 
 @pytest.mark.asyncio
@@ -267,8 +270,8 @@ async def test_team_spend_report_uses_team_id_filter(monkeypatch):
         team_id=None,
         user_api_key_dict=_internal_user(),
     )
-    args, _ = pc.db.query_raw.await_args
-    sql, sd, ed, t = args[0], args[1], args[2], args[3]
+    args, _kw = pc.db.query_raw.await_args
+    sql, _sd, _ed, t = args[0], args[1], args[2], args[3]
     assert "sl.team_id = $3" in sql
     assert t == "team-blue"
 
@@ -287,8 +290,8 @@ async def test_org_spend_report_org_admin_runs_against_own_org_teams(monkeypatch
         organization_id=None,
         user_api_key_dict=_org_admin(),
     )
-    args, _ = pc.db.query_raw.await_args
-    sql, sd, ed, teams_param = args[0], args[1], args[2], args[3]
+    args, _kw = pc.db.query_raw.await_args
+    sql, _sd, _ed, teams_param = args[0], args[1], args[2], args[3]
     assert "team_id = ANY($3::text[])" in sql
     assert teams_param == ["team-red", "team-blue"]
 

--- a/tests/test_litellm/proxy/spend_tracking/test_scoped_spend_report.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_scoped_spend_report.py
@@ -1,0 +1,340 @@
+"""Tests for caller-scoped /spend/report endpoints (LIT-2401)."""
+import datetime
+import os
+import sys
+from datetime import timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+sys.path.insert(0, os.path.abspath("../../../.."))
+
+import litellm.proxy.proxy_server as ps
+from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+from litellm.proxy.spend_tracking import spend_management_endpoints as sme
+
+
+def _admin():
+    return UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+        user_id="admin-1",
+        api_key="sk-admin-hashed",
+        team_id="team-admin",
+        org_id="org-admin",
+    )
+
+
+def _internal_user():
+    return UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        user_id="user-7",
+        api_key="sk-user-hashed",
+        team_id="team-blue",
+        org_id="org-acme",
+    )
+
+
+def _org_admin():
+    return UserAPIKeyAuth(
+        user_role=LitellmUserRoles.ORG_ADMIN,
+        user_id="orgadmin-1",
+        api_key="sk-orgadmin-hashed",
+        team_id="team-red",
+        org_id="org-acme",
+    )
+
+
+def test_resolve_api_key_defaults_to_caller():
+    auth = _internal_user()
+    assert sme._resolve_api_key_scope(user_api_key_dict=auth, api_key=None) == auth.api_key
+
+
+def test_resolve_api_key_non_admin_override_forbidden():
+    auth = _internal_user()
+    with pytest.raises(HTTPException) as ei:
+        sme._resolve_api_key_scope(
+            user_api_key_dict=auth, api_key="someone-elses-hashed-token"
+        )
+    assert ei.value.status_code == 403
+
+
+def test_resolve_api_key_admin_can_override():
+    auth = _admin()
+    assert (
+        sme._resolve_api_key_scope(
+            user_api_key_dict=auth, api_key="another-hashed-token"
+        )
+        == "another-hashed-token"
+    )
+
+
+def test_resolve_api_key_sk_prefix_gets_hashed():
+    auth = _admin()
+    out = sme._resolve_api_key_scope(user_api_key_dict=auth, api_key="sk-12345")
+    assert not out.startswith("sk-")
+    assert len(out) == 64
+
+
+def test_resolve_api_key_no_caller_key_raises_400():
+    auth = UserAPIKeyAuth(user_role=LitellmUserRoles.INTERNAL_USER, user_id="u")
+    with pytest.raises(HTTPException) as ei:
+        sme._resolve_api_key_scope(user_api_key_dict=auth, api_key=None)
+    assert ei.value.status_code == 400
+
+
+def test_resolve_user_defaults_to_caller():
+    auth = _internal_user()
+    assert (
+        sme._resolve_user_scope(user_api_key_dict=auth, internal_user_id=None)
+        == auth.user_id
+    )
+
+
+def test_resolve_user_non_admin_override_forbidden():
+    auth = _internal_user()
+    with pytest.raises(HTTPException) as ei:
+        sme._resolve_user_scope(user_api_key_dict=auth, internal_user_id="someone-else")
+    assert ei.value.status_code == 403
+
+
+def test_resolve_user_admin_can_override():
+    auth = _admin()
+    assert (
+        sme._resolve_user_scope(user_api_key_dict=auth, internal_user_id="other-user")
+        == "other-user"
+    )
+
+
+def test_resolve_user_no_user_id_raises_400():
+    auth = UserAPIKeyAuth(user_role=LitellmUserRoles.INTERNAL_USER, api_key="sk-x")
+    with pytest.raises(HTTPException) as ei:
+        sme._resolve_user_scope(user_api_key_dict=auth, internal_user_id=None)
+    assert ei.value.status_code == 400
+
+
+def test_resolve_team_defaults_to_caller():
+    auth = _internal_user()
+    assert sme._resolve_team_scope(user_api_key_dict=auth, team_id=None) == auth.team_id
+
+
+def test_resolve_team_non_admin_override_forbidden():
+    auth = _internal_user()
+    with pytest.raises(HTTPException) as ei:
+        sme._resolve_team_scope(user_api_key_dict=auth, team_id="other-team")
+    assert ei.value.status_code == 403
+
+
+def test_resolve_team_admin_can_override():
+    auth = _admin()
+    assert (
+        sme._resolve_team_scope(user_api_key_dict=auth, team_id="other-team")
+        == "other-team"
+    )
+
+
+def test_resolve_team_no_team_id_raises_400():
+    auth = UserAPIKeyAuth(user_role=LitellmUserRoles.INTERNAL_USER, user_id="u")
+    with pytest.raises(HTTPException) as ei:
+        sme._resolve_team_scope(user_api_key_dict=auth, team_id=None)
+    assert ei.value.status_code == 400
+
+
+def _mock_prisma_with_teams(team_ids):
+    pc = MagicMock()
+    team_rows = [MagicMock(team_id=t) for t in team_ids]
+    pc.db.litellm_teamtable.find_many = AsyncMock(return_value=team_rows)
+    return pc
+
+
+@pytest.mark.asyncio
+async def test_resolve_org_internal_user_denied():
+    auth = _internal_user()
+    pc = _mock_prisma_with_teams(["team-blue"])
+    with pytest.raises(HTTPException) as ei:
+        await sme._resolve_org_scope(
+            user_api_key_dict=auth, organization_id=None, prisma_client=pc
+        )
+    assert ei.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_resolve_org_org_admin_defaults_to_own_org():
+    auth = _org_admin()
+    pc = _mock_prisma_with_teams(["team-red", "team-blue"])
+    out = await sme._resolve_org_scope(
+        user_api_key_dict=auth, organization_id=None, prisma_client=pc
+    )
+    assert out == ["team-red", "team-blue"]
+    pc.db.litellm_teamtable.find_many.assert_awaited_once_with(
+        where={"organization_id": "org-acme"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_org_admin_can_override():
+    auth = _admin()
+    pc = _mock_prisma_with_teams(["team-x"])
+    out = await sme._resolve_org_scope(
+        user_api_key_dict=auth, organization_id="other-org", prisma_client=pc
+    )
+    assert out == ["team-x"]
+    pc.db.litellm_teamtable.find_many.assert_awaited_once_with(
+        where={"organization_id": "other-org"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_org_org_admin_cannot_override_to_other_org():
+    auth = _org_admin()
+    pc = _mock_prisma_with_teams([])
+    with pytest.raises(HTTPException) as ei:
+        await sme._resolve_org_scope(
+            user_api_key_dict=auth,
+            organization_id="not-my-org",
+            prisma_client=pc,
+        )
+    assert ei.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_resolve_org_no_org_raises_400():
+    auth = UserAPIKeyAuth(user_role=LitellmUserRoles.ORG_ADMIN, user_id="oa")
+    pc = _mock_prisma_with_teams([])
+    with pytest.raises(HTTPException) as ei:
+        await sme._resolve_org_scope(
+            user_api_key_dict=auth, organization_id=None, prisma_client=pc
+        )
+    assert ei.value.status_code == 400
+
+
+def test_build_spend_by_model_sql_inlines_column_and_index():
+    s = sme._build_spend_by_model_sql(filter_column="team_id", filter_param_index=3)
+    assert "sl.team_id = $3" in s
+    assert "sl.api_key" in s
+    assert "model_details" in s
+
+
+def _mock_prisma_with_response(rows):
+    pc = MagicMock()
+    pc.db.query_raw = AsyncMock(return_value=rows)
+    return pc
+
+
+@pytest.mark.asyncio
+async def test_key_spend_report_calls_query_with_resolved_hash(monkeypatch):
+    pc = _mock_prisma_with_response([{"api_key": "h", "total_cost": 1.0}])
+    monkeypatch.setattr(ps, "prisma_client", pc, raising=False)
+    monkeypatch.setattr(ps, "premium_user", True, raising=False)
+    auth = _internal_user()
+    out = await sme.get_key_spend_report(
+        start_date="2026-05-01",
+        end_date="2026-05-28",
+        api_key=None,
+        user_api_key_dict=auth,
+    )
+    assert out == [{"api_key": "h", "total_cost": 1.0}]
+    args, _ = pc.db.query_raw.await_args
+    sql, sd, ed, k = args[0], args[1], args[2], args[3]
+    assert "sl.api_key = $3" in sql
+    assert k == auth.api_key
+    assert isinstance(sd, datetime.datetime) and sd.tzinfo == timezone.utc
+
+
+@pytest.mark.asyncio
+async def test_user_spend_report_non_admin_cannot_override(monkeypatch):
+    pc = _mock_prisma_with_response([])
+    monkeypatch.setattr(ps, "prisma_client", pc, raising=False)
+    monkeypatch.setattr(ps, "premium_user", True, raising=False)
+    with pytest.raises(HTTPException) as ei:
+        await sme.get_user_spend_report(
+            start_date="2026-05-01",
+            end_date="2026-05-28",
+            internal_user_id="someone-else",
+            user_api_key_dict=_internal_user(),
+        )
+    assert ei.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_team_spend_report_uses_team_id_filter(monkeypatch):
+    pc = _mock_prisma_with_response([{"api_key": "h"}])
+    monkeypatch.setattr(ps, "prisma_client", pc, raising=False)
+    monkeypatch.setattr(ps, "premium_user", True, raising=False)
+    await sme.get_team_spend_report(
+        start_date="2026-05-01",
+        end_date="2026-05-28",
+        team_id=None,
+        user_api_key_dict=_internal_user(),
+    )
+    args, _ = pc.db.query_raw.await_args
+    sql, sd, ed, t = args[0], args[1], args[2], args[3]
+    assert "sl.team_id = $3" in sql
+    assert t == "team-blue"
+
+
+@pytest.mark.asyncio
+async def test_org_spend_report_org_admin_runs_against_own_org_teams(monkeypatch):
+    pc = MagicMock()
+    team_rows = [MagicMock(team_id="team-red"), MagicMock(team_id="team-blue")]
+    pc.db.litellm_teamtable.find_many = AsyncMock(return_value=team_rows)
+    pc.db.query_raw = AsyncMock(return_value=[{"api_key": "h"}])
+    monkeypatch.setattr(ps, "prisma_client", pc, raising=False)
+    monkeypatch.setattr(ps, "premium_user", True, raising=False)
+    await sme.get_org_spend_report(
+        start_date="2026-05-01",
+        end_date="2026-05-28",
+        organization_id=None,
+        user_api_key_dict=_org_admin(),
+    )
+    args, _ = pc.db.query_raw.await_args
+    sql, sd, ed, teams_param = args[0], args[1], args[2], args[3]
+    assert "team_id = ANY($3::text[])" in sql
+    assert teams_param == ["team-red", "team-blue"]
+
+
+@pytest.mark.asyncio
+async def test_org_spend_report_no_teams_short_circuits(monkeypatch):
+    pc = MagicMock()
+    pc.db.litellm_teamtable.find_many = AsyncMock(return_value=[])
+    pc.db.query_raw = AsyncMock(return_value=[])
+    monkeypatch.setattr(ps, "prisma_client", pc, raising=False)
+    monkeypatch.setattr(ps, "premium_user", True, raising=False)
+    out = await sme.get_org_spend_report(
+        start_date="2026-05-01",
+        end_date="2026-05-28",
+        organization_id=None,
+        user_api_key_dict=_org_admin(),
+    )
+    assert out == []
+    pc.db.query_raw.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_key_spend_report_not_premium_returns_403(monkeypatch):
+    pc = _mock_prisma_with_response([])
+    monkeypatch.setattr(ps, "prisma_client", pc, raising=False)
+    monkeypatch.setattr(ps, "premium_user", False, raising=False)
+    with pytest.raises(HTTPException) as ei:
+        await sme.get_key_spend_report(
+            start_date="2026-05-01",
+            end_date="2026-05-28",
+            api_key=None,
+            user_api_key_dict=_admin(),
+        )
+    assert ei.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_key_spend_report_missing_dates_400(monkeypatch):
+    pc = _mock_prisma_with_response([])
+    monkeypatch.setattr(ps, "prisma_client", pc, raising=False)
+    monkeypatch.setattr(ps, "premium_user", True, raising=False)
+    with pytest.raises(HTTPException) as ei:
+        await sme.get_key_spend_report(
+            start_date=None,
+            end_date=None,
+            api_key=None,
+            user_api_key_dict=_admin(),
+        )
+    assert ei.value.status_code == 400


### PR DESCRIPTION
## What

Adds four caller-scoped variants of `/global/spend/report` that auto-scope
spend reporting to the caller's identity, so non-admin callers can see their
own slice without an admin-only override path. Proxy admins (and org admins,
for the org variant) may still pass an override query param.

| Route | Auto-scopes to | Override (admin only) |
| --- | --- | --- |
| `GET /key/spend/report` | caller's hashed `api_key` | `?api_key=` |
| `GET /user/spend/report` | caller's `user_id` | `?internal_user_id=` |
| `GET /team/spend/report` | caller's `team_id` | `?team_id=` |
| `GET /org/spend/report` | caller's `org_id` (org/proxy admin only) | `?organization_id=` |

All four reuse the existing `LiteLLM_SpendLogs` aggregation pattern from
`get_global_spend_report` and return the same per-api-key + per-model row
shape (org variant also surfaces `team_id` in the per-model break-down).

Linear: [LIT-2401](https://linear.app/litellm-ai/issue/LIT-2401)

## Why

`/global/spend/report` requires the caller to supply the scope (`api_key=`,
`internal_user_id=`, `team_id=`, `customer_id=`) as a query param, with no
identity gating in the endpoint itself. That means there is no first-class
path for an internal user, team member, or org admin to retrieve _their own_
spend report — they have to know how to call a global query and the proxy
trusts whatever scope they pass. The four new endpoints close that gap:
non-admins are auto-scoped to their own identity, and any attempt to
override the scope to a value that doesn't match the caller is rejected
with HTTP 403.

## Change

- `litellm/proxy/spend_tracking/spend_management_endpoints.py`
  - `_build_spend_by_model_sql(filter_column, filter_param_index)` — shared
    SQL builder for the `WHERE sl.<col> = $N` cut.
  - `_parse_spend_report_date_range` — shared `start_date`/`end_date` parser
    that returns UTC-aware `datetime` objects.
  - `_resolve_api_key_scope`, `_resolve_user_scope`, `_resolve_team_scope`
    — identity resolvers that default to caller and 403 on non-admin
    override.
  - `_resolve_org_scope` (async) — role gate (proxy admin OR org admin),
    auto-scopes org admins to their own `org_id`, then expands to the list
    of team_ids in the org via `LiteLLM_TeamTable.find_many`.
  - Four new `@router.get(...)` endpoints — `/key/spend/report`,
    `/user/spend/report`, `/team/spend/report`, `/org/spend/report`.
- `tests/test_litellm/proxy/spend_tracking/test_scoped_spend_report.py` —
  26 regression tests covering each resolver (default-to-caller / non-admin
  override blocked / admin override allowed / missing-identity 400) plus
  endpoint-level integration with `monkeypatched` Prisma asserting:
  - correct hashed `api_key` reaches the SQL,
  - `sl.team_id = $3` for the team variant,
  - `team_id = ANY($3::text[])` with the org admin's resolved team list for
    the org variant,
  - empty-org early-return short-circuits the SQL call,
  - `premium_user is not True` returns 403,
  - missing `start_date`/`end_date` returns 400.

## Evidence

Runtime evidence captured via `fastapi.TestClient` against the patched
router, with `prisma_client.db.query_raw` and `prisma_client.db.litellm_teamtable.find_many`
mocked to return canned rows (full repro script: `/tmp/evidence_run.py` in
the agent sandbox). Each block is a single HTTP request + the live HTTP
response from the patched router, plus the SQL that reached the mocked
Prisma. No customer name is referenced anywhere.

```
==============================================================================
A. /key/spend/report - internal user defaults to own hash
Request:  GET /key/spend/report?start_date=2026-05-01&end_date=2026-05-28  (caller role=internal_user, key=hashed-token-1)
HTTP:     200
Body:     [{"api_key": "hashed-token-1", "total_cost": 12.34, "total_input_tokens": 1000, "total_output_tokens": 500, "model_details": [{"model": "gpt-4", "total_cost": 12.34}]}]
==============================================================================
B. /key/spend/report - internal user OVERRIDE to other key -> 403
Request:  GET /key/spend/report?start_date=2026-05-01&end_date=2026-05-28&api_key=some-other-hashed-token  (caller role=internal_user, key=hashed-token-1)
HTTP:     403
Body:     {"detail": {"error": "Not authorized to view spend for a different api_key."}}
==============================================================================
C. /key/spend/report - admin override sk-1234 -> 200 (hashed before DB)
Request:  GET /key/spend/report?start_date=2026-05-01&end_date=2026-05-28&api_key=sk-1234  (caller role=proxy_admin, key=hashed-token-1)
HTTP:     200
Body:     [{"api_key": "88dc28d0f030c55ed4ab77ed8faf098196cb1c05df778539800c9f1243fe6b4b", "total_cost": 12.34, "total_input_tokens": 1000, "total_output_tokens": 500, "model_details": [{"model": "gpt-4", "total_cost": 12.34}]}]
==============================================================================
D. /user/spend/report - internal user defaults to own user_id
Request:  GET /user/spend/report?start_date=2026-05-01&end_date=2026-05-28  (caller role=internal_user, key=hashed-token-1)
HTTP:     200
Body:     [{"api_key": "u-42", "total_cost": 12.34, "total_input_tokens": 1000, "total_output_tokens": 500, "model_details": [{"model": "gpt-4", "total_cost": 12.34}]}]
==============================================================================
E. /user/spend/report - internal user OVERRIDE to other user_id -> 403
Request:  GET /user/spend/report?start_date=2026-05-01&end_date=2026-05-28&internal_user_id=someone-else  (caller role=internal_user, key=hashed-token-1)
HTTP:     403
Body:     {"detail": {"error": "Not authorized to view spend for a different user_id."}}
==============================================================================
F. /team/spend/report - internal user defaults to own team_id
Request:  GET /team/spend/report?start_date=2026-05-01&end_date=2026-05-28  (caller role=internal_user, key=hashed-token-1)
HTTP:     200
Body:     [{"api_key": "team-blue", "total_cost": 12.34, "total_input_tokens": 1000, "total_output_tokens": 500, "model_details": [{"model": "gpt-4", "total_cost": 12.34}]}]
==============================================================================
G. /org/spend/report - internal user denied -> 403
Request:  GET /org/spend/report?start_date=2026-05-01&end_date=2026-05-28  (caller role=internal_user, key=hashed-token-1)
HTTP:     403
Body:     {"detail": {"error": "Only proxy or organization admins may call /org/spend/report."}}
==============================================================================
H. /org/spend/report - org_admin defaults to own org -> 200
Request:  GET /org/spend/report?start_date=2026-05-01&end_date=2026-05-28  (caller role=org_admin, key=hashed-token-1)
HTTP:     200
Body:     [{"api_key": "team-blue", "total_cost": 12.34, "total_input_tokens": 1000, "total_output_tokens": 500, "model_details": [{"model": "gpt-4", "total_cost": 12.34}]}]
==============================================================================
I. /key/spend/report - missing dates -> 400
Request:  GET /key/spend/report  (caller role=internal_user, key=hashed-token-1)
HTTP:     400
Body:     {"detail": {"error": "Please provide start_date and end_date"}}
==============================================================================
CAPTURED SQL CALLS: 5
--- call #1 ---
WHERE: WITH SpendByModelApiKey AS (
            SELECT
                sl.api_key,
                sl.model,
                SUM(sl.spend) AS model_cost,
                SUM(sl.prompt_tokens) AS model_input_tokens,
                SUM(sl.completion_tokens) AS model_output_tokens
            FROM
                "LiteLLM_SpendLogs" sl
            WHERE
                sl."startTime" >= ($1::timestamptz AT TIME ZONE 'UTC')
                AND sl."startTime" <  (($2::timestamptz + INTERVAL '1 day') AT TIME ZONE 'UTC')
                AND sl.api_key = $3
            GROUP BY
                sl.api_key,
                sl.model
        )
        SELECT
            api_key,
            SUM(model_cost) AS total_cost,
            SUM(model_input_tokens) AS total_input_tokens,
            SUM(model_output_tokens) AS total_output_tokens,
            jsonb_agg(jsonb_build_object(
                'model', model,
                'total_cost', model_cost,
                'total_input_tokens', model_input_tokens,
                'total_output_tokens', model_output_tokens
            )) AS model_details
        FROM
            SpendByModelApiKey
        GROUP BY
            api_key
        ORDER BY
            total_cost DESC;
params: (datetime.datetime(2026, 5, 1, 0, 0, tzinfo=datetime.timezone.utc), datetime.datetime(2026, 5, 28, 0, 0, tzinfo=datetime.timezone.utc), 'hashed-token-1')
--- call #2 ---
WHERE: WITH SpendByModelApiKey AS (
            SELECT
                sl.api_key,
                sl.model,
                SUM(sl.spend) AS model_cost,
                SUM(sl.prompt_tokens) AS model_input_tokens,
                SUM(sl.completion_tokens) AS model_output_tokens
            FROM
                "LiteLLM_SpendLogs" sl
            WHERE
                sl."startTime" >= ($1::timestamptz AT TIME ZONE 'UTC')
                AND sl."startTime" <  (($2::timestamptz + INTERVAL '1 day') AT TIME ZONE 'UTC')
                AND sl.api_key = $3
            GROUP BY
                sl.api_key,
                sl.model
        )
        SELECT
            api_key,
            SUM(model_cost) AS total_cost,
            SUM(model_input_tokens) AS total_input_tokens,
            SUM(model_output_tokens) AS total_output_tokens,
            jsonb_agg(jsonb_build_object(
                'model', model,
                'total_cost', model_cost,
                'total_input_tokens', model_input_tokens,
                'total_output_tokens', model_output_tokens
            )) AS model_details
        FROM
            SpendByModelApiKey
        GROUP BY
            api_key
        ORDER BY
            total_cost DESC;
params: (datetime.datetime(2026, 5, 1, 0, 0, tzinfo=datetime.timezone.utc), datetime.datetime(2026, 5, 28, 0, 0, tzinfo=datetime.timezone.utc), '88dc28d0f030c55ed4ab77ed8faf098196cb1c05df778539800c9f1243fe6b4b')
--- call #3 ---
WHERE: WITH SpendByModelApiKey AS (
            SELECT
                sl.api_key,
                sl.model,
                SUM(sl.spend) AS model_cost,
                SUM(sl.prompt_tokens) AS model_input_tokens,
                SUM(sl.completion_tokens) AS model_output_tokens
            FROM
                "LiteLLM_SpendLogs" sl
            WHERE
                sl."startTime" >= ($1::timestamptz AT TIME ZONE 'UTC')
                AND sl."startTime" <  (($2::timestamptz + INTERVAL '1 day') AT TIME ZONE 'UTC')
                AND sl.user = $3
            GROUP BY
                sl.api_key,
                sl.model
        )
        SELECT
            api_key,
            SUM(model_cost) AS total_cost,
            SUM(model_input_tokens) AS total_input_tokens,
            SUM(model_output_tokens) AS total_output_tokens,
            jsonb_agg(jsonb_build_object(
                'model', model,
                'total_cost', model_cost,
                'total_input_tokens', model_input_tokens,
                'total_output_tokens', model_output_tokens
            )) AS model_details
        FROM
            SpendByModelApiKey
        GROUP BY
            api_key
        ORDER BY
            total_cost DESC;
params: (datetime.datetime(2026, 5, 1, 0, 0, tzinfo=datetime.timezone.utc), datetime.datetime(2026, 5, 28, 0, 0, tzinfo=datetime.timezone.utc), 'u-42')
--- call #4 ---
WHERE: WITH SpendByModelApiKey AS (
            SELECT
                sl.api_key,
                sl.model,
                SUM(sl.spend) AS model_cost,
                SUM(sl.prompt_tokens) AS model_input_tokens,
                SUM(sl.completion_tokens) AS model_output_tokens
            FROM
                "LiteLLM_SpendLogs" sl
            WHERE
                sl."startTime" >= ($1::timestamptz AT TIME ZONE 'UTC')
                AND sl."startTime" <  (($2::timestamptz + INTERVAL '1 day') AT TIME ZONE 'UTC')
                AND sl.team_id = $3
            GROUP BY
                sl.api_key,
                sl.model
        )
        SELECT
            api_key,
            SUM(model_cost) AS total_cost,
            SUM(model_input_tokens) AS total_input_tokens,
            SUM(model_output_tokens) AS total_output_tokens,
            jsonb_agg(jsonb_build_object(
                'model', model,
                'total_cost', model_cost,
                'total_input_tokens', model_input_tokens,
                'total_output_tokens', model_output_tokens
            )) AS model_details
        FROM
            SpendByModelApiKey
        GROUP BY
            api_key
        ORDER BY
            total_cost DESC;
params: (datetime.datetime(2026, 5, 1, 0, 0, tzinfo=datetime.timezone.utc), datetime.datetime(2026, 5, 28, 0, 0, tzinfo=datetime.timezone.utc), 'team-blue')
--- call #5 ---
WHERE: WITH SpendByModelApiKey AS (
                SELECT
                    sl.api_key,
                    sl.team_id,
                    sl.model,
                    SUM(sl.spend) AS model_cost,
                    SUM(sl.prompt_tokens) AS model_input_tokens,
                    SUM(sl.completion_tokens) AS model_output_tokens
                FROM
                    "LiteLLM_SpendLogs" sl
                WHERE
                    sl."startTime" >= ($1::timestamptz AT TIME ZONE 'UTC')
                    AND sl."startTime" <  (($2::timestamptz + INTERVAL '1 day') AT TIME ZONE 'UTC')
                    AND sl.team_id = ANY($3::text[])
                GROUP BY
                    sl.api_key,
                    sl.team_id,
                    sl.model
            )
            SELECT
                api_key,
                SUM(model_cost) AS total_cost,
                SUM(model_input_tokens) AS total_input_tokens,
                SUM(model_output_tokens) AS total_output_tokens,
                jsonb_agg(jsonb_build_object(
                    'team_id', team_id,
                    'model', model,
                    'total_cost', model_cost,
                    'total_input_tokens', model_input_tokens,
                    'total_output_tokens', model_output_tokens
                )) AS model_details
            FROM
                SpendByModelApiKey
            GROUP BY
                api_key
            ORDER BY
                total_cost DESC;
params: (datetime.datetime(2026, 5, 1, 0, 0, tzinfo=datetime.timezone.utc), datetime.datetime(2026, 5, 28, 0, 0, tzinfo=datetime.timezone.utc), ['team-red', 'team-blue'])

```

## Branch

Source: contents-API push (current `GITHUB_TOKEN` lacks `repo` + `workflow`
scopes), so the diff is computed from `litellm_oss_agent_shin_daily_branch`
HEAD `1fe911d89d` at PR creation time.

Session: https://litellm-agent-platform.onrender.com/sessions/7502a3fe-6010-4ebb-a344-6f4c65255db7
