### PR TITLE
fix(e2e): tolerate trailing slash in SERVER_ROOT_PATH login redirect

### DIFF
--- a/ui/litellm-dashboard/e2e_tests/tests/login/serverRootPathRedirect.spec.ts
+++ b/ui/litellm-dashboard/e2e_tests/tests/login/serverRootPathRedirect.spec.ts
@@ -26,7 +26,7 @@ test("unauth redirect preserves SERVER_ROOT_PATH prefix", async ({ page }) => {
 
   await page.goto(`http://localhost:4000${ROOT_PATH}/ui/?page=virtual-keys`);
 
-  await page.waitForURL((url) => url.pathname.endsWith("/ui/login"), { timeout: 15_000 });
+  await page.waitForURL((url) => url.pathname.includes("/ui/login"), { timeout: 15_000 });
 
   expect(page.url()).toContain(`${ROOT_PATH}/ui/login`);
 });


### PR DESCRIPTION
## Relevant issues

Workflow run that exposed it: https://github.com/BerriAI/litellm/actions/runs/26700650815/job/78693265270?pr=29366

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## CI (LiteLLM team)

- [ ] Branch creation CI run
       Link:

- [ ] CI run for the last commit
       Link:

- [ ] Merge / cherry-pick CI run
       Links:

## Screenshots / Proof of Fix

The test booted at `ui/litellm-dashboard/e2e_tests/tests/login/serverRootPathRedirect.spec.ts` waits for the login redirect with `pathname.endsWith("/ui/login")`. Next.js is configured with `trailingSlash: true` in `ui/litellm-dashboard/next.config.mjs`, so the proxy serves the login page at `/ui/login/index.html` and 308's `/ui/login` to `/ui/login/`. The predicate never matches the canonicalized URL and `waitForURL` times out after 15s with:

```
TimeoutError: page.waitForURL: Timeout 15000ms exceeded.
navigated to "http://localhost:4000/api/v1/ui/login/?redirect_to=http%3A%2F%2Flocalhost%3A4000%2Fapi%2Fv1%2Fui%2F%3Fpage%3Dvirtual-keys"
```

The assertion mismatch was masked from 2026-05-26 until #29366 because every PR's CI run carried the older static export (last regenerated 2026-05-25 with `trailingSlash: true` already on, but without the AuthContext race fix from #28910). In that bundle the redirect fired before `proxyBaseUrl` was populated, sending the browser straight to `/ui/login` with no `SERVER_ROOT_PATH` prefix and no server-side trailing-slash normalization, which happened to satisfy `endsWith("/ui/login")`. #29366 was the first PR to ship the regenerated bundle with the fix, so it was the first run where the assertion was actually exercised against the corrected URL.

Swapping `endsWith` for `includes` accepts both shapes; the `expect(page.url()).toContain(\`${'$'}{ROOT_PATH}/ui/login\`)` line below still pins the actual contract (the SERVER_ROOT_PATH prefix is preserved).

End-to-end re-verification will run as part of the `test-server-root-path` GitHub Actions matrix on this PR; that workflow boots the Docker image with `SERVER_ROOT_PATH=/api/v1` and `=/llmproxy`, hits the same real proxy via Playwright, and is the same surface that flagged the bug. No separate localhost curl needed.

## Type

🐛 Bug Fix
✅ Test

## Changes

Single-line change in `ui/litellm-dashboard/e2e_tests/tests/login/serverRootPathRedirect.spec.ts`: the `waitForURL` predicate now uses `includes("/ui/login")` instead of `endsWith("/ui/login")` so it matches both `/ui/login` and `/ui/login/` after the proxy's trailing-slash 308.