### PR TITLE
docs: fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ Support for more providers. Missing a provider or LLM Platform, raise a [feature
 ### Run in Developer Mode
 #### Services
 1. Setup .env file in root
-2. Run dependant services `docker-compose up db prometheus`
+2. Run dependent services `docker-compose up db prometheus`
 
 #### Backend
 1. (In root) create virtual environment `python -m venv .venv`


### PR DESCRIPTION
## Relevant issues

None.

## Linear ticket

None.

## Pre-Submission checklist

This is a documentation-only typo fix. Unit tests are not applicable; I verified the diff with `git diff --check`.

## Screenshots / Proof of Fix

Documentation-only change: the developer mode instructions now say "dependent services".

## Type

Documentation

## Changes

Fixes a typo in the README developer mode setup instructions.