### PR TITLE
fix(ui): align RunwayML provider key with UI enum so credential form renders fields

### DIFF
--- a/litellm/proxy/public_endpoints/provider_create_fields.json
+++ b/litellm/proxy/public_endpoints/provider_create_fields.json
@@ -2451,8 +2451,8 @@
     "default_model_placeholder": "gpt-3.5-turbo"
   },
   {
-    "provider": "RUNWAYML",
-    "provider_display_name": "Runwayml",
+    "provider": "RunwayML",
+    "provider_display_name": "RunwayML",
     "litellm_provider": "runwayml",
     "credential_fields": [
       {

--- a/tests/test_litellm/proxy/public_endpoints/test_public_endpoints.py
+++ b/tests/test_litellm/proxy/public_endpoints/test_public_endpoints.py
@@ -639,3 +639,32 @@ def test_clean_display_name_strips_suffix():
 def test_clean_display_name_passthrough_when_no_suffix():
     assert _clean_display_name("OpenAI") == "OpenAI"
     assert _clean_display_name("") == ""
+
+
+def test_runwayml_provider_entry_matches_ui_enum():
+    """Regression for #29302.
+
+    The UI's Providers.RunwayML enum is `"RunwayML"` (key==value), and the
+    field lookup in provider_specific_fields.tsx matches the backend entry by
+    `provider` (against the enum key) or `provider_display_name` (against the
+    enum value). Both must be `"RunwayML"` or the form renders no inputs and
+    POST /credentials returns 422.
+    """
+    app_instance = FastAPI()
+    app_instance.include_router(router)
+    client = TestClient(app_instance)
+
+    response = client.get("/public/providers/fields")
+    assert response.status_code == 200
+
+    runwayml_entries = [
+        p for p in response.json() if p.get("litellm_provider") == "runwayml"
+    ]
+    assert len(runwayml_entries) == 1, "expected exactly one runwayml entry"
+    entry = runwayml_entries[0]
+
+    assert entry["provider"] == "RunwayML"
+    assert entry["provider_display_name"] == "RunwayML"
+
+    field_keys = {f["key"] for f in entry["credential_fields"]}
+    assert {"api_key", "api_base"}.issubset(field_keys)

--- a/ui/litellm-dashboard/src/components/provider_info_helpers.test.tsx
+++ b/ui/litellm-dashboard/src/components/provider_info_helpers.test.tsx
@@ -78,6 +78,16 @@ describe("provider_info_helpers", () => {
       expect(result.displayName).toBe(Providers.ZAI);
     });
 
+    it("should point the RunwayML logo at the existing runway.png asset", () => {
+      // Regression for https://github.com/BerriAI/litellm/issues/29302 —
+      // the helper previously referenced runwayml.png which doesn't exist
+      // (the asset is shipped as runway.png), producing a 404 in the UI.
+      const result = getProviderLogoAndName("runwayml");
+      expect(result.displayName).toBe(Providers.RunwayML);
+      expect(result.logo).toContain("runway.png");
+      expect(result.logo).not.toContain("runwayml.png");
+    });
+
     it("should return provider value as display name when no mapping exists", () => {
       const unknownProvider = "unknown_provider";
       const result = getProviderLogoAndName(unknownProvider);

--- a/ui/litellm-dashboard/src/components/provider_info_helpers.tsx
+++ b/ui/litellm-dashboard/src/components/provider_info_helpers.tsx
@@ -281,7 +281,7 @@ export const providerLogoMap: Record<string, string> = {
   [Providers.Perplexity]: `${asset_logos_folder}perplexity-ai.svg`,
   [Providers.RECRAFT]: `${asset_logos_folder}recraft.svg`,
   [Providers.REPLICATE]: `${asset_logos_folder}replicate.svg`,
-  [Providers.RunwayML]: `${asset_logos_folder}runwayml.png`,
+  [Providers.RunwayML]: `${asset_logos_folder}runway.png`,
   [Providers.SAGEMAKER_LEGACY]: `${asset_logos_folder}bedrock.svg`,
   [Providers.Sambanova]: `${asset_logos_folder}sambanova.svg`,
   [Providers.SAP]: `${asset_logos_folder}sap.png`,


### PR DESCRIPTION
## Relevant issues

Fixes #29302

## Pre-Submission checklist

- [x] I have added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory (1 backend regression test + 1 UI logo test).
- [x] My PR passes all unit tests on `make test-unit` (50/50 UI + 26/26 backend tests in touched files passing locally).
- [x] My PR's scope is isolated to one specific problem (RunwayML credential form).
- [ ] I will request a Greptile review by commenting `@greptileai` after this PR is opened.

## Type

🐛 Bug Fix

## Changes

**Root cause** — the per-provider field lookup in [provider_specific_fields.tsx](https://github.com/BerriAI/litellm/blob/main/ui/litellm-dashboard/src/components/add_model/provider_specific_fields.tsx) matches each backend entry by `provider`, `provider_display_name`, or `litellm_provider`. The RunwayML entry in `provider_create_fields.json` was the only outlier in casing:

| Field | Was | UI enum expects |
|---|---|---|
| `provider` | `"RUNWAYML"` | `"RunwayML"` (enum key) |
| `provider_display_name` | `"Runwayml"` | `"RunwayML"` (enum value) |
| `litellm_provider` | `"runwayml"` | `"runwayml"` (unchanged) |

With no key matching, `providerInfo` resolved to `undefined`, `credential_fields` became `[]`, and the form rendered zero inputs. The user then submitted empty `credential_values: {}`, which fails the `CreateCredentialItem.check_credential_params` validator and returns 422.

**Secondary bug** — `provider_info_helpers.tsx:284` referenced `runwayml.png`, but the asset is shipped as `runway.png`, causing a console 404 for the provider logo.

**Fix** — align the JSON entry to the convention used by every other provider (`provider` = UI enum key, `provider_display_name` = UI enum value) and point the helper at the correct asset filename.

## Not in scope

- Auditing other providers for similar case mismatches — separate sweep.
- Refactoring `provider_specific_fields.tsx` lookup to be case-insensitive — the 3-OR logic works for every other provider; touching it risks regressions.
- Renaming the asset file (`runway.png` → `runwayml.png`) — minimal-diff.

## Screenshots / Proof of Fix

**Before (on main):**

~~~
1. Open Admin UI → Credentials → Add Credential
2. Select RunwayML from the Provider dropdown
3. -> API Key and API Base inputs do not render (form has Credential Name + Provider only)
4. Submit -> 422 Unprocessable Content
5. Console: GET /ui/assets/logos/runwayml.png -> 404
~~~

**After:**

~~~
1. Open Admin UI → Credentials → Add Credential
2. Select RunwayML
3. -> API Key (password) and API Base (text) inputs render
4. Fill them in, set credential_name, submit
5. -> 201 Created
6. RunwayML logo renders (runway.png loads, no 404)
~~~

Regression tests:
- `test_runwayml_provider_entry_matches_ui_enum` (backend) — asserts the JSON entry's `provider` and `provider_display_name` are both `"RunwayML"` and that `api_key` + `api_base` are present in `credential_fields`.
- `should point the RunwayML logo at the existing runway.png asset` (UI) — asserts the helper resolves to `runway.png`.