### PR TITLE
Add Parasail as an OpenAI-compatible chat provider

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -616,6 +616,7 @@ snowflake_models: Set = set()
 gradient_ai_models: Set = set()
 llama_models: Set = set()
 nscale_models: Set = set()
+parasail_models: Set = set()
 nebius_models: Set = set()
 nebius_embedding_models: Set = set()
 aiml_models: Set = set()
@@ -805,6 +806,8 @@ def add_known_models(model_cost_map: Optional[Dict] = None):
             llama_models.add(key)
         elif value.get("litellm_provider") == "nscale":
             nscale_models.add(key)
+        elif value.get("litellm_provider") == "parasail":
+            parasail_models.add(key)
         elif value.get("litellm_provider") == "azure_ai":
             azure_ai_models.add(key)
         elif value.get("litellm_provider") == "voyage":
@@ -1009,6 +1012,7 @@ model_list = list(
     | llama_models
     | featherless_ai_models
     | nscale_models
+    | parasail_models
     | deepgram_models
     | elevenlabs_models
     | dashscope_models
@@ -1107,6 +1111,7 @@ models_by_provider: dict = {
     "gradient_ai": gradient_ai_models,
     "meta_llama": llama_models,
     "nscale": nscale_models,
+    "parasail": parasail_models,
     "featherless_ai": featherless_ai_models,
     "deepgram": deepgram_models,
     "elevenlabs": elevenlabs_models,
@@ -1787,6 +1792,9 @@ if TYPE_CHECKING:
         PerplexityChatConfig as _PerplexityChatConfig,
     )
     from .llms.nscale.chat.transformation import NscaleConfig as _NscaleConfig
+    from .llms.parasail.chat.transformation import (
+        ParasailConfig as _ParasailConfig,
+    )
     from .llms.watsonx.chat.transformation import (
         IBMWatsonXChatConfig as _IBMWatsonXChatConfig,
     )
@@ -1821,6 +1829,7 @@ if TYPE_CHECKING:
     AzureOpenAIO1Config: Type[_AzureOpenAIO1Config]
     PerplexityChatConfig: Type[_PerplexityChatConfig]
     NscaleConfig: Type[_NscaleConfig]
+    ParasailConfig: Type[_ParasailConfig]
     IBMWatsonXChatConfig: Type[_IBMWatsonXChatConfig]
     IBMWatsonXAIConfig: Type[_IBMWatsonXAIConfig]
     LiteLLMProxyChatConfig: Type[_LiteLLMProxyChatConfig]

--- a/litellm/_lazy_imports_registry.py
+++ b/litellm/_lazy_imports_registry.py
@@ -285,6 +285,7 @@ LLM_CONFIG_NAMES = (
     "LMStudioChatConfig",
     "LmStudioEmbeddingConfig",
     "NscaleConfig",
+    "ParasailConfig",
     "PerplexityChatConfig",
     "AzureOpenAIO1Config",
     "IBMWatsonXAIConfig",
@@ -1088,6 +1089,10 @@ _LLM_CONFIGS_IMPORT_MAP = {
         "LmStudioEmbeddingConfig",
     ),
     "NscaleConfig": (".llms.nscale.chat.transformation", "NscaleConfig"),
+    "ParasailConfig": (
+        ".llms.parasail.chat.transformation",
+        "ParasailConfig",
+    ),
     "PerplexityChatConfig": (
         ".llms.perplexity.chat.transformation",
         "PerplexityChatConfig",

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -611,6 +611,7 @@ LITELLM_CHAT_PROVIDERS = [
     "meta_llama",
     "featherless_ai",
     "nscale",
+    "parasail",
     "nebius",
     "dashscope",
     "moonshot",
@@ -766,6 +767,7 @@ openai_compatible_endpoints: List = [
     "api.llama.com/compat/v1/",
     "api.featherless.ai/v1",
     "inference.api.nscale.com/v1",
+    "api.parasail.io/v1",
     "api.studio.nebius.ai/v1",
     "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
     "https://api.moonshot.ai/v1",
@@ -826,6 +828,7 @@ openai_compatible_providers: List = [
     "chutes",  # Chutes - JSON-configured provider
     "featherless_ai",
     "nscale",
+    "parasail",
     "nebius",
     "dashscope",
     "moonshot",

--- a/litellm/litellm_core_utils/get_llm_provider_logic.py
+++ b/litellm/litellm_core_utils/get_llm_provider_logic.py
@@ -311,6 +311,9 @@ def get_llm_provider(  # noqa: PLR0915
                     elif endpoint == litellm.NscaleConfig.API_BASE_URL:
                         custom_llm_provider = "nscale"
                         dynamic_api_key = litellm.NscaleConfig.get_api_key()
+                    elif endpoint == "api.parasail.io/v1":
+                        custom_llm_provider = "parasail"
+                        dynamic_api_key = litellm.ParasailConfig.get_api_key()
                     elif endpoint == "dashscope-intl.aliyuncs.com/compatible-mode/v1":
                         custom_llm_provider = "dashscope"
                         dynamic_api_key = get_secret_str("DASHSCOPE_API_KEY")
@@ -879,6 +882,13 @@ def _get_openai_compatible_provider_info(  # noqa: PLR0915
             api_base,
             dynamic_api_key,
         ) = litellm.NscaleConfig()._get_openai_compatible_provider_info(
+            api_base=api_base, api_key=api_key
+        )
+    elif custom_llm_provider == "parasail":
+        (
+            api_base,
+            dynamic_api_key,
+        ) = litellm.ParasailConfig()._get_openai_compatible_provider_info(
             api_base=api_base, api_key=api_key
         )
     elif custom_llm_provider == "heroku":

--- a/litellm/litellm_core_utils/get_supported_openai_params.py
+++ b/litellm/litellm_core_utils/get_supported_openai_params.py
@@ -261,6 +261,8 @@ def get_supported_openai_params(  # noqa: PLR0915
         return litellm.PerplexityChatConfig().get_supported_openai_params(model=model)
     elif custom_llm_provider == "nscale":
         return litellm.NscaleConfig().get_supported_openai_params(model=model)
+    elif custom_llm_provider == "parasail":
+        return litellm.ParasailConfig().get_supported_openai_params(model=model)
     elif custom_llm_provider == "anyscale":
         return [
             "temperature",

--- a/litellm/llms/parasail/chat/transformation.py
+++ b/litellm/llms/parasail/chat/transformation.py
@@ -1,0 +1,56 @@
+from typing import Optional, Tuple
+
+from litellm.llms.openai.chat.gpt_transformation import OpenAIGPTConfig
+from litellm.secret_managers.main import get_secret_str
+
+
+class ParasailConfig(OpenAIGPTConfig):
+    """
+    Reference: Parasail is OpenAI compatible.
+
+    API Key: PARASAIL_API_KEY
+    Default API Base: https://api.parasail.io/v1
+    """
+
+    API_BASE_URL = "https://api.parasail.io/v1"
+
+    @property
+    def custom_llm_provider(self) -> Optional[str]:
+        return "parasail"
+
+    @staticmethod
+    def get_api_key(api_key: Optional[str] = None) -> Optional[str]:
+        return api_key or get_secret_str("PARASAIL_API_KEY")
+
+    @staticmethod
+    def get_api_base(api_base: Optional[str] = None) -> Optional[str]:
+        return (
+            api_base
+            or get_secret_str("PARASAIL_API_BASE")
+            or ParasailConfig.API_BASE_URL
+        )
+
+    def _get_openai_compatible_provider_info(
+        self, api_base: Optional[str], api_key: Optional[str]
+    ) -> Tuple[Optional[str], Optional[str]]:
+        resolved_api_base = ParasailConfig.get_api_base(api_base)
+        resolved_api_key = ParasailConfig.get_api_key(api_key)
+        return resolved_api_base, resolved_api_key
+
+    def get_supported_openai_params(self, model: str) -> list:
+        return [
+            "max_tokens",
+            "n",
+            "temperature",
+            "top_p",
+            "stream",
+            "logprobs",
+            "top_logprobs",
+            "frequency_penalty",
+            "presence_penalty",
+            "response_format",
+            "stop",
+            "logit_bias",
+            "tools",
+            "tool_choice",
+        ]

--- a/litellm/llms/parasail/chat/transformation.py
+++ b/litellm/llms/parasail/chat/transformation.py
@@ -40,10 +40,13 @@ class ParasailConfig(OpenAIGPTConfig):
     def get_supported_openai_params(self, model: str) -> list:
         return [
             "max_tokens",
+            "max_completion_tokens",
             "n",
             "temperature",
             "top_p",
+            "seed",
             "stream",
+            "stream_options",
             "logprobs",
             "top_logprobs",
             "frequency_penalty",
@@ -53,4 +56,6 @@ class ParasailConfig(OpenAIGPTConfig):
             "logit_bias",
             "tools",
             "tool_choice",
+            "parallel_tool_calls",
+            "user",
         ]

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3335,6 +3335,7 @@ class LlmProviders(str, Enum):
     GRADIENT_AI = "gradient_ai"
     LLAMA = "meta_llama"
     NSCALE = "nscale"
+    PARASAIL = "parasail"
     PG_VECTOR = "pg_vector"
     S3_VECTORS = "s3_vectors"
     HELICONE = "helicone"

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -8331,6 +8331,10 @@ class ProviderConfigManager:
             ),
             LlmProviders.GRADIENT_AI: (lambda: litellm.GradientAIConfig(), False),
             LlmProviders.NSCALE: (lambda: litellm.NscaleConfig(), False),
+            LlmProviders.PARASAIL: (
+                lambda: litellm.ParasailConfig(),
+                False,
+            ),
             LlmProviders.HEROKU: (lambda: litellm.HerokuChatConfig(), False),
             LlmProviders.OCI: (lambda: litellm.OCIChatConfig(), False),
             LlmProviders.HYPERBOLIC: (lambda: litellm.HyperbolicChatConfig(), False),

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -32,6 +32,24 @@
     }
   },
   "providers": {
+    "parasail": {
+      "display_name": "Parasail (`parasail`)",
+      "url": "https://docs.litellm.ai/docs/providers/parasail",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": true,
+        "responses": true,
+        "embeddings": false,
+        "image_generations": false,
+        "audio_transcriptions": false,
+        "audio_speech": false,
+        "moderations": false,
+        "batches": false,
+        "rerank": false,
+        "a2a": true,
+        "interactions": true
+      }
+    },
     "a2a": {
       "display_name": "A2A (Agent-to-Agent) (`a2a`)",
       "url": "https://docs.litellm.ai/docs/providers/a2a",

--- a/tests/test_litellm/llms/parasail/chat/test_parasail_chat_transformation.py
+++ b/tests/test_litellm/llms/parasail/chat/test_parasail_chat_transformation.py
@@ -1,0 +1,98 @@
+import os
+import sys
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath("../../../../.."))
+
+import litellm
+from litellm import get_llm_provider, get_supported_openai_params
+from litellm.llms.parasail.chat.transformation import ParasailConfig
+
+
+class TestParasailConfig:
+    def setup_method(self):
+        self.config = ParasailConfig()
+
+    def test_custom_llm_provider(self):
+        assert self.config.custom_llm_provider == "parasail"
+
+    def test_get_api_key(self):
+        assert self.config.get_api_key("test-key") == "test-key"
+
+        with patch(
+            "litellm.llms.parasail.chat.transformation.get_secret_str",
+            return_value="env-key",
+        ):
+            assert self.config.get_api_key() == "env-key"
+
+        with patch.dict(os.environ, {"PARASAIL_API_KEY": "env-key"}, clear=False):
+            assert self.config.get_api_key() == "env-key"
+
+    def test_get_api_base_precedence(self):
+        # Explicit argument wins over everything.
+        assert (
+            self.config.get_api_base("https://custom-base.com/v1")
+            == "https://custom-base.com/v1"
+        )
+
+        # PARASAIL_API_BASE override.
+        with patch(
+            "litellm.llms.parasail.chat.transformation.get_secret_str",
+            return_value="https://proxy.internal/v1",
+        ):
+            assert self.config.get_api_base() == "https://proxy.internal/v1"
+
+        # Falls back to the default endpoint.
+        with patch(
+            "litellm.llms.parasail.chat.transformation.get_secret_str",
+            return_value=None,
+        ):
+            assert self.config.get_api_base() == ParasailConfig.API_BASE_URL
+            assert ParasailConfig.API_BASE_URL == "https://api.parasail.io/v1"
+
+    def test_get_openai_compatible_provider_info(self):
+        with patch.dict(os.environ, {"PARASAIL_API_KEY": "sk-secret"}, clear=False):
+            api_base, api_key = self.config._get_openai_compatible_provider_info(
+                api_base=None, api_key=None
+            )
+        assert api_base == "https://api.parasail.io/v1"
+        assert api_key == "sk-secret"
+
+    def test_supported_params_include_tools(self):
+        params = self.config.get_supported_openai_params(model="parasail-deepseek-r1")
+        for expected in ("temperature", "stream", "tools", "tool_choice"):
+            assert expected in params
+
+
+class TestParasailProviderResolution:
+    def test_get_llm_provider_resolves_prefixed_model(self):
+        with patch.dict(os.environ, {"PARASAIL_API_KEY": "sk-secret"}, clear=False):
+            model, provider, api_key, api_base = get_llm_provider(
+                model="parasail/parasail-deepseek-r1"
+            )
+        assert model == "parasail-deepseek-r1"
+        assert provider == "parasail"
+        assert api_key == "sk-secret"
+        assert api_base == "https://api.parasail.io/v1"
+
+    def test_get_llm_provider_detects_provider_from_api_base(self):
+        _, provider, _, _ = get_llm_provider(
+            model="parasail-deepseek-r1",
+            api_base="https://api.parasail.io/v1",
+            api_key="sk-secret",
+        )
+        assert provider == "parasail"
+
+    def test_get_supported_openai_params_routes_to_config(self):
+        params = get_supported_openai_params(
+            model="parasail-deepseek-r1", custom_llm_provider="parasail"
+        )
+        assert params is not None
+        assert "tools" in params
+
+    def test_provider_registered_in_enum_and_lists(self):
+        from litellm.types.utils import LlmProviders
+
+        assert LlmProviders.PARASAIL.value == "parasail"
+        assert "parasail" in litellm.openai_compatible_providers
+        assert "api.parasail.io/v1" in litellm.openai_compatible_endpoints

--- a/tests/test_litellm/llms/parasail/chat/test_parasail_chat_transformation.py
+++ b/tests/test_litellm/llms/parasail/chat/test_parasail_chat_transformation.py
@@ -51,7 +51,13 @@ class TestParasailConfig:
             assert ParasailConfig.API_BASE_URL == "https://api.parasail.io/v1"
 
     def test_get_openai_compatible_provider_info(self):
-        with patch.dict(os.environ, {"PARASAIL_API_KEY": "sk-secret"}, clear=False):
+        def fake_secret(name, *args, **kwargs):
+            return "sk-secret" if name == "PARASAIL_API_KEY" else None
+
+        with patch(
+            "litellm.llms.parasail.chat.transformation.get_secret_str",
+            side_effect=fake_secret,
+        ):
             api_base, api_key = self.config._get_openai_compatible_provider_info(
                 api_base=None, api_key=None
             )


### PR DESCRIPTION
## Relevant issues

N/A. Parasail is a popular OpenAI-compatible serverless inference provider that is not yet supported; this adds it under the existing OpenAI-compatible provider pattern.

## Linear ticket

N/A (external contribution)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Live proxy hitting the real Parasail API. Replace the model id with a currently listed Parasail model if needed.

```bash
export PARASAIL_API_KEY=...

cat > parasail_test.yaml <<'YAML'
model_list:
  - model_name: parasail-test
    litellm_params:
      model: parasail/parasail-deepseek-r1
      api_key: os.environ/PARASAIL_API_KEY
YAML

python litellm/proxy/proxy_cli.py --config parasail_test.yaml --detailed_debug &

curl http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d '{"model":"parasail-test","messages":[{"role":"user","content":"say hi in 3 words"}]}'
```

Live request/response output against the real Parasail API will be added as a follow-up comment on this PR.

## Type

🆕 New Feature

## Changes

This adds Parasail as a first-class OpenAI-compatible chat provider.

The core of the change is `ParasailConfig` in `litellm/llms/parasail/chat/transformation.py`, a thin subclass of `OpenAIGPTConfig` that resolves the API key from `PARASAIL_API_KEY` and the API base from `PARASAIL_API_BASE`, defaulting to `https://api.parasail.io/v1`. The config follows the same shape as the existing `NscaleConfig`.

The provider is then registered everywhere the other OpenAI-compatible providers are: the `LlmProviders` enum, the `LITELLM_CHAT_PROVIDERS`, `openai_compatible_providers`, and `openai_compatible_endpoints` lists in `constants.py`, the model-set wiring and lazy config import in `__init__.py`, the lazy import registry, the provider detection and provider-info resolution in `get_llm_provider_logic.py`, the supported-params dispatch in `get_supported_openai_params.py`, and the provider config map in `utils.py`. With this wiring, both `model="parasail/<model>"` and an explicit Parasail `api_base` resolve to the provider with the right key and base.

Tests live in `tests/test_litellm/llms/parasail/chat/test_parasail_chat_transformation.py`. They cover API key and API base precedence (explicit argument over `PARASAIL_API_BASE` over the default), the OpenAI-compatible provider-info resolution, the supported-params surface, end-to-end provider resolution from both a prefixed model and an explicit `api_base`, and the provider being present in the enum and the compatibility lists. The tests are mocked and make no network calls, so they fit `tests/test_litellm/`.

Model price and context-window entries are intentionally left out of this PR to keep the scope isolated and avoid committing pricing that drifts; they can follow once verified against Parasail's current pricing.
