### PR TITLE
fix(mcp): resolve 11 MCP server bugs across tool routing, BYOK, REST filtering, auth, and admin UI

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -892,6 +892,7 @@ class MCPServerManager:
             is_byok=bool(getattr(mcp_server, "is_byok", False)),
             byok_description=getattr(mcp_server, "byok_description", None) or [],
             byok_api_key_help_url=getattr(mcp_server, "byok_api_key_help_url", None),
+            submitted_by=getattr(mcp_server, "submitted_by", None),
             # AWS SigV4 fields
             aws_access_key_id=aws_creds.get("aws_access_key_id"),
             aws_secret_access_key=aws_creds.get("aws_secret_access_key"),
@@ -995,6 +996,18 @@ class MCPServerManager:
             if server.allow_all_keys is True
         ]
 
+    def get_server_ids_submitted_by(self, user_id: str) -> List[str]:
+        """Return server IDs that ``user_id`` submitted.
+
+        A user who submits a server for review keeps visibility of it after an
+        admin approves it, even if no access group grants them access.
+        """
+        return [
+            server.server_id
+            for server in self.get_registry().values()
+            if server.submitted_by == user_id
+        ]
+
     async def get_allowed_mcp_servers(
         self, user_api_key_auth: Optional[UserAPIKeyAuth] = None
     ) -> List[str]:
@@ -1052,6 +1065,15 @@ class MCPServerManager:
             in_toolset_scope = _mcp_active_toolset_id.get() is not None
             if not in_toolset_scope:
                 combined_servers.update(allow_all_server_ids)
+                submitter_user_id = (
+                    getattr(user_api_key_auth, "user_id", None)
+                    if user_api_key_auth
+                    else None
+                )
+                if submitter_user_id:
+                    combined_servers.update(
+                        self.get_server_ids_submitted_by(submitter_user_id)
+                    )
 
             # For anonymous callers (no user_id, no role), also surface any
             # servers the operator has opted into upstream-delegated auth.

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -2538,6 +2538,7 @@ class MCPServerManager:
         server: MCPServer,
         tool_name: str,
         arguments: Dict[str, Any],
+        mcp_auth_header: Optional[str] = None,
     ) -> CallToolResult:
         """
         Call an OpenAPI tool handler directly.
@@ -2570,6 +2571,23 @@ class MCPServerManager:
                 isError=True,
             )
 
+        # BYOK credential injection for the Responses/Playground path: OpenAPI
+        # tool handlers read the Authorization header from this ContextVar. The
+        # direct /mcp route sets it in execute_mcp_tool; set it here too so the
+        # stored credential reaches the upstream HTTP request.
+        from litellm.proxy._experimental.mcp_server.openapi_to_mcp_generator import (
+            _request_auth_header,
+            format_byok_authorization_header,
+        )
+
+        auth_header_value = format_byok_authorization_header(
+            getattr(server, "auth_type", None), mcp_auth_header
+        )
+        auth_token_reset = (
+            _request_auth_header.set(auth_header_value)
+            if auth_header_value is not None
+            else None
+        )
         try:
             # Call the tool handler with the arguments
             # The handler is an async function that makes the HTTP request
@@ -2590,6 +2608,9 @@ class MCPServerManager:
                 content=[TextContent(type="text", text=error_msg)],
                 isError=True,
             )
+        finally:
+            if auth_token_reset is not None:
+                _request_auth_header.reset(auth_token_reset)
 
     async def pre_call_tool_check(
         self,
@@ -3056,6 +3077,26 @@ class MCPServerManager:
         start_time = datetime.datetime.now()
         mcp_server = self._resolve_mcp_server_for_tool_call(server_name, name)
 
+        # Inject the stored BYOK credential for paths that don't pre-resolve it
+        # (e.g. the Responses/Playground path, which calls call_tool directly
+        # rather than through execute_mcp_tool). The direct /mcp route already
+        # sets mcp_auth_header, so the guard below leaves it untouched there.
+        if (
+            mcp_server is not None
+            and getattr(mcp_server, "is_byok", False)
+            and not mcp_auth_header
+            and user_api_key_auth is not None
+            and user_api_key_auth.user_id
+        ):
+            from litellm.proxy._experimental.mcp_server.server import (
+                get_user_byok_credential,
+            )
+
+            mcp_auth_header = await get_user_byok_credential(
+                user_id=user_api_key_auth.user_id,
+                server_id=mcp_server.server_id,
+            )
+
         #########################################################
         # Pre MCP Tool Call Hook
         # Allow validation and modification of tool calls before execution
@@ -3107,7 +3148,9 @@ class MCPServerManager:
                 )
             tasks.append(
                 asyncio.create_task(
-                    self._call_openapi_tool_handler(mcp_server, name, arguments)
+                    self._call_openapi_tool_handler(
+                        mcp_server, name, arguments, mcp_auth_header=mcp_auth_header
+                    )
                 )
             )
         else:

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -3790,6 +3790,8 @@ class MCPServerManager:
             allow_all_keys=server.allow_all_keys,
             available_on_public_internet=server.available_on_public_internet,
             delegate_auth_to_upstream=server.delegate_auth_to_upstream,
+            tool_name_to_display_name=server.tool_name_to_display_name,
+            tool_name_to_description=server.tool_name_to_description,
             is_byok=server.is_byok,
             byok_description=server.byok_description,
             byok_api_key_help_url=server.byok_api_key_help_url,

--- a/litellm/proxy/_experimental/mcp_server/openapi_to_mcp_generator.py
+++ b/litellm/proxy/_experimental/mcp_server/openapi_to_mcp_generator.py
@@ -63,6 +63,26 @@ _request_extra_headers: contextvars.ContextVar[Optional[Dict[str, str]]] = (
 )
 
 
+def format_byok_authorization_header(
+    auth_type: Any, token: Optional[str]
+) -> Optional[str]:
+    """Build the full Authorization header value for a BYOK credential.
+
+    The OpenAPI tool handler injects this verbatim as the Authorization header
+    (via the _request_auth_header ContextVar), so the auth-type prefix is baked
+    in here rather than known by the generator. Returns None when no token.
+    """
+    if not token:
+        return None
+    from litellm.types.mcp import MCPAuth
+
+    if auth_type == MCPAuth.api_key:
+        return f"ApiKey {token}"
+    if auth_type == MCPAuth.basic:
+        return f"Basic {token}"
+    return f"Bearer {token}"
+
+
 def _sanitize_path_parameter_value(param_value: Any, param_name: str) -> str:
     """Ensure path params cannot introduce directory traversal."""
     if param_value is None:

--- a/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
@@ -605,11 +605,49 @@ if MCP_AVAILABLE:
             "message": "Successfully retrieved tools",
         }
 
+    async def _resolve_toolset_filter(
+        toolset_name: Optional[str],
+    ) -> Optional[Dict[str, List[str]]]:
+        """Resolve a toolset name to its {server_id: [tool_names]} permission map.
+
+        Returns None when no toolset filter is requested. Raises 404 when the
+        named toolset does not exist.
+        """
+        if not toolset_name:
+            return None
+
+        from litellm.proxy.utils import get_prisma_client_or_throw
+
+        prisma_client = get_prisma_client_or_throw(
+            "Database not connected. Connect a database to use MCP toolsets."
+        )
+        toolset = await global_mcp_server_manager.get_toolset_by_name_cached(
+            prisma_client, toolset_name
+        )
+        if toolset is None:
+            raise HTTPException(
+                status_code=404,
+                detail={
+                    "error": "toolset_not_found",
+                    "message": f"Toolset '{toolset_name}' not found",
+                },
+            )
+        return await global_mcp_server_manager.resolve_toolset_tool_permissions(
+            toolset_ids=[toolset.toolset_id]
+        )
+
     @router.get("/tools/list", dependencies=[Depends(user_api_key_auth)])
     async def list_tool_rest_api(
         request: Request,
         server_id: Optional[str] = Query(
             None, description="The server id to list tools for"
+        ),
+        mcp_server_name: Optional[str] = Query(
+            None,
+            description="The server name or alias to list tools for (alias for server_id)",
+        ),
+        toolset_name: Optional[str] = Query(
+            None, description="The toolset name to scope the listed tools to"
         ),
         user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
     ) -> dict:
@@ -669,10 +707,11 @@ if MCP_AVAILABLE:
             list_tools_result = []
             error_message = None
 
-            # If server_id is specified, only query that specific server
-            if server_id:
+            # If a server is specified (by id, name, or alias), only query it.
+            single_server_identifier = server_id or mcp_server_name
+            if single_server_identifier:
                 return await _list_tools_for_single_server(
-                    server_id=server_id,
+                    server_id=single_server_identifier,
                     allowed_server_ids=allowed_server_ids,
                     rest_client_ip=_rest_client_ip,
                     mcp_server_auth_headers=mcp_server_auth_headers,
@@ -711,9 +750,19 @@ if MCP_AVAILABLE:
                     else {}
                 )
 
+                # When a toolset filter is supplied, scope the listing to the
+                # toolset's servers and tools, reusing the same resolution the
+                # streamable HTTP /toolset/{name}/mcp path uses.
+                toolset_tool_permissions = await _resolve_toolset_filter(toolset_name)
+
                 # Query all servers the user has access to
                 errors = []
-                for allowed_server_id in allowed_server_ids:
+                servers_to_query = (
+                    [s for s in allowed_server_ids if s in toolset_tool_permissions]
+                    if toolset_tool_permissions is not None
+                    else allowed_server_ids
+                )
+                for allowed_server_id in servers_to_query:
                     server = global_mcp_server_manager.get_mcp_server_by_id(
                         allowed_server_id
                     )
@@ -737,6 +786,15 @@ if MCP_AVAILABLE:
                             user_api_key_dict,
                             extra_headers=user_oauth_extra_headers,
                         )
+                        if toolset_tool_permissions is not None:
+                            allowed_names = toolset_tool_permissions.get(
+                                allowed_server_id, []
+                            )
+                            tools_result = [
+                                tool
+                                for tool in tools_result
+                                if _tool_name_matches(tool.name, allowed_names)
+                            ]
                         list_tools_result.extend(tools_result)
                     except Exception as e:
                         verbose_logger.exception(

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -94,6 +94,36 @@ def _write_byok_cred_cache(
     _byok_cred_cache[(user_id, server_id)] = (credential, time.monotonic())
 
 
+async def get_user_byok_credential(
+    user_id: Optional[str], server_id: str
+) -> Optional[str]:
+    """Fetch a stored per-user BYOK credential, using the shared TTL cache.
+
+    Shared by the direct /mcp route and the Responses/Playground path so both
+    inject the same credential, keyed on user_id + server_id. Returns None when
+    no credential is stored or the database is unavailable.
+    """
+    if not user_id:
+        return None
+
+    cached = _byok_cred_cache.get((user_id, server_id))
+    if cached is not None:
+        credential, ts = cached
+        if time.monotonic() - ts < _BYOK_CRED_CACHE_TTL:
+            return credential
+
+    from litellm.proxy._experimental.mcp_server.db import get_user_credential
+    from litellm.proxy.proxy_server import prisma_client
+
+    if prisma_client is None:
+        return None
+    credential = await get_user_credential(
+        prisma_client=prisma_client, user_id=user_id, server_id=server_id
+    )
+    _write_byok_cred_cache(user_id, server_id, credential)
+    return credential
+
+
 # Check if MCP is available
 # "mcp" requires python 3.10 or higher, but several litellm users use python 3.8
 # We're making this conditional import to avoid breaking users who use python 3.8.
@@ -164,6 +194,7 @@ if MCP_AVAILABLE:
     from litellm.proxy._experimental.mcp_server.openapi_to_mcp_generator import (
         _request_auth_header,
         _request_extra_headers,
+        format_byok_authorization_header,
     )
     from litellm.proxy._experimental.mcp_server.sse_transport import SseServerTransport
     from litellm.proxy._experimental.mcp_server.tool_registry import (
@@ -1944,29 +1975,8 @@ if MCP_AVAILABLE:
         """
         if not mcp_server.is_byok:
             return None
-        user_id = (user_api_key_auth.user_id if user_api_key_auth else None) or ""
-        if not user_id:
-            return None
-
-        cache_key = (user_id, mcp_server.server_id)
-        cached = _byok_cred_cache.get(cache_key)
-        if cached is not None:
-            credential, ts = cached
-            if time.monotonic() - ts < _BYOK_CRED_CACHE_TTL:
-                return credential
-
-        from litellm.proxy._experimental.mcp_server.db import get_user_credential
-        from litellm.proxy.proxy_server import prisma_client
-
-        if prisma_client is None:
-            return None
-        credential = await get_user_credential(
-            prisma_client=prisma_client,
-            user_id=user_id,
-            server_id=mcp_server.server_id,
-        )
-        _write_byok_cred_cache(user_id, mcp_server.server_id, credential)
-        return credential
+        user_id = user_api_key_auth.user_id if user_api_key_auth else None
+        return await get_user_byok_credential(user_id, mcp_server.server_id)
 
     async def _check_byok_credential(
         mcp_server: MCPServer,
@@ -2269,17 +2279,10 @@ if MCP_AVAILABLE:
             # because the tool function has headers baked into its closure.
             # Pre-format the full Authorization header value using the server's
             # configured auth_type so the generator doesn't need to know the prefix.
-            auth_header_value: Optional[str] = None
-            if mcp_auth_header:
-                server_auth_type = (
-                    getattr(mcp_server, "auth_type", None) if mcp_server else None
-                )
-                if server_auth_type == MCPAuth.api_key:
-                    auth_header_value = f"ApiKey {mcp_auth_header}"
-                elif server_auth_type == MCPAuth.basic:
-                    auth_header_value = f"Basic {mcp_auth_header}"
-                else:
-                    auth_header_value = f"Bearer {mcp_auth_header}"
+            auth_header_value = format_byok_authorization_header(
+                getattr(mcp_server, "auth_type", None) if mcp_server else None,
+                mcp_auth_header,
+            )
 
             # Forward named client headers to OpenAPI tool upstream requests.
             # MCPServer.extra_headers lists header names to copy from raw_headers.

--- a/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
+++ b/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
@@ -1085,6 +1085,12 @@ async def update_mcp_semantic_filter_settings(
     Update MCP semantic filter settings in database.
     Settings will be picked up by all pods within approximately 10 seconds via background polling.
     """
+    if user_api_key_dict.user_role != LitellmUserRoles.PROXY_ADMIN:
+        raise HTTPException(
+            status_code=403,
+            detail="Only proxy admins can update MCP semantic filter settings.",
+        )
+
     result = await _update_litellm_setting(
         settings=settings,
         settings_key="mcp_semantic_tool_filter",

--- a/litellm/responses/mcp/litellm_proxy_mcp_handler.py
+++ b/litellm/responses/mcp/litellm_proxy_mcp_handler.py
@@ -16,7 +16,11 @@ from typing import (
 from litellm._logging import verbose_logger
 from litellm.constants import MAXIMUM_TRACEBACK_LINES_TO_LOG
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
-from litellm.proxy._experimental.mcp_server.utils import split_server_prefix_from_name
+from litellm.proxy._experimental.mcp_server.utils import (
+    iter_known_server_prefixes,
+    normalize_server_name,
+    split_server_prefix_from_name,
+)
 from litellm.responses.main import aresponses
 from litellm.responses.streaming_iterator import BaseResponsesAPIStreamingIterator
 from litellm.types.llms.openai import ResponsesAPIResponse
@@ -348,6 +352,42 @@ class LiteLLM_Proxy_MCP_Handler:
                     )
 
         return deduplicated_tools, tool_server_map
+
+    @staticmethod
+    def _resolve_upstream_tool_name(
+        tool_name: str,
+        server_name: str,
+        mcp_server: Optional[Any],
+    ) -> str:
+        """Translate the model-facing tool name back to the upstream tool name.
+
+        tools/list exposes each tool prefixed with the server's alias and, when
+        configured, renamed to a display name. The model echoes that name back,
+        so reverse both transformations before dispatching upstream, mirroring
+        the direct /mcp path's _resolve_display_name_to_original.
+        """
+        unprefixed_name, prefixed_server_name = split_server_prefix_from_name(tool_name)
+        upstream_name = tool_name
+        if prefixed_server_name and unprefixed_name:
+            if mcp_server is not None:
+                known_prefixes = {
+                    normalize_server_name(prefix)
+                    for prefix in iter_known_server_prefixes(mcp_server)
+                }
+            else:
+                known_prefixes = {normalize_server_name(server_name)}
+            if normalize_server_name(prefixed_server_name) in known_prefixes:
+                upstream_name = unprefixed_name
+
+        if mcp_server is not None:
+            display_to_original = {
+                display_name: original_name
+                for original_name, display_name in (
+                    getattr(mcp_server, "tool_name_to_display_name", None) or {}
+                ).items()
+            }
+            return display_to_original.get(upstream_name, upstream_name)
+        return upstream_name
 
     @staticmethod
     def _filter_mcp_tools_by_allowed_tools(
@@ -690,18 +730,21 @@ class LiteLLM_Proxy_MCP_Handler:
                 from litellm.proxy.proxy_server import proxy_logging_obj
 
                 server_name = tool_server_map[tool_name]
-
-                # Remove the server name prefix if the tool name includes it.
-                sanitized_tool_name = tool_name
-                unprefixed_name, prefixed_server_name = split_server_prefix_from_name(
-                    tool_name
+                mcp_server = global_mcp_server_manager.get_mcp_server_by_name(
+                    server_name
                 )
-                if (
-                    prefixed_server_name
-                    and prefixed_server_name == server_name
-                    and unprefixed_name
-                ):
-                    sanitized_tool_name = unprefixed_name
+
+                # The model calls tools by the name shown during tools/list, which
+                # is prefixed with the server's alias and may be a configured
+                # display name. Reverse both so the upstream server receives the
+                # tool name it actually knows.
+                sanitized_tool_name = (
+                    LiteLLM_Proxy_MCP_Handler._resolve_upstream_tool_name(
+                        tool_name=tool_name,
+                        server_name=server_name,
+                        mcp_server=mcp_server,
+                    )
+                )
 
                 start_time = datetime.now()
                 logging_input = [
@@ -784,9 +827,6 @@ class LiteLLM_Proxy_MCP_Handler:
                     "arguments": parsed_arguments,
                     "namespaced_tool_name": tool_name,
                 }
-                mcp_server = global_mcp_server_manager._get_mcp_server_from_tool_name(
-                    tool_name
-                )
                 if mcp_server:
                     mcp_info = mcp_server.mcp_info or {}
                     standard_logging_mcp_tool_call["mcp_server_name"] = (

--- a/litellm/types/mcp_server/mcp_server_manager.py
+++ b/litellm/types/mcp_server/mcp_server_manager.py
@@ -77,6 +77,7 @@ class MCPServer(BaseModel):
     is_byok: bool = False
     byok_description: List[str] = []
     byok_api_key_help_url: Optional[str] = None
+    submitted_by: Optional[str] = None
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
     # OAuth2 flow type.  Defaults to None (interactive / authorization_code).

--- a/tests/mcp_tests/test_mcp_server.py
+++ b/tests/mcp_tests/test_mcp_server.py
@@ -1500,6 +1500,7 @@ async def test_add_update_server_with_alias():
     mock_mcp_server.created_at = None
     mock_mcp_server.updated_at = None
     mock_mcp_server.instructions = None
+    mock_mcp_server.submitted_by = None
     mock_mcp_server.approval_status = "active"
 
     # Add server to manager
@@ -1558,6 +1559,7 @@ async def test_add_update_server_without_alias():
     mock_mcp_server.created_at = None
     mock_mcp_server.updated_at = None
     mock_mcp_server.instructions = None
+    mock_mcp_server.submitted_by = None
     mock_mcp_server.approval_status = "active"
 
     # Add server to manager
@@ -1617,6 +1619,7 @@ async def test_add_update_server_fallback_to_server_id():
     mock_mcp_server.created_at = None
     mock_mcp_server.updated_at = None
     mock_mcp_server.instructions = None
+    mock_mcp_server.submitted_by = None
     mock_mcp_server.approval_status = "active"
     # Add server to manager
     await test_manager.add_server(mock_mcp_server)

--- a/tests/mcp_tests/test_mcp_server.py
+++ b/tests/mcp_tests/test_mcp_server.py
@@ -2186,6 +2186,8 @@ async def test_list_tool_rest_api_all_servers_with_auth():
                     result = await list_tool_rest_api(
                         request=mock_request,
                         server_id=None,
+                        mcp_server_name=None,
+                        toolset_name=None,
                         user_api_key_dict=mock_user_api_key_dict,
                     )
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -1689,6 +1689,51 @@ async def test_mcp_manager_merges_public_and_restricted_servers():
 
 
 @pytest.mark.asyncio
+async def test_mcp_manager_surfaces_servers_to_their_submitter():
+    """Bug #16: an internal user who submits a server keeps visibility of it
+    after approval, even with no access group and allow_all_keys=false; an
+    unrelated non-admin must not see it."""
+    try:
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            MCPServerManager,
+        )
+        from litellm.proxy._types import MCPTransport
+        from litellm.types.mcp_server.mcp_server_manager import MCPServer
+    except ImportError:
+        pytest.skip("MCP server not available")
+
+    manager = MCPServerManager()
+    submitted_server = MCPServer(
+        server_id="submitted",
+        name="submitted",
+        transport=MCPTransport.http,
+        allow_all_keys=False,
+        submitted_by="submitter-user",
+    )
+    manager.registry = {submitted_server.server_id: submitted_server}
+
+    with (
+        patch(
+            "litellm.proxy.management_endpoints.common_utils._user_has_admin_view",
+            return_value=False,
+        ),
+        patch(
+            "litellm.proxy._experimental.mcp_server.mcp_server_manager.MCPRequestHandler.get_allowed_mcp_servers",
+            AsyncMock(return_value=[]),
+        ),
+    ):
+        submitter_allowed = await manager.get_allowed_mcp_servers(
+            UserAPIKeyAuth(user_id="submitter-user")
+        )
+        other_allowed = await manager.get_allowed_mcp_servers(
+            UserAPIKeyAuth(user_id="someone-else")
+        )
+
+    assert submitter_allowed == ["submitted"]
+    assert other_allowed == []
+
+
+@pytest.mark.asyncio
 async def test_call_mcp_tool_user_unauthorized_access():
     """Test that a user cannot call a tool from a server they don't have access to"""
     from fastapi import HTTPException

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -283,6 +283,131 @@ async def test_call_tool_m2m_skips_authorization_headers():
 
 
 @pytest.mark.asyncio
+async def test_call_tool_injects_byok_credential_for_regular_server():
+    """Bug #13: the Responses/Playground path calls call_tool() directly (not
+    execute_mcp_tool), so the stored BYOK credential must be looked up here and
+    injected into the upstream MCP client. Before the fix the client received
+    mcp_auth_header=None -> upstream 401."""
+    from litellm.proxy._experimental.mcp_server import server as server_module
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+        MCPServerManager,
+    )
+
+    server_module._byok_cred_cache.clear()
+
+    manager = MCPServerManager()
+    server = MCPServer(
+        server_id="byok-server-1",
+        name="byok_server",
+        server_name="byok_server",
+        transport=MCPTransport.http,
+        auth_type=MCPAuth.bearer_token,
+        is_byok=True,
+    )
+    manager.registry[server.server_id] = server
+    manager.tool_name_to_mcp_server_name_mapping["echo"] = server.name
+
+    user_api_key_auth = UserAPIKeyAuth(
+        api_key="ui-token", user_id="sso-user-123", team_id="litellm-dashboard"
+    )
+
+    mock_client = MagicMock()
+    mock_client.call_tool = AsyncMock(return_value=MagicMock())
+
+    with (
+        patch(
+            "litellm.proxy._experimental.mcp_server.db.get_user_credential",
+            new=AsyncMock(return_value="stored-byok-secret"),
+        ) as get_cred_mock,
+        patch("litellm.proxy.proxy_server.prisma_client", new=MagicMock()),
+        patch.object(
+            manager, "_create_mcp_client", new=AsyncMock(return_value=mock_client)
+        ) as create_client_mock,
+    ):
+        await manager.call_tool(
+            server_name="byok_server",
+            name="echo",
+            arguments={"message": "hello"},
+            user_api_key_auth=user_api_key_auth,
+            mcp_auth_header=None,
+            proxy_logging_obj=None,
+        )
+
+    get_cred_mock.assert_awaited_once()
+    assert get_cred_mock.await_args.kwargs["user_id"] == "sso-user-123"
+    assert get_cred_mock.await_args.kwargs["server_id"] == "byok-server-1"
+    assert (
+        create_client_mock.await_args.kwargs["mcp_auth_header"]
+        == "stored-byok-secret"
+    )
+
+
+@pytest.mark.asyncio
+async def test_call_tool_injects_byok_credential_for_openapi_server():
+    """Bug #13 (OpenAPI / Firecrawl repro): OpenAPI tool handlers read the
+    Authorization header from the _request_auth_header ContextVar. The
+    Playground path must set it from the stored BYOK credential, formatted with
+    the server's auth-type prefix."""
+    from litellm.proxy._experimental.mcp_server import server as server_module
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+        MCPServerManager,
+    )
+    from litellm.proxy._experimental.mcp_server.openapi_to_mcp_generator import (
+        _request_auth_header,
+    )
+    from litellm.proxy._experimental.mcp_server.tool_registry import (
+        global_mcp_tool_registry,
+    )
+
+    server_module._byok_cred_cache.clear()
+
+    manager = MCPServerManager()
+    server = MCPServer(
+        server_id="byok-openapi-1",
+        name="firecrawl_byok",
+        server_name="firecrawl_byok",
+        transport=MCPTransport.http,
+        auth_type=MCPAuth.bearer_token,
+        is_byok=True,
+        spec_path="/tmp/firecrawl_openapi.json",
+    )
+    manager.registry[server.server_id] = server
+    manager.tool_name_to_mcp_server_name_mapping["scrape"] = server.name
+
+    observed = {}
+
+    async def fake_handler(**kwargs):
+        observed["auth"] = _request_auth_header.get()
+        return "scraped content"
+
+    tool = MagicMock()
+    tool.handler = fake_handler
+
+    with (
+        patch.object(global_mcp_tool_registry, "get_tool", return_value=tool),
+        patch(
+            "litellm.proxy._experimental.mcp_server.db.get_user_credential",
+            new=AsyncMock(return_value="fc-secret"),
+        ),
+        patch("litellm.proxy.proxy_server.prisma_client", new=MagicMock()),
+    ):
+        await manager.call_tool(
+            server_name="firecrawl_byok",
+            name="scrape",
+            arguments={"url": "https://example.com"},
+            user_api_key_auth=UserAPIKeyAuth(api_key="ui", user_id="user-9"),
+            mcp_auth_header=None,
+            proxy_logging_obj=None,
+        )
+
+    # The upstream OpenAPI request must carry the stored credential as a fully
+    # formatted Authorization header.
+    assert observed["auth"] == "Bearer fc-secret"
+    # And the ContextVar must be reset afterwards (no leakage across requests).
+    assert _request_auth_header.get() is None
+
+
+@pytest.mark.asyncio
 async def test_get_prompts_from_mcp_servers_success():
     try:
         from litellm.proxy._experimental.mcp_server.server import (

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -132,6 +132,31 @@ class TestMCPServerManager:
         assert client.stdio_config["env"]["NODE_ENV"] == "test"
         assert client.stdio_config["env"]["NPM_CONFIG_CACHE"] == MCP_NPM_CACHE_DIR
 
+    def test_build_mcp_server_table_preserves_tool_overrides(self):
+        """Bug #12: the list endpoint's converter must carry the saved
+        tool_name_to_display_name / tool_name_to_description overrides so the
+        edit UI pre-populates them instead of always showing the upstream values."""
+        manager = MCPServerManager()
+        server = MCPServer(
+            server_id="override-server",
+            name="override_server",
+            transport=MCPTransport.http,
+            url="https://example.com/mcp",
+            tool_name_to_display_name={"read_wiki_structure": "browse_docs"},
+            tool_name_to_description={
+                "read_wiki_structure": "Browse repository docs"
+            },
+        )
+
+        table = manager._build_mcp_server_table(server)
+
+        assert table.tool_name_to_display_name == {
+            "read_wiki_structure": "browse_docs"
+        }
+        assert table.tool_name_to_description == {
+            "read_wiki_structure": "Browse repository docs"
+        }
+
     async def test_create_mcp_client_stdio_injects_npm_config_cache(self):
         """Test that _create_mcp_client injects NPM_CONFIG_CACHE when not already set,
         and preserves user-provided NPM_CONFIG_CACHE when present."""

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_sigv4_auth.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_sigv4_auth.py
@@ -857,6 +857,7 @@ class TestSigV4BuildFromTable:
         table_record.byok_api_key_help_url = None
         table_record.oauth2_flow = None
         table_record.instructions = None
+        table_record.submitted_by = None
 
         manager = MCPServerManager()
 
@@ -915,6 +916,7 @@ class TestSigV4BuildFromTable:
         table_record.byok_api_key_help_url = None
         table_record.oauth2_flow = None
         table_record.instructions = None
+        table_record.submitted_by = None
 
         manager = MCPServerManager()
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
@@ -544,6 +544,165 @@ class TestListToolsRestAPI:
         assert result["error"] is None
         assert result["message"] == "Successfully retrieved tools"
 
+    async def test_mcp_server_name_scopes_to_single_server(self, monkeypatch):
+        """Bug #9: mcp_server_name must scope the listing to that one server
+        instead of being silently dropped and listing every server's tools."""
+
+        class StubTool:
+            def __init__(self, name):
+                self.name = name
+
+        class StubServer:
+            def __init__(self, server_id):
+                self.server_id = server_id
+                self.alias = server_id
+                self.server_name = server_id
+                self.name = server_id
+                self.allowed_tools = None
+                self.mcp_info = {"server_name": server_id}
+                self.available_on_public_internet = True
+
+        servers = {"server-a": StubServer("server-a"), "server-b": StubServer("server-b")}
+        server_tools = {"server-a": ["a_tool"], "server-b": ["b_tool"]}
+        queried = []
+
+        async def fake_contexts(user_api_key_auth):
+            return [user_api_key_auth]
+
+        async def fake_get_allowed_mcp_servers(*args, **kwargs):
+            return ["server-a", "server-b"]
+
+        async def fake_get_tools(
+            server, server_auth_header, raw_headers=None,
+            user_api_key_auth=None, extra_headers=None,
+        ):
+            queried.append(server.server_id)
+            return [StubTool(n) for n in server_tools[server.server_id]]
+
+        monkeypatch.setattr(rest_endpoints, "build_effective_auth_contexts", fake_contexts, raising=False)
+        monkeypatch.setattr(rest_endpoints.global_mcp_server_manager, "get_allowed_mcp_servers", fake_get_allowed_mcp_servers, raising=False)
+        monkeypatch.setattr(rest_endpoints.global_mcp_server_manager, "get_mcp_server_by_id", lambda sid: servers.get(sid), raising=False)
+        monkeypatch.setattr(rest_endpoints, "_get_tools_for_single_server", fake_get_tools, raising=False)
+
+        request = _build_request(path="/mcp-rest/tools/list", method="GET")
+        result = await rest_endpoints.list_tool_rest_api(
+            request,
+            server_id=None,
+            mcp_server_name="server-a",
+            toolset_name=None,
+            user_api_key_dict=UserAPIKeyAuth(),
+        )
+
+        assert result["error"] is None
+        assert [t.name for t in result["tools"]] == ["a_tool"]
+        # server-b must never be queried when a single server is requested.
+        assert queried == ["server-a"]
+
+    async def test_filters_tools_by_toolset_name(self, monkeypatch):
+        """Bug #9: toolset_name must scope the listing to the toolset's servers
+        and tools, reusing resolve_toolset_tool_permissions like the streamable
+        HTTP /toolset/{name}/mcp path. Without a filter, all tools are returned."""
+
+        class StubTool:
+            def __init__(self, name):
+                self.name = name
+
+        class StubServer:
+            def __init__(self, server_id):
+                self.server_id = server_id
+                self.alias = server_id
+                self.server_name = server_id
+                self.name = server_id
+                self.allowed_tools = None
+                self.mcp_info = {"server_name": server_id}
+                self.available_on_public_internet = True
+
+        servers = {"server-a": StubServer("server-a"), "server-b": StubServer("server-b")}
+        server_tools = {"server-a": ["tool1", "tool2"], "server-b": ["tool3", "tool4"]}
+
+        async def fake_contexts(user_api_key_auth):
+            return [user_api_key_auth]
+
+        async def fake_get_allowed_mcp_servers(*args, **kwargs):
+            return ["server-a", "server-b"]
+
+        async def fake_get_tools(
+            server, server_auth_header, raw_headers=None,
+            user_api_key_auth=None, extra_headers=None,
+        ):
+            return [StubTool(n) for n in server_tools[server.server_id]]
+
+        class StubToolset:
+            toolset_id = "toolset-xyz"
+
+        async def fake_get_toolset_by_name_cached(prisma_client, name):
+            return StubToolset() if name == "my-toolset" else None
+
+        async def fake_resolve_toolset_tool_permissions(toolset_ids):
+            assert toolset_ids == ["toolset-xyz"]
+            # Grant only tool2 on server-a; server-b is excluded entirely.
+            return {"server-a": ["tool2"]}
+
+        monkeypatch.setattr(rest_endpoints, "build_effective_auth_contexts", fake_contexts, raising=False)
+        monkeypatch.setattr(rest_endpoints.global_mcp_server_manager, "get_allowed_mcp_servers", fake_get_allowed_mcp_servers, raising=False)
+        monkeypatch.setattr(rest_endpoints.global_mcp_server_manager, "get_mcp_server_by_id", lambda sid: servers.get(sid), raising=False)
+        monkeypatch.setattr(rest_endpoints.global_mcp_server_manager, "get_toolset_by_name_cached", fake_get_toolset_by_name_cached, raising=False)
+        monkeypatch.setattr(rest_endpoints.global_mcp_server_manager, "resolve_toolset_tool_permissions", fake_resolve_toolset_tool_permissions, raising=False)
+        monkeypatch.setattr(rest_endpoints, "_get_tools_for_single_server", fake_get_tools, raising=False)
+        monkeypatch.setattr("litellm.proxy.utils.get_prisma_client_or_throw", lambda *a, **k: object(), raising=False)
+
+        request = _build_request(path="/mcp-rest/tools/list", method="GET")
+
+        all_result = await rest_endpoints.list_tool_rest_api(
+            request, server_id=None, mcp_server_name=None, toolset_name=None,
+            user_api_key_dict=UserAPIKeyAuth(),
+        )
+        assert all_result["error"] is None
+        assert sorted(t.name for t in all_result["tools"]) == ["tool1", "tool2", "tool3", "tool4"]
+
+        scoped = await rest_endpoints.list_tool_rest_api(
+            request, server_id=None, mcp_server_name=None, toolset_name="my-toolset",
+            user_api_key_dict=UserAPIKeyAuth(),
+        )
+        assert scoped["error"] is None
+        assert [t.name for t in scoped["tools"]] == ["tool2"]
+
+    async def test_unknown_toolset_name_returns_not_found(self, monkeypatch):
+        """Bug #9: an unknown toolset_name surfaces toolset_not_found rather than
+        silently returning every tool."""
+
+        async def fake_contexts(user_api_key_auth):
+            return [user_api_key_auth]
+
+        async def fake_get_allowed_mcp_servers(*args, **kwargs):
+            return ["server-a"]
+
+        async def fake_get_toolset_by_name_cached(prisma_client, name):
+            return None
+
+        class StubServer:
+            server_id = "server-a"
+            alias = "server-a"
+            server_name = "server-a"
+            name = "server-a"
+            allowed_tools = None
+            mcp_info = {"server_name": "server-a"}
+            available_on_public_internet = True
+
+        monkeypatch.setattr(rest_endpoints, "build_effective_auth_contexts", fake_contexts, raising=False)
+        monkeypatch.setattr(rest_endpoints.global_mcp_server_manager, "get_allowed_mcp_servers", fake_get_allowed_mcp_servers, raising=False)
+        monkeypatch.setattr(rest_endpoints.global_mcp_server_manager, "get_mcp_server_by_id", lambda sid: StubServer() if sid == "server-a" else None, raising=False)
+        monkeypatch.setattr(rest_endpoints.global_mcp_server_manager, "get_toolset_by_name_cached", fake_get_toolset_by_name_cached, raising=False)
+        monkeypatch.setattr("litellm.proxy.utils.get_prisma_client_or_throw", lambda *a, **k: object(), raising=False)
+
+        request = _build_request(path="/mcp-rest/tools/list", method="GET")
+        result = await rest_endpoints.list_tool_rest_api(
+            request, server_id=None, mcp_server_name=None, toolset_name="does-not-exist",
+            user_api_key_dict=UserAPIKeyAuth(),
+        )
+        assert result["tools"] == []
+        assert "toolset_not_found" in result["message"]
+
     async def test_name_resolution_finds_server_by_uuid(self, monkeypatch):
         """When server_id is a name string, it should be resolved to its UUID
         and used for the tools lookup when the UUID is in allowed_server_ids."""

--- a/tests/test_litellm/proxy/ui_crud_endpoints/test_proxy_setting_endpoints.py
+++ b/tests/test_litellm/proxy/ui_crud_endpoints/test_proxy_setting_endpoints.py
@@ -1869,3 +1869,112 @@ class TestProxySettingEndpoints:
         assert "field_schema" in data
         assert "properties" in data["field_schema"]
         assert "role_mappings" in data["field_schema"]["properties"]
+
+
+class TestUpdateMCPSemanticFilterSettingsAuthorization:
+    """Regression tests for Bug #17: PATCH /update/mcp_semantic_filter_settings
+    must be restricted to PROXY_ADMIN. Before the fix, any authenticated
+    principal (internal user, viewer, or a virtual key) could rewrite the global
+    MCP semantic filter config that applies across the whole proxy."""
+
+    @pytest.mark.parametrize(
+        "user_role",
+        [
+            LitellmUserRoles.INTERNAL_USER,
+            LitellmUserRoles.INTERNAL_USER_VIEW_ONLY,
+            LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY,
+        ],
+    )
+    def test_non_admin_cannot_update_mcp_semantic_filter_settings(
+        self, monkeypatch, user_role
+    ):
+        from litellm.proxy._types import UserAPIKeyAuth
+        from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+
+        # store_model_in_db is True so that, absent a role gate, the write would
+        # otherwise succeed -- this isolates the assertion to authorization.
+        monkeypatch.setattr("litellm.proxy.proxy_server.store_model_in_db", True)
+
+        app.dependency_overrides[user_api_key_auth] = lambda: UserAPIKeyAuth(
+            user_id="non-admin-user",
+            user_role=user_role,
+        )
+
+        payload = {
+            "enabled": True,
+            "embedding_model": "text-embedding-3-large",
+            "top_k": 5,
+            "similarity_threshold": 0.9,
+        }
+
+        try:
+            response = client.patch(
+                "/update/mcp_semantic_filter_settings", json=payload
+            )
+        finally:
+            app.dependency_overrides.clear()
+
+        assert response.status_code == 403, (
+            f"role {user_role} must not be able to update global MCP semantic "
+            f"filter settings, got {response.status_code}: {response.text}"
+        )
+
+    def test_proxy_admin_can_update_mcp_semantic_filter_settings(self, monkeypatch):
+        from unittest.mock import AsyncMock, MagicMock
+
+        import litellm
+        from litellm.proxy._types import UserAPIKeyAuth
+        from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+        from litellm.proxy.proxy_server import proxy_config
+
+        monkeypatch.setattr("litellm.proxy.proxy_server.store_model_in_db", True)
+        monkeypatch.setattr(litellm, "mcp_semantic_tool_filter", {}, raising=False)
+
+        captured = {}
+
+        async def mock_get_config():
+            return {"litellm_settings": {}}
+
+        async def mock_save_config(new_config=None):
+            captured["config"] = new_config
+
+        monkeypatch.setattr(proxy_config, "get_config", mock_get_config)
+        monkeypatch.setattr(proxy_config, "save_config", mock_save_config)
+        monkeypatch.setattr(
+            proxy_config, "_init_semantic_filter_settings_in_db", AsyncMock()
+        )
+        monkeypatch.setattr(
+            "litellm.proxy.proxy_server.prisma_client", MagicMock()
+        )
+
+        app.dependency_overrides[user_api_key_auth] = lambda: UserAPIKeyAuth(
+            user_id="admin-user",
+            user_role=LitellmUserRoles.PROXY_ADMIN,
+        )
+
+        payload = {
+            "enabled": True,
+            "embedding_model": "text-embedding-3-large",
+            "top_k": 5,
+            "similarity_threshold": 0.9,
+        }
+
+        try:
+            response = client.patch(
+                "/update/mcp_semantic_filter_settings", json=payload
+            )
+        finally:
+            app.dependency_overrides.clear()
+
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert data["status"] == "success"
+        assert data["settings"]["embedding_model"] == "text-embedding-3-large"
+        assert data["settings"]["top_k"] == 5
+        # The global write path actually ran for an admin.
+        assert (
+            captured["config"]["litellm_settings"]["mcp_semantic_tool_filter"][
+                "embedding_model"
+            ]
+            == "text-embedding-3-large"
+        )

--- a/tests/test_litellm/responses/mcp/test_litellm_proxy_mcp_handler.py
+++ b/tests/test_litellm/responses/mcp/test_litellm_proxy_mcp_handler.py
@@ -28,6 +28,7 @@ def _setup_mcp_call_environment(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
         call_tool=AsyncMock(return_value=_DummyMCPResult()),
         # Newer logging path calls this to enrich spend logs metadata
         _get_mcp_server_from_tool_name=MagicMock(return_value=None),
+        get_mcp_server_by_name=MagicMock(return_value=None),
     )
     monkeypatch.setattr(
         "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager",
@@ -280,6 +281,82 @@ async def test_execute_tool_calls_keeps_tool_name_when_equal_to_server(monkeypat
 
 
 @pytest.mark.asyncio
+async def test_execute_tool_calls_strips_alias_prefix_when_alias_differs_from_server_name(
+    monkeypatch,
+):
+    """Bug #8: tools/list prefixes tool names with the server alias. When the
+    alias differs from server_name, the prefix must still be stripped so the
+    upstream server receives the original tool name, not the alias-prefixed one.
+    """
+    call_tool_mock = _setup_mcp_call_environment(monkeypatch)
+
+    fake_server = types.SimpleNamespace(
+        alias="my_alias",
+        server_name="deepwiki_test",
+        server_id="srv-123",
+        short_prefix=None,
+        name="deepwiki_test",
+        mcp_info={},
+        tool_name_to_display_name=None,
+    )
+    monkeypatch.setattr(
+        "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager.get_mcp_server_by_name",
+        MagicMock(return_value=fake_server),
+    )
+
+    tool_name = "my_alias-read_wiki_structure"
+    tool_calls = [{"id": "call-1", "function": {"name": tool_name, "arguments": "{}"}}]
+
+    await LiteLLM_Proxy_MCP_Handler._execute_tool_calls(
+        tool_server_map={tool_name: "deepwiki_test"},
+        tool_calls=tool_calls,
+        user_api_key_auth=None,
+    )
+
+    assert call_tool_mock.await_count == 1
+    assert call_tool_mock.await_args is not None
+    assert call_tool_mock.await_args.kwargs["name"] == "read_wiki_structure"
+    assert call_tool_mock.await_args.kwargs["server_name"] == "deepwiki_test"
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_calls_reverse_maps_display_name_to_original(monkeypatch):
+    """Bug #11: when a tool has a display-name override, the model calls it by
+    the display name. _execute_tool_calls must reverse-map it to the original
+    upstream tool name before dispatching, matching the direct /mcp path.
+    """
+    call_tool_mock = _setup_mcp_call_environment(monkeypatch)
+
+    fake_server = types.SimpleNamespace(
+        alias="deepwiki",
+        server_name="deepwiki",
+        server_id="srv-9",
+        short_prefix=None,
+        name="deepwiki",
+        mcp_info={},
+        tool_name_to_display_name={"read_wiki_structure": "browse_repo_docs"},
+    )
+    monkeypatch.setattr(
+        "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager.get_mcp_server_by_name",
+        MagicMock(return_value=fake_server),
+    )
+
+    tool_name = "deepwiki-browse_repo_docs"
+    tool_calls = [{"id": "call-2", "function": {"name": tool_name, "arguments": "{}"}}]
+
+    await LiteLLM_Proxy_MCP_Handler._execute_tool_calls(
+        tool_server_map={tool_name: "deepwiki"},
+        tool_calls=tool_calls,
+        user_api_key_auth=None,
+    )
+
+    assert call_tool_mock.await_count == 1
+    assert call_tool_mock.await_args is not None
+    assert call_tool_mock.await_args.kwargs["name"] == "read_wiki_structure"
+    assert call_tool_mock.await_args.kwargs["server_name"] == "deepwiki"
+
+
+@pytest.mark.asyncio
 async def test_execute_tool_calls_logs_failure_via_post_call_failure_hook(monkeypatch):
     """
     Regression test for ae4d92ad...:
@@ -288,7 +365,8 @@ async def test_execute_tool_calls_logs_failure_via_post_call_failure_hook(monkey
     post_call_failure_hook = _setup_proxy_logging(monkeypatch)
 
     fake_manager = types.SimpleNamespace(
-        call_tool=AsyncMock(side_effect=HTTPException(status_code=500, detail="boom"))
+        call_tool=AsyncMock(side_effect=HTTPException(status_code=500, detail="boom")),
+        get_mcp_server_by_name=MagicMock(return_value=None),
     )
     monkeypatch.setattr(
         "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager",

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
@@ -542,4 +542,38 @@ describe("CreateMCPServer", () => {
       expect(onBackToDiscovery).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe("tool preview gating by role (Bug #15)", () => {
+    async function fillFetchableHttpForm() {
+      await selectAntOption("Transport Type", "Streamable HTTP");
+      await waitFor(() => {
+        expect(
+          screen.getByPlaceholderText("https://your-mcp-server.com"),
+        ).toBeInTheDocument();
+      });
+      const user = userEvent.setup({ delay: null });
+      await user.type(getServerNameInput(), "Preview_Server");
+      await user.type(
+        screen.getByPlaceholderText("https://your-mcp-server.com"),
+        "https://example.com/mcp",
+      );
+      await selectAntOption("Authentication", "None");
+    }
+
+    it("admin create form fetches the tool preview", async () => {
+      render(<CreateMCPServer {...defaultProps} userRole="Admin" />);
+      await fillFetchableHttpForm();
+      await waitFor(() => {
+        expect(networking.testMCPToolsListRequest).toHaveBeenCalled();
+      });
+    });
+
+    it("non-admin submit form does not call the admin-only tool preview", async () => {
+      render(<CreateMCPServer {...defaultProps} userRole="Internal User" />);
+      await fillFetchableHttpForm();
+      // Allow any auto-fetch effect to settle; it must stay gated for non-admins.
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(networking.testMCPToolsListRequest).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
@@ -14,7 +14,7 @@ import MCPPermissionManagement from "./MCPPermissionManagement";
 import OpenAPIFormSection, { OpenAPIKeyTool } from "./OpenAPIFormSection";
 import MCPLogoSelector from "./MCPLogoSelector";
 import { isAdminRole } from "@/utils/roles";
-import { validateMCPServerUrl, validateMCPServerName } from "./utils";
+import { validateMCPServerUrl, validateMCPServerName, findInvalidToolDisplayName, TOOL_DISPLAY_NAME_ERROR } from "./utils";
 import NotificationsManager from "../molecules/notifications_manager";
 import { useMcpOAuthFlow } from "@/hooks/useMcpOAuthFlow";
 import { useTestMCPConnection } from "@/hooks/useTestMCPConnection";
@@ -280,6 +280,14 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
 
   const handleCreate = async (values: Record<string, any>) => {
     setIsLoading(true);
+    const invalidDisplayName = findInvalidToolDisplayName(toolNameToDisplayName);
+    if (invalidDisplayName) {
+      NotificationsManager.fromBackend(
+        `Invalid display name "${invalidDisplayName.displayName}" for tool "${invalidDisplayName.toolName}". ${TOOL_DISPLAY_NAME_ERROR}`,
+      );
+      setIsLoading(false);
+      return;
+    }
     try {
       const {
         static_headers: staticHeadersList,

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
@@ -635,6 +635,17 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
               />
             </Form.Item>
 
+            <Form.Item
+              label={<span className="text-sm font-medium text-gray-700">Instructions</span>}
+              name="instructions"
+            >
+              <Input.TextArea
+                rows={4}
+                placeholder="Server-level instructions sent to the model alongside the tool list"
+                className="rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500"
+              />
+            </Form.Item>
+
             <MCPLogoSelector value={logoUrl} onChange={setLogoUrl} />
 
             <Form.Item

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
@@ -78,12 +78,16 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
   const [logoUrl, setLogoUrl] = useState<string | undefined>(undefined);
   const [oauthDocsUrl, setOauthDocsUrl] = useState<string | null>(null);
 
+  const isAdmin = isAdminRole(userRole);
+
   // Single hook call shared by MCPConnectionStatus and MCPToolConfiguration to avoid duplicate requests.
+  // The tool preview hits the admin-only /mcp_server/test/tools/list endpoint, so only
+  // enable it for admins; non-admin submitters would otherwise get a 403 on every change.
   const { tools, isLoadingTools, toolsError, toolsErrorStackTrace, canFetchTools, fetchTools, clearTools } = useTestMCPConnection({
     accessToken,
     oauthAccessToken,
     formValues,
-    enabled: true,
+    enabled: isAdmin,
   });
 
   const authType = formValues.auth_type as string | undefined;
@@ -529,8 +533,6 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
       setFormValues({});
     }
   }, [isModalVisible]);
-
-  const isAdmin = isAdminRole(userRole);
 
   // rendering
   return (

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.test.tsx
@@ -503,3 +503,34 @@ describe("MCPServerEdit (instructions, Bug #14)", () => {
     expect(payload.instructions).toBe("Updated guidance.");
   });
 });
+
+describe("MCPServerEdit (tool display name validation, Bug #10)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("blocks save when a tool display name contains invalid characters", async () => {
+    render(
+      <MCPServerEdit
+        mcpServer={{
+          ...interactiveOAuthServer,
+          tool_name_to_display_name: { some_tool: "Bad Name" },
+        }}
+        accessToken="access-token"
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+        availableAccessGroups={[]}
+      />,
+    );
+
+    const saveButtons = screen.getAllByRole("button", { name: "Save Changes" });
+    await act(async () => {
+      fireEvent.click(saveButtons[0]);
+    });
+
+    await waitFor(() => {
+      expect(NotificationsManager.fromBackend).toHaveBeenCalled();
+    });
+    expect(networking.updateMCPServer).not.toHaveBeenCalled();
+  });
+});

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.test.tsx
@@ -442,3 +442,64 @@ describe("MCPServerEdit (interactive OAuth)", () => {
     expect(payload.token_storage_ttl_seconds).toBe(7200);
   });
 });
+
+describe("MCPServerEdit (instructions, Bug #14)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const baseServer = {
+    server_id: "instr-server-1",
+    server_name: "InstrServer",
+    alias: "instr_server",
+    description: "desc",
+    transport: "stdio",
+    url: null,
+    auth_type: "none",
+    command: "npx",
+    args: ["-y", "pkg"],
+    env: {},
+    created_at: "2024-01-01T00:00:00Z",
+    created_by: "user-1",
+    updated_at: "2024-01-01T00:00:00Z",
+    updated_by: "user-1",
+    mcp_access_groups: [],
+  };
+
+  it("pre-populates Instructions and forwards edits in the update payload", async () => {
+    vi.mocked(networking.updateMCPServer).mockResolvedValue({
+      ...baseServer,
+      instructions: "Updated guidance.",
+    });
+
+    render(
+      <MCPServerEdit
+        mcpServer={{ ...baseServer, instructions: "Original guidance." }}
+        accessToken="access-token"
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+        availableAccessGroups={[]}
+      />,
+    );
+
+    const field = document.getElementById("instructions") as HTMLTextAreaElement;
+    await waitFor(() => expect(field).not.toBeNull());
+    expect(field.value).toBe("Original guidance.");
+
+    await act(async () => {
+      fireEvent.change(field, { target: { value: "Updated guidance." } });
+    });
+
+    const saveButtons = screen.getAllByRole("button", { name: "Save Changes" });
+    await act(async () => {
+      fireEvent.click(saveButtons[0]);
+    });
+
+    await waitFor(() => {
+      expect(networking.updateMCPServer).toHaveBeenCalledTimes(1);
+    });
+
+    const [, payload] = vi.mocked(networking.updateMCPServer).mock.calls[0];
+    expect(payload.instructions).toBe("Updated guidance.");
+  });
+});

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
@@ -619,6 +619,13 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
             <Form.Item label="Description" name="description">
               <Input className="rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500" />
             </Form.Item>
+            <Form.Item label="Instructions" name="instructions">
+              <Input.TextArea
+                rows={4}
+                placeholder="Server-level instructions sent to the model alongside the tool list"
+                className="rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500"
+              />
+            </Form.Item>
             <MCPLogoSelector value={logoUrl} onChange={setLogoUrl} />
             <Form.Item label="Transport Type" name="transport" rules={[{ required: true }]}>
               <Select onChange={handleTransportChange}>

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
@@ -9,7 +9,7 @@ import MCPPermissionManagement from "./MCPPermissionManagement";
 import MCPToolConfiguration from "./mcp_tool_configuration";
 import StdioConfiguration from "./StdioConfiguration";
 import MCPLogoSelector from "./MCPLogoSelector";
-import { validateMCPServerUrl, validateMCPServerName } from "./utils";
+import { validateMCPServerUrl, validateMCPServerName, findInvalidToolDisplayName, TOOL_DISPLAY_NAME_ERROR } from "./utils";
 import NotificationsManager from "../molecules/notifications_manager";
 import { useMcpOAuthFlow } from "@/hooks/useMcpOAuthFlow";
 import { getSecureItem, setSecureItem } from "@/utils/secureStorage";
@@ -373,6 +373,13 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
 
   const handleSave = async (values: Record<string, any>) => {
     if (!accessToken) return;
+    const invalidDisplayName = findInvalidToolDisplayName(toolNameToDisplayName);
+    if (invalidDisplayName) {
+      NotificationsManager.fromBackend(
+        `Invalid display name "${invalidDisplayName.displayName}" for tool "${invalidDisplayName.toolName}". ${TOOL_DISPLAY_NAME_ERROR}`,
+      );
+      return;
+    }
     try {
       // Ensure access groups is always a string array
       const {

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_servers.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_servers.test.tsx
@@ -431,4 +431,38 @@ describe("MCPServers", () => {
     // The server list refresh must NOT trigger a second health check
     expect(networking.fetchMCPServerHealth).toHaveBeenCalledTimes(1);
   });
+
+  it("hides the Network Settings tab for non-admin roles", async () => {
+    vi.mocked(networking.fetchMCPServers).mockResolvedValue([]);
+
+    const queryClient = createQueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MCPServers {...defaultProps} userRole="internal_user" />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("MCP Servers")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByRole("tab", { name: "Network Settings" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the Network Settings tab for admin roles", async () => {
+    vi.mocked(networking.fetchMCPServers).mockResolvedValue([]);
+
+    const queryClient = createQueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MCPServers {...defaultProps} userRole="Admin" />
+      </QueryClientProvider>,
+    );
+
+    expect(
+      await screen.findByRole("tab", { name: "Network Settings" }),
+    ).toBeInTheDocument();
+  });
 });

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_servers.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_servers.tsx
@@ -354,7 +354,7 @@ const MCPServers: React.FC<MCPServerProps> = ({ accessToken, userRole, userID })
             <Tab>Toolsets</Tab>
             <Tab>Connect</Tab>
             <Tab>Semantic Filter</Tab>
-            <Tab>Network Settings</Tab>
+            {isAdminRole(userRole) && <Tab>Network Settings</Tab>}
             {isAdminRole(userRole) && <Tab><span className="flex items-center gap-2">Submitted MCPs <NewBadge /></span></Tab>}
           </div>
         </TabList>
@@ -439,9 +439,11 @@ const MCPServers: React.FC<MCPServerProps> = ({ accessToken, userRole, userID })
           <TabPanel>
             <MCPSemanticFilterSettings accessToken={accessToken} />
           </TabPanel>
-          <TabPanel>
-            <MCPNetworkSettings accessToken={accessToken} />
-          </TabPanel>
+          {isAdminRole(userRole) && (
+            <TabPanel>
+              <MCPNetworkSettings accessToken={accessToken} />
+            </TabPanel>
+          )}
           {isAdminRole(userRole) && (
             <TabPanel>
               <MCPSubmissionsTab accessToken={accessToken} />

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_tool_configuration.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_tool_configuration.tsx
@@ -4,6 +4,7 @@ import { ToolOutlined, CheckCircleOutlined, SearchOutlined, EditOutlined } from 
 import { Badge, Spin, Checkbox, Input, Radio } from "antd";
 import { useTestMCPConnection } from "../../hooks/useTestMCPConnection";
 import McpCrudPermissionPanel from "./McpCrudPermissionPanel";
+import { isValidToolDisplayName, TOOL_DISPLAY_NAME_ERROR } from "./utils";
 
 interface KeyTool {
   name: string;
@@ -118,12 +119,17 @@ const ToolRow: React.FC<ToolRowProps> = ({
           <Text className="text-xs font-medium text-gray-600 mb-1 block">Display Name</Text>
           <Input
             placeholder={tool.name}
+            status={isValidToolDisplayName(toolNameToDisplayName[tool.name] || "") ? undefined : "error"}
             value={toolNameToDisplayName[tool.name] || ""}
             onChange={(e) => onDisplayNameChange(tool.name, e.target.value)}
           />
-          <Text className="text-xs text-gray-400 mt-1 block">
-            Override how this tool&apos;s name appears to users. Leave blank to use original.
-          </Text>
+          {isValidToolDisplayName(toolNameToDisplayName[tool.name] || "") ? (
+            <Text className="text-xs text-gray-400 mt-1 block">
+              Override how this tool&apos;s name appears to users. Leave blank to use original.
+            </Text>
+          ) : (
+            <Text className="text-xs text-red-500 mt-1 block">{TOOL_DISPLAY_NAME_ERROR}</Text>
+          )}
         </div>
         <div>
           <Text className="text-xs font-medium text-gray-600 mb-1 block">Description</Text>

--- a/ui/litellm-dashboard/src/components/mcp_tools/types.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/types.tsx
@@ -181,6 +181,7 @@ export interface MCPServer {
   server_name?: string | null;
   alias?: string | null;
   description?: string | null;
+  instructions?: string | null;
   /**
    * Only required for HTTP/SSE transports.
    * For `stdio`, the backend can return null/undefined.

--- a/ui/litellm-dashboard/src/components/mcp_tools/utils.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/utils.test.tsx
@@ -5,6 +5,8 @@ import {
   getMaskedAndFullUrl,
   validateMCPServerUrl,
   validateMCPServerName,
+  isValidToolDisplayName,
+  findInvalidToolDisplayName,
 } from "./utils";
 
 describe("extractMCPToken", () => {
@@ -71,5 +73,39 @@ describe("validateMCPServerName", () => {
 
   it("should reject names containing spaces", async () => {
     await expect(validateMCPServerName("my server")).rejects.toBeDefined();
+  });
+});
+
+describe("isValidToolDisplayName (Bug #10)", () => {
+  it("accepts names matching [a-zA-Z0-9_-]+", () => {
+    expect(isValidToolDisplayName("browse_repo_docs")).toBe(true);
+    expect(isValidToolDisplayName("Browse-Repo-Docs-123")).toBe(true);
+  });
+
+  it("treats empty string as valid (means 'use original')", () => {
+    expect(isValidToolDisplayName("")).toBe(true);
+  });
+
+  it("rejects spaces (Bedrock pattern violation)", () => {
+    expect(isValidToolDisplayName("Browse Repo Docs")).toBe(false);
+  });
+
+  it("rejects special characters", () => {
+    expect(isValidToolDisplayName("browse.repo")).toBe(false);
+    expect(isValidToolDisplayName("browse/repo")).toBe(false);
+    expect(isValidToolDisplayName("emoji😀")).toBe(false);
+  });
+});
+
+describe("findInvalidToolDisplayName (Bug #10)", () => {
+  it("returns null when all display names are valid", () => {
+    expect(findInvalidToolDisplayName({ tool_a: "Alias_A", tool_b: "" })).toBeNull();
+  });
+
+  it("returns the offending tool/name when a display name is invalid", () => {
+    expect(findInvalidToolDisplayName({ tool_a: "ok_name", tool_b: "Bad Name" })).toEqual({
+      toolName: "tool_b",
+      displayName: "Bad Name",
+    });
   });
 });

--- a/ui/litellm-dashboard/src/components/mcp_tools/utils.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/utils.tsx
@@ -51,3 +51,25 @@ export const validateMCPServerName = (value: string) => {
     ? Promise.reject("Cannot contain '-' (hyphen) or spaces. Please use '_' (underscore) instead.")
     : Promise.resolve();
 };
+
+// A tool's display name replaces the tool name sent to the LLM provider. Providers
+// such as AWS Bedrock require tool names to match [a-zA-Z0-9_-]+, so spaces and
+// special characters must be rejected before they are persisted.
+const TOOL_DISPLAY_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
+
+export const TOOL_DISPLAY_NAME_ERROR =
+  "Display name may only contain letters, numbers, underscores, and hyphens (a-z, A-Z, 0-9, _, -). It replaces the tool name sent to the provider; spaces or special characters fail with providers like AWS Bedrock.";
+
+export const isValidToolDisplayName = (value: string): boolean =>
+  value === "" || TOOL_DISPLAY_NAME_PATTERN.test(value);
+
+export const findInvalidToolDisplayName = (
+  map: Record<string, string>,
+): { toolName: string; displayName: string } | null => {
+  for (const [toolName, displayName] of Object.entries(map || {})) {
+    if (!isValidToolDisplayName(displayName)) {
+      return { toolName, displayName };
+    }
+  }
+  return null;
+};

--- a/ui/litellm-dashboard/src/hooks/useTestMCPConnection.test.tsx
+++ b/ui/litellm-dashboard/src/hooks/useTestMCPConnection.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { useTestMCPConnection } from "./useTestMCPConnection";
+import * as networking from "../components/networking";
+
+vi.mock("../components/networking", () => ({
+  testMCPToolsListRequest: vi.fn().mockResolvedValue({ tools: [], error: null }),
+}));
+
+describe("useTestMCPConnection (Bug #15)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const formValues = {
+    url: "https://example.com/mcp",
+    transport: "http",
+    auth_type: "none",
+  };
+
+  it("does not call the admin-only preview endpoint when disabled", async () => {
+    renderHook(() =>
+      useTestMCPConnection({ accessToken: "sk-test", formValues, enabled: false }),
+    );
+
+    // Give the auto-fetch effect a chance to run; it must stay gated.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(networking.testMCPToolsListRequest).not.toHaveBeenCalled();
+  });
+
+  it("calls the preview endpoint when enabled", async () => {
+    renderHook(() =>
+      useTestMCPConnection({ accessToken: "sk-test", formValues, enabled: true }),
+    );
+
+    await waitFor(() => {
+      expect(networking.testMCPToolsListRequest).toHaveBeenCalled();
+    });
+  });
+});

--- a/ui/litellm-dashboard/src/hooks/useTestMCPConnection.tsx
+++ b/ui/litellm-dashboard/src/hooks/useTestMCPConnection.tsx
@@ -75,6 +75,9 @@ export const useTestMCPConnection = ({
   const credentialsKey = JSON.stringify(formValues.credentials ?? {});
 
   const fetchTools = async () => {
+    if (!enabled) {
+      return;
+    }
     if (!accessToken || (!formValues.url && !formValues.spec_path)) {
       return;
     }


### PR DESCRIPTION
## Relevant issues

Resolves the MCP Servers bug batch reported against v1.85.0 (Bugs #8 through #18). Each fix is an isolated commit so any one can be cherry-picked independently; the security fix (Bug #17) is the first commit on the branch for exactly that reason.

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

Scope note: this PR intentionally bundles eleven related MCP bugs that were reported together. They are split into one clean commit per bug so each remains independently reviewable and cherry-pickable.

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:
- [ ] **CI run for the last commit**
       Link:
- [ ] **Merge / cherry-pick CI run**
       Links:

## Changes

Eleven bugs, one commit each (in severity order, security first):

**Bug #17 (High, security) — Semantic filter settings writable by any authenticated user.** `PATCH /update/mcp_semantic_filter_settings` only depended on `user_api_key_auth` with no role gate, so any internal user, viewer, or virtual key could rewrite the global embedding model, top_k, and similarity threshold for the whole proxy. Added an inline `PROXY_ADMIN` check mirroring `update_ui_settings`, so the gate holds regardless of how the request authenticated into the route (the route-map layer alone misses keys with a permissive `allowed_routes`).

**Bug #8 (High) — Alias != server_name breaks tool invocation.** In the Responses auto-execution path, the single-server tool map recorded the resolved `server_name` while `tools/list` prefixes tool names with the alias, so the prefix-strip guard `prefixed == server_name` never matched and the upstream server got the alias-prefixed name ("Unknown tool"). Resolution is now alias-aware via `iter_known_server_prefixes`.

**Bug #11 (High) — Display-name overrides break Responses auto-execution.** The same path forwarded the model-facing display name as-is instead of reverse-mapping it to the original tool name ("Tool not found"). Bugs #8 and #11 are fixed together in one coherent `_resolve_upstream_tool_name` helper that strips the alias prefix and inverts the `tool_name_to_display_name` map, mirroring the direct `/mcp` path.

**Bug #13 (High) — BYOK credential not injected in the Playground.** The Responses/Playground path calls `MCPServerManager.call_tool` directly rather than through `execute_mcp_tool`, so the stored per-user credential was never looked up and upstream calls went out unauthenticated (401). The lookup (keyed on `user_id` + `server_id`) now runs in `call_tool`, guarded so the direct path is untouched, and injects for both transports: regular MCP servers via the auth header, OpenAPI servers via the `_request_auth_header` ContextVar their generated handlers read. `get_user_byok_credential` and `format_byok_authorization_header` are extracted as shared helpers so both paths use one implementation. (The `litellm-dashboard` team 404 in the logs is a benign red herring; it does not block discovery or execution.)

**Bug #9 (Medium) — REST `/mcp-rest/tools/list` ignored filters.** The endpoint accepted only `server_id` and had no toolset filter, so `mcp_server_name` and `toolset_name` were silently dropped and every tool from every accessible server was returned. Added `mcp_server_name` as an alias for the name/alias/uuid-resolving single-server path, and `toolset_name`, which resolves to the toolset's `{server_id: [tool_names]}` map (the same resolution the streamable HTTP `/toolset/{name}/mcp` path uses) and scopes both the servers queried and the tools returned. An unknown toolset surfaces `toolset_not_found`.

**Bug #10 (Medium) — Tool display names accepted invalid characters.** A display name replaces the tool name sent to the provider, and Bedrock requires `[a-zA-Z0-9_-]+`, so a name with spaces saved cleanly and then failed every Bedrock tool call. Added an `isValidToolDisplayName` validator, an inline error on the Display Name input, and a hard save-block in both the create and edit forms.

**Bug #12 (Medium) — Saved tool overrides invisible in the edit UI.** `_build_mcp_server_table` (behind `GET /v1/mcp/server`) omitted `tool_name_to_display_name` / `tool_name_to_description`, so the edit form always rendered upstream values even though overrides were stored and applied at runtime. Both maps are now copied onto the response. (The UI merge logic was already correct; the bug was purely the backend converter dropping the fields.)

**Bug #15 (Medium) — Non-admin tool preview 403.** The Submit form shared `CreateMCPServer` with the admin Add flow and unconditionally ran the preview hook against the admin-only `/mcp_server/test/tools/list`, so non-admin submitters got a 403 on every change. The preview hook is now gated with `enabled: isAdmin`, and the hook treats `enabled` as a hard gate so a manual trigger is blocked too. Submission itself was always functional and remains so.

**Bug #16 (Medium) — Approved submissions invisible to the submitter.** A server submitted by a non-admin is created with `allow_all_keys=false` and no access groups, and approval only flips `approval_status`, so the approved server was invisible to its submitter and all non-admins. Implemented creator visibility: `submitted_by` is carried onto the registry server and `get_allowed_mcp_servers` surfaces servers to the user who submitted them, so a submitter keeps visibility of their approved server without exposing it proxy-wide. (Chosen over a blanket `allow_all_keys=true`, which would over-expose, and over an approval-dialog access editor, which is a larger change worth doing separately if desired.)

**Bug #14 (Low) — `instructions` field missing from the UI.** The server-level `instructions` field was API-only. Added an Instructions textarea to both the create and edit forms; the value flows through the existing payload spread and pre-populates on edit.

**Bug #18 (Low, UX) — Network Settings tab interactive for non-admins.** The tab and panel rendered for every role, but `/config/field/update` is admin-only, so non-admins got a fully interactive form that failed on Save. Gated the tab and panel with `isAdminRole`, matching the existing Submitted MCPs pattern (gated together so Tremor tab/panel indices stay aligned). This is UX-only; the backend was already protected.

### Tests

Every fix ships a regression test that fails before the change and passes after; I verified each by reverting the fix (or mutating the key line) and confirming the test fails, then restoring. Backend tests are pytest under `tests/test_litellm/...`; UI tests are Vitest under `ui/litellm-dashboard/...` (this UI uses Vitest, not jest). `black` and `ruff` pass on all changed Python files; the touched UI source files are TypeScript-clean.

Bugs #8/#11, #9, #12, #13, #16 and #17 are covered by backend tests; #10, #14, #15 and #18 by Vitest tests.

## Screenshots / Proof of Fix

I could not run a live proxy hitting real provider APIs from the build environment (no `.env`/config/network to providers there). Below is a per-bug runbook to capture the real proof on a local proxy. Start the proxy with:

```
python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log
```

For model-driven steps use a current small/fast model (e.g. `gpt-5.5-instant` or `gpt-5.4-mini` as of 2026-05).

**Bug #17 (security):** create an internal-user key, then
```
curl -s -o /dev/null -w "%{http_code}\n" -X PATCH http://localhost:4000/update/mcp_semantic_filter_settings \
  -H "Authorization: Bearer <NON_ADMIN_KEY>" -H "Content-Type: application/json" \
  -d '{"enabled": true, "top_k": 99, "similarity_threshold": 0.01}'
```
Expect `403`. Repeat with the master key and expect `200` with `"status":"success"`.

**Bug #8:** register a server with `alias` different from `server_name` (e.g. server_name `deepwiki_test`, alias `my_deepwiki`, url `https://mcp.deepwiki.com/mcp`). Drive a Responses call with `require_approval: "never"` that triggers a tool; before the fix the response carries "Unknown tool: my_deepwiki-...", after it returns the tool result. `litellm.log` shows the upstream `name` sent without the alias prefix.

**Bug #11:** set `tool_name_to_display_name: {read_wiki_structure: browse_repo_docs}` on a server, then run a Responses call that calls `browse_repo_docs`. Before: "Tool browse_repo_docs not found"; after: the real result, and `litellm.log` shows the upstream call sent `read_wiki_structure`.

**Bug #13:** configure an OpenAPI BYOK server (e.g. Firecrawl), connect a credential via the UI, then run a Playground/Responses tool call. Before: `401 Unauthorized` from upstream; after: the call succeeds and `litellm.log` shows the outbound request carrying the BYOK Authorization header. Confirm the direct `/mcp/<server>` + master-key path still works unchanged.

**Bug #9:** with two servers registered and a toolset configured,
```
curl -s "http://localhost:4000/mcp-rest/tools/list" -H "Authorization: Bearer <KEY>" | jq '.tools|length'
curl -s "http://localhost:4000/mcp-rest/tools/list?mcp_server_name=<server>" -H "Authorization: Bearer <KEY>" | jq '[.tools[].name]'
curl -s "http://localhost:4000/mcp-rest/tools/list?toolset_name=<toolset>" -H "Authorization: Bearer <KEY>" | jq '[.tools[].name]'
```
The server- and toolset-scoped results are strict subsets of the unscoped one and match the streamable HTTP `/toolset/<toolset>/mcp` listing. An unknown `toolset_name` returns `toolset_not_found`.

**Bug #12:** set a display-name and description override on a tool, save, navigate away and back; the edit form pre-fills the saved values. Cross-check `curl -s http://localhost:4000/v1/mcp/server -H "Authorization: Bearer <MASTER_KEY>" | jq '.[] | {tool_name_to_display_name, tool_name_to_description}'` now returns the maps (was null before).

**Bug #10:** in the tool config (Flat List, edit a tool), enter a Display Name with spaces; the input shows an inline error and Save is blocked. A valid `[a-zA-Z0-9_-]+` name saves.

**Bug #14:** confirm the Instructions textarea appears on both the create and edit MCP server forms, set it, and verify persistence via `curl -s http://localhost:4000/v1/mcp/server -H "Authorization: Bearer <MASTER_KEY>" | jq '.[].instructions'`.

**Bug #15:** as an internal user, open Submit MCP Server and fill a URL; no `POST /mcp_server/test/tools/list` is made (no 403). Submission still succeeds. As an admin, the Add form still fetches the preview.

**Bug #16:** as an internal user submit a server; as admin approve it under Submitted MCPs; back as the submitter, the approved server now appears in All Servers. An unrelated internal user does not see it.

**Bug #18:** as a non-admin, the Network Settings tab is no longer present under MCP Servers; as an admin it is present and Save works. Verify the other tabs still render the correct panels (no index drift).

UI pages to check live: http://localhost:4000/ui/?page=mcp-servers (tabs, create/edit forms, tool configuration, submitted/approval flow).

## Type

🐛 Bug Fix


---
_Generated by [Claude Code](https://claude.ai/code/session_01FDLKH15zfCNkkG1CyvjRdU)_