### PR TITLE
fix(proxy): drop empty chat tools before routing

### DIFF
--- a/litellm/proxy/route_llm_request.py
+++ b/litellm/proxy/route_llm_request.py
@@ -46,6 +46,15 @@ def _is_a2a_agent_model(model_name: Any) -> bool:
     return isinstance(model_name, str) and model_name.startswith("a2a/")
 
 
+def _drop_empty_chat_tools(data: dict, route_type: str) -> None:
+    """Treat an empty chat tools list the same as omitting tools."""
+    if route_type != "acompletion":
+        return
+    if data.get("tools") == []:
+        data.pop("tools", None)
+        data.pop("tool_choice", None)
+
+
 ROUTE_ENDPOINT_MAPPING = {
     "acompletion": "/chat/completions",
     "atext_completion": "/completions",
@@ -344,6 +353,7 @@ async def route_request(  # noqa: PLR0915 - Complex routing function, refactorin
     Common helper to route the request
     """
     await add_shared_session_to_data(data)
+    _drop_empty_chat_tools(data=data, route_type=route_type)
 
     # Strip router-internal mock_testing_* flags. Combined with an
     # unauthorized fallback in ``router_settings_override`` they let a

--- a/tests/proxy_unit_tests/test_route_llm_request.py
+++ b/tests/proxy_unit_tests/test_route_llm_request.py
@@ -1,0 +1,85 @@
+import pytest
+
+from litellm.proxy.route_llm_request import route_request
+
+
+class _RouterSettings:
+    pass_through_all_models = False
+
+
+class _PatternRouter:
+    patterns = []
+
+
+class _FakeRouter:
+    model_names = ["qwen3.6"]
+    model_group_alias = None
+    default_deployment = None
+    deployment_names = []
+    router_general_settings = _RouterSettings()
+    pattern_router = _PatternRouter()
+
+    def __init__(self):
+        self.kwargs = None
+
+    def has_model_id(self, model):
+        return False
+
+    def map_team_model(self, model, team_id):
+        return None
+
+    def acompletion(self, **kwargs):
+        self.kwargs = kwargs
+        return kwargs
+
+
+@pytest.mark.asyncio
+async def test_route_request_drops_empty_chat_tools():
+    router = _FakeRouter()
+    data = {
+        "model": "qwen3.6",
+        "messages": [{"role": "user", "content": "hello"}],
+        "tools": [],
+        "tool_choice": "auto",
+    }
+
+    result = await route_request(
+        data=data,
+        route_type="acompletion",
+        llm_router=router,
+        user_model=None,
+    )
+
+    assert result == router.kwargs
+    assert "tools" not in router.kwargs
+    assert "tool_choice" not in router.kwargs
+
+
+@pytest.mark.asyncio
+async def test_route_request_preserves_non_empty_chat_tools():
+    router = _FakeRouter()
+    tool = {
+        "type": "function",
+        "function": {
+            "name": "lookup",
+            "description": "Lookup a value",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+    data = {
+        "model": "qwen3.6",
+        "messages": [{"role": "user", "content": "hello"}],
+        "tools": [tool],
+        "tool_choice": "auto",
+    }
+
+    result = await route_request(
+        data=data,
+        route_type="acompletion",
+        llm_router=router,
+        user_model=None,
+    )
+
+    assert result == router.kwargs
+    assert router.kwargs["tools"] == [tool]
+    assert router.kwargs["tool_choice"] == "auto"


### PR DESCRIPTION
## What changed

Drops empty `tools: []` from chat completion requests at the proxy routing boundary, and also removes `tool_choice` when no tools remain.

## Why

Some providers reject requests that include an empty tools array or a tool choice without actual tools. Treating `tools: []` the same as omitted tools avoids sending invalid provider payloads while preserving non-empty tool requests.

## Validation

- `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY uv run pytest tests/proxy_unit_tests/test_route_llm_request.py -q`