### PR TITLE
fix(proxy): restructure UI before mounting; fall back to temp dir when UI path is read-only

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1659,33 +1659,38 @@ try:
                     # Another process may have already moved this file.
                     continue
 
-    try:
-        is_pre_restructured = _is_ui_pre_restructured(ui_path)
-        is_writable = os.access(ui_path, os.W_OK)
-
-        if is_pre_restructured:
+    def _prepare_ui_directory(path: str) -> str:
+        """Return a fully restructured UI path, copying to a temp dir if the source is read-only."""
+        if _is_ui_pre_restructured(path):
             verbose_proxy_logger.info(
-                f"Skipping UI restructuring: {ui_path} is already pre-restructured"
+                f"Skipping UI restructuring: {path} is already pre-restructured"
             )
-        elif is_writable:
-            _restructure_ui_html_files(ui_path)
-            verbose_proxy_logger.info(f"Restructured UI directory: {ui_path}")
-        else:
-            tmp_dir = tempfile.mkdtemp(prefix="litellm_ui_")
-            try:
-                shutil.copytree(ui_path, tmp_dir, dirs_exist_ok=True)
-                _restructure_ui_html_files(tmp_dir)
-                atexit.register(shutil.rmtree, tmp_dir, True)
-                ui_path = tmp_dir
-                verbose_proxy_logger.info(
-                    f"Copied read-only UI to temp dir and restructured: {tmp_dir}"
-                )
-            except Exception:
-                shutil.rmtree(tmp_dir, ignore_errors=True)
-                verbose_proxy_logger.warning(
-                    f"Failed to copy and restructure UI from {ui_path}; "
-                    f"extensionless routes like /ui/login may return 404"
-                )
+            return path
+
+        if os.access(path, os.W_OK):
+            _restructure_ui_html_files(path)
+            verbose_proxy_logger.info(f"Restructured UI directory: {path}")
+            return path
+
+        tmp_dir = tempfile.mkdtemp(prefix="litellm_ui_")
+        try:
+            shutil.copytree(path, tmp_dir, dirs_exist_ok=True, symlinks=True)
+            _restructure_ui_html_files(tmp_dir)
+            atexit.register(shutil.rmtree, tmp_dir, True)
+            verbose_proxy_logger.info(
+                f"Copied read-only UI to temp dir and restructured: {tmp_dir}"
+            )
+            return tmp_dir
+        except Exception:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+            verbose_proxy_logger.warning(
+                f"Failed to copy and restructure UI from {path}; "
+                f"extensionless routes like /ui/login may return 404"
+            )
+            return path
+
+    try:
+        ui_path = _prepare_ui_directory(ui_path)
     except PermissionError as e:
         verbose_proxy_logger.exception(
             f"Permission error while restructuring UI directory {ui_path}: {e}"

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -11,6 +11,7 @@ import secrets
 import shutil
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 import traceback
@@ -1631,21 +1632,6 @@ try:
                         # Skip binary files or files we can't write to
                         continue
 
-    # # Mount the _next directory at the root level
-    app.mount(
-        "/_next",
-        StaticFiles(directory=os.path.join(ui_path, "_next")),
-        name="next_static",
-    )
-    app.mount(
-        f"{litellm_asset_prefix}/_next",
-        StaticFiles(directory=os.path.join(ui_path, "_next")),
-        name="next_static",
-    )
-    # print(f"mounted _next at {server_root_path}/ui/_next")
-
-    app.mount("/ui", StaticFiles(directory=ui_path, html=True), name="ui")
-
     def _restructure_ui_html_files(ui_root: str) -> None:
         """Ensure each exported HTML route is available as <route>/index.html."""
 
@@ -1672,10 +1658,6 @@ try:
                     # Another process may have already moved this file.
                     continue
 
-    # Handle HTML file restructuring
-    # Only restructure if:
-    # 1. UI is not already pre-restructured
-    # 2. Filesystem is writable
     try:
         is_pre_restructured = _is_ui_pre_restructured(ui_path)
         is_writable = os.access(ui_path, os.W_OK)
@@ -1684,15 +1666,17 @@ try:
             verbose_proxy_logger.info(
                 f"Skipping UI restructuring: {ui_path} is already pre-restructured"
             )
-        elif not is_writable:
-            verbose_proxy_logger.warning(
-                f"Cannot restructure UI at {ui_path}: path is not writable. "
-                f"UI may not work correctly for extensionless routes. "
-                f"Pre-build and restructure UI in Dockerfile for read-only deployments."
-            )
-        else:
+        elif is_writable:
             _restructure_ui_html_files(ui_path)
             verbose_proxy_logger.info(f"Restructured UI directory: {ui_path}")
+        else:
+            tmp_dir = tempfile.mkdtemp(prefix="litellm_ui_")
+            shutil.copytree(ui_path, tmp_dir, dirs_exist_ok=True)
+            _restructure_ui_html_files(tmp_dir)
+            ui_path = tmp_dir
+            verbose_proxy_logger.info(
+                f"Copied read-only UI to temp dir and restructured: {tmp_dir}"
+            )
     except PermissionError as e:
         verbose_proxy_logger.exception(
             f"Permission error while restructuring UI directory {ui_path}: {e}"
@@ -1701,6 +1685,20 @@ try:
         verbose_proxy_logger.exception(
             f"Error while restructuring UI directory {ui_path}: {e}"
         )
+
+    # Mount _next and UI using the (possibly updated) ui_path
+    app.mount(
+        "/_next",
+        StaticFiles(directory=os.path.join(ui_path, "_next")),
+        name="next_static",
+    )
+    app.mount(
+        f"{litellm_asset_prefix}/_next",
+        StaticFiles(directory=os.path.join(ui_path, "_next")),
+        name="next_static",
+    )
+
+    app.mount("/ui", StaticFiles(directory=ui_path, html=True), name="ui")
 
 except Exception:
     pass

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -9,6 +9,7 @@ import random
 import re
 import secrets
 import shutil
+import atexit
 import subprocess
 import sys
 import tempfile
@@ -1671,12 +1672,20 @@ try:
             verbose_proxy_logger.info(f"Restructured UI directory: {ui_path}")
         else:
             tmp_dir = tempfile.mkdtemp(prefix="litellm_ui_")
-            shutil.copytree(ui_path, tmp_dir, dirs_exist_ok=True)
-            _restructure_ui_html_files(tmp_dir)
-            ui_path = tmp_dir
-            verbose_proxy_logger.info(
-                f"Copied read-only UI to temp dir and restructured: {tmp_dir}"
-            )
+            try:
+                shutil.copytree(ui_path, tmp_dir, dirs_exist_ok=True)
+                _restructure_ui_html_files(tmp_dir)
+                atexit.register(shutil.rmtree, tmp_dir, True)
+                ui_path = tmp_dir
+                verbose_proxy_logger.info(
+                    f"Copied read-only UI to temp dir and restructured: {tmp_dir}"
+                )
+            except Exception:
+                shutil.rmtree(tmp_dir, ignore_errors=True)
+                verbose_proxy_logger.warning(
+                    f"Failed to copy and restructure UI from {ui_path}; "
+                    f"extensionless routes like /ui/login may return 404"
+                )
     except PermissionError as e:
         verbose_proxy_logger.exception(
             f"Permission error while restructuring UI directory {ui_path}: {e}"

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -646,6 +646,70 @@ def test_read_only_ui_dir_falls_back_to_temp_dir_for_extensionless_routes(tmp_pa
         shutil.rmtree(tmp_dir, ignore_errors=True)
 
 
+def test_prepare_ui_uses_temp_dir_when_not_writable(tmp_path, monkeypatch):
+    import shutil
+
+    from litellm.proxy import proxy_server
+
+    ui_root = tmp_path / "ui"
+    ui_root.mkdir()
+    (ui_root / "index.html").write_text("<html>index</html>")
+    (ui_root / "login.html").write_text("<html>login</html>")
+    (ui_root / "_next").mkdir()
+
+    monkeypatch.setattr(proxy_server.os, "access", lambda path, mode: False)
+
+    result = proxy_server._prepare_ui_directory(str(ui_root))
+    try:
+        assert result != str(ui_root)
+        assert (Path(result) / "login" / "index.html").exists()
+        assert not (Path(result) / "login.html").exists()
+
+        app = FastAPI()
+        app.mount("/ui", StaticFiles(directory=result, html=True), name="ui")
+        response = TestClient(app).get("/ui/login")
+        assert response.status_code == 200
+        assert "login" in response.text
+    finally:
+        shutil.rmtree(result, ignore_errors=True)
+
+
+def test_prepare_ui_cleans_up_temp_dir_on_copy_failure(tmp_path, monkeypatch):
+    import shutil
+
+    from litellm.proxy import proxy_server
+
+    ui_root = tmp_path / "ui"
+    ui_root.mkdir()
+    (ui_root / "index.html").write_text("<html>index</html>")
+    (ui_root / "_next").mkdir()
+
+    monkeypatch.setattr(proxy_server.os, "access", lambda path, mode: False)
+    monkeypatch.setattr(
+        proxy_server.shutil,
+        "copytree",
+        lambda *a, **kw: (_ for _ in ()).throw(OSError("disk full")),
+    )
+
+    import tempfile
+
+    created_dirs: list = []
+    real_mkdtemp = tempfile.mkdtemp
+
+    def tracking_mkdtemp(**kwargs):
+        d = real_mkdtemp(**kwargs)
+        created_dirs.append(d)
+        return d
+
+    monkeypatch.setattr(proxy_server.tempfile, "mkdtemp", tracking_mkdtemp)
+
+    result = proxy_server._prepare_ui_directory(str(ui_root))
+
+    assert result == str(ui_root)
+    for d in created_dirs:
+        assert not Path(d).exists(), f"temp dir {d} was not cleaned up"
+
+
 def test_admin_ui_export_serves_nested_extensionless_routes():
     out_dir = Path(litellm.__file__).parent / "proxy" / "_experimental" / "out"
     assert out_dir.is_dir(), f"missing UI export at {out_dir}"

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -604,6 +604,48 @@ def test_ui_extensionless_route_requires_restructure(tmp_path):
     assert "login" in response.text
 
 
+def test_read_only_ui_dir_falls_back_to_temp_dir_for_extensionless_routes(tmp_path):
+    """
+    Regression for pip-install 404: when the UI directory cannot be restructured
+    in-place (e.g., read-only site-packages), copying it to a writable temp dir
+    and restructuring there must make /ui/login return 200.
+    """
+    import shutil
+    import tempfile
+
+    from litellm.proxy import proxy_server
+
+    ui_root = tmp_path / "ui"
+    ui_root.mkdir()
+    (ui_root / "index.html").write_text("<html>index</html>")
+    (ui_root / "login.html").write_text("<html>login</html>")
+    (ui_root / "_next").mkdir()
+
+    # Confirm that without restructuring the extensionless route returns 404.
+    fastapi_before = FastAPI()
+    fastapi_before.mount(
+        "/ui", StaticFiles(directory=str(ui_root), html=True), name="ui"
+    )
+    assert TestClient(fastapi_before).get("/ui/login").status_code == 404
+
+    # Apply the read-only fallback: copy to a temp dir and restructure.
+    tmp_dir = tempfile.mkdtemp(prefix="litellm_ui_test_")
+    try:
+        shutil.copytree(str(ui_root), tmp_dir, dirs_exist_ok=True)
+        proxy_server._restructure_ui_html_files(tmp_dir)
+
+        assert (Path(tmp_dir) / "login" / "index.html").exists()
+        assert not (Path(tmp_dir) / "login.html").exists()
+
+        fastapi_after = FastAPI()
+        fastapi_after.mount("/ui", StaticFiles(directory=tmp_dir, html=True), name="ui")
+        response = TestClient(fastapi_after).get("/ui/login")
+        assert response.status_code == 200
+        assert "login" in response.text
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
 def test_admin_ui_export_serves_nested_extensionless_routes():
     out_dir = Path(litellm.__file__).parent / "proxy" / "_experimental" / "out"
     assert out_dir.is_dir(), f"missing UI export at {out_dir}"


### PR DESCRIPTION
## Relevant issues

Closes #29340

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Start the proxy and hit `/ui/login`:

```
$ python litellm/proxy/proxy_cli.py --config litellm/proxy/example_config_yaml/simple_config.yaml --port 4000

$ curl -v http://127.0.0.1:4000/ui/login
> GET /ui/login HTTP/1.1
< HTTP/1.1 307 Temporary Redirect
< location: http://127.0.0.1:4000/ui/login/

$ curl -v http://127.0.0.1:4000/ui/login/
> GET /ui/login/ HTTP/1.1
< HTTP/1.1 200 OK
< content-type: text/html; charset=utf-8
< content-length: 11520
```

Before the fix, users who installed via pip got a 404 on `/ui/login` because the restructuring step was silently skipped when the site-packages directory was not writable. The regression test `test_read_only_ui_dir_falls_back_to_temp_dir_for_extensionless_routes` explicitly verifies the 404-before / 200-after transition.

## Type

Bug Fix

## Changes

`StaticFiles(html=True)` serves extensionless routes like `/ui/login` only when the file is at `login/index.html`, not `login.html`. The existing `_restructure_ui_html_files` helper moves files into the correct structure, but it was silently skipped when the UI directory was not writable (e.g., a pip-installed site-packages path) and not already pre-restructured, leaving `/ui/login` to return 404.

The fix copies the UI tree to `tempfile.mkdtemp()` before restructuring when the source directory is read-only, then mounts from the temp copy. The writable-directory path (dev installs, Docker) is unchanged.