### PR TITLE
fix(guardrails): handle dict input in update_in_memory_litellm_params (#29484)

### DIFF
--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -842,9 +842,7 @@ class CustomGuardrail(CustomLogger):
         handle both dict and pydantic-model inputs.
         """
         params = (
-            litellm_params
-            if isinstance(litellm_params, dict)
-            else vars(litellm_params)
+            litellm_params if isinstance(litellm_params, dict) else vars(litellm_params)
         )
         for key, value in params.items():
             setattr(self, key, value)

--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -831,11 +831,22 @@ class CustomGuardrail(CustomLogger):
         # Mask the content
         return content_string[:start_index] + mask_string + content_string[end_index:]
 
-    def update_in_memory_litellm_params(self, litellm_params: LitellmParams) -> None:
+    def update_in_memory_litellm_params(
+        self, litellm_params: Union[LitellmParams, dict]
+    ) -> None:
         """
         Update the guardrails litellm params in memory
+
+        ``litellm_params`` may arrive as a plain dict (e.g. when read from the
+        DB and ``cast()`` to ``LitellmParams`` without actual conversion), so
+        handle both dict and pydantic-model inputs.
         """
-        for key, value in vars(litellm_params).items():
+        params = (
+            litellm_params
+            if isinstance(litellm_params, dict)
+            else vars(litellm_params)
+        )
+        for key, value in params.items():
             setattr(self, key, value)
 
     def get_guardrails_messages_for_call_type(

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -1381,16 +1381,22 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         inputs["texts"] = new_texts
         return inputs
 
-    def update_in_memory_litellm_params(self, litellm_params: LitellmParams) -> None:
+    def update_in_memory_litellm_params(
+        self, litellm_params: Union[LitellmParams, dict]
+    ) -> None:
         """
         Update the guardrails litellm params in memory
+
+        ``litellm_params`` may arrive as a plain dict (see the base class), so
+        read fields in a way that works for both dict and pydantic inputs.
         """
         super().update_in_memory_litellm_params(litellm_params)
-        if litellm_params.pii_entities_config:
-            self.pii_entities_config = litellm_params.pii_entities_config
-        if litellm_params.presidio_score_thresholds:
-            self.presidio_score_thresholds = litellm_params.presidio_score_thresholds
-        if litellm_params.presidio_entities_deny_list:
-            self.presidio_entities_deny_list = (
-                litellm_params.presidio_entities_deny_list
-            )
+        params = (
+            litellm_params if isinstance(litellm_params, dict) else vars(litellm_params)
+        )
+        if params.get("pii_entities_config"):
+            self.pii_entities_config = params["pii_entities_config"]
+        if params.get("presidio_score_thresholds"):
+            self.presidio_score_thresholds = params["presidio_score_thresholds"]
+        if params.get("presidio_entities_deny_list"):
+            self.presidio_entities_deny_list = params["presidio_entities_deny_list"]


### PR DESCRIPTION
## Summary

Fixes #29484.

`CustomGuardrail.update_in_memory_litellm_params()` raises
`vars() argument must have __dict__ attribute` when it receives a plain
`dict` instead of a `LitellmParams` model.

This happens on the `PUT /guardrails/{id}` path: `update_in_memory_guardrail`
in `guardrail_registry.py` does

```python
updated_litellm_params = cast(LitellmParams, guardrail.get("litellm_params", {}))
```

`cast()` is only a type hint — it does not convert — so when the DB value is a
dict, `vars()` blows up.

### Impact (from the report)
- Immediate in-memory guardrail sync fails silently after an update.
- The guardrail keeps serving its **old version** until the 30s periodic DB
  sync (or an instance restart).
- In multi-instance deployments (e.g. ECS Fargate), the instance that processed
  the update logs a warning and stays on the stale version.

### Fix
Accept both `dict` and pydantic-model inputs; only the dict branch is new, so
existing model behavior is unchanged.

## Test plan
- [ ] `update_in_memory_litellm_params({...})` no longer raises and sets attrs.
- [ ] `update_in_memory_litellm_params(LitellmParams(...))` behaves as before.
- [ ] Existing guardrail registry tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)