### PR TITLE
fix(tests): drop module-level test calls that break local_testing collection

### DIFF
--- a/tests/local_testing/test_lunary.py
+++ b/tests/local_testing/test_lunary.py
@@ -26,9 +26,6 @@ def test_lunary_logging():
         print(e)
 
 
-test_lunary_logging()
-
-
 def test_lunary_template():
     import lunary
 

--- a/tests/local_testing/test_multiple_deployments.py
+++ b/tests/local_testing/test_multiple_deployments.py
@@ -49,6 +49,3 @@ def test_multiple_deployments():
     except Exception as e:
         traceback.print_exc()
         pytest.fail(f"An exception occurred: {e}")
-
-
-test_multiple_deployments()

--- a/tests/local_testing/test_no_top_level_test_invocations.py
+++ b/tests/local_testing/test_no_top_level_test_invocations.py
@@ -19,7 +19,10 @@ def _top_level_test_invocations(tree):
 def test_no_module_level_test_invocations():
     offenders = []
     for path in sorted(LOCAL_TESTING_DIR.rglob("*.py")):
-        tree = ast.parse(path.read_text(), filename=str(path))
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        except SyntaxError:
+            continue
         for name, lineno in _top_level_test_invocations(tree):
             offenders.append(
                 f"{path.relative_to(LOCAL_TESTING_DIR)}:{lineno} calls {name}()"

--- a/tests/local_testing/test_no_top_level_test_invocations.py
+++ b/tests/local_testing/test_no_top_level_test_invocations.py
@@ -1,0 +1,33 @@
+import ast
+from pathlib import Path
+
+LOCAL_TESTING_DIR = Path(__file__).parent
+
+
+def _top_level_test_invocations(tree):
+    invocations = []
+    for node in tree.body:
+        if not isinstance(node, ast.Expr) or not isinstance(node.value, ast.Call):
+            continue
+        func = node.value.func
+        name = getattr(func, "id", None) or getattr(func, "attr", None)
+        if name and name.startswith("test_"):
+            invocations.append((name, node.lineno))
+    return invocations
+
+
+def test_no_module_level_test_invocations():
+    offenders = []
+    for path in sorted(LOCAL_TESTING_DIR.rglob("*.py")):
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for name, lineno in _top_level_test_invocations(tree):
+            offenders.append(
+                f"{path.relative_to(LOCAL_TESTING_DIR)}:{lineno} calls {name}()"
+            )
+
+    assert not offenders, (
+        "Test functions are invoked at module scope, so they run during pytest "
+        "collection (making network calls and erroring collection for every job "
+        "that globs this directory). Remove these calls; pytest collects test "
+        "functions automatically:\n" + "\n".join(offenders)
+    )

--- a/tests/local_testing/test_register_model.py
+++ b/tests/local_testing/test_register_model.py
@@ -60,6 +60,3 @@ def test_update_model_cost_via_completion():
         assert litellm.model_cost["gpt-3.5-turbo"]["output_cost_per_token"] == 0.4
     except Exception as e:
         pytest.fail(f"An error occurred: {e}")
-
-
-test_update_model_cost_via_completion()

--- a/tests/local_testing/test_wandb.py
+++ b/tests/local_testing/test_wandb.py
@@ -51,9 +51,6 @@ def test_wandb_logging_async():
         pass
 
 
-test_wandb_logging_async()
-
-
 def test_wandb_logging():
     try:
         response = completion(


### PR DESCRIPTION
## Relevant issues

CircleCI failures on pipeline 80150 in `langfuse_logging_unit_tests` (job 1757575) and `litellm_assistants_api_testing` (job 1757577)

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Type

🐛 Bug Fix

## Changes

Both failing jobs glob `tests/local_testing/**/test_*.py` and then narrow with `-k "langfuse"` or `-k "assistants"`. The `-k` filter only applies after pytest has collected every file in that glob, so anything that breaks collection of any file breaks the whole job regardless of the keyword.

`tests/local_testing/test_register_model.py` ended with a bare `test_update_model_cost_via_completion()` at module scope. That call runs while the module is being imported during collection, and the function fires a real `litellm.completion(model="gpt-3.5-turbo", ...)`. On this run OpenAI returned a 429 (quota exceeded), the function's except block called `pytest.fail(...)`, and pytest reported it as `ERROR collecting tests/local_testing/test_register_model.py`. With `-x` the session stopped there, so both jobs failed at collection time even though neither one actually exercises register_model.

The CircleCI reruns linked in the issue are the "rerun from failed" attempt; their logs only show the rerun plugin choking on the recorded failure (`file or directory not found: pytest.py`), which is why the real cause is not visible there. The original attempt (jobs 1756105 and 1756113) shows the 429 collection error at `test_register_model.py:65`.

Three sibling files had the same leftover pattern (`test_wandb.py`, `test_lunary.py`, `test_multiple_deployments.py`). Two of them swallow exceptions so they did not error collection, but `test_multiple_deployments.py` also calls `pytest.fail(...)` in its except block, so it was one bad network call away from taking down every `local_testing` job the same way. pytest discovers and runs all four `test_*` functions on its own, so the top-level calls were dead and only harmful; this removes all four.

To keep the class of bug from coming back, `test_no_top_level_test_invocations.py` parses every file under `tests/local_testing/` and fails if any test function is invoked at module scope. It flags all four call sites on the pre-fix tree and passes once they are gone. It is pure AST parsing with no imports or network, so it is fast and deterministic.

## Screenshots / Proof of Fix

This is a pytest collection-time bug in CI, so there is no proxy endpoint to curl; the faithful reproduction is the exact collection the jobs do.

Before (the original job logs, `tests/local_testing` collection):

```
==================================== ERRORS ====================================
_________ ERROR collecting tests/local_testing/test_register_model.py __________
...
tests/local_testing/test_register_model.py:65: in <module>
    test_update_model_cost_via_completion()
...
E   litellm.exceptions.RateLimitError: OpenAIException - You exceeded your current quota
ERROR tests/local_testing/test_register_model.py - Failed: An error occurred: litellm.RateLimitError
!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!
============================== 1 error in 19.09s ===============================
```

After (collection no longer imports-and-runs anything, no network call):

```
$ uv run --no-sync python -m pytest \
    tests/local_testing/test_register_model.py \
    tests/local_testing/test_wandb.py \
    tests/local_testing/test_lunary.py \
    tests/local_testing/test_multiple_deployments.py --collect-only -q
...
tests/local_testing/test_register_model.py::test_update_model_cost_via_completion
tests/local_testing/test_wandb.py::test_wandb_logging
tests/local_testing/test_wandb.py::test_wandb_logging_async
11 tests collected in 0.08s
```

Regression test green, and confirmed it flags the pre-fix tree:

```
$ uv run --no-sync python -m pytest tests/local_testing/test_no_top_level_test_invocations.py -q
1 passed

# scanning the HEAD (pre-fix) versions reports 4 violations:
tests/local_testing/test_register_model.py:65 calls test_update_model_cost_via_completion()
tests/local_testing/test_wandb.py:54 calls test_wandb_logging_async()
tests/local_testing/test_lunary.py:29 calls test_lunary_logging()
tests/local_testing/test_multiple_deployments.py:54 calls test_multiple_deployments()
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01CPptUj7WkzUjjZHRzRgnVd)_