### PR TITLE
fix(vertex_ai): stream large batch JSONL uploads to GCS via temp file

### DIFF
--- a/litellm/llms/base_llm/files/transformation.py
+++ b/litellm/llms/base_llm/files/transformation.py
@@ -5,7 +5,7 @@ import httpx
 from openai.types.file_deleted import FileDeleted
 
 from litellm.proxy._types import UserAPIKeyAuth
-from litellm.types.files import TwoStepFileUploadConfig
+from litellm.types.files import StreamingFileUploadBody, TwoStepFileUploadConfig
 from litellm.types.llms.openai import (
     AllMessageValues,
     CreateFileRequest,
@@ -78,7 +78,7 @@ class BaseFilesConfig(BaseConfig):
         create_file_data: CreateFileRequest,
         optional_params: dict,
         litellm_params: dict,
-    ) -> Union[dict, str, bytes, "TwoStepFileUploadConfig"]:
+    ) -> Union[dict, str, bytes, "TwoStepFileUploadConfig", StreamingFileUploadBody]:
         """
         Transform OpenAI-style file creation request into provider-specific format.
 
@@ -86,6 +86,7 @@ class BaseFilesConfig(BaseConfig):
             - dict: For pre-signed single-step uploads (e.g., Bedrock S3)
             - str/bytes: For traditional file uploads
             - TwoStepFileUploadConfig: For two-step upload process (e.g., Manus, GCS)
+            - StreamingFileUploadBody: For large uploads streamed from a temp file
         """
         pass
 

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -7,6 +7,7 @@ from typing import (
     AsyncIterator,
     Coroutine,
     Dict,
+    Iterator,
     List,
     Literal,
     Optional,
@@ -78,7 +79,7 @@ from litellm.types.containers.main import (
     ContainerObject,
     DeleteContainerResult,
 )
-from litellm.types.files import TwoStepFileUploadConfig
+from litellm.types.files import StreamingFileUploadBody, TwoStepFileUploadConfig
 from litellm.types.integrations.custom_logger import (
     AgenticLoopPlan,
     AgenticLoopRequestPatch,
@@ -3194,6 +3195,17 @@ class BaseLLMHTTPHandler:
                 data=presigned_request["data"],
                 timeout=timeout,
             )
+        elif isinstance(transformed_request, StreamingFileUploadBody):
+            # Stream the upload body from disk in chunks instead of buffering
+            # the whole (multi-GB) payload in memory.
+            upload_response = self._stream_file_upload_sync(
+                streaming_body=transformed_request,
+                sync_httpx_client=sync_httpx_client,
+                api_base=api_base,
+                headers=headers,
+                provider_config=provider_config,
+                timeout=timeout,
+            )
         elif isinstance(transformed_request, str) or isinstance(
             transformed_request, bytes
         ):
@@ -3249,7 +3261,9 @@ class BaseLLMHTTPHandler:
 
     async def async_create_file(
         self,
-        transformed_request: Union[bytes, str, dict, "TwoStepFileUploadConfig"],
+        transformed_request: Union[
+            bytes, str, dict, "TwoStepFileUploadConfig", StreamingFileUploadBody
+        ],
         litellm_params: dict,
         provider_config: BaseFilesConfig,
         headers: dict,
@@ -3352,6 +3366,17 @@ class BaseLLMHTTPHandler:
                 data=presigned_request["data"],
                 timeout=timeout,
             )
+        elif isinstance(transformed_request, StreamingFileUploadBody):
+            # Stream the upload body from disk in chunks instead of buffering
+            # the whole (multi-GB) payload in memory.
+            upload_response = await self._stream_file_upload_async(
+                streaming_body=transformed_request,
+                async_httpx_client=async_httpx_client,
+                api_base=api_base,
+                headers=headers,
+                provider_config=provider_config,
+                timeout=timeout,
+            )
         elif isinstance(transformed_request, str) or isinstance(
             transformed_request, bytes
         ):
@@ -3394,6 +3419,128 @@ class BaseLLMHTTPHandler:
             logging_obj=logging_obj,
             litellm_params=litellm_params,
         )
+
+    def _build_streaming_upload_headers(
+        self, streaming_body: StreamingFileUploadBody, headers: dict
+    ) -> dict:
+        upload_headers = {**headers}
+        if streaming_body.content_type:
+            upload_headers.setdefault("Content-Type", streaming_body.content_type)
+        if streaming_body.headers:
+            upload_headers.update(streaming_body.headers)
+        return upload_headers
+
+    async def _stream_file_upload_async(
+        self,
+        streaming_body: StreamingFileUploadBody,
+        async_httpx_client: AsyncHTTPHandler,
+        api_base: str,
+        headers: dict,
+        provider_config: BaseFilesConfig,
+        timeout: Optional[Union[float, httpx.Timeout]],
+    ) -> httpx.Response:
+        """
+        Stream a temp-file upload body to the provider in chunks.
+
+        Reads the file in 1MB chunks off the event loop and sends them with
+        httpx's streaming request body (chunked transfer-encoding), so peak
+        memory stays flat regardless of file size. The temp file is always
+        deleted, and a single retry is attempted on a dropped connection
+        (re-reading the file from the start).
+        """
+        import asyncio
+        import os as _os
+
+        upload_headers = self._build_streaming_upload_headers(streaming_body, headers)
+        http_method = provider_config.file_upload_http_method.upper()
+        raw_client = async_httpx_client.client
+
+        async def _aiter_chunks() -> AsyncIterator[bytes]:
+            chunk_size = 1024 * 1024
+            with open(streaming_body.path, "rb") as f:
+                while True:
+                    chunk = await asyncio.to_thread(f.read, chunk_size)
+                    if not chunk:
+                        break
+                    yield chunk
+
+        async def _do_upload() -> httpx.Response:
+            request = raw_client.build_request(
+                http_method,
+                api_base,
+                headers=upload_headers,
+                content=_aiter_chunks(),
+                timeout=timeout,
+            )
+            response = await raw_client.send(request)
+            response.raise_for_status()
+            return response
+
+        try:
+            try:
+                return await _do_upload()
+            except (httpx.RemoteProtocolError, httpx.ConnectError):
+                # Connection dropped mid-stream; retry once with a fresh body.
+                return await _do_upload()
+        except Exception as e:
+            verbose_logger.exception(f"Error streaming file upload: {e}")
+            raise self._handle_error(e=e, provider_config=provider_config)
+        finally:
+            try:
+                _os.remove(streaming_body.path)
+            except OSError:
+                pass
+
+    def _stream_file_upload_sync(
+        self,
+        streaming_body: StreamingFileUploadBody,
+        sync_httpx_client: HTTPHandler,
+        api_base: str,
+        headers: dict,
+        provider_config: BaseFilesConfig,
+        timeout: Optional[Union[float, httpx.Timeout]],
+    ) -> httpx.Response:
+        """Sync counterpart of ``_stream_file_upload_async``."""
+        import os as _os
+
+        upload_headers = self._build_streaming_upload_headers(streaming_body, headers)
+        http_method = provider_config.file_upload_http_method.upper()
+        raw_client = sync_httpx_client.client
+
+        def _iter_chunks() -> Iterator[bytes]:
+            chunk_size = 1024 * 1024
+            with open(streaming_body.path, "rb") as f:
+                while True:
+                    chunk = f.read(chunk_size)
+                    if not chunk:
+                        break
+                    yield chunk
+
+        def _do_upload() -> httpx.Response:
+            request = raw_client.build_request(
+                http_method,
+                api_base,
+                headers=upload_headers,
+                content=_iter_chunks(),
+                timeout=timeout,
+            )
+            response = raw_client.send(request)
+            response.raise_for_status()
+            return response
+
+        try:
+            try:
+                return _do_upload()
+            except (httpx.RemoteProtocolError, httpx.ConnectError):
+                return _do_upload()
+        except Exception as e:
+            verbose_logger.exception(f"Error streaming file upload: {e}")
+            raise self._handle_error(e=e, provider_config=provider_config)
+        finally:
+            try:
+                _os.remove(streaming_body.path)
+            except OSError:
+                pass
 
     def create_batch(
         self,

--- a/litellm/llms/vertex_ai/files/handler.py
+++ b/litellm/llms/vertex_ai/files/handler.py
@@ -64,8 +64,9 @@ class VertexAIFilesHandler(GCSBucketBase):
         (
             logging_payload,
             object_name,
-        ) = vertex_ai_files_transformation.transform_openai_file_content_to_vertex_ai_file_content(
-            openai_file_content=create_file_data.get("file")
+        ) = await asyncio.to_thread(
+            vertex_ai_files_transformation.transform_openai_file_content_to_vertex_ai_file_content,
+            create_file_data.get("file"),
         )
         gcs_upload_response = await self._log_json_data_on_gcs(
             headers=headers,

--- a/litellm/llms/vertex_ai/files/transformation.py
+++ b/litellm/llms/vertex_ai/files/transformation.py
@@ -1,9 +1,11 @@
 import base64
+import io
 import json
 import os
 import re
+import tempfile
 import time
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union
 
 import httpx
 from httpx import Headers, Response
@@ -44,6 +46,7 @@ from litellm.types.llms.openai import (
     OpenAIFileObject,
     PathLike,
 )
+from litellm.types.files import StreamingFileUploadBody
 from litellm.types.llms.vertex_ai import GcsBucketResponse
 from litellm.types.utils import ExtractedFileData, LlmProviders, ModelResponse
 
@@ -137,6 +140,46 @@ def _get_litellm_batch_custom_id_from_labels(labels: Dict[str, Any]) -> str:
     return str(labels.get("litellm_custom_id", "unknown"))
 
 
+def _iter_nonempty_jsonl_lines(file_content: str) -> Iterator[str]:
+    """Yield non-empty lines from JSONL content lazily.
+
+    Avoids ``str.splitlines()``, which materializes the whole file as a list of
+    strings (a full extra copy in RAM) - prohibitive for large batch uploads.
+    """
+    for line in io.StringIO(file_content):
+        if line.strip():
+            yield line
+
+
+def _openai_batch_jsonl_entry_to_vertex_wrapped_request(
+    openai_jsonl_entry: Dict[str, Any],
+    map_openai_to_vertex_params: Callable[[Dict[str, Any]], Dict[str, Any]],
+) -> Dict[str, Any]:
+    """
+    Transforms a single OpenAI JSONL batch entry to a Vertex AI wrapped request.
+
+    jsonl body for vertex is {"request": <request_body>}
+    """
+    openai_request_body = openai_jsonl_entry.get("body") or {}
+    vertex_request_body = _transform_request_body(
+        messages=openai_request_body.get("messages", []),
+        model=openai_request_body.get("model", ""),
+        optional_params=map_openai_to_vertex_params(openai_request_body),
+        custom_llm_provider="vertex_ai",
+        litellm_params={},
+        cached_content=None,
+    )
+
+    # Add custom_id as a label for correlation in batch outputs
+    custom_id = openai_jsonl_entry.get("custom_id")
+    if custom_id is not None:
+        if "labels" not in vertex_request_body:
+            vertex_request_body["labels"] = {}
+        _set_litellm_batch_custom_id_labels(vertex_request_body["labels"], custom_id)
+
+    return {"request": vertex_request_body}
+
+
 def _openai_batch_jsonl_entries_to_vertex_wrapped_requests(
     openai_jsonl_content: List[Dict[str, Any]],
     map_openai_to_vertex_params: Callable[[Dict[str, Any]], Dict[str, Any]],
@@ -149,30 +192,128 @@ def _openai_batch_jsonl_entries_to_vertex_wrapped_requests(
     {"request":{"contents": [{"role": "user", "parts": [{"text": "What is the relation between the following video and image samples?"}, {"fileData": {"fileUri": "gs://cloud-samples-data/generative-ai/video/animals.mp4", "mimeType": "video/mp4"}}, {"fileData": {"fileUri": "gs://cloud-samples-data/generative-ai/image/cricket.jpeg", "mimeType": "image/jpeg"}}]}]}}
     {"request":{"contents": [{"role": "user", "parts": [{"text": "Describe what is happening in this video."}, {"fileData": {"fileUri": "gs://cloud-samples-data/generative-ai/video/another_video.mov", "mimeType": "video/mov"}}]}]}}
     """
-
-    vertex_jsonl_content = []
-    for _openai_jsonl_content in openai_jsonl_content:
-        openai_request_body = _openai_jsonl_content.get("body") or {}
-        vertex_request_body = _transform_request_body(
-            messages=openai_request_body.get("messages", []),
-            model=openai_request_body.get("model", ""),
-            optional_params=map_openai_to_vertex_params(openai_request_body),
-            custom_llm_provider="vertex_ai",
-            litellm_params={},
-            cached_content=None,
+    return [
+        _openai_batch_jsonl_entry_to_vertex_wrapped_request(
+            openai_jsonl_entry, map_openai_to_vertex_params
         )
+        for openai_jsonl_entry in openai_jsonl_content
+    ]
 
-        # Add custom_id as a label for correlation in batch outputs
-        custom_id = _openai_jsonl_content.get("custom_id")
-        if custom_id is not None:
-            if "labels" not in vertex_request_body:
-                vertex_request_body["labels"] = {}
-            _set_litellm_batch_custom_id_labels(
-                vertex_request_body["labels"], custom_id
-            )
 
-        vertex_jsonl_content.append({"request": vertex_request_body})
-    return vertex_jsonl_content
+def _stream_openai_jsonl_to_vertex_jsonl_string(
+    file_content: str,
+    map_openai_to_vertex_params: Callable[[Dict[str, Any]], Dict[str, Any]],
+) -> Tuple[str, Optional[Dict[str, Any]]]:
+    """Transform OpenAI batch JSONL to a Vertex JSONL string, one line at a time.
+
+    Returns the serialized Vertex JSONL string plus the first parsed OpenAI
+    entry (used to derive the GCS object name). Processing line-by-line keeps at
+    most one parsed/transformed request in memory at once, instead of holding
+    two full lists of dicts for the entire file - the latter inflates a 1GB
+    upload to 10GB+ and OOM-kills the worker.
+    """
+    first_entry: Optional[Dict[str, Any]] = None
+    transformed_lines: List[str] = []
+    for line in _iter_nonempty_jsonl_lines(file_content):
+        openai_jsonl_entry = json.loads(line)
+        if first_entry is None:
+            first_entry = openai_jsonl_entry
+        vertex_wrapped_request = _openai_batch_jsonl_entry_to_vertex_wrapped_request(
+            openai_jsonl_entry, map_openai_to_vertex_params
+        )
+        transformed_lines.append(json.dumps(vertex_wrapped_request))
+    return "\n".join(transformed_lines), first_entry
+
+
+def _safe_remove_file(path: str) -> None:
+    """Best-effort temp file deletion; never raises."""
+    try:
+        os.remove(path)
+    except OSError:
+        pass
+
+
+def _iter_nonempty_jsonl_lines_from_content(
+    content: Union[str, bytes],
+) -> Iterator[str]:
+    """Yield non-empty JSONL lines from raw content without duplicating it.
+
+    Walks the buffer by newline and slices one line at a time. Unlike
+    ``str.splitlines()`` or wrapping the payload in ``io.BytesIO``/
+    ``io.StringIO``, this never holds a second full-size copy of a multi-GB
+    upload in memory - only one small per-line slice at a time.
+    """
+    if isinstance(content, bytes):
+        newline: Any = b"\n"
+    elif isinstance(content, str):
+        newline = "\n"
+    else:
+        raise ValueError(f"Unsupported JSONL content type: {type(content)}")
+
+    start = 0
+    total = len(content)
+    find = content.find
+    while start < total:
+        nl = find(newline, start)
+        if nl == -1:
+            chunk = content[start:]
+            start = total
+        else:
+            chunk = content[start:nl]
+            start = nl + 1
+        line = chunk.decode("utf-8") if isinstance(chunk, bytes) else chunk
+        if line.strip():
+            yield line
+
+
+def _first_jsonl_entry_from_content(
+    content: Union[str, bytes],
+) -> Optional[Dict[str, Any]]:
+    """Parse only the first non-empty JSONL entry (e.g. to derive the model)."""
+    for line in _iter_nonempty_jsonl_lines_from_content(content):
+        return json.loads(line)
+    return None
+
+
+def _stream_openai_jsonl_to_vertex_tempfile(
+    content: Union[str, bytes],
+    map_openai_to_vertex_params: Callable[[Dict[str, Any]], Dict[str, Any]],
+) -> Tuple[str, int, Optional[Dict[str, Any]]]:
+    """Transform OpenAI batch JSONL to Vertex JSONL, spooled to a temp file.
+
+    Reads the input one line at a time and writes the transformed Vertex JSONL
+    straight to disk, so neither the full transformed payload nor a list of
+    parsed rows is ever held in memory. Returns the temp file path, its byte
+    size, and the first parsed OpenAI entry (used for GCS object naming).
+
+    The caller owns the returned temp file and must delete it.
+    """
+    first_entry: Optional[Dict[str, Any]] = None
+    fd, tmp_path = tempfile.mkstemp(prefix="litellm_vertex_batch_", suffix=".jsonl")
+    size = 0
+    try:
+        with os.fdopen(fd, "wb") as out_file:
+            is_first_line = True
+            for line in _iter_nonempty_jsonl_lines_from_content(content):
+                openai_jsonl_entry = json.loads(line)
+                if first_entry is None:
+                    first_entry = openai_jsonl_entry
+                vertex_wrapped_request = (
+                    _openai_batch_jsonl_entry_to_vertex_wrapped_request(
+                        openai_jsonl_entry, map_openai_to_vertex_params
+                    )
+                )
+                serialized = json.dumps(vertex_wrapped_request)
+                encoded = (serialized if is_first_line else "\n" + serialized).encode(
+                    "utf-8"
+                )
+                out_file.write(encoded)
+                size += len(encoded)
+                is_first_line = False
+    except BaseException:
+        _safe_remove_file(tmp_path)
+        raise
+    return tmp_path, size, first_entry
 
 
 class VertexAIFilesConfig(VertexBase, BaseFilesConfig):
@@ -274,16 +415,12 @@ class VertexAIFilesConfig(VertexBase, BaseFilesConfig):
 
         if purpose == "batch":
             ## 1. If jsonl, check if there's a model name
-            file_content = self._get_content_from_openai_file(
-                extracted_file_data_content
-            )
-
-            # Split into lines and parse each line as JSON
-            openai_jsonl_content = [
-                json.loads(line) for line in file_content.splitlines() if line.strip()
-            ]
-            if len(openai_jsonl_content) > 0:
-                return self._get_gcs_object_name_from_batch_jsonl(openai_jsonl_content)
+            # Only the first entry is needed to derive the object name; read a
+            # single line straight from the raw bytes instead of decoding and
+            # parsing the whole file.
+            first_entry = _first_jsonl_entry_from_content(extracted_file_data_content)
+            if first_entry is not None:
+                return self._get_gcs_object_name_from_batch_jsonl([first_entry])
 
         ## 2. If not jsonl, store under a server-generated managed object name
         filename = extracted_file_data.get("filename")
@@ -380,7 +517,7 @@ class VertexAIFilesConfig(VertexBase, BaseFilesConfig):
         create_file_data: CreateFileRequest,
         optional_params: dict,
         litellm_params: dict,
-    ) -> Union[bytes, str, dict]:
+    ) -> Union[bytes, str, dict, StreamingFileUploadBody]:
         """
         2 Cases:
         1. Handle basic file upload
@@ -399,21 +536,22 @@ class VertexAIFilesConfig(VertexBase, BaseFilesConfig):
             create_file_data=create_file_data,
             extracted_file_data=extracted_file_data,
         ):
-            ## 1. If jsonl, check if there's a model name
-            file_content = self._get_content_from_openai_file(
-                extracted_file_data_content
+            ## 1. JSONL batch input: stream the transform straight to a temp
+            ## file on disk so neither the full transformed payload nor a list
+            ## of parsed rows is held in memory. The handler streams this file
+            ## to GCS in chunks and deletes it afterwards.
+            tmp_path, size, first_entry = _stream_openai_jsonl_to_vertex_tempfile(
+                content=extracted_file_data_content,
+                map_openai_to_vertex_params=self._map_openai_to_vertex_params,
             )
-
-            # Split into lines and parse each line as JSON
-            openai_jsonl_content = [
-                json.loads(line) for line in file_content.splitlines() if line.strip()
-            ]
-            vertex_jsonl_content = (
-                self._transform_openai_jsonl_content_to_vertex_ai_jsonl_content(
-                    openai_jsonl_content
-                )
+            if first_entry is None:
+                _safe_remove_file(tmp_path)
+                raise ValueError("file content is empty")
+            return StreamingFileUploadBody(
+                path=tmp_path,
+                size=size,
+                content_type="application/jsonl",
             )
-            return "\n".join(json.dumps(item) for item in vertex_jsonl_content)
         elif isinstance(extracted_file_data_content, bytes):
             return extracted_file_data_content
         else:
@@ -814,21 +952,16 @@ class VertexAIJsonlFilesTransformation(VertexGeminiConfig):
         # Read the content of the file
         file_content = self._get_content_from_openai_file(openai_file_content)
 
-        # Split into lines and parse each line as JSON
-        openai_jsonl_content = [
-            json.loads(line) for line in file_content.splitlines() if line.strip()
-        ]
-        vertex_jsonl_content = (
-            self._transform_openai_jsonl_content_to_vertex_ai_jsonl_content(
-                openai_jsonl_content
-            )
+        # Stream the transform line-by-line. Buffering the whole file as two
+        # full lists of dicts (parsed OpenAI + transformed Vertex) inflates a
+        # 1GB upload to 10GB+ and OOM-kills the proxy worker.
+        vertex_jsonl_string, first_entry = _stream_openai_jsonl_to_vertex_jsonl_string(
+            file_content=file_content,
+            map_openai_to_vertex_params=self._map_openai_to_vertex_params,
         )
-        vertex_jsonl_string = "\n".join(
-            json.dumps(item) for item in vertex_jsonl_content
-        )
-        object_name = self._get_gcs_object_name(
-            openai_jsonl_content=openai_jsonl_content
-        )
+        if first_entry is None:
+            raise ValueError("contents of file are empty")
+        object_name = self._get_gcs_object_name(openai_jsonl_content=[first_entry])
         return vertex_jsonl_string, object_name
 
     def _transform_openai_jsonl_content_to_vertex_ai_jsonl_content(

--- a/litellm/types/files.py
+++ b/litellm/types/files.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass, field
 from enum import Enum
 from types import MappingProxyType
 from typing import Any, Dict, List, Literal, Mapping, Set, Union
@@ -321,3 +322,31 @@ class TwoStepFileUploadConfig(TypedDict, total=False):
     upload_request: Required[TwoStepFileUploadRequest]
     upload_url_location: Required[Literal["headers", "body"]]
     upload_url_key: str
+
+
+"""
+Streaming File Upload Types
+"""
+
+
+@dataclass
+class StreamingFileUploadBody:
+    """A transformed upload payload spooled to a local temp file.
+
+    Returned by a provider's ``transform_create_file_request`` to signal that
+    the upload body should be streamed from disk in chunks rather than buffered
+    in memory. This keeps peak memory flat for multi-GB uploads. The HTTP
+    handler streams ``path`` to the provider and is responsible for deleting it
+    afterwards.
+
+    Properties:
+        path: Absolute path to the temp file holding the upload body.
+        size: Size of the temp file in bytes.
+        content_type: Content-Type to send with the upload.
+        headers: Extra headers to merge into the upload request.
+    """
+
+    path: str
+    size: int
+    content_type: str = "application/octet-stream"
+    headers: Dict[str, str] = field(default_factory=dict)

--- a/tests/test_litellm/llms/vertex_ai/files/test_vertex_ai_binary_file_upload.py
+++ b/tests/test_litellm/llms/vertex_ai/files/test_vertex_ai_binary_file_upload.py
@@ -14,7 +14,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 
 from litellm.llms.custom_httpx.llm_http_handler import AsyncHTTPHandler
-from litellm.llms.vertex_ai.files.transformation import VertexAIFilesConfig
+from litellm.llms.vertex_ai.files.transformation import (
+    VertexAIFilesConfig,
+    _safe_remove_file,
+)
+from litellm.types.files import StreamingFileUploadBody
 from litellm.types.llms.openai import CreateFileRequest
 
 
@@ -137,9 +141,10 @@ class TestVertexAIBinaryFileUpload:
         ), "Binary file data should remain as bytes"
 
     @pytest.mark.asyncio
-    async def test_jsonl_file_upload_returns_string(self):
+    async def test_jsonl_file_upload_returns_streaming_body(self):
         """
-        Test that JSONL files (text) are correctly transformed to strings.
+        Test that JSONL batch files are transformed and spooled to a temp file
+        so the upload can be streamed (instead of buffering the whole payload).
 
         This ensures we handle both binary and text files correctly.
         """
@@ -164,10 +169,18 @@ class TestVertexAIBinaryFileUpload:
             litellm_params={},
         )
 
-        # JSONL files should be transformed to string
+        # JSONL batch files are streamed from a temp file on disk
         assert isinstance(
-            transformed_request, str
-        ), f"Expected string for JSONL file, got {type(transformed_request)}"
+            transformed_request, StreamingFileUploadBody
+        ), f"Expected StreamingFileUploadBody for JSONL file, got {type(transformed_request)}"
+        try:
+            with open(transformed_request.path, "rb") as f:
+                on_disk = f.read()
+            assert len(on_disk) == transformed_request.size
+            # The spooled payload is valid transformed Vertex JSONL (text)
+            assert '"request"' in on_disk.decode("utf-8")
+        finally:
+            _safe_remove_file(transformed_request.path)
 
     @pytest.mark.asyncio
     async def test_mixed_file_types_in_sequence(self):
@@ -208,7 +221,8 @@ class TestVertexAIBinaryFileUpload:
             optional_params={},
             litellm_params={},
         )
-        assert isinstance(result2, str)
+        assert isinstance(result2, StreamingFileUploadBody)
+        _safe_remove_file(result2.path)
 
         # Test 3: Upload another binary file
         binary_content2 = b"\xc4\xe5\xf2\xe5\xeb"
@@ -234,7 +248,8 @@ class TestVertexAIBinaryFileUpload:
 
         This test documents the expected behavior:
         - Binary files (PDF, images, etc.) should remain as bytes
-        - Text files (JSONL) should be strings
+        - JSONL batch files are spooled to a temp file (StreamingFileUploadBody)
+          and streamed to the provider
         - httpx accepts both bytes and strings in the 'data' parameter
         - bytes should NEVER be decoded to UTF-8 for binary files
         """
@@ -251,7 +266,7 @@ class TestVertexAIBinaryFileUpload:
             },
             "text_files": {
                 "input_type": "str or bytes",
-                "output_type": "str",
+                "output_type": "StreamingFileUploadBody (temp file, streamed)",
                 "examples": ["JSONL", "CSV", "TXT"],
                 "http_method": "POST",
                 "encoding": "UTF-8",

--- a/tests/test_litellm/llms/vertex_ai/files/test_vertex_streaming_file_upload.py
+++ b/tests/test_litellm/llms/vertex_ai/files/test_vertex_streaming_file_upload.py
@@ -1,0 +1,162 @@
+"""Tests for streaming (temp-file) Vertex batch file uploads.
+
+Covers the no-copy JSONL line iteration, the temp-file transform, the
+``transform_create_file_request`` contract returning a ``StreamingFileUploadBody``,
+and the HTTP handler streaming that temp file and cleaning it up.
+"""
+
+import json
+import os
+import tempfile
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from litellm.llms.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
+from litellm.llms.vertex_ai.files import transformation as t
+from litellm.llms.vertex_ai.files.transformation import VertexAIFilesConfig
+from litellm.types.files import StreamingFileUploadBody
+
+
+def _map(_body):
+    return {}
+
+
+def _batch_rows(n):
+    rows = [
+        {
+            "custom_id": f"r-{i}",
+            "method": "POST",
+            "url": "/v1/chat/completions",
+            "body": {
+                "model": "gemini-2.5-flash",
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 4,
+            },
+        }
+        for i in range(n)
+    ]
+    return ("\n".join(json.dumps(r) for r in rows) + "\n").encode("utf-8")
+
+
+def test_iter_nonempty_lines_bytes_and_str_skip_blanks():
+    raw = b'{"a":1}\n\n  \n{"b":2}\n'
+    lines = list(t._iter_nonempty_jsonl_lines_from_content(raw))
+    assert lines == ['{"a":1}', '{"b":2}']
+    assert list(t._iter_nonempty_jsonl_lines_from_content(raw.decode())) == lines
+
+
+def test_first_entry_from_content_skips_blanks():
+    raw = b'\n  \n{"custom_id":"x","body":{"model":"m"}}\n{"custom_id":"y"}\n'
+    first = t._first_jsonl_entry_from_content(raw)
+    assert first["custom_id"] == "x"
+
+
+def test_stream_to_tempfile_roundtrip_and_size():
+    content = _batch_rows(4)
+    path, size, first = t._stream_openai_jsonl_to_vertex_tempfile(content, _map)
+    try:
+        assert first["custom_id"] == "r-0"
+        with open(path, "rb") as f:
+            on_disk = f.read()
+        assert len(on_disk) == size
+        out_lines = on_disk.decode("utf-8").split("\n")
+        assert len(out_lines) == 4
+        for ln in out_lines:
+            d = json.loads(ln)
+            assert "request" in d
+            assert d["request"]["labels"]["litellm_custom_id"].startswith("r-")
+    finally:
+        t._safe_remove_file(path)
+    assert not os.path.exists(path)
+
+
+def test_transform_create_file_request_returns_streaming_body():
+    cfg = VertexAIFilesConfig()
+    create_file_data = {
+        "file": ("batch.jsonl", _batch_rows(1), "application/jsonl"),
+        "purpose": "batch",
+    }
+    result = cfg.transform_create_file_request(
+        model="",
+        create_file_data=create_file_data,
+        optional_params={},
+        litellm_params={},
+    )
+    assert isinstance(result, StreamingFileUploadBody)
+    try:
+        assert result.size > 0
+        assert os.path.exists(result.path)
+        assert result.content_type == "application/jsonl"
+    finally:
+        t._safe_remove_file(result.path)
+
+
+def test_empty_batch_raises_and_cleans_up():
+    cfg = VertexAIFilesConfig()
+    create_file_data = {
+        "file": ("batch.jsonl", b"\n   \n", "application/jsonl"),
+        "purpose": "batch",
+    }
+    with pytest.raises(ValueError):
+        cfg.transform_create_file_request(
+            model="",
+            create_file_data=create_file_data,
+            optional_params={},
+            litellm_params={},
+        )
+
+
+class _FakeRawClient:
+    """Mimics httpx.AsyncClient.build_request/send, draining the streamed body."""
+
+    def __init__(self):
+        self.received = b""
+
+    def build_request(self, method, url, headers=None, content=None, timeout=None):
+        return SimpleNamespace(
+            method=method, url=url, headers=headers, _content=content
+        )
+
+    async def send(self, request):
+        async for chunk in request._content:
+            self.received += chunk
+        return httpx.Response(
+            status_code=200,
+            json={
+                "id": "bucket/obj/123",
+                "name": "obj",
+                "size": str(len(self.received)),
+                "timeCreated": "2026-05-29T00:00:00Z",
+            },
+            request=httpx.Request("POST", request.url),
+        )
+
+
+@pytest.mark.asyncio
+async def test_async_streaming_upload_consumes_body_and_cleans_up():
+    handler = BaseLLMHTTPHandler()
+    raw = _FakeRawClient()
+    async_client = SimpleNamespace(client=raw)
+
+    fd, path = tempfile.mkstemp(suffix=".jsonl")
+    payload = b'{"request": {"contents": []}}\n{"request": {"contents": []}}'
+    with os.fdopen(fd, "wb") as f:
+        f.write(payload)
+    body = StreamingFileUploadBody(
+        path=path, size=len(payload), content_type="application/jsonl"
+    )
+
+    resp = await handler._stream_file_upload_async(
+        streaming_body=body,
+        async_httpx_client=async_client,
+        api_base="https://storage.googleapis.com/upload",
+        headers={"Authorization": "Bearer x"},
+        provider_config=VertexAIFilesConfig(),
+        timeout=60.0,
+    )
+
+    assert resp.status_code == 200
+    assert raw.received == payload  # full body streamed through unchanged
+    assert not os.path.exists(path)  # temp file cleaned up


### PR DESCRIPTION
## Summary
- Fixes proxy worker OOM / `Child process died` on large Vertex batch file uploads by avoiding in-memory buffering of the full transformed JSONL.
- Transforms OpenAI batch JSONL line-by-line into a temp file, then streams that file to GCS in 1MB chunks via `StreamingFileUploadBody`.
- Adds tests for streaming transform, temp-file cleanup, and handler chunked upload.

## Test plan
- [x] `pytest tests/test_litellm/llms/vertex_ai/files/test_vertex_streaming_file_upload.py`
- [x] `pytest tests/test_litellm/llms/vertex_ai/files/test_vertex_ai_binary_file_upload.py`
- [x] `pytest tests/test_litellm/llms/vertex_ai/files/test_vertex_ai_files_transformation.py`
- [ ] Manual: upload ~500MB–1GB batch JSONL via proxy with `custom-llm-provider: vertex_ai`; confirm worker stays alive and file reaches GCS


Made with [Cursor](https://cursor.com)