### PR TITLE
fix(bedrock): strip workspace_id from Anthropic request body in Bedrock Claude Platform

### DIFF
--- a/litellm/llms/bedrock/claude_platform/transformation.py
+++ b/litellm/llms/bedrock/claude_platform/transformation.py
@@ -87,13 +87,13 @@ class BedrockClaudePlatformConfig(BedrockClaudePlatformMixin, AnthropicConfig):
         litellm_params: dict,
         headers: dict,
     ) -> dict:
-        for key in (
+        _WORKSPACE_KEYS = {
             "workspace_id",
             "aws_workspace_id",
             "anthropic_workspace_id",
             "anthropic-workspace-id",
-        ):
-            optional_params.pop(key, None)
+        }
+        optional_params = {k: v for k, v in optional_params.items() if k not in _WORKSPACE_KEYS}
         return super().transform_request(
             model=model,
             messages=messages,

--- a/litellm/llms/bedrock/claude_platform/transformation.py
+++ b/litellm/llms/bedrock/claude_platform/transformation.py
@@ -79,6 +79,29 @@ class BedrockClaudePlatformConfig(BedrockClaudePlatformMixin, AnthropicConfig):
         anthropic_headers["anthropic-workspace-id"] = workspace_id
         return {**headers, **anthropic_headers}
 
+    def transform_request(
+        self,
+        model: str,
+        messages: List[AllMessageValues],
+        optional_params: dict,
+        litellm_params: dict,
+        headers: dict,
+    ) -> dict:
+        for key in (
+            "workspace_id",
+            "aws_workspace_id",
+            "anthropic_workspace_id",
+            "anthropic-workspace-id",
+        ):
+            optional_params.pop(key, None)
+        return super().transform_request(
+            model=model,
+            messages=messages,
+            optional_params=optional_params,
+            litellm_params=litellm_params,
+            headers=headers,
+        )
+
     def get_model_response_iterator(
         self,
         streaming_response: Any,

--- a/litellm/llms/bedrock/claude_platform/transformation.py
+++ b/litellm/llms/bedrock/claude_platform/transformation.py
@@ -93,7 +93,9 @@ class BedrockClaudePlatformConfig(BedrockClaudePlatformMixin, AnthropicConfig):
             "anthropic_workspace_id",
             "anthropic-workspace-id",
         }
-        optional_params = {k: v for k, v in optional_params.items() if k not in _WORKSPACE_KEYS}
+        optional_params = {
+            k: v for k, v in optional_params.items() if k not in _WORKSPACE_KEYS
+        }
         return super().transform_request(
             model=model,
             messages=messages,

--- a/tests/test_litellm/llms/bedrock/test_claude_platform_provider.py
+++ b/tests/test_litellm/llms/bedrock/test_claude_platform_provider.py
@@ -276,6 +276,36 @@ def test_chat_completion_routes_bedrock_claude_platform_to_messages_api():
     assert requests[0]["body"]["model"] == "claude-sonnet-4-6"
 
 
+@pytest.mark.parametrize(
+    "workspace_key",
+    ["workspace_id", "aws_workspace_id", "anthropic_workspace_id"],
+)
+def test_workspace_id_not_leaked_into_request_body(workspace_key):
+    import litellm
+
+    requests = []
+
+    def mock_post(self, url, data=None, headers=None, **kwargs):
+        requests.append(_capture_request(url=url, headers=headers or {}, data=data))
+        return _anthropic_response(url)
+
+    with patch("litellm.llms.custom_httpx.http_handler.HTTPHandler.post", mock_post):
+        litellm.completion(
+            model="bedrock/claude_platform/claude-sonnet-4-6",
+            messages=[{"role": "user", "content": "hello"}],
+            max_tokens=10,
+            api_base="https://aws-external-anthropic.us-west-2.api.aws",
+            api_key="fake-platform-key",
+            **{workspace_key: "wrkspc_test"},
+        )
+
+    assert len(requests) == 1
+    body = requests[0]["body"]
+    for key in ("workspace_id", "aws_workspace_id", "anthropic_workspace_id"):
+        assert key not in body, f"{key!r} must not appear in the Anthropic request body"
+    assert requests[0]["headers"]["anthropic-workspace-id"] == "wrkspc_test"
+
+
 @pytest.mark.asyncio
 async def test_anthropic_messages_routes_bedrock_claude_platform_to_messages_api():
     import litellm

--- a/tests/test_litellm/llms/bedrock/test_claude_platform_provider.py
+++ b/tests/test_litellm/llms/bedrock/test_claude_platform_provider.py
@@ -278,7 +278,7 @@ def test_chat_completion_routes_bedrock_claude_platform_to_messages_api():
 
 @pytest.mark.parametrize(
     "workspace_key",
-    ["workspace_id", "aws_workspace_id", "anthropic_workspace_id"],
+    ["workspace_id", "aws_workspace_id", "anthropic_workspace_id", "anthropic-workspace-id"],
 )
 def test_workspace_id_not_leaked_into_request_body(workspace_key):
     import litellm


### PR DESCRIPTION
## Relevant issues

Fixes #29272

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

**Before fix** -- `workspace_id` appears inside the Anthropic request body:

<img width="1487" height="167" alt="Screenshot 2026-05-30 222418" src="https://github.com/user-attachments/assets/bb81ec39-d58a-4e2b-ac8e-18dfe42e33c4" />

**After fix** -- `workspace_id` is stripped from the body and sent as the `anthropic-workspace-id` header only:

<img width="1460" height="171" alt="Screenshot 2026-05-30 222256" src="https://github.com/user-attachments/assets/32ea54c3-66d1-484a-a24a-7f2785c769e0" />
## Type

Bug Fix

## Changes

`workspace_id` (and its aliases `aws_workspace_id`, `anthropic_workspace_id`, `anthropic-workspace-id`) was being forwarded into the Anthropic request body when using the Bedrock Claude Platform provider. The Anthropic Messages API rejects unknown top-level fields, so any call that passed `workspace_id` as a parameter would fail.

The fix adds a `transform_request()` override in `BedrockClaudePlatformConfig` that strips those keys from `optional_params` before the parent `AnthropicConfig.transform_request()` serialises the body. The value is already correctly placed in the `anthropic-workspace-id` header by `validate_environment()`.

A parametrised regression test (`test_workspace_id_not_leaked_into_request_body`) covers all three alias spellings.