### PR TITLE
refactor(ui): move MCP delegate-auth toggle into OAuth section

### DIFF
--- a/ui/litellm-dashboard/src/components/mcp_tools/DelegateAuthUpstreamField.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/DelegateAuthUpstreamField.test.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { Form, Switch } from "antd";
+
+import DelegateAuthUpstreamField from "./DelegateAuthUpstreamField";
+
+const WARNING = /Internal server with upstream OAuth delegation/i;
+
+// The warning watches `available_on_public_internet`, a field owned by the host
+// form. Register it (hidden) so Form.useWatch resolves it from initialValues,
+// mirroring how the real create/edit forms provide it.
+const renderField = (initialValues: Record<string, any> = {}) => {
+  const Wrapper: React.FC = () => {
+    const [form] = Form.useForm();
+    return (
+      <Form form={form} initialValues={initialValues}>
+        <Form.Item name="available_on_public_internet" valuePropName="checked" hidden>
+          <Switch />
+        </Form.Item>
+        <DelegateAuthUpstreamField initialValue={initialValues.delegate_auth_to_upstream ?? false} />
+      </Form>
+    );
+  };
+  return render(<Wrapper />);
+};
+
+describe("DelegateAuthUpstreamField", () => {
+  it("renders the toggle, unchecked by default", () => {
+    renderField();
+    expect(screen.getByText("Delegate auth to upstream (PKCE passthrough)")).toBeInTheDocument();
+    expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("reflects an initialValue of true", () => {
+    renderField({ delegate_auth_to_upstream: true });
+    expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("hides the internal-only warning when delegation is off", () => {
+    renderField({ delegate_auth_to_upstream: false, available_on_public_internet: false });
+    expect(screen.queryByText(WARNING)).not.toBeInTheDocument();
+  });
+
+  it("hides the internal-only warning when the server is public", () => {
+    renderField({ delegate_auth_to_upstream: true, available_on_public_internet: true });
+    expect(screen.queryByText(WARNING)).not.toBeInTheDocument();
+  });
+
+  it("shows the internal-only warning only when delegating on an internal-only server", () => {
+    renderField({ delegate_auth_to_upstream: true, available_on_public_internet: false });
+    expect(screen.getByText(WARNING)).toBeInTheDocument();
+  });
+});

--- a/ui/litellm-dashboard/src/components/mcp_tools/DelegateAuthUpstreamField.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/DelegateAuthUpstreamField.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { Alert, Form, Switch, Tooltip } from "antd";
+import { InfoCircleOutlined } from "@ant-design/icons";
+
+interface DelegateAuthUpstreamFieldProps {
+  initialValue?: boolean;
+}
+
+const DelegateAuthUpstreamField: React.FC<DelegateAuthUpstreamFieldProps> = ({ initialValue = false }) => {
+  const form = Form.useFormInstance();
+  const watchedDelegateAuth = Form.useWatch("delegate_auth_to_upstream", form);
+  const watchedPublicInternet = Form.useWatch("available_on_public_internet", form);
+  const showInternalWarning = watchedDelegateAuth === true && watchedPublicInternet === false;
+
+  return (
+    <>
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <span className="text-sm font-medium text-gray-700 flex items-center">
+            Delegate auth to upstream (PKCE passthrough)
+            <Tooltip title="When on, LiteLLM skips its own API key/SSO check for this server and lets the client complete PKCE directly with the upstream MCP server. No spend tracking or per-key rate limiting will run on this route.">
+              <InfoCircleOutlined className="ml-2 text-blue-400 hover:text-blue-600 cursor-help" />
+            </Tooltip>
+          </span>
+          <p className="text-sm text-gray-600 mt-1">
+            Bypass LiteLLM auth so clients authenticate directly with the upstream OAuth MCP server.
+          </p>
+        </div>
+        <Form.Item
+          name="delegate_auth_to_upstream"
+          valuePropName="checked"
+          initialValue={initialValue}
+          className="mb-0"
+        >
+          <Switch />
+        </Form.Item>
+      </div>
+
+      {showInternalWarning && (
+        <Alert
+          type="warning"
+          showIcon
+          className="mt-3"
+          message="Internal server with upstream OAuth delegation"
+          description="This MCP server is configured as internal-only but delegates auth to upstream. Anonymous users will be able to reach the upstream OAuth2 /authorize flow without a LiteLLM session. Ensure your upstream provider and network enforce access controls."
+        />
+      )}
+    </>
+  );
+};
+
+export default DelegateAuthUpstreamField;

--- a/ui/litellm-dashboard/src/components/mcp_tools/MCPPermissionManagement.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/MCPPermissionManagement.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from "react";
-import { Alert, Form, Select, Tooltip, Collapse, Input, Space, Button, Switch } from "antd";
+import { Form, Select, Tooltip, Collapse, Input, Space, Button, Switch } from "antd";
 import { InfoCircleOutlined, MinusCircleOutlined, PlusOutlined } from "@ant-design/icons";
-import { MCPServer, AUTH_TYPE } from "./types";
+import { MCPServer } from "./types";
 const { Panel } = Collapse;
 
 interface MCPPermissionManagementProps {
@@ -23,14 +23,6 @@ const MCPPermissionManagement: React.FC<MCPPermissionManagementProps> = ({
   getAccessGroupOptions,
 }) => {
   const form = Form.useFormInstance();
-  const watchedAuthType = Form.useWatch("auth_type", form);
-  const isOAuth2 = watchedAuthType === AUTH_TYPE.OAUTH2;
-  const watchedDelegateAuth = Form.useWatch("delegate_auth_to_upstream", form);
-  const watchedPublicInternet = Form.useWatch("available_on_public_internet", form);
-  const showInternalDelegatePkceWarning =
-    isOAuth2 &&
-    watchedDelegateAuth === true &&
-    watchedPublicInternet === false;
 
   // Set initial values when mcpServer changes
   useEffect(() => {
@@ -48,24 +40,11 @@ const MCPPermissionManagement: React.FC<MCPPermissionManagementProps> = ({
       if (typeof mcpServer.available_on_public_internet === "boolean") {
         form.setFieldValue("available_on_public_internet", mcpServer.available_on_public_internet);
       }
-      if (typeof mcpServer.delegate_auth_to_upstream === "boolean") {
-        form.setFieldValue("delegate_auth_to_upstream", mcpServer.delegate_auth_to_upstream);
-      }
     } else {
       form.setFieldValue("allow_all_keys", false);
       form.setFieldValue("available_on_public_internet", true);
-      form.setFieldValue("delegate_auth_to_upstream", false);
     }
   }, [mcpServer, form]);
-
-  // delegate_auth_to_upstream is only honored server-side when auth_type=oauth2.
-  // Force it back to false whenever the user switches away from oauth2 so a
-  // stale toggle value doesn't get persisted with another auth type.
-  useEffect(() => {
-    if (!isOAuth2) {
-      form.setFieldValue("delegate_auth_to_upstream", false);
-    }
-  }, [isOAuth2, form]);
 
   return (
     <Collapse className="bg-gray-50 border border-gray-200 rounded-lg" expandIconPosition="end" ghost={false}>
@@ -92,7 +71,9 @@ const MCPPermissionManagement: React.FC<MCPPermissionManagementProps> = ({
                   <InfoCircleOutlined className="ml-2 text-blue-400 hover:text-blue-600 cursor-help" />
                 </Tooltip>
               </span>
-              <p className="text-sm text-gray-600 mt-1">Enable if this server should be &quot;public&quot; to all keys.</p>
+              <p className="text-sm text-gray-600 mt-1">
+                Enable if this server should be &quot;public&quot; to all keys.
+              </p>
             </div>
             <Form.Item
               name="allow_all_keys"
@@ -112,7 +93,9 @@ const MCPPermissionManagement: React.FC<MCPPermissionManagementProps> = ({
                   <InfoCircleOutlined className="ml-2 text-blue-400 hover:text-blue-600 cursor-help" />
                 </Tooltip>
               </span>
-              <p className="text-sm text-gray-600 mt-1">Turn on to restrict access to callers within your internal network only.</p>
+              <p className="text-sm text-gray-600 mt-1">
+                Turn on to restrict access to callers within your internal network only.
+              </p>
             </div>
             <Form.Item
               name="available_on_public_internet"
@@ -125,40 +108,6 @@ const MCPPermissionManagement: React.FC<MCPPermissionManagementProps> = ({
               <Switch />
             </Form.Item>
           </div>
-
-          {isOAuth2 && (
-            <div className="flex items-start justify-between gap-4">
-              <div>
-                <span className="text-sm font-medium text-gray-700 flex items-center">
-                  Delegate auth to upstream (PKCE passthrough)
-                  <Tooltip title="When on, LiteLLM skips its own API key/SSO check for this server and lets the client complete PKCE directly with the upstream MCP server. Only honored when Auth Type is oauth2. No spend tracking or per-key rate limiting will run on this route.">
-                    <InfoCircleOutlined className="ml-2 text-blue-400 hover:text-blue-600 cursor-help" />
-                  </Tooltip>
-                </span>
-                <p className="text-sm text-gray-600 mt-1">
-                  Bypass LiteLLM auth so clients authenticate directly with the upstream OAuth MCP server.
-                </p>
-              </div>
-              <Form.Item
-                name="delegate_auth_to_upstream"
-                valuePropName="checked"
-                initialValue={mcpServer?.delegate_auth_to_upstream ?? false}
-                className="mb-0"
-              >
-                <Switch />
-              </Form.Item>
-            </div>
-          )}
-
-          {showInternalDelegatePkceWarning && (
-            <Alert
-              type="warning"
-              showIcon
-              className="mb-2"
-              message="Internal server with upstream OAuth delegation"
-              description="This MCP server is configured as internal-only but delegates auth to upstream. Anonymous users will be able to reach the upstream OAuth2 /authorize flow without a LiteLLM session. Ensure your upstream provider and network enforce access controls."
-            />
-          )}
 
           <Form.Item
             label={
@@ -251,12 +200,7 @@ const MCPPermissionManagement: React.FC<MCPPermissionManagementProps> = ({
                         className="flex-1"
                         rules={[{ required: true, message: "Header value is required" }]}
                       >
-                        <Input
-                          size="large"
-                          allowClear
-                          className="rounded-lg"
-                          placeholder="Header value"
-                        />
+                        <Input size="large" allowClear className="rounded-lg" placeholder="Header value" />
                       </Form.Item>
                       <MinusCircleOutlined
                         onClick={() => remove(name)}

--- a/ui/litellm-dashboard/src/components/mcp_tools/OAuthFormFields.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/OAuthFormFields.tsx
@@ -3,6 +3,7 @@ import { Form, Input, InputNumber, Select, Tooltip } from "antd";
 import { InfoCircleOutlined } from "@ant-design/icons";
 import { Button, TextInput } from "@tremor/react";
 import { OAUTH_FLOW } from "./types";
+import DelegateAuthUpstreamField from "./DelegateAuthUpstreamField";
 
 interface OAuthFlowStatus {
   startOAuthFlow: () => void;
@@ -75,14 +76,24 @@ const OAuthFormFields: React.FC<OAuthFormFieldsProps> = ({
             name={["credentials", "client_id"]}
             rules={[{ required: true, message: "Client ID is required for M2M OAuth" }]}
           >
-            <TextInput type="password" placeholder={`Enter OAuth client ID${placeholderSuffix}`} className={fieldClassName} />
+            <TextInput
+              type="password"
+              placeholder={`Enter OAuth client ID${placeholderSuffix}`}
+              className={fieldClassName}
+            />
           </Form.Item>
           <Form.Item
-            label={<FieldLabel label="Client Secret" tooltip="OAuth2 client secret for the client_credentials grant." />}
+            label={
+              <FieldLabel label="Client Secret" tooltip="OAuth2 client secret for the client_credentials grant." />
+            }
             name={["credentials", "client_secret"]}
             rules={[{ required: true, message: "Client Secret is required for M2M OAuth" }]}
           >
-            <TextInput type="password" placeholder={`Enter OAuth client secret${placeholderSuffix}`} className={fieldClassName} />
+            <TextInput
+              type="password"
+              placeholder={`Enter OAuth client secret${placeholderSuffix}`}
+              className={fieldClassName}
+            />
           </Form.Item>
           <Form.Item
             label={<FieldLabel label="Token URL" tooltip="Token endpoint URL for the client_credentials grant." />}
@@ -92,7 +103,12 @@ const OAuthFormFields: React.FC<OAuthFormFieldsProps> = ({
             <TextInput placeholder="https://auth.example.com/oauth/token" className={fieldClassName} />
           </Form.Item>
           <Form.Item
-            label={<FieldLabel label="Scopes (optional)" tooltip="Optional scopes to request with the client_credentials grant." />}
+            label={
+              <FieldLabel
+                label="Scopes (optional)"
+                tooltip="Optional scopes to request with the client_credentials grant."
+              />
+            }
             name={["credentials", "scopes"]}
           >
             <Select mode="tags" tokenSeparators={[","]} placeholder="Add scopes" className="rounded-lg" size="large" />
@@ -103,7 +119,10 @@ const OAuthFormFields: React.FC<OAuthFormFieldsProps> = ({
           <Form.Item
             label={
               <span className="flex items-center justify-between w-full">
-                <FieldLabel label="Client ID (optional)" tooltip="Provide only if your MCP server cannot handle dynamic client registration." />
+                <FieldLabel
+                  label="Client ID (optional)"
+                  tooltip="Provide only if your MCP server cannot handle dynamic client registration."
+                />
                 {docsUrl && (
                   <a
                     href={docsUrl}
@@ -122,19 +141,38 @@ const OAuthFormFields: React.FC<OAuthFormFieldsProps> = ({
             <TextInput type="password" placeholder={`Enter client ID${placeholderSuffix}`} className={fieldClassName} />
           </Form.Item>
           <Form.Item
-            label={<FieldLabel label="Client Secret (optional)" tooltip="Provide only if your MCP server cannot handle dynamic client registration." />}
+            label={
+              <FieldLabel
+                label="Client Secret (optional)"
+                tooltip="Provide only if your MCP server cannot handle dynamic client registration."
+              />
+            }
             name={["credentials", "client_secret"]}
           >
-            <TextInput type="password" placeholder={`Enter client secret${placeholderSuffix}`} className={fieldClassName} />
+            <TextInput
+              type="password"
+              placeholder={`Enter client secret${placeholderSuffix}`}
+              className={fieldClassName}
+            />
           </Form.Item>
           <Form.Item
-            label={<FieldLabel label="Scopes (optional)" tooltip="Optional scopes requested during token exchange. Separate multiple scopes with enter or commas." />}
+            label={
+              <FieldLabel
+                label="Scopes (optional)"
+                tooltip="Optional scopes requested during token exchange. Separate multiple scopes with enter or commas."
+              />
+            }
             name={["credentials", "scopes"]}
           >
             <Select mode="tags" tokenSeparators={[","]} placeholder="Add scopes" className="rounded-lg" size="large" />
           </Form.Item>
           <Form.Item
-            label={<FieldLabel label="Authorization URL (optional)" tooltip="Optional override for the authorization endpoint." />}
+            label={
+              <FieldLabel
+                label="Authorization URL (optional)"
+                tooltip="Optional override for the authorization endpoint."
+              />
+            }
             name="authorization_url"
           >
             <TextInput placeholder="https://example.com/oauth/authorize" className={fieldClassName} />
@@ -146,7 +184,12 @@ const OAuthFormFields: React.FC<OAuthFormFieldsProps> = ({
             <TextInput placeholder="https://example.com/oauth/token" className={fieldClassName} />
           </Form.Item>
           <Form.Item
-            label={<FieldLabel label="Registration URL (optional)" tooltip="Optional override for the dynamic client registration endpoint." />}
+            label={
+              <FieldLabel
+                label="Registration URL (optional)"
+                tooltip="Optional override for the dynamic client registration endpoint."
+              />
+            }
             name="registration_url"
           >
             <TextInput placeholder="https://example.com/oauth/register" className={fieldClassName} />
@@ -188,17 +231,14 @@ const OAuthFormFields: React.FC<OAuthFormFieldsProps> = ({
             }
             name="token_storage_ttl_seconds"
           >
-            <InputNumber
-              min={1}
-              placeholder="e.g. 3600"
-              className="w-full rounded-lg"
-              style={{ width: "100%" }}
-            />
+            <InputNumber min={1} placeholder="e.g. 3600" className="w-full rounded-lg" style={{ width: "100%" }} />
           </Form.Item>
+          <DelegateAuthUpstreamField />
           {oauthFlow && (
             <div className="rounded-lg border border-dashed border-gray-300 p-4 space-y-2">
               <p className="text-sm text-gray-600">
-                Use OAuth to fetch a fresh access token and temporarily save it in the session as the authentication value.
+                Use OAuth to fetch a fresh access token and temporarily save it in the session as the authentication
+                value.
               </p>
               <Button
                 variant="secondary"

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
@@ -476,6 +476,63 @@ describe("CreateMCPServer", () => {
         expect(inlineError !== null || notCalled).toBe(true);
       });
     });
+
+    const DELEGATE_LABEL = "Delegate auth to upstream (PKCE passthrough)";
+
+    it("shows the delegate auth toggle for the interactive flow", async () => {
+      await setupOAuthInteractive();
+      expect(screen.getByText(DELEGATE_LABEL)).toBeInTheDocument();
+    });
+
+    it("hides the delegate auth toggle when the M2M flow is selected", async () => {
+      await setupOAuthInteractive();
+      await selectAntOption("OAuth Flow Type", "Machine-to-Machine");
+      await waitFor(() => {
+        expect(screen.queryByText(DELEGATE_LABEL)).not.toBeInTheDocument();
+      });
+    });
+
+    it("sends delegate_auth_to_upstream=true when the toggle is on for interactive OAuth", async () => {
+      vi.mocked(networking.createMCPServer).mockResolvedValue({
+        server_id: "new-server-oauth",
+        server_name: "OAuth_Server",
+        alias: "OAuth_Server",
+        url: "https://example.com/mcp",
+        transport: "http",
+        auth_type: "oauth2",
+        created_at: "2024-01-01T00:00:00Z",
+        created_by: "user-1",
+        updated_at: "2024-01-01T00:00:00Z",
+        updated_by: "user-1",
+      });
+
+      await setupOAuthInteractive();
+
+      const nameInput = document.getElementById("server_name") as HTMLInputElement;
+      await act(async () => {
+        fireEvent.change(nameInput, { target: { value: "OAuth_Server" } });
+      });
+      const urlInput = screen.getByPlaceholderText("https://your-mcp-server.com");
+      await act(async () => {
+        fireEvent.change(urlInput, { target: { value: "https://example.com/mcp" } });
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("switch"));
+      });
+
+      const submitButton = screen.getByRole("button", { name: "Add MCP Server" });
+      await act(async () => {
+        fireEvent.click(submitButton);
+      });
+
+      await waitFor(() => {
+        expect(networking.createMCPServer).toHaveBeenCalledTimes(1);
+      });
+
+      const [, payload] = vi.mocked(networking.createMCPServer).mock.calls[0];
+      expect(payload.delegate_auth_to_upstream).toBe(true);
+    });
   });
 
   describe("when modal is cancelled", () => {

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
@@ -79,12 +79,13 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
   const [oauthDocsUrl, setOauthDocsUrl] = useState<string | null>(null);
 
   // Single hook call shared by MCPConnectionStatus and MCPToolConfiguration to avoid duplicate requests.
-  const { tools, isLoadingTools, toolsError, toolsErrorStackTrace, canFetchTools, fetchTools, clearTools } = useTestMCPConnection({
-    accessToken,
-    oauthAccessToken,
-    formValues,
-    enabled: true,
-  });
+  const { tools, isLoadingTools, toolsError, toolsErrorStackTrace, canFetchTools, fetchTools, clearTools } =
+    useTestMCPConnection({
+      accessToken,
+      oauthAccessToken,
+      formValues,
+      enabled: true,
+    });
 
   const authType = formValues.auth_type as string | undefined;
   const shouldShowAuthValueField = authType ? AUTH_TYPES_REQUIRING_AUTH_VALUE.includes(authType) : false;
@@ -392,7 +393,10 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
         tool_name_to_description: Object.keys(toolNameToDescription).length > 0 ? toolNameToDescription : null,
         allow_all_keys: Boolean(allowAllKeysRaw),
         available_on_public_internet: Boolean(availableOnPublicInternetRaw),
-        delegate_auth_to_upstream: Boolean(delegateAuthToUpstreamRaw),
+        delegate_auth_to_upstream:
+          restValues.auth_type === AUTH_TYPE.OAUTH2 && restValues.oauth_flow_type !== OAUTH_FLOW.M2M
+            ? Boolean(delegateAuthToUpstreamRaw)
+            : false,
         static_headers: staticHeaders,
         ...(tokenValidation !== null && { token_validation: tokenValidation }),
       };
@@ -428,9 +432,7 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
         }
 
         NotificationsManager.success(
-          isAdmin
-            ? "MCP Server created successfully"
-            : "MCP Server submitted for admin review"
+          isAdmin ? "MCP Server created successfully" : "MCP Server submitted for admin review",
         );
         form.resetFields();
         setCostConfig({});
@@ -444,7 +446,7 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
     } catch (error) {
       const reason = error instanceof Error ? error.message : String(error);
       NotificationsManager.fromBackend(
-        isAdmin ? `Error creating MCP Server: ${reason}` : `Error submitting MCP Server: ${reason}`
+        isAdmin ? `Error creating MCP Server: ${reason}` : `Error submitting MCP Server: ${reason}`,
       );
     } finally {
       setIsLoading(false);
@@ -574,8 +576,8 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
         >
           {!isAdmin && (
             <div className="rounded-md bg-blue-50 border border-blue-200 px-4 py-3 text-sm text-blue-800">
-              Your submission will be sent for admin review before it becomes active.
-              {" "}Note: the request must be made with a team-scoped API key.
+              Your submission will be sent for admin review before it becomes active. Note: the request must be made
+              with a team-scoped API key.
             </div>
           )}
           <div className="grid grid-cols-1 gap-6">
@@ -688,9 +690,7 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
               <OpenAPIFormSection
                 form={form}
                 accessToken={isModalVisible ? accessToken : null}
-                onValuesChange={(updates) =>
-                  setFormValues((prev) => ({ ...prev, ...updates }))
-                }
+                onValuesChange={(updates) => setFormValues((prev) => ({ ...prev, ...updates }))}
                 onKeyToolsChange={setKeyTools}
                 onLogoUrlChange={setLogoUrl}
                 onOAuthDocsUrlChange={setOauthDocsUrl}
@@ -715,7 +715,10 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
                   <Switch />
                 </Form.Item>
 
-                <Form.Item noStyle shouldUpdate={(prev, cur) => prev.is_byok !== cur.is_byok || prev.auth_type !== cur.auth_type}>
+                <Form.Item
+                  noStyle
+                  shouldUpdate={(prev, cur) => prev.is_byok !== cur.is_byok || prev.auth_type !== cur.auth_type}
+                >
                   {({ getFieldValue }) =>
                     getFieldValue("is_byok") ? (
                       <>
@@ -739,7 +742,10 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
                         {!getFieldValue("auth_type") && (
                           <div className="mb-4 p-3 bg-yellow-50 rounded-lg text-sm text-yellow-700 flex items-start gap-2">
                             <InfoCircleOutlined className="mt-0.5 flex-shrink-0" />
-                            <span>Set the <strong>Authentication Type</strong> below to specify how user keys are sent (e.g., Bearer Token, API Key header).</span>
+                            <span>
+                              Set the <strong>Authentication Type</strong> below to specify how user keys are sent
+                              (e.g., Bearer Token, API Key header).
+                            </span>
                           </div>
                         )}
                         <Form.Item
@@ -792,10 +798,7 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
                     label: <span className="text-sm font-semibold text-gray-700">Authentication</span>,
                     children: (
                       <>
-                        <Form.Item
-                          name="auth_type"
-                          rules={[{ required: true, message: "Please select an auth type" }]}
-                        >
+                        <Form.Item name="auth_type" rules={[{ required: true, message: "Please select an auth type" }]}>
                           <Select placeholder="Select auth type" className="rounded-lg" size="large">
                             <Select.Option value="none">None</Select.Option>
                             <Select.Option value="api_key">API Key</Select.Option>
@@ -859,7 +862,12 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
               <>
                 <p className="text-sm text-gray-500 mb-2">
                   For MCP servers hosted on AWS Bedrock AgentCore.{" "}
-                  <a href="https://docs.litellm.ai/docs/mcp_aws_sigv4" target="_blank" rel="noopener noreferrer" className="text-blue-500 hover:text-blue-700">
+                  <a
+                    href="https://docs.litellm.ai/docs/mcp_aws_sigv4"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-500 hover:text-blue-700"
+                  >
                     View docs &rarr;
                   </a>
                 </p>
@@ -912,7 +920,9 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
                       validator(_, value) {
                         const secretKey = getFieldValue(["credentials", "aws_secret_access_key"]);
                         if (secretKey && !value) {
-                          return Promise.reject(new Error("Access Key ID is required when Secret Access Key is provided"));
+                          return Promise.reject(
+                            new Error("Access Key ID is required when Secret Access Key is provided"),
+                          );
                         }
                         return Promise.resolve();
                       },
@@ -940,7 +950,9 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
                       validator(_, value) {
                         const accessKeyId = getFieldValue(["credentials", "aws_access_key_id"]);
                         if (accessKeyId && !value) {
-                          return Promise.reject(new Error("Secret Access Key is required when Access Key ID is provided"));
+                          return Promise.reject(
+                            new Error("Secret Access Key is required when Access Key ID is provided"),
+                          );
                         }
                         return Promise.resolve();
                       },

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.test.tsx
@@ -43,7 +43,7 @@ vi.mock("./mcp_tool_configuration", () => ({
 const interactiveOAuthServer = {
   server_id: "oauth_server_1",
   server_name: "OAuthServer",
-  alias: "oauth_server",   // underscores: hyphens fail validateMCPServerName
+  alias: "oauth_server", // underscores: hyphens fail validateMCPServerName
   description: "Interactive OAuth MCP server",
   transport: "http",
   url: "https://example.com/mcp",
@@ -215,6 +215,56 @@ describe("MCPServerEdit (delegate auth)", () => {
     const [, payload] = vi.mocked(networking.updateMCPServer).mock.calls[0];
     expect(payload.auth_type).toBe("none");
     expect(payload.delegate_auth_to_upstream).toBe(false);
+  });
+
+  const saveAndGetPayload = async () => {
+    const saveButtons = screen.getAllByRole("button", { name: "Save Changes" });
+    await act(async () => {
+      fireEvent.click(saveButtons[0]);
+    });
+    await waitFor(() => {
+      expect(networking.updateMCPServer).toHaveBeenCalledTimes(1);
+    });
+    return vi.mocked(networking.updateMCPServer).mock.calls[0][1];
+  };
+
+  it("renders the toggle checked for an interactive OAuth server and keeps it true on save", async () => {
+    vi.mocked(networking.updateMCPServer).mockResolvedValue(interactiveOAuthServer);
+
+    render(
+      <MCPServerEdit
+        mcpServer={{ ...interactiveOAuthServer, delegate_auth_to_upstream: true }}
+        accessToken="access-token"
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+        availableAccessGroups={[]}
+      />,
+    );
+
+    expect(screen.getByText("Delegate auth to upstream (PKCE passthrough)")).toBeInTheDocument();
+    expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "true");
+
+    expect((await saveAndGetPayload()).delegate_auth_to_upstream).toBe(true);
+  });
+
+  it("persists delegation turned off", async () => {
+    vi.mocked(networking.updateMCPServer).mockResolvedValue(interactiveOAuthServer);
+
+    render(
+      <MCPServerEdit
+        mcpServer={{ ...interactiveOAuthServer, delegate_auth_to_upstream: true }}
+        accessToken="access-token"
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+        availableAccessGroups={[]}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("switch"));
+    });
+
+    expect((await saveAndGetPayload()).delegate_auth_to_upstream).toBe(false);
   });
 });
 

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
@@ -6,6 +6,7 @@ import { AUTH_TYPE, OAUTH_FLOW, MCPServer, MCPServerCostInfo, TRANSPORT } from "
 import { updateMCPServer, listMCPTools } from "../networking";
 import MCPServerCostConfig from "./mcp_server_cost_config";
 import MCPPermissionManagement from "./MCPPermissionManagement";
+import DelegateAuthUpstreamField from "./DelegateAuthUpstreamField";
 import MCPToolConfiguration from "./mcp_tool_configuration";
 import StdioConfiguration from "./StdioConfiguration";
 import MCPLogoSelector from "./MCPLogoSelector";
@@ -135,7 +136,7 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
     },
     onTokenReceived: (token) => {
       setOauthAccessToken(token?.access_token ?? null);
-      
+
       if (token?.access_token) {
         const credentials = {
           access_token: token.access_token,
@@ -143,11 +144,11 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
           ...(token.expires_in && { expires_in: token.expires_in }),
           ...(token.scope && { scope: token.scope }),
         };
-        
+
         form.setFieldsValue({ credentials });
-        
+
         NotificationsManager.success(
-          "OAuth authorization successful! Please click 'Update MCP Server' to save the credentials."
+          "OAuth authorization successful! Please click 'Update MCP Server' to save the credentials.",
         );
       }
     },
@@ -175,7 +176,6 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
       return "";
     }
   }, [mcpServer.env]);
-
 
   // If server has spec_path, show it as "openapi" transport in the UI
   const effectiveTransport = React.useMemo(() => {
@@ -563,12 +563,11 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
             ? Boolean(delegateAuthToUpstreamRaw ?? mcpServer.delegate_auth_to_upstream)
             : false,
         // Include token_validation when it is set (non-null) or when clearing an existing value
-        ...(tokenValidation !== null || mcpServer.token_validation
-          ? { token_validation: tokenValidation }
-          : {}),
+        ...(tokenValidation !== null || mcpServer.token_validation ? { token_validation: tokenValidation } : {}),
       };
 
-      const includeCredentials = restValues.auth_type && AUTH_TYPES_REQUIRING_CREDENTIALS.includes(restValues.auth_type);
+      const includeCredentials =
+        restValues.auth_type && AUTH_TYPES_REQUIRING_CREDENTIALS.includes(restValues.auth_type);
 
       if (includeCredentials && credentialsPayload && Object.keys(credentialsPayload).length > 0) {
         payload.credentials = credentialsPayload;
@@ -700,10 +699,7 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
                   />
                 </Form.Item>
 
-                <Form.Item
-                  label="Args"
-                  name="args"
-                >
+                <Form.Item label="Args" name="args">
                   <Select
                     mode="tags"
                     size="large"
@@ -916,17 +912,16 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
                       }
                       name="token_storage_ttl_seconds"
                     >
-                      <InputNumber
-                        min={1}
-                        placeholder="e.g. 3600"
-                        style={{ width: "100%" }}
-                        className="rounded-lg"
-                      />
+                      <InputNumber min={1} placeholder="e.g. 3600" style={{ width: "100%" }} className="rounded-lg" />
                     </Form.Item>
+                    <DelegateAuthUpstreamField initialValue={mcpServer.delegate_auth_to_upstream ?? false} />
                   </>
                 )}
                 <div className="rounded-lg border border-dashed border-gray-300 p-4 space-y-2">
-                  <p className="text-sm text-gray-600">Use OAuth to fetch a fresh access token and temporarily save it in the session as the authentication value.</p>
+                  <p className="text-sm text-gray-600">
+                    Use OAuth to fetch a fresh access token and temporarily save it in the session as the authentication
+                    value.
+                  </p>
                   <Button
                     variant="secondary"
                     onClick={startOAuthFlow}
@@ -952,7 +947,12 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
               <>
                 <p className="text-sm text-gray-500 mb-2">
                   For MCP servers hosted on AWS Bedrock AgentCore.{" "}
-                  <a href="https://docs.litellm.ai/docs/mcp_aws_sigv4" target="_blank" rel="noopener noreferrer" className="text-blue-500 hover:text-blue-700">
+                  <a
+                    href="https://docs.litellm.ai/docs/mcp_aws_sigv4"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-500 hover:text-blue-700"
+                  >
                     View docs &rarr;
                   </a>
                 </p>
@@ -1098,7 +1098,7 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
                   transport: transportType ?? mcpServer.transport,
                   auth_type: currentAuthType ?? mcpServer.auth_type,
                   mcp_info: mcpServer.mcp_info,
-                  oauth_flow_type: (currentTokenUrl ?? mcpServer.token_url) ? OAUTH_FLOW.M2M : OAUTH_FLOW.INTERACTIVE,
+                  oauth_flow_type: currentTokenUrl ?? mcpServer.token_url ? OAUTH_FLOW.M2M : OAUTH_FLOW.INTERACTIVE,
                   static_headers: currentStaticHeaders ?? mcpServer.static_headers,
                   credentials: currentCredentials,
                   authorization_url: currentAuthorizationUrl ?? mcpServer.authorization_url,


### PR DESCRIPTION
## Summary

The "Delegate auth to upstream (PKCE passthrough)" toggle for MCP servers used to live inside the collapsible "Permission Management / Access Control" panel, so operators setting up OAuth rarely noticed it. This moves it into the Authentication section, right beside the OAuth flow config and the "Authorize & Fetch Token" button (that section is open by default), and scopes it to the OAuth2 Interactive (PKCE) flow, which is the only flow where the flag is honored server-side. The toggle and its internal-only security warning are extracted into a small shared `DelegateAuthUpstreamField` component so the create and edit forms share one implementation.

On the create form, which has a real OAuth flow-type selector, the toggle now correctly hides for the M2M (client_credentials) flow and the submit payload forces `delegate_auth_to_upstream=false` for non-interactive flows. The data key, the network call (`POST`/`PUT /v1/mcp/server`), and the server-side behavior are unchanged; only the control's placement and visibility scope change.

Known limitation, left as a separate follow-up: the edit form has no OAuth flow-type selector and infers M2M purely from `token_url`, read via `Form.useWatch` on a field it never registers, so its `isM2MFlow` is effectively always false. As a result the edit form already shows its interactive-only fields (Token Validation, Token Storage TTL, and now this toggle) even for M2M servers. The toggle is placed in that same interactive-only block, so it will auto-correct once edit's flow detection is fixed.

## Screenshots

Toggle now sits in the Authentication section (Interactive/PKCE), above "Authorize & Fetch Token":

![Delegate toggle in the Authentication section](https://raw.githubusercontent.com/BerriAI/litellm/mcp-delegate-toggle-screenshots/shot_auth_section.png)

Internal-only delegation warning fires when the toggle is on and the server is internal-only:

![Internal-only delegation warning](https://raw.githubusercontent.com/BerriAI/litellm/mcp-delegate-toggle-screenshots/shot_warning.png)

## Test plan

Unit/component:
- [x] `DelegateAuthUpstreamField.test.tsx` — toggle renders, reflects initialValue, and the internal-only warning fires only when delegation is on AND the server is internal-only
- [x] `create_mcp_server.test.tsx` — toggle shows for the Interactive flow, hides for M2M, and the submit payload sends `delegate_auth_to_upstream=true` when toggled on
- [x] `mcp_server_edit.test.tsx` — toggle reflects an interactive server's saved value, persists on/off through save, and is forced false for non-oauth2 servers

Manual e2e against a live proxy (dev UI on :3000, proxy on :4000), using the Atlassian MCP URL from the ticket:
- [x] Toggle renders in the Authentication section for OAuth2 Interactive; disappears when switching to Machine-to-Machine; reappears on switching back
- [x] Internal-only warning appears with the toggle on and "Internal network only" on
- [x] Created `atlassian_e2e`; `GET /v1/mcp/server` returned `delegate_auth_to_upstream: true`, `auth_type: oauth2`
- [x] Edited the server, toggled delegation off, saved; `GET /v1/mcp/server` then returned `delegate_auth_to_upstream: false`

Related to LIT-3264