### PR TITLE
fix(prisma): add consecutive-failures gate before watchdog reconnect

### DIFF
--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -4750,11 +4750,12 @@ class PrismaClient:
             self._db_health_watchdog_loop()
         )
         verbose_proxy_logger.info(
-            "Started Prisma DB health watchdog (interval=%ss, reconnect_cooldown=%ss, probe_timeout=%ss, reconnect_timeout=%ss)",
+            "Started Prisma DB health watchdog (interval=%ss, reconnect_cooldown=%ss, probe_timeout=%ss, reconnect_timeout=%ss, failures_before_reconnect=%s)",
             self._db_health_watchdog_interval_seconds,
             self._db_reconnect_cooldown_seconds,
             self._db_health_watchdog_probe_timeout_seconds,
             self._db_watchdog_reconnect_timeout_seconds,
+            self._watchdog_failures_before_reconnect,
         )
         await self._start_engine_watcher()
 

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -2925,6 +2925,10 @@ class PrismaClient:
         self._reconnect_escalation_threshold: int = max(
             1, int(os.getenv("PRISMA_RECONNECT_ESCALATION_THRESHOLD", "3"))
         )
+        self._watchdog_failures_before_reconnect: int = max(
+            1, int(os.getenv("PRISMA_WATCHDOG_FAILURES_BEFORE_RECONNECT", "1"))
+        )
+        self._consecutive_probe_failures: int = 0
         self._engine_pidfd: int = -1
         self._engine_pid: int = 0
         self._watching_engine: bool = False
@@ -4775,16 +4779,29 @@ class PrismaClient:
                     self.db.query_raw("SELECT 1"),
                     timeout=self._db_health_watchdog_probe_timeout_seconds,
                 )
+                self._consecutive_probe_failures = 0
             except asyncio.CancelledError:
                 break
             except Exception as e:
                 if isinstance(
                     e, asyncio.TimeoutError
                 ) or PrismaDBExceptionHandler.is_database_connection_error(e):
-                    await self.attempt_db_reconnect(
-                        reason="db_health_watchdog_connection_error",
-                        timeout_seconds=self._db_watchdog_reconnect_timeout_seconds,
-                    )
+                    self._consecutive_probe_failures += 1
+                    if (
+                        self._consecutive_probe_failures
+                        >= self._watchdog_failures_before_reconnect
+                    ):
+                        self._consecutive_probe_failures = 0
+                        await self.attempt_db_reconnect(
+                            reason="db_health_watchdog_connection_error",
+                            timeout_seconds=self._db_watchdog_reconnect_timeout_seconds,
+                        )
+                    else:
+                        verbose_proxy_logger.debug(
+                            "Prisma DB watchdog probe failure %d/%d; deferring reconnect.",
+                            self._consecutive_probe_failures,
+                            self._watchdog_failures_before_reconnect,
+                        )
                 else:
                     verbose_proxy_logger.debug(
                         "Prisma DB health watchdog observed non-DB error: %s", e

--- a/tests/test_litellm/proxy/db/test_prisma_self_heal.py
+++ b/tests/test_litellm/proxy/db/test_prisma_self_heal.py
@@ -486,3 +486,90 @@ async def test_engine_confirmed_dead_persists_across_failed_heavy_reconnect(
     # The flag must STILL be True so the next attempt re-enters the heavy
     # branch instead of silently demoting to the lightweight path.
     assert client._engine_confirmed_dead is True
+
+
+# ---------------------------------------------------------------------------
+# Consecutive-failures gate (PR 3)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_db_health_watchdog_defers_reconnect_below_threshold(mock_proxy_logging):
+    """With threshold=3, two consecutive probe failures must NOT trigger reconnect."""
+    client = PrismaClient(
+        database_url="mock://test", proxy_logging_obj=mock_proxy_logging
+    )
+    client.db.query_raw = AsyncMock(side_effect=asyncio.TimeoutError())
+    client.attempt_db_reconnect = AsyncMock(return_value=True)
+    client._db_health_watchdog_interval_seconds = 1
+    client._db_health_watchdog_probe_timeout_seconds = 0.2
+    client._watchdog_failures_before_reconnect = 3
+
+    with patch(
+        "litellm.proxy.utils.asyncio.sleep",
+        AsyncMock(side_effect=[None, None, asyncio.CancelledError()]),
+    ):
+        await client._db_health_watchdog_loop()
+
+    client.attempt_db_reconnect.assert_not_awaited()
+    assert client._consecutive_probe_failures == 2
+
+
+@pytest.mark.asyncio
+async def test_db_health_watchdog_triggers_reconnect_at_threshold(mock_proxy_logging):
+    """With threshold=3, exactly three consecutive failures must trigger one reconnect."""
+    client = PrismaClient(
+        database_url="mock://test", proxy_logging_obj=mock_proxy_logging
+    )
+    client.db.query_raw = AsyncMock(side_effect=asyncio.TimeoutError())
+    client.attempt_db_reconnect = AsyncMock(return_value=True)
+    client._db_health_watchdog_interval_seconds = 1
+    client._db_health_watchdog_probe_timeout_seconds = 0.2
+    client._db_watchdog_reconnect_timeout_seconds = 7.0
+    client._watchdog_failures_before_reconnect = 3
+
+    with patch(
+        "litellm.proxy.utils.asyncio.sleep",
+        AsyncMock(side_effect=[None, None, None, asyncio.CancelledError()]),
+    ):
+        await client._db_health_watchdog_loop()
+
+    client.attempt_db_reconnect.assert_awaited_once_with(
+        reason="db_health_watchdog_connection_error",
+        timeout_seconds=7.0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_db_health_watchdog_resets_failure_counter_on_successful_probe(
+    mock_proxy_logging,
+):
+    """A successful probe resets the failure counter so two failures before and two
+    after do not add up to a threshold of three."""
+    client = PrismaClient(
+        database_url="mock://test", proxy_logging_obj=mock_proxy_logging
+    )
+    client.db.query_raw = AsyncMock(
+        side_effect=[
+            asyncio.TimeoutError(),
+            asyncio.TimeoutError(),
+            [{"1": 1}],
+            asyncio.TimeoutError(),
+            asyncio.TimeoutError(),
+        ]
+    )
+    client.attempt_db_reconnect = AsyncMock(return_value=True)
+    client._db_health_watchdog_interval_seconds = 1
+    client._db_health_watchdog_probe_timeout_seconds = 0.2
+    client._watchdog_failures_before_reconnect = 3
+
+    with patch(
+        "litellm.proxy.utils.asyncio.sleep",
+        AsyncMock(
+            side_effect=[None, None, None, None, None, asyncio.CancelledError()]
+        ),
+    ):
+        await client._db_health_watchdog_loop()
+
+    client.attempt_db_reconnect.assert_not_awaited()
+    assert client._consecutive_probe_failures == 2


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

The Prisma DB health watchdog triggered a full engine reconnect on every single
probe failure, with no grace window. A transient `SELECT 1` timeout (from
momentary event loop contention, a resolver delay, or any other short-lived
condition) immediately killed and respawned the query engine, turning a
self-clearing hiccup into a hard outage.

A new counter tracks consecutive probe failures. A reconnect is triggered only
after K consecutive failures, where K is controlled by the env var
`PRISMA_WATCHDOG_FAILURES_BEFORE_RECONNECT` (default: `1`, preserving current
behavior). Any successful probe resets the counter to zero. The counter is also
reset to zero when a reconnect is triggered, so the gate re-arms cleanly for
the next failure window.
The watchdog startup log also includes the resolved threshold value (failures_before_reconnect=N) alongside the other tunables, so the setting can be confirmed from logs without inspecting env vars directly.

At the default of `1` the code path is identical to before. Setting it to `3`
or `4` (with the default 30-second probe interval) gives a ~90–120 second
grace window before any engine kill is attempted, which is enough to absorb
transient stalls while still detecting genuine engine failures promptly.

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Run a LiteLLM proxy locally with `PRISMA_WATCHDOG_FAILURES_BEFORE_RECONNECT=3`
set and observe that the first two watchdog probe timeouts log
`"Prisma DB watchdog probe failure 1/3; deferring reconnect."` and
`"Prisma DB watchdog probe failure 2/3; deferring reconnect."` rather than
immediately initiating a reconnect. The reconnect fires only on the third
consecutive failure.

```bash
PRISMA_WATCHDOG_FAILURES_BEFORE_RECONNECT=3 \
  python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml \
  --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log
```
