### PR TITLE
fix(helm): default image tag to chart appVersion

### DIFF
--- a/deploy/charts/litellm-helm/Chart.yaml
+++ b/deploy/charts/litellm-helm/Chart.yaml
@@ -24,7 +24,7 @@ version: 1.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: v1.80.12
+appVersion: v1.85.1
 
 annotations:
   org.opencontainers.image.source: "https://github.com/BerriAI/litellm"

--- a/deploy/charts/litellm-helm/templates/deployment.yaml
+++ b/deploy/charts/litellm-helm/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
         - name: {{ include "litellm.name" . }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "main-%s" .Chart.AppVersion) }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: HOST

--- a/deploy/charts/litellm-helm/templates/migrations-job.yaml
+++ b/deploy/charts/litellm-helm/templates/migrations-job.yaml
@@ -41,7 +41,7 @@ spec:
       {{- end }} 
       containers:
         - name: prisma-migrations
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "main-%s" .Chart.AppVersion) }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}

--- a/deploy/charts/litellm-helm/tests/deployment_tests.yaml
+++ b/deploy/charts/litellm-helm/tests/deployment_tests.yaml
@@ -6,9 +6,9 @@ tests:
   - it: should default image tag to chart appVersion
     template: deployment.yaml
     asserts:
-      - equal:
+      - matchRegex:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/berriai/litellm-database:v1.85.1
+          pattern: ^ghcr\.io/berriai/litellm-database:v[0-9]+\.[0-9]+\.[0-9]+$
       - notMatchRegex:
           path: spec.template.spec.containers[0].image
           pattern: :main-

--- a/deploy/charts/litellm-helm/tests/deployment_tests.yaml
+++ b/deploy/charts/litellm-helm/tests/deployment_tests.yaml
@@ -3,6 +3,16 @@ templates:
   - deployment.yaml
   - configmap-litellm.yaml
 tests:
+  - it: should default image tag to chart appVersion
+    template: deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/berriai/litellm-database:v1.85.1
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: :main-
+
   - it: should work
     template: deployment.yaml
     set:

--- a/deploy/charts/litellm-helm/tests/migrations-job_tests.yaml
+++ b/deploy/charts/litellm-helm/tests/migrations-job_tests.yaml
@@ -8,9 +8,9 @@ tests:
       migrationJob:
         enabled: true
     asserts:
-      - equal:
+      - matchRegex:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/berriai/litellm-database:v1.85.1
+          pattern: ^ghcr\.io/berriai/litellm-database:v[0-9]+\.[0-9]+\.[0-9]+$
       - notMatchRegex:
           path: spec.template.spec.containers[0].image
           pattern: :main-

--- a/deploy/charts/litellm-helm/tests/migrations-job_tests.yaml
+++ b/deploy/charts/litellm-helm/tests/migrations-job_tests.yaml
@@ -2,6 +2,19 @@ suite: test migrations job
 templates:
   - migrations-job.yaml
 tests:
+  - it: should default image tag to chart appVersion
+    template: migrations-job.yaml
+    set:
+      migrationJob:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/berriai/litellm-database:v1.85.1
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: :main-
+
   - it: should work with envVars
     template: migrations-job.yaml
     set:

--- a/deploy/charts/litellm-helm/values.yaml
+++ b/deploy/charts/litellm-helm/values.yaml
@@ -10,7 +10,7 @@ image:
   repository: ghcr.io/berriai/litellm-database
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  # tag: "main-latest"
+  # tag: "latest"
   tag: ""
 
 imagePullSecrets: []


### PR DESCRIPTION
## Problem

Default Helm installs from the OSS branch render image refs like `ghcr.io/berriai/litellm-database:main-<appVersion>`. Recent stable releases publish the plain app version tag, not `main-<version>`, so the default Deployment and migrations Job can hit `ImagePullBackOff` as reported in #29348.

## Fix

- Default the Deployment image tag to `.Chart.AppVersion` instead of `main-<appVersion>`.
- Apply the same default to the migrations Job image.
- Update the in-tree chart `appVersion` from the stale `v1.80.12` to `v1.85.1` and the example override to `latest`.
- Add Helm unit tests that cover the unset `image.tag` path and assert the rendered image does not use a `:main-` prefix.

This mirrors the main-branch fix from #28710, but applies it to `litellm_oss_branch` where external PRs are expected to target.

## Test

- `make test-unit-helm` -> 55 passed
- `helm lint ./deploy/charts/litellm-helm` -> passed
- `git diff --check` -> passed

Note: with Helm 4 locally, I had to install the existing pinned `helm-unittest` plugin with `--verify=false`; after that, the repo's `make test-unit-helm` command ran successfully.

## Risk

Low. This changes only the Helm chart default image tag path and adds chart tests. Explicit `image.tag` overrides still render unchanged.
