### PR TITLE
fix(streaming): use exact match for [DONE] SSE termination in BaseModelResponseIterator

### DIFF
--- a/litellm/llms/base_llm/base_model_iterator.py
+++ b/litellm/llms/base_llm/base_model_iterator.py
@@ -103,7 +103,15 @@ class BaseModelResponseIterator:
         stripped_json_chunk = BaseModelResponseIterator._string_to_dict_parser(
             str_line=str_line
         )
-        if "[DONE]" in str_line:
+        if stripped_json_chunk:
+            return self.chunk_parser(chunk=stripped_json_chunk)
+        # Only treat as termination when the stripped payload is exactly "[DONE]".
+        # A substring check ("in") would falsely match JSON chunks whose string
+        # values contain "[DONE]" — e.g. tool-call arguments like `"[DONE]`,`".
+        stripped_chunk = litellm.CustomStreamWrapper._strip_sse_data_from_chunk(
+            str_line
+        )
+        if stripped_chunk is not None and stripped_chunk.strip() == "[DONE]":
             return GenericStreamingChunk(
                 text="",
                 is_finished=True,
@@ -112,17 +120,14 @@ class BaseModelResponseIterator:
                 index=0,
                 tool_use=None,
             )
-        elif stripped_json_chunk:
-            return self.chunk_parser(chunk=stripped_json_chunk)
-        else:
-            return GenericStreamingChunk(
-                text="",
-                is_finished=False,
-                finish_reason="",
-                usage=None,
-                index=0,
-                tool_use=None,
-            )
+        return GenericStreamingChunk(
+            text="",
+            is_finished=False,
+            finish_reason="",
+            usage=None,
+            index=0,
+            tool_use=None,
+        )
 
     def __next__(self):
         while True:

--- a/tests/llm_translation/test_databricks.py
+++ b/tests/llm_translation/test_databricks.py
@@ -297,6 +297,90 @@ def mock_chat_streaming_response_chunks() -> List[str]:
     ]
 
 
+def mock_chat_streaming_response_chunks_with_done_in_args() -> List[str]:
+    """Streaming chunks where a tool-call argument value contains '[DONE]'."""
+    return [
+        json.dumps(
+            {
+                "id": "chatcmpl-test",
+                "object": "chat.completion.chunk",
+                "created": 1726469651,
+                "model": "dbrx-instruct-071224",
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {"role": "assistant", "content": "prefix"},
+                        "finish_reason": None,
+                    }
+                ],
+            }
+        ),
+        json.dumps(
+            {
+                "id": "chatcmpl-test",
+                "object": "chat.completion.chunk",
+                "created": 1726469651,
+                "model": "dbrx-instruct-071224",
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "id": "call_1",
+                                    "type": "function",
+                                    "function": {"name": "Write", "arguments": ""},
+                                }
+                            ]
+                        },
+                        "finish_reason": None,
+                    }
+                ],
+            }
+        ),
+        # This chunk's argument value contains "[DONE]" — must NOT terminate stream.
+        json.dumps(
+            {
+                "id": "chatcmpl-test",
+                "object": "chat.completion.chunk",
+                "created": 1726469651,
+                "model": "dbrx-instruct-071224",
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {
+                            "tool_calls": [
+                                {"index": 0, "function": {"arguments": "[DONE]`,"}}
+                            ]
+                        },
+                        "finish_reason": None,
+                    }
+                ],
+            }
+        ),
+        json.dumps(
+            {
+                "id": "chatcmpl-test",
+                "object": "chat.completion.chunk",
+                "created": 1726469651,
+                "model": "dbrx-instruct-071224",
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {
+                            "tool_calls": [
+                                {"index": 0, "function": {"arguments": " more args}"}}
+                            ]
+                        },
+                        "finish_reason": "stop",
+                    }
+                ],
+            }
+        ),
+    ]
+
+
 def mock_chat_streaming_response_chunks_bytes() -> List[bytes]:
     string_chunks = mock_chat_streaming_response_chunks()
     bytes_chunks = [chunk.encode("utf-8") + b"\n" for chunk in string_chunks]
@@ -631,6 +715,57 @@ def test_completions_streaming_with_async_http_handler(monkeypatch):
             "extraparam": "testpassingextraparam",
         }
         assert actual_data == expected_data, f"Unexpected JSON data: {actual_data}"
+
+
+def test_completions_streaming_tool_call_with_done_in_arguments(monkeypatch):
+    """
+    Regression: a streaming chunk whose tool-call arguments value contains
+    the string '[DONE]' must not be mistaken for the SSE termination signal.
+
+    Before the fix, BaseModelResponseIterator._handle_string_chunk used
+    `if "[DONE]" in str_line` (substring check), which caused any chunk
+    containing '[DONE]' anywhere in the line to be treated as the end-of-stream
+    sentinel, silently dropping subsequent chunks.
+    """
+    base_url = "https://my.workspace.cloud.databricks.com/serving-endpoints"
+    api_key = "dapimykey"
+    monkeypatch.setenv("DATABRICKS_API_BASE", base_url)
+    monkeypatch.setenv("DATABRICKS_API_KEY", api_key)
+
+    mock_chunks = mock_chat_streaming_response_chunks_with_done_in_args()
+
+    def mock_iter_lines():
+        for chunk in mock_chunks:
+            yield chunk
+
+    mock_response = MagicMock()
+    mock_response.iter_lines.side_effect = mock_iter_lines
+    mock_response.status_code = 200
+
+    with patch.object(HTTPHandler, "post", return_value=mock_response):
+        response_stream: CustomStreamWrapper = litellm.completion(
+            model="databricks/dbrx-instruct-071224",
+            messages=[{"role": "user", "content": "test"}],
+            stream=True,
+        )
+        chunks = list(response_stream)
+
+    # Collect all tool-call argument fragments emitted by the stream.
+    all_args = "".join(
+        tc.function.arguments or ""
+        for c in chunks
+        if c.choices[0].delta.tool_calls
+        for tc in c.choices[0].delta.tool_calls
+        if tc.function and tc.function.arguments
+    )
+    # The "[DONE]" fragment must have been forwarded as content, not dropped.
+    assert (
+        "[DONE]" in all_args
+    ), f"Tool call arg '[DONE]' was dropped (regression). all_args={all_args!r}"
+    # The chunk that follows "[DONE]" must also be present.
+    assert (
+        "more args" in all_args
+    ), f"Subsequent args after '[DONE]' were dropped. all_args={all_args!r}"
 
 
 @pytest.mark.skipif(not databricks_sdk_installed, reason="Databricks SDK not installed")

--- a/tests/test_litellm/llms/base_llm/test_base_model_iterator.py
+++ b/tests/test_litellm/llms/base_llm/test_base_model_iterator.py
@@ -68,6 +68,38 @@ class TestBaseModelResponseIterator:
         # Should have 2 chunks: 1 content + 1 DONE
         assert len(chunks) == 2, f"Expected 2 chunks, got {len(chunks)}"
 
+    def test_done_string_in_tool_call_arguments_not_treated_as_termination(self):
+        """
+        Regression: a chunk whose tool-call arguments JSON value contains the
+        string '[DONE]' must NOT trigger the SSE termination path.
+
+        Bug: `if "[DONE]" in str_line` was a substring check, so any line
+        carrying `[DONE]` as part of a JSON string value caused a false stop.
+        """
+        sse_lines = [
+            'data: {"id":"1","choices":[{"delta":{"content":"hello"},"finish_reason":null,"index":0}]}',
+            # Tool-call argument chunk whose value contains "[DONE]" as content
+            'data: {"id":"1","choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"[DONE]`,"}}]},"finish_reason":null,"index":0}]}',
+            'data: {"id":"1","choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":" more args"}}]},"finish_reason":null,"index":0}]}',
+            'data: {"id":"1","choices":[{"delta":{},"finish_reason":"stop","index":0}]}',
+            "data: [DONE]",
+        ]
+
+        iterator = BaseModelResponseIterator(
+            streaming_response=iter(sse_lines), sync_stream=True
+        )
+
+        chunks = list(iterator)
+        # Expect 5 chunks: text + 2 tool-arg + finish + [DONE].
+        # Before the fix the tool-arg chunk with [DONE] was wrongly treated as
+        # the terminator, collapsing everything after it.
+        assert len(chunks) == 5, f"Expected 5 chunks, got {len(chunks)}: {chunks}"
+        # The first three chunks must NOT be finished
+        for i, chunk in enumerate(chunks[:3]):
+            assert not chunk[
+                "is_finished"
+            ], f"Chunk {i} should not be finished: {chunk}"
+
     def test_valid_chunks_not_filtered_sync(self):
         """Test that valid data chunks are not filtered"""
         sse_lines = [


### PR DESCRIPTION
## Summary

- Fix false stream termination when tool-call arguments contain the literal string `[DONE]` as JSON content (e.g. when an LLM streams markdown containing `` `[DONE]` ``)
- The bug was in `BaseModelResponseIterator._handle_string_chunk` which used `if "[DONE]" in str_line` (substring check) — this matched any SSE line containing `[DONE]` anywhere, including inside valid JSON payloads
- Fix: reorder logic so valid JSON is always parsed first, and only check for `[DONE]` as an exact match on the stripped SSE payload

Affects all providers using `BaseModelResponseIterator`: Databricks, OpenRouter, OVHCloud, Cloudflare, Triton, A2A, Watsonx, Anthropic completion, Ollama, CometAPI, Bedrock DeepSeek, Vertex AI agent engine.

## Test plan

- [x] Unit test: `tests/test_litellm/llms/base_llm/test_base_model_iterator.py::test_done_string_in_tool_call_arguments_not_treated_as_termination`
- [x] Integration test: `tests/llm_translation/test_databricks.py::test_completions_streaming_tool_call_with_done_in_arguments`
- [x] All existing `test_base_model_iterator.py` tests pass (no regression in `data: [DONE]` handling)
- [x] Existing Databricks streaming tests pass