### PR TITLE
fix(proxy): forward model_info in /health/test_connection (#29266)

### DIFF
--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -78,6 +78,56 @@ def _reject_os_environ_references(params: dict) -> None:
                 stack.append(value)
 
 
+# Caller-supplied `model_info` keys that are safe to forward to
+# `_update_litellm_params_for_health_check` even when no server-side
+# deployment was resolved. Routing-affecting keys (e.g.
+# `health_check_model`, `mode`, `health_check_voice`, `id`, `team_id`)
+# are intentionally excluded — letting a request override them after
+# `can_user_make_model_call()` has authorized the original deployment
+# would allow a caller to redirect this endpoint to probe a different
+# provider model with the deployment's credentials.
+_HEALTH_CHECK_SAFE_MODEL_INFO_KEYS: frozenset = frozenset(
+    {
+        "health_check_supports_max_tokens",
+        "health_check_max_tokens",
+        "health_check_max_tokens_reasoning",
+        "health_check_max_tokens_non_reasoning",
+        "health_check_reasoning_effort",
+        "health_check_timeout",
+    }
+)
+
+
+def _safe_health_check_model_info(
+    *,
+    resolved_model_info: Optional[dict],
+    request_model_info: Optional[dict],
+) -> dict:
+    """
+    Return the `model_info` to pass into
+    `_update_litellm_params_for_health_check` for the
+    `/health/test_connection` endpoint.
+
+    - When the deployment was resolved server-side via the router, use
+      that `model_info` so routing-affecting fields come from server
+      config, not the request body.
+    - Otherwise (e.g. ad-hoc curl with raw credentials), forward only an
+      allow-listed set of caller-supplied non-routing flags so health
+      tuning still works without letting the caller redirect the probe.
+    """
+    if resolved_model_info is not None:
+        return dict(resolved_model_info)
+
+    if not request_model_info:
+        return {}
+
+    return {
+        k: v
+        for k, v in request_model_info.items()
+        if k in _HEALTH_CHECK_SAFE_MODEL_INFO_KEYS
+    }
+
+
 def get_callback_identifier(callback):
     """
     Get the callback identifier string, handling both strings and objects.
@@ -1768,6 +1818,16 @@ async def test_model_connection(
         # Look up model configuration from router if model name is provided
         # This gets the litellm_params from proxy config (with resolved env vars)
         config_litellm_params: dict = {}
+        # Resolved server-side `model_info` for the deployment we authorize
+        # against. Used to drive `_update_litellm_params_for_health_check`
+        # so caller-supplied routing fields (e.g. `health_check_model`,
+        # `mode`, `health_check_voice`) cannot override server config —
+        # `_update_litellm_params_for_health_check` rewrites
+        # `litellm_params["model"]` from `model_info.health_check_model`,
+        # which would otherwise let a caller make the proxy use this
+        # deployment's credentials to call a different provider model
+        # after `can_user_make_model_call()` has authorized the original.
+        resolved_model_info: Optional[dict] = None
         if llm_router is not None:
             # Prefer disambiguation by deployment id (`model_info.id`) when
             # the caller supplies it. This is required when multiple
@@ -1788,6 +1848,9 @@ async def test_model_connection(
 
                 if deployment_by_id is not None:
                     config_litellm_params = deployment_by_id.litellm_params.model_dump(
+                        exclude_none=True
+                    )
+                    resolved_model_info = deployment_by_id.model_info.model_dump(
                         exclude_none=True
                     )
                 elif model_name:
@@ -1816,6 +1879,9 @@ async def test_model_connection(
                         config_litellm_params = dict(
                             deployments[0].get("litellm_params", {})
                         )
+                        resolved_model_info = dict(
+                            deployments[0].get("model_info", {}) or {}
+                        )
             except Exception as e:
                 verbose_proxy_logger.debug(
                     f"Could not find model {model_name} in router: {e}. "
@@ -1843,8 +1909,22 @@ async def test_model_connection(
         # behavior of the background `/health` endpoint. Previously this
         # was hardcoded to `{}`, silently dropping those flags and always
         # injecting `max_tokens: 5`.
+        #
+        # Security: prefer server-side `model_info` when we resolved the
+        # deployment from the router. The helper rewrites
+        # `litellm_params["model"]` from `model_info.health_check_model`
+        # (and reads `mode`, `health_check_voice`, etc.); trusting the
+        # request body would let a caller authorized for one deployment
+        # use its credentials to probe a different provider model. When
+        # no server-side deployment was resolved (e.g. ad-hoc curl with
+        # raw credentials), restrict caller `model_info` to the
+        # non-routing flags this endpoint legitimately needs.
+        helper_model_info = _safe_health_check_model_info(
+            resolved_model_info=resolved_model_info,
+            request_model_info=model_info,
+        )
         litellm_params = _update_litellm_params_for_health_check(
-            model_info=model_info or {},
+            model_info=helper_model_info,
             litellm_params=litellm_params,
         )
         mode = mode or litellm_params.pop("mode", None)

--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -1837,9 +1837,14 @@ async def test_model_connection(
             prisma_client=prisma_client,
             premium_user=premium_user,
         )
-        # Include health_check_params if provided
+        # Include health_check_params if provided. Pass through the
+        # caller-supplied `model_info` so flags like
+        # `health_check_supports_max_tokens` are honored — matches the
+        # behavior of the background `/health` endpoint. Previously this
+        # was hardcoded to `{}`, silently dropping those flags and always
+        # injecting `max_tokens: 5`.
         litellm_params = _update_litellm_params_for_health_check(
-            model_info={},
+            model_info=model_info or {},
             litellm_params=litellm_params,
         )
         mode = mode or litellm_params.pop("mode", None)

--- a/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
+++ b/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
@@ -777,6 +777,166 @@ async def test_test_model_connection_passes_model_info_to_health_check_helper():
 
 
 @pytest.mark.asyncio
+async def test_test_model_connection_does_not_trust_caller_health_check_model():
+    """
+    Security regression: `_update_litellm_params_for_health_check`
+    rewrites `litellm_params["model"]` from `model_info.health_check_model`.
+    `test_model_connection` must not let the request body inject that
+    field after `can_user_make_model_call()` has already authorized the
+    deployment, otherwise a caller could redirect the probe to a
+    different provider model while reusing the resolved deployment's
+    credentials.
+
+    Verify two things:
+      1. When the deployment is resolved server-side via the router,
+         the helper receives the deployment's `model_info` (not the
+         request body's).
+      2. When no deployment is resolved (ad-hoc curl flow), the helper
+         only receives the allow-listed non-routing flags — keys like
+         `health_check_model` and `mode` from the request body are
+         dropped.
+    """
+    from litellm.types.router import Deployment, LiteLLM_Params
+
+    mock_request = MagicMock()
+    mock_user_api_key_dict = MagicMock()
+    mock_user_api_key_dict.user_id = "test-user"
+    mock_user_api_key_dict.token = "test-token"
+
+    mock_prisma_client = MagicMock()
+    mock_can_user_make_model_call = AsyncMock()
+    mock_health_check_result = {"status": "healthy"}
+    mock_run_with_timeout = AsyncMock(return_value=mock_health_check_result)
+    mock_ahealth_check = AsyncMock(return_value=mock_health_check_result)
+
+    captured = {}
+
+    def mock_update_params(model_info, litellm_params):
+        captured["model_info"] = model_info
+        params = litellm_params.copy()
+        params["messages"] = [{"role": "user", "content": "test"}]
+        return params
+
+    def mock_reject_os_environ(params):
+        return None
+
+    # 1. With server-side deployment resolved by id.
+    server_side_model_info = {
+        "id": "deployment-1",
+        "health_check_supports_max_tokens": True,
+    }
+    server_side_deployment = Deployment(
+        model_name="gpt-4o",
+        litellm_params=LiteLLM_Params(
+            model="azure/gpt-4o",
+            api_key="server-key",
+            api_base="https://server.invalid/v1",
+        ),
+        model_info=server_side_model_info,
+    )
+
+    mock_router_with_deployment = MagicMock()
+    mock_router_with_deployment.get_deployment.return_value = server_side_deployment
+
+    malicious_model_info = {
+        "id": "deployment-1",
+        # Attacker-controlled: would otherwise be honored by the helper
+        # to rewrite litellm_params["model"] to a different provider model.
+        "health_check_model": "openai/gpt-5-attacker",
+        "mode": "audio_speech",
+        "health_check_voice": "evil",
+    }
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client),
+        patch("litellm.proxy.proxy_server.llm_router", mock_router_with_deployment),
+        patch("litellm.proxy.proxy_server.premium_user", False),
+        patch(
+            "litellm.proxy.management_endpoints.model_management_endpoints.ModelManagementAuthChecks.can_user_make_model_call",
+            mock_can_user_make_model_call,
+        ),
+        patch(
+            "litellm.proxy.health_endpoints._health_endpoints.litellm.ahealth_check",
+            mock_ahealth_check,
+        ),
+        patch(
+            "litellm.proxy.health_endpoints._health_endpoints.run_with_timeout",
+            mock_run_with_timeout,
+        ),
+        patch(
+            "litellm.proxy.health_endpoints._health_endpoints._update_litellm_params_for_health_check",
+            mock_update_params,
+        ),
+        patch(
+            "litellm.proxy.health_endpoints._health_endpoints._reject_os_environ_references",
+            mock_reject_os_environ,
+        ),
+    ):
+        await health_test_model_connection(
+            request=mock_request,
+            mode="chat",
+            litellm_params={"model": "azure/gpt-4o"},
+            model_info=malicious_model_info,
+            user_api_key_dict=mock_user_api_key_dict,
+        )
+
+    helper_model_info = captured["model_info"]
+    # Server-side flag survives.
+    assert helper_model_info.get("health_check_supports_max_tokens") is True
+    # Caller-supplied routing fields must not have been forwarded.
+    assert "health_check_model" not in helper_model_info
+    assert helper_model_info.get("mode") != "audio_speech"
+    assert "health_check_voice" not in helper_model_info
+
+    # 2. With no router-resolved deployment, only safe non-routing flags pass through.
+    captured.clear()
+    mock_router_no_match = MagicMock()
+    mock_router_no_match.get_deployment.return_value = None
+    mock_router_no_match.get_model_list.return_value = []
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client),
+        patch("litellm.proxy.proxy_server.llm_router", mock_router_no_match),
+        patch("litellm.proxy.proxy_server.premium_user", False),
+        patch(
+            "litellm.proxy.management_endpoints.model_management_endpoints.ModelManagementAuthChecks.can_user_make_model_call",
+            mock_can_user_make_model_call,
+        ),
+        patch(
+            "litellm.proxy.health_endpoints._health_endpoints.litellm.ahealth_check",
+            mock_ahealth_check,
+        ),
+        patch(
+            "litellm.proxy.health_endpoints._health_endpoints.run_with_timeout",
+            mock_run_with_timeout,
+        ),
+        patch(
+            "litellm.proxy.health_endpoints._health_endpoints._update_litellm_params_for_health_check",
+            mock_update_params,
+        ),
+        patch(
+            "litellm.proxy.health_endpoints._health_endpoints._reject_os_environ_references",
+            mock_reject_os_environ,
+        ),
+    ):
+        await health_test_model_connection(
+            request=mock_request,
+            mode="chat",
+            litellm_params={"model": "azure/gpt-4o"},
+            model_info={
+                "health_check_supports_max_tokens": False,
+                "health_check_model": "openai/gpt-5-attacker",
+                "mode": "audio_speech",
+                "health_check_voice": "evil",
+            },
+            user_api_key_dict=mock_user_api_key_dict,
+        )
+
+    helper_model_info = captured["model_info"]
+    assert helper_model_info == {"health_check_supports_max_tokens": False}
+
+
+@pytest.mark.asyncio
 async def test_health_services_endpoint_datadog_llm_observability():
     """
     Verify that 'datadog_llm_observability' is accepted as a valid service

--- a/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
+++ b/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
@@ -697,6 +697,86 @@ async def test_test_model_connection_falls_back_to_deployments_zero_without_id()
 
 
 @pytest.mark.asyncio
+async def test_test_model_connection_passes_model_info_to_health_check_helper():
+    """
+    Regression test for https://github.com/BerriAI/litellm/issues/29266
+
+    `test_model_connection` previously hardcoded `model_info={}` when
+    calling `_update_litellm_params_for_health_check`, silently dropping
+    flags like `health_check_supports_max_tokens: False`. As a result,
+    `max_tokens: 5` was always injected by the UI "Test Connection"
+    button — even when the operator had configured the deployment to
+    skip it. Verify that the caller-supplied `model_info` is forwarded
+    through to the helper so the UI matches the background `/health`
+    behavior.
+    """
+    mock_request = MagicMock()
+    mock_user_api_key_dict = MagicMock()
+    mock_user_api_key_dict.user_id = "test-user"
+    mock_user_api_key_dict.token = "test-token"
+
+    mock_prisma_client = MagicMock()
+    mock_router = MagicMock()
+    mock_router.get_model_list.return_value = []
+
+    mock_can_user_make_model_call = AsyncMock()
+    mock_health_check_result = {"status": "healthy"}
+    mock_ahealth_check = AsyncMock(return_value=mock_health_check_result)
+    mock_run_with_timeout = AsyncMock(return_value=mock_health_check_result)
+
+    captured = {}
+
+    def mock_update_params(model_info, litellm_params):
+        captured["model_info"] = model_info
+        params = litellm_params.copy()
+        params["messages"] = [{"role": "user", "content": "test"}]
+        return params
+
+    def mock_reject_os_environ(params):
+        return None
+
+    request_model_info = {"health_check_supports_max_tokens": False}
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client),
+        patch("litellm.proxy.proxy_server.llm_router", mock_router),
+        patch("litellm.proxy.proxy_server.premium_user", False),
+        patch(
+            "litellm.proxy.management_endpoints.model_management_endpoints.ModelManagementAuthChecks.can_user_make_model_call",
+            mock_can_user_make_model_call,
+        ),
+        patch(
+            "litellm.proxy.health_endpoints._health_endpoints.litellm.ahealth_check",
+            mock_ahealth_check,
+        ),
+        patch(
+            "litellm.proxy.health_endpoints._health_endpoints.run_with_timeout",
+            mock_run_with_timeout,
+        ),
+        patch(
+            "litellm.proxy.health_endpoints._health_endpoints._update_litellm_params_for_health_check",
+            mock_update_params,
+        ),
+        patch(
+            "litellm.proxy.health_endpoints._health_endpoints._reject_os_environ_references",
+            mock_reject_os_environ,
+        ),
+    ):
+        await health_test_model_connection(
+            request=mock_request,
+            mode="chat",
+            litellm_params={"model": "azure/gpt-4o"},
+            model_info=request_model_info,
+            user_api_key_dict=mock_user_api_key_dict,
+        )
+
+    # The caller-supplied model_info must reach the helper unchanged so
+    # that `health_check_supports_max_tokens: False` is honored. Before
+    # the fix this was always `{}`.
+    assert captured["model_info"] == request_model_info
+
+
+@pytest.mark.asyncio
 async def test_health_services_endpoint_datadog_llm_observability():
     """
     Verify that 'datadog_llm_observability' is accepted as a valid service


### PR DESCRIPTION
## Title
fix(proxy): forward `model_info` in `/health/test_connection`

## Relevant issues
Fixes #29266

## Pre-Submission checklist
- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory
- [x] I have added a screenshot of my new test passing locally

## Type
🐛 Bug Fix

## Changes

`test_model_connection` (UI \"Test Connection\" button) was hardcoding
\`model_info={}\` when calling \`_update_litellm_params_for_health_check\`,
silently dropping flags such as
\`health_check_supports_max_tokens: false\` and always injecting
\`max_tokens: 5\`. The background \`/health\` endpoint already honors this
flag — only the UI button was broken.

### Root cause
\`\`\`python
# litellm/proxy/health_endpoints/_health_endpoints.py
litellm_params = _update_litellm_params_for_health_check(
    model_info={},          # <-- always empty, ignores request body
    litellm_params=litellm_params,
)
\`\`\`

### Fix
Forward the caller-supplied \`model_info\` (already extracted from the
request body earlier in the function) through to the helper:

\`\`\`python
litellm_params = _update_litellm_params_for_health_check(
    model_info=model_info or {},
    litellm_params=litellm_params,
)
\`\`\`

### Impact
Azure AI Foundry deployments (and similar providers) that only accept
\`max_completion_tokens\` and reject \`max_tokens\` will no longer fail the
UI Test Connection button when configured with
\`model_info.health_check_supports_max_tokens: false\`. The UI now matches
the background \`/health\` behavior.

## Tests
Added \`test_test_model_connection_passes_model_info_to_health_check_helper\`
in \`tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py\`
that asserts the caller-supplied \`model_info\` reaches
\`_update_litellm_params_for_health_check\` unchanged. Also re-ran the
three existing \`test_model_connection\` regression tests — all pass.

\`\`\`
$ uv run pytest tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py -k "test_model_connection" -q
4 passed, 41 deselected
\`\`\`