### PR TITLE
refactor(proxy/auth): cherry-pick #29343 into patch/v1.87.0rc2

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2741,13 +2741,16 @@ class UserAPIKeyAuth(
         1. Regular API keys from LiteLLM DB
         2. JWT tokens used for connecting to LiteLLM API
         """
-        if api_key.startswith("sk-"):
-            return hash_token(api_key)
+        normalized = api_key
+        if normalized[:7].lower() == "bearer ":
+            normalized = normalized[7:]
+        if normalized.startswith("sk-"):
+            return hash_token(normalized)
         from litellm.proxy.auth.handle_jwt import JWTHandler
 
-        if JWTHandler.is_jwt(token=api_key):
-            return f"hashed-jwt-{hash_token(token=api_key)}"
-        return api_key
+        if JWTHandler.is_jwt(token=normalized):
+            return f"hashed-jwt-{hash_token(token=normalized)}"
+        return normalized
 
     @classmethod
     def get_litellm_internal_health_check_user_api_key_auth(cls) -> "UserAPIKeyAuth":

--- a/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
@@ -213,7 +213,7 @@ class TestMCPRequestHandler:
             # Test case 2: Authorization header present (fallback)
             (
                 [(b"authorization", b"Bearer test-auth-token")],
-                "Bearer test-auth-token",
+                "test-auth-token",
                 None,
                 {},
             ),
@@ -674,7 +674,9 @@ class TestMCPOAuth2AuthFlow:
             ) = await MCPRequestHandler.process_mcp_request(scope)
 
             # Should succeed with the LiteLLM key from Authorization header
-            assert auth_result.api_key == "Bearer sk-litellm-valid-key"
+            from litellm.proxy.utils import hash_token
+
+            assert auth_result.api_key == hash_token("sk-litellm-valid-key")
             mock_auth.assert_called_once()
 
     async def test_non_auth_http_exception_still_raises(self):

--- a/tests/test_litellm/proxy/test_proxy_types.py
+++ b/tests/test_litellm/proxy/test_proxy_types.py
@@ -69,3 +69,21 @@ def test_internal_jobs_user_has_proxy_admin_role():
     assert system_user.user_id == "system"
     assert system_user.team_id == "system"
     assert system_user.team_alias == "system"
+
+
+def test_user_api_key_auth_hashes_authorization_header_form_of_key():
+    from litellm.proxy._types import UserAPIKeyAuth
+
+    raw_key = "sk-AbCdEfGhIjKlMnOpQrStUvWxYz0123456789"
+    baseline = UserAPIKeyAuth(api_key=raw_key)
+
+    for header_form in (
+        f"Bearer {raw_key}",
+        f"bearer {raw_key}",
+        f"BEARER {raw_key}",
+        f"BeArEr {raw_key}",
+    ):
+        from_header = UserAPIKeyAuth(api_key=header_form)
+        assert from_header.api_key == baseline.api_key
+        assert from_header.token == baseline.token
+        assert not from_header.api_key.lower().startswith("bearer")


### PR DESCRIPTION
## Relevant issues

Cherry-pick of #29343 (merge commit `94a043efb2`) onto the `patch/v1.87.0rc2` branch (= tag `v1.87.0-rc.2`). Supersedes #29362, which targeted the older `patch/v1.87.0rc1` base.

## Linear ticket

n/a

## Pre-Submission checklist

- [x] I have added meaningful tests (carried over verbatim from #29343)
- [x] My PR passes all unit tests on `make test-unit` (asserted in #29343; this PR is a verbatim cherry-pick of the function body — see verification below)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review and received a Confidence Score of at least 4/5

## CI (LiteLLM team)

- [ ] Branch creation CI run -- link:
- [ ] CI run for the last commit -- link:
- [ ] Merge / cherry-pick CI run -- links:

## Bug verification on v1.87.0-rc.2

Confirmed the bug is still present at the v1.87.0-rc.2 tag (head of `patch/v1.87.0rc2`) before this cherry-pick lands. rc.2 = rc.1 + 2 patch commits, neither of which touched `_types.py`, so the rc.1 verification carries over unchanged.

```
$ git show v1.87.0-rc.2:litellm/proxy/_types.py | sed -n '/def _safe_hash_litellm_api_key/,/^    @/p'
    def _safe_hash_litellm_api_key(cls, api_key: str) -> str:
        """
        Helper to ensure all logged keys are hashed
        Covers:
        1. Regular API keys from LiteLLM DB
        2. JWT tokens used for connecting to LiteLLM API
        """
        if api_key.startswith("sk-"):
            return hash_token(api_key)
        from litellm.proxy.auth.handle_jwt import JWTHandler

        if JWTHandler.is_jwt(token=api_key):
            return f"hashed-jwt-{hash_token(token=api_key)}"
        return api_key
```

Any caller that passes the raw `Authorization` header value (`Bearer sk-...`) falls through to `return api_key` unchanged, so observability labels (e.g. Prometheus `litellm_proxy_failed_requests_metric_total{hashed_api_key=...}`) leak the literal `Bearer sk-...` string instead of the sha256 hash.

After this cherry-pick lands, the function body matches the source merge commit byte-for-byte — a case-insensitive `Bearer ` strip runs before the existing sk-/JWT classification.

## Screenshots / Proof of Fix

End-to-end proof-of-fix (curl-driven Prometheus scrape showing the metric row going from `hashed_api_key="Bearer sk-..."` to a proper sha256 hash) is captured in the original PR body at #29343 and was run against a live proxy with prometheus enabled. The cherry-pick is verbatim, so the same harness output applies.

## Type

Refactoring + Test

## Changes

Verbatim cherry-pick of #29343's merge commit `94a043efb226c5ccdbfc028fbb930ce45fb965eb` onto `patch/v1.87.0rc2`. Auto-merged cleanly (no conflicts). 3 files, +30/-7 — matches the sum of the three original commits exactly (+8/-5 in `_types.py`, +4/-2 in the MCP auth test, +18/-0 for the new contract test). The `_safe_hash_litellm_api_key` body on this branch is byte-identical to the merge commit's version. Full rationale lives in the #29343 PR body.