### PR TITLE
test(responses): bump deprecated gemini-3-pro-preview to gemini-3.1-pro-preview

### DIFF
--- a/tests/llm_responses_api_testing/test_google_ai_studio_responses_api.py
+++ b/tests/llm_responses_api_testing/test_google_ai_studio_responses_api.py
@@ -97,7 +97,7 @@ async def test_gemini_3_responses_api_with_thought_signatures():
         pytest.skip("GEMINI_API_KEY not set")
 
     litellm.set_verbose = False
-    request_model = "gemini/gemini-3-pro-preview"
+    request_model = "gemini/gemini-3.1-pro-preview"
 
     tools = [
         {
@@ -197,7 +197,7 @@ async def test_gemini_3_responses_api_streaming_with_thought_signatures():
         pytest.skip("GEMINI_API_KEY not set")
 
     litellm.set_verbose = False
-    request_model = "gemini/gemini-3-pro-preview"
+    request_model = "gemini/gemini-3.1-pro-preview"
 
     tools = [
         {


### PR DESCRIPTION
## Relevant issues

No tracked issue. This surfaced while reviewing the CI on #29426, whose `llm_responses_api_testing` job was red. The failure is unrelated to that PR; Google sunset the `gemini-3-pro-preview` model, so the two AI Studio thought-signature tests now return a 404 on every branch. This PR fixes just that test breakage.

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## CI (LiteLLM team)

- [ ] Branch creation CI run
       Link:

- [ ] CI run for the last commit
       Link:

- [ ] Merge / cherry-pick CI run
       Links:

## Screenshots / Proof of Fix

The root cause is the Gemini API itself, so the proof is a direct call to it. With the old model id you get a 404; with the new one you get a 200. Run with a real `GEMINI_API_KEY`:

```bash
body='{"contents":[{"role":"user","parts":[{"text":"What is the weather in Mumbai? Reply briefly."}]}]}'
for m in gemini-3-pro-preview gemini-3.1-pro-preview; do
  echo "===== model: $m ====="
  curl -s -o /tmp/g.json -w "HTTP %{http_code}\n" \
    "https://generativelanguage.googleapis.com/v1beta/models/$m:generateContent" \
    -H "x-goog-api-key: $GEMINI_API_KEY" -H "Content-Type: application/json" -d "$body"
  python3 -c "import json;d=json.load(open('/tmp/g.json'));print('error:',d['error']['code'],d['error']['message'][:120]) if 'error' in d else print('ok: got',len(d.get('candidates',[])),'candidate(s)')"
done
```

Output:

```
===== model: gemini-3-pro-preview =====
HTTP 404
error: 404 This model models/gemini-3-pro-preview is no longer available. Please update your code to use a newer model for the late
===== model: gemini-3.1-pro-preview =====
HTTP 200
ok: got 1 candidate(s)
```

The two tests in question both pass live against `gemini/gemini-3.1-pro-preview` after the bump.

## Type

Test

## Changes

Google deprecated `gemini-3-pro-preview`, so `test_gemini_3_responses_api_with_thought_signatures` and `test_gemini_3_responses_api_streaming_with_thought_signatures` in `tests/llm_responses_api_testing/test_google_ai_studio_responses_api.py` started failing with a 404 from the live API. Both now point at `gemini/gemini-3.1-pro-preview`, the documented successor, which litellm already has registered and which supports the function calling, reasoning, and native streaming these tests rely on. No production code changes.