### PR TITLE
ci(release): create stable/X.Y.x line branch on X.Y.0 tags

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -63,3 +63,28 @@ jobs:
               sha: commitHash,
             });
             core.info(`Created branch ${branchName} at ${commitHash}`);
+
+      - name: Create stable line branch
+        env:
+          TAG: ${{ inputs.tag }}
+          COMMIT_HASH: ${{ inputs.commit_hash }}
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const tag = process.env.TAG;
+            const commitHash = process.env.COMMIT_HASH;
+
+            const match = tag.match(/^v?(\d+)\.(\d+)\.0$/);
+            if (!match) {
+              core.info(`Tag ${tag} is not the X.Y.0 stable opener; skipping stable line branch`);
+              return;
+            }
+            const lineBranch = `stable/${match[1]}.${match[2]}.x`;
+
+            await github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `refs/heads/${lineBranch}`,
+              sha: commitHash,
+            });
+            core.info(`Created branch ${lineBranch} at ${commitHash}`);


### PR DESCRIPTION
## Relevant issues

None.

## Linear ticket

N/A

## Pre-Submission checklist

- [ ] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

No live workflow dispatch on this branch. The new step is additive and structurally mirrors the existing `Create release branch` step (same `uses`, same `permissions`, same env-threading), differing only in the gate regex and the branch name; the gate is a single regex over a constrained input.

Static verification covered three angles:

1. Regex `^v?(\d+)\.(\d+)\.0$` classified against every tag form the upstream `Validate inputs` regex in `create-release.yml` accepts (`1.84.0`, `v1.84.0`, `1.84.1`, `1.84.0rc1`, `1.84.0-rc.1`, `1.84.0.dev42`, `1.84.0-dev.2`, `1.84.0.post1`, `v1.83.10-stable`, plus leading-zero and uppercase variants). Behavior matches the intended classification in every case.
2. `actions/github-script@v7.0.1` API surface (`github.rest.git.createRef`, `core.info`, `context.repo.owner`, top-level `return`), YAML well-formedness, the `60a0d83039c74a4aee543508d2ffcb1c3799cdea` SHA pin (matches the existing pinned use in the same file), and `contents: write` sufficiency for ref creation.
3. Repo-wide CI fan-out: no GHA `pull_request: branches:` filter and no CircleCI workflow filter accidentally matches `stable/*`, so the new branches don't trigger inappropriate CI on creation.

Trade-off accepted: a re-run of the workflow on the same `X.Y.0` tag will 422 on the second `createRef` (same behavior as the sibling `release/<tag>` step). The line branch is born exactly once per minor, so the failure mode is a one-time edge case and no try/catch was added.

## Type

🚄 Infrastructure

## Changes

Today every release dispatch creates `release/<tag>` for one tag, so backports for each patch live on a throwaway branch like `patch/v1.84.3` that exists only long enough to base the next patch's cherry-picks on. Discovery of "what is queued for the next 1.84.x" requires knowing which `patch/v1.84.N` is the current one, and stale per-patch branches accumulate.

Switching to one long-lived line branch per minor (`stable/1.84.x`, `stable/1.85.x`, ...) collapses all 1.84-line backports onto a single durable branch. The next patch in the line becomes a `git tag` on the existing branch; `git log v1.84.4..origin/stable/1.84.x` answers what is queued.

The new step gates on `^v?(\d+)\.(\d+)\.0$`. rc, dev, nightly, `.post`, and patch tags all skip; the line branch is created exactly once per minor at the first stable opener. Existing `release/<tag>` creation is untouched (additive step). RC patches continue to use the existing `patch/v1.87.0rcN` flow for now; the RC story gets its own follow-up.

Backfill of `stable/1.84.x`, `stable/1.85.x`, `stable/1.86.x` at the respective latest tags happens manually outside this PR.

Follow-up worth noting (not for this PR): the existing GHA `pull_request: branches:` lists and CircleCI's `main_branches` filter don't include `stable/**`, so backport PRs into the new lines won't trigger unit tests or CCI runs until those filters are extended. Same gap exists today for PRs into `patch/v1.84.3`, so it's not a regression introduced here.