### PR TITLE
fix(focus): fix ConsumedQuantity/PricingQuantity BigInt cast and null fallback

### DIFF
--- a/litellm/integrations/focus/transformer.py
+++ b/litellm/integrations/focus/transformer.py
@@ -9,7 +9,6 @@ import polars as pl
 
 from .schema import FOCUS_NORMALIZED_SCHEMA
 
-
 _TAG_KEYS = (
     "team_id",
     "team_alias",

--- a/litellm/integrations/focus/transformer.py
+++ b/litellm/integrations/focus/transformer.py
@@ -9,6 +9,7 @@ import polars as pl
 
 from .schema import FOCUS_NORMALIZED_SCHEMA
 
+
 _TAG_KEYS = (
     "team_id",
     "team_alias",
@@ -95,9 +96,9 @@ class FocusTransformer:
             pl.lit("Usage-Based").alias("ChargeFrequency"),
             fmt(pl.col("ChargePeriodEnd")).alias("ChargePeriodEnd"),
             fmt(pl.col("ChargePeriodStart")).alias("ChargePeriodStart"),
-            dec(pl.col("api_requests").cast(pl.Int64).cast(pl.Float64).fill_null(0.0)).alias(
-                "ConsumedQuantity"
-            ),
+            dec(
+                pl.col("api_requests").cast(pl.Int64).cast(pl.Float64).fill_null(0.0)
+            ).alias("ConsumedQuantity"),
             pl.lit("Requests").alias("ConsumedUnit"),
             dec(pl.col("spend").fill_null(0.0)).alias("ContractedCost"),
             none_str.alias("ContractedUnitPrice"),
@@ -109,9 +110,9 @@ class FocusTransformer:
             none_str.alias("AvailabilityZone"),
             pl.lit("USD").alias("PricingCurrency"),
             none_str.alias("PricingCategory"),
-            dec(pl.col("api_requests").cast(pl.Int64).cast(pl.Float64).fill_null(0.0)).alias(
-                "PricingQuantity"
-            ),
+            dec(
+                pl.col("api_requests").cast(pl.Int64).cast(pl.Float64).fill_null(0.0)
+            ).alias("PricingQuantity"),
             none_dec.alias("PricingCurrencyContractedUnitPrice"),
             dec(pl.col("spend").fill_null(0.0)).alias("PricingCurrencyEffectiveCost"),
             none_dec.alias("PricingCurrencyListUnitPrice"),

--- a/litellm/integrations/focus/transformer.py
+++ b/litellm/integrations/focus/transformer.py
@@ -95,7 +95,9 @@ class FocusTransformer:
             pl.lit("Usage-Based").alias("ChargeFrequency"),
             fmt(pl.col("ChargePeriodEnd")).alias("ChargePeriodEnd"),
             fmt(pl.col("ChargePeriodStart")).alias("ChargePeriodStart"),
-            dec(pl.lit(1.0)).alias("ConsumedQuantity"),
+            dec(pl.col("api_requests").cast(pl.Int64).cast(pl.Float64).fill_null(0.0)).alias(
+                "ConsumedQuantity"
+            ),
             pl.lit("Requests").alias("ConsumedUnit"),
             dec(pl.col("spend").fill_null(0.0)).alias("ContractedCost"),
             none_str.alias("ContractedUnitPrice"),
@@ -107,7 +109,9 @@ class FocusTransformer:
             none_str.alias("AvailabilityZone"),
             pl.lit("USD").alias("PricingCurrency"),
             none_str.alias("PricingCategory"),
-            dec(pl.lit(1.0)).alias("PricingQuantity"),
+            dec(pl.col("api_requests").cast(pl.Int64).cast(pl.Float64).fill_null(0.0)).alias(
+                "PricingQuantity"
+            ),
             none_dec.alias("PricingCurrencyContractedUnitPrice"),
             dec(pl.col("spend").fill_null(0.0)).alias("PricingCurrencyEffectiveCost"),
             none_dec.alias("PricingCurrencyListUnitPrice"),

--- a/tests/test_litellm/integrations/focus/test_focus_transformer.py
+++ b/tests/test_litellm/integrations/focus/test_focus_transformer.py
@@ -1,0 +1,70 @@
+"""Tests for FocusTransformer — ConsumedQuantity / PricingQuantity correctness."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import polars as pl
+import pytest
+
+from litellm.integrations.focus.transformer import FocusTransformer
+
+
+def _base_row(**overrides) -> dict:
+    row = {
+        "date": "2026-05-25",
+        "user_id": "u1",
+        "api_key": "sk-test",
+        "api_key_alias": "my-key",
+        "model": "gpt-4o",
+        "model_group": "openai",
+        "custom_llm_provider": "openai",
+        "spend": 0.05,
+        "api_requests": 3,
+        "team_id": "team1",
+        "team_alias": "Engineering",
+        "user_email": "user@example.com",
+    }
+    row.update(overrides)
+    return row
+
+
+def _transform(rows: list[dict]) -> pl.DataFrame:
+    frame = pl.DataFrame(rows, infer_schema_length=None)
+    return FocusTransformer().transform(frame)
+
+
+def test_consumed_quantity_reflects_api_requests():
+    result = _transform([_base_row(api_requests=7)])
+    assert result["ConsumedQuantity"][0] == Decimal("7.000000")
+
+
+def test_pricing_quantity_reflects_api_requests():
+    result = _transform([_base_row(api_requests=7)])
+    assert result["PricingQuantity"][0] == Decimal("7.000000")
+
+
+def test_null_api_requests_falls_back_to_zero_not_one():
+    """Rows with NULL api_requests (old schema rows) must produce 0, not 1."""
+    result = _transform([_base_row(api_requests=None)])
+    assert result["ConsumedQuantity"][0] == Decimal("0.000000")
+    assert result["PricingQuantity"][0] == Decimal("0.000000")
+
+
+def test_zero_api_requests_stays_zero():
+    result = _transform([_base_row(api_requests=0)])
+    assert result["ConsumedQuantity"][0] == Decimal("0.000000")
+    assert result["PricingQuantity"][0] == Decimal("0.000000")
+
+
+def test_bigint_api_requests_cast_correctly():
+    """api_requests comes from Postgres as BigInt — large values must not overflow."""
+    result = _transform([_base_row(api_requests=1_000_000)])
+    assert result["ConsumedQuantity"][0] == Decimal("1000000.000000")
+    assert result["PricingQuantity"][0] == Decimal("1000000.000000")
+
+
+def test_consumed_and_pricing_quantity_match():
+    """ConsumedQuantity and PricingQuantity must always be equal."""
+    result = _transform([_base_row(api_requests=42)])
+    assert result["ConsumedQuantity"][0] == result["PricingQuantity"][0]

--- a/tests/test_litellm/integrations/focus/test_focus_transformer.py
+++ b/tests/test_litellm/integrations/focus/test_focus_transformer.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from decimal import Decimal
 
 import polars as pl
-import pytest
 
 from litellm.integrations.focus.transformer import FocusTransformer
 


### PR DESCRIPTION
## What

Fixes `ConsumedQuantity` and `PricingQuantity` in `FocusTransformer` — both were hardcoded to `pl.lit(1.0)` instead of reading the actual `api_requests` value from the DB.

## Why this is a logical error, not just a placeholder

The upstream code pairs `ConsumedUnit = "Requests"` with `ConsumedQuantity = 1.0`. The [FOCUS v1.2 spec](https://focus.finops.org/focus-specification/v1-2/) defines `ConsumedQuantity` as *"the volume of a metered SKU associated with a resource or service used"* — so if the unit is `"Requests"`, the quantity must be the actual request count, not `1.0`.

A hardcoded `1.0` with unit `"Requests"` means every row is reported as exactly 1 request regardless of actual traffic, making the field meaningless for cost analytics tools that rely on it for attribution and aggregation.

## Fix

```python
# before — hardcoded, unit/quantity inconsistent
dec(pl.lit(1.0)).alias("ConsumedQuantity")
dec(pl.lit(1.0)).alias("PricingQuantity")

# after — reads actual request count, consistent with ConsumedUnit = "Requests"
dec(pl.col("api_requests").cast(pl.Int64).cast(pl.Float64).fill_null(0.0)).alias("ConsumedQuantity")
dec(pl.col("api_requests").cast(pl.Int64).cast(pl.Float64).fill_null(0.0)).alias("PricingQuantity")
```

The `.cast(pl.Int64)` step is needed because `api_requests` is a Postgres `BigInt` — skipping it can cause silent null production on some driver versions before widening to `Float64`. The `fill_null(0.0)` handles rows written before the column existed (schema default is `0`, but legacy rows may be `NULL`).

## Tests

Added `tests/test_litellm/integrations/focus/test_focus_transformer.py` covering:
- Normal `api_requests` value is reflected correctly in both fields
- `NULL` api_requests falls back to `0`, not `1`
- Zero api_requests stays zero
- Large BigInt values (1M+) cast without overflow
- `ConsumedQuantity` and `PricingQuantity` always match

🤖 Generated with [Claude Code](https://claude.ai/claude-code)