### PR TITLE
fix(policy_registry): preserve config-loaded policies across DB sync

### DIFF
--- a/litellm/proxy/policy_engine/policy_registry.py
+++ b/litellm/proxy/policy_engine/policy_registry.py
@@ -9,7 +9,7 @@ by policy_attachments (see AttachmentRegistry).
 
 import json
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple
 
 from litellm._logging import verbose_proxy_logger
 from litellm.types.proxy.policy_engine import (
@@ -73,6 +73,7 @@ class PolicyRegistry:
         self._policies: Dict[str, Policy] = {}
         self._policies_by_id: Dict[str, Tuple[str, Policy]] = {}
         self._initialized: bool = False
+        self._config_policy_names: Set[str] = set()
 
     def load_policies(self, policies_config: Dict[str, Any]) -> None:
         """
@@ -84,11 +85,13 @@ class PolicyRegistry:
         """
         self._policies = {}
         self._policies_by_id = {}
+        self._config_policy_names = set()
 
         for policy_name, policy_data in policies_config.items():
             try:
                 policy = self._parse_policy(policy_name, policy_data)
                 self._policies[policy_name] = policy
+                self._config_policy_names.add(policy_name)
                 verbose_proxy_logger.debug(f"Loaded policy: {policy_name}")
             except Exception as e:
                 verbose_proxy_logger.error(
@@ -533,7 +536,13 @@ class PolicyRegistry:
           policy_<uuid> overrides can be resolved without DB access in the hot path.
         """
         try:
-            self._policies = {}
+            # Preserve config-loaded policies so a DB sync with no results does not wipe them.
+            # DB entries for the same name will override the config version below.
+            self._policies = {
+                name: policy
+                for name, policy in self._policies.items()
+                if name in self._config_policy_names
+            }
             production = await self.get_all_policies_from_db(
                 prisma_client, version_status="production"
             )


### PR DESCRIPTION
## Problem

When a proxy instance loads policies from the config file, they are stored in
`PolicyRegistry._policies`. Shortly after, `sync_policies_from_db` runs and starts
with `self._policies = {}`, wiping all config-loaded policies. If the database has no
policies (because config-defined policies are never persisted to the DB), the registry
ends up empty and all guardrail policies are silently dropped for the lifetime of
that sync cycle.

The user's workaround is to add `supported_db_objects` exclusions to prevent the sync
from running, which defeats the purpose of live DB-backed policy management.

## Root cause

`sync_policies_from_db` (line 536) unconditionally resets `_policies = {}` before
fetching from the DB. There is no tracking of which policies came from the config vs
the DB, so the "start fresh" approach always deletes config entries.

## Fix

1. Add `_config_policy_names: Set[str]` to `PolicyRegistry` to record which policy
   names were loaded from the YAML config via `load_policies`.
2. `load_policies` populates `_config_policy_names` alongside `_policies`.
3. `sync_policies_from_db` now initialises the working dict from config-only entries
   instead of an empty dict. DB entries for the same name still override the config
   version, so operator-managed DB policies continue to take precedence.

## Before / After

```python
# Before
self._policies = {}   # wipes config-loaded policies every sync cycle

# After
self._policies = {
    name: policy
    for name, policy in self._policies.items()
    if name in self._config_policy_names
}  # keeps config-loaded policies; DB entries override on add_policy() below
```

## Testing

Start a proxy with one policy defined in `config.yaml` and no policies in the DB.
After the first `sync_policies_from_db` completes, the policy should still be
resolvable. Previously it would be gone.

Fixes #29416
