### PR TITLE
fix(caching): retain references to background cache-write tasks

### DIFF
--- a/litellm/caching/caching_handler.py
+++ b/litellm/caching/caching_handler.py
@@ -1038,7 +1038,9 @@ class LLMCachingHandler:
                     _track_cache_task(
                         asyncio.create_task(
                             litellm.cache.async_add_cache_pipeline(
-                                result, dynamic_cache_object=self.dual_cache, **new_kwargs
+                                result,
+                                dynamic_cache_object=self.dual_cache,
+                                **new_kwargs,
                             )
                         )
                     )

--- a/litellm/caching/caching_handler.py
+++ b/litellm/caching/caching_handler.py
@@ -27,6 +27,7 @@ from typing import (
     Generator,
     List,
     Optional,
+    Set,
     Tuple,
     Union,
 )
@@ -107,6 +108,20 @@ def _should_defer_streaming_cache_hit_callbacks(*, kwargs: Dict[str, Any]) -> bo
     spend and callback records.
     """
     return kwargs.get("stream", False) is True
+
+
+# Strong references to fire-and-forget cache-write tasks. asyncio only keeps a
+# weak reference to a task created with create_task, so without this a cache
+# write could be garbage-collected before it completes, silently dropping the
+# entry. Tasks remove themselves from the set on completion.
+_background_cache_tasks: Set["asyncio.Task[Any]"] = set()
+
+
+def _track_cache_task(task: "asyncio.Task[Any]") -> "asyncio.Task[Any]":
+    """Retain a strong reference to a background cache-write task until done."""
+    _background_cache_tasks.add(task)
+    task.add_done_callback(_background_cache_tasks.discard)
+    return task
 
 
 class LLMCachingHandler:
@@ -1020,21 +1035,29 @@ class LLMCachingHandler:
                         litellm.cache.cache, S3Cache
                     )  # s3 doesn't support bulk writing. Exclude.
                 ):
-                    asyncio.create_task(
-                        litellm.cache.async_add_cache_pipeline(
-                            result, dynamic_cache_object=self.dual_cache, **new_kwargs
+                    _track_cache_task(
+                        asyncio.create_task(
+                            litellm.cache.async_add_cache_pipeline(
+                                result, dynamic_cache_object=self.dual_cache, **new_kwargs
+                            )
                         )
                     )
                 else:
-                    asyncio.create_task(
-                        litellm.cache.async_add_cache(
-                            result.model_dump_json(),
-                            dynamic_cache_object=self.dual_cache,
-                            **new_kwargs,
+                    _track_cache_task(
+                        asyncio.create_task(
+                            litellm.cache.async_add_cache(
+                                result.model_dump_json(),
+                                dynamic_cache_object=self.dual_cache,
+                                **new_kwargs,
+                            )
                         )
                     )
             else:
-                asyncio.create_task(litellm.cache.async_add_cache(result, **new_kwargs))
+                _track_cache_task(
+                    asyncio.create_task(
+                        litellm.cache.async_add_cache(result, **new_kwargs)
+                    )
+                )
 
     def sync_set_cache(
         self,

--- a/tests/litellm/caching/test_background_cache_tasks.py
+++ b/tests/litellm/caching/test_background_cache_tasks.py
@@ -1,0 +1,50 @@
+"""Tests for background cache-write task tracking in the caching handler.
+
+asyncio only keeps a weak reference to a task created with create_task, so a
+fire-and-forget cache write can be garbage-collected before it finishes,
+silently dropping the entry. _track_cache_task retains a strong reference until
+the task completes.
+"""
+
+import asyncio
+
+import pytest
+
+from litellm.caching.caching_handler import (
+    _background_cache_tasks,
+    _track_cache_task,
+)
+
+
+@pytest.mark.asyncio
+async def test_track_cache_task_keeps_reference_until_done():
+    async def _write():
+        await asyncio.sleep(0)
+        return "written"
+
+    task = _track_cache_task(asyncio.create_task(_write()))
+
+    # While pending, a strong reference is held in the tracking set.
+    assert task in _background_cache_tasks
+
+    result = await task
+
+    # Once done, the task delivers its result and the reference is released.
+    assert result == "written"
+    await asyncio.sleep(0)  # allow the done-callback to run
+    assert task not in _background_cache_tasks
+
+
+@pytest.mark.asyncio
+async def test_track_cache_task_releases_reference_on_exception():
+    async def _boom():
+        raise RuntimeError("cache backend down")
+
+    task = _track_cache_task(asyncio.create_task(_boom()))
+    assert task in _background_cache_tasks
+
+    with pytest.raises(RuntimeError, match="cache backend down"):
+        await task
+
+    await asyncio.sleep(0)
+    assert task not in _background_cache_tasks


### PR DESCRIPTION
## Title
fix(caching): retain references to background cache-write tasks

## Relevant issues
Found via static analysis of fire-and-forget `asyncio.create_task` usage.

## Type
🐛 Bug Fix

## Changes

`LLMCachingHandler.async_set_cache` scheduled cache writes with bare `asyncio.create_task(...)` whose results were discarded (three sites). asyncio only keeps a **weak** reference to a task ([docs](https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task)), so these writes can be garbage-collected before completing — silently dropping cache entries and wasting spend on the resulting cache misses.

This tracks the tasks in a module-level set and releases them via a done-callback. The pattern already exists elsewhere in litellm — e.g. `responses/streaming_iterator.py` keeps `cache_write_task` + `add_done_callback`, and the akto guardrail and logging worker use the same `set` + `discard` approach. This change makes `async_set_cache` consistent with them.

## Testing

Added `tests/litellm/caching/test_background_cache_tasks.py` covering:
- a strong reference is held while the task is pending and released once it completes (success path),
- the reference is released when the task raises (exception path).

`ruff check` passes on both files.
