### PR TITLE
fix(logging): pass through Response*Event when /v1/messages bridges OpenAI Responses API

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -3424,7 +3424,7 @@ class Logging(LiteLLMLoggingBaseClass):
         else:
             return None
 
-    def _handle_anthropic_messages_response_logging(self, result: Any) -> ModelResponse:
+    def _handle_anthropic_messages_response_logging(self, result: Any) -> Any:
         """
         Handles logging for Anthropic messages responses.
 
@@ -3436,9 +3436,19 @@ class Logging(LiteLLMLoggingBaseClass):
 
         - For Non-streaming responses, we need to transform the response to a ModelResponse object.
         - For streaming responses, anthropic_messages handler calls success_handler with a assembled ModelResponse.
+        - When /v1/messages is routed through the OpenAI Responses API bridge, the
+          streaming handler emits raw Response*Event objects. They have already been
+          translated to anthropic-shape SSE for the client by
+          AnthropicResponsesStreamWrapper, so pass them through untouched here instead
+          of crashing in AnthropicResponse.model_validate.
         """
         import httpx
 
+        if self.stream and isinstance(
+            result,
+            (ResponseCompletedEvent, ResponseIncompleteEvent, ResponseFailedEvent),
+        ):
+            return result
         if self.stream and isinstance(result, ModelResponse):
             return result
         elif isinstance(result, ModelResponse):

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -1975,6 +1975,91 @@ def test_get_assembled_streaming_response_returns_none_for_non_streaming_text_co
     assert assembled is None
 
 
+# ──────────────────────────────────────────────────────────────────────
+# Tests for _handle_anthropic_messages_response_logging stream early return
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _make_anthropic_messages_logging_obj(stream: bool) -> LitellmLogging:
+    return LitellmLogging(
+        model="claude-sonnet-4-20250514",
+        messages=[{"role": "user", "content": "Hi"}],
+        stream=stream,
+        call_type="anthropic_messages",
+        start_time=time.time(),
+        litellm_call_id="test-anthropic-1",
+        function_id="test-fn",
+    )
+
+
+def _make_responses_api_response():
+    import datetime
+
+    from litellm.types.llms.openai import ResponsesAPIResponse
+
+    return ResponsesAPIResponse(
+        id="resp_test",
+        created_at=int(datetime.datetime.now().timestamp()),
+        status="completed",
+        model="test-model",
+        object="response",
+        output=[],
+    )
+
+
+@pytest.mark.parametrize(
+    "event_cls_name,event_type_attr",
+    [
+        ("ResponseCompletedEvent", "RESPONSE_COMPLETED"),
+        ("ResponseIncompleteEvent", "RESPONSE_INCOMPLETE"),
+        ("ResponseFailedEvent", "RESPONSE_FAILED"),
+    ],
+)
+def test_handle_anthropic_messages_response_logging_passes_through_response_events(
+    event_cls_name, event_type_attr
+):
+    """When /v1/messages is routed through the Responses API bridge, streaming
+    success logging receives raw Response*Event objects. They must be returned
+    untouched instead of crashing in AnthropicResponse.model_validate.
+
+    Regression test for BerriAI/litellm#28595 and #28943.
+    """
+    from litellm.types.llms import openai as openai_types
+    from litellm.types.llms.anthropic import AnthropicResponse
+
+    event_cls = getattr(openai_types, event_cls_name)
+    event_type = getattr(openai_types.ResponsesAPIStreamEvents, event_type_attr)
+    event = event_cls(type=event_type, response=_make_responses_api_response())
+
+    logging_obj = _make_anthropic_messages_logging_obj(stream=True)
+    with patch.object(AnthropicResponse, "model_validate") as mock_validate:
+        result = logging_obj._handle_anthropic_messages_response_logging(result=event)
+
+    assert result is event
+    mock_validate.assert_not_called()
+
+
+def test_handle_anthropic_messages_response_logging_does_not_swallow_response_events_for_non_streaming():
+    """Non-streaming requests should not take the new early-return path: a raw
+    Response*Event is unexpected here and must still flow into the existing
+    AnthropicResponse validation branch.
+    """
+    from litellm.types.llms import openai as openai_types
+    from litellm.types.llms.anthropic import AnthropicResponse
+
+    event = openai_types.ResponseCompletedEvent(
+        type=openai_types.ResponsesAPIStreamEvents.RESPONSE_COMPLETED,
+        response=_make_responses_api_response(),
+    )
+
+    logging_obj = _make_anthropic_messages_logging_obj(stream=False)
+    with patch.object(AnthropicResponse, "model_validate") as mock_validate:
+        mock_validate.side_effect = RuntimeError("validation reached")
+        with pytest.raises(RuntimeError, match="validation reached"):
+            logging_obj._handle_anthropic_messages_response_logging(result=event)
+    mock_validate.assert_called_once()
+
+
 @pytest.mark.asyncio
 async def test_non_streaming_computes_standard_logging_object_once():
     """


### PR DESCRIPTION
## Relevant issues

Fixes #28595
Fixes #28943

## Changes

When `/v1/messages` is routed to a backend that returns **OpenAI Responses API** stream events instead of native Anthropic shape (e.g. an OpenAI-Responses-compatible Ollama backend), the success handler crashes inside `AnthropicResponse.model_validate(result)`. The exception is caught by `_success_handler_helper_fn` as `[Non-Blocking]`, so the client gets a normal streaming response — but **the spend_logs row is silently dropped** and the UI shows no entry.

`AnthropicResponsesStreamWrapper.async_anthropic_sse_wrapper` already translates the events back to anthropic-shape SSE for the client. The logging path does not need to re-translate; passing the raw event through preserves usage fields for downstream cost tracking.

This PR adds an early return in `_handle_anthropic_messages_response_logging` for streaming requests when `result` is a `ResponseCompletedEvent` / `ResponseIncompleteEvent` / `ResponseFailedEvent`, and updates the return type annotation from `ModelResponse` to `Any` to match the existing branches that return non-ModelResponse objects.

Non-streaming requests are unaffected — a `Response*Event` arriving on a non-streaming path is still unexpected and continues into the existing `AnthropicResponse.model_validate` branch.

## Testing

- Added a parametrized regression test covering all three event types (`ResponseCompletedEvent`, `ResponseIncompleteEvent`, `ResponseFailedEvent`): with `stream=True` and `call_type=\"anthropic_messages\"`, the handler returns the event untouched and never calls `AnthropicResponse.model_validate`
- Added a guard test that the non-streaming path still flows into `AnthropicResponse.model_validate` for `Response*Event` inputs (preventing accidental over-swallowing)
- Verified the parametrized cases fail without this fix (drop the patch from `litellm_logging.py`, re-run, all three fail — proving the tests aren't no-ops)
- Ran \`uv run pytest tests/test_litellm/litellm_core_utils/test_litellm_logging.py\` — 86 passed

## Type

🐛 Bug Fix