### PR TITLE
fix(router): handle InternalServerErrorAllowedFails in get_allowed_fails_from_policy

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -11688,6 +11688,11 @@ class Router:
             and allowed_fails_policy.BadRequestErrorAllowedFails is not None
         ):
             return allowed_fails_policy.BadRequestErrorAllowedFails
+        if (
+            isinstance(exception, litellm.InternalServerError)
+            and allowed_fails_policy.InternalServerErrorAllowedFails is not None
+        ):
+            return allowed_fails_policy.InternalServerErrorAllowedFails
 
     def _initialize_alerting(self):
         from litellm.integrations.SlackAlerting.slack_alerting import SlackAlerting

--- a/tests/test_litellm/router_utils/test_health_check_allowed_fails_integration.py
+++ b/tests/test_litellm/router_utils/test_health_check_allowed_fails_integration.py
@@ -123,6 +123,7 @@ class TestGetAllowedFailsFromPolicyWithHealthCheckExceptions:
                 2,
             ),
             (litellm.BadRequestError, "BadRequestErrorAllowedFails", 7),
+            (litellm.InternalServerError, "InternalServerErrorAllowedFails", 4),
         ],
     )
     def test_policy_resolves_for_health_check_exception_types(
@@ -226,8 +227,7 @@ class TestHealthCheckCooldownIntegration:
             allowed_fails=1,
         )
 
-        # Use an exception that doesn't match TimeoutErrorAllowedFails
-        # InternalServerError is not checked by get_allowed_fails_from_policy
+        # Use a generic exception that doesn't match any policy field
         # so it will fall back to allowed_fails=1
         generic_exc = Exception("Some internal error")
 


### PR DESCRIPTION
## Relevant issues

Fixes #29283

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [make test-unit](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting @greptileai and received a Confidence Score of at least 4/5 before requesting a maintainer review
## Type

🐛 Bug Fix

## Changes

AllowedFailsPolicy.InternalServerErrorAllowedFails is defined in litellm/types/router.py but get_allowed_fails_from_policy() in litellm/router.py does not have a branch for InternalServerError. The setting is accepted in config but silently ignored at runtime, falling back to the global allowed_fails value.

This is the same class of bug that was fixed for RetryPolicy in #25644; the AllowedFailsPolicy side was missed in that PR.