### PR TITLE
fix(prisma): reset reconnect failure counter on successful watchdog probe

### DIFF
--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -4775,6 +4775,7 @@ class PrismaClient:
                     self.db.query_raw("SELECT 1"),
                     timeout=self._db_health_watchdog_probe_timeout_seconds,
                 )
+                self._consecutive_reconnect_failures = 0
             except asyncio.CancelledError:
                 break
             except Exception as e:

--- a/tests/test_litellm/proxy/db/test_prisma_self_heal.py
+++ b/tests/test_litellm/proxy/db/test_prisma_self_heal.py
@@ -486,3 +486,24 @@ async def test_engine_confirmed_dead_persists_across_failed_heavy_reconnect(
     # The flag must STILL be True so the next attempt re-enters the heavy
     # branch instead of silently demoting to the lightweight path.
     assert client._engine_confirmed_dead is True
+
+
+@pytest.mark.asyncio
+async def test_db_health_watchdog_resets_failure_counter_on_successful_probe(
+    mock_proxy_logging,
+):
+    client = PrismaClient(
+        database_url="mock://test", proxy_logging_obj=mock_proxy_logging
+    )
+    client.db.query_raw = AsyncMock(return_value=[{"result": 1}])
+    client._consecutive_reconnect_failures = 3
+    client._db_health_watchdog_interval_seconds = 1
+    client._db_health_watchdog_probe_timeout_seconds = 0.2
+
+    with patch(
+        "litellm.proxy.utils.asyncio.sleep",
+        AsyncMock(side_effect=[None, asyncio.CancelledError()]),
+    ):
+        await client._db_health_watchdog_loop()
+
+    assert client._consecutive_reconnect_failures == 0


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Start the proxy with detailed logging:

```bash
python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug 2>&1 | tee litellm.log
```

To reproduce: briefly make the database unavailable (e.g. pause the Postgres container) so that a watchdog probe fails and a reconnect attempt is logged as failed. Then restore the database and wait for the watchdog interval. With the fix, the `_consecutive_reconnect_failures` counter resets to 0 on the next successful probe. Without the fix, the counter stays elevated indefinitely, causing the next transient probe failure to immediately escalate to the heavy reconnect path.

## Type

Bug Fix

## Changes

`PrismaClient` keeps a `_consecutive_reconnect_failures` counter that drives escalation to a heavier reconnect path once a threshold is crossed. The counter increments when a reconnect cycle fails and resets to 0 when one succeeds. The watchdog loop runs a `SELECT 1` probe on a fixed interval; when the probe fails it triggers a reconnect, but when the probe succeeds it left the counter untouched.

This meant a single failed reconnect left the counter permanently elevated. The engine could serve traffic normally for an extended period while the counter remained non-zero, so the next transient probe failure would immediately escalate to the heavy reconnect path instead of the lightweight one.

The fix resets `_consecutive_reconnect_failures` to 0 after a successful probe in `_db_health_watchdog_loop`. A passing `SELECT 1` is the direct signal that the engine is healthy; the counter should reflect that state.

A regression test (`test_db_health_watchdog_resets_failure_counter_on_successful_probe` in `tests/test_litellm/proxy/db/test_prisma_self_heal.py`) covers this directly: it pre-sets the counter to 3, runs a successful probe iteration, and asserts the counter is 0 afterwards. The test fails on the unpatched code and passes with the fix.
