### PR TITLE
fix: omit list encoding_format for hosted vLLM embeddings

### DIFF
--- a/litellm/llms/hosted_vllm/embedding/transformation.py
+++ b/litellm/llms/hosted_vllm/embedding/transformation.py
@@ -110,10 +110,14 @@ class HostedVLLMEmbeddingConfig(BaseEmbeddingConfig):
         if model.startswith("hosted_vllm/"):
             model = model.replace("hosted_vllm/", "", 1)
 
+        request_optional_params = optional_params.copy()
+        if isinstance(request_optional_params.get("encoding_format"), list):
+            request_optional_params.pop("encoding_format")
+
         return {
             "model": model,
             "input": input,
-            **optional_params,
+            **request_optional_params,
         }
 
     def transform_embedding_response(

--- a/tests/test_litellm/llms/hosted_vllm/embedding/test_hosted_vllm_embedding_transformation.py
+++ b/tests/test_litellm/llms/hosted_vllm/embedding/test_hosted_vllm_embedding_transformation.py
@@ -8,13 +8,11 @@ especially ensuring that encoding_format is not included when not provided.
 import json
 import os
 import sys
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import Mock, patch
 
 import pytest
 
-sys.path.insert(
-    0, os.path.abspath("../../../../..")
-)  # Adds the parent directory to the system path
+sys.path.insert(0, os.path.abspath("../../../../.."))  # Adds the parent directory to the system path
 
 import litellm
 from litellm.llms.hosted_vllm.embedding.transformation import (
@@ -92,9 +90,7 @@ class TestHostedVLLMEmbeddingTransformation:
             headers={},
         )
 
-        assert (
-            "encoding_format" not in result
-        ), "encoding_format should not be in request when not provided"
+        assert "encoding_format" not in result, "encoding_format should not be in request when not provided"
 
     def test_encoding_format_not_included_when_none(self):
         """
@@ -141,6 +137,24 @@ class TestHostedVLLMEmbeddingTransformation:
         )
 
         assert result["encoding_format"] == "base64"
+
+    def test_encoding_format_list_is_not_included(self):
+        """Test that list-valued encoding_format defaults are not sent."""
+        input_data = ["hello world"]
+        optional_params = {
+            "dimensions": 384,
+            "encoding_format": ["float", "base64", "ubyte", "int8"],
+        }
+
+        result = self.config.transform_embedding_request(
+            model=self.model,
+            input=input_data,
+            optional_params=optional_params,
+            headers={},
+        )
+
+        assert result["dimensions"] == 384
+        assert "encoding_format" not in result
 
     def test_get_supported_openai_params(self):
         """Test that supported OpenAI parameters are correctly listed."""
@@ -283,9 +297,7 @@ class TestHostedVLLMEmbeddingTransformation:
             sent_data = json.loads(call_kwargs["data"])
 
             # Assert that encoding_format is NOT in the sent data
-            assert (
-                "encoding_format" not in sent_data
-            ), "encoding_format should not be in request when not provided"
+            assert "encoding_format" not in sent_data, "encoding_format should not be in request when not provided"
             assert sent_data["model"] == "BAAI/bge-small-en-v1.5"
             assert sent_data["input"] == ["Hello world"]
 


### PR DESCRIPTION
## Relevant issues

Fixes #28239

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Focused local validation:

`uv run pytest tests/test_litellm/llms/hosted_vllm/embedding/test_hosted_vllm_embedding_transformation.py -q`

Result: `15 passed in 0.34s`

Also ran:

`uv run ruff check litellm/llms/hosted_vllm/embedding/transformation.py tests/test_litellm/llms/hosted_vllm/embedding/test_hosted_vllm_embedding_transformation.py`

Result: `All checks passed!`

## Type

Bug Fix
Test

## Changes

Hosted vLLM embeddings are OpenAI-compatible, but vLLM expects `encoding_format` to be a single value such as `float` or `base64`. When LiteLLM model parameters contain the supported values as a list, calls that do not explicitly choose one can forward that list to vLLM and fail validation.

This change removes list-valued `encoding_format` defaults from the final hosted-vLLM embedding request payload. Explicit string values such as `float` and `base64` are still forwarded, and unrelated request parameters such as `dimensions` are preserved. A regression test covers the list-valued default case.
