### PR TITLE
fix(responses): drop server-hosted built-in tools when bridging Responses API → Chat Completions

### DIFF
--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -10,6 +10,7 @@ from openai.types.responses.response_create_params import ResponseInputParam
 from openai.types.responses.tool_param import FunctionToolParam
 from typing_extensions import TypedDict
 
+from litellm._logging import verbose_logger
 from litellm.caching import InMemoryCache
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.responses.litellm_completion_transformation.session_handler import (
@@ -60,6 +61,24 @@ from litellm.types.utils import (
 
 ########### Initialize Classes used for Responses API  ###########
 TOOL_CALLS_CACHE = InMemoryCache()
+
+# OpenAI server-hosted Responses built-in tools that run on OpenAI's side and
+# have no Chat Completions equivalent. When the Responses API is bridged to Chat
+# Completions, forwarding these verbatim breaks backends that only accept tools
+# with type == "function" (e.g. self-hosted vLLM and many OpenAI-compatible
+# gateways) -- the whole request is rejected, taking the request's real
+# (function/mcp) tools down with it. They are therefore dropped during the
+# transform. Notes:
+#   - "web_search"/"web_search_preview" and "mcp" are handled explicitly above.
+#   - Client-executed built-ins ("computer_use"/"computer_use_preview",
+#     "local_shell") are intentionally NOT listed: they are passed through so
+#     backends that support them (e.g. Anthropic computer use) still work.
+UNSUPPORTED_RESPONSES_BUILTIN_TOOL_TYPES: Set[str] = {
+    "image_generation",
+    "image_generation_call",
+    "code_interpreter",
+    "file_search",
+}
 
 
 class ChatCompletionSession(TypedDict, total=False):
@@ -1413,6 +1432,21 @@ class LiteLLMCompletionResponsesConfig:
                     cast(ChatCompletionToolParam, chat_completion_tool)
                 )
             else:
+                # Drop OpenAI server-hosted built-in tools (image_generation,
+                # code_interpreter, file_search, ...) that have no Chat
+                # Completions equivalent: forwarding them verbatim makes strict
+                # chat-completions backends reject the entire request (and thus
+                # the request's real function/mcp tools). Any other type is
+                # passed through unchanged, preserving existing behavior.
+                _tool_type = tool.get("type")
+                if _tool_type in UNSUPPORTED_RESPONSES_BUILTIN_TOOL_TYPES:
+                    verbose_logger.debug(
+                        "responses->chat-completions bridge: dropping unsupported "
+                        "Responses built-in tool type '%s' (no chat-completions "
+                        "equivalent)",
+                        _tool_type,
+                    )
+                    continue
                 chat_completion_tools.append(
                     cast(Union[ChatCompletionToolParam, OpenAIMcpServerTool], tool)
                 )

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -1067,6 +1067,67 @@ class TestToolTransformation:
         assert result_tools[0]["type"] == "computer_use"
         assert web_search_options is None
 
+    def test_drop_unsupported_server_hosted_builtin_tools(self):
+        """
+        Server-hosted Responses built-in tools (image_generation, code_interpreter,
+        file_search) have no Chat Completions equivalent and must be dropped when
+        bridging to Chat Completions, instead of being forwarded verbatim (which
+        makes strict backends reject the whole request). Real function tools in the
+        same request must be preserved.
+        """
+        function_tool = {
+            "type": "function",
+            "name": "get_weather",
+            "description": "Get the weather",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+            },
+        }
+        tools = [
+            {"type": "image_generation"},
+            {"type": "code_interpreter"},
+            {"type": "file_search"},
+            function_tool,
+        ]
+
+        # Execute
+        (
+            result_tools,
+            web_search_options,
+        ) = LiteLLMCompletionResponsesConfig.transform_responses_api_tools_to_chat_completion_tools(
+            tools=tools
+        )
+
+        # Assert: the three server-hosted built-ins are dropped; only the
+        # function tool survives so the request can still call its real tools.
+        assert len(result_tools) == 1
+        assert result_tools[0]["type"] == "function"
+        assert result_tools[0]["function"]["name"] == "get_weather"
+        assert web_search_options is None
+
+    def test_client_executed_builtin_tools_still_passed_through(self):
+        """
+        Client-executed built-ins (e.g. local_shell) are intentionally passed
+        through unchanged so backends that support them keep working; only the
+        server-hosted built-ins are dropped.
+        """
+        local_shell_tool = {"type": "local_shell"}
+        tools = [local_shell_tool]
+
+        # Execute
+        (
+            result_tools,
+            web_search_options,
+        ) = LiteLLMCompletionResponsesConfig.transform_responses_api_tools_to_chat_completion_tools(
+            tools=tools
+        )
+
+        # Assert
+        assert len(result_tools) == 1
+        assert result_tools[0] == local_shell_tool
+        assert web_search_options is None
+
     def test_transform_web_search_tools_to_web_search_options(self):
         """Test that web_search tools are converted to web_search_options"""
         web_search_tool = {


### PR DESCRIPTION
## Summary

When the Responses API is bridged to Chat Completions (`use_chat_completions_api: true`, or any chat-only / `hosted_vllm` backend), `LiteLLMCompletionResponsesConfig.transform_responses_api_tools_to_chat_completion_tools` converts the tool list. Its `else` branch forwards **any unrecognized tool type verbatim**.

OpenAI **server-hosted** built-in Responses tools — `image_generation`, `code_interpreter`, `file_search` — have no Chat Completions equivalent. Forwarding them to a chat-completions backend that only accepts `type == "function"` makes the backend reject the **entire request**, which takes the request's real `function`/`mcp` tools down with it — so the agent can't call *any* tool.

## Repro (validated)

- OpenAI **Codex CLI 0.130** (which requires the Responses API) → LiteLLM proxy `/v1/responses` (`use_chat_completions_api: true`) → a self-hosted **vLLM** OpenAI-compatible model.
- Codex always includes `image_generation` in its tool list. The vLLM backend returns:

```
400 - {'type': 'literal_error', 'loc': ('body','tools',7,'type'),
       'msg': "Input should be 'function'", 'input': 'image_generation'}
```

Every Codex turn fails — the agent cannot use even its (function-type) `shell`/`apply_patch`/MCP tools, because the whole request is rejected.

## Fix

In the `else` branch, drop the OpenAI **server-hosted** built-ins that have no Chat Completions representation (`image_generation`, `image_generation_call`, `code_interpreter`, `file_search`) instead of forwarding them verbatim. Everything else is passed through unchanged, and the request's `function`/`mcp` tools are preserved.

Deliberately **not** dropped:
- `web_search` / `web_search_preview` and `mcp` — already handled explicitly earlier in the function.
- `computer_use` / `computer_use_preview`, `local_shell` — **client-executed** built-ins that some chat backends support (e.g. Anthropic computer use). LiteLLM already passes `computer_use` through (covered by an existing test), so these remain pass-through.

Dropped types are logged at debug level.

## Tests

- `test_drop_unsupported_server_hosted_builtin_tools` — the three server-hosted built-ins are dropped while a co-submitted `function` tool is preserved.
- `test_client_executed_builtin_tools_still_passed_through` — `local_shell` still passes through unchanged.
- Existing `test_transform_computer_use_tools`, `test_transform_mcp_tools`, `test_transform_web_search_tools_to_web_search_options`, and the `function` transformation tests are unchanged and continue to pass.

## Notes

- Behavior for `function`, `mcp`, `web_search`, and pass-through types is unchanged.
- The diagnosis was confirmed against a live vLLM backend: dropping the `image_generation` built-in **before it reaches the backend** lets Codex 0.130 (`/v1/responses` → vLLM) complete an agentic task end-to-end (it issues a `shell` tool call that succeeds), whereas without it every turn 400s. In that setup the drop was done by an equivalent request filter in front of the proxy; this PR moves the same logic into the Responses→Chat bridge so it works for any such backend. The transform itself is covered by the unit tests above.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
