### PR TITLE
fix(proxy): enforce key team boundary on /model/new

### DIFF
--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -671,7 +671,21 @@ class ModelManagementAuthChecks:
             and user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN
         ):
             return True
-        elif team_obj is None or not _is_user_team_admin(
+
+        if (
+            user_api_key_dict.team_id is not None
+            and user_api_key_dict.team_id != team_id
+        ):
+            raise HTTPException(
+                status_code=403,
+                detail={
+                    "error": "Team ID={} does not match the API key's team ID={}. A key scoped to a team can only manage models for that team.".format(
+                        team_id, user_api_key_dict.team_id
+                    )
+                },
+            )
+
+        if team_obj is None or not _is_user_team_admin(
             user_api_key_dict=user_api_key_dict, team_obj=team_obj
         ):
             raise HTTPException(

--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -691,8 +691,8 @@ class ModelManagementAuthChecks:
             raise HTTPException(
                 status_code=403,
                 detail={
-                    "error": "Team ID={} does not match the API key's team ID={}, OR you are not the admin for this team. Check `/user/info` to verify your team admin status.".format(
-                        team_id, user_api_key_dict.team_id
+                    "error": "You are not an admin for team ID={}. Only team admins can manage this team's models. Check `/user/info` to verify your team admin status.".format(
+                        team_id
                     )
                 },
             )

--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -165,6 +165,53 @@ class TestModelManagementAuthChecks:
         assert result is True
 
     @pytest.mark.asyncio
+    async def test_can_user_make_team_model_call_key_scoped_to_other_team_fails(self):
+        """A key scoped to team B cannot create a model for team A, even if the
+        key's user is an admin of team A."""
+        key_scoped_to_team_b = UserAPIKeyAuth(
+            user_id="test_user",
+            team_id="team_b",
+            user_role=LitellmUserRoles.INTERNAL_USER,
+        )
+        team_a_obj = LiteLLM_TeamTable(
+            team_id="team_a",
+            team_alias="team_a",
+            members_with_roles=[
+                Member(user_id="test_user", role="admin"),
+            ],
+        )
+
+        with pytest.raises(Exception) as exc_info:
+            ModelManagementAuthChecks.can_user_make_team_model_call(
+                team_id="team_a",
+                user_api_key_dict=key_scoped_to_team_b,
+                team_obj=team_a_obj,
+                premium_user=True,
+            )
+        assert "403" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_can_user_make_team_model_call_no_team_id_key_succeeds(self):
+        """A key with no team_id falls back to the team-admin check (unchanged)."""
+        key_without_team = UserAPIKeyAuth(
+            user_id="test_user",
+            user_role=LitellmUserRoles.INTERNAL_USER,
+        )
+        team_obj = LiteLLM_TeamTable(
+            team_id="test_team",
+            team_alias="test_team",
+            members_with_roles=[Member(user_id="test_user", role="admin")],
+        )
+
+        result = ModelManagementAuthChecks.can_user_make_team_model_call(
+            team_id="test_team",
+            user_api_key_dict=key_without_team,
+            team_obj=team_obj,
+            premium_user=True,
+        )
+        assert result is True
+
+    @pytest.mark.asyncio
     async def test_allow_team_model_action_success(self):
         """Test successful team model action"""
         model_params = Deployment(


### PR DESCRIPTION
## Summary

A virtual key scoped to one team (say Team B) could create a model owned by a *different* team (Team A) via `POST /model/new`, as long as the key's user happened to be an admin of Team A. The auth path (`can_user_make_team_model_call`) only checked team-admin membership of the *target* team by `user_id` and never compared the calling key's own `team_id` to the target — so the key's team scope was effectively ignored. This change rejects the call with a 403 when a team-scoped key targets a different team, so a team-scoped key can only manage models for its own team.

`PROXY_ADMIN` keys and keys with no `team_id` (e.g. UI sessions / user-owned keys) are unaffected and continue through the existing team-admin check.

Resolves LIT-3211

## Screenshots 

<img width="634" height="367" alt="Screenshot 2026-05-30 at 9 14 23 PM" src="https://github.com/user-attachments/assets/4a1ed49d-4ec8-41ec-ae46-045f9454d193" />
<img width="639" height="422" alt="Screenshot 2026-05-30 at 9 14 28 PM" src="https://github.com/user-attachments/assets/605b204b-6638-4c3a-b9d6-34c3df8a7be0" />


## Test plan
- [x] `tests/.../test_model_management_endpoints.py::TestModelManagementAuthChecks::test_can_user_make_team_model_call_key_scoped_to_other_team_fails` — Team-B key targeting Team A now 403s even when the user admins both
- [x] `...::test_can_user_make_team_model_call_no_team_id_key_succeeds` — keys with no team_id still pass via the team-admin check
- [x] Existing `TestModelManagementAuthChecks` cases still pass (10/10)
- [x] Manual before/after: same scenario returns HTTP 200 before the fix, HTTP 403 after