### PR TITLE
[internal copy of #29089] fix: duplicate claude code traces

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1643,7 +1643,12 @@ class Logging(LiteLLMLoggingBaseClass):
         prefer_async_handlers: bool = False,
         **kwargs,
     ) -> None:
-        """Route success logging to async and/or sync handlers for this request."""
+        """Route success logging to async and/or sync handlers for this request.
+
+        ``prefer_async_handlers`` only bypasses the sync-SDK-only shortcut (e.g.
+        ``async for`` on a stream from ``completion()``). Legacy string callbacks
+        still run via ``executor.submit(success_handler)`` when configured.
+        """
         from litellm.litellm_core_utils.thread_pool_executor import executor
 
         if self._is_assembled_stream_success(result):
@@ -1672,10 +1677,7 @@ class Logging(LiteLLMLoggingBaseClass):
             **kwargs,
         )
 
-        if (
-            prefer_async_handlers
-            or not self._should_run_sync_callbacks_for_async_calls()
-        ):
+        if not self._should_run_sync_callbacks_for_async_calls():
             return
 
         executor.submit(

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -16,9 +16,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    ClassVar,
     Dict,
-    FrozenSet,
     List,
     Literal,
     Optional,
@@ -1614,35 +1612,9 @@ class Logging(LiteLLMLoggingBaseClass):
     ) -> Optional[float]:
         return self._response_cost_calculator(result=result, cache_hit=cache_hit)
 
-    # Async completion-family call types whose async flag is NOT stored in
-    # ``litellm_params`` by ``get_litellm_params`` (which only stores
-    # ``acompletion``/``aembedding``). Without this set they fall through to the
-    # flag checks below and are misclassified as sync. ``call_type`` is
-    # ``original_function.__name__`` (set in ``function_setup``), so these carry
-    # the async-prefixed name; listed explicitly rather than tested by an "a"
-    # prefix because not every "a"-prefixed call_type is async (e.g.
-    # ``anthropic_messages``).
-    _ASYNC_ONLY_CALL_TYPES: ClassVar[FrozenSet[str]] = frozenset(
-        {
-            CallTypes.aresponses.value,
-            CallTypes.atranscription.value,
-            CallTypes.aimage_generation.value,
-            CallTypes.atext_completion.value,
-        }
-    )
-
-    def _is_sync_litellm_request(self, litellm_params: dict) -> bool:
-        """True for sync SDK entrypoints (``completion``), false for async (``acompletion``, etc.).
-
-        ``acompletion``/``aembedding`` are detected from the ``litellm_params``
-        flags that ``get_litellm_params`` stores. The remaining async
-        completion-family call types (``aresponses``, ``atranscription``,
-        ``aimage_generation``, ``atext_completion``) have no stored flag, so
-        they are detected from ``call_type`` — otherwise they would be
-        misclassified as sync and skip the async-only success/failure callbacks.
-        """
-        if self.call_type in self._ASYNC_ONLY_CALL_TYPES:
-            return False
+    @staticmethod
+    def _is_sync_litellm_request(litellm_params: dict) -> bool:
+        """True for sync SDK entrypoints (``completion``), false for async (``acompletion``, etc.)."""
         return (
             litellm_params.get(CallTypes.acompletion.value, False) is not True
             and litellm_params.get(CallTypes.aresponses.value, False) is not True

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1623,6 +1623,16 @@ class Logging(LiteLLMLoggingBaseClass):
             and litellm_params.get(CallTypes.atranscription.value, False) is not True
         )
 
+    def _should_dispatch_sync_success_only(
+        self, litellm_params: dict, *, prefer_async_handlers: bool
+    ) -> bool:
+        """Sync-only dispatch for sync SDK calls; proxy pass-through always uses async."""
+        if prefer_async_handlers:
+            return False
+        if self.call_type == CallTypes.pass_through.value:
+            return False
+        return self._is_sync_litellm_request(litellm_params)
+
     def _is_assembled_stream_success(self, result=None) -> bool:
         """True when exporting an assembled streaming response (not a per-chunk call)."""
         if self.stream is not True:
@@ -1659,7 +1669,9 @@ class Logging(LiteLLMLoggingBaseClass):
             return
 
         litellm_params = self.model_call_details.get("litellm_params", {}) or {}
-        if self._is_sync_litellm_request(litellm_params) and not prefer_async_handlers:
+        if self._should_dispatch_sync_success_only(
+            litellm_params, prefer_async_handlers=prefer_async_handlers
+        ):
             self.success_handler(
                 result,
                 start_time=start_time,
@@ -2568,9 +2580,10 @@ class Logging(LiteLLMLoggingBaseClass):
         print_verbose(
             "Logging Details LiteLLM-Async Success Call, cache_hit={}".format(cache_hit)
         )
-        if (
-            not self._is_assembled_stream_success(result)
-            and not self.should_run_logging(event_type="async_success")
+        if not self._is_assembled_stream_success(
+            result
+        ) and not self.should_run_logging(
+            event_type="async_success"
         ):  # prevent double logging (non-streaming)
             return
 

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1623,41 +1623,24 @@ class Logging(LiteLLMLoggingBaseClass):
             and litellm_params.get(CallTypes.atranscription.value, False) is not True
         )
 
-    def _is_final_streaming_success_emission(self) -> bool:
+    def _is_assembled_stream_success(self, result=None) -> bool:
+        """True when exporting an assembled streaming response (not a per-chunk call)."""
         if self.stream is not True:
             return False
+        if result is not None:
+            return True
         return (
             "async_complete_streaming_response" in self.model_call_details
             or self.model_call_details.get("complete_streaming_response") is not None
         )
 
-    def _is_streaming_final_success_dispatch_context(self, result=None) -> bool:
-        if self.stream is not True:
+    def _skip_repeat_final_stream_dispatch(self, result=None) -> bool:
+        """True if this final-stream dispatch should be dropped (already handled)."""
+        if not self._is_assembled_stream_success(result):
             return False
-        if self._is_final_streaming_success_emission():
+        if self.model_call_details.get("has_dispatched_final_stream_success"):
             return True
-        # Assembled response passed to dispatch before model_call_details is updated.
-        return result is not None
-
-    def _should_skip_duplicate_final_stream_success_log(self) -> bool:
-        """Skip repeat final-stream exports (per-chunk logging disables has_logged_*)."""
-        if not self._is_final_streaming_success_emission():
-            return False
-        if self.model_call_details.get("has_logged_async_success_final") is True:
-            return True
-        self.model_call_details["has_logged_async_success_final"] = True
-        return False
-
-    def _should_skip_duplicate_final_stream_dispatch(self, result=None) -> bool:
-        """Skip a second ``dispatch_success_handlers`` for the same final stream."""
-        if not self._is_streaming_final_success_dispatch_context(result):
-            return False
-        if (
-            self.model_call_details.get("has_dispatched_final_stream_success_handlers")
-            is True
-        ):
-            return True
-        self.model_call_details["has_dispatched_final_stream_success_handlers"] = True
+        self.model_call_details["has_dispatched_final_stream_success"] = True
         return False
 
     async def dispatch_success_handlers(
@@ -1672,7 +1655,7 @@ class Logging(LiteLLMLoggingBaseClass):
         """Route success logging to async and/or sync handlers for this request."""
         from litellm.litellm_core_utils.thread_pool_executor import executor
 
-        if self._should_skip_duplicate_final_stream_dispatch(result):
+        if self._skip_repeat_final_stream_dispatch(result):
             return
 
         litellm_params = self.model_call_details.get("litellm_params", {}) or {}
@@ -2585,10 +2568,8 @@ class Logging(LiteLLMLoggingBaseClass):
         print_verbose(
             "Logging Details LiteLLM-Async Success Call, cache_hit={}".format(cache_hit)
         )
-        if self._should_skip_duplicate_final_stream_success_log():
-            return
         if (
-            not self._is_final_streaming_success_emission()
+            not self._is_assembled_stream_success(result)
             and not self.should_run_logging(event_type="async_success")
         ):  # prevent double logging (non-streaming)
             return

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1631,6 +1631,14 @@ class Logging(LiteLLMLoggingBaseClass):
             or self.model_call_details.get("complete_streaming_response") is not None
         )
 
+    def _is_streaming_final_success_dispatch_context(self, result=None) -> bool:
+        if self.stream is not True:
+            return False
+        if self._is_final_streaming_success_emission():
+            return True
+        # Assembled response passed to dispatch before model_call_details is updated.
+        return result is not None
+
     def _should_skip_duplicate_final_stream_success_log(self) -> bool:
         """Skip repeat final-stream exports (per-chunk logging disables has_logged_*)."""
         if not self._is_final_streaming_success_emission():
@@ -1640,19 +1648,35 @@ class Logging(LiteLLMLoggingBaseClass):
         self.model_call_details["has_logged_async_success_final"] = True
         return False
 
+    def _should_skip_duplicate_final_stream_dispatch(self, result=None) -> bool:
+        """Skip a second ``dispatch_success_handlers`` for the same final stream."""
+        if not self._is_streaming_final_success_dispatch_context(result):
+            return False
+        if (
+            self.model_call_details.get("has_dispatched_final_stream_success_handlers")
+            is True
+        ):
+            return True
+        self.model_call_details["has_dispatched_final_stream_success_handlers"] = True
+        return False
+
     async def dispatch_success_handlers(
         self,
         result=None,
         start_time=None,
         end_time=None,
         cache_hit=None,
+        prefer_async_handlers: bool = False,
         **kwargs,
     ) -> None:
         """Route success logging to async and/or sync handlers for this request."""
         from litellm.litellm_core_utils.thread_pool_executor import executor
 
+        if self._should_skip_duplicate_final_stream_dispatch(result):
+            return
+
         litellm_params = self.model_call_details.get("litellm_params", {}) or {}
-        if self._is_sync_litellm_request(litellm_params):
+        if self._is_sync_litellm_request(litellm_params) and not prefer_async_handlers:
             self.success_handler(
                 result,
                 start_time=start_time,
@@ -1669,6 +1693,9 @@ class Logging(LiteLLMLoggingBaseClass):
             cache_hit=cache_hit,
             **kwargs,
         )
+
+        if prefer_async_handlers:
+            return
 
         if self._should_run_sync_callbacks_for_async_calls():
             executor.submit(
@@ -3372,11 +3399,39 @@ class Logging(LiteLLMLoggingBaseClass):
     ) -> List:
         """Merge dynamic and global callbacks; dedupe duplicate list entries only."""
         combined_callbacks = (dynamic_success_callbacks or []) + list(global_callbacks)
+
+        string_integration_slugs: set[str] = set()
+        for callback in combined_callbacks:
+            if isinstance(callback, str):
+                slug = self._integration_slug_from_callback(callback)
+                if slug is not None:
+                    string_integration_slugs.add(slug)
+
         deduped_callbacks: List[Any] = []
-        seen_callback_keys = set()
+        seen_callback_keys: set[Any] = set()
+        object_claimed_integration_slugs: set[str] = set()
 
         for callback in combined_callbacks:
-            callback_key = self._get_callback_dedupe_key(callback)
+            integration_slug = self._integration_slug_from_callback(callback)
+
+            if isinstance(callback, str) and integration_slug is not None:
+                callback_key = ("integration", integration_slug)
+            elif isinstance(callback, CustomLogger) and integration_slug is not None:
+                if (
+                    integration_slug in string_integration_slugs
+                    and integration_slug not in object_claimed_integration_slugs
+                ):
+                    object_claimed_integration_slugs.add(integration_slug)
+                    callback_key = ("integration", integration_slug)
+                else:
+                    callback_key = ("instance", id(callback))
+            elif isinstance(callback, str):
+                callback_key = ("string", callback.lower())
+            elif callable(callback):
+                callback_key = ("callable", self._get_callback_name(callback))
+            else:
+                callback_key = ("object", str(callback))
+
             if callback_key in seen_callback_keys:
                 continue
             seen_callback_keys.add(callback_key)
@@ -3395,25 +3450,26 @@ class Logging(LiteLLMLoggingBaseClass):
         )
         return normalized
 
-    def _get_callback_dedupe_key(self, callback: Any):
-        """
-        Stable key for duplicate entries in a merged callback *list* only.
-        """
+    def _integration_slug_from_callback(self, callback: Any) -> Optional[str]:
+        raw_name: Optional[str] = None
         if isinstance(callback, str):
-            callback_name = callback.lower()
-            if callback_name in litellm._known_custom_logger_compatible_callbacks:
-                return ("integration", self._normalize_callback_slug(callback_name))
-            return ("string", callback_name)
+            raw_name = callback.lower()
+        elif isinstance(callback, CustomLogger):
+            raw_name = (
+                getattr(callback, "callback_name", None) or callback.__class__.__name__
+            ).lower()
 
-        if isinstance(callback, CustomLogger):
-            callback_name = getattr(callback, "callback_name", None)
-            identity_source = callback_name or callback.__class__.__name__
-            return ("integration", self._normalize_callback_slug(identity_source))
+        if raw_name is None:
+            return None
 
-        if callable(callback):
-            return ("callable", self._get_callback_name(callback))
+        if raw_name in litellm._known_custom_logger_compatible_callbacks:
+            return self._normalize_callback_slug(raw_name)
 
-        return ("object", str(callback))
+        normalized = self._normalize_callback_slug(raw_name)
+        for known_callback in litellm._known_custom_logger_compatible_callbacks:
+            if self._normalize_callback_slug(known_callback) == normalized:
+                return normalized
+        return None
 
     def _remove_internal_litellm_callbacks(self, callbacks: List) -> List:
         """

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -16,7 +16,9 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    ClassVar,
     Dict,
+    FrozenSet,
     List,
     Literal,
     Optional,
@@ -1612,9 +1614,35 @@ class Logging(LiteLLMLoggingBaseClass):
     ) -> Optional[float]:
         return self._response_cost_calculator(result=result, cache_hit=cache_hit)
 
-    @staticmethod
-    def _is_sync_litellm_request(litellm_params: dict) -> bool:
-        """True for sync SDK entrypoints (``completion``), false for async (``acompletion``, etc.)."""
+    # Async completion-family call types whose async flag is NOT stored in
+    # ``litellm_params`` by ``get_litellm_params`` (which only stores
+    # ``acompletion``/``aembedding``). Without this set they fall through to the
+    # flag checks below and are misclassified as sync. ``call_type`` is
+    # ``original_function.__name__`` (set in ``function_setup``), so these carry
+    # the async-prefixed name; listed explicitly rather than tested by an "a"
+    # prefix because not every "a"-prefixed call_type is async (e.g.
+    # ``anthropic_messages``).
+    _ASYNC_ONLY_CALL_TYPES: ClassVar[FrozenSet[str]] = frozenset(
+        {
+            CallTypes.aresponses.value,
+            CallTypes.atranscription.value,
+            CallTypes.aimage_generation.value,
+            CallTypes.atext_completion.value,
+        }
+    )
+
+    def _is_sync_litellm_request(self, litellm_params: dict) -> bool:
+        """True for sync SDK entrypoints (``completion``), false for async (``acompletion``, etc.).
+
+        ``acompletion``/``aembedding`` are detected from the ``litellm_params``
+        flags that ``get_litellm_params`` stores. The remaining async
+        completion-family call types (``aresponses``, ``atranscription``,
+        ``aimage_generation``, ``atext_completion``) have no stored flag, so
+        they are detected from ``call_type`` — otherwise they would be
+        misclassified as sync and skip the async-only success/failure callbacks.
+        """
+        if self.call_type in self._ASYNC_ONLY_CALL_TYPES:
+            return False
         return (
             litellm_params.get(CallTypes.acompletion.value, False) is not True
             and litellm_params.get(CallTypes.aresponses.value, False) is not True

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1624,10 +1624,17 @@ class Logging(LiteLLMLoggingBaseClass):
         )
 
     def _is_assembled_stream_success(self, result=None) -> bool:
-        """Final assembled stream export (not a per-chunk success call)."""
+        """Final assembled stream export (not a per-chunk success call).
+
+        Per-chunk callers pass a ``ModelResponseStream`` (or ``None``); the
+        final assembled response is any other non-``None`` value (typically a
+        ``ModelResponse``). Treating a chunk as the assembled response would
+        prematurely set the ``has_dispatched_final_stream_success`` dedup
+        guard and silently suppress the real final stream log.
+        """
         if self.stream is not True:
             return False
-        if result is not None:
+        if result is not None and not isinstance(result, ModelResponseStream):
             return True
         return (
             "async_complete_streaming_response" in self.model_call_details

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1623,18 +1623,8 @@ class Logging(LiteLLMLoggingBaseClass):
             and litellm_params.get(CallTypes.atranscription.value, False) is not True
         )
 
-    def _should_dispatch_sync_success_only(
-        self, litellm_params: dict, *, prefer_async_handlers: bool
-    ) -> bool:
-        """Sync-only dispatch for sync SDK calls; proxy pass-through always uses async."""
-        if prefer_async_handlers:
-            return False
-        if self.call_type == CallTypes.pass_through.value:
-            return False
-        return self._is_sync_litellm_request(litellm_params)
-
     def _is_assembled_stream_success(self, result=None) -> bool:
-        """True when exporting an assembled streaming response (not a per-chunk call)."""
+        """Final assembled stream export (not a per-chunk success call)."""
         if self.stream is not True:
             return False
         if result is not None:
@@ -1643,15 +1633,6 @@ class Logging(LiteLLMLoggingBaseClass):
             "async_complete_streaming_response" in self.model_call_details
             or self.model_call_details.get("complete_streaming_response") is not None
         )
-
-    def _skip_repeat_final_stream_dispatch(self, result=None) -> bool:
-        """True if this final-stream dispatch should be dropped (already handled)."""
-        if not self._is_assembled_stream_success(result):
-            return False
-        if self.model_call_details.get("has_dispatched_final_stream_success"):
-            return True
-        self.model_call_details["has_dispatched_final_stream_success"] = True
-        return False
 
     async def dispatch_success_handlers(
         self,
@@ -1665,13 +1646,15 @@ class Logging(LiteLLMLoggingBaseClass):
         """Route success logging to async and/or sync handlers for this request."""
         from litellm.litellm_core_utils.thread_pool_executor import executor
 
-        if self._skip_repeat_final_stream_dispatch(result):
-            return
+        if self._is_assembled_stream_success(result):
+            if self.model_call_details.get("has_dispatched_final_stream_success"):
+                return
+            self.model_call_details["has_dispatched_final_stream_success"] = True
 
         litellm_params = self.model_call_details.get("litellm_params", {}) or {}
-        if self._should_dispatch_sync_success_only(
-            litellm_params, prefer_async_handlers=prefer_async_handlers
-        ):
+        sync_sdk = self._is_sync_litellm_request(litellm_params)
+        passthrough = self.call_type == CallTypes.pass_through.value
+        if sync_sdk and not prefer_async_handlers and not passthrough:
             self.success_handler(
                 result,
                 start_time=start_time,
@@ -1689,18 +1672,20 @@ class Logging(LiteLLMLoggingBaseClass):
             **kwargs,
         )
 
-        if prefer_async_handlers:
+        if (
+            prefer_async_handlers
+            or not self._should_run_sync_callbacks_for_async_calls()
+        ):
             return
 
-        if self._should_run_sync_callbacks_for_async_calls():
-            executor.submit(
-                self.success_handler,
-                result,
-                start_time=start_time,
-                end_time=end_time,
-                cache_hit=cache_hit,
-                **kwargs,
-            )
+        executor.submit(
+            self.success_handler,
+            result,
+            start_time=start_time,
+            end_time=end_time,
+            cache_hit=cache_hit,
+            **kwargs,
+        )
 
     def should_run_logging(
         self,
@@ -3391,79 +3376,9 @@ class Logging(LiteLLMLoggingBaseClass):
     def get_combined_callback_list(
         self, dynamic_success_callbacks: Optional[List], global_callbacks: List
     ) -> List:
-        """Merge dynamic and global callbacks; dedupe duplicate list entries only."""
-        combined_callbacks = (dynamic_success_callbacks or []) + list(global_callbacks)
-
-        string_integration_slugs: set[str] = set()
-        for callback in combined_callbacks:
-            if isinstance(callback, str):
-                slug = self._integration_slug_from_callback(callback)
-                if slug is not None:
-                    string_integration_slugs.add(slug)
-
-        deduped_callbacks: List[Any] = []
-        seen_callback_keys: set[Any] = set()
-        object_claimed_integration_slugs: set[str] = set()
-
-        for callback in combined_callbacks:
-            integration_slug = self._integration_slug_from_callback(callback)
-
-            if isinstance(callback, str) and integration_slug is not None:
-                callback_key = ("integration", integration_slug)
-            elif isinstance(callback, CustomLogger) and integration_slug is not None:
-                if (
-                    integration_slug in string_integration_slugs
-                    and integration_slug not in object_claimed_integration_slugs
-                ):
-                    object_claimed_integration_slugs.add(integration_slug)
-                    callback_key = ("integration", integration_slug)
-                else:
-                    callback_key = ("instance", id(callback))
-            elif isinstance(callback, str):
-                callback_key = ("string", callback.lower())
-            elif callable(callback):
-                callback_key = ("callable", self._get_callback_name(callback))
-            else:
-                callback_key = ("object", str(callback))
-
-            if callback_key in seen_callback_keys:
-                continue
-            seen_callback_keys.add(callback_key)
-            deduped_callbacks.append(callback)
-
-        return deduped_callbacks
-
-    @staticmethod
-    def _normalize_callback_slug(raw_name: str) -> str:
-        normalized = (
-            raw_name.lower()
-            .replace("-", "")
-            .replace("_", "")
-            .replace(" ", "")
-            .replace("logger", "")
-        )
-        return normalized
-
-    def _integration_slug_from_callback(self, callback: Any) -> Optional[str]:
-        raw_name: Optional[str] = None
-        if isinstance(callback, str):
-            raw_name = callback.lower()
-        elif isinstance(callback, CustomLogger):
-            raw_name = (
-                getattr(callback, "callback_name", None) or callback.__class__.__name__
-            ).lower()
-
-        if raw_name is None:
-            return None
-
-        if raw_name in litellm._known_custom_logger_compatible_callbacks:
-            return self._normalize_callback_slug(raw_name)
-
-        normalized = self._normalize_callback_slug(raw_name)
-        for known_callback in litellm._known_custom_logger_compatible_callbacks:
-            if self._normalize_callback_slug(known_callback) == normalized:
-                return normalized
-        return None
+        if dynamic_success_callbacks is None:
+            return list(global_callbacks)
+        return list(set(dynamic_success_callbacks + global_callbacks))
 
     def _remove_internal_litellm_callbacks(self, callbacks: List) -> List:
         """

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1612,6 +1612,74 @@ class Logging(LiteLLMLoggingBaseClass):
     ) -> Optional[float]:
         return self._response_cost_calculator(result=result, cache_hit=cache_hit)
 
+    @staticmethod
+    def _is_sync_litellm_request(litellm_params: dict) -> bool:
+        """True for sync SDK entrypoints (``completion``), false for async (``acompletion``, etc.)."""
+        return (
+            litellm_params.get(CallTypes.acompletion.value, False) is not True
+            and litellm_params.get(CallTypes.aresponses.value, False) is not True
+            and litellm_params.get(CallTypes.aembedding.value, False) is not True
+            and litellm_params.get(CallTypes.aimage_generation.value, False) is not True
+            and litellm_params.get(CallTypes.atranscription.value, False) is not True
+        )
+
+    def _is_final_streaming_success_emission(self) -> bool:
+        if self.stream is not True:
+            return False
+        return (
+            "async_complete_streaming_response" in self.model_call_details
+            or self.model_call_details.get("complete_streaming_response") is not None
+        )
+
+    def _should_skip_duplicate_final_stream_success_log(self) -> bool:
+        """Skip repeat final-stream exports (per-chunk logging disables has_logged_*)."""
+        if not self._is_final_streaming_success_emission():
+            return False
+        if self.model_call_details.get("has_logged_async_success_final") is True:
+            return True
+        self.model_call_details["has_logged_async_success_final"] = True
+        return False
+
+    async def dispatch_success_handlers(
+        self,
+        result=None,
+        start_time=None,
+        end_time=None,
+        cache_hit=None,
+        **kwargs,
+    ) -> None:
+        """Route success logging to async and/or sync handlers for this request."""
+        from litellm.litellm_core_utils.thread_pool_executor import executor
+
+        litellm_params = self.model_call_details.get("litellm_params", {}) or {}
+        if self._is_sync_litellm_request(litellm_params):
+            self.success_handler(
+                result,
+                start_time=start_time,
+                end_time=end_time,
+                cache_hit=cache_hit,
+                **kwargs,
+            )
+            return
+
+        await self.async_success_handler(
+            result,
+            start_time=start_time,
+            end_time=end_time,
+            cache_hit=cache_hit,
+            **kwargs,
+        )
+
+        if self._should_run_sync_callbacks_for_async_calls():
+            executor.submit(
+                self.success_handler,
+                result,
+                start_time=start_time,
+                end_time=end_time,
+                cache_hit=cache_hit,
+                **kwargs,
+            )
+
     def should_run_logging(
         self,
         event_type: Literal[
@@ -2034,13 +2102,7 @@ class Logging(LiteLLMLoggingBaseClass):
             standard_logging_object=kwargs.get("standard_logging_object", None),
         )
         litellm_params = self.model_call_details.get("litellm_params", {})
-        is_sync_request = (
-            litellm_params.get(CallTypes.acompletion.value, False) is not True
-            and litellm_params.get(CallTypes.aresponses.value, False) is not True
-            and litellm_params.get(CallTypes.aembedding.value, False) is not True
-            and litellm_params.get(CallTypes.aimage_generation.value, False) is not True
-            and litellm_params.get(CallTypes.atranscription.value, False) is not True
-        )
+        is_sync_request = self._is_sync_litellm_request(litellm_params)
         try:
             ## BUILD COMPLETE STREAMED RESPONSE
             complete_streaming_response: Optional[
@@ -2496,9 +2558,12 @@ class Logging(LiteLLMLoggingBaseClass):
         print_verbose(
             "Logging Details LiteLLM-Async Success Call, cache_hit={}".format(cache_hit)
         )
-        if not self.should_run_logging(
-            event_type="async_success"
-        ):  # prevent double logging
+        if self._should_skip_duplicate_final_stream_success_log():
+            return
+        if (
+            not self._is_final_streaming_success_emission()
+            and not self.should_run_logging(event_type="async_success")
+        ):  # prevent double logging (non-streaming)
             return
 
         ## CALCULATE COST FOR BATCH JOBS
@@ -2948,13 +3013,7 @@ class Logging(LiteLLMLoggingBaseClass):
         ):  # prevent double logging
             return
         litellm_params = self.model_call_details.get("litellm_params", {})
-        is_sync_request = (
-            litellm_params.get(CallTypes.acompletion.value, False) is not True
-            and litellm_params.get(CallTypes.aresponses.value, False) is not True
-            and litellm_params.get(CallTypes.aembedding.value, False) is not True
-            and litellm_params.get(CallTypes.aimage_generation.value, False) is not True
-            and litellm_params.get(CallTypes.atranscription.value, False) is not True
-        )
+        is_sync_request = self._is_sync_litellm_request(litellm_params)
 
         try:
             start_time, end_time = self._failure_handler_helper_fn(
@@ -3311,9 +3370,50 @@ class Logging(LiteLLMLoggingBaseClass):
     def get_combined_callback_list(
         self, dynamic_success_callbacks: Optional[List], global_callbacks: List
     ) -> List:
-        if dynamic_success_callbacks is None:
-            return list(global_callbacks)
-        return list(set(dynamic_success_callbacks + global_callbacks))
+        """Merge dynamic and global callbacks; dedupe duplicate list entries only."""
+        combined_callbacks = (dynamic_success_callbacks or []) + list(global_callbacks)
+        deduped_callbacks: List[Any] = []
+        seen_callback_keys = set()
+
+        for callback in combined_callbacks:
+            callback_key = self._get_callback_dedupe_key(callback)
+            if callback_key in seen_callback_keys:
+                continue
+            seen_callback_keys.add(callback_key)
+            deduped_callbacks.append(callback)
+
+        return deduped_callbacks
+
+    @staticmethod
+    def _normalize_callback_slug(raw_name: str) -> str:
+        normalized = (
+            raw_name.lower()
+            .replace("-", "")
+            .replace("_", "")
+            .replace(" ", "")
+            .replace("logger", "")
+        )
+        return normalized
+
+    def _get_callback_dedupe_key(self, callback: Any):
+        """
+        Stable key for duplicate entries in a merged callback *list* only.
+        """
+        if isinstance(callback, str):
+            callback_name = callback.lower()
+            if callback_name in litellm._known_custom_logger_compatible_callbacks:
+                return ("integration", self._normalize_callback_slug(callback_name))
+            return ("string", callback_name)
+
+        if isinstance(callback, CustomLogger):
+            callback_name = getattr(callback, "callback_name", None)
+            identity_source = callback_name or callback.__class__.__name__
+            return ("integration", self._normalize_callback_slug(identity_source))
+
+        if callable(callback):
+            return ("callable", self._get_callback_name(callback))
+
+        return ("object", str(callback))
 
     def _remove_internal_litellm_callbacks(self, callbacks: List) -> List:
         """

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -1808,8 +1808,10 @@ class CustomStreamWrapper:
                     processed_chunk, None, None, cache_hit
                 )
             )
-        ## SYNC LOGGING
-        self.logging_obj.success_handler(processed_chunk, None, None, cache_hit)
+        ## SYNC LOGGING — only for sync SDK entrypoints; async proxy paths export via async_success_handler
+        litellm_params = self.logging_obj.model_call_details.get("litellm_params", {})
+        if self.logging_obj._is_sync_litellm_request(litellm_params):
+            self.logging_obj.success_handler(processed_chunk, None, None, cache_hit)
 
     def finish_reason_handler(self):
         model_response = self.model_response_creator()
@@ -2207,20 +2209,12 @@ class CustomStreamWrapper:
                     )
                 else:
                     asyncio.create_task(
-                        self.logging_obj.async_success_handler(
+                        self.logging_obj.dispatch_success_handlers(
                             complete_streaming_response,
                             cache_hit=cache_hit,
                             start_time=None,
                             end_time=None,
                         )
-                    )
-
-                    executor.submit(
-                        self.logging_obj.success_handler,
-                        complete_streaming_response,
-                        cache_hit=cache_hit,
-                        start_time=None,
-                        end_time=None,
                     )
 
                 raise StopAsyncIteration  # Re-raise StopIteration

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -2208,6 +2208,9 @@ class CustomStreamWrapper:
                         cache_hit,
                     )
                 else:
+                    # prefer_async_handlers routes CustomLogger to async_success_handler
+                    # when consumers use ``async for`` on sync-SDK streams. Legacy string
+                    # callbacks still run via executor.submit inside dispatch_success_handlers.
                     asyncio.create_task(
                         self.logging_obj.dispatch_success_handlers(
                             complete_streaming_response,

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -2214,6 +2214,7 @@ class CustomStreamWrapper:
                             cache_hit=cache_hit,
                             start_time=None,
                             end_time=None,
+                            prefer_async_handlers=True,
                         )
                     )
 

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -1290,7 +1290,7 @@ class ProxyBaseLLMRequestProcessing:
                 # (ProxyLogging._fire_deferred_stream_logging) fires the
                 # closure after the full streaming pipeline finishes.
                 # The closure runs non-apply_guardrail hooks on the
-                # assembled response, then fires both logging handlers.
+                # assembled response, then fires success logging.
                 # Only for CustomStreamWrapper — raw async generators from
                 # passthrough routes bypass CSW and would orphan the closure.
                 from litellm.litellm_core_utils.streaming_handler import (
@@ -1411,7 +1411,7 @@ class ProxyBaseLLMRequestProcessing:
                     logging_obj._on_deferred_stream_complete = None  # type: ignore[union-attr]
                     try:
                         asyncio.create_task(
-                            logging_obj.async_success_handler(
+                            logging_obj.dispatch_success_handlers(
                                 response,
                                 cache_hit=None,
                                 start_time=None,
@@ -1639,7 +1639,7 @@ class ProxyBaseLLMRequestProcessing:
     ) -> None:
         """
         Run non-streaming post-call guardrail hooks on an assembled streaming
-        response, then fire both async and sync logging handlers.
+        response, then fire success logging via ``dispatch_success_handlers``.
 
         Called by ProxyLogging._fire_deferred_stream_logging after the full
         streaming pipeline (including unified_guardrail end-of-stream blocks)
@@ -1655,8 +1655,6 @@ class ProxyBaseLLMRequestProcessing:
         Extracted as a static method so tests can call the production
         implementation directly rather than reimplementing the closure.
         """
-        from litellm.litellm_core_utils.thread_pool_executor import executor
-
         _response = assembled_response
         try:
             from litellm.proxy.proxy_server import llm_router as _global_llm_router
@@ -1716,7 +1714,7 @@ class ProxyBaseLLMRequestProcessing:
         finally:
             try:
                 asyncio.create_task(
-                    captured_logging_obj.async_success_handler(
+                    captured_logging_obj.dispatch_success_handlers(
                         _response,
                         cache_hit=cache_hit,
                         start_time=None,

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -1422,22 +1422,6 @@ class ProxyBaseLLMRequestProcessing:
                         verbose_proxy_logger.exception(
                             "Error in orphaned streaming async logging: %s", e
                         )
-                    try:
-                        from litellm.litellm_core_utils.thread_pool_executor import (
-                            executor as _exc,
-                        )
-
-                        _exc.submit(
-                            logging_obj.success_handler,
-                            response,
-                            cache_hit=None,
-                            start_time=None,
-                            end_time=None,
-                        )
-                    except Exception as e:
-                        verbose_proxy_logger.exception(
-                            "Error in orphaned streaming sync logging: %s", e
-                        )
 
         # Always return the client-requested model name (not provider-prefixed internal identifiers)
         # for OpenAI-compatible responses.

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -1416,6 +1416,7 @@ class ProxyBaseLLMRequestProcessing:
                                 cache_hit=None,
                                 start_time=None,
                                 end_time=None,
+                                prefer_async_handlers=True,
                             )
                         )
                     except Exception as e:
@@ -1697,12 +1698,18 @@ class ProxyBaseLLMRequestProcessing:
             )
         finally:
             try:
+                # Proxy streaming always runs in async context and proxy spend
+                # logging is async-only; force async dispatch so DB/spend
+                # callbacks fire regardless of the call-type heuristic in
+                # _is_sync_litellm_request (which only recognizes a subset of
+                # async markers stored in litellm_params).
                 asyncio.create_task(
                     captured_logging_obj.dispatch_success_handlers(
                         _response,
                         cache_hit=cache_hit,
                         start_time=None,
                         end_time=None,
+                        prefer_async_handlers=True,
                     )
                 )
             except Exception as e:

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -1723,21 +1723,7 @@ class ProxyBaseLLMRequestProcessing:
                 )
             except Exception as e:
                 verbose_proxy_logger.exception(
-                    "Error in deferred streaming async logging: %s",
-                    e,
-                )
-
-            try:
-                executor.submit(
-                    captured_logging_obj.success_handler,
-                    _response,
-                    cache_hit=cache_hit,
-                    start_time=None,
-                    end_time=None,
-                )
-            except Exception as e:
-                verbose_proxy_logger.exception(
-                    "Error in deferred streaming sync logging: %s",
+                    "Error in deferred streaming success logging: %s",
                     e,
                 )
 

--- a/litellm/proxy/pass_through_endpoints/streaming_handler.py
+++ b/litellm/proxy/pass_through_endpoints/streaming_handler.py
@@ -144,11 +144,16 @@ class PassThroughStreamingHandler:
                 end_time=end_time,
                 model=model,
             )
+            # Always reached from an async context (anthropic_messages,
+            # google_genai, and proxy pass-through stream tasks). prefer_async_handlers
+            # keeps async-only loggers running even when call_type isn't pass_through
+            # and litellm_params lacks an async flag (e.g. aanthropic_messages).
             await litellm_logging_obj.dispatch_success_handlers(
                 result=standard_logging_response_object,
                 start_time=start_time,
                 end_time=end_time,
                 cache_hit=False,
+                prefer_async_handlers=True,
                 **kwargs,
             )
         except Exception as e:

--- a/litellm/proxy/pass_through_endpoints/streaming_handler.py
+++ b/litellm/proxy/pass_through_endpoints/streaming_handler.py
@@ -7,7 +7,6 @@ import httpx
 import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
-from litellm.litellm_core_utils.thread_pool_executor import executor
 from litellm.proxy._types import PassThroughEndpointLoggingResultValues
 from litellm.proxy.common_request_processing import ProxyBaseLLMRequestProcessing
 from litellm.types.passthrough_endpoints.pass_through_endpoints import EndpointType
@@ -145,25 +144,11 @@ class PassThroughStreamingHandler:
                 end_time=end_time,
                 model=model,
             )
-            await litellm_logging_obj.async_success_handler(
+            await litellm_logging_obj.dispatch_success_handlers(
                 result=standard_logging_response_object,
                 start_time=start_time,
                 end_time=end_time,
                 cache_hit=False,
-                **kwargs,
-            )
-            if (
-                litellm_logging_obj._should_run_sync_callbacks_for_async_calls()
-                is False
-            ):
-                return
-
-            executor.submit(
-                litellm_logging_obj.success_handler,
-                result=standard_logging_response_object,
-                end_time=end_time,
-                cache_hit=False,
-                start_time=start_time,
                 **kwargs,
             )
         except Exception as e:

--- a/litellm/proxy/pass_through_endpoints/success_handler.py
+++ b/litellm/proxy/pass_through_endpoints/success_handler.py
@@ -94,6 +94,13 @@ class PassThroughEndpointLogging:
         **kwargs,
     ):
         """Log pass-through success via the shared async dispatch path."""
+        # Always reached from pass_through_async_success_handler, which runs in
+        # an async context. call_type is "pass_through_endpoint" here, so the
+        # passthrough guard in dispatch_success_handlers already forces the
+        # async handler to run; pass prefer_async_handlers explicitly to match
+        # the streaming sibling (_route_streaming_logging_to_handler) and keep
+        # async-only loggers (e.g. the proxy spend logger) firing regardless of
+        # how the call-type classification evolves.
         await logging_obj.dispatch_success_handlers(
             result=(
                 json.dumps(result)
@@ -103,6 +110,7 @@ class PassThroughEndpointLogging:
             start_time=start_time,
             end_time=end_time,
             cache_hit=False,
+            prefer_async_handlers=True,
             **kwargs,
         )
 

--- a/litellm/proxy/pass_through_endpoints/success_handler.py
+++ b/litellm/proxy/pass_through_endpoints/success_handler.py
@@ -11,7 +11,6 @@ from litellm.types.passthrough_endpoints.pass_through_endpoints import (
     PassthroughStandardLoggingPayload,
 )
 from litellm.types.utils import StandardPassThroughResponseObject
-from litellm.utils import executor as thread_pool_executor
 
 from .llm_provider_handlers.anthropic_passthrough_logging_handler import (
     AnthropicPassthroughLoggingHandler,
@@ -94,19 +93,8 @@ class PassThroughEndpointLogging:
         cache_hit: bool,
         **kwargs,
     ):
-        """Helper function to handle both sync and async logging operations"""
-        # Submit to thread pool for sync logging
-        thread_pool_executor.submit(
-            logging_obj.success_handler,
-            standard_logging_response_object,
-            start_time,
-            end_time,
-            cache_hit,
-            **kwargs,
-        )
-
-        # Handle async logging
-        await logging_obj.async_success_handler(
+        """Log pass-through success via the shared async dispatch path."""
+        await logging_obj.dispatch_success_handlers(
             result=(
                 json.dumps(result)
                 if isinstance(result, dict)

--- a/tests/pass_through_unit_tests/test_unit_test_streaming.py
+++ b/tests/pass_through_unit_tests/test_unit_test_streaming.py
@@ -97,6 +97,65 @@ async def test_chunk_processor_yields_raw_bytes(endpoint_type, url_route):
     ), "Collected chunks do not match raw chunks"
 
 
+@pytest.mark.asyncio
+async def test_route_streaming_logging_runs_async_handler_for_sdk_passthrough():
+    """
+    SDK pass-through streaming (anthropic_messages, google generate_content) must run
+    the async success handler so async-only loggers record the assembled stream.
+
+    Regression for duplicate-trace dedupe: dispatch_success_handlers treated these as
+    sync SDK requests because call_type is not ``pass_through_endpoint`` and
+    litellm_params carries no ``acompletion`` flag, so only the sync success_handler
+    ran and CustomLogger.async_log_success_event never fired.
+    """
+    import time
+
+    from litellm.types.utils import CallTypes
+
+    logging_obj = LiteLLMLoggingObj(
+        model="claude-sonnet-4-5",
+        messages=[{"role": "user", "content": "hi"}],
+        stream=True,
+        call_type=CallTypes.anthropic_messages.value,
+        start_time=time.time(),
+        litellm_call_id="test-id",
+        function_id="fn",
+    )
+    logging_obj.model_call_details["litellm_params"] = {"anthropic_messages": True}
+
+    with (
+        patch.object(
+            PassThroughStreamingHandler,
+            "_build_passthrough_logging_result",
+            return_value=({"id": "slp"}, {}),
+        ),
+        patch.object(
+            logging_obj, "async_success_handler", new_callable=AsyncMock
+        ) as mock_async,
+        patch.object(
+            logging_obj, "success_handler", new_callable=MagicMock
+        ) as mock_sync,
+        patch.object(
+            logging_obj,
+            "_should_run_sync_callbacks_for_async_calls",
+            return_value=False,
+        ),
+    ):
+        await PassThroughStreamingHandler._route_streaming_logging_to_handler(
+            litellm_logging_obj=logging_obj,
+            passthrough_success_handler_obj=MagicMock(),
+            url_route="/v1/messages",
+            request_body={},
+            endpoint_type=EndpointType.ANTHROPIC,
+            start_time=datetime.now(),
+            raw_bytes=[],
+            end_time=datetime.now(),
+        )
+
+    mock_async.assert_awaited_once()
+    mock_sync.assert_not_called()
+
+
 def test_convert_raw_bytes_to_str_lines():
     """
     Test that the _convert_raw_bytes_to_str_lines method correctly converts raw bytes to a list of strings

--- a/tests/pass_through_unit_tests/test_unit_test_streaming.py
+++ b/tests/pass_through_unit_tests/test_unit_test_streaming.py
@@ -156,6 +156,64 @@ async def test_route_streaming_logging_runs_async_handler_for_sdk_passthrough():
     mock_sync.assert_not_called()
 
 
+@pytest.mark.asyncio
+async def test_handle_logging_runs_async_handler_for_passthrough():
+    """
+    Non-streaming pass-through logging (_handle_logging) must always run the
+    async success handler so async-only loggers (e.g. the proxy spend logger)
+    record the request.
+
+    _handle_logging is only ever reached from pass_through_async_success_handler
+    (an async context), so it forces async dispatch via prefer_async_handlers.
+    This pins that contract independent of the call-type classification: even a
+    call_type that _is_sync_litellm_request would classify as sync (here
+    "completion" with no async marker in litellm_params) must still reach
+    async_success_handler. Without prefer_async_handlers=True the sync-only
+    branch would return early and async_log_success_event would never fire.
+    """
+    import time
+
+    from litellm.types.utils import CallTypes
+
+    logging_obj = LiteLLMLoggingObj(
+        model="claude-sonnet-4-5",
+        messages=[{"role": "user", "content": "hi"}],
+        stream=False,
+        call_type=CallTypes.completion.value,
+        start_time=time.time(),
+        litellm_call_id="test-id",
+        function_id="fn",
+    )
+    logging_obj.model_call_details["litellm_params"] = {}
+
+    handler = PassThroughEndpointLogging()
+
+    with (
+        patch.object(
+            logging_obj, "async_success_handler", new_callable=AsyncMock
+        ) as mock_async,
+        patch.object(
+            logging_obj, "success_handler", new_callable=MagicMock
+        ) as mock_sync,
+        patch.object(
+            logging_obj,
+            "_should_run_sync_callbacks_for_async_calls",
+            return_value=False,
+        ),
+    ):
+        await handler._handle_logging(
+            logging_obj=logging_obj,
+            standard_logging_response_object={"id": "slp"},
+            result="",
+            start_time=datetime.now(),
+            end_time=datetime.now(),
+            cache_hit=False,
+        )
+
+    mock_async.assert_awaited_once()
+    mock_sync.assert_not_called()
+
+
 def test_convert_raw_bytes_to_str_lines():
     """
     Test that the _convert_raw_bytes_to_str_lines method correctly converts raw bytes to a list of strings

--- a/tests/proxy_unit_tests/test_proxy_reject_logging.py
+++ b/tests/proxy_unit_tests/test_proxy_reject_logging.py
@@ -95,6 +95,21 @@ router = Router(
 )
 
 
+def _register_proxy_test_logger(callback_logger: testLogger) -> None:
+    """
+    Register the test logger on global callback lists.
+
+    ``function_setup`` dedupes by object identity; each parametrized case
+    constructs a new ``testLogger`` and must replace the global lists, not
+    only ``litellm.callbacks``.
+    """
+    litellm.callbacks = [callback_logger]
+    litellm.success_callback = [callback_logger]
+    litellm.failure_callback = [callback_logger]
+    litellm._async_success_callback = [callback_logger]
+    litellm._async_failure_callback = [callback_logger]
+
+
 @pytest.mark.parametrize(
     "route, body",
     [
@@ -115,7 +130,7 @@ router = Router(
             "/v1/embeddings",
             {
                 "input": "The food was delicious and the waiter...",
-                "model": "text-embedding-ada-002",
+                "model": "fake-model",
                 "encoding_format": "float",
             },
         ),
@@ -133,7 +148,7 @@ async def test_chat_completion_request_with_redaction(route, body):
 
     setattr(proxy_server, "llm_router", router)
     _test_logger = testLogger()
-    litellm.callbacks = [_test_logger]
+    _register_proxy_test_logger(_test_logger)
     litellm.set_verbose = True
 
     # Prepare the query string

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -787,6 +787,11 @@ def test_success_handler_runs_sync_callbacks_for_sync_requests(logging_obj, call
     dummy_logger.log_stream_event.assert_not_called()
 
 
+def test_is_sync_litellm_request():
+    assert LitellmLogging._is_sync_litellm_request({}) is True
+    assert LitellmLogging._is_sync_litellm_request({"acompletion": True}) is False
+
+
 @pytest.mark.asyncio
 async def test_dispatch_success_handlers_invokes_callbacks_once_for_final_stream(
     logging_obj,

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -862,21 +862,125 @@ async def test_dispatch_success_handlers_skips_duplicate_final_stream_dispatch(
 
 
 @pytest.mark.asyncio
-async def test_async_success_handler_skips_duplicate_final_stream_emission(logging_obj):
-    logging_obj.model_call_details["async_complete_streaming_response"] = (
-        ModelResponse()
+async def test_dispatch_success_handlers_invokes_callbacks_once_for_final_stream(
+    logging_obj,
+):
+    """Final-stream dispatch must export once; a second dispatch must not re-run callbacks."""
+    import asyncio
+
+    import litellm
+    from litellm.integrations.custom_logger import CustomLogger
+
+    class MockCallback(CustomLogger):
+        pass
+
+    mock_callback = MockCallback()
+    original_async_callbacks = list(litellm._async_success_callback or [])
+    litellm._async_success_callback = [mock_callback]
+
+    result = ModelResponse(
+        id="resp-dedupe",
+        model="gpt-4o-mini",
+        choices=[
+            {
+                "message": {"role": "assistant", "content": "hi"},
+                "finish_reason": "stop",
+                "index": 0,
+            }
+        ],
+        usage={"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
     )
 
-    with (
-        patch.object(
-            logging_obj, "_success_handler_helper_fn", return_value=(None, None, None)
-        ),
-        patch.object(logging_obj, "get_combined_callback_list", return_value=[]),
-    ):
-        await logging_obj.async_success_handler(result=ModelResponse())
-        await logging_obj.async_success_handler(result=ModelResponse())
+    try:
+        logging_obj.stream = True
+        logging_obj.model_call_details["litellm_params"] = {"acompletion": True}
 
-    assert logging_obj.model_call_details.get("has_logged_async_success_final") is True
+        with (
+            patch.object(
+                mock_callback, "async_log_success_event", new_callable=AsyncMock
+            ) as mock_async_log,
+            patch.object(mock_callback, "log_success_event") as mock_sync_log,
+            patch.object(
+                logging_obj,
+                "_success_handler_helper_fn",
+                return_value=(time.time(), time.time(), result),
+            ),
+            patch.object(
+                logging_obj,
+                "_get_assembled_streaming_response",
+                return_value=result,
+            ),
+            patch.object(
+                logging_obj,
+                "_should_run_sync_callbacks_for_async_calls",
+                return_value=True,
+            ),
+        ):
+            await logging_obj.dispatch_success_handlers(result=result)
+            await logging_obj.dispatch_success_handlers(result=result)
+            await asyncio.sleep(0.5)
+
+        mock_async_log.assert_awaited_once()
+        mock_sync_log.assert_not_called()
+    finally:
+        litellm._async_success_callback = original_async_callbacks
+
+
+@pytest.mark.asyncio
+async def test_dispatch_success_handlers_sync_path_invokes_callback_once_for_final_stream(
+    logging_obj,
+):
+    """Sync dispatch path must also dedupe when dispatch is called twice."""
+    import litellm
+    from litellm.integrations.custom_logger import CustomLogger
+
+    class MockCallback(CustomLogger):
+        pass
+
+    mock_callback = MockCallback()
+    original_success_callbacks = list(litellm.success_callback or [])
+    litellm.success_callback = [mock_callback]
+
+    result = ModelResponse(
+        id="resp-sync-dedupe",
+        model="gpt-4o-mini",
+        choices=[
+            {
+                "message": {"role": "assistant", "content": "hi"},
+                "finish_reason": "stop",
+                "index": 0,
+            }
+        ],
+        usage={"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    )
+
+    try:
+        logging_obj.stream = True
+        logging_obj.model_call_details["litellm_params"] = {}
+
+        with (
+            patch.object(mock_callback, "log_success_event") as mock_sync_log,
+            patch.object(
+                mock_callback, "async_log_success_event", new_callable=AsyncMock
+            ) as mock_async_log,
+            patch.object(
+                logging_obj,
+                "_success_handler_helper_fn",
+                return_value=(time.time(), time.time(), result),
+            ),
+            patch.object(
+                logging_obj,
+                "_get_assembled_streaming_response",
+                return_value=result,
+            ),
+        ):
+            await logging_obj.dispatch_success_handlers(result=result)
+            await logging_obj.dispatch_success_handlers(result=result)
+
+        mock_sync_log.assert_called_once()
+        mock_async_log.assert_not_awaited()
+    finally:
+        litellm.success_callback = original_success_callbacks
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -812,6 +812,55 @@ def test_get_combined_callback_list_keeps_distinct_callbacks(logging_obj):
     assert callbacks == ["datadog", "prometheus", "langfuse_otel"]
 
 
+def test_get_combined_callback_list_keeps_distinct_custom_logger_instances(logging_obj):
+    from litellm.integrations.custom_logger import CustomLogger
+
+    class DataDogLogger(CustomLogger):
+        pass
+
+    first = DataDogLogger()
+    second = DataDogLogger()
+
+    callbacks = logging_obj.get_combined_callback_list(
+        dynamic_success_callbacks=[first, second],
+        global_callbacks=[],
+    )
+
+    assert callbacks == [first, second]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_success_handlers_skips_duplicate_final_stream_dispatch(
+    logging_obj,
+):
+    logging_obj.stream = True
+    logging_obj.model_call_details["litellm_params"] = {"acompletion": True}
+    result = ModelResponse()
+
+    with (
+        patch.object(
+            logging_obj, "async_success_handler", new_callable=AsyncMock
+        ) as mock_async,
+        patch.object(
+            logging_obj, "success_handler", new_callable=MagicMock
+        ) as mock_sync,
+        patch.object(
+            logging_obj,
+            "_should_run_sync_callbacks_for_async_calls",
+            return_value=True,
+        ),
+        patch(
+            "litellm.litellm_core_utils.litellm_logging.executor.submit"
+        ) as mock_submit,
+    ):
+        await logging_obj.dispatch_success_handlers(result=result)
+        await logging_obj.dispatch_success_handlers(result=result)
+
+    mock_async.assert_awaited_once()
+    mock_sync.assert_not_called()
+    mock_submit.assert_called_once()
+
+
 @pytest.mark.asyncio
 async def test_async_success_handler_skips_duplicate_final_stream_emission(logging_obj):
     logging_obj.model_call_details["async_complete_streaming_response"] = (

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -1006,6 +1006,66 @@ async def test_dispatch_success_handlers_uses_async_path_for_acompletion(logging
     mock_sync.assert_not_called()
 
 
+@pytest.mark.asyncio
+async def test_dispatch_success_handlers_uses_async_path_for_pass_through(logging_obj):
+    from litellm.types.utils import CallTypes
+
+    logging_obj.call_type = CallTypes.pass_through.value
+    logging_obj.model_call_details["litellm_params"] = {}
+
+    with (
+        patch.object(
+            logging_obj, "async_success_handler", new_callable=AsyncMock
+        ) as mock_async,
+        patch.object(
+            logging_obj, "success_handler", new_callable=MagicMock
+        ) as mock_sync,
+        patch.object(
+            logging_obj,
+            "_should_run_sync_callbacks_for_async_calls",
+            return_value=False,
+        ),
+    ):
+        await logging_obj.dispatch_success_handlers(result={"id": "pt-1"})
+
+    mock_async.assert_awaited_once()
+    mock_sync.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_success_handlers_invokes_async_callback_for_pass_through(
+    logging_obj,
+):
+    import litellm
+    from litellm.integrations.custom_logger import CustomLogger
+    from litellm.types.utils import CallTypes
+
+    class MockCallback(CustomLogger):
+        pass
+
+    mock_callback = MockCallback()
+    original_async_callbacks = list(litellm._async_success_callback or [])
+    litellm._async_success_callback = [mock_callback]
+
+    logging_obj.call_type = CallTypes.pass_through.value
+    logging_obj.stream = False
+    logging_obj.model_call_details["litellm_params"] = {}
+
+    try:
+        with (
+            patch.object(
+                mock_callback, "async_log_success_event", new_callable=AsyncMock
+            ) as mock_async_log,
+            patch.object(mock_callback, "log_success_event") as mock_sync_log,
+        ):
+            await logging_obj.dispatch_success_handlers(result={"id": "pt-1"})
+
+        mock_async_log.assert_awaited_once()
+        mock_sync_log.assert_not_called()
+    finally:
+        litellm._async_success_callback = original_async_callbacks
+
+
 def test_success_handler_skips_guardrail_logging_hook_when_disabled(logging_obj):
     """Ensure CustomGuardrail logging_hook is skipped when should_run_guardrail is False."""
     import datetime

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -786,88 +786,11 @@ def test_success_handler_runs_sync_callbacks_for_sync_requests(logging_obj, call
     dummy_logger.log_stream_event.assert_not_called()
 
 
-def test_get_combined_callback_list_dedupes_known_callback_str_and_object(logging_obj):
-    from litellm.integrations.custom_logger import CustomLogger
-
-    class DataDogLogger(CustomLogger):
-        pass
-
-    datadog_logger_obj = DataDogLogger()
-
-    callbacks = logging_obj.get_combined_callback_list(
-        dynamic_success_callbacks=[datadog_logger_obj],
-        global_callbacks=["datadog"],
-    )
-
-    assert len(callbacks) == 1
-    assert callbacks[0] is datadog_logger_obj
-
-
-def test_get_combined_callback_list_keeps_distinct_callbacks(logging_obj):
-    callbacks = logging_obj.get_combined_callback_list(
-        dynamic_success_callbacks=["datadog", "prometheus"],
-        global_callbacks=["langfuse_otel"],
-    )
-
-    assert callbacks == ["datadog", "prometheus", "langfuse_otel"]
-
-
-def test_get_combined_callback_list_keeps_distinct_custom_logger_instances(logging_obj):
-    from litellm.integrations.custom_logger import CustomLogger
-
-    class DataDogLogger(CustomLogger):
-        pass
-
-    first = DataDogLogger()
-    second = DataDogLogger()
-
-    callbacks = logging_obj.get_combined_callback_list(
-        dynamic_success_callbacks=[first, second],
-        global_callbacks=[],
-    )
-
-    assert callbacks == [first, second]
-
-
-@pytest.mark.asyncio
-async def test_dispatch_success_handlers_skips_duplicate_final_stream_dispatch(
-    logging_obj,
-):
-    logging_obj.stream = True
-    logging_obj.model_call_details["litellm_params"] = {"acompletion": True}
-    result = ModelResponse()
-
-    with (
-        patch.object(
-            logging_obj, "async_success_handler", new_callable=AsyncMock
-        ) as mock_async,
-        patch.object(
-            logging_obj, "success_handler", new_callable=MagicMock
-        ) as mock_sync,
-        patch.object(
-            logging_obj,
-            "_should_run_sync_callbacks_for_async_calls",
-            return_value=True,
-        ),
-        patch(
-            "litellm.litellm_core_utils.litellm_logging.executor.submit"
-        ) as mock_submit,
-    ):
-        await logging_obj.dispatch_success_handlers(result=result)
-        await logging_obj.dispatch_success_handlers(result=result)
-
-    mock_async.assert_awaited_once()
-    mock_sync.assert_not_called()
-    mock_submit.assert_called_once()
-
-
 @pytest.mark.asyncio
 async def test_dispatch_success_handlers_invokes_callbacks_once_for_final_stream(
     logging_obj,
 ):
-    """Final-stream dispatch must export once; a second dispatch must not re-run callbacks."""
-    import asyncio
-
+    """Second final-stream dispatch must not re-export (CSW + deferred guardrail paths)."""
     import litellm
     from litellm.integrations.custom_logger import CustomLogger
 
@@ -918,7 +841,6 @@ async def test_dispatch_success_handlers_invokes_callbacks_once_for_final_stream
         ):
             await logging_obj.dispatch_success_handlers(result=result)
             await logging_obj.dispatch_success_handlers(result=result)
-            await asyncio.sleep(0.5)
 
         mock_async_log.assert_awaited_once()
         mock_sync_log.assert_not_called()
@@ -984,58 +906,10 @@ async def test_dispatch_success_handlers_sync_path_invokes_callback_once_for_fin
 
 
 @pytest.mark.asyncio
-async def test_dispatch_success_handlers_uses_async_path_for_acompletion(logging_obj):
-    logging_obj.model_call_details["litellm_params"] = {"acompletion": True}
-
-    with (
-        patch.object(
-            logging_obj, "async_success_handler", new_callable=AsyncMock
-        ) as mock_async,
-        patch.object(
-            logging_obj, "success_handler", new_callable=MagicMock
-        ) as mock_sync,
-        patch.object(
-            logging_obj,
-            "_should_run_sync_callbacks_for_async_calls",
-            return_value=False,
-        ),
-    ):
-        await logging_obj.dispatch_success_handlers(result=ModelResponse())
-
-    mock_async.assert_awaited_once()
-    mock_sync.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_dispatch_success_handlers_uses_async_path_for_pass_through(logging_obj):
-    from litellm.types.utils import CallTypes
-
-    logging_obj.call_type = CallTypes.pass_through.value
-    logging_obj.model_call_details["litellm_params"] = {}
-
-    with (
-        patch.object(
-            logging_obj, "async_success_handler", new_callable=AsyncMock
-        ) as mock_async,
-        patch.object(
-            logging_obj, "success_handler", new_callable=MagicMock
-        ) as mock_sync,
-        patch.object(
-            logging_obj,
-            "_should_run_sync_callbacks_for_async_calls",
-            return_value=False,
-        ),
-    ):
-        await logging_obj.dispatch_success_handlers(result={"id": "pt-1"})
-
-    mock_async.assert_awaited_once()
-    mock_sync.assert_not_called()
-
-
-@pytest.mark.asyncio
 async def test_dispatch_success_handlers_invokes_async_callback_for_pass_through(
     logging_obj,
 ):
+    """Pass-through must use async_success_handler (CustomLogger skips sync success_handler)."""
     import litellm
     from litellm.integrations.custom_logger import CustomLogger
     from litellm.types.utils import CallTypes

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -786,6 +786,73 @@ def test_success_handler_runs_sync_callbacks_for_sync_requests(logging_obj, call
     dummy_logger.log_stream_event.assert_not_called()
 
 
+def test_get_combined_callback_list_dedupes_known_callback_str_and_object(logging_obj):
+    from litellm.integrations.custom_logger import CustomLogger
+
+    class DataDogLogger(CustomLogger):
+        pass
+
+    datadog_logger_obj = DataDogLogger()
+
+    callbacks = logging_obj.get_combined_callback_list(
+        dynamic_success_callbacks=[datadog_logger_obj],
+        global_callbacks=["datadog"],
+    )
+
+    assert len(callbacks) == 1
+    assert callbacks[0] is datadog_logger_obj
+
+
+def test_get_combined_callback_list_keeps_distinct_callbacks(logging_obj):
+    callbacks = logging_obj.get_combined_callback_list(
+        dynamic_success_callbacks=["datadog", "prometheus"],
+        global_callbacks=["langfuse_otel"],
+    )
+
+    assert callbacks == ["datadog", "prometheus", "langfuse_otel"]
+
+
+@pytest.mark.asyncio
+async def test_async_success_handler_skips_duplicate_final_stream_emission(logging_obj):
+    logging_obj.model_call_details["async_complete_streaming_response"] = (
+        ModelResponse()
+    )
+
+    with (
+        patch.object(
+            logging_obj, "_success_handler_helper_fn", return_value=(None, None, None)
+        ),
+        patch.object(logging_obj, "get_combined_callback_list", return_value=[]),
+    ):
+        await logging_obj.async_success_handler(result=ModelResponse())
+        await logging_obj.async_success_handler(result=ModelResponse())
+
+    assert logging_obj.model_call_details.get("has_logged_async_success_final") is True
+
+
+@pytest.mark.asyncio
+async def test_dispatch_success_handlers_uses_async_path_for_acompletion(logging_obj):
+    logging_obj.model_call_details["litellm_params"] = {"acompletion": True}
+
+    with (
+        patch.object(
+            logging_obj, "async_success_handler", new_callable=AsyncMock
+        ) as mock_async,
+        patch.object(
+            logging_obj, "success_handler", new_callable=MagicMock
+        ) as mock_sync,
+        patch.object(
+            logging_obj,
+            "_should_run_sync_callbacks_for_async_calls",
+            return_value=False,
+        ),
+    ):
+        await logging_obj.dispatch_success_handlers(result=ModelResponse())
+
+    mock_async.assert_awaited_once()
+    mock_sync.assert_not_called()
+
+
 def test_success_handler_skips_guardrail_logging_hook_when_disabled(logging_obj):
     """Ensure CustomGuardrail logging_hook is skipped when should_run_guardrail is False."""
     import datetime
@@ -1351,7 +1418,7 @@ async def test_e2e_generate_cold_storage_object_key_with_custom_logger_s3_path()
     Test that _generate_cold_storage_object_key uses s3_path from custom logger instance.
     """
     from datetime import datetime, timezone
-    from unittest.mock import MagicMock, patch
+    from unittest.mock import AsyncMock, MagicMock, patch
 
     from litellm.litellm_core_utils.litellm_logging import StandardLoggingPayloadSetup
 
@@ -1404,7 +1471,7 @@ async def test_e2e_generate_cold_storage_object_key_with_logger_no_s3_path():
     Test that _generate_cold_storage_object_key falls back to empty s3_path when logger has no s3_path.
     """
     from datetime import datetime, timezone
-    from unittest.mock import MagicMock, patch
+    from unittest.mock import AsyncMock, MagicMock, patch
 
     from litellm.litellm_core_utils.litellm_logging import StandardLoggingPayloadSetup
 

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -903,6 +904,52 @@ async def test_dispatch_success_handlers_sync_path_invokes_callback_once_for_fin
         mock_async_log.assert_not_awaited()
     finally:
         litellm.success_callback = original_success_callbacks
+
+
+@pytest.mark.asyncio
+async def test_dispatch_prefer_async_handlers_runs_legacy_callbacks(
+    logging_obj,
+):
+    """``prefer_async_handlers`` must not skip executor.submit for string callbacks."""
+    result = ModelResponse(
+        id="resp-prefer-async",
+        model="gpt-4o-mini",
+        choices=[
+            {
+                "message": {"role": "assistant", "content": "hi"},
+                "finish_reason": "stop",
+                "index": 0,
+            }
+        ],
+    )
+
+    logging_obj.stream = True
+    logging_obj.model_call_details["litellm_params"] = {}
+
+    with (
+        patch.object(
+            logging_obj, "async_success_handler", new_callable=AsyncMock
+        ) as mock_async,
+        patch.object(
+            logging_obj, "success_handler", new_callable=MagicMock
+        ) as mock_sync,
+        patch.object(
+            logging_obj,
+            "_should_run_sync_callbacks_for_async_calls",
+            return_value=True,
+        ),
+        patch(
+            "litellm.litellm_core_utils.litellm_logging.executor.submit"
+        ) as mock_submit,
+    ):
+        await logging_obj.dispatch_success_handlers(
+            result=result,
+            prefer_async_handlers=True,
+        )
+
+    mock_async.assert_awaited_once()
+    mock_sync.assert_not_called()
+    mock_submit.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -787,9 +787,61 @@ def test_success_handler_runs_sync_callbacks_for_sync_requests(logging_obj, call
     dummy_logger.log_stream_event.assert_not_called()
 
 
+def _logging_obj_with_call_type(call_type: str) -> LitellmLogging:
+    return LitellmLogging(
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": "Hey"}],
+        stream=False,
+        call_type=call_type,
+        start_time=time.time(),
+        litellm_call_id="12345",
+        function_id="1245",
+    )
+
+
 def test_is_sync_litellm_request():
-    assert LitellmLogging._is_sync_litellm_request({}) is True
-    assert LitellmLogging._is_sync_litellm_request({"acompletion": True}) is False
+    """Sync/async classification mixes call_type and litellm_params flags.
+
+    get_litellm_params only stores acompletion/aembedding, so those are detected
+    via the litellm_params flags. aresponses/atranscription/aimage_generation/
+    atext_completion have no stored flag and were therefore misclassified as
+    sync; they are now detected from call_type (the SDK function name).
+    """
+    # Sync SDK entrypoints with no flag -> True.
+    for sync_call_type in (
+        "completion",
+        "text_completion",
+        "embedding",
+        "image_generation",
+        "transcription",
+        "responses",
+    ):
+        obj = _logging_obj_with_call_type(sync_call_type)
+        assert obj._is_sync_litellm_request({}) is True, sync_call_type
+
+    # Async-only call types (no flag stored by get_litellm_params) -> False,
+    # detected from call_type. This is the previously-misclassified gap.
+    for async_call_type in (
+        "aresponses",
+        "atranscription",
+        "aimage_generation",
+        "atext_completion",
+    ):
+        obj = _logging_obj_with_call_type(async_call_type)
+        assert obj._is_sync_litellm_request({}) is False, async_call_type
+
+    # "a"-prefixed but sync call type must not be misread as async.
+    assert (
+        _logging_obj_with_call_type("anthropic_messages")._is_sync_litellm_request({})
+        is True
+    )
+
+    # acompletion/aembedding are detected from the stored litellm_params flags,
+    # not call_type (matching get_litellm_params behavior).
+    sync_obj = _logging_obj_with_call_type("completion")
+    assert sync_obj._is_sync_litellm_request({"acompletion": True}) is False
+    assert sync_obj._is_sync_litellm_request({"aembedding": True}) is False
+    assert sync_obj._is_sync_litellm_request({"aresponses": True}) is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -787,61 +787,9 @@ def test_success_handler_runs_sync_callbacks_for_sync_requests(logging_obj, call
     dummy_logger.log_stream_event.assert_not_called()
 
 
-def _logging_obj_with_call_type(call_type: str) -> LitellmLogging:
-    return LitellmLogging(
-        model="gpt-4o-mini",
-        messages=[{"role": "user", "content": "Hey"}],
-        stream=False,
-        call_type=call_type,
-        start_time=time.time(),
-        litellm_call_id="12345",
-        function_id="1245",
-    )
-
-
 def test_is_sync_litellm_request():
-    """Sync/async classification mixes call_type and litellm_params flags.
-
-    get_litellm_params only stores acompletion/aembedding, so those are detected
-    via the litellm_params flags. aresponses/atranscription/aimage_generation/
-    atext_completion have no stored flag and were therefore misclassified as
-    sync; they are now detected from call_type (the SDK function name).
-    """
-    # Sync SDK entrypoints with no flag -> True.
-    for sync_call_type in (
-        "completion",
-        "text_completion",
-        "embedding",
-        "image_generation",
-        "transcription",
-        "responses",
-    ):
-        obj = _logging_obj_with_call_type(sync_call_type)
-        assert obj._is_sync_litellm_request({}) is True, sync_call_type
-
-    # Async-only call types (no flag stored by get_litellm_params) -> False,
-    # detected from call_type. This is the previously-misclassified gap.
-    for async_call_type in (
-        "aresponses",
-        "atranscription",
-        "aimage_generation",
-        "atext_completion",
-    ):
-        obj = _logging_obj_with_call_type(async_call_type)
-        assert obj._is_sync_litellm_request({}) is False, async_call_type
-
-    # "a"-prefixed but sync call type must not be misread as async.
-    assert (
-        _logging_obj_with_call_type("anthropic_messages")._is_sync_litellm_request({})
-        is True
-    )
-
-    # acompletion/aembedding are detected from the stored litellm_params flags,
-    # not call_type (matching get_litellm_params behavior).
-    sync_obj = _logging_obj_with_call_type("completion")
-    assert sync_obj._is_sync_litellm_request({"acompletion": True}) is False
-    assert sync_obj._is_sync_litellm_request({"aembedding": True}) is False
-    assert sync_obj._is_sync_litellm_request({"aresponses": True}) is False
+    assert LitellmLogging._is_sync_litellm_request({}) is True
+    assert LitellmLogging._is_sync_litellm_request({"acompletion": True}) is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
@@ -569,8 +569,6 @@ async def test_streaming_with_usage_and_logging(sync_mode: bool):
                 == final_usage_block
             )
 
-        print(mock_log_success_event.call_args.kwargs.keys())
-
 
 def test_streaming_handler_with_stop_chunk(
     initialized_custom_stream_wrapper: CustomStreamWrapper,
@@ -2036,23 +2034,19 @@ async def test_azure_streaming_role_preserved_with_include_usage(sync_mode: bool
             chunks.append(chunk)
 
     # The prompt_filter chunk should be forwarded with choices=[]
-    assert len(chunks[0].choices) == 0, (
-        f"Expected prompt_filter chunk with choices=[], got {len(chunks[0].choices)} choices"
-    )
+    assert (
+        len(chunks[0].choices) == 0
+    ), f"Expected prompt_filter chunk with choices=[], got {len(chunks[0].choices)} choices"
 
     # At least one chunk must have role='assistant' in its delta
     has_role = any(
-        len(c.choices) > 0
-        and getattr(c.choices[0].delta, "role", None) == "assistant"
+        len(c.choices) > 0 and getattr(c.choices[0].delta, "role", None) == "assistant"
         for c in chunks
     )
     assert has_role, (
         "No chunk contained role='assistant' in delta (issue #24221). "
         "Chunk deltas: "
-        + str([
-            c.choices[0].delta if c.choices else "no choices"
-            for c in chunks
-        ])
+        + str([c.choices[0].delta if c.choices else "no choices" for c in chunks])
     )
 
 

--- a/tests/test_litellm/proxy/guardrails/test_deferred_guardrail_logging.py
+++ b/tests/test_litellm/proxy/guardrails/test_deferred_guardrail_logging.py
@@ -1033,9 +1033,9 @@ class TestDeferredStreamingClosure:
             litellm_call_id="test-id",
             function_id="fn",
         )
-        # call_type "completion" with no async marker -> classified sync.
+        # litellm_params with no recognized async marker -> classified sync.
         logging_obj.model_call_details["litellm_params"] = {}
-        assert logging_obj._is_sync_litellm_request({}) is True
+        assert LiteLLMLoggingObj._is_sync_litellm_request({}) is True
 
         with (
             patch.object(

--- a/tests/test_litellm/proxy/guardrails/test_deferred_guardrail_logging.py
+++ b/tests/test_litellm/proxy/guardrails/test_deferred_guardrail_logging.py
@@ -38,6 +38,24 @@ from litellm.types.guardrails import GuardrailEventHooks
 # ---------------------------------------------------------------------------
 
 
+def _attach_mock_success_dispatch(mock_logging_obj, async_success_fn):
+    """Match production entrypoint: ``_run_deferred_stream_guardrails`` uses dispatch."""
+
+    async def dispatch_success_handlers(
+        result=None, start_time=None, end_time=None, cache_hit=None, **kwargs
+    ):
+        await async_success_fn(
+            result,
+            start_time=start_time,
+            end_time=end_time,
+            cache_hit=cache_hit,
+            **kwargs,
+        )
+
+    mock_logging_obj.dispatch_success_handlers = dispatch_success_handlers
+    mock_logging_obj.async_success_handler = async_success_fn
+
+
 class PostCallGuardrail(CustomGuardrail):
     """A post-call guardrail."""
 
@@ -454,7 +472,7 @@ class TestDeferredStreamingClosure:
         async def track_async_success(*args, **kwargs):
             pass
 
-        mock_logging_obj.async_success_handler = track_async_success
+        _attach_mock_success_dispatch(mock_logging_obj, track_async_success)
 
         tracking_guardrail = TrackingGuardrail()
         tracking_logger = TrackingLogger()
@@ -511,7 +529,7 @@ class TestDeferredStreamingClosure:
             nonlocal logged_response
             logged_response = args[0] if args else None
 
-        mock_logging_obj.async_success_handler = track_async_success
+        _attach_mock_success_dispatch(mock_logging_obj, track_async_success)
 
         class ModifyingGuardrail(CustomGuardrail):
             def __init__(self):
@@ -573,7 +591,7 @@ class TestDeferredStreamingClosure:
             nonlocal logging_called
             logging_called = True
 
-        mock_logging_obj.async_success_handler = track_async_success
+        _attach_mock_success_dispatch(mock_logging_obj, track_async_success)
 
         guardrail = BlockingGuardrail()
 
@@ -621,7 +639,7 @@ class TestDeferredStreamingClosure:
         async def track_async_success(*args, **kwargs):
             pass
 
-        mock_logging_obj.async_success_handler = track_async_success
+        _attach_mock_success_dispatch(mock_logging_obj, track_async_success)
 
         guardrail = TransientErrorGuardrail()
 
@@ -656,7 +674,7 @@ class TestDeferredStreamingClosure:
             nonlocal logged_response
             logged_response = args[0] if args else None
 
-        mock_logging_obj.async_success_handler = track_async_success
+        _attach_mock_success_dispatch(mock_logging_obj, track_async_success)
 
         class TestGuardrail(CustomGuardrail):
             def __init__(self):
@@ -739,7 +757,7 @@ class TestDeferredStreamingClosure:
         async def track_async_success(*args, **kwargs):
             pass
 
-        mock_logging_obj.async_success_handler = track_async_success
+        _attach_mock_success_dispatch(mock_logging_obj, track_async_success)
 
         guardrail = ApplyGuardrailType()
 
@@ -792,7 +810,7 @@ class TestDeferredStreamingClosure:
         async def track_async_success(*args, **kwargs):
             pass
 
-        mock_logging_obj.async_success_handler = track_async_success
+        _attach_mock_success_dispatch(mock_logging_obj, track_async_success)
 
         guardrail = IteratorHookGuardrail()
 
@@ -847,7 +865,7 @@ class TestDeferredStreamingClosure:
         async def track_async_success(*args, **kwargs):
             pass
 
-        mock_logging_obj.async_success_handler = track_async_success
+        _attach_mock_success_dispatch(mock_logging_obj, track_async_success)
 
         guardrail = InspectingGuardrail()
 
@@ -914,7 +932,7 @@ class TestDeferredStreamingClosure:
         async def track_async_success(*args, **kwargs):
             pass
 
-        mock_logging_obj.async_success_handler = track_async_success
+        _attach_mock_success_dispatch(mock_logging_obj, track_async_success)
 
         guardrail_a = TaggedGuardrail("guardrail-a")
         guardrail_b = TaggedGuardrail("guardrail-b")
@@ -962,7 +980,7 @@ class TestDeferredStreamingClosure:
             nonlocal logging_called
             logging_called = True
 
-        mock_logging_obj.async_success_handler = track_async_success
+        _attach_mock_success_dispatch(mock_logging_obj, track_async_success)
 
         def exploding_merge(data, llm_router):
             raise RuntimeError("Simulated init failure")
@@ -1054,7 +1072,7 @@ class TestFireDeferredStreamLogging:
             nonlocal logged_response
             logged_response = args[0] if args else None
 
-        mock_logging_obj.async_success_handler = track_async_success
+        _attach_mock_success_dispatch(mock_logging_obj, track_async_success)
 
         class InfoWritingGuardrail(CustomGuardrail):
             def __init__(self):

--- a/tests/test_litellm/proxy/guardrails/test_deferred_guardrail_logging.py
+++ b/tests/test_litellm/proxy/guardrails/test_deferred_guardrail_logging.py
@@ -18,7 +18,7 @@ import asyncio
 import os
 import sys
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -1003,6 +1003,67 @@ class TestDeferredStreamingClosure:
         assert (
             logging_called is True
         ), "Logging must fire even when guardrail initialization raises"
+
+    @pytest.mark.asyncio
+    async def test_deferred_logging_forces_async_for_sync_classified_call_type(self):
+        """
+        Regression: proxy deferred streaming logging must reach the async success
+        handler (which runs the async-only DB/spend logger) even when the call
+        type is classified as a sync SDK request by _is_sync_litellm_request.
+
+        Without prefer_async_handlers=True, an async proxy stream whose
+        litellm_params lacks a recognized async marker would enter the sync
+        branch of dispatch_success_handlers and silently skip spend tracking.
+
+        Uses the real dispatch_success_handlers via the production
+        _run_deferred_stream_guardrails entrypoint.
+        """
+        import time
+
+        from litellm.litellm_core_utils.litellm_logging import (
+            Logging as LiteLLMLoggingObj,
+        )
+
+        logging_obj = LiteLLMLoggingObj(
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "hi"}],
+            stream=True,
+            call_type="completion",  # not pass_through_endpoint
+            start_time=time.time(),
+            litellm_call_id="test-id",
+            function_id="fn",
+        )
+        # litellm_params with no recognized async marker -> classified sync.
+        logging_obj.model_call_details["litellm_params"] = {}
+        assert LiteLLMLoggingObj._is_sync_litellm_request({}) is True
+
+        with (
+            patch.object(
+                logging_obj, "async_success_handler", new_callable=AsyncMock
+            ) as mock_async,
+            patch.object(
+                logging_obj, "success_handler", new_callable=MagicMock
+            ) as mock_sync,
+            patch.object(
+                logging_obj,
+                "_should_run_sync_callbacks_for_async_calls",
+                return_value=False,
+            ),
+            patch("litellm.callbacks", [PostCallGuardrail()]),
+        ):
+            await ProxyBaseLLMRequestProcessing._run_deferred_stream_guardrails(
+                captured_data={"model": "gpt-4o-mini", "metadata": {}},
+                captured_user_api_key_dict=UserAPIKeyAuth(api_key="test"),
+                captured_logging_obj=logging_obj,
+                assembled_response=MagicMock(),
+                cache_hit=False,
+            )
+
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+
+        mock_async.assert_awaited_once()
+        mock_sync.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_litellm/proxy/guardrails/test_deferred_guardrail_logging.py
+++ b/tests/test_litellm/proxy/guardrails/test_deferred_guardrail_logging.py
@@ -1033,9 +1033,9 @@ class TestDeferredStreamingClosure:
             litellm_call_id="test-id",
             function_id="fn",
         )
-        # litellm_params with no recognized async marker -> classified sync.
+        # call_type "completion" with no async marker -> classified sync.
         logging_obj.model_call_details["litellm_params"] = {}
-        assert LiteLLMLoggingObj._is_sync_litellm_request({}) is True
+        assert logging_obj._is_sync_litellm_request({}) is True
 
         with (
             patch.object(


### PR DESCRIPTION
Automated copy of https://github.com/BerriAI/litellm/pull/29089 into `litellm_internal_staging` for pr-babysitter.

Original head: `mubashir1osmani/litellm:litellm__duplicate_cc_trce` @ `f770d8e98716`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit f770d8e987161b0b78df1f590435e4037573abd9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->