### PR TITLE
fix(proxy): persist key-level disable_global_guardrails toggle (LIT-3416)

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1065,6 +1065,7 @@ class KeyRequestBase(GenerateRequestBase):
     budget_id: Optional[str] = None
     tags: Optional[List[str]] = None
     enforced_params: Optional[List[str]] = None
+    disable_global_guardrails: Optional[bool] = None
     allowed_routes: Optional[list] = []
     allowed_passthrough_routes: Optional[list] = None
     allowed_vector_store_indexes: Optional[List[AllowedVectorStoreIndexItem]] = None
@@ -4284,6 +4285,7 @@ LiteLLM_ManagementEndpoint_MetadataFields = [
 
 LiteLLM_ManagementEndpoint_MetadataFields_Premium = [
     "guardrails",
+    "disable_global_guardrails",
     "policies",
     "tags",
     "team_member_key_duration",

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -1166,7 +1166,6 @@ async def test_generate_service_account_works_with_team_id():
             "litellm.proxy.management_endpoints.key_management_endpoints.generate_key_helper_fn"
         ) as mock_generate_key,
     ):
-
         # Configure mocks
         mock_prisma.return_value = AsyncMock()
         mock_router.return_value = None
@@ -1531,17 +1530,35 @@ def test_lit3416_generate_path_merges_into_metadata(monkeypatch):
         _set_object_metadata_field,
     )
 
-    req = GenerateKeyRequest(disable_global_guardrails=True, key_alias="lit3416")
-    for field in LiteLLM_ManagementEndpoint_MetadataFields_Premium:
-        if getattr(req, field, None) is not None:
-            _set_object_metadata_field(req, field, getattr(req, field))
-            delattr(req, field)
-    for field in LiteLLM_ManagementEndpoint_MetadataFields:
-        if getattr(req, field, None) is not None:
-            _set_object_metadata_field(req, field, getattr(req, field))
-            delattr(req, field)
+    def run(req):
+        for field in LiteLLM_ManagementEndpoint_MetadataFields_Premium:
+            if getattr(req, field, None) is not None:
+                _set_object_metadata_field(req, field, getattr(req, field))
+                delattr(req, field)
+        for field in LiteLLM_ManagementEndpoint_MetadataFields:
+            if getattr(req, field, None) is not None:
+                _set_object_metadata_field(req, field, getattr(req, field))
+                delattr(req, field)
 
-    assert req.metadata["disable_global_guardrails"] is True
+    # Generate with True
+    req_true = GenerateKeyRequest(
+        disable_global_guardrails=True, key_alias="lit3416-on"
+    )
+    run(req_true)
+    assert req_true.metadata["disable_global_guardrails"] is True
+
+    # Generate with False — explicit opt-out at create time must still persist,
+    # not be confused with "field omitted". (Greptile follow-up.)
+    req_false = GenerateKeyRequest(
+        disable_global_guardrails=False, key_alias="lit3416-off"
+    )
+    run(req_false)
+    assert req_false.metadata["disable_global_guardrails"] is False
+
+    # Generate without the field — metadata should not gain a stray entry.
+    req_omit = GenerateKeyRequest(key_alias="lit3416-omit")
+    run(req_omit)
+    assert "disable_global_guardrails" not in (req_omit.metadata or {})
 
 
 @pytest.mark.asyncio
@@ -2158,7 +2175,6 @@ async def test_validate_key_team_change_with_member_permissions():
                 with patch(
                     "litellm.proxy.management_endpoints.key_management_endpoints.TeamMemberPermissionChecks.does_team_member_have_permissions_for_endpoint"
                 ) as mock_has_perms:
-
                     mock_get_user.return_value = mock_member_object
                     mock_is_admin.return_value = False
                     mock_has_perms.return_value = True

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -1428,6 +1428,144 @@ async def test_prepare_key_update_data_duration_none_never_expires():
     assert result["expires"] is None
 
 
+# ---------------------------------------------------------------------------
+# LIT-3416: disable_global_guardrails toggle persists on /key/update and
+# /key/generate. Before the fix, the toggle was sent at the top level by the
+# UI; Pydantic silently dropped it because KeyRequestBase had no such field,
+# so key.metadata never received it and runtime kept running global guardrails.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_lit3416_update_persists_disable_global_guardrails_true(monkeypatch):
+    """Top-level `disable_global_guardrails=true` lands in metadata."""
+    from litellm.proxy import proxy_server
+
+    monkeypatch.setattr(proxy_server, "premium_user", True)
+
+    data = UpdateKeyRequest(key="sk-1", disable_global_guardrails=True)
+    existing_key = LiteLLM_VerificationToken(
+        token="hashed", team_id="IJ", metadata={"unrelated": "kept"}
+    )
+
+    result = await prepare_key_update_data(data=data, existing_key_row=existing_key)
+
+    assert result["metadata"]["disable_global_guardrails"] is True
+    # Unrelated existing metadata must not be wiped
+    assert result["metadata"]["unrelated"] == "kept"
+
+
+@pytest.mark.asyncio
+async def test_lit3416_update_persists_disable_global_guardrails_false(monkeypatch):
+    """Setting the toggle back to False is also persisted (turn-off path)."""
+    from litellm.proxy import proxy_server
+
+    monkeypatch.setattr(proxy_server, "premium_user", True)
+
+    data = UpdateKeyRequest(key="sk-1", disable_global_guardrails=False)
+    existing_key = LiteLLM_VerificationToken(
+        token="hashed",
+        team_id="IJ",
+        metadata={"disable_global_guardrails": True},
+    )
+
+    result = await prepare_key_update_data(data=data, existing_key_row=existing_key)
+
+    assert result["metadata"]["disable_global_guardrails"] is False
+
+
+@pytest.mark.asyncio
+async def test_lit3416_update_omit_preserves_existing_disable_global_guardrails(
+    monkeypatch,
+):
+    """Unrelated update (e.g. just renaming the key) must not clear the toggle."""
+    from litellm.proxy import proxy_server
+
+    monkeypatch.setattr(proxy_server, "premium_user", True)
+
+    data = UpdateKeyRequest(key="sk-1", key_alias="renamed")
+    existing_key = LiteLLM_VerificationToken(
+        token="hashed",
+        team_id="IJ",
+        metadata={"disable_global_guardrails": True, "other": "v"},
+    )
+
+    result = await prepare_key_update_data(data=data, existing_key_row=existing_key)
+
+    assert result["metadata"]["disable_global_guardrails"] is True
+    assert result["metadata"]["other"] == "v"
+
+
+def test_lit3416_field_on_schema():
+    """Pydantic schema must declare the field, otherwise Pydantic v2 drops it."""
+    from litellm.proxy._types import GenerateKeyRequest, UpdateKeyRequest
+
+    assert "disable_global_guardrails" in GenerateKeyRequest.model_fields
+    assert "disable_global_guardrails" in UpdateKeyRequest.model_fields
+
+
+def test_lit3416_field_in_premium_metadata_fields():
+    """Premium-list membership is what causes prepare_metadata_fields to
+    fold the top-level value into key.metadata. Lock that in."""
+    from litellm.proxy._types import (
+        LiteLLM_ManagementEndpoint_MetadataFields_Premium,
+    )
+
+    assert (
+        "disable_global_guardrails" in LiteLLM_ManagementEndpoint_MetadataFields_Premium
+    )
+
+
+def test_lit3416_generate_path_merges_into_metadata(monkeypatch):
+    """Mirror the metadata sweep _common_key_generation_helper runs at key
+    creation: top-level disable_global_guardrails -> data.metadata."""
+    from litellm.proxy import proxy_server
+
+    monkeypatch.setattr(proxy_server, "premium_user", True)
+
+    from litellm.proxy._types import (
+        LiteLLM_ManagementEndpoint_MetadataFields,
+        LiteLLM_ManagementEndpoint_MetadataFields_Premium,
+    )
+    from litellm.proxy.management_endpoints.common_utils import (
+        _set_object_metadata_field,
+    )
+
+    req = GenerateKeyRequest(disable_global_guardrails=True, key_alias="lit3416")
+    for field in LiteLLM_ManagementEndpoint_MetadataFields_Premium:
+        if getattr(req, field, None) is not None:
+            _set_object_metadata_field(req, field, getattr(req, field))
+            delattr(req, field)
+    for field in LiteLLM_ManagementEndpoint_MetadataFields:
+        if getattr(req, field, None) is not None:
+            _set_object_metadata_field(req, field, getattr(req, field))
+            delattr(req, field)
+
+    assert req.metadata["disable_global_guardrails"] is True
+
+
+@pytest.mark.asyncio
+async def test_lit3416_update_field_alongside_existing_metadata(monkeypatch):
+    """A caller may submit metadata={...} AND top-level toggle in the same
+    request; the toggle must be merged into the same final dict (not lost
+    because the request-supplied metadata clobbered it)."""
+    from litellm.proxy import proxy_server
+
+    monkeypatch.setattr(proxy_server, "premium_user", True)
+
+    data = UpdateKeyRequest(
+        key="sk-1",
+        metadata={"caller_field": "x"},
+        disable_global_guardrails=True,
+    )
+    existing_key = LiteLLM_VerificationToken(token="hashed", team_id="IJ")
+
+    result = await prepare_key_update_data(data=data, existing_key_row=existing_key)
+
+    assert result["metadata"]["disable_global_guardrails"] is True
+    assert result["metadata"]["caller_field"] == "x"
+
+
 @pytest.mark.asyncio
 async def test_validate_team_id_used_in_service_account_request_requires_team_id():
     """


### PR DESCRIPTION
## LIT-3416 — `disable_global_guardrails` toggle now persists on key create / update

### Root cause

The **Disable Global Guardrails** switch on the LiteLLM dashboard key edit + create UI binds to a top-level form field (`name="disable_global_guardrails"` in `templates/key_edit_view.tsx` and `organisms/create_key_button.tsx`). Both handlers send that value as a top-level body field on `POST /key/generate` / `POST /key/update`.

But `KeyRequestBase` (`litellm/proxy/_types.py`) had no such field, and `LiteLLMPydanticObjectBase` uses Pydantic's default `extra="ignore"` policy — so the toggle was **silently dropped** before reaching `_common_key_generation_helper` / `prepare_key_update_data`. `key.metadata.disable_global_guardrails` was never written, and the runtime read at `litellm/proxy/litellm_pre_call_utils.py:1080` (which keys off that metadata field) kept evaluating to absent → global guardrails kept running.

The team save path was unaffected because the team UI already nests the value inside `metadata.disable_global_guardrails` before submit.

### Fix

Two-line schema/data-classification change in `litellm/proxy/_types.py`:

1. Declare the field on `KeyRequestBase` (`disable_global_guardrails: Optional[bool] = None`) so it propagates through `GenerateKeyRequest`, `UpdateKeyRequest`, and `RegenerateKeyRequest`.
2. Add `"disable_global_guardrails"` to `LiteLLM_ManagementEndpoint_MetadataFields_Premium`, so the existing `_set_object_metadata_field` sweep inside `_common_key_generation_helper` and the `prepare_metadata_fields` step inside `prepare_key_update_data` fold the top-level value into `key.metadata` — exactly the same mechanism that already moves `guardrails`, `policies`, `tags`, etc. into metadata. The premium gate (`_premium_user_check`) is preserved.

Diff is small on purpose — `metadata`/`field`/`premium-gate` plumbing existed already; the field just wasn't on the schema or in the metadata-fields lists.

### Evidence

Driven against the actual `prepare_key_update_data` function (the same coroutine invoked by `POST /key/update` immediately before the database write).

**BEFORE** (clean `litellm_oss_agent_shin_daily_branch` HEAD `1fe911d89d`, fix stashed):

```
[1] POST /key/update body: {"key":"sk-test-key","disable_global_guardrails":true}
    -> prepared metadata payload:
        {"key_alias": "preexisting"}
    -> metadata.disable_global_guardrails = None
AssertionError: Fix failed: True flag missing from metadata
```

**AFTER** (same HEAD + fix applied):

```
[1] POST /key/update body: {"key":"sk-test-key","disable_global_guardrails":true}
    -> prepared metadata payload:
        {"key_alias": "preexisting", "disable_global_guardrails": true}
    -> metadata.disable_global_guardrails = True

[2] POST /key/update body: {"key":"sk-test-key","disable_global_guardrails":false}
    -> prepared metadata payload:
        {"key_alias": "preexisting", "disable_global_guardrails": false}
    -> metadata.disable_global_guardrails = False

[3] POST /key/update body: {"key":"sk-test-key","key_alias":"renamed"} (omit toggle)
    -> prepared metadata payload:
        {"disable_global_guardrails": true, "key_alias": "old"}
    -> metadata.disable_global_guardrails = True  (preserved from existing)

ALL ASSERTIONS PASSED ✅
```

The runtime side reading from `key_metadata["disable_global_guardrails"]` (`litellm_pre_call_utils.py:1080-1085`) is already correct and was tested upstream by the LIT-3299 / custom_guardrail tests; this PR makes the persistence path symmetric so the metadata it reads can actually arrive.

### Tests

7 new regression tests in `tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py`:

- `test_lit3416_field_on_schema` — `GenerateKeyRequest` / `UpdateKeyRequest` Pydantic schemas declare `disable_global_guardrails`. (Pinning this prevents a future field-rename from silently re-introducing the drop bug.)
- `test_lit3416_field_in_premium_metadata_fields` — the premium-list membership that drives the metadata merge.
- `test_lit3416_update_persists_disable_global_guardrails_true` — top-level `true` → `metadata.disable_global_guardrails: True`, existing metadata preserved.
- `test_lit3416_update_persists_disable_global_guardrails_false` — explicit turn-off path.
- `test_lit3416_update_omit_preserves_existing_disable_global_guardrails` — unrelated field updates do not clear the toggle.
- `test_lit3416_generate_path_merges_into_metadata` — mirrors `_common_key_generation_helper`'s premium-field sweep on a `GenerateKeyRequest` for **True**, **False**, and **omitted** (added the False/omitted shapes after Greptile P2).
- `test_lit3416_update_field_alongside_existing_metadata` — caller submits both `metadata={...}` and the top-level toggle; both land in the final dict.

Full key_management_endpoints test suite: **266 passed**. Adjacent tests still green (`test_litellm_pre_call_utils.py` 135, `test_auth_checks.py` + `test_custom_guardrail.py` 167).

### Note on push path

Branch was uploaded via the GitHub Contents API because the agent token lacks `repo` + `workflow` scope for `git push`. Merge-base diff stays narrow because the branch was opened at the daily-branch HEAD before the contents-API commits were applied.

### Evidence (this PR has executable surface)

Runtime evidence above is from the actual `prepare_key_update_data` coroutine that `POST /key/update` calls before the prisma write. Unit tests cover both the `/key/generate` and `/key/update` paths through the same machinery the live endpoints use.

### Verification (ship-pr)

- ✅ **Base branch**: `litellm_oss_agent_shin_daily_branch` (verified via `gh api repos/BerriAI/litellm/pulls/29235 → base.ref`).
- ✅ **Diff scope**: 2 files (`litellm/proxy/_types.py` +2 lines, `test_key_management_endpoints.py` +156 lines). No vendored / generated noise.
- ✅ **Customer name**: no Linear project name leaked in PR title, body, branch, or commits.
- ✅ **Runtime evidence**: BEFORE / AFTER from `prepare_key_update_data` (the function `POST /key/update` calls before the DB write). Captured before/after via `git stash`. Inline in `### Evidence`.
- ✅ **Unit tests**: 7 regression tests, all PASS locally. Full `test_key_management_endpoints.py` suite (266 tests) PASS. Adjacent suites (`test_litellm_pre_call_utils.py`, `test_auth_checks.py`, `test_custom_guardrail.py`) still green.
- ✅ **Greptile**: 5/5 — "Safe to merge — the change is additive (new optional field, new metadata-list entry) and the existing premium gate is preserved."
- ✅ **GitHub Actions**: 43/44 green, 0 failed. The single remaining `Veria AI - PR Review` is a known-flake in-progress check (stuck for >1h on this and many other recent Shin PRs); no functional or test failures.
- ✅ **Codecov**: 100% patch coverage.
- ✅ **CLA**: oss-agent-shin is the commit author (verified via `gh api repos/BerriAI/litellm/pulls/29235/commits`); CLA badge still pending on the CLA-assistant index but should auto-clear on a recheck.
