### PR TITLE
fix(sap): forward dimensions param in SAP embedding requests

### DIFF
--- a/litellm/llms/sap/embed/transformation.py
+++ b/litellm/llms/sap/embed/transformation.py
@@ -136,6 +136,10 @@ class GenAIHubEmbeddingConfig(BaseEmbeddingConfig):
         model: str,
         drop_params: bool,
     ) -> dict:
+        supported_params = self.get_supported_openai_params(model)
+        for key, value in non_default_params.items():
+            if key in supported_params:
+                optional_params[key] = value
         return optional_params
 
     def validate_environment(self, headers: dict, *args, **kwargs) -> dict:
@@ -163,7 +167,12 @@ class GenAIHubEmbeddingConfig(BaseEmbeddingConfig):
         model_dict = {}
         model_dict["name"] = model
         model_dict["version"] = optional_params.get("version", "latest")
-        model_dict["params"] = optional_params.get("parameters", {})
+        params = optional_params.get("parameters", {}).copy()
+        if "dimensions" in optional_params:
+            params["dimensions"] = optional_params["dimensions"]
+        if "encoding_format" in optional_params:
+            params["encoding_format"] = optional_params["encoding_format"]
+        model_dict["params"] = params
         timeout = optional_params.get("timeout", None)
         if timeout is not None:
             model_dict["timeout"] = timeout

--- a/tests/test_litellm/llms/sap/embed/test_sap_embed_transformation.py
+++ b/tests/test_litellm/llms/sap/embed/test_sap_embed_transformation.py
@@ -172,6 +172,34 @@ def test_map_openai_params_forwards_supported_params(fake_token_creator):
         assert result == {"dimensions": 1024}
 
 
+def test_encoding_format_forwarded_to_model_params(
+    fake_token_creator, fake_deployment_url
+):
+    with (
+        patch(
+            "litellm.llms.sap.embed.transformation.GenAIHubEmbeddingConfig.deployment_url",
+            new_callable=PropertyMock,
+            return_value=fake_deployment_url,
+        ),
+        patch(
+            "litellm.llms.sap.embed.transformation.get_token_creator",
+            return_value=fake_token_creator,
+        ),
+    ):
+        body = GenAIHubEmbeddingConfig().transform_embedding_request(
+            model="text-embedding-3-large",
+            input="Hi",
+            optional_params={"encoding_format": "float"},
+            headers={},
+        )
+        assert (
+            body["config"]["modules"]["embeddings"]["model"]["params"][
+                "encoding_format"
+            ]
+            == "float"
+        )
+
+
 def test_map_openai_params_no_dimensions_for_non_v3_model(fake_token_creator):
     with patch(
         "litellm.llms.sap.embed.transformation.get_token_creator",

--- a/tests/test_litellm/llms/sap/embed/test_sap_embed_transformation.py
+++ b/tests/test_litellm/llms/sap/embed/test_sap_embed_transformation.py
@@ -106,3 +106,83 @@ def test_embed_with_masking(fake_token_creator, fake_deployment_url):
             headers={},
         )
         assert body["config"]["modules"]["masking"] == masking_config
+
+
+def test_dimensions_forwarded_to_model_params(fake_token_creator, fake_deployment_url):
+    with (
+        patch(
+            "litellm.llms.sap.embed.transformation.GenAIHubEmbeddingConfig.deployment_url",
+            new_callable=PropertyMock,
+            return_value=fake_deployment_url,
+        ),
+        patch(
+            "litellm.llms.sap.embed.transformation.get_token_creator",
+            return_value=fake_token_creator,
+        ),
+    ):
+        body = GenAIHubEmbeddingConfig().transform_embedding_request(
+            model="text-embedding-3-large",
+            input="Hi",
+            optional_params={"dimensions": 2000},
+            headers={},
+        )
+        assert (
+            body["config"]["modules"]["embeddings"]["model"]["params"]["dimensions"]
+            == 2000
+        )
+
+
+def test_dimensions_merged_with_existing_parameters(
+    fake_token_creator, fake_deployment_url
+):
+    with (
+        patch(
+            "litellm.llms.sap.embed.transformation.GenAIHubEmbeddingConfig.deployment_url",
+            new_callable=PropertyMock,
+            return_value=fake_deployment_url,
+        ),
+        patch(
+            "litellm.llms.sap.embed.transformation.get_token_creator",
+            return_value=fake_token_creator,
+        ),
+    ):
+        body = GenAIHubEmbeddingConfig().transform_embedding_request(
+            model="text-embedding-3-large",
+            input="Hi",
+            optional_params={"parameters": {"truncate": "END"}, "dimensions": 512},
+            headers={},
+        )
+        params = body["config"]["modules"]["embeddings"]["model"]["params"]
+        assert params["truncate"] == "END"
+        assert params["dimensions"] == 512
+
+
+def test_map_openai_params_forwards_supported_params(fake_token_creator):
+    with patch(
+        "litellm.llms.sap.embed.transformation.get_token_creator",
+        return_value=fake_token_creator,
+    ):
+        config = GenAIHubEmbeddingConfig()
+        result = config.map_openai_params(
+            non_default_params={"dimensions": 1024, "user": "alice"},
+            optional_params={},
+            model="text-embedding-3-large",
+            drop_params=False,
+        )
+        assert result == {"dimensions": 1024}
+
+
+def test_map_openai_params_no_dimensions_for_non_v3_model(fake_token_creator):
+    with patch(
+        "litellm.llms.sap.embed.transformation.get_token_creator",
+        return_value=fake_token_creator,
+    ):
+        config = GenAIHubEmbeddingConfig()
+        result = config.map_openai_params(
+            non_default_params={"dimensions": 512, "encoding_format": "float"},
+            optional_params={},
+            model="text-embedding-ada-002",
+            drop_params=False,
+        )
+        assert "dimensions" not in result
+        assert result.get("encoding_format") == "float"


### PR DESCRIPTION
## Relevant issues

Re-submission of #27614 (closed; was incorrectly targeted at main).

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Before the fix, calling `litellm.embedding(model="sap/text-embedding-3-large", input=["test"], dimensions=2000)` always returns a 3072-dim vector because the `dimensions` parameter is silently dropped. After the fix, it correctly returns a 2000-dim vector.

To verify against a live proxy with SAP AI Core credentials configured:

```bash
# Start the proxy
python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload

# Request 2000-dim embedding (should return 2000 floats, not 3072)
curl -s http://localhost:4000/v1/embeddings \
  -H "Content-Type: application/json" \
  -d '{"model": "sap/text-embedding-3-large", "input": ["hello world"], "dimensions": 2000}' \
  | python -c "import sys,json; d=json.load(sys.stdin); print(len(d['data'][0]['embedding']))"
# Expected: 2000
```

## Type

Bug Fix

## Changes

`GenAIHubEmbeddingConfig` declares `dimensions` as a supported OpenAI parameter for text-embedding-3 models via `get_supported_openai_params()`, but fails to actually include it in the API request body sent to SAP AI Core.

Two bugs in the same class:

`map_openai_params()` returns `optional_params` unchanged without copying supported params from `non_default_params`. This means `dimensions` and `encoding_format` are silently dropped before reaching `transform_embedding_request()`.

`transform_embedding_request()` only reads `optional_params.get("parameters", {})` for the model params dict. Even if `dimensions` were present in `optional_params`, it would never be extracted into `model_dict["params"]`.

The fix makes `map_openai_params()` iterate `non_default_params` and copy keys present in `get_supported_openai_params()` into `optional_params`. It also makes `transform_embedding_request()` extract `dimensions` and `encoding_format` from `optional_params` and merge them into `model_dict["params"]`.

Four new tests added to the existing test file covering both the param mapping and the request body construction.