### PR TITLE
fix(ci): restore real Bedrock batch S3 bucket/role in oai_misc_config

### DIFF
--- a/litellm/proxy/example_config_yaml/oai_misc_config.yaml
+++ b/litellm/proxy/example_config_yaml/oai_misc_config.yaml
@@ -23,11 +23,11 @@ model_list:
       model: bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0
       #########################################################
       ########## batch specific params ########################
-      s3_bucket_name: litellm-proxy-123456789012
+      s3_bucket_name: litellm-proxy-941277531214
       s3_region_name: us-west-2
       s3_access_key_id: os.environ/AWS_ACCESS_KEY_ID
       s3_secret_access_key: os.environ/AWS_SECRET_ACCESS_KEY
-      aws_batch_role_arn: arn:aws:iam::123456789012:role/service-role/AmazonBedrockExecutionRoleForAgents_EXAMPLE
+      aws_batch_role_arn: arn:aws:iam::941277531214:role/service-role/AmazonBedrockExecutionRoleForAgents_BB9HNW6V4CV
     model_info: 
       mode: batch
 


### PR DESCRIPTION
## Summary

`test_bedrock_batches_api` in the `e2e_openai_endpoints` CI job was failing with:

```
openai.NotFoundError: 404 - NoSuchBucket: The specified bucket does not exist
<BucketName>litellm-proxy-123456789012</BucketName>
Received Model Group=bedrock/batch-us.anthropic.claude-haiku-4-5-20251001-v1:0
```

### Root cause

The job loads `litellm/proxy/example_config_yaml/oai_misc_config.yaml` and injects the CI AWS credentials (account **941277531214**) into the proxy. The Bedrock batch model writes the uploaded batch file to S3.

The OSS-staging sync commit `d52fbfb45` overwrote the batch model's real `s3_bucket_name` and `aws_batch_role_arn` with public-safe placeholders (`123456789012` / `*_EXAMPLE`), so the proxy tried to write to a bucket that doesn't exist in the CI account → `NoSuchBucket`.

The AWS resources themselves were migrated correctly — both `litellm-proxy-941277531214` (us-west-2) and `arn:aws:iam::941277531214:role/service-role/AmazonBedrockExecutionRoleForAgents_BB9HNW6V4CV` exist in account 941277531214. It was only the config that got clobbered.

### Fix

Restore the real bucket name and batch role ARN — the same values already referenced in `tests/batches_tests/test_bedrock_files_and_batches.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)