### PR TITLE
Add kluster.ai as an OpenAI-compatible chat provider

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -616,6 +616,7 @@ snowflake_models: Set = set()
 gradient_ai_models: Set = set()
 llama_models: Set = set()
 nscale_models: Set = set()
+kluster_ai_models: Set = set()
 nebius_models: Set = set()
 nebius_embedding_models: Set = set()
 aiml_models: Set = set()
@@ -805,6 +806,8 @@ def add_known_models(model_cost_map: Optional[Dict] = None):
             llama_models.add(key)
         elif value.get("litellm_provider") == "nscale":
             nscale_models.add(key)
+        elif value.get("litellm_provider") == "kluster_ai":
+            kluster_ai_models.add(key)
         elif value.get("litellm_provider") == "azure_ai":
             azure_ai_models.add(key)
         elif value.get("litellm_provider") == "voyage":
@@ -1009,6 +1012,7 @@ model_list = list(
     | llama_models
     | featherless_ai_models
     | nscale_models
+    | kluster_ai_models
     | deepgram_models
     | elevenlabs_models
     | dashscope_models
@@ -1107,6 +1111,7 @@ models_by_provider: dict = {
     "gradient_ai": gradient_ai_models,
     "meta_llama": llama_models,
     "nscale": nscale_models,
+    "kluster_ai": kluster_ai_models,
     "featherless_ai": featherless_ai_models,
     "deepgram": deepgram_models,
     "elevenlabs": elevenlabs_models,
@@ -1787,6 +1792,9 @@ if TYPE_CHECKING:
         PerplexityChatConfig as _PerplexityChatConfig,
     )
     from .llms.nscale.chat.transformation import NscaleConfig as _NscaleConfig
+    from .llms.kluster_ai.chat.transformation import (
+        KlusterAIConfig as _KlusterAIConfig,
+    )
     from .llms.watsonx.chat.transformation import (
         IBMWatsonXChatConfig as _IBMWatsonXChatConfig,
     )
@@ -1821,6 +1829,7 @@ if TYPE_CHECKING:
     AzureOpenAIO1Config: Type[_AzureOpenAIO1Config]
     PerplexityChatConfig: Type[_PerplexityChatConfig]
     NscaleConfig: Type[_NscaleConfig]
+    KlusterAIConfig: Type[_KlusterAIConfig]
     IBMWatsonXChatConfig: Type[_IBMWatsonXChatConfig]
     IBMWatsonXAIConfig: Type[_IBMWatsonXAIConfig]
     LiteLLMProxyChatConfig: Type[_LiteLLMProxyChatConfig]

--- a/litellm/_lazy_imports_registry.py
+++ b/litellm/_lazy_imports_registry.py
@@ -285,6 +285,7 @@ LLM_CONFIG_NAMES = (
     "LMStudioChatConfig",
     "LmStudioEmbeddingConfig",
     "NscaleConfig",
+    "KlusterAIConfig",
     "PerplexityChatConfig",
     "AzureOpenAIO1Config",
     "IBMWatsonXAIConfig",
@@ -1088,6 +1089,10 @@ _LLM_CONFIGS_IMPORT_MAP = {
         "LmStudioEmbeddingConfig",
     ),
     "NscaleConfig": (".llms.nscale.chat.transformation", "NscaleConfig"),
+    "KlusterAIConfig": (
+        ".llms.kluster_ai.chat.transformation",
+        "KlusterAIConfig",
+    ),
     "PerplexityChatConfig": (
         ".llms.perplexity.chat.transformation",
         "PerplexityChatConfig",

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -611,6 +611,7 @@ LITELLM_CHAT_PROVIDERS = [
     "meta_llama",
     "featherless_ai",
     "nscale",
+    "kluster_ai",
     "nebius",
     "dashscope",
     "moonshot",
@@ -766,6 +767,7 @@ openai_compatible_endpoints: List = [
     "api.llama.com/compat/v1/",
     "api.featherless.ai/v1",
     "inference.api.nscale.com/v1",
+    "api.kluster.ai/v1",
     "api.studio.nebius.ai/v1",
     "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
     "https://api.moonshot.ai/v1",
@@ -826,6 +828,7 @@ openai_compatible_providers: List = [
     "chutes",  # Chutes - JSON-configured provider
     "featherless_ai",
     "nscale",
+    "kluster_ai",
     "nebius",
     "dashscope",
     "moonshot",

--- a/litellm/litellm_core_utils/get_llm_provider_logic.py
+++ b/litellm/litellm_core_utils/get_llm_provider_logic.py
@@ -311,6 +311,9 @@ def get_llm_provider(  # noqa: PLR0915
                     elif endpoint == litellm.NscaleConfig.API_BASE_URL:
                         custom_llm_provider = "nscale"
                         dynamic_api_key = litellm.NscaleConfig.get_api_key()
+                    elif endpoint == "api.kluster.ai/v1":
+                        custom_llm_provider = "kluster_ai"
+                        dynamic_api_key = litellm.KlusterAIConfig.get_api_key()
                     elif endpoint == "dashscope-intl.aliyuncs.com/compatible-mode/v1":
                         custom_llm_provider = "dashscope"
                         dynamic_api_key = get_secret_str("DASHSCOPE_API_KEY")
@@ -879,6 +882,13 @@ def _get_openai_compatible_provider_info(  # noqa: PLR0915
             api_base,
             dynamic_api_key,
         ) = litellm.NscaleConfig()._get_openai_compatible_provider_info(
+            api_base=api_base, api_key=api_key
+        )
+    elif custom_llm_provider == "kluster_ai":
+        (
+            api_base,
+            dynamic_api_key,
+        ) = litellm.KlusterAIConfig()._get_openai_compatible_provider_info(
             api_base=api_base, api_key=api_key
         )
     elif custom_llm_provider == "heroku":

--- a/litellm/litellm_core_utils/get_supported_openai_params.py
+++ b/litellm/litellm_core_utils/get_supported_openai_params.py
@@ -261,6 +261,8 @@ def get_supported_openai_params(  # noqa: PLR0915
         return litellm.PerplexityChatConfig().get_supported_openai_params(model=model)
     elif custom_llm_provider == "nscale":
         return litellm.NscaleConfig().get_supported_openai_params(model=model)
+    elif custom_llm_provider == "kluster_ai":
+        return litellm.KlusterAIConfig().get_supported_openai_params(model=model)
     elif custom_llm_provider == "anyscale":
         return [
             "temperature",

--- a/litellm/llms/kluster_ai/chat/transformation.py
+++ b/litellm/llms/kluster_ai/chat/transformation.py
@@ -40,10 +40,13 @@ class KlusterAIConfig(OpenAIGPTConfig):
     def get_supported_openai_params(self, model: str) -> list:
         return [
             "max_tokens",
+            "max_completion_tokens",
             "n",
             "temperature",
             "top_p",
+            "seed",
             "stream",
+            "stream_options",
             "logprobs",
             "top_logprobs",
             "frequency_penalty",
@@ -53,4 +56,6 @@ class KlusterAIConfig(OpenAIGPTConfig):
             "logit_bias",
             "tools",
             "tool_choice",
+            "parallel_tool_calls",
+            "user",
         ]

--- a/litellm/llms/kluster_ai/chat/transformation.py
+++ b/litellm/llms/kluster_ai/chat/transformation.py
@@ -1,0 +1,56 @@
+from typing import Optional, Tuple
+
+from litellm.llms.openai.chat.gpt_transformation import OpenAIGPTConfig
+from litellm.secret_managers.main import get_secret_str
+
+
+class KlusterAIConfig(OpenAIGPTConfig):
+    """
+    Reference: kluster.ai is OpenAI compatible.
+
+    API Key: KLUSTER_AI_API_KEY
+    Default API Base: https://api.kluster.ai/v1
+    """
+
+    API_BASE_URL = "https://api.kluster.ai/v1"
+
+    @property
+    def custom_llm_provider(self) -> Optional[str]:
+        return "kluster_ai"
+
+    @staticmethod
+    def get_api_key(api_key: Optional[str] = None) -> Optional[str]:
+        return api_key or get_secret_str("KLUSTER_AI_API_KEY")
+
+    @staticmethod
+    def get_api_base(api_base: Optional[str] = None) -> Optional[str]:
+        return (
+            api_base
+            or get_secret_str("KLUSTER_AI_API_BASE")
+            or KlusterAIConfig.API_BASE_URL
+        )
+
+    def _get_openai_compatible_provider_info(
+        self, api_base: Optional[str], api_key: Optional[str]
+    ) -> Tuple[Optional[str], Optional[str]]:
+        resolved_api_base = KlusterAIConfig.get_api_base(api_base)
+        resolved_api_key = KlusterAIConfig.get_api_key(api_key)
+        return resolved_api_base, resolved_api_key
+
+    def get_supported_openai_params(self, model: str) -> list:
+        return [
+            "max_tokens",
+            "n",
+            "temperature",
+            "top_p",
+            "stream",
+            "logprobs",
+            "top_logprobs",
+            "frequency_penalty",
+            "presence_penalty",
+            "response_format",
+            "stop",
+            "logit_bias",
+            "tools",
+            "tool_choice",
+        ]

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3335,6 +3335,7 @@ class LlmProviders(str, Enum):
     GRADIENT_AI = "gradient_ai"
     LLAMA = "meta_llama"
     NSCALE = "nscale"
+    KLUSTER_AI = "kluster_ai"
     PG_VECTOR = "pg_vector"
     S3_VECTORS = "s3_vectors"
     HELICONE = "helicone"

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -8331,6 +8331,10 @@ class ProviderConfigManager:
             ),
             LlmProviders.GRADIENT_AI: (lambda: litellm.GradientAIConfig(), False),
             LlmProviders.NSCALE: (lambda: litellm.NscaleConfig(), False),
+            LlmProviders.KLUSTER_AI: (
+                lambda: litellm.KlusterAIConfig(),
+                False,
+            ),
             LlmProviders.HEROKU: (lambda: litellm.HerokuChatConfig(), False),
             LlmProviders.OCI: (lambda: litellm.OCIChatConfig(), False),
             LlmProviders.HYPERBOLIC: (lambda: litellm.HyperbolicChatConfig(), False),

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -32,6 +32,24 @@
     }
   },
   "providers": {
+    "kluster_ai": {
+      "display_name": "Kluster AI (`kluster_ai`)",
+      "url": "https://docs.litellm.ai/docs/providers/kluster_ai",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": true,
+        "responses": true,
+        "embeddings": false,
+        "image_generations": false,
+        "audio_transcriptions": false,
+        "audio_speech": false,
+        "moderations": false,
+        "batches": false,
+        "rerank": false,
+        "a2a": true,
+        "interactions": true
+      }
+    },
     "a2a": {
       "display_name": "A2A (Agent-to-Agent) (`a2a`)",
       "url": "https://docs.litellm.ai/docs/providers/a2a",

--- a/tests/test_litellm/llms/kluster_ai/chat/test_kluster_ai_chat_transformation.py
+++ b/tests/test_litellm/llms/kluster_ai/chat/test_kluster_ai_chat_transformation.py
@@ -51,7 +51,13 @@ class TestKlusterAIConfig:
             assert KlusterAIConfig.API_BASE_URL == "https://api.kluster.ai/v1"
 
     def test_get_openai_compatible_provider_info(self):
-        with patch.dict(os.environ, {"KLUSTER_AI_API_KEY": "sk-secret"}, clear=False):
+        def fake_secret(name, *args, **kwargs):
+            return "sk-secret" if name == "KLUSTER_AI_API_KEY" else None
+
+        with patch(
+            "litellm.llms.kluster_ai.chat.transformation.get_secret_str",
+            side_effect=fake_secret,
+        ):
             api_base, api_key = self.config._get_openai_compatible_provider_info(
                 api_base=None, api_key=None
             )

--- a/tests/test_litellm/llms/kluster_ai/chat/test_kluster_ai_chat_transformation.py
+++ b/tests/test_litellm/llms/kluster_ai/chat/test_kluster_ai_chat_transformation.py
@@ -1,0 +1,101 @@
+import os
+import sys
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath("../../../../.."))
+
+import litellm
+from litellm import get_llm_provider, get_supported_openai_params
+from litellm.llms.kluster_ai.chat.transformation import KlusterAIConfig
+
+
+class TestKlusterAIConfig:
+    def setup_method(self):
+        self.config = KlusterAIConfig()
+
+    def test_custom_llm_provider(self):
+        assert self.config.custom_llm_provider == "kluster_ai"
+
+    def test_get_api_key(self):
+        assert self.config.get_api_key("test-key") == "test-key"
+
+        with patch(
+            "litellm.llms.kluster_ai.chat.transformation.get_secret_str",
+            return_value="env-key",
+        ):
+            assert self.config.get_api_key() == "env-key"
+
+        with patch.dict(os.environ, {"KLUSTER_AI_API_KEY": "env-key"}, clear=False):
+            assert self.config.get_api_key() == "env-key"
+
+    def test_get_api_base_precedence(self):
+        # Explicit argument wins over everything.
+        assert (
+            self.config.get_api_base("https://custom-base.com/v1")
+            == "https://custom-base.com/v1"
+        )
+
+        # KLUSTER_AI_API_BASE override.
+        with patch(
+            "litellm.llms.kluster_ai.chat.transformation.get_secret_str",
+            return_value="https://proxy.internal/v1",
+        ):
+            assert self.config.get_api_base() == "https://proxy.internal/v1"
+
+        # Falls back to the default endpoint.
+        with patch(
+            "litellm.llms.kluster_ai.chat.transformation.get_secret_str",
+            return_value=None,
+        ):
+            assert self.config.get_api_base() == KlusterAIConfig.API_BASE_URL
+            assert KlusterAIConfig.API_BASE_URL == "https://api.kluster.ai/v1"
+
+    def test_get_openai_compatible_provider_info(self):
+        with patch.dict(os.environ, {"KLUSTER_AI_API_KEY": "sk-secret"}, clear=False):
+            api_base, api_key = self.config._get_openai_compatible_provider_info(
+                api_base=None, api_key=None
+            )
+        assert api_base == "https://api.kluster.ai/v1"
+        assert api_key == "sk-secret"
+
+    def test_supported_params_include_tools(self):
+        params = self.config.get_supported_openai_params(
+            model="klusterai/Meta-Llama-3.1-405B-Instruct-Turbo"
+        )
+        for expected in ("temperature", "stream", "tools", "tool_choice"):
+            assert expected in params
+
+
+class TestKlusterAIProviderResolution:
+    def test_get_llm_provider_resolves_prefixed_model(self):
+        with patch.dict(os.environ, {"KLUSTER_AI_API_KEY": "sk-secret"}, clear=False):
+            model, provider, api_key, api_base = get_llm_provider(
+                model="kluster_ai/Meta-Llama-3.1-405B-Instruct-Turbo"
+            )
+        assert model == "Meta-Llama-3.1-405B-Instruct-Turbo"
+        assert provider == "kluster_ai"
+        assert api_key == "sk-secret"
+        assert api_base == "https://api.kluster.ai/v1"
+
+    def test_get_llm_provider_detects_provider_from_api_base(self):
+        _, provider, _, _ = get_llm_provider(
+            model="Meta-Llama-3.1-405B-Instruct-Turbo",
+            api_base="https://api.kluster.ai/v1",
+            api_key="sk-secret",
+        )
+        assert provider == "kluster_ai"
+
+    def test_get_supported_openai_params_routes_to_config(self):
+        params = get_supported_openai_params(
+            model="Meta-Llama-3.1-405B-Instruct-Turbo",
+            custom_llm_provider="kluster_ai",
+        )
+        assert params is not None
+        assert "tools" in params
+
+    def test_provider_registered_in_enum_and_lists(self):
+        from litellm.types.utils import LlmProviders
+
+        assert LlmProviders.KLUSTER_AI.value == "kluster_ai"
+        assert "kluster_ai" in litellm.openai_compatible_providers
+        assert "api.kluster.ai/v1" in litellm.openai_compatible_endpoints


### PR DESCRIPTION
## Relevant issues

N/A. kluster.ai is a popular OpenAI-compatible inference provider that is not yet supported; this adds it under the existing OpenAI-compatible provider pattern.

## Linear ticket

N/A (external contribution)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Live proxy hitting the real kluster.ai API. Replace the model id with a currently listed kluster.ai model if needed.

```bash
export KLUSTER_AI_API_KEY=sk-...

cat > kluster_test.yaml <<'YAML'
model_list:
  - model_name: kluster-test
    litellm_params:
      model: kluster_ai/klusterai/Meta-Llama-3.1-405B-Instruct-Turbo
      api_key: os.environ/KLUSTER_AI_API_KEY
YAML

python litellm/proxy/proxy_cli.py --config kluster_test.yaml --detailed_debug &

curl http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d '{"model":"kluster-test","messages":[{"role":"user","content":"say hi in 3 words"}]}'
```

Live request/response output against the real kluster.ai API will be added as a follow-up comment on this PR.

## Type

🆕 New Feature

## Changes

This adds kluster.ai as a first-class OpenAI-compatible chat provider.

The core of the change is `KlusterAIConfig` in `litellm/llms/kluster_ai/chat/transformation.py`, a thin subclass of `OpenAIGPTConfig` that resolves the API key from `KLUSTER_AI_API_KEY` and the API base from `KLUSTER_AI_API_BASE`, defaulting to `https://api.kluster.ai/v1`. The config follows the same shape as the existing `NscaleConfig`.

The provider is then registered everywhere the other OpenAI-compatible providers are: the `LlmProviders` enum, the `LITELLM_CHAT_PROVIDERS`, `openai_compatible_providers`, and `openai_compatible_endpoints` lists in `constants.py`, the model-set wiring and lazy config import in `__init__.py`, the lazy import registry, the provider detection and provider-info resolution in `get_llm_provider_logic.py`, the supported-params dispatch in `get_supported_openai_params.py`, and the provider config map in `utils.py`. With this wiring, both `model="kluster_ai/<model>"` and an explicit kluster.ai `api_base` resolve to the provider with the right key and base.

Tests live in `tests/test_litellm/llms/kluster_ai/chat/test_kluster_ai_chat_transformation.py`. They cover API key and API base precedence (explicit argument over `KLUSTER_AI_API_BASE` over the default), the OpenAI-compatible provider-info resolution, the supported-params surface, end-to-end provider resolution from both a prefixed model and an explicit `api_base`, and the provider being present in the enum and the compatibility lists. The tests are mocked and make no network calls, so they fit `tests/test_litellm/`.

Model price and context-window entries are intentionally left out of this PR to keep the scope isolated and avoid committing pricing that drifts; they can follow once verified against kluster.ai's current pricing.
