### PR TITLE
feat(langfuse_otel): honor per-key/per-request langfuse_environment (parity with #11289)

### DIFF
--- a/litellm/integrations/langfuse/langfuse_otel.py
+++ b/litellm/integrations/langfuse/langfuse_otel.py
@@ -232,7 +232,22 @@ class LangfuseOtelLogger(OpenTelemetry):
         from litellm.integrations.arize._utils import safe_set_attribute
         from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 
-        langfuse_environment = os.environ.get("LANGFUSE_TRACING_ENVIRONMENT")
+        metadata = LangfuseOtelLogger._extract_langfuse_metadata(kwargs)
+
+        # Resolve the Langfuse environment with precedence:
+        #   per-request dynamic param / metadata -> LANGFUSE_TRACING_ENVIRONMENT.
+        # This mirrors the `langfuse_environment` key wired into the vanilla
+        # Langfuse integration in #11289 (which fixed #10020), so a single proxy
+        # serving multiple deployment environments via separate virtual keys can
+        # tag each trace with the correct environment on the OTEL path too. Falls
+        # back to the existing env var when no per-request value is provided.
+        dynamic_params = kwargs.get("standard_callback_dynamic_params") or {}
+        langfuse_environment = (
+            dynamic_params.get("langfuse_environment")
+            or metadata.get("langfuse_environment")
+            or metadata.get("environment")
+            or os.environ.get("LANGFUSE_TRACING_ENVIRONMENT")
+        )
         if langfuse_environment:
             safe_set_attribute(
                 span,
@@ -240,7 +255,6 @@ class LangfuseOtelLogger(OpenTelemetry):
                 langfuse_environment,
             )
 
-        metadata = LangfuseOtelLogger._extract_langfuse_metadata(kwargs)
         LangfuseOtelLogger._set_metadata_attributes(span=span, metadata=metadata)
 
         messages = kwargs.get("messages")

--- a/litellm/litellm_core_utils/initialize_dynamic_callback_params.py
+++ b/litellm/litellm_core_utils/initialize_dynamic_callback_params.py
@@ -36,6 +36,7 @@ _supported_callback_params = [
     "langfuse_secret",
     "langfuse_secret_key",
     "langfuse_host",
+    "langfuse_environment",
     "langfuse_prompt_version",
     "langsmith_api_key",
     "langsmith_project",

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -2979,6 +2979,7 @@ class StandardCallbackDynamicParams(TypedDict, total=False):
     langfuse_secret: Optional[str]
     langfuse_secret_key: Optional[str]
     langfuse_host: Optional[str]
+    langfuse_environment: Optional[str]
 
     # Langfuse prompt version
     langfuse_prompt_version: Optional[int]

--- a/tests/test_litellm/integrations/test_langfuse_otel.py
+++ b/tests/test_litellm/integrations/test_langfuse_otel.py
@@ -134,6 +134,66 @@ class TestLangfuseOtelIntegration:
                     mock_span, "langfuse.environment", test_env
                 )
 
+    def test_langfuse_environment_from_dynamic_param(self):
+        """A per-request/per-key `langfuse_environment` dynamic param is written
+        to the langfuse.environment span attribute."""
+        mock_span = MagicMock()
+        mock_kwargs = {
+            "standard_callback_dynamic_params": {"langfuse_environment": "development"}
+        }
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("LANGFUSE_TRACING_ENVIRONMENT", None)
+            with patch(
+                "litellm.integrations.arize._utils.safe_set_attribute"
+            ) as mock_safe_set_attribute:
+                LangfuseOtelLogger._set_langfuse_specific_attributes(
+                    mock_span, mock_kwargs, {}
+                )
+
+                mock_safe_set_attribute.assert_called_once_with(
+                    mock_span, "langfuse.environment", "development"
+                )
+
+    def test_langfuse_environment_from_metadata(self):
+        """A per-request `environment` in litellm_params.metadata is written to
+        the langfuse.environment span attribute."""
+        mock_span = MagicMock()
+        mock_kwargs = {"litellm_params": {"metadata": {"environment": "staging"}}}
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("LANGFUSE_TRACING_ENVIRONMENT", None)
+            with patch(
+                "litellm.integrations.arize._utils.safe_set_attribute"
+            ) as mock_safe_set_attribute:
+                LangfuseOtelLogger._set_langfuse_specific_attributes(
+                    mock_span, mock_kwargs, {}
+                )
+
+                mock_safe_set_attribute.assert_called_once_with(
+                    mock_span, "langfuse.environment", "staging"
+                )
+
+    def test_langfuse_environment_dynamic_param_overrides_env_var(self):
+        """The per-request dynamic param takes precedence over the
+        LANGFUSE_TRACING_ENVIRONMENT env var fallback."""
+        mock_span = MagicMock()
+        mock_kwargs = {
+            "standard_callback_dynamic_params": {"langfuse_environment": "production"}
+        }
+
+        with patch.dict(os.environ, {"LANGFUSE_TRACING_ENVIRONMENT": "staging"}):
+            with patch(
+                "litellm.integrations.arize._utils.safe_set_attribute"
+            ) as mock_safe_set_attribute:
+                LangfuseOtelLogger._set_langfuse_specific_attributes(
+                    mock_span, mock_kwargs, {}
+                )
+
+                mock_safe_set_attribute.assert_called_once_with(
+                    mock_span, "langfuse.environment", "production"
+                )
+
     def test_extract_langfuse_metadata_basic(self):
         """Ensure metadata is correctly pulled from litellm_params."""
         metadata_in = {"generation_name": "my-gen", "custom": "data"}

--- a/tests/test_litellm/litellm_core_utils/test_initialize_dynamic_callback_params.py
+++ b/tests/test_litellm/litellm_core_utils/test_initialize_dynamic_callback_params.py
@@ -36,6 +36,22 @@ def test_resolves_plain_values_from_metadata():
     assert params.get("langfuse_host") == "https://test.langfuse.com"
 
 
+def test_resolves_langfuse_environment_at_top_level():
+    kwargs = {"langfuse_environment": "production"}
+
+    params = initialize_standard_callback_dynamic_params(kwargs)
+
+    assert params.get("langfuse_environment") == "production"
+
+
+def test_resolves_langfuse_environment_from_metadata():
+    kwargs = {"metadata": {"langfuse_environment": "staging"}}
+
+    params = initialize_standard_callback_dynamic_params(kwargs)
+
+    assert params.get("langfuse_environment") == "staging"
+
+
 def test_env_reference_at_top_level_raises_with_guidance():
     kwargs = {"langfuse_public_key": "os.environ/LANGFUSE_PUBLIC_KEY"}
 


### PR DESCRIPTION
## What

Make the Langfuse **OTEL** integration honor a per-request/per-key `langfuse_environment`, mirroring what #11289 added for the vanilla `langfuse` callback. Falls back to the existing `LANGFUSE_TRACING_ENVIRONMENT` env var.

## Why

#11289 (Fixes #10020) added `langfuse_environment` as a dynamic-callback param and wired it through the vanilla `langfuse` integration, so a single proxy serving multiple environments via separate virtual keys can tag each trace with the right Langfuse environment.

That change did not touch `langfuse_otel.py`. The OTEL integration still sets the `langfuse.environment` span attribute solely from `os.environ.get("LANGFUSE_TRACING_ENVIRONMENT")` (`LangfuseOtelLogger._set_langfuse_specific_attributes`), so on the OTEL path every trace from one process gets the same static environment, with no per-key override. The OTEL exporter is the recommended path for self-hosted Langfuse v3, so this leaves v3 self-hosters without the #10020 capability.

## Change

In `_set_langfuse_specific_attributes`, resolve the environment with precedence **dynamic param / request metadata → env var**, reusing #11289's `langfuse_environment` key for consistency:

```python
metadata = LangfuseOtelLogger._extract_langfuse_metadata(kwargs)
dynamic_params = kwargs.get("standard_callback_dynamic_params") or {}
langfuse_environment = (
    dynamic_params.get("langfuse_environment")
    or metadata.get("langfuse_environment")
    or metadata.get("environment")
    or os.environ.get("LANGFUSE_TRACING_ENVIRONMENT")
)
```

This makes `callback_vars: { langfuse_environment: ... }` on a key/team (accepted since #11289) flow through to the OTEL `langfuse.environment` span attribute, and also supports a per-request value via metadata / the existing `langfuse_`-prefixed header enrichment.

## Backward compatibility

Fully backward compatible: with no per-key/per-request value, behavior is unchanged (the `LANGFUSE_TRACING_ENVIRONMENT` env var still applies).

## Notes

- The Langfuse server already reads a per-span `langfuse.environment` attribute, so no server-side change is required.
- Scope is isolated to the OTEL callback's environment resolution; the `deployment.environment` OTEL resource attribute is unchanged.

## Test

Added unit tests in `tests/test_litellm/integrations/test_langfuse_otel.py` (alongside the existing `test_set_langfuse_environment_attribute`): a `langfuse_environment` dynamic param and a metadata `environment` value are each written to the `langfuse.environment` span attribute, and the dynamic param takes precedence over the `LANGFUSE_TRACING_ENVIRONMENT` env-var fallback.