### PR TITLE
fix(ci): make litellm_internal_staging green (logging test + Bedrock Opus 4.7 self-heal)

### DIFF
--- a/tests/llm_translation/reasoning_effort_grid/grid_spec.py
+++ b/tests/llm_translation/reasoning_effort_grid/grid_spec.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass, field
 from typing import Dict, FrozenSet, List, Optional, Tuple
 
-
 OMIT = object()
 
 
@@ -22,6 +21,7 @@ class ModelEntry:
     extra_params: Tuple[Tuple[str, str], ...] = field(default_factory=tuple)
     required_env: FrozenSet[str] = field(default_factory=frozenset)
     caps: FrozenSet[str] = field(default_factory=frozenset)
+    unavailable_error: Optional[str] = None
     bedrock_effort_ceiling: Optional[str] = None
 
     def params(self) -> Dict[str, str]:
@@ -234,6 +234,7 @@ BEDROCK_CONVERSE_MODELS: Tuple[ModelEntry, ...] = (
         extra_params=(("aws_region_name", "us-east-1"),),
         required_env=_BEDROCK_REQ,
         caps=_CAPS_OPUS_4_7,
+        unavailable_error="is not available for this account",
     ),
     ModelEntry(
         alias="bedrock-claude-opus-4-6",

--- a/tests/llm_translation/reasoning_effort_grid/test_reasoning_effort_grid.py
+++ b/tests/llm_translation/reasoning_effort_grid/test_reasoning_effort_grid.py
@@ -15,7 +15,6 @@ from .grid_spec import (
     all_cells,
 )
 
-
 _PROMPT_MESSAGES: List[Dict[str, str]] = [
     {"role": "user", "content": "Step by step, calculate 47 * 53. Show your work."}
 ]
@@ -133,6 +132,12 @@ def _classify_status(exc: Exception) -> int:
     return 500
 
 
+def _model_unavailable(model: ModelEntry, exc: Optional[Exception]) -> bool:
+    if not model.unavailable_error or exc is None:
+        return False
+    return model.unavailable_error in str(exc)
+
+
 async def _call_chat(model: ModelEntry, effort: str) -> Tuple[int, Optional[Exception]]:
     kwargs = _build_completion_kwargs(model, effort)
     try:
@@ -173,6 +178,9 @@ async def test_reasoning_effort_grid(
     else:
         status, exc = await _call_chat(model, effort)
 
+    if _model_unavailable(model, exc):
+        pytest.skip(f"{model.alias}: {model.unavailable_error}")
+
     record = wire_capture.latest()
     body = record["body"] if record else None
     if route_name == "bedrock_converse" and isinstance(body, str):
@@ -205,3 +213,30 @@ def test_grid_route_coverage() -> None:
         "bedrock_invoke_chat",
         "bedrock_invoke_messages",
     }
+
+
+def test_model_unavailable_tolerates_only_the_declared_error() -> None:
+    gated = ModelEntry(
+        alias="bedrock-claude-opus-4-7",
+        model="bedrock/converse/us.anthropic.claude-opus-4-7",
+        mode="adaptive",
+        unavailable_error="is not available for this account",
+    )
+    entitlement_error = Exception(
+        "litellm.APIConnectionError: BedrockException - "
+        '{"message":"anthropic.claude-opus-4-7 is not available for this account."}'
+    )
+
+    assert _model_unavailable(gated, entitlement_error) is True
+    assert (
+        _model_unavailable(gated, Exception("ThrottlingException: rate exceeded"))
+        is False
+    )
+    assert _model_unavailable(gated, None) is False
+
+    ungated = ModelEntry(
+        alias="bedrock-claude-opus-4-6",
+        model="bedrock/converse/us.anthropic.claude-opus-4-6-v1",
+        mode="adaptive",
+    )
+    assert _model_unavailable(ungated, entitlement_error) is False

--- a/tests/logging_callback_tests/test_log_db_redis_services.py
+++ b/tests/logging_callback_tests/test_log_db_redis_services.py
@@ -2,7 +2,6 @@ import io
 import os
 import sys
 
-
 sys.path.insert(0, os.path.abspath("../.."))
 
 import asyncio
@@ -59,7 +58,38 @@ async def test_log_db_metrics_success():
         assert isinstance(call_args["duration"], float)
         assert isinstance(call_args["start_time"], datetime)
         assert isinstance(call_args["end_time"], datetime)
-        assert "function_name" in call_args["event_metadata"]
+        assert call_args["event_metadata"] is None
+
+
+@pytest.mark.asyncio
+async def test_log_db_metrics_event_metadata_is_safe():
+    """event_metadata must surface only the table name, never the raw
+    kwargs/args which carry live clients (Prisma, OTel spans) and secrets.
+
+    Regression guard for #28909: a previous version dumped function_kwargs and
+    function_args onto the span.
+    """
+    with patch("litellm.proxy.proxy_server.proxy_logging_obj") as mock_proxy_logging:
+        mock_proxy_logging.service_logging_obj.async_service_success_hook = AsyncMock()
+
+        @log_db_metrics
+        async def db_call(**kwargs):
+            return "success"
+
+        await db_call(
+            parent_otel_span="test_span",
+            table_name="LiteLLM_SpendLogs",
+            token="sk-secret-should-not-leak",
+            prisma_client=object(),
+        )
+        await asyncio.sleep(0)
+
+        call_args = (
+            mock_proxy_logging.service_logging_obj.async_service_success_hook.call_args[
+                1
+            ]
+        )
+        assert call_args["event_metadata"] == {"table_name": "LiteLLM_SpendLogs"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Relevant issues

`litellm_internal_staging` CI was red. GitHub Actions was fully green, but the CircleCI `build_and_test` workflow on staging HEAD (`f11c12d`, pipeline #79824) had two failing jobs: `logging_testing` and `llm_translation_testing`. This PR fixes both. (Supersedes #29341, which was on a `claude/` branch the CircleCI branch filter skips; moved here to a `litellm_*` branch so CircleCI runs.)

## What this fixes

**1. `logging_testing`.**

#28909 hardened `log_db_metrics` to emit a minimal, non-sensitive `event_metadata` (only `table_name` when present, otherwise `None`) instead of dumping `function_name`, `function_kwargs`, and `function_args` onto the span; the function name still rides on the separate `call_type` argument. `test_log_db_redis_services.py` was not updated and still asserted `"function_name" in event_metadata`, so on the no-`table_name` path `event_metadata` is `None` and the assertion raised `TypeError: argument of type 'NoneType' is not iterable`.

This updates `test_log_db_metrics_success` to assert `event_metadata is None` for that path and adds `test_log_db_metrics_event_metadata_is_safe`, a regression guard that only the table name surfaces and that sensitive kwargs (tokens, prisma client) are never dumped.

**2. `llm_translation_testing`.**

All 8 failures were `test_reasoning_effort_grid[bedrock_converse-bedrock-claude-opus-4-7-*]` with `BedrockException - {"message":"anthropic.claude-opus-4-7 is not available for this account..."}`. The revert in #29326 dropped the workaround for the unentitled Opus cells on the assumption that the reactivated Bedrock account (888602223428) carries flagship Opus. Live Bedrock `converse` calls with that account (in both us-east-1 and us-west-2) confirm `us.anthropic.claude-opus-4-6-v1` works but `us.anthropic.claude-opus-4-7` returns "is not available for this account", so opus-4-7 is genuinely unentitled there and access requires an AWS Sales request rather than self-serve. The CircleCI `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` already point at 888602223428, so no credential rotation was needed.

Rather than restore the old `xfail` (which keeps reporting the cells as expected failures even after access is granted, so the wire translation never gets verified again), the `bedrock-claude-opus-4-7` cell now runs the call and skips only when Bedrock replies "is not available for this account". The moment opus-4-7 is entitled, the same cells run their full wire assertions with no test edit. A focused unit test (`test_model_unavailable_tolerates_only_the_declared_error`) pins the tolerance predicate so any other failure still surfaces loudly and the available path still asserts.

## Stacked PR

#29327 (Opus 4.8 reasoning-effort grid) branches off this PR. Its Bedrock opus-4-8 cell reuses this self-heal path; its Azure and Vertex opus-4-8 cells use a separate `fail_reason` xfail until a Foundry deployment exists and Vertex availability is confirmed.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests
- [x] My PR's scope is as isolated as possible
- [ ] I have requested a Greptile review

## Proof of Fix

CI-only test fix; the proof is the two previously-red CircleCI jobs turning green on this PR's branch. With opus-4-7 still unentitled on the CI account, the 8 `bedrock-claude-opus-4-7` cells now report as skipped (`bedrock-claude-opus-4-7: is not available for this account`) instead of failing the suite, and `logging_testing` passes.

Before (staging HEAD pipeline #79824):

```
FAILED .../test_log_db_redis_services.py::test_log_db_metrics_success - TypeError: NoneType not iterable   (1 failed)
FAILED .../test_reasoning_effort_grid[bedrock_converse-bedrock-claude-opus-4-7-*] - "opus-4-7 is not available for this account"   (8 failed)
```

The CircleCI run on this PR's latest commit is the live proof.

## CI (LiteLLM team)

- [ ] Branch creation CI run: Link:
- [ ] CI run for the last commit: Link:
- [ ] Merge / cherry-pick CI run: Links:

## Type

🐛 Bug Fix
✅ Test

## Changes

`tests/logging_callback_tests/test_log_db_redis_services.py`: align `event_metadata` assertions with the redacted contract from #28909 and add a redaction regression test.

`tests/llm_translation/reasoning_effort_grid/grid_spec.py` and `test_reasoning_effort_grid.py`: replace the opus-4-7 `xfail` with a self-heal `unavailable_error` guard that skips only on Bedrock's "is not available for this account" reply and otherwise runs the full assertions, plus a unit test for the tolerance predicate.