### PR TITLE
fix: preserve text deltas with empty tool calls

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -1476,7 +1476,7 @@ class LiteLLMAnthropicMessagesAdapter:
         for choice in choices:
             if choice.delta.content is not None and len(choice.delta.content) > 0:
                 text += choice.delta.content
-            if choice.delta.tool_calls is not None:
+            if choice.delta.tool_calls:
                 partial_json = ""
                 for tool in choice.delta.tool_calls:
                     if (

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_streaming_iterator_tool_args.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_streaming_iterator_tool_args.py
@@ -239,6 +239,35 @@ async def test_async_stream_no_extra_delta_when_tool_args_empty():
     assert input_json_deltas[0]["delta"]["partial_json"] == '{"location": "NYC"}'
 
 
+@pytest.mark.asyncio
+async def test_async_stream_treats_empty_tool_calls_as_text():
+    text_chunk = _make_chunk(Delta(content="Hello", role="assistant", tool_calls=[]))
+    finish_chunk = _make_chunk(
+        Delta(content=None, role="assistant", tool_calls=None),
+        finish_reason="stop",
+    )
+
+    async def mock_stream():
+        for c in [text_chunk, finish_chunk]:
+            yield c
+
+    wrapper = AnthropicStreamWrapper(
+        completion_stream=mock_stream(),
+        model="test-model",
+    )
+
+    events = await _collect_events_async(wrapper)
+    deltas = [
+        e["delta"]
+        for e in events
+        if isinstance(e, dict)
+        and e.get("type") == "content_block_delta"
+        and isinstance(e.get("delta"), dict)
+    ]
+
+    assert deltas == [{"type": "text_delta", "text": "Hello"}]
+
+
 def test_sync_stream_emits_input_json_delta_for_bundled_tool_args():
     """
     Sync counterpart: when a provider bundles tool_call arguments in the first
@@ -381,3 +410,27 @@ def test_sync_stream_no_extra_delta_when_tool_args_empty():
         f"got {len(input_json_deltas)}"
     )
     assert input_json_deltas[0]["delta"]["partial_json"] == '{"location": "NYC"}'
+
+
+def test_sync_stream_treats_empty_tool_calls_as_text():
+    text_chunk = _make_chunk(Delta(content="Hello", role="assistant", tool_calls=[]))
+    finish_chunk = _make_chunk(
+        Delta(content=None, role="assistant", tool_calls=None),
+        finish_reason="stop",
+    )
+
+    wrapper = AnthropicStreamWrapper(
+        completion_stream=iter([text_chunk, finish_chunk]),
+        model="test-model",
+    )
+
+    events = _collect_events_sync(wrapper)
+    deltas = [
+        e["delta"]
+        for e in events
+        if isinstance(e, dict)
+        and e.get("type") == "content_block_delta"
+        and isinstance(e.get("delta"), dict)
+    ]
+
+    assert deltas == [{"type": "text_delta", "text": "Hello"}]


### PR DESCRIPTION
﻿## What changed

Fixes #29286.

OpenAI-compatible backends such as vLLM can stream plain text chunks with both `delta.content` and an empty `delta.tool_calls: []`. The Anthropic `/v1/messages` adapter treated any non-`None` `tool_calls` value as a tool-use delta, so those chunks became empty `input_json_delta` events instead of `text_delta` events.

This now only enters the tool-call path when `tool_calls` is non-empty. Empty lists fall through to the text path.

## To verify

Ran locally:

```bash
python -m pytest tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_streaming_iterator_tool_args.py -q
uv run --no-sync black --check litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_streaming_iterator_tool_args.py
uv run --no-sync ruff check litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_streaming_iterator_tool_args.py
python -m py_compile litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_streaming_iterator_tool_args.py
git diff --check
```
