### PR TITLE
fix: avoid logging raw cache key payload

### DIFF
--- a/litellm/caching/caching.py
+++ b/litellm/caching/caching.py
@@ -309,7 +309,9 @@ class Cache:
                     param_value = kwargs[param]
                     cache_key += f"{str(param)}: {str(param_value)}"
 
-        verbose_logger.debug("\nCreated cache key: %s", cache_key)
+        verbose_logger.debug(
+            "\nCreated cache key payload length before hashing: %s", len(cache_key)
+        )
         hashed_cache_key = Cache._get_hashed_cache_key(cache_key)
         hashed_cache_key = self._add_namespace_to_cache_key(hashed_cache_key, **kwargs)
         # Remove preset_cache_key from kwargs to avoid "got multiple values" TypeError

--- a/tests/test_litellm/caching/test_cache_key_logging.py
+++ b/tests/test_litellm/caching/test_cache_key_logging.py
@@ -1,0 +1,53 @@
+import logging
+
+from litellm.caching.caching import Cache
+
+
+def test_cache_key_logging_does_not_emit_raw_request_payload(caplog):
+    cache = Cache()
+    payload_marker = "RAW_PAYLOAD_MARKER_29414"
+    tool_marker = "RAW_TOOL_MARKER_29414"
+    schema_marker = "RAW_SCHEMA_MARKER_29414"
+
+    with caplog.at_level(logging.DEBUG, logger="LiteLLM"):
+        cache_key = cache.get_cache_key(
+            model="gpt-4.1",
+            messages=[
+                {
+                    "role": "user",
+                    "content": f"Please summarize {payload_marker}.",
+                }
+            ],
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "lookup_customer",
+                        "description": tool_marker,
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"customer_id": {"type": "string"}},
+                        },
+                    },
+                }
+            ],
+            response_format={
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "summary",
+                    "schema": {
+                        "type": "object",
+                        "description": schema_marker,
+                    },
+                },
+            },
+        )
+
+    log_output = "\n".join(
+        record.getMessage() for record in caplog.records if record.name == "LiteLLM"
+    )
+
+    assert payload_marker not in log_output
+    assert tool_marker not in log_output
+    assert schema_marker not in log_output
+    assert cache_key in log_output


### PR DESCRIPTION
## Relevant issues

Addresses #29414

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## CI (LiteLLM team)

- [ ] Branch creation CI run
       Link:

- [ ] CI run for the last commit
       Link:

- [ ] Merge / cherry-pick CI run
       Links:

## Screenshots / Proof of Fix

This change is covered by a mocked regression test for cache-key logging. The test passes raw markers through `messages`, `tools`, and `response_format`, then asserts those markers are not emitted in LiteLLM debug logs while the final hashed cache key still is. I did not run a live provider/proxy proof because the change is limited to avoiding raw request payloads in logs and should not require exposing real prompt content or API keys.

## Type

Bug Fix
Test

## Changes

`Cache.get_cache_key()` previously logged the full pre-hash cache-key payload with `Created cache key: %s`. That payload can include raw message content, tools, and response formats. The method already returns the SHA-256-derived cache key, so this PR keeps cache-key behavior unchanged and replaces the raw debug log with the pre-hash payload length.

A regression test now verifies that raw request markers from messages, tools, and response_format do not appear in the `LiteLLM` debug log, while the returned hashed cache key still appears.

## Validation

- `uvx --from uv==0.10.9 uv run pytest tests/test_litellm/caching/test_cache_key_logging.py tests/local_testing/test_unit_test_caching.py -q` passed, 11 tests.
- `uvx --from uv==0.10.9 uv run black --target-version py312 --check litellm/caching/caching.py tests/test_litellm/caching/test_cache_key_logging.py` passed.
- `uvx --from uv==0.10.9 uv run ruff check litellm/caching/caching.py tests/test_litellm/caching/test_cache_key_logging.py` passed.
- `git diff --check origin/litellm_internal_staging...HEAD` passed.
