### PR TITLE
feat(models): add minimax/MiniMax-M3 to model cost map

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -24185,6 +24185,21 @@
         "max_input_tokens": 200000,
         "max_output_tokens": 8192
     },
+    "minimax/MiniMax-M3": {
+        "input_cost_per_token": 6e-07,
+        "output_cost_per_token": 2.4e-06,
+        "cache_read_input_token_cost": 1.2e-07,
+        "litellm_provider": "minimax",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_system_messages": true,
+        "supports_vision": true,
+        "max_input_tokens": 512000,
+        "max_output_tokens": 128000
+    },
     "mistral.devstral-2-123b": {
         "input_cost_per_token": 4e-07,
         "litellm_provider": "bedrock_converse",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -23993,6 +23993,21 @@
         "max_input_tokens": 200000,
         "max_output_tokens": 8192
     },
+    "minimax/MiniMax-M3": {
+        "input_cost_per_token": 6e-07,
+        "output_cost_per_token": 2.4e-06,
+        "cache_read_input_token_cost": 1.2e-07,
+        "litellm_provider": "minimax",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_system_messages": true,
+        "supports_vision": true,
+        "max_input_tokens": 512000,
+        "max_output_tokens": 128000
+    },
     "mistral.devstral-2-123b": {
         "input_cost_per_token": 4e-07,
         "litellm_provider": "bedrock_converse",


### PR DESCRIPTION
## Relevant issues

N/A — adds a newly released model to the cost map.

## What

Adds MiniMax's new flagship **`minimax/MiniMax-M3`** to the native `minimax` provider in the model cost map.

| field | value |
|---|---|
| max_input_tokens | 512000 |
| max_output_tokens | 128000 |
| supports_vision | true (native multimodal) |
| supports_reasoning / prompt_caching / function_calling / tool_choice | true |
| input_cost_per_token | 6e-07 ($0.60 /M) |
| output_cost_per_token | 2.4e-06 ($2.40 /M) |
| cache_read_input_token_cost | 1.2e-07 ($0.12 /M) |

M3 has no active prompt-cache-write tier, so `cache_creation_input_token_cost` is intentionally omitted (reads are cacheable, writes are not billed/supported).

Updated **both** files in sync, per repo convention:
- `model_prices_and_context_window.json` (remote source)
- `litellm/model_prices_and_context_window_backup.json` (bundled local fallback)

## Pre-Submission checklist

- [x] My PR's scope is as isolated as possible; it only adds one model entry (no other models touched, zero deletions)
- [x] Verified `get_model_info("minimax/MiniMax-M3")` returns the expected context/output/vision/cost with `LITELLM_LOCAL_MODEL_COST_MAP=True`
- [x] Both JSON files validated as well-formed and kept in sync