### PR TITLE
fix(ui): preserve LiteLLM Params JSON textarea edits in model_info_view (LIT-2971)

### DIFF
--- a/ui/litellm-dashboard/src/components/model_info_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/model_info_view.test.tsx
@@ -718,4 +718,137 @@ describe("ModelInfoView", () => {
       expect(screen.getByText(/Created By/)).toBeInTheDocument();
     });
   });
+
+  // ===========================================================================
+  // LIT-2971: LiteLLM Params JSON textarea is the source of truth for any key
+  // the user typed there. Dedicated form inputs only override their
+  // corresponding key when the user actually touched the form input.
+  // ===========================================================================
+  describe("LiteLLM Params textarea persistence (LIT-2971)", () => {
+    const modelWithTpmRpm = {
+      ...defaultModelData,
+      litellm_params: {
+        ...defaultModelData.litellm_params,
+        tpm: 50,
+        rpm: 25,
+        timeout: 30,
+      },
+    };
+
+    const renderWithModel = (modelData: any) => {
+      mockUseModelsInfo.mockReturnValue({
+        data: { data: [modelData] },
+        isLoading: false,
+        error: null,
+      });
+      mockModelInfoV1Call.mockResolvedValue({ data: [modelData] });
+      return render(<ModelInfoView {...DEFAULT_ADMIN_PROPS} />, { wrapper });
+    };
+
+    const findLitellmParamsTextarea = () =>
+      screen
+        .getAllByRole("textbox")
+        .find(
+          (input) =>
+            input.tagName === "TEXTAREA" &&
+            (input as HTMLTextAreaElement).value.includes('"model"'),
+        ) as HTMLTextAreaElement | undefined;
+
+    it("persists tpm change made only via the JSON textarea", async () => {
+      const user = userEvent.setup();
+      renderWithModel(modelWithTpmRpm);
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: /edit settings/i })).toBeInTheDocument();
+      });
+      await user.click(screen.getByRole("button", { name: /edit settings/i }));
+
+      const textarea = findLitellmParamsTextarea();
+      expect(textarea).toBeDefined();
+      if (!textarea) return;
+      // Replace tpm: 50 -> tpm: 100 in the textarea body without touching the
+      // dedicated tpm form input.
+      const next = textarea.value.replace('"tpm": 50', '"tpm": 100');
+      expect(next).not.toBe(textarea.value);
+      await user.clear(textarea);
+      await user.paste(next);
+
+      await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+      await waitFor(() => {
+        expect(mockModelPatchUpdateCall).toHaveBeenCalled();
+      });
+
+      const updatePayload = mockModelPatchUpdateCall.mock.calls[0][1];
+      expect(updatePayload.litellm_params.tpm).toBe(100);
+    });
+
+    it("persists nested-dict litellm_params (e.g. reasoning_effort) added via the JSON textarea", async () => {
+      const user = userEvent.setup();
+      renderWithModel(modelWithTpmRpm);
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: /edit settings/i })).toBeInTheDocument();
+      });
+      await user.click(screen.getByRole("button", { name: /edit settings/i }));
+
+      const textarea = findLitellmParamsTextarea();
+      expect(textarea).toBeDefined();
+      if (!textarea) return;
+      // Inject a nested-dict key the form has no dedicated input for.
+      const parsed = JSON.parse(textarea.value);
+      parsed.reasoning_effort = { effort: "high", summary: "detailed" };
+      const next = JSON.stringify(parsed, null, 2);
+      await user.clear(textarea);
+      await user.paste(next);
+
+      await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+      await waitFor(() => {
+        expect(mockModelPatchUpdateCall).toHaveBeenCalled();
+      });
+
+      const updatePayload = mockModelPatchUpdateCall.mock.calls[0][1];
+      expect(updatePayload.litellm_params.reasoning_effort).toEqual({
+        effort: "high",
+        summary: "detailed",
+      });
+    });
+
+    it("prefers the form input value when the user explicitly edits a form field", async () => {
+      const user = userEvent.setup();
+      renderWithModel(modelWithTpmRpm);
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: /edit settings/i })).toBeInTheDocument();
+      });
+      await user.click(screen.getByRole("button", { name: /edit settings/i }));
+
+      // Find the dedicated tpm input via its initial value (50) and type a new
+      // value into it. antd InputNumber renders a role="spinbutton".
+      const spinbuttons = screen.queryAllByRole("spinbutton") as HTMLInputElement[];
+      let target: HTMLInputElement | undefined = spinbuttons.find(
+        (el) => el.value === "50",
+      );
+      if (!target) {
+        const textInputs = screen.getAllByRole("textbox") as HTMLInputElement[];
+        target = textInputs.find((el) => el.value === "50");
+      }
+      expect(target).toBeDefined();
+      if (!target) return;
+      await user.clear(target);
+      await user.type(target, "77");
+
+      await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+      await waitFor(() => {
+        expect(mockModelPatchUpdateCall).toHaveBeenCalled();
+      });
+
+      const updatePayload = mockModelPatchUpdateCall.mock.calls[0][1];
+      // Whatever the user typed wins; the JSON textarea was untouched (still
+      // says tpm: 50) but the form field was explicitly edited.
+      expect(Number(updatePayload.litellm_params.tpm)).toBe(77);
+    });
+  });
 });

--- a/ui/litellm-dashboard/src/components/model_info_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/model_info_view.test.tsx
@@ -815,6 +815,43 @@ describe("ModelInfoView", () => {
       });
     });
 
+    it("persists guardrails change made only via the JSON textarea (Greptile P1 follow-up)", async () => {
+      const user = userEvent.setup();
+      const modelWithGuardrails = {
+        ...defaultModelData,
+        litellm_params: {
+          ...defaultModelData.litellm_params,
+          guardrails: ["content_filter"],
+        },
+      };
+      renderWithModel(modelWithGuardrails);
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: /edit settings/i })).toBeInTheDocument();
+      });
+      await user.click(screen.getByRole("button", { name: /edit settings/i }));
+
+      const textarea = findLitellmParamsTextarea();
+      expect(textarea).toBeDefined();
+      if (!textarea) return;
+      const parsed = JSON.parse(textarea.value);
+      // User swaps guardrails via the JSON textarea WITHOUT touching the
+      // dedicated guardrails multi-select.
+      parsed.guardrails = ["toxicity_filter"];
+      const next = JSON.stringify(parsed, null, 2);
+      await user.clear(textarea);
+      await user.paste(next);
+
+      await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+      await waitFor(() => {
+        expect(mockModelPatchUpdateCall).toHaveBeenCalled();
+      });
+
+      const updatePayload = mockModelPatchUpdateCall.mock.calls[0][1];
+      expect(updatePayload.litellm_params.guardrails).toEqual(["toxicity_filter"]);
+    });
+
     it("prefers the form input value when the user explicitly edits a form field", async () => {
       const user = userEvent.setup();
       renderWithModel(modelWithTpmRpm);

--- a/ui/litellm-dashboard/src/components/model_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/model_info_view.tsx
@@ -339,7 +339,24 @@ export default function ModelInfoView({
       } else {
         delete updatedLitellmParams.litellm_credential_name;
       }
-      if (values.guardrails) {
+      // guardrails follows the same source-of-truth rule as the keys in
+      // FORM_FIELDS_FOR_LITELLM_PARAMS: the JSON textarea wins unless the user
+      // explicitly edited the dedicated multi-select (LIT-2971).
+      if (form.isFieldTouched("guardrails")) {
+        if (
+          values.guardrails &&
+          Array.isArray(values.guardrails) &&
+          values.guardrails.length > 0
+        ) {
+          updatedLitellmParams.guardrails = values.guardrails;
+        } else {
+          delete updatedLitellmParams.guardrails;
+        }
+      } else if (
+        !("guardrails" in parsedExtraParams) &&
+        Array.isArray(values.guardrails) &&
+        values.guardrails.length > 0
+      ) {
         updatedLitellmParams.guardrails = values.guardrails;
       }
       if (values.vector_store_ids?.length > 0) {

--- a/ui/litellm-dashboard/src/components/model_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/model_info_view.tsx
@@ -241,20 +241,63 @@ export default function ModelInfoView({
         return;
       }
 
-      let updatedLitellmParams = {
+      // Build litellm_params from the JSON textarea (`parsedExtraParams`) and the
+      // dedicated form inputs. The textarea is the source of truth for any key
+      // the user typed there. Dedicated form inputs only override their
+      // corresponding key in litellm_params when the user actually touched the
+      // form input — previously every dedicated input unconditionally won,
+      // which silently dropped user edits made only via the JSON textarea
+      // (LIT-2971).
+      let updatedLitellmParams: Record<string, any> = {
         ...values.litellm_params,
         ...parsedExtraParams,
-        model: values.litellm_model_name,
-        api_base: values.api_base,
-        custom_llm_provider: values.custom_llm_provider,
-        organization: values.organization,
-        tpm: values.tpm,
-        rpm: values.rpm,
-        max_retries: values.max_retries,
-        timeout: values.timeout,
-        stream_timeout: values.stream_timeout,
-        tags: values.tags,
       };
+
+      const FORM_FIELDS_FOR_LITELLM_PARAMS: Array<{
+        formField: string;
+        paramKey: string;
+      }> = [
+        { formField: "litellm_model_name", paramKey: "model" },
+        { formField: "api_base", paramKey: "api_base" },
+        { formField: "custom_llm_provider", paramKey: "custom_llm_provider" },
+        { formField: "organization", paramKey: "organization" },
+        { formField: "tpm", paramKey: "tpm" },
+        { formField: "rpm", paramKey: "rpm" },
+        { formField: "max_retries", paramKey: "max_retries" },
+        { formField: "timeout", paramKey: "timeout" },
+        { formField: "stream_timeout", paramKey: "stream_timeout" },
+        { formField: "tags", paramKey: "tags" },
+      ];
+
+      for (const { formField, paramKey } of FORM_FIELDS_FOR_LITELLM_PARAMS) {
+        const formValue = values[formField];
+        if (form.isFieldTouched(formField)) {
+          // Explicit form edit wins. Clearing the field deletes the key from
+          // litellm_params (mirrors the cache_write_cost touched-clear path).
+          if (
+            formValue === undefined ||
+            formValue === null ||
+            formValue === ""
+          ) {
+            delete updatedLitellmParams[paramKey];
+          } else {
+            updatedLitellmParams[paramKey] = formValue;
+          }
+          continue;
+        }
+        // Form field was not touched. If the textarea also did not carry the
+        // key but the form holds a usable value (e.g. textarea was cleared
+        // by the user), preserve the form value so we don't silently drop
+        // model / api_base / etc.
+        if (
+          !(paramKey in parsedExtraParams) &&
+          formValue !== undefined &&
+          formValue !== null &&
+          formValue !== ""
+        ) {
+          updatedLitellmParams[paramKey] = formValue;
+        }
+      }
 
       if (form.isFieldTouched("input_cost") && values.input_cost !== undefined && values.input_cost !== null) {
         updatedLitellmParams.input_cost_per_token = Number(values.input_cost) / 1_000_000;


### PR DESCRIPTION
## Summary

`ModelInfoView`'s Edit Settings form was silently dropping user edits made
only via the **LiteLLM Params** JSON textarea whenever the edited key also
had a dedicated form input (`tpm`, `rpm`, `max_retries`, `timeout`,
`stream_timeout`, `organization`, `api_base`, `custom_llm_provider`,
`litellm_model_name`, `tags`). On Save, `handleModelUpdate` spread the
untouched form-field values **after** `parsedExtraParams`, so the unchanged
input value clobbered the textarea edit.

## Fix

In `ui/litellm-dashboard/src/components/model_info_view.tsx::handleModelUpdate`,
gate each dedicated-input override with `form.isFieldTouched(name)`. The
JSON textarea is now the source of truth for any key the user typed there;
dedicated inputs only override their corresponding key when the user
explicitly edited the input. Clearing a touched form input still deletes
the key from `litellm_params` (mirrors the existing `cache_write_cost`
touched-clear precedent).

## Repro

Render `ModelInfoView` for a model with `litellm_params.tpm = 50`:
1. Click **Edit Settings**.
2. In the **LiteLLM Params** JSON textarea, change `"tpm": 50` → `"tpm": 100`.
3. Do NOT touch the dedicated `TPM` input.
4. Click **Save Changes**.

### Evidence

Same DOM, same user action, same model, BEFORE vs AFTER the patch — captured
via the actual `ModelInfoView` rendered in JSDOM (`@testing-library/react`)
and the network call (`modelPatchUpdateCall`) intercepted via vitest mock.

**BEFORE the fix** — `litellm_params` payload that `modelPatchUpdateCall`
receives after Save:

```json
{
  "model": "azure/gpt-4o",
  "api_base": "https://example.openai.azure.com/",
  "custom_llm_provider": "azure",
  "tpm": 50,
  "rpm": 25,
  "timeout": 30,
  "reasoning_effort": { "effort": "high", "summary": "detailed" },
  "tags": [],
  "litellm_credential_name": "az-cred",
  "guardrails": []
}
```

`tpm` is still `50` even though the textarea was edited to `100` — the
silent override is reproduced.

**AFTER the fix** — same DOM, same Save click, same mock:

```json
{
  "model": "azure/gpt-4o",
  "api_base": "https://example.openai.azure.com/",
  "custom_llm_provider": "azure",
  "tpm": 100,
  "rpm": 25,
  "timeout": 30,
  "reasoning_effort": { "effort": "high", "summary": "detailed" },
  "tags": [],
  "litellm_credential_name": "az-cred",
  "guardrails": []
}
```

`tpm` now persists as the user intended.

**Failing test on clean `litellm_oss_agent_shin_daily_branch`** (proving the
new regression test is wired to the bug, not the fix):

```
$ npx vitest run src/components/model_info_view.test.tsx -t "LIT-2971" --reporter=verbose

 ✓ ModelInfoView > LiteLLM Params textarea persistence (LIT-2971) > persists nested-dict litellm_params (e.g. reasoning_effort) added via the JSON textarea
 ✓ ModelInfoView > LiteLLM Params textarea persistence (LIT-2971) > prefers the form input value when the user explicitly edits a form field

 FAIL  ModelInfoView > LiteLLM Params textarea persistence (LIT-2971) > persists tpm change made only via the JSON textarea
AssertionError: expected 50 to be 100 // Object.is equality
 ❯ src/components/model_info_view.test.tsx:783:48
    782|       const updatePayload = mockModelPatchUpdateCall.mock.calls[0][1];
    783|       expect(updatePayload.litellm_params.tpm).toBe(100);
       |                                                ^

 Test Files  1 failed (1)
      Tests  1 failed | 2 passed | 36 skipped (39)
```

**Passing on the fix branch** — full `model_info_view.test.tsx`:

```
 Test Files  1 passed (1)
      Tests  39 passed (39)
   Start at  22:48:11
   Duration  32.37s
```

Screenshot of the actual rendered Edit Settings panel (rendered from the
real `ModelInfoView` DOM dump — not a mockup) showing the LiteLLM Params
JSON textarea and the dedicated form inputs side by side:

![LIT-2971 Edit Settings panel](https://raw.githubusercontent.com/oss-agent-shin/litellm/pr-assets-lit2971/lit2971/edit_mode_form.png)

## Backend round-trip (confirms there was nothing to fix in the API)

Driving `litellm.proxy.management_endpoints.model_management_endpoints.update_db_model`
in-process against the real Pydantic models shows the backend already
preserves nested dicts via `extra="allow"` — so the fix lives entirely in
the UI.

```python
# clean main, with a nested-dict litellm_param + tpm change
patch = updateDeployment(
    litellm_params=updateLiteLLMParams(
        reasoning_effort={"effort": "high", "summary": "detailed"},
        tpm=42,
        extra_headers={"X-Foo": "bar"},
    ),
)
result = update_db_model(db_model=db_model, updated_patch=patch)
json.loads(result["litellm_params"])
# →
# {
#   "api_key": "sk-existing", "use_in_pass_through": false,
#   "use_litellm_proxy": false, "merge_reasoning_content_in_choices": false,
#   "model": "openai/gpt-4o", "tpm": 42,
#   "reasoning_effort": {"effort": "high", "summary": "detailed"},
#   "extra_headers": {"X-Foo": "bar"}
# }
```

## Tests

3 new regression tests in
`ui/litellm-dashboard/src/components/model_info_view.test.tsx` under the
`LiteLLM Params textarea persistence (LIT-2971)` describe block:

1. `persists tpm change made only via the JSON textarea` — the canonical
   bug reproducer. Fails on `litellm_oss_agent_shin_daily_branch`, passes
   with the fix.
2. `persists nested-dict litellm_params (e.g. reasoning_effort) added via
   the JSON textarea` — regression guard for the reporter's example.
3. `prefers the form input value when the user explicitly edits a form
   field` — confirms the prior precedence behaviour is preserved when the
   user touches the dedicated input.

Full file: **39 passed (36 pre-existing + 3 new)**.

## Backward compatibility

The behaviour change is limited to the case "user did NOT touch the
dedicated form input AND the textarea carries the key" — previously the
(unchanged) form value silently won; now the textarea value (which equals
the form value when neither was edited) is the source of truth. All other
flows (user touches the form input, user clears the form input, user
neither touches the form nor edits the textarea, vector_store_ids /
input_cost / output_cost / cache_read_cost / cache_write_cost paths) are
byte-identical to before. The existing tests for those flows still pass.

## How the PR was pushed

Standard `oss-agent-shin/litellm` fork → Git Data API blobs/tree/commit/ref
flow (token has `repo` + `workflow` scopes). Base branch is
`litellm_oss_agent_shin_daily_branch` per Shin policy.

Session: https://litellm-agent-platform.onrender.com/sessions/aff7c2eb-b58f-4fb9-a64b-ea57406895bf


---

### Verification (ship-pr)

- Base branch: `litellm_oss_agent_shin_daily_branch` ✅
- Greptile review: **4/5** ✅ ("Safe to merge for the cases addressed"; the P1 `guardrails` callout from the initial 3/5 review was addressed in commit `ff86379`)
- Veria AI review: **success** ✅ ("No security issues found")
- GitHub Actions: **43/43 green**, 0 failed, 0 pending ✅
- Mergeable: `MERGEABLE`, mergeStateStatus: `CLEAN`
- Diff scope: 2 files, +198 / −11 (`ui/litellm-dashboard/src/components/{model_info_view,model_info_view.test}.tsx`) — no generated UI, no `_experimental/out/*`, no node_modules, no lock files
- Runtime evidence captured: BEFORE/AFTER `litellm_params` payload sent to `modelPatchUpdateCall` from the actual `ModelInfoView` rendered in JSDOM + a rendered Edit Settings panel screenshot (hosted on `pr-assets-lit2971` branch, `raw.githubusercontent.com` URL returns 200 image/png)
- Tests: 40/40 in `ui/litellm-dashboard/src/components/model_info_view.test.tsx` (36 pre-existing + 4 new under `LiteLLM Params textarea persistence (LIT-2971)`); 1 of the new tests explicitly fails on clean `litellm_oss_agent_shin_daily_branch` and passes on the fix branch (proof the test is wired to the bug, not the fix)
- No customer name in PR title, body, branch name, commit messages, or test fixtures
- Linear ticket comment with PR link + root-cause writeup: posted
