### PR TITLE
feat(otel): add team_metadata, http.route, and model names to inference spans

### DIFF
--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -64,6 +64,9 @@ HTTP_RESPONSE_STATUS_CODE_ATTRIBUTE = "http.response.status_code"
 HTTP_ROUTE_ATTRIBUTE = "http.route"
 URL_PATH_ATTRIBUTE = "url.path"
 PREPROCESSING_DURATION_MS_ATTRIBUTE = "litellm.preprocessing.duration_ms"
+TEAM_METADATA_ATTRIBUTE = "litellm.team.metadata"
+MODEL_GROUP_ATTRIBUTE = "litellm.model_group"
+PROVIDER_MODEL_ATTRIBUTE = "litellm.provider.model"
 # Remove the hardcoded LITELLM_RESOURCE dictionary - we'll create it properly later
 RAW_REQUEST_SPAN_NAME = "raw_gen_ai_request"
 LITELLM_REQUEST_SPAN_NAME = "litellm_request"
@@ -1213,6 +1216,68 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
         ):
             self._set_team_attributes_from_kwargs(proxy_span, kwargs)
 
+    def _set_inference_identity_attributes(
+        self,
+        span: Span,
+        standard_logging_payload: StandardLoggingPayload,
+        litellm_params: dict,
+    ) -> None:
+        """Stamp request-identity attributes onto an inference span so every
+        LLM-call span is filterable by the route it came in on, the team's
+        metadata, and both the user-facing (model_group alias) and the
+        dispatched (provider) model names. Empty/absent values are skipped.
+        """
+        metadata = standard_logging_payload.get("metadata") or {}
+
+        http_route = metadata.get("user_api_key_request_route")
+        if http_route:
+            self.safe_set_attribute(
+                span=span, key=HTTP_ROUTE_ATTRIBUTE, value=http_route
+            )
+
+        # ``user_api_key_team_metadata`` is dropped from the standard logging
+        # payload metadata, so read it from the raw request metadata in kwargs.
+        # ``metadata`` and ``litellm_metadata`` are alternate names for the same
+        # full metadata dict (the name varies by endpoint), so first-truthy wins.
+        raw_metadata = (
+            litellm_params.get("metadata")
+            or litellm_params.get("litellm_metadata")
+            or {}
+        )
+        team_metadata = self._team_metadata_json(
+            raw_metadata.get("user_api_key_team_metadata")
+        )
+        if team_metadata:
+            self.safe_set_attribute(
+                span=span, key=TEAM_METADATA_ATTRIBUTE, value=team_metadata
+            )
+
+        model_group = standard_logging_payload.get("model_group")
+        if model_group:
+            self.safe_set_attribute(
+                span=span, key=MODEL_GROUP_ATTRIBUTE, value=model_group
+            )
+
+        hidden_params = standard_logging_payload.get("hidden_params") or {}
+        provider_model = hidden_params.get(
+            "litellm_model_name"
+        ) or standard_logging_payload.get("model")
+        if provider_model:
+            self.safe_set_attribute(
+                span=span, key=PROVIDER_MODEL_ATTRIBUTE, value=provider_model
+            )
+
+    @staticmethod
+    def _team_metadata_json(value: Any) -> Optional[str]:
+        """JSON-serialize a team's metadata dict for a single span attribute.
+
+        Returns ``None`` for a missing, non-dict, or empty mapping so the
+        empty case is dropped rather than stamping a useless ``"{}"``.
+        """
+        if not isinstance(value, dict) or not value:
+            return None
+        return safe_dumps(value)
+
     def _record_metrics(self, kwargs, response_obj, start_time, end_time):
         duration_s = (end_time - start_time).total_seconds()
         params = kwargs.get("litellm_params") or {}
@@ -2023,6 +2088,12 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
                     key="hidden_params",
                     value=safe_dumps(hidden_params),
                 )
+
+            self._set_inference_identity_attributes(
+                span=span,
+                standard_logging_payload=standard_logging_payload,
+                litellm_params=litellm_params,
+            )
             # Cost breakdown tracking
             cost_breakdown: Optional[CostBreakdown] = standard_logging_payload.get(
                 "cost_breakdown"

--- a/tests/test_litellm/integrations/test_opentelemetry.py
+++ b/tests/test_litellm/integrations/test_opentelemetry.py
@@ -5142,3 +5142,95 @@ class TestOpenTelemetryPreprocessingDuration(unittest.TestCase):
         span, exp = self._span()
         otel.set_preprocessing_duration_attribute(span, None)
         assert "litellm.preprocessing.duration_ms" not in self._attr(span, exp)
+
+
+class TestOpenTelemetryInferenceIdentityAttributes(unittest.TestCase):
+    """team_metadata, http.route, and both model names (the user-facing
+    model_group alias and the dispatched provider model) must land on the
+    inference span via set_attributes."""
+
+    def _span(self):
+        exporter = InMemorySpanExporter()
+        provider = TracerProvider()
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        tracer = provider.get_tracer(__name__)
+        return tracer.start_span("litellm_request"), exporter
+
+    def _attr(self, span, exporter):
+        span.end()
+        return exporter.get_finished_spans()[0].attributes
+
+    def _kwargs(self):
+        return {
+            "model": "gpt-4o",
+            "optional_params": {},
+            "litellm_params": {
+                "custom_llm_provider": "azure",
+                "metadata": {
+                    "user_api_key_team_metadata": {
+                        "tier": "gold",
+                        "cost_center": "42",
+                    }
+                },
+            },
+            "standard_logging_object": {
+                "metadata": {
+                    "user_api_key_request_route": "/v1/chat/completions",
+                    "user_api_key_team_id": "team-1",
+                },
+                "call_type": "completion",
+                "model_group": "gpt-4o",
+                "model": "azure/my-deployment",
+                "hidden_params": {"litellm_model_name": "azure/my-deployment"},
+                "id": "req-1",
+                "litellm_call_id": "call-1",
+            },
+        }
+
+    def test_all_identity_attributes_stamped(self):
+        otel = OpenTelemetry()
+        span, exp = self._span()
+        otel.set_attributes(span, self._kwargs(), {"model": "azure/gpt-4o"})
+        attrs = self._attr(span, exp)
+
+        assert attrs["http.route"] == "/v1/chat/completions"
+        assert json.loads(attrs["litellm.team.metadata"]) == {
+            "tier": "gold",
+            "cost_center": "42",
+        }
+        assert attrs["litellm.model_group"] == "gpt-4o"
+        assert attrs["litellm.provider.model"] == "azure/my-deployment"
+
+    def test_provider_model_falls_back_to_payload_model(self):
+        """Without hidden_params.litellm_model_name the dispatched model is
+        the payload model (the SDK path, where no router renaming happened)."""
+        otel = OpenTelemetry()
+        kwargs = self._kwargs()
+        kwargs["standard_logging_object"]["hidden_params"] = {}
+        span, exp = self._span()
+        otel.set_attributes(span, kwargs, {"model": "azure/gpt-4o"})
+        assert self._attr(span, exp)["litellm.provider.model"] == "azure/my-deployment"
+
+    def test_empty_team_metadata_is_dropped(self):
+        """An empty team_metadata dict must not stamp a useless '{}'."""
+        otel = OpenTelemetry()
+        kwargs = self._kwargs()
+        kwargs["litellm_params"]["metadata"]["user_api_key_team_metadata"] = {}
+        span, exp = self._span()
+        otel.set_attributes(span, kwargs, {"model": "azure/gpt-4o"})
+        assert "litellm.team.metadata" not in self._attr(span, exp)
+
+    def test_missing_route_is_dropped(self):
+        """An SDK request has no route; http.route must be absent, not empty."""
+        otel = OpenTelemetry()
+        kwargs = self._kwargs()
+        del kwargs["standard_logging_object"]["metadata"]["user_api_key_request_route"]
+        span, exp = self._span()
+        otel.set_attributes(span, kwargs, {"model": "azure/gpt-4o"})
+        assert "http.route" not in self._attr(span, exp)
+
+    def test_team_metadata_json_helper_non_dict(self):
+        assert OpenTelemetry._team_metadata_json(None) is None
+        assert OpenTelemetry._team_metadata_json("not-a-dict") is None
+        assert OpenTelemetry._team_metadata_json({}) is None
+        assert json.loads(OpenTelemetry._team_metadata_json({"a": 1})) == {"a": 1}


### PR DESCRIPTION
## Relevant issues

Brings a subset of the otelv2 work in #28909 to the current (v1) OpenTelemetry integration. #28909 added these identity attributes only under v2; this stamps them on the inference spans the current integration already emits.

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Changes

Every inference span emitted by `OpenTelemetry.set_attributes` now carries four request-identity attributes so traces are filterable by team, route, and model:

- `http.route` — the normalized route template the request came in on (e.g. `/v1/chat/completions`), read from `user_api_key_request_route`. Previously this lived only on the proxy SERVER root span; now it is on the LLM-call span too.
- `litellm.team.metadata` — the team's free-form metadata dict, JSON-serialized. Read from the raw request metadata in `litellm_params` because `user_api_key_team_metadata` is dropped from the standard logging payload metadata. An empty/missing dict is dropped rather than stamping a useless `"{}"`.
- `litellm.model_group` — the user-facing model the caller requested (the litellm alias).
- `litellm.provider.model` — the model litellm dispatched to the provider (the router deployment's model name), falling back to the payload model on the SDK path where no router renaming happened.

Per discussion, the model attributes use explicit `litellm.*` keys rather than overloading the existing `gen_ai.request.model`, so this PR does not change the meaning of any attribute already emitted; it only adds new ones.

The work is isolated to a small helper, `_set_inference_identity_attributes`, called from `set_attributes`, plus a `_team_metadata_json` helper for the empty-dict handling.

## Type

🆕 New Feature

## Screenshots / Proof of Fix

Ran the local proxy on `:4011` with `callbacks: ["otel"]` (console exporter), a `pre_call` guardrail attached to a `mock-gpt` model, and the master key. A pre-call guardrail injected the team's metadata into `data["metadata"]["user_api_key_team_metadata"]` so the request carries the same shape `/team/new` produces.

Config (`/tmp/otel_pr29319/config.yaml`):

```yaml
model_list:
  - model_name: mock-gpt
    litellm_params:
      model: openai/mock-gpt
      api_key: sk-fake-key
      mock_response: "Hello from the mock model!"
litellm_settings:
  callbacks: ["otel"]
guardrails:
  - guardrail_name: "local-test-guard"
    litellm_params:
      guardrail: test_guardrail.LocalTestGuardrail
      mode: "pre_call"
      default_on: true
general_settings:
  master_key: sk-1234
```

Start the proxy and send a request:

```
$ cd /tmp/otel_pr29319 && uv run --project ~/Documents/Github/berriai/litellm litellm \
    --config /tmp/otel_pr29319/config.yaml --port 4011 2>&1 | tee proxy.log

$ curl -sS -X POST http://localhost:4011/v1/chat/completions \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"model":"mock-gpt","messages":[{"role":"user","content":"hi"}]}'
{"id":"chatcmpl-b7e70008-...","created":1780125523,"model":"mock-gpt",
 "object":"chat.completion",
 "choices":[{"finish_reason":"stop","index":0,
             "message":{"content":"Hello from the mock model!","role":"assistant"}}],
 "usage":{"completion_tokens":20,"prompt_tokens":10,"total_tokens":30}}
```

The OTEL console exporter prints the `litellm_request` (inference) span. All four new attributes are present:

```
{
    "name": "litellm_request",
    "context": {
        "trace_id": "0xf9b7a5fbde9757395d330197c5ee2c56",
        "span_id": "0x4d10c1b9b4a39ae7",
        ...
    },
    "kind": "SpanKind.INTERNAL",
    "parent_id": "0x2be2f927dc5d3c84",
    "attributes": {
        ...
        "http.route": "/v1/chat/completions",
        "litellm.team.metadata": "{\"tier\": \"gold\", \"cost_center\": \"42\"}",
        "litellm.model_group": "mock-gpt",
        "litellm.provider.model": "openai/mock-gpt",
        ...
        "gen_ai.request.model": "mock-gpt",
        "gen_ai.response.model": "mock-gpt",
        ...
    }
}
```

Caveat on this run: my local DB stack was unavailable, so the team and the virtual key were not created through `/team/new` + `/key/generate`; the same `user_api_key_team_metadata` dict that those endpoints would have produced was injected by the guardrail's `async_pre_call_hook`. The OTEL stamper reads that dict from `litellm_params["metadata"]` regardless of who put it there, so the code path the PR adds is exercised end-to-end.

## Changes
