### PR TITLE
fix(proxy): remove ghost team BYOK models from /models on delete

### DIFF
--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -61,6 +61,84 @@ from litellm.utils import get_utc_datetime
 router = APIRouter()
 
 
+def _resolve_team_public_model_name(model_params: Deployment) -> str:
+    """
+    Return the user-visible public model name for a team BYOK deployment.
+
+    For team BYOK models, the actual public name is stored in
+    model_info.team_public_model_name. model_params.model_name contains
+    the internal unique name (model_name_{team_id}_{uuid}).
+
+    Falls back to model_params.model_name for non-BYOK or legacy models.
+    """
+    team_public_name = (
+        getattr(model_params.model_info, "team_public_model_name", None)
+        if model_params.model_info
+        else None
+    )
+    if team_public_name:
+        return team_public_name
+    return model_params.model_name
+
+
+async def _cleanup_team_model_references(
+    team_id: str,
+    internal_model_name: str,
+    public_model_name: str,
+    prisma_client: PrismaClient,
+) -> Optional[LiteLLM_TeamTable]:
+    """
+    Remove a deleted model's references from the team's alias map and models list.
+
+    Builds a set of names to remove from team.models:
+    1. The public_model_name (always; handles the BYOK case where aliases are empty)
+    2. Any alias keys whose values match internal_model_name (handles populated alias maps)
+
+    Returns the updated team row, or None if team not found.
+    """
+    team_row = await prisma_client.db.litellm_teamtable.find_unique(
+        where={"team_id": team_id}
+    )
+    if team_row is None:
+        return None
+
+    names_to_remove: set = {public_model_name}
+
+    if team_row.model_id is not None:
+        model_table_row = await prisma_client.db.litellm_modeltable.find_unique(
+            where={"id": team_row.model_id}
+        )
+        if model_table_row is not None and model_table_row.model_aliases:
+            existing_aliases = model_table_row.model_aliases
+            if isinstance(existing_aliases, str):
+                existing_aliases = json.loads(existing_aliases)
+
+            updated_aliases = {}
+            for alias_key, alias_value in existing_aliases.items():
+                if alias_value == internal_model_name:
+                    names_to_remove.add(alias_key)
+                else:
+                    updated_aliases[alias_key] = alias_value
+
+            if updated_aliases != existing_aliases:
+                await prisma_client.db.litellm_modeltable.update(
+                    where={"id": team_row.model_id},
+                    data={"model_aliases": json.dumps(updated_aliases)},
+                )
+
+    existing_models = list(team_row.models or [])
+    updated_models = [m for m in existing_models if m not in names_to_remove]
+    if updated_models != existing_models:
+        updated_row = await prisma_client.db.litellm_teamtable.update(
+            where={"team_id": team_id},
+            data={"models": updated_models},
+            include={"object_permission": True, "litellm_model_table": True},  # type: ignore
+        )
+        return updated_row
+
+    return None
+
+
 async def update_team(*args, **kwargs):
     """
     Backward-compatible shim for tests/legacy call sites that patch this symbol.
@@ -796,34 +874,37 @@ async def delete_model(
             premium_user=premium_user,
         )
 
-        # delete team model alias
+        # Clean up team model references
         if model_params.model_info.team_id is not None:
-            removed_model_aliases = await delete_team_model_alias(
-                public_model_name=model_params.model_name,
+            public_model_name = _resolve_team_public_model_name(model_params)
+            updated_team_row = await _cleanup_team_model_references(
+                team_id=model_params.model_info.team_id,
+                internal_model_name=model_params.model_name,
+                public_model_name=public_model_name,
                 prisma_client=prisma_client,
             )
+            if updated_team_row is not None:
+                try:
+                    from litellm.proxy._types import LiteLLM_TeamTableCachedObj
+                    from litellm.proxy.auth.auth_checks import _cache_team_object
+                    from litellm.proxy.proxy_server import (
+                        proxy_logging_obj,
+                        user_api_key_cache,
+                    )
 
-            valid_team_model_aliases = [
-                model
-                for team_id, model in removed_model_aliases
-                if team_id == model_params.model_info.team_id
-            ]
-
-            ## UPDATE TEAM TO NOT LIST MODEL ##
-            existing_team_row = await prisma_client.db.litellm_teamtable.find_unique(
-                where={"team_id": model_params.model_info.team_id}
-            )
-            if existing_team_row is not None:
-                existing_team_row.models = [
-                    model
-                    for model in existing_team_row.models
-                    if model not in valid_team_model_aliases
-                ]
-
-                await prisma_client.db.litellm_teamtable.update(
-                    where={"team_id": model_params.model_info.team_id},
-                    data={"models": existing_team_row.models},
-                )
+                    await _cache_team_object(
+                        team_id=updated_team_row.team_id,
+                        team_table=LiteLLM_TeamTableCachedObj(
+                            **updated_team_row.model_dump()
+                        ),
+                        user_api_key_cache=user_api_key_cache,
+                        proxy_logging_obj=proxy_logging_obj,
+                    )
+                except Exception:
+                    verbose_proxy_logger.debug(
+                        "Failed to refresh team cache after model delete, "
+                        "cache will update on next TTL expiry"
+                    )
 
         # update DB
         if store_model_in_db is True:

--- a/tests/test_litellm/proxy/management_endpoints/test_delete_team_byok_cleanup.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_delete_team_byok_cleanup.py
@@ -1,0 +1,264 @@
+"""
+Tests for team BYOK model delete cleanup.
+
+Regression tests for https://github.com/BerriAI/litellm/issues/22594
+Deleting a team BYOK model must remove the public model name from
+team.models and the alias map, even when the alias was previously
+overwritten or never populated.
+"""
+
+import json
+import os
+import sys
+from typing import List, Optional
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../../.."))
+
+from litellm.proxy._types import (
+    LiteLLM_ModelTable,
+    LiteLLM_TeamTable,
+    UserAPIKeyAuth,
+)
+from litellm.types.router import Deployment, LiteLLM_Params, ModelInfo
+
+
+def _make_deployment(
+    model_name: str,
+    model_id: str,
+    team_id: str,
+    team_public_model_name: str,
+) -> Deployment:
+    return Deployment(
+        model_name=model_name,
+        litellm_params=LiteLLM_Params(model="openai/fake"),
+        model_info=ModelInfo(
+            id=model_id,
+            team_id=team_id,
+            team_public_model_name=team_public_model_name,
+        ),
+    )
+
+
+class MockTeamRow:
+    def __init__(self, team_id: str, models: List[str], model_id: Optional[int] = None):
+        self.team_id = team_id
+        self.models = list(models)
+        self.model_id = model_id
+
+    def model_dump(self):
+        return {
+            "team_id": self.team_id,
+            "models": self.models,
+            "model_id": self.model_id,
+        }
+
+
+class TestResolveTeamPublicModelName:
+
+    def test_returns_team_public_model_name_when_present(self):
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _resolve_team_public_model_name,
+        )
+
+        deployment = _make_deployment(
+            model_name="model_name_team1_uuid1",
+            model_id="uuid1",
+            team_id="team1",
+            team_public_model_name="my-gpt4",
+        )
+        assert _resolve_team_public_model_name(deployment) == "my-gpt4"
+
+    def test_falls_back_to_model_name(self):
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _resolve_team_public_model_name,
+        )
+
+        deployment = Deployment(
+            model_name="plain-model",
+            litellm_params=LiteLLM_Params(model="openai/fake"),
+            model_info=ModelInfo(id="uuid1", team_id="team1"),
+        )
+        assert _resolve_team_public_model_name(deployment) == "plain-model"
+
+
+class TestCleanupTeamModelReferences:
+
+    @pytest.mark.asyncio
+    async def test_removes_public_name_from_team_models(self):
+        """Public name must be removed from team.models even when alias map is empty."""
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _cleanup_team_model_references,
+        )
+
+        team_row = MockTeamRow(
+            team_id="team1",
+            models=["my-gpt4", "other-model"],
+            model_id=1,
+        )
+
+        updated_team_row = MockTeamRow(
+            team_id="team1", models=["other-model"], model_id=1
+        )
+
+        team_update_calls = []
+
+        def capture_and_return(**kw):
+            team_update_calls.append(kw)
+            return updated_team_row
+
+        mock_team_table = AsyncMock()
+        mock_team_table.find_unique = AsyncMock(return_value=team_row)
+        mock_team_table.update = AsyncMock(side_effect=capture_and_return)
+
+        mock_model_row = MagicMock()
+        mock_model_row.model_aliases = json.dumps({})
+        mock_model_table = AsyncMock()
+        mock_model_table.find_unique = AsyncMock(return_value=mock_model_row)
+        mock_model_table.update = AsyncMock()
+
+        prisma_client = MagicMock()
+        prisma_client.db.litellm_teamtable = mock_team_table
+        prisma_client.db.litellm_modeltable = mock_model_table
+
+        result = await _cleanup_team_model_references(
+            team_id="team1",
+            internal_model_name="model_name_team1_uuid1",
+            public_model_name="my-gpt4",
+            prisma_client=prisma_client,
+        )
+
+        assert len(team_update_calls) == 1
+        updated_models = team_update_calls[0]["data"]["models"]
+        assert "my-gpt4" not in updated_models
+        assert "other-model" in updated_models
+        assert result is not None
+        assert result.team_id == "team1"
+
+    @pytest.mark.asyncio
+    async def test_removes_alias_entry_by_internal_name(self):
+        """If the alias map has an entry pointing to the internal name, remove it."""
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _cleanup_team_model_references,
+        )
+
+        team_row = MockTeamRow(
+            team_id="team1",
+            models=["my-gpt4", "other-model"],
+            model_id=1,
+        )
+
+        updated_team_row = MockTeamRow(
+            team_id="team1", models=["other-model"], model_id=1
+        )
+
+        team_update_calls = []
+        alias_update_calls = []
+
+        def capture_team_update(**kw):
+            team_update_calls.append(kw)
+            return updated_team_row
+
+        mock_team_table = AsyncMock()
+        mock_team_table.find_unique = AsyncMock(return_value=team_row)
+        mock_team_table.update = AsyncMock(side_effect=capture_team_update)
+
+        mock_model_row = MagicMock()
+        mock_model_row.model_aliases = json.dumps(
+            {
+                "my-gpt4": "model_name_team1_uuid1",
+                "other-model": "model_name_team1_uuid2",
+            }
+        )
+        mock_model_table = AsyncMock()
+        mock_model_table.find_unique = AsyncMock(return_value=mock_model_row)
+        mock_model_table.update = AsyncMock(
+            side_effect=lambda **kw: alias_update_calls.append(kw)
+        )
+
+        prisma_client = MagicMock()
+        prisma_client.db.litellm_teamtable = mock_team_table
+        prisma_client.db.litellm_modeltable = mock_model_table
+
+        await _cleanup_team_model_references(
+            team_id="team1",
+            internal_model_name="model_name_team1_uuid1",
+            public_model_name="my-gpt4",
+            prisma_client=prisma_client,
+        )
+
+        assert len(alias_update_calls) == 1
+        updated_aliases = json.loads(alias_update_calls[0]["data"]["model_aliases"])
+        assert "my-gpt4" not in updated_aliases
+        assert updated_aliases == {"other-model": "model_name_team1_uuid2"}
+
+        # team.models must also be updated to remove the public name
+        assert len(team_update_calls) == 1
+        updated_models = team_update_calls[0]["data"]["models"]
+        assert "my-gpt4" not in updated_models
+        assert "other-model" in updated_models
+
+    @pytest.mark.asyncio
+    async def test_no_update_when_nothing_to_remove(self):
+        """If public name is not in team.models, no team update should happen."""
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _cleanup_team_model_references,
+        )
+
+        team_row = MockTeamRow(
+            team_id="team1",
+            models=["other-model"],
+            model_id=1,
+        )
+
+        team_update_calls = []
+
+        mock_team_table = AsyncMock()
+        mock_team_table.find_unique = AsyncMock(return_value=team_row)
+        mock_team_table.update = AsyncMock(
+            side_effect=lambda **kw: team_update_calls.append(kw)
+        )
+
+        mock_model_row = MagicMock()
+        mock_model_row.model_aliases = json.dumps({})
+        mock_model_table = AsyncMock()
+        mock_model_table.find_unique = AsyncMock(return_value=mock_model_row)
+        mock_model_table.update = AsyncMock()
+
+        prisma_client = MagicMock()
+        prisma_client.db.litellm_teamtable = mock_team_table
+        prisma_client.db.litellm_modeltable = mock_model_table
+
+        result = await _cleanup_team_model_references(
+            team_id="team1",
+            internal_model_name="model_name_team1_uuid1",
+            public_model_name="not-in-team",
+            prisma_client=prisma_client,
+        )
+
+        assert len(team_update_calls) == 0
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_team_not_found(self):
+        """If the team doesn't exist, return None."""
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _cleanup_team_model_references,
+        )
+
+        mock_team_table = AsyncMock()
+        mock_team_table.find_unique = AsyncMock(return_value=None)
+
+        prisma_client = MagicMock()
+        prisma_client.db.litellm_teamtable = mock_team_table
+
+        result = await _cleanup_team_model_references(
+            team_id="nonexistent",
+            internal_model_name="internal",
+            public_model_name="public",
+            prisma_client=prisma_client,
+        )
+
+        assert result is None


### PR DESCRIPTION
## Relevant issues

Addresses issue - https://github.com/BerriAI/litellm/issues/22594

Related PRs: #29528 (companion create-side fix)

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Reproduction script creates a team with 2 BYOK models sequentially, then deletes them. Before the fix, both models persist as ghosts in `team.models` and `/models` indefinitely. After the fix, deleted models are removed immediately.

```
Before (v1.85.0):
  After deleting both models:
  team.models in DB: ['all-proxy-models', 'bug2-model-1', 'bug2-model-2']
  Ghosts: both models still visible via /models

After (this PR):
  After deleting model-2:
  team.models in DB: ['all-proxy-models', 'bug2-model-1']
  After deleting model-1:
  team.models in DB: ['all-proxy-models']
  No ghosts.
```

Also tested the alias-overwrite scenario: create model-1, create model-2 (overwrites model-1's alias entry), delete model-1. Before the fix, model-1 persists as a ghost. After the fix, model-1 is cleaned up and model-2 is preserved.

## Type

Bug Fix

## Changes

`delete_model` passed `model_params.model_name` (the internal name, e.g. `model_name_{team_id}_{uuid}`) to `delete_team_model_alias`, which searched alias map values for a match. For BYOK models the alias map is typically empty or was overwritten by a later model create, so the lookup always failed and the public name was never removed from `team.models`.

This PR adds two helpers and rewires the delete path:

- `_resolve_team_public_model_name`: extracts the user-visible name from `model_info.team_public_model_name`, falling back to `model_params.model_name` for non-BYOK models.
- `_cleanup_team_model_references`: builds a `names_to_remove` set starting with the public name (unconditionally), then adds any alias keys whose values match the internal name. Strips all matched names from `team.models` and cleans up the alias map in the same pass.

After the DB cleanup, refreshes the team cache via `_cache_team_object` so `/models` reflects the deletion without waiting for cache TTL. The cache refresh is wrapped in try/except so a Redis failure does not undo the DB delete.

`delete_team_model_alias` is left in place; other code paths may still reference it.