### PR TITLE
fix(pricing): add canonical cache_read_input_token_cost for deepseek cache-hit models

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -12869,6 +12869,7 @@
     },
     "deepseek/deepseek-coder": {
         "input_cost_per_token": 1.4e-07,
+        "cache_read_input_token_cost": 1.4e-08,
         "input_cost_per_token_cache_hit": 1.4e-08,
         "litellm_provider": "deepseek",
         "max_input_tokens": 128000,
@@ -12883,6 +12884,7 @@
     },
     "deepseek/deepseek-r1": {
         "input_cost_per_token": 5.5e-07,
+        "cache_read_input_token_cost": 1.4e-07,
         "input_cost_per_token_cache_hit": 1.4e-07,
         "litellm_provider": "deepseek",
         "max_input_tokens": 65536,
@@ -12938,6 +12940,7 @@
     },
     "deepseek/deepseek-v3.2": {
         "input_cost_per_token": 2.8e-07,
+        "cache_read_input_token_cost": 2.8e-08,
         "input_cost_per_token_cache_hit": 2.8e-08,
         "litellm_provider": "deepseek",
         "max_input_tokens": 163840,
@@ -27076,6 +27079,7 @@
     },
     "openrouter/deepseek/deepseek-chat-v3.1": {
         "input_cost_per_token": 2e-07,
+        "cache_read_input_token_cost": 2e-08,
         "input_cost_per_token_cache_hit": 2e-08,
         "litellm_provider": "openrouter",
         "max_input_tokens": 163840,
@@ -27091,6 +27095,7 @@
     },
     "openrouter/deepseek/deepseek-v3.2": {
         "input_cost_per_token": 2.8e-07,
+        "cache_read_input_token_cost": 2.8e-08,
         "input_cost_per_token_cache_hit": 2.8e-08,
         "litellm_provider": "openrouter",
         "max_input_tokens": 163840,
@@ -27106,6 +27111,7 @@
     },
     "openrouter/deepseek/deepseek-v3.2-exp": {
         "input_cost_per_token": 2e-07,
+        "cache_read_input_token_cost": 2e-08,
         "input_cost_per_token_cache_hit": 2e-08,
         "litellm_provider": "openrouter",
         "max_input_tokens": 163840,
@@ -27121,6 +27127,7 @@
     },
     "openrouter/deepseek/deepseek-r1": {
         "input_cost_per_token": 5.5e-07,
+        "cache_read_input_token_cost": 1.4e-07,
         "input_cost_per_token_cache_hit": 1.4e-07,
         "litellm_provider": "openrouter",
         "max_input_tokens": 65336,
@@ -27136,6 +27143,7 @@
     },
     "openrouter/deepseek/deepseek-r1-0528": {
         "input_cost_per_token": 5e-07,
+        "cache_read_input_token_cost": 1.4e-07,
         "input_cost_per_token_cache_hit": 1.4e-07,
         "litellm_provider": "openrouter",
         "max_input_tokens": 65336,

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -983,6 +983,55 @@ def test_aaamodel_prices_and_context_window_json_is_valid():
         raise AssertionError(error_message)
 
 
+def test_input_cost_per_token_cache_hit_has_canonical_field():
+    """
+    Guard against the legacy `input_cost_per_token_cache_hit` field being set
+    without the canonical `cache_read_input_token_cost` field.
+
+    The cost calculator only reads `cache_read_input_token_cost` for cached
+    prompt tokens. When a model entry only declares
+    `input_cost_per_token_cache_hit`, cached tokens are silently billed at $0.
+    See Issue #28854.
+    """
+    json_path = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "model_prices_and_context_window.json",
+    )
+    with open(json_path, "r") as f:
+        models = json.load(f)
+
+    violations = []
+    for model_name, model_info in models.items():
+        if not isinstance(model_info, dict):
+            continue
+        if model_name == "sample_spec":
+            continue
+        legacy = model_info.get("input_cost_per_token_cache_hit")
+        if legacy is None:
+            continue
+        canonical = model_info.get("cache_read_input_token_cost")
+        if canonical is None:
+            violations.append(
+                f"{model_name}: declares `input_cost_per_token_cache_hit`={legacy} "
+                f"but is missing the canonical `cache_read_input_token_cost`. "
+                f"Cached prompt tokens for this model are silently priced at $0."
+            )
+        elif canonical != legacy:
+            violations.append(
+                f"{model_name}: `cache_read_input_token_cost`={canonical} "
+                f"disagrees with legacy `input_cost_per_token_cache_hit`={legacy}."
+            )
+
+    if violations:
+        raise AssertionError(
+            "Models declaring legacy `input_cost_per_token_cache_hit` must also "
+            "declare matching `cache_read_input_token_cost` (the field actually "
+            "consumed by the cost calculator):\n  - " + "\n  - ".join(violations)
+        )
+
+
 def test_max_tokens_consistency():
     """
     Test that max_tokens == max_output_tokens for all models.


### PR DESCRIPTION
## Title
fix(pricing): add canonical `cache_read_input_token_cost` for deepseek cache-hit models

## Relevant issues
Fixes #28854

## Pre-Submission checklist
**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type
🐛 Bug Fix

## Changes

### Root cause
The cost calculator in `litellm/cost_calculator.py` only consults `cache_read_input_token_cost` when pricing cached prompt tokens. The legacy field `input_cost_per_token_cache_hit` is still declared on `ModelInfoBase` but is **not read** by any pricing path. Eight DeepSeek-family entries in `model_prices_and_context_window.json` only declared the legacy field, so cached tokens for those models were silently billed at $0 instead of the documented per-token cache price.

### Fix
1. For each affected model, add a matching `cache_read_input_token_cost` next to the existing `input_cost_per_token_cache_hit` (values are identical to the legacy field — no pricing change for users, just makes the existing intent take effect):
   - `deepseek/deepseek-coder` → `1.4e-08`
   - `deepseek/deepseek-r1` → `1.4e-07`
   - `deepseek/deepseek-v3.2` → `2.8e-08`
   - `openrouter/deepseek/deepseek-chat-v3.1` → `2e-08`
   - `openrouter/deepseek/deepseek-v3.2` → `2.8e-08`
   - `openrouter/deepseek/deepseek-v3.2-exp` → `2e-08`
   - `openrouter/deepseek/deepseek-r1` → `1.4e-07`
   - `openrouter/deepseek/deepseek-r1-0528` → `1.4e-07`

2. Add a CI guard test `test_input_cost_per_token_cache_hit_has_canonical_field` in `tests/test_litellm/test_utils.py` that walks the full pricing JSON and fails if any model declares `input_cost_per_token_cache_hit` without a matching `cache_read_input_token_cost`. This prevents the same drift from recurring for future models.

This aligns with option (b) suggested in #28854 (CI / schema enforcement) and is purely additive — existing rows remain valid because the canonical field already shadows the legacy one when both are present.