### PR TITLE
feat(proxy): harden uvloop configuration to mitigate thread-pool starvation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,8 @@ RUN apk add --no-cache bash openssl tzdata nodejs npm python3 libsndfile && \
     { apk del --no-cache npm 2>/dev/null || true; }
 
 WORKDIR /app
-ENV PATH="/app/.venv/bin:${PATH}"
+ENV PATH="/app/.venv/bin:${PATH}" \
+    UV_THREADPOOL_SIZE=16
 
 COPY --from=builder /app /app
 # Prisma binaries live in $HOME/.cache (default prisma-python location),

--- a/docker/Dockerfile.database
+++ b/docker/Dockerfile.database
@@ -88,7 +88,8 @@ RUN apk add --no-cache bash openssl tzdata nodejs npm python3 libsndfile && \
     { apk del --no-cache npm 2>/dev/null || true; }
 
 WORKDIR /app
-ENV PATH="/app/.venv/bin:${PATH}"
+ENV PATH="/app/.venv/bin:${PATH}" \
+    UV_THREADPOOL_SIZE=16
 
 COPY --from=builder /app /app
 # Prisma binaries live in $HOME/.cache (default prisma-python location),

--- a/docker/Dockerfile.non_root
+++ b/docker/Dockerfile.non_root
@@ -107,7 +107,8 @@ ENV PATH="/app/.venv/bin:${PATH}" \
     PRISMA_SKIP_POSTINSTALL_GENERATE=1 \
     PRISMA_HIDE_UPDATE_MESSAGE=1 \
     PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 \
-    PRISMA_OFFLINE_MODE=true
+    PRISMA_OFFLINE_MODE=true \
+    UV_THREADPOOL_SIZE=16
 
 RUN mkdir -p /nonexistent /var/lib/litellm/assets /var/lib/litellm/ui && \
     chown -R nobody:nogroup /app /var/lib/litellm/ui /var/lib/litellm/assets /nonexistent && \

--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -479,6 +479,12 @@ class ProxyInitializationHelpers:
 
     @staticmethod
     def _get_loop_type():
+        """Return the uvicorn event-loop type for the current platform.
+
+        Returns ``None`` on Windows (uvicorn default), ``"asyncio"`` when
+        ``LITELLM_DISABLE_UVLOOP`` is set to ``1``, ``true``, or ``yes``, and
+        ``"uvloop"`` otherwise.
+        """
         if sys.platform in ("win32", "cygwin", "cli"):
             return None
         if os.environ.get("LITELLM_DISABLE_UVLOOP", "").strip().lower() in (

--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -479,9 +479,14 @@ class ProxyInitializationHelpers:
 
     @staticmethod
     def _get_loop_type():
-        """Helper function to determine the event loop type based on platform"""
         if sys.platform in ("win32", "cygwin", "cli"):
-            return None  # Let uvicorn choose the default loop on Windows
+            return None
+        if os.environ.get("LITELLM_DISABLE_UVLOOP", "").strip().lower() in (
+            "1",
+            "true",
+            "yes",
+        ):
+            return "asyncio"
         return "uvloop"
 
     @staticmethod

--- a/tests/test_litellm/proxy/test_proxy_cli.py
+++ b/tests/test_litellm/proxy/test_proxy_cli.py
@@ -354,11 +354,29 @@ class TestProxyInitializationHelpers:
         assert ProxyInitializationHelpers._is_port_in_use(8000) is False
 
     def test_get_loop_type(self):
-        # Test on Windows
         with patch("sys.platform", "win32"):
             assert ProxyInitializationHelpers._get_loop_type() is None
 
-        # Test on Linux
+        with patch("sys.platform", "linux"):
+            assert ProxyInitializationHelpers._get_loop_type() == "uvloop"
+
+    @patch.dict(os.environ, {"LITELLM_DISABLE_UVLOOP": "1"})
+    def test_get_loop_type_disable_uvloop_numeric(self):
+        with patch("sys.platform", "linux"):
+            assert ProxyInitializationHelpers._get_loop_type() == "asyncio"
+
+    @patch.dict(os.environ, {"LITELLM_DISABLE_UVLOOP": "true"})
+    def test_get_loop_type_disable_uvloop_string(self):
+        with patch("sys.platform", "linux"):
+            assert ProxyInitializationHelpers._get_loop_type() == "asyncio"
+
+    @patch.dict(os.environ, {"LITELLM_DISABLE_UVLOOP": "yes"})
+    def test_get_loop_type_disable_uvloop_yes(self):
+        with patch("sys.platform", "linux"):
+            assert ProxyInitializationHelpers._get_loop_type() == "asyncio"
+
+    @patch.dict(os.environ, {"LITELLM_DISABLE_UVLOOP": "0"})
+    def test_get_loop_type_disable_uvloop_false(self):
         with patch("sys.platform", "linux"):
             assert ProxyInitializationHelpers._get_loop_type() == "uvloop"
 

--- a/tests/test_litellm/proxy/test_proxy_cli.py
+++ b/tests/test_litellm/proxy/test_proxy_cli.py
@@ -353,6 +353,7 @@ class TestProxyInitializationHelpers:
         # Execute and Assert
         assert ProxyInitializationHelpers._is_port_in_use(8000) is False
 
+    @patch.dict(os.environ, {}, clear=True)
     def test_get_loop_type(self):
         with patch("sys.platform", "win32"):
             assert ProxyInitializationHelpers._get_loop_type() is None


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

To verify that `LITELLM_DISABLE_UVLOOP` works: start the proxy with and without the flag and observe the uvicorn startup log line that reports the selected event loop.

```bash
# Without flag -- expect uvloop
python litellm/proxy/proxy_cli.py \
    --config litellm/proxy/dev_config.yaml --port 4000 2>&1 | grep -i "loop"

# With flag -- expect asyncio
LITELLM_DISABLE_UVLOOP=1 python litellm/proxy/proxy_cli.py \
    --config litellm/proxy/dev_config.yaml --port 4000 2>&1 | grep -i "loop"
```

To verify `UV_THREADPOOL_SIZE` is picked up in a container:

```bash
docker run --rm <image> python -c "import os; print(os.environ.get('UV_THREADPOOL_SIZE', '(not set)'))"
```

## Type

Infrastructure / New Feature

## Changes

### Background: the failure mode this addresses

Every query the LiteLLM proxy makes to its database traverses two hops:

```
Python async code --httpx--> Prisma query engine (child process) --TCP pool--> Postgres
```

Under uvloop, `getaddrinfo` calls are dispatched to libuv's fixed thread pool, which defaults to 4 threads (`UV_THREADPOOL_SIZE`), shared across all resolver and filesystem operations in the process. When the proxy runs under concurrent load -- user requests issuing queries, spend log flushes, provider-hostname DNS lookups -- those 4 threads can be fully occupied. Any new resolver call queues behind that work. No `connect()` syscall runs until a thread is free, no SYN packet is sent. The httpx connection attempt times out (`ConnectTimeout`) with the engine sitting healthy, idle, and completely unreachable from Python's perspective.

This stall then cascades through the reconnect logic in `_db_health_watchdog_loop` (`proxy/utils.py`):

1. The watchdog's periodic `SELECT 1` probe issues an HTTP request to the engine. It stalls at TCP connect establishment. `asyncio.wait_for` fires with `TimeoutError`.
2. `_db_health_watchdog_loop` treats any `TimeoutError` or `is_database_connection_error` as a signal to call `attempt_db_reconnect()`.
3. `attempt_db_reconnect()` kills the engine via `disconnect()` / `_kill_engine_process()` -- even though the engine had zero active connections, zero queued connections, and was completely idle and healthy.
4. A new engine spawns. If the thread pool is still starved, the new client hits the same stall. The post-connect `SELECT 1` times out. The reconnect is counted as failed; `_consecutive_reconnect_failures` increments.
5. All DB-dependent operations fail during this window: authentication, spend tracking, rate limiting, the management API.

The stall is invisible to `PYTHONASYNCIODEBUG`, which only instruments callbacks running on the event loop itself. Work queued in libuv resolver threads never appears as a "slow callback." The symptoms look exactly like a Prisma engine failure -- `httpx.ConnectTimeout` errors, engine kills, reconnect loops -- but the Prisma engine is healthy throughout.

One factor worth noting: prisma-client-py hardcodes the engine URL as `http://localhost:{port}` (`prisma/engine/query.py`). anyio fast-paths numeric IP literals and skips `getaddrinfo` for them, but for any hostname string -- including `localhost` -- it always calls `getaddrinfo`. This adds unnecessary resolver-thread pressure to the same pool at risk of starvation. Connecting to `127.0.0.1` instead would eliminate this contribution; that change requires coordination with prisma-client-py's hardcoded URL construction and is left as a follow-up.

### Change 1: `UV_THREADPOOL_SIZE=16` in all production Dockerfiles

Sets `UV_THREADPOOL_SIZE=16` in the `ENV` block of the runtime stage in `Dockerfile`, `docker/Dockerfile.non_root`, and `docker/Dockerfile.database`. libuv reads this variable once at process startup; it cannot be changed at runtime, so the Dockerfile `ENV` is the right place to set it.

16 threads is 4x the default. It gives the resolver pool substantially more headroom to absorb concurrent DNS and filesystem work without stalling pending resolver calls. The memory overhead is negligible (each libuv thread uses a small, fixed-size stack).

### Change 2: `LITELLM_DISABLE_UVLOOP` env var in `_get_loop_type`

`ProxyInitializationHelpers._get_loop_type()` (`proxy/proxy_cli.py`) currently returns `"uvloop"` unconditionally on all non-Windows platforms. When `LITELLM_DISABLE_UVLOOP` is set to `"1"`, `"true"`, or `"yes"`, it now returns `"asyncio"` instead. uvicorn accepts `"asyncio"` as a valid `loop=` value; the standard asyncio event loop uses a `ThreadPoolExecutor` with `min(32, cpu_count + 4)` threads for resolver work, which is far harder to saturate than libuv's fixed pool of 4.

This gives operators a zero-rebuild escape hatch: set the env var on the container and restart. An operator who sets this flag is explicitly trading uvloop's raw throughput advantage for a resolver pool that doesn't saturate under the load patterns described above.