### PR TITLE
fix(proxy): forward model_info in /health/test_connection

### DIFF
--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -1771,6 +1771,7 @@ async def test_model_connection(
         # Look up model configuration from router if model name is provided
         # This gets the litellm_params from proxy config (with resolved env vars)
         config_litellm_params: dict = {}
+        resolved_model_info: Optional[dict] = None
         if llm_router is not None:
             # Prefer disambiguation by deployment id (`model_info.id`) when
             # the caller supplies it. This is required when multiple
@@ -1791,6 +1792,9 @@ async def test_model_connection(
 
                 if deployment_by_id is not None:
                     config_litellm_params = deployment_by_id.litellm_params.model_dump(
+                        exclude_none=True
+                    )
+                    resolved_model_info = deployment_by_id.model_info.model_dump(
                         exclude_none=True
                     )
                 elif model_name:
@@ -1819,6 +1823,9 @@ async def test_model_connection(
                         config_litellm_params = dict(
                             deployments[0].get("litellm_params", {})
                         )
+                        resolved_model_info = dict(
+                            deployments[0].get("model_info", {}) or {}
+                        )
             except Exception as e:
                 verbose_proxy_logger.debug(
                     f"Could not find model {model_name} in router: {e}. "
@@ -1842,7 +1849,7 @@ async def test_model_connection(
         )
         # Include health_check_params if provided
         litellm_params = _update_litellm_params_for_health_check(
-            model_info={},
+            model_info=resolved_model_info if resolved_model_info is not None else (model_info or {}),
             litellm_params=litellm_params,
         )
         mode = mode or litellm_params.pop("mode", None)

--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -1849,7 +1849,11 @@ async def test_model_connection(
         )
         # Include health_check_params if provided
         litellm_params = _update_litellm_params_for_health_check(
-            model_info=resolved_model_info if resolved_model_info is not None else (model_info or {}),
+            model_info=(
+                resolved_model_info
+                if resolved_model_info is not None
+                else (model_info or {})
+            ),
             litellm_params=litellm_params,
         )
         mode = mode or litellm_params.pop("mode", None)

--- a/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
+++ b/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
@@ -697,6 +697,71 @@ async def test_test_model_connection_falls_back_to_deployments_zero_without_id()
 
 
 @pytest.mark.asyncio
+async def test_test_model_connection_respects_health_check_supports_max_tokens():
+    """
+    Regression test for https://github.com/BerriAI/litellm/issues/29266.
+
+    When model_info.health_check_supports_max_tokens is False, the outgoing
+    request must not include max_tokens. Previously model_info={} was hardcoded
+    in the call to _update_litellm_params_for_health_check, so the flag was
+    silently dropped and max_tokens: 5 was always injected for chat mode.
+    """
+    mock_request = MagicMock()
+    mock_user_api_key_dict = MagicMock()
+    mock_user_api_key_dict.user_id = "test-user"
+    mock_user_api_key_dict.token = "test-token"
+    mock_prisma_client = MagicMock()
+    mock_router = MagicMock()
+    mock_router.get_deployment.return_value = None
+    mock_router.get_model_list.return_value = []
+    mock_can_user_make_model_call = AsyncMock()
+    mock_ahealth_check = AsyncMock(return_value={"status": "healthy"})
+    mock_run_with_timeout = AsyncMock(return_value={"status": "healthy"})
+
+    def mock_reject_os_environ(params):
+        return None
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client),
+        patch("litellm.proxy.proxy_server.llm_router", mock_router),
+        patch("litellm.proxy.proxy_server.premium_user", False),
+        patch(
+            "litellm.proxy.management_endpoints.model_management_endpoints.ModelManagementAuthChecks.can_user_make_model_call",
+            mock_can_user_make_model_call,
+        ),
+        patch(
+            "litellm.proxy.health_endpoints._health_endpoints.litellm.ahealth_check",
+            mock_ahealth_check,
+        ),
+        patch(
+            "litellm.proxy.health_endpoints._health_endpoints.run_with_timeout",
+            mock_run_with_timeout,
+        ),
+        patch(
+            "litellm.proxy.health_endpoints._health_endpoints._reject_os_environ_references",
+            mock_reject_os_environ,
+        ),
+    ):
+        await health_test_model_connection(
+            request=mock_request,
+            mode="chat",
+            litellm_params={
+                "model": "azure/gpt-4o",
+                "api_key": "fake-key",
+                "api_base": "https://fake.invalid",
+            },
+            model_info={"health_check_supports_max_tokens": False},
+            user_api_key_dict=mock_user_api_key_dict,
+        )
+
+    model_params = mock_ahealth_check.call_args.kwargs.get("model_params", {})
+    assert "max_tokens" not in model_params, (
+        "max_tokens must not be sent when health_check_supports_max_tokens is False; "
+        f"got model_params={model_params}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_health_services_endpoint_datadog_llm_observability():
     """
     Verify that 'datadog_llm_observability' is accepted as a valid service

--- a/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
+++ b/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
@@ -762,6 +762,78 @@ async def test_test_model_connection_respects_health_check_supports_max_tokens()
 
 
 @pytest.mark.asyncio
+async def test_test_model_connection_uses_server_model_info_when_deployment_resolved():
+    """
+    When the router resolves a deployment by id, the server-side model_info
+    must be forwarded to the health-check helper, not the caller-supplied one.
+
+    This covers the router-resolved path for the same bug as
+    test_test_model_connection_respects_health_check_supports_max_tokens.
+    """
+    from litellm.types.router import Deployment, LiteLLM_Params
+
+    mock_request = MagicMock()
+    mock_user_api_key_dict = MagicMock()
+    mock_user_api_key_dict.user_id = "test-user"
+    mock_user_api_key_dict.token = "test-token"
+    mock_prisma_client = MagicMock()
+    mock_can_user_make_model_call = AsyncMock()
+    mock_ahealth_check = AsyncMock(return_value={"status": "healthy"})
+    mock_run_with_timeout = AsyncMock(return_value={"status": "healthy"})
+
+    server_deployment = Deployment(
+        model_name="my-model",
+        litellm_params=LiteLLM_Params(
+            model="azure/gpt-4o",
+            api_key="server-key",
+            api_base="https://server.invalid/v1",
+        ),
+        model_info={"id": "dep-1", "health_check_supports_max_tokens": False},
+    )
+    mock_router = MagicMock()
+    mock_router.get_deployment.return_value = server_deployment
+
+    def mock_reject_os_environ(params):
+        return None
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client),
+        patch("litellm.proxy.proxy_server.llm_router", mock_router),
+        patch("litellm.proxy.proxy_server.premium_user", False),
+        patch(
+            "litellm.proxy.management_endpoints.model_management_endpoints.ModelManagementAuthChecks.can_user_make_model_call",
+            mock_can_user_make_model_call,
+        ),
+        patch(
+            "litellm.proxy.health_endpoints._health_endpoints.litellm.ahealth_check",
+            mock_ahealth_check,
+        ),
+        patch(
+            "litellm.proxy.health_endpoints._health_endpoints.run_with_timeout",
+            mock_run_with_timeout,
+        ),
+        patch(
+            "litellm.proxy.health_endpoints._health_endpoints._reject_os_environ_references",
+            mock_reject_os_environ,
+        ),
+    ):
+        await health_test_model_connection(
+            request=mock_request,
+            mode="chat",
+            litellm_params={"model": "azure/gpt-4o"},
+            model_info={"id": "dep-1"},
+            user_api_key_dict=mock_user_api_key_dict,
+        )
+
+    model_params = mock_ahealth_check.call_args.kwargs.get("model_params", {})
+    assert "max_tokens" not in model_params, (
+        "max_tokens must not be sent when server model_info has "
+        "health_check_supports_max_tokens: False; "
+        f"got model_params={model_params}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_health_services_endpoint_datadog_llm_observability():
     """
     Verify that 'datadog_llm_observability' is accepted as a valid service


### PR DESCRIPTION
## Relevant issues

Fixes #29266

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting \`@greptileai\` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

To verify:

1. Start the proxy with a config that has \`model_info.health_check_supports_max_tokens: false\`:

\`\`\`yaml
model_list:
  - model_name: my-model
    litellm_params:
      model: openai/my-deployment
      api_base: https://your-endpoint
      api_key: your-key
    model_info:
      health_check_supports_max_tokens: false
\`\`\`

\`\`\`bash
python litellm/proxy/proxy_cli.py --config your-config.yaml --detailed_debug
\`\`\`

2. Hit the test connection endpoint and confirm \`max_tokens\` is absent from the outgoing request:

\`\`\`bash
curl -s -X POST http://localhost:4000/health/test_connection \
  -H "Authorization: Bearer your-master-key" \
  -H "Content-Type: application/json" \
  -d '{"mode": "chat", "litellm_params": {"model": "my-model"}, "model_info": {"health_check_supports_max_tokens": false}}'
\`\`\`

Before the fix, \`max_tokens: 5\` appeared in the outgoing request regardless of this flag. After the fix, it is absent.

## Type

Bug Fix

## Changes

\`test_model_connection\` (the UI "Test Connection" button) hardcoded \`model_info={}\` when calling \`_update_litellm_params_for_health_check\`, silently dropping flags like \`health_check_supports_max_tokens: false\`. As a result, \`max_tokens: 5\` was always injected for chat mode, causing Azure AI Foundry deployments (and similar providers that only accept \`max_completion_tokens\`) to fail the UI health check even though the background \`/health\` endpoint passed.

The fix tracks the server-side \`model_info\` when the router resolves a deployment and forwards it to the helper. When a deployment is resolved, the server-side \`model_info\` is used (routing-affecting fields like \`health_check_model\` cannot be injected from the request body after authorization). When no deployment is resolved (ad-hoc credentials), the caller-supplied \`model_info\` is forwarded directly.

Two regression tests are added: one for the ad-hoc credentials path (no router match) and one for the router-resolved-by-id path.

### Unit test results

1196 tests pass locally. The 4 failures (`test_bridge_flag_forwarded_to_file_search_emulation`, `test_E2_no_provider_config_routes_to_emulated_handler`, `test_async_non_message_items_filtered`, `test_deprecated_key_grace_period_cache_hit_path`) are pre-existing on `litellm_internal_staging` and unrelated to this PR — verified by running them against the base branch without these changes. The `test_check_licenses.py` failure is a local Python 3.10 limitation (`tomllib` is 3.11+ only); CI uses Python 3.12.