### PR TITLE
fix(streaming): keep streamed tool calls that have no id

### DIFF
--- a/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
+++ b/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
@@ -290,7 +290,7 @@ class ChunkProcessor:
         # Convert the map to a list of tool calls
         for index in sorted(tool_call_map.keys()):
             tool_call_data = tool_call_map[index]
-            if tool_call_data["id"] and tool_call_data["name"]:
+            if tool_call_data["name"]:
                 combined_arguments = "".join(tool_call_data["arguments"]) or "{}"
 
                 # Build function - provider_specific_fields should be on tool_call level, not function level

--- a/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
@@ -613,3 +613,76 @@ def test_stream_chunk_builder_dict_snapshot_preserves_hidden_provider_fields():
     assert (
         response._hidden_params["provider_specific_fields"]["traffic_type"] == "default"
     )
+
+
+def test_get_combined_tool_content_without_id():
+    """A streamed tool call that carries a name and arguments but no id must
+    still be reassembled (id auto-generated), not silently dropped."""
+    chunks = [
+        ModelResponseStream(
+            id="chatcmpl-no-id",
+            created=1744771912,
+            model="some-model",
+            object="chat.completion.chunk",
+            choices=[
+                StreamingChoices(
+                    finish_reason=None,
+                    index=0,
+                    delta=Delta(
+                        role="assistant",
+                        content=None,
+                        tool_calls=[
+                            ChatCompletionDeltaToolCall(
+                                id=None,
+                                function=Function(
+                                    arguments='{"location": "Berlin"',
+                                    name="get_current_weather",
+                                ),
+                                type="function",
+                                index=0,
+                            )
+                        ],
+                    ),
+                )
+            ],
+        ),
+        ModelResponseStream(
+            id="chatcmpl-no-id",
+            created=1744771912,
+            model="some-model",
+            object="chat.completion.chunk",
+            choices=[
+                StreamingChoices(
+                    finish_reason=None,
+                    index=0,
+                    delta=Delta(
+                        role="assistant",
+                        content=None,
+                        tool_calls=[
+                            ChatCompletionDeltaToolCall(
+                                id=None,
+                                function=Function(
+                                    arguments=', "unit": "metric"}',
+                                    name=None,
+                                ),
+                                type=None,
+                                index=0,
+                            )
+                        ],
+                    ),
+                )
+            ],
+        ),
+    ]
+    chunk_processor = ChunkProcessor(chunks=chunks)
+
+    tool_calls_list = chunk_processor.get_combined_tool_content(chunks)
+
+    assert len(tool_calls_list) == 1
+    tool_call = tool_calls_list[0]
+    assert tool_call.function.name == "get_current_weather"
+    assert json.loads(tool_call.function.arguments) == {
+        "location": "Berlin",
+        "unit": "metric",
+    }
+    assert tool_call.id


### PR DESCRIPTION
## Relevant issues

None filed; found while reading the streaming reassembly path.

## Pre-Submission checklist

- [x] I have added a meaningful regression test
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Changes

`ChunkProcessor.get_combined_tool_content` reassembles streamed tool-call deltas into a single non-streaming message. The emit guard required both `id` and `name` to be truthy:

```python
if tool_call_data["id"] and tool_call_data["name"]:
```

When a provider streams a tool call that carries a `name` and `arguments` but never sends an `id`, the fully-formed call is discarded and the final message ends up with `tool_calls=[]`. The `id` is optional on the wire; the field that identifies a real tool call is `name`. This also diverges from litellm's own behavior elsewhere, where a missing tool-call id is backfilled rather than treated as a reason to drop the call.

The fix gates on `name` only. `ChatCompletionMessageToolCall` already synthesizes an id when one is not provided, so an id-less tool call now reassembles correctly with a generated id, its name, and its combined arguments. A tool call with no name is still skipped.

## Test

Added `test_get_combined_tool_content_without_id` in the mapped test file. It streams a tool call across two chunks with `id=None` throughout, and asserts that one tool call is produced with the correct name, the combined arguments, and a non-empty id. The test fails before this change (the call is dropped, `tool_calls` is empty) and passes after. Existing tests in the file remain green.

## Type

🐛 Bug Fix
