### PR TITLE
fix(bedrock-converse): accept Reasoning(effort=..., summary=...) dict for reasoning_effort

### DIFF
--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -411,6 +411,28 @@ class AmazonConverseConfig(BaseConfig):
             }
         }
 
+    @staticmethod
+    def _coerce_reasoning_effort(value: Any) -> Optional[str]:
+        """
+        Normalize `reasoning_effort` into the bare-string shape that
+        `_handle_reasoning_effort_parameter` and `AnthropicConfig._map_reasoning_effort`
+        expect.
+
+        Accepts:
+        - bare string ("low" / "high" / ...)
+        - OpenAI Responses `Reasoning(effort, summary)` dict — extract `effort`
+          (see #25359 / #28196)
+
+        Returns the effort string, or None if `value` is None / malformed
+        (e.g. dict without an `effort` key). Malformed values are dropped
+        silently to match the direct Anthropic adapter's behavior.
+        """
+        if value is None:
+            return None
+        if isinstance(value, dict):
+            value = value.get("effort")
+        return value if isinstance(value, str) else None
+
     def _handle_reasoning_effort_parameter(
         self, model: str, reasoning_effort: str, optional_params: dict
     ) -> None:
@@ -946,19 +968,14 @@ class AmazonConverseConfig(BaseConfig):
                 }
             if param == "thinking":
                 optional_params["thinking"] = value
-            elif param == "reasoning_effort" and value is not None:
-                # Accept both string ("low") and dict ({"effort": "low",
-                # "summary": "concise"}). The Responses->Chat parser keeps the
-                # full dict when `summary` is set (see #25359 / #28196), so a
-                # dict here is the standard shape Otto/OpenAI-Responses-Bridge
-                # callers send. Same coercion the direct Anthropic path at
-                # `litellm/llms/anthropic/chat/transformation.py:_map_openai_params`
-                # already implements.
-                effort_value: Any = value
-                if isinstance(effort_value, dict):
-                    effort_value = effort_value.get("effort")
-                if not isinstance(effort_value, str):
-                    continue
+            elif (
+                param == "reasoning_effort"
+                and (effort_value := self._coerce_reasoning_effort(value)) is not None
+            ):
+                # See `_coerce_reasoning_effort` — accepts both bare string
+                # and the OpenAI Responses `{effort, summary}` dict shape
+                # (#25359 / #28196). Same coercion the direct Anthropic
+                # adapter already does.
                 self._handle_reasoning_effort_parameter(
                     model=model,
                     reasoning_effort=effort_value,

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -6,7 +6,7 @@ import copy
 import json
 import time
 import types
-from typing import List, Literal, Optional, Tuple, Union, cast, overload
+from typing import Any, List, Literal, Optional, Tuple, Union, cast, overload
 
 import httpx
 
@@ -946,9 +946,23 @@ class AmazonConverseConfig(BaseConfig):
                 }
             if param == "thinking":
                 optional_params["thinking"] = value
-            elif param == "reasoning_effort" and isinstance(value, str):
+            elif param == "reasoning_effort" and value is not None:
+                # Accept both string ("low") and dict ({"effort": "low",
+                # "summary": "concise"}). The Responses->Chat parser keeps the
+                # full dict when `summary` is set (see #25359 / #28196), so a
+                # dict here is the standard shape Otto/OpenAI-Responses-Bridge
+                # callers send. Same coercion the direct Anthropic path at
+                # `litellm/llms/anthropic/chat/transformation.py:_map_openai_params`
+                # already implements.
+                effort_value: Any = value
+                if isinstance(effort_value, dict):
+                    effort_value = effort_value.get("effort")
+                if not isinstance(effort_value, str):
+                    continue
                 self._handle_reasoning_effort_parameter(
-                    model=model, reasoning_effort=value, optional_params=optional_params
+                    model=model,
+                    reasoning_effort=effort_value,
+                    optional_params=optional_params,
                 )
             elif param == "context_management" and isinstance(value, (dict, list)):
                 self._map_context_management_param(value, optional_params)

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -5294,9 +5294,9 @@ def test_reasoning_effort_accepts_dict_shape_on_bedrock_converse(model):
         drop_params=False,
     )
 
-    assert "thinking" in optional_params, (
-        f"reasoning_effort dict was dropped on {model}: {optional_params!r}"
-    )
+    assert (
+        "thinking" in optional_params
+    ), f"reasoning_effort dict was dropped on {model}: {optional_params!r}"
     # Adaptive Claude 4.6 / 4.7: dict effort should drive output_config too.
     assert optional_params.get("output_config") == {"effort": "low"}
 

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -5268,3 +5268,50 @@ def test_transform_response_does_not_leak_body_on_parse_failure():
     msg = str(exc_info.value)
     assert "secret content" not in msg
     assert "Error converting to valid response block" in msg
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "bedrock/converse/us.anthropic.claude-opus-4-7",
+        "bedrock/converse/us.anthropic.claude-sonnet-4-6",
+    ],
+)
+def test_reasoning_effort_accepts_dict_shape_on_bedrock_converse(model):
+    """Regression for #28196 — OpenAI Responses callers send
+    ``reasoning_effort={'effort': 'low', 'summary': 'concise'}``; the
+    Bedrock Converse adapter must coerce the dict to ``low`` instead of
+    silently dropping it (the way the direct Anthropic path already does).
+    """
+    config = AmazonConverseConfig()
+
+    optional_params = config.map_openai_params(
+        non_default_params={
+            "reasoning_effort": {"effort": "low", "summary": "concise"},
+        },
+        optional_params={},
+        model=model,
+        drop_params=False,
+    )
+
+    assert "thinking" in optional_params, (
+        f"reasoning_effort dict was dropped on {model}: {optional_params!r}"
+    )
+    # Adaptive Claude 4.6 / 4.7: dict effort should drive output_config too.
+    assert optional_params.get("output_config") == {"effort": "low"}
+
+
+def test_reasoning_effort_invalid_dict_does_not_crash_or_emit_thinking():
+    """Defensive: a malformed dict (missing ``effort`` key) must silently
+    drop instead of raising, matching the direct Anthropic path."""
+    config = AmazonConverseConfig()
+
+    optional_params = config.map_openai_params(
+        non_default_params={"reasoning_effort": {"summary": "concise"}},
+        optional_params={},
+        model="bedrock/converse/us.anthropic.claude-opus-4-7",
+        drop_params=False,
+    )
+
+    assert "thinking" not in optional_params
+    assert "output_config" not in optional_params


### PR DESCRIPTION
Companion to #28196 — the direct Anthropic path was already fixed (`litellm/llms/anthropic/chat/transformation.py` accepts both string and dict reasoning_effort, see #25359), but Bedrock Converse's `map_openai_params` still had the old `isinstance(value, str)` guard, silently dropping the dict shape OpenAI Responses callers send (`{"effort": "low", "summary": "concise"}`).

Symptom: `reasoning_tokens == 0` on Bedrock Claude after upgrading; same as the direct path before fix.

## fix

Same shape coercion as the Anthropic adapter — pull `value["effort"]` out before dispatch:

```python
elif param == "reasoning_effort" and value is not None:
    effort_value: Any = value
    if isinstance(effort_value, dict):
        effort_value = effort_value.get("effort")
    if not isinstance(effort_value, str):
        continue
    self._handle_reasoning_effort_parameter(...)
```

## proof

```
$ .venv/bin/python -m pytest tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py -k reasoning_effort -v
[...]
test_reasoning_effort_accepts_dict_shape_on_bedrock_converse[bedrock/converse/us.anthropic.claude-opus-4-7] PASSED
test_reasoning_effort_accepts_dict_shape_on_bedrock_converse[bedrock/converse/us.anthropic.claude-sonnet-4-6] PASSED
test_reasoning_effort_invalid_dict_does_not_crash_or_emit_thinking PASSED
(+ 15 pre-existing reasoning_effort tests)
====================== 18 passed, 113 deselected in 0.21s ======================
```

## scope

Bedrock Converse only. Vertex/Databricks Anthropic-via-partner paths use the direct AnthropicConfig path (which is already fixed), so they pick this up transitively — but I haven't audited the partner-model dispatch on those providers, leaving that as a separate triage if reports come in.
