### PR TITLE
fix(openrouter): support cache_control for qwen models (#29322)

### DIFF
--- a/litellm/llms/openrouter/chat/transformation.py
+++ b/litellm/llms/openrouter/chat/transformation.py
@@ -30,6 +30,7 @@ class CacheControlSupportedModels(str, Enum):
     MINIMAX = "minimax"
     GLM = "glm"
     ZAI = "z-ai"
+    QWEN = "qwen"
 
 
 class OpenrouterConfig(OpenAIGPTConfig):
@@ -44,6 +45,11 @@ class OpenrouterConfig(OpenAIGPTConfig):
             ) or litellm.supports_reasoning(model=model):
                 supported_params.append("reasoning_effort")
                 supported_params.append("thinking")
+
+            if "qwen" in model.lower():
+                supported_params.append("cache_control")
+                supported_params.append("cache_control_injection_points")
+
         except Exception:
             pass
         return list(dict.fromkeys(supported_params))

--- a/litellm/llms/openrouter/chat/transformation.py
+++ b/litellm/llms/openrouter/chat/transformation.py
@@ -46,7 +46,7 @@ class OpenrouterConfig(OpenAIGPTConfig):
                 supported_params.append("reasoning_effort")
                 supported_params.append("thinking")
 
-            if "qwen" in model.lower():
+            if self._supports_cache_control_in_content(model):
                 supported_params.append("cache_control")
                 supported_params.append("cache_control_injection_points")
 

--- a/tests/llm_translation/test_openrouter.py
+++ b/tests/llm_translation/test_openrouter.py
@@ -45,3 +45,25 @@ def test_openrouter_embedding():
     assert resp.data[0]["embedding"] is not None
     assert isinstance(resp.data[0]["embedding"], list)
     assert len(resp.data[0]["embedding"]) > 0
+
+
+def test_openrouter_qwen_cache_control_supported():
+    """
+    Validates that Qwen models routed through OpenRouter cleanly support 
+    cache_control and cache_control_injection_points parameters,
+    resolving issue #29322.
+    """
+    from litellm.llms.openrouter.chat.transformation import OpenrouterConfig
+
+    config = OpenrouterConfig()
+    qwen_model = "openrouter/qwen/qwen3.6-flash"
+    
+    # Retrieve the dynamically mapped parameters for the Qwen endpoint
+    supported_params = config.get_supported_openai_params(model=qwen_model)
+    
+    # Assertions to ensure the translation layer captures the caching parameters
+    assert "cache_control" in supported_params, f"cache_control missing from supported parameters for {qwen_model}"
+    assert "cache_control_injection_points" in supported_params, f"cache_control_injection_points missing from supported parameters for {qwen_model}"
+    print("✅ test_openrouter_qwen_cache_control_supported passed!")
+
+


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #29322" -->

### What does this PR do?
Fixes an issue where `cache_control` and `cache_control_injection_points` parameters were being stripped out of payload requests dispatched to OpenRouter Qwen models.

Closes #29322

## Linear ticket

<!-- if you are an internal contributor, add the Linear ticket e.g. "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [*] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [*] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or log output demonstrating that your changes work as expected.
     For bug fixes: show reproduction before the fix and passing behavior after.
     For new features: show the feature working end-to-end.
     For UI changes: include before/after screenshots. -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix


## Changes
* Updated `OpenrouterConfig.get_supported_openai_params` to dynamically append `cache_control` and `cache_control_injection_points` whenever a model contains the `"qwen"` substring.
* Added a comprehensive unit test `test_openrouter_qwen_cache_control_supported` inside `tests/llm_translation/test_openrouter.py` to assert that these parameters are tracked by the translation pipeline.
