### PR TITLE
build(ui): pin trailingSlash=true and verify Node v20 in build_ui.sh

### DIFF
--- a/tests/test_litellm/ui/test_ui_build_pinning_lit_2723.py
+++ b/tests/test_litellm/ui/test_ui_build_pinning_lit_2723.py
@@ -1,0 +1,62 @@
+"""
+Regression tests for LIT-2723 - pin the UI build output layout and Node version
+so committed `litellm/proxy/_experimental/out/` diffs stop flipping between
+`<route>.html` and `<route>/index.html`, and so the build does not silently
+fall back to a non-v20 Node.
+
+These are file-level assertions on the build config + script. They do not run
+npm or restructure the export; they only guard the locking lines.
+"""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+NEXT_CONFIG = REPO_ROOT / "ui" / "litellm-dashboard" / "next.config.mjs"
+BUILD_UI_SH = REPO_ROOT / "ui" / "litellm-dashboard" / "build_ui.sh"
+
+
+def test_next_config_pins_trailing_slash_true():
+    """next.config.mjs must declare `trailingSlash: true` so every build emits
+    the `<route>/index.html` directory-index layout. Flipping back to the
+    `<route>.html` form rewrites every file in `_experimental/out` and breaks
+    deployments that rely on directory-index routing (e.g. the MCP OAuth
+    callback)."""
+    assert NEXT_CONFIG.is_file(), f"next.config.mjs missing at {NEXT_CONFIG}"
+    text = NEXT_CONFIG.read_text()
+    assert "trailingSlash: true" in text or "trailingSlash:true" in text, (
+        "next.config.mjs must set `trailingSlash: true` (LIT-2723). "
+        "Removing it makes the static export flip back to the bare "
+        "<route>.html form on the next local build."
+    )
+
+
+def test_build_ui_sh_installs_node_v20_and_verifies():
+    """build_ui.sh must install v20 (not just `nvm use`), error-check both
+    steps, and verify `node -v` actually reports v20 before running the
+    build. Without these guards the script silently succeeds against any
+    Node version on PATH in non-interactive shells, and the committed
+    artifacts pick up the wrong Node."""
+    assert BUILD_UI_SH.is_file(), f"build_ui.sh missing at {BUILD_UI_SH}"
+    text = BUILD_UI_SH.read_text()
+
+    assert "nvm install v20" in text, (
+        "build_ui.sh must `nvm install v20` before `nvm use v20` - "
+        "`use` alone silently no-ops when v20 is not already installed."
+    )
+    assert "nvm install v20 failed" in text, (
+        "build_ui.sh must surface `nvm install v20` failure with an "
+        "error message and non-zero exit (LIT-2723)."
+    )
+    assert "Failed to switch to Node.js v20" in text, (
+        "build_ui.sh must surface `nvm use v20` failure with an error "
+        "message and non-zero exit."
+    )
+    assert "node -v" in text, (
+        "build_ui.sh must read `node -v` to verify the active Node "
+        "version after `nvm use v20`."
+    )
+    assert "v20." in text, (
+        "build_ui.sh must check that `node -v` output starts with "
+        "`v20.` and abort otherwise (LIT-2723)."
+    )

--- a/ui/litellm-dashboard/build_ui.sh
+++ b/ui/litellm-dashboard/build_ui.sh
@@ -22,14 +22,28 @@ if ! command -v nvm &> /dev/null; then
   [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 fi
 
-# Use nvm to set the required Node.js version
-nvm use v20
+# Install + use the pinned Node.js version. `nvm use` alone silently no-ops
+# when v20 isn't installed in the current shell (e.g. non-interactive CI),
+# and the build then runs against whatever node is on PATH. Install first, use
+# second, and verify `node -v` actually reports v20 before continuing.
+if ! nvm install v20; then
+  echo "Error: nvm install v20 failed. Deployment aborted."
+  exit 1
+fi
 
-# Check if nvm use was successful
-if [ $? -ne 0 ]; then
+if ! nvm use v20; then
   echo "Error: Failed to switch to Node.js v20. Deployment aborted."
   exit 1
 fi
+
+NODE_VER="$(node -v 2>/dev/null || true)"
+case "$NODE_VER" in
+  v20.*) echo "Confirmed Node.js $NODE_VER" ;;
+  *)
+    echo "Error: expected Node.js v20.* but got '$NODE_VER'. Deployment aborted."
+    exit 1
+    ;;
+esac
 
 # print contents of ui_colors.json
 echo "Contents of ui_colors.json:"

--- a/ui/litellm-dashboard/build_ui.sh
+++ b/ui/litellm-dashboard/build_ui.sh
@@ -74,4 +74,6 @@ if [ $? -eq 0 ]; then
   echo "Deployment completed."
 else
   echo "Build failed. Deployment aborted."
+  exit 1
 fi
+

--- a/ui/litellm-dashboard/next.config.mjs
+++ b/ui/litellm-dashboard/next.config.mjs
@@ -7,6 +7,12 @@ const __dirname = path.dirname(__filename);
 
 const nextConfig = {
   output: "export",
+  // Pin the directory-index layout (<route>/index.html). Otherwise different
+  // Next.js patch versions or stale .next caches flip the export between
+  // foo.html and foo/index.html, producing massive rename-only diffs in
+  // litellm/proxy/_experimental/out and breaking deployments that rely on
+  // directory-index routing for nested paths (e.g. /ui/mcp/oauth/callback).
+  trailingSlash: true,
   // Required with output: "export" — default image optimizer runs only in server mode.
   // See https://nextjs.org/docs/messages/export-image-api
   images: {


### PR DESCRIPTION
## Summary

LIT-2723. Two small build-time locks for the admin UI:

1. **`ui/litellm-dashboard/next.config.mjs`** — set `trailingSlash: true`. The static export then consistently emits `<route>/index.html` (directory-index). Different Next.js patch versions and stale `.next/` caches were flipping the export between `foo.html` and `foo/index.html`, producing massive rename-only diffs in `litellm/proxy/_experimental/out` and breaking deployments that rely on the directory-index form (e.g. nested OAuth callback routes — see #28106 / #28112).
2. **`ui/litellm-dashboard/build_ui.sh`** — `nvm install v20` first (the bare `nvm use v20` silently no-ops when v20 isn't already installed in non-interactive shells, e.g. CI), error-check both nvm steps, then verify `node -v` actually reports `v20.*` before running `npm run build`. Without this guard, committed artifacts can slip in built against Node v22 (which has happened on recent commits per the ticket).

The ticket also mentions `docker/Dockerfile.custom_ui` — that file no longer exists in this tree. The Dockerfile.non_root path was already updated in #28112, so there's nothing else to touch on the Docker side here.

## Note on review diff

The fork's `GITHUB_TOKEN` lacks `repo` + `workflow` scopes, so I pushed via the `PUT /repos/{owner}/{repo}/contents/{path}` REST API rather than `git push`. The merge-base diff is exactly the three files below; see "Files changed" for the canonical view.

### Evidence

#### 1. `trailingSlash: true` flips the export from `<route>.html` to `<route>/index.html`

Built a minimal Next.js 15 project mirroring the dashboard's nested route structure (`/`, `/login`, `/settings/admin-settings`, `/tools/mcp-servers`) and ran `next build` with `output: "export"` both ways.

**Before — `output: "export"` only (current state of `ui/litellm-dashboard/next.config.mjs`):**

```
out/404.html
out/index.html
out/login.html
out/settings/admin-settings.html
out/tools/mcp-servers.html
```

**After — `output: "export"` + `trailingSlash: true` (this PR):**

```
out/404.html
out/404/index.html
out/index.html
out/login/index.html
out/settings/admin-settings/index.html
out/tools/mcp-servers/index.html
```

Every nested route now lives at `<route>/index.html`. The existing committed `litellm/proxy/_experimental/out/` on `litellm_oss_agent_shin_daily_branch` currently has the bare-`.html` form for nested routes (e.g. `organizations.html`, `settings/admin-settings.html`, `tools/mcp-servers.html`), which is exactly the form the customer fix in #28106 / #28112 needed to move away from. Without `trailingSlash: true`, the very next local rebuild flips it right back.

#### 2. build_ui.sh node-version guard fires on the wrong Node

Stubbed `node` to return `v22.16.0` (the version that was sneaking into recent committed artifacts per the ticket), then exercised the new guard:

```
[stub nvm] install v20
[stub nvm] use v20
Error: expected Node.js v20.* but got 'v22.16.0'. Deployment aborted.
```

Same fragment with a stub returning `v20.18.0`:

```
[stub nvm] install v20
[stub nvm] use v20
Confirmed Node.js v20.18.0
(would now run npm build — guard passed)
```

Same fragment with `node` missing (the silent-no-op-on-non-interactive-shell scenario):

```
Error: expected Node.js v20.* but got ''. Deployment aborted.
```

The previous code in `build_ui.sh` was `nvm use v20` followed by a check of `$?`. That check fires only when `nvm use` actually returned non-zero — which it doesn't when nvm isn't loaded in the shell at all (the `nvm` function simply isn't defined, the `nvm use v20` line itself errors with "command not found" but `set -e` is not in effect, so the script just walks past it and `npm run build` runs against whatever `node` is on `PATH`). The new `nvm install v20` + `nvm use v20` + `node -v` triple closes that hole.

### Tests

`tests/test_litellm/ui/test_ui_build_pinning_lit_2723.py`:

```
tests/test_litellm/ui/test_ui_build_pinning_lit_2723.py::test_build_ui_sh_installs_node_v20_and_verifies PASSED [ 50%]
tests/test_litellm/ui/test_ui_build_pinning_lit_2723.py::test_next_config_pins_trailing_slash_true PASSED [100%]
2 passed in 0.99s
```

The tests assert on the locking lines — `trailingSlash: true` in `next.config.mjs`, and the `nvm install v20` / `Failed to switch to Node.js v20` / `node -v` / `v20.` markers in `build_ui.sh` — so a later cleanup can't silently regress either piece without breaking the test.

### Out of scope

* `docker/Dockerfile.custom_ui` was named in the ticket but no longer exists in this tree (Dockerfile.non_root was updated in #28112).
* `docker/build_admin_ui.sh` separately uses `nvm install v18.17.0` before invoking `build_ui.sh`. That's the enterprise UI build path; touching it would expand scope. Left as-is.

## Linear

LIT-2723.


### Verification (ship-pr)

- Base branch is `litellm_oss_agent_shin_daily_branch` (required for fork PRs).
- CI 44/44 green at HEAD `f0fa7d1`. `mergeable_state=clean`.
- Greptile: 5/5 — "Safe to merge — all three files contain targeted, well-scoped changes with no logic regressions introduced." (initial 4/5 with one P1 about the pre-existing `npm run build` else-branch missing `exit 1`; addressed in `f0fa7d1`, re-review bumped to 5/5).
- Veria AI - PR Review: completed/success (low risk).
- Runtime evidence captured in the `### Evidence` section above (Next.js export layout before/after + build_ui.sh node-version guard fires on v22 / empty / passes on v20).
- Unit tests pass locally (`pytest tests/test_litellm/ui/test_ui_build_pinning_lit_2723.py` — 2 passed). Tests are in **addition to** runtime evidence, not in place of.
- No customer name in PR title or body.
- No secrets in PR title or body (token redacted on every push).
- Diff scope = 3 files (the two locking lines + the regression test). No vendored/generated noise.
