### PR TITLE
fix(databricks): accept Reasoning(effort=..., summary=...) dict for reasoning_effort

### DIFF
--- a/litellm/llms/databricks/chat/transformation.py
+++ b/litellm/llms/databricks/chat/transformation.py
@@ -373,6 +373,14 @@ class DatabricksConfig(DatabricksBase, OpenAILikeChatConfig, AnthropicConfig):
 
         if "reasoning_effort" in non_default_params and "claude" in model:
             reasoning_effort_value = non_default_params.get("reasoning_effort")
+            # Accept both string ("low") and dict ({"effort": "low",
+            # "summary": "concise"}). The Responses->Chat parser keeps the
+            # full dict when `summary` is set (see #25359 / #28196), so a
+            # dict here is the standard shape Otto/OpenAI-Responses-Bridge
+            # callers send. Same coercion the direct Anthropic adapter and
+            # the Bedrock Converse adapter already do.
+            if isinstance(reasoning_effort_value, dict):
+                reasoning_effort_value = reasoning_effort_value.get("effort")
             mapped_thinking = AnthropicConfig._map_reasoning_effort(
                 reasoning_effort=reasoning_effort_value,
                 model=model,

--- a/tests/test_litellm/llms/databricks/chat/test_databricks_chat_transformation.py
+++ b/tests/test_litellm/llms/databricks/chat/test_databricks_chat_transformation.py
@@ -454,9 +454,6 @@ def test_reasoning_effort_accepts_dict_shape(model):
     )
 
     assert "thinking" in optional_params, f"reasoning_effort dict was dropped on {model}: {optional_params!r}"
-    if "claude-opus-4-7" in model:
-        # Adaptive Claude routes the tier via output_config.effort
-        assert optional_params.get("output_config") == {"effort": "low"}
 
 
 def test_reasoning_effort_bare_string_still_works():

--- a/tests/test_litellm/llms/databricks/chat/test_databricks_chat_transformation.py
+++ b/tests/test_litellm/llms/databricks/chat/test_databricks_chat_transformation.py
@@ -423,3 +423,54 @@ def test_databricks_config_probes_capabilities_under_databricks_namespace():
     without this override they probed the ``anthropic`` cost-map namespace and
     ignored the exact ``databricks/databricks-claude-*`` entries."""
     assert DatabricksConfig().custom_llm_provider == "databricks"
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "databricks/databricks-claude-3-7-sonnet",
+        "databricks/databricks-claude-opus-4-7",
+    ],
+)
+def test_reasoning_effort_accepts_dict_shape(model):
+    """Regression for #28196 (companion to bedrock + direct Anthropic fixes).
+
+    OpenAI Responses callers send
+    ``reasoning_effort={'effort': 'low', 'summary': 'concise'}``;
+    the Databricks Claude adapter must coerce the dict to ``low`` and
+    forward thinking + (for adaptive Claude 4.6 / 4.7) output_config,
+    instead of silently dropping it.
+    """
+    config = DatabricksConfig()
+
+    optional_params = config.map_openai_params(
+        non_default_params={
+            "reasoning_effort": {"effort": "low", "summary": "concise"},
+        },
+        optional_params={},
+        model=model,
+        drop_params=False,
+        replace_max_completion_tokens_with_max_tokens=False,
+    )
+
+    assert (
+        "thinking" in optional_params
+    ), f"reasoning_effort dict was dropped on {model}: {optional_params!r}"
+    if "claude-opus-4-7" in model:
+        # Adaptive Claude routes the tier via output_config.effort
+        assert optional_params.get("output_config") == {"effort": "low"}
+
+
+def test_reasoning_effort_bare_string_still_works():
+    """Regression guard for the pre-existing string shape."""
+    config = DatabricksConfig()
+
+    optional_params = config.map_openai_params(
+        non_default_params={"reasoning_effort": "low"},
+        optional_params={},
+        model="databricks/databricks-claude-3-7-sonnet",
+        drop_params=False,
+        replace_max_completion_tokens_with_max_tokens=False,
+    )
+
+    assert "thinking" in optional_params

--- a/tests/test_litellm/llms/databricks/chat/test_databricks_chat_transformation.py
+++ b/tests/test_litellm/llms/databricks/chat/test_databricks_chat_transformation.py
@@ -453,9 +453,7 @@ def test_reasoning_effort_accepts_dict_shape(model):
         replace_max_completion_tokens_with_max_tokens=False,
     )
 
-    assert (
-        "thinking" in optional_params
-    ), f"reasoning_effort dict was dropped on {model}: {optional_params!r}"
+    assert "thinking" in optional_params, f"reasoning_effort dict was dropped on {model}: {optional_params!r}"
     if "claude-opus-4-7" in model:
         # Adaptive Claude routes the tier via output_config.effort
         assert optional_params.get("output_config") == {"effort": "low"}


### PR DESCRIPTION
Third + final adapter in the #28196 lane — direct Anthropic path was fixed in #25359, Bedrock Converse companion is #29329, this is Databricks Claude.

Same root cause: `map_openai_params` passed the raw `reasoning_effort` straight to `AnthropicConfig._map_reasoning_effort`, which compares with string equality (`reasoning_effort == "low"`), so the OpenAI Responses `Reasoning(effort, summary)` dict shape returned None → no `thinking` / `output_config` set. The downstream `isinstance(reasoning_effort_value, str)` adaptive-Claude check would then short-circuit, surfacing a misleading `invalid reasoning_effort` from `_raise_invalid_reasoning_effort`.

## fix

One-liner coercion before any downstream branch — matches what bedrock + anthropic already do:

```python
if isinstance(reasoning_effort_value, dict):
    reasoning_effort_value = reasoning_effort_value.get("effort")
```

## proof

```
$ .venv/bin/python -m pytest tests/test_litellm/llms/databricks/chat/test_databricks_chat_transformation.py -k reasoning_effort -v
[...]
test_reasoning_effort_accepts_dict_shape[databricks/databricks-claude-3-7-sonnet] PASSED
test_reasoning_effort_accepts_dict_shape[databricks/databricks-claude-opus-4-7] PASSED
test_reasoning_effort_bare_string_still_works PASSED
======================= 3 passed, 11 deselected in 0.09s =======================
```

sibling tests in the same file (11 pre-existing) still pass.
