### PR TITLE
feat(guardrails): capture user and model metadata in CrowdStrike AIDR

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/crowdstrike_aidr/crowdstrike_aidr.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/crowdstrike_aidr/crowdstrike_aidr.py
@@ -312,10 +312,26 @@ class CrowdStrikeAIDRHandler(CustomGuardrail):
             event_type = "output"
             hook_name = "apply_guardrail (response)"
 
-        ai_guard_payload = {
+        ai_guard_payload: dict[str, Any] = {
             "guard_input": guard_input.model_dump(mode="json"),
             "event_type": event_type,
         }
+
+        model = inputs.get("model")
+        if model:
+            ai_guard_payload["model"] = model
+
+        metadata = request_data.get("litellm_metadata", request_data.get("metadata"))
+        if isinstance(metadata, Mapping):
+            user_id = metadata.get("user_api_key_user_id")
+            if user_id:
+                ai_guard_payload["user_id"] = user_id
+
+            extra_info: dict[str, str] = {}
+            user_email = metadata.get("user_api_key_user_email")
+            if user_email:
+                extra_info["user_name"] = user_email
+            ai_guard_payload["extra_info"] = extra_info
 
         ai_guard_response = await self._call_crowdstrike_aidr_guard(
             ai_guard_payload, hook_name

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_crowdstrike_aidr.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_crowdstrike_aidr.py
@@ -41,7 +41,8 @@ def test_crowdstrike_aidr_guardrail_config() -> None:
     )
 
 
-def test_crowdstrike_aidr_guardrail_config_no_api_key() -> None:
+def test_crowdstrike_aidr_guardrail_config_no_api_key(monkeypatch) -> None:
+    monkeypatch.delenv("CS_AIDR_TOKEN", raising=False)
     with pytest.raises(CrowdStrikeAIDRGuardrailMissingSecrets):
         init_guardrails_v2(
             all_guardrails=[
@@ -59,7 +60,8 @@ def test_crowdstrike_aidr_guardrail_config_no_api_key() -> None:
         )
 
 
-def test_crowdstrike_aidr_guardrail_config_no_api_base() -> None:
+def test_crowdstrike_aidr_guardrail_config_no_api_base(monkeypatch) -> None:
+    monkeypatch.delenv("CS_AIDR_BASE_URL", raising=False)
     with pytest.raises(CrowdStrikeAIDRGuardrailMissingSecrets):
         init_guardrails_v2(
             all_guardrails=[
@@ -410,6 +412,121 @@ async def test_apply_guardrail_response_ok(
     assert called_kwargs["json"]["guard_input"]["messages"] == expected_messages
     # Should return original inputs when not transformed
     assert result["texts"] == inputs["texts"]
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_sends_user_id_model_and_extra_info(
+    crowdstrike_aidr_guardrail: CrowdStrikeAIDRHandler,
+) -> None:
+    inputs: GenericGuardrailAPIInputs = {
+        "texts": ["Hello"],
+        "structured_messages": [{"role": "user", "content": "Hello"}],
+        "model": "gpt-4o",
+    }
+    request_data = {
+        "messages": inputs["structured_messages"],
+        "model": "gpt-4o",
+        "litellm_metadata": {
+            "user_api_key_user_id": "uid-abc",
+            "user_api_key_user_email": "alice@example.com",
+        },
+    }
+    guardrail_endpoint = (
+        f"{crowdstrike_aidr_guardrail.api_base}/v1/guard_chat_completions"
+    )
+
+    with patch(
+        "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+        return_value=httpx.Response(
+            status_code=200,
+            json={"result": {"blocked": False, "transformed": False}},
+            request=httpx.Request(method="POST", url=guardrail_endpoint),
+        ),
+    ) as mock_method:
+        await crowdstrike_aidr_guardrail.apply_guardrail(
+            inputs=inputs,
+            request_data=request_data,
+            input_type="request",
+        )
+
+    payload = mock_method.call_args.kwargs["json"]
+    assert payload["user_id"] == "uid-abc"
+    assert payload["model"] == "gpt-4o"
+    assert payload["extra_info"] == {"user_name": "alice@example.com"}
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_empty_extra_info_when_no_email(
+    crowdstrike_aidr_guardrail: CrowdStrikeAIDRHandler,
+) -> None:
+    inputs: GenericGuardrailAPIInputs = {
+        "texts": ["Hello"],
+        "structured_messages": [{"role": "user", "content": "Hello"}],
+        "model": "gemini-flash",
+    }
+    request_data = {
+        "messages": inputs["structured_messages"],
+        "model": "gemini-flash",
+        "litellm_metadata": {
+            "user_api_key_user_id": "uid-no-email",
+            "user_api_key_user_email": None,
+        },
+    }
+    guardrail_endpoint = (
+        f"{crowdstrike_aidr_guardrail.api_base}/v1/guard_chat_completions"
+    )
+
+    with patch(
+        "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+        return_value=httpx.Response(
+            status_code=200,
+            json={"result": {"blocked": False, "transformed": False}},
+            request=httpx.Request(method="POST", url=guardrail_endpoint),
+        ),
+    ) as mock_method:
+        await crowdstrike_aidr_guardrail.apply_guardrail(
+            inputs=inputs,
+            request_data=request_data,
+            input_type="request",
+        )
+
+    payload = mock_method.call_args.kwargs["json"]
+    assert payload["user_id"] == "uid-no-email"
+    assert payload["model"] == "gemini-flash"
+    assert payload["extra_info"] == {}
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_no_metadata_skips_user_fields(
+    crowdstrike_aidr_guardrail: CrowdStrikeAIDRHandler,
+) -> None:
+    inputs: GenericGuardrailAPIInputs = {
+        "texts": ["Hello"],
+        "structured_messages": [{"role": "user", "content": "Hello"}],
+    }
+    request_data = {"messages": inputs["structured_messages"]}
+    guardrail_endpoint = (
+        f"{crowdstrike_aidr_guardrail.api_base}/v1/guard_chat_completions"
+    )
+
+    with patch(
+        "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+        return_value=httpx.Response(
+            status_code=200,
+            json={"result": {"blocked": False, "transformed": False}},
+            request=httpx.Request(method="POST", url=guardrail_endpoint),
+        ),
+    ) as mock_method:
+        await crowdstrike_aidr_guardrail.apply_guardrail(
+            inputs=inputs,
+            request_data=request_data,
+            input_type="request",
+        )
+
+    payload = mock_method.call_args.kwargs["json"]
+    assert "user_id" not in payload
+    assert "model" not in payload
+    assert "extra_info" not in payload
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or log output demonstrating that your changes work as expected.
     For bug fixes: show reproduction before the fix and passing behavior after.
     For new features: show the feature working end-to-end.
     For UI changes: include before/after screenshots. -->
     
```shell
$ poetry run pytest -v tests/test_litellm/proxy/guardrails/guardrail_hooks/test_crowdstrike_aidr.py
tests/test_litellm/proxy/guardrails/guardrail_hooks/test_crowdstrike_aidr.py::test_apply_guardrail_empty_extra_info_when_no_email PASSED         [  7%]
tests/test_litellm/proxy/guardrails/guardrail_hooks/test_crowdstrike_aidr.py::test_apply_guardrail_no_metadata_skips_user_fields PASSED          [ 15%]
tests/test_litellm/proxy/guardrails/guardrail_hooks/test_crowdstrike_aidr.py::test_apply_guardrail_request_blocked PASSED                        [ 23%]
tests/test_litellm/proxy/guardrails/guardrail_hooks/test_crowdstrike_aidr.py::test_apply_guardrail_request_ok PASSED                             [ 30%]
tests/test_litellm/proxy/guardrails/guardrail_hooks/test_crowdstrike_aidr.py::test_apply_guardrail_request_skipped_messages_stay_aligned PASSED  [ 38%]
tests/test_litellm/proxy/guardrails/guardrail_hooks/test_crowdstrike_aidr.py::test_apply_guardrail_request_transformed PASSED                    [ 46%]
tests/test_litellm/proxy/guardrails/guardrail_hooks/test_crowdstrike_aidr.py::test_apply_guardrail_response_blocked PASSED                       [ 53%]
tests/test_litellm/proxy/guardrails/guardrail_hooks/test_crowdstrike_aidr.py::test_apply_guardrail_response_ok PASSED                            [ 61%]
tests/test_litellm/proxy/guardrails/guardrail_hooks/test_crowdstrike_aidr.py::test_apply_guardrail_response_transformed PASSED                   [ 69%]
tests/test_litellm/proxy/guardrails/guardrail_hooks/test_crowdstrike_aidr.py::test_apply_guardrail_sends_user_id_model_and_extra_info PASSED     [ 76%]
tests/test_litellm/proxy/guardrails/guardrail_hooks/test_crowdstrike_aidr.py::test_crowdstrike_aidr_guardrail_config PASSED                      [ 84%]
tests/test_litellm/proxy/guardrails/guardrail_hooks/test_crowdstrike_aidr.py::test_crowdstrike_aidr_guardrail_config_no_api_base PASSED          [ 92%]
tests/test_litellm/proxy/guardrails/guardrail_hooks/test_crowdstrike_aidr.py::test_crowdstrike_aidr_guardrail_config_no_api_key PASSED           [100%]
```

<img width="989" height="782" alt="Screenshot 2026-06-02 at 2 24 08 PM" src="https://github.com/user-attachments/assets/7fa14bfd-a429-4fd4-a515-8efee754d661" />


## Type

🆕 New Feature

## Changes

Capture user and model metadata in the CrowdStrike AIDR guardrail.