### PR TITLE
bump: version 1.85.2 → 1.85.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "litellm"
-version = "1.85.2"
+version = "1.85.3"
 description = "Library to easily interface with LLM API providers"
 readme = "README.md"
 requires-python = ">=3.10, <3.14"
@@ -250,7 +250,7 @@ source-exclude = [
 profile = "black"
 
 [tool.commitizen]
-version = "1.85.2"
+version = "1.85.3"
 version_files = [
     "pyproject.toml:^version",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-24T07:23:21.190322Z"
+exclude-newer = "2026-05-30T01:59:13.763795Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -3189,7 +3189,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.85.2"
+version = "1.85.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Relevant issues

Cuts v1.85.3 off the 1.85 line; carries the five cherry-picks landed via #29460 (#29089/#29311, #29343, #29358, #27913, #29447 plus the #29089 helper-extraction follow-on).

## Linear ticket

N/A

## Pre-Submission checklist

- [ ] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

Two-commit bump produced by the standard release prep: `cz bump --increment PATCH` followed by `uv lock`. No code changes; pyproject's version pin moves 1.85.2 → 1.85.3 and uv.lock follows. The matching uv.lock `exclude-newer` timestamp drift is the rolling 3-day window per the existing `exclude-newer-span = "P3D"` setting.

## Type

🚄 Infrastructure

## Changes

Version bump only. Two commits matching the v1.84.4 release pattern (`01ab351a42` + `2ee25a3c92`): the cz-generated bump commit on pyproject.toml, then a separate uv.lock refresh.

Once this lands, `stable/1.85.x` is ready to tag v1.85.3.