### PR TITLE
fix: keep claude platform workspace out of body

### DIFF
--- a/litellm/llms/bedrock/claude_platform/common_utils.py
+++ b/litellm/llms/bedrock/claude_platform/common_utils.py
@@ -8,6 +8,12 @@ CLAUDE_PLATFORM_SERVICE_NAME: Literal["aws-external-anthropic"] = (
     "aws-external-anthropic"
 )
 CLAUDE_PLATFORM_BEDROCK_ROUTE = "claude_platform/"
+CLAUDE_PLATFORM_WORKSPACE_PARAM_KEYS = (
+    "workspace_id",
+    "aws_workspace_id",
+    "anthropic-workspace-id",
+    "anthropic_workspace_id",
+)
 
 
 def strip_claude_platform_route(model: str) -> str:

--- a/litellm/llms/bedrock/claude_platform/transformation.py
+++ b/litellm/llms/bedrock/claude_platform/transformation.py
@@ -5,7 +5,10 @@ from litellm.llms.anthropic.chat.transformation import AnthropicConfig
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.llms.openai import AllMessageValues
 
-from .common_utils import BedrockClaudePlatformMixin
+from .common_utils import (
+    CLAUDE_PLATFORM_WORKSPACE_PARAM_KEYS,
+    BedrockClaudePlatformMixin,
+)
 
 
 class BedrockClaudePlatformConfig(BedrockClaudePlatformMixin, AnthropicConfig):
@@ -78,6 +81,27 @@ class BedrockClaudePlatformConfig(BedrockClaudePlatformMixin, AnthropicConfig):
         )
         anthropic_headers["anthropic-workspace-id"] = workspace_id
         return {**headers, **anthropic_headers}
+
+    def transform_request(
+        self,
+        model: str,
+        messages: List[AllMessageValues],
+        optional_params: dict,
+        litellm_params: dict,
+        headers: dict,
+    ) -> dict:
+        optional_params = {
+            key: value
+            for key, value in optional_params.items()
+            if key not in CLAUDE_PLATFORM_WORKSPACE_PARAM_KEYS
+        }
+        return super().transform_request(
+            model=model,
+            messages=messages,
+            optional_params=optional_params,
+            litellm_params=litellm_params,
+            headers=headers,
+        )
 
     def get_model_response_iterator(
         self,

--- a/tests/test_litellm/llms/bedrock/test_claude_platform_provider.py
+++ b/tests/test_litellm/llms/bedrock/test_claude_platform_provider.py
@@ -276,6 +276,41 @@ def test_chat_completion_routes_bedrock_claude_platform_to_messages_api():
     assert requests[0]["body"]["model"] == "claude-sonnet-4-6"
 
 
+@pytest.mark.parametrize(
+    "workspace_param",
+    ("workspace_id", "aws_workspace_id", "anthropic_workspace_id"),
+)
+def test_chat_completion_keeps_claude_platform_workspace_out_of_body(
+    workspace_param,
+):
+    import litellm
+
+    requests = []
+
+    def mock_post(self, url, data=None, headers=None, **kwargs):
+        requests.append(_capture_request(url=url, headers=headers or {}, data=data))
+        return _anthropic_response(url)
+
+    with patch("litellm.llms.custom_httpx.http_handler.HTTPHandler.post", mock_post):
+        response = litellm.completion(
+            model="bedrock/claude_platform/claude-sonnet-4-6",
+            messages=[{"role": "user", "content": "hello"}],
+            max_tokens=10,
+            api_base="https://aws-external-anthropic.us-west-2.api.aws",
+            api_key="fake-platform-key",
+            **{workspace_param: "wrkspc_test"},
+        )
+
+    assert response.choices[0].message.content == "ok"
+    assert len(requests) == 1
+    assert requests[0]["headers"]["anthropic-workspace-id"] == "wrkspc_test"
+    assert requests[0]["body"]["model"] == "claude-sonnet-4-6"
+    assert "workspace_id" not in requests[0]["body"]
+    assert "aws_workspace_id" not in requests[0]["body"]
+    assert "anthropic-workspace-id" not in requests[0]["body"]
+    assert "anthropic_workspace_id" not in requests[0]["body"]
+
+
 @pytest.mark.asyncio
 async def test_anthropic_messages_routes_bedrock_claude_platform_to_messages_api():
     import litellm


### PR DESCRIPTION
## Relevant issues

Fixes #29272

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

This is a draft PR. I verified the request transformation with mocked HTTP transport, matching the existing Claude Platform provider tests.

Before this change, the chat-completions route used the workspace parameter for the `anthropic-workspace-id` header but also left it in `optional_params`, which is serialized into the Anthropic `/v1/messages` JSON body. Anthropic rejects unknown top-level body fields, so `workspace_id` could cause a 400 even though the header was correct.

After this change, the Claude Platform chat transformer removes workspace auth parameters before delegating to the Anthropic request body builder. The header remains present, and the JSON body no longer contains `workspace_id`, `aws_workspace_id`, `anthropic-workspace-id`, or `anthropic_workspace_id`.

Targeted validation run locally:

```bash
uvx --from uv==0.10.9 uv run pytest tests/test_litellm/llms/bedrock/test_claude_platform_provider.py -q
uvx --from uv==0.10.9 uv run black --target-version py312 --check litellm/llms/bedrock/claude_platform/common_utils.py litellm/llms/bedrock/claude_platform/transformation.py tests/test_litellm/llms/bedrock/test_claude_platform_provider.py
uvx --from uv==0.10.9 uv run ruff check litellm/llms/bedrock/claude_platform/common_utils.py litellm/llms/bedrock/claude_platform/transformation.py tests/test_litellm/llms/bedrock/test_claude_platform_provider.py
```

Results: `14 passed`; Black and Ruff passed.

## Type

Bug Fix

## Changes

This adds a shared list of Claude Platform workspace auth parameter names and strips those parameters from `BedrockClaudePlatformConfig.transform_request()` before the Anthropic Messages request body is built.

The regression test covers `workspace_id`, `aws_workspace_id`, and `anthropic_workspace_id` on the chat-completions route and asserts that the outgoing request still has the `anthropic-workspace-id` header while none of the workspace parameter spellings are present in the body.
