### PR TITLE
fix(router): persist global retry_policy via /config/update (LIT-3152)

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -10133,6 +10133,7 @@ class Router:
             "retry_after",
             "fallbacks",
             "context_window_fallbacks",
+            "retry_policy",
             "model_group_retry_policy",
             "model_group_alias",
             "enable_weighted_failover",
@@ -10156,6 +10157,15 @@ class Router:
                 elif var == "routing_groups":
                     self._routing_groups_input = kwargs[var]
                     rebuild_routing_groups = True
+                elif var == "retry_policy":
+                    # Mirror Router.__init__ semantics: accept dict | RetryPolicy
+                    # | None, coercing dicts to RetryPolicy so the runtime retry
+                    # path (which reads ``self.retry_policy``) keeps seeing the
+                    # typed object regardless of write path.
+                    value = kwargs[var]
+                    if isinstance(value, dict):
+                        value = RetryPolicy(**value)
+                    setattr(self, var, value)
                 else:
                     value = kwargs[var]
                     # only run routing strategy init if it has changed

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -91,6 +91,11 @@ class UpdateRouterConfig(BaseModel):
     routing_strategy_args: Optional[dict] = None
     routing_strategy: Optional[str] = None
     routing_groups: Optional[List[RoutingGroup]] = None
+    # Global retry policy (per-exception-type retry counts). Persisted as a
+    # plain dict so this schema does not need to import the typed
+    # ``RetryPolicy`` model; ``Router.update_settings`` coerces the dict to
+    # ``RetryPolicy`` before storing it on the router instance.
+    retry_policy: Optional[dict] = None
     model_group_retry_policy: Optional[dict] = None
     model_group_affinity_config: Optional[Dict[str, List[str]]] = None
     allowed_fails: Optional[int] = None

--- a/tests/test_litellm/test_router_retry_policy_update.py
+++ b/tests/test_litellm/test_router_retry_policy_update.py
@@ -53,7 +53,7 @@ def test_update_router_config_accepts_retry_policy_payload():
         }
     }
     cfg = UpdateRouterConfig(**payload)
-    dumped = cfg.dict(exclude_none=True)
+    dumped = cfg.model_dump(exclude_none=True)
     assert "retry_policy" in dumped
     assert dumped["retry_policy"]["BadRequestErrorRetries"] == 5
     assert dumped["retry_policy"]["RateLimitErrorRetries"] == 7

--- a/tests/test_litellm/test_router_retry_policy_update.py
+++ b/tests/test_litellm/test_router_retry_policy_update.py
@@ -1,0 +1,143 @@
+"""
+Tests for the retry_policy fix on Router.update_settings (LIT-3152).
+
+Bug: the Admin UI Model Retry Settings tab posts a global ``retry_policy``
+through ``POST /config/update`` -> ``UpdateRouterConfig`` ->
+``Router.update_settings``. Both the pydantic schema and
+``update_settings`` were dropping the field silently:
+
+- ``UpdateRouterConfig`` had no ``retry_policy`` attribute, so
+  ``model_dump(exclude_none=True)`` returned ``{}`` for that key.
+- ``Router.update_settings`` had no ``"retry_policy"`` entry in
+  ``_allowed_settings``, so even when fed directly the call was a no-op
+  (``Setting {} is not allowed`` debug log).
+
+The net effect was that after saving retry counts in the UI and
+reloading, every value snapped back to ``defaultRetry = num_retries``
+(2 by default), exactly matching the ticket repro.
+
+This file pins both halves of the fix.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("../.."))
+
+import litellm
+from litellm.types.router import RetryPolicy, UpdateRouterConfig
+
+# ---------------------------------------------------------------------------
+# UpdateRouterConfig schema membership (LIT-3152 part 1)
+# ---------------------------------------------------------------------------
+
+
+def test_update_router_config_exposes_retry_policy_field():
+    """retry_policy must be a declared field on UpdateRouterConfig.
+
+    Without it, Pydantic silently strips the key from the /config/update
+    payload before the proxy even calls llm_router.update_settings.
+    """
+    assert "retry_policy" in UpdateRouterConfig.model_fields
+
+
+def test_update_router_config_accepts_retry_policy_payload():
+    """The exact payload the Admin UI Model Retry Settings tab sends must
+    round-trip through the schema's ``dict(exclude_none=True)`` form, since
+    that is what /config/update writes to the LiteLLM_Config row."""
+    payload = {
+        "retry_policy": {
+            "BadRequestErrorRetries": 5,
+            "RateLimitErrorRetries": 7,
+            "TimeoutErrorRetries": 3,
+        }
+    }
+    cfg = UpdateRouterConfig(**payload)
+    dumped = cfg.dict(exclude_none=True)
+    assert "retry_policy" in dumped
+    assert dumped["retry_policy"]["BadRequestErrorRetries"] == 5
+    assert dumped["retry_policy"]["RateLimitErrorRetries"] == 7
+    assert dumped["retry_policy"]["TimeoutErrorRetries"] == 3
+
+
+# ---------------------------------------------------------------------------
+# Router.update_settings retry_policy path (LIT-3152 part 2)
+# ---------------------------------------------------------------------------
+
+
+def _build_router() -> litellm.Router:
+    return litellm.Router(
+        model_list=[
+            {
+                "model_name": "test-model",
+                "litellm_params": {
+                    "model": "openai/gpt-4",
+                    "api_key": "sk-fake",
+                    "api_base": "http://localhost:9999",
+                },
+            }
+        ]
+    )
+
+
+def test_update_settings_persists_retry_policy_dict():
+    """When the proxy's ``_add_router_settings_from_db_config`` calls
+    ``llm_router.update_settings(retry_policy={...})`` after reading the
+    DB row, the dict must land on ``self.retry_policy`` as a typed
+    ``RetryPolicy`` (mirroring ``Router.__init__`` semantics)."""
+    router = _build_router()
+    assert router.retry_policy is None  # baseline
+
+    router.update_settings(
+        retry_policy={
+            "BadRequestErrorRetries": 5,
+            "RateLimitErrorRetries": 7,
+            "TimeoutErrorRetries": 3,
+        }
+    )
+
+    assert isinstance(router.retry_policy, RetryPolicy)
+    assert router.retry_policy.BadRequestErrorRetries == 5
+    assert router.retry_policy.RateLimitErrorRetries == 7
+    assert router.retry_policy.TimeoutErrorRetries == 3
+
+
+def test_update_settings_accepts_retry_policy_object_unchanged():
+    """A pre-built ``RetryPolicy`` instance must pass through verbatim so
+    callers that already constructed one (e.g. tests or programmatic
+    callers) keep working."""
+    router = _build_router()
+
+    policy = RetryPolicy(BadRequestErrorRetries=2)
+    router.update_settings(retry_policy=policy)
+
+    assert router.retry_policy is policy
+
+
+def test_update_settings_get_settings_round_trip_for_retry_policy():
+    """``GET /get/config/callbacks`` serializes ``llm_router.get_settings()``
+    back to the UI. After updating, the round-trip must reflect the new
+    values rather than the pre-update sentinel."""
+    router = _build_router()
+    pre = router.get_settings().get("retry_policy")
+    assert pre is None
+
+    router.update_settings(
+        retry_policy={
+            "BadRequestErrorRetries": 5,
+            "RateLimitErrorRetries": 7,
+        }
+    )
+    post = router.get_settings().get("retry_policy")
+    assert post is not None
+    assert post.BadRequestErrorRetries == 5
+    assert post.RateLimitErrorRetries == 7
+
+
+def test_update_settings_unrelated_kwargs_still_skipped():
+    """Regression guard: the new branch must not relax the
+    ``_allowed_settings`` allowlist for unrelated keys. An unknown
+    setting should still be dropped silently as before."""
+    router = _build_router()
+    router.update_settings(this_is_not_a_router_setting=123)
+    assert not hasattr(router, "this_is_not_a_router_setting")


### PR DESCRIPTION
## Linear ticket

Fixes [LIT-3152](https://linear.app/litellm-ai/issue/LIT-3152) — *Model retries selection does not work*: the "Model Retry Settings" tab on the Models and Endpoints page lets an admin set per-exception-type retry counts (BadRequestError, RateLimitError, TimeoutError, etc.), click **Save**, refresh — and every value snaps back to `defaultRetry = num_retries` (2 by default).

## Root cause

The Admin UI's *Model Retry Settings* tab POSTs `{ router_settings: { retry_policy: { ... } } }` to `/config/update`. That payload was being silently dropped on **two** layers, and the field was never persisted:

1. `litellm.types.router.UpdateRouterConfig` (the Pydantic schema bound to `/config/update`) did not declare `retry_policy` as a field. With Pydantic's default behaviour (no `extra="allow"`), `config_info.router_settings.dict(exclude_none=True)` returned `{}` for that key, so the DB upsert never wrote it.
2. Even if a caller bypassed the schema and called `Router.update_settings(retry_policy={...})` directly, the function's `_allowed_settings` allowlist had no `"retry_policy"` entry — the assignment was a no-op and only printed `Setting {} is not allowed` at DEBUG.

Net effect: the DB row stayed at `{"model_group_alias": {}}`, the in-memory `llm_router.retry_policy` stayed `None`, and on the next `GET /get/config/callbacks` the UI fell back to `defaultRetry = num_retries = 2` for every exception type.

This affects only the **global** retry policy from the UI. Per-model `model_group_retry_policy` and the per-deployment `litellm_params.max_retries` (set through `model_info_view`) round-trip correctly today and are unchanged by this PR.

## Fix

Two narrow edits, scoped to the same write path the UI uses:

1. `litellm/types/router.py` — declare `retry_policy: Optional[dict] = None` on `UpdateRouterConfig` so the field survives Pydantic deserialization and `dict(exclude_none=True)`. Persisted as a plain dict (matches the JSON the UI sends and the existing `model_group_retry_policy` shape on the same model), with coercion done in the router.
2. `litellm/router.py::Router.update_settings` — add `"retry_policy"` to `_allowed_settings` and coerce `dict` payloads to `RetryPolicy` before `setattr`, mirroring `Router.__init__`'s exact semantics (`isinstance(value, dict): value = RetryPolicy(**value)`).

## Scope guard (what is NOT changed)

- `Router.__init__` is untouched.
- `Router.get_settings()`'s `vars_to_include` already contained `"retry_policy"` — no change there. The bug was strictly that updates didn't reach `self.retry_policy`, not that `get_settings()` ignored it.
- `_int_settings`, the routing-strategy normalization branch, and the `model_group_retry_policy` branch are unchanged.
- Per-deployment `litellm_params.max_retries` (the **Max Retries** input on `model_info_view`) round-trips correctly on `main` already; no changes there. Verified by direct PATCH `/model/{id}/update` round-trip.
- `proxy/_experimental/out/*` (the built UI bundle) is intentionally not staged.

## Evidence

Both runs use the same fresh DB and the same payload — the JSON the Admin UI's `setCallbacksCall` call actually sends from `ModelRetrySettingsTab.handleSaveRetrySettings` when `selectedModelGroup === "global"`.

### Before (clean daily-branch HEAD `1fe911d89d`)

```
$ curl -sS -X POST http://127.0.0.1:PORT/config/update \
    -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
    --data '{"router_settings":{"retry_policy":{"BadRequestErrorRetries":5,"RateLimitErrorRetries":7,"TimeoutErrorRetries":3}}}'
{"message":"Config updated successfully"}

$ psql -c "SELECT param_value FROM \"LiteLLM_Config\" WHERE param_name='router_settings';"
        param_value
---------------------------
 {"model_group_alias": {}}      <-- retry_policy silently dropped at the schema layer
(1 row)

$ curl -sS http://127.0.0.1:PORT/get/config/callbacks -H "Authorization: Bearer $KEY" \
    | python3 -c "import json,sys; r=json.load(sys.stdin)['router_settings']; print('retry_policy =', r.get('retry_policy')); print('num_retries =', r.get('num_retries'))"
retry_policy = None
num_retries = 2
# UI ModelRetrySettingsTab then renders defaultRetry = num_retries = 2 for every row.
```

### After (this branch)

```
$ curl -sS -X POST http://127.0.0.1:PORT/config/update \
    -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
    --data '{"router_settings":{"retry_policy":{"BadRequestErrorRetries":5,"RateLimitErrorRetries":7,"TimeoutErrorRetries":3}}}'
{"message":"Config updated successfully"}

$ psql -c "SELECT param_value FROM \"LiteLLM_Config\" WHERE param_name='router_settings';"
                                                          param_value
--------------------------------------------------------------------------------------------------------------------------------
 {"retry_policy": {"TimeoutErrorRetries": 3, "RateLimitErrorRetries": 7, "BadRequestErrorRetries": 5}, "model_group_alias": {}}
(1 row)

$ curl -sS http://127.0.0.1:PORT/get/config/callbacks -H "Authorization: Bearer $KEY" \
    | python3 -c "import json,sys; r=json.load(sys.stdin)['router_settings']; print('retry_policy =', r.get('retry_policy')); print('num_retries =', r.get('num_retries'))"
retry_policy = {'BadRequestErrorRetries': 5, 'AuthenticationErrorRetries': None, 'TimeoutErrorRetries': 3, 'RateLimitErrorRetries': 7, 'ContentPolicyViolationErrorRetries': None, 'InternalServerErrorRetries': None}
num_retries = 2
# UI ModelRetrySettingsTab now renders the persisted values; user-set counts survive refresh.
```

## Tests

`tests/test_litellm/test_router_retry_policy_update.py` — 6 new cases, all green:

```
tests/test_litellm/test_router_retry_policy_update.py::test_update_router_config_accepts_retry_policy_payload PASSED
tests/test_litellm/test_router_retry_policy_update.py::test_update_router_config_exposes_retry_policy_field PASSED
tests/test_litellm/test_router_retry_policy_update.py::test_update_settings_accepts_retry_policy_object_unchanged PASSED
tests/test_litellm/test_router_retry_policy_update.py::test_update_settings_get_settings_round_trip_for_retry_policy PASSED
tests/test_litellm/test_router_retry_policy_update.py::test_update_settings_persists_retry_policy_dict PASSED
tests/test_litellm/test_router_retry_policy_update.py::test_update_settings_unrelated_kwargs_still_skipped PASSED
======================== 6 passed, 3 warnings in 1.02s =========================
```

Pre-existing pin `tests/router_unit_tests/test_router_helper_utils.py::test_update_settings` still passes:

```
tests/router_unit_tests/test_router_helper_utils.py::test_update_settings PASSED
========================= 1 passed, 1 warning in 0.68s =========================
```

## Push path

Branch was pushed via the GitHub Contents API because this agent's `GITHUB_TOKEN` lacks `repo` + `workflow` scopes for direct `git push`. The merge-base diff still resolves to the 3 file changes shown in this PR.

## Linear

LIT-3152 (project: redacted — see Linear).


---

### Verification (ship-pr)

- **Greptile**: **5/5** — "Safe to merge; the fix is narrowly scoped to the write path for global retry policy and leaves all other settings paths, __init__, and per-model retry logic untouched." P2 (`cfg.dict` → `cfg.model_dump`) addressed in commit `77c537de`; tests still 6/6 green.
- **Veria AI - PR Review**: ✅ success.
- **GitHub Actions**: **44/44 green** at HEAD `77c537de` (`code-quality`, `documentation`, `lint`, `semgrep`, `secret-scan`, Codecov ✅ "All modified and coverable lines are covered by tests", every `Run tests` worker, `proxy-*` suites, `test-server-root-path` × 2, integrations, Vertex AI, All Other Providers).
- **Mergeable state**: `clean`.
- **Base**: `litellm_oss_agent_shin_daily_branch` (Shin fork policy).
- **Scope**: 3 files, +158 LOC (`litellm/router.py` +10, `litellm/types/router.py` +5, new test file +143). No other files modified — `proxy/_experimental/out/*` not staged.
- **Runtime evidence**: BEFORE (DB row `{"model_group_alias": {}}`, GET `retry_policy=None`) and AFTER (DB row contains saved retry counts, GET returns the typed `RetryPolicy` payload) captured in the PR body. Same fresh-DB + identical UI payload for both runs.
- **Tests**: 6/6 new regression tests pass locally; pre-existing `tests/router_unit_tests/test_router_helper_utils.py::test_update_settings` still passes.
