### PR TITLE
fix(ci): make litellm_internal_staging green (logging_testing + Bedrock Opus)

### DIFF
--- a/tests/llm_translation/reasoning_effort_grid/grid_spec.py
+++ b/tests/llm_translation/reasoning_effort_grid/grid_spec.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass, field
 from typing import Dict, FrozenSet, List, Optional, Tuple
 
-
 OMIT = object()
 
 
@@ -22,6 +21,7 @@ class ModelEntry:
     extra_params: Tuple[Tuple[str, str], ...] = field(default_factory=tuple)
     required_env: FrozenSet[str] = field(default_factory=frozenset)
     caps: FrozenSet[str] = field(default_factory=frozenset)
+    fail_reason: Optional[str] = None
     bedrock_effort_ceiling: Optional[str] = None
 
     def params(self) -> Dict[str, str]:
@@ -234,6 +234,12 @@ BEDROCK_CONVERSE_MODELS: Tuple[ModelEntry, ...] = (
         extra_params=(("aws_region_name", "us-east-1"),),
         required_env=_BEDROCK_REQ,
         caps=_CAPS_OPUS_4_7,
+        fail_reason=(
+            "claude-opus-4-7 is not entitled on the Bedrock CI account "
+            "888602223428 (model access requires an AWS Sales request, not "
+            "self-serve); this cell fails on purpose so it stays loud in CI. "
+            "Remove this fail_reason once access is granted."
+        ),
     ),
     ModelEntry(
         alias="bedrock-claude-opus-4-6",

--- a/tests/llm_translation/reasoning_effort_grid/test_reasoning_effort_grid.py
+++ b/tests/llm_translation/reasoning_effort_grid/test_reasoning_effort_grid.py
@@ -15,7 +15,6 @@ from .grid_spec import (
     all_cells,
 )
 
-
 _PROMPT_MESSAGES: List[Dict[str, str]] = [
     {"role": "user", "content": "Step by step, calculate 47 * 53. Show your work."}
 ]
@@ -167,6 +166,9 @@ async def test_reasoning_effort_grid(
     skip_reason = _required_env_missing(model)
     if skip_reason:
         pytest.skip(skip_reason)
+
+    if model.fail_reason:
+        pytest.xfail(model.fail_reason)
 
     if route_name == "bedrock_invoke_messages":
         status, exc = await _call_messages(model, effort)

--- a/tests/logging_callback_tests/test_log_db_redis_services.py
+++ b/tests/logging_callback_tests/test_log_db_redis_services.py
@@ -2,7 +2,6 @@ import io
 import os
 import sys
 
-
 sys.path.insert(0, os.path.abspath("../.."))
 
 import asyncio
@@ -59,7 +58,38 @@ async def test_log_db_metrics_success():
         assert isinstance(call_args["duration"], float)
         assert isinstance(call_args["start_time"], datetime)
         assert isinstance(call_args["end_time"], datetime)
-        assert "function_name" in call_args["event_metadata"]
+        assert call_args["event_metadata"] is None
+
+
+@pytest.mark.asyncio
+async def test_log_db_metrics_event_metadata_is_safe():
+    """event_metadata must surface only the table name, never the raw
+    kwargs/args which carry live clients (Prisma, OTel spans) and secrets.
+
+    Regression guard for #28909: a previous version dumped function_kwargs and
+    function_args onto the span.
+    """
+    with patch("litellm.proxy.proxy_server.proxy_logging_obj") as mock_proxy_logging:
+        mock_proxy_logging.service_logging_obj.async_service_success_hook = AsyncMock()
+
+        @log_db_metrics
+        async def db_call(**kwargs):
+            return "success"
+
+        await db_call(
+            parent_otel_span="test_span",
+            table_name="LiteLLM_SpendLogs",
+            token="sk-secret-should-not-leak",
+            prisma_client=object(),
+        )
+        await asyncio.sleep(0)
+
+        call_args = (
+            mock_proxy_logging.service_logging_obj.async_service_success_hook.call_args[
+                1
+            ]
+        )
+        assert call_args["event_metadata"] == {"table_name": "LiteLLM_SpendLogs"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Relevant issues

`litellm_internal_staging` CI was red. GitHub Actions was fully green (75/75), but the CircleCI `build_and_test` workflow on staging HEAD (`f11c12d`, pipeline #79824) had two failing jobs: `logging_testing` and `llm_translation_testing`. This PR fixes both.

## What this fixes

**1. `logging_testing`.**

`#28909` hardened `log_db_metrics` to emit a minimal, non-sensitive `event_metadata` (only `table_name` when present, otherwise `None`) instead of dumping `function_name`, `function_kwargs`, and `function_args` onto the span; the function name still rides on the separate `call_type` argument. `test_log_db_redis_services.py` was not updated and still asserted `"function_name" in event_metadata`, so on the no-`table_name` path `event_metadata` is `None` and the assertion raised `TypeError: argument of type 'NoneType' is not iterable`.

This updates `test_log_db_metrics_success` to assert `event_metadata is None` for that path and adds `test_log_db_metrics_event_metadata_is_safe`, a regression guard that only the table name surfaces and that sensitive kwargs (tokens, prisma client) are never dumped.

**2. `llm_translation_testing`.**

All 8 failures were `test_reasoning_effort_grid[bedrock_converse-bedrock-claude-opus-4-7-*]` with `BedrockException - {"message":"anthropic.claude-opus-4-7 is not available for this account..."}`. The revert in `#29326` dropped the `grid_spec` `fail_reason` xfail workaround for the unentitled Opus cells on the assumption that the reactivated Bedrock account (888602223428) has flagship Opus. Live Bedrock `converse` calls with that account (in both us-east-1 and us-west-2) confirm `us.anthropic.claude-opus-4-6-v1` works but `us.anthropic.claude-opus-4-7` returns "not available for this account", so opus-4-7 is genuinely unentitled there and access "requires an AWS Sales request, not self-serve". The CircleCI `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` already point at 888602223428, so no credential rotation was needed.

This restores the `ModelEntry.fail_reason` field and the `pytest.xfail` consumer, and marks the `bedrock-claude-opus-4-7` cell xfail (account reference updated to 888602223428). The 8 cells now xfail (loud and documented) instead of failing the suite; remove the `fail_reason` once opus-4-7 access is granted.

## Stacked PR

`#29327` (Opus 4.8 reasoning-effort grid) depends on the `fail_reason` mechanism this PR restores, so it has been rebased to branch off this PR. Its opus-4-8 Azure/Vertex/Bedrock cells use the same xfail guard, with the Bedrock account reference aligned to 888602223428.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests
- [x] My PR's scope is as isolated as possible
- [ ] I have requested a Greptile review

## Proof of Fix

This is a CI-only test fix; the proof is the two previously-red CircleCI jobs turning green. Before (staging HEAD pipeline #79824, jobs 1743867 / 1743865):

```
FAILED tests/logging_callback_tests/test_log_db_redis_services.py::test_log_db_metrics_success
  - TypeError: argument of type 'NoneType' is not iterable     (1 failed, 343 passed)

FAILED tests/llm_translation/reasoning_effort_grid/...::test_reasoning_effort_grid[bedrock_converse-bedrock-claude-opus-4-7-*]
  - BedrockException ... "anthropic.claude-opus-4-7 is not available for this account"   (8 failed)
```

After (this branch, locally, with the CI Bedrock creds for the xfail path):

```
tests/logging_callback_tests/test_log_db_redis_services.py ... 10 passed (1 DD_API_KEY-gated test passes in CI)
reasoning_effort_grid ... bedrock opus-4-7 cells xfailed (no live call; pytest.xfail raises first)
```

The CircleCI run on this PR is the live proof for both jobs.

## Type

🐛 Bug Fix
✅ Test

## Changes

`tests/logging_callback_tests/test_log_db_redis_services.py`: align `event_metadata` assertions with the redacted contract from `#28909` and add a redaction regression test.

`tests/llm_translation/reasoning_effort_grid/grid_spec.py` and `test_reasoning_effort_grid.py`: restore the `ModelEntry.fail_reason` field and `pytest.xfail` consumer, and mark the unentitled `bedrock-claude-opus-4-7` cell xfail (account 888602223428).