### PR TITLE
fix(azure_ai): strip tool-level extra fields on 400 and retry

### DIFF
--- a/litellm/llms/azure_ai/chat/transformation.py
+++ b/litellm/llms/azure_ai/chat/transformation.py
@@ -1,4 +1,5 @@
 import enum
+import re
 from typing import Any, List, Optional, Tuple, cast
 from urllib.parse import urlparse
 
@@ -292,8 +293,6 @@ class AzureAIStudioConfig(OpenAIConfig):
         )
 
     def _error_has_tool_level_extra_fields(self, error_text: str) -> bool:
-        import re
-
         return bool(re.search(r"tools\[\d+\]\.", error_text))
 
     @property
@@ -330,9 +329,7 @@ class AzureAIStudioConfig(OpenAIConfig):
     def _drop_tool_level_extra_fields(
         self, request_data: dict, error_text: str
     ) -> dict:
-        import re
-
-        fields_to_drop = set(re.findall(r"tools\[\d+\]\.(\w+)", error_text))
+        fields_to_drop = set(re.findall(r"tools\[\d+\]\.([\w-]+)", error_text))
         tools = request_data.get("tools")
         if fields_to_drop and isinstance(tools, list):
             for tool in tools:
@@ -358,9 +355,6 @@ class AzureAIStudioConfig(OpenAIConfig):
         Error text looks like this"
             "Extra parameters ['stream_options', 'extra-parameters'] are not allowed when extra-parameters is not set or set to be 'error'.
         """
-        import re
-
-        # Extract parameters within square brackets
         match = re.search(r"\[(.*?)\]", error_text)
         if not match:
             return []

--- a/litellm/llms/azure_ai/chat/transformation.py
+++ b/litellm/llms/azure_ai/chat/transformation.py
@@ -275,20 +275,26 @@ class AzureAIStudioConfig(OpenAIConfig):
         should_drop_params = litellm_params.get("drop_params") or litellm.drop_params
         error_text = e.response.text
 
-        if should_drop_params and "Extra inputs are not permitted" in error_text:
+        if "Extra inputs are not permitted" in error_text:
+            if should_drop_params or self._error_has_tool_level_extra_fields(
+                error_text
+            ):
+                return True
+        if "unknown field: parameter index is not a valid field" in error_text:
             return True
-        elif (
-            "unknown field: parameter index is not a valid field" in error_text
-        ):  # remove index from tool calls
-            return True
-        elif (
+        if (
             AzureFoundryErrorStrings.SET_EXTRA_PARAMETERS_TO_PASS_THROUGH.value
             in error_text
-        ):  # remove extra-parameters from tool calls
+        ):
             return True
         return super().should_retry_llm_api_inside_llm_translation_on_http_error(
             e=e, litellm_params=litellm_params
         )
+
+    def _error_has_tool_level_extra_fields(self, error_text: str) -> bool:
+        import re
+
+        return bool(re.search(r"tools\[\d+\]\.", error_text))
 
     @property
     def max_retry_on_unprocessable_entity_error(self) -> int:
@@ -297,9 +303,10 @@ class AzureAIStudioConfig(OpenAIConfig):
     def transform_request_on_unprocessable_entity_error(
         self, e: httpx.HTTPStatusError, request_data: dict
     ) -> dict:
+        error_text = e.response.text
         _messages = cast(Optional[List[AllMessageValues]], request_data.get("messages"))
         if (
-            "unknown field: parameter index is not a valid field" in e.response.text
+            "unknown field: parameter index is not a valid field" in error_text
             and _messages is not None
         ):
             litellm.remove_index_from_tool_calls(
@@ -307,13 +314,32 @@ class AzureAIStudioConfig(OpenAIConfig):
             )
         elif (
             AzureFoundryErrorStrings.SET_EXTRA_PARAMETERS_TO_PASS_THROUGH.value
-            in e.response.text
+            in error_text
         ):
             request_data = self._drop_extra_params_from_request_data(
-                request_data, e.response.text
+                request_data, error_text
             )
+        if (
+            "Extra inputs are not permitted" in error_text
+            and self._error_has_tool_level_extra_fields(error_text)
+        ):
+            request_data = self._drop_tool_level_extra_fields(request_data, error_text)
         data = drop_params_from_unprocessable_entity_error(e=e, data=request_data)
         return data
+
+    def _drop_tool_level_extra_fields(
+        self, request_data: dict, error_text: str
+    ) -> dict:
+        import re
+
+        fields_to_drop = set(re.findall(r"tools\[\d+\]\.(\w+)", error_text))
+        tools = request_data.get("tools")
+        if fields_to_drop and isinstance(tools, list):
+            for tool in tools:
+                if isinstance(tool, dict):
+                    for field in fields_to_drop:
+                        tool.pop(field, None)
+        return request_data
 
     def _drop_extra_params_from_request_data(
         self, request_data: dict, error_text: str

--- a/tests/test_litellm/llms/azure_ai/chat/test_azure_ai_transformation.py
+++ b/tests/test_litellm/llms/azure_ai/chat/test_azure_ai_transformation.py
@@ -200,3 +200,65 @@ def test_azure_model_router_response_shows_actual_model():
         f"Expected model to be 'azure_ai/gpt-5-nano-2025-08-07' (actual model used), "
         f"but got '{result.model}'"
     )
+
+
+def test_drop_tool_level_extra_fields_strips_copilot_mcp_server_name():
+    """
+    Regression test: Azure AI returns 400 when tools contain copilot_mcp_server_name.
+    LiteLLM should strip the field and retry automatically.
+    """
+    import httpx
+
+    config = AzureAIStudioConfig()
+
+    error_text = json.dumps(
+        {
+            "error": {
+                "message": "2 request validation errors: Extra inputs are not permitted, field: 'tools[0].copilot_mcp_server_name', value: 'github-mcp-server'; Extra inputs are not permitted, field: 'tools[1].copilot_mcp_server_name', value: 'ide'"
+            }
+        }
+    )
+    mock_response = MagicMock(spec=httpx.Response)
+    mock_response.text = error_text
+    mock_response.json.return_value = json.loads(error_text)
+    mock_response.status_code = 400
+    e = httpx.HTTPStatusError(
+        message="400", request=MagicMock(), response=mock_response
+    )
+
+    assert config._error_has_tool_level_extra_fields(error_text) is True
+    assert (
+        config.should_retry_llm_api_inside_llm_translation_on_http_error(e, {}) is True
+    )
+
+    request_data = {
+        "model": "FW-Kimi-K2.6",
+        "messages": [{"role": "user", "content": "Say hi."}],
+        "tools": [
+            {
+                "type": "function",
+                "copilot_mcp_server_name": "github-mcp-server",
+                "function": {
+                    "name": "github_search_code",
+                    "description": "Search code",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            },
+            {
+                "type": "function",
+                "copilot_mcp_server_name": "ide",
+                "function": {
+                    "name": "read_file",
+                    "description": "Read a file",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            },
+        ],
+    }
+
+    result = config.transform_request_on_unprocessable_entity_error(e, request_data)
+
+    for tool in result["tools"]:
+        assert "copilot_mcp_server_name" not in tool
+    assert result["tools"][0]["type"] == "function"
+    assert result["tools"][1]["function"]["name"] == "read_file"


### PR DESCRIPTION
## Relevant issues
Fixes LIT-3507
GitHub Copilot sends tools with a `copilot_mcp_server_name` field on each tool object. Azure AI Foundry (e.g. FW-Kimi-K2.6) rejects these with a 400:

```
Extra inputs are not permitted, field: 'tools[0].copilot_mcp_server_name'
Extra inputs are not permitted, field: 'tools[1].copilot_mcp_server_name'
```

LiteLLM was not stripping the field, so the 400 bubbled up to the caller.

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Changes

`litellm/llms/azure_ai/chat/transformation.py`

`should_retry_llm_api_inside_llm_translation_on_http_error` now returns `True` for "Extra inputs are not permitted" errors that reference `tools[N].field` paths, regardless of `drop_params`. The offending field is always safe to strip since the provider explicitly rejects it.

`transform_request_on_unprocessable_entity_error` calls a new `_drop_tool_level_extra_fields` helper that parses field names out of the error text (e.g. `tools[0].copilot_mcp_server_name`) and removes them from every tool object in `request_data["tools"]`. The fix is generic; any unknown tool-level field reported by Azure AI is stripped, not just `copilot_mcp_server_name`.

Regression test added in `tests/test_litellm/llms/azure_ai/chat/test_azure_ai_transformation.py`.

## Screenshots / Proof of Fix

Start the proxy and run the repro script:

```bash
python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log
```

```bash
export LITELLM_API_KEY=sk-1234
export PROXY_URL=http://127.0.0.1:4000
export MODEL=fw-kimi-k2.6   # must be configured with azure_ai provider + Foundry api_base
./repro_fw_kimi_copilot_mcp_tools.sh
```

Before this fix: `400 BadRequest — Extra inputs are not permitted, field: 'tools[0].copilot_mcp_server_name'`.

After this fix: the proxy strips `copilot_mcp_server_name` from every tool object on the first 400, retries transparently, and returns a successful completion.

## Type

Bug Fix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Azure AI 422/400 retry and request mutation for provider-rejected tool keys; covered by a targeted regression test.
> 
> **Overview**
> Azure AI chat translation now **automatically retries** after a 400 when the error mentions **unknown fields on tool objects** (e.g. `tools[0].copilot_mcp_server_name` from Copilot MCP), even if `drop_params` is off.
> 
> On retry, **`_drop_tool_level_extra_fields`** parses those field names from the error text and removes them from every entry in `request_data["tools"]`, then the existing unprocessable-entity handling still runs. **`should_retry_llm_api_inside_llm_translation_on_http_error`** treats “Extra inputs are not permitted” as retriable when the message matches `tools[N].…`.
> 
> A regression test covers stripping `copilot_mcp_server_name` while leaving tool `function` payloads intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff6ceaf49e360e6643734166d37cb10743b79185. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->