### PR TITLE
fix: propagate upstream status code in proxy API exception handler

### DIFF
--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -1951,23 +1951,17 @@ class ProxyBaseLLMRequestProcessing:
         if (
             _exc_status_code is not None
             and isinstance(_exc_status_code, int)
-            and 100 <= _exc_status_code <= 599
+            and 400 <= _exc_status_code <= 599
         ):
-            raise ProxyException(
-                message=getattr(e, "message", error_msg),
-                type=getattr(e, "type", "None"),
-                param=getattr(e, "param", "None"),
-                openai_code=getattr(e, "code", None),
-                code=_exc_status_code,
-                provider_specific_fields=getattr(e, "provider_specific_fields", None),
-                headers=headers,
-            )
+            _code = _exc_status_code
+        else:
+            _code = status.HTTP_500_INTERNAL_SERVER_ERROR
         raise ProxyException(
             message=getattr(e, "message", error_msg),
             type=getattr(e, "type", "None"),
             param=getattr(e, "param", "None"),
             openai_code=getattr(e, "code", None),
-            code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            code=_code,
             provider_specific_fields=getattr(e, "provider_specific_fields", None),
             headers=headers,
         )

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -1942,12 +1942,28 @@ class ProxyBaseLLMRequestProcessing:
                 code=status.HTTP_400_BAD_REQUEST,
                 headers=headers,
             )
+        # Extract status_code from the exception if it carries one.
+        # Provider exceptions (NotFoundError, BadRequestError, GeminiError,
+        # VertexAIError, etc.) all have a status_code attribute reflecting
+        # the upstream API response. Use it to return the correct HTTP code
+        # instead of defaulting to 500.
+        _exc_status_code = getattr(e, "status_code", None)
+        if _exc_status_code is not None and isinstance(_exc_status_code, int) and 100 <= _exc_status_code <= 599:
+            raise ProxyException(
+                message=getattr(e, "message", error_msg),
+                type=getattr(e, "type", "None"),
+                param=getattr(e, "param", "None"),
+                openai_code=getattr(e, "code", None),
+                code=_exc_status_code,
+                provider_specific_fields=getattr(e, "provider_specific_fields", None),
+                headers=headers,
+            )
         raise ProxyException(
             message=getattr(e, "message", error_msg),
             type=getattr(e, "type", "None"),
             param=getattr(e, "param", "None"),
             openai_code=getattr(e, "code", None),
-            code=getattr(e, "status_code", 500),
+            code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             provider_specific_fields=getattr(e, "provider_specific_fields", None),
             headers=headers,
         )

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -1948,7 +1948,11 @@ class ProxyBaseLLMRequestProcessing:
         # the upstream API response. Use it to return the correct HTTP code
         # instead of defaulting to 500.
         _exc_status_code = getattr(e, "status_code", None)
-        if _exc_status_code is not None and isinstance(_exc_status_code, int) and 100 <= _exc_status_code <= 599:
+        if (
+            _exc_status_code is not None
+            and isinstance(_exc_status_code, int)
+            and 100 <= _exc_status_code <= 599
+        ):
             raise ProxyException(
                 message=getattr(e, "message", error_msg),
                 type=getattr(e, "type", "None"),

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -2244,6 +2244,36 @@ class TestHandleLLMApiExceptionDictDetail:
         assert proxy_exc.message == "Content blocked by guardrail"
         assert proxy_exc.provider_specific_fields is None
 
+    async def test_not_found_error_preserves_404(self):
+        """NotFoundError with status_code=404 should map to ProxyException code=404."""
+        from litellm.exceptions import NotFoundError
+
+        exc = NotFoundError(
+            message="Model gemini-3.1-flash-lite-preview not found",
+            model="gemini-3.1-flash-lite-preview",
+            llm_provider="gemini",
+        )
+        proxy_exc = await self._invoke(exc)
+        assert proxy_exc.code == "404"
+        assert "NotFoundError" in proxy_exc.message
+
+    async def test_exception_with_status_code_propagates(self):
+        """Exception with a statically-set status_code should propagate it."""
+        from litellm.llms.vertex_ai.common_utils import VertexAIError
+
+        exc = VertexAIError(
+            status_code=429,
+            message="Rate limit exceeded",
+        )
+        proxy_exc = await self._invoke(exc)
+        assert proxy_exc.code == "429"
+
+    async def test_exception_without_status_code_defaults_to_500(self):
+        """Exception with no status_code attribute defaults to 500."""
+        exc = ValueError("Something broke")
+        proxy_exc = await self._invoke(exc)
+        assert proxy_exc.code == "500"
+
 
 class TestAsyncStreamingDataGeneratorFastPath:
     """Fast/slow path branching in async_streaming_data_generator."""


### PR DESCRIPTION
When Google GenAI / Vertex returns a 404 for deprecated or missing models via streamGenerateContent, the exception was falling through to a generic handler that defaulted to 500. Now provider exceptions carrying a valid HTTP status_code correctly propagate it through to the ProxyException.

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Linear ticket

<!-- if you are an internal contributor, add the Linear ticket e.g. "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or log output demonstrating that your changes work as expected.
     For bug fixes: show reproduction before the fix and passing behavior after.
     For new features: show the feature working end-to-end.
     For UI changes: include before/after screenshots. -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes
