### PR TITLE
fix(ui/agents): make A2A skill tags enterable and validated

### DIFF
--- a/ui/litellm-dashboard/src/components/agents/add_agent_form.tsx
+++ b/ui/litellm-dashboard/src/components/agents/add_agent_form.tsx
@@ -197,7 +197,7 @@ const AddAgentForm: React.FC<AddAgentFormProps> = ({
   const handleNext = async () => {
     try {
       if (currentStep === 0) {
-        await form.validateFields(["agent_name"]);
+        await form.validateFields();
         const agentName = form.getFieldValue("agent_name");
         if (agentName && !newKeyName) {
           setNewKeyName(`${agentName}-key`);

--- a/ui/litellm-dashboard/src/components/agents/agent_config.ts
+++ b/ui/litellm-dashboard/src/components/agents/agent_config.ts
@@ -212,14 +212,14 @@ export const SKILL_FIELD_CONFIG = {
   },
   tags: {
     name: "tags",
-    label: "Tags (comma-separated)",
+    label: "Tags",
     required: true,
-    placeholder: "e.g., hello world, greeting",
+    placeholder: "Type a tag and press Enter",
   },
   examples: {
     name: "examples",
-    label: "Examples (comma-separated)",
-    placeholder: "e.g., hi, hello world",
+    label: "Examples",
+    placeholder: "Type an example and press Enter",
   },
 };
 

--- a/ui/litellm-dashboard/src/components/agents/agent_form_fields.tsx
+++ b/ui/litellm-dashboard/src/components/agents/agent_form_fields.tsx
@@ -56,7 +56,7 @@ const AgentFormFields: React.FC<AgentFormFieldsProps> = ({ showAgentName = true,
 
         {/* Skills */}
         {shouldShow(AGENT_FORM_CONFIG.skills.key) && (
-        <Panel header={`${AGENT_FORM_CONFIG.skills.title} (Required)`} key={AGENT_FORM_CONFIG.skills.key}>
+        <Panel header={`${AGENT_FORM_CONFIG.skills.title}`} key={AGENT_FORM_CONFIG.skills.key}>
           <Form.List name="skills">
             {(fields, { add, remove }) => (
               <>
@@ -94,20 +94,28 @@ const AgentFormFields: React.FC<AgentFormFieldsProps> = ({ showAgentName = true,
                       label={SKILL_FIELD_CONFIG.tags.label}
                       name={[field.name, 'tags']}
                       rules={[{ required: SKILL_FIELD_CONFIG.tags.required, message: 'Required' }]}
-                      getValueFromEvent={(e) => e.target.value.split(',').map((s: string) => s.trim())}
-                      getValueProps={(value) => ({ value: Array.isArray(value) ? value.join(', ') : value })}
                     >
-                      <Input placeholder={SKILL_FIELD_CONFIG.tags.placeholder} />
+                      <Select
+                        mode="tags"
+                        style={{ width: '100%' }}
+                        tokenSeparators={[',']}
+                        open={false}
+                        placeholder={SKILL_FIELD_CONFIG.tags.placeholder}
+                      />
                     </Form.Item>
                     
                     <Form.Item
                       {...field}
                       label={SKILL_FIELD_CONFIG.examples.label}
                       name={[field.name, 'examples']}
-                      getValueFromEvent={(e) => e.target.value.split(',').map((s: string) => s.trim()).filter((s: string) => s)}
-                      getValueProps={(value) => ({ value: Array.isArray(value) ? value.join(', ') : '' })}
                     >
-                      <Input placeholder={SKILL_FIELD_CONFIG.examples.placeholder} />
+                      <Select
+                        mode="tags"
+                        style={{ width: '100%' }}
+                        tokenSeparators={[',']}
+                        open={false}
+                        placeholder={SKILL_FIELD_CONFIG.examples.placeholder}
+                      />
                     </Form.Item>
                     
                     <AntButton 

--- a/ui/litellm-dashboard/src/components/agents/agent_form_fields.tsx
+++ b/ui/litellm-dashboard/src/components/agents/agent_form_fields.tsx
@@ -99,7 +99,6 @@ const AgentFormFields: React.FC<AgentFormFieldsProps> = ({ showAgentName = true,
                         mode="tags"
                         style={{ width: '100%' }}
                         tokenSeparators={[',']}
-                        open={false}
                         placeholder={SKILL_FIELD_CONFIG.tags.placeholder}
                       />
                     </Form.Item>
@@ -113,7 +112,6 @@ const AgentFormFields: React.FC<AgentFormFieldsProps> = ({ showAgentName = true,
                         mode="tags"
                         style={{ width: '100%' }}
                         tokenSeparators={[',']}
-                        open={false}
                         placeholder={SKILL_FIELD_CONFIG.examples.placeholder}
                       />
                     </Form.Item>


### PR DESCRIPTION
## Summary

A2A skill **Tags** were marked required but rendered as a comma-split text input, so there was no real way to enter them and an empty value still saved. Tags and Examples now use `Select mode="tags"` inputs (real `string[]`), so the required rule on tags actually fires. The misleading "Required" label on the Skills panel is dropped because the API accepts agents with zero skills, and the configure step now validates all its fields so an *added* skill must be complete (id/name/description/tags) before advancing.

Behavior: skills are optional, but if you add one it must be complete.

## Screenshots

### After
<img width="732" height="888" alt="Screenshot 2026-06-02 at 10 06 09 AM" src="https://github.com/user-attachments/assets/36580c6f-808b-498d-af4d-2e318b46d7b6" />


## Test plan
- [x] `tsc --noEmit` passes for the changed agent components
- [ ] Agentic → Agents → add A2A agent: add a skill, confirm Tags accepts entries via Enter / comma and shows chips
- [ ] Leave a skill's Tags empty → "Next" is blocked with a validation error
- [ ] Add no skills at all → can advance (API allows empty skills)
- [ ] Edit an existing agent with skills → tags/examples prefill as chips

Resolves LIT-3153