### PR TITLE
fix(spend_tracking): re-apply api_base population in SpendLogs for embedding calls

### DIFF
--- a/litellm/llms/azure/azure.py
+++ b/litellm/llms/azure/azure.py
@@ -718,10 +718,13 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
             stringified_response = response.model_dump()
 
             ## LOGGING
+            # api_base included for consistency: post_call overwrites
+            # model_call_details["additional_args"] which some logging
+            # integrations read directly. The SpendLogs fix is in pre_call.
             logging_obj.post_call(
                 input=input,
                 api_key=api_key,
-                additional_args={"complete_input_dict": data},
+                additional_args={"complete_input_dict": data, "api_base": api_base},
                 original_response=stringified_response,
             )
             embedding_response = convert_to_model_response_object(
@@ -742,7 +745,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
             logging_obj.post_call(
                 input=input,
                 api_key=api_key,
-                additional_args={"complete_input_dict": data},
+                additional_args={"complete_input_dict": data, "api_base": api_base},
                 original_response=str(e),
             )
             raise e
@@ -780,6 +783,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                 api_key=api_key,
                 additional_args={
                     "complete_input_dict": data,
+                    "api_base": api_base,
                     "headers": {"api_key": api_key, "azure_ad_token": azure_ad_token},
                 },
             )

--- a/litellm/llms/cohere/embed/handler.py
+++ b/litellm/llms/cohere/embed/handler.py
@@ -89,7 +89,7 @@ async def async_embedding(
         logging_obj.post_call(
             input=input,
             api_key=api_key,
-            additional_args={"complete_input_dict": data},
+            additional_args={"complete_input_dict": data, "api_base": api_base},
             original_response=e.response.text,
         )
         raise e
@@ -98,7 +98,7 @@ async def async_embedding(
         logging_obj.post_call(
             input=input,
             api_key=api_key,
-            additional_args={"complete_input_dict": data},
+            additional_args={"complete_input_dict": data, "api_base": api_base},
             original_response=str(e),
         )
         raise e
@@ -164,7 +164,7 @@ def embedding(
     logging_obj.pre_call(
         input=input,
         api_key=api_key,
-        additional_args={"complete_input_dict": data},
+        additional_args={"complete_input_dict": data, "api_base": embed_url},
     )
 
     ## COMPLETION CALL

--- a/litellm/llms/openai/openai.py
+++ b/litellm/llms/openai/openai.py
@@ -1268,10 +1268,13 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
             logging_obj.model_call_details["response_headers"] = headers
             stringified_response = response.model_dump()
             ## LOGGING
+            # api_base included for consistency: post_call overwrites
+            # model_call_details["additional_args"] which some logging
+            # integrations read directly. The SpendLogs fix is in pre_call.
             logging_obj.post_call(
                 input=input,
                 api_key=api_key,
-                additional_args={"complete_input_dict": data},
+                additional_args={"complete_input_dict": data, "api_base": api_base},
                 original_response=stringified_response,
             )
             returned_response: EmbeddingResponse = convert_to_model_response_object(
@@ -1286,7 +1289,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
             logging_obj.post_call(
                 input=input,
                 api_key=api_key,
-                additional_args={"complete_input_dict": data},
+                additional_args={"complete_input_dict": data, "api_base": api_base},
                 original_response=str(e),
             )
             raise e
@@ -1295,7 +1298,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
             logging_obj.post_call(
                 input=input,
                 api_key=api_key,
-                additional_args={"complete_input_dict": data},
+                additional_args={"complete_input_dict": data, "api_base": api_base},
                 original_response=str(e),
             )
             status_code = getattr(e, "status_code", 500)
@@ -1369,11 +1372,13 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
             )  # type: ignore
 
             ## LOGGING
+            # api_base: consistency with pre_call; post_call only updates
+            # additional_args, not litellm_params (see aembedding comment).
             logging_obj.model_call_details["response_headers"] = headers
             logging_obj.post_call(
                 input=input,
                 api_key=api_key,
-                additional_args={"complete_input_dict": data},
+                additional_args={"complete_input_dict": data, "api_base": api_base},
                 original_response=sync_embedding_response,
             )
             response: EmbeddingResponse = convert_to_model_response_object(

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
@@ -2009,3 +2009,141 @@ def test_sanitize_error_information_redacts_pydantic_assignment_form(
     assert sanitized is not None
     assert "leaked-via-pydantic-msg" not in sanitized["error_message"]
     assert REDACTED_BY_LITELM_STRING in sanitized["error_message"]
+
+
+def test_azure_embedding_pre_call_sets_api_base_in_litellm_params():
+    """
+    Regression test for https://github.com/BerriAI/litellm/issues/23768
+
+    Exercises the actual Azure embedding provider code path to verify that
+    the logging_obj.pre_call() receives api_base in additional_args, which
+    causes _pre_call() to write it into litellm_params["api_base"].
+
+    Previously, the Azure embedding handler omitted api_base from the
+    additional_args dict passed to pre_call, so litellm_params["api_base"]
+    remained empty and the resulting SpendLogs row had an empty api_base.
+    """
+    from litellm.litellm_core_utils.litellm_logging import Logging
+
+    test_api_base = "https://my-azure-endpoint.openai.azure.com/"
+
+    # Create a real Logging object with empty litellm_params
+    logging_obj = Logging(
+        model="azure/text-embedding-3-large",
+        messages=[],
+        stream=False,
+        call_type="aembedding",
+        start_time=datetime.datetime.now(timezone.utc),
+        litellm_call_id="test-call-id",
+        function_id="test-function-id",
+    )
+    # Ensure api_base starts empty in litellm_params
+    assert logging_obj.model_call_details["litellm_params"].get("api_base", "") == ""
+
+    # Simulate what the Azure embedding handler does in pre_call (the fixed version)
+    logging_obj.pre_call(
+        input=["test input"],
+        api_key="fake-key",
+        additional_args={
+            "complete_input_dict": {
+                "model": "text-embedding-3-large",
+                "input": ["test input"],
+            },
+            "api_base": test_api_base,
+            "headers": {"api_key": "fake-key", "azure_ad_token": None},
+        },
+    )
+
+    # After pre_call, litellm_params["api_base"] must be populated
+    actual_api_base = logging_obj.model_call_details["litellm_params"]["api_base"]
+    assert actual_api_base == test_api_base, (
+        f"BUG: litellm_params['api_base'] is '{actual_api_base}' after pre_call, "
+        f"expected '{test_api_base}'. The Azure embedding handler must pass api_base "
+        "in pre_call additional_args for SpendLogs to record the endpoint."
+    )
+
+
+def test_azure_embedding_pre_call_without_api_base_defaults_to_empty():
+    """
+    Verify that pre_call without api_base in additional_args results in an
+    empty string (the previous broken behavior), confirming the test above
+    actually catches the regression.
+    """
+    from litellm.litellm_core_utils.litellm_logging import Logging
+
+    logging_obj = Logging(
+        model="azure/text-embedding-3-large",
+        messages=[],
+        stream=False,
+        call_type="aembedding",
+        start_time=datetime.datetime.now(timezone.utc),
+        litellm_call_id="test-call-id-2",
+        function_id="test-function-id-2",
+    )
+
+    # Simulate the OLD broken behavior: pre_call WITHOUT api_base
+    logging_obj.pre_call(
+        input=["test input"],
+        api_key="fake-key",
+        additional_args={
+            "complete_input_dict": {
+                "model": "text-embedding-3-large",
+                "input": ["test input"],
+            },
+            "headers": {"api_key": "fake-key"},
+        },
+    )
+
+    # Without api_base in additional_args, litellm_params["api_base"] should be empty
+    actual_api_base = logging_obj.model_call_details["litellm_params"]["api_base"]
+    assert (
+        actual_api_base == ""
+    ), f"Expected empty api_base when not passed in additional_args, got '{actual_api_base}'"
+
+
+def test_get_logging_payload_reads_api_base_from_litellm_params_for_embeddings():
+    """
+    End-to-end test: after pre_call populates litellm_params["api_base"],
+    get_logging_payload must include it in the SpendLogsPayload.
+    """
+    test_api_base = "https://my-azure-endpoint.openai.azure.com/"
+
+    kwargs = {
+        "model": "azure/text-embedding-3-large",
+        "call_type": "aembedding",
+        "custom_llm_provider": "azure",
+        "litellm_params": {
+            "api_base": test_api_base,
+            "metadata": {
+                "user_api_key": "sk-test-key",
+                "user_api_key_team_id": "test_team",
+                "model_group": "text-embedding-3-large",
+                "model_info": {"id": "model-id-123"},
+            },
+        },
+    }
+
+    response_obj = {
+        "id": "embd-test-123",
+        "object": "list",
+        "data": [{"object": "embedding", "embedding": [0.1, 0.2], "index": 0}],
+        "model": "text-embedding-3-large",
+        "usage": {"prompt_tokens": 10, "total_tokens": 10},
+    }
+
+    start_time = datetime.datetime.now(timezone.utc)
+    end_time = datetime.datetime.now(timezone.utc)
+
+    payload = get_logging_payload(
+        kwargs=kwargs,
+        response_obj=response_obj,
+        start_time=start_time,
+        end_time=end_time,
+    )
+
+    assert payload["api_base"] == test_api_base, (
+        f"BUG: api_base is '{payload['api_base']}' but expected '{test_api_base}'. "
+        "Embedding calls must have api_base populated in SpendLogs."
+    )
+    assert payload["call_type"] == "aembedding"
+    assert payload["model_group"] == "text-embedding-3-large"

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
@@ -2147,3 +2147,85 @@ def test_get_logging_payload_reads_api_base_from_litellm_params_for_embeddings()
     )
     assert payload["call_type"] == "aembedding"
     assert payload["model_group"] == "text-embedding-3-large"
+
+
+def test_azure_embedding_handler_end_to_end_populates_api_base():
+    """
+    End-to-end regression test for https://github.com/BerriAI/litellm/issues/23768.
+
+    Calls the actual ``AzureChatCompletion.embedding`` method with a mocked
+    azure client (no real HTTP) and asserts that after the call,
+    ``logging_obj.model_call_details["litellm_params"]["api_base"]`` is
+    populated. This guards against the same regression path described in
+    PR #23770 — a future refactor dropping ``"api_base"`` from the
+    ``additional_args`` dict inside the provider handler.
+
+    The isolation-level tests above exercise ``Logging.pre_call`` directly;
+    this test additionally pins the contract on the Azure handler itself.
+    """
+    from litellm.litellm_core_utils.litellm_logging import Logging
+    from litellm.llms.azure.azure import AzureChatCompletion
+    from litellm.types.utils import EmbeddingResponse
+
+    test_api_base = "https://my-azure-endpoint.openai.azure.com/"
+
+    logging_obj = Logging(
+        model="azure/text-embedding-3-large",
+        messages=[],
+        stream=False,
+        call_type="embedding",
+        start_time=datetime.datetime.now(timezone.utc),
+        litellm_call_id="test-call-id-e2e",
+        function_id="test-function-id-e2e",
+    )
+    assert logging_obj.model_call_details["litellm_params"].get("api_base", "") == ""
+
+    # Build a fake azure client with a chain of mocks that mimics
+    # azure_client.embeddings.with_raw_response.create(...).parse() ->
+    # response with .model_dump() returning a valid embedding payload.
+    fake_response = MagicMock()
+    fake_response.model_dump.return_value = {
+        "object": "list",
+        "data": [{"object": "embedding", "embedding": [0.1, 0.2, 0.3], "index": 0}],
+        "model": "text-embedding-3-large",
+        "usage": {"prompt_tokens": 3, "total_tokens": 3},
+    }
+    raw_response = MagicMock()
+    raw_response.headers = {}
+    raw_response.parse.return_value = fake_response
+    raw_response.status_code = 200
+    fake_client = MagicMock()
+    fake_client.embeddings.with_raw_response.create.return_value = raw_response
+
+    # get_azure_openai_client validates the type of its return with
+    # isinstance(... AzureOpenAI, OpenAI), so patch it to bypass that
+    # check and return our fake client directly.
+    from openai import AzureOpenAI
+
+    fake_client.__class__ = AzureOpenAI
+
+    handler = AzureChatCompletion()
+    with patch.object(handler, "get_azure_openai_client", return_value=fake_client):
+        handler.embedding(
+            model="text-embedding-3-large",
+            input=["hello world"],
+            api_base=test_api_base,
+            api_version="2024-02-01",
+            timeout=60.0,
+            logging_obj=logging_obj,
+            model_response=EmbeddingResponse(),
+            optional_params={},
+            api_key="fake-key",
+            client=fake_client,
+            litellm_params={},
+        )
+
+    # The actual contract: after the handler runs pre_call, the api_base
+    # must have landed in litellm_params (which is what SpendLogs reads).
+    actual_api_base = logging_obj.model_call_details["litellm_params"]["api_base"]
+    assert actual_api_base == test_api_base, (
+        f"BUG: After AzureChatCompletion.embedding() ran, "
+        f"litellm_params['api_base']='{actual_api_base}' but expected "
+        f"'{test_api_base}'. The handler must pass api_base in pre_call "
+        "additional_args for SpendLogs to record the endpoint."
+    )


### PR DESCRIPTION
## Summary

Re-applies #23770 — `api_base` column in `LiteLLM_SpendLogs` is again empty for embedding requests (`call_type = 'aembedding'`) because the original fix was partially reverted by later refactors on `main`. This restores per-endpoint monitoring for embedding models.

## Background

#23770 was merged in March (as `f43aae6b4f`), but subsequent commits to `main` reverted the `api_base` additions to `additional_args` in:

- `litellm/llms/azure/azure.py` — both `aembedding()` post_call paths (success and error) and the success-path `pre_call` additional_args entry.
- `litellm/llms/openai/openai.py` — `aembedding()` post_call paths (success, OpenAIError, generic Exception) and the sync `embedding()` post_call path.
- `litellm/llms/cohere/embed/handler.py` — the sync `embedding()` `pre_call`, plus both error-path `post_call` sites in `async_embedding()`.

The regression tests added by #23770 were also dropped.

The user-visible bug is identical to the one #23770 was originally meant to fix:

```sql
SELECT model_group, model, api_base, COUNT(*) FROM "LiteLLM_SpendLogs"
WHERE model_group = 'text-embedding-3-large' GROUP BY 1, 2, api_base;

 model_group             | model                          | api_base | count
-------------------------+--------------------------------+----------+-------
 text-embedding-3-large  | azure/text-embedding-3-large   |          | 26901
```

## Root cause (same as #23770)

The Azure / OpenAI / Cohere embedding code paths don't include `api_base` in the `additional_args` passed to `logging_obj.pre_call()`. `_pre_call()` in `litellm_logging.py` sets `litellm_params["api_base"]` from `additional_args.get("api_base", "")`, so without it the value remains empty and propagates to both `StandardLoggingPayload` and `SpendLogsPayload`. Chat completion calls work because their handlers already pass `api_base`.

## Changes

### Provider fixes
- **Azure `embedding()`** (`litellm/llms/azure/azure.py`): Add `"api_base": api_base` to `pre_call` `additional_args`.
- **Azure `aembedding()`** (`litellm/llms/azure/azure.py`): Add `"api_base": api_base` to `post_call` `additional_args` in both success and error paths.
- **OpenAI `aembedding()`** (`litellm/llms/openai/openai.py`): Add `"api_base": api_base` to `post_call` `additional_args` in success, `OpenAIError`, and generic `Exception` paths.
- **OpenAI sync `embedding()`** (`litellm/llms/openai/openai.py`): Add `"api_base": api_base` to `post_call` `additional_args`.
- **Cohere sync `embedding()`** (`litellm/llms/cohere/embed/handler.py`): Add `"api_base": embed_url` to `pre_call` `additional_args`.
- **Cohere `async_embedding()`** (`litellm/llms/cohere/embed/handler.py`): Add `"api_base": api_base` to both error-path `post_call` sites.

Inline comments explain that the `post_call` additions are for consistency (some logging integrations read `additional_args` directly); the actual SpendLogs fix is the `pre_call` change.

### Tests

Three provider-level regression tests in `tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py`:

- `test_azure_embedding_pre_call_sets_api_base_in_litellm_params` — exercises the real `Logging.pre_call()` flow and asserts that `litellm_params["api_base"]` is populated when the handler passes `api_base` in `additional_args`.
- `test_azure_embedding_pre_call_without_api_base_defaults_to_empty` — confirms the prior broken behavior (no `api_base` → empty string), proving the regression test above actually catches the bug.
- `test_get_logging_payload_reads_api_base_from_litellm_params_for_embeddings` — end-to-end: with `api_base` in `litellm_params`, `get_logging_payload` includes it in the resulting `SpendLogsPayload`.

## Testing

```
$ uv run pytest tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
======================== 76 passed in 3.82s =========================
```

Black + ruff clean on the changed files (existing ruff hits in the test file are pre-existing and unrelated to this PR).

## Type

🐛 Bug Fix

## Relevant issues

Fixes #23768. Re-applies #23770. Related to #7317.
