### PR TITLE
ci: require Resolves LIT-XXXX in PRs targeting litellm_internal_staging

### DIFF
--- a/.github/workflows/require-linear-ticket.yml
+++ b/.github/workflows/require-linear-ticket.yml
@@ -18,9 +18,9 @@ jobs:
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          if echo "$PR_BODY" | grep -qiE 'Resolves LIT-[0-9]+'; then
+          if echo "$PR_BODY" | grep -qiE 'Resolves LIT-0*[1-9][0-9]*'; then
             echo "Found Linear ticket reference."
             exit 0
           fi
-          echo "::error::PRs targeting 'litellm_internal_staging' must reference a Linear ticket in the description using the format 'Resolves LIT-XXXX' (e.g. 'Resolves LIT-1234')."
+          echo "::error::PRs targeting 'litellm_internal_staging' must reference a real Linear ticket in the description using the format 'Resolves LIT-XXXX' (e.g. 'Resolves LIT-1234'). Placeholder values like LIT-0000 are not accepted."
           exit 1

--- a/.github/workflows/require-linear-ticket.yml
+++ b/.github/workflows/require-linear-ticket.yml
@@ -1,0 +1,26 @@
+name: Require Linear ticket
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+    branches:
+      - litellm_internal_staging
+
+permissions: {}
+
+jobs:
+  require-linear-ticket:
+    name: Verify Resolves LIT-XXXX in PR description
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Check PR description for Linear ticket reference
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          if echo "$PR_BODY" | grep -qiE 'Resolves LIT-[0-9]+'; then
+            echo "Found Linear ticket reference."
+            exit 0
+          fi
+          echo "::error::PRs targeting 'litellm_internal_staging' must reference a Linear ticket in the description using the format 'Resolves LIT-XXXX' (e.g. 'Resolves LIT-1234')."
+          exit 1


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-3508

## What this does

Adds a CI check that gates pull requests targeting `litellm_internal_staging`. The new workflow `.github/workflows/require-linear-ticket.yml` runs on `pull_request` events (opened, edited, reopened, synchronize) whose base branch is `litellm_internal_staging` and fails unless the PR description references a Linear ticket in the form `Resolves LIT-XXXX`. The match is case-insensitive so `resolves lit-1234` is also accepted, and all-zero placeholder values like `LIT-0000` are rejected so the gate can't be satisfied by copying the template; the number must contain at least one non-zero digit. Because `edited` is included in the trigger types, the check re-runs when someone updates the description to add the reference, so a failing PR can be fixed without an empty commit.

The job reads the description from the `github.event.pull_request.body` context, so no checkout is needed and the workflow runs with `permissions: {}`.

## Type

🚄 Infrastructure

## Changes

New workflow file `.github/workflows/require-linear-ticket.yml`.
