### PR TITLE
fix(ui/agents): use Select tags for Skills tags/examples (LIT-3153)

### DIFF
--- a/ui/litellm-dashboard/src/components/agents/agent_config.ts
+++ b/ui/litellm-dashboard/src/components/agents/agent_config.ts
@@ -212,14 +212,14 @@ export const SKILL_FIELD_CONFIG = {
   },
   tags: {
     name: "tags",
-    label: "Tags (comma-separated)",
+    label: "Tags",
     required: true,
-    placeholder: "e.g., hello world, greeting",
+    placeholder: "Add tags (press Enter to confirm)",
   },
   examples: {
     name: "examples",
-    label: "Examples (comma-separated)",
-    placeholder: "e.g., hi, hello world",
+    label: "Examples",
+    placeholder: "Add examples (press Enter to confirm)",
   },
 };
 

--- a/ui/litellm-dashboard/src/components/agents/agent_form_fields.test.tsx
+++ b/ui/litellm-dashboard/src/components/agents/agent_form_fields.test.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import { describe, it, expect } from "vitest";
+import { Form } from "antd";
+import { render, screen, fireEvent, act, waitFor } from "@testing-library/react";
+import AgentFormFields from "./agent_form_fields";
+
+function renderSkillsPanel(initialValues: any = {}) {
+  return render(
+    <Form initialValues={initialValues}>
+      <AgentFormFields showAgentName={false} visiblePanels={["skills"]} />
+    </Form>,
+  );
+}
+
+describe("AgentFormFields (Skills > Tags)", () => {
+  it("should render the Skills panel header", () => {
+    renderSkillsPanel();
+    expect(screen.getByText(/Skills \(Required\)/i)).toBeInTheDocument();
+  });
+
+  it("should render a real tag input control after Add Skill is clicked (LIT-3153)", async () => {
+    renderSkillsPanel();
+    await act(async () => {
+      fireEvent.click(screen.getByText(/Skills \(Required\)/i));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /Add Skill/i }));
+    });
+    await waitFor(() =>
+      expect(
+        screen.getByText("Tags", { selector: "label, .ant-form-item-label *" }),
+      ).toBeInTheDocument(),
+    );
+    const combos = screen.getAllByRole("combobox");
+    expect(combos.length).toBeGreaterThan(0);
+    expect(
+      screen.getByText("Add tags (press Enter to confirm)"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/comma-separated/i)).not.toBeInTheDocument();
+  });
+
+  it("should preserve existing tag values from initialValues as chips", async () => {
+    renderSkillsPanel({
+      skills: [
+        {
+          id: "hello_world",
+          name: "Hello world",
+          description: "Returns hello",
+          tags: ["hello", "greeting"],
+          examples: ["hi", "hello world"],
+        },
+      ],
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText(/Skills \(Required\)/i));
+    });
+    await waitFor(() => {
+      expect(screen.getByText("hello")).toBeInTheDocument();
+      expect(screen.getByText("greeting")).toBeInTheDocument();
+      expect(screen.getByText("hi")).toBeInTheDocument();
+      expect(screen.getByText("hello world")).toBeInTheDocument();
+    });
+  });
+});

--- a/ui/litellm-dashboard/src/components/agents/agent_form_fields.tsx
+++ b/ui/litellm-dashboard/src/components/agents/agent_form_fields.tsx
@@ -93,21 +93,37 @@ const AgentFormFields: React.FC<AgentFormFieldsProps> = ({ showAgentName = true,
                       {...field}
                       label={SKILL_FIELD_CONFIG.tags.label}
                       name={[field.name, 'tags']}
-                      rules={[{ required: SKILL_FIELD_CONFIG.tags.required, message: 'Required' }]}
-                      getValueFromEvent={(e) => e.target.value.split(',').map((s: string) => s.trim())}
-                      getValueProps={(value) => ({ value: Array.isArray(value) ? value.join(', ') : value })}
+                      rules={[
+                        {
+                          required: SKILL_FIELD_CONFIG.tags.required,
+                          validator: (_, value) =>
+                            Array.isArray(value) && value.length > 0
+                              ? Promise.resolve()
+                              : Promise.reject(new Error('At least one tag is required')),
+                        },
+                      ]}
                     >
-                      <Input placeholder={SKILL_FIELD_CONFIG.tags.placeholder} />
+                      <Select
+                        mode="tags"
+                        style={{ width: '100%' }}
+                        placeholder={SKILL_FIELD_CONFIG.tags.placeholder}
+                        tokenSeparators={[',']}
+                        notFoundContent={null}
+                      />
                     </Form.Item>
                     
                     <Form.Item
                       {...field}
                       label={SKILL_FIELD_CONFIG.examples.label}
                       name={[field.name, 'examples']}
-                      getValueFromEvent={(e) => e.target.value.split(',').map((s: string) => s.trim()).filter((s: string) => s)}
-                      getValueProps={(value) => ({ value: Array.isArray(value) ? value.join(', ') : '' })}
                     >
-                      <Input placeholder={SKILL_FIELD_CONFIG.examples.placeholder} />
+                      <Select
+                        mode="tags"
+                        style={{ width: '100%' }}
+                        placeholder={SKILL_FIELD_CONFIG.examples.placeholder}
+                        tokenSeparators={[',']}
+                        notFoundContent={null}
+                      />
                     </Form.Item>
                     
                     <AntButton 


### PR DESCRIPTION
## Summary

Fixes **LIT-3153** — on the Agents → "+ Add New Agent" → Configure → Skills (Required) → Add Skill flow, the `tags` field was marked required but rendered as a plain `<Input>` labelled "Tags (comma-separated)". Users could not tell it was an array input — the control was visually identical to the adjacent "Skill ID" / "Skill Name" text fields, and the required validator only checked for non-null, so the form would happily save with an empty tag list.

## Root cause

`ui/litellm-dashboard/src/components/agents/agent_form_fields.tsx` rendered:

```tsx
<Form.Item
  label="Tags (comma-separated)"
  rules={[{ required: true, message: 'Required' }]}
  getValueFromEvent={(e) => e.target.value.split(',').map(s => s.trim())}
  getValueProps={(value) => ({ value: Array.isArray(value) ? value.join(', ') : value })}
>
  <Input placeholder="e.g., hello world, greeting" />
</Form.Item>
```

A plain text input with a fragile comma-split shim. The `required` rule fires only when the field is null/undefined; an empty `[]` from a click-into-and-out-of dance passed the rule.

## Fix

Swap both `tags` and `examples` to antd `<Select mode="tags">` — which is what the same form already uses for "Forward Client Headers". This:

- Renders as a multi-select with chips, matching what a user expects for "Tags"
- Accepts both Enter and comma as token separators (`tokenSeparators={[',']}`)
- Produces a native `string[]` value — no `getValueFromEvent` / `getValueProps` shim
- Uses a custom validator on `tags` that requires `Array.isArray(value) && value.length > 0` so an empty selection actually fails validation

Updates `SKILL_FIELD_CONFIG` labels (drop "(comma-separated)") and placeholders ("Add tags (press Enter to confirm)").

Adds `agent_form_fields.test.tsx` with three vitest cases:
1. Skills panel renders
2. After clicking "Add Skill", a tag input (combobox role) is rendered with the new placeholder, and "(comma-separated)" is gone
3. Existing `string[]` values from `initialValues` round-trip as chips (covers the edit-existing-agent path)

### Evidence

Real Add Agent modal in the running proxy in this sandbox, before/after the fix. The proxy was started with `litellm-up` (postgres + LiteLLM proxy bundled), I logged in with the dev master key, opened `+ Add New Agent`, expanded the Skills panel, clicked "Add Skill", and screenshotted the resulting fields.

**Before** — the `Tags (comma-separated)` field is a plain `<Input>` indistinguishable from "Skill ID" / "Skill Name". Same story for `Examples (comma-separated)`.

![before — plain Input labelled "Tags (comma-separated)"](https://raw.githubusercontent.com/oss-agent-shin/litellm/pr-assets-lit3153/before_skill_tags.png)

**After** — `Tags` is an antd `Select mode="tags"` (note the dropdown caret on the right), the label drops the "(comma-separated)" suffix, the placeholder is "Add tags (press Enter to confirm)". `Examples` likewise.

![after — Select mode=tags](https://raw.githubusercontent.com/oss-agent-shin/litellm/pr-assets-lit3153/after_skill_tags.png)

Component test run (vitest, jsdom):

```
$ ./node_modules/.bin/vitest run --reporter=verbose src/components/agents/agent_form_fields.test.tsx

 ✓ src/components/agents/agent_form_fields.test.tsx > AgentFormFields (Skills > Tags) > should render the Skills panel header
 ✓ src/components/agents/agent_form_fields.test.tsx > AgentFormFields (Skills > Tags) > should render a real tag input control after Add Skill is clicked (LIT-3153)
 ✓ src/components/agents/agent_form_fields.test.tsx > AgentFormFields (Skills > Tags) > should preserve existing tag values from initialValues as chips

 Test Files  1 passed (1)
      Tests  3 passed (3)
```

Existing agents-folder tests still pass (`agent_card.test.tsx`, `agent_card_grid.test.tsx`):

```
 Test Files  3 passed (3)
      Tests  17 passed (17)
```

## Scope notes

- `getDefaultFormValues` / `buildAgentDataFromForm` already treat `tags` / `examples` as `string[]`, so the wire format is unchanged.
- The edit-existing-agent path renders the same `<AgentFormFields>` inside `agent_info.tsx`; covered by the round-trip test.
- No backend changes.


### Verification (ship-pr)
- change-type: `ui/litellm-dashboard/src/components/agents/{agent_config.ts, agent_form_fields.tsx}` -> UI screenshots required; `agent_form_fields.test.tsx` -> tests only (no runtime)
- evidence present: PASS (2 embedded screenshots under `### Evidence`)
- image sanity: PASS
  - before_skill_tags.png: size=84688 bytes, mean=209.6, stddev=57.5
  - after_skill_tags.png: size=84437 bytes, mean=209.7, stddev=57.4
- image content matches caption: PASS — before screenshot's modal body text contained "Tags (comma-separated)" (verified via Playwright body.innerText scrape of the running proxy on the unpatched baseline); after screenshot's modal body text contained "Add tags (press Enter to confirm)" (verified the same way on the rebuilt UI).
- backend evidence from running system: N/A (UI-only change)
- screenshots host: hosted on the orphan branch `oss-agent-shin:pr-assets-lit3153` and embedded via `raw.githubusercontent.com` URLs (each verified `200 image/png`). Used this path because `sandbox_upload_artifact` returned `503 artifact storage not configured` in this session — filed as a sandbox/LAP issue, but not a blocker for this PR.
