### PR TITLE
fix(vector-stores): default-deny destructive verbs on registered indexes for non-admins (LIT-2384)

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -230,13 +230,14 @@ use_legacy_interactions_schema: bool = (
 )  # When True, sends Api-Revision: 2026-05-07 to Google so responses use the legacy `outputs`
 # schema instead of the new `steps` schema. Remove this flag after June 8, 2026.
 vector_store_allow_destructive_passthrough: bool = (
-    os.getenv("LITELLM_VECTOR_STORE_ALLOW_DESTRUCTIVE_PASSTHROUGH", "false").lower()
-    == "true"
-)  # LIT-2384 escape hatch: when True, restore the legacy silent-allow behaviour
-# for non-admin DELETE/PUT/POST/PATCH on unenumerated vector store passthrough
-# paths (e.g. DELETE /azure_ai/indexes/<name>). Default False keeps the secure
-# default-deny. Operators with legitimate non-admin destructive flows can set
-# this to True (or set the env var) until they migrate to admin-only callers.
+    False  # LIT-2384 escape hatch: when True, restore the legacy silent-allow
+)
+# behaviour for non-admin DELETE/PUT/POST/PATCH on unenumerated vector store
+# passthrough paths (e.g. DELETE /azure_ai/indexes/<name>). Default False keeps
+# the secure default-deny. Operators with legitimate non-admin destructive
+# flows can set this attribute to True (or set
+# litellm_settings.vector_store_allow_destructive_passthrough: true in the
+# proxy YAML config) until they migrate to admin-only callers.
 
 retry = True
 ### AUTH ###

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -229,6 +229,15 @@ use_legacy_interactions_schema: bool = (
     os.getenv("LITELLM_USE_LEGACY_INTERACTIONS_SCHEMA", "false").lower() == "true"
 )  # When True, sends Api-Revision: 2026-05-07 to Google so responses use the legacy `outputs`
 # schema instead of the new `steps` schema. Remove this flag after June 8, 2026.
+vector_store_allow_destructive_passthrough: bool = (
+    os.getenv("LITELLM_VECTOR_STORE_ALLOW_DESTRUCTIVE_PASSTHROUGH", "false").lower()
+    == "true"
+)  # LIT-2384 escape hatch: when True, restore the legacy silent-allow behaviour
+# for non-admin DELETE/PUT/POST/PATCH on unenumerated vector store passthrough
+# paths (e.g. DELETE /azure_ai/indexes/<name>). Default False keeps the secure
+# default-deny. Operators with legitimate non-admin destructive flows can set
+# this to True (or set the env var) until they migrate to admin-only callers.
+
 retry = True
 ### AUTH ###
 api_key: Optional[str] = None

--- a/litellm/proxy/vector_store_endpoints/utils.py
+++ b/litellm/proxy/vector_store_endpoints/utils.py
@@ -357,7 +357,9 @@ def is_allowed_to_call_vector_store_endpoint(
         # /azure_ai/indexes/<name> on an admin-created Azure AI Search index).
         # Default-deny destructive verbs for non-admin callers on a registered
         # litellm-managed vector store index. Admin role is bypassed above.
-        if request.method.upper() in _DESTRUCTIVE_VECTOR_STORE_METHODS:
+        if request.method.upper() in _DESTRUCTIVE_VECTOR_STORE_METHODS and not getattr(
+            litellm, "vector_store_allow_destructive_passthrough", False
+        ):
             raise HTTPException(
                 status_code=403,
                 detail=(
@@ -365,7 +367,11 @@ def is_allowed_to_call_vector_store_endpoint(
                     f'litellm-managed vector store "{index_name}" are '
                     "restricted to proxy admins. Ask your administrator to "
                     "perform this operation, or use the managed "
-                    "/v1/indexes API which enforces admin-only access."
+                    "/v1/indexes API which enforces admin-only access. To "
+                    "preserve the legacy silent-allow behaviour during "
+                    "migration, set litellm.vector_store_allow_destructive_"
+                    "passthrough = True (or env var "
+                    "LITELLM_VECTOR_STORE_ALLOW_DESTRUCTIVE_PASSTHROUGH=true)."
                 ),
             )
         return None

--- a/litellm/proxy/vector_store_endpoints/utils.py
+++ b/litellm/proxy/vector_store_endpoints/utils.py
@@ -15,6 +15,9 @@ from litellm.types.vector_stores import LiteLLM_ManagedVectorStore
 from litellm.utils import ProviderConfigManager
 
 
+_DESTRUCTIVE_VECTOR_STORE_METHODS = frozenset({"DELETE", "PUT", "POST", "PATCH"})
+
+
 def _normalize_litellm_params(
     vector_store: LiteLLM_ManagedVectorStore,
 ) -> LiteLLM_ManagedVectorStore:
@@ -348,6 +351,24 @@ def is_allowed_to_call_vector_store_endpoint(
                 break
 
     if permission_type is None:
+        # SECURITY (LIT-2384): a request method/path that is NOT enumerated in
+        # the provider read/write endpoint list previously fell through to a
+        # silent return None, which let any caller with general vector-store
+        # access mutate the underlying provider index (e.g. DELETE
+        # /azure_ai/indexes/<name> on an admin-created Azure AI Search index).
+        # Default-deny destructive verbs for non-admin callers on a registered
+        # litellm-managed vector store index. Admin role is bypassed above.
+        if request.method.upper() in _DESTRUCTIVE_VECTOR_STORE_METHODS:
+            raise HTTPException(
+                status_code=403,
+                detail=(
+                    f"Destructive {request.method.upper()} requests on "
+                    f"litellm-managed vector store \"{index_name}\" are "
+                    "restricted to proxy admins. Ask your administrator to "
+                    "perform this operation, or use the managed "
+                    "/v1/indexes API which enforces admin-only access."
+                ),
+            )
         return None
 
     # Check if key has specific permission for allowed_vector_store_indexes

--- a/litellm/proxy/vector_store_endpoints/utils.py
+++ b/litellm/proxy/vector_store_endpoints/utils.py
@@ -14,7 +14,6 @@ from litellm.types.utils import LlmProviders
 from litellm.types.vector_stores import LiteLLM_ManagedVectorStore
 from litellm.utils import ProviderConfigManager
 
-
 _DESTRUCTIVE_VECTOR_STORE_METHODS = frozenset({"DELETE", "PUT", "POST", "PATCH"})
 
 
@@ -363,7 +362,7 @@ def is_allowed_to_call_vector_store_endpoint(
                 status_code=403,
                 detail=(
                     f"Destructive {request.method.upper()} requests on "
-                    f"litellm-managed vector store \"{index_name}\" are "
+                    f'litellm-managed vector store "{index_name}" are '
                     "restricted to proxy admins. Ask your administrator to "
                     "perform this operation, or use the managed "
                     "/v1/indexes API which enforces admin-only access."

--- a/litellm/proxy/vector_store_endpoints/utils.py
+++ b/litellm/proxy/vector_store_endpoints/utils.py
@@ -370,8 +370,9 @@ def is_allowed_to_call_vector_store_endpoint(
                     "/v1/indexes API which enforces admin-only access. To "
                     "preserve the legacy silent-allow behaviour during "
                     "migration, set litellm.vector_store_allow_destructive_"
-                    "passthrough = True (or env var "
-                    "LITELLM_VECTOR_STORE_ALLOW_DESTRUCTIVE_PASSTHROUGH=true)."
+                    "passthrough = True (or "
+                    "litellm_settings.vector_store_allow_destructive_passthrough: "
+                    "true in proxy config)."
                 ),
             )
         return None

--- a/tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_endpoints.py
+++ b/tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_endpoints.py
@@ -2479,3 +2479,63 @@ class TestLit2384DestructiveVerbDefaultDeny:
                     user_api_key_dict=non_admin_with_read_perm,
                 )
         assert exc.value.status_code == 403
+
+    def test_escape_hatch_flag_restores_legacy_behaviour(
+        self, mock_azure_ai_provider_config, non_admin_with_read_perm
+    ):
+        """LIT-2384 escape hatch: setting
+        ``litellm.vector_store_allow_destructive_passthrough = True`` (or the
+        ``LITELLM_VECTOR_STORE_ALLOW_DESTRUCTIVE_PASSTHROUGH`` env var) restores
+        the legacy silent-allow (return ``None``) so operators with a
+        legitimate non-admin destructive flow can preserve the old behaviour
+        during migration."""
+        import litellm
+
+        mock_request = MagicMock(spec=Request)
+        mock_request.method = "DELETE"
+        mock_request.url.path = "/azure_ai/indexes/admin-created-index"
+
+        prev = getattr(litellm, "vector_store_allow_destructive_passthrough", False)
+        try:
+            litellm.vector_store_allow_destructive_passthrough = True
+            with patch(
+                "litellm.proxy.vector_store_endpoints.utils.ProviderConfigManager.get_provider_vector_stores_config",
+                return_value=mock_azure_ai_provider_config,
+            ):
+                result = is_allowed_to_call_vector_store_endpoint(
+                    provider=LlmProviders.AZURE_AI,
+                    index_name="admin-created-index",
+                    request=mock_request,
+                    user_api_key_dict=non_admin_with_read_perm,
+                )
+            assert result is None
+        finally:
+            litellm.vector_store_allow_destructive_passthrough = prev
+
+    def test_escape_hatch_flag_false_keeps_default_deny(
+        self, mock_azure_ai_provider_config, non_admin_with_read_perm
+    ):
+        """Explicit ``False`` on the escape-hatch flag must keep default-deny."""
+        import litellm
+
+        mock_request = MagicMock(spec=Request)
+        mock_request.method = "DELETE"
+        mock_request.url.path = "/azure_ai/indexes/admin-created-index"
+
+        prev = getattr(litellm, "vector_store_allow_destructive_passthrough", False)
+        try:
+            litellm.vector_store_allow_destructive_passthrough = False
+            with patch(
+                "litellm.proxy.vector_store_endpoints.utils.ProviderConfigManager.get_provider_vector_stores_config",
+                return_value=mock_azure_ai_provider_config,
+            ):
+                with pytest.raises(HTTPException) as exc:
+                    is_allowed_to_call_vector_store_endpoint(
+                        provider=LlmProviders.AZURE_AI,
+                        index_name="admin-created-index",
+                        request=mock_request,
+                        user_api_key_dict=non_admin_with_read_perm,
+                    )
+            assert exc.value.status_code == 403
+        finally:
+            litellm.vector_store_allow_destructive_passthrough = prev

--- a/tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_endpoints.py
+++ b/tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_endpoints.py
@@ -2347,18 +2347,22 @@ class TestLit2384DestructiveVerbDefaultDeny:
     @pytest.fixture
     def non_admin_with_read_perm(self):
         from litellm.proxy._types import UserAPIKeyAuth, LitellmUserRoles
+
         return UserAPIKeyAuth(
             token="sk-non-admin",
             key_name="sk-...nadm",
             user_role=LitellmUserRoles.INTERNAL_USER,
-            metadata={"allowed_vector_store_indexes": [
-                {"index_name": "admin-created-index", "index_permissions": ["read"]}
-            ]},
+            metadata={
+                "allowed_vector_store_indexes": [
+                    {"index_name": "admin-created-index", "index_permissions": ["read"]}
+                ]
+            },
         )
 
     @pytest.fixture
     def proxy_admin(self):
         from litellm.proxy._types import UserAPIKeyAuth, LitellmUserRoles
+
         return UserAPIKeyAuth(
             token="sk-admin",
             key_name="sk-...adm",
@@ -2475,4 +2479,3 @@ class TestLit2384DestructiveVerbDefaultDeny:
                     user_api_key_dict=non_admin_with_read_perm,
                 )
         assert exc.value.status_code == 403
-

--- a/tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_endpoints.py
+++ b/tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_endpoints.py
@@ -652,10 +652,10 @@ class TestIsAllowedToCallVectorStoreEndpoint:
         assert result is None
 
     def test_endpoint_not_recognized(self):
-        """Test when endpoint doesn't match any read or write patterns."""
+        """Test that a non-destructive (GET) request on an unenumerated path still falls through silently (returns None) so the caller can run the downstream ownership check. Destructive verbs on unenumerated paths are covered separately by test_unrecognized_destructive_verbs_*."""
         # Mock request with unrecognized path
         mock_request = MagicMock(spec=Request)
-        mock_request.method = "DELETE"
+        mock_request.method = "GET"
         mock_request.url.path = "/v1/vector_stores/my-index/unknown"
 
         mock_user_api_key = MagicMock(spec=UserAPIKeyAuth)
@@ -2324,3 +2324,155 @@ class TestUpdateVectorStoreAccessControlAndRedaction:
         params = response["vector_store"]["litellm_params"]
         assert params["api_key"] == REDACTED_BY_LITELM_STRING
         assert params["api_base"] == "https://api.openai.com/v1"
+
+
+class TestLit2384DestructiveVerbDefaultDeny:
+    """LIT-2384 regression: non-admin keys must not be able to DELETE/PUT/POST
+    against unenumerated paths on a registered litellm-managed vector store
+    index (e.g. DELETE /azure_ai/indexes/<name>). Previously these
+    silently returned None and fell through to the broader ownership check,
+    which let any caller with general access mutate the underlying provider
+    index. Default-deny applies to non-admins; admin role still bypasses.
+    """
+
+    @pytest.fixture
+    def mock_azure_ai_provider_config(self):
+        cfg = MagicMock()
+        cfg.get_vector_store_endpoints_by_type.return_value = {
+            "read": [("GET", "/docs/search"), ("POST", "/docs/search")],
+            "write": [("PUT", "/docs")],
+        }
+        return cfg
+
+    @pytest.fixture
+    def non_admin_with_read_perm(self):
+        from litellm.proxy._types import UserAPIKeyAuth, LitellmUserRoles
+        return UserAPIKeyAuth(
+            token="sk-non-admin",
+            key_name="sk-...nadm",
+            user_role=LitellmUserRoles.INTERNAL_USER,
+            metadata={"allowed_vector_store_indexes": [
+                {"index_name": "admin-created-index", "index_permissions": ["read"]}
+            ]},
+        )
+
+    @pytest.fixture
+    def proxy_admin(self):
+        from litellm.proxy._types import UserAPIKeyAuth, LitellmUserRoles
+        return UserAPIKeyAuth(
+            token="sk-admin",
+            key_name="sk-...adm",
+            user_role=LitellmUserRoles.PROXY_ADMIN,
+        )
+
+    @pytest.mark.parametrize("method", ["DELETE", "PUT", "POST", "PATCH"])
+    def test_unrecognized_destructive_verbs_blocked_for_non_admin(
+        self, method, mock_azure_ai_provider_config, non_admin_with_read_perm
+    ):
+        mock_request = MagicMock(spec=Request)
+        mock_request.method = method
+        mock_request.url.path = "/azure_ai/indexes/admin-created-index"
+
+        with patch(
+            "litellm.proxy.vector_store_endpoints.utils.ProviderConfigManager.get_provider_vector_stores_config",
+            return_value=mock_azure_ai_provider_config,
+        ):
+            with pytest.raises(HTTPException) as exc:
+                is_allowed_to_call_vector_store_endpoint(
+                    provider=LlmProviders.AZURE_AI,
+                    index_name="admin-created-index",
+                    request=mock_request,
+                    user_api_key_dict=non_admin_with_read_perm,
+                )
+        assert exc.value.status_code == 403
+        # Error message references the method, index name, and the managed API
+        assert method in exc.value.detail
+        assert "admin-created-index" in exc.value.detail
+        assert "/v1/indexes" in exc.value.detail
+
+    def test_unrecognized_destructive_verbs_allowed_for_admin(
+        self, mock_azure_ai_provider_config, proxy_admin
+    ):
+        mock_request = MagicMock(spec=Request)
+        mock_request.method = "DELETE"
+        mock_request.url.path = "/azure_ai/indexes/admin-created-index"
+
+        with patch(
+            "litellm.proxy.vector_store_endpoints.utils.ProviderConfigManager.get_provider_vector_stores_config",
+            return_value=mock_azure_ai_provider_config,
+        ):
+            result = is_allowed_to_call_vector_store_endpoint(
+                provider=LlmProviders.AZURE_AI,
+                index_name="admin-created-index",
+                request=mock_request,
+                user_api_key_dict=proxy_admin,
+            )
+        # Admin bypass: returns True without consulting the endpoint table
+        assert result is True
+
+    def test_non_admin_get_on_enumerated_read_path_still_allowed(
+        self, mock_azure_ai_provider_config, non_admin_with_read_perm
+    ):
+        """Regression guard: legitimate non-admin reads on enumerated paths
+        must NOT be blocked by the LIT-2384 default-deny."""
+        mock_request = MagicMock(spec=Request)
+        mock_request.method = "GET"
+        mock_request.url.path = "/azure_ai/indexes/admin-created-index/docs/search"
+
+        with patch(
+            "litellm.proxy.vector_store_endpoints.utils.ProviderConfigManager.get_provider_vector_stores_config",
+            return_value=mock_azure_ai_provider_config,
+        ):
+            result = is_allowed_to_call_vector_store_endpoint(
+                provider=LlmProviders.AZURE_AI,
+                index_name="admin-created-index",
+                request=mock_request,
+                user_api_key_dict=non_admin_with_read_perm,
+            )
+        assert result is True
+
+    def test_non_admin_unrecognized_get_still_falls_through(
+        self, mock_azure_ai_provider_config, non_admin_with_read_perm
+    ):
+        """Regression guard: non-destructive GET on an unenumerated path
+        still returns None (legacy behaviour) so the broader ownership
+        check can run downstream. Default-deny is limited to destructive
+        verbs."""
+        mock_request = MagicMock(spec=Request)
+        mock_request.method = "GET"
+        mock_request.url.path = "/azure_ai/indexes/admin-created-index/something/else"
+
+        with patch(
+            "litellm.proxy.vector_store_endpoints.utils.ProviderConfigManager.get_provider_vector_stores_config",
+            return_value=mock_azure_ai_provider_config,
+        ):
+            result = is_allowed_to_call_vector_store_endpoint(
+                provider=LlmProviders.AZURE_AI,
+                index_name="admin-created-index",
+                request=mock_request,
+                user_api_key_dict=non_admin_with_read_perm,
+            )
+        assert result is None
+
+    def test_method_lowercase_is_handled(
+        self, mock_azure_ai_provider_config, non_admin_with_read_perm
+    ):
+        """Defensive: lowercase request.method (some test frameworks /
+        proxies may not uppercase it) still triggers the destructive guard."""
+        mock_request = MagicMock(spec=Request)
+        mock_request.method = "delete"
+        mock_request.url.path = "/azure_ai/indexes/admin-created-index"
+
+        with patch(
+            "litellm.proxy.vector_store_endpoints.utils.ProviderConfigManager.get_provider_vector_stores_config",
+            return_value=mock_azure_ai_provider_config,
+        ):
+            with pytest.raises(HTTPException) as exc:
+                is_allowed_to_call_vector_store_endpoint(
+                    provider=LlmProviders.AZURE_AI,
+                    index_name="admin-created-index",
+                    request=mock_request,
+                    user_api_key_dict=non_admin_with_read_perm,
+                )
+        assert exc.value.status_code == 403
+


### PR DESCRIPTION
## Summary

Restrict destructive HTTP verbs (DELETE, PUT, POST, PATCH) on litellm-managed vector store indexes to proxy admins when the request method/path is not enumerated in the provider's read/write endpoint table.

Previously `is_allowed_to_call_vector_store_endpoint` silently returned `None` whenever the request method/path didn't match any enumerated read/write endpoint. The caller then fell through to `assert_user_can_access_vector_store`, which only checks that the caller has *general* access to the vector store. For the Azure AI Search passthrough this meant that **any non-admin key with shared access to a vector store could `DELETE /azure_ai/indexes/<name>` and the request would be forwarded to Azure, deleting the underlying provider index**. Same story for `PUT`/`POST`/`PATCH` on the same path.

## Root cause

`AzureAIVectorStoreConfig.get_vector_store_endpoints_by_type()` enumerates only:

```
read:  GET  /docs/search, POST /docs/search
write: PUT  /docs
```

So `DELETE /azure_ai/indexes/<name>` matches neither read nor write -> `permission_type = None` -> `return None` (silent allow). This shape is provider-agnostic; the same gap exists on any provider whose `get_vector_store_endpoints_by_type()` doesn't enumerate the destructive admin verb.

## Fix

In `litellm/proxy/vector_store_endpoints/utils.py::is_allowed_to_call_vector_store_endpoint`, when `permission_type is None`, default-deny destructive methods (`DELETE`, `PUT`, `POST`, `PATCH`) for non-admin callers on a registered litellm-managed vector store index with `HTTPException(403, ...)`. Proxy admins continue to bypass via the existing fast path at the top of the function. Non-destructive `GET` on an unenumerated path keeps the legacy `return None` fall-through so the downstream ownership check still runs.

Net change: **+21 lines** in the auth helper, all behind the existing admin-bypass.

### Evidence

Driving `is_allowed_to_call_vector_store_endpoint` directly with the same request shape the proxy receives for `DELETE /azure_ai/indexes/<name>` on an admin-created Azure AI Search index. Same script, same fixtures, only diff is the patch.

BEFORE (clean `litellm_oss_agent_shin_daily_branch` @ `1fe911d`):

```
======================================================================
LIT-2384: Non-admin DELETE /azure_ai/indexes/<name>
======================================================================

[1] non-admin DELETE on admin-created Azure AI Search index
    DELETE /azure_ai/indexes/admin-created-index?api-version=2024-07-01
    ('RETURN', None)

[2] non-admin PUT (replace) on admin-created Azure AI Search index
    PUT /azure_ai/indexes/admin-created-index?api-version=2024-07-01
    ('RETURN', None)

[3] PROXY_ADMIN DELETE on the same index -- admin bypass preserved
    DELETE /azure_ai/indexes/admin-created-index?api-version=2024-07-01
    ('RETURN', True)

[4] non-admin GET on enumerated read path -- legitimate read NOT blocked
    GET /azure_ai/indexes/admin-created-index/docs/search
    ('RETURN', True)

[5] non-admin GET on unenumerated path -- legacy fall-through preserved
    GET /azure_ai/indexes/admin-created-index/something/else
    ('RETURN', None)
```

AFTER (with this PR applied):

```
======================================================================
LIT-2384: Non-admin DELETE /azure_ai/indexes/<name>
======================================================================

[1] non-admin DELETE on admin-created Azure AI Search index
    DELETE /azure_ai/indexes/admin-created-index?api-version=2024-07-01
    ('HTTPException', 403, 'Destructive DELETE requests on litellm-managed vector store "admin-created-index" are restricted to proxy admins. Ask your administrator to perform this operation, or use the managed /v1/indexes API which enforces admin-only access.')

[2] non-admin PUT (replace) on admin-created Azure AI Search index
    PUT /azure_ai/indexes/admin-created-index?api-version=2024-07-01
    ('HTTPException', 403, 'Destructive PUT requests on litellm-managed vector store "admin-created-index" are restricted to proxy admins. Ask your administrator to perform this operation, or use the managed /v1/indexes API which enforces admin-only access.')

[3] PROXY_ADMIN DELETE on the same index -- admin bypass preserved
    DELETE /azure_ai/indexes/admin-created-index?api-version=2024-07-01
    ('RETURN', True)

[4] non-admin GET on enumerated read path -- legitimate read NOT blocked
    GET /azure_ai/indexes/admin-created-index/docs/search
    ('RETURN', True)

[5] non-admin GET on unenumerated path -- legacy fall-through preserved
    GET /azure_ai/indexes/admin-created-index/something/else
    ('RETURN', None)
```

Cases [1] and [2] are the regression — non-admin destructive verbs are now 403 instead of silently `None`. Case [3] confirms admin still bypasses. Cases [4] and [5] are the regression guards: a non-admin's enumerated GET read is still allowed, and an unenumerated GET still falls through silently so the broader ownership check downstream can decide.

### Tests

- `tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_endpoints.py::TestLit2384DestructiveVerbDefaultDeny` — 8 new cases (4-way method parametrize for DELETE/PUT/POST/PATCH + admin bypass + GET-read-still-allowed + GET-unenumerated-fall-through + lowercase-method defensive).
- Existing `TestIsAllowedToCallVectorStoreEndpoint::test_endpoint_not_recognized` updated: it previously asserted `None` for `DELETE` on an unenumerated path (which encoded the silent-allow bug). It now asserts the same `None` fall-through for `GET` on an unenumerated path (the only legacy contract the patch preserves).
- All 65 tests in `tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_endpoints.py` pass on the patched branch.
- All 54 tests in `tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py` pass — no regression in the passthrough surface that calls this helper.

### Note on push path

Pushed via the GitHub Contents API because the current `GITHUB_TOKEN` lacks `repo` + `workflow` scopes and `git push` returns "Password authentication is not supported". Diff is two files; merge-base diff may include noisy CRLF on prerendered `_experimental/out/*.html` artifacts but no source file outside the two listed is touched.

Closes LIT-2384.

### Verification (ship-pr)

- [x] **Greptile**: 5/5 — *"Safe to merge — the change closes a real auth bypass, the admin fast-path is untouched, and the backwards-compatibility escape hatch satisfies existing operator workflows."*
- [x] **Veria AI - PR Review**: ✅ success (no security issues found on `977e032`)
- [x] **GitHub Actions**: 44/44 green at head `977e032` (lint, code-quality, ruff/black, secret-scan, semgrep, build-ui, validate-model-prices-json, documentation, every `Run tests` shard, both `test-server-root-path` variants, `Verify PR source branch`, every Codecov upload step)
- [x] **Codecov**: ✅ "All modified and coverable lines are covered by tests"
- [x] **mergeable_state**: clean
- [x] **Base branch**: `litellm_oss_agent_shin_daily_branch` (per Shin fork policy)
- [x] **Runtime evidence**: BEFORE (silent `return None`) and AFTER (`HTTPException 403` for non-admin, `True` for admin) captured in the `### Evidence` section above, driving the actual `is_allowed_to_call_vector_store_endpoint` function with the same request shape the proxy receives for `DELETE /azure_ai/indexes/<name>`. Escape-hatch behaviour verified end-to-end (`flag=True` restores silent-allow).
- [x] **Unit tests**: 67 tests in `test_vector_store_endpoints.py` pass on patched branch (`TestLit2384DestructiveVerbDefaultDeny` adds 10 new cases — 4 destructive-verb parametrize, admin bypass, enumerated-read still allowed, unenumerated GET fall-through, lowercase-method defensive, escape-hatch on/off).
- [x] **No customer name** in diff, PR title, PR body, or comments.
