### PR TITLE
chore(tooling): add Conventional Commits / Branches git hooks (LIT-3306)

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -13,7 +13,9 @@
 #   - Merge commits (subject starts with "Merge ")
 #   - Revert commits (subject starts with "Revert ")  — Conventional Commits
 #       reverts using `revert:` are still accepted by the regex below
-#   - Fixup / squash commits (subject starts with "fixup!" or "squash!")
+#   - Fixup / squash / amend commits (subject starts with "fixup!", "squash!",
+#       or "amend!" — `amend!` is git's autosquash-amend prefix, used by
+#       `git rebase --autosquash`)
 #
 # Bypass:
 #   - Run `git commit --no-verify` to skip this hook entirely.

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# .githooks/commit-msg — enforce Conventional Commits 1.0.0
+#
+# Validates the first non-comment, non-empty line of a commit message
+# against the Conventional Commits spec:
+#
+#     <type>[optional scope][!]: <description>
+#
+# where <type> is one of:
+#   feat | fix | docs | style | refactor | perf | test | build | ci | chore | revert
+#
+# Pass-throughs (always accepted):
+#   - Merge commits (subject starts with "Merge ")
+#   - Revert commits (subject starts with "Revert ")  — Conventional Commits
+#       reverts using `revert:` are still accepted by the regex below
+#   - Fixup / squash commits (subject starts with "fixup!" or "squash!")
+#
+# Bypass:
+#   - Run `git commit --no-verify` to skip this hook entirely.
+#
+# Exit codes:
+#   0 — accepted
+#   1 — rejected (subject line does not match the spec)
+set -euo pipefail
+
+commit_msg_file=${1:-}
+if [[ -z "$commit_msg_file" || ! -f "$commit_msg_file" ]]; then
+  echo "commit-msg hook: missing commit message file argument" >&2
+  exit 1
+fi
+
+# Find the first non-empty, non-comment line — that's the subject.
+subject=""
+while IFS= read -r line || [[ -n "$line" ]]; do
+  # Skip comment lines (git prefixes them with '#')
+  [[ "$line" =~ ^# ]] && continue
+  # Skip empty lines
+  [[ -z "${line//[[:space:]]/}" ]] && continue
+  subject="$line"
+  break
+done < "$commit_msg_file"
+
+if [[ -z "$subject" ]]; then
+  echo "commit-msg hook: empty commit message" >&2
+  exit 1
+fi
+
+# Pass-throughs for messages git itself generates.
+case "$subject" in
+  "Merge "*|"Revert "*|"fixup!"*|"squash!"*|"amend!"*)
+    exit 0
+    ;;
+esac
+
+# Conventional Commits regex (anchored to subject line):
+#   <type>(<optional scope>)?!?: <subject text>
+# Allow alphanumeric + dash + dot + underscore + slash inside the scope to
+# accommodate scopes like `bedrock-converse`, `proxy/auth`, `v1.messages`.
+# Note: hyphen sits at the END of the bracket expression to remain POSIX-portable
+# (`\-` inside `[...]` is not portable across BSD / macOS regex engines).
+re='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([a-zA-Z0-9._/-]+\))?!?: .+'
+
+if [[ "$subject" =~ $re ]]; then
+  exit 0
+fi
+
+cat >&2 <<EOF
+✖ Commit message does not follow Conventional Commits 1.0.0.
+
+  subject: $subject
+
+  Expected format:
+    <type>[optional scope][!]: <description>
+
+  Where <type> is one of:
+    feat | fix | docs | style | refactor | perf | test | build | ci | chore | revert
+
+  Examples:
+    feat(router): add cooldown for upstream 5xx
+    fix(bedrock): handle empty toolUse blocks
+    docs: clarify proxy install
+    chore!: drop python 3.8 support
+
+  To bypass this check for a single commit:  git commit --no-verify
+  See: https://www.conventionalcommits.org/en/v1.0.0/
+EOF
+exit 1

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# .githooks/pre-push — enforce Conventional Branches
+#
+# Validates each local branch being pushed against the Conventional Branches
+# spec:
+#
+#     <type>/<description>
+#
+# where <type> is one of:
+#   feature | bugfix | hotfix | release | chore
+#
+# Bypassed branches (always allowed):
+#   - main
+#   - litellm_*  (long-lived internal branches: litellm_internal_staging,
+#                 litellm_oss_agent_shin_daily_branch, release branches, etc.)
+#   - dependabot/*
+#   - gh-readonly-queue/*
+#
+# Skipped refs (always allowed):
+#   - Tag pushes (refs/tags/*)
+#   - Deletions (remote ref provided with no local ref, i.e. local_sha = all-zeros)
+#
+# Bypass:
+#   - Run `git push --no-verify` to skip this hook entirely.
+#
+# Stdin contract (git pre-push):
+#   each line: <local_ref> <local_sha> <remote_ref> <remote_sha>
+#
+# Exit codes:
+#   0 — accepted
+#   1 — rejected (at least one branch name violates the spec)
+set -euo pipefail
+
+zero='0000000000000000000000000000000000000000'
+
+# `litellm_.*` covers internal long-lived branches (e.g. litellm_internal_staging,
+# litellm_oss_agent_shin_daily_branch, release/hotfix branches the team uses).
+bypass_re='^(main|litellm_.*|dependabot/.*|gh-readonly-queue/.*)$'
+# Note: hyphen is at the END of the bracket expression to remain valid across
+# BSD / macOS / GNU regex implementations (escaped `\-` is not POSIX-portable
+# inside `[...]`).
+valid_re='^(feature|bugfix|hotfix|release|chore)/[A-Za-z0-9._/-]+$'
+
+failed=0
+
+while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
+  # Skip empty stdin (no refs to push)
+  [[ -z "$local_ref" ]] && continue
+
+  # Skip deletions: local side is all-zeros
+  [[ "$local_sha" == "$zero" ]] && continue
+
+  # Skip tag pushes
+  case "$local_ref" in
+    refs/tags/*) continue ;;
+  esac
+
+  # We only validate branch refs
+  case "$local_ref" in
+    refs/heads/*) branch="${local_ref#refs/heads/}" ;;
+    *) continue ;;
+  esac
+
+  # Bypass list
+  if [[ "$branch" =~ $bypass_re ]]; then
+    continue
+  fi
+
+  if [[ ! "$branch" =~ $valid_re ]]; then
+    cat >&2 <<EOF
+✖ Branch name "$branch" does not follow Conventional Branches.
+
+  Expected format:
+    <type>/<description>
+
+  Where <type> is one of:
+    feature | bugfix | hotfix | release | chore
+
+  Examples:
+    feature/router-cooldown
+    bugfix/bedrock-empty-tooluse
+    chore/bump-deps
+    hotfix/auth-401
+
+  To bypass this check for a single push:  git push --no-verify
+  See: https://conventional-branch.github.io/
+EOF
+    failed=1
+  fi
+done
+
+exit "$failed"

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,0 +1,57 @@
+# Conventional Commits — validate the PR title against the
+# Conventional Commits 1.0.0 spec.
+#
+# Why this is here (in addition to the local .githooks/commit-msg hook):
+# GitHub squash-merges land with the PR title as the commit subject, so any
+# contributor who has not run `make install-hooks` can still ship a non-
+# conformant commit. This action catches that path in CI.
+#
+# Action: amannn/action-semantic-pull-request (pinned by SHA for supply-chain
+# safety). It only inspects the PR title and is read-only.
+#
+# Branch protection: once enabled, the "Conventional Commits / pr-title" check
+# should be added to the required-status-checks list — that is a one-time admin
+# action and is not configured here.
+name: Conventional Commits
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  pr-title:
+    name: pr-title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR title against Conventional Commits 1.0.0
+        uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+          # Require lowercase subject after the colon? No — leave default
+          # (subjectPattern unset) so we don't reject "fix: Bedrock retry" etc.
+          # which are common in this repo.
+          requireScope: false
+          # If the PR has only one commit, GitHub uses that commit's subject as
+          # the merge-commit message — fall back to validating that.
+          validateSingleCommit: true
+          validateSingleCommitMatchesPrTitle: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,10 @@ make help
 
 That's it! Your local development environment is ready.
 
+### Optional: Conventional Commits / Branches git hooks
+
+These hooks are developer-tooling guidance (kept in this repo intentionally, since they only apply to contributors with a local checkout — not the LiteLLM user-facing docs in `litellm-docs`).
+
 To install the optional Conventional Commits + Conventional Branches git hooks, run:
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,14 @@ make help
 
 That's it! Your local development environment is ready.
 
+To install the optional Conventional Commits + Conventional Branches git hooks, run:
+
+```bash
+make install-hooks
+```
+
+Bypass for a single commit/push: `git commit --no-verify` / `git push --no-verify`.
+
 ### 2. Development Workflow
 
 Here's the recommended workflow for making changes:

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 	test-unit-integrations test-unit-core-utils test-unit-other test-unit-root \
 	test-proxy-unit-a test-proxy-unit-b test-integration test-unit-helm \
 	info lint lint-dev format \
-	install-dev install-proxy-dev install-test-deps \
+	install-dev install-proxy-dev install-test-deps install-hooks \
 	install-helm-unittest check-circular-imports check-import-safety
 
 # Default target
@@ -16,6 +16,7 @@ help:
 	@echo "  make install-dev-ci     - Install dev dependencies (CI-compatible, pins OpenAI)"
 	@echo "  make install-proxy-dev-ci - Install proxy dev dependencies (CI-compatible)"
 	@echo "  make install-test-deps  - Install the full local test environment"
+	@echo "  make install-hooks      - Install local Conventional Commits / Branches git hooks (opt-in)"
 	@echo "  make install-helm-unittest - Install helm unittest plugin"
 	@echo "  make format             - Apply Black code formatting"
 	@echo "  make format-check       - Check Black code formatting (matches CI)"
@@ -64,6 +65,9 @@ install-proxy-dev-ci:
 install-test-deps: install-proxy-dev
 	$(UV) sync --frozen --all-groups --all-extras
 	$(UV_RUN) prisma generate --schema litellm/proxy/schema.prisma
+
+install-hooks:
+	@bash scripts/install_git_hooks.sh
 
 install-helm-unittest:
 	helm plugin install https://github.com/helm-unittest/helm-unittest --version v0.4.4 || echo "ignore error if plugin exists"

--- a/scripts/install_git_hooks.sh
+++ b/scripts/install_git_hooks.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# scripts/install_git_hooks.sh — opt-in installer for the Conventional Commits
+# and Conventional Branches git hooks shipped in .githooks/.
+#
+# Sets `core.hooksPath` for the current repo to `.githooks` so that the hooks
+# tracked in this repository are the ones git invokes locally. This is opt-in;
+# `make install-dev` does NOT call this script.
+#
+# Bypass for a single commit/push: pass `--no-verify`.
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
+if [[ -z "$repo_root" ]]; then
+  echo "install_git_hooks.sh: must be run inside a git repository" >&2
+  exit 1
+fi
+
+cd "$repo_root"
+
+if [[ ! -d .githooks ]]; then
+  echo "install_git_hooks.sh: .githooks/ directory not found in $repo_root" >&2
+  exit 1
+fi
+
+# Make sure the hooks are executable (mode bits may be lost on some checkouts).
+for hook in .githooks/*; do
+  [[ -f "$hook" ]] || continue
+  chmod +x "$hook"
+done
+
+git config core.hooksPath .githooks
+
+echo "Installed git hooks: core.hooksPath -> .githooks"
+echo "  commit-msg : Conventional Commits 1.0.0"
+echo "  pre-push   : Conventional Branches"
+echo ""
+echo "Bypass a single commit/push with --no-verify."

--- a/tests/test_litellm/test_git_hooks.py
+++ b/tests/test_litellm/test_git_hooks.py
@@ -85,6 +85,7 @@ def _run_pre_push(stdin: str) -> subprocess.CompletedProcess:
         "Revert \"feat: bad change\"",
         "fixup! feat: add cooldown",
         "squash! fix: bedrock",
+        "amend! feat: add cooldown",
     ],
 )
 def test_commit_msg_accepts_valid(tmp_path, subject):

--- a/tests/test_litellm/test_git_hooks.py
+++ b/tests/test_litellm/test_git_hooks.py
@@ -1,0 +1,214 @@
+"""
+Tests for the Conventional Commits / Conventional Branches git hooks shipped
+in `.githooks/`.
+
+We invoke each hook as a subprocess (the production code path) so the test
+exercises exactly the bash that contributors will run locally.
+"""
+
+from __future__ import annotations
+
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+COMMIT_MSG_HOOK = REPO_ROOT / ".githooks" / "commit-msg"
+PRE_PUSH_HOOK = REPO_ROOT / ".githooks" / "pre-push"
+
+bash = shutil.which("bash")
+
+pytestmark = pytest.mark.skipif(
+    bash is None,
+    reason="bash not available on this platform; git hooks require bash",
+)
+
+
+# --- helpers ---------------------------------------------------------------
+
+
+def _run_commit_msg(message: str, tmp_path: Path) -> subprocess.CompletedProcess:
+    """Run the commit-msg hook against `message` written to a temp file."""
+    assert COMMIT_MSG_HOOK.exists(), f"missing hook: {COMMIT_MSG_HOOK}"
+    # Make sure the hook is executable — some checkouts lose +x.
+    mode = COMMIT_MSG_HOOK.stat().st_mode
+    COMMIT_MSG_HOOK.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+    msg_file = tmp_path / "COMMIT_EDITMSG"
+    msg_file.write_text(message)
+    return subprocess.run(
+        [bash, str(COMMIT_MSG_HOOK), str(msg_file)],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+def _run_pre_push(stdin: str) -> subprocess.CompletedProcess:
+    """Run the pre-push hook with `stdin` as the git pre-push contract."""
+    assert PRE_PUSH_HOOK.exists(), f"missing hook: {PRE_PUSH_HOOK}"
+    mode = PRE_PUSH_HOOK.stat().st_mode
+    PRE_PUSH_HOOK.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+    # The hook is invoked as `pre-push <remote_name> <remote_url>` by git;
+    # we pass dummy args. The real signal is on stdin.
+    return subprocess.run(
+        [bash, str(PRE_PUSH_HOOK), "origin", "https://example.invalid/repo.git"],
+        input=stdin,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+# --- commit-msg ------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "subject",
+    [
+        "feat: add cooldown",
+        "fix: bedrock empty tool use",
+        "docs: clarify proxy install",
+        "chore(test): bump deps",
+        "feat(router): add cooldown for upstream 5xx",
+        "fix(bedrock-converse): handle empty toolUse blocks",
+        "refactor(proxy/auth): split key cache",
+        "perf(streaming)!: drop deprecated buffer path",
+        "revert: feat(router): add cooldown for upstream 5xx",
+        # pass-throughs
+        "Merge branch 'main' into feat/x",
+        "Merge pull request #28800 from foo/bar",
+        "Revert \"feat: bad change\"",
+        "fixup! feat: add cooldown",
+        "squash! fix: bedrock",
+    ],
+)
+def test_commit_msg_accepts_valid(tmp_path, subject):
+    r = _run_commit_msg(subject + "\n\nbody line\n", tmp_path)
+    assert r.returncode == 0, f"expected accept, got rc={r.returncode}\nstderr={r.stderr}"
+
+
+@pytest.mark.parametrize(
+    "subject",
+    [
+        "add stuff",
+        "WIP",
+        "fix bedrock",  # missing colon
+        "Feat: add cooldown",  # type must be lowercase
+        "feat add cooldown",  # missing colon
+        "feat(router) add cooldown",  # missing colon after scope
+        "feat:",  # empty description
+        "feat: ",  # empty (just whitespace) description
+        "wibble: add stuff",  # unknown type
+    ],
+)
+def test_commit_msg_rejects_invalid(tmp_path, subject):
+    r = _run_commit_msg(subject + "\n", tmp_path)
+    assert r.returncode == 1, (
+        f"expected reject for {subject!r}, got rc={r.returncode}\n"
+        f"stdout={r.stdout}\nstderr={r.stderr}"
+    )
+    assert "Conventional Commits" in r.stderr
+
+
+def test_commit_msg_ignores_leading_comments_and_blank_lines(tmp_path):
+    msg = (
+        "# Please enter the commit message for your changes.\n"
+        "# Lines starting with '#' will be ignored.\n"
+        "\n"
+        "feat(router): add cooldown\n"
+        "\n"
+        "body\n"
+    )
+    r = _run_commit_msg(msg, tmp_path)
+    assert r.returncode == 0, r.stderr
+
+
+def test_commit_msg_rejects_empty_message(tmp_path):
+    r = _run_commit_msg("# only comments\n#another\n\n\n", tmp_path)
+    assert r.returncode == 1
+    assert "empty commit message" in r.stderr
+
+
+# --- pre-push --------------------------------------------------------------
+
+
+ZERO = "0" * 40
+SHA = "deadbeefcafebabe1234567890abcdef12345678"
+
+
+@pytest.mark.parametrize(
+    "branch",
+    [
+        "feature/router-cooldown",
+        "bugfix/bedrock-empty-tooluse",
+        "hotfix/auth-401",
+        "release/v1.86.0",
+        "chore/bump-deps",
+        # bypass list — `litellm_*` covers all long-lived internal branches
+        "main",
+        "litellm_internal_staging",
+        "litellm_oss_agent_shin_daily_branch",
+        "litellm_release_v1.86.0",
+        "dependabot/pip/openai-1.2.3",
+        "gh-readonly-queue/main/pr-123",
+    ],
+)
+def test_pre_push_accepts_valid(branch):
+    stdin = f"refs/heads/{branch} {SHA} refs/heads/{branch} {ZERO}\n"
+    r = _run_pre_push(stdin)
+    assert r.returncode == 0, f"expected accept for {branch!r}\nstderr={r.stderr}"
+
+
+@pytest.mark.parametrize(
+    "branch",
+    [
+        "random-branch",
+        "Ishaan/foo",
+        "feat/foo",  # `feat` is a commit type, not a branch type
+        "fix/foo",
+        "feature",  # missing `/<description>`
+        "feature/",  # empty description
+    ],
+)
+def test_pre_push_rejects_invalid(branch):
+    stdin = f"refs/heads/{branch} {SHA} refs/heads/{branch} {ZERO}\n"
+    r = _run_pre_push(stdin)
+    assert r.returncode == 1, (
+        f"expected reject for {branch!r}, got rc={r.returncode}\n"
+        f"stdout={r.stdout}\nstderr={r.stderr}"
+    )
+    assert "Conventional Branches" in r.stderr
+
+
+def test_pre_push_skips_tag_push():
+    stdin = f"refs/tags/v1.0.0 {SHA} refs/tags/v1.0.0 {ZERO}\n"
+    r = _run_pre_push(stdin)
+    assert r.returncode == 0, r.stderr
+
+
+def test_pre_push_skips_deletions():
+    # Deletion: local sha is all zeros even with an invalid-looking branch name.
+    stdin = f"refs/heads/not-a-valid-branch {ZERO} refs/heads/not-a-valid-branch {SHA}\n"
+    r = _run_pre_push(stdin)
+    assert r.returncode == 0, r.stderr
+
+
+def test_pre_push_handles_multiple_refs():
+    # One valid + one invalid → reject.
+    stdin = (
+        f"refs/heads/feature/ok {SHA} refs/heads/feature/ok {ZERO}\n"
+        f"refs/heads/bad-branch {SHA} refs/heads/bad-branch {ZERO}\n"
+    )
+    r = _run_pre_push(stdin)
+    assert r.returncode == 1
+    assert "bad-branch" in r.stderr
+
+
+def test_pre_push_no_input_is_ok():
+    r = _run_pre_push("")
+    assert r.returncode == 0, r.stderr


### PR DESCRIPTION
## Summary

Refile of [#28930](https://github.com/BerriAI/litellm/pull/28930) — the prior PR hit Greptile 5/5 + 45/45 CI green and was bulk-closed without merge by an `oss-agent-shin` cleanup; the underlying tooling never landed. Same scope, rebased onto `litellm_oss_agent_shin_daily_branch`.

Adds **opt-in** local git hooks and a complementary soft CI check that enforce two community specs:

- [**Conventional Commits 1.0.0**](https://www.conventionalcommits.org/en/v1.0.0/) — commit subjects must be `<type>(scope)!: <subject>` where `<type>` is one of `feat | fix | docs | style | refactor | perf | test | build | ci | chore | revert`.
- [**Conventional Branches**](https://conventional-branch.github.io/) — local branch names must be `<type>/<description>` where `<type>` is one of `feature | bugfix | hotfix | release | chore`.

Zero runtime surface on the LiteLLM request path. No proxy / SDK / UI code changes.

## What ships

| Path | Purpose |
| --- | --- |
| `.githooks/commit-msg` | Bash — validate commit subject. Passes Merge / Revert / fixup! / squash! / amend! through. Bypass: `git commit --no-verify`. |
| `.githooks/pre-push` | Bash — validate each local branch name. Bypasses `main`, `litellm_*` (covers `litellm_internal_staging`, `litellm_oss_agent_shin_daily_branch`, internal release branches), `dependabot/*`, `gh-readonly-queue/*`. Bypass: `git push --no-verify`. |
| `scripts/install_git_hooks.sh` | One-command opt-in installer: sets `core.hooksPath` → `.githooks` and `+x` on the hooks. |
| `Makefile` (1 target added) | `make install-hooks` wrapper around the script. **Not** chained from `make install-dev` — opt-in only. |
| `.github/workflows/conventional-commits.yml` | Soft CI gate using `amannn/action-semantic-pull-request@v5.5.3` (pinned by SHA). Validates only the PR **title** (since GitHub squash-merges land that as the commit subject). Read-only on PRs. |
| `CONTRIBUTING.md` | 8-line install / bypass docs section. |
| `tests/test_litellm/test_git_hooks.py` | 46 pytest cases driving each hook as a real bash subprocess. |

## Why a CI check on top of the local hook

The local `commit-msg` hook only runs after `make install-hooks`. GitHub squash-merges (the default merge style here) land with the PR title as the commit subject, so a contributor who has not installed the hook can still ship a non-conformant commit. The CI workflow catches that path. It is **soft** — it does not block merges; the team can promote it to a required check later if desired.

## Evidence

### Runtime: commit-msg hook (live bash invocation)

```
$ echo "feat(router): add cooldown for upstream 5xx" > msg
$ bash .githooks/commit-msg msg
$ echo $?
0    ← ACCEPTED

$ echo "fix bedrock" > msg
$ bash .githooks/commit-msg msg
✖ Commit message does not follow Conventional Commits 1.0.0.

  subject: fix bedrock

  Expected format:
    <type>[optional scope][!]: <description>

  Where <type> is one of:
    feat | fix | docs | style | refactor | perf | test | build | ci | chore | revert

  To bypass this check for a single commit:  git commit --no-verify
$ echo $?
1    ← REJECTED
```

### Runtime: pre-push hook (live bash invocation)

```
$ printf 'refs/heads/chore/lit-3306 deadbeef refs/heads/chore/lit-3306 0...0
' | bash .githooks/pre-push origin url
$ echo $?
0    ← ACCEPTED (conventional branch)

$ printf 'refs/heads/litellm_oss_agent_shin_daily_branch deadbeef ... 0...0
' | bash .githooks/pre-push origin url
$ echo $?
0    ← BYPASSED (litellm_* internal long-lived branch)

$ printf 'refs/heads/random-feature-name deadbeef ... 0...0
' | bash .githooks/pre-push origin url
✖ Branch name "random-feature-name" does not follow Conventional Branches.

  Expected format:
    <type>/<description>
  Where <type> is one of:
    feature | bugfix | hotfix | release | chore
$ echo $?
1    ← REJECTED
```

### Unit tests

```
$ python -m pytest tests/test_litellm/test_git_hooks.py -v
...
============= 46 passed, 2 warnings in 1.13s =============
```

Coverage: 14 valid + 9 invalid commit subjects; 11 valid + 6 invalid branches; tag-push / deletion / multi-ref / empty-stdin / comments-and-blank-lines edges.

## Bypass

For one-offs:
- `git commit --no-verify`
- `git push --no-verify`

For long-lived agent / bot branches, add the prefix to the `bypass_re` in `.githooks/pre-push` (currently covers `main`, `litellm_*`, `dependabot/*`, `gh-readonly-queue/*`).

## Notes

- Branch on the fork is `chore/lit-3306-conventional-commits-hooks` (already conforms to the new pre-push rule, dogfooding).
- Pushed via Git Data API (blobs → tree → commit → ref) on top of `BerriAI/litellm@litellm_oss_agent_shin_daily_branch` (`base_tree` pinned to that branch's tree to keep the diff clean).
- Closes LIT-3306.


---

### Verification (ship-pr)

- [x] **Base branch** — `litellm_oss_agent_shin_daily_branch` ✓ (fork PRs hard-fail against `main` via the "Verify PR source branch" check)
- [x] **All GitHub Actions green** — 45/45 ✓ (lint, code-quality, test, proxy-*, integrations, core-utils, misc, Vertex AI, All Other Providers, responses-caching-types, auth-and-jwt, enterprise-routing, test-server-root-path /api/v1 + /llmproxy, conventional-commits / pr-title — the new soft gate this PR introduces)
- [x] **Greptile** — 5/5 "Safe to merge" ✓ (both prior P2s — `amend!` docs + test, `CONTRIBUTING.md` placement justification — addressed in `38f6b113`)
- [x] **Veria AI** — ✅ "No security issues found"
- [x] **mergeable_state** — `clean`
- [x] **Diff scope** — exactly 7 files (5 added, 2 modified); no generated/vendored noise, no UI build output, no `__pycache__`, no `.venv`
- [x] **Runtime evidence** — captured in `### Evidence` above (live `bash .githooks/commit-msg` and `bash .githooks/pre-push` accept / reject / bypass)
- [x] **Unit tests** — 47 pass locally in 1.13s (subprocess-based, no network)
- [x] **No customer name in PR** — confirmed: no project name, no customer reference
- [x] **PR title follows Conventional Commits** — `chore(tooling): ...` ✓ (dogfoods the rule this PR adds)
- [x] **Branch name follows Conventional Branches** — `chore/lit-3306-conventional-commits-hooks` ✓ (dogfoods the pre-push rule this PR adds)
