### PR TITLE
fix(images): honor provider in async image generation

### DIFF
--- a/litellm/images/main.py
+++ b/litellm/images/main.py
@@ -112,7 +112,10 @@ async def aimage_generation(*args, **kwargs) -> ImageResponse:
         func_with_context = partial(ctx.run, func)
 
         _, custom_llm_provider, _, _ = get_llm_provider(
-            model=model, api_base=kwargs.get("api_base", None)
+            model=model,
+            custom_llm_provider=kwargs.get("custom_llm_provider", None),
+            api_base=kwargs.get("api_base", None),
+            api_key=kwargs.get("api_key", None),
         )
 
         # Await normally

--- a/tests/test_litellm/llms/openai/image_generation/test_openai_image_generation_extra_headers.py
+++ b/tests/test_litellm/llms/openai/image_generation/test_openai_image_generation_extra_headers.py
@@ -210,3 +210,30 @@ class TestImageGenerationEntryPointHeaders:
         mock_openai_client.images.generate.assert_called_once()
         _, kwargs = mock_openai_client.images.generate.call_args
         assert kwargs.get("extra_headers") == test_headers
+
+    @pytest.mark.asyncio
+    async def test_custom_provider_is_used_before_async_entrypoint_runs(self):
+        import litellm
+
+        mock_image_data = MagicMock()
+        mock_image_data.model_dump.return_value = {
+            "created": 1700000000,
+            "data": [{"url": "https://example.com/image.png"}],
+        }
+
+        mock_openai_client = MagicMock()
+        mock_openai_client.images.generate = AsyncMock(return_value=mock_image_data)
+        mock_openai_client.api_key = "test-key"
+        mock_openai_client._base_url._uri_reference = "https://api.openai.com"
+
+        await litellm.aimage_generation(
+            model="Qwen-Image",
+            prompt="A white cat",
+            custom_llm_provider="openai",
+            client=mock_openai_client,
+            api_key="test-key",
+        )
+
+        mock_openai_client.images.generate.assert_called_once()
+        _, kwargs = mock_openai_client.images.generate.call_args
+        assert kwargs["model"] == "Qwen-Image"


### PR DESCRIPTION
﻿## What changed

Fixes #29280.

`aimage_generation()` resolves the provider before it calls the sync `image_generation()` implementation in an executor. That early lookup ignored an explicit `custom_llm_provider`, so a proxy health check such as `model="Qwen-Image", custom_llm_provider="openai"` failed before the OpenAI-compatible image generation path ever ran.

This passes the explicit provider, `api_base`, and `api_key` into the early `get_llm_provider()` call so async image generation follows the same provider routing as the actual image generation call.

## To verify

- `python -m pytest tests\test_litellm\llms\openai\image_generation\test_openai_image_generation_extra_headers.py -q`
- `python -m py_compile litellm\images\main.py tests\test_litellm\llms\openai\image_generation\test_openai_image_generation_extra_headers.py`
- `python -m ruff check litellm\images\main.py tests\test_litellm\llms\openai\image_generation\test_openai_image_generation_extra_headers.py`
- `git diff --check`
