### PR TITLE
fix: handle InternalServerError in router policies and trim email whitespace on user creation

### DIFF
--- a/litellm/proxy/auth/login_utils.py
+++ b/litellm/proxy/auth/login_utils.py
@@ -135,6 +135,10 @@ async def authenticate_user(  # noqa: PLR0915
             code=500,
         )
 
+    # Strip whitespace from username/email to prevent login failures caused
+    # by accidental leading or trailing spaces in the login form.
+    username = username.strip()
+
     ui_username, ui_password = get_ui_credentials(master_key)
 
     # Check if we can find the `username` in the db. On the UI, users can enter username=their email

--- a/litellm/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/proxy/management_endpoints/internal_user_endpoints.py
@@ -428,6 +428,11 @@ async def new_user(
                 status_code=500,
                 detail=CommonProxyErrors.db_not_connected_error.value,
             )
+        # Normalize email — strip leading/trailing whitespace so a user created
+        # with " user@example.com" can still log in as "user@example.com".
+        if data.user_email is not None:
+            data.user_email = data.user_email.strip()
+
         # Check for duplicate user_id or email
         await _check_duplicate_user_id(data.user_id, prisma_client)
         await _check_duplicate_user_email(data.user_email, prisma_client)

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -11688,6 +11688,11 @@ class Router:
             and allowed_fails_policy.BadRequestErrorAllowedFails is not None
         ):
             return allowed_fails_policy.BadRequestErrorAllowedFails
+        if (
+            isinstance(exception, litellm.InternalServerError)
+            and allowed_fails_policy.InternalServerErrorAllowedFails is not None
+        ):
+            return allowed_fails_policy.InternalServerErrorAllowedFails
 
     def _initialize_alerting(self):
         from litellm.integrations.SlackAlerting.slack_alerting import SlackAlerting

--- a/litellm/router_utils/get_retry_from_policy.py
+++ b/litellm/router_utils/get_retry_from_policy.py
@@ -10,6 +10,7 @@ from litellm.exceptions import (
     AuthenticationError,
     BadRequestError,
     ContentPolicyViolationError,
+    InternalServerError,
     RateLimitError,
     Timeout,
 )
@@ -65,6 +66,11 @@ def get_num_retries_from_retry_policy(
         and retry_policy.BadRequestErrorRetries is not None
     ):
         return retry_policy.BadRequestErrorRetries
+    if (
+        isinstance(exception, InternalServerError)
+        and retry_policy.InternalServerErrorRetries is not None
+    ):
+        return retry_policy.InternalServerErrorRetries
 
 
 def reset_retry_policy() -> RetryPolicy:

--- a/tests/router_unit_tests/test_router_helper_utils.py
+++ b/tests/router_unit_tests/test_router_helper_utils.py
@@ -1030,6 +1030,7 @@ def test_track_deployment_metrics(model_list):
             "ContentPolicyViolationError",
             7,
         ),
+        (litellm.exceptions.InternalServerError, "InternalServerError", 5),
     ],
 )
 def test_get_num_retries_from_retry_policy(
@@ -1064,6 +1065,7 @@ def test_get_num_retries_from_retry_policy(
             "ContentPolicyViolationError",
             7,
         ),
+        (litellm.exceptions.InternalServerError, "InternalServerError", 5),
     ],
 )
 def test_get_allowed_fails_from_policy(

--- a/tests/test_litellm/proxy/auth/test_login_utils.py
+++ b/tests/test_litellm/proxy/auth/test_login_utils.py
@@ -559,3 +559,55 @@ async def test_authenticate_user_database_login_with_non_ascii_password():
             assert isinstance(result, LoginResult)
             assert result.user_id == "test-user-123"
             assert result.user_email == user_email
+
+
+@pytest.mark.asyncio
+async def test_authenticate_user_strips_whitespace_from_username():
+    """Leading/trailing whitespace in username should not prevent login."""
+    master_key = "sk-1234"
+    user_email = "user@example.com"
+    password = "correct-password"
+    hashed_password = hash_token(token=password)
+
+    mock_user = MagicMock()
+    mock_user.user_id = "user-id-123"
+    mock_user.user_email = user_email
+    mock_user.password = hashed_password
+    mock_user.user_role = LitellmUserRoles.INTERNAL_USER
+
+    def mock_find_first(**kwargs):
+        where = kwargs.get("where", {})
+        user_email_filter = where.get("user_email", {})
+        if str(user_email_filter.get("equals", "")).lower() == user_email.lower():
+            return mock_user
+        return None
+
+    mock_prisma_client = MagicMock()
+    mock_prisma_client.db.litellm_usertable.find_first = AsyncMock(
+        side_effect=mock_find_first
+    )
+
+    with patch.dict(
+        os.environ,
+        {
+            "UI_USERNAME": "admin",
+            "UI_PASSWORD": "admin-password",
+            "DATABASE_URL": "postgresql://test:test@localhost/test",
+        },
+    ):
+        with patch(
+            "litellm.proxy.auth.login_utils.generate_key_helper_fn",
+            new_callable=AsyncMock,
+            return_value={"token": "test-token"},
+        ):
+            # Username with leading and trailing whitespace — should still authenticate
+            result = await authenticate_user(
+                username=f"  {user_email}  ",
+                password=password,
+                master_key=master_key,
+                prisma_client=mock_prisma_client,
+            )
+
+            assert isinstance(result, LoginResult)
+            assert result.user_id == "user-id-123"
+            assert result.user_email == user_email

--- a/tests/test_litellm/router_utils/test_get_retry_from_policy.py
+++ b/tests/test_litellm/router_utils/test_get_retry_from_policy.py
@@ -1,0 +1,43 @@
+"""Unit tests for get_retry_from_policy module."""
+
+import pytest
+
+import litellm
+from litellm.router_utils.get_retry_from_policy import get_num_retries_from_retry_policy
+from litellm.types.router import RetryPolicy
+
+
+def _make_exc(exc_class):
+    return exc_class(message="test", llm_provider="openai", model="gpt-4o")
+
+
+@pytest.mark.parametrize(
+    "exc_class, field, retries",
+    [
+        (litellm.AuthenticationError, "AuthenticationErrorRetries", 1),
+        (litellm.Timeout, "TimeoutErrorRetries", 2),
+        (litellm.RateLimitError, "RateLimitErrorRetries", 3),
+        (litellm.ContentPolicyViolationError, "ContentPolicyViolationErrorRetries", 4),
+        (litellm.BadRequestError, "BadRequestErrorRetries", 5),
+        (litellm.InternalServerError, "InternalServerErrorRetries", 6),
+    ],
+)
+def test_get_num_retries_returns_configured_value(exc_class, field, retries):
+    policy = RetryPolicy(**{field: retries})
+    result = get_num_retries_from_retry_policy(
+        exception=_make_exc(exc_class), retry_policy=policy
+    )
+    assert result == retries
+
+
+def test_get_num_retries_returns_none_when_policy_is_none():
+    assert get_num_retries_from_retry_policy(
+        exception=_make_exc(litellm.InternalServerError), retry_policy=None
+    ) is None
+
+
+def test_get_num_retries_returns_none_when_field_not_set():
+    policy = RetryPolicy()
+    assert get_num_retries_from_retry_policy(
+        exception=_make_exc(litellm.InternalServerError), retry_policy=policy
+    ) is None

--- a/tests/test_litellm/router_utils/test_health_check_allowed_fails_integration.py
+++ b/tests/test_litellm/router_utils/test_health_check_allowed_fails_integration.py
@@ -123,6 +123,7 @@ class TestGetAllowedFailsFromPolicyWithHealthCheckExceptions:
                 2,
             ),
             (litellm.BadRequestError, "BadRequestErrorAllowedFails", 7),
+            (litellm.InternalServerError, "InternalServerErrorAllowedFails", 4),
         ],
     )
     def test_policy_resolves_for_health_check_exception_types(
@@ -226,9 +227,8 @@ class TestHealthCheckCooldownIntegration:
             allowed_fails=1,
         )
 
-        # Use an exception that doesn't match TimeoutErrorAllowedFails
-        # InternalServerError is not checked by get_allowed_fails_from_policy
-        # so it will fall back to allowed_fails=1
+        # Use a generic Exception that doesn't match any AllowedFailsPolicy field,
+        # so it falls back to the global allowed_fails=1
         generic_exc = Exception("Some internal error")
 
         # Fail 1: should not cooldown (1 <= 1)


### PR DESCRIPTION
Fixes two separate bugs — both are silent failures where configured values were accepted but never actually applied.

## Changes

### 1. `InternalServerError` missing from `get_allowed_fails_from_policy` (closes #29283)

`AllowedFailsPolicy.InternalServerErrorAllowedFails` exists in the type definition but `get_allowed_fails_from_policy` had no branch for it. The setting was accepted in config but silently ignored at runtime, so the router always fell back to the global `allowed_fails` value instead of the configured per-error limit.

### 2. `InternalServerError` missing from `get_num_retries_from_retry_policy` (related to #29283)

Same class of bug in the parallel retry function. `RetryPolicy.InternalServerErrorRetries` is defined but was never read — `InternalServerError` retries were silently ignored.

### 3. Email whitespace not stripped on user creation (closes #28880)

The `/user/new` endpoint did not strip leading or trailing whitespace from `user_email`. A user created via the UI with an accidental space in the email field could activate their account and log in once, but could not log back in after logging out — the stored email (with space) did not match the login lookup (without space).

### 4. Username whitespace not stripped at login

Added a `strip()` on the username input in `authenticate_user` so users who accidentally type extra spaces in the login form are not locked out.

## Tests

- Added `InternalServerError` case to the existing parametrized `test_get_num_retries_from_retry_policy` test
- Added `InternalServerError` case to the existing parametrized `test_get_allowed_fails_from_policy` test
- Added `test_authenticate_user_strips_whitespace_from_username` to `test_login_utils.py`