### PR TITLE
fix(responses): default completion_tokens_details when provider omits output_tokens_details (LIT-1771)

### DIFF
--- a/litellm/responses/utils.py
+++ b/litellm/responses/utils.py
@@ -959,6 +959,14 @@ class ResponseAPILoggingUtils:
                 image_tokens=getattr(output_tokens_details, "image_tokens", None),
                 text_tokens=getattr(output_tokens_details, "text_tokens", None),
             )
+        elif prompt_tokens_details is not None:
+            # Some providers (e.g. Azure non-reasoning Responses API) omit
+            # output_tokens_details even when input_tokens_details is populated.
+            # Default to reasoning_tokens=0 so downstream logging / cost callbacks
+            # receive a symmetric Usage object instead of completion_tokens_details=None.
+            completion_tokens_details = CompletionTokensDetailsWrapper(
+                reasoning_tokens=0,
+            )
 
         chat_usage = Usage(
             prompt_tokens=prompt_tokens,

--- a/tests/test_litellm/responses/test_responses_utils.py
+++ b/tests/test_litellm/responses/test_responses_utils.py
@@ -348,6 +348,71 @@ class TestResponseAPILoggingUtils:
         assert result.completion_tokens_details.image_tokens == 100
         assert result.completion_tokens_details.text_tokens == 70
 
+    def test_transform_response_api_usage_defaults_completion_details_when_only_prompt_present(
+        self,
+    ):
+        """Regression test for #15377 / LIT-1771.
+
+        Some providers (e.g. Azure OpenAI Responses API for non-reasoning
+        models) omit ``output_tokens_details`` from the usage payload while
+        still emitting ``input_tokens_details``. Without the fix, callers see
+        an asymmetric ``Usage`` object where ``prompt_tokens_details`` is
+        populated but ``completion_tokens_details`` is ``None``, breaking
+        downstream cost and observability callbacks.
+        """
+        usage = {
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "total_tokens": 150,
+            "input_tokens_details": {"cached_tokens": 0},
+            # output_tokens_details deliberately omitted
+        }
+
+        result = ResponseAPILoggingUtils._transform_response_api_usage_to_chat_usage(
+            usage
+        )
+
+        assert result.prompt_tokens_details is not None
+        assert result.prompt_tokens_details.cached_tokens == 0
+
+        assert result.completion_tokens_details is not None
+        assert result.completion_tokens_details.reasoning_tokens == 0
+
+    def test_transform_response_api_usage_no_details_stays_none(self):
+        """When neither ``input_tokens_details`` nor ``output_tokens_details``
+        is present, both wrappers should remain ``None`` -- the default only
+        applies on the asymmetric path."""
+        usage = {
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "total_tokens": 15,
+        }
+
+        result = ResponseAPILoggingUtils._transform_response_api_usage_to_chat_usage(
+            usage
+        )
+
+        assert result.prompt_tokens_details is None
+        assert result.completion_tokens_details is None
+
+    def test_transform_response_api_usage_preserves_existing_completion_details(self):
+        """When ``output_tokens_details`` is populated, it must pass through
+        unchanged -- the new default must not overwrite real data."""
+        usage = {
+            "input_tokens": 100,
+            "output_tokens": 200,
+            "total_tokens": 300,
+            "input_tokens_details": {"cached_tokens": 5},
+            "output_tokens_details": {"reasoning_tokens": 42},
+        }
+
+        result = ResponseAPILoggingUtils._transform_response_api_usage_to_chat_usage(
+            usage
+        )
+
+        assert result.completion_tokens_details is not None
+        assert result.completion_tokens_details.reasoning_tokens == 42
+
 
 class TestResponsesAPIProviderSpecificParams:
     """


### PR DESCRIPTION
## Summary

Fixes [#15377](https://github.com/BerriAI/litellm/issues/15377) / LIT-1771.

When upstream Responses API providers (e.g. Azure OpenAI on non-reasoning models like `gpt-4o-mini`) include `input_tokens_details` but omit `output_tokens_details` from the usage payload, `ResponseAPILoggingUtils._transform_response_api_usage_to_chat_usage` in `litellm/responses/utils.py` returned an asymmetric `Usage` object where `prompt_tokens_details` was populated but `completion_tokens_details` was `None`. Downstream logging and cost callbacks (Langfuse, Datadog, custom) then lose reasoning-token visibility for that request.

This was previously filed as #28952 (Greptile 5/5, codecov green) and closed in bulk cleanup without merge — refile against `litellm_oss_agent_shin_daily_branch`.

## Fix

`litellm/responses/utils.py` — `_transform_response_api_usage_to_chat_usage`. When the upstream omits `output_tokens_details` but `input_tokens_details` is populated, default `completion_tokens_details` to `CompletionTokensDetailsWrapper(reasoning_tokens=0)`. Matches OpenAI's own convention for non-reasoning Chat Completions responses. The populated path and the no-details-at-all path are untouched.

```python
        if output_tokens_details:
            completion_tokens_details = CompletionTokensDetailsWrapper(
                reasoning_tokens=getattr(output_tokens_details, "reasoning_tokens", None),
                image_tokens=getattr(output_tokens_details, "image_tokens", None),
                text_tokens=getattr(output_tokens_details, "text_tokens", None),
            )
        elif prompt_tokens_details is not None:
            # Some providers (e.g. Azure non-reasoning Responses API) omit
            # output_tokens_details even when input_tokens_details is populated.
            # Default to reasoning_tokens=0 so downstream logging / cost callbacks
            # receive a symmetric Usage object instead of completion_tokens_details=None.
            completion_tokens_details = CompletionTokensDetailsWrapper(
                reasoning_tokens=0,
            )
```

## Evidence

Runtime evidence captured by driving the exact transform path that every Response API logging callback flows through, with a payload matching the customer-reported asymmetric shape (input details populated, output details absent).

**BEFORE (pre-fix branch logic)** — asymmetric `Usage` reaches logging callbacks:

```text
Upstream usage payload: {"input_tokens": 100, "output_tokens": 50, "total_tokens": 150,
                         "input_tokens_details": {"cached_tokens": 0}}

prompt_tokens_details     = PromptTokensDetailsWrapper(cached_tokens=0, ...)
completion_tokens_details = None
```

**AFTER (patched function on the same payload)** — symmetric:

```text
prompt_tokens_details     = PromptTokensDetailsWrapper(cached_tokens=0, ...)
completion_tokens_details = CompletionTokensDetailsWrapper(reasoning_tokens=0, ...)
```

**AFTER: populated `output_tokens_details` path preserved** — no regression:

```text
Input: {"input_tokens": 100, "output_tokens": 50, "total_tokens": 150,
        "input_tokens_details": {"cached_tokens": 5},
        "output_tokens_details": {"reasoning_tokens": 20}}

completion_tokens_details.reasoning_tokens = 20  (passes through unchanged)
```

**AFTER: empty payload stays `None` on both sides** — default only applies on the asymmetric path:

```text
Input: {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15}

prompt_tokens_details     = None
completion_tokens_details = None
```

## Tests

`tests/test_litellm/responses/test_responses_utils.py` — adds three regression tests pinned to the three paths shown above. All 8 `_transform_response_api_usage_to_chat_usage` tests pass:

```text
$ python -m pytest tests/test_litellm/responses/test_responses_utils.py -v -k "transform_response_api_usage"
test_transform_response_api_usage_calculates_total_from_input_and_output_tokens_if_available PASSED
test_transform_response_api_usage_defaults_completion_details_when_only_prompt_present PASSED   # NEW
test_transform_response_api_usage_mixed_details PASSED
test_transform_response_api_usage_no_details_stays_none PASSED                                   # NEW
test_transform_response_api_usage_preserves_existing_completion_details PASSED                   # NEW
test_transform_response_api_usage_to_chat_usage PASSED
test_transform_response_api_usage_with_image_tokens PASSED
test_transform_response_api_usage_with_none_values PASSED
======================= 8 passed in 0.75s =======================
```

## Notes

- Single-branch logic change, no API surface change, no new dependency.
- Pushed via the GitHub Contents API (one PUT per file) because `GITHUB_TOKEN` lacks the `repo` scope needed for `git push`.

🤖 Filed via agent session: https://litellm-agent-platform.onrender.com/sessions/147a31f4-19ea-43b5-ad3d-95f21267805b


---

### Verification

- **Greptile**: 5/5 ("Safe to merge — the change is a single targeted fallback in one transform function with no effect on existing code paths.")
- **Veria AI**: ✅ No security issues found
- **Codecov**: ✅ All modified and coverable lines are covered by tests
- **GitHub Actions**: 44/44 green, 0 failures
- **Unit tests**: 8/8 transform tests pass (3 new regression tests + 5 existing)
- **Runtime evidence**: captured above (before / after / populated-path / empty-path)
- **Scope**: single `elif` branch, ~7 LOC of logic + comment; no public API change
- **Base branch**: `litellm_oss_agent_shin_daily_branch` ✅
