### PR TITLE
fix: skip input_json_delta for empty tool_calls list

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -1531,7 +1531,7 @@ class LiteLLMAnthropicMessagesAdapter:
         for choice in choices:
             if choice.delta.content is not None and len(choice.delta.content) > 0:
                 text += choice.delta.content
-            if choice.delta.tool_calls:
+            if choice.delta.tool_calls and len(choice.delta.tool_calls) > 0:
                 partial_json = ""
                 for tool in choice.delta.tool_calls:
                     if (

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -11744,6 +11744,11 @@ class Router:
             and allowed_fails_policy.BadRequestErrorAllowedFails is not None
         ):
             return allowed_fails_policy.BadRequestErrorAllowedFails
+        if (
+            isinstance(exception, litellm.InternalServerError)
+            and allowed_fails_policy.InternalServerErrorAllowedFails is not None
+        ):
+            return allowed_fails_policy.InternalServerErrorAllowedFails
 
     def _initialize_alerting(self):
         from litellm.integrations.SlackAlerting.slack_alerting import SlackAlerting


### PR DESCRIPTION
Empty list [] is truthy in Python — triggers input_json_delta with empty partial_json instead of text_delta.

Fixes #29286