### PR TITLE
fix(vertex/anthropic): handle namespace tools and strip client_metadata for codex compatibility

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -918,7 +918,34 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
         anthropic_tools = []
         mcp_servers = []
         for tool in tools:
-            if "input_schema" in tool:  # assume in anthropic format
+            if tool.get("type") == "namespace":
+                # Namespace is a grouping container (e.g. codex's multi_agent_v1).
+                # Extract its nested tools and map them individually.
+                for nested in tool.get("tools") or []:
+                    if "input_schema" in nested:
+                        # Already in Anthropic format.
+                        anthropic_tools.append(nested)
+                    elif "function" not in nested and "name" in nested:
+                        # Flat format: {type, name, description, parameters, ...}.
+                        # Normalize to OpenAI-wrapped format before mapping.
+                        wrapped = {
+                            "type": nested.get("type", "function"),
+                            "function": {
+                                k: v for k, v in nested.items() if k != "type"
+                            },
+                        }
+                        nested_tool, nested_mcp = self._map_tool_helper(wrapped)
+                        if nested_tool is not None:
+                            anthropic_tools.append(nested_tool)
+                        if nested_mcp is not None:
+                            mcp_servers.append(nested_mcp)
+                    else:
+                        nested_tool, nested_mcp = self._map_tool_helper(nested)
+                        if nested_tool is not None:
+                            anthropic_tools.append(nested_tool)
+                        if nested_mcp is not None:
+                            mcp_servers.append(nested_mcp)
+            elif "input_schema" in tool:  # assume in anthropic format
                 anthropic_tools.append(tool)
             else:  # assume openai tool call
                 new_tool, mcp_server_tool = self._map_tool_helper(tool)
@@ -1978,6 +2005,7 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
 
         # Remove internal LiteLLM parameters that should not be sent to Anthropic API
         optional_params.pop("is_vertex_request", None)
+        optional_params.pop("client_metadata", None)
 
         data = {
             "model": model,

--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -928,19 +928,24 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                     elif "function" not in nested and "name" in nested:
                         # Flat format: {type, name, description, parameters, ...}.
                         # Normalize to OpenAI-wrapped format before mapping.
-                        wrapped = {
-                            "type": nested.get("type", "function"),
-                            "function": {
-                                k: v for k, v in nested.items() if k != "type"
+                        wrapped = cast(
+                            ChatCompletionToolParam,
+                            {
+                                "type": nested.get("type", "function"),
+                                "function": {
+                                    k: v for k, v in nested.items() if k != "type"
+                                },
                             },
-                        }
+                        )
                         nested_tool, nested_mcp = self._map_tool_helper(wrapped)
                         if nested_tool is not None:
                             anthropic_tools.append(nested_tool)
                         if nested_mcp is not None:
                             mcp_servers.append(nested_mcp)
-                    else:
-                        nested_tool, nested_mcp = self._map_tool_helper(nested)
+                    elif "function" in nested:
+                        nested_tool, nested_mcp = self._map_tool_helper(
+                            cast(ChatCompletionToolParam, nested)
+                        )
                         if nested_tool is not None:
                             anthropic_tools.append(nested_tool)
                         if nested_mcp is not None:

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -5090,3 +5090,101 @@ def test_map_tool_helper_collision_prefers_definitions_over_components_schemas()
     # Cross-namespace ref *also* resolves to the `definitions` body because
     # ``unpack_defs`` keys by last path segment -- documented limitation.
     assert transformed["input_schema"]["properties"]["from_components"] == expected
+
+
+def test_namespace_tool_flat_nested_tools_are_extracted():
+    """Codex sends nested tools in flat format {type, name, description, parameters} with no 'function' wrapper.
+    These must be normalized and mapped without raising KeyError: 'function'."""
+    config = AnthropicConfig()
+    tools = [
+        {
+            "type": "namespace",
+            "name": "multi_agent_v1",
+            "tools": [
+                {
+                    "type": "function",
+                    "name": "close_agent",
+                    "description": "Close an agent.",
+                    "strict": False,
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"target": {"type": "string"}},
+                        "required": ["target"],
+                        "additionalProperties": False,
+                    },
+                },
+            ],
+        }
+    ]
+    anthropic_tools, _ = config._map_tools(tools)
+    assert len(anthropic_tools) == 1
+    assert anthropic_tools[0]["name"] == "close_agent"
+
+
+def test_namespace_tool_nested_tools_are_extracted():
+    """Codex sends type='namespace' wrapping nested tools in Anthropic format.
+    The namespace container must be dropped and its nested tools extracted individually.
+    """
+    config = AnthropicConfig()
+    tools = [
+        {
+            "type": "namespace",
+            "name": "multi_agent_v1",
+            "description": "Tools for spawning and managing sub-agents.",
+            "tools": [
+                {
+                    "name": "close_agent",
+                    "type": "custom",
+                    "description": "Close an agent.",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {"target": {"type": "string"}},
+                        "required": ["target"],
+                    },
+                },
+                {
+                    "name": "resume_agent",
+                    "type": "custom",
+                    "description": "Resume a closed agent.",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {"id": {"type": "string"}},
+                        "required": ["id"],
+                    },
+                },
+            ],
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "exec_command",
+                "description": "Run a command.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"cmd": {"type": "string"}},
+                    "required": ["cmd"],
+                },
+            },
+        },
+    ]
+    anthropic_tools, mcp_servers = config._map_tools(tools)
+    names = [t["name"] for t in anthropic_tools]
+    assert "close_agent" in names
+    assert "resume_agent" in names
+    assert "exec_command" in names
+    assert "multi_agent_v1" not in names
+    assert len(anthropic_tools) == 3
+    assert mcp_servers == []
+
+
+def test_client_metadata_stripped_from_anthropic_request():
+    """client_metadata passed by codex must not reach the Anthropic (or Vertex Anthropic) payload."""
+    config = AnthropicConfig()
+    result = config.transform_request(
+        model="claude-3-5-haiku-20241022",
+        messages=[{"role": "user", "content": "hello"}],
+        optional_params={"max_tokens": 10, "client_metadata": {"originator": "codex"}},
+        litellm_params={},
+        headers={},
+    )
+    assert "client_metadata" not in result


### PR DESCRIPTION
## Relevant issues

Fixes LIT-2100
Fixes #22312

## Changes

**Issue 1: `type: \"namespace\"` tools raised `Unsupported tool type: namespace`**

Codex sends a `namespace` grouping container (e.g. `multi_agent_v1`) alongside real callable tools. The Anthropic transformation didn't know about this type and raised `ValueError`. The fix extracts the nested tools from the container and maps them individually, dropping the container itself since Anthropic has no equivalent. Handles both Anthropic-format nested tools (with `input_schema`) and flat-format nested tools (`{type, name, parameters}` at top level, no `function` wrapper).

**Issue 2: `client_metadata` in outbound payload caused 400 from Vertex**

Codex passes `client_metadata` as a top-level request field. It flowed through `optional_params` into the outbound payload. Vertex Anthropic's strict validation rejected it with `Extra inputs are not permitted`. The fix strips it in `AnthropicConfig.transform_request`, where `is_vertex_request` is already stripped for the same reason. This covers all Anthropic-backed providers (direct, Vertex, Bedrock, Azure).

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Type

🐛 Bug Fix

## Screenshots / Proof of Fix
<img width="1151" height="497" alt="image" src="https://github.com/user-attachments/assets/bc5f7f46-a681-4255-9067-3c10189e7ea7" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Anthropic request mapping and param stripping with new unit tests; no auth, billing, or broad API surface changes.
> 
> **Overview**
> Fixes **Codex → Anthropic/Vertex** compatibility in two places.
> 
> **`type: "namespace"` tools** (e.g. `multi_agent_v1`): Codex sends a grouping container with nested callable tools. LiteLLM previously treated the container as a single tool and failed with *Unsupported tool type: namespace*. **`_map_tools`** now unwraps the namespace, maps each nested tool (Anthropic `input_schema`, flat `{name, parameters}`, or OpenAI `function` shape), and **does not** forward the container name to the provider.
> 
> **`client_metadata`**: Codex passes this in `optional_params`; it was merged into the outbound body and **Vertex Anthropic** rejected it (*Extra inputs are not permitted*). **`transform_request`** now drops `client_metadata` the same way it already drops `is_vertex_request`, for all Anthropic-backed routes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 226caa2043df3ec16d026bfe595fc898d54ea749. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->