### PR TITLE
fix(proxy): add default=None to LiteLLM_TeamMembership.litellm_budget_table

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -3892,7 +3892,9 @@ class LiteLLM_TeamMembership(LiteLLMPydanticObjectBase):
     # Union so Pydantic picks Full when data has server-managed fields
     # (/team/info) and Base when callers/tests construct with only
     # user-settable fields.
-    litellm_budget_table: Optional[Union[LiteLLM_BudgetTableFull, LiteLLM_BudgetTable]]
+    litellm_budget_table: Optional[
+        Union[LiteLLM_BudgetTableFull, LiteLLM_BudgetTable]
+    ] = None
 
     def safe_get_team_member_rpm_limit(self) -> Optional[int]:
         if self.litellm_budget_table is not None:

--- a/tests/test_litellm/proxy/test_proxy_types.py
+++ b/tests/test_litellm/proxy/test_proxy_types.py
@@ -47,6 +47,24 @@ def test_audit_log_masking():
     assert json_before_value["key"] == "sk-1*****7890"
 
 
+def test_team_membership_null_budget_table():
+    """
+    Regression test for: LiteLLM_TeamMembership.litellm_budget_table missing = None.
+    In Pydantic v2, Optional[T] without a default is required; rows with budget_id=null
+    raised a validation error and returned 401.
+    Related: https://github.com/BerriAI/litellm/issues/28689
+    """
+    from litellm.proxy._types import LiteLLM_TeamMembership
+
+    membership = LiteLLM_TeamMembership(user_id="u1", team_id="t1")
+    assert membership.litellm_budget_table is None
+
+    membership_explicit = LiteLLM_TeamMembership(
+        user_id="u1", team_id="t1", litellm_budget_table=None
+    )
+    assert membership_explicit.litellm_budget_table is None
+
+
 def test_internal_jobs_user_has_proxy_admin_role():
     """
     Test that the internal jobs system user has PROXY_ADMIN role.


### PR DESCRIPTION
## Relevant issues

Fixes #28689, #29066

## Summary

In Pydantic v2, `Optional[T]` without a default is a required field. `LiteLLM_TeamMembership.litellm_budget_table` was declared as `Optional[Union[LiteLLM_BudgetTableFull, LiteLLM_BudgetTable]]` with no default, so any row with `budget_id=null` triggered a validation error and returned 401. Adding `= None` restores the expected behaviour.

This supersedes #28699 (CLA blocker) and #28700 (CI red).

## Backport request

This is a production regression present since v1.85.1, v1.85.2, and v1.86.2. Please cherry-pick to patch releases. We reverted from v1.85.1 back to v1.83.14-stable because of this.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Test plan

- [x] `uv run pytest tests/test_litellm/proxy/test_proxy_types.py::test_team_membership_null_budget_table -v`
- [x] Construct `LiteLLM_TeamMembership(user_id="u", team_id="t")` without `litellm_budget_table` — no ValidationError raised, field is `None`

## Type

🐛 Bug Fix

## Changes

- `litellm/proxy/_types.py`: add `= None` default to `LiteLLM_TeamMembership.litellm_budget_table`
- `tests/test_litellm/proxy/test_proxy_types.py`: regression test