### PR TITLE
fix(router): honor internal server allowed fails policy

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -11986,11 +11986,12 @@ class Router:
 
     def get_allowed_fails_from_policy(self, exception: Exception):
         """
-        BadRequestErrorRetries: Optional[int] = None
-        AuthenticationErrorRetries: Optional[int] = None
-        TimeoutErrorRetries: Optional[int] = None
-        RateLimitErrorRetries: Optional[int] = None
-        ContentPolicyViolationErrorRetries: Optional[int] = None
+        AuthenticationErrorAllowedFails: Optional[int] = None
+        TimeoutErrorAllowedFails: Optional[int] = None
+        RateLimitErrorAllowedFails: Optional[int] = None
+        ContentPolicyViolationErrorAllowedFails: Optional[int] = None
+        InternalServerErrorAllowedFails: Optional[int] = None
+        BadRequestErrorAllowedFails: Optional[int] = None
         """
         # if we can find the exception then in the retry policy -> return the number of retries
         allowed_fails_policy: Optional[AllowedFailsPolicy] = self.allowed_fails_policy

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -12019,6 +12019,11 @@ class Router:
         ):
             return allowed_fails_policy.ContentPolicyViolationErrorAllowedFails
         if (
+            isinstance(exception, litellm.InternalServerError)
+            and allowed_fails_policy.InternalServerErrorAllowedFails is not None
+        ):
+            return allowed_fails_policy.InternalServerErrorAllowedFails
+        if (
             isinstance(exception, litellm.BadRequestError)
             and allowed_fails_policy.BadRequestErrorAllowedFails is not None
         ):

--- a/litellm/router_utils/cooldown_handlers.py
+++ b/litellm/router_utils/cooldown_handlers.py
@@ -407,11 +407,13 @@ def should_cooldown_based_on_allowed_fails_policy(
     - True if fails exceed the allowed limit (should cooldown)
     - False if fails are within the allowed limit (should not cooldown)
     """
+    policy_allowed_fails = litellm_router_instance.get_allowed_fails_from_policy(
+        exception=original_exception,
+    )
     allowed_fails = (
-        litellm_router_instance.get_allowed_fails_from_policy(
-            exception=original_exception,
-        )
-        or litellm_router_instance.allowed_fails
+        policy_allowed_fails
+        if policy_allowed_fails is not None
+        else litellm_router_instance.allowed_fails
     )
     cooldown_time = (
         litellm_router_instance.cooldown_time or DEFAULT_COOLDOWN_TIME_SECONDS

--- a/tests/test_litellm/router_utils/test_health_check_allowed_fails_integration.py
+++ b/tests/test_litellm/router_utils/test_health_check_allowed_fails_integration.py
@@ -245,6 +245,29 @@ class TestHealthCheckCooldownIntegration:
         )
         assert result is True
 
+    def test_zero_policy_threshold_triggers_cooldown_before_default_allowed_fails(self):
+        from litellm.router_utils.cooldown_handlers import (
+            should_cooldown_based_on_allowed_fails_policy,
+        )
+
+        router = Router(
+            model_list=[_make_model("deploy-1"), _make_model("deploy-2", "gpt-5")],
+            allowed_fails_policy=AllowedFailsPolicy(InternalServerErrorAllowedFails=0),
+            allowed_fails=3,
+        )
+        internal_error = litellm.InternalServerError(
+            message="server error", model="gpt-4", llm_provider="openai"
+        )
+
+        result = should_cooldown_based_on_allowed_fails_policy(
+            litellm_router_instance=router,
+            deployment="deploy-1",
+            original_exception=internal_error,
+        )
+
+        assert result is True
+        assert router.failed_calls.get_cache(key="deploy-1") is None
+
     def test_healthy_endpoints_do_not_trigger_cooldown(self):
         """Healthy endpoints should not increment any failure counters."""
         router = Router(

--- a/tests/test_litellm/router_utils/test_health_check_allowed_fails_integration.py
+++ b/tests/test_litellm/router_utils/test_health_check_allowed_fails_integration.py
@@ -123,6 +123,7 @@ class TestGetAllowedFailsFromPolicyWithHealthCheckExceptions:
                 2,
             ),
             (litellm.BadRequestError, "BadRequestErrorAllowedFails", 7),
+            (litellm.InternalServerError, "InternalServerErrorAllowedFails", 4),
         ],
     )
     def test_policy_resolves_for_health_check_exception_types(
@@ -226,9 +227,6 @@ class TestHealthCheckCooldownIntegration:
             allowed_fails=1,
         )
 
-        # Use an exception that doesn't match TimeoutErrorAllowedFails
-        # InternalServerError is not checked by get_allowed_fails_from_policy
-        # so it will fall back to allowed_fails=1
         generic_exc = Exception("Some internal error")
 
         # Fail 1: should not cooldown (1 <= 1)
@@ -249,8 +247,6 @@ class TestHealthCheckCooldownIntegration:
 
     def test_healthy_endpoints_do_not_trigger_cooldown(self):
         """Healthy endpoints should not increment any failure counters."""
-        from litellm.router_utils.cooldown_handlers import _set_cooldown_deployments
-
         router = Router(
             model_list=[_make_model("deploy-1")],
             allowed_fails_policy=AllowedFailsPolicy(TimeoutErrorAllowedFails=1),
@@ -528,10 +524,6 @@ class TestAllDeploymentsInCooldownSafetyNet:
         """In the async routing path, all-in-cooldown with enable_health_check_routing
         returns the full list instead of empty (safety net)."""
         from unittest.mock import AsyncMock
-
-        from litellm.router_utils.cooldown_handlers import (
-            _async_get_cooldown_deployments,
-        )
 
         router = Router(
             model_list=[_make_model("deploy-1"), _make_model("deploy-2", "gpt-5")],


### PR DESCRIPTION
## Relevant issues

Fixes #29283

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on `make test-unit`. I ran the targeted router policy tests, the health-check allowed-fails file with proxy extras, and lint for the touched files.
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Delays in PR merge?

N/A

## CI (LiteLLM team)

- [ ] Branch creation CI run
       Link:

- [ ] CI run for the last commit
       Link:

- [ ] Merge / cherry-pick CI run
       Links:

## Screenshots / Proof of Fix

Configured `AllowedFailsPolicy(InternalServerErrorAllowedFails=4)` now returns 4 for a `litellm.InternalServerError`. Before this change the same policy lookup returned `None`, so router cooldown handling fell back to the generic `allowed_fails` value.

Configured `AllowedFailsPolicy(InternalServerErrorAllowedFails=0)` now triggers cooldown on the first internal-server-error health-check failure instead of falling back to the generic/default threshold.

## Type

Bug Fix
Test

## Changes

`Router.get_allowed_fails_from_policy` now handles `litellm.InternalServerError` with the existing `InternalServerErrorAllowedFails` policy field. The cooldown path now preserves explicit zero policy thresholds by falling back to the generic `allowed_fails` value only when no matching policy exists. The health-check allowed-fails regression coverage includes both the internal-server-error exception type and the zero-threshold cooldown case.

Validation run locally: `uv run --with-editable . --with pytest python -m pytest tests/test_litellm/router_utils/test_health_check_allowed_fails_integration.py::TestHealthCheckCooldownIntegration::test_zero_policy_threshold_triggers_cooldown_before_default_allowed_fails -q`; `uv run --with-editable . --with pytest python -m pytest tests/test_litellm/router_utils/test_health_check_allowed_fails_integration.py::TestGetAllowedFailsFromPolicyWithHealthCheckExceptions tests/test_litellm/router_utils/test_health_check_allowed_fails_integration.py::TestHealthCheckCooldownIntegration -q`; `uv run --extra proxy --with pytest python -m pytest tests/test_litellm/router_utils/test_health_check_allowed_fails_integration.py -q`; `uv run --with ruff ruff check litellm/router_utils/cooldown_handlers.py tests/test_litellm/router_utils/test_health_check_allowed_fails_integration.py`.
