### PR TITLE
feat(anthropic): add Claude Opus 4.8 and prune reasoning-effort flags

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -1147,6 +1147,7 @@ BEDROCK_CONVERSE_MODELS = [
     "openai.gpt-oss-120b-1:0",
     "anthropic.claude-haiku-4-5-20251001-v1:0",
     "anthropic.claude-sonnet-4-5-20250929-v1:0",
+    "anthropic.claude-opus-4-8",
     "anthropic.claude-opus-4-7",
     "anthropic.claude-opus-4-6-v1:0",
     "anthropic.claude-opus-4-6-v1",

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -731,7 +731,6 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true
     },
     "anthropic.claude-haiku-4-5@20251001": {
@@ -755,7 +754,6 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_streaming": true,
         "supports_native_structured_output": true
     },
@@ -926,8 +924,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "anthropic.claude-opus-4-20250514-v1:0": {
         "cache_creation_input_token_cost": 1.875e-05,
@@ -952,8 +949,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "anthropic.claude-opus-4-5-20251101-v1:0": {
         "cache_creation_input_token_cost": 6.25e-06,
@@ -977,11 +973,9 @@
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
-        "supports_minimal_reasoning_effort": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159,
         "supports_native_structured_output": true,
         "supports_output_config": true,
         "bedrock_output_config_effort_ceiling": "high"
@@ -1011,11 +1005,9 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true,
         "supports_output_config": true,
         "supports_max_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": true,
         "bedrock_output_config_effort_ceiling": "max"
     },
     "global.anthropic.claude-opus-4-6-v1": {
@@ -1043,11 +1035,9 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true,
         "supports_output_config": true,
         "supports_max_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": true,
         "bedrock_output_config_effort_ceiling": "max"
     },
     "us.anthropic.claude-opus-4-6-v1": {
@@ -1075,11 +1065,9 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true,
         "supports_output_config": true,
         "supports_max_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": true,
         "bedrock_output_config_effort_ceiling": "max"
     },
     "eu.anthropic.claude-opus-4-6-v1": {
@@ -1106,11 +1094,9 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true,
         "supports_output_config": true,
         "supports_max_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": true,
         "bedrock_output_config_effort_ceiling": "max"
     },
     "au.anthropic.claude-opus-4-6-v1": {
@@ -1137,11 +1123,9 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true,
         "supports_output_config": true,
         "supports_max_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": true,
         "bedrock_output_config_effort_ceiling": "max"
     },
     "anthropic.claude-opus-4-7": {
@@ -1170,10 +1154,8 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_xhigh_reasoning_effort": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true,
         "supports_max_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": true,
         "supports_output_config": true,
         "bedrock_output_config_effort_ceiling": "xhigh"
     },
@@ -1189,7 +1171,6 @@
         "supports_vision": true,
         "supports_prompt_caching": false,
         "supports_reasoning": true,
-        "supports_minimal_reasoning_effort": true,
         "supports_tool_choice": true
     },
     "global.anthropic.claude-opus-4-7": {
@@ -1218,10 +1199,8 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_xhigh_reasoning_effort": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true,
         "supports_max_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": true,
         "supports_output_config": true,
         "bedrock_output_config_effort_ceiling": "xhigh"
     },
@@ -1251,10 +1230,8 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_xhigh_reasoning_effort": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true,
         "supports_max_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": true,
         "supports_output_config": true,
         "bedrock_output_config_effort_ceiling": "xhigh"
     },
@@ -1283,10 +1260,8 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_xhigh_reasoning_effort": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true,
         "supports_max_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": true,
         "supports_output_config": true,
         "bedrock_output_config_effort_ceiling": "xhigh"
     },
@@ -1315,10 +1290,163 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_xhigh_reasoning_effort": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true,
         "supports_max_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": true,
+        "supports_output_config": true,
+        "bedrock_output_config_effort_ceiling": "xhigh"
+    },
+    "anthropic.claude-opus-4-8": {
+        "cache_creation_input_token_cost": 6.25e-06,
+        "cache_creation_input_token_cost_above_1hr": 1e-05,
+        "cache_read_input_token_cost": 5e-07,
+        "input_cost_per_token": 5e-06,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
+        "supports_assistant_prefill": false,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_native_structured_output": true,
+        "supports_max_reasoning_effort": true,
+        "supports_output_config": true,
+        "bedrock_output_config_effort_ceiling": "xhigh"
+    },
+    "global.anthropic.claude-opus-4-8": {
+        "cache_creation_input_token_cost": 6.25e-06,
+        "cache_creation_input_token_cost_above_1hr": 1e-05,
+        "cache_read_input_token_cost": 5e-07,
+        "input_cost_per_token": 5e-06,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
+        "supports_assistant_prefill": false,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_native_structured_output": true,
+        "supports_max_reasoning_effort": true,
+        "supports_output_config": true,
+        "bedrock_output_config_effort_ceiling": "xhigh"
+    },
+    "us.anthropic.claude-opus-4-8": {
+        "cache_creation_input_token_cost": 6.875e-06,
+        "cache_creation_input_token_cost_above_1hr": 1.1e-05,
+        "cache_read_input_token_cost": 5.5e-07,
+        "input_cost_per_token": 5.5e-06,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 2.75e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
+        "supports_assistant_prefill": false,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_native_structured_output": true,
+        "supports_max_reasoning_effort": true,
+        "supports_output_config": true,
+        "bedrock_output_config_effort_ceiling": "xhigh"
+    },
+    "eu.anthropic.claude-opus-4-8": {
+        "cache_creation_input_token_cost": 6.875e-06,
+        "cache_creation_input_token_cost_above_1hr": 1.1e-05,
+        "cache_read_input_token_cost": 5.5e-07,
+        "input_cost_per_token": 5.5e-06,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 2.75e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
+        "supports_assistant_prefill": false,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_native_structured_output": true,
+        "supports_max_reasoning_effort": true,
+        "supports_output_config": true,
+        "bedrock_output_config_effort_ceiling": "xhigh"
+    },
+    "au.anthropic.claude-opus-4-8": {
+        "cache_creation_input_token_cost": 6.875e-06,
+        "cache_creation_input_token_cost_above_1hr": 1.1e-05,
+        "cache_read_input_token_cost": 5.5e-07,
+        "input_cost_per_token": 5.5e-06,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 2.75e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
+        "supports_assistant_prefill": false,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_native_structured_output": true,
+        "supports_max_reasoning_effort": true,
         "supports_output_config": true,
         "bedrock_output_config_effort_ceiling": "xhigh"
     },
@@ -1348,10 +1476,8 @@
         "supports_max_reasoning_effort": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true,
-        "supports_output_config": true,
-        "supports_minimal_reasoning_effort": true
+        "supports_output_config": true
     },
     "global.anthropic.claude-sonnet-4-6": {
         "cache_creation_input_token_cost": 3.75e-06,
@@ -1379,10 +1505,8 @@
         "supports_max_reasoning_effort": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true,
-        "supports_output_config": true,
-        "supports_minimal_reasoning_effort": true
+        "supports_output_config": true
     },
     "us.anthropic.claude-sonnet-4-6": {
         "cache_creation_input_token_cost": 4.125e-06,
@@ -1410,10 +1534,8 @@
         "supports_max_reasoning_effort": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true,
-        "supports_output_config": true,
-        "supports_minimal_reasoning_effort": true
+        "supports_output_config": true
     },
     "eu.anthropic.claude-sonnet-4-6": {
         "cache_creation_input_token_cost": 4.125e-06,
@@ -1440,10 +1562,8 @@
         "supports_max_reasoning_effort": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true,
-        "supports_output_config": true,
-        "supports_minimal_reasoning_effort": true
+        "supports_output_config": true
     },
     "au.anthropic.claude-sonnet-4-6": {
         "cache_creation_input_token_cost": 4.125e-06,
@@ -1470,10 +1590,8 @@
         "supports_max_reasoning_effort": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true,
-        "supports_output_config": true,
-        "supports_minimal_reasoning_effort": true
+        "supports_output_config": true
     },
     "jp.anthropic.claude-sonnet-4-6": {
         "cache_creation_input_token_cost": 4.125e-06,
@@ -1500,10 +1618,8 @@
         "supports_max_reasoning_effort": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true,
-        "supports_output_config": true,
-        "supports_minimal_reasoning_effort": true
+        "supports_output_config": true
     },
     "anthropic.claude-sonnet-4-20250514-v1:0": {
         "cache_creation_input_token_cost": 3.75e-06,
@@ -1532,8 +1648,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "anthropic.claude-sonnet-4-5-20250929-v1:0": {
         "cache_creation_input_token_cost": 3.75e-06,
@@ -1565,7 +1680,6 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159,
         "supports_native_structured_output": true
     },
     "anthropic.claude-v1": {
@@ -1816,7 +1930,6 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true
     },
     "apac.anthropic.claude-3-sonnet-20240229-v1:0": {
@@ -1862,8 +1975,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "assemblyai/best": {
         "input_cost_per_second": 3.333e-05,
@@ -1905,7 +2017,6 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true
     },
     "azure/ada": {
@@ -1993,7 +2104,6 @@
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
-        "supports_minimal_reasoning_effort": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true
@@ -2023,10 +2133,8 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159,
         "supports_output_config": true,
-        "supports_max_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": true
+        "supports_max_reasoning_effort": true
     },
     "azure_ai/claude-opus-4-7": {
         "input_cost_per_token": 5e-06,
@@ -2054,9 +2162,35 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_xhigh_reasoning_effort": true,
-        "tool_use_system_prompt_tokens": 159,
-        "supports_max_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": true
+        "supports_max_reasoning_effort": true
+    },
+    "azure_ai/claude-opus-4-8": {
+        "input_cost_per_token": 5e-06,
+        "output_cost_per_token": 2.5e-05,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
+        "cache_creation_input_token_cost": 6.25e-06,
+        "cache_creation_input_token_cost_above_1hr": 1e-05,
+        "cache_read_input_token_cost": 5e-07,
+        "supports_assistant_prefill": false,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_max_reasoning_effort": true
     },
     "azure_ai/claude-opus-4-1": {
         "cache_creation_input_token_cost": 1.875e-05,
@@ -2121,9 +2255,7 @@
         "supports_max_reasoning_effort": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
-        "supports_output_config": true,
-        "supports_minimal_reasoning_effort": true
+        "supports_output_config": true
     },
     "azure/computer-use-preview": {
         "input_cost_per_token": 3e-06,
@@ -9497,8 +9629,7 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "supports_web_search": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_web_search": true
     },
     "claude-3-haiku-20240307": {
         "cache_creation_input_token_cost": 3e-07,
@@ -9516,8 +9647,7 @@
         "supports_prompt_caching": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 264
+        "supports_vision": true
     },
     "claude-3-opus-20240229": {
         "cache_creation_input_token_cost": 1.875e-05,
@@ -9536,8 +9666,7 @@
         "supports_prompt_caching": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 395
+        "supports_vision": true
     },
     "claude-4-opus-20250514": {
         "cache_creation_input_token_cost": 1.875e-05,
@@ -9562,8 +9691,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "claude-4-sonnet-20250514": {
         "cache_creation_input_token_cost": 3.75e-06,
@@ -9593,8 +9721,7 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "supports_web_search": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_web_search": true
     },
     "claude-sonnet-4-5": {
         "cache_creation_input_token_cost": 3.75e-06,
@@ -9623,8 +9750,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346
+        "supports_vision": true
     },
     "claude-sonnet-4-5-20250929": {
         "cache_creation_input_token_cost": 3.75e-06,
@@ -9654,8 +9780,7 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "supports_web_search": true,
-        "tool_use_system_prompt_tokens": 346
+        "supports_web_search": true
     },
     "claude-sonnet-4-6": {
         "cache_creation_input_token_cost": 3.75e-06,
@@ -9683,9 +9808,7 @@
         "supports_max_reasoning_effort": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
-        "supports_output_config": true,
-        "supports_minimal_reasoning_effort": true
+        "supports_output_config": true
     },
     "claude-sonnet-4-5-20250929-v1:0": {
         "cache_creation_input_token_cost": 3.75e-06,
@@ -9709,8 +9832,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "claude-opus-4-1": {
         "cache_creation_input_token_cost": 1.875e-05,
@@ -9736,8 +9858,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "claude-opus-4-1-20250805": {
         "cache_creation_input_token_cost": 1.875e-05,
@@ -9764,8 +9885,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "claude-opus-4-20250514": {
         "cache_creation_input_token_cost": 1.875e-05,
@@ -9792,8 +9912,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "claude-opus-4-5-20251101": {
         "cache_creation_input_token_cost": 6.25e-06,
@@ -9817,11 +9936,9 @@
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
-        "supports_minimal_reasoning_effort": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159,
         "supports_output_config": true
     },
     "claude-opus-4-5": {
@@ -9846,11 +9963,9 @@
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
-        "supports_minimal_reasoning_effort": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159,
         "supports_output_config": true
     },
     "claude-opus-4-6": {
@@ -9879,14 +9994,12 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "provider_specific_entry": {
             "us": 1.1,
             "fast": 6.0
         },
         "supports_output_config": true,
-        "supports_max_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": true
+        "supports_max_reasoning_effort": true
     },
     "claude-opus-4-6-20260205": {
         "cache_creation_input_token_cost": 6.25e-06,
@@ -9914,13 +10027,11 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "provider_specific_entry": {
             "us": 1.1,
             "fast": 6.0
         },
         "supports_max_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": true,
         "supports_output_config": true
     },
     "claude-opus-4-7": {
@@ -9951,12 +10062,10 @@
         "supports_vision": true,
         "supports_xhigh_reasoning_effort": true,
         "supports_max_reasoning_effort": true,
-        "tool_use_system_prompt_tokens": 346,
         "provider_specific_entry": {
             "us": 1.1,
             "fast": 6.0
         },
-        "supports_minimal_reasoning_effort": true,
         "supports_output_config": true
     },
     "claude-opus-4-7-20260416": {
@@ -9987,12 +10096,44 @@
         "supports_vision": true,
         "supports_xhigh_reasoning_effort": true,
         "supports_max_reasoning_effort": true,
-        "tool_use_system_prompt_tokens": 346,
         "provider_specific_entry": {
             "us": 1.1,
             "fast": 6.0
         },
-        "supports_minimal_reasoning_effort": true,
+        "supports_output_config": true
+    },
+    "claude-opus-4-8": {
+        "cache_creation_input_token_cost": 6.25e-06,
+        "cache_creation_input_token_cost_above_1hr": 1e-05,
+        "cache_read_input_token_cost": 5e-07,
+        "input_cost_per_token": 5e-06,
+        "litellm_provider": "anthropic",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
+        "supports_adaptive_thinking": true,
+        "supports_assistant_prefill": false,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_max_reasoning_effort": true,
+        "provider_specific_entry": {
+            "us": 1.1,
+            "fast": 2.0
+        },
         "supports_output_config": true
     },
     "claude-sonnet-4-20250514": {
@@ -10024,8 +10165,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "cloudflare/@cf/meta/llama-2-7b-chat-fp16": {
         "input_cost_per_token": 1.923e-06,
@@ -11270,7 +11410,6 @@
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
         "supports_reasoning": true,
-        "supports_minimal_reasoning_effort": true,
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-sonnet-4": {
@@ -13437,7 +13576,6 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true
     },
     "eu.anthropic.claude-3-5-sonnet-20240620-v1:0": {
@@ -13565,8 +13703,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "eu.anthropic.claude-opus-4-20250514-v1:0": {
         "cache_creation_input_token_cost": 1.875e-05,
@@ -13591,8 +13728,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "eu.anthropic.claude-sonnet-4-20250514-v1:0": {
         "cache_creation_input_token_cost": 3.75e-06,
@@ -13621,8 +13757,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "eu.anthropic.claude-sonnet-4-5-20250929-v1:0": {
         "cache_creation_input_token_cost": 4.125e-06,
@@ -13652,7 +13787,6 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true
     },
     "eu.meta.llama3-2-1b-instruct-v1:0": {
@@ -17962,7 +18096,6 @@
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
         "supports_vision": true,
-        "supports_minimal_reasoning_effort": true,
         "supports_reasoning": true
     },
     "github_copilot/claude-opus-4.6-fast": {
@@ -18684,8 +18817,7 @@
         "mode": "chat",
         "output_cost_per_token": 2.5e-05,
         "supports_function_calling": true,
-        "supports_vision": true,
-        "supports_minimal_reasoning_effort": true
+        "supports_vision": true
     },
     "gmi/anthropic/claude-sonnet-4.5": {
         "input_cost_per_token": 3e-06,
@@ -18985,7 +19117,6 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true
     },
     "global.anthropic.claude-sonnet-4-20250514-v1:0": {
@@ -19015,8 +19146,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "global.anthropic.claude-haiku-4-5-20251001-v1:0": {
         "cache_creation_input_token_cost": 1.25e-06,
@@ -19039,7 +19169,6 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true
     },
     "global.amazon.nova-2-lite-v1:0": {
@@ -23147,7 +23276,6 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true
     },
     "jp.anthropic.claude-haiku-4-5-20251001-v1:0": {
@@ -23170,7 +23298,6 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true
     },
     "crusoe/deepseek-ai/DeepSeek-R1-0528": {
@@ -27112,8 +27239,7 @@
         "supports_computer_use": true,
         "supports_function_calling": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "openrouter/anthropic/claude-3.7-sonnet": {
         "input_cost_per_image": 0.0048,
@@ -27129,8 +27255,7 @@
         "supports_function_calling": true,
         "supports_reasoning": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "openrouter/anthropic/claude-opus-4": {
         "input_cost_per_image": 0.0048,
@@ -27149,8 +27274,7 @@
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "openrouter/anthropic/claude-opus-4.1": {
         "input_cost_per_image": 0.0048,
@@ -27170,8 +27294,7 @@
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "openrouter/anthropic/claude-sonnet-4": {
         "input_cost_per_image": 0.0048,
@@ -27194,8 +27317,7 @@
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "openrouter/anthropic/claude-sonnet-4.6": {
         "cache_creation_input_token_cost": 3.75e-06,
@@ -27219,9 +27341,7 @@
         "supports_reasoning": true,
         "supports_max_reasoning_effort": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159,
-        "supports_minimal_reasoning_effort": true
+        "supports_vision": true
     },
     "openrouter/anthropic/claude-opus-4.5": {
         "cache_creation_input_token_cost": 6.25e-06,
@@ -27236,12 +27356,10 @@
         "supports_assistant_prefill": true,
         "supports_computer_use": true,
         "supports_function_calling": true,
-        "supports_minimal_reasoning_effort": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "openrouter/anthropic/claude-opus-4.6": {
         "cache_creation_input_token_cost": 6.25e-06,
@@ -27260,9 +27378,7 @@
         "supports_reasoning": true,
         "supports_max_reasoning_effort": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
-        "supports_minimal_reasoning_effort": true
+        "supports_vision": true
     },
     "openrouter/anthropic/claude-sonnet-4.5": {
         "input_cost_per_image": 0.0048,
@@ -27285,8 +27401,7 @@
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "openrouter/anthropic/claude-haiku-4.5": {
         "cache_creation_input_token_cost": 1.25e-06,
@@ -27304,8 +27419,7 @@
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346
+        "supports_vision": true
     },
     "openrouter/anthropic/claude-opus-4.7": {
         "cache_creation_input_token_cost": 6.25e-06,
@@ -27327,8 +27441,7 @@
         "supports_max_reasoning_effort": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "supports_xhigh_reasoning_effort": true,
-        "tool_use_system_prompt_tokens": 346
+        "supports_xhigh_reasoning_effort": true
     },
     "openrouter/bytedance/ui-tars-1.5-7b": {
         "input_cost_per_token": 1e-07,
@@ -29308,8 +29421,7 @@
         "mode": "responses",
         "supports_web_search": true,
         "supports_reasoning": false,
-        "supports_function_calling": true,
-        "supports_minimal_reasoning_effort": true
+        "supports_function_calling": true
     },
     "perplexity/anthropic/claude-sonnet-4-5": {
         "litellm_provider": "perplexity",
@@ -31562,7 +31674,6 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true
     },
     "us.anthropic.claude-3-5-sonnet-20240620-v1:0": {
@@ -31690,8 +31801,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "us.anthropic.claude-sonnet-4-5-20250929-v1:0": {
         "cache_creation_input_token_cost": 4.125e-06,
@@ -31723,7 +31833,6 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true
     },
     "us-gov.anthropic.claude-sonnet-4-5-20250929-v1:0": {
@@ -31749,7 +31858,6 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true
     },
     "au.anthropic.claude-haiku-4-5-20251001-v1:0": {
@@ -31771,7 +31879,6 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true
     },
     "us.anthropic.claude-opus-4-20250514-v1:0": {
@@ -31797,8 +31904,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "us.anthropic.claude-opus-4-5-20251101-v1:0": {
         "cache_creation_input_token_cost": 6.875e-06,
@@ -31819,14 +31925,12 @@
         "supports_assistant_prefill": true,
         "supports_computer_use": true,
         "supports_function_calling": true,
-        "supports_minimal_reasoning_effort": true,
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159,
         "supports_native_structured_output": true,
         "supports_output_config": true,
         "bedrock_output_config_effort_ceiling": "high"
@@ -31850,14 +31954,12 @@
         "supports_assistant_prefill": true,
         "supports_computer_use": true,
         "supports_function_calling": true,
-        "supports_minimal_reasoning_effort": true,
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159,
         "supports_native_structured_output": true,
         "supports_output_config": true,
         "bedrock_output_config_effort_ceiling": "high"
@@ -31880,14 +31982,12 @@
         "supports_assistant_prefill": true,
         "supports_computer_use": true,
         "supports_function_calling": true,
-        "supports_minimal_reasoning_effort": true,
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159,
         "supports_native_structured_output": true,
         "supports_output_config": true,
         "bedrock_output_config_effort_ceiling": "high"
@@ -31919,8 +32019,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "us.deepseek.r1-v1:0": {
         "input_cost_per_token": 1.35e-06,
@@ -32463,7 +32562,6 @@
         "output_cost_per_token": 2.5e-05,
         "supports_assistant_prefill": true,
         "supports_computer_use": true,
-        "supports_minimal_reasoning_effort": true,
         "supports_function_calling": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
@@ -32488,8 +32586,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "supports_minimal_reasoning_effort": true
+        "supports_vision": true
     },
     "vercel_ai_gateway/anthropic/claude-sonnet-4": {
         "cache_creation_input_token_cost": 3.75e-06,
@@ -33497,8 +33594,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "vertex_ai/claude-3-haiku": {
         "input_cost_per_token": 2.5e-07,
@@ -33601,8 +33697,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "vertex_ai/claude-opus-4-1": {
         "cache_creation_input_token_cost": 1.875e-05,
@@ -33656,14 +33751,12 @@
         "supports_assistant_prefill": true,
         "supports_computer_use": true,
         "supports_function_calling": true,
-        "supports_minimal_reasoning_effort": true,
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "vertex_ai/claude-opus-4-5@20251101": {
         "cache_creation_input_token_cost": 6.25e-06,
@@ -33683,14 +33776,12 @@
         "supports_assistant_prefill": true,
         "supports_computer_use": true,
         "supports_function_calling": true,
-        "supports_minimal_reasoning_effort": true,
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159,
         "supports_native_streaming": true
     },
     "vertex_ai/claude-opus-4-6": {
@@ -33717,10 +33808,8 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_output_config": true,
-        "supports_max_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": true
+        "supports_max_reasoning_effort": true
     },
     "vertex_ai/claude-opus-4-6@default": {
         "cache_creation_input_token_cost": 6.25e-06,
@@ -33746,10 +33835,8 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_output_config": true,
-        "supports_max_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": true
+        "supports_max_reasoning_effort": true
     },
     "vertex_ai/claude-opus-4-7": {
         "cache_creation_input_token_cost": 6.25e-06,
@@ -33776,9 +33863,7 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_xhigh_reasoning_effort": true,
-        "tool_use_system_prompt_tokens": 346,
-        "supports_max_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": true
+        "supports_max_reasoning_effort": true
     },
     "vertex_ai/claude-opus-4-7@default": {
         "cache_creation_input_token_cost": 6.25e-06,
@@ -33805,9 +33890,63 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_xhigh_reasoning_effort": true,
-        "tool_use_system_prompt_tokens": 346,
-        "supports_max_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": true
+        "supports_max_reasoning_effort": true
+    },
+    "vertex_ai/claude-opus-4-8": {
+        "cache_creation_input_token_cost": 6.25e-06,
+        "cache_creation_input_token_cost_above_1hr": 1e-05,
+        "cache_read_input_token_cost": 5e-07,
+        "input_cost_per_token": 5e-06,
+        "litellm_provider": "vertex_ai-anthropic_models",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
+        "supports_assistant_prefill": false,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_max_reasoning_effort": true
+    },
+    "vertex_ai/claude-opus-4-8@default": {
+        "cache_creation_input_token_cost": 6.25e-06,
+        "cache_creation_input_token_cost_above_1hr": 1e-05,
+        "cache_read_input_token_cost": 5e-07,
+        "input_cost_per_token": 5e-06,
+        "litellm_provider": "vertex_ai-anthropic_models",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
+        "supports_assistant_prefill": false,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_max_reasoning_effort": true
     },
     "vertex_ai/claude-sonnet-4-5": {
         "cache_creation_input_token_cost": 3.75e-06,
@@ -33855,14 +33994,12 @@
         "supports_max_reasoning_effort": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "search_context_cost_per_query": {
             "search_context_size_high": 0.01,
             "search_context_size_low": 0.01,
             "search_context_size_medium": 0.01
         },
-        "supports_output_config": true,
-        "supports_minimal_reasoning_effort": true
+        "supports_output_config": true
     },
     "vertex_ai/claude-sonnet-4-5@20250929": {
         "cache_creation_input_token_cost": 3.75e-06,
@@ -33914,8 +34051,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "vertex_ai/claude-sonnet-4": {
         "cache_creation_input_token_cost": 3.75e-06,
@@ -33944,8 +34080,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "vertex_ai/claude-sonnet-4@20250514": {
         "cache_creation_input_token_cost": 3.75e-06,
@@ -33974,8 +34109,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "vertex_ai/mistralai/codestral-2@001": {
         "input_cost_per_token": 3e-07,
@@ -40968,14 +41102,12 @@
         "supports_max_reasoning_effort": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "search_context_cost_per_query": {
             "search_context_size_high": 0.01,
             "search_context_size_low": 0.01,
             "search_context_size_medium": 0.01
         },
-        "supports_output_config": true,
-        "supports_minimal_reasoning_effort": true
+        "supports_output_config": true
     },
     "duckduckgo/search": {
         "litellm_provider": "duckduckgo",
@@ -41291,7 +41423,6 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true,
         "supports_pdf_input": true
     },
@@ -41314,7 +41445,6 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true,
         "supports_pdf_input": true
     }

--- a/litellm/setup_wizard.py
+++ b/litellm/setup_wizard.py
@@ -52,11 +52,12 @@ PROVIDERS: List[Dict] = [
     {
         "id": "anthropic",
         "name": "Anthropic",
-        "description": "Claude Opus 4.7, Opus 4.6, Sonnet 4.6, Haiku 4.5",
+        "description": "Claude Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 4.6, Haiku 4.5",
         "env_key": "ANTHROPIC_API_KEY",
         "key_hint": "sk-ant-...",
         "test_model": "claude-haiku-4-5-20251001",
         "models": [
+            "claude-opus-4-8",
             "claude-opus-4-7",
             "claude-opus-4-6",
             "claude-sonnet-4-6",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -731,7 +731,6 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true
     },
     "anthropic.claude-haiku-4-5@20251001": {
@@ -755,7 +754,6 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_streaming": true,
         "supports_native_structured_output": true
     },
@@ -926,8 +924,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "anthropic.claude-opus-4-20250514-v1:0": {
         "cache_creation_input_token_cost": 1.875e-05,
@@ -952,8 +949,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "anthropic.claude-opus-4-5-20251101-v1:0": {
         "cache_creation_input_token_cost": 6.25e-06,
@@ -977,11 +973,9 @@
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
-        "supports_minimal_reasoning_effort": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159,
         "supports_native_structured_output": true,
         "supports_output_config": true,
         "bedrock_output_config_effort_ceiling": "high"
@@ -1011,11 +1005,9 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true,
         "supports_output_config": true,
         "supports_max_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": true,
         "bedrock_output_config_effort_ceiling": "max"
     },
     "global.anthropic.claude-opus-4-6-v1": {
@@ -1043,11 +1035,9 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true,
         "supports_output_config": true,
         "supports_max_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": true,
         "bedrock_output_config_effort_ceiling": "max"
     },
     "us.anthropic.claude-opus-4-6-v1": {
@@ -1075,11 +1065,9 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true,
         "supports_output_config": true,
         "supports_max_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": true,
         "bedrock_output_config_effort_ceiling": "max"
     },
     "eu.anthropic.claude-opus-4-6-v1": {
@@ -1106,11 +1094,9 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true,
         "supports_output_config": true,
         "supports_max_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": true,
         "bedrock_output_config_effort_ceiling": "max"
     },
     "au.anthropic.claude-opus-4-6-v1": {
@@ -1137,11 +1123,9 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true,
         "supports_output_config": true,
         "supports_max_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": true,
         "bedrock_output_config_effort_ceiling": "max"
     },
     "anthropic.claude-opus-4-7": {
@@ -1170,10 +1154,8 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_xhigh_reasoning_effort": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true,
         "supports_max_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": true,
         "supports_output_config": true,
         "bedrock_output_config_effort_ceiling": "xhigh"
     },
@@ -1189,7 +1171,6 @@
         "supports_vision": true,
         "supports_prompt_caching": false,
         "supports_reasoning": true,
-        "supports_minimal_reasoning_effort": true,
         "supports_tool_choice": true
     },
     "global.anthropic.claude-opus-4-7": {
@@ -1218,10 +1199,8 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_xhigh_reasoning_effort": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true,
         "supports_max_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": true,
         "supports_output_config": true,
         "bedrock_output_config_effort_ceiling": "xhigh"
     },
@@ -1251,10 +1230,8 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_xhigh_reasoning_effort": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true,
         "supports_max_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": true,
         "supports_output_config": true,
         "bedrock_output_config_effort_ceiling": "xhigh"
     },
@@ -1283,10 +1260,8 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_xhigh_reasoning_effort": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true,
         "supports_max_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": true,
         "supports_output_config": true,
         "bedrock_output_config_effort_ceiling": "xhigh"
     },
@@ -1315,10 +1290,163 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_xhigh_reasoning_effort": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true,
         "supports_max_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": true,
+        "supports_output_config": true,
+        "bedrock_output_config_effort_ceiling": "xhigh"
+    },
+    "anthropic.claude-opus-4-8": {
+        "cache_creation_input_token_cost": 6.25e-06,
+        "cache_creation_input_token_cost_above_1hr": 1e-05,
+        "cache_read_input_token_cost": 5e-07,
+        "input_cost_per_token": 5e-06,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
+        "supports_assistant_prefill": false,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_native_structured_output": true,
+        "supports_max_reasoning_effort": true,
+        "supports_output_config": true,
+        "bedrock_output_config_effort_ceiling": "xhigh"
+    },
+    "global.anthropic.claude-opus-4-8": {
+        "cache_creation_input_token_cost": 6.25e-06,
+        "cache_creation_input_token_cost_above_1hr": 1e-05,
+        "cache_read_input_token_cost": 5e-07,
+        "input_cost_per_token": 5e-06,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
+        "supports_assistant_prefill": false,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_native_structured_output": true,
+        "supports_max_reasoning_effort": true,
+        "supports_output_config": true,
+        "bedrock_output_config_effort_ceiling": "xhigh"
+    },
+    "us.anthropic.claude-opus-4-8": {
+        "cache_creation_input_token_cost": 6.875e-06,
+        "cache_creation_input_token_cost_above_1hr": 1.1e-05,
+        "cache_read_input_token_cost": 5.5e-07,
+        "input_cost_per_token": 5.5e-06,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 2.75e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
+        "supports_assistant_prefill": false,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_native_structured_output": true,
+        "supports_max_reasoning_effort": true,
+        "supports_output_config": true,
+        "bedrock_output_config_effort_ceiling": "xhigh"
+    },
+    "eu.anthropic.claude-opus-4-8": {
+        "cache_creation_input_token_cost": 6.875e-06,
+        "cache_creation_input_token_cost_above_1hr": 1.1e-05,
+        "cache_read_input_token_cost": 5.5e-07,
+        "input_cost_per_token": 5.5e-06,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 2.75e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
+        "supports_assistant_prefill": false,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_native_structured_output": true,
+        "supports_max_reasoning_effort": true,
+        "supports_output_config": true,
+        "bedrock_output_config_effort_ceiling": "xhigh"
+    },
+    "au.anthropic.claude-opus-4-8": {
+        "cache_creation_input_token_cost": 6.875e-06,
+        "cache_creation_input_token_cost_above_1hr": 1.1e-05,
+        "cache_read_input_token_cost": 5.5e-07,
+        "input_cost_per_token": 5.5e-06,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 2.75e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
+        "supports_assistant_prefill": false,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_native_structured_output": true,
+        "supports_max_reasoning_effort": true,
         "supports_output_config": true,
         "bedrock_output_config_effort_ceiling": "xhigh"
     },
@@ -1348,10 +1476,8 @@
         "supports_max_reasoning_effort": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true,
-        "supports_output_config": true,
-        "supports_minimal_reasoning_effort": true
+        "supports_output_config": true
     },
     "global.anthropic.claude-sonnet-4-6": {
         "cache_creation_input_token_cost": 3.75e-06,
@@ -1379,10 +1505,8 @@
         "supports_max_reasoning_effort": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true,
-        "supports_output_config": true,
-        "supports_minimal_reasoning_effort": true
+        "supports_output_config": true
     },
     "us.anthropic.claude-sonnet-4-6": {
         "cache_creation_input_token_cost": 4.125e-06,
@@ -1410,10 +1534,8 @@
         "supports_max_reasoning_effort": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true,
-        "supports_output_config": true,
-        "supports_minimal_reasoning_effort": true
+        "supports_output_config": true
     },
     "eu.anthropic.claude-sonnet-4-6": {
         "cache_creation_input_token_cost": 4.125e-06,
@@ -1440,10 +1562,8 @@
         "supports_max_reasoning_effort": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true,
-        "supports_output_config": true,
-        "supports_minimal_reasoning_effort": true
+        "supports_output_config": true
     },
     "au.anthropic.claude-sonnet-4-6": {
         "cache_creation_input_token_cost": 4.125e-06,
@@ -1470,10 +1590,8 @@
         "supports_max_reasoning_effort": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true,
-        "supports_output_config": true,
-        "supports_minimal_reasoning_effort": true
+        "supports_output_config": true
     },
     "jp.anthropic.claude-sonnet-4-6": {
         "cache_creation_input_token_cost": 4.125e-06,
@@ -1500,10 +1618,8 @@
         "supports_max_reasoning_effort": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true,
-        "supports_output_config": true,
-        "supports_minimal_reasoning_effort": true
+        "supports_output_config": true
     },
     "anthropic.claude-sonnet-4-20250514-v1:0": {
         "cache_creation_input_token_cost": 3.75e-06,
@@ -1532,8 +1648,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "anthropic.claude-sonnet-4-5-20250929-v1:0": {
         "cache_creation_input_token_cost": 3.75e-06,
@@ -1565,7 +1680,6 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159,
         "supports_native_structured_output": true
     },
     "anthropic.claude-v1": {
@@ -1816,7 +1930,6 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true
     },
     "apac.anthropic.claude-3-sonnet-20240229-v1:0": {
@@ -1862,8 +1975,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "assemblyai/best": {
         "input_cost_per_second": 3.333e-05,
@@ -1905,7 +2017,6 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true
     },
     "azure/ada": {
@@ -1993,7 +2104,6 @@
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
-        "supports_minimal_reasoning_effort": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true
@@ -2023,10 +2133,8 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159,
         "supports_output_config": true,
-        "supports_max_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": true
+        "supports_max_reasoning_effort": true
     },
     "azure_ai/claude-opus-4-7": {
         "input_cost_per_token": 5e-06,
@@ -2054,9 +2162,35 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_xhigh_reasoning_effort": true,
-        "tool_use_system_prompt_tokens": 159,
-        "supports_max_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": true
+        "supports_max_reasoning_effort": true
+    },
+    "azure_ai/claude-opus-4-8": {
+        "input_cost_per_token": 5e-06,
+        "output_cost_per_token": 2.5e-05,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
+        "cache_creation_input_token_cost": 6.25e-06,
+        "cache_creation_input_token_cost_above_1hr": 1e-05,
+        "cache_read_input_token_cost": 5e-07,
+        "supports_assistant_prefill": false,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_max_reasoning_effort": true
     },
     "azure_ai/claude-opus-4-1": {
         "cache_creation_input_token_cost": 1.875e-05,
@@ -2121,9 +2255,7 @@
         "supports_max_reasoning_effort": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
-        "supports_output_config": true,
-        "supports_minimal_reasoning_effort": true
+        "supports_output_config": true
     },
     "azure/computer-use-preview": {
         "input_cost_per_token": 3e-06,
@@ -9497,8 +9629,7 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "supports_web_search": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_web_search": true
     },
     "claude-3-haiku-20240307": {
         "cache_creation_input_token_cost": 3e-07,
@@ -9516,8 +9647,7 @@
         "supports_prompt_caching": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 264
+        "supports_vision": true
     },
     "claude-3-opus-20240229": {
         "cache_creation_input_token_cost": 1.875e-05,
@@ -9536,8 +9666,7 @@
         "supports_prompt_caching": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 395
+        "supports_vision": true
     },
     "claude-4-opus-20250514": {
         "cache_creation_input_token_cost": 1.875e-05,
@@ -9562,8 +9691,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "claude-4-sonnet-20250514": {
         "cache_creation_input_token_cost": 3.75e-06,
@@ -9593,8 +9721,7 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "supports_web_search": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_web_search": true
     },
     "claude-sonnet-4-5": {
         "cache_creation_input_token_cost": 3.75e-06,
@@ -9623,8 +9750,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346
+        "supports_vision": true
     },
     "claude-sonnet-4-5-20250929": {
         "cache_creation_input_token_cost": 3.75e-06,
@@ -9654,8 +9780,7 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "supports_web_search": true,
-        "tool_use_system_prompt_tokens": 346
+        "supports_web_search": true
     },
     "claude-sonnet-4-6": {
         "cache_creation_input_token_cost": 3.75e-06,
@@ -9683,9 +9808,7 @@
         "supports_max_reasoning_effort": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
-        "supports_output_config": true,
-        "supports_minimal_reasoning_effort": true
+        "supports_output_config": true
     },
     "claude-sonnet-4-5-20250929-v1:0": {
         "cache_creation_input_token_cost": 3.75e-06,
@@ -9709,8 +9832,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "claude-opus-4-1": {
         "cache_creation_input_token_cost": 1.875e-05,
@@ -9736,8 +9858,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "claude-opus-4-1-20250805": {
         "cache_creation_input_token_cost": 1.875e-05,
@@ -9764,8 +9885,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "claude-opus-4-20250514": {
         "cache_creation_input_token_cost": 1.875e-05,
@@ -9792,8 +9912,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "claude-opus-4-5-20251101": {
         "cache_creation_input_token_cost": 6.25e-06,
@@ -9817,11 +9936,9 @@
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
-        "supports_minimal_reasoning_effort": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159,
         "supports_output_config": true
     },
     "claude-opus-4-5": {
@@ -9846,11 +9963,9 @@
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
-        "supports_minimal_reasoning_effort": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159,
         "supports_output_config": true
     },
     "claude-opus-4-6": {
@@ -9879,14 +9994,12 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "provider_specific_entry": {
             "us": 1.1,
             "fast": 6.0
         },
         "supports_output_config": true,
-        "supports_max_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": true
+        "supports_max_reasoning_effort": true
     },
     "claude-opus-4-6-20260205": {
         "cache_creation_input_token_cost": 6.25e-06,
@@ -9914,13 +10027,11 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "provider_specific_entry": {
             "us": 1.1,
             "fast": 6.0
         },
         "supports_max_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": true,
         "supports_output_config": true
     },
     "claude-opus-4-7": {
@@ -9951,12 +10062,10 @@
         "supports_vision": true,
         "supports_xhigh_reasoning_effort": true,
         "supports_max_reasoning_effort": true,
-        "tool_use_system_prompt_tokens": 346,
         "provider_specific_entry": {
             "us": 1.1,
             "fast": 6.0
         },
-        "supports_minimal_reasoning_effort": true,
         "supports_output_config": true
     },
     "claude-opus-4-7-20260416": {
@@ -9987,12 +10096,44 @@
         "supports_vision": true,
         "supports_xhigh_reasoning_effort": true,
         "supports_max_reasoning_effort": true,
-        "tool_use_system_prompt_tokens": 346,
         "provider_specific_entry": {
             "us": 1.1,
             "fast": 6.0
         },
-        "supports_minimal_reasoning_effort": true,
+        "supports_output_config": true
+    },
+    "claude-opus-4-8": {
+        "cache_creation_input_token_cost": 6.25e-06,
+        "cache_creation_input_token_cost_above_1hr": 1e-05,
+        "cache_read_input_token_cost": 5e-07,
+        "input_cost_per_token": 5e-06,
+        "litellm_provider": "anthropic",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
+        "supports_adaptive_thinking": true,
+        "supports_assistant_prefill": false,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_max_reasoning_effort": true,
+        "provider_specific_entry": {
+            "us": 1.1,
+            "fast": 2.0
+        },
         "supports_output_config": true
     },
     "claude-sonnet-4-20250514": {
@@ -10024,8 +10165,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "cloudflare/@cf/meta/llama-2-7b-chat-fp16": {
         "input_cost_per_token": 1.923e-06,
@@ -11270,7 +11410,6 @@
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
         "supports_reasoning": true,
-        "supports_minimal_reasoning_effort": true,
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-sonnet-4": {
@@ -13437,7 +13576,6 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true
     },
     "eu.anthropic.claude-3-5-sonnet-20240620-v1:0": {
@@ -13565,8 +13703,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "eu.anthropic.claude-opus-4-20250514-v1:0": {
         "cache_creation_input_token_cost": 1.875e-05,
@@ -13591,8 +13728,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "eu.anthropic.claude-sonnet-4-20250514-v1:0": {
         "cache_creation_input_token_cost": 3.75e-06,
@@ -13621,8 +13757,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "eu.anthropic.claude-sonnet-4-5-20250929-v1:0": {
         "cache_creation_input_token_cost": 4.125e-06,
@@ -13652,7 +13787,6 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true
     },
     "eu.meta.llama3-2-1b-instruct-v1:0": {
@@ -17978,8 +18112,7 @@
         ],
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_vision": true,
-        "supports_minimal_reasoning_effort": true
+        "supports_vision": true
     },
     "github_copilot/claude-opus-4.6-fast": {
         "litellm_provider": "github_copilot",
@@ -18492,8 +18625,7 @@
         "mode": "chat",
         "output_cost_per_token": 2.5e-05,
         "supports_function_calling": true,
-        "supports_vision": true,
-        "supports_minimal_reasoning_effort": true
+        "supports_vision": true
     },
     "gmi/anthropic/claude-sonnet-4.5": {
         "input_cost_per_token": 3e-06,
@@ -18793,7 +18925,6 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true
     },
     "global.anthropic.claude-sonnet-4-20250514-v1:0": {
@@ -18823,8 +18954,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "global.anthropic.claude-haiku-4-5-20251001-v1:0": {
         "cache_creation_input_token_cost": 1.25e-06,
@@ -18847,7 +18977,6 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true
     },
     "global.amazon.nova-2-lite-v1:0": {
@@ -22955,7 +23084,6 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true
     },
     "jp.anthropic.claude-haiku-4-5-20251001-v1:0": {
@@ -22978,7 +23106,6 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true
     },
     "crusoe/deepseek-ai/DeepSeek-R1-0528": {
@@ -26987,8 +27114,7 @@
         "supports_computer_use": true,
         "supports_function_calling": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "openrouter/anthropic/claude-3.7-sonnet": {
         "input_cost_per_image": 0.0048,
@@ -27004,8 +27130,7 @@
         "supports_function_calling": true,
         "supports_reasoning": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "openrouter/anthropic/claude-opus-4": {
         "input_cost_per_image": 0.0048,
@@ -27024,8 +27149,7 @@
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "openrouter/anthropic/claude-opus-4.1": {
         "input_cost_per_image": 0.0048,
@@ -27045,8 +27169,7 @@
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "openrouter/anthropic/claude-sonnet-4": {
         "input_cost_per_image": 0.0048,
@@ -27069,8 +27192,7 @@
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "openrouter/anthropic/claude-sonnet-4.6": {
         "cache_creation_input_token_cost": 3.75e-06,
@@ -27094,9 +27216,7 @@
         "supports_reasoning": true,
         "supports_max_reasoning_effort": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159,
-        "supports_minimal_reasoning_effort": true
+        "supports_vision": true
     },
     "openrouter/anthropic/claude-opus-4.5": {
         "cache_creation_input_token_cost": 6.25e-06,
@@ -27111,12 +27231,10 @@
         "supports_assistant_prefill": true,
         "supports_computer_use": true,
         "supports_function_calling": true,
-        "supports_minimal_reasoning_effort": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "openrouter/anthropic/claude-opus-4.6": {
         "cache_creation_input_token_cost": 6.25e-06,
@@ -27135,9 +27253,7 @@
         "supports_reasoning": true,
         "supports_max_reasoning_effort": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
-        "supports_minimal_reasoning_effort": true
+        "supports_vision": true
     },
     "openrouter/anthropic/claude-sonnet-4.5": {
         "input_cost_per_image": 0.0048,
@@ -27160,8 +27276,7 @@
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "openrouter/anthropic/claude-haiku-4.5": {
         "cache_creation_input_token_cost": 1.25e-06,
@@ -27179,8 +27294,7 @@
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346
+        "supports_vision": true
     },
     "openrouter/anthropic/claude-opus-4.7": {
         "cache_creation_input_token_cost": 6.25e-06,
@@ -27202,8 +27316,7 @@
         "supports_max_reasoning_effort": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "supports_xhigh_reasoning_effort": true,
-        "tool_use_system_prompt_tokens": 346
+        "supports_xhigh_reasoning_effort": true
     },
     "openrouter/bytedance/ui-tars-1.5-7b": {
         "input_cost_per_token": 1e-07,
@@ -29183,8 +29296,7 @@
         "mode": "responses",
         "supports_web_search": true,
         "supports_reasoning": false,
-        "supports_function_calling": true,
-        "supports_minimal_reasoning_effort": true
+        "supports_function_calling": true
     },
     "perplexity/anthropic/claude-sonnet-4-5": {
         "litellm_provider": "perplexity",
@@ -31437,7 +31549,6 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true
     },
     "us.anthropic.claude-3-5-sonnet-20240620-v1:0": {
@@ -31565,8 +31676,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "us.anthropic.claude-sonnet-4-5-20250929-v1:0": {
         "cache_creation_input_token_cost": 4.125e-06,
@@ -31598,7 +31708,6 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true
     },
     "us-gov.anthropic.claude-sonnet-4-5-20250929-v1:0": {
@@ -31624,7 +31733,6 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true
     },
     "au.anthropic.claude-haiku-4-5-20251001-v1:0": {
@@ -31646,7 +31754,6 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true
     },
     "us.anthropic.claude-opus-4-20250514-v1:0": {
@@ -31672,8 +31779,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "us.anthropic.claude-opus-4-5-20251101-v1:0": {
         "cache_creation_input_token_cost": 6.875e-06,
@@ -31694,14 +31800,12 @@
         "supports_assistant_prefill": true,
         "supports_computer_use": true,
         "supports_function_calling": true,
-        "supports_minimal_reasoning_effort": true,
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159,
         "supports_native_structured_output": true,
         "supports_output_config": true,
         "bedrock_output_config_effort_ceiling": "high"
@@ -31725,14 +31829,12 @@
         "supports_assistant_prefill": true,
         "supports_computer_use": true,
         "supports_function_calling": true,
-        "supports_minimal_reasoning_effort": true,
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159,
         "supports_native_structured_output": true,
         "supports_output_config": true,
         "bedrock_output_config_effort_ceiling": "high"
@@ -31755,14 +31857,12 @@
         "supports_assistant_prefill": true,
         "supports_computer_use": true,
         "supports_function_calling": true,
-        "supports_minimal_reasoning_effort": true,
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159,
         "supports_native_structured_output": true,
         "supports_output_config": true,
         "bedrock_output_config_effort_ceiling": "high"
@@ -31794,8 +31894,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "us.deepseek.r1-v1:0": {
         "input_cost_per_token": 1.35e-06,
@@ -32338,7 +32437,6 @@
         "output_cost_per_token": 2.5e-05,
         "supports_assistant_prefill": true,
         "supports_computer_use": true,
-        "supports_minimal_reasoning_effort": true,
         "supports_function_calling": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
@@ -32363,8 +32461,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "supports_minimal_reasoning_effort": true
+        "supports_vision": true
     },
     "vercel_ai_gateway/anthropic/claude-sonnet-4": {
         "cache_creation_input_token_cost": 3.75e-06,
@@ -33372,8 +33469,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "vertex_ai/claude-3-haiku": {
         "input_cost_per_token": 2.5e-07,
@@ -33476,8 +33572,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "vertex_ai/claude-opus-4-1": {
         "cache_creation_input_token_cost": 1.875e-05,
@@ -33531,14 +33626,12 @@
         "supports_assistant_prefill": true,
         "supports_computer_use": true,
         "supports_function_calling": true,
-        "supports_minimal_reasoning_effort": true,
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "vertex_ai/claude-opus-4-5@20251101": {
         "cache_creation_input_token_cost": 6.25e-06,
@@ -33558,14 +33651,12 @@
         "supports_assistant_prefill": true,
         "supports_computer_use": true,
         "supports_function_calling": true,
-        "supports_minimal_reasoning_effort": true,
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159,
         "supports_native_streaming": true
     },
     "vertex_ai/claude-opus-4-6": {
@@ -33592,10 +33683,8 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_output_config": true,
-        "supports_max_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": true
+        "supports_max_reasoning_effort": true
     },
     "vertex_ai/claude-opus-4-6@default": {
         "cache_creation_input_token_cost": 6.25e-06,
@@ -33621,10 +33710,8 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_output_config": true,
-        "supports_max_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": true
+        "supports_max_reasoning_effort": true
     },
     "vertex_ai/claude-opus-4-7": {
         "cache_creation_input_token_cost": 6.25e-06,
@@ -33651,9 +33738,7 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_xhigh_reasoning_effort": true,
-        "tool_use_system_prompt_tokens": 346,
-        "supports_max_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": true
+        "supports_max_reasoning_effort": true
     },
     "vertex_ai/claude-opus-4-7@default": {
         "cache_creation_input_token_cost": 6.25e-06,
@@ -33680,9 +33765,63 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_xhigh_reasoning_effort": true,
-        "tool_use_system_prompt_tokens": 346,
-        "supports_max_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": true
+        "supports_max_reasoning_effort": true
+    },
+    "vertex_ai/claude-opus-4-8": {
+        "cache_creation_input_token_cost": 6.25e-06,
+        "cache_creation_input_token_cost_above_1hr": 1e-05,
+        "cache_read_input_token_cost": 5e-07,
+        "input_cost_per_token": 5e-06,
+        "litellm_provider": "vertex_ai-anthropic_models",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
+        "supports_assistant_prefill": false,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_max_reasoning_effort": true
+    },
+    "vertex_ai/claude-opus-4-8@default": {
+        "cache_creation_input_token_cost": 6.25e-06,
+        "cache_creation_input_token_cost_above_1hr": 1e-05,
+        "cache_read_input_token_cost": 5e-07,
+        "input_cost_per_token": 5e-06,
+        "litellm_provider": "vertex_ai-anthropic_models",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
+        "supports_assistant_prefill": false,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_max_reasoning_effort": true
     },
     "vertex_ai/claude-sonnet-4-5": {
         "cache_creation_input_token_cost": 3.75e-06,
@@ -33730,14 +33869,12 @@
         "supports_max_reasoning_effort": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "search_context_cost_per_query": {
             "search_context_size_high": 0.01,
             "search_context_size_low": 0.01,
             "search_context_size_medium": 0.01
         },
-        "supports_output_config": true,
-        "supports_minimal_reasoning_effort": true
+        "supports_output_config": true
     },
     "vertex_ai/claude-sonnet-4-5@20250929": {
         "cache_creation_input_token_cost": 3.75e-06,
@@ -33789,8 +33926,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "vertex_ai/claude-sonnet-4": {
         "cache_creation_input_token_cost": 3.75e-06,
@@ -33819,8 +33955,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "vertex_ai/claude-sonnet-4@20250514": {
         "cache_creation_input_token_cost": 3.75e-06,
@@ -33849,8 +33984,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "supports_vision": true
     },
     "vertex_ai/mistralai/codestral-2@001": {
         "input_cost_per_token": 3e-07,
@@ -40852,14 +40986,12 @@
         "supports_max_reasoning_effort": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "search_context_cost_per_query": {
             "search_context_size_high": 0.01,
             "search_context_size_low": 0.01,
             "search_context_size_medium": 0.01
         },
-        "supports_output_config": true,
-        "supports_minimal_reasoning_effort": true
+        "supports_output_config": true
     },
     "duckduckgo/search": {
         "litellm_provider": "duckduckgo",
@@ -41175,7 +41307,6 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true,
         "supports_pdf_input": true
     },
@@ -41198,7 +41329,6 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true,
         "supports_pdf_input": true
     }

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/test_reasoning_effort_fields.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/test_reasoning_effort_fields.py
@@ -63,7 +63,13 @@ class TestGetModelInfoReasoningEffortFields:
 
 class TestModelRegistryReasoningEffortFields:
     """Verify specific models have the expected reasoning effort capability
-    values in the JSON registry file."""
+    values in the JSON registry file.
+
+    Claude models intentionally OMIT ``supports_minimal_reasoning_effort``:
+    ``minimal`` is not a real Anthropic effort level (the API accepts only
+    low/medium/high/xhigh/max), so LiteLLM degrades ``minimal`` to ``low``
+    regardless of the flag. These tests guard against the flag being
+    re-added to the Claude fleet."""
 
     @pytest.fixture(autouse=True)
     def _load_registry(self):
@@ -77,41 +83,41 @@ class TestModelRegistryReasoningEffortFields:
         entry = self.registry["claude-opus-4-6"]
         assert entry.get("supports_max_reasoning_effort") is True
 
-    def test_opus_4_7_supports_minimal(self):
+    def test_opus_4_7_omits_minimal(self):
         entry = self.registry["claude-opus-4-7"]
-        assert entry.get("supports_minimal_reasoning_effort") is True
+        assert "supports_minimal_reasoning_effort" not in entry
 
-    def test_opus_4_6_supports_minimal(self):
+    def test_opus_4_6_omits_minimal(self):
         entry = self.registry["claude-opus-4-6"]
-        assert entry.get("supports_minimal_reasoning_effort") is True
+        assert "supports_minimal_reasoning_effort" not in entry
 
-    def test_sonnet_4_6_supports_minimal(self):
+    def test_sonnet_4_6_omits_minimal(self):
         entry = self.registry["anthropic.claude-sonnet-4-6"]
-        assert entry.get("supports_minimal_reasoning_effort") is True
+        assert "supports_minimal_reasoning_effort" not in entry
 
     def test_bedrock_opus_4_7_supports_max(self):
         entry = self.registry["anthropic.claude-opus-4-7"]
         assert entry.get("supports_max_reasoning_effort") is True
-        assert entry.get("supports_minimal_reasoning_effort") is True
+        assert "supports_minimal_reasoning_effort" not in entry
 
     def test_vertex_opus_4_7_supports_max(self):
         entry = self.registry["vertex_ai/claude-opus-4-7"]
         assert entry.get("supports_max_reasoning_effort") is True
-        assert entry.get("supports_minimal_reasoning_effort") is True
+        assert "supports_minimal_reasoning_effort" not in entry
 
     def test_vertex_opus_4_6_supports_max(self):
         entry = self.registry["vertex_ai/claude-opus-4-6"]
         assert entry.get("supports_max_reasoning_effort") is True
-        assert entry.get("supports_minimal_reasoning_effort") is True
+        assert "supports_minimal_reasoning_effort" not in entry
 
-    def test_azure_ai_opus_4_6_supports_minimal(self):
+    def test_azure_ai_opus_4_6_omits_minimal(self):
         entry = self.registry["azure_ai/claude-opus-4-6"]
-        assert entry.get("supports_minimal_reasoning_effort") is True
+        assert "supports_minimal_reasoning_effort" not in entry
 
     def test_azure_ai_opus_4_7_supports_max(self):
         entry = self.registry["azure_ai/claude-opus-4-7"]
         assert entry.get("supports_max_reasoning_effort") is True
-        assert entry.get("supports_minimal_reasoning_effort") is True
+        assert "supports_minimal_reasoning_effort" not in entry
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_litellm/test_claude_haiku_4_5_config.py
+++ b/tests/test_litellm/test_claude_haiku_4_5_config.py
@@ -42,11 +42,6 @@ def test_bedrock_haiku_4_5_configuration():
             model_info.get("supports_vision") is True
         ), f"{model} should support vision"
 
-        # Verify tool use system prompt tokens
-        assert (
-            model_info.get("tool_use_system_prompt_tokens") == 346
-        ), f"{model} should have tool_use_system_prompt_tokens set to 346"
-
         # Verify core capabilities
         assert model_info.get("supports_computer_use") is True
         assert model_info.get("supports_function_calling") is True
@@ -96,7 +91,6 @@ def test_bedrock_haiku_4_5_matches_sonnet_capabilities():
         "supports_pdf_input",
         "supports_assistant_prefill",
         "supports_reasoning",
-        "tool_use_system_prompt_tokens",
     ]
 
     for capability in shared_capabilities:

--- a/tests/test_litellm/test_claude_opus_4_6_config.py
+++ b/tests/test_litellm/test_claude_opus_4_6_config.py
@@ -82,31 +82,26 @@ def test_opus_4_6_model_pricing_and_capabilities():
         "claude-opus-4-6": {
             "provider": "anthropic",
             "has_long_context_pricing": False,
-            "tool_use_system_prompt_tokens": 346,
             "max_input_tokens": 1000000,
         },
         "claude-opus-4-6-20260205": {
             "provider": "anthropic",
             "has_long_context_pricing": False,
-            "tool_use_system_prompt_tokens": 346,
             "max_input_tokens": 1000000,
         },
         "anthropic.claude-opus-4-6-v1": {
             "provider": "bedrock_converse",
             "has_long_context_pricing": False,
-            "tool_use_system_prompt_tokens": 346,
             "max_input_tokens": 1000000,
         },
         "vertex_ai/claude-opus-4-6": {
             "provider": "vertex_ai-anthropic_models",
             "has_long_context_pricing": False,
-            "tool_use_system_prompt_tokens": 346,
             "max_input_tokens": 1000000,
         },
         "azure_ai/claude-opus-4-6": {
             "provider": "azure_ai",
             "has_long_context_pricing": False,
-            "tool_use_system_prompt_tokens": 159,
             "max_input_tokens": 200000,
         },
     }
@@ -143,10 +138,6 @@ def test_opus_4_6_model_pricing_and_capabilities():
         assert info["supports_reasoning"] is True
         assert info["supports_tool_choice"] is True
         assert info["supports_vision"] is True
-        assert (
-            info["tool_use_system_prompt_tokens"]
-            == config["tool_use_system_prompt_tokens"]
-        )
 
 
 def test_opus_4_6_bedrock_regional_model_pricing():
@@ -191,7 +182,6 @@ def test_opus_4_6_bedrock_regional_model_pricing():
         assert info["max_output_tokens"] == 128000
         assert info["max_tokens"] == 128000
         assert info["supports_assistant_prefill"] is False
-        assert info["tool_use_system_prompt_tokens"] == 346
         assert "input_cost_per_token_above_200k_tokens" not in info
         assert "output_cost_per_token_above_200k_tokens" not in info
         assert "cache_creation_input_token_cost_above_200k_tokens" not in info
@@ -220,7 +210,6 @@ def test_opus_4_6_alias_and_dated_metadata_match():
         "cache_creation_input_token_cost_above_1hr",
         "cache_read_input_token_cost",
         "supports_assistant_prefill",
-        "tool_use_system_prompt_tokens",
     ]
     for key in keys_to_match:
         assert alias[key] == dated[key], f"Mismatch for {key}"

--- a/tests/test_litellm/test_claude_opus_4_8_config.py
+++ b/tests/test_litellm/test_claude_opus_4_8_config.py
@@ -1,0 +1,184 @@
+"""
+Validate Claude Opus 4.8 model configuration entries.
+
+Regression coverage for the wildcard-routing failure where a bare model name
+(``claude-opus-4-8``) could not match an ``anthropic/*`` deployment because
+LiteLLM could not infer its provider — the model was simply missing from the
+model cost map, so ``get_llm_provider`` raised and the router returned
+"no healthy deployments for this model". The fix is the cost-map entries added
+for Anthropic, Bedrock, Vertex AI, and Azure AI; those entries are what populate
+``litellm.anthropic_models`` at import time, which is what the bare-name lookup
+in ``get_llm_provider`` consumes.
+"""
+
+import json
+import os
+
+import pytest
+
+import litellm
+from litellm.constants import BEDROCK_CONVERSE_MODELS
+from litellm.litellm_core_utils.get_model_cost_map import GetModelCostMap
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "../..")
+
+
+def _load_root_cost_map() -> dict:
+    json_path = os.path.join(REPO_ROOT, "model_prices_and_context_window.json")
+    with open(json_path) as f:
+        return json.load(f)
+
+
+@pytest.fixture
+def local_model_cost_map(monkeypatch):
+    """Force the bundled backup cost map so assertions don't depend on the
+    network-fetched ``main`` copy (which lags this branch until merge)."""
+    original_model_cost = litellm.model_cost
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+    litellm.get_model_info.cache_clear()
+    try:
+        yield
+    finally:
+        litellm.model_cost = original_model_cost
+        litellm.get_model_info.cache_clear()
+
+
+def test_opus_4_8_model_pricing_and_capabilities():
+    model_data = _load_root_cost_map()
+
+    expected_models = {
+        "claude-opus-4-8": {
+            "provider": "anthropic",
+            "max_input_tokens": 1000000,
+        },
+        "anthropic.claude-opus-4-8": {
+            "provider": "bedrock_converse",
+            "max_input_tokens": 1000000,
+        },
+        "vertex_ai/claude-opus-4-8": {
+            "provider": "vertex_ai-anthropic_models",
+            "max_input_tokens": 1000000,
+        },
+        # Microsoft Foundry / Azure caps Opus 4.8 at a 200k context window.
+        "azure_ai/claude-opus-4-8": {
+            "provider": "azure_ai",
+            "max_input_tokens": 200000,
+        },
+    }
+
+    for model_name, config in expected_models.items():
+        assert model_name in model_data, f"Missing model entry: {model_name}"
+        info = model_data[model_name]
+
+        assert info["litellm_provider"] == config["provider"]
+        assert info["mode"] == "chat"
+        assert info["max_input_tokens"] == config["max_input_tokens"]
+        assert info["max_output_tokens"] == 128000
+        assert info["max_tokens"] == 128000
+
+        # Base pricing matches Opus 4.7: $5 / $25 per MTok, with the standard
+        # 1.25x cache-write and 0.1x cache-read multipliers.
+        assert info["input_cost_per_token"] == 5e-06
+        assert info["output_cost_per_token"] == 2.5e-05
+        assert info["cache_creation_input_token_cost"] == 6.25e-06
+        assert info["cache_read_input_token_cost"] == 5e-07
+
+        # Opus 4.x flagships are flat-rate across the full context window.
+        assert "input_cost_per_token_above_200k_tokens" not in info
+        assert "output_cost_per_token_above_200k_tokens" not in info
+
+        assert info["supports_assistant_prefill"] is False
+        assert info["supports_function_calling"] is True
+        assert info["supports_prompt_caching"] is True
+        assert info["supports_reasoning"] is True
+        assert info["supports_tool_choice"] is True
+        assert info["supports_vision"] is True
+
+
+def test_opus_4_8_bedrock_regional_model_pricing():
+    model_data = _load_root_cost_map()
+
+    # Global endpoints use base pricing; regional endpoints carry a 10% premium.
+    expected_models = {
+        "global.anthropic.claude-opus-4-8": {
+            "input_cost_per_token": 5e-06,
+            "output_cost_per_token": 2.5e-05,
+            "cache_creation_input_token_cost": 6.25e-06,
+            "cache_read_input_token_cost": 5e-07,
+        },
+        "us.anthropic.claude-opus-4-8": {
+            "input_cost_per_token": 5.5e-06,
+            "output_cost_per_token": 2.75e-05,
+            "cache_creation_input_token_cost": 6.875e-06,
+            "cache_read_input_token_cost": 5.5e-07,
+        },
+        "eu.anthropic.claude-opus-4-8": {
+            "input_cost_per_token": 5.5e-06,
+            "output_cost_per_token": 2.75e-05,
+            "cache_creation_input_token_cost": 6.875e-06,
+            "cache_read_input_token_cost": 5.5e-07,
+        },
+        "au.anthropic.claude-opus-4-8": {
+            "input_cost_per_token": 5.5e-06,
+            "output_cost_per_token": 2.75e-05,
+            "cache_creation_input_token_cost": 6.875e-06,
+            "cache_read_input_token_cost": 5.5e-07,
+        },
+    }
+
+    for model_name, expected in expected_models.items():
+        assert model_name in model_data, f"Missing model entry: {model_name}"
+        info = model_data[model_name]
+        assert info["litellm_provider"] == "bedrock_converse"
+        assert info["max_input_tokens"] == 1000000
+        assert info["max_output_tokens"] == 128000
+        assert info["bedrock_output_config_effort_ceiling"] == "xhigh"
+        for key, value in expected.items():
+            assert info[key] == value
+
+
+def test_opus_4_8_fast_mode_multiplier():
+    """Opus 4.8 dropped fast-mode pricing to 2x base ($10/$50 per MTok);
+    Opus 4.7 was 6x ($30/$150)."""
+    model_data = _load_root_cost_map()
+    entry = model_data["claude-opus-4-8"]["provider_specific_entry"]
+    assert entry["us"] == 1.1
+    assert entry["fast"] == 2.0
+
+
+def test_opus_4_8_present_in_bundled_backup():
+    """The bundled backup is the runtime fallback (and what tests load with
+    ``LITELLM_LOCAL_MODEL_COST_MAP=True``) — it must carry the same entries as
+    the root cost map, otherwise the model resolves on one path but not the
+    other."""
+    backup = GetModelCostMap.load_local_model_cost_map()
+    for model_name in (
+        "claude-opus-4-8",
+        "anthropic.claude-opus-4-8",
+        "global.anthropic.claude-opus-4-8",
+        "us.anthropic.claude-opus-4-8",
+        "eu.anthropic.claude-opus-4-8",
+        "au.anthropic.claude-opus-4-8",
+        "vertex_ai/claude-opus-4-8",
+        "vertex_ai/claude-opus-4-8@default",
+        "azure_ai/claude-opus-4-8",
+    ):
+        assert model_name in backup, f"Missing from backup cost map: {model_name}"
+
+
+def test_opus_4_8_registered_for_bedrock_converse():
+    assert "anthropic.claude-opus-4-8" in BEDROCK_CONVERSE_MODELS
+
+
+def test_opus_4_8_provider_resolves_via_model_info(local_model_cost_map):
+    """Regression: ``claude-opus-4-8`` must resolve to provider ``anthropic``.
+
+    Before the cost-map entry existed, the model was unknown to LiteLLM, so it
+    could not be tied to the ``anthropic`` provider and an ``anthropic/*``
+    wildcard deployment would not match it.
+    """
+    info = litellm.get_model_info(model="claude-opus-4-8")
+    assert info["litellm_provider"] == "anthropic"
+    assert info["max_input_tokens"] == 1000000
+    assert info["max_output_tokens"] == 128000

--- a/tests/test_litellm/test_claude_sonnet_4_6_config.py
+++ b/tests/test_litellm/test_claude_sonnet_4_6_config.py
@@ -50,7 +50,6 @@ def test_bedrock_sonnet_4_6_region_prefixes():
         assert model_info.get("supports_pdf_input") is True
         assert model_info.get("supports_assistant_prefill") is True
         assert model_info.get("supports_reasoning") is True
-        assert model_info.get("tool_use_system_prompt_tokens") == 346
 
 
 def test_bedrock_sonnet_4_6_jp_matches_other_regional_pricing():

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -864,7 +864,6 @@ def test_aaamodel_prices_and_context_window_json_is_valid():
                     "type": "string",
                     "enum": ["low", "medium", "high", "max", "xhigh"],
                 },
-                "tool_use_system_prompt_tokens": {"type": "number"},
                 "tpm": {"type": "number"},
                 "provider_specific_entry": {"type": "object"},
                 "supported_endpoints": {


### PR DESCRIPTION
## What

Adds **Claude Opus 4.8** to the model registry and prunes two reasoning-effort fields from the cost map.

### Opus 4.8
- Register `claude-opus-4-8` across the anthropic / bedrock_converse / vertex_ai / azure_ai cost-map entries (root + bundled backup).
- Add `anthropic.claude-opus-4-8` to `BEDROCK_CONVERSE_MODELS`.
- Add Opus 4.8 to the setup-wizard Anthropic provider list.

### Reasoning-effort field cleanup
- **Drop `supports_minimal_reasoning_effort` from the Claude fleet (58 entries).** `minimal` is not a real Anthropic effort level — the API accepts only `low/medium/high/xhigh/max` — so LiteLLM degrades `minimal` → `low` regardless of the flag (`_map_reasoning_effort` / `REASONING_EFFORT_TO_OUTPUT_CONFIG_EFFORT`). The flag was inert and misleading on Anthropic. The 48 OpenAI GPT-5.x entries, where `minimal` is a genuine wire value, are untouched.
- **Remove `tool_use_system_prompt_tokens` everywhere (103 entries).** It is not in the `ModelInfo` TypedDict and is read by no production code.

## Behavior
No functional change for Anthropic: a request with `reasoning_effort="minimal"` already resolved to `low` effort before reaching the API, and still does.

## Tests
- Updated the Claude config tests (`opus-4-8`, `opus-4-6`, `sonnet-4-6`, `haiku-4-5`) and the price-file JSON schema test to drop `tool_use_system_prompt_tokens`.
- The reasoning-effort registry tests now assert the Claude fleet **omits** `supports_minimal_reasoning_effort` (regression guard against re-adding it); the `normalize_reasoning_effort_value` behavioral tests are unchanged.
- `make`-targeted run: 92 passed.
