### PR TITLE
fix(proxy): strip NUL bytes from spend log payloads to prevent PostgreSQL 22P05

### DIFF
--- a/litellm/litellm_core_utils/safe_json_dumps.py
+++ b/litellm/litellm_core_utils/safe_json_dumps.py
@@ -6,10 +6,16 @@ from pydantic import BaseModel
 from litellm.constants import DEFAULT_MAX_RECURSE_DEPTH
 
 
+def strip_null_bytes(value: str) -> str:
+    """Strip NUL bytes, which PostgreSQL text/jsonb columns reject (error 22P05)."""
+    return value.replace("\x00", "")
+
+
 def safe_dumps(data: Any, max_depth: int = DEFAULT_MAX_RECURSE_DEPTH) -> str:
     """
     Recursively serialize data while detecting circular references.
     If a circular reference is detected then a marker string is returned.
+    NUL bytes are stripped from strings to prevent PostgreSQL 22P05 errors.
     """
 
     def _serialize(obj: Any, seen: set, depth: int) -> Any:
@@ -17,7 +23,9 @@ def safe_dumps(data: Any, max_depth: int = DEFAULT_MAX_RECURSE_DEPTH) -> str:
         if depth > max_depth:
             return "MaxDepthExceeded"
         # Base-case: if it is a primitive, simply return it.
-        if isinstance(obj, (str, int, float, bool, type(None))):
+        if isinstance(obj, str):
+            return strip_null_bytes(obj)
+        if isinstance(obj, (int, float, bool, type(None))):
             return obj
         # Check for circular reference.
         if id(obj) in seen:
@@ -28,7 +36,7 @@ def safe_dumps(data: Any, max_depth: int = DEFAULT_MAX_RECURSE_DEPTH) -> str:
             result = {}
             for k, v in obj.items():
                 if isinstance(k, (str)):
-                    result[k] = _serialize(v, seen, depth + 1)
+                    result[strip_null_bytes(k)] = _serialize(v, seen, depth + 1)
             seen.remove(id(obj))
             return result
         elif isinstance(obj, list):
@@ -51,7 +59,7 @@ def safe_dumps(data: Any, max_depth: int = DEFAULT_MAX_RECURSE_DEPTH) -> str:
         else:
             # Fall back to string conversion for non-serializable objects.
             try:
-                return str(obj)
+                return strip_null_bytes(str(obj))
             except Exception:
                 return "Unserializable Object"
 

--- a/litellm/proxy/spend_tracking/spend_tracking_utils.py
+++ b/litellm/proxy/spend_tracking/spend_tracking_utils.py
@@ -24,7 +24,7 @@ from litellm.litellm_core_utils.core_helpers import (
     get_litellm_metadata_from_kwargs,
     reconstruct_model_name,
 )
-from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
+from litellm.litellm_core_utils.safe_json_dumps import safe_dumps, strip_null_bytes
 from litellm.proxy._types import SpendLogsMetadata, SpendLogsPayload
 from litellm.proxy.spend_tracking.spend_log_error_logger import spend_log_error
 from litellm.proxy.utils import PrismaClient, hash_token
@@ -304,7 +304,7 @@ def get_logging_payload(  # noqa: PLR0915
     # BUG FIX: Don't overwrite api_key when standard_logging_payload is None
     # The api_key was already extracted from metadata (line 243) and hashed (lines 256-259)
     request_tags = (
-        json.dumps(metadata.get("tags", []))
+        safe_dumps(metadata.get("tags", []))
         if isinstance(metadata.get("tags", []), list)
         else "[]"
     )
@@ -312,7 +312,7 @@ def get_logging_payload(  # noqa: PLR0915
         standard_logging_payload is not None
         and standard_logging_payload.get("request_tags") is not None
     ):  # use 'tags' from standard logging payload instead
-        request_tags = json.dumps(standard_logging_payload["request_tags"])
+        request_tags = safe_dumps(standard_logging_payload["request_tags"])
 
     _model_id = metadata.get("model_info", {}).get("id", "")
     _model_group = metadata.get("model_group", "")
@@ -606,7 +606,7 @@ def _get_messages_for_spend_logs_payload(
                 messages = standard_logging_payload.get("messages")
                 if messages is not None:
                     try:
-                        return json.dumps(messages, default=str)
+                        return safe_dumps(messages)
                     except Exception:
                         return "{}"
     return "{}"
@@ -976,7 +976,7 @@ def _get_proxy_server_request_for_spend_logs_payload(
                     perform_redaction(model_call_details=_request_body, result=None)
 
             _request_body = _sanitize_request_body_for_spend_logs_payload(_request_body)
-            _request_body_json_str = json.dumps(_request_body, default=str)
+            _request_body_json_str = safe_dumps(_request_body)
             if LITELLM_TRUNCATED_PAYLOAD_FIELD in _request_body_json_str:
                 verbose_proxy_logger.info(
                     "Spend Log: request body was truncated before storing in DB. %s",
@@ -1059,7 +1059,7 @@ def _get_response_for_spend_logs_payload(
         if sanitized_response is None:
             return "{}"
         if isinstance(sanitized_response, str):
-            result_str = sanitized_response
+            result_str = strip_null_bytes(sanitized_response)
         else:
             result_str = safe_dumps(sanitized_response)
         if LITELLM_TRUNCATED_PAYLOAD_FIELD in result_str:

--- a/tests/test_litellm/litellm_core_utils/test_safe_json_dumps.py
+++ b/tests/test_litellm/litellm_core_utils/test_safe_json_dumps.py
@@ -8,7 +8,7 @@ sys.path.insert(
     0, os.path.abspath("../../..")
 )  # Adds the parent directory to the system path
 
-from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
+from litellm.litellm_core_utils.safe_json_dumps import safe_dumps, strip_null_bytes
 
 
 def test_primitive_types():
@@ -138,6 +138,40 @@ def test_non_standard_dict_keys_complex():
 
         traceback.print_exc()
         raise e
+
+
+def test_strip_null_bytes_helper():
+    assert strip_null_bytes("hello\x00world") == "helloworld"
+    assert strip_null_bytes("\x00\x00abc\x00") == "abc"
+    assert strip_null_bytes("no null here") == "no null here"
+
+
+def test_null_byte_stripped_from_string():
+    out = safe_dumps("hello\x00world")
+    assert "\\u0000" not in out
+    assert json.loads(out) == "helloworld"
+
+
+def test_null_byte_stripped_in_nested_structure():
+    data = {
+        "messages": [{"role": "user", "content": "bad\x00content"}],
+        "nested": {"k\x00ey": "v\x00alue"},
+    }
+    out = safe_dumps(data)
+    assert "\\u0000" not in out
+    result = json.loads(out)
+    assert result["messages"][0]["content"] == "badcontent"
+    assert result["nested"] == {"key": "value"}
+
+
+def test_null_byte_stripped_in_fallback_str():
+    class WithNullStr:
+        def __str__(self):
+            return "obj\x00repr"
+
+    out = safe_dumps({"obj": WithNullStr()})
+    assert "\\u0000" not in out
+    assert json.loads(out)["obj"] == "objrepr"
 
 
 def test_pydantic_base_model():

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
@@ -303,6 +303,25 @@ def test_get_messages_for_spend_logs_realtime_returns_messages(mock_should_store
 @patch(
     "litellm.proxy.spend_tracking.spend_tracking_utils._should_store_prompts_and_responses_in_spend_logs"
 )
+def test_get_messages_for_spend_logs_strips_null_bytes(mock_should_store):
+    """Regression for PostgreSQL 22P05: NUL bytes must be stripped from messages."""
+    mock_should_store.return_value = True
+    payload = cast(
+        StandardLoggingPayload,
+        {
+            "call_type": "_arealtime",
+            "messages": [{"role": "user", "content": "hello\x00world"}],
+        },
+    )
+    result = _get_messages_for_spend_logs_payload(payload)
+    assert "\\u0000" not in result
+    parsed = json.loads(result)
+    assert parsed[0]["content"] == "helloworld"
+
+
+@patch(
+    "litellm.proxy.spend_tracking.spend_tracking_utils._should_store_prompts_and_responses_in_spend_logs"
+)
 def test_get_messages_for_spend_logs_realtime_empty_when_disabled(mock_should_store):
     """
     Test that _get_messages_for_spend_logs_payload returns '{}' for realtime calls
@@ -368,6 +387,21 @@ def test_get_response_for_spend_logs_payload_truncates_large_base64(mock_should_
     assert len(truncated_value) < len(large_text)
     assert LITELLM_TRUNCATED_PAYLOAD_FIELD in truncated_value
     assert parsed["data"][0]["other_field"] == "value"
+
+
+@patch(
+    "litellm.proxy.spend_tracking.spend_tracking_utils._should_store_prompts_and_responses_in_spend_logs"
+)
+def test_get_response_for_spend_logs_payload_strips_null_bytes(mock_should_store):
+    """Regression for PostgreSQL 22P05: NUL bytes must be stripped from response."""
+    mock_should_store.return_value = True
+    payload = cast(
+        StandardLoggingPayload,
+        {"response": {"content": "answer\x00here"}},
+    )
+    response_json = _get_response_for_spend_logs_payload(payload)
+    assert "\\u0000" not in response_json
+    assert json.loads(response_json)["content"] == "answerhere"
 
 
 @patch(
@@ -934,6 +968,36 @@ def test_get_logging_payload_includes_overhead_in_spend_logs_metadata():
     assert (
         metadata.get("litellm_overhead_time_ms") == test_overhead_ms
     ), f"Expected overhead '{test_overhead_ms}', got '{metadata.get('litellm_overhead_time_ms')}'"
+
+
+@patch("litellm.proxy.proxy_server.master_key", None)
+@patch("litellm.proxy.proxy_server.general_settings", {})
+def test_get_logging_payload_strips_null_bytes_from_request_tags():
+    """Regression for PostgreSQL 22P05: NUL bytes must be stripped from request_tags."""
+    kwargs = {
+        "model": "gpt-3.5-turbo",
+        "litellm_params": {
+            "metadata": {
+                "user_api_key": "sk-test-key",
+                "tags": ["clean-tag", "bad\x00tag"],
+            }
+        },
+    }
+
+    start_time = datetime.datetime.now(timezone.utc)
+    end_time = datetime.datetime.now(timezone.utc)
+
+    payload = get_logging_payload(
+        kwargs=kwargs,
+        response_obj={},
+        start_time=start_time,
+        end_time=end_time,
+    )
+
+    request_tags = payload.get("request_tags")
+    assert request_tags is not None
+    assert "\\u0000" not in request_tags
+    assert json.loads(request_tags) == ["clean-tag", "badtag"]
 
 
 @patch("litellm.proxy.proxy_server.master_key", None)


### PR DESCRIPTION
## Relevant issues

Fixes the recurring `update_spend` crash where a NUL byte (`\u0000`) in request/response content makes the spend-log batch insert fail with PostgreSQL `22P05` ("unsupported Unicode escape sequence ... cannot be converted to text").

Fixes #24310
Related: #15519, #21290, #21882 (and prior unmerged attempts #24314, #19898, #21884)

Resolves LIT-3527

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code) — targeted suites: `test_safe_json_dumps.py` + `test_spend_tracking_utils.py` (88 passed)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

Live proxy repro against Postgres (`store_prompts_in_spend_logs: true`). A single chat request whose content contains a NUL byte (`\u0000`) poisons the spend-log batch. Both runs use the **same** request; only the LiteLLM code differs.

**Before — latest staging (`litellm_internal_staging` @ `84c4c12`):** request returns HTTP 200, then the periodic `update_spend` job crashes with PostgreSQL `22P05` and the spend-log batch is dropped.

<img width="484" height="240" alt="image" src="https://github.com/user-attachments/assets/57b7548f-79e7-456d-b7e9-6b95dcbf0b29" />

**After — this branch (`litellm_fix_spend_log_null_bytes`):** same request, no exception in the proxy logs, and the spend-log row persists with the NUL byte stripped (`helloworld`).

<img width="484" height="229" alt="image" src="https://github.com/user-attachments/assets/2204ada6-30d0-4b8e-880a-9da5c3c528c7" />

## Type

🐛 Bug Fix

## Changes

A raw NUL byte (`\x00`) in LLM request/response content (e.g. tool outputs, multimodal/binary-ish payloads) is serialized by `json.dumps` into the JSON escape `\u0000`. That escape is valid JSON, so Prisma accepts it client-side — but when `update_spend_logs` writes it to the `LiteLLM_SpendLogs` `jsonb` columns, PostgreSQL rejects the whole `create_many` batch with `22P05`. Because it's a `DataError` (not a connection error), it is **not retried**: the batch was already popped from the in-memory queue, so those spend-log rows are lost and the `update_spend` job re-errors every interval.

**Fix:**
- `litellm/litellm_core_utils/safe_json_dumps.py`: add `strip_null_bytes()` and remove `\x00` at the string base case, in dict **keys**, and in the `str()` fallback. This centrally protects every `safe_dumps` caller (including the spend-log `metadata` and `response` paths).
- `litellm/proxy/spend_tracking/spend_tracking_utils.py`: route the `messages` (`_get_messages_for_spend_logs_payload`) and request-body (`_get_proxy_server_request_for_spend_logs_payload`) payloads through `safe_dumps` instead of plain `json.dumps`.

Stripping the raw byte before serialization is the only safe option, since the value cannot be stored in a Postgres text/jsonb column regardless.

**Tests added:**
- `test_strip_null_bytes_helper` — helper removes only NUL bytes
- `test_null_byte_stripped_from_string` / `test_null_byte_stripped_in_nested_structure` / `test_null_byte_stripped_in_fallback_str` — `safe_dumps` never emits `\u0000`
- `test_get_messages_for_spend_logs_strips_null_bytes` — spend-log message payload is NUL-safe