### PR TITLE
fix(gemini/veo): move image from parameters into instances[0]

### DIFF
--- a/litellm/llms/gemini/videos/transformation.py
+++ b/litellm/llms/gemini/videos/transformation.py
@@ -283,13 +283,14 @@ class GeminiVideoConfig(BaseVideoConfig):
 
         params_copy = video_create_optional_request_params.copy()
 
-        if "image" in params_copy and params_copy["image"] is not None:
+        if "image" in params_copy:
             image = params_copy.pop("image")
-            if isinstance(image, dict):
-                image_data = image
-            else:
-                image_data = _convert_image_to_gemini_format(image)
-            instance["image"] = image_data
+            if image is not None:
+                if isinstance(image, dict):
+                    image_data = image
+                else:
+                    image_data = _convert_image_to_gemini_format(image)
+                instance["image"] = image_data
 
         parameters = GeminiVideoGenerationParameters(**params_copy)
 

--- a/litellm/llms/gemini/videos/transformation.py
+++ b/litellm/llms/gemini/videos/transformation.py
@@ -265,7 +265,11 @@ class GeminiVideoConfig(BaseVideoConfig):
         {
             "instances": [
                 {
-                    "prompt": "A cat playing with a ball of yarn"
+                    "prompt": "A cat playing with a ball of yarn",
+                    "image": {
+                        "bytesBase64Encoded": "...",
+                        "mimeType": "image/jpeg"
+                    }
                 }
             ],
             "parameters": {
@@ -275,13 +279,17 @@ class GeminiVideoConfig(BaseVideoConfig):
             }
         }
         """
-        instance = GeminiVideoGenerationInstance(prompt=prompt)
+        instance: GeminiVideoGenerationInstance = {"prompt": prompt}
 
         params_copy = video_create_optional_request_params.copy()
 
         if "image" in params_copy and params_copy["image"] is not None:
-            image_data = _convert_image_to_gemini_format(params_copy["image"])
-            params_copy["image"] = image_data
+            image = params_copy.pop("image")
+            if isinstance(image, dict):
+                image_data = image
+            else:
+                image_data = _convert_image_to_gemini_format(image)
+            instance["image"] = image_data
 
         parameters = GeminiVideoGenerationParameters(**params_copy)
 

--- a/litellm/types/llms/gemini.py
+++ b/litellm/types/llms/gemini.py
@@ -230,10 +230,11 @@ class GeminiImageGenerationResponse(TypedDict):
 
 
 # Video Generation Types
-class GeminiVideoGenerationInstance(TypedDict):
+class GeminiVideoGenerationInstance(TypedDict, total=False):
     """Instance data for Gemini video generation request"""
 
-    prompt: str
+    prompt: Required[str]
+    image: Dict[str, Any]
 
 
 class GeminiVideoGenerationParameters(BaseModel):
@@ -260,11 +261,6 @@ class GeminiVideoGenerationParameters(BaseModel):
 
     negativePrompt: Optional[str] = None
     """Text describing what not to include in the video."""
-
-    image: Optional[Any] = None
-    """
-    An initial image to animate (Image object).
-    """
 
     lastFrame: Optional[Any] = None
     """

--- a/tests/test_litellm/llms/gemini/videos/test_gemini_video_transformation.py
+++ b/tests/test_litellm/llms/gemini/videos/test_gemini_video_transformation.py
@@ -2,6 +2,7 @@
 Tests for Gemini (Veo) video generation transformation.
 """
 
+import io
 import json
 import os
 from unittest.mock import MagicMock, Mock, patch
@@ -156,6 +157,62 @@ class TestGeminiVideoConfig:
         assert "image" not in data.get("parameters", {})
         assert data["parameters"]["aspectRatio"] == "16:9"
         assert data["parameters"]["durationSeconds"] == 4
+
+    def test_transform_video_create_request_image_filelike_goes_to_instance(self):
+        """File-like image (BytesIO) gets base64-encoded into instances[0]['image']."""
+        prompt = "Animate this still"
+        api_base = "https://generativelanguage.googleapis.com/v1beta/models/veo-3.0-generate-preview:predictLongRunning"
+        # 1x1 PNG (8 bytes after magic + minimal IHDR is not legal — but the
+        # transformer only cares that ImageEditRequestUtils can sniff a MIME and
+        # that .read() returns bytes; an explicit name="image.jpeg" hands the
+        # MIME sniffer a clean answer regardless of payload).
+        image_bytes = b"\xff\xd8\xff\xe0fake-jpeg-bytes"
+        image_file = io.BytesIO(image_bytes)
+        image_file.name = "still.jpeg"
+
+        data, _, _ = self.config.transform_video_create_request(
+            model="veo-3.0-generate-preview",
+            prompt=prompt,
+            api_base=api_base,
+            video_create_optional_request_params={
+                "image": image_file,
+                "aspectRatio": "16:9",
+            },
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+
+        # File-like took the _convert_image_to_gemini_format branch and landed
+        # in instances[0]["image"], not in parameters.
+        instance_image = data["instances"][0]["image"]
+        assert isinstance(instance_image, dict)
+        assert instance_image["mimeType"].startswith("image/")
+        assert instance_image["bytesBase64Encoded"]
+        # Round-trip the base64 — should equal the original bytes.
+        import base64
+
+        assert base64.b64decode(instance_image["bytesBase64Encoded"]) == image_bytes
+        assert "image" not in data.get("parameters", {})
+
+    def test_transform_video_create_request_image_none_is_dropped(self):
+        """Explicit image=None is popped and never reaches parameters."""
+        prompt = "no image at all"
+        api_base = "https://generativelanguage.googleapis.com/v1beta/models/veo-3.0-generate-preview:predictLongRunning"
+
+        data, _, _ = self.config.transform_video_create_request(
+            model="veo-3.0-generate-preview",
+            prompt=prompt,
+            api_base=api_base,
+            video_create_optional_request_params={
+                "image": None,
+                "aspectRatio": "16:9",
+            },
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+
+        assert "image" not in data["instances"][0]
+        assert "image" not in data.get("parameters", {})
 
     def test_map_openai_params(self):
         """Test parameter mapping from OpenAI format to Veo format."""

--- a/tests/test_litellm/llms/gemini/videos/test_gemini_video_transformation.py
+++ b/tests/test_litellm/llms/gemini/videos/test_gemini_video_transformation.py
@@ -132,6 +132,31 @@ class TestGeminiVideoConfig:
         assert data["parameters"]["durationSeconds"] == 8
         assert data["parameters"]["resolution"] == "1080p"
 
+    def test_transform_video_create_request_image_goes_to_instance(self):
+        """Image belongs in instances[0], not in parameters (per Veo API)."""
+        prompt = "Animate this still"
+        api_base = "https://generativelanguage.googleapis.com/v1beta/models/veo-3.0-generate-preview:predictLongRunning"
+        image_dict = {"bytesBase64Encoded": "aGVsbG8=", "mimeType": "image/jpeg"}
+
+        data, _, _ = self.config.transform_video_create_request(
+            model="veo-3.0-generate-preview",
+            prompt=prompt,
+            api_base=api_base,
+            video_create_optional_request_params={
+                "image": image_dict,
+                "aspectRatio": "16:9",
+                "durationSeconds": 4,
+            },
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+
+        assert data["instances"][0]["prompt"] == prompt
+        assert data["instances"][0]["image"] == image_dict
+        assert "image" not in data.get("parameters", {})
+        assert data["parameters"]["aspectRatio"] == "16:9"
+        assert data["parameters"]["durationSeconds"] == 4
+
     def test_map_openai_params(self):
         """Test parameter mapping from OpenAI format to Veo format."""
         openai_params = {


### PR DESCRIPTION
## Summary

**Problem:** for Gemini Veo, the request image lands under `parameters` instead of `instances[0]`, so the API ignores it. (#29498)

**Why it matters:** image-to-video on the Gemini path is effectively no-op — Veo only reads image from the instance.

**What changed:** in `litellm/llms/gemini/videos/transformation.py`, pop `image` from `params_copy` and put it on the instance dict before constructing `GeminiVideoGenerationParameters`. Mirrors the existing Vertex path. Type moved alongside: `image` off `GeminiVideoGenerationParameters`, onto `GeminiVideoGenerationInstance`.

**Scope:** Gemini Veo only. `lastFrame` / `referenceImages` are left where they are — not part of the reported bug, separate PR if those need the same move.

## Real-behavior proof

```
$ .venv/bin/python -m pytest tests/test_litellm/llms/gemini/videos/test_gemini_video_transformation.py -q
.................................                                       [100%]
33 passed in 0.41s
```

new test `test_transform_video_create_request_image_goes_to_instance` asserts:
- `data["instances"][0]["image"] == image_dict`
- `"image" not in data["parameters"]`
- the other parameter fields (aspectRatio/durationSeconds) still land on `parameters`.

Fixes #29498