### PR TITLE
fix(anthropic): stop injecting unsupported output_config.effort=xhigh for Claude Code on Sonnet/Opus 4.6

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
@@ -230,6 +230,8 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
         """Translate legacy ``thinking.type=enabled`` to adaptive for 4.6/4.7.
         Caller-provided ``output_config.effort`` is never overridden.
         """
+        from litellm.llms.anthropic.chat.transformation import AnthropicConfig
+
         if not AnthropicModelInfo._is_adaptive_thinking_model(model):
             return
         thinking = optional_params.get("thinking")
@@ -237,7 +239,7 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
             return
 
         budget = int(thinking.get("budget_tokens") or 0)
-        if budget >= 24000:
+        if budget >= 24000 and AnthropicConfig._supports_effort_level(model, "xhigh"):
             effort = "xhigh"
         elif budget >= 10000:
             effort = "high"

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_reasoning_effort_translation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_reasoning_effort_translation.py
@@ -251,11 +251,14 @@ def test_reasoning_effort_in_supported_params():
         "claude-sonnet-4-6",
         "bedrock/invoke/us.anthropic.claude-sonnet-4-6",
         "vertex_ai/claude-sonnet-4-6",
+        "claude-opus-4-6",
+        "bedrock/invoke/us.anthropic.claude-opus-4-6",
+        "vertex_ai/claude-opus-4-6",
     ],
 )
 def test_legacy_thinking_high_budget_clamps_to_high_when_xhigh_unsupported(model):
-    """Claude Code sends ``thinking.budget_tokens=31999``; Sonnet 4.6 has no
-    ``xhigh`` tier, so the translator must emit ``high`` rather than the
+    """Claude Code sends ``thinking.budget_tokens=31999``; Sonnet 4.6 and Opus 4.6
+    have no ``xhigh`` tier, so the translator must emit ``high`` rather than the
     provider-invalid ``xhigh`` (regression for issue #29282)."""
     config = AnthropicMessagesConfig()
     optional_params = {

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_reasoning_effort_translation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_reasoning_effort_translation.py
@@ -243,3 +243,121 @@ def test_reasoning_effort_in_supported_params():
     assert "reasoning_effort" in config.get_supported_anthropic_messages_params(
         "claude-opus-4-7"
     )
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "claude-sonnet-4-6",
+        "bedrock/invoke/us.anthropic.claude-sonnet-4-6",
+        "vertex_ai/claude-sonnet-4-6",
+    ],
+)
+def test_legacy_thinking_high_budget_clamps_to_high_when_xhigh_unsupported(model):
+    """Claude Code sends ``thinking.budget_tokens=31999``; Sonnet 4.6 has no
+    ``xhigh`` tier, so the translator must emit ``high`` rather than the
+    provider-invalid ``xhigh`` (regression for issue #29282)."""
+    config = AnthropicMessagesConfig()
+    optional_params = {
+        "max_tokens": 1024,
+        "thinking": {"type": "enabled", "budget_tokens": 31999},
+    }
+
+    result = config.transform_anthropic_messages_request(
+        model=model,
+        messages=[{"role": "user", "content": "Hello"}],
+        anthropic_messages_optional_request_params=optional_params,
+        litellm_params={},
+        headers={},
+    )
+
+    assert result.get("thinking") == {"type": "adaptive"}
+    assert result.get("output_config") == {"effort": "high"}
+
+
+def test_legacy_thinking_high_budget_keeps_xhigh_when_supported():
+    """Opus 4.7 advertises an ``xhigh`` tier, so the high-budget bucket keeps it."""
+    config = AnthropicMessagesConfig()
+    optional_params = {
+        "max_tokens": 1024,
+        "thinking": {"type": "enabled", "budget_tokens": 31999},
+    }
+
+    result = config.transform_anthropic_messages_request(
+        model="claude-opus-4-7",
+        messages=[{"role": "user", "content": "Hello"}],
+        anthropic_messages_optional_request_params=optional_params,
+        litellm_params={},
+        headers={},
+    )
+
+    assert result.get("thinking") == {"type": "adaptive"}
+    assert result.get("output_config") == {"effort": "xhigh"}
+
+
+@pytest.mark.parametrize(
+    "budget_tokens,expected_effort",
+    [
+        (31999, "high"),
+        (24000, "high"),
+        (10000, "high"),
+        (9999, "medium"),
+        (5000, "medium"),
+        (4999, "low"),
+        (1024, "low"),
+    ],
+)
+def test_legacy_thinking_budget_buckets_on_sonnet_46(budget_tokens, expected_effort):
+    config = AnthropicMessagesConfig()
+    optional_params = {
+        "max_tokens": 1024,
+        "thinking": {"type": "enabled", "budget_tokens": budget_tokens},
+    }
+
+    result = config.transform_anthropic_messages_request(
+        model="claude-sonnet-4-6",
+        messages=[{"role": "user", "content": "Hello"}],
+        anthropic_messages_optional_request_params=optional_params,
+        litellm_params={},
+        headers={},
+    )
+
+    assert result.get("output_config") == {"effort": expected_effort}
+
+
+def test_legacy_thinking_does_not_override_explicit_output_config():
+    config = AnthropicMessagesConfig()
+    optional_params = {
+        "max_tokens": 1024,
+        "thinking": {"type": "enabled", "budget_tokens": 31999},
+        "output_config": {"effort": "low"},
+    }
+
+    result = config.transform_anthropic_messages_request(
+        model="claude-sonnet-4-6",
+        messages=[{"role": "user", "content": "Hello"}],
+        anthropic_messages_optional_request_params=optional_params,
+        litellm_params={},
+        headers={},
+    )
+
+    assert result.get("output_config") == {"effort": "low"}
+
+
+def test_legacy_thinking_left_untouched_on_non_adaptive_model():
+    config = AnthropicMessagesConfig()
+    optional_params = {
+        "max_tokens": 1024,
+        "thinking": {"type": "enabled", "budget_tokens": 31999},
+    }
+
+    result = config.transform_anthropic_messages_request(
+        model="claude-opus-4-5",
+        messages=[{"role": "user", "content": "Hello"}],
+        anthropic_messages_optional_request_params=optional_params,
+        litellm_params={},
+        headers={},
+    )
+
+    assert result.get("thinking") == {"type": "enabled", "budget_tokens": 31999}
+    assert "output_config" not in result


### PR DESCRIPTION
## Relevant issues

Fixes https://github.com/BerriAI/litellm/issues/29282

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

Verified against a live proxy hitting real Bedrock and Anthropic APIs. The proxy was run twice on the same `dev_config.yaml`: once on the pre-fix code (current `litellm_internal_staging`) for the baseline, and once on this branch.

```
python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --port 4000
```

The request is exactly what Claude Code emits for the `claude-sonnet-4.6` alias: the legacy thinking shape with `budget_tokens` 31999, sent to the `/v1/messages` route against a Bedrock Sonnet 4.6 deployment.

```
curl -s -w "\nHTTP_STATUS=%{http_code}\n" http://localhost:4000/v1/messages \
  -H "content-type: application/json" \
  -H "x-api-key: sk-1234" \
  -H "anthropic-version: 2023-06-01" \
  -d '{"model":"bedrock-invoke-sonnet-4-6","max_tokens":64,"thinking":{"type":"enabled","budget_tokens":31999},"messages":[{"role":"user","content":"Reply with the single word: ok"}]}'
```

Before (pre-fix code), the translator injected `output_config.effort = "xhigh"` and Bedrock rejected it with the exact error from the issue:

```
{"error":{"message":"{\"message\":\"output_config.effort: Input should be 'low', 'medium', 'high' or 'max'\"}. Received Model Group=bedrock-invoke-sonnet-4-6\nAvailable Model Group Fallbacks=None","type":"None","param":"None","code":"400"}}
HTTP_STATUS=400
```

After (this branch), the same request maps to `output_config.effort = "high"` and returns a normal completion:

```
{"model":"bedrock-invoke-sonnet-4-6","id":"msg_bdrk_01TjR8RPmszcXrwJvjhj4Lce","type":"message","role":"assistant","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn","usage":{"input_tokens":14,"output_tokens":4,"total_tokens":18}}
HTTP_STATUS=200
```

Control: a model that does advertise the `xhigh` tier must still send `xhigh`. Opus 4.7 on the direct Anthropic API with the same 31999 budget returns 200, confirming the gate does not over-clamp:

```
curl -s -w "\nHTTP_STATUS=%{http_code}\n" http://localhost:4000/v1/messages \
  -H "content-type: application/json" -H "x-api-key: sk-1234" -H "anthropic-version: 2023-06-01" \
  -d '{"model":"anthropic-opus-4-7","max_tokens":64,"thinking":{"type":"enabled","budget_tokens":31999},"messages":[{"role":"user","content":"Reply with the single word: ok"}]}'

{"model":"anthropic-opus-4-7","id":"msg_01GBj3vbStAGBAj5UmmeaTPv","type":"message","role":"assistant","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn", ...}
HTTP_STATUS=200
```

## Type

🐛 Bug Fix

## Changes

`_translate_legacy_thinking_for_adaptive_model` on the Anthropic `/v1/messages` route rewrites Claude Code's legacy `thinking.type=enabled` request into the adaptive `output_config.effort` shape that 4.6/4.7 models expect. Its budget-to-effort ladder mapped any `budget_tokens >= 24000` to `effort=xhigh` and injected that value without checking whether the target model actually supports the `xhigh` tier. Claude Code's default thinking budget is 31999, so every Claude Code session against Sonnet 4.6 (and Opus 4.6) on Bedrock or Vertex started failing with `output_config.effort: Input should be 'low', 'medium', 'high' or 'max'` once this translator shipped in v1.83.9 (PR #25867). `xhigh` is not even in the provider's accepted set there.

The sibling `reasoning_effort` translator already gates effort through `AnthropicConfig._validate_effort_for_model`; the legacy-thinking path skipped that check entirely. The fix gates the `xhigh` choice on `AnthropicConfig._supports_effort_level(model, "xhigh")`, reusing the same capability signal driven by `supports_xhigh_reasoning_effort` in the model map. Models that advertise the tier (Opus 4.7) keep `xhigh`; everything else falls through to `high`, which is valid on Sonnet 4.6 and Opus 4.6. The lower budget buckets are unchanged.

Tests cover the regression directly: both Sonnet 4.6 and Opus 4.6, each in its bare, `bedrock/invoke/...`, and `vertex_ai/...` routed forms, clamp the high-budget bucket to `high` (Opus 4.6 carries `supports_adaptive_thinking` without `supports_xhigh_reasoning_effort`, so it hits the same path as Sonnet 4.6). Opus 4.7 preserves `xhigh`, the full budget-to-effort ladder is pinned, a caller-supplied `output_config.effort` still wins over the inferred value, and a non-adaptive model leaves the legacy `thinking` block untouched. The clamp assertions fail against the pre-fix code.

