### PR TITLE
fix(router): resolve model_group_alias on the fallback lookup path

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -6339,6 +6339,16 @@ class Router:
         if disable_fallbacks is True or original_model_group is None:
             raise e
 
+        # If the caller routed to a `model_group_alias`, fallbacks may be
+        # declared against the underlying real model group (see #10317).
+        # Resolve the alias here so the downstream exact-match lookup in
+        # `get_fallback_model_group` works in both cases. `original_model_group`
+        # intentionally keeps the alias name for logging / fallback headers.
+        if model_group is not None:
+            aliased_model_group = self._get_model_from_alias(model=model_group)
+            if aliased_model_group is not None:
+                model_group = aliased_model_group
+
         input_kwargs = {
             "litellm_router": self,
             "original_exception": original_exception,

--- a/tests/local_testing/test_router_fallbacks.py
+++ b/tests/local_testing/test_router_fallbacks.py
@@ -1626,3 +1626,57 @@ async def test_router_attempted_fallbacks_in_response(expected_attempted_fallbac
             resp._hidden_params["additional_headers"]["x-litellm-attempted-fallbacks"]
             == expected_attempted_fallbacks
         )
+
+
+@pytest.mark.parametrize("sync_mode", [True, False])
+@pytest.mark.asyncio
+async def test_model_group_alias_respects_fallbacks(sync_mode):
+    """
+    Related issue - https://github.com/BerriAI/litellm/issues/10317
+
+    When a request targets a model via ``model_group_alias``, fallbacks
+    declared against the underlying real model group should still fire.
+    Previously the fallback lookup was performed against the alias name
+    (e.g. ``"alias-model"``) which never matched a fallback keyed by the
+    real model (``"real-bad-model"``), so the router raised the original
+    error with ``No fallback model group found for original
+    model_group=alias-model``.
+    """
+    router = Router(
+        model_list=[
+            {
+                "model_name": "real-bad-model",
+                "litellm_params": {
+                    "model": "openai/my-bad-model",
+                    "api_key": "my-bad-api-key",
+                },
+            },
+            {
+                "model_name": "my-good-model",
+                "litellm_params": {
+                    "model": "gpt-4o",
+                    "api_key": os.getenv("OPENAI_API_KEY"),
+                },
+            },
+        ],
+        model_group_alias={"alias-model": "real-bad-model"},
+        fallbacks=[{"real-bad-model": ["my-good-model"]}],
+    )
+
+    if sync_mode:
+        response = router.completion(
+            model="alias-model",
+            messages=[{"role": "user", "content": "Hey, how's it going?"}],
+            mock_testing_fallbacks=True,
+            mock_response="Hey! nice day",
+        )
+    else:
+        response = await router.acompletion(
+            model="alias-model",
+            messages=[{"role": "user", "content": "Hey, how's it going?"}],
+            mock_testing_fallbacks=True,
+            mock_response="Hey! nice day",
+        )
+
+    assert isinstance(response, litellm.ModelResponse)
+    assert response.model == "gpt-4o"


### PR DESCRIPTION
## Summary

When a request is dispatched to a model defined via Router's `model_group_alias` (e.g. `model_group_alias={"alias-model": "real-model"}`), the configured `fallbacks` for the underlying real model are silently ignored. The router re-raises the original exception with:

```
No fallback model group found for original model_group=alias-model. Fallbacks=[{'real-model': ['my-good-model']}]
```

This is the verbatim error from #10317 (363 days old, 9 comments, multiple independent +1s).

Fixes #10317

## Root cause

`Router.async_function_with_fallbacks_common_utils` captures `model_group = kwargs["model"]` — which is the alias name (`"alias-model"`) — and passes it directly into `get_fallback_model_group`. Fallbacks are keyed by the real model group (`"real-model"`), so the exact-match lookup in `fallback_event_handlers.py:64` never hits, falls through, and the router re-raises the original exception.

`Router._get_model_from_alias` already exists and is used on the **request** path to resolve aliases to real model names. The fallback path just doesn't call it.

## Fix

`litellm/router.py` (10 LOC added): right after the early-exit guard in `async_function_with_fallbacks_common_utils`, call `self._get_model_from_alias(model=model_group)`; if it returns non-None, swap `model_group` to the resolved real name. `original_model_group` is intentionally **kept** as the alias so user-facing logs and fallback headers remain stable for callers who watch them.

## Tests

`tests/local_testing/test_router_fallbacks.py::test_model_group_alias_respects_fallbacks` (parametrised sync + async, 54 LOC). Sets:

- `model_group_alias={"alias-model": "real-bad-model"}`
- `fallbacks=[{"real-bad-model": ["my-good-model"]}]`

Fires with `mock_testing_fallbacks=True`, asserts the response model is the good fallback.

**RED proof on main** (exact error string from the bug report):
```
litellm.exceptions.InternalServerError: ... No fallback model group found for original model_group=alias-model. Fallbacks=[{'real-bad-model': ['my-good-model']}]
```

**GREEN after patch**: 2/2 pass (sync + async). Nearby logic-only fallback tests still pass (`test_get_fallback_model_group`, `test_default_model_fallbacks`, `test_client_side_fallbacks_list`, `test_using_default_fallback`, `test_router_fallbacks_default_and_model_specific_fallbacks`, `test_router_disable_fallbacks_dynamically`, `test_router_fallbacks_with_wildcard_model_name`). `ruff check` clean on the added lines.

## Risk notes

- `_get_model_from_alias` returns `None` for non-alias model names, so behaviour is unchanged when no `model_group_alias` is configured.
- `original_model_group` keeps the user-facing alias for logs / fallback headers, so downstream metrics / observability are unaffected.
- Only mutates `model_group` in the fallback-lookup scope; no state leaks out.

Refs #10317