### PR TITLE
fix(mcp): preserve omitted fields on partial PUT /v1/mcp/server (LIT-3423)

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/db.py
+++ b/litellm/proxy/_experimental/mcp_server/db.py
@@ -30,6 +30,7 @@ from litellm.types.mcp import MCPCredentials
 
 def _prepare_mcp_server_data(
     data: Union[NewMCPServerRequest, UpdateMCPServerRequest],
+    exclude_unset: bool = False,
 ) -> Dict[str, Any]:
     """
     Helper function to prepare MCP server data for database operations.
@@ -37,17 +38,32 @@ def _prepare_mcp_server_data(
 
     Args:
         data: NewMCPServerRequest or UpdateMCPServerRequest object
+        exclude_unset: When True, only fields the caller explicitly set are
+            included. Use this on the partial-update path so Pydantic defaults
+            (e.g. ``transport=sse``, ``mcp_access_groups=[]``, ``allow_all_keys=False``)
+            do not silently overwrite existing DB values for fields the caller
+            omitted. See LIT-3423.
 
     Returns:
         Dict with properly serialized JSON fields
     """
     from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 
-    # Convert model to dict
-    data_dict = data.model_dump(exclude_none=True)
-    # Ensure alias is always present in the dict (even if None)
-    if "alias" not in data_dict:
-        data_dict["alias"] = getattr(data, "alias", None)
+    # Convert model to dict.
+    # - Create path (exclude_unset=False): include all fields with schema
+    #   defaults via ``exclude_none=True`` so a fresh row gets the defaults
+    #   for non-Optional fields.
+    # - Update path (exclude_unset=True): only include fields the caller
+    #   explicitly set. This prevents a partial PUT from clobbering omitted
+    #   columns with Pydantic defaults — the LIT-3423 regression.
+    if exclude_unset:
+        data_dict = data.model_dump(exclude_unset=True)
+    else:
+        data_dict = data.model_dump(exclude_none=True)
+        # Ensure alias is always present in the dict (even if None) so the
+        # create row has the column populated.
+        if "alias" not in data_dict:
+            data_dict["alias"] = getattr(data, "alias", None)
 
     # Handle credentials serialization
     credentials = data_dict.get("credentials")
@@ -57,33 +73,27 @@ def _prepare_mcp_server_data(
         )
         data_dict["credentials"] = safe_dumps(data_dict["credentials"])
 
-    # Handle static_headers serialization
-    if data.static_headers is not None:
-        data_dict["static_headers"] = safe_dumps(data.static_headers)
-
-    # Handle mcp_info serialization
-    if data.mcp_info is not None:
-        data_dict["mcp_info"] = safe_dumps(data.mcp_info)
-
-    # Handle env serialization
-    if data.env is not None:
-        data_dict["env"] = safe_dumps(data.env)
-
-    # Handle tool name override serialization
-    if data.tool_name_to_display_name is not None:
-        data_dict["tool_name_to_display_name"] = safe_dumps(
-            data.tool_name_to_display_name
-        )
-    if data.tool_name_to_description is not None:
-        data_dict["tool_name_to_description"] = safe_dumps(
-            data.tool_name_to_description
-        )
+    # JSON-serialize dict/list fields ONLY when they are present in
+    # ``data_dict``. Reading off the model attribute directly (as the previous
+    # implementation did) re-introduced Pydantic defaults for fields the
+    # caller did not set (e.g. ``env={}``), which on the update path silently
+    # cleared existing rows.
+    for json_field in (
+        "static_headers",
+        "mcp_info",
+        "env",
+        "tool_name_to_display_name",
+        "tool_name_to_description",
+    ):
+        if json_field in data_dict and data_dict[json_field] is not None:
+            data_dict[json_field] = safe_dumps(data_dict[json_field])
 
     # mcp_access_groups is already List[str], no serialization needed
 
-    # Force include is_byok even when False (exclude_none=True would not drop it,
-    # but be explicit to ensure a False value is always written to the DB).
-    data_dict["is_byok"] = getattr(data, "is_byok", False)
+    if not exclude_unset:
+        # Create path: ensure ``is_byok`` is always written (False if absent)
+        # so the column has a non-null value on insert.
+        data_dict["is_byok"] = getattr(data, "is_byok", False)
 
     return data_dict
 
@@ -407,8 +417,11 @@ async def update_mcp_server(
 
     from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 
-    # Use helper to prepare data with proper JSON serialization
-    data_dict = _prepare_mcp_server_data(data)
+    # Use helper to prepare data with proper JSON serialization.
+    # ``exclude_unset=True`` is critical here: only fields the caller
+    # explicitly sent participate in the update, so a partial PUT does NOT
+    # overwrite omitted columns with Pydantic defaults (LIT-3423).
+    data_dict = _prepare_mcp_server_data(data, exclude_unset=True)
 
     # Pre-fetch existing record once if we need it for auth_type or credential logic
     existing = None

--- a/litellm/proxy/_experimental/mcp_server/utils.py
+++ b/litellm/proxy/_experimental/mcp_server/utils.py
@@ -194,8 +194,11 @@ def validate_and_normalize_mcp_server_payload(payload: Any) -> None:
     elif alias:
         alias = normalize_server_name(alias)
 
-    # Update the payload with normalized alias
-    if hasattr(payload, "alias"):
+    # Update the payload with normalized alias ONLY when it actually changed.
+    # Blind assignment marks ``alias`` as set on the Pydantic model, which
+    # causes ``model_dump(exclude_unset=True)`` to include ``alias=None`` and
+    # silently clear the column on a partial PUT (LIT-3423).
+    if hasattr(payload, "alias") and getattr(payload, "alias", None) != alias:
         payload.alias = alias
 
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_db_partial_update.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_db_partial_update.py
@@ -208,3 +208,24 @@ class TestPartialUpdatePreservesOmittedFields:
             "validate_and_normalize_mcp_server_payload should not assign "
             "alias when caller omitted both alias and server_name (LIT-3423)."
         )
+
+
+    def test_validate_and_normalize_assigns_alias_when_normalization_changes_it(self):
+        """When the caller provides an alias with spaces, validate_and_normalize
+        must reassign payload.alias to the normalized form (covers the True
+        branch of the new equality guard added for LIT-3423)."""
+        from litellm.proxy._experimental.mcp_server.utils import (
+            validate_and_normalize_mcp_server_payload,
+        )
+        from litellm.proxy._types import NewMCPServerRequest
+
+        payload = NewMCPServerRequest(
+            server_name="srv",
+            alias="My Server",  # space normalizes to underscore
+            url="https://example.com/mcp",
+        )
+        validate_and_normalize_mcp_server_payload(payload)
+        assert payload.alias == "My_Server"
+        # alias should be marked as set (we DID change it).
+        assert "alias" in payload.model_fields_set
+

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_db_partial_update.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_db_partial_update.py
@@ -1,0 +1,210 @@
+"""
+Regression tests for LIT-3423: Partial PUT /v1/mcp/server must not silently
+overwrite omitted fields with Pydantic defaults.
+
+Before the fix, ``_prepare_mcp_server_data`` used ``model_dump(exclude_none=True)``,
+which kept the schema defaults (transport=sse, mcp_access_groups=[],
+allow_all_keys=False, available_on_public_internet=True,
+delegate_auth_to_upstream=False, is_byok=False, args=[], env={},
+byok_description=[]). The update path then wrote those defaults to the DB
+row, silently clobbering the existing values. The fix switches the update
+path to ``model_dump(exclude_unset=True)`` so only fields the caller
+actually sent end up in the UPDATE statement.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+class TestPartialUpdatePreservesOmittedFields:
+    """LIT-3423: omitted fields must NOT appear in the update dict."""
+
+    @pytest.mark.asyncio
+    async def test_partial_update_omits_transport_when_caller_did_not_set_it(self):
+        """A PUT updating only ``description`` must NOT include transport in
+        the dict passed to prisma.update — otherwise an HTTP-configured server
+        would silently flip to SSE (the production incident this fixes)."""
+        from litellm.proxy._experimental.mcp_server.db import update_mcp_server
+        from litellm.proxy._types import UpdateMCPServerRequest
+
+        mock_prisma = MagicMock()
+        mock_prisma.db.litellm_mcpservertable.update = AsyncMock(
+            return_value=MagicMock()
+        )
+
+        data = UpdateMCPServerRequest(
+            server_id="test-server",
+            description="Updated description",
+        )
+
+        await update_mcp_server(mock_prisma, data, "test-user")
+
+        data_dict = mock_prisma.db.litellm_mcpservertable.update.call_args[1]["data"]
+        assert "transport" not in data_dict
+        for field in (
+            "mcp_access_groups",
+            "allow_all_keys",
+            "available_on_public_internet",
+            "delegate_auth_to_upstream",
+            "is_byok",
+            "args",
+            "env",
+            "byok_description",
+            "alias",
+        ):
+            assert field not in data_dict, (
+                f"{field!r} was silently included in the update; "
+                "this would overwrite the existing DB row (LIT-3423)."
+            )
+        assert data_dict["description"] == "Updated description"
+        assert data_dict["updated_by"] == "test-user"
+
+    @pytest.mark.asyncio
+    async def test_partial_update_only_includes_explicitly_set_fields(self):
+        """Update with allowed_tools=["tool_a"] must touch only allowed_tools."""
+        from litellm.proxy._experimental.mcp_server.db import update_mcp_server
+        from litellm.proxy._types import UpdateMCPServerRequest
+
+        mock_prisma = MagicMock()
+        mock_prisma.db.litellm_mcpservertable.update = AsyncMock(
+            return_value=MagicMock()
+        )
+
+        data = UpdateMCPServerRequest(
+            server_id="test-server",
+            allowed_tools=["tool_a"],
+        )
+
+        await update_mcp_server(mock_prisma, data, "test-user")
+
+        data_dict = mock_prisma.db.litellm_mcpservertable.update.call_args[1]["data"]
+        assert data_dict.get("allowed_tools") == ["tool_a"]
+        assert "transport" not in data_dict
+        assert "mcp_access_groups" not in data_dict
+        assert "allow_all_keys" not in data_dict
+        assert "is_byok" not in data_dict
+        assert "env" not in data_dict
+
+    @pytest.mark.asyncio
+    async def test_partial_update_explicit_field_value_is_included(self):
+        """Explicitly setting transport=http must be persisted."""
+        from litellm.proxy._experimental.mcp_server.db import update_mcp_server
+        from litellm.proxy._types import MCPTransport, UpdateMCPServerRequest
+
+        mock_prisma = MagicMock()
+        mock_prisma.db.litellm_mcpservertable.update = AsyncMock(
+            return_value=MagicMock()
+        )
+
+        data = UpdateMCPServerRequest(
+            server_id="test-server",
+            transport=MCPTransport.http,
+            url="https://example.com/mcp",
+        )
+
+        await update_mcp_server(mock_prisma, data, "test-user")
+
+        data_dict = mock_prisma.db.litellm_mcpservertable.update.call_args[1]["data"]
+        assert data_dict["transport"] in (MCPTransport.http, "http")
+        assert data_dict["url"] == "https://example.com/mcp"
+
+    @pytest.mark.asyncio
+    async def test_partial_update_does_not_reset_allow_all_keys(self):
+        """A row with allow_all_keys=True must NOT be reset by an omitting PUT."""
+        from litellm.proxy._experimental.mcp_server.db import update_mcp_server
+        from litellm.proxy._types import UpdateMCPServerRequest
+
+        mock_prisma = MagicMock()
+        mock_prisma.db.litellm_mcpservertable.update = AsyncMock(
+            return_value=MagicMock()
+        )
+
+        data = UpdateMCPServerRequest(
+            server_id="test-server",
+            description="new description",
+        )
+
+        await update_mcp_server(mock_prisma, data, "test-user")
+        data_dict = mock_prisma.db.litellm_mcpservertable.update.call_args[1]["data"]
+        assert "allow_all_keys" not in data_dict
+
+    @pytest.mark.asyncio
+    async def test_partial_update_does_not_clear_mcp_access_groups(self):
+        """A row with mcp_access_groups=["x"] must NOT be cleared by an omitting PUT."""
+        from litellm.proxy._experimental.mcp_server.db import update_mcp_server
+        from litellm.proxy._types import UpdateMCPServerRequest
+
+        mock_prisma = MagicMock()
+        mock_prisma.db.litellm_mcpservertable.update = AsyncMock(
+            return_value=MagicMock()
+        )
+
+        data = UpdateMCPServerRequest(
+            server_id="test-server",
+            url="https://example.com/mcp",
+        )
+
+        await update_mcp_server(mock_prisma, data, "test-user")
+        data_dict = mock_prisma.db.litellm_mcpservertable.update.call_args[1]["data"]
+        assert "mcp_access_groups" not in data_dict
+
+    def test_create_path_still_writes_defaults(self):
+        """Create path (NewMCPServerRequest) must still include defaults so
+        non-nullable columns are populated on insert. Use exclude_unset=False."""
+        from litellm.proxy._experimental.mcp_server.db import (
+            _prepare_mcp_server_data,
+        )
+        from litellm.proxy._types import NewMCPServerRequest
+
+        data = NewMCPServerRequest(
+            server_id="srv-1",
+            server_name="srv",
+            url="https://example.com/mcp",
+        )
+
+        prepared = _prepare_mcp_server_data(data, exclude_unset=False)
+
+        assert "transport" in prepared
+        assert "is_byok" in prepared
+        assert prepared["is_byok"] is False
+        assert "alias" in prepared
+
+    def test_update_explicit_null_clears_allowed_tools(self):
+        """LIT-3424 bonus: caller sending allowed_tools=None must clear the
+        field. Previously exclude_none=True dropped it so the row stuck."""
+        from litellm.proxy._experimental.mcp_server.db import (
+            _prepare_mcp_server_data,
+        )
+        from litellm.proxy._types import UpdateMCPServerRequest
+
+        data = UpdateMCPServerRequest(
+            server_id="srv-1",
+            allowed_tools=None,
+        )
+
+        prepared = _prepare_mcp_server_data(data, exclude_unset=True)
+
+        assert "allowed_tools" in prepared
+        assert prepared["allowed_tools"] is None
+
+    def test_validate_and_normalize_does_not_force_alias_when_omitted(self):
+        """validate_and_normalize_mcp_server_payload must NOT mark alias as
+        set on the model when the caller did not provide one — otherwise our
+        exclude_unset payload would include alias=None and clear the row
+        (LIT-3423 secondary fix)."""
+        from litellm.proxy._experimental.mcp_server.utils import (
+            validate_and_normalize_mcp_server_payload,
+        )
+        from litellm.proxy._types import UpdateMCPServerRequest
+
+        payload = UpdateMCPServerRequest(
+            server_id="srv-1",
+            description="d",
+        )
+        assert "alias" not in payload.model_fields_set
+        validate_and_normalize_mcp_server_payload(payload)
+        assert "alias" not in payload.model_fields_set, (
+            "validate_and_normalize_mcp_server_payload should not assign "
+            "alias when caller omitted both alias and server_name (LIT-3423)."
+        )


### PR DESCRIPTION
## Summary

Fix the partial-PUT regression in `PUT /v1/mcp/server` where omitted fields were silently overwritten with Pydantic schema defaults. Reported as LIT-3423.

`UpdateMCPServerRequest` was serialized with `model_dump(exclude_none=True)`, which kept the non-`Optional` defaults (`transport=sse`, `mcp_access_groups=[]`, `allow_all_keys=False`, `available_on_public_internet=True`, `delegate_auth_to_upstream=False`, `is_byok=False`, `args=[]`, `env={}`, `byok_description=[]`). The update path then wrote those defaults to the DB row on every PUT, so a partial PUT meant to touch a single field would flip an HTTP-configured server to SSE, clear access groups, and reset all the boolean flags.

## Fix

- `litellm/proxy/_experimental/mcp_server/db.py`
  - `_prepare_mcp_server_data()` now takes `exclude_unset: bool = False`.
  - `update_mcp_server()` calls it with `exclude_unset=True`, so only fields the caller actually set end up in the UPDATE statement.
  - The create path is unchanged (`exclude_none=True`), so non-nullable columns still get defaults on insert.
  - JSON serialization is gated on field presence in `data_dict` rather than on the raw Pydantic attribute (fixes `env={}` being re-introduced via `data.env`).
- `litellm/proxy/_experimental/mcp_server/utils.py`
  - `validate_and_normalize_mcp_server_payload()` only assigns `payload.alias` when the value actually changes — otherwise the blind assignment marks `alias` as set on the Pydantic model and the `exclude_unset` payload would still clear `alias` on every partial PUT.

Side effect: an explicit `allowed_tools: null` now propagates and clears the column (previously `exclude_none=True` dropped it silently — same root cause as LIT-3424).

## Evidence

Proxy started locally with the bundled Postgres. Same `POST` then partial `PUT` (`description` only) was run on clean `main` and on this branch.

### Before fix (clean upstream/main @ `a021a5be`)

```
=== POST create (HTTP + access_groups + allow_all_keys=true) ===
{
  "server_id": "repro-main-20950",
  "transport": "http",
  "alias": "x_repro",
  "mcp_access_groups": ["mcp-dev-sandbox"],
  "allow_all_keys": true,
  "available_on_public_internet": false,
  "delegate_auth_to_upstream": true
}

=== PUT (description only) ===
{
  "server_id": "repro-main-20950",
  "description": "only updating description",
  "transport": "sse",                        <-- regressed
  "alias": null,                              <-- regressed
  "mcp_access_groups": [],                    <-- regressed
  "allow_all_keys": false,                    <-- regressed
  "available_on_public_internet": true,       <-- regressed
  "delegate_auth_to_upstream": false          <-- regressed
}
```

### After fix (this branch)

```
=== POST create (HTTP + access_groups + allow_all_keys=true) ===
{
  "server_id": "repro-fix-30198",
  "transport": "http",
  "alias": "x_repro",
  "mcp_access_groups": ["mcp-dev-sandbox"],
  "allow_all_keys": true,
  "available_on_public_internet": false,
  "delegate_auth_to_upstream": true
}

=== PUT (description only) ===
{
  "server_id": "repro-fix-30198",
  "description": "only updating description",
  "transport": "http",                       <-- preserved
  "alias": "x_repro",                         <-- preserved
  "mcp_access_groups": ["mcp-dev-sandbox"],   <-- preserved
  "allow_all_keys": true,                     <-- preserved
  "available_on_public_internet": false,      <-- preserved
  "delegate_auth_to_upstream": true           <-- preserved
}
```

## Tests

8 new regression tests in `tests/test_litellm/proxy/_experimental/mcp_server/test_db_partial_update.py` cover:

- partial PUT with only `description` does not include `transport` / `mcp_access_groups` / `allow_all_keys` / `available_on_public_internet` / `delegate_auth_to_upstream` / `is_byok` / `args` / `env` / `byok_description` / `alias` in the dict passed to `prisma.update`
- partial PUT with only `allowed_tools=["tool_a"]` includes only `allowed_tools`
- explicit `transport=http` is still written through
- create path (`NewMCPServerRequest`) still writes defaults so a fresh row is complete
- explicit `allowed_tools=null` now propagates so the column can actually be cleared
- `validate_and_normalize_mcp_server_payload` does not mark `alias` as set when caller omits it

```
$ pytest tests/test_litellm/proxy/_experimental/mcp_server/test_db_partial_update.py \
         tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_sigv4_auth.py \
         tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py -q
... 118 passed
```

## Notes

- Pushed via the GitHub Contents API (one PUT per file) — the agent token lacks the `repo`/`workflow` scopes that `git push` needs. Reviewers should expect a noisier merge-base diff than a `git push`-based PR.
- Closes LIT-3423.


### Verification (ship-pr)

- Reproduced LIT-3423 against clean upstream/main (`a021a5be`) with a local proxy + bundled Postgres — captured the corrupted PUT response inline above.
- Applied the fix on this branch, restarted the proxy, replayed the same `POST` + partial `PUT` — every previously clobbered column is now preserved (`transport`, `alias`, `mcp_access_groups`, `allow_all_keys`, `available_on_public_internet`, `delegate_auth_to_upstream`).
- Unit tests: 9 new regression tests + 110 existing related tests pass locally (`tests/test_litellm/proxy/_experimental/mcp_server/test_db_partial_update.py`, `test_mcp_sigv4_auth.py`, `tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py`).
- Greptile review: **4/5** ("Safe to merge; changes are tightly scoped to the partial-PUT update path and the create path is untouched.").
- GitHub Actions: all 43 check-runs green on `2eaff133`. Veria AI was still stuck `in_progress` ≥30 min at hand-off (known harness issue, separately tracked).
- PR contains no customer-name strings (verified — `atlassian`/`jira`/`confluence` all absent from title and body).
- Files pushed via the GitHub Contents API (one PUT per file) because the agent token lacks `repo`/`workflow` scopes; reviewers should expect a noisier merge-base diff than a `git push`-based PR.
