### PR TITLE
fix(logging): handle ResponseCompletedEvent in anthropic_messages streaming spend log

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -3503,7 +3503,9 @@ class Logging(LiteLLMLoggingBaseClass):
         else:
             return None
 
-    def _handle_anthropic_messages_response_logging(self, result: Any) -> ModelResponse:
+    def _handle_anthropic_messages_response_logging(
+        self, result: Any
+    ) -> Union[ModelResponse, ResponsesAPIResponse]:
         """
         Handles logging for Anthropic messages responses.
 
@@ -3522,12 +3524,15 @@ class Logging(LiteLLMLoggingBaseClass):
             return result
         elif isinstance(result, ModelResponse):
             return result
-        elif isinstance(result, ResponseCompletedEvent):
+        elif isinstance(
+            result,
+            (ResponseCompletedEvent, ResponseIncompleteEvent, ResponseFailedEvent),
+        ):
             # anthropic_messages() can route to OpenAI Responses API; in that path
-            # the assembled streaming result is a ResponseCompletedEvent rather than
+            # the assembled streaming result is one of these terminal events rather than
             # a ModelResponse. Return the inner response so downstream handlers
             # (_transform_usage_objects, normalize_logging_result) can process it.
-            return result.response  # type: ignore[return-value]
+            return result.response
 
         httpx_response = self.model_call_details.get("httpx_response", None)
         if httpx_response and isinstance(httpx_response, httpx.Response):

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -3522,6 +3522,12 @@ class Logging(LiteLLMLoggingBaseClass):
             return result
         elif isinstance(result, ModelResponse):
             return result
+        elif isinstance(result, ResponseCompletedEvent):
+            # anthropic_messages() can route to OpenAI Responses API; in that path
+            # the assembled streaming result is a ResponseCompletedEvent rather than
+            # a ModelResponse. Return the inner response so downstream handlers
+            # (_transform_usage_objects, normalize_logging_result) can process it.
+            return result.response  # type: ignore[return-value]
 
         httpx_response = self.model_call_details.get("httpx_response", None)
         if httpx_response and isinstance(httpx_response, httpx.Response):

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -3116,12 +3116,26 @@ def test_get_error_information_prefers_message_attribute_over_empty_str():
     assert info["error_code"] == "401"
 
 
-def test_handle_anthropic_messages_response_logging_with_response_completed_event():
+@pytest.mark.parametrize(
+    "event_cls, event_type",
+    [
+        ("ResponseCompletedEvent", "response.completed"),
+        ("ResponseIncompleteEvent", "response.incomplete"),
+        ("ResponseFailedEvent", "response.failed"),
+    ],
+)
+def test_handle_anthropic_messages_response_logging_with_terminal_responses_api_events(
+    event_cls, event_type
+):
     """Regression test for #28943: when anthropic_messages routes to OpenAI Responses
-    API and stream=True, success_handler receives a ResponseCompletedEvent instead of
-    a ModelResponse. The handler must return the inner ResponsesAPIResponse rather than
-    crashing with AnthropicResponse.model_validate."""
-    from litellm.types.llms.openai import ResponseCompletedEvent, ResponsesAPIResponse
+    API and stream=True, success_handler receives a terminal ResponsesAPI event instead
+    of a ModelResponse. The handler must return the inner ResponsesAPIResponse rather
+    than crashing with AnthropicResponse.model_validate."""
+    import importlib
+
+    openai_types = importlib.import_module("litellm.types.llms.openai")
+    EventClass = getattr(openai_types, event_cls)
+    from litellm.types.llms.openai import ResponsesAPIResponse
 
     logging_obj = LitellmLogging(
         model="gpt-4o",
@@ -3136,7 +3150,7 @@ def test_handle_anthropic_messages_response_logging_with_response_completed_even
     inner_response = ResponsesAPIResponse(
         id="resp_test", created_at=1700000000, output=[]
     )
-    event = ResponseCompletedEvent(type="response.completed", response=inner_response)
+    event = EventClass(type=event_type, response=inner_response)
 
     result = logging_obj._handle_anthropic_messages_response_logging(result=event)
 

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -3114,3 +3114,30 @@ def test_get_error_information_prefers_message_attribute_over_empty_str():
     )
     assert info["error_message"] == "real failure detail"
     assert info["error_code"] == "401"
+
+
+def test_handle_anthropic_messages_response_logging_with_response_completed_event():
+    """Regression test for #28943: when anthropic_messages routes to OpenAI Responses
+    API and stream=True, success_handler receives a ResponseCompletedEvent instead of
+    a ModelResponse. The handler must return the inner ResponsesAPIResponse rather than
+    crashing with AnthropicResponse.model_validate."""
+    from litellm.types.llms.openai import ResponseCompletedEvent, ResponsesAPIResponse
+
+    logging_obj = LitellmLogging(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": "hello"}],
+        stream=True,
+        call_type="anthropic_messages",
+        start_time=time.time(),
+        litellm_call_id="test-rce-123",
+        function_id="test-fn",
+    )
+
+    inner_response = ResponsesAPIResponse(
+        id="resp_test", created_at=1700000000, output=[]
+    )
+    event = ResponseCompletedEvent(type="response.completed", response=inner_response)
+
+    result = logging_obj._handle_anthropic_messages_response_logging(result=event)
+
+    assert result is inner_response


### PR DESCRIPTION
Relevant issues

Fixes #28943

Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

Screenshots / Proof of Fix

Before fix -- _handle_anthropic_messages_response_logging crashes with a Pydantic ValidationError when stream=True and the result is a terminal OpenAI Responses API event:

<img width="919" height="228" alt="image" src="https://github.com/user-attachments/assets/779d415d-6739-4288-a858-dd10cabc4e02" />

After fix -- the handler returns the inner ResponsesAPIResponse without raising:

<img width="931" height="93" alt="image" src="https://github.com/user-attachments/assets/46c00bd0-6ac0-49dc-a97d-baa29eec653d" />

Type

Bug Fix

Changes

When litellm.anthropic_messages() is called with stream=True and the underlying provider is OpenAI (which routes to the OpenAI Responses API internally), the assembled streaming result passed to success_handler is one of three terminal event types (ResponseCompletedEvent, ResponseIncompleteEvent, ResponseFailedEvent) rather than a ModelResponse. _handle_anthropic_messages_response_logging only checked for ModelResponse and fell through to AnthropicResponse.model_validate(result), which raises a Pydantic ValidationError because none of these event types are valid AnthropicResponse instances. This caused spend logs to never be written for this code path.

The fix extends the isinstance check to cover all three terminal event types, matching the pattern already used in _get_assembled_streaming_response, and returns result.response (a ResponsesAPIResponse) directly. ResponsesAPIResponse is already handled correctly by both _transform_usage_objects and _is_recognized_call_type_for_logging; _process_hidden_params_and_response_cost is already skipped for stream=True, so spend calculation is unaffected. The return type annotation is corrected to Union[ModelResponse, ResponsesAPIResponse].

A regression test (test_handle_anthropic_messages_response_logging_with_terminal_responses_api_events) is parametrized over all three terminal event types and asserts that passing any of them to the handler returns the inner ResponsesAPIResponse without raising.