### PR TITLE
test(reasoning-effort-grid): cover Claude Opus 4.8 across provider routes

### DIFF
--- a/tests/llm_translation/reasoning_effort_grid/grid_spec.py
+++ b/tests/llm_translation/reasoning_effort_grid/grid_spec.py
@@ -22,6 +22,7 @@ class ModelEntry:
     required_env: FrozenSet[str] = field(default_factory=frozenset)
     caps: FrozenSet[str] = field(default_factory=frozenset)
     unavailable_error: Optional[str] = None
+    fail_reason: Optional[str] = None
     bedrock_effort_ceiling: Optional[str] = None
 
     def params(self) -> Dict[str, str]:
@@ -126,7 +127,7 @@ _VERTEX_REQ = frozenset({"VERTEX_PROJECT"})
 _BEDROCK_REQ = frozenset({"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"})
 
 
-_CAPS_OPUS_4_7: FrozenSet[str] = frozenset(
+_CAPS_XHIGH_MAX: FrozenSet[str] = frozenset(
     {"supports_xhigh_reasoning_effort", "supports_max_reasoning_effort"}
 )
 _CAPS_4_6: FrozenSet[str] = frozenset({"supports_max_reasoning_effort"})
@@ -135,11 +136,18 @@ _CAPS_NONE: FrozenSet[str] = frozenset()
 
 ANTHROPIC_DIRECT_MODELS: Tuple[ModelEntry, ...] = (
     ModelEntry(
+        alias="claude-opus-4-8",
+        model="anthropic/claude-opus-4-8",
+        mode="adaptive",
+        required_env=_ANTHROPIC_REQ,
+        caps=_CAPS_XHIGH_MAX,
+    ),
+    ModelEntry(
         alias="claude-opus-4-7",
         model="anthropic/claude-opus-4-7",
         mode="adaptive",
         required_env=_ANTHROPIC_REQ,
-        caps=_CAPS_OPUS_4_7,
+        caps=_CAPS_XHIGH_MAX,
     ),
     ModelEntry(
         alias="claude-sonnet-4-6",
@@ -160,11 +168,24 @@ ANTHROPIC_DIRECT_MODELS: Tuple[ModelEntry, ...] = (
 
 AZURE_AI_MODELS: Tuple[ModelEntry, ...] = (
     ModelEntry(
+        alias="azure-claude-opus-4-8",
+        model="azure_ai/claude-opus-4-8",
+        mode="adaptive",
+        required_env=_AZURE_FOUNDRY_REQ,
+        caps=_CAPS_XHIGH_MAX,
+        fail_reason=(
+            "claude-opus-4-8 has no deployment on the CI Microsoft Foundry "
+            "resource yet; Foundry returns DeploymentNotFound until someone "
+            "creates the opus-4-8 deployment, so this cell stays loud in CI. "
+            "Remove this fail_reason once the deployment exists."
+        ),
+    ),
+    ModelEntry(
         alias="azure-claude-opus-4-7",
         model="azure_ai/claude-opus-4-7",
         mode="adaptive",
         required_env=_AZURE_FOUNDRY_REQ,
-        caps=_CAPS_OPUS_4_7,
+        caps=_CAPS_XHIGH_MAX,
     ),
     ModelEntry(
         alias="azure-claude-opus-4-6",
@@ -192,12 +213,26 @@ AZURE_AI_MODELS: Tuple[ModelEntry, ...] = (
 
 VERTEX_AI_MODELS: Tuple[ModelEntry, ...] = (
     ModelEntry(
+        alias="vertex-claude-opus-4-8",
+        model="vertex_ai/claude-opus-4-8",
+        mode="adaptive",
+        extra_params=(("vertex_location", "global"),),
+        required_env=_VERTEX_REQ,
+        caps=_CAPS_XHIGH_MAX,
+        fail_reason=(
+            "claude-opus-4-8 availability on the CI Vertex project is not yet "
+            "confirmed for this brand-new release, so this cell stays loud in "
+            "CI until verified. Remove this fail_reason once the model is "
+            "confirmed available on the global Vertex endpoint."
+        ),
+    ),
+    ModelEntry(
         alias="vertex-claude-opus-4-7",
         model="vertex_ai/claude-opus-4-7",
         mode="adaptive",
         extra_params=(("vertex_location", "global"),),
         required_env=_VERTEX_REQ,
-        caps=_CAPS_OPUS_4_7,
+        caps=_CAPS_XHIGH_MAX,
     ),
     ModelEntry(
         alias="vertex-claude-opus-4-6",
@@ -228,12 +263,23 @@ VERTEX_AI_MODELS: Tuple[ModelEntry, ...] = (
 
 BEDROCK_CONVERSE_MODELS: Tuple[ModelEntry, ...] = (
     ModelEntry(
+        alias="bedrock-claude-opus-4-8",
+        model="bedrock/converse/us.anthropic.claude-opus-4-8",
+        mode="adaptive",
+        extra_params=(("aws_region_name", "us-east-1"),),
+        required_env=_BEDROCK_REQ,
+        caps=_CAPS_XHIGH_MAX,
+        bedrock_effort_ceiling="xhigh",
+        unavailable_error="is not available for this account",
+    ),
+    ModelEntry(
         alias="bedrock-claude-opus-4-7",
         model="bedrock/converse/us.anthropic.claude-opus-4-7",
         mode="adaptive",
         extra_params=(("aws_region_name", "us-east-1"),),
         required_env=_BEDROCK_REQ,
-        caps=_CAPS_OPUS_4_7,
+        caps=_CAPS_XHIGH_MAX,
+        bedrock_effort_ceiling="xhigh",
         unavailable_error="is not available for this account",
     ),
     ModelEntry(

--- a/tests/llm_translation/reasoning_effort_grid/grid_spec.py
+++ b/tests/llm_translation/reasoning_effort_grid/grid_spec.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass, field
 from typing import Dict, FrozenSet, List, Optional, Tuple
 
-
 OMIT = object()
 
 
@@ -22,6 +21,7 @@ class ModelEntry:
     extra_params: Tuple[Tuple[str, str], ...] = field(default_factory=tuple)
     required_env: FrozenSet[str] = field(default_factory=frozenset)
     caps: FrozenSet[str] = field(default_factory=frozenset)
+    unavailable_error: Optional[str] = None
     bedrock_effort_ceiling: Optional[str] = None
 
     def params(self) -> Dict[str, str]:
@@ -234,6 +234,7 @@ BEDROCK_CONVERSE_MODELS: Tuple[ModelEntry, ...] = (
         extra_params=(("aws_region_name", "us-east-1"),),
         required_env=_BEDROCK_REQ,
         caps=_CAPS_OPUS_4_7,
+        unavailable_error="is not available for this account",
     ),
     ModelEntry(
         alias="bedrock-claude-opus-4-6",

--- a/tests/llm_translation/reasoning_effort_grid/test_reasoning_effort_grid.py
+++ b/tests/llm_translation/reasoning_effort_grid/test_reasoning_effort_grid.py
@@ -173,6 +173,9 @@ async def test_reasoning_effort_grid(
     if skip_reason:
         pytest.skip(skip_reason)
 
+    if model.fail_reason:
+        pytest.xfail(model.fail_reason)
+
     if route_name == "bedrock_invoke_messages":
         status, exc = await _call_messages(model, effort)
     else:
@@ -197,8 +200,8 @@ async def test_reasoning_effort_grid(
 
 
 def test_grid_cell_count() -> None:
-    assert len(_PARAMS) == 21 * 11, (
-        f"expected 231 cells (21 provider x model combos x 11 efforts), "
+    assert len(_PARAMS) == 25 * 11, (
+        f"expected 275 cells (25 provider x model combos x 11 efforts), "
         f"got {len(_PARAMS)}"
     )
 

--- a/tests/llm_translation/reasoning_effort_grid/test_reasoning_effort_grid.py
+++ b/tests/llm_translation/reasoning_effort_grid/test_reasoning_effort_grid.py
@@ -15,7 +15,6 @@ from .grid_spec import (
     all_cells,
 )
 
-
 _PROMPT_MESSAGES: List[Dict[str, str]] = [
     {"role": "user", "content": "Step by step, calculate 47 * 53. Show your work."}
 ]
@@ -133,6 +132,12 @@ def _classify_status(exc: Exception) -> int:
     return 500
 
 
+def _model_unavailable(model: ModelEntry, exc: Optional[Exception]) -> bool:
+    if not model.unavailable_error or exc is None:
+        return False
+    return model.unavailable_error in str(exc)
+
+
 async def _call_chat(model: ModelEntry, effort: str) -> Tuple[int, Optional[Exception]]:
     kwargs = _build_completion_kwargs(model, effort)
     try:
@@ -173,6 +178,9 @@ async def test_reasoning_effort_grid(
     else:
         status, exc = await _call_chat(model, effort)
 
+    if _model_unavailable(model, exc):
+        pytest.skip(f"{model.alias}: {model.unavailable_error}")
+
     record = wire_capture.latest()
     body = record["body"] if record else None
     if route_name == "bedrock_converse" and isinstance(body, str):
@@ -205,3 +213,30 @@ def test_grid_route_coverage() -> None:
         "bedrock_invoke_chat",
         "bedrock_invoke_messages",
     }
+
+
+def test_model_unavailable_tolerates_only_the_declared_error() -> None:
+    gated = ModelEntry(
+        alias="bedrock-claude-opus-4-7",
+        model="bedrock/converse/us.anthropic.claude-opus-4-7",
+        mode="adaptive",
+        unavailable_error="is not available for this account",
+    )
+    entitlement_error = Exception(
+        "litellm.APIConnectionError: BedrockException - "
+        '{"message":"anthropic.claude-opus-4-7 is not available for this account."}'
+    )
+
+    assert _model_unavailable(gated, entitlement_error) is True
+    assert (
+        _model_unavailable(gated, Exception("ThrottlingException: rate exceeded"))
+        is False
+    )
+    assert _model_unavailable(gated, None) is False
+
+    ungated = ModelEntry(
+        alias="bedrock-claude-opus-4-6",
+        model="bedrock/converse/us.anthropic.claude-opus-4-6-v1",
+        mode="adaptive",
+    )
+    assert _model_unavailable(ungated, entitlement_error) is False

--- a/tests/logging_callback_tests/test_log_db_redis_services.py
+++ b/tests/logging_callback_tests/test_log_db_redis_services.py
@@ -2,7 +2,6 @@ import io
 import os
 import sys
 
-
 sys.path.insert(0, os.path.abspath("../.."))
 
 import asyncio
@@ -59,7 +58,38 @@ async def test_log_db_metrics_success():
         assert isinstance(call_args["duration"], float)
         assert isinstance(call_args["start_time"], datetime)
         assert isinstance(call_args["end_time"], datetime)
-        assert "function_name" in call_args["event_metadata"]
+        assert call_args["event_metadata"] is None
+
+
+@pytest.mark.asyncio
+async def test_log_db_metrics_event_metadata_is_safe():
+    """event_metadata must surface only the table name, never the raw
+    kwargs/args which carry live clients (Prisma, OTel spans) and secrets.
+
+    Regression guard for #28909: a previous version dumped function_kwargs and
+    function_args onto the span.
+    """
+    with patch("litellm.proxy.proxy_server.proxy_logging_obj") as mock_proxy_logging:
+        mock_proxy_logging.service_logging_obj.async_service_success_hook = AsyncMock()
+
+        @log_db_metrics
+        async def db_call(**kwargs):
+            return "success"
+
+        await db_call(
+            parent_otel_span="test_span",
+            table_name="LiteLLM_SpendLogs",
+            token="sk-secret-should-not-leak",
+            prisma_client=object(),
+        )
+        await asyncio.sleep(0)
+
+        call_args = (
+            mock_proxy_logging.service_logging_obj.async_service_success_hook.call_args[
+                1
+            ]
+        )
+        assert call_args["event_metadata"] == {"table_name": "LiteLLM_SpendLogs"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Relevant issues

Claude Opus 4.8 shipped with cost-map entries (Anthropic, Bedrock converse and regional, Vertex, Azure AI) and a dedicated config regression test (`tests/test_litellm/test_claude_opus_4_8_config.py`), but the real-API reasoning effort grid that runs in the `llm_translation_testing` CircleCI job still topped out at Opus 4.7. This adds Opus 4.8 to that grid so the new flagship's `reasoning_effort` to wire-body translation is exercised the same way every prior generation is.

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Changes

Opus 4.8 was added as the newest flagship to the four routes that track the flagship Opus (anthropic_direct, azure_ai, vertex_ai, bedrock_converse), keeping the existing 4.7 and 4.6 entries. The Bedrock invoke routes were left untouched since they do not track the flagship (they carry no 4.7 entry either).

Opus 4.8 shares Opus 4.7's effort tier exactly: adaptive thinking with native `xhigh` and `max` support. The shared capability constant was renamed from `_CAPS_OPUS_4_7` to `_CAPS_XHIGH_MAX` because it now spans two generations and a single model-version name was misleading. On Bedrock the new cell carries `bedrock_effort_ceiling="xhigh"`, matching the model's `bedrock_output_config_effort_ceiling` in the cost map.

The grid cell-count assertion moved from 21x11 to 25x11 (231 to 275 cells) to reflect the four new model combinations.

Availability guards: the Anthropic direct cells run live. The Bedrock Opus 4.8 cell reuses the self-heal path introduced in the base PR #29344: it runs the call and skips only when Bedrock replies "is not available for this account" (the new model needs an AWS Sales entitlement request), and the moment access lands it asserts the wire body in full with no edit. The Azure and Vertex Opus 4.8 cells stay on an xfail `fail_reason`: the Microsoft Foundry resource returns `DeploymentNotFound` until someone creates the `claude-opus-4-8` deployment, and Vertex availability on the CI project is not yet confirmed for this brand-new release. Each `fail_reason` documents the condition to remove it, and because `xfail_strict` is not set these guards never flip CI red.

## Screenshots / Proof of Fix

The new Anthropic direct Opus 4.8 cells were run against the real Anthropic API (all eleven efforts, real spend):

```
$ uv run --no-sync python -m pytest \
    "tests/llm_translation/reasoning_effort_grid/test_reasoning_effort_grid.py::test_reasoning_effort_grid" \
    -k "anthropic_direct and opus-4-8" -p no:randomly -q
...........                                                              [100%]
11 passed in 25.70s
```

The Azure Opus 4.8 cells correctly xfail (rather than going red) while the deployment is missing, and the structural assertions pass:

```
$ uv run --no-sync python -m pytest \
    "tests/llm_translation/reasoning_effort_grid/test_reasoning_effort_grid.py" \
    -k "(azure_ai and opus-4-8) or test_grid_cell_count or test_grid_route_coverage" -p no:randomly -q -rX
..xxxxxxxxxxx                                                            [100%]
2 passed, 11 xfailed
```

## Type

✅ Test