### PR TITLE
refactor(proxy/auth): normalize Bearer prefix in safe-hash helper

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2747,13 +2747,18 @@ class UserAPIKeyAuth(
         1. Regular API keys from LiteLLM DB
         2. JWT tokens used for connecting to LiteLLM API
         """
-        if api_key.startswith("sk-"):
-            return hash_token(api_key)
+        normalized = api_key
+        for prefix in ("Bearer ", "bearer "):
+            if normalized.startswith(prefix):
+                normalized = normalized[len(prefix):]
+                break
+        if normalized.startswith("sk-"):
+            return hash_token(normalized)
         from litellm.proxy.auth.handle_jwt import JWTHandler
 
-        if JWTHandler.is_jwt(token=api_key):
-            return f"hashed-jwt-{hash_token(token=api_key)}"
-        return api_key
+        if JWTHandler.is_jwt(token=normalized):
+            return f"hashed-jwt-{hash_token(token=normalized)}"
+        return normalized
 
     @classmethod
     def get_litellm_internal_health_check_user_api_key_auth(cls) -> "UserAPIKeyAuth":

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2748,10 +2748,8 @@ class UserAPIKeyAuth(
         2. JWT tokens used for connecting to LiteLLM API
         """
         normalized = api_key
-        for prefix in ("Bearer ", "bearer "):
-            if normalized.startswith(prefix):
-                normalized = normalized[len(prefix):]
-                break
+        if normalized[:7].lower() == "bearer ":
+            normalized = normalized[7:]
         if normalized.startswith("sk-"):
             return hash_token(normalized)
         from litellm.proxy.auth.handle_jwt import JWTHandler

--- a/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
@@ -213,7 +213,7 @@ class TestMCPRequestHandler:
             # Test case 2: Authorization header present (fallback)
             (
                 [(b"authorization", b"Bearer test-auth-token")],
-                "Bearer test-auth-token",
+                "test-auth-token",
                 None,
                 {},
             ),
@@ -674,7 +674,9 @@ class TestMCPOAuth2AuthFlow:
             ) = await MCPRequestHandler.process_mcp_request(scope)
 
             # Should succeed with the LiteLLM key from Authorization header
-            assert auth_result.api_key == "Bearer sk-litellm-valid-key"
+            from litellm.proxy.utils import hash_token
+
+            assert auth_result.api_key == hash_token("sk-litellm-valid-key")
             mock_auth.assert_called_once()
 
     async def test_non_auth_http_exception_still_raises(self):

--- a/tests/test_litellm/proxy/test_proxy_types.py
+++ b/tests/test_litellm/proxy/test_proxy_types.py
@@ -69,3 +69,16 @@ def test_internal_jobs_user_has_proxy_admin_role():
     assert system_user.user_id == "system"
     assert system_user.team_id == "system"
     assert system_user.team_alias == "system"
+
+
+def test_user_api_key_auth_hashes_authorization_header_form_of_key():
+    from litellm.proxy._types import UserAPIKeyAuth
+
+    raw_key = "sk-AbCdEfGhIjKlMnOpQrStUvWxYz0123456789"
+    baseline = UserAPIKeyAuth(api_key=raw_key)
+
+    for header_form in (f"Bearer {raw_key}", f"bearer {raw_key}"):
+        from_header = UserAPIKeyAuth(api_key=header_form)
+        assert from_header.api_key == baseline.api_key
+        assert from_header.token == baseline.token
+        assert not from_header.api_key.lower().startswith("bearer")

--- a/tests/test_litellm/proxy/test_proxy_types.py
+++ b/tests/test_litellm/proxy/test_proxy_types.py
@@ -77,7 +77,12 @@ def test_user_api_key_auth_hashes_authorization_header_form_of_key():
     raw_key = "sk-AbCdEfGhIjKlMnOpQrStUvWxYz0123456789"
     baseline = UserAPIKeyAuth(api_key=raw_key)
 
-    for header_form in (f"Bearer {raw_key}", f"bearer {raw_key}"):
+    for header_form in (
+        f"Bearer {raw_key}",
+        f"bearer {raw_key}",
+        f"BEARER {raw_key}",
+        f"BeArEr {raw_key}",
+    ):
         from_header = UserAPIKeyAuth(api_key=header_form)
         assert from_header.api_key == baseline.api_key
         assert from_header.token == baseline.token


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

Run a proxy with prometheus enabled and a key whose owning user has an exceeded budget; the failure-metric label is now hashed regardless of whether the caller stripped the `Bearer ` prefix:

```bash
python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log

# Mint a user whose budget is already exceeded, and a key tied to that user.
USER_ID=$(curl -s http://localhost:4000/user/new \
  -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"max_budget": 0.0000001, "user_role": "internal_user"}' \
  | python3 -c 'import json,sys;print(json.load(sys.stdin)["user_id"])')
curl -s http://localhost:4000/user/update \
  -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d "{\"user_id\": \"$USER_ID\", \"spend\": 1.0}" >/dev/null
KEY=$(curl -s http://localhost:4000/key/generate \
  -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d "{\"user_id\": \"$USER_ID\", \"duration\": \"1h\"}" \
  | python3 -c 'import json,sys;print(json.load(sys.stdin)["key"])')

# Hit /chat/completions and /v1/messages with that key; both return 429 BudgetExceededError.
for path in chat/completions v1/messages; do
  curl -s http://localhost:4000/$path \
    -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' \
    -d '{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}],"max_tokens":10}' \
    -o /dev/null -w "$path http=%{http_code}\n"
done

# Inspect the metric: hashed_api_key is the 64-char sha256, never a Bearer-prefixed string.
curl -sL http://localhost:4000/metrics -H 'Authorization: Bearer sk-1234' \
  | grep '^litellm_proxy_failed_requests_metric_total{'
```

Before this PR, the metric rows for both routes carried `hashed_api_key="Bearer sk-…"` literally; after, the same rows carry the proper sha256 hash.

The new contract test covers the same property at the helper level:

```bash
uv run pytest tests/test_litellm/proxy/test_proxy_types.py::test_user_api_key_auth_hashes_authorization_header_form_of_key -v
```

## Type

🧹 Refactoring
✅ Test

## Changes

`UserAPIKeyAuth._safe_hash_litellm_api_key` now strips a leading `Bearer ` / `bearer ` prefix before its existing `sk-` / JWT classification, so callers that pass the raw Authorization header value get the same hashed output as callers that strip the prefix themselves. Adds a contract test (`test_user_api_key_auth_hashes_authorization_header_form_of_key`) that asserts the helper produces the same hashed `api_key` and `token` fields for `Bearer <sk>`, `bearer <sk>`, and bare `<sk>` inputs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to key normalization for logging/metrics with a focused unit test; no auth policy or storage changes.
> 
> **Overview**
> **`UserAPIKeyAuth._safe_hash_litellm_api_key`** now strips a leading **`Bearer `** or **`bearer `** before applying the existing **`sk-`** / JWT hashing logic, so callers that pass the raw Authorization header value get the same hashed **`api_key`** and **`token`** as callers that pass the bare key.
> 
> That fixes cases where observability labels (e.g. Prometheus **`hashed_api_key`** on failed requests) previously showed the literal **`Bearer sk-…`** string instead of the SHA-256 hash.
> 
> A contract test asserts **`Bearer`**, **`bearer`**, and bare **`sk-`** inputs all normalize to the same hashed fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 773b1f0a80fd1c4f2564793537768dda3d8b9388. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->