### PR TITLE
fix(health_check): don't inject max_tokens into embedding health checks when mode is unset

### DIFF
--- a/litellm/proxy/health_check.py
+++ b/litellm/proxy/health_check.py
@@ -45,19 +45,55 @@ MINIMAL_DISPLAY_PARAMS = ["model", "mode_error"]
 _MAX_TOKEN_SUPPORT_MODES: frozenset = frozenset({"chat", "completion", "responses"})
 
 
-def _should_inject_health_check_max_tokens(model_info: dict) -> bool:
+def _resolve_health_check_mode(model_info: dict, litellm_params: dict) -> Optional[str]:
+    """
+    Mode used to shape the health-check probe (e.g. whether to send `max_tokens`).
+
+    Mirrors the resolution `ahealth_check` does, so the probe matches the call it
+    actually makes: an explicit `model_info.mode` wins, otherwise the mode is read
+    from `litellm.model_cost` (looked up by the raw model string and the
+    provider-stripped form, e.g. `bedrock/amazon.titan-embed-text-v2:0` ->
+    `amazon.titan-embed-text-v2:0`). Returns None when nothing matches.
+    """
+    explicit_mode = model_info.get("mode")
+    if explicit_mode is not None:
+        return explicit_mode
+
+    model = litellm_params.get("model") or ""
+    if not model or "*" in model:
+        return None
+
+    candidate_models = [model]
+    try:
+        stripped_model, _, _, _ = litellm.get_llm_provider(model=model)
+        candidate_models.append(stripped_model)
+    except Exception:
+        pass
+
+    for candidate in candidate_models:
+        cost_entry = litellm.model_cost.get(candidate)
+        if cost_entry and cost_entry.get("mode") is not None:
+            return cost_entry["mode"]
+
+    return None
+
+
+def _should_inject_health_check_max_tokens(
+    model_info: dict, litellm_params: dict
+) -> bool:
     """
     Whether the health-check probe should include `max_tokens`.
 
     Order:
       1. `model_info.health_check_supports_max_tokens` (operator override).
-      2. `_MAX_TOKEN_SUPPORT_MODES`. Missing `mode` is treated as `chat`
-         for backward compatibility.
+      2. Effective mode (explicit `model_info.mode`, else resolved from
+         `litellm.model_cost`) against `_MAX_TOKEN_SUPPORT_MODES`. A mode that
+         cannot be resolved is treated as `chat` for backward compatibility.
     """
     explicit = model_info.get("health_check_supports_max_tokens")
     if explicit is not None:
         return bool(explicit)
-    mode = model_info.get("mode") or "chat"
+    mode = _resolve_health_check_mode(model_info, litellm_params) or "chat"
     return mode in _MAX_TOKEN_SUPPORT_MODES
 
 
@@ -424,7 +460,7 @@ def _update_litellm_params_for_health_check(
     - for Bedrock models with region routing (bedrock/region/model), strips the litellm routing prefix but preserves the model ID
     """
     litellm_params["messages"] = _get_random_llm_message()
-    if _should_inject_health_check_max_tokens(model_info):
+    if _should_inject_health_check_max_tokens(model_info, litellm_params):
         _resolved_max_tokens = _resolve_health_check_max_tokens(
             model_info, litellm_params
         )

--- a/tests/test_litellm/proxy/test_health_check_max_tokens.py
+++ b/tests/test_litellm/proxy/test_health_check_max_tokens.py
@@ -353,6 +353,52 @@ def test_explicit_override_false_suppresses_injection_inside_allowlist():
     assert "max_tokens" not in updated
 
 
+@pytest.mark.parametrize(
+    "model",
+    [
+        "bedrock/amazon.titan-embed-text-v2:0",
+        "text-embedding-3-small",
+    ],
+)
+def test_embedding_model_without_mode_skips_max_tokens(model):
+    """
+    Regression: an embedding deployment with no `mode` set must not get
+    `max_tokens` injected into its health-check probe. The probe resolves the
+    embedding mode from model_cost (same as ahealth_check) and routes to the
+    embeddings endpoint, which 400s on `max_tokens`
+    ("extraneous key [max_tokens] is not permitted").
+    """
+    updated = _update_litellm_params_for_health_check({}, {"model": model})
+
+    assert "max_tokens" not in updated
+
+
+def test_chat_model_without_mode_still_injects_max_tokens():
+    """A chat model with no explicit mode keeps the chat-style probe."""
+    updated = _update_litellm_params_for_health_check({}, {"model": "gpt-4"})
+
+    assert updated["max_tokens"] == 5
+
+
+def test_unknown_model_without_mode_defaults_to_chat():
+    """A model absent from model_cost falls back to a chat-style probe."""
+    updated = _update_litellm_params_for_health_check(
+        {}, {"model": "openai/some-unlisted-model"}
+    )
+
+    assert updated["max_tokens"] == 5
+
+
+def test_explicit_override_injects_for_unmoded_embedding_model():
+    """health_check_supports_max_tokens wins over the resolved embedding mode."""
+    updated = _update_litellm_params_for_health_check(
+        {"health_check_supports_max_tokens": True},
+        {"model": "bedrock/amazon.titan-embed-text-v2:0"},
+    )
+
+    assert updated["max_tokens"] == 5
+
+
 def test_update_litellm_params_health_check_reasoning_effort():
     """model_info.health_check_reasoning_effort sets reasoning_effort for chat-style health checks."""
     model_info = {"health_check_reasoning_effort": "low"}

--- a/tests/test_litellm/proxy/test_health_check_max_tokens.py
+++ b/tests/test_litellm/proxy/test_health_check_max_tokens.py
@@ -389,6 +389,19 @@ def test_unknown_model_without_mode_defaults_to_chat():
     assert updated["max_tokens"] == 5
 
 
+def test_unresolvable_provider_without_mode_falls_back_to_chat():
+    """
+    If get_llm_provider can't resolve the provider (no prefix, not a known
+    model), mode resolution must not raise; the probe falls back to chat and
+    still injects max_tokens.
+    """
+    updated = _update_litellm_params_for_health_check(
+        {}, {"model": "random-unknown-model-xyz"}
+    )
+
+    assert updated["max_tokens"] == 5
+
+
 def test_explicit_override_injects_for_unmoded_embedding_model():
     """health_check_supports_max_tokens wins over the resolved embedding mode."""
     updated = _update_litellm_params_for_health_check(


### PR DESCRIPTION
## Relevant issues

Internal support ticket: a Bedrock Titan embeddings deployment fails its `/health` check with `BedrockException - {"message":"Malformed input request: extraneous key [max_tokens] is not permitted, please reformat your input and try again."}`, and neither `drop_params` nor `additional_drop_params: ["max_tokens"]` makes it go away.

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Root cause

The health-check probe only adds `max_tokens` for chat-style modes (`chat`, `completion`, `responses`), which is correct. The problem is how the mode is decided: `_should_inject_health_check_max_tokens` read `model_info.mode` alone and treated a missing mode as `chat`. But `ahealth_check` independently resolves the real mode from `litellm.model_cost`, so for an embedding deployment that omits `mode` (for example `bedrock/amazon.titan-embed-text-v2:0`, which `model_cost` knows is `mode: embedding`), the two disagree: the probe gets `max_tokens=5` injected, then `ahealth_check` routes the call to the Bedrock embeddings handler. `AmazonTitanV2Config._transform_request` splats every inference param into the request body, so `max_tokens` reaches Bedrock and is rejected.

`drop_params` / `additional_drop_params` don't help because `max_tokens` is not a recognized OpenAI embedding param (only `dimensions`/`encoding_format`/`user` are). It is filtered out before the drop-params check ever runs, then re-added as a provider passthrough in `add_provider_specific_params_to_optional_params`.

## Changes

Resolve the effective mode the same way `ahealth_check` already does, so the injection decision matches the call that actually gets made. An explicit `model_info.mode` still wins; otherwise the mode is looked up from `litellm.model_cost` by both the raw model string and the provider-stripped form (so `bedrock/amazon.titan-embed-text-v2:0` resolves to `amazon.titan-embed-text-v2:0`). A model that cannot be resolved keeps defaulting to `chat`, preserving current behavior for chat and wildcard deployments. The `health_check_supports_max_tokens` operator override continues to take precedence.

Setting `mode: embedding` on the deployment was already a valid workaround; this makes the omitted-mode case behave correctly on its own.

## Proof of Fix

Reproduces against a live proxy hitting real Bedrock. Config (`config.yaml`), note no `mode` set:

```yaml
model_list:
  - model_name: titan-embed-text-v2
    litellm_params:
      model: bedrock/amazon.titan-embed-text-v2:0
```

1. `python litellm/proxy/proxy_cli.py --config config.yaml --detailed_debug`
2. `curl -sS http://localhost:4000/health -H "Authorization: Bearer $LITELLM_MASTER_KEY" | jq`

Before this change the deployment shows under `unhealthy_endpoints` with `"error": "...extraneous key [max_tokens] is not permitted..."` and `"max_tokens": 5` in the entry. After this change it moves to `healthy_endpoints` with no `max_tokens` injected.

## Type

🐛 Bug Fix


---
_Generated by [Claude Code](https://claude.ai/code/session_01RfjLVm12fXTuKm86xY1s8n)_