### PR TITLE
Clarify LiteLLM Helm chart options

### DIFF
--- a/deploy/charts/litellm-helm/README.md
+++ b/deploy/charts/litellm-helm/README.md
@@ -4,6 +4,22 @@
 > This is community maintained, Please make an issue if you run into a bug
 > We recommend using [Docker or Kubernetes for production deployments](https://docs.litellm.ai/docs/proxy/prod)
 
+## Which LiteLLM Helm chart should I use?
+
+This README documents `deploy/charts/litellm-helm`, the existing single-proxy
+LiteLLM chart used by the current Helm documentation path.
+
+The repository also contains `helm/litellm`, a newer componentized chart that
+splits the deployment into gateway, backend, and UI services. Use that chart
+only when you intentionally want to evaluate the split-service deployment model
+and can provide the required external Secrets, database, and optional Redis
+settings. See [`helm/litellm/README.md`](../../../helm/litellm/README.md) for
+its current scope and install notes.
+
+When you do not need separate gateway/backend/UI workloads, start with this
+chart because it is the documented path and includes the standalone Postgres /
+Redis dependency wiring described below.
+
 ## Prerequisites
 
 - Kubernetes 1.21+

--- a/helm/litellm/README.md
+++ b/helm/litellm/README.md
@@ -1,0 +1,63 @@
+# LiteLLM Componentized Helm Chart
+
+This chart deploys LiteLLM as separate gateway, backend, and UI workloads.
+
+Use this chart when you intentionally want the split-service deployment model:
+
+- `gateway`: LiteLLM data-plane service on port 4000.
+- `backend`: UI / management API service on port 4001.
+- `ui`: static UI service on port 3000.
+- `migrationJob`: pre-install / pre-upgrade Prisma migration job.
+
+If you want the existing single-proxy chart with optional bundled Postgres and
+Redis dependency wiring, use `deploy/charts/litellm-helm` instead.
+
+## Required External Resources
+
+Before installing this chart, create or provide:
+
+- a Secret containing the proxy master key, referenced by `masterKey`;
+- a writer Postgres database, referenced by `database.writer`;
+- a Secret containing the writer database username and password, unless using
+  IAM authentication;
+- optionally, a Redis endpoint and password Secret, referenced by `redis`.
+
+This chart does not accept inline secret values. Sensitive values are passed by
+Kubernetes Secret references.
+
+## Minimal Install Shape
+
+Set the required values in a file such as `values.local.yaml`:
+
+```yaml
+masterKey:
+  secretName: litellm-master-key-secret
+  secretKey: master-key
+
+database:
+  writer:
+    host: postgres.example.internal
+    port: 5432
+    dbname: litellm
+    passwordSecret:
+      name: litellm-writer-secret
+      usernameKey: username
+      passwordKey: password
+```
+
+Then install with:
+
+```bash
+helm install litellm ./helm/litellm -f values.local.yaml
+```
+
+Enable `ingress.enabled=true` when you want one L7 entrypoint that routes to
+the UI, gateway, and backend services.
+
+## Relationship To `deploy/charts/litellm-helm`
+
+`deploy/charts/litellm-helm` is the existing documented chart for the
+single-proxy deployment path. This `helm/litellm` chart is for operators who
+want to evaluate or adopt separate gateway, backend, and UI workloads. Pick one
+chart per release; they are not meant to be installed over the same Helm
+release name.


### PR DESCRIPTION
### Description

Clarifies the relationship between the two Helm charts currently present in the repository:

- `deploy/charts/litellm-helm`, the existing documented single-proxy chart.
- `helm/litellm`, the newer componentized chart that splits gateway, backend, and UI workloads.

This does not change chart behavior. It adds chart-selection guidance and gives the componentized chart its own README so operators can understand its scope, required external resources, and when to use it.

Fixes #28619.

### Changes

- Add a "Which LiteLLM Helm chart should I use?" section to `deploy/charts/litellm-helm/README.md`.
- Add `helm/litellm/README.md` describing:
  - gateway/backend/UI split;
  - required master-key and database Secret references;
  - optional Redis configuration;
  - minimal install shape;
  - relationship to `deploy/charts/litellm-helm`.

### Verification

```powershell
Resolve-Path -LiteralPath deploy\charts\litellm-helm\..\..\..\helm\litellm\README.md
rg -n "Which LiteLLM Helm chart|componentized|single-proxy|deploy/charts/litellm-helm|helm/litellm" deploy/charts/litellm-helm/README.md helm/litellm/README.md
git diff --check
```

Notes:

- `helm version --short` was attempted but `helm` is not installed in the current Windows PATH.
- No chart templates or values files were changed.
