### PR TITLE
fix(google_genai): pass through raw SSE bytes in async stream wrapper

### DIFF
--- a/litellm/google_genai/adapters/transformation.py
+++ b/litellm/google_genai/adapters/transformation.py
@@ -175,7 +175,13 @@ class GoogleGenAIStreamWrapper(AdapterCompletionStreamWrapper):
                     continue
             else:
                 # For other chunk types, yield them directly
-                if hasattr(chunk, "encode"):
+                if isinstance(chunk, (bytes, bytearray)):
+                    # Already-encoded SSE bytes: pass through unchanged.
+                    # bytes has no .encode(), so the old hasattr() check fell
+                    # through to str(chunk) -> "b'data: {...}'", corrupting the
+                    # SSE frame and breaking client-side JSON parsing.
+                    yield bytes(chunk)
+                elif isinstance(chunk, str):
                     yield chunk.encode()
                 else:
                     yield str(chunk).encode()

--- a/tests/test_litellm/google_genai/test_google_genai_adapter_fixes.py
+++ b/tests/test_litellm/google_genai/test_google_genai_adapter_fixes.py
@@ -337,3 +337,30 @@ def test_extra_headers_not_present():
     # Verify metadata is still forwarded
     assert "metadata" in completion_kwargs
     assert completion_kwargs["metadata"]["user_id"] == "test-user"
+
+
+@pytest.mark.asyncio
+async def test_async_sse_wrapper_passes_through_raw_bytes():
+    """Regression test: raw bytes SSE frames must be yielded verbatim.
+
+    Previously the non-dict fallback used ``str(chunk).encode()``. Because
+    ``bytes`` has no ``.encode()``, the ``hasattr(chunk, "encode")`` check was
+    False and bytes frames were stringified to ``b'data: {...}'``, corrupting
+    the SSE stream and breaking client-side JSON parsing.
+    """
+    from litellm.google_genai.adapters.transformation import (
+        GoogleGenAIStreamWrapper,
+    )
+
+    raw_frame = b'data: {"candidates": []}\n\n'
+
+    async def _byte_stream():
+        yield raw_frame
+
+    wrapper = GoogleGenAIStreamWrapper(completion_stream=_byte_stream())
+
+    out = [chunk async for chunk in wrapper.async_google_genai_sse_wrapper()]
+
+    assert out == [raw_frame]
+    # The corrupted form must never appear on the wire.
+    assert not out[0].startswith(b"b'")


### PR DESCRIPTION
Fixes #29494

`async_google_genai_sse_wrapper` fell back to `str(chunk).encode()` for non-dict chunks. Raw `bytes` SSE frames have no `.encode()`, so `hasattr(chunk, "encode")` was `False` and they got stringified to `b'data: {...}'`, corrupting the SSE stream and breaking client-side JSON parsing.

Fix: handle `bytes`/`bytearray` explicitly (pass through unchanged) before the `str` path.
