### PR TITLE
fix: handle InternalServerError in allowed fails policy

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -11744,6 +11744,11 @@ class Router:
             and allowed_fails_policy.BadRequestErrorAllowedFails is not None
         ):
             return allowed_fails_policy.BadRequestErrorAllowedFails
+        if (
+            isinstance(exception, litellm.InternalServerError)
+            and allowed_fails_policy.InternalServerErrorAllowedFails is not None
+        ):
+            return allowed_fails_policy.InternalServerErrorAllowedFails
 
     def _initialize_alerting(self):
         from litellm.integrations.SlackAlerting.slack_alerting import SlackAlerting


### PR DESCRIPTION
Fixes issue #29283 - InternalServerErrorAllowedFails was silently ignored in get_allowed_fails_from_policy.

Added handling for InternalServerError exception type in the get_allowed_fails_from_policy function, checking if allowed_fails_policy.InternalServerErrorAllowedFails is set and returning it.