### PR TITLE
fix(health): pass model_info to _update_litellm_params_for_health_check in test_connection

### DIFF
--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -1842,7 +1842,7 @@ async def test_model_connection(
         )
         # Include health_check_params if provided
         litellm_params = _update_litellm_params_for_health_check(
-            model_info={},
+            model_info=model_info or {},
             litellm_params=litellm_params,
         )
         mode = mode or litellm_params.pop("mode", None)


### PR DESCRIPTION
## Summary

Fixes #29266

### Problem

`test_model_connection` (`/health/test_connection`) calls `_update_litellm_params_for_health_check` with a hardcoded `model_info={}`, discarding the `model_info` received from the request body. This means `health_check_supports_max_tokens: false` set in `model_info` is silently ignored when using the UI "Test Connection" button — `max_tokens: 5` is always injected regardless of the setting.

The background `/health` endpoint correctly respects `health_check_supports_max_tokens: false`, making the inconsistency confusing: the model shows as healthy in the background check but fails the UI test button.

### Fix

One-line change: pass `model_info=model_info or {}` instead of the hardcoded empty dict, so the caller's model metadata is forwarded to the health check helper.

```python
# Before (bug):
litellm_params = _update_litellm_params_for_health_check(
    model_info={},
    litellm_params=litellm_params,
)

# After (fix):
litellm_params = _update_litellm_params_for_health_check(
    model_info=model_info or {},
    litellm_params=litellm_params,
)
```

### Impact

Azure AI Foundry deployments (and similar providers) that only accept `max_completion_tokens` and reject `max_tokens` will now correctly pass the UI Test Connection button when `health_check_supports_max_tokens: false` is configured in `model_info`.