### PR TITLE
fix(passthrough): run async success handler for SDK pass-through streaming

### DIFF
--- a/litellm/proxy/pass_through_endpoints/streaming_handler.py
+++ b/litellm/proxy/pass_through_endpoints/streaming_handler.py
@@ -144,11 +144,16 @@ class PassThroughStreamingHandler:
                 end_time=end_time,
                 model=model,
             )
+            # Always reached from an async context (anthropic_messages,
+            # google_genai, and proxy pass-through stream tasks). prefer_async_handlers
+            # keeps async-only loggers running even when call_type isn't pass_through
+            # and litellm_params lacks an async flag (e.g. aanthropic_messages).
             await litellm_logging_obj.dispatch_success_handlers(
                 result=standard_logging_response_object,
                 start_time=start_time,
                 end_time=end_time,
                 cache_hit=False,
+                prefer_async_handlers=True,
                 **kwargs,
             )
         except Exception as e:

--- a/tests/pass_through_unit_tests/test_unit_test_streaming.py
+++ b/tests/pass_through_unit_tests/test_unit_test_streaming.py
@@ -97,6 +97,65 @@ async def test_chunk_processor_yields_raw_bytes(endpoint_type, url_route):
     ), "Collected chunks do not match raw chunks"
 
 
+@pytest.mark.asyncio
+async def test_route_streaming_logging_runs_async_handler_for_sdk_passthrough():
+    """
+    SDK pass-through streaming (anthropic_messages, google generate_content) must run
+    the async success handler so async-only loggers record the assembled stream.
+
+    Regression for duplicate-trace dedupe: dispatch_success_handlers treated these as
+    sync SDK requests because call_type is not ``pass_through_endpoint`` and
+    litellm_params carries no ``acompletion`` flag, so only the sync success_handler
+    ran and CustomLogger.async_log_success_event never fired.
+    """
+    import time
+
+    from litellm.types.utils import CallTypes
+
+    logging_obj = LiteLLMLoggingObj(
+        model="claude-sonnet-4-5",
+        messages=[{"role": "user", "content": "hi"}],
+        stream=True,
+        call_type=CallTypes.anthropic_messages.value,
+        start_time=time.time(),
+        litellm_call_id="test-id",
+        function_id="fn",
+    )
+    logging_obj.model_call_details["litellm_params"] = {"anthropic_messages": True}
+
+    with (
+        patch.object(
+            PassThroughStreamingHandler,
+            "_build_passthrough_logging_result",
+            return_value=({"id": "slp"}, {}),
+        ),
+        patch.object(
+            logging_obj, "async_success_handler", new_callable=AsyncMock
+        ) as mock_async,
+        patch.object(
+            logging_obj, "success_handler", new_callable=MagicMock
+        ) as mock_sync,
+        patch.object(
+            logging_obj,
+            "_should_run_sync_callbacks_for_async_calls",
+            return_value=False,
+        ),
+    ):
+        await PassThroughStreamingHandler._route_streaming_logging_to_handler(
+            litellm_logging_obj=logging_obj,
+            passthrough_success_handler_obj=MagicMock(),
+            url_route="/v1/messages",
+            request_body={},
+            endpoint_type=EndpointType.ANTHROPIC,
+            start_time=datetime.now(),
+            raw_bytes=[],
+            end_time=datetime.now(),
+        )
+
+    mock_async.assert_awaited_once()
+    mock_sync.assert_not_called()
+
+
 def test_convert_raw_bytes_to_str_lines():
     """
     Test that the _convert_raw_bytes_to_str_lines method correctly converts raw bytes to a list of strings


### PR DESCRIPTION
## Relevant issues

Fixes two CircleCI failures on #29311 (internal copy of #29089). This PR targets that PR's branch so the fix lands directly on it.

## What was failing and why

Two streaming-plus-logging tests were red on #29311:

- `pass_through_unit_testing`: `tests/pass_through_unit_tests/test_anthropic_messages_passthrough.py::TestAnthropicBedrockAPI::test_anthropic_messages_litellm_router_streaming_with_logging` and the `TestAnthropicDirectAPI` variant, both with "Logging payload should not be None".
- `google_generate_content_endpoint_testing`: `tests/unified_google_tests/test_google_ai_studio.py::TestGoogleGenAIStudio::test_async_streaming_with_logging`, with `standard_logging_object is not None` failing.

Both SDK streaming paths (`aanthropic_messages`, google `agenerate_content`) export their assembled stream through `PassThroughStreamingHandler._route_streaming_logging_to_handler`, which #29089 changed to call `dispatch_success_handlers`. That method treated these calls as synchronous SDK requests because their `call_type` is not `pass_through_endpoint` and their `litellm_params` carries no `acompletion` flag. As a result only the sync `success_handler` ran, so async-only loggers (`CustomLogger.async_log_success_event`) never fired and the standard logging payload stayed `None`.

The other two CircleCI reds on #29311 are not caused by this branch: `local_testing_part1` fails on `test_vertex_ai_llama_tool_calling` with a Vertex `ACCESS_TOKEN_EXPIRED` error, and `batches_testing` fails on `test_async_file_and_batch` with a Bedrock "account is not authorized" error. Both are environment/credential issues.

## The fix

`_route_streaming_logging_to_handler` now passes `prefer_async_handlers=True`. That is always valid because the function only runs from an async context (anthropic_messages, google_genai, and proxy pass-through stream tasks). It restores the pre-#29089 behavior of awaiting `async_success_handler` and conditionally submitting the sync handler for legacy string callbacks, while keeping the new `has_dispatched_final_stream_success` dedupe guard that #29089 added to stop the duplicate Claude Code traces.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Screenshots / Proof of Fix

The new regression test `test_route_streaming_logging_runs_async_handler_for_sdk_passthrough` constructs a real `Logging` object configured like an `anthropic_messages` streaming call, drives the production `_route_streaming_logging_to_handler`, and asserts the async handler is awaited once and the sync handler is not called. It fails before the change (async awaited 0 times) and passes after.

To confirm against the originally failing CircleCI cases with real provider keys set:

```
uv run --no-sync python -m pytest \
  "tests/pass_through_unit_tests/test_anthropic_messages_passthrough.py::TestAnthropicDirectAPI::test_anthropic_messages_litellm_router_streaming_with_logging" \
  "tests/unified_google_tests/test_google_ai_studio.py::TestGoogleGenAIStudio::test_async_streaming_with_logging" \
  -vv
```

## Type

🐛 Bug Fix

## Changes

`litellm/proxy/pass_through_endpoints/streaming_handler.py`: pass `prefer_async_handlers=True` when routing assembled-stream logging, so async loggers run for SDK pass-through streaming whose `call_type` is not `pass_through_endpoint`.

`tests/pass_through_unit_tests/test_unit_test_streaming.py`: add a regression test that drives `_route_streaming_logging_to_handler` for an `anthropic_messages` streaming call and asserts the async success handler runs.


---
_Generated by [Claude Code](https://claude.ai/code/session_018Fawe7GQF6wULjPhAffmyi)_