### PR TITLE
Fix LIT-3417: validate proxy aliases for managed batch input files

### DIFF
--- a/litellm/proxy/hooks/batch_rate_limiter.py
+++ b/litellm/proxy/hooks/batch_rate_limiter.py
@@ -252,10 +252,21 @@ class _PROXY_BatchRateLimiter(CustomLogger):
             # could smuggle restricted/expensive models inside the file
             # and the upstream provider would execute the batch under
             # the proxy's shared API key.
+            #
+            # For managed/unified file IDs, the JSONL `body.model` has
+            # already been rewritten by `replace_model_in_jsonl` to the
+            # upstream provider name (e.g. `litellm_params.model`) — the
+            # caller's key is scoped to the proxy alias (`model_name`),
+            # so we validate the aliases recorded in the unified file ID
+            # itself rather than the rewritten upstream names.
             if user_api_key_dict is not None:
+                unified_file_id = (
+                    is_managed_file if isinstance(is_managed_file, str) else None
+                )
                 await self._enforce_batch_file_model_access(
                     user_api_key_dict=user_api_key_dict,
                     file_content_as_dict=file_content_as_dict,
+                    unified_file_id=unified_file_id,
                 )
 
             input_file_usage = _get_batch_job_input_file_usage(
@@ -291,9 +302,20 @@ class _PROXY_BatchRateLimiter(CustomLogger):
         self,
         user_api_key_dict: UserAPIKeyAuth,
         file_content_as_dict: List[dict],
+        unified_file_id: Optional[str] = None,
     ) -> None:
         """Reject the batch if the caller is not authorized for every
-        ``body.model`` named inside the JSONL.
+        model named in the input file.
+
+        For raw uploads, the relevant names are the distinct ``body.model``
+        values inside the JSONL. For managed/unified file IDs, the JSONL
+        ``body.model`` field has been rewritten to the upstream provider
+        name (``litellm_params.model``) by ``replace_model_in_jsonl``; the
+        caller's key is scoped to the proxy alias (``model_name`` in
+        config), so we validate against the proxy aliases recorded in the
+        unified file ID (``target_model_names``) instead. Managed-file
+        uploads themselves are already authorized against those aliases
+        when the unified file ID is minted.
 
         Reuses ``can_key_call_model`` so the same allowlist semantics
         (wildcards, access groups, ``all-proxy-models``, team aliases)
@@ -302,7 +324,21 @@ class _PROXY_BatchRateLimiter(CustomLogger):
         from litellm.proxy.auth.auth_checks import can_key_call_model
         from litellm.proxy.proxy_server import llm_router
 
-        models = _get_models_from_batch_input_file_content(file_content_as_dict)
+        if unified_file_id is not None:
+            from litellm.proxy.openai_files_endpoints.common_utils import (
+                get_models_from_unified_file_id,
+            )
+
+            models = get_models_from_unified_file_id(unified_file_id)
+            if not models:
+                # Managed file with no recoverable target_model_names —
+                # fall back to the JSONL check so we don't silently skip
+                # validation for a malformed unified ID.
+                models = _get_models_from_batch_input_file_content(
+                    file_content_as_dict
+                )
+        else:
+            models = _get_models_from_batch_input_file_content(file_content_as_dict)
         if not models:
             return
 

--- a/litellm/proxy/hooks/batch_rate_limiter.py
+++ b/litellm/proxy/hooks/batch_rate_limiter.py
@@ -334,9 +334,7 @@ class _PROXY_BatchRateLimiter(CustomLogger):
                 # Managed file with no recoverable target_model_names —
                 # fall back to the JSONL check so we don't silently skip
                 # validation for a malformed unified ID.
-                models = _get_models_from_batch_input_file_content(
-                    file_content_as_dict
-                )
+                models = _get_models_from_batch_input_file_content(file_content_as_dict)
         else:
             models = _get_models_from_batch_input_file_content(file_content_as_dict)
         if not models:

--- a/tests/test_litellm/proxy/hooks/test_batch_file_validation.py
+++ b/tests/test_litellm/proxy/hooks/test_batch_file_validation.py
@@ -285,7 +285,6 @@ async def test_pre_call_skips_check_when_no_models_present():
     )
 
 
-
 # ---------------------------------------------------------------------------
 # Managed/unified file ID — proxy-alias validation
 # ---------------------------------------------------------------------------
@@ -361,9 +360,7 @@ async def test_managed_file_validates_proxy_alias_not_upstream_jsonl_model():
         )
 
     # Critically: the alias was validated, not the upstream JSONL name.
-    assert seen == ["proxy-alias-batch"], (
-        f"expected proxy-alias validation, got {seen}"
-    )
+    assert seen == ["proxy-alias-batch"], f"expected proxy-alias validation, got {seen}"
 
 
 @pytest.mark.asyncio
@@ -400,9 +397,7 @@ async def test_managed_file_rejects_unauthorized_proxy_alias():
     )
 
     async def _reject(**kwargs):
-        raise Exception(
-            f"Key not allowed to access model={kwargs['model']}"
-        )
+        raise Exception(f"Key not allowed to access model={kwargs['model']}")
 
     with (
         patch(

--- a/tests/test_litellm/proxy/hooks/test_batch_file_validation.py
+++ b/tests/test_litellm/proxy/hooks/test_batch_file_validation.py
@@ -283,3 +283,286 @@ async def test_pre_call_skips_check_when_no_models_present():
         user_api_key_dict=user,
         file_content_as_dict=[{"body": {}}],
     )
+
+
+
+# ---------------------------------------------------------------------------
+# Managed/unified file ID — proxy-alias validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_managed_file_validates_proxy_alias_not_upstream_jsonl_model():
+    """Regression test for LIT-3417.
+
+    Batch JSONL for a managed/unified file ID has its `body.model` rewritten
+    by `replace_model_in_jsonl` to the upstream provider name (taken from
+    `litellm_params.model`). Callers are authorized for the proxy alias
+    (`model_name` in config), not the upstream name. Validating the
+    rewritten JSONL `body.model` therefore returns a spurious 403 even when
+    the caller is fully authorized for the alias.
+
+    The fix validates the proxy aliases recorded in the unified file ID
+    (`target_model_names`) instead, so an authorized caller succeeds.
+    """
+    from litellm.proxy.hooks.batch_rate_limiter import _PROXY_BatchRateLimiter
+
+    rate_limiter = _PROXY_BatchRateLimiter(
+        internal_usage_cache=MagicMock(),
+        parallel_request_limiter=MagicMock(),
+    )
+
+    # JSONL has been rewritten by replace_model_in_jsonl to the upstream
+    # name (e.g. "upstream-batch-name"). The caller is NOT authorized for
+    # that name — only for the proxy alias "proxy-alias-batch".
+    file_dict = [
+        {
+            "body": {
+                "model": "upstream-batch-name",
+                "messages": [{"role": "user", "content": "x"}],
+            }
+        }
+    ]
+    unified_file_id = (
+        "litellm_proxy:application/octet-stream;unified_id,abc-123;"
+        "target_model_names,proxy-alias-batch;llm_output_file_id,;"
+        "llm_output_file_model_id,"
+    )
+
+    user = UserAPIKeyAuth(
+        api_key="sk-aliased",
+        user_id="alice",
+        models=["proxy-alias-batch"],
+        user_role=LitellmUserRoles.INTERNAL_USER.value,
+    )
+
+    seen: list = []
+
+    async def _record(**kwargs):
+        seen.append(kwargs["model"])
+        if kwargs["model"] not in (kwargs["valid_token"].models or []):
+            raise Exception(
+                f"Key not allowed to access model. allowed={kwargs['valid_token'].models}"
+            )
+        return True
+
+    with (
+        patch(
+            "litellm.proxy.auth.auth_checks.can_key_call_model",
+            new=AsyncMock(side_effect=_record),
+        ),
+        patch("litellm.proxy.proxy_server.llm_router", None),
+    ):
+        # Should NOT raise — caller is authorized for the proxy alias.
+        await rate_limiter._enforce_batch_file_model_access(
+            user_api_key_dict=user,
+            file_content_as_dict=file_dict,
+            unified_file_id=unified_file_id,
+        )
+
+    # Critically: the alias was validated, not the upstream JSONL name.
+    assert seen == ["proxy-alias-batch"], (
+        f"expected proxy-alias validation, got {seen}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_managed_file_rejects_unauthorized_proxy_alias():
+    """Symmetric to the above: when the caller is not authorized for the
+    proxy alias recorded in the unified file ID, the batch must be rejected
+    with 403."""
+    from litellm.proxy.hooks.batch_rate_limiter import _PROXY_BatchRateLimiter
+
+    rate_limiter = _PROXY_BatchRateLimiter(
+        internal_usage_cache=MagicMock(),
+        parallel_request_limiter=MagicMock(),
+    )
+
+    file_dict = [
+        {
+            "body": {
+                "model": "upstream-name",
+                "messages": [{"role": "user", "content": "x"}],
+            }
+        }
+    ]
+    unified_file_id = (
+        "litellm_proxy:application/octet-stream;unified_id,xyz;"
+        "target_model_names,restricted-alias;llm_output_file_id,;"
+        "llm_output_file_model_id,"
+    )
+
+    user = UserAPIKeyAuth(
+        api_key="sk-narrow",
+        user_id="bob",
+        models=["some-other-alias"],
+        user_role=LitellmUserRoles.INTERNAL_USER.value,
+    )
+
+    async def _reject(**kwargs):
+        raise Exception(
+            f"Key not allowed to access model={kwargs['model']}"
+        )
+
+    with (
+        patch(
+            "litellm.proxy.auth.auth_checks.can_key_call_model",
+            new=AsyncMock(side_effect=_reject),
+        ),
+        patch("litellm.proxy.proxy_server.llm_router", None),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await rate_limiter._enforce_batch_file_model_access(
+                user_api_key_dict=user,
+                file_content_as_dict=file_dict,
+                unified_file_id=unified_file_id,
+            )
+
+    assert exc.value.status_code == 403
+    # The reported model is the alias, not the upstream name.
+    assert "restricted-alias" in str(exc.value.detail)
+    assert "upstream-name" not in str(exc.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_managed_file_with_multiple_aliases_validates_each():
+    """A unified file ID can carry several `target_model_names`. Every one
+    must be validated."""
+    from litellm.proxy.hooks.batch_rate_limiter import _PROXY_BatchRateLimiter
+
+    rate_limiter = _PROXY_BatchRateLimiter(
+        internal_usage_cache=MagicMock(),
+        parallel_request_limiter=MagicMock(),
+    )
+
+    file_dict = [
+        {"body": {"model": "upstream-a", "messages": []}},
+        {"body": {"model": "upstream-b", "messages": []}},
+    ]
+    unified_file_id = (
+        "litellm_proxy:application/octet-stream;unified_id,multi;"
+        "target_model_names,alias-a, alias-b;llm_output_file_id,;"
+        "llm_output_file_model_id,"
+    )
+
+    user = UserAPIKeyAuth(
+        api_key="sk-multi",
+        user_id="alice",
+        models=["alias-a", "alias-b"],
+        user_role=LitellmUserRoles.INTERNAL_USER.value,
+    )
+
+    seen: list = []
+
+    async def _ok(**kwargs):
+        seen.append(kwargs["model"])
+        return True
+
+    with (
+        patch(
+            "litellm.proxy.auth.auth_checks.can_key_call_model",
+            new=AsyncMock(side_effect=_ok),
+        ),
+        patch("litellm.proxy.proxy_server.llm_router", None),
+    ):
+        await rate_limiter._enforce_batch_file_model_access(
+            user_api_key_dict=user,
+            file_content_as_dict=file_dict,
+            unified_file_id=unified_file_id,
+        )
+
+    # Both aliases validated; whitespace stripped by the extractor.
+    assert seen == ["alias-a", "alias-b"]
+
+
+@pytest.mark.asyncio
+async def test_managed_file_with_no_target_model_names_falls_back_to_jsonl():
+    """If the unified file ID is malformed and has no target_model_names,
+    fall back to validating the JSONL `body.model` so we don't silently
+    drop the security check."""
+    from litellm.proxy.hooks.batch_rate_limiter import _PROXY_BatchRateLimiter
+
+    rate_limiter = _PROXY_BatchRateLimiter(
+        internal_usage_cache=MagicMock(),
+        parallel_request_limiter=MagicMock(),
+    )
+
+    file_dict = [
+        {"body": {"model": "gpt-4o", "messages": [{"role": "user", "content": "x"}]}}
+    ]
+    # Valid prefix but no target_model_names field
+    unified_file_id = (
+        "litellm_proxy:application/octet-stream;unified_id,broken;"
+        "llm_output_file_id,;llm_output_file_model_id,"
+    )
+
+    user = UserAPIKeyAuth(
+        api_key="sk-broken",
+        user_id="alice",
+        models=["gpt-3.5-turbo"],
+        user_role=LitellmUserRoles.INTERNAL_USER.value,
+    )
+
+    async def _raise(**kwargs):
+        raise Exception(f"not allowed: {kwargs['model']}")
+
+    with (
+        patch(
+            "litellm.proxy.auth.auth_checks.can_key_call_model",
+            new=AsyncMock(side_effect=_raise),
+        ),
+        patch("litellm.proxy.proxy_server.llm_router", None),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await rate_limiter._enforce_batch_file_model_access(
+                user_api_key_dict=user,
+                file_content_as_dict=file_dict,
+                unified_file_id=unified_file_id,
+            )
+
+    assert exc.value.status_code == 403
+    assert "gpt-4o" in str(exc.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_raw_upload_still_validates_jsonl_model_names():
+    """Non-managed uploads (no unified_file_id passed) keep the existing
+    behavior: validate the distinct `body.model` values from the JSONL.
+    This preserves the VERIA-39 protection for raw uploads."""
+    from litellm.proxy.hooks.batch_rate_limiter import _PROXY_BatchRateLimiter
+
+    rate_limiter = _PROXY_BatchRateLimiter(
+        internal_usage_cache=MagicMock(),
+        parallel_request_limiter=MagicMock(),
+    )
+
+    file_dict = [
+        {"body": {"model": "gpt-4o", "messages": [{"role": "user", "content": "x"}]}}
+    ]
+
+    user = UserAPIKeyAuth(
+        api_key="sk-raw",
+        user_id="alice",
+        models=["gpt-3.5-turbo"],
+        user_role=LitellmUserRoles.INTERNAL_USER.value,
+    )
+
+    async def _raise(**kwargs):
+        raise Exception(f"not allowed: {kwargs['model']}")
+
+    with (
+        patch(
+            "litellm.proxy.auth.auth_checks.can_key_call_model",
+            new=AsyncMock(side_effect=_raise),
+        ),
+        patch("litellm.proxy.proxy_server.llm_router", None),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await rate_limiter._enforce_batch_file_model_access(
+                user_api_key_dict=user,
+                file_content_as_dict=file_dict,
+                # No unified_file_id — raw upload path
+            )
+
+    assert exc.value.status_code == 403
+    assert "gpt-4o" in str(exc.value.detail)


### PR DESCRIPTION
## Summary

For managed/unified file IDs used by `POST /v1/batches`, the JSONL `body.model`
has been rewritten by `replace_model_in_jsonl` (called in `Router.acreate_batch`)
to the upstream provider name (`litellm_params.model`). The caller's key is
scoped to the proxy alias (`model_name` in config), so the existing
`_enforce_batch_file_model_access` check — which validates the rewritten JSONL
`body.model` — spuriously rejects authorized callers with a 403.

This is a regression from the VERIA-39 batch-file model-allowlist hardening.
Raw (non-managed) batch uploads are unaffected by the JSONL rewrite, so the
old behaviour is correct there.

## Fix

In `_enforce_batch_file_model_access`, when the input file is a managed/unified
file ID, validate the proxy aliases recorded in the unified file ID
(`target_model_names`) instead of the rewritten JSONL `body.model`.
Managed-file uploads themselves are already authorized against those aliases
when the unified file ID is minted, so this preserves the security guarantee.

Raw (non-managed) uploads keep the existing JSONL-model check intact, so the
VERIA-39 smuggling protection still applies there.

If the unified file ID is malformed and no `target_model_names` can be
extracted, the JSONL check is used as a defensive fallback rather than
silently skipped.

## Files
- `litellm/proxy/hooks/batch_rate_limiter.py` — extend
  `_enforce_batch_file_model_access` with optional `unified_file_id`, used when
  `count_input_file_usage` detected a managed file.
- `tests/test_litellm/proxy/hooks/test_batch_file_validation.py` — 5 new
  regression tests: alias allowed; alias rejected; multiple aliases; malformed
  unified ID falls back to JSONL; raw-upload path unchanged.

### Evidence

Runtime evidence captured by driving `_PROXY_BatchRateLimiter._enforce_batch_file_model_access`
— the same hook `POST /v1/batches` invokes — with realistic inputs and the
**real** `litellm.proxy.auth.auth_checks.can_key_call_model` (the function that
raises the 403 from the customer report):

```text
=== BEFORE (clean main behavior — JSONL body.model check) ===
RESULT: BLOCKED — HTTPException: status_code=403
detail: {'error': "Batch input file references a model the caller is not authorized to use: model=openai/upstream-batch-name, reason=key not allowed to access model. This key can only access models=['openai/proxy-alias-batch']. Tried to access openai/upstream-batch-name"}

=== AFTER (this branch — target_model_names check) ===
RESULT: allowed (no exception). Batch authorization succeeds.
```

Repro details:
- `model_list`: `model_name="openai/proxy-alias-batch"` → `litellm_params.model="openai/upstream-batch-name"`
- caller key `models=["openai/proxy-alias-batch"]`
- JSONL `body.model` rewritten by `replace_model_in_jsonl` to the upstream name
- `unified_file_id` includes `target_model_names=openai/proxy-alias-batch`

The 403 in BEFORE matches the customer report exactly: caller authorized for
the proxy alias, but the check fails on the rewritten upstream name.

### Tests

```text
$ python3 -m pytest tests/test_litellm/proxy/hooks/test_batch_file_validation.py -q
.................                                                        [100%]
17 passed in 8.87s
```

### Notes for reviewers

- Pushed via `PUT /repos/{owner}/{repo}/contents/{path}` (token lacks `repo`
  scope for `git push`); merge-base diff may look noisier than a single
  squashed commit.


### Verification (ship-pr)

- **Greptile**: 4/5 — "Safe to merge; the change is narrowly scoped to the managed-file path and all five new regression tests pass."
- **GitHub Actions**: 43/44 completed, 0 failures (lint reformat round-trip + all proxy/auth/core test workers green). The remaining `Veria AI - PR Review` check has been in_progress for >30 min — known agent-platform issue (Veria stuck in_progress on otherwise-green PRs). Not blocking.
- **Mergeable state**: `unstable` is from the still-running Veria check only; all required CI is green.
- **Base branch**: `litellm_oss_agent_shin_daily_branch` ✅
- **Customer name**: no customer name appears in this PR, the linked Linear ticket reference, or the runtime evidence — generic `proxy-alias-batch` / `upstream-batch-name` are used in the repro.
- **Runtime evidence**: captured BEFORE (status_code=403 from real `can_key_call_model`) and AFTER (allowed) — see `### Evidence` above. Unit tests are in addition, not instead.
- **Tests**: 17/17 pass in `tests/test_litellm/proxy/hooks/test_batch_file_validation.py` (12 prior + 5 new regression).
