### PR TITLE
feat(pricing): add zai/glm-5-turbo model pricing

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -36583,6 +36583,21 @@
         "supports_tool_choice": true,
         "source": "https://docs.z.ai/guides/overview/pricing"
     },
+    "zai/glm-5-turbo": {
+        "cache_creation_input_token_cost": 0,
+        "cache_read_input_token_cost": 2.4e-07,
+        "input_cost_per_token": 1.2e-06,
+        "output_cost_per_token": 4e-06,
+        "litellm_provider": "zai",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "source": "https://docs.z.ai/guides/overview/pricing"
+    },
     "zai/glm-4.7": {
         "cache_creation_input_token_cost": 0,
         "cache_read_input_token_cost": 1.1e-07,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -36467,6 +36467,21 @@
         "supports_tool_choice": true,
         "source": "https://docs.z.ai/guides/overview/pricing"
     },
+    "zai/glm-5-turbo": {
+        "cache_creation_input_token_cost": 0,
+        "cache_read_input_token_cost": 2.4e-07,
+        "input_cost_per_token": 1.2e-06,
+        "output_cost_per_token": 4e-06,
+        "litellm_provider": "zai",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "source": "https://docs.z.ai/guides/overview/pricing"
+    },
     "zai/glm-4.7": {
         "cache_creation_input_token_cost": 0,
         "cache_read_input_token_cost": 1.1e-07,


### PR DESCRIPTION
## Summary

Add pricing entry for Z.AI's **GLM-5-Turbo** model to `model_prices_and_context_window.json` and its backup.

### Pricing (per million tokens)

| Item | Cost |
|------|------|
| Input | $1.20 |
| Output | $4.00 |
| Cached Input Read | $0.24 |
| Cached Input Storage | Free (limited-time) |

**Source**: https://docs.z.ai/guides/overview/pricing

### Changes

- Added `"zai/glm-5-turbo"` entry to `model_prices_and_context_window.json`
- Added matching entry to `litellm/model_prices_and_context_window_backup.json`

### Context

The existing file already includes `zai/glm-5` and `zai/glm-5-code` but is missing the `glm-5-turbo` variant, which has distinct pricing from both. This entry follows the same format as existing Z.AI model entries.

## Test plan

- [x] JSON syntax validated for both files
- [ ] `make format && make lint && make test-unit` passes (not run locally — this is a JSON-only change with no code modifications)