### PR TITLE
implementation for compaction

### DIFF
--- a/litellm/responses/litellm_completion_transformation/handler.py
+++ b/litellm/responses/litellm_completion_transformation/handler.py
@@ -4,11 +4,8 @@ Handler for transforming responses api requests to litellm.completion requests
 
 from typing import Any, Coroutine, Dict, List, Optional, Union
 
-import base64
-import random
-import string
-import json
 import litellm
+from litellm.litellm_core_utils.asyncify import run_async_function
 from litellm.responses.litellm_completion_transformation.streaming_iterator import (
     LiteLLMCompletionStreamingIterator,
 )
@@ -25,6 +22,39 @@ from litellm.types.utils import ModelResponse
 
 
 class LiteLLMCompletionTransformationHandler:
+
+    @staticmethod
+    def _prepend_compaction_to_response(
+        responses_api_response: ResponsesAPIResponse,
+        compaction_item: Dict[str, Any],
+    ) -> ResponsesAPIResponse:
+        if responses_api_response.output is None:
+            responses_api_response.output = []
+        responses_api_response.output.insert(0, compaction_item)
+        return responses_api_response
+
+    async def _maybe_compact_messages(
+        self,
+        model: str,
+        messages: List[Any],
+        context_management: Optional[List[Dict[str, Any]]],
+        **kwargs: Any,
+    ) -> tuple[Optional[Dict[str, Any]], List[Any]]:
+        if not context_management:
+            return None, messages
+
+        new_messages, compaction_item = (
+            await LiteLLMCompletionResponsesConfig._transform_context_management(
+                model=model,
+                input=messages,
+                context_management=context_management,
+                **kwargs,
+            )
+        )
+        if compaction_item is None:
+            return None, messages
+        return compaction_item, new_messages
+
     def response_api_handler(
         self,
         model: str,
@@ -64,9 +94,18 @@ class LiteLLMCompletionTransformationHandler:
                 **kwargs,
             )
 
-        completion_args = {}
-        completion_args.update(kwargs)
-        completion_args.update(litellm_completion_request)
+        compaction_item: Optional[Dict[str, Any]] = None
+        if context_management:
+            compact_model = litellm_completion_request.get("model", model)
+            compaction_item, compacted_messages = run_async_function(
+                self._maybe_compact_messages,
+                model=compact_model,
+                messages=litellm_completion_request.get("messages", []),
+                context_management=context_management,
+                **kwargs,
+            )
+            if compaction_item:
+                litellm_completion_request["messages"] = compacted_messages
 
         litellm_completion_response: Union[
             ModelResponse, litellm.CustomStreamWrapper
@@ -83,7 +122,10 @@ class LiteLLMCompletionTransformationHandler:
                     responses_api_request=responses_api_request,
                 )
             )
-
+            if compaction_item:
+                return self._prepend_compaction_to_response(
+                    responses_api_response, compaction_item
+                )
             return responses_api_response
 
         elif isinstance(litellm_completion_response, litellm.CustomStreamWrapper):
@@ -94,6 +136,7 @@ class LiteLLMCompletionTransformationHandler:
                 responses_api_request=responses_api_request,
                 custom_llm_provider=custom_llm_provider,
                 litellm_metadata=kwargs.get("litellm_metadata", {}),
+                compaction_item=compaction_item,
             )
         raise ValueError(
             f"Unexpected response type: {type(litellm_completion_response)}"
@@ -116,37 +159,23 @@ class LiteLLMCompletionTransformationHandler:
                 litellm_completion_request=litellm_completion_request,
             )
 
-        # breakpoint()
-        compacted = False
-        if context_management:
-            model = litellm_completion_request.get("model", "")
-            provider = litellm_completion_request.get("custom_llm_provider", "")
-            if provider:
-                model = provider + "/" + model
+        model = litellm_completion_request.get("model", "")
 
-            litellm_completion_request["messages"], compacted = (
-                await LiteLLMCompletionResponsesConfig._transform_context_management(
-                    model=model,
-                    input=litellm_completion_request.get("messages", []),
-                    context_management=context_management,
-                    **kwargs,
-                )
-            )
-            if compacted:
-                compact_input = litellm_completion_request["messages"][0]
+        compaction_item, compacted_messages = await self._maybe_compact_messages(
+            model=model,
+            messages=litellm_completion_request.get("messages", []),
+            context_management=context_management,
+            **kwargs,
+        )
+        if compaction_item:
+            litellm_completion_request["messages"] = compacted_messages
 
-        acompletion_args = {}
-        acompletion_args.update(kwargs)
-        acompletion_args.update(litellm_completion_request)
-
-        if "context_management" in acompletion_args:
-            del acompletion_args["context_management"]
+        acompletion_args = {**kwargs, **litellm_completion_request}
+        acompletion_args.pop("context_management", None)
 
         litellm_completion_response: Union[
             ModelResponse, litellm.CustomStreamWrapper
-        ] = await litellm.acompletion(
-            **acompletion_args,
-        )
+        ] = await litellm.acompletion(**acompletion_args)
 
         if isinstance(litellm_completion_response, ModelResponse):
             responses_api_response: ResponsesAPIResponse = (
@@ -156,20 +185,10 @@ class LiteLLMCompletionTransformationHandler:
                     responses_api_request=responses_api_request,
                 )
             )
-            if compacted:
-                responses_api_response.output.append(
-                    {
-                        "id": "cmp_"
-                        + "".join(
-                            random.choices(string.ascii_letters + string.digits, k=20)
-                        ),
-                        "type": "compaction",
-                        "encrypted_content": base64.b64encode(
-                            json.dumps(compact_input).encode("utf-8")
-                        ).decode("utf-8"),
-                    }
+            if compaction_item:
+                return self._prepend_compaction_to_response(
+                    responses_api_response, compaction_item
                 )
-
             return responses_api_response
 
         elif isinstance(litellm_completion_response, litellm.CustomStreamWrapper):
@@ -182,6 +201,7 @@ class LiteLLMCompletionTransformationHandler:
                     "custom_llm_provider"
                 ),
                 litellm_metadata=kwargs.get("litellm_metadata", {}),
+                compaction_item=compaction_item,
             )
         raise ValueError(
             f"Unexpected response type: {type(litellm_completion_response)}"

--- a/litellm/responses/litellm_completion_transformation/streaming_iterator.py
+++ b/litellm/responses/litellm_completion_transformation/streaming_iterator.py
@@ -57,6 +57,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
         responses_api_request: ResponsesAPIOptionalRequestParams,
         custom_llm_provider: Optional[str] = None,
         litellm_metadata: Optional[dict] = None,
+        compaction_item: Optional[Dict[str, Any]] = None,
     ):
         self.model: str = model
         self.litellm_custom_stream_wrapper: litellm.CustomStreamWrapper = (
@@ -68,6 +69,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
         )
         self.custom_llm_provider: Optional[str] = custom_llm_provider
         self.litellm_metadata: Optional[dict] = litellm_metadata or {}
+        self.compaction_item: Optional[Dict[str, Any]] = compaction_item
         # Store lightweight dict snapshots for stream_chunk_builder to reduce
         # repeated Pydantic attribute access in end-of-stream assembly.
         self.collected_chat_completion_chunks: List[Dict[str, Any]] = []
@@ -1186,6 +1188,11 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
                 custom_llm_provider=self.custom_llm_provider,
                 litellm_metadata=self.litellm_metadata,
             )
+
+            if self.compaction_item:
+                if encoded_response.output is None:
+                    encoded_response.output = []
+                encoded_response.output.insert(0, self.compaction_item)
 
             return ResponseCompletedEvent(
                 type=ResponsesAPIStreamEvents.RESPONSE_COMPLETED,

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -5,6 +5,8 @@ Handles transforming from Responses API -> LiteLLM completion  (Chat Completion 
 from collections.abc import Sequence
 import json
 import base64
+import random
+import string
 from typing import Any, Dict, List, Literal, Optional, Set, Tuple, Union, cast
 
 from openai.types.responses import ResponseFunctionToolCall
@@ -166,111 +168,125 @@ class LiteLLMCompletionResponsesConfig:
         ]
     ]
 
+    COMPACTION_SUMMARY_PREFIX = "[Previous conversation summary: "
+
     @staticmethod
-    async def _compact_input(
+    def should_execute_compaction(
+        input_token_size: int,
+        context_management: Optional[List[Dict[str, Any]]],
+    ) -> bool:
+        if not context_management:
+            return False
+        entry = context_management[0]
+        if entry.get("type") != "compaction":
+            return False
+        threshold = entry.get("compact_threshold")
+        if threshold is None or threshold <= 0:
+            return False
+        return input_token_size >= int(threshold)
+
+    @staticmethod
+    def _cheap_token_counter_for_messages(messages: Messages) -> int:
+        total = 0
+        for message in messages:
+            content = (
+                message.get("content", "")
+                if isinstance(message, dict)
+                else getattr(message, "content", "")
+            )
+            if isinstance(content, list):
+                for part in content:
+                    if isinstance(part, dict):
+                        total += len(str(part.get("text", ""))) // 4
+            else:
+                total += len(str(content or "")) // 4
+        return total
+
+    @staticmethod
+    def _cheap_token_counter(
+        input: Union[str, List[Any], Messages],
+    ) -> int:
+        json_str = json.dumps(input)
+        return len(json_str) // 4
+
+    @staticmethod
+    async def _apply_compaction_to_messages(
         model: str,
-        input: Messages,
-        **kwargs,
-    ) -> Messages:
-        """
-        Make a 2nd LLM call to compact/summarize the conversation history.
-        Returns the compacted input as a single user message list.
-        """
+        messages: Messages,
+        **kwargs: Any,
+    ) -> Tuple[Messages, Dict[str, Any]]:
         import litellm
 
-        summary_args = {}
-        # summary_args.update(kwargs)
-        if "context_management" in summary_args:
-            del summary_args["context_management"]
-        summary_args["model"] = model
-        conversation_history = json.dumps(input)
-        summary_args["messages"] = [
-            {
-                "role": "user",
-                "content": f"Provide a summary of the conversation below in your response directly with no special formatting. Focus on the key points and important details. Be concise but include relevant context that would help answer the next user message. The summary should be in a compact format that captures the essence of the conversation history.\n\n<conversation>\n{conversation_history}\n</conversation>",
-            }
-        ]
-        # breakpoint()
-        summary_response = litellm.completion(**summary_args)
+        if len(messages) <= 1:
+            raise ValueError("Compaction requires at least two messages")
 
-        if not isinstance(summary_response, ModelResponse):
+        history = messages[:-1]
+        last_message = messages[-1]
+        response = await litellm.acompletion(
+            model=model,
+            messages=[
+                {
+                    "role": "user",
+                    "content": (
+                        "Provide a concise summary of the conversation below. "
+                        "Focus on key points needed to answer the next user message.\n\n"
+                        f"<conversation>\n{json.dumps(history)}\n</conversation>"
+                    ),
+                }
+            ]
+        )
+
+        if not isinstance(response, ModelResponse):
             raise ValueError("Expected a ModelResponse object")
 
         summary = (
-            summary_response.choices[0].message.content
-            if summary_response.choices
+            response.choices[0].message.content
+            if response.choices and response.choices[0].message
             else ""
         )
-        return [
-            {
-                "role": "developer",
-                "content": f"The following is a compacted summary of the prior conversation. Treat it as historical context, not as a new user request. Use it only to answer the latest user message.\n\n<conversation_summary>\nEarlier conversation: {summary}\n</conversation_summary>",
-            }
-        ]
+        summary = str(summary or "")
 
-    @staticmethod
-    def _cheap_token_counter(input: Messages) -> int:
-        """
-        Cheaply estimate the token count of the input.
-        ~4 chars per token for strings; for message lists, stringify first.
-
-        Note: 1. not using an actual tokenizer
-              2. transformation from ResponseInputParam to str is ugly and not precise
-        """
-        json_str = json.dumps(input)
-        return len(json_str) // 4
+        summary_message: Dict[str, Any] = {
+            "role": "user",
+            "content": f"{LiteLLMCompletionResponsesConfig.COMPACTION_SUMMARY_PREFIX}{summary}]",
+        }
+        last_dict = (
+            dict(last_message)
+            if isinstance(last_message, dict)
+            else {"role": getattr(last_message, "role", "user"), "content": getattr(last_message, "content", "")}
+        )
+        compaction_item = {
+            "id": "cmp_"
+            + "".join(random.choices(string.ascii_letters + string.digits, k=20)),
+            "type": "compaction",
+            "encrypted_content": base64.b64encode(summary.encode()).decode(),
+        }
+        return [summary_message, last_dict], compaction_item
 
     @staticmethod
     async def _transform_context_management(
         model: str,
         input: Messages,
         context_management: Optional[List[Dict[str, Any]]],
-        **kwargs,
-    ) -> Tuple[Messages, bool]:
-        """
-        Handle context_management compaction for the Responses API -> Chat Completion path.
+        **kwargs: Any,
+    ) -> Tuple[Messages, Optional[Dict[str, Any]]]:
+        if not context_management or len(input) <= 1:
+            return input, None
 
-        1. Check if at compaction threshold. Early exit if no need to do compaction.
-        2. If reached threshold, make a 2nd LLM call to compact the input.
-
-        Returns the (possibly compacted) input.
-        """
-        if not context_management:
-            return input, False
-        ctx_mgmt_type = context_management[0].get("type", "")
-        ctx_mgmt_threshold = context_management[0].get("compact_threshold", 0)
-        if not ctx_mgmt_type or not ctx_mgmt_threshold:
-            return input, False
-
-        # Note: for now skip compaction if input is a string or only has 1 message
-        if len(input) <= 1:
-            return input, False
-
-        # Note: exclude the last user message from token count since that's the new input we want to preserve in full
-        input_token_size = LiteLLMCompletionResponsesConfig._cheap_token_counter(
-            input[:-1]
+        input_token_size = (
+            LiteLLMCompletionResponsesConfig._cheap_token_counter_for_messages(input)
         )
-        if input_token_size < ctx_mgmt_threshold:
-            return input, False
+        if not LiteLLMCompletionResponsesConfig.should_execute_compaction(
+            input_token_size=input_token_size,
+            context_management=context_management,
+        ):
+            return input, None
 
-        compacted_input = await LiteLLMCompletionResponsesConfig._compact_input(
+        return await LiteLLMCompletionResponsesConfig._apply_compaction_to_messages(
             model=model,
-            input=input[:-1],
+            messages=input,
             **kwargs,
         )
-        # Append the latest user message back to the compacted history
-        compacted_input.append(input[-1])
-        return compacted_input, True
-
-    # @staticmethod
-    # def should_execute_compaction(
-    #     input_token_size: int,
-    #     context_management: Optional[List[Dict[str, Any]]],
-    # ) -> bool:
-    #     """
-    #     Check if compaction should be executed
-    #     """
-    #     pass
 
     @staticmethod
     def transform_responses_api_request_to_chat_completion_request(
@@ -331,7 +347,6 @@ class LiteLLMCompletionResponsesConfig:
             "web_search_options": web_search_options,
             "response_format": response_format,
             "reasoning_effort": reasoning_effort,
-            "context_management": responses_api_request.get("context_management"),
             # litellm specific params
             "custom_llm_provider": custom_llm_provider,
             "extra_headers": extra_headers,
@@ -1094,12 +1109,17 @@ class LiteLLMCompletionResponsesConfig:
                 function_call=input_item
             )
         elif input_item.get("type") == "compaction":
+            encrypted_content = input_item.get("encrypted_content") or ""
+            if not encrypted_content:
+                return []
+            summary = (
+                base64.b64decode(encrypted_content).decode("utf-8")
+            )
             return [
-                json.loads(
-                    base64.b64decode(input_item.get("encrypted_content")).decode(
-                        "utf-8"
-                    )
-                )
+                {
+                    "role": "user",
+                    "content": f"{LiteLLMCompletionResponsesConfig.COMPACTION_SUMMARY_PREFIX}{summary}]",
+                }
             ]
         else:
             content = input_item.get("content")

--- a/tests/test_compaction_interview.py
+++ b/tests/test_compaction_interview.py
@@ -1,0 +1,159 @@
+import base64
+import os
+
+import pytest
+
+import litellm
+
+pytestmark = pytest.mark.skipif(
+    not os.getenv("ANTHROPIC_API_KEY"),
+    reason="ANTHROPIC_API_KEY required",
+)
+
+MODEL = os.getenv("ANTHROPIC_COMPACTION_MODEL", "claude-haiku-4-5-20251001")
+FAT = "word " * 5000
+
+
+def _types(response):
+    out = []
+    for item in response.output or []:
+        out.append(item.get("type") if isinstance(item, dict) else getattr(item, "type", None))
+    return out
+
+
+def _compaction_item(response):
+    for item in response.output or []:
+        t = item.get("type") if isinstance(item, dict) else getattr(item, "type", None)
+        if t == "compaction":
+            return item if isinstance(item, dict) else dict(item)
+    return None
+
+
+# --- Required matrix (cases 1–3) ---
+
+
+@pytest.mark.asyncio
+async def test_compaction_noop_under_threshold():
+    """Case 1: under threshold → no compaction."""
+    response = await litellm.aresponses(
+        model=MODEL,
+        input=[
+            {"type": "message", "role": "user", "content": "Help me debug a production incident."},
+            {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "What symptoms are you seeing?"}],
+            },
+            {
+                "type": "message",
+                "role": "user",
+                "content": "We are seeing intermittent 502s from one provider path.",
+            },
+        ],
+        context_management=[{"type": "compaction", "compact_threshold": 200000}],
+        store=False,
+        max_output_tokens=200,
+    )
+    assert response is not None
+    assert "compaction" not in _types(response)
+
+
+@pytest.mark.asyncio
+async def test_compaction_triggers_over_threshold():
+    """Case 2: over threshold → compaction item with encrypted_content."""
+    response = await litellm.aresponses(
+        model=MODEL,
+        input=[
+            {"type": "message", "role": "user", "content": "Help me debug a production incident."},
+            {"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": FAT}]},
+            {
+                "type": "message",
+                "role": "user",
+                "content": "We are seeing intermittent 502s from one provider path.",
+            },
+        ],
+        context_management=[{"type": "compaction", "compact_threshold": 100}],
+        store=False,
+        max_output_tokens=200,
+    )
+    assert response is not None
+    cmp = _compaction_item(response)
+    assert cmp is not None
+    assert cmp.get("encrypted_content")
+    assert "message" in _types(response)
+
+
+@pytest.mark.asyncio
+async def test_no_recompaction_when_under_threshold():
+    """Case 3: prior compaction + short follow-up → no new compaction id."""
+    prior_cmp = {
+        "type": "compaction",
+        "id": "cmp_prior_001",
+        "encrypted_content": base64.b64encode(b"Previous conversation summary.").decode(),
+    }
+    response = await litellm.aresponses(
+        model=MODEL,
+        input=[
+            prior_cmp,
+            {"type": "message", "role": "user", "content": "What was the main issue?"},
+        ],
+        context_management=[{"type": "compaction", "compact_threshold": 200000}],
+        store=False,
+        max_output_tokens=100,
+    )
+    assert response is not None
+    new_cmp = [
+        i
+        for i in response.output
+        if (i.get("type") if isinstance(i, dict) else getattr(i, "type", None)) == "compaction"
+        and (i.get("id") if isinstance(i, dict) else getattr(i, "id", None)) != "cmp_prior_001"
+    ]
+    assert not new_cmp
+
+
+# --- A few extras from the "additional cases" list ---
+
+
+@pytest.mark.asyncio
+async def test_no_context_management_param_is_noop():
+    """No param → plain response, no compaction."""
+    response = await litellm.aresponses(
+        model=MODEL,
+        input=[{"type": "message", "role": "user", "content": "What is the capital of France?"}],
+        store=False,
+        max_output_tokens=50,
+    )
+    assert response is not None
+    assert "compaction" not in _types(response)
+
+
+@pytest.mark.asyncio
+async def test_encrypted_content_round_trip():
+    """Turn 1 compaction → turn 2 input with same item → assistant message."""
+    resp1 = await litellm.aresponses(
+        model=MODEL,
+        input=[
+            {"type": "message", "role": "user", "content": "Help me debug a production incident."},
+            {"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": FAT}]},
+            {
+                "type": "message",
+                "role": "user",
+                "content": "We are seeing intermittent 502s from one provider path.",
+            },
+        ],
+        context_management=[{"type": "compaction", "compact_threshold": 100}],
+        store=False,
+        max_output_tokens=120,
+    )
+    cmp = _compaction_item(resp1)
+    assert cmp is not None
+
+    resp2 = await litellm.aresponses(
+        model=MODEL,
+        input=[cmp, {"type": "message", "role": "user", "content": "What were we discussing?"}],
+        context_management=[{"type": "compaction", "compact_threshold": 200000}],
+        store=False,
+        max_output_tokens=100,
+    )
+    assert resp2 is not None
+    assert "message" in _types(resp2)


### PR DESCRIPTION
Implements V0 client-side context compaction for /v1/responses on the completion-bridge path (Anthropic, and other providers without a native Responses API config). When context_management=[{"type": "compaction", "compact_threshold": N}] is set and estimated input size meets the threshold, LiteLLM summarizes prior history via a pre-call acompletion, runs the main request on shortened messages, and returns a compaction item with base64-encoded summary text.

Design notes
Opt-in only — no context_management  -> no extra LLM call, no compaction in output.
compact_threshold <= 0 treated as disabled (no crash).
Turn 2 — client sends prior compaction item; we base64-decode and inject summary before the main model call (not raw blob to the provider).
Encoding — encrypted_content = base64(utf-8 summary) (V0 simplicity, not provider Fernet blobs).
