### PR TITLE
fix(proxy): refresh models_by_provider after register_model / add_known_models (LIT-1695)

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -1171,6 +1171,7 @@ def _refresh_models_by_provider() -> None:
     models_by_provider.clear()
     models_by_provider.update(fresh)
 
+
 # mapping for those models which have larger equivalents
 longer_context_model_fallback_dict: dict = {
     # openai chat completion models

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -919,7 +919,7 @@ def add_known_models(model_cost_map: Optional[Dict] = None):
     # dropdowns see the new models. On the very first call (at module init
     # below) ``models_by_provider`` has not been built yet — guard accordingly.
     # See LIT-1695.
-    if "models_by_provider" in globals():
+    if "models_by_provider" in globals() and "_refresh_models_by_provider" in globals():
         _refresh_models_by_provider()
 
 

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -915,6 +915,13 @@ def add_known_models(model_cost_map: Optional[Dict] = None):
         elif value.get("litellm_provider") == "bedrock_mantle":
             bedrock_mantle_models.add(key)
 
+    # Propagate to merged per-provider lookup so wildcard expansion / UI
+    # dropdowns see the new models. On the very first call (at module init
+    # below) ``models_by_provider`` has not been built yet — guard accordingly.
+    # See LIT-1695.
+    if "models_by_provider" in globals():
+        _refresh_models_by_provider()
+
 
 add_known_models()
 # known openai compatible endpoints - we'll eventually move this list to the model_prices_and_context_window.json dictionary
@@ -1033,106 +1040,136 @@ model_list_set = set(model_list)
 # provider_list is lazy-loaded via __getattr__ to avoid importing LlmProviders at import time
 
 
-models_by_provider: dict = {
-    "openai": open_ai_chat_completion_models | open_ai_text_completion_models,
-    "text-completion-openai": open_ai_text_completion_models,
-    "cohere": cohere_models | cohere_chat_models,
-    "cohere_chat": cohere_chat_models,
-    "anthropic": anthropic_models,
-    "replicate": replicate_models,
-    "huggingface": huggingface_models,
-    "together_ai": together_ai_models,
-    "baseten": baseten_models,
-    "openrouter": openrouter_models,
-    "vercel_ai_gateway": vercel_ai_gateway_models,
-    "datarobot": datarobot_models,
-    "vertex_ai": vertex_chat_models
-    | vertex_text_models
-    | vertex_anthropic_models
-    | vertex_vision_models
-    | vertex_language_models
-    | vertex_deepseek_models
-    | vertex_minimax_models
-    | vertex_moonshot_models
-    | vertex_zai_models,
-    "ai21": ai21_models,
-    "bedrock": bedrock_models | bedrock_converse_models,
-    "petals": petals_models,
-    "ollama": ollama_models,
-    "ollama_chat": ollama_models,
-    "deepinfra": deepinfra_models,
-    "perplexity": perplexity_models,
-    "maritalk": maritalk_models,
-    "watsonx": watsonx_models,
-    "gemini": gemini_models,
-    "fireworks_ai": fireworks_ai_models | fireworks_ai_embedding_models,
-    "aleph_alpha": aleph_alpha_models,
-    "text-completion-codestral": text_completion_codestral_models,
-    "xai": xai_models,
-    "zai": zai_models,
-    "fal_ai": fal_ai_models,
-    "deepseek": deepseek_models,
-    "runwayml": runwayml_models,
-    "mistral": mistral_chat_models,
-    "azure_ai": azure_ai_models,
-    "voyage": voyage_models,
-    "infinity": infinity_models,
-    "databricks": databricks_models,
-    "cloudflare": cloudflare_models,
-    "codestral": codestral_models,
-    "nlp_cloud": nlp_cloud_models,
-    "friendliai": friendliai_models,
-    "palm": palm_models,
-    "groq": groq_models,
-    "azure": azure_models | azure_text_models,
-    "azure_anthropic": azure_anthropic_models,
-    "azure_text": azure_text_models,
-    "anyscale": anyscale_models,
-    "cerebras": cerebras_models,
-    "galadriel": galadriel_models,
-    "nvidia_nim": nvidia_nim_models,
-    "nvidia_riva": nvidia_riva_models,
-    "sambanova": sambanova_models | sambanova_embedding_models,
-    "novita": novita_models,
-    "nebius": nebius_models | nebius_embedding_models,
-    "aiml": aiml_models,
-    "assemblyai": assemblyai_models,
-    "jina_ai": jina_ai_models,
-    "snowflake": snowflake_models,
-    "gradient_ai": gradient_ai_models,
-    "meta_llama": llama_models,
-    "nscale": nscale_models,
-    "featherless_ai": featherless_ai_models,
-    "deepgram": deepgram_models,
-    "elevenlabs": elevenlabs_models,
-    "heroku": heroku_models,
-    "dashscope": dashscope_models,
-    "moonshot": moonshot_models,
-    "publicai": publicai_models,
-    "v0": v0_models,
-    "morph": morph_models,
-    "lambda_ai": lambda_ai_models,
-    "hyperbolic": hyperbolic_models,
-    "black_forest_labs": black_forest_labs_models,
-    "recraft": recraft_models,
-    "cometapi": cometapi_models,
-    "oci": oci_models,
-    "volcengine": volcengine_models,
-    "wandb": wandb_models,
-    "ovhcloud": ovhcloud_models | ovhcloud_embedding_models,
-    "lemonade": lemonade_models,
-    "clarifai": clarifai_models,
-    "amazon_nova": amazon_nova_models,
-    "stability": stability_models,
-    "github_copilot": github_copilot_models,
-    "chatgpt": chatgpt_models,
-    "minimax": minimax_models,
-    "aws_polly": aws_polly_models,
-    "gigachat": gigachat_models,
-    "llamagate": llamagate_models,
-    "reducto": reducto_models,
-    "bedrock_mantle": bedrock_mantle_models,
-}
+def _compute_models_by_provider() -> dict:
+    """Build the per-provider merged model list from the current per-provider sets.
+
+    Several entries in ``models_by_provider`` are eager set unions
+    (e.g. ``open_ai_chat_completion_models | open_ai_text_completion_models``)
+    which produce **new** set objects frozen at evaluation time. Whenever the
+    underlying per-provider sets are mutated later — via :func:`add_known_models`
+    (called at import time and when the proxy ``/reload/model_cost_map`` admin
+    endpoint runs) or :func:`register_model` — those frozen unions become stale.
+
+    This helper re-derives the dict so callers like ``get_provider_models`` /
+    ``get_valid_models`` (used by wildcard expansion for UI hub/playground
+    dropdowns) see newly registered models. See LIT-1695.
+    """
+    return {
+        "openai": open_ai_chat_completion_models | open_ai_text_completion_models,
+        "text-completion-openai": open_ai_text_completion_models,
+        "cohere": cohere_models | cohere_chat_models,
+        "cohere_chat": cohere_chat_models,
+        "anthropic": anthropic_models,
+        "replicate": replicate_models,
+        "huggingface": huggingface_models,
+        "together_ai": together_ai_models,
+        "baseten": baseten_models,
+        "openrouter": openrouter_models,
+        "vercel_ai_gateway": vercel_ai_gateway_models,
+        "datarobot": datarobot_models,
+        "vertex_ai": vertex_chat_models
+        | vertex_text_models
+        | vertex_anthropic_models
+        | vertex_vision_models
+        | vertex_language_models
+        | vertex_deepseek_models
+        | vertex_minimax_models
+        | vertex_moonshot_models
+        | vertex_zai_models,
+        "ai21": ai21_models,
+        "bedrock": bedrock_models | bedrock_converse_models,
+        "petals": petals_models,
+        "ollama": ollama_models,
+        "ollama_chat": ollama_models,
+        "deepinfra": deepinfra_models,
+        "perplexity": perplexity_models,
+        "maritalk": maritalk_models,
+        "watsonx": watsonx_models,
+        "gemini": gemini_models,
+        "fireworks_ai": fireworks_ai_models | fireworks_ai_embedding_models,
+        "aleph_alpha": aleph_alpha_models,
+        "text-completion-codestral": text_completion_codestral_models,
+        "xai": xai_models,
+        "zai": zai_models,
+        "fal_ai": fal_ai_models,
+        "deepseek": deepseek_models,
+        "runwayml": runwayml_models,
+        "mistral": mistral_chat_models,
+        "azure_ai": azure_ai_models,
+        "voyage": voyage_models,
+        "infinity": infinity_models,
+        "databricks": databricks_models,
+        "cloudflare": cloudflare_models,
+        "codestral": codestral_models,
+        "nlp_cloud": nlp_cloud_models,
+        "friendliai": friendliai_models,
+        "palm": palm_models,
+        "groq": groq_models,
+        "azure": azure_models | azure_text_models,
+        "azure_anthropic": azure_anthropic_models,
+        "azure_text": azure_text_models,
+        "anyscale": anyscale_models,
+        "cerebras": cerebras_models,
+        "galadriel": galadriel_models,
+        "nvidia_nim": nvidia_nim_models,
+        "nvidia_riva": nvidia_riva_models,
+        "sambanova": sambanova_models | sambanova_embedding_models,
+        "novita": novita_models,
+        "nebius": nebius_models | nebius_embedding_models,
+        "aiml": aiml_models,
+        "assemblyai": assemblyai_models,
+        "jina_ai": jina_ai_models,
+        "snowflake": snowflake_models,
+        "gradient_ai": gradient_ai_models,
+        "meta_llama": llama_models,
+        "nscale": nscale_models,
+        "featherless_ai": featherless_ai_models,
+        "deepgram": deepgram_models,
+        "elevenlabs": elevenlabs_models,
+        "heroku": heroku_models,
+        "dashscope": dashscope_models,
+        "moonshot": moonshot_models,
+        "publicai": publicai_models,
+        "v0": v0_models,
+        "morph": morph_models,
+        "lambda_ai": lambda_ai_models,
+        "hyperbolic": hyperbolic_models,
+        "black_forest_labs": black_forest_labs_models,
+        "recraft": recraft_models,
+        "cometapi": cometapi_models,
+        "oci": oci_models,
+        "volcengine": volcengine_models,
+        "wandb": wandb_models,
+        "ovhcloud": ovhcloud_models | ovhcloud_embedding_models,
+        "lemonade": lemonade_models,
+        "clarifai": clarifai_models,
+        "amazon_nova": amazon_nova_models,
+        "stability": stability_models,
+        "github_copilot": github_copilot_models,
+        "chatgpt": chatgpt_models,
+        "minimax": minimax_models,
+        "aws_polly": aws_polly_models,
+        "gigachat": gigachat_models,
+        "llamagate": llamagate_models,
+        "reducto": reducto_models,
+        "bedrock_mantle": bedrock_mantle_models,
+    }
+
+
+models_by_provider: dict = _compute_models_by_provider()
+
+
+def _refresh_models_by_provider() -> None:
+    """Re-derive ``models_by_provider`` from the current per-provider sets.
+
+    Call this whenever the per-provider sets mutate so wildcard expansion
+    (UI hub/playground dropdowns, ``get_provider_models`` / ``get_valid_models``)
+    reflects the change. ``add_known_models`` and ``register_model`` call this
+    automatically. See LIT-1695.
+    """
+    fresh = _compute_models_by_provider()
+    models_by_provider.clear()
+    models_by_provider.update(fresh)
 
 # mapping for those models which have larger equivalents
 longer_context_model_fallback_dict: dict = {

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -2997,6 +2997,17 @@ def register_model(model_cost: Union[str, dict]):  # noqa: PLR0915
         elif value.get("litellm_provider") == "novita":
             if key not in litellm.novita_models:
                 litellm.novita_models.add(key)
+
+    # Propagate to the merged per-provider lookup so wildcard expansion
+    # (UI hub/playground dropdowns via ``get_provider_models`` →
+    # ``get_valid_models`` → ``litellm.models_by_provider``) reflects the
+    # newly registered models. See LIT-1695.
+    try:
+        litellm._refresh_models_by_provider()
+    except AttributeError:
+        # Defensive: in partial-import scenarios the helper may be missing.
+        pass
+
     return model_cost
 
 

--- a/tests/test_litellm/proxy/auth/test_lit1695_models_by_provider_refresh.py
+++ b/tests/test_litellm/proxy/auth/test_lit1695_models_by_provider_refresh.py
@@ -17,6 +17,7 @@ Fix: refresh ``models_by_provider`` from the underlying sets at the end of
 ``add_known_models`` and ``register_model`` so wildcard expansion via
 ``get_provider_models`` / ``get_valid_models`` reflects the new state.
 """
+
 import pytest
 
 import litellm
@@ -25,7 +26,6 @@ from litellm.proxy.auth.model_checks import (
     get_known_models_from_wildcard,
     get_provider_models,
 )
-
 
 # Use clearly-fictional keys so they cannot collide with the bundled
 # model_prices_and_context_window.json or any other test fixture.
@@ -102,9 +102,9 @@ def test_register_model_propagates_openai_union_to_models_by_provider(
     )
 
     assert _NEW_OPENAI in litellm.open_ai_chat_completion_models
-    assert _NEW_OPENAI in litellm.models_by_provider["openai"], (
-        "register_model must refresh models_by_provider for union-backed providers"
-    )
+    assert (
+        _NEW_OPENAI in litellm.models_by_provider["openai"]
+    ), "register_model must refresh models_by_provider for union-backed providers"
 
 
 def test_add_known_models_propagates_to_union_provider(_restore_provider_state):
@@ -127,9 +127,9 @@ def test_add_known_models_propagates_to_union_provider(_restore_provider_state):
     )
 
     assert _NEW_VERTEX in litellm.vertex_chat_models
-    assert _NEW_VERTEX in litellm.models_by_provider["vertex_ai"], (
-        "add_known_models must refresh union-backed entries in models_by_provider"
-    )
+    assert (
+        _NEW_VERTEX in litellm.models_by_provider["vertex_ai"]
+    ), "add_known_models must refresh union-backed entries in models_by_provider"
 
 
 def test_wildcard_expansion_sees_newly_registered_model(_restore_provider_state):

--- a/tests/test_litellm/proxy/auth/test_lit1695_models_by_provider_refresh.py
+++ b/tests/test_litellm/proxy/auth/test_lit1695_models_by_provider_refresh.py
@@ -1,0 +1,241 @@
+"""Regression tests for LIT-1695.
+
+Bug: `litellm.models_by_provider` was built at import time as a dict whose
+values include set *unions* (e.g.
+``open_ai_chat_completion_models | open_ai_text_completion_models``). The
+``|`` operator returns a NEW set, frozen at evaluation time. When the
+underlying per-provider sets were later mutated by ``add_known_models`` (called
+by the proxy ``/reload/model_cost_map`` admin endpoint) or ``register_model``,
+those union snapshots became stale.
+
+Customer-visible effect: a wildcard route like ``openai/*`` configured on the
+proxy, plus a newly added model entry in ``model_prices_and_context_window.json``,
+did not surface that new model in the hub/playground drop-down list — even
+after the user clicked "Refresh model price listing".
+
+Fix: refresh ``models_by_provider`` from the underlying sets at the end of
+``add_known_models`` and ``register_model`` so wildcard expansion via
+``get_provider_models`` / ``get_valid_models`` reflects the new state.
+"""
+import pytest
+
+import litellm
+from litellm.proxy.auth.model_checks import (
+    get_complete_model_list,
+    get_known_models_from_wildcard,
+    get_provider_models,
+)
+
+
+# Use clearly-fictional keys so they cannot collide with the bundled
+# model_prices_and_context_window.json or any other test fixture.
+_NEW_OPENAI = "openai/lit1695-fictional-openai-zz"
+_NEW_ANTHROPIC = "claude-lit1695-fictional-anthropic-zz"
+_NEW_VERTEX = "vertex_ai/lit1695-fictional-vertex-zz"
+
+
+@pytest.fixture
+def _restore_provider_state():
+    """Snapshot + restore per-provider sets and model_cost so individual
+    tests cannot leak into each other (or into the rest of the suite)."""
+    snapshots = {
+        "open_ai_chat_completion_models": set(litellm.open_ai_chat_completion_models),
+        "open_ai_text_completion_models": set(litellm.open_ai_text_completion_models),
+        "anthropic_models": set(litellm.anthropic_models),
+        "vertex_chat_models": set(litellm.vertex_chat_models),
+        "vertex_text_models": set(litellm.vertex_text_models),
+        "model_cost": dict(litellm.model_cost),
+        "models_by_provider": {
+            k: set(v) if isinstance(v, set) else v
+            for k, v in litellm.models_by_provider.items()
+        },
+    }
+    try:
+        yield
+    finally:
+        litellm.open_ai_chat_completion_models.clear()
+        litellm.open_ai_chat_completion_models.update(
+            snapshots["open_ai_chat_completion_models"]
+        )
+        litellm.open_ai_text_completion_models.clear()
+        litellm.open_ai_text_completion_models.update(
+            snapshots["open_ai_text_completion_models"]
+        )
+        litellm.anthropic_models.clear()
+        litellm.anthropic_models.update(snapshots["anthropic_models"])
+        litellm.vertex_chat_models.clear()
+        litellm.vertex_chat_models.update(snapshots["vertex_chat_models"])
+        litellm.vertex_text_models.clear()
+        litellm.vertex_text_models.update(snapshots["vertex_text_models"])
+        litellm.model_cost.clear()
+        litellm.model_cost.update(snapshots["model_cost"])
+        # Rebuild the merged map from the now-restored per-provider sets.
+        litellm._refresh_models_by_provider()
+
+
+def test_helper_is_exposed():
+    """The refresh helper must be on the public ``litellm`` namespace so the
+    proxy ``/reload/model_cost_map`` endpoint (and ``register_model``) can call
+    it across process boundaries / module imports."""
+    assert callable(litellm._refresh_models_by_provider)
+
+
+def test_register_model_propagates_openai_union_to_models_by_provider(
+    _restore_provider_state,
+):
+    """``models_by_provider['openai']`` is an eager union of two underlying
+    sets — the original LIT-1695 bug surface. After ``register_model``, the
+    new key must appear there."""
+    assert _NEW_OPENAI not in litellm.open_ai_chat_completion_models
+    assert _NEW_OPENAI not in litellm.models_by_provider["openai"]
+
+    litellm.register_model(
+        {
+            _NEW_OPENAI: {
+                "max_tokens": 1024,
+                "input_cost_per_token": 1e-6,
+                "output_cost_per_token": 2e-6,
+                "litellm_provider": "openai",
+                "mode": "chat",
+            }
+        }
+    )
+
+    assert _NEW_OPENAI in litellm.open_ai_chat_completion_models
+    assert _NEW_OPENAI in litellm.models_by_provider["openai"], (
+        "register_model must refresh models_by_provider for union-backed providers"
+    )
+
+
+def test_add_known_models_propagates_to_union_provider(_restore_provider_state):
+    """``add_known_models`` is what the proxy ``/reload/model_cost_map`` admin
+    endpoint calls after refetching the price map. It must also propagate to
+    ``models_by_provider`` for union-backed entries (here ``vertex_ai``)."""
+    assert _NEW_VERTEX not in litellm.vertex_chat_models
+    assert _NEW_VERTEX not in litellm.models_by_provider["vertex_ai"]
+
+    litellm.add_known_models(
+        {
+            _NEW_VERTEX: {
+                "max_tokens": 1024,
+                "input_cost_per_token": 0,
+                "output_cost_per_token": 0,
+                "litellm_provider": "vertex_ai-chat-models",
+                "mode": "chat",
+            }
+        }
+    )
+
+    assert _NEW_VERTEX in litellm.vertex_chat_models
+    assert _NEW_VERTEX in litellm.models_by_provider["vertex_ai"], (
+        "add_known_models must refresh union-backed entries in models_by_provider"
+    )
+
+
+def test_wildcard_expansion_sees_newly_registered_model(_restore_provider_state):
+    """End-to-end through the same path the UI hub/playground dropdown uses:
+    ``get_known_models_from_wildcard('openai/*')`` -> ``get_provider_models`` ->
+    ``get_valid_models`` -> ``litellm.models_by_provider['openai']``."""
+    pre = get_known_models_from_wildcard("openai/*")
+    assert _NEW_OPENAI not in pre
+
+    litellm.register_model(
+        {
+            _NEW_OPENAI: {
+                "max_tokens": 1024,
+                "input_cost_per_token": 1e-6,
+                "output_cost_per_token": 2e-6,
+                "litellm_provider": "openai",
+                "mode": "chat",
+            }
+        }
+    )
+
+    post = get_known_models_from_wildcard("openai/*")
+    assert _NEW_OPENAI in post, (
+        "Wildcard expansion for openai/* must include models registered after "
+        "module init — this is the LIT-1695 customer-visible regression."
+    )
+
+
+def test_complete_model_list_surfaces_new_model_for_wildcard_route(
+    _restore_provider_state,
+):
+    """The Models / Playground page renders ``get_complete_model_list`` output
+    when the proxy ``model_list`` contains a wildcard like ``openai/*``."""
+    before = get_complete_model_list(
+        key_models=[],
+        team_models=[],
+        proxy_model_list=["openai/*"],
+        user_model=None,
+        infer_model_from_keys=None,
+        return_wildcard_routes=False,
+        llm_router=None,
+        model_access_groups={},
+    )
+    assert _NEW_OPENAI not in before
+
+    litellm.register_model(
+        {
+            _NEW_OPENAI: {
+                "max_tokens": 1024,
+                "input_cost_per_token": 1e-6,
+                "output_cost_per_token": 2e-6,
+                "litellm_provider": "openai",
+                "mode": "chat",
+            }
+        }
+    )
+
+    after = get_complete_model_list(
+        key_models=[],
+        team_models=[],
+        proxy_model_list=["openai/*"],
+        user_model=None,
+        infer_model_from_keys=None,
+        return_wildcard_routes=False,
+        llm_router=None,
+        model_access_groups={},
+    )
+    assert _NEW_OPENAI in after
+
+
+def test_direct_reference_provider_still_works(_restore_provider_state):
+    """``models_by_provider['anthropic']`` is a direct reference to
+    ``anthropic_models`` (not a union), so mutations were ALREADY visible
+    pre-fix. Guard against accidentally regressing that path by replacing the
+    reference with a stale copy."""
+    assert _NEW_ANTHROPIC not in litellm.models_by_provider["anthropic"]
+
+    litellm.register_model(
+        {
+            _NEW_ANTHROPIC: {
+                "max_tokens": 1024,
+                "input_cost_per_token": 1e-6,
+                "output_cost_per_token": 2e-6,
+                "litellm_provider": "anthropic",
+                "mode": "chat",
+            }
+        }
+    )
+
+    assert _NEW_ANTHROPIC in litellm.anthropic_models
+    assert _NEW_ANTHROPIC in litellm.models_by_provider["anthropic"]
+
+
+def test_refresh_helper_is_idempotent(_restore_provider_state):
+    """Calling the helper multiple times in a row must not duplicate, lose, or
+    permute entries."""
+    before = {
+        k: set(v) if isinstance(v, set) else v
+        for k, v in litellm.models_by_provider.items()
+    }
+    litellm._refresh_models_by_provider()
+    litellm._refresh_models_by_provider()
+    after = {
+        k: set(v) if isinstance(v, set) else v
+        for k, v in litellm.models_by_provider.items()
+    }
+    assert before.keys() == after.keys()
+    for k in before:
+        assert before[k] == after[k], f"refresh changed contents for provider {k}"


### PR DESCRIPTION
## Summary

Fixes **[LIT-1695]** — newly added / reloaded models did not appear in the hub or playground drop-down list when a wildcard route (e.g. `openai/*`) was configured.

## Root cause

`litellm.models_by_provider` is built once at import time as a dict whose values include eager set **unions** — e.g.

```python
models_by_provider: dict = {
    "openai": open_ai_chat_completion_models | open_ai_text_completion_models,
    "vertex_ai": vertex_chat_models | vertex_text_models | vertex_anthropic_models | ...,
    "bedrock": bedrock_models | bedrock_converse_models,
    ...
}
```

The `|` operator returns a **new** set, frozen at evaluation time. When the underlying per-provider sets are later mutated — either by `litellm.register_model(...)` or by `litellm.add_known_models(...)` (which the proxy `/reload/model_cost_map` admin endpoint calls after refetching the price map) — those frozen unions stay stale.

UI hub / playground dropdowns reach the merged dict through:

```
get_complete_model_list -> _get_wildcard_models
  -> get_known_models_from_wildcard -> get_provider_models
  -> get_valid_models -> litellm.models_by_provider[provider]
```

so newly added models did not appear in dropdowns under wildcard routes even after the operator clicked "Refresh model price listing".

Direct-reference entries (e.g. `"anthropic": anthropic_models`, `"openrouter": openrouter_models`) were unaffected — only the union-backed entries (`openai`, `vertex_ai`, `bedrock`, `cohere`, `fireworks_ai`, `azure`, `sambanova`, `nebius`, `ovhcloud`) hit the stale snapshot.

## Fix

- Encapsulate the dict construction in `_compute_models_by_provider()`.
- Add `_refresh_models_by_provider()` that re-derives the merged map in place (`models_by_provider.clear()` + `update(_compute_models_by_provider())`), preserving the *dict* identity while replacing each value.
- Call it at the end of `add_known_models()` (`litellm/__init__.py`) and `register_model()` (`litellm/utils.py`).
- The very first `add_known_models()` invocation runs at module init *before* `models_by_provider` itself is built — guarded with an `if "models_by_provider" in globals()` check there.

## Evidence

Both runs against `litellm_oss_agent_shin_daily_branch` HEAD `1fe911d89d`, with a clean checkout for the BEFORE run and the patch applied for the AFTER run. Driver script registers a fictional model name (`openai/lit1695-shin-fictional-z9`, `vertex_ai/lit1695-vertex-fictional-z9`) guaranteed not to exist in `model_prices_and_context_window.json`, then asks the same code paths the UI uses whether the model is visible.

**Before (clean main):**

```
# Path A — register_model() (the litellm.register_model() public API; OpenAI is a UNION in models_by_provider)
{
  "registered_key": "openai/lit1695-shin-fictional-z9",
  "in_open_ai_chat_completion_models": true,
  "in_models_by_provider_openai": false,
  "in_wildcard_expansion_openai_star": false
}

# Path B — add_known_models() simulating proxy /reload/model_cost_map (also UNION case via vertex_ai)
{
  "registered_key": "vertex_ai/lit1695-vertex-fictional-z9",
  "in_vertex_chat_models": true,
  "in_models_by_provider_vertex_ai": false,
  "in_wildcard_expansion_vertex_ai_star": false
}

# Path C — get_complete_model_list (the UI hub/playground dropdown path with wildcard openai/*)
{
  "proxy_model_list": [
    "openai/*"
  ],
  "openai/lit1695-shin-fictional-z9_visible_in_UI_dropdown": false,
  "dropdown_size": 206
}
```

**After (this PR):**

```
# Path A — register_model() (the litellm.register_model() public API; OpenAI is a UNION in models_by_provider)
{
  "registered_key": "openai/lit1695-shin-fictional-z9",
  "in_open_ai_chat_completion_models": true,
  "in_models_by_provider_openai": true,
  "in_wildcard_expansion_openai_star": true
}

# Path B — add_known_models() simulating proxy /reload/model_cost_map (also UNION case via vertex_ai)
{
  "registered_key": "vertex_ai/lit1695-vertex-fictional-z9",
  "in_vertex_chat_models": true,
  "in_models_by_provider_vertex_ai": true,
  "in_wildcard_expansion_vertex_ai_star": true
}

# Path C — get_complete_model_list (the UI hub/playground dropdown path with wildcard openai/*)
{
  "proxy_model_list": [
    "openai/*"
  ],
  "openai/lit1695-shin-fictional-z9_visible_in_UI_dropdown": true,
  "dropdown_size": 207
}
```

Key deltas:

```
in_models_by_provider_openai:              false -> true
in_wildcard_expansion_openai_star:         false -> true
in_models_by_provider_vertex_ai:           false -> true
in_wildcard_expansion_vertex_ai_star:      false -> true
openai/lit1695-shin-fictional-z9_visible_in_UI_dropdown: false -> true
dropdown_size (proxy_model_list=["openai/*"]):           206 -> 207
```

Path C exercises the exact `get_complete_model_list` call the proxy emits for the hub / playground page when `model_list` contains `openai/*`.

## Tests

`tests/test_litellm/proxy/auth/test_lit1695_models_by_provider_refresh.py` — 7 new regression tests, all passing locally:

```
tests/test_litellm/proxy/auth/test_lit1695_models_by_provider_refresh.py::test_add_known_models_propagates_to_union_provider PASSED
tests/test_litellm/proxy/auth/test_lit1695_models_by_provider_refresh.py::test_complete_model_list_surfaces_new_model_for_wildcard_route PASSED
tests/test_litellm/proxy/auth/test_lit1695_models_by_provider_refresh.py::test_direct_reference_provider_still_works PASSED
tests/test_litellm/proxy/auth/test_lit1695_models_by_provider_refresh.py::test_helper_is_exposed PASSED
tests/test_litellm/proxy/auth/test_lit1695_models_by_provider_refresh.py::test_refresh_helper_is_idempotent PASSED
tests/test_litellm/proxy/auth/test_lit1695_models_by_provider_refresh.py::test_register_model_propagates_openai_union_to_models_by_provider PASSED
tests/test_litellm/proxy/auth/test_lit1695_models_by_provider_refresh.py::test_wildcard_expansion_sees_newly_registered_model PASSED
====== 7 passed in 12.81s ======
```

Existing suites that touch the same surface still pass:

```
tests/test_litellm/proxy/auth/test_model_checks.py        ... 24 passed
tests/test_litellm/proxy/auth/test_model_checks_fallbacks.py ... 2 passed
tests/test_litellm/test_register_model_custom_pricing.py  ... 10 passed
tests/test_litellm/test_utils.py -k "register_model"      ... 2 passed
```

Each test snapshots and restores `open_ai_chat_completion_models` / `vertex_chat_models` / `anthropic_models` / `model_cost` / `models_by_provider` so it cannot leak fictional probe keys into the rest of the run.

## Scope

| File | Change |
| --- | --- |
| `litellm/__init__.py` | Extract the `models_by_provider` dict literal into `_compute_models_by_provider()`; add `_refresh_models_by_provider()`; call it from `add_known_models()` end. |
| `litellm/utils.py` | Call `litellm._refresh_models_by_provider()` at the end of `register_model()` (`try/except AttributeError` for partial-import safety). |
| `tests/test_litellm/proxy/auth/test_lit1695_models_by_provider_refresh.py` | 7 new regression tests. |

Base: `litellm_oss_agent_shin_daily_branch` (per Shin fork policy).

Note on push path: pushed via the GitHub Git Data API (blobs -> tree -> commit -> ref) because the agent's `GITHUB_TOKEN` lacks `repo + workflow` scopes for `git push`. This produces a single clean commit on top of the daily branch base SHA.


---

### Verification (ship-pr)

| Check | Result |
| --- | --- |
| PR URL | https://github.com/BerriAI/litellm/pull/29221 |
| Base branch | `litellm_oss_agent_shin_daily_branch` ✓ (per Shin fork policy) |
| Head SHA | `1a13de74a9d5fe19d96e7241d2ba1f6f84990e39` |
| GitHub Actions | **44/44 green**, 0 failures (lint, code-quality, secret-scan, semgrep, build-ui, validate-model-prices-json, unit-test, test, test-server-root-path × 2, integrations, core-utils, responses-caching-types, Vertex AI, All Other Providers, proxy-* suites, enterprise-routing, auth-and-jwt, key-generation, documentation, Codecov, etc.) |
| Greptile | **5/5** — *"Safe to merge — the change is well-scoped, the core fix is correct, and thorough regression tests cover the affected paths."* |
| Veria AI - PR Review | ✅ success — *"No security issues found"* |
| Mergeable state | `mergeable=True` |
| Runtime evidence | Captured (Path A `register_model`, Path B `add_known_models`, Path C `get_complete_model_list`) — see Evidence section above, before/after JSON on `litellm_oss_agent_shin_daily_branch` HEAD `1fe911d89d` |
| Tests added | 7 (all pass locally + in CI), pre-existing model_checks + register_model + utils tests untouched |
| Push path | GitHub Git Data API (blobs → tree → commit → ref) — token lacks `repo + workflow` scopes for `git push` |

Follow-up commit after the initial PR:
- `1a13de7` — tighten guard to require both `models_by_provider` and `_refresh_models_by_provider` in `globals()` before calling the refresh (Greptile P2 nit, addressed).
