### PR TITLE
feat(vector-stores): forward per-request params to Vertex AI Search

### DIFF
--- a/litellm/llms/vertex_ai/vector_stores/search_api/transformation.py
+++ b/litellm/llms/vertex_ai/vector_stores/search_api/transformation.py
@@ -152,7 +152,9 @@ class VertexSearchAPIVectorStoreConfig(BaseVectorStoreConfig, VertexBase):
         if isinstance(extra_body, dict):
             request_body.update(extra_body)
 
-        litellm_logging_obj.model_call_details["query"] = query
+        litellm_logging_obj.model_call_details["query"] = request_body.get(
+            "query", query
+        )
 
         return url, request_body
 

--- a/litellm/llms/vertex_ai/vector_stores/search_api/transformation.py
+++ b/litellm/llms/vertex_ai/vector_stores/search_api/transformation.py
@@ -26,6 +26,52 @@ else:
     LiteLLMLoggingObj = Any
 
 
+VERTEX_SEARCH_TARGET_SELECTING_FIELDS = frozenset(
+    {
+        "dataStoreSpecs",
+        "branch",
+        "servingConfig",
+        "entity",
+    }
+)
+
+VERTEX_SEARCH_SUPPORTED_EXTRA_BODY_FIELDS = frozenset(
+    {
+        "query",
+        "pageSize",
+        "pageToken",
+        "offset",
+        "oneBoxPageSize",
+        "numResultsPerDataStore",
+        "pageCategories",
+        "imageQuery",
+        "filter",
+        "canonicalFilter",
+        "orderBy",
+        "userInfo",
+        "languageCode",
+        "facetSpecs",
+        "boostSpec",
+        "params",
+        "queryExpansionSpec",
+        "spellCorrectionSpec",
+        "userPseudoId",
+        "contentSearchSpec",
+        "rankingExpression",
+        "rankingExpressionBackend",
+        "safeSearch",
+        "userLabels",
+        "naturalLanguageQueryUnderstandingSpec",
+        "searchAsYouTypeSpec",
+        "displaySpec",
+        "crowdingSpecs",
+        "relevanceThreshold",
+        "relevanceScoreSpec",
+        "customRankingParams",
+    }
+)
+
+
 class VertexSearchAPIVectorStoreConfig(BaseVectorStoreConfig, VertexBase):
     """
     Configuration for Vertex AI Search API Vector Store
@@ -35,6 +81,42 @@ class VertexSearchAPIVectorStoreConfig(BaseVectorStoreConfig, VertexBase):
 
     def __init__(self):
         super().__init__()
+
+    @staticmethod
+    def get_supported_extra_body_fields() -> frozenset:
+        """Native SearchRequest fields callers may forward via ``extra_body``."""
+        return VERTEX_SEARCH_SUPPORTED_EXTRA_BODY_FIELDS
+
+    @classmethod
+    def _filter_extra_body(cls, extra_body: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Validate ``extra_body`` against the supported-field allowlist.
+
+        Raises ``ValueError`` if the caller includes a target-selecting field
+        (e.g. ``dataStoreSpecs``) or any field not on the allowlist, so the
+        request fails loudly instead of silently searching the wrong store.
+        """
+        supported = cls.get_supported_extra_body_fields()
+        filtered = {
+            key: value for key, value in extra_body.items() if value is not None
+        }
+
+        target_selecting = set(filtered) & VERTEX_SEARCH_TARGET_SELECTING_FIELDS
+        if target_selecting:
+            raise ValueError(
+                "Vertex AI Search extra_body may not set target-selecting fields "
+                f"{sorted(target_selecting)}: the data store is scoped by "
+                "vector_store_id / vertex_engine_id and cannot be overridden per request."
+            )
+
+        unsupported = set(filtered) - supported
+        if unsupported:
+            raise ValueError(
+                f"Unsupported Vertex AI Search extra_body fields {sorted(unsupported)}. "
+                f"Supported fields: {sorted(supported)}."
+            )
+
+        return filtered
 
     def get_auth_credentials(
         self, litellm_params: dict
@@ -136,9 +218,14 @@ class VertexSearchAPIVectorStoreConfig(BaseVectorStoreConfig, VertexBase):
         Transform a search request for the Vertex AI Search (Discovery Engine) API.
 
         Per-request params pass through to the engine: max_num_results maps to
-        pageSize, and extra_body is merged in raw and takes precedence, so callers
-        can send native Discovery Engine fields such as dataStoreSpecs, filter,
+        pageSize, and extra_body fields on the supported allowlist
+        (`get_supported_extra_body_fields`) are merged in with precedence, so
+        callers can send native Discovery Engine tuning fields such as filter,
         boostSpec, or contentSearchSpec.
+
+        Target-selecting fields (e.g. dataStoreSpecs, branch) are rejected: the
+        data store is scoped by the URL path (vector_store_id / vertex_engine_id)
+        and must not be overridable per request.
         """
         if isinstance(query, list):
             query = " ".join(query)
@@ -150,7 +237,7 @@ class VertexSearchAPIVectorStoreConfig(BaseVectorStoreConfig, VertexBase):
         if max_num_results is not None:
             request_body["pageSize"] = max_num_results
         if isinstance(extra_body, dict):
-            request_body.update(extra_body)
+            request_body.update(self._filter_extra_body(extra_body))
 
         litellm_logging_obj.model_call_details["query"] = request_body.get(
             "query", query

--- a/litellm/llms/vertex_ai/vector_stores/search_api/transformation.py
+++ b/litellm/llms/vertex_ai/vector_stores/search_api/transformation.py
@@ -16,6 +16,8 @@ from litellm.types.vector_stores import (
     VectorStoreSearchOptionalRequestParams,
     VectorStoreSearchResponse,
     VectorStoreSearchResult,
+    VertexSearchDataStoreExtraBody,
+    VertexSearchEngineExtraBody,
 )
 
 if TYPE_CHECKING:
@@ -26,49 +28,28 @@ else:
     LiteLLMLoggingObj = Any
 
 
+# Fields that select which data store / serving config to search. These are
+# always determined by the request URL path (vector_store_id / vertex_engine_id),
+# so allowing them per request could silently redirect the search to a different
+# target. Rejected in both data-store and engine/app modes.
 VERTEX_SEARCH_TARGET_SELECTING_FIELDS = frozenset(
     {
-        "dataStoreSpecs",
         "branch",
         "servingConfig",
         "entity",
     }
 )
 
-VERTEX_SEARCH_SUPPORTED_EXTRA_BODY_FIELDS = frozenset(
-    {
-        "query",
-        "pageSize",
-        "pageToken",
-        "offset",
-        "oneBoxPageSize",
-        "numResultsPerDataStore",
-        "pageCategories",
-        "imageQuery",
-        "filter",
-        "canonicalFilter",
-        "orderBy",
-        "userInfo",
-        "languageCode",
-        "facetSpecs",
-        "boostSpec",
-        "params",
-        "queryExpansionSpec",
-        "spellCorrectionSpec",
-        "userPseudoId",
-        "contentSearchSpec",
-        "rankingExpression",
-        "rankingExpressionBackend",
-        "safeSearch",
-        "userLabels",
-        "naturalLanguageQueryUnderstandingSpec",
-        "searchAsYouTypeSpec",
-        "displaySpec",
-        "crowdingSpecs",
-        "relevanceThreshold",
-        "relevanceScoreSpec",
-        "customRankingParams",
-    }
+# Allowlists of native Discovery Engine SearchRequest fields callers may forward
+# via extra_body, derived from the TypedDicts so the type is the source of truth.
+# Engine/app mode is a superset (adds dataStoreSpecs, numResultsPerDataStore),
+# since an app fans out across multiple member data stores.
+VERTEX_SEARCH_DATASTORE_EXTRA_BODY_FIELDS = frozenset(
+    VertexSearchDataStoreExtraBody.__annotations__
+)
+
+VERTEX_SEARCH_ENGINE_EXTRA_BODY_FIELDS = frozenset(
+    VertexSearchEngineExtraBody.__annotations__
 )
 
 
@@ -83,20 +64,34 @@ class VertexSearchAPIVectorStoreConfig(BaseVectorStoreConfig, VertexBase):
         super().__init__()
 
     @staticmethod
-    def get_supported_extra_body_fields() -> frozenset:
-        """Native SearchRequest fields callers may forward via ``extra_body``."""
-        return VERTEX_SEARCH_SUPPORTED_EXTRA_BODY_FIELDS
+    def get_supported_extra_body_fields(is_engine: bool = False) -> frozenset:
+        """
+        Native SearchRequest fields callers may forward via ``extra_body``.
+
+        The set depends on which serving config the request targets:
+        - engine/app mode (``is_engine=True``): includes multi-store fields such
+          as ``dataStoreSpecs`` and ``numResultsPerDataStore``.
+        - data-store mode: the engine-only fields are excluded.
+        """
+        if is_engine:
+            return VERTEX_SEARCH_ENGINE_EXTRA_BODY_FIELDS
+        return VERTEX_SEARCH_DATASTORE_EXTRA_BODY_FIELDS
 
     @classmethod
-    def _filter_extra_body(cls, extra_body: Dict[str, Any]) -> Dict[str, Any]:
+    def _filter_extra_body(
+        cls, extra_body: Dict[str, Any], is_engine: bool = False
+    ) -> Dict[str, Any]:
         """
-        Validate ``extra_body`` against the supported-field allowlist.
+        Validate ``extra_body`` against the supported-field allowlist for the
+        active serving config (engine/app vs data store).
 
         Raises ``ValueError`` if the caller includes a target-selecting field
-        (e.g. ``dataStoreSpecs``) or any field not on the allowlist, so the
-        request fails loudly instead of silently searching the wrong store.
+        (e.g. ``servingConfig``) or any field not supported for the active mode,
+        so the request fails loudly instead of silently searching the wrong
+        target. Engine-only fields (``dataStoreSpecs``, ``numResultsPerDataStore``)
+        are rejected in data-store mode where they are meaningless.
         """
-        supported = cls.get_supported_extra_body_fields()
+        supported = cls.get_supported_extra_body_fields(is_engine=is_engine)
         filtered = {
             key: value for key, value in extra_body.items() if value is not None
         }
@@ -111,9 +106,10 @@ class VertexSearchAPIVectorStoreConfig(BaseVectorStoreConfig, VertexBase):
 
         unsupported = set(filtered) - supported
         if unsupported:
+            mode = "engine/app" if is_engine else "data store"
             raise ValueError(
-                f"Unsupported Vertex AI Search extra_body fields {sorted(unsupported)}. "
-                f"Supported fields: {sorted(supported)}."
+                f"Unsupported Vertex AI Search extra_body fields {sorted(unsupported)} "
+                f"for {mode} mode. Supported fields: {sorted(supported)}."
             )
 
         return filtered
@@ -223,21 +219,29 @@ class VertexSearchAPIVectorStoreConfig(BaseVectorStoreConfig, VertexBase):
         callers can send native Discovery Engine tuning fields such as filter,
         boostSpec, or contentSearchSpec.
 
-        Target-selecting fields (e.g. dataStoreSpecs, branch) are rejected: the
-        data store is scoped by the URL path (vector_store_id / vertex_engine_id)
-        and must not be overridable per request.
+        The allowlist depends on the serving config: engine/app mode (when
+        `vertex_engine_id` is set) additionally accepts multi-store fields like
+        `dataStoreSpecs` and `numResultsPerDataStore`, while data-store mode
+        rejects them. Target-selecting fields (e.g. servingConfig, branch) are
+        rejected in both modes: the target is scoped by the URL path
+        (vector_store_id / vertex_engine_id) and must not be overridable per
+        request.
         """
         if isinstance(query, list):
             query = " ".join(query)
 
         url = f"{api_base}:search"
 
+        is_engine = bool(litellm_params.get("vertex_engine_id"))
+
         request_body: Dict[str, Any] = {"query": query, "pageSize": 10}
         max_num_results = vector_store_search_optional_params.get("max_num_results")
         if max_num_results is not None:
             request_body["pageSize"] = max_num_results
         if isinstance(extra_body, dict):
-            request_body.update(self._filter_extra_body(extra_body))
+            request_body.update(
+                self._filter_extra_body(extra_body, is_engine=is_engine)
+            )
 
         litellm_logging_obj.model_call_details["query"] = request_body.get(
             "query", query

--- a/litellm/llms/vertex_ai/vector_stores/search_api/transformation.py
+++ b/litellm/llms/vertex_ai/vector_stores/search_api/transformation.py
@@ -133,22 +133,25 @@ class VertexSearchAPIVectorStoreConfig(BaseVectorStoreConfig, VertexBase):
         extra_body: Optional[Dict[str, Any]] = None,
     ) -> Tuple[str, Dict[str, Any]]:
         """
-        Transform search request for Vertex AI RAG API
+        Transform a search request for the Vertex AI Search (Discovery Engine) API.
+
+        Per-request params pass through to the engine: max_num_results maps to
+        pageSize, and extra_body is merged in raw and takes precedence, so callers
+        can send native Discovery Engine fields such as dataStoreSpecs, filter,
+        boostSpec, or contentSearchSpec.
         """
-        # Convert query to string if it's a list
         if isinstance(query, list):
             query = " ".join(query)
 
-        # Vertex AI RAG API endpoint for retrieving contexts
         url = f"{api_base}:search"
 
-        # Construct full rag corpus path
-        # Build the request body for Vertex AI Search API
-        request_body = {"query": query, "pageSize": 10}
+        request_body: Dict[str, Any] = {"query": query, "pageSize": 10}
+        max_num_results = vector_store_search_optional_params.get("max_num_results")
+        if max_num_results is not None:
+            request_body["pageSize"] = max_num_results
+        if isinstance(extra_body, dict):
+            request_body.update(extra_body)
 
-        #########################################################
-        # Update logging object with details of the request
-        #########################################################
         litellm_logging_obj.model_call_details["query"] = query
 
         return url, request_body

--- a/litellm/llms/vertex_ai/vector_stores/search_api/transformation.py
+++ b/litellm/llms/vertex_ai/vector_stores/search_api/transformation.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 import httpx
 
 from litellm import get_model_info
+from litellm.exceptions import BadRequestError
 from litellm.litellm_core_utils.url_utils import encode_url_path_segment
 from litellm.llms.base_llm.vector_store.transformation import BaseVectorStoreConfig
 from litellm.llms.vertex_ai.vertex_llm_base import VertexBase
@@ -85,11 +86,12 @@ class VertexSearchAPIVectorStoreConfig(BaseVectorStoreConfig, VertexBase):
         Validate ``extra_body`` against the supported-field allowlist for the
         active serving config (engine/app vs data store).
 
-        Raises ``ValueError`` if the caller includes a target-selecting field
-        (e.g. ``servingConfig``) or any field not supported for the active mode,
-        so the request fails loudly instead of silently searching the wrong
-        target. Engine-only fields (``dataStoreSpecs``, ``numResultsPerDataStore``)
-        are rejected in data-store mode where they are meaningless.
+        Raises ``BadRequestError`` (HTTP 400) if the caller includes a
+        target-selecting field (e.g. ``servingConfig``) or any field not
+        supported for the active mode, so the request fails loudly instead of
+        silently searching the wrong target. Engine-only fields
+        (``dataStoreSpecs``, ``numResultsPerDataStore``) are rejected in
+        data-store mode where they are meaningless.
         """
         supported = cls.get_supported_extra_body_fields(is_engine=is_engine)
         filtered = {
@@ -98,18 +100,26 @@ class VertexSearchAPIVectorStoreConfig(BaseVectorStoreConfig, VertexBase):
 
         target_selecting = set(filtered) & VERTEX_SEARCH_TARGET_SELECTING_FIELDS
         if target_selecting:
-            raise ValueError(
-                "Vertex AI Search extra_body may not set target-selecting fields "
-                f"{sorted(target_selecting)}: the data store is scoped by "
-                "vector_store_id / vertex_engine_id and cannot be overridden per request."
+            raise BadRequestError(
+                message=(
+                    "Vertex AI Search extra_body may not set target-selecting fields "
+                    f"{sorted(target_selecting)}: the data store is scoped by "
+                    "vector_store_id / vertex_engine_id and cannot be overridden per request."
+                ),
+                model="vertex_ai/search_api",
+                llm_provider="vertex_ai",
             )
 
         unsupported = set(filtered) - supported
         if unsupported:
             mode = "engine/app" if is_engine else "data store"
-            raise ValueError(
-                f"Unsupported Vertex AI Search extra_body fields {sorted(unsupported)} "
-                f"for {mode} mode. Supported fields: {sorted(supported)}."
+            raise BadRequestError(
+                message=(
+                    f"Unsupported Vertex AI Search extra_body fields {sorted(unsupported)} "
+                    f"for {mode} mode. Supported fields: {sorted(supported)}."
+                ),
+                model="vertex_ai/search_api",
+                llm_provider="vertex_ai",
             )
 
         return filtered

--- a/litellm/types/vector_stores.py
+++ b/litellm/types/vector_stores.py
@@ -112,6 +112,66 @@ class VectorStoreSearchRequest(VectorStoreSearchOptionalRequestParams, total=Fal
     query: Union[str, List[str]]
 
 
+class VertexSearchDataStoreExtraBody(TypedDict, total=False):
+    """
+    Native Discovery Engine ``SearchRequest`` fields callers may forward via
+    ``extra_body`` when searching a Vertex AI Search **data store** serving
+    config (``.../dataStores/{id}/servingConfigs/default_config``).
+
+    The data store is scoped by the request URL path, so target-selecting
+    fields (``servingConfig``, ``branch``, ``entity``) are intentionally
+    omitted and rejected by the transformation layer. Engine/app-only fields
+    such as ``dataStoreSpecs`` and ``numResultsPerDataStore`` live on
+    ``VertexSearchEngineExtraBody`` instead.
+    """
+
+    query: str
+    pageSize: int
+    pageToken: str
+    offset: int
+    oneBoxPageSize: int
+    pageCategories: List[str]
+    imageQuery: Dict[str, Any]
+    filter: str
+    canonicalFilter: str
+    orderBy: str
+    userInfo: Dict[str, Any]
+    languageCode: str
+    facetSpecs: List[Dict[str, Any]]
+    boostSpec: Dict[str, Any]
+    params: Dict[str, Any]
+    queryExpansionSpec: Dict[str, Any]
+    spellCorrectionSpec: Dict[str, Any]
+    userPseudoId: str
+    contentSearchSpec: Dict[str, Any]
+    rankingExpression: str
+    rankingExpressionBackend: str
+    safeSearch: bool
+    userLabels: Dict[str, str]
+    naturalLanguageQueryUnderstandingSpec: Dict[str, Any]
+    searchAsYouTypeSpec: Dict[str, Any]
+    displaySpec: Dict[str, Any]
+    crowdingSpecs: List[Dict[str, Any]]
+    relevanceThreshold: str
+    relevanceScoreSpec: Dict[str, Any]
+    customRankingParams: Dict[str, Any]
+
+
+class VertexSearchEngineExtraBody(VertexSearchDataStoreExtraBody, total=False):
+    """
+    Native Discovery Engine ``SearchRequest`` fields callers may forward via
+    ``extra_body`` when searching a Vertex AI Search **engine/app** serving
+    config (``.../engines/{id}/servingConfigs/default_serving_config``).
+
+    Inherits every data-store field and adds fields that only make sense when
+    an app fans out across multiple member data stores, e.g. ``dataStoreSpecs``
+    (per-store scoping/filtering) and ``numResultsPerDataStore``.
+    """
+
+    dataStoreSpecs: List[Dict[str, Any]]
+    numResultsPerDataStore: int
+
+
 # Vector Store Creation Types
 class VectorStoreExpirationPolicy(TypedDict, total=False):
     """The expiration policy for a vector store"""

--- a/tests/test_litellm/llms/vertex_ai/test_vertex_ai_search_vector_store_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex_ai_search_vector_store_transformation.py
@@ -135,13 +135,35 @@ _ENGINE_BASE = (
     "collections/default_collection/engines/app-2/servingConfigs/default_serving_config"
 )
 
+_DATASTORE_BASE = (
+    "https://discoveryengine.googleapis.com/v1/projects/p/locations/global/"
+    "collections/default_collection/dataStores/ds-1/servingConfigs/default_config"
+)
+
 
 def _search_request(**overrides):
+    """Engine/app-mode search request (vertex_engine_id set)."""
     kwargs = dict(
         vector_store_id="vs",
         query="hello",
         vector_store_search_optional_params={},
         api_base=_ENGINE_BASE,
+        litellm_logging_obj=SimpleNamespace(model_call_details={}),
+        litellm_params={"vertex_engine_id": "app-2"},
+    )
+    kwargs.update(overrides)
+    return VertexSearchAPIVectorStoreConfig().transform_search_vector_store_request(
+        **kwargs
+    )
+
+
+def _datastore_search_request(**overrides):
+    """Data-store-mode search request (no vertex_engine_id)."""
+    kwargs = dict(
+        vector_store_id="ds-1",
+        query="hello",
+        vector_store_search_optional_params={},
+        api_base=_DATASTORE_BASE,
         litellm_logging_obj=SimpleNamespace(model_call_details={}),
         litellm_params={},
     )
@@ -166,23 +188,46 @@ def test_search_request_maps_max_num_results_to_pagesize():
     assert body["pageSize"] == 25
 
 
-def test_search_request_rejects_datastorespecs_in_extra_body():
+def test_engine_search_request_forwards_datastorespecs():
     specs = [
         {
             "dataStore": "projects/p/locations/global/collections/default_collection/dataStores/ds-beta"
         }
     ]
 
-    with pytest.raises(ValueError, match="target-selecting"):
-        _search_request(extra_body={"dataStoreSpecs": specs})
+    _, body = _search_request(extra_body={"dataStoreSpecs": specs})
+
+    assert body["dataStoreSpecs"] == specs
 
 
-@pytest.mark.parametrize(
-    "field", ["dataStoreSpecs", "branch", "servingConfig", "entity"]
-)
+def test_engine_search_request_forwards_num_results_per_data_store():
+    _, body = _search_request(extra_body={"numResultsPerDataStore": 3})
+
+    assert body["numResultsPerDataStore"] == 3
+
+
+def test_datastore_search_request_rejects_datastorespecs():
+    specs = [{"dataStore": "projects/p/.../dataStores/ds-beta"}]
+
+    with pytest.raises(ValueError, match="data store mode"):
+        _datastore_search_request(extra_body={"dataStoreSpecs": specs})
+
+
+def test_datastore_search_request_rejects_num_results_per_data_store():
+    with pytest.raises(ValueError, match="data store mode"):
+        _datastore_search_request(extra_body={"numResultsPerDataStore": 3})
+
+
+@pytest.mark.parametrize("field", ["branch", "servingConfig", "entity"])
 def test_search_request_rejects_target_selecting_fields(field):
     with pytest.raises(ValueError, match="target-selecting"):
         _search_request(extra_body={field: "x"})
+
+
+@pytest.mark.parametrize("field", ["branch", "servingConfig", "entity"])
+def test_datastore_search_request_rejects_target_selecting_fields(field):
+    with pytest.raises(ValueError, match="target-selecting"):
+        _datastore_search_request(extra_body={field: "x"})
 
 
 def test_search_request_rejects_unsupported_extra_body_field():
@@ -201,6 +246,14 @@ def test_search_request_forwards_supported_extra_body_fields():
     assert body["filter"] == 'category: ANY("docs")'
     assert body["boostSpec"] == {"conditionBoostSpecs": []}
     assert body["query"] == "hello"
+
+
+def test_datastore_search_request_forwards_supported_extra_body_fields():
+    _, body = _datastore_search_request(
+        extra_body={"filter": 'category: ANY("docs")'}
+    )
+
+    assert body["filter"] == 'category: ANY("docs")'
 
 
 def test_search_request_ignores_none_valued_extra_body_fields():

--- a/tests/test_litellm/llms/vertex_ai/test_vertex_ai_search_vector_store_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex_ai_search_vector_store_transformation.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from litellm.exceptions import BadRequestError
 from litellm.llms.vertex_ai.vector_stores.search_api.transformation import (
     VertexSearchAPIVectorStoreConfig,
 )
@@ -209,30 +210,37 @@ def test_engine_search_request_forwards_num_results_per_data_store():
 def test_datastore_search_request_rejects_datastorespecs():
     specs = [{"dataStore": "projects/p/.../dataStores/ds-beta"}]
 
-    with pytest.raises(ValueError, match="data store mode"):
+    with pytest.raises(BadRequestError, match="data store mode"):
         _datastore_search_request(extra_body={"dataStoreSpecs": specs})
 
 
 def test_datastore_search_request_rejects_num_results_per_data_store():
-    with pytest.raises(ValueError, match="data store mode"):
+    with pytest.raises(BadRequestError, match="data store mode"):
         _datastore_search_request(extra_body={"numResultsPerDataStore": 3})
 
 
 @pytest.mark.parametrize("field", ["branch", "servingConfig", "entity"])
 def test_search_request_rejects_target_selecting_fields(field):
-    with pytest.raises(ValueError, match="target-selecting"):
+    with pytest.raises(BadRequestError, match="target-selecting"):
         _search_request(extra_body={field: "x"})
 
 
 @pytest.mark.parametrize("field", ["branch", "servingConfig", "entity"])
 def test_datastore_search_request_rejects_target_selecting_fields(field):
-    with pytest.raises(ValueError, match="target-selecting"):
+    with pytest.raises(BadRequestError, match="target-selecting"):
         _datastore_search_request(extra_body={field: "x"})
 
 
 def test_search_request_rejects_unsupported_extra_body_field():
-    with pytest.raises(ValueError, match="Unsupported Vertex AI Search extra_body"):
+    with pytest.raises(BadRequestError, match="Unsupported Vertex AI Search extra_body"):
         _search_request(extra_body={"notARealField": True})
+
+
+def test_rejected_extra_body_raises_http_400():
+    with pytest.raises(BadRequestError) as exc_info:
+        _search_request(extra_body={"notARealField": True})
+
+    assert exc_info.value.status_code == 400
 
 
 def test_search_request_forwards_supported_extra_body_fields():

--- a/tests/test_litellm/llms/vertex_ai/test_vertex_ai_search_vector_store_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex_ai_search_vector_store_transformation.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 import pytest
 
 from litellm.llms.vertex_ai.vector_stores.search_api.transformation import (
@@ -126,3 +128,69 @@ def test_should_raise_when_neither_engine_id_nor_vector_store_id_provided():
                 "vertex_location": "global",
             },
         )
+
+
+_ENGINE_BASE = (
+    "https://discoveryengine.googleapis.com/v1/projects/p/locations/global/"
+    "collections/default_collection/engines/app-2/servingConfigs/default_serving_config"
+)
+
+
+def _search_request(**overrides):
+    kwargs = dict(
+        vector_store_id="vs",
+        query="hello",
+        vector_store_search_optional_params={},
+        api_base=_ENGINE_BASE,
+        litellm_logging_obj=SimpleNamespace(model_call_details={}),
+        litellm_params={},
+    )
+    kwargs.update(overrides)
+    return VertexSearchAPIVectorStoreConfig().transform_search_vector_store_request(
+        **kwargs
+    )
+
+
+def test_search_request_defaults_to_query_and_pagesize_10():
+    url, body = _search_request()
+
+    assert url == _ENGINE_BASE + ":search"
+    assert body == {"query": "hello", "pageSize": 10}
+
+
+def test_search_request_maps_max_num_results_to_pagesize():
+    _, body = _search_request(
+        vector_store_search_optional_params={"max_num_results": 25}
+    )
+
+    assert body["pageSize"] == 25
+
+
+def test_search_request_passes_datastorespecs_through_extra_body():
+    specs = [
+        {
+            "dataStore": "projects/p/locations/global/collections/default_collection/dataStores/ds-beta"
+        }
+    ]
+
+    _, body = _search_request(extra_body={"dataStoreSpecs": specs})
+
+    assert body["dataStoreSpecs"] == specs
+    assert body["query"] == "hello"
+    assert body["pageSize"] == 10
+
+
+def test_search_request_extra_body_takes_precedence_over_defaults():
+    _, body = _search_request(
+        vector_store_search_optional_params={"max_num_results": 5},
+        extra_body={"pageSize": 50, "filter": 'category: ANY("docs")'},
+    )
+
+    assert body["pageSize"] == 50
+    assert body["filter"] == 'category: ANY("docs")'
+
+
+def test_search_request_joins_list_query():
+    _, body = _search_request(query=["foo", "bar"])
+
+    assert body["query"] == "foo bar"

--- a/tests/test_litellm/llms/vertex_ai/test_vertex_ai_search_vector_store_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex_ai_search_vector_store_transformation.py
@@ -194,3 +194,16 @@ def test_search_request_joins_list_query():
     _, body = _search_request(query=["foo", "bar"])
 
     assert body["query"] == "foo bar"
+
+
+def test_search_request_logs_effective_query_when_extra_body_overrides_query():
+    log = SimpleNamespace(model_call_details={})
+
+    _, body = _search_request(
+        query="original",
+        extra_body={"query": "from-extra-body"},
+        litellm_logging_obj=log,
+    )
+
+    assert body["query"] == "from-extra-body"
+    assert log.model_call_details["query"] == "from-extra-body"

--- a/tests/test_litellm/llms/vertex_ai/test_vertex_ai_search_vector_store_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex_ai_search_vector_store_transformation.py
@@ -166,18 +166,47 @@ def test_search_request_maps_max_num_results_to_pagesize():
     assert body["pageSize"] == 25
 
 
-def test_search_request_passes_datastorespecs_through_extra_body():
+def test_search_request_rejects_datastorespecs_in_extra_body():
     specs = [
         {
             "dataStore": "projects/p/locations/global/collections/default_collection/dataStores/ds-beta"
         }
     ]
 
-    _, body = _search_request(extra_body={"dataStoreSpecs": specs})
+    with pytest.raises(ValueError, match="target-selecting"):
+        _search_request(extra_body={"dataStoreSpecs": specs})
 
-    assert body["dataStoreSpecs"] == specs
+
+@pytest.mark.parametrize(
+    "field", ["dataStoreSpecs", "branch", "servingConfig", "entity"]
+)
+def test_search_request_rejects_target_selecting_fields(field):
+    with pytest.raises(ValueError, match="target-selecting"):
+        _search_request(extra_body={field: "x"})
+
+
+def test_search_request_rejects_unsupported_extra_body_field():
+    with pytest.raises(ValueError, match="Unsupported Vertex AI Search extra_body"):
+        _search_request(extra_body={"notARealField": True})
+
+
+def test_search_request_forwards_supported_extra_body_fields():
+    _, body = _search_request(
+        extra_body={
+            "filter": 'category: ANY("docs")',
+            "boostSpec": {"conditionBoostSpecs": []},
+        }
+    )
+
+    assert body["filter"] == 'category: ANY("docs")'
+    assert body["boostSpec"] == {"conditionBoostSpecs": []}
     assert body["query"] == "hello"
-    assert body["pageSize"] == 10
+
+
+def test_search_request_ignores_none_valued_extra_body_fields():
+    _, body = _search_request(extra_body={"filter": None})
+
+    assert "filter" not in body
 
 
 def test_search_request_extra_body_takes_precedence_over_defaults():


### PR DESCRIPTION
## Summary

The `vertex_ai/search_api` managed vector store search forwarded only the query (plus a hardcoded `pageSize: 10`), so callers could not control a search per request. This maps the standard `max_num_results` to `pageSize` and merges `extra_body` into the Discovery Engine request with precedence, so native engine fields like `filter`, `boostSpec`, and `contentSearchSpec` now reach the API. It is a transform-only change; the upstream plumbing already carried these params to the transform, and Bedrock and Vertex RAG already follow the same pattern.

`extra_body` is validated against an allowlist of native Discovery Engine `SearchRequest` fields, derived from two TypedDicts in `types/vector_stores.py`. The allowlist is **mode-aware**, keyed off whether `vertex_engine_id` is set:

- **Engine/app mode** (`vertex_engine_id` set): additionally accepts multi-store fields — `dataStoreSpecs` (per-store scoping) and `numResultsPerDataStore` — since an app fans out across its member data stores.
- **Data-store mode** (no `vertex_engine_id`): those engine-only fields are **rejected** with a clear `ValueError`, because a single data store is scoped by the URL path and they are meaningless there.

In both modes, target-selecting fields (`branch`, `servingConfig`, `entity`) and any field not on the allowlist are rejected loudly rather than silently dropped, so a typo'd or unsupported field fails fast instead of redirecting the search to the wrong target.

## Proof of Fix

Live against real GCP Discovery Engine. App `app-2` is a search app spanning two data stores, `ds-alpha` (alpha docs) and `ds-beta` (beta docs), registered as a managed vector store with `vertex_engine_id: app-2` (engine/app mode — the mode where `dataStoreSpecs` is accepted).

Before (current `litellm_internal_staging`); both per-request params are dropped, outbound body is always `{"query":"alpha beta","pageSize":10}`:

```
$ curl -s localhost:4000/v1/vector_stores/app2/search -H "Authorization: Bearer sk-1234" \
    -d '{"query":"alpha beta","extra_body":{"dataStoreSpecs":[{"dataStore":".../dataStores/ds-beta"}]}}' \
  | jq -r '.data[].file_id'
gs://.../alpha/alpha-billing.txt
gs://.../beta/beta-release.txt
gs://.../alpha/alpha-onboarding.txt
gs://.../beta/beta-security.txt          # 4 results: dataStoreSpecs ignored

$ curl ... -d '{"query":"alpha beta","max_num_results":1}' | jq '.data | length'
4                                        # max_num_results ignored
```

After (this branch):

```
$ curl ... -d '{"query":"alpha beta","extra_body":{"dataStoreSpecs":[{"dataStore":".../dataStores/ds-beta"}]}}' \
  | jq -r '.data[].file_id'
gs://.../beta/beta-release.txt
gs://.../beta/beta-security.txt          # 2 results: targeting honored (engine mode)

$ curl ... -d '{"query":"alpha beta","max_num_results":1}' | jq '.data | length'
1                                        # honored, maps to pageSize:1
```

Outbound bodies to Discovery Engine after the change: `{"query":"alpha beta","pageSize":10,"dataStoreSpecs":[{"dataStore":".../ds-beta"}]}` and `{"query":"alpha beta","pageSize":1}`.
<img width="916" height="289" alt="Screenshot 2026-06-01 at 5 19 47 PM" src="https://github.com/user-attachments/assets/b2b294db-6bd0-4f40-bf27-7af207bbbea6" />

## Test plan
- [x] `tests/test_litellm/llms/vertex_ai/test_vertex_ai_search_vector_store_transformation.py` (26 pass total). Covers, across both modes: default body; `max_num_results` to `pageSize`; supported `extra_body` passthrough; `extra_body` precedence over defaults; list query join; effective-query logging. Mode-specific: `dataStoreSpecs` / `numResultsPerDataStore` pass through in engine mode and are rejected in data-store mode; target-selecting fields (`branch`/`servingConfig`/`entity`) and unsupported fields are rejected in both modes.
- [x] Live proxy against real GCP Discovery Engine, before/after shown above. `dataStoreSpecs` reaches the engine in engine mode (confirmed in the outbound request body) and `max_num_results` maps to `pageSize`.

## Type

New Feature

Resolves LIT-3506
