### PR TITLE
fix(callbacks): unify callback failure metrics across integrations

### DIFF
--- a/litellm/integrations/azure_sentinel/azure_sentinel.py
+++ b/litellm/integrations/azure_sentinel/azure_sentinel.py
@@ -374,15 +374,24 @@ class AzureSentinelLogger(CustomBatchLogger):
             return
 
         async with self.flush_lock:
-            try:
-                if self.log_queue:
+            flush_failed = False
+            if self.log_queue:
+                try:
                     await self.async_send_batch()
-                if self.audit_log_queue:
+                except Exception:
+                    flush_failed = True
+                    verbose_logger.exception(
+                        "Azure Sentinel: log flush failed; preserving events for retry"
+                    )
+            if self.audit_log_queue:
+                try:
                     await self.async_send_audit_batch()
-            except Exception:
-                verbose_logger.exception(
-                    "Azure Sentinel: flush failed; preserving events for retry"
-                )
+                except Exception:
+                    flush_failed = True
+                    verbose_logger.exception(
+                        "Azure Sentinel: audit log flush failed; preserving events for retry"
+                    )
+            if flush_failed:
                 if not self._is_in_failure_state:
                     self.handle_callback_failure(
                         callback_name=self._get_callback_failure_name()

--- a/litellm/integrations/azure_sentinel/azure_sentinel.py
+++ b/litellm/integrations/azure_sentinel/azure_sentinel.py
@@ -227,7 +227,7 @@ class AzureSentinelLogger(CustomBatchLogger):
             self.log_queue.append(standard_logging_payload)
 
             if len(self.log_queue) >= self.batch_size:
-                await self.async_send_batch()
+                await self.flush_queue()
 
         except Exception as e:
             verbose_logger.exception(
@@ -262,7 +262,7 @@ class AzureSentinelLogger(CustomBatchLogger):
             self.log_queue.append(standard_logging_payload)
 
             if len(self.log_queue) >= self.batch_size:
-                await self.async_send_batch()
+                await self.flush_queue()
 
         except Exception as e:
             verbose_logger.exception(
@@ -327,61 +327,67 @@ class AzureSentinelLogger(CustomBatchLogger):
         api_endpoint: str,
         log_type: str,
     ) -> None:
-        try:
-            if not log_queue:
-                return
+        if not log_queue:
+            return
 
-            verbose_logger.debug(
-                "Azure Sentinel - about to flush %s %s", len(log_queue), log_type
-            )
+        verbose_logger.debug(
+            "Azure Sentinel - about to flush %s %s", len(log_queue), log_type
+        )
 
-            # Get OAuth2 token
-            bearer_token = await self._get_oauth_token()
+        # Get OAuth2 token
+        bearer_token = await self._get_oauth_token()
 
-            # Convert log queue to JSON array format expected by Logs Ingestion API
-            # Each log entry should be a JSON object in the array
-            body = safe_dumps(log_queue)
+        # Convert log queue to JSON array format expected by Logs Ingestion API
+        # Each log entry should be a JSON object in the array
+        body = safe_dumps(log_queue)
 
-            # Set headers for Logs Ingestion API
-            headers = {
-                "Authorization": f"Bearer {bearer_token}",
-                "Content-Type": "application/json",
-            }
+        # Set headers for Logs Ingestion API
+        headers = {
+            "Authorization": f"Bearer {bearer_token}",
+            "Content-Type": "application/json",
+        }
 
-            # Send the request
-            response = await self.async_httpx_client.post(
-                url=api_endpoint, data=body.encode("utf-8"), headers=headers
-            )
+        # Send the request
+        response = await self.async_httpx_client.post(
+            url=api_endpoint, data=body.encode("utf-8"), headers=headers
+        )
 
-            if response.status_code not in [200, 204]:
-                verbose_logger.error(
-                    "Azure Sentinel API error: status_code=%s, response=%s",
-                    response.status_code,
-                    response.text,
-                )
-                raise Exception(
-                    f"Failed to send logs to Azure Sentinel: {response.status_code} - {response.text}"
-                )
-
-            verbose_logger.debug(
-                "Azure Sentinel: Response from API status_code: %s",
+        if response.status_code not in [200, 204]:
+            verbose_logger.error(
+                "Azure Sentinel API error: status_code=%s, response=%s",
                 response.status_code,
+                response.text,
+            )
+            raise Exception(
+                f"Failed to send logs to Azure Sentinel: {response.status_code} - {response.text}"
             )
 
-        except Exception as e:
-            verbose_logger.exception(
-                f"Azure Sentinel Error sending batch API - {str(e)}\n{traceback.format_exc()}"
-            )
-        finally:
-            log_queue.clear()
+        verbose_logger.debug(
+            "Azure Sentinel: Response from API status_code: %s",
+            response.status_code,
+        )
+
+        log_queue.clear()
 
     async def flush_queue(self):
         if self.flush_lock is None:
             return
 
         async with self.flush_lock:
-            if self.log_queue:
-                await self.async_send_batch()
-            if self.audit_log_queue:
-                await self.async_send_audit_batch()
+            try:
+                if self.log_queue:
+                    await self.async_send_batch()
+                if self.audit_log_queue:
+                    await self.async_send_audit_batch()
+            except Exception:
+                verbose_logger.exception(
+                    "Azure Sentinel: flush failed; preserving events for retry"
+                )
+                if not self._is_in_failure_state:
+                    self.handle_callback_failure(
+                        callback_name=self._get_callback_failure_name()
+                    )
+                    self._is_in_failure_state = True
+                return
             self.last_flush_time = time.time()
+            self._is_in_failure_state = False

--- a/litellm/integrations/custom_batch_logger.py
+++ b/litellm/integrations/custom_batch_logger.py
@@ -67,6 +67,7 @@ class CustomBatchLogger(CustomLogger):
 
         async with self.flush_lock:
             if self.log_queue:
+                log_queue = self.log_queue
                 log_queue_length = len(self.log_queue)
                 verbose_logger.debug(
                     "CustomLogger: Flushing batch of %s events", len(self.log_queue)
@@ -100,7 +101,8 @@ class CustomBatchLogger(CustomLogger):
                         )
                     return
                 if self.preserve_events_added_during_flush:
-                    del self.log_queue[:log_queue_length]
+                    if self.log_queue is log_queue:
+                        del self.log_queue[:log_queue_length]
                 else:
                     self.log_queue.clear()
                 self.last_flush_time = time.time()

--- a/litellm/integrations/custom_batch_logger.py
+++ b/litellm/integrations/custom_batch_logger.py
@@ -46,8 +46,12 @@ class CustomBatchLogger(CustomLogger):
             if max_queue_size is not None
             else self.DEFAULT_MAX_QUEUE_SIZE
         )
+        self._is_in_failure_state: bool = False
 
         super().__init__(**kwargs)
+
+    def _get_callback_failure_name(self) -> str:
+        return self.callback_name or self.__class__.__name__
 
     async def periodic_flush(self):
         while True:
@@ -72,14 +76,16 @@ class CustomBatchLogger(CustomLogger):
                 except Exception:
                     # If the underlying batch send raised, do NOT drop the
                     # in-flight events. They will be retried on the next flush.
-                    # Most existing async_send_batch implementations swallow
-                    # their own errors, so this only affects loggers that opt
-                    # in to surfacing failures (e.g. Rubrik).
                     verbose_logger.exception(
                         "CustomLogger: async_send_batch raised; preserving "
                         "%s events in queue for retry",
                         log_queue_length,
                     )
+                    if not self._is_in_failure_state:
+                        self.handle_callback_failure(
+                            callback_name=self._get_callback_failure_name()
+                        )
+                        self._is_in_failure_state = True
                     # Guard against unbounded queue growth if the destination
                     # is persistently unreachable. Drop the oldest events
                     # beyond ``max_queue_size``.
@@ -98,6 +104,7 @@ class CustomBatchLogger(CustomLogger):
                 else:
                     self.log_queue.clear()
                 self.last_flush_time = time.time()
+                self._is_in_failure_state = False
 
     async def async_send_batch(self, *args, **kwargs):
         pass

--- a/litellm/integrations/custom_logger.py
+++ b/litellm/integrations/custom_logger.py
@@ -67,7 +67,8 @@ _BASE64_INLINE_PATTERN = re.compile(
 
 
 class CustomLogger:  # https://docs.litellm.ai/docs/observability/custom_callback#callback-class
-    # Class variables or attributes
+    callback_name: Optional[str]
+
     def __init__(
         self,
         turn_off_message_logging: bool = False,

--- a/litellm/integrations/custom_logger.py
+++ b/litellm/integrations/custom_logger.py
@@ -82,6 +82,7 @@ class CustomLogger:  # https://docs.litellm.ai/docs/observability/custom_callbac
         """
         self.message_logging = message_logging
         self.turn_off_message_logging = turn_off_message_logging
+        self.callback_name: Optional[str] = None
         pass
 
     @staticmethod

--- a/litellm/integrations/custom_logger.py
+++ b/litellm/integrations/custom_logger.py
@@ -82,7 +82,9 @@ class CustomLogger:  # https://docs.litellm.ai/docs/observability/custom_callbac
         """
         self.message_logging = message_logging
         self.turn_off_message_logging = turn_off_message_logging
-        self.callback_name: Optional[str] = None
+        # Subclasses (e.g. OpenTelemetry) may set callback_name before super().__init__().
+        if not hasattr(self, "callback_name"):
+            self.callback_name = None
         pass
 
     @staticmethod

--- a/litellm/integrations/datadog/datadog.py
+++ b/litellm/integrations/datadog/datadog.py
@@ -309,7 +309,7 @@ class DataDogLogger(
             )
         return None
 
-    async def async_send_batch(self):
+    async def async_send_batch(self) -> bool:
         """
         Sends the in memory logs queue to datadog api
 
@@ -317,14 +317,18 @@ class DataDogLogger(
 
         DD Ref: https://docs.datadoghq.com/api/latest/logs/
 
+        Returns:
+            True if the in-flight batch was accepted by Datadog, False if there was
+            nothing to send or the batch was requeued (e.g. 413).
+
         Raises:
-            Raises a NON Blocking verbose_logger.exception if an error occurs
+            On terminal send failures after requeueing the batch for retry.
         """
         batch_to_send: list = []
         try:
             if not self.log_queue:
                 verbose_logger.exception("Datadog: log_queue does not exist")
-                return
+                return False
 
             batch_to_send = self.log_queue[:]
             self.log_queue = []
@@ -344,7 +348,7 @@ class DataDogLogger(
             if response.status_code == 413:
                 verbose_logger.exception(DD_ERRORS.DATADOG_413_ERROR.value)
                 self.log_queue = batch_to_send + self.log_queue
-                return
+                return False
 
             response.raise_for_status()
             if response.status_code != 202:
@@ -363,6 +367,8 @@ class DataDogLogger(
                     response.text,
                 )
 
+            return True
+
         except Exception:
             self.log_queue = batch_to_send + self.log_queue
             raise
@@ -377,7 +383,7 @@ class DataDogLogger(
                     "Datadog: Flushing batch of %s events", len(self.log_queue)
                 )
                 try:
-                    await self.async_send_batch()
+                    batch_delivered = await self.async_send_batch()
                 except Exception:
                     verbose_logger.exception(
                         "Datadog Error sending batch API; preserving events for retry"
@@ -388,7 +394,7 @@ class DataDogLogger(
                         )
                         self._is_in_failure_state = True
                     return
-                if not self.log_queue:
+                if batch_delivered:
                     self.last_flush_time = time.time()
                     self._is_in_failure_state = False
 

--- a/litellm/integrations/datadog/datadog.py
+++ b/litellm/integrations/datadog/datadog.py
@@ -320,6 +320,7 @@ class DataDogLogger(
         Raises:
             Raises a NON Blocking verbose_logger.exception if an error occurs
         """
+        batch_to_send: list = []
         try:
             if not self.log_queue:
                 verbose_logger.exception("Datadog: log_queue does not exist")
@@ -362,11 +363,9 @@ class DataDogLogger(
                     response.text,
                 )
 
-        except Exception as e:
+        except Exception:
             self.log_queue = batch_to_send + self.log_queue
-            verbose_logger.exception(
-                f"Datadog Error sending batch API - {str(e)}\n{traceback.format_exc()}"
-            )
+            raise
 
     async def flush_queue(self):
         if self.flush_lock is None:
@@ -377,9 +376,21 @@ class DataDogLogger(
                 verbose_logger.debug(
                     "Datadog: Flushing batch of %s events", len(self.log_queue)
                 )
-                await self.async_send_batch()
+                try:
+                    await self.async_send_batch()
+                except Exception:
+                    verbose_logger.exception(
+                        "Datadog Error sending batch API; preserving events for retry"
+                    )
+                    if not self._is_in_failure_state:
+                        self.handle_callback_failure(
+                            callback_name=self._get_callback_failure_name()
+                        )
+                        self._is_in_failure_state = True
+                    return
                 if not self.log_queue:
                     self.last_flush_time = time.time()
+                    self._is_in_failure_state = False
 
     def log_success_event(self, kwargs, response_obj, start_time, end_time):
         """

--- a/litellm/integrations/datadog/datadog_cost_management.py
+++ b/litellm/integrations/datadog/datadog_cost_management.py
@@ -44,6 +44,8 @@ _RESERVED_TAG_KEYS: frozenset = frozenset(
 
 
 class DatadogCostManagementLogger(CustomBatchLogger):
+    preserve_events_added_during_flush = True
+
     def __init__(self, cost_tag_keys: Optional[List[str]] = None, **kwargs):
         self.cost_tag_keys: List[str] = list(cost_tag_keys) if cost_tag_keys else []
         self.dd_api_key = os.getenv("DD_API_KEY")

--- a/litellm/integrations/datadog/datadog_cost_management.py
+++ b/litellm/integrations/datadog/datadog_cost_management.py
@@ -85,7 +85,7 @@ class DatadogCostManagementLogger(CustomBatchLogger):
                 self.log_queue.append(standard_logging_object)
 
                 if len(self.log_queue) >= self.batch_size:
-                    await self.async_send_batch()
+                    await self.flush_queue()
 
         except Exception as e:
             verbose_logger.exception(
@@ -114,6 +114,7 @@ class DatadogCostManagementLogger(CustomBatchLogger):
             verbose_logger.exception(
                 f"Datadog Cost Management: Error in async_send_batch: {str(e)}"
             )
+            raise
 
     def _aggregate_costs(
         self, logs: List[StandardLoggingPayload]

--- a/litellm/integrations/datadog/datadog_llm_obs.py
+++ b/litellm/integrations/datadog/datadog_llm_obs.py
@@ -161,7 +161,7 @@ class DataDogLLMObsLogger(CustomBatchLogger):
             self.log_queue.append(payload)
 
             if len(self.log_queue) >= self.batch_size:
-                await self.async_send_batch()
+                await self.flush_queue()
         except Exception as e:
             verbose_logger.exception(
                 f"DataDogLLMObs: Error logging success event - {str(e)}"
@@ -177,7 +177,7 @@ class DataDogLLMObsLogger(CustomBatchLogger):
             self.log_queue.append(payload)
 
             if len(self.log_queue) >= self.batch_size:
-                await self.async_send_batch()
+                await self.flush_queue()
         except Exception as e:
             verbose_logger.exception(
                 f"DataDogLLMObs: Error logging failure event - {str(e)}"
@@ -249,8 +249,10 @@ class DataDogLLMObsLogger(CustomBatchLogger):
             verbose_logger.exception(
                 f"DataDogLLMObs: Error sending batch - {e.response.text}"
             )
+            raise
         except Exception as e:
             verbose_logger.exception(f"DataDogLLMObs: Error sending batch - {str(e)}")
+            raise
 
     def create_llm_obs_payload(
         self, kwargs: Dict, start_time: datetime, end_time: datetime

--- a/litellm/integrations/gcs_bucket/gcs_bucket.py
+++ b/litellm/integrations/gcs_bucket/gcs_bucket.py
@@ -254,17 +254,24 @@ class GCSBucketLogger(GCSBucketBase, AdditionalLoggingUtils):
             )
             return (success_count, error_count)
 
-    async def _send_individual_logs(self, items: List[GCSLogQueueItem]) -> None:
+    async def _send_individual_logs(self, items: List[GCSLogQueueItem]) -> int:
         """
         Send each log individually as separate GCS objects (legacy behavior).
         This is used when GCS_USE_BATCHED_LOGGING is disabled.
-        """
-        for item in items:
-            await self._send_single_log_item(item)
 
-    async def _send_single_log_item(self, item: GCSLogQueueItem) -> None:
+        Returns the number of items that failed to upload.
+        """
+        error_count = 0
+        for item in items:
+            if not await self._send_single_log_item(item):
+                error_count += 1
+        return error_count
+
+    async def _send_single_log_item(self, item: GCSLogQueueItem) -> bool:
         """
         Send a single log item to GCS as an individual object.
+
+        Returns True on success, False on failure.
         """
         try:
             gcs_logging_config: GCSLoggingConfig = await self.get_gcs_logging_config(
@@ -289,10 +296,12 @@ class GCSBucketLogger(GCSBucketBase, AdditionalLoggingUtils):
                 object_name=object_name,
                 logging_payload=item["payload"],
             )
+            return True
         except Exception as e:
             verbose_logger.exception(
                 f"GCS Bucket error logging individual payload to GCS bucket: {str(e)}"
             )
+            return False
 
     async def async_send_batch(self):
         """
@@ -308,13 +317,20 @@ class GCSBucketLogger(GCSBucketBase, AdditionalLoggingUtils):
         if not items_to_process:
             return
 
+        error_count = 0
         if self.use_batched_logging:
             grouped_items = self._group_items_by_config(items_to_process)
 
             for config_key, group_items in grouped_items.items():
-                await self._send_grouped_batch(group_items, config_key)
+                _, group_errors = await self._send_grouped_batch(
+                    group_items, config_key
+                )
+                error_count += group_errors
         else:
-            await self._send_individual_logs(items_to_process)
+            error_count = await self._send_individual_logs(items_to_process)
+
+        if error_count > 0:
+            raise Exception(f"GCS Bucket: failed to upload {error_count} log(s) to GCS")
 
     def _get_object_name(
         self, kwargs: Dict, logging_payload: StandardLoggingPayload, response_obj: Any
@@ -406,8 +422,19 @@ class GCSBucketLogger(GCSBucketBase, AdditionalLoggingUtils):
         """
         Override flush_queue to work with asyncio.Queue.
         """
-        await self.async_send_batch()
+        try:
+            await self.async_send_batch()
+        except Exception:
+            verbose_logger.exception("GCS Bucket: flush failed")
+            if not self._is_in_failure_state:
+                self.handle_callback_failure(
+                    callback_name=self._get_callback_failure_name()
+                )
+                self._is_in_failure_state = True
+            self.last_flush_time = time.time()
+            return
         self.last_flush_time = time.time()
+        self._is_in_failure_state = False
 
     async def periodic_flush(self):
         """

--- a/litellm/integrations/gcs_bucket/gcs_bucket.py
+++ b/litellm/integrations/gcs_bucket/gcs_bucket.py
@@ -431,7 +431,6 @@ class GCSBucketLogger(GCSBucketBase, AdditionalLoggingUtils):
                     callback_name=self._get_callback_failure_name()
                 )
                 self._is_in_failure_state = True
-            self.last_flush_time = time.time()
             return
         self.last_flush_time = time.time()
         self._is_in_failure_state = False

--- a/litellm/integrations/gcs_pubsub/pub_sub.py
+++ b/litellm/integrations/gcs_pubsub/pub_sub.py
@@ -152,8 +152,13 @@ class GcsPubSubLogger(CustomBatchLogger):
 
         verbose_logger.debug(f"PubSub - about to flush {len(self.log_queue)} events")
 
-        for message in self.log_queue:
-            await self.publish_message(message)
+        batch_to_send = self.log_queue[:]
+        for idx, message in enumerate(batch_to_send):
+            try:
+                await self.publish_message(message)
+            except Exception:
+                del self.log_queue[:idx]
+                raise
 
     async def publish_message(
         self, message: Union[SpendLogsPayload, StandardLoggingPayload]

--- a/litellm/integrations/gcs_pubsub/pub_sub.py
+++ b/litellm/integrations/gcs_pubsub/pub_sub.py
@@ -135,7 +135,7 @@ class GcsPubSubLogger(CustomBatchLogger):
                 self.log_queue.append(standard_logging_payload)
 
             if len(self.log_queue) >= self.batch_size:
-                await self.async_send_batch()
+                await self.flush_queue()
 
         except Exception as e:
             verbose_logger.exception(
@@ -147,23 +147,13 @@ class GcsPubSubLogger(CustomBatchLogger):
         """
         Sends the batch of messages to Pub/Sub
         """
-        try:
-            if not self.log_queue:
-                return
+        if not self.log_queue:
+            return
 
-            verbose_logger.debug(
-                f"PubSub - about to flush {len(self.log_queue)} events"
-            )
+        verbose_logger.debug(f"PubSub - about to flush {len(self.log_queue)} events")
 
-            for message in self.log_queue:
-                await self.publish_message(message)
-
-        except Exception as e:
-            verbose_logger.exception(
-                f"PubSub Error sending batch - {str(e)}\n{traceback.format_exc()}"
-            )
-        finally:
-            self.log_queue.clear()
+        for message in self.log_queue:
+            await self.publish_message(message)
 
     async def publish_message(
         self, message: Union[SpendLogsPayload, StandardLoggingPayload]
@@ -211,4 +201,4 @@ class GcsPubSubLogger(CustomBatchLogger):
 
         except Exception as e:
             verbose_logger.error("Pub/Sub publish error: %s", str(e))
-            return None
+            raise

--- a/litellm/integrations/generic_api/generic_api_callback.py
+++ b/litellm/integrations/generic_api/generic_api_callback.py
@@ -379,18 +379,20 @@ class GenericAPILogger(CustomBatchLogger):
         )
 
         if self.log_format == "single":
-            # Send each log as individual HTTP request in parallel
-            tasks = []
-            for log_entry in self.log_queue:
-                task = self._post_with_retries(data=safe_dumps(log_entry))
-                tasks.append(task)
+            batch_to_send = self.log_queue[:]
+            tasks = [
+                self._post_with_retries(data=safe_dumps(log_entry))
+                for log_entry in batch_to_send
+            ]
 
             # Execute all requests in parallel
             responses = await asyncio.gather(*tasks, return_exceptions=True)
 
             errors = [r for r in responses if isinstance(r, Exception)]
+            failed_entries = []
             for idx, result in enumerate(responses):
                 if isinstance(result, Exception):
+                    failed_entries.append(batch_to_send[idx])
                     verbose_logger.exception(
                         f"Generic API Logger - Error sending log {idx}: {result}"
                     )
@@ -399,6 +401,9 @@ class GenericAPILogger(CustomBatchLogger):
                         f"Generic API Logger - sent log {idx}, status: {result.status_code}"  # type: ignore
                     )
             if errors:
+                self.log_queue[:] = (
+                    failed_entries + self.log_queue[len(batch_to_send) :]
+                )
                 raise errors[0]
         else:
             # Format the payload based on log_format

--- a/litellm/integrations/generic_api/generic_api_callback.py
+++ b/litellm/integrations/generic_api/generic_api_callback.py
@@ -319,7 +319,7 @@ class GenericAPILogger(CustomBatchLogger):
                 self.log_queue.append(standard_logging_payload)
 
             if len(self.log_queue) >= self.batch_size:
-                await self.async_send_batch()
+                await self.flush_queue()
 
         except Exception as e:
             verbose_logger.exception(
@@ -355,7 +355,7 @@ class GenericAPILogger(CustomBatchLogger):
                 self.log_queue.append(standard_logging_payload)
 
             if len(self.log_queue) >= self.batch_size:
-                await self.async_send_batch()
+                await self.flush_queue()
 
         except Exception as e:
             verbose_logger.exception(
@@ -371,58 +371,51 @@ class GenericAPILogger(CustomBatchLogger):
         - ndjson: Sends logs as newline-delimited JSON
         - single: Sends each log as individual HTTP request in parallel
         """
-        try:
-            if not self.log_queue:
-                return
+        if not self.log_queue:
+            return
+
+        verbose_logger.debug(
+            f"Generic API Logger - about to flush {len(self.log_queue)} events in '{self.log_format}' format"
+        )
+
+        if self.log_format == "single":
+            # Send each log as individual HTTP request in parallel
+            tasks = []
+            for log_entry in self.log_queue:
+                task = self._post_with_retries(data=safe_dumps(log_entry))
+                tasks.append(task)
+
+            # Execute all requests in parallel
+            responses = await asyncio.gather(*tasks, return_exceptions=True)
+
+            errors = [r for r in responses if isinstance(r, Exception)]
+            for idx, result in enumerate(responses):
+                if isinstance(result, Exception):
+                    verbose_logger.exception(
+                        f"Generic API Logger - Error sending log {idx}: {result}"
+                    )
+                else:
+                    verbose_logger.debug(
+                        f"Generic API Logger - sent log {idx}, status: {result.status_code}"  # type: ignore
+                    )
+            if errors:
+                raise errors[0]
+        else:
+            # Format the payload based on log_format
+            if self.log_format == "json_array":
+                data = safe_dumps(self.log_queue)
+            elif self.log_format == "ndjson":
+                data = "\n".join(safe_dumps(log) for log in self.log_queue)
+            else:
+                raise ValueError(f"Unknown log_format: {self.log_format}")
+
+            # Make POST request
+            response = await self._post_with_retries(data=data)
 
             verbose_logger.debug(
-                f"Generic API Logger - about to flush {len(self.log_queue)} events in '{self.log_format}' format"
+                f"Generic API Logger - sent batch to {self.endpoint}, "
+                f"status: {response.status_code}, format: {self.log_format}"
             )
-
-            if self.log_format == "single":
-                # Send each log as individual HTTP request in parallel
-                tasks = []
-                for log_entry in self.log_queue:
-                    task = self._post_with_retries(data=safe_dumps(log_entry))
-                    tasks.append(task)
-
-                # Execute all requests in parallel
-                responses = await asyncio.gather(*tasks, return_exceptions=True)
-
-                # Log results
-                for idx, result in enumerate(responses):
-                    if isinstance(result, Exception):
-                        verbose_logger.exception(
-                            f"Generic API Logger - Error sending log {idx}: {result}"
-                        )
-                    else:
-                        # result is a Response object
-                        verbose_logger.debug(
-                            f"Generic API Logger - sent log {idx}, status: {result.status_code}"  # type: ignore
-                        )
-            else:
-                # Format the payload based on log_format
-                if self.log_format == "json_array":
-                    data = safe_dumps(self.log_queue)
-                elif self.log_format == "ndjson":
-                    data = "\n".join(safe_dumps(log) for log in self.log_queue)
-                else:
-                    raise ValueError(f"Unknown log_format: {self.log_format}")
-
-                # Make POST request
-                response = await self._post_with_retries(data=data)
-
-                verbose_logger.debug(
-                    f"Generic API Logger - sent batch to {self.endpoint}, "
-                    f"status: {response.status_code}, format: {self.log_format}"
-                )
-
-        except Exception as e:
-            verbose_logger.exception(
-                f"Generic API Logger Error sending batch - {str(e)}\n{traceback.format_exc()}"
-            )
-        finally:
-            self.log_queue.clear()
 
     def _get_v1_logging_payload(
         self, kwargs, response_obj, start_time, end_time

--- a/litellm/integrations/langfuse/langfuse_prompt_management.py
+++ b/litellm/integrations/langfuse/langfuse_prompt_management.py
@@ -327,7 +327,7 @@ class LangfusePromptManagement(LangFuseLogger, PromptManagementBase, CustomLogge
             verbose_logger.exception(
                 f"Langfuse Layer Error - Exception occurred while logging success event: {str(e)}"
             )
-            self.handle_callback_failure(callback_name="langfuse")
+            self.handle_callback_failure(callback_name=self.__class__.__name__)
 
     async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
         try:
@@ -363,4 +363,4 @@ class LangfusePromptManagement(LangFuseLogger, PromptManagementBase, CustomLogge
             verbose_logger.exception(
                 f"Langfuse Layer Error - Exception occurred while logging failure event: {str(e)}"
             )
-            self.handle_callback_failure(callback_name="langfuse")
+            self.handle_callback_failure(callback_name=self.__class__.__name__)

--- a/litellm/integrations/langfuse/langfuse_prompt_management.py
+++ b/litellm/integrations/langfuse/langfuse_prompt_management.py
@@ -327,7 +327,7 @@ class LangfusePromptManagement(LangFuseLogger, PromptManagementBase, CustomLogge
             verbose_logger.exception(
                 f"Langfuse Layer Error - Exception occurred while logging success event: {str(e)}"
             )
-            self.handle_callback_failure(callback_name=self.__class__.__name__)
+            self.handle_callback_failure(callback_name="langfuse")
 
     async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
         try:
@@ -363,4 +363,4 @@ class LangfusePromptManagement(LangFuseLogger, PromptManagementBase, CustomLogge
             verbose_logger.exception(
                 f"Langfuse Layer Error - Exception occurred while logging failure event: {str(e)}"
             )
-            self.handle_callback_failure(callback_name=self.__class__.__name__)
+            self.handle_callback_failure(callback_name="langfuse")

--- a/litellm/integrations/langsmith.py
+++ b/litellm/integrations/langsmith.py
@@ -440,7 +440,7 @@ class LangsmithLogger(CustomBatchLogger):
 
         Returns: None
 
-        Raises: Does not raise an exception, will only verbose_logger.exception()
+        Raises: Re-raises on send failure so the batch flush can report the failure.
         """
         langsmith_api_base = credentials["LANGSMITH_BASE_URL"]
         langsmith_api_key = credentials["LANGSMITH_API_KEY"]
@@ -483,10 +483,12 @@ class LangsmithLogger(CustomBatchLogger):
             verbose_logger.exception(
                 f"Langsmith HTTP Error: {e.response.status_code} - {e.response.text}"
             )
+            raise
         except Exception:
             verbose_logger.exception(
                 f"Langsmith Layer Error - {traceback.format_exc()}"
             )
+            raise
 
     def _group_batches_by_credentials(self) -> Dict[CredentialsKey, BatchGroup]:
         """Groups queue objects by credentials using a proper key structure"""
@@ -580,13 +582,13 @@ class LangsmithLogger(CustomBatchLogger):
             loop = asyncio.get_event_loop()
             if loop.is_running():
                 # If we're already in an event loop, create a task
-                asyncio.create_task(self.async_send_batch())
+                asyncio.create_task(self.flush_queue())
             else:
                 # If no event loop is running, run the coroutine directly
-                loop.run_until_complete(self.async_send_batch())
+                loop.run_until_complete(self.flush_queue())
         except RuntimeError:
             # If we can't get an event loop, create a new one
-            asyncio.run(self.async_send_batch())
+            asyncio.run(self.flush_queue())
 
     def get_run_by_id(self, run_id):
         langsmith_api_key = self.default_credentials["LANGSMITH_API_KEY"]

--- a/litellm/integrations/langsmith.py
+++ b/litellm/integrations/langsmith.py
@@ -409,11 +409,24 @@ class LangsmithLogger(CustomBatchLogger):
             return
 
         batch_groups = self._group_batches_by_credentials()
+        sent_queue_objects: List[LangsmithQueueObject] = []
         for batch_group in batch_groups.values():
-            await self._log_batch_on_langsmith(
-                credentials=batch_group.credentials,
-                queue_objects=batch_group.queue_objects,
-            )
+            try:
+                await self._log_batch_on_langsmith(
+                    credentials=batch_group.credentials,
+                    queue_objects=batch_group.queue_objects,
+                )
+            except Exception:
+                sent_queue_object_ids = {
+                    id(queue_object) for queue_object in sent_queue_objects
+                }
+                self.log_queue = [
+                    queue_object
+                    for queue_object in self.log_queue
+                    if id(queue_object) not in sent_queue_object_ids
+                ]
+                raise
+            sent_queue_objects.extend(batch_group.queue_objects)
 
     def _add_endpoint_to_url(
         self, url: str, endpoint: str, api_version: str = "/api/v1"

--- a/litellm/integrations/s3_v2.py
+++ b/litellm/integrations/s3_v2.py
@@ -315,7 +315,7 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
             )
         except Exception as e:
             verbose_logger.exception(f"s3 Layer Error - {str(e)}")
-            self.handle_callback_failure(callback_name="S3Logger")
+            self.handle_callback_failure(callback_name=self.__class__.__name__)
 
     async def async_upload_data_to_s3(
         self, batch_logging_element: s3BatchLoggingElement
@@ -428,7 +428,7 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
                 break
         except Exception as e:
             verbose_logger.exception(f"Error uploading to s3: {str(e)}")
-            self.handle_callback_failure(callback_name="S3Logger")
+            self.handle_callback_failure(callback_name=self.__class__.__name__)
 
     async def async_send_batch(self):
         """
@@ -624,7 +624,7 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
                 break
         except Exception as e:
             verbose_logger.exception(f"Error uploading to s3: {str(e)}")
-            self.handle_callback_failure(callback_name="S3Logger")
+            self.handle_callback_failure(callback_name=self.__class__.__name__)
 
     async def _download_object_from_s3(self, s3_object_key: str) -> Optional[dict]:
         """

--- a/tests/logging_callback_tests/test_callback_logging_failure_metric.py
+++ b/tests/logging_callback_tests/test_callback_logging_failure_metric.py
@@ -1,0 +1,151 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("../.."))
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+import litellm
+from litellm.integrations.custom_logger import CustomLogger
+
+
+class FakePrometheusLogger(CustomLogger):
+    """Stand-in for the prometheus logger that records failure-metric increments."""
+
+    def __init__(self):
+        super().__init__()
+        self.failures: list[str] = []
+
+    def increment_callback_logging_failure(self, callback_name: str):
+        self.failures.append(callback_name)
+
+
+@pytest.fixture(autouse=True)
+def reset_callbacks():
+    original = litellm.callbacks
+    litellm.callbacks = []
+    yield
+    litellm.callbacks = original
+
+
+def _register(prometheus, logger):
+    litellm.callbacks = [prometheus, logger]
+
+
+def _make_payload():
+    return {"id": "test", "response_cost": 1.0, "messages": [], "response": {}}
+
+
+@pytest.mark.asyncio
+async def test_pubsub_inline_flush_failure_increments_metric():
+    from litellm.integrations.gcs_pubsub.pub_sub import GcsPubSubLogger
+
+    prometheus = FakePrometheusLogger()
+    logger = GcsPubSubLogger(
+        project_id="P", topic_id="T", flush_interval=999, batch_size=1
+    )
+    logger.construct_request_headers = AsyncMock(return_value={})
+    failing_post = AsyncMock()
+    failing_post.return_value.status_code = 500
+    failing_post.return_value.text = "boom"
+    logger.async_httpx_client.post = failing_post
+    _register(prometheus, logger)
+
+    await logger.async_log_success_event(
+        kwargs={"standard_logging_object": _make_payload()},
+        response_obj=None,
+        start_time=0,
+        end_time=0,
+    )
+
+    assert prometheus.failures == ["GcsPubSubLogger"]
+    # queue retained for retry
+    assert len(logger.log_queue) == 1
+
+
+@pytest.mark.asyncio
+async def test_failure_metric_dedup_and_reset():
+    from litellm.integrations.gcs_pubsub.pub_sub import GcsPubSubLogger
+
+    prometheus = FakePrometheusLogger()
+    logger = GcsPubSubLogger(
+        project_id="P", topic_id="T", flush_interval=999, batch_size=1
+    )
+    logger.construct_request_headers = AsyncMock(return_value={})
+    failing_post = AsyncMock()
+    failing_post.return_value.status_code = 500
+    failing_post.return_value.text = "boom"
+    logger.async_httpx_client.post = failing_post
+    _register(prometheus, logger)
+
+    payload = _make_payload()
+
+    # two consecutive failing flushes -> only one increment
+    await logger.async_log_success_event(
+        kwargs={"standard_logging_object": payload},
+        response_obj=None,
+        start_time=0,
+        end_time=0,
+    )
+    await logger.flush_queue()
+    assert prometheus.failures == ["GcsPubSubLogger"]
+
+    # a success resets failure state
+    ok_post = AsyncMock()
+    ok_post.return_value.status_code = 200
+    ok_post.return_value.text = "ok"
+    ok_post.return_value.json = lambda: {}
+    logger.async_httpx_client.post = ok_post
+    await logger.flush_queue()
+    assert logger._is_in_failure_state is False
+
+    # next failure increments again
+    logger.async_httpx_client.post = failing_post
+    logger.log_queue.append(payload)
+    await logger.flush_queue()
+    assert prometheus.failures == ["GcsPubSubLogger", "GcsPubSubLogger"]
+
+
+@pytest.mark.asyncio
+async def test_generic_api_inline_flush_failure_increments_metric():
+    from litellm.integrations.generic_api.generic_api_callback import GenericAPILogger
+
+    prometheus = FakePrometheusLogger()
+    logger = GenericAPILogger(
+        endpoint="https://example.invalid",
+        headers={},
+        flush_interval=999,
+        batch_size=1,
+    )
+    logger._post_with_retries = AsyncMock(side_effect=Exception("network down"))
+    _register(prometheus, logger)
+
+    await logger.async_log_success_event(
+        kwargs={"standard_logging_object": _make_payload()},
+        response_obj=None,
+        start_time=0,
+        end_time=0,
+    )
+
+    assert prometheus.failures == ["GenericAPILogger"]
+    assert len(logger.log_queue) == 1
+
+
+@pytest.mark.asyncio
+async def test_datadog_flush_failure_increments_and_retains_queue():
+    os.environ["DD_API_KEY"] = "fake"
+    os.environ["DD_SITE"] = "us5.datadoghq.com"
+    from litellm.integrations.datadog.datadog import DataDogLogger
+
+    prometheus = FakePrometheusLogger()
+    logger = DataDogLogger(flush_interval=999)
+    logger.async_send_compressed_data = AsyncMock(side_effect=Exception("dd down"))
+    _register(prometheus, logger)
+
+    logger.log_queue = [{"id": "1"}]
+    await logger.flush_queue()
+
+    assert prometheus.failures == ["DataDogLogger"]
+    assert len(logger.log_queue) == 1

--- a/tests/logging_callback_tests/test_gcs_pub_sub.py
+++ b/tests/logging_callback_tests/test_gcs_pub_sub.py
@@ -2,7 +2,6 @@ import io
 import os
 import sys
 
-
 sys.path.insert(0, os.path.abspath("../.."))
 
 import asyncio
@@ -295,3 +294,47 @@ async def test_async_gcs_pub_sub_v1():
     assert_gcs_pubsub_request_matches_expected(
         actual_request, "spend_logs_payload.json"
     )
+
+
+@pytest.mark.asyncio
+async def test_async_gcs_pub_sub_partial_failure_retries_failed_and_unsent_only():
+    gcs_pub_sub_logger = GcsPubSubLogger.__new__(GcsPubSubLogger)
+    gcs_pub_sub_logger.flush_lock = asyncio.Lock()
+    gcs_pub_sub_logger.max_queue_size = 50_000
+    gcs_pub_sub_logger._is_in_failure_state = False
+    gcs_pub_sub_logger.callback_name = None
+    gcs_pub_sub_logger.log_queue = [
+        {"id": "sent"},
+        {"id": "failed"},
+        {"id": "unsent"},
+    ]
+    sent_ids = []
+
+    async def publish_with_partial_failure(message):
+        sent_ids.append(message["id"])
+        if message["id"] == "failed":
+            raise Exception("boom")
+        return {}
+
+    gcs_pub_sub_logger.publish_message = publish_with_partial_failure
+
+    await gcs_pub_sub_logger.flush_queue()
+
+    assert sent_ids == ["sent", "failed"]
+    assert gcs_pub_sub_logger.log_queue == [
+        {"id": "failed"},
+        {"id": "unsent"},
+    ]
+
+    retried_ids = []
+
+    async def successful_publish(message):
+        retried_ids.append(message["id"])
+        return {}
+
+    gcs_pub_sub_logger.publish_message = successful_publish
+
+    await gcs_pub_sub_logger.flush_queue()
+
+    assert retried_ids == ["failed", "unsent"]
+    assert gcs_pub_sub_logger.log_queue == []

--- a/tests/logging_callback_tests/test_generic_api_callback.py
+++ b/tests/logging_callback_tests/test_generic_api_callback.py
@@ -348,6 +348,51 @@ async def test_generic_api_callback_single_format():
 
 
 @pytest.mark.asyncio
+async def test_generic_api_callback_single_format_partial_failure_retries_failed_only():
+    test_endpoint = "https://example.com/api/logs"
+    generic_logger = GenericAPILogger(
+        endpoint=test_endpoint,
+        headers={},
+        flush_interval=999,
+        log_format="single",
+    )
+    generic_logger.log_queue = [
+        {"id": "sent-1"},
+        {"id": "failed"},
+        {"id": "sent-2"},
+    ]
+    sent_ids = []
+
+    async def post_with_partial_failure(data: str):
+        event = json.loads(data)
+        sent_ids.append(event["id"])
+        if event["id"] == "failed":
+            raise Exception("boom")
+        return type("Response", (), {"status_code": 200})()
+
+    generic_logger._post_with_retries = post_with_partial_failure
+
+    await generic_logger.flush_queue()
+
+    assert sent_ids == ["sent-1", "failed", "sent-2"]
+    assert generic_logger.log_queue == [{"id": "failed"}]
+
+    retried_ids = []
+
+    async def successful_post(data: str):
+        event = json.loads(data)
+        retried_ids.append(event["id"])
+        return type("Response", (), {"status_code": 200})()
+
+    generic_logger._post_with_retries = successful_post
+
+    await generic_logger.flush_queue()
+
+    assert retried_ids == ["failed"]
+    assert generic_logger.log_queue == []
+
+
+@pytest.mark.asyncio
 async def test_generic_api_callback_json_array_format_explicit():
     """
     Test the GenericAPILogger callback with explicit json_array format.

--- a/tests/logging_callback_tests/test_generic_api_callback.py
+++ b/tests/logging_callback_tests/test_generic_api_callback.py
@@ -2,7 +2,6 @@ import io
 import os
 import sys
 
-
 sys.path.insert(0, os.path.abspath("../.."))
 
 import asyncio
@@ -561,6 +560,7 @@ async def test_generic_api_callback_does_not_retry_4xx():
     generic_logger.async_httpx_client.post = mock_post
     generic_logger.log_queue = [{"event": "4xx-no-retry"}]
 
-    await generic_logger.async_send_batch()
+    with pytest.raises(httpx.HTTPStatusError):
+        await generic_logger.async_send_batch()
 
     mock_post.assert_called_once()

--- a/tests/logging_callback_tests/test_langsmith_batch_retry.py
+++ b/tests/logging_callback_tests/test_langsmith_batch_retry.py
@@ -1,0 +1,42 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from litellm.integrations.langsmith import LangsmithLogger, LangsmithQueueObject
+
+
+@pytest.mark.asyncio
+async def test_flush_queue_preserves_only_failed_langsmith_credential_group():
+    logger = LangsmithLogger(langsmith_api_key="test-key")
+    successful_queue_obj = LangsmithQueueObject(
+        data={"test": "data1"},
+        credentials={
+            "LANGSMITH_API_KEY": "key1",
+            "LANGSMITH_PROJECT": "proj1",
+            "LANGSMITH_BASE_URL": "url1",
+            "LANGSMITH_TENANT_ID": None,
+        },
+    )
+    failed_queue_obj = LangsmithQueueObject(
+        data={"test": "data2"},
+        credentials={
+            "LANGSMITH_API_KEY": "key2",
+            "LANGSMITH_PROJECT": "proj2",
+            "LANGSMITH_BASE_URL": "url2",
+            "LANGSMITH_TENANT_ID": None,
+        },
+    )
+    logger.log_queue = [successful_queue_obj, failed_queue_obj]
+
+    mock_success_response = MagicMock()
+    mock_success_response.status_code = 200
+    mock_success_response.raise_for_status = MagicMock()
+    logger.async_httpx_client = MagicMock()
+    logger.async_httpx_client.post = AsyncMock(
+        side_effect=[mock_success_response, RuntimeError("send failed")]
+    )
+
+    await logger.flush_queue()
+
+    assert logger.log_queue == [failed_queue_obj]
+    assert logger.async_httpx_client.post.await_count == 2

--- a/tests/test_litellm/integrations/datadog/test_datadog_cost_management.py
+++ b/tests/test_litellm/integrations/datadog/test_datadog_cost_management.py
@@ -225,6 +225,36 @@ async def test_async_send_batch_preserves_events_added_during_upload(clean_env):
 
 
 @pytest.mark.asyncio
+async def test_flush_queue_preserves_events_added_during_upload(clean_env):
+    logger = DatadogCostManagementLogger()
+    later_event = StandardLoggingPayload(
+        custom_llm_provider="anthropic",
+        model="claude-3",
+        response_cost=0.02,
+        startTime=time.time(),
+    )
+
+    async def slow_put(*args, **kwargs):
+        logger.log_queue.append(later_event)
+        return Response(202, json={"status": "ok"}, request=_PUT_REQUEST)
+
+    logger.async_client = AsyncMock()
+    logger.async_client.put.side_effect = slow_put
+    logger.log_queue = [
+        StandardLoggingPayload(
+            custom_llm_provider="openai",
+            model="gpt-4",
+            response_cost=0.01,
+            startTime=time.time(),
+        )
+    ]
+
+    await logger.flush_queue()
+
+    assert logger.log_queue == [later_event]
+
+
+@pytest.mark.asyncio
 async def test_async_send_batch_requeues_on_upload_failure(clean_env):
     """Failed upload requeues the original batch (no data loss)."""
     logger = DatadogCostManagementLogger()

--- a/tests/test_litellm/integrations/datadog/test_datadog_cost_management.py
+++ b/tests/test_litellm/integrations/datadog/test_datadog_cost_management.py
@@ -142,7 +142,9 @@ async def test_async_send_batch(clean_env):
     """
     logger = DatadogCostManagementLogger()
     logger.async_client = AsyncMock()
-    logger.async_client.put.return_value = Response(202, json={"status": "ok"})
+    logger.async_client.put.return_value = Response(
+        202, json={"status": "ok"}, request=_PUT_REQUEST
+    )
 
     # Add logs directly to queue
     logger.log_queue = [
@@ -235,7 +237,8 @@ async def test_async_send_batch_requeues_on_upload_failure(clean_env):
         startTime=time.time(),
     )
     logger.log_queue = [original]
-    await logger.async_send_batch()
+    with pytest.raises(Exception, match="boom"):
+        await logger.async_send_batch()
     assert logger.log_queue == [original]
 
 

--- a/tests/test_litellm/integrations/datadog/test_datadog_logger_batching.py
+++ b/tests/test_litellm/integrations/datadog/test_datadog_logger_batching.py
@@ -141,7 +141,8 @@ async def test_async_send_batch_requeues_events_on_exception(datadog_env):
 
     logger.async_send_compressed_data = AsyncMock(side_effect=RuntimeError("boom"))
 
-    await logger.async_send_batch()
+    with pytest.raises(RuntimeError, match="boom"):
+        await logger.async_send_batch()
 
     assert [event["message"] for event in logger.log_queue] == [
         '{"event": 0}',
@@ -196,6 +197,7 @@ async def test_flush_queue_updates_last_flush_time(datadog_env):
 
     async def _successful_send():
         logger.log_queue = []
+        return True
 
     logger.async_send_batch = AsyncMock(side_effect=_successful_send)
 

--- a/tests/test_litellm/integrations/test_azure_sentinel.py
+++ b/tests/test_litellm/integrations/test_azure_sentinel.py
@@ -263,3 +263,79 @@ async def test_azure_sentinel_flushes_standard_and_audit_logs_separately():
     ]
     assert "Custom-LiteLLM-Audit" in audit_call.kwargs["url"]
     assert json.loads(audit_call.kwargs["data"].decode("utf-8")) == [audit_log]
+
+
+@pytest.mark.asyncio
+async def test_azure_sentinel_flush_attempts_audit_logs_when_standard_logs_fail():
+    with patch("asyncio.create_task", side_effect=_close_periodic_flush_task):
+        logger = AzureSentinelLogger(
+            dcr_immutable_id="dcr-test123456789",
+            stream_name="Custom-LiteLLM-Standard",
+            audit_stream_name="Custom-LiteLLM-Audit",
+            endpoint="https://test-dce.eastus-1.ingest.monitor.azure.com",
+            tenant_id="test-tenant-id",
+            client_id="test-client-id",
+            client_secret="test-client-secret",
+        )
+
+    standard_payload = StandardLoggingPayload(
+        id="standard-123",
+        call_type="completion",
+        model="gpt-3.5-turbo",
+        status="success",
+        messages=[{"role": "user", "content": "Hello"}],
+        response={"choices": [{"message": {"content": "Hi"}}]},
+    )
+    audit_log = StandardAuditLogPayload(
+        id="audit-123",
+        updated_at="2026-05-06T04:39:00+00:00",
+        changed_by="user-1",
+        changed_by_api_key="sk-test",
+        action="created",
+        table_name="LiteLLM_TeamTable",
+        object_id="team-1",
+        before_value=None,
+        updated_values='{"team_alias": "sentinel-demo"}',
+    )
+    logger.log_queue.append(standard_payload)
+    logger.audit_log_queue.append(audit_log)
+
+    mock_token_response = MagicMock()
+    mock_token_response.status_code = 200
+    mock_token_response.json = MagicMock(
+        return_value={
+            "access_token": "test-bearer-token",
+            "expires_in": 3600,
+        }
+    )
+    mock_token_response.text = "Success"
+
+    mock_standard_error_response = MagicMock()
+    mock_standard_error_response.status_code = 500
+    mock_standard_error_response.text = "Standard endpoint unavailable"
+    mock_audit_success_response = MagicMock()
+    mock_audit_success_response.status_code = 204
+    mock_audit_success_response.text = "Success"
+
+    async def mock_post(*args, **kwargs):
+        url = kwargs.get("url", "")
+        if "oauth2/v2.0/token" in url:
+            return mock_token_response
+        if "Custom-LiteLLM-Standard" in url:
+            return mock_standard_error_response
+        return mock_audit_success_response
+
+    logger.async_httpx_client.post = AsyncMock(side_effect=mock_post)
+
+    await logger.flush_queue()
+
+    ingestion_calls = [
+        call
+        for call in logger.async_httpx_client.post.call_args_list
+        if "dataCollectionRules" in call.kwargs["url"]
+    ]
+    assert len(ingestion_calls) == 2
+    assert "Custom-LiteLLM-Standard" in ingestion_calls[0].kwargs["url"]
+    assert "Custom-LiteLLM-Audit" in ingestion_calls[1].kwargs["url"]
+    assert logger.log_queue == [standard_payload]
+    assert logger.audit_log_queue == []


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Summary
## Type

🆕 New Feature

## Changes
-Added a way to unify callback failure metric


### Testing
```yml
model_list:
  - model_name: gpt-4o-mini
    litellm_params:
      model: openai/gpt-4o-mini
      api_key: os.environ/OPENAI_API_KEY

litellm_settings:
  callbacks: ["prometheus", "generic_api"]

environment_variables:
  GENERIC_LOGGER_ENDPOINT: "http://127.0.0.1:9/dead"   # unreachable -> flush fails
  GENERIC_API_BATCH_SIZE: "1"          # flush after every event
  GENERIC_API_FLUSH_INTERVAL: "2"      # seconds
```
<img width="1354" height="395" alt="image" src="https://github.com/user-attachments/assets/f161d779-92e7-4125-bad6-7f48c3bd17f9" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect all batched logging callbacks (queue retention, partial retries, and failure metrics); mis-handling could duplicate or drop logs at destinations, but behavior is covered by new tests and is mostly failure-path hardening.
> 
> **Overview**
> This PR **unifies observability when logging callbacks fail** and **tightens batch flush semantics** so events are not dropped silently and can be retried.
> 
> **Callback failure metrics:** `CustomBatchLogger` tracks `_is_in_failure_state` and calls `handle_callback_failure` (via `_get_callback_failure_name()` using optional `callback_name` on `CustomLogger`) **once per outage**, resetting after a successful flush. Datadog, Azure Sentinel, and GCS add integration-specific `flush_queue` handling on top of the shared batch logger behavior.
> 
> **Flush path:** Many integrations now trigger **`flush_queue()`** at batch size (and LangSmith sync paths use it too) so locking, queue clearing, and failure handling stay consistent instead of calling `async_send_batch()` directly.
> 
> **Send failures surface and retry:** Datadog’s `async_send_batch` returns success/failure, requeues on error, and raises on terminal failures. Pub/Sub, Generic API (`single` format), Azure Sentinel, GCS, LangSmith, and Datadog LLM Obs/Cost Management **propagate errors** instead of swallowing them; Pub/Sub and Generic API **retain only failed (and unsent) items** after partial batch failures. Datadog Cost Management sets **`preserve_events_added_during_flush`** so events appended during upload are not wiped with the in-flight batch.
> 
> **Tests** cover Prometheus failure-metric dedup/reset and partial-failure retry for Pub/Sub and Generic API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d8d7db6697419b19822474a6d381ef9d08004cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->