### PR TITLE
feat(ui): show coding-agent onboarding prompt after creating a virtual key

### DIFF
--- a/ui/litellm-dashboard/e2e_tests/tests/proxy-admin/keys.spec.ts
+++ b/ui/litellm-dashboard/e2e_tests/tests/proxy-admin/keys.spec.ts
@@ -41,8 +41,8 @@ test.describe("Proxy Admin - Keys", () => {
     // Submit
     await page.getByRole("button", { name: "Create Key", exact: true }).click();
 
-    // Success shows "Save your Key" in a second dialog
-    await expect(page.getByText("Save your Key")).toBeVisible({ timeout: 10_000 });
+    // Success shows "API Key Created" in a second dialog
+    await expect(page.getByText("API Key Created")).toBeVisible({ timeout: 10_000 });
     await page.keyboard.press("Escape");
 
     // Verify the new key appears in the table
@@ -150,7 +150,7 @@ test.describe("Proxy Admin - Keys", () => {
 
     await page.getByRole("button", { name: "Create Key", exact: true }).click();
 
-    await expect(page.getByText("Save your Key")).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText("API Key Created")).toBeVisible({ timeout: 10_000 });
     await page.keyboard.press("Escape");
 
     await expect(page.getByText(keyName)).toBeVisible({ timeout: 10_000 });
@@ -182,7 +182,7 @@ test.describe("Proxy Admin - Keys", () => {
 
     await page.getByRole("button", { name: "Create Key", exact: true }).click();
 
-    await expect(page.getByText("Save your Key")).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText("API Key Created")).toBeVisible({ timeout: 10_000 });
 
     // Grab the new key from the success modal (rendered inside a <pre>) and
     // verify it can call /chat/completions for the model it was scoped to.

--- a/ui/litellm-dashboard/e2e_tests/tests/team-admin/teamAdmin.spec.ts
+++ b/ui/litellm-dashboard/e2e_tests/tests/team-admin/teamAdmin.spec.ts
@@ -109,7 +109,7 @@ test.describe("Team Admin", () => {
 
     await page.getByRole("button", { name: "Create Key", exact: true }).click();
 
-    await expect(page.getByText("Save your Key")).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText("API Key Created")).toBeVisible({ timeout: 10_000 });
     await page.keyboard.press("Escape");
 
     await expect(page.getByText(keyName)).toBeVisible({ timeout: 10_000 });

--- a/ui/litellm-dashboard/src/components/organisms/create_key_button.test.tsx
+++ b/ui/litellm-dashboard/src/components/organisms/create_key_button.test.tsx
@@ -52,6 +52,8 @@ vi.mock("@/app/(dashboard)/hooks/keys/useKeys", () => ({
 
 vi.mock("@ant-design/icons", () => ({
   InfoCircleOutlined: () => null,
+  CopyOutlined: () => null,
+  WarningOutlined: () => null,
 }));
 
 vi.mock("react-copy-to-clipboard", () => ({

--- a/ui/litellm-dashboard/src/components/organisms/create_key_button.tsx
+++ b/ui/litellm-dashboard/src/components/organisms/create_key_button.tsx
@@ -1657,17 +1657,12 @@ const CreateKey: React.FC<CreateKeyProps> = ({ team, teams, data, addKey, autoOp
       )}
 
       {apiKey && (
-        <Modal open={isModalVisible} onOk={handleOk} onCancel={handleCancel} footer={null}>
-          <Grid numItems={1} className="gap-2 w-full">
-            <Title>Save your Key</Title>
-            <Col numColSpan={1}>
-              {apiKey != null ? (
-                <CreatedKeyDisplay apiKey={apiKey} />
-              ) : (
-                <Text>Key being created, this might take 30s</Text>
-              )}
-            </Col>
-          </Grid>
+        <Modal open={isModalVisible} onOk={handleOk} onCancel={handleCancel} footer={null} width={560}>
+          {apiKey != null ? (
+            <CreatedKeyDisplay apiKey={apiKey} />
+          ) : (
+            <Text>Key being created, this might take 30s</Text>
+          )}
         </Modal>
       )}
     </div>

--- a/ui/litellm-dashboard/src/components/shared/CreatedKeyDisplay.test.tsx
+++ b/ui/litellm-dashboard/src/components/shared/CreatedKeyDisplay.test.tsx
@@ -7,51 +7,74 @@ vi.mock("@/components/molecules/message_manager", () => ({
   default: { success: vi.fn(), error: vi.fn(), warning: vi.fn(), info: vi.fn(), loading: vi.fn(), destroy: vi.fn() },
 }));
 
+vi.mock("@/components/networking", () => ({
+  proxyBaseUrl: "https://litellm.example.com",
+}));
+
 import MessageManager from "@/components/molecules/message_manager";
 
 describe("CreatedKeyDisplay", () => {
   beforeEach(() => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.mocked(MessageManager.success).mockClear();
   });
 
   afterEach(() => {
     vi.useRealTimers();
   });
 
-  it("should render", () => {
+  it("renders the API key value", () => {
     render(<CreatedKeyDisplay apiKey="sk-test-123" />);
-    expect(screen.getByText("sk-test-123")).toBeInTheDocument();
+    expect(screen.getByTestId("created-key-value")).toHaveTextContent("sk-test-123");
   });
 
-  it("should display the security warning", () => {
+  it("displays the security warning and modal heading", () => {
     render(<CreatedKeyDisplay apiKey="sk-test-123" />);
-    expect(screen.getByText(/you will not be able to view it again/i)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /api key created/i })).toBeInTheDocument();
+    expect(
+      screen.getByText(/make sure to copy your api key now/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/you won't be able to see it again/i)).toBeInTheDocument();
   });
 
-  it("should show the copy button with initial label", () => {
+  it("builds a coding agent prompt that embeds the key, base URL, and docs links", () => {
     render(<CreatedKeyDisplay apiKey="sk-test-123" />);
-    expect(screen.getByRole("button", { name: /copy virtual key/i })).toBeInTheDocument();
+    const prompt = screen.getByTestId("coding-agent-prompt").textContent ?? "";
+
+    expect(prompt).toMatch(/Base URL: https:\/\/litellm\.example\.com/);
+    expect(prompt).toMatch(/API key: sk-test-123/);
+    expect(prompt).toContain("Authorization: Bearer sk-test-123");
+    expect(prompt).toContain("https://litellm.example.com/v1/models");
+    expect(prompt).toContain("https://docs.litellm.ai/llms.txt");
+    expect(prompt).toContain("https://docs.litellm.ai/llms-full.txt");
   });
 
-  it("should change button text to Copied after clicking copy", async () => {
-    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+  it("does not produce a trailing slash in the base URL when proxyBaseUrl is provided", () => {
     render(<CreatedKeyDisplay apiKey="sk-test-123" />);
-
-    await user.click(screen.getByRole("button", { name: /copy virtual key/i }));
-
-    expect(screen.getByRole("button", { name: /copied/i })).toBeInTheDocument();
+    const prompt = screen.getByTestId("coding-agent-prompt").textContent ?? "";
+    expect(prompt).not.toMatch(/Base URL: https:\/\/litellm\.example\.com\//);
   });
 
-  it("should show a success message when the key is copied", async () => {
+  it("copies the API key to clipboard when the primary button is clicked", async () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
     render(<CreatedKeyDisplay apiKey="sk-test-123" />);
 
     await user.click(screen.getByRole("button", { name: /copy virtual key/i }));
 
     expect(MessageManager.success).toHaveBeenCalledWith("Key copied to clipboard");
+    expect(screen.getByRole("button", { name: /copied/i })).toBeInTheDocument();
   });
 
-  it("should revert button text back after 2 seconds", async () => {
+  it("copies the coding agent prompt to clipboard when its copy button is clicked", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    render(<CreatedKeyDisplay apiKey="sk-test-123" />);
+
+    await user.click(screen.getByRole("button", { name: /copy prompt for coding agents/i }));
+
+    expect(MessageManager.success).toHaveBeenCalledWith("Prompt copied to clipboard");
+  });
+
+  it("reverts the primary button label after 2 seconds", async () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
     render(<CreatedKeyDisplay apiKey="sk-test-123" />);
 

--- a/ui/litellm-dashboard/src/components/shared/CreatedKeyDisplay.test.tsx
+++ b/ui/litellm-dashboard/src/components/shared/CreatedKeyDisplay.test.tsx
@@ -65,6 +65,20 @@ describe("CreatedKeyDisplay", () => {
     expect(screen.getByRole("button", { name: /copied/i })).toBeInTheDocument();
   });
 
+  it("renders coding agent logos next to the prompt heading", () => {
+    render(<CreatedKeyDisplay apiKey="sk-test-123" />);
+    const logos = screen.getByTestId("coding-agent-logos");
+    const images = logos.querySelectorAll("img");
+    const altText = Array.from(images).map((img) => img.getAttribute("alt"));
+
+    expect(altText).toEqual([
+      "Cursor",
+      "Claude Code",
+      "OpenAI Codex",
+      "GitHub Copilot",
+    ]);
+  });
+
   it("copies the coding agent prompt to clipboard when its copy button is clicked", async () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
     render(<CreatedKeyDisplay apiKey="sk-test-123" />);

--- a/ui/litellm-dashboard/src/components/shared/CreatedKeyDisplay.test.tsx
+++ b/ui/litellm-dashboard/src/components/shared/CreatedKeyDisplay.test.tsx
@@ -31,22 +31,30 @@ describe("CreatedKeyDisplay", () => {
   it("displays the security warning and modal heading", () => {
     render(<CreatedKeyDisplay apiKey="sk-test-123" />);
     expect(screen.getByRole("heading", { name: /api key created/i })).toBeInTheDocument();
-    expect(
-      screen.getByText(/make sure to copy your api key now/i),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/make sure to copy your api key now/i)).toBeInTheDocument();
     expect(screen.getByText(/you won't be able to see it again/i)).toBeInTheDocument();
   });
 
-  it("builds a coding agent prompt that embeds the key, base URL, and docs links", () => {
+  it("builds a coding agent prompt that advertises the gateway endpoints and docs without leaking the key", () => {
     render(<CreatedKeyDisplay apiKey="sk-test-123" />);
     const prompt = screen.getByTestId("coding-agent-prompt").textContent ?? "";
 
     expect(prompt).toMatch(/Base URL: https:\/\/litellm\.example\.com/);
-    expect(prompt).toMatch(/API key: sk-test-123/);
-    expect(prompt).toContain("Authorization: Bearer sk-test-123");
-    expect(prompt).toContain("https://litellm.example.com/v1/models");
+    expect(prompt).not.toContain("sk-test-123");
+    expect(prompt).toContain("$LITELLM_API_KEY");
+    expect(prompt).toContain("Authorization: Bearer <key>");
+
+    expect(prompt).toContain("/chat/completions");
+    expect(prompt).toContain("/v1/messages");
+    expect(prompt).toContain("/v1/responses");
+    expect(prompt).toContain("/mcp");
+    expect(prompt).toContain("/v1/models");
+
+    expect(prompt).toContain("https://docs.litellm.ai/docs/learn/gateway_quickstart");
+    expect(prompt).toContain("https://docs.litellm.ai/docs/tutorials/claude_responses_api");
+    expect(prompt).toContain("https://docs.litellm.ai/docs/anthropic_unified");
+    expect(prompt).toContain("https://docs.litellm.ai/docs/mcp");
     expect(prompt).toContain("https://docs.litellm.ai/llms.txt");
-    expect(prompt).toContain("https://docs.litellm.ai/llms-full.txt");
   });
 
   it("does not produce a trailing slash in the base URL when proxyBaseUrl is provided", () => {
@@ -71,12 +79,7 @@ describe("CreatedKeyDisplay", () => {
     const images = logos.querySelectorAll("img");
     const altText = Array.from(images).map((img) => img.getAttribute("alt"));
 
-    expect(altText).toEqual([
-      "Cursor",
-      "Claude Code",
-      "OpenAI Codex",
-      "GitHub Copilot",
-    ]);
+    expect(altText).toEqual(["Cursor", "Claude Code", "OpenAI Codex", "GitHub Copilot"]);
   });
 
   it("copies the coding agent prompt to clipboard when its copy button is clicked", async () => {

--- a/ui/litellm-dashboard/src/components/shared/CreatedKeyDisplay.test.tsx
+++ b/ui/litellm-dashboard/src/components/shared/CreatedKeyDisplay.test.tsx
@@ -104,4 +104,23 @@ describe("CreatedKeyDisplay", () => {
 
     expect(screen.getByRole("button", { name: /copy virtual key/i })).toBeInTheDocument();
   });
+
+  it("does not relabel the primary button when the icon copy button is clicked", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    render(<CreatedKeyDisplay apiKey="sk-test-123" />);
+
+    await user.click(screen.getByRole("button", { name: /^copy api key$/i }));
+
+    expect(screen.getByRole("button", { name: /copy virtual key/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^copied!$/i })).not.toBeInTheDocument();
+  });
+
+  it("uses absolute /ui/assets/logos/ paths so logos resolve regardless of the current route", () => {
+    render(<CreatedKeyDisplay apiKey="sk-test-123" />);
+    const images = screen.getByTestId("coding-agent-logos").querySelectorAll("img");
+
+    Array.from(images).forEach((img) => {
+      expect(img.getAttribute("src")).toMatch(/^\/ui\/assets\/logos\//);
+    });
+  });
 });

--- a/ui/litellm-dashboard/src/components/shared/CreatedKeyDisplay.tsx
+++ b/ui/litellm-dashboard/src/components/shared/CreatedKeyDisplay.tsx
@@ -17,11 +17,7 @@ const codingAgentLogos: { name: string; src: string }[] = [
 ];
 
 const CodingAgentLogos: React.FC = () => (
-  <div
-    className="flex items-center"
-    aria-label="Compatible coding agents"
-    data-testid="coding-agent-logos"
-  >
+  <div className="flex items-center" aria-label="Compatible coding agents" data-testid="coding-agent-logos">
     {codingAgentLogos.map((logo, index) => (
       <img
         key={logo.name}
@@ -44,18 +40,25 @@ const CodingAgentLogos: React.FC = () => (
   </div>
 );
 
-const buildCodingAgentPrompt = (apiKey: string, baseUrl: string): string => {
-  return `You have access to LiteLLM, an OpenAI-compatible AI gateway that lets you call 100+ LLMs (OpenAI, Anthropic, Gemini, Bedrock, etc.) through a single API.
+const buildCodingAgentPrompt = (baseUrl: string): string => {
+  return `You have access to LiteLLM, a single AI gateway that fronts 100+ LLMs (OpenAI, Anthropic, Gemini, Bedrock, Vertex, etc.) plus MCP tools.
 
-Use these credentials:
-- Base URL: ${baseUrl}
-- API key: ${apiKey}
+Base URL: ${baseUrl}
+Auth: pass the user's LiteLLM virtual key (e.g. from \`$LITELLM_API_KEY\`) as \`Authorization: Bearer <key>\`. Do not hardcode the key in source.
 
-LiteLLM is a drop-in replacement for the OpenAI SDK. Point the SDK's \`base_url\` at the URL above and use the key as your \`OPENAI_API_KEY\`. To list the models available to this key, GET ${baseUrl}/v1/models with header \`Authorization: Bearer ${apiKey}\`.
+Through this one base URL you can call:
+- POST /chat/completions  - OpenAI Chat Completions format
+- POST /v1/messages       - Anthropic Messages format (works with any provider)
+- POST /v1/responses      - OpenAI Responses API, including MCP tools via \`"server_url": "litellm_proxy"\`
+- GET  /mcp               - MCP Gateway for tool discovery and invocation
+- GET  /v1/models         - list the models this key can use
 
-LiteLLM docs:
-- llms.txt (overview + all doc links): https://docs.litellm.ai/llms.txt
-- llms-full.txt (complete reference with inline code examples): https://docs.litellm.ai/llms-full.txt`;
+Docs:
+- Getting started: https://docs.litellm.ai/docs/learn/gateway_quickstart
+- Claude Code with LiteLLM: https://docs.litellm.ai/docs/tutorials/claude_responses_api
+- /v1/messages (Anthropic format) on LiteLLM: https://docs.litellm.ai/docs/anthropic_unified
+- MCP gateway: https://docs.litellm.ai/docs/mcp
+- Full doc index: https://docs.litellm.ai/llms.txt`;
 };
 
 const resolveProxyBaseUrl = (): string => {
@@ -70,10 +73,7 @@ const CreatedKeyDisplay: React.FC<CreatedKeyDisplayProps> = ({ apiKey }) => {
   const [copiedKey, setCopiedKey] = useState(false);
   const [copiedPrompt, setCopiedPrompt] = useState(false);
 
-  const codingAgentPrompt = useMemo(
-    () => buildCodingAgentPrompt(apiKey, resolveProxyBaseUrl()),
-    [apiKey],
-  );
+  const codingAgentPrompt = useMemo(() => buildCodingAgentPrompt(resolveProxyBaseUrl()), []);
 
   const handleCopyKey = () => {
     setCopiedKey(true);
@@ -107,20 +107,12 @@ const CreatedKeyDisplay: React.FC<CreatedKeyDisplayProps> = ({ apiKey }) => {
         </span>
       </div>
 
-      <div
-        className="rounded-md border mb-4"
-        style={{ borderColor: "#e5e7eb", background: "#fafafa" }}
-      >
+      <div className="rounded-md border mb-4" style={{ borderColor: "#e5e7eb", background: "#fafafa" }}>
         <div className="flex items-center justify-between px-3 pt-3 pb-1">
           <span className="text-sm font-medium text-gray-700">Your API Key</span>
           <Tooltip title={copiedKey ? "Copied!" : "Copy API key"}>
             <CopyToClipboard text={apiKey} onCopy={handleCopyKey}>
-              <Button
-                type="text"
-                size="small"
-                aria-label="Copy API key"
-                icon={<CopyOutlined />}
-              />
+              <Button type="text" size="small" aria-label="Copy API key" icon={<CopyOutlined />} />
             </CopyToClipboard>
           </Tooltip>
         </div>
@@ -140,25 +132,15 @@ const CreatedKeyDisplay: React.FC<CreatedKeyDisplayProps> = ({ apiKey }) => {
         </div>
       </div>
 
-      <div
-        className="rounded-md border"
-        style={{ borderColor: "#e5e7eb", background: "#fafafa" }}
-      >
+      <div className="rounded-md border" style={{ borderColor: "#e5e7eb", background: "#fafafa" }}>
         <div className="flex items-center justify-between px-3 pt-3 pb-1">
           <div className="flex items-center gap-2">
-            <span className="text-sm font-medium text-gray-700">
-              Prompt for coding agents
-            </span>
+            <span className="text-sm font-medium text-gray-700">Prompt for coding agents</span>
             <CodingAgentLogos />
           </div>
           <Tooltip title={copiedPrompt ? "Copied!" : "Copy prompt"}>
             <CopyToClipboard text={codingAgentPrompt} onCopy={handleCopyPrompt}>
-              <Button
-                type="text"
-                size="small"
-                aria-label="Copy prompt for coding agents"
-                icon={<CopyOutlined />}
-              />
+              <Button type="text" size="small" aria-label="Copy prompt for coding agents" icon={<CopyOutlined />} />
             </CopyToClipboard>
           </Tooltip>
         </div>

--- a/ui/litellm-dashboard/src/components/shared/CreatedKeyDisplay.tsx
+++ b/ui/litellm-dashboard/src/components/shared/CreatedKeyDisplay.tsx
@@ -1,50 +1,150 @@
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import { CopyToClipboard } from "react-copy-to-clipboard";
-import { Button } from "antd";
+import { Button, Tooltip } from "antd";
+import { CopyOutlined, WarningOutlined } from "@ant-design/icons";
 import MessageManager from "@/components/molecules/message_manager";
+import { proxyBaseUrl } from "@/components/networking";
 
 interface CreatedKeyDisplayProps {
   apiKey: string;
 }
 
-/**
- * Shared component for displaying a newly-created virtual key.
- * Used on the Virtual Keys page and in the Add Agent wizard.
- */
-const CreatedKeyDisplay: React.FC<CreatedKeyDisplayProps> = ({ apiKey }) => {
-  const [copied, setCopied] = useState(false);
+const buildCodingAgentPrompt = (apiKey: string, baseUrl: string): string => {
+  return `You have access to LiteLLM, an OpenAI-compatible AI gateway that lets you call 100+ LLMs (OpenAI, Anthropic, Gemini, Bedrock, etc.) through a single API.
 
-  const handleCopy = () => {
-    setCopied(true);
+Use these credentials:
+- Base URL: ${baseUrl}
+- API key: ${apiKey}
+
+LiteLLM is a drop-in replacement for the OpenAI SDK. Point the SDK's \`base_url\` at the URL above and use the key as your \`OPENAI_API_KEY\`. To list the models available to this key, GET ${baseUrl}/v1/models with header \`Authorization: Bearer ${apiKey}\`.
+
+LiteLLM docs:
+- llms.txt (overview + all doc links): https://docs.litellm.ai/llms.txt
+- llms-full.txt (complete reference with inline code examples): https://docs.litellm.ai/llms-full.txt`;
+};
+
+const resolveProxyBaseUrl = (): string => {
+  if (proxyBaseUrl) return proxyBaseUrl.replace(/\/$/, "");
+  if (typeof window !== "undefined" && window.location?.origin) {
+    return window.location.origin;
+  }
+  return "https://your-litellm-proxy";
+};
+
+const CreatedKeyDisplay: React.FC<CreatedKeyDisplayProps> = ({ apiKey }) => {
+  const [copiedKey, setCopiedKey] = useState(false);
+  const [copiedPrompt, setCopiedPrompt] = useState(false);
+
+  const codingAgentPrompt = useMemo(
+    () => buildCodingAgentPrompt(apiKey, resolveProxyBaseUrl()),
+    [apiKey],
+  );
+
+  const handleCopyKey = () => {
+    setCopiedKey(true);
     MessageManager.success("Key copied to clipboard");
-    setTimeout(() => setCopied(false), 2000);
+    setTimeout(() => setCopiedKey(false), 2000);
+  };
+
+  const handleCopyPrompt = () => {
+    setCopiedPrompt(true);
+    MessageManager.success("Prompt copied to clipboard");
+    setTimeout(() => setCopiedPrompt(false), 2000);
   };
 
   return (
-    <div>
-      <p className="mb-2">
-        Please save this secret key somewhere safe and accessible. For security reasons,{" "}
-        <b>you will not be able to view it again</b> through your LiteLLM account. If you
-        lose this secret key, you will need to generate a new one.
-      </p>
-
-      <p className="text-sm text-gray-600 mt-3 mb-1">Virtual Key:</p>
-      <div
-        style={{
-          background: "#f8f8f8",
-          padding: "10px",
-          borderRadius: "5px",
-          marginBottom: "10px",
-        }}
-      >
-        <pre style={{ wordWrap: "break-word", whiteSpace: "normal", margin: 0 }}>
-          {apiKey}
-        </pre>
+    <div className="created-key-display">
+      <div className="mb-2">
+        <h2 className="text-lg font-semibold m-0">API Key Created</h2>
+        <p className="text-sm text-gray-500 mt-1 mb-0">
+          Paste this prompt into any coding agent to start using LiteLLM.
+        </p>
       </div>
 
-      <CopyToClipboard text={apiKey} onCopy={handleCopy}>
-        <Button type="primary" style={{ marginTop: 12 }}>
-          {copied ? "Copied!" : "Copy Virtual Key"}
+      <div
+        className="flex items-start gap-2 px-3 py-2 mb-4 rounded-md border"
+        style={{ background: "#fffbeb", borderColor: "#fde68a" }}
+        role="alert"
+      >
+        <WarningOutlined style={{ color: "#b45309", marginTop: 3 }} />
+        <span className="text-sm" style={{ color: "#92400e" }}>
+          Make sure to copy your API key now. You won&apos;t be able to see it again.
+        </span>
+      </div>
+
+      <div
+        className="rounded-md border mb-4"
+        style={{ borderColor: "#e5e7eb", background: "#fafafa" }}
+      >
+        <div className="flex items-center justify-between px-3 pt-3 pb-1">
+          <span className="text-sm font-medium text-gray-700">Your API Key</span>
+          <Tooltip title={copiedKey ? "Copied!" : "Copy API key"}>
+            <CopyToClipboard text={apiKey} onCopy={handleCopyKey}>
+              <Button
+                type="text"
+                size="small"
+                aria-label="Copy API key"
+                icon={<CopyOutlined />}
+              />
+            </CopyToClipboard>
+          </Tooltip>
+        </div>
+        <div className="px-3 pb-3">
+          <pre
+            className="m-0 text-sm"
+            style={{
+              wordBreak: "break-all",
+              whiteSpace: "pre-wrap",
+              fontFamily:
+                "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",
+            }}
+            data-testid="created-key-value"
+          >
+            {apiKey}
+          </pre>
+        </div>
+      </div>
+
+      <div
+        className="rounded-md border"
+        style={{ borderColor: "#e5e7eb", background: "#fafafa" }}
+      >
+        <div className="flex items-center justify-between px-3 pt-3 pb-1">
+          <span className="text-sm font-medium text-gray-700">
+            Prompt for coding agents
+          </span>
+          <Tooltip title={copiedPrompt ? "Copied!" : "Copy prompt"}>
+            <CopyToClipboard text={codingAgentPrompt} onCopy={handleCopyPrompt}>
+              <Button
+                type="text"
+                size="small"
+                aria-label="Copy prompt for coding agents"
+                icon={<CopyOutlined />}
+              />
+            </CopyToClipboard>
+          </Tooltip>
+        </div>
+        <div className="px-3 pb-3">
+          <pre
+            className="m-0 text-sm text-gray-700"
+            style={{
+              maxHeight: 200,
+              overflowY: "auto",
+              whiteSpace: "pre-wrap",
+              wordBreak: "break-word",
+              fontFamily:
+                "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",
+            }}
+            data-testid="coding-agent-prompt"
+          >
+            {codingAgentPrompt}
+          </pre>
+        </div>
+      </div>
+
+      <CopyToClipboard text={apiKey} onCopy={handleCopyKey}>
+        <Button type="primary" style={{ marginTop: 16 }}>
+          {copiedKey ? "Copied!" : "Copy Virtual Key"}
         </Button>
       </CopyToClipboard>
     </div>

--- a/ui/litellm-dashboard/src/components/shared/CreatedKeyDisplay.tsx
+++ b/ui/litellm-dashboard/src/components/shared/CreatedKeyDisplay.tsx
@@ -10,10 +10,10 @@ interface CreatedKeyDisplayProps {
 }
 
 const codingAgentLogos: { name: string; src: string }[] = [
-  { name: "Cursor", src: "../ui/assets/logos/cursor.svg" },
-  { name: "Claude Code", src: "../ui/assets/logos/anthropic.svg" },
-  { name: "OpenAI Codex", src: "../ui/assets/logos/openai_small.svg" },
-  { name: "GitHub Copilot", src: "../ui/assets/logos/github_copilot.svg" },
+  { name: "Cursor", src: "/ui/assets/logos/cursor.svg" },
+  { name: "Claude Code", src: "/ui/assets/logos/anthropic.svg" },
+  { name: "OpenAI Codex", src: "/ui/assets/logos/openai_small.svg" },
+  { name: "GitHub Copilot", src: "/ui/assets/logos/github_copilot.svg" },
 ];
 
 const CodingAgentLogos: React.FC = () => (
@@ -70,15 +70,22 @@ const resolveProxyBaseUrl = (): string => {
 };
 
 const CreatedKeyDisplay: React.FC<CreatedKeyDisplayProps> = ({ apiKey }) => {
-  const [copiedKey, setCopiedKey] = useState(false);
+  const [copiedKeyIcon, setCopiedKeyIcon] = useState(false);
+  const [copiedKeyButton, setCopiedKeyButton] = useState(false);
   const [copiedPrompt, setCopiedPrompt] = useState(false);
 
   const codingAgentPrompt = useMemo(() => buildCodingAgentPrompt(resolveProxyBaseUrl()), []);
 
-  const handleCopyKey = () => {
-    setCopiedKey(true);
+  const handleCopyKeyIcon = () => {
+    setCopiedKeyIcon(true);
     MessageManager.success("Key copied to clipboard");
-    setTimeout(() => setCopiedKey(false), 2000);
+    setTimeout(() => setCopiedKeyIcon(false), 2000);
+  };
+
+  const handleCopyKeyButton = () => {
+    setCopiedKeyButton(true);
+    MessageManager.success("Key copied to clipboard");
+    setTimeout(() => setCopiedKeyButton(false), 2000);
   };
 
   const handleCopyPrompt = () => {
@@ -110,8 +117,8 @@ const CreatedKeyDisplay: React.FC<CreatedKeyDisplayProps> = ({ apiKey }) => {
       <div className="rounded-md border mb-4" style={{ borderColor: "#e5e7eb", background: "#fafafa" }}>
         <div className="flex items-center justify-between px-3 pt-3 pb-1">
           <span className="text-sm font-medium text-gray-700">Your API Key</span>
-          <Tooltip title={copiedKey ? "Copied!" : "Copy API key"}>
-            <CopyToClipboard text={apiKey} onCopy={handleCopyKey}>
+          <Tooltip title={copiedKeyIcon ? "Copied!" : "Copy API key"}>
+            <CopyToClipboard text={apiKey} onCopy={handleCopyKeyIcon}>
               <Button type="text" size="small" aria-label="Copy API key" icon={<CopyOutlined />} />
             </CopyToClipboard>
           </Tooltip>
@@ -162,9 +169,9 @@ const CreatedKeyDisplay: React.FC<CreatedKeyDisplayProps> = ({ apiKey }) => {
         </div>
       </div>
 
-      <CopyToClipboard text={apiKey} onCopy={handleCopyKey}>
+      <CopyToClipboard text={apiKey} onCopy={handleCopyKeyButton}>
         <Button type="primary" style={{ marginTop: 16 }}>
-          {copiedKey ? "Copied!" : "Copy Virtual Key"}
+          {copiedKeyButton ? "Copied!" : "Copy Virtual Key"}
         </Button>
       </CopyToClipboard>
     </div>

--- a/ui/litellm-dashboard/src/components/shared/CreatedKeyDisplay.tsx
+++ b/ui/litellm-dashboard/src/components/shared/CreatedKeyDisplay.tsx
@@ -9,6 +9,41 @@ interface CreatedKeyDisplayProps {
   apiKey: string;
 }
 
+const codingAgentLogos: { name: string; src: string }[] = [
+  { name: "Cursor", src: "../ui/assets/logos/cursor.svg" },
+  { name: "Claude Code", src: "../ui/assets/logos/anthropic.svg" },
+  { name: "OpenAI Codex", src: "../ui/assets/logos/openai_small.svg" },
+  { name: "GitHub Copilot", src: "../ui/assets/logos/github_copilot.svg" },
+];
+
+const CodingAgentLogos: React.FC = () => (
+  <div
+    className="flex items-center"
+    aria-label="Compatible coding agents"
+    data-testid="coding-agent-logos"
+  >
+    {codingAgentLogos.map((logo, index) => (
+      <img
+        key={logo.name}
+        src={logo.src}
+        alt={logo.name}
+        title={logo.name}
+        style={{
+          width: 18,
+          height: 18,
+          borderRadius: "50%",
+          background: "#fff",
+          border: "1px solid #e5e7eb",
+          padding: 2,
+          marginLeft: index === 0 ? 0 : -6,
+          objectFit: "contain",
+          boxSizing: "border-box",
+        }}
+      />
+    ))}
+  </div>
+);
+
 const buildCodingAgentPrompt = (apiKey: string, baseUrl: string): string => {
   return `You have access to LiteLLM, an OpenAI-compatible AI gateway that lets you call 100+ LLMs (OpenAI, Anthropic, Gemini, Bedrock, etc.) through a single API.
 
@@ -110,9 +145,12 @@ const CreatedKeyDisplay: React.FC<CreatedKeyDisplayProps> = ({ apiKey }) => {
         style={{ borderColor: "#e5e7eb", background: "#fafafa" }}
       >
         <div className="flex items-center justify-between px-3 pt-3 pb-1">
-          <span className="text-sm font-medium text-gray-700">
-            Prompt for coding agents
-          </span>
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-medium text-gray-700">
+              Prompt for coding agents
+            </span>
+            <CodingAgentLogos />
+          </div>
           <Tooltip title={copiedPrompt ? "Copied!" : "Copy prompt"}>
             <CopyToClipboard text={codingAgentPrompt} onCopy={handleCopyPrompt}>
               <Button


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Relevant issues

Mirrors the Browser Use post-create dialog Ishaan flagged in #product-qa-feedback so that a freshly created LiteLLM virtual key ships with a ready-to-paste prompt for any coding agent.


<img width="1280" height="800" alt="image" src="https://github.com/user-attachments/assets/96d5e779-4785-4119-bdb6-38ec0cffbeb2" />

## Linear ticket

n/a

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

To verify against a real proxy locally; run the proxy with `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log`, open <http://localhost:4000/ui/?page=api-keys>, click `+ Create New Key`, fill in a name and team, and click `Create Key`. The success dialog should now show an "API Key Created" header, an amber callout warning the key is shown only once, a "Your API Key" card with a copy icon, and a "Prompt for coding agents" card with the Cursor, Claude Code, OpenAI Codex, and GitHub Copilot logos rendered as overlapping circles next to the heading.

Then click each copy icon in turn and paste the contents into a scratch buffer. The "Your API Key" copy icon should yield just the raw `sk-...` virtual key, and clicking it must not relabel the primary "Copy Virtual Key" button at the bottom. The "Prompt for coding agents" copy icon should yield the full prompt with the proxy's base URL substituted in and an `$LITELLM_API_KEY` placeholder rather than the literal key; for example:

```
You have access to LiteLLM, a single AI gateway that fronts 100+ LLMs (OpenAI, Anthropic, Gemini, Bedrock, Vertex, etc.) plus MCP tools.

Base URL: http://localhost:4000
Auth: pass the user's LiteLLM virtual key (e.g. from `$LITELLM_API_KEY`) as `Authorization: Bearer <key>`. Do not hardcode the key in source.

Through this one base URL you can call:
- POST /chat/completions  - OpenAI Chat Completions format
- POST /v1/messages       - Anthropic Messages format (works with any provider)
- POST /v1/responses      - OpenAI Responses API, including MCP tools via `"server_url": "litellm_proxy"`
- GET  /mcp               - MCP Gateway for tool discovery and invocation
- GET  /v1/models         - list the models this key can use

Docs:
- Getting started: https://docs.litellm.ai/docs/learn/gateway_quickstart
- Claude Code with LiteLLM: https://docs.litellm.ai/docs/tutorials/claude_responses_api
- /v1/messages (Anthropic format) on LiteLLM: https://docs.litellm.ai/docs/anthropic_unified
- MCP gateway: https://docs.litellm.ai/docs/mcp
- Full doc index: https://docs.litellm.ai/llms.txt
```

To verify the prompt is wired against a live gateway, take the copied key and run something like the following from the same terminal, swapping the model for whatever your config exposes:

```
export LITELLM_API_KEY="sk-..."   # from the "Your API Key" copy icon

curl -sS http://localhost:4000/v1/models \
  -H "Authorization: Bearer $LITELLM_API_KEY" | jq '.data[0]'

curl -sS http://localhost:4000/chat/completions \
  -H "Authorization: Bearer $LITELLM_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"say hi in 3 words"}]}' | jq '.choices[0].message.content'

curl -sS http://localhost:4000/v1/messages \
  -H "Authorization: Bearer $LITELLM_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"model":"claude-haiku-4-5","max_tokens":64,"messages":[{"role":"user","content":"say hi in 3 words"}]}' | jq '.content[0].text'
```

Each request should succeed against the real provider and incur real spend, exercising the same endpoints the prompt advertises.

## Type

New Feature

## Changes

`CreatedKeyDisplay.tsx` is rewritten so the post-create dialog matches the Browser Use flow Ishaan called out. The dialog now leads with an "API Key Created" heading and a single-sentence subtitle, surfaces an amber "key shown only once" callout, renders the raw key in its own card with a dedicated copy icon, and adds a "Prompt for coding agents" card with its own copy icon. The original primary "Copy Virtual Key" button is preserved so the existing muscle memory still works.

Next to the prompt heading we render four overlapping circular logos (Cursor, Claude Code, OpenAI Codex, GitHub Copilot) reusing SVGs already shipped under `public/assets/logos/`, so the affordance reads as "this prompt is meant for coding agents" without extra copy. The prompt body itself was rewritten to stop framing LiteLLM as "OpenAI-compatible only" and instead advertise the four endpoints reachable through one base URL (`/chat/completions`, `/v1/messages`, `/v1/responses`, `/mcp`) plus `/v1/models` discovery, and to link the gateway quickstart, the Claude Code tutorial, the `/v1/messages` doc, the MCP gateway doc, and `llms.txt`. The literal API key is intentionally left out of the prompt body; the agent is told to read it from `$LITELLM_API_KEY` and send it as `Authorization: Bearer <key>`, while the "Your API Key" card above still shows the raw key once for the user to copy. The base URL comes from `proxyBaseUrl`, falling back to `window.location.origin` when the UI is co-hosted with the proxy.

`create_key_button.tsx` keeps using `CreatedKeyDisplay` so the new UI lands in the real virtual-key creation flow rather than a preview route. The component test mocks for `@ant-design/icons` were extended to cover `CopyOutlined` and `WarningOutlined`, the `CreatedKeyDisplay` unit tests assert that both copy buttons fire the right toasts, that all four logos render in order with the correct alt text, that each new endpoint and docs URL appears in the prompt body, and that the prompt body does not contain the literal key (regressing back to embedding the key will fail the suite). The two e2e specs that previously asserted on the old "Save your Key" heading now assert on "API Key Created".

### Greptile follow-up (commit `1c9d66eacd`)

Addresses both items from Greptile's first review:

- P1: the four `codingAgentLogos` `src` entries were `../ui/assets/logos/...`, a relative form that resolves against the current URL and only happens to land on the right path when the page is served at `/ui/`. Switched them to the absolute form `/ui/assets/logos/...` so they resolve regardless of route (same convention used in `MCPLogoSelector.tsx`). A new test pins that every `src` starts with `/ui/assets/logos/`.
- P2: the small icon copy button next to "Your API Key" and the primary "Copy Virtual Key" button shared a single `copiedKey` boolean, so clicking the icon flipped the primary button's label to "Copied!" even though the user never touched it. Split into `copiedKeyIcon` / `copiedKeyButton` with their own handlers. A new test pins that clicking the icon does not relabel the primary button.

All 25 unit tests in `CreatedKeyDisplay.test.tsx` (10) and `create_key_button.test.tsx` (15) pass on the new commit.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://berriaillm.slack.com/archives/C07Q2CUDA57/p1780029370611649?thread_ts=1780029370.611649&cid=C07Q2CUDA57)

<div><a href="https://cursor.com/agents/bc-2d95baea-23ca-50dd-8783-767e52de213a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d95baea-23ca-50dd-8783-767e52de213a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

