### PR TITLE
Revert Bedrock CI back to the reactivated AWS account (888602223428)

### DIFF
--- a/litellm/llms/bedrock/chat/agentcore/transformation.py
+++ b/litellm/llms/bedrock/chat/agentcore/transformation.py
@@ -157,8 +157,8 @@ class AmazonAgentCoreConfig(BaseConfig, BaseAWSLLM):
     def _get_agent_runtime_arn(self, model: str) -> str:
         """
         Extract ARN from model string
-        model = "agentcore/arn:aws:bedrock-agentcore:us-west-2:941277531214:runtime/hosted_agent_r9jvp-Rq79QFC2fp"
-        returns: "arn:aws:bedrock-agentcore:us-west-2:941277531214:runtime/hosted_agent_r9jvp-Rq79QFC2fp"
+        model = "agentcore/arn:aws:bedrock-agentcore:us-west-2:888602223428:runtime/hosted_agent_r9jvp-3ySZuRHjLC"
+        returns: "arn:aws:bedrock-agentcore:us-west-2:888602223428:runtime/hosted_agent_r9jvp-3ySZuRHjLC"
         """
         parts = model.split("/", 1)
         if len(parts) != 2 or parts[0] != "agentcore":
@@ -170,7 +170,7 @@ class AmazonAgentCoreConfig(BaseConfig, BaseAWSLLM):
     def _extract_region_from_arn(self, arn: str) -> str:
         """
         Extract region from ARN
-        arn:aws:bedrock-agentcore:us-west-2:941277531214:runtime/hosted_agent_r9jvp-Rq79QFC2fp
+        arn:aws:bedrock-agentcore:us-west-2:888602223428:runtime/hosted_agent_r9jvp-3ySZuRHjLC
         returns: us-west-2
         """
         parts = arn.split(":")

--- a/litellm/proxy/example_config_yaml/oai_misc_config.yaml
+++ b/litellm/proxy/example_config_yaml/oai_misc_config.yaml
@@ -23,11 +23,11 @@ model_list:
       model: bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0
       #########################################################
       ########## batch specific params ########################
-      s3_bucket_name: litellm-proxy-941277531214
+      s3_bucket_name: litellm-proxy
       s3_region_name: us-west-2
       s3_access_key_id: os.environ/AWS_ACCESS_KEY_ID
       s3_secret_access_key: os.environ/AWS_SECRET_ACCESS_KEY
-      aws_batch_role_arn: arn:aws:iam::941277531214:role/service-role/AmazonBedrockExecutionRoleForAgents_BB9HNW6V4CV
+      aws_batch_role_arn: arn:aws:iam::888602223428:role/service-role/AmazonBedrockExecutionRoleForAgents_BB9HNW6V4CV
     model_info: 
       mode: batch
 

--- a/litellm/proxy/example_config_yaml/otel_test_config.yaml
+++ b/litellm/proxy/example_config_yaml/otel_test_config.yaml
@@ -55,7 +55,7 @@ guardrails:
     litellm_params:
       guardrail: bedrock  # supported values: "bedrock", "lakera"
       mode: "during_call"
-      guardrailIdentifier: 4w3d1di3snt5
+      guardrailIdentifier: ff6ujrregl1q
       guardrailVersion: "DRAFT"
   - guardrail_name: "custom-pre-guard"
     litellm_params:

--- a/tests/agent_tests/local_only_agent_tests/test_a2a_completion_bridge.py
+++ b/tests/agent_tests/local_only_agent_tests/test_a2a_completion_bridge.py
@@ -168,7 +168,7 @@ async def test_a2a_completion_bridge_bedrock_agentcore():
     litellm._turn_on_debug()
 
     # Bedrock AgentCore ARN (streaming-capable runtime)
-    agentcore_arn = "arn:aws:bedrock-agentcore:us-west-2:941277531214:runtime/hosted_agent_r9jvp-Rq79QFC2fp"
+    agentcore_arn = "arn:aws:bedrock-agentcore:us-west-2:888602223428:runtime/hosted_agent_r9jvp-3ySZuRHjLC"
 
     send_message_payload = {
         "message": {

--- a/tests/batches_tests/test_bedrock_files_and_batches.py
+++ b/tests/batches_tests/test_bedrock_files_and_batches.py
@@ -38,7 +38,7 @@ async def test_async_create_file():
         file=open(file_path, "rb"),
         purpose="batch",
         custom_llm_provider="bedrock",
-        s3_bucket_name="litellm-proxy-941277531214",
+        s3_bucket_name="litellm-proxy",
     )
 
 
@@ -55,7 +55,7 @@ async def test_async_file_and_batch():
         file=open(file_path, "rb"),
         purpose="batch",
         custom_llm_provider="bedrock",
-        s3_bucket_name="litellm-proxy-941277531214",
+        s3_bucket_name="litellm-proxy",
     )
     print("CREATED FILE RESPONSE=", file_obj)
 
@@ -70,7 +70,7 @@ async def test_async_file_and_batch():
         # bedrock specific params
         #########################################################
         model="us.anthropic.claude-haiku-4-5-20251001-v1:0",
-        aws_batch_role_arn="arn:aws:iam::941277531214:role/service-role/AmazonBedrockExecutionRoleForAgents_BB9HNW6V4CV",
+        aws_batch_role_arn="arn:aws:iam::888602223428:role/service-role/AmazonBedrockExecutionRoleForAgents_BB9HNW6V4CV",
     )
     print("CREATED BATCH RESPONSE=", create_batch_response)
 
@@ -129,7 +129,7 @@ async def test_mock_bedrock_file_url_mapping():
             ),
             purpose="batch",
             custom_llm_provider="bedrock",
-            s3_bucket_name="litellm-proxy-941277531214",
+            s3_bucket_name="litellm-proxy",
         )
 
         print(f"PUT URL: {captured_put_url}")

--- a/tests/guardrails_tests/test_bedrock_guardrails.py
+++ b/tests/guardrails_tests/test_bedrock_guardrails.py
@@ -20,7 +20,7 @@ async def test_bedrock_guardrails_pii_masking():
     mock_user_api_key_dict = UserAPIKeyAuth()
 
     guardrail = BedrockGuardrail(
-        guardrailIdentifier="zgkmukebruil",
+        guardrailIdentifier="wf0hkdb5x07f",
         guardrailVersion="DRAFT",
     )
 
@@ -60,7 +60,7 @@ async def test_bedrock_guardrails_pii_masking_content_list():
     mock_user_api_key_dict = UserAPIKeyAuth()
 
     guardrail = BedrockGuardrail(
-        guardrailIdentifier="zgkmukebruil",
+        guardrailIdentifier="wf0hkdb5x07f",
         guardrailVersion="DRAFT",
     )
 
@@ -115,7 +115,7 @@ async def test_bedrock_guardrails_block_messages_api():
     mock_user_api_key_dict = UserAPIKeyAuth()
 
     guardrail = BedrockGuardrail(
-        guardrailIdentifier="4w3d1di3snt5",
+        guardrailIdentifier="ff6ujrregl1q",
         guardrailVersion="DRAFT",
     )
 
@@ -166,7 +166,7 @@ async def test_bedrock_guardrails_block_responses_api():
     mock_user_api_key_dict = UserAPIKeyAuth()
 
     guardrail = BedrockGuardrail(
-        guardrailIdentifier="4w3d1di3snt5",
+        guardrailIdentifier="ff6ujrregl1q",
         guardrailVersion="DRAFT",
     )
 
@@ -211,7 +211,7 @@ async def test_bedrock_guardrails_with_streaming():
         )
 
         guardrail = BedrockGuardrail(
-            guardrailIdentifier="4w3d1di3snt5",
+            guardrailIdentifier="ff6ujrregl1q",
             guardrailVersion="DRAFT",
             supported_event_hooks=[GuardrailEventHooks.post_call],
             guardrail_name="bedrock-post-guard",
@@ -255,7 +255,7 @@ async def test_bedrock_guardrails_with_streaming_no_violation():
     )
 
     guardrail = BedrockGuardrail(
-        guardrailIdentifier="4w3d1di3snt5",
+        guardrailIdentifier="ff6ujrregl1q",
         guardrailVersion="DRAFT",
         supported_event_hooks=[GuardrailEventHooks.post_call],
         guardrail_name="bedrock-post-guard",
@@ -299,7 +299,7 @@ async def test_bedrock_guardrails_streaming_request_body_mock():
 
     # Create the guardrail
     guardrail = BedrockGuardrail(
-        guardrailIdentifier="zgkmukebruil",
+        guardrailIdentifier="wf0hkdb5x07f",
         guardrailVersion="DRAFT",
         supported_event_hooks=[GuardrailEventHooks.post_call],
         guardrail_name="bedrock-post-guard",
@@ -382,7 +382,7 @@ async def test_bedrock_guardrail_aws_param_persistence():
     from litellm.types.guardrails import GuardrailEventHooks
 
     guardrail = BedrockGuardrail(
-        guardrailIdentifier="zgkmukebruil",
+        guardrailIdentifier="wf0hkdb5x07f",
         guardrailVersion="DRAFT",
         aws_access_key_id="test-access-key",
         aws_secret_access_key="test-secret-key",

--- a/tests/image_gen_tests/test_bedrock_image_gen_unit_tests.py
+++ b/tests/image_gen_tests/test_bedrock_image_gen_unit_tests.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import os
 import sys
@@ -44,9 +43,6 @@ from litellm.llms.bedrock.image_generation.image_handler import (
     BedrockImagePreparedRequest,
 )
 from litellm.llms.bedrock.common_utils import BedrockError
-
-# Base64 placeholder used for mocked Bedrock image responses (a 1x1 PNG).
-_MOCK_BEDROCK_IMAGE_B64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
 
 
 @pytest.mark.parametrize(
@@ -532,34 +528,17 @@ def test_backward_compatibility_regular_nova_model():
 
 
 def test_amazon_titan_image_gen():
-    """Test Amazon Titan image generation with cost tracking.
-
-    The Bedrock CI account is not entitled to amazon.titan-image-generator, so
-    the network call is mocked and only the transform + cost-tracking path is
-    exercised.
-    """
-    from litellm.llms.custom_httpx.http_handler import HTTPHandler
+    """Test Amazon Titan image generation with cost tracking."""
+    from litellm import image_generation
 
     # Use v2 as v1 has reached end of life
     model_id = "bedrock/amazon.titan-image-generator-v2:0"
 
-    mock_payload = {"images": [_MOCK_BEDROCK_IMAGE_B64]}
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_response.json.return_value = mock_payload
-    mock_response.text = json.dumps(mock_payload)
-    mock_response.headers = {}
-
-    client = HTTPHandler()
-    with patch.object(client, "post", return_value=mock_response):
-        response = litellm.image_generation(
-            model=model_id,
-            prompt="A serene mountain landscape at sunset with a lake reflection",
-            aws_region_name="us-east-1",
-            aws_access_key_id="fake-access-key-id",
-            aws_secret_access_key="fake-secret-access-key",
-            client=client,
-        )
+    response = litellm.image_generation(
+        model=model_id,
+        prompt="A serene mountain landscape at sunset with a lake reflection",
+        aws_region_name="us-east-1",
+    )
 
     print(f"response cost: {response._hidden_params['response_cost']}")
 

--- a/tests/image_gen_tests/test_image_generation.py
+++ b/tests/image_gen_tests/test_image_generation.py
@@ -7,6 +7,7 @@ import sys
 import traceback
 from unittest.mock import AsyncMock, MagicMock, patch
 
+
 sys.path.insert(
     0, os.path.abspath("../..")
 )  # Adds the parent directory to the system path
@@ -135,51 +136,6 @@ class TestVertexAIGeminiImageGeneration(BaseImageGenTest):
         }
 
 
-# Base64 placeholder used for mocked Bedrock image responses (a 1x1 PNG).
-_MOCK_BEDROCK_IMAGE_B64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
-
-
-async def _assert_mocked_bedrock_image_generation(call_args: dict) -> None:
-    """Run ``aimage_generation`` with the Bedrock HTTP call mocked.
-
-    The CI account is not entitled to Nova Canvas, so the network call is
-    replaced with a canned Bedrock response. This keeps the request transform,
-    response transform, and cost-tracking path under test without live access.
-    """
-    mock_payload = {"images": [_MOCK_BEDROCK_IMAGE_B64]}
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_response.json.return_value = mock_payload
-    mock_response.text = json.dumps(mock_payload)
-    mock_response.headers = {}
-
-    custom_logger = TestCustomLogger()
-    litellm.logging_callback_manager._reset_all_callbacks()
-    litellm.callbacks = [custom_logger]
-
-    with patch(
-        "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
-        new_callable=AsyncMock,
-        return_value=mock_response,
-    ):
-        response = await litellm.aimage_generation(
-            **call_args,
-            prompt="A image of a otter",
-            aws_access_key_id="fake-access-key-id",
-            aws_secret_access_key="fake-secret-access-key",
-        )
-
-    await asyncio.sleep(1)
-
-    assert custom_logger.standard_logging_payload is not None
-    assert custom_logger.standard_logging_payload["response_cost"] is not None
-    assert custom_logger.standard_logging_payload["response_cost"] > 0
-    assert response.data is not None
-    for d in response.data:
-        assert isinstance(d, Image)
-        assert d.b64_json is not None or d.url is not None
-
-
 class TestBedrockNovaCanvasTextToImage(BaseImageGenTest):
     def get_base_image_generation_call_args(self) -> dict:
         litellm.in_memory_llm_clients_cache = InMemoryCache()
@@ -191,12 +147,6 @@ class TestBedrockNovaCanvasTextToImage(BaseImageGenTest):
             "taskType": "TEXT_IMAGE",
             "aws_region_name": "us-east-1",
         }
-
-    @pytest.mark.asyncio(scope="module")
-    async def test_basic_image_generation(self):
-        await _assert_mocked_bedrock_image_generation(
-            self.get_base_image_generation_call_args()
-        )
 
 
 class TestBedrockNovaCanvasColorGuidedGeneration(BaseImageGenTest):
@@ -211,12 +161,6 @@ class TestBedrockNovaCanvasColorGuidedGeneration(BaseImageGenTest):
             "colorGuidedGenerationParams": {"colors": ["#FFFFFF"]},
             "aws_region_name": "us-east-1",
         }
-
-    @pytest.mark.asyncio(scope="module")
-    async def test_basic_image_generation(self):
-        await _assert_mocked_bedrock_image_generation(
-            self.get_base_image_generation_call_args()
-        )
 
 
 class TestOpenAIGPTImage1(BaseImageGenTest):

--- a/tests/litellm_utils_tests/test_litellm_overhead.py
+++ b/tests/litellm_utils_tests/test_litellm_overhead.py
@@ -82,7 +82,7 @@ async def _vertex_ai_mocks():
         "bedrock/mistral.mistral-7b-instruct-v0:2",
         "openai/gpt-4o",
         "openai/self_hosted",
-        "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
+        "bedrock/anthropic.claude-3-5-haiku-20241022-v1:0",
         "vertex_ai/gemini-1.5-flash",
     ],
 )
@@ -147,7 +147,7 @@ async def test_litellm_overhead_non_streaming(model):
     [
         "bedrock/mistral.mistral-7b-instruct-v0:2",
         "openai/gpt-4o",
-        "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
+        "bedrock/anthropic.claude-3-5-haiku-20241022-v1:0",
         "openai/self_hosted",
     ],
 )

--- a/tests/llm_translation/reasoning_effort_grid/grid_spec.py
+++ b/tests/llm_translation/reasoning_effort_grid/grid_spec.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, field
 from typing import Dict, FrozenSet, List, Optional, Tuple
 
+
 OMIT = object()
 
 
@@ -21,7 +22,6 @@ class ModelEntry:
     extra_params: Tuple[Tuple[str, str], ...] = field(default_factory=tuple)
     required_env: FrozenSet[str] = field(default_factory=frozenset)
     caps: FrozenSet[str] = field(default_factory=frozenset)
-    fail_reason: Optional[str] = None
     bedrock_effort_ceiling: Optional[str] = None
 
     def params(self) -> Dict[str, str]:
@@ -234,12 +234,6 @@ BEDROCK_CONVERSE_MODELS: Tuple[ModelEntry, ...] = (
         extra_params=(("aws_region_name", "us-east-1"),),
         required_env=_BEDROCK_REQ,
         caps=_CAPS_OPUS_4_7,
-        fail_reason=(
-            "claude-opus-4-7 is not entitled on the Bedrock CI account "
-            "941277531214 (model access requires an AWS Sales request, not "
-            "self-serve); this cell fails on purpose so it stays loud in CI — "
-            "remove this fail_reason once access is granted"
-        ),
     ),
     ModelEntry(
         alias="bedrock-claude-opus-4-6",

--- a/tests/llm_translation/reasoning_effort_grid/test_reasoning_effort_grid.py
+++ b/tests/llm_translation/reasoning_effort_grid/test_reasoning_effort_grid.py
@@ -15,6 +15,7 @@ from .grid_spec import (
     all_cells,
 )
 
+
 _PROMPT_MESSAGES: List[Dict[str, str]] = [
     {"role": "user", "content": "Step by step, calculate 47 * 53. Show your work."}
 ]
@@ -166,9 +167,6 @@ async def test_reasoning_effort_grid(
     skip_reason = _required_env_missing(model)
     if skip_reason:
         pytest.skip(skip_reason)
-
-    if model.fail_reason:
-        pytest.xfail(model.fail_reason)
 
     if route_name == "bedrock_invoke_messages":
         status, exc = await _call_messages(model, effort)

--- a/tests/llm_translation/test_bedrock_agentcore.py
+++ b/tests/llm_translation/test_bedrock_agentcore.py
@@ -19,8 +19,8 @@ import httpx
 @pytest.mark.parametrize(
     "model",
     [
-        "bedrock/agentcore/arn:aws:bedrock-agentcore:us-west-2:941277531214:runtime/hosted_agent_13sf6-4046UzHSwy",  # non-streaming invocation
-        "bedrock/agentcore/arn:aws:bedrock-agentcore:us-west-2:941277531214:runtime/hosted_agent_r9jvp-Rq79QFC2fp",  # streaming invocation
+        "bedrock/agentcore/arn:aws:bedrock-agentcore:us-west-2:888602223428:runtime/hosted_agent_13sf6-cALnp38iZD",  # non-streaming invocation
+        "bedrock/agentcore/arn:aws:bedrock-agentcore:us-west-2:888602223428:runtime/hosted_agent_r9jvp-3ySZuRHjLC",  # streaming invocation
     ],
 )
 def test_bedrock_agentcore_basic(model):
@@ -44,7 +44,7 @@ def test_bedrock_agentcore_basic(model):
 @pytest.mark.parametrize(
     "model",
     [
-        "bedrock/agentcore/arn:aws:bedrock-agentcore:us-west-2:941277531214:runtime/hosted_agent_13sf6-4046UzHSwy",  # streaming invocation
+        "bedrock/agentcore/arn:aws:bedrock-agentcore:us-west-2:888602223428:runtime/hosted_agent_13sf6-cALnp38iZD",  # streaming invocation
     ],
 )
 async def test_bedrock_agentcore_with_streaming(model):
@@ -54,7 +54,7 @@ async def test_bedrock_agentcore_with_streaming(model):
     print("running streming test for model=", model)
     # litellm._turn_on_debug()
     response = await litellm.acompletion(
-        model="bedrock/agentcore/arn:aws:bedrock-agentcore:us-west-2:941277531214:runtime/hosted_agent_r9jvp-Rq79QFC2fp",
+        model="bedrock/agentcore/arn:aws:bedrock-agentcore:us-west-2:888602223428:runtime/hosted_agent_r9jvp-3ySZuRHjLC",
         messages=[
             {
                 "role": "user",
@@ -82,7 +82,7 @@ def test_bedrock_agentcore_with_custom_params():
     with patch.object(client, "post", return_value=MagicMock()) as mock_post:
         try:
             response = litellm.completion(
-                model="bedrock/agentcore/arn:aws:bedrock-agentcore:us-west-2:941277531214:runtime/hosted_agent_r9jvp-Rq79QFC2fp",
+                model="bedrock/agentcore/arn:aws:bedrock-agentcore:us-west-2:888602223428:runtime/hosted_agent_r9jvp-3ySZuRHjLC",
                 messages=[
                     {
                         "role": "user",
@@ -105,7 +105,7 @@ def test_bedrock_agentcore_with_custom_params():
         url = call_kwargs["url"]
         print(f"URL: {url}")
         assert (
-            "/runtimes/arn%3Aaws%3Abedrock-agentcore%3Aus-west-2%3A941277531214%3Aruntime%2Fhosted_agent_r9jvp-Rq79QFC2fp/invocations"
+            "/runtimes/arn%3Aaws%3Abedrock-agentcore%3Aus-west-2%3A888602223428%3Aruntime%2Fhosted_agent_r9jvp-3ySZuRHjLC/invocations"
             in url
         )
         assert "qualifier=DEFAULT" in url
@@ -150,7 +150,7 @@ def test_bedrock_agentcore_with_runtime_user_id():
     with patch.object(client, "post", return_value=MagicMock()) as mock_post:
         try:
             response = litellm.completion(
-                model="bedrock/agentcore/arn:aws:bedrock-agentcore:us-west-2:941277531214:runtime/hosted_agent_r9jvp-Rq79QFC2fp",
+                model="bedrock/agentcore/arn:aws:bedrock-agentcore:us-west-2:888602223428:runtime/hosted_agent_r9jvp-3ySZuRHjLC",
                 messages=[
                     {
                         "role": "user",
@@ -189,7 +189,7 @@ def test_bedrock_agentcore_with_session_and_user():
     with patch.object(client, "post", return_value=MagicMock()) as mock_post:
         try:
             response = litellm.completion(
-                model="bedrock/agentcore/arn:aws:bedrock-agentcore:us-west-2:941277531214:runtime/hosted_agent_r9jvp-Rq79QFC2fp",
+                model="bedrock/agentcore/arn:aws:bedrock-agentcore:us-west-2:888602223428:runtime/hosted_agent_r9jvp-3ySZuRHjLC",
                 messages=[
                     {
                         "role": "user",
@@ -234,7 +234,7 @@ def test_bedrock_agentcore_with_api_key_bearer_token():
     with patch.object(client, "post", return_value=MagicMock()) as mock_post:
         try:
             response = litellm.completion(
-                model="bedrock/agentcore/arn:aws:bedrock-agentcore:us-west-2:941277531214:runtime/hosted_agent_r9jvp-Rq79QFC2fp",
+                model="bedrock/agentcore/arn:aws:bedrock-agentcore:us-west-2:888602223428:runtime/hosted_agent_r9jvp-3ySZuRHjLC",
                 messages=[
                     {
                         "role": "user",
@@ -282,7 +282,7 @@ def test_bedrock_agentcore_with_all_parameters():
     with patch.object(client, "post", return_value=MagicMock()) as mock_post:
         try:
             response = litellm.completion(
-                model="bedrock/agentcore/arn:aws:bedrock-agentcore:us-west-2:941277531214:runtime/hosted_agent_r9jvp-Rq79QFC2fp",
+                model="bedrock/agentcore/arn:aws:bedrock-agentcore:us-west-2:888602223428:runtime/hosted_agent_r9jvp-3ySZuRHjLC",
                 messages=[
                     {
                         "role": "user",
@@ -350,7 +350,7 @@ def test_bedrock_agentcore_without_api_key_uses_sigv4():
     with patch.object(client, "post", return_value=MagicMock()) as mock_post:
         try:
             response = litellm.completion(
-                model="bedrock/agentcore/arn:aws:bedrock-agentcore:us-west-2:941277531214:runtime/hosted_agent_r9jvp-Rq79QFC2fp",
+                model="bedrock/agentcore/arn:aws:bedrock-agentcore:us-west-2:888602223428:runtime/hosted_agent_r9jvp-3ySZuRHjLC",
                 messages=[
                     {
                         "role": "user",
@@ -625,7 +625,7 @@ def test_agentcore_synchronous_non_streaming_response():
     with patch.object(client, "post", return_value=mock_response) as mock_post:
         # Make a synchronous (non-streaming) completion call
         response = litellm.completion(
-            model="bedrock/agentcore/arn:aws:bedrock-agentcore:us-west-2:941277531214:runtime/hosted_agent_r9jvp-Rq79QFC2fp",
+            model="bedrock/agentcore/arn:aws:bedrock-agentcore:us-west-2:888602223428:runtime/hosted_agent_r9jvp-3ySZuRHjLC",
             messages=[
                 {
                     "role": "user",

--- a/tests/llm_translation/test_bedrock_completion.py
+++ b/tests/llm_translation/test_bedrock_completion.py
@@ -115,7 +115,7 @@ def test_completion_bedrock_guardrails(streaming):
                 ],
                 max_tokens=10,
                 guardrailConfig={
-                    "guardrailIdentifier": "4w3d1di3snt5",
+                    "guardrailIdentifier": "ff6ujrregl1q",
                     "guardrailVersion": "DRAFT",
                     "trace": "enabled",
                 },
@@ -144,7 +144,7 @@ def test_completion_bedrock_guardrails(streaming):
                 stream=True,
                 max_tokens=10,
                 guardrailConfig={
-                    "guardrailIdentifier": "4w3d1di3snt5",
+                    "guardrailIdentifier": "ff6ujrregl1q",
                     "guardrailVersion": "DRAFT",
                     "trace": "enabled",
                 },
@@ -475,7 +475,7 @@ def test_bedrock_claude_3(image_url):
             ],
         }
         response: ModelResponse = completion(
-            model="bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+            model="bedrock/anthropic.claude-3-sonnet-20240229-v1:0",
             num_retries=3,
             **data,
         )  # type: ignore
@@ -498,7 +498,7 @@ def test_bedrock_claude_3(image_url):
 @pytest.mark.parametrize(
     "model",
     [
-        "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        "anthropic.claude-3-sonnet-20240229-v1:0",
         # "meta.llama3-70b-instruct-v1:0",
         # "anthropic.claude-v2",
         # "mistral.mixtral-8x7b-instruct-v0:1",
@@ -537,7 +537,7 @@ def test_bedrock_stop_value(stop, model):
 @pytest.mark.parametrize(
     "model",
     [
-        "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        "anthropic.claude-3-sonnet-20240229-v1:0",
         "mistral.mixtral-8x7b-instruct-v0:1",
     ],
 )
@@ -602,7 +602,7 @@ def test_bedrock_claude_3_tool_calling():
             }
         ]
         response: ModelResponse = completion(
-            model="bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+            model="bedrock/anthropic.claude-3-sonnet-20240229-v1:0",
             messages=messages,
             tools=tools,
             tool_choice="auto",
@@ -630,7 +630,7 @@ def test_bedrock_claude_3_tool_calling():
         )
         # In the second response, Claude should deduce answer from tool results
         second_response = completion(
-            model="bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+            model="bedrock/anthropic.claude-3-sonnet-20240229-v1:0",
             messages=messages,
             tools=tools,
             tool_choice="auto",
@@ -737,7 +737,7 @@ def test_bedrock_ptu():
         from openai.types.chat import ChatCompletion
 
         model_id = (
-            "arn:aws:bedrock:us-west-2:941277531214:provisioned-model/8fxff74qyhs3"
+            "arn:aws:bedrock:us-west-2:888602223428:provisioned-model/8fxff74qyhs3"
         )
         try:
             response = litellm.completion(
@@ -752,7 +752,7 @@ def test_bedrock_ptu():
         assert "url" in mock_client_post.call_args.kwargs
         assert (
             mock_client_post.call_args.kwargs["url"]
-            == "https://bedrock-runtime.us-west-2.amazonaws.com/model/arn%3Aaws%3Abedrock%3Aus-west-2%3A941277531214%3Aprovisioned-model%2F8fxff74qyhs3/converse"
+            == "https://bedrock-runtime.us-west-2.amazonaws.com/model/arn%3Aaws%3Abedrock%3Aus-west-2%3A888602223428%3Aprovisioned-model%2F8fxff74qyhs3/converse"
         )
         mock_client_post.assert_called_once()
 
@@ -2327,7 +2327,7 @@ def test_bedrock_cross_region_inference(monkeypatch):
 
 def test_bedrock_empty_content_real_call():
     completion(
-        model="bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        model="bedrock/anthropic.claude-3-sonnet-20240229-v1:0",
         messages=[
             {
                 "role": "user",

--- a/tests/local_testing/test_completion.py
+++ b/tests/local_testing/test_completion.py
@@ -299,10 +299,7 @@ def test_completion_claude_3():
 
 @pytest.mark.parametrize(
     "model",
-    [
-        "anthropic/claude-sonnet-4-5-20250929",
-        "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
-    ],
+    ["anthropic/claude-sonnet-4-5-20250929", "anthropic.claude-3-sonnet-20240229-v1:0"],
 )
 def test_completion_claude_3_function_call(model):
     litellm.set_verbose = True
@@ -388,7 +385,7 @@ def test_completion_claude_3_function_call(model):
     [
         ("gpt-3.5-turbo", None, None),
         ("claude-sonnet-4-5-20250929", None, None),
-        ("us.anthropic.claude-sonnet-4-5-20250929-v1:0", None, None),
+        ("anthropic.claude-3-sonnet-20240229-v1:0", None, None),
         # (
         #     "azure_ai/command-r-plus",
         #     os.getenv("AZURE_COHERE_API_KEY"),
@@ -1581,7 +1578,7 @@ def test_completion_openai():
     [
         # ("gpt-4o-2024-08-06", None),
         # ("azure/gpt-4.1-mini", None),
-        ("bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0", None),
+        ("bedrock/anthropic.claude-3-sonnet-20240229-v1:0", None),
         # ("azure/gpt-4o-new-test", "2024-08-01-preview"),
     ],
 )
@@ -1669,13 +1666,15 @@ def custom_callback(
 
         #################################################
 
-        print(f"""
+        print(
+            f"""
                 Model: {model},
                 Messages: {messages},
                 User: {user},
                 Seed: {kwargs["seed"]},
                 temperature: {kwargs["temperature"]},
-            """)
+            """
+        )
 
         assert kwargs["user"] == "ishaans app"
         assert kwargs["model"] == "gpt-3.5-turbo-1106"
@@ -2700,7 +2699,7 @@ def test_bedrock_deepseek_custom_prompt_dict():
 
 def test_bedrock_deepseek_known_tokenizer_config(monkeypatch):
     model = (
-        "deepseek_r1/arn:aws:bedrock:us-west-2:941277531214:imported-model/bnnr6463ejgf"
+        "deepseek_r1/arn:aws:bedrock:us-west-2:888602223428:imported-model/bnnr6463ejgf"
     )
     from litellm.llms.custom_httpx.http_handler import HTTPHandler
     from unittest.mock import Mock
@@ -2915,8 +2914,8 @@ def response_format_tests(response: litellm.ModelResponse):
     "model",
     [
         "bedrock/mistral.mistral-large-2407-v1:0",
-        "us.anthropic.claude-haiku-4-5-20251001-v1:0",
-        "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        "bedrock/cohere.command-r-plus-v1:0",
+        "anthropic.claude-3-sonnet-20240229-v1:0",
         "mistral.mistral-7b-instruct-v0:2",
         "meta.llama3-8b-instruct-v1:0",
     ],

--- a/tests/local_testing/test_function_call_parsing.py
+++ b/tests/local_testing/test_function_call_parsing.py
@@ -142,8 +142,7 @@ def trade(model_name: str) -> List[Trade]:  # type: ignore
 
 
 @pytest.mark.parametrize(
-    "model",
-    ["claude-haiku-4-5-20251001", "us.anthropic.claude-haiku-4-5-20251001-v1:0"],
+    "model", ["claude-haiku-4-5-20251001", "anthropic.claude-3-haiku-20240307-v1:0"]
 )
 @pytest.mark.flaky(retries=6, delay=10)
 def test_function_call_parsing(model):

--- a/tests/local_testing/test_function_calling.py
+++ b/tests/local_testing/test_function_calling.py
@@ -49,7 +49,7 @@ def get_current_weather(location, unit="fahrenheit"):
         "mistral/mistral-large-latest",
         "claude-haiku-4-5-20251001",
         "gemini/gemini-2.5-flash-lite",
-        "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        "anthropic.claude-3-sonnet-20240229-v1:0",
     ],
 )
 @pytest.mark.flaky(retries=3, delay=1)
@@ -267,6 +267,7 @@ def test_aaparallel_function_call_with_anthropic_thinking(model):
 
 from litellm.types.utils import ChatCompletionMessageToolCall, Function, Message
 
+
 _PARALLEL_TOOL_HISTORY_MESSAGES = [
     {
         "role": "user",
@@ -302,7 +303,7 @@ _PARALLEL_TOOL_HISTORY_MESSAGES = [
     [
         # Bedrock Converse still requires modify_params to inject the dummy tool.
         (
-            "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+            "anthropic.claude-3-sonnet-20240229-v1:0",
             _PARALLEL_TOOL_HISTORY_MESSAGES,
             True,
         ),
@@ -313,7 +314,7 @@ _PARALLEL_TOOL_HISTORY_MESSAGES = [
             False,
         ),
         (
-            "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+            "anthropic.claude-3-sonnet-20240229-v1:0",
             [
                 {
                     "role": "user",
@@ -578,7 +579,7 @@ def test_groq_parallel_function_call():
 @pytest.mark.parametrize(
     "model",
     [
-        "bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        "bedrock/anthropic.claude-3-sonnet-20240229-v1:0",
     ],
 )
 def test_passing_tool_result_as_list(model):

--- a/tests/local_testing/test_sagemaker.py
+++ b/tests/local_testing/test_sagemaker.py
@@ -57,7 +57,7 @@ async def test_completion_sagemaker(sync_mode):
         print("testing sagemaker")
         if sync_mode is True:
             response = litellm.completion(
-                model="sagemaker/litellm-ci-textgen",
+                model="sagemaker/jumpstart-dft-hf-textgeneration1-mp-20240815-185614",
                 messages=[
                     {"role": "user", "content": "hi"},
                 ],
@@ -67,7 +67,7 @@ async def test_completion_sagemaker(sync_mode):
             )
         else:
             response = await litellm.acompletion(
-                model="sagemaker/litellm-ci-textgen",
+                model="sagemaker/jumpstart-dft-hf-textgeneration1-mp-20240815-185614",
                 messages=[
                     {"role": "user", "content": "hi"},
                 ],
@@ -158,7 +158,7 @@ async def test_completion_sagemaker_messages_api(sync_mode):
     "model",
     [
         # "sagemaker_chat/huggingface-pytorch-tgi-inference-2024-08-23-15-48-59-245",
-        "sagemaker/litellm-ci-textgen",
+        "sagemaker/jumpstart-dft-hf-textgeneration1-mp-20240815-185614",
     ],
 )
 # @pytest.mark.flaky(retries=3, delay=1)
@@ -218,7 +218,7 @@ async def test_completion_sagemaker_stream(sync_mode, model):
     "model",
     [
         # "sagemaker_chat/huggingface-pytorch-tgi-inference-2024-08-23-15-48-59-245",
-        "sagemaker/litellm-ci-textgen",
+        "sagemaker/jumpstart-dft-hf-textgeneration1-mp-20240815-185614",
     ],
 )
 async def test_completion_sagemaker_streaming_bad_request(sync_mode, model):
@@ -256,7 +256,7 @@ async def test_acompletion_sagemaker_non_stream():
             "id": "cmpl-mockid",
             "object": "text_completion",
             "created": 1629800000,
-            "model": "sagemaker/litellm-ci-textgen",
+            "model": "sagemaker/jumpstart-dft-hf-textgeneration1-mp-20240815-185614",
             "choices": [
                 {
                     "text": "This is a mock response from SageMaker.",
@@ -282,7 +282,7 @@ async def test_acompletion_sagemaker_non_stream():
     ) as mock_post:
         # Act: Call the litellm.acompletion function
         response = await litellm.acompletion(
-            model="sagemaker/litellm-ci-textgen",
+            model="sagemaker/jumpstart-dft-hf-textgeneration1-mp-20240815-185614",
             messages=[
                 {"role": "user", "content": "hi"},
             ],
@@ -302,7 +302,7 @@ async def test_acompletion_sagemaker_non_stream():
         assert args_to_sagemaker == expected_payload
         assert (
             kwargs["url"]
-            == "https://runtime.sagemaker.us-west-2.amazonaws.com/endpoints/litellm-ci-textgen/invocations"
+            == "https://runtime.sagemaker.us-west-2.amazonaws.com/endpoints/jumpstart-dft-hf-textgeneration1-mp-20240815-185614/invocations"
         )
 
 
@@ -316,7 +316,7 @@ async def test_completion_sagemaker_non_stream():
             "id": "cmpl-mockid",
             "object": "text_completion",
             "created": 1629800000,
-            "model": "sagemaker/litellm-ci-textgen",
+            "model": "sagemaker/jumpstart-dft-hf-textgeneration1-mp-20240815-185614",
             "choices": [
                 {
                     "text": "This is a mock response from SageMaker.",
@@ -342,7 +342,7 @@ async def test_completion_sagemaker_non_stream():
     ) as mock_post:
         # Act: Call the litellm.acompletion function
         response = litellm.completion(
-            model="sagemaker/litellm-ci-textgen",
+            model="sagemaker/jumpstart-dft-hf-textgeneration1-mp-20240815-185614",
             messages=[
                 {"role": "user", "content": "hi"},
             ],
@@ -362,7 +362,7 @@ async def test_completion_sagemaker_non_stream():
         assert args_to_sagemaker == expected_payload
         assert (
             kwargs["url"]
-            == "https://runtime.sagemaker.us-west-2.amazonaws.com/endpoints/litellm-ci-textgen/invocations"
+            == "https://runtime.sagemaker.us-west-2.amazonaws.com/endpoints/jumpstart-dft-hf-textgeneration1-mp-20240815-185614/invocations"
         )
 
 
@@ -377,7 +377,7 @@ async def test_completion_sagemaker_prompt_template_non_stream():
             "id": "cmpl-mockid",
             "object": "text_completion",
             "created": 1629800000,
-            "model": "sagemaker/litellm-ci-textgen",
+            "model": "sagemaker/jumpstart-dft-hf-textgeneration1-mp-20240815-185614",
             "choices": [
                 {
                     "text": "This is a mock response from SageMaker.",
@@ -433,7 +433,7 @@ async def test_completion_sagemaker_non_stream_with_aws_params():
             "id": "cmpl-mockid",
             "object": "text_completion",
             "created": 1629800000,
-            "model": "sagemaker/litellm-ci-textgen",
+            "model": "sagemaker/jumpstart-dft-hf-textgeneration1-mp-20240815-185614",
             "choices": [
                 {
                     "text": "This is a mock response from SageMaker.",
@@ -459,7 +459,7 @@ async def test_completion_sagemaker_non_stream_with_aws_params():
     ) as mock_post:
         # Act: Call the litellm.acompletion function
         response = litellm.completion(
-            model="sagemaker/litellm-ci-textgen",
+            model="sagemaker/jumpstart-dft-hf-textgeneration1-mp-20240815-185614",
             messages=[
                 {"role": "user", "content": "hi"},
             ],
@@ -482,5 +482,5 @@ async def test_completion_sagemaker_non_stream_with_aws_params():
         assert args_to_sagemaker == expected_payload
         assert (
             kwargs["url"]
-            == "https://runtime.sagemaker.us-west-5.amazonaws.com/endpoints/litellm-ci-textgen/invocations"
+            == "https://runtime.sagemaker.us-west-5.amazonaws.com/endpoints/jumpstart-dft-hf-textgeneration1-mp-20240815-185614/invocations"
         )

--- a/tests/local_testing/test_streaming.py
+++ b/tests/local_testing/test_streaming.py
@@ -1174,7 +1174,7 @@ async def test_completion_replicate_llama3_streaming(sync_mode):
     [
         # ["bedrock/ai21.jamba-instruct-v1:0", "us-east-1"],
         # ["bedrock/cohere.command-r-plus-v1:0", None],
-        ["us.anthropic.claude-sonnet-4-5-20250929-v1:0", None],
+        ["anthropic.claude-3-sonnet-20240229-v1:0", None],
         # ["mistral.mistral-7b-instruct-v0:2", None],
         # ["meta.llama3-8b-instruct-v1:0", None],
     ],
@@ -1246,7 +1246,7 @@ def test_bedrock_claude_3_streaming():
     try:
         litellm.set_verbose = True
         response: ModelResponse = completion(  # type: ignore
-            model="bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+            model="bedrock/anthropic.claude-3-sonnet-20240229-v1:0",
             messages=messages,
             max_tokens=10,  # type: ignore
             stream=True,
@@ -1276,7 +1276,7 @@ def test_bedrock_claude_3_streaming():
     "model",
     [
         "claude-haiku-4-5-20251001",
-        "us.anthropic.claude-haiku-4-5-20251001-v1:0",  # bedrock
+        "cohere.command-r-plus-v1:0",  # bedrock
         "gpt-3.5-turbo",
     ],
 )
@@ -3500,7 +3500,7 @@ def test_unit_test_perplexity_citations_chunk():
     [
         "gpt-3.5-turbo",
         "claude-sonnet-4-5-20250929",
-        "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        "anthropic.claude-3-sonnet-20240229-v1:0",
         # "vertex_ai/claude-3-5-sonnet@20240620",
     ],
 )

--- a/tests/logging_callback_tests/test_amazing_s3_logs.py
+++ b/tests/logging_callback_tests/test_amazing_s3_logs.py
@@ -27,7 +27,7 @@ async def test_basic_s3_logging(sync_mode, streaming):
     verbose_logger.setLevel(level=logging.DEBUG)
     litellm.success_callback = ["s3"]
     litellm.s3_callback_params = {
-        "s3_bucket_name": "load-testing-oct-941277531214",
+        "s3_bucket_name": "load-testing-oct",
         "s3_aws_secret_access_key": "os.environ/AWS_SECRET_ACCESS_KEY",
         "s3_aws_access_key_id": "os.environ/AWS_ACCESS_KEY_ID",
         "s3_region_name": "us-west-2",
@@ -64,14 +64,14 @@ async def test_basic_s3_logging(sync_mode, streaming):
         await asyncio.sleep(2)
     print(f"response: {response}")
 
-    total_objects, all_s3_keys = list_all_s3_objects("load-testing-oct-941277531214")
+    total_objects, all_s3_keys = list_all_s3_objects("load-testing-oct")
 
     # assert that atlest one key has response.id in it
     assert any(response_id in key for key in all_s3_keys)
     s3 = boto3.client("s3")
     # delete all objects
     for key in all_s3_keys:
-        s3.delete_object(Bucket="load-testing-oct-941277531214", Key=key)
+        s3.delete_object(Bucket="load-testing-oct", Key=key)
 
 
 @pytest.mark.asyncio
@@ -82,7 +82,7 @@ async def test_basic_s3_v2_logging(streaming):
     from litellm.integrations.s3_v2 import S3Logger
 
     litellm.s3_callback_params = {
-        "s3_bucket_name": "load-testing-oct-941277531214",
+        "s3_bucket_name": "load-testing-oct",
         "s3_aws_secret_access_key": "test-secret",
         "s3_aws_access_key_id": "test-key",
         "s3_region_name": "us-west-2",

--- a/tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py
+++ b/tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py
@@ -2,6 +2,7 @@ import io
 import os
 import sys
 
+
 sys.path.insert(0, os.path.abspath("../.."))
 
 import asyncio
@@ -66,7 +67,7 @@ def setup_vector_store_registry():
     litellm.vector_store_registry = VectorStoreRegistry(
         vector_stores=[
             LiteLLM_ManagedVectorStore(
-                vector_store_id="LCYXFBR2TU", custom_llm_provider="bedrock"
+                vector_store_id="T37J8R4WTM", custom_llm_provider="bedrock"
             )
         ]
     )
@@ -110,7 +111,7 @@ async def test_e2e_bedrock_knowledgebase_retrieval_with_completion(
             response = await litellm.acompletion(
                 model="anthropic/claude-3.5-sonnet",
                 messages=[{"role": "user", "content": "what is litellm?"}],
-                vector_store_ids=["LCYXFBR2TU"],
+                vector_store_ids=["T37J8R4WTM"],
                 client=client,
             )
         except Exception as e:
@@ -151,7 +152,7 @@ async def test_e2e_bedrock_knowledgebase_retrieval_with_llm_api_call(
     response = await litellm.acompletion(
         model="bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
         messages=[{"role": "user", "content": "what is litellm?"}],
-        vector_store_ids=["LCYXFBR2TU"],
+        vector_store_ids=["T37J8R4WTM"],
         client=async_client,
     )
     print("OPENAI RESPONSE:", json.dumps(dict(response), indent=4, default=str))
@@ -195,7 +196,7 @@ async def test_e2e_bedrock_knowledgebase_retrieval_with_llm_api_call_streaming(
     response = await litellm.acompletion(
         model=f"anthropic/{os.environ.get('CI_CD_DEFAULT_ANTHROPIC_MODEL', 'claude-haiku-4-5-20251001')}",
         messages=[{"role": "user", "content": "what is litellm?"}],
-        vector_store_ids=["LCYXFBR2TU"],
+        vector_store_ids=["T37J8R4WTM"],
         stream=True,
         client=async_client,
     )
@@ -254,7 +255,7 @@ async def test_e2e_bedrock_knowledgebase_retrieval_with_llm_api_call_with_tools(
         model=f"anthropic/{os.environ.get('CI_CD_DEFAULT_ANTHROPIC_MODEL', 'claude-haiku-4-5-20251001')}",
         messages=[{"role": "user", "content": "what is litellm?"}],
         max_tokens=10,
-        tools=[{"type": "file_search", "vector_store_ids": ["LCYXFBR2TU"]}],
+        tools=[{"type": "file_search", "vector_store_ids": ["T37J8R4WTM"]}],
     )
     assert response is not None
 
@@ -278,7 +279,7 @@ async def test_e2e_bedrock_knowledgebase_retrieval_with_llm_api_call_with_tools_
         tools=[
             {
                 "type": "file_search",
-                "vector_store_ids": ["LCYXFBR2TU"],
+                "vector_store_ids": ["T37J8R4WTM"],
                 "filters": {
                     "key": "user_id",
                     "value": "fake-user-id",
@@ -386,7 +387,7 @@ async def test_bedrock_kb_request_body_has_transformed_filters(
             tools=[
                 {
                     "type": "file_search",
-                    "vector_store_ids": ["LCYXFBR2TU"],
+                    "vector_store_ids": ["T37J8R4WTM"],
                     "filters": {
                         "key": "user_id",
                         "value": "fake-user-id",
@@ -460,7 +461,7 @@ async def test_openai_with_knowledge_base_mock_openai(setup_vector_store_registr
             await litellm.acompletion(
                 model="gpt-5.5",
                 messages=[{"role": "user", "content": "what is litellm?"}],
-                vector_store_ids=["LCYXFBR2TU"],
+                vector_store_ids=["T37J8R4WTM"],
                 client=client,
             )
         except Exception as e:
@@ -536,7 +537,7 @@ async def test_openai_with_vector_store_ids_in_tool_call_mock_openai(
             await litellm.acompletion(
                 model="gpt-5.5",
                 messages=[{"role": "user", "content": "what is litellm?"}],
-                tools=[{"type": "file_search", "vector_store_ids": ["LCYXFBR2TU"]}],
+                tools=[{"type": "file_search", "vector_store_ids": ["T37J8R4WTM"]}],
                 client=client,
             )
         except Exception as e:
@@ -610,7 +611,7 @@ async def test_openai_with_mixed_tool_call_mock_openai(setup_vector_store_regist
                 model="gpt-5.5",
                 messages=[{"role": "user", "content": "what is litellm?"}],
                 tools=[
-                    {"type": "file_search", "vector_store_ids": ["LCYXFBR2TU"]},
+                    {"type": "file_search", "vector_store_ids": ["T37J8R4WTM"]},
                     {"type": "file_search", "vector_store_ids": ["unknownVS"]},
                 ],
                 client=client,
@@ -644,7 +645,7 @@ async def test_openai_with_mixed_tool_call_mock_openai(setup_vector_store_regist
 #         model="gpt-5.5",
 #         messages=[{"role": "user", "content": "what is litellm?"}],
 #         vector_store_ids = [
-#             "LCYXFBR2TU"
+#             "T37J8R4WTM"
 #         ],
 #     )
 
@@ -666,7 +667,7 @@ async def test_openai_with_mixed_tool_call_mock_openai(setup_vector_store_regist
 
 #     # expect the vector store request metadata object to have the correct values
 #     vector_store_request_metadata = standard_logging_vector_store_request_metadata[0]
-#     assert vector_store_request_metadata.get("vector_store_id") == "LCYXFBR2TU"
+#     assert vector_store_request_metadata.get("vector_store_id") == "T37J8R4WTM"
 #     assert vector_store_request_metadata.get("query") == "what is litellm?"
 #     assert vector_store_request_metadata.get("custom_llm_provider") == "bedrock"
 
@@ -722,7 +723,7 @@ async def test_e2e_bedrock_knowledgebase_retrieval_without_vector_store_registry
             response = await litellm.acompletion(
                 model="anthropic/claude-3.5-sonnet",
                 messages=[{"role": "user", "content": "what is litellm?"}],
-                vector_store_ids=["LCYXFBR2TU"],
+                vector_store_ids=["T37J8R4WTM"],
                 client=client,
             )
         except Exception as e:

--- a/tests/test_litellm/llms/bedrock/chat/agentcore/test_agentcore_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/agentcore/test_agentcore_transformation.py
@@ -76,7 +76,7 @@ class TestAgentCoreAcceptHeader:
         with patch.object(client, "post", return_value=MagicMock()) as mock_post:
             try:
                 litellm.completion(
-                    model="bedrock/agentcore/arn:aws:bedrock-agentcore:us-west-2:941277531214:runtime/test_runtime",
+                    model="bedrock/agentcore/arn:aws:bedrock-agentcore:us-west-2:888602223428:runtime/test_runtime",
                     messages=[{"role": "user", "content": "test"}],
                     api_key="test-jwt-token",
                     client=client,
@@ -281,7 +281,7 @@ class TestAgentCoreStreamingJsonFallback:
 
         with patch.object(client, "post", return_value=mock_response):
             response = litellm.completion(
-                model="bedrock/agentcore/arn:aws:bedrock-agentcore:us-west-2:941277531214:runtime/test_agent",
+                model="bedrock/agentcore/arn:aws:bedrock-agentcore:us-west-2:888602223428:runtime/test_agent",
                 messages=[{"role": "user", "content": "test"}],
                 stream=True,
                 client=client,
@@ -318,7 +318,7 @@ class TestAgentCoreStreamingJsonFallback:
             client, "post", new_callable=AsyncMock, return_value=mock_response
         ):
             response = await litellm.acompletion(
-                model="bedrock/agentcore/arn:aws:bedrock-agentcore:us-west-2:941277531214:runtime/test_agent",
+                model="bedrock/agentcore/arn:aws:bedrock-agentcore:us-west-2:888602223428:runtime/test_agent",
                 messages=[{"role": "user", "content": "test"}],
                 stream=True,
                 client=client,
@@ -353,7 +353,7 @@ class TestAgentCoreStreamingJsonFallback:
                 Exception, match="Failed to read/parse JSON response body"
             ):
                 litellm.completion(
-                    model="bedrock/agentcore/arn:aws:bedrock-agentcore:us-west-2:941277531214:runtime/test_agent",
+                    model="bedrock/agentcore/arn:aws:bedrock-agentcore:us-west-2:888602223428:runtime/test_agent",
                     messages=[{"role": "user", "content": "test"}],
                     stream=True,
                     client=client,
@@ -383,7 +383,7 @@ class TestAgentCoreStreamingJsonFallback:
                 Exception, match="Failed to read/parse JSON response body"
             ):
                 await litellm.acompletion(
-                    model="bedrock/agentcore/arn:aws:bedrock-agentcore:us-west-2:941277531214:runtime/test_agent",
+                    model="bedrock/agentcore/arn:aws:bedrock-agentcore:us-west-2:888602223428:runtime/test_agent",
                     messages=[{"role": "user", "content": "test"}],
                     stream=True,
                     client=client,

--- a/tests/test_openai_endpoints.py
+++ b/tests/test_openai_endpoints.py
@@ -446,7 +446,7 @@ async def test_chat_completion_anthropic_structured_output():
     client = AsyncOpenAI(api_key="sk-1234", base_url="http://0.0.0.0:4000")
 
     res = await client.beta.chat.completions.parse(
-        model="bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        model="bedrock/us.anthropic.claude-3-sonnet-20240229-v1:0",
         messages=messages,
         response_format=EventsList,
         timeout=60,

--- a/tests/vector_store_tests/test_bedrock_vector_store.py
+++ b/tests/vector_store_tests/test_bedrock_vector_store.py
@@ -22,7 +22,7 @@ class TestBedrockVectorStore(BaseVectorStoreTest):
 
     def get_base_request_args(self):
         return {
-            "vector_store_id": "LCYXFBR2TU",
+            "vector_store_id": "T37J8R4WTM",
             "custom_llm_provider": "bedrock",
             "query": "what happens after we add a model",
         }
@@ -106,7 +106,7 @@ async def test_bedrock_search_with_router():
     _router = Router(model_list=[])
     search_response = await _router.avector_store_search(
         query="what happens after we add a model",
-        vector_store_id="LCYXFBR2TU",
+        vector_store_id="T37J8R4WTM",
         custom_llm_provider="bedrock",
     )
     print(search_response)
@@ -150,7 +150,7 @@ async def test_bedrock_search_with_credentials_managed_registry():
 
         # Create vector store with credential reference
         vector_store = LiteLLM_ManagedVectorStore(
-            vector_store_id="LCYXFBR2TU",
+            vector_store_id="T37J8R4WTM",
             custom_llm_provider="bedrock",
             created_at=datetime.now(timezone.utc),
             updated_at=datetime.now(timezone.utc),
@@ -162,7 +162,7 @@ async def test_bedrock_search_with_credentials_managed_registry():
         litellm.vector_store_registry = registry
 
         # Verify credentials can be retrieved from registry
-        retrieved_credentials = registry.get_credentials_for_vector_store("LCYXFBR2TU")
+        retrieved_credentials = registry.get_credentials_for_vector_store("T37J8R4WTM")
         assert retrieved_credentials, "Should retrieve credentials from registry"
         assert retrieved_credentials.get("aws_access_key_id") == "test_access_key"
         assert retrieved_credentials.get("aws_secret_access_key") == "test_secret_key"
@@ -194,7 +194,7 @@ async def test_bedrock_search_with_credentials_managed_registry():
 
                 search_response = await _router.avector_store_search(
                     query="what happens after we add a model",
-                    vector_store_id="LCYXFBR2TU",
+                    vector_store_id="T37J8R4WTM",
                     custom_llm_provider="bedrock",
                 )
 
@@ -203,7 +203,7 @@ async def test_bedrock_search_with_credentials_managed_registry():
                 call_kwargs = mock_handler.call_args[1]
 
                 # Verify that the credential accessor was called with the correct vector store ID
-                mock_get_creds.assert_called_with("LCYXFBR2TU")
+                mock_get_creds.assert_called_with("T37J8R4WTM")
 
                 # Verify the credentials were injected into the search call
                 litellm_params = call_kwargs.get("litellm_params", {})
@@ -224,7 +224,7 @@ async def test_bedrock_search_with_credentials_managed_registry():
                 assert search_response["data"][0]["id"] == "test_result"
 
                 print(
-                    f"✅ Test passed: Credential accessor was called with vector store ID: LCYXFBR2TU"
+                    f"✅ Test passed: Credential accessor was called with vector store ID: T37J8R4WTM"
                 )
                 print(f"✅ Retrieved credentials: {retrieved_credentials}")
                 print(f"✅ Credentials were injected into search call")


### PR DESCRIPTION
## Relevant issues

Reverts the Bedrock CI account migration in #28728.

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

The change is a code-side revert of resource identifiers; the live proof is the CI Bedrock jobs going green once the CircleCI credentials are repointed (see the action item below). The verification done locally is the structural side: the mock-based AgentCore transformation tests and the reasoning-effort grid both pass against the reverted ARNs and grid_spec.

```
$ python -m pytest tests/test_litellm/llms/bedrock/chat/agentcore/test_agentcore_transformation.py -q
20 passed in 0.32s

$ python -m pytest tests/llm_translation/reasoning_effort_grid/test_reasoning_effort_grid.py -q
46 passed, 187 skipped in 116.90s
```

(The 187 skips are the live grid cells that skip when AWS creds are absent in the dev container.)

## Type

🧹 Refactoring
✅ Test

## Changes

#28728 migrated every Bedrock-touching CI resource from account 888602223428 to a fresh account (941277531214) after the original account was put under an AWS security restriction following a leaked key. That account has since been reactivated, and the replacement account never gained access to several models the suites exercise (legacy Bedrock Claude 3 models, Cohere, Nova Canvas image generation, Bedrock batch inference, and flagship Opus). This PR is the exact inverse of #28728 so CI points back at the reactivated account and regains that coverage.

Concretely, all hardcoded `941277531214` references revert to `888602223428` (provisioned- and imported-model ARNs, AgentCore runtime ARNs including their regenerated suffixes, the batch execution role ARN, and the example proxy config). The S3 buckets revert to `litellm-proxy` and `load-testing-oct`; the guardrail IDs revert to `wf0hkdb5x07f` and `ff6ujrregl1q`; the SageMaker endpoint and Bedrock Knowledge Base revert to their original ids; and the live-call tests go back to the legacy model strings. The `fail_reason`/xfail workaround that #28728 added for the unentitled Opus grid cells is dropped, while the unrelated `bedrock_effort_ceiling` field added to `grid_spec.py` after the migration is preserved.

One thing this PR cannot do on its own: the CircleCI `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` project env vars still hold the 941277531214 credentials and must be set to the reactivated account's fresh credentials separately via the CircleCI API. `AWS_REGION_NAME` stays `us-west-2`. Until those are repointed, the live Bedrock CI jobs will still run against the new account.