### PR TITLE
fix(mcp): partial PUT no longer clobbers omitted fields

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/db.py
+++ b/litellm/proxy/_experimental/mcp_server/db.py
@@ -30,6 +30,7 @@ from litellm.types.mcp import MCPCredentials
 
 def _prepare_mcp_server_data(
     data: Union[NewMCPServerRequest, UpdateMCPServerRequest],
+    is_update: bool = False,
 ) -> Dict[str, Any]:
     """
     Helper function to prepare MCP server data for database operations.
@@ -37,17 +38,33 @@ def _prepare_mcp_server_data(
 
     Args:
         data: NewMCPServerRequest or UpdateMCPServerRequest object
+        is_update: When True, only fields the caller explicitly set on the
+            request participate in the dict. This is required for partial
+            PUT /v1/mcp/server so non-Optional fields with Pydantic
+            defaults (transport, mcp_access_groups, allow_all_keys,
+            available_on_public_internet, delegate_auth_to_upstream,
+            is_byok, args, env, byok_description) do not
+            silently overwrite the stored row. See LIT-3423 / LIT-3424.
 
     Returns:
         Dict with properly serialized JSON fields
     """
     from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 
-    # Convert model to dict
-    data_dict = data.model_dump(exclude_none=True)
-    # Ensure alias is always present in the dict (even if None)
-    if "alias" not in data_dict:
-        data_dict["alias"] = getattr(data, "alias", None)
+    if is_update:
+        # Partial-update semantics: only fields the caller explicitly set are
+        # in data_dict. Explicit None survives (e.g. clearing
+        # allowed_tools) while unset fields are absent so we never
+        # clobber the DB with Pydantic defaults.
+        data_dict = data.model_dump(exclude_unset=True)
+    else:
+        # Create semantics: defaults should be applied so the new row has a
+        # well-defined state. Drop None values from the dump exactly as
+        # before so optional columns stay null.
+        data_dict = data.model_dump(exclude_none=True)
+        # Ensure alias is always present in the dict (even if None)
+        if "alias" not in data_dict:
+            data_dict["alias"] = getattr(data, "alias", None)
 
     # Handle credentials serialization
     credentials = data_dict.get("credentials")
@@ -57,33 +74,27 @@ def _prepare_mcp_server_data(
         )
         data_dict["credentials"] = safe_dumps(data_dict["credentials"])
 
-    # Handle static_headers serialization
-    if data.static_headers is not None:
-        data_dict["static_headers"] = safe_dumps(data.static_headers)
+    # Handle JSON-serialized fields. Drive the check off data_dict (not the
+    # model attribute) so we never serialize a default value the caller did
+    # not send on an update.
+    for field in (
+        "static_headers",
+        "mcp_info",
+        "env",
+        "tool_name_to_display_name",
+        "tool_name_to_description",
+    ):
+        value = data_dict.get(field)
+        if value is not None:
+            data_dict[field] = safe_dumps(value)
 
-    # Handle mcp_info serialization
-    if data.mcp_info is not None:
-        data_dict["mcp_info"] = safe_dumps(data.mcp_info)
+    # mcp_access_groups is already List[str], no serialization needed.
 
-    # Handle env serialization
-    if data.env is not None:
-        data_dict["env"] = safe_dumps(data.env)
-
-    # Handle tool name override serialization
-    if data.tool_name_to_display_name is not None:
-        data_dict["tool_name_to_display_name"] = safe_dumps(
-            data.tool_name_to_display_name
-        )
-    if data.tool_name_to_description is not None:
-        data_dict["tool_name_to_description"] = safe_dumps(
-            data.tool_name_to_description
-        )
-
-    # mcp_access_groups is already List[str], no serialization needed
-
-    # Force include is_byok even when False (exclude_none=True would not drop it,
-    # but be explicit to ensure a False value is always written to the DB).
-    data_dict["is_byok"] = getattr(data, "is_byok", False)
+    if not is_update:
+        # Force include is_byok on creates so a False value is always written.
+        # On updates this would resurrect the original LIT-3423 bug for
+        # is_byok, so we only do it for the create path.
+        data_dict["is_byok"] = getattr(data, "is_byok", False)
 
     return data_dict
 
@@ -407,8 +418,10 @@ async def update_mcp_server(
 
     from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 
-    # Use helper to prepare data with proper JSON serialization
-    data_dict = _prepare_mcp_server_data(data)
+    # Use helper to prepare data with proper JSON serialization. is_update
+    # switches the dump to exclude_unset=True so a partial PUT does not
+    # silently overwrite omitted fields with Pydantic defaults (LIT-3423).
+    data_dict = _prepare_mcp_server_data(data, is_update=True)
 
     # Pre-fetch existing record once if we need it for auth_type or credential logic
     existing = None

--- a/litellm/proxy/_experimental/mcp_server/utils.py
+++ b/litellm/proxy/_experimental/mcp_server/utils.py
@@ -194,8 +194,11 @@ def validate_and_normalize_mcp_server_payload(payload: Any) -> None:
     elif alias:
         alias = normalize_server_name(alias)
 
-    # Update the payload with normalized alias
-    if hasattr(payload, "alias"):
+    # Update the payload with the normalized alias only when we actually
+    # computed one. Writing payload.alias = None would otherwise mark the
+    # field as set on Pydantic v2 models and clobber the stored alias on a
+    # partial update that did not include alias or server_name (LIT-3423).
+    if hasattr(payload, "alias") and alias is not None:
         payload.alias = alias
 
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_lit_3423_partial_update.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_lit_3423_partial_update.py
@@ -1,0 +1,260 @@
+"""
+Regression tests for LIT-3423 / LIT-3424.
+
+Bug summary
+-----------
+PUT /v1/mcp/server with a partial body was silently overwriting omitted
+non-Optional fields with their Pydantic defaults because
+_prepare_mcp_server_data called model_dump(exclude_none=True).
+This caused fields like transport, mcp_access_groups, allow_all_keys,
+available_on_public_internet, delegate_auth_to_upstream and is_byok
+to be reset on the DB row when the caller only intended to update one field
+(e.g. allowed_tools). A related symptom (LIT-3424) was that
+allowed_tools: null sent from the UI to clear the list was silently dropped
+by exclude_none=True and the existing value stuck.
+
+Fix
+---
+The update path now uses model_dump(exclude_unset=True) so only fields
+the caller explicitly set on the request participate in the dict, and explicit
+None survives so the UI can clear nullable fields.
+"""
+
+import json
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../../../.."))
+
+from litellm.proxy._experimental.mcp_server.db import (
+    _prepare_mcp_server_data,
+    update_mcp_server,
+)
+from litellm.proxy._experimental.mcp_server.utils import (
+    validate_and_normalize_mcp_server_payload,
+)
+from litellm.proxy._types import (
+    LiteLLM_MCPServerTable,
+    NewMCPServerRequest,
+    UpdateMCPServerRequest,
+)
+
+
+# ---------------------------------------------------------------------------
+# _prepare_mcp_server_data — pure-function level
+# ---------------------------------------------------------------------------
+
+
+class TestPrepareUpdateOmitsUnsetFields:
+    """LIT-3423: partial UpdateMCPServerRequest must not pull in Pydantic defaults."""
+
+    def test_partial_update_omits_transport_default(self):
+        req = UpdateMCPServerRequest(
+            server_id="srv-1", allowed_tools=["read"]
+        )
+        out = _prepare_mcp_server_data(req, is_update=True)
+        assert "transport" not in out
+        assert out.get("allowed_tools") == ["read"]
+
+    def test_partial_update_omits_mcp_access_groups_default(self):
+        req = UpdateMCPServerRequest(server_id="srv-1", allowed_tools=["read"])
+        out = _prepare_mcp_server_data(req, is_update=True)
+        assert "mcp_access_groups" not in out
+
+    def test_partial_update_omits_allow_all_keys_default(self):
+        req = UpdateMCPServerRequest(server_id="srv-1", allowed_tools=["read"])
+        out = _prepare_mcp_server_data(req, is_update=True)
+        assert "allow_all_keys" not in out
+
+    def test_partial_update_omits_available_on_public_internet_default(self):
+        req = UpdateMCPServerRequest(server_id="srv-1", allowed_tools=["read"])
+        out = _prepare_mcp_server_data(req, is_update=True)
+        assert "available_on_public_internet" not in out
+
+    def test_partial_update_omits_delegate_auth_to_upstream_default(self):
+        req = UpdateMCPServerRequest(server_id="srv-1", allowed_tools=["read"])
+        out = _prepare_mcp_server_data(req, is_update=True)
+        assert "delegate_auth_to_upstream" not in out
+
+    def test_partial_update_omits_is_byok_default(self):
+        req = UpdateMCPServerRequest(server_id="srv-1", allowed_tools=["read"])
+        out = _prepare_mcp_server_data(req, is_update=True)
+        assert "is_byok" not in out
+
+    def test_partial_update_omits_args_env_byok_description_defaults(self):
+        req = UpdateMCPServerRequest(server_id="srv-1", allowed_tools=["read"])
+        out = _prepare_mcp_server_data(req, is_update=True)
+        for field in ("args", "env", "byok_description"):
+            assert field not in out, f"{field} must not be set from default on a partial update"
+
+    def test_partial_update_keeps_only_explicit_fields(self):
+        req = UpdateMCPServerRequest(server_id="srv-1", allowed_tools=["read", "write"])
+        out = _prepare_mcp_server_data(req, is_update=True)
+        # Only the caller-provided fields plus nothing else should show up.
+        assert set(out.keys()) == {"server_id", "allowed_tools"}
+
+    def test_explicit_field_in_update_passes_through(self):
+        req = UpdateMCPServerRequest(
+            server_id="srv-1", transport="http", url="https://example.com/mcp"
+        )
+        out = _prepare_mcp_server_data(req, is_update=True)
+        assert out.get("transport") == "http"
+        assert out.get("url") == "https://example.com/mcp"
+
+
+class TestPrepareUpdateClearsExplicitNone:
+    """LIT-3424: explicit allowed_tools: null must reach the DB as None."""
+
+    def test_allowed_tools_explicit_null_clears(self):
+        req = UpdateMCPServerRequest(server_id="srv-1", allowed_tools=None)
+        out = _prepare_mcp_server_data(req, is_update=True)
+        assert "allowed_tools" in out
+        assert out["allowed_tools"] is None
+
+
+class TestPrepareCreateUnchanged:
+    """Create path must keep the historical default-applying behaviour."""
+
+    def test_create_includes_transport_default(self):
+        # NewMCPServerRequest requires url/spec_path for http/sse transport.
+        req = NewMCPServerRequest(
+            server_name="created",
+            url="https://example.com/mcp",
+            transport="http",
+        )
+        out = _prepare_mcp_server_data(req, is_update=False)
+        assert out.get("transport") == "http"
+
+    def test_create_force_includes_is_byok_false(self):
+        req = NewMCPServerRequest(
+            server_name="created",
+            url="https://example.com/mcp",
+            transport="http",
+        )
+        out = _prepare_mcp_server_data(req, is_update=False)
+        # Historical contract: is_byok is force-included on creates so the
+        # column always has a deterministic False even when the caller omits it.
+        assert "is_byok" in out
+        assert out["is_byok"] is False
+
+
+# ---------------------------------------------------------------------------
+# alias normalization — must not clobber stored alias on partial update
+# ---------------------------------------------------------------------------
+
+
+class TestValidatorDoesNotClobberAliasOnPartialUpdate:
+    """LIT-3423: validator used to assign payload.alias = None when neither
+    alias nor server_name was sent, marking the field as set and erasing
+    the stored alias on a partial update."""
+
+    def test_partial_update_without_alias_or_server_name_does_not_set_alias(self):
+        req = UpdateMCPServerRequest(server_id="srv-1", allowed_tools=["read"])
+        validate_and_normalize_mcp_server_payload(req)
+        # The validator must not have written alias back, so it stays absent
+        # from the exclude_unset dump and the DB column is untouched.
+        out = _prepare_mcp_server_data(req, is_update=True)
+        assert "alias" not in out
+
+    def test_partial_update_with_server_name_defaults_alias(self):
+        req = UpdateMCPServerRequest(server_id="srv-1", server_name="my_server")
+        validate_and_normalize_mcp_server_payload(req)
+        out = _prepare_mcp_server_data(req, is_update=True)
+        # The normalization should backfill alias when server_name is provided.
+        assert out.get("alias") == "my_server"
+        assert out.get("server_name") == "my_server"
+
+
+# ---------------------------------------------------------------------------
+# update_mcp_server — integration with mocked Prisma
+# ---------------------------------------------------------------------------
+
+
+def _existing_row(**overrides):
+    row = MagicMock()
+    row.server_id = overrides.get("server_id", "srv-1")
+    row.alias = overrides.get("alias", "stored_alias")
+    row.url = overrides.get("url", "https://upstream.example.com/mcp")
+    row.transport = overrides.get("transport", "http")
+    row.auth_type = overrides.get("auth_type", None)
+    row.credentials = overrides.get("credentials", None)
+    row.allowed_tools = overrides.get("allowed_tools", ["read", "write"])
+    row.mcp_access_groups = overrides.get("mcp_access_groups", ["dev-sandbox"])
+    row.allow_all_keys = overrides.get("allow_all_keys", True)
+    row.available_on_public_internet = overrides.get("available_on_public_internet", False)
+    row.is_byok = overrides.get("is_byok", True)
+    return row
+
+
+def _mock_prisma(existing, captured):
+    prisma = MagicMock()
+    prisma.db = MagicMock()
+    prisma.db.litellm_mcpservertable = MagicMock()
+    prisma.db.litellm_mcpservertable.find_unique = AsyncMock(return_value=existing)
+
+    async def _update(*, where, data):
+        captured["where"] = where
+        captured["data"] = data
+        return existing
+
+    prisma.db.litellm_mcpservertable.update = _update
+    return prisma
+
+
+@pytest.mark.asyncio
+async def test_partial_update_does_not_overwrite_omitted_fields():
+    """LIT-3423 root repro: PUT with only allowed_tools must not send
+    transport, mcp_access_groups, allow_all_keys,
+    available_on_public_internet or is_byok to Prisma."""
+    captured: dict = {}
+    existing = _existing_row()
+    prisma = _mock_prisma(existing, captured)
+
+    payload = UpdateMCPServerRequest(
+        server_id="srv-1", allowed_tools=["read"]
+    )
+    validate_and_normalize_mcp_server_payload(payload)
+
+    await update_mcp_server(prisma, payload, touched_by="admin")
+
+    data = captured["data"]
+    # Caller-set fields propagate.
+    assert data["server_id"] == "srv-1"
+    assert data["allowed_tools"] == ["read"]
+    assert data["updated_by"] == "admin"
+    # The whole point of the fix:
+    for forbidden in (
+        "transport",
+        "mcp_access_groups",
+        "allow_all_keys",
+        "available_on_public_internet",
+        "delegate_auth_to_upstream",
+        "is_byok",
+        "args",
+        "env",
+        "byok_description",
+        "alias",
+    ):
+        assert forbidden not in data, (
+            f"{forbidden} leaked into partial-update payload — would clobber DB"
+        )
+
+
+@pytest.mark.asyncio
+async def test_partial_update_allowed_tools_null_clears():
+    """LIT-3424: explicit allowed_tools: null must reach Prisma as None."""
+    captured: dict = {}
+    existing = _existing_row()
+    prisma = _mock_prisma(existing, captured)
+
+    payload = UpdateMCPServerRequest(server_id="srv-1", allowed_tools=None)
+    validate_and_normalize_mcp_server_payload(payload)
+
+    await update_mcp_server(prisma, payload, touched_by="admin")
+
+    data = captured["data"]
+    assert "allowed_tools" in data, "explicit null must propagate"
+    assert data["allowed_tools"] is None


### PR DESCRIPTION
## Summary

`PUT /v1/mcp/server` with a partial body was silently overwriting omitted fields with Pydantic defaults because the update path used `model_dump(exclude_none=True)`. `UpdateMCPServerRequest` declares non-Optional fields with defaults (`transport=sse`, `mcp_access_groups=[]`, `allow_all_keys=False`, `available_on_public_internet=True`, `delegate_auth_to_upstream=False`, `is_byok=False`, `args=[]`, `env={}`, `byok_description=[]`); Pydantic populates them on input, `exclude_none` keeps them, and they overwrite the stored row.

The same bug dropped an explicit `allowed_tools: null` from the payload, so UI attempts to clear the allowed-tools list silently failed.

## Fix

- `_prepare_mcp_server_data` now takes an `is_update` flag. The update path uses `model_dump(exclude_unset=True)` so only fields the caller explicitly set on the request participate in the dict, and explicit `None` survives (clearing nullable columns works).
- `update_mcp_server` passes `is_update=True`.
- `validate_and_normalize_mcp_server_payload` no longer writes `alias = None` back to the model when neither alias nor server_name was sent (which would otherwise mark the field as set on Pydantic v2 and erase the stored alias on a partial update).
- Create path is unchanged: defaults still apply so new rows have a well-defined state.

## Linear

LIT-3423 (partial PUT resets omitted fields) and LIT-3424 (UI "clear allowed_tools" silently no-ops) share this exact root cause. Both repros are covered in the new regression suite.

## Note on review diff

`GITHUB_TOKEN` for this fork lacks `repo`/`workflow` scopes, so I pushed via the `PUT /repos/{owner}/{repo}/contents/{path}` REST API rather than `git push`. The merge-base diff is exactly the three files below; see the "Files changed" tab if anything looks noisier upstream.

### Evidence

The repro drives the real `update_mcp_server()` against a mocked Prisma client, captures the `data=` dict the endpoint hands to `prisma.update`, and prints it. Stored row before each PUT:

```json
{
  "transport": "http",
  "mcp_access_groups": ["dev-sandbox"],
  "allow_all_keys": true,
  "available_on_public_internet": false,
  "is_byok": true,
  "allowed_tools": ["read", "write"],
  "alias": "stored_alias"
}
```

#### Scenario A — partial PUT (caller sends only `allowed_tools: ["read"]`)

**Before (clean main `01e83e2`):**

```json
{
  "server_id": "srv-1",
  "transport": "sse",
  "mcp_access_groups": [],
  "allowed_tools": ["read"],
  "args": [],
  "env": "{}",
  "allow_all_keys": false,
  "available_on_public_internet": true,
  "delegate_auth_to_upstream": false,
  "is_byok": false,
  "byok_description": [],
  "alias": null,
  "updated_by": "admin"
}
```

Every field other than `server_id`/`allowed_tools`/`updated_by` is an unintended silent overwrite. `transport` flips http→sse (the originally reported HTTP-only failure mode), `mcp_access_groups` is cleared, `allow_all_keys` flips true→false, `is_byok` flips true→false, `alias` is cleared.

**After (this PR):**

```json
{
  "server_id": "srv-1",
  "allowed_tools": ["read"],
  "updated_by": "admin"
}
```

Only the caller-set fields plus the audit column reach Prisma. All omitted fields are untouched on the row.

#### Scenario B — explicit `allowed_tools: null` to clear the list

**Before (clean main `01e83e2`):** `allowed_tools` is dropped from the payload entirely (and every default field still leaks):

```json
{
  "server_id": "srv-1",
  "transport": "sse",
  "mcp_access_groups": [],
  "args": [],
  "env": "{}",
  "allow_all_keys": false,
  "available_on_public_internet": true,
  "delegate_auth_to_upstream": false,
  "is_byok": false,
  "byok_description": [],
  "alias": null,
  "updated_by": "admin"
}
```

**After (this PR):**

```json
{
  "server_id": "srv-1",
  "allowed_tools": null,
  "updated_by": "admin"
}
```

`allowed_tools` propagates as `None`, clearing the column.

### Tests

16 new tests in `tests/test_litellm/proxy/_experimental/mcp_server/test_lit_3423_partial_update.py`:

- `TestPrepareUpdateOmitsUnsetFields` (8): every non-Optional default field is absent from a partial update dict and only caller-provided fields show up.
- `TestPrepareUpdateClearsExplicitNone` (1): explicit `allowed_tools: null` propagates as `None`.
- `TestPrepareCreateUnchanged` (2): create path still applies `transport` default and force-includes `is_byok=False`.
- `TestValidatorDoesNotClobberAliasOnPartialUpdate` (2): alias is not written back as `None` on a partial update, and is still backfilled from `server_name` when provided.
- `test_partial_update_does_not_overwrite_omitted_fields`, `test_partial_update_allowed_tools_null_clears` (2): end-to-end through `update_mcp_server` with a mocked Prisma, asserting on the `data=` dict it passes to `prisma.update`.

```
tests/test_litellm/proxy/_experimental/mcp_server/test_lit_3423_partial_update.py ................ [100%]
16 passed in 12.69s
```

Adjacent suites also clean:

- `tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py` — 72 passed
- `tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py` — 75 passed
- `tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py` — 143 passed
- `tests/test_litellm/proxy/_experimental/mcp_server/test_byok_oauth_endpoints.py` + `test_db_credentials.py` — 89 passed
- `tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py` + `tests/test_litellm/proxy/db/mcp_server/` — 37 passed


### Verification

- Base branch: `litellm_oss_agent_shin_daily_branch` ✅
- mergeable_state: `clean` ✅
- GitHub Actions: **44/44 green**, 0 failures ✅
- Greptile: **5/5** ("Safe to merge") ✅
- Veria AI - PR Review: ✅ success
- Codecov / patch: ✅ success (1 line resolved on second sweep)
- Runtime evidence (before vs after) captured in `### Evidence` above; drives real `update_mcp_server` against mocked Prisma and asserts on the `data=` dict actually passed to `prisma.update`.
- 16 new regression tests + 416 adjacent MCP tests passing locally.
- Customer-name leak check: PR title + body scanned, no customer identifier present.
