### PR TITLE
fix: stop use_chat_completions_api flag from leaking into provider request body

### DIFF
--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3180,6 +3180,7 @@ all_litellm_params = (
         "allowed_openai_params",
         "litellm_session_id",
         "use_litellm_proxy",
+        "use_chat_completions_api",
         "prompt_label",
         "shared_session",
         "search_tool_name",

--- a/tests/test_litellm/llms/openai/test_use_chat_completions_api_no_leak.py
+++ b/tests/test_litellm/llms/openai/test_use_chat_completions_api_no_leak.py
@@ -1,0 +1,74 @@
+"""
+Regression test for issue #28146.
+
+`use_chat_completions_api` is a LiteLLM-internal control flag (it forces the
+/responses -> /chat/completions bridge). When set as a model-level param in the
+proxy config, it must never be forwarded to the upstream provider's request
+body. OpenAI/Anthropic reject unknown body params with HTTP 400.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.abspath("../../../.."))
+
+import litellm
+from litellm.types.utils import all_litellm_params
+from litellm.utils import get_non_default_completion_params
+
+
+def test_use_chat_completions_api_is_a_known_litellm_param():
+    assert "use_chat_completions_api" in all_litellm_params
+
+
+def test_use_chat_completions_api_not_forwarded_as_provider_param():
+    forwarded = get_non_default_completion_params(
+        {"use_chat_completions_api": True, "temperature": 0.5}
+    )
+    assert "use_chat_completions_api" not in forwarded
+
+
+def test_completion_does_not_leak_flag_into_provider_request_body():
+    mock_response = MagicMock()
+    mock_response.model_dump.return_value = {
+        "id": "chatcmpl-1",
+        "object": "chat.completion",
+        "created": 1234567890,
+        "model": "gpt-4o-mini",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "hi"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 1,
+            "completion_tokens": 1,
+            "total_tokens": 2,
+        },
+    }
+
+    mock_raw_response = MagicMock()
+    mock_raw_response.headers = {}
+    mock_raw_response.parse.return_value = mock_response
+
+    mock_client = MagicMock()
+    mock_client.chat.completions.with_raw_response.create.return_value = (
+        mock_raw_response
+    )
+
+    litellm.completion(
+        model="openai/gpt-4o-mini",
+        messages=[{"role": "user", "content": "hi"}],
+        use_chat_completions_api=True,
+        api_key="sk-test",
+        client=mock_client,
+    )
+
+    create_kwargs = (
+        mock_client.chat.completions.with_raw_response.create.call_args.kwargs
+    )
+    assert "use_chat_completions_api" not in create_kwargs
+    assert "use_chat_completions_api" not in create_kwargs.get("extra_body", {}) or {}

--- a/tests/test_litellm/llms/openai/test_use_chat_completions_api_no_leak.py
+++ b/tests/test_litellm/llms/openai/test_use_chat_completions_api_no_leak.py
@@ -71,4 +71,4 @@ def test_completion_does_not_leak_flag_into_provider_request_body():
         mock_client.chat.completions.with_raw_response.create.call_args.kwargs
     )
     assert "use_chat_completions_api" not in create_kwargs
-    assert "use_chat_completions_api" not in create_kwargs.get("extra_body", {}) or {}
+    assert "use_chat_completions_api" not in (create_kwargs.get("extra_body") or {})


### PR DESCRIPTION
## Relevant issues

Addresses the `use_chat_completions_api` portion of #28146.

That issue covers two distinct leaks. The original report (the `_litellm_rate_limit_descriptors` / `_litellm_tpm_reserved_*` keys from the v3 limiter's TPM/RPM reservation flow) was already fixed in #27913, which keeps those keys in the internal metadata channels and strips any that surface on the request body. This PR handles the separate leak raised later in the thread: the `use_chat_completions_api` control flag.

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Live-proxy runbook (config a model with the flag set, then call `/chat/completions`; before this change OpenAI rejects the request with HTTP 400 for an unknown body field, after it succeeds):

1. Add a model that carries the flag at config level, then start the proxy:

```yaml
model_list:
  - model_name: bridge-model
    litellm_params:
      model: openai/gpt-4o-mini
      api_key: os.environ/OPENAI_API_KEY
      use_chat_completions_api: true
```

```bash
python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log
```

2. Send a request and confirm HTTP 200 with real content:

```bash
curl -sS -X POST http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"bridge-model","messages":[{"role":"user","content":"say hi"}],"max_tokens":5}'
```

Before this change the same request returns `OpenAIException - Unrecognized request arguments supplied: use_chat_completions_api`. After it, a normal completion comes back.

## Type

🐛 Bug Fix

## Changes

`use_chat_completions_api` is a LiteLLM control flag that forces the `/responses` to `/chat/completions` bridge. It was absent from `all_litellm_params`, so `get_non_default_completion_params` classified it as a model-specific param and forwarded it to the upstream provider. The `/responses` entrypoint pops the flag before any provider call, but a model-level `use_chat_completions_api: true` in the proxy config reaches the chat-completions path (directly, or via the bridge handler that calls `litellm.completion`), where it leaked into the request body and strict providers rejected it with HTTP 400.

The fix registers the flag in `all_litellm_params`, the single source of truth for params that are LiteLLM-internal and must never be forwarded. This strips it on every path that consults that list (`get_non_default_completion_params` and `filter_out_litellm_params`).

The accompanying regression test drives a real `litellm.completion()` with a mocked OpenAI client and asserts the flag is absent from the kwargs sent to `chat.completions.with_raw_response.create`. It fails before the fix and passes after, and the existing responses-bridge and optional-params suites stay green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single allowlist entry plus tests; no auth or routing logic changes beyond stripping one internal param.
> 
> **Overview**
> Registers **`use_chat_completions_api`** in **`all_litellm_params`** so LiteLLM treats it as an internal control flag (responses → chat-completions bridge) and **stops forwarding it** in upstream request bodies—fixing HTTP 400s when the flag is set on proxy model config.
> 
> Adds regression tests that assert the param is known to LiteLLM, is stripped by **`get_non_default_completion_params`**, and does not appear in mocked OpenAI **`chat.completions.create`** kwargs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 157f5cfcdd855a51ec904e032d45c1d1c1aed904. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->