### PR TITLE
feat(proxy): add disable_budget_reservation general setting (#27639)

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2536,7 +2536,21 @@ class ConfigGeneralSettings(LiteLLMPydanticObjectBase):
     )
     disable_budget_reservation: Optional[bool] = Field(
         None,
-        description="If True, disables the optimistic per-request budget reservation added in v1.84.0 and reverts to read-time budget enforcement only (the pre-v1.84.0 behavior). Budgets are still checked on every request, but without the reservation a burst of concurrent requests can each pass the spend check before their cost is recorded, so a budget can be briefly exceeded under high concurrency. Intended as an opt-out for operators hit by phantom BudgetExceededError from leaked reservations.",
+        description=(
+            "If True, disables the optimistic per-request budget reservation "
+            "introduced in v1.84.0. "
+            "WARNING: This weakens hard budget enforcement. Without the reservation, "
+            "a burst of concurrent requests from a single key can each pass the "
+            "read-time spend check before any of them is charged, allowing a "
+            "configured budget to be exceeded under high concurrency. "
+            "Budgets are still evaluated on every request at read time, so "
+            "an already-exhausted budget is still rejected. "
+            "Enable only if your deployment is experiencing phantom "
+            "BudgetExceededError responses caused by leaked reservations "
+            "(see GitHub issue #27639). "
+            "A proxy-level WARNING is logged on every request while this flag "
+            "is active as a reminder that hard enforcement is relaxed."
+        ),
     )
 
 

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2534,6 +2534,10 @@ class ConfigGeneralSettings(LiteLLMPydanticObjectBase):
         None,
         description="List of MCP server fields that must be filled in for a submission to pass standards checks (e.g. ['description', 'source_url', 'alias']).",
     )
+    disable_budget_reservation: Optional[bool] = Field(
+        None,
+        description="If True, disables the optimistic per-request budget reservation (the v1.84.0 Redis pre-charge) and falls back to read-time budget enforcement only. Budgets are still enforced.",
+    )
 
 
 class ConfigYAML(LiteLLMPydanticObjectBase):

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2536,7 +2536,7 @@ class ConfigGeneralSettings(LiteLLMPydanticObjectBase):
     )
     disable_budget_reservation: Optional[bool] = Field(
         None,
-        description="If True, disables the optimistic per-request budget reservation (the v1.84.0 Redis pre-charge) and falls back to read-time budget enforcement only. Budgets are still enforced.",
+        description="If True, disables the optimistic per-request budget reservation added in v1.84.0 and reverts to read-time budget enforcement only (the pre-v1.84.0 behavior). Budgets are still checked on every request, but without the reservation a burst of concurrent requests can each pass the spend check before their cost is recorded, so a budget can be briefly exceeded under high concurrency. Intended as an opt-out for operators hit by phantom BudgetExceededError from leaked reservations.",
     )
 
 

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -2132,6 +2132,14 @@ async def _reserve_budget_after_common_checks(
     if skip_budget_checks:
         return
     if general_settings.get("disable_budget_reservation") is True:
+        verbose_proxy_logger.warning(
+            "disable_budget_reservation is enabled: skipping optimistic budget "
+            "reservation. Budget enforcement is read-time only — concurrent "
+            "requests can each pass the spend check before their cost is recorded, "
+            "so a configured budget may be briefly exceeded under high concurrency. "
+            "Set disable_budget_reservation to False or remove it to restore "
+            "hard per-request budget enforcement."
+        )
         return
 
     from litellm.proxy.spend_tracking.budget_reservation import (

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -2103,6 +2103,7 @@ async def _run_centralized_common_checks(  # noqa: PLR0915
         user_api_key_cache=user_api_key_cache,
         proxy_logging_obj=proxy_logging_obj,
         skip_budget_checks=skip_budget_checks,
+        general_settings=general_settings,
     )
 
 
@@ -2123,11 +2124,14 @@ async def _reserve_budget_after_common_checks(
     user_api_key_cache: UserApiKeyCache,
     proxy_logging_obj: ProxyLogging,
     skip_budget_checks: bool,
+    general_settings: dict,
     end_user_id: Optional[str] = None,
     end_user_object: Optional[LiteLLM_EndUserTable] = None,
 ) -> None:
     user_api_key_auth_obj.budget_reservation = None
     if skip_budget_checks:
+        return
+    if general_settings.get("disable_budget_reservation") is True:
         return
 
     from litellm.proxy.spend_tracking.budget_reservation import (

--- a/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
+++ b/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
@@ -110,9 +110,69 @@ async def test_should_clear_stale_budget_reservation_when_budget_checks_skip():
         user_api_key_cache=MagicMock(),
         proxy_logging_obj=MagicMock(),
         skip_budget_checks=True,
+        general_settings={},
     )
 
     assert user_api_key_auth_obj.budget_reservation is None
+
+
+@pytest.mark.asyncio
+async def test_disable_budget_reservation_skips_reservation():
+    """#27639: general_settings.disable_budget_reservation turns off the optimistic Redis
+    reservation so operators hit by phantom BudgetExceededError can opt out of it."""
+    user_api_key_auth_obj = UserAPIKeyAuth(token="test_token")
+
+    with patch(
+        "litellm.proxy.spend_tracking.budget_reservation.reserve_budget_for_request",
+        new=AsyncMock(return_value={"reserved_cost": 0.5, "entries": []}),
+    ) as mock_reserve:
+        await _reserve_budget_after_common_checks(
+            user_api_key_auth_obj=user_api_key_auth_obj,
+            request_data={"model": "gpt-4o"},
+            route="/v1/chat/completions",
+            llm_router=None,
+            team_object=None,
+            user_object=None,
+            prisma_client=None,
+            user_api_key_cache=MagicMock(),
+            proxy_logging_obj=MagicMock(),
+            skip_budget_checks=False,
+            general_settings={"disable_budget_reservation": True},
+        )
+
+    mock_reserve.assert_not_called()
+    assert user_api_key_auth_obj.budget_reservation is None
+
+
+@pytest.mark.asyncio
+async def test_budget_reservation_runs_when_not_disabled():
+    """Control for #27639: with the flag absent, the reservation still runs and is stored."""
+    user_api_key_auth_obj = UserAPIKeyAuth(token="test_token")
+    reservation = {
+        "reserved_cost": 0.5,
+        "entries": [{"counter_key": "spend:key:test_token"}],
+    }
+
+    with patch(
+        "litellm.proxy.spend_tracking.budget_reservation.reserve_budget_for_request",
+        new=AsyncMock(return_value=reservation),
+    ) as mock_reserve:
+        await _reserve_budget_after_common_checks(
+            user_api_key_auth_obj=user_api_key_auth_obj,
+            request_data={"model": "gpt-4o"},
+            route="/v1/chat/completions",
+            llm_router=None,
+            team_object=None,
+            user_object=None,
+            prisma_client=None,
+            user_api_key_cache=MagicMock(),
+            proxy_logging_obj=MagicMock(),
+            skip_budget_checks=False,
+            general_settings={},
+        )
+
+    mock_reserve.assert_awaited_once()
+    assert user_api_key_auth_obj.budget_reservation == reservation
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Relevant issues

#27639

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

### Background

Since the optimistic budget reservation feature shipped in v1.84.0, operators running multiple replicas with a Redis spend counter have reported intermittent `BudgetExceededError` (HTTP 429) for keys and end users whose actual database spend is well under budget. The reported shape is a phantom reservation: the per-request reservation increments the cross-pod counter (`spend:key:<token>`, `spend:end_user:<id>`) up front, and several reporters observe counters that climb to clean integer multiples of the real spend, which is consistent with increments that are never decremented on some terminal paths. The phantom value accumulates over the budget window and eventually rejects legitimate requests.

The lifecycle that produces this: `reserve_budget_for_request` runs during auth (in `_reserve_budget_after_common_checks`) and increments the counter, while the matching decrement happens later, either in the cost-tracking success callback or in the post-call failure hook. A request that reserves budget but then terminates without reaching either of those, for example a client disconnect mid-stream, an upstream timeout, or a pod restart, leaves its reservation behind.

Hardening that lifecycle so every terminal path reconciles is a larger, separate effort. In the meantime, reporters on #27639 asked for a way to turn the feature off so they can fall back to the enforcement behavior that worked before v1.84.0.

### What this PR does

This adds a `disable_budget_reservation` general setting. When it is set, `_reserve_budget_after_common_checks` returns before reserving, so no reservation entry is created and the reservation counter is never incremented. Nothing downstream needs to unwind because there is nothing to unwind: the request metadata writer only attaches a reservation when one exists, and `reconcile_budget_reservation(None)` is a no-op.

Budget enforcement is preserved. `common_checks` already evaluates the team, key, organization, user, and end-user budgets at read time, before the reservation step, so an over-budget caller is still rejected with the flag on. Disabling the reservation only removes the optimistic pre-charge; it reverts to the read-time enforcement that predates v1.84.0. It does not disable budgets.

The tradeoff is the one that existed before v1.84.0, and it is called out in the setting description. Without the reservation, a burst of concurrent requests from one caller can each pass the read-time spend check before any of them is charged, so a configured budget can be briefly exceeded under high concurrency. An operator enabling this flag is accepting that looser concurrency-time enforcement in exchange for not receiving phantom `BudgetExceededError` responses from leaked reservations. The strict `disable_budget_reservation is True` gate is deliberate so that an ambiguous or string-typed config value fails safe by leaving the reservation enabled rather than silently weakening enforcement.

The default is unchanged. Reservation stays on unless an operator opts out:

```yaml
general_settings:
  disable_budget_reservation: true
```

The setting is registered on `ConfigGeneralSettings` so it appears in the config schema and can be toggled through the dynamic `/config/field/update` API, not only by editing `config.yaml` and restarting. It is dependency-injected into the helper rather than read from a module global, so the behavior is unit-testable without patching globals or proxy state.

### Scope

This is the opt-out the issue thread requested. It is intentionally limited to that and does not modify the reservation lifecycle itself, which is being hardened separately. A related but distinct report (#28283) attributes some counter drift to the cross-pod spend counter rather than to reservations; that is out of scope here.

### Tests

`tests/test_litellm/proxy/auth/test_user_api_key_auth.py` gets two regression tests on the helper. With `disable_budget_reservation` set, `reserve_budget_for_request` is asserted to never be called and no reservation is stored. With the flag absent, the reservation still runs and is stored on the auth object. Deleting the gate fails the first test, so the tests pin the behavior rather than just exercising it.

## Screenshots / Proof of Fix

Start a proxy with the flag enabled and a Redis cache, against a config that has a real model:

```bash
python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log
```

with `disable_budget_reservation: true` under `general_settings` in that config.

A normal request still succeeds (hits a live provider, costs a few cents):

```bash
curl -i http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model": "<a-model-in-your-config>", "messages": [{"role": "user", "content": "hi"}]}'
```

Budget enforcement is still active. Create a key with a tiny budget, exhaust it with one real call, then confirm inference is rejected at read time:

```bash
KEY=$(curl -s http://localhost:4000/key/generate \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"max_budget": 0.00001, "models": ["<a-model-in-your-config>"]}' | jq -r .key)

curl -s http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
  -d '{"model": "<a-model-in-your-config>", "messages": [{"role": "user", "content": "hi"}]}' > /dev/null

# still returns 429 Budget Exceeded, so disabling reservation does not disable enforcement
curl -i http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
  -d '{"model": "<a-model-in-your-config>", "messages": [{"role": "user", "content": "hi"}]}'
```

With the flag on, grepping the log for the reserved counter keys shows no reservation increments while requests are in flight:

```bash
grep -i "spend:key:\|spend:end_user:\|reserve" litellm.log
```
