### PR TITLE
chore(cookbook): bump Go directive to 1.26.3 in gollem example

### DIFF
--- a/cookbook/gollem_go_agent_framework/go.mod
+++ b/cookbook/gollem_go_agent_framework/go.mod
@@ -1,5 +1,5 @@
 module github.com/BerriAI/litellm/cookbook/gollem_go_agent_framework
 
-go 1.25.1
+go 1.26.3
 
 require github.com/fugue-labs/gollem v0.1.0


### PR DESCRIPTION
## Summary
- Bumps the `go` directive in `cookbook/gollem_go_agent_framework/go.mod` from `1.25.1` to `1.26.3` (current stable Go).
- Clears the stale Go stdlib advisories osv-scanner reports against the older directive, keeping dependency scans clean.
- Directive-only change: no source edits, `go.sum` unchanged. The single pinned dependency (`gollem v0.1.0`) is backward compatible and already built under 1.25.

## Notes
- This cookbook example is not built by CI; the bump only raises the minimum Go to build the example by hand. With default `GOTOOLCHAIN=auto`, Go auto-fetches 1.26.3; offline/`GOTOOLCHAIN=local` users on older Go would need to upgrade.
- Could not run `go build` locally (Go not installed in this environment); the change is a manifest/directive bump validated by inspection.

## Test plan
- [ ] `go build ./...` in `cookbook/gollem_go_agent_framework` on a Go 1.26.3 toolchain
- [ ] Re-run osv-scanner against `go.mod` and confirm the stdlib findings clear