### PR TITLE
fix(anthropic/adapter): emit thinking block for reasoning_content-only streaming chunks

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -1446,14 +1446,17 @@ class LiteLLMAnthropicMessagesAdapter:
                         return "thinking", ChatCompletionThinkingBlock(
                             type="thinking", thinking=thinking, signature=signature
                         )
-                # OpenAI-compatible reasoning backends (e.g. vLLM/SGLang reasoning
-                # parsers) populate ``reasoning_content`` instead of
-                # ``thinking_blocks``. Open a ``thinking`` block so the matching
-                # ``thinking_delta`` stream is not emitted into a text block.
-                elif getattr(choice.delta, "reasoning_content", None):
-                    return "thinking", ChatCompletionThinkingBlock(
-                        type="thinking", thinking="", signature=""
-                    )
+            # OpenAI-compatible reasoning backends (e.g. vLLM/SGLang reasoning
+            # parsers) populate ``reasoning_content`` without ``thinking_blocks``.
+            # ``Delta`` deletes the ``thinking_blocks`` attribute when unset, so the
+            # branch above is skipped entirely; open a ``thinking`` block here so the
+            # matching ``thinking_delta`` stream is not emitted into a text block.
+            elif isinstance(choice, StreamingChoices) and getattr(
+                choice.delta, "reasoning_content", None
+            ):
+                return "thinking", ChatCompletionThinkingBlock(
+                    type="thinking", thinking="", signature=""
+                )
 
         return "text", TextBlock(type="text", text="")
 

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -1446,6 +1446,14 @@ class LiteLLMAnthropicMessagesAdapter:
                         return "thinking", ChatCompletionThinkingBlock(
                             type="thinking", thinking=thinking, signature=signature
                         )
+                # OpenAI-compatible reasoning backends (e.g. vLLM/SGLang reasoning
+                # parsers) populate ``reasoning_content`` instead of
+                # ``thinking_blocks``. Open a ``thinking`` block so the matching
+                # ``thinking_delta`` stream is not emitted into a text block.
+                elif getattr(choice.delta, "reasoning_content", None):
+                    return "thinking", ChatCompletionThinkingBlock(
+                        type="thinking", thinking="", signature=""
+                    )
 
         return "text", TextBlock(type="text", text="")
 

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -170,6 +170,44 @@ def test_translate_streaming_openai_chunk_to_anthropic_thinking_content_block():
     }
 
 
+def test_translate_streaming_openai_chunk_to_anthropic_reasoning_content_only_content_block():
+    """OpenAI-compatible reasoning backends (vLLM/SGLang) emit ``reasoning_content``
+    without ``thinking_blocks``. The content-block classifier must still open a
+    ``thinking`` block so the matching ``thinking_delta`` stream is not emitted
+    inside a text block (which silently drops chain-of-thought for /v1/messages
+    streaming clients)."""
+    choices = [
+        StreamingChoices(
+            finish_reason=None,
+            index=0,
+            delta=Delta(
+                reasoning_content="Let me think",
+                thinking_blocks=None,
+                content=None,
+                role="assistant",
+                function_call=None,
+                tool_calls=None,
+                audio=None,
+            ),
+            logprobs=None,
+        )
+    ]
+
+    (
+        block_type,
+        content_block_start,
+    ) = LiteLLMAnthropicMessagesAdapter()._translate_streaming_openai_chunk_to_anthropic_content_block(
+        choices=choices
+    )
+
+    assert block_type == "thinking"
+    assert content_block_start == {
+        "type": "thinking",
+        "thinking": "",
+        "signature": "",
+    }
+
+
 def test_translate_streaming_openai_chunk_to_anthropic_thinking_signature_block():
     choices = [
         StreamingChoices(


### PR DESCRIPTION
## Summary

Fixes #29518. On the `/v1/messages` Anthropic-shape streaming path, chain-of-thought from OpenAI-compatible reasoning backends (vLLM/SGLang reasoning parsers — DeepSeek-R1, Qwen3-reasoning, gpt-oss, etc.) is silently dropped: the visible answer is preserved but no `thinking` content block / `thinking_delta` reaches the client.

## Root cause

The streaming **content-block classifier** `_translate_streaming_openai_chunk_to_anthropic_content_block` decides the `content_block_start` *type*. It only recognizes `thinking_blocks`. These backends populate `Message.reasoning_content` and explicitly set `thinking_blocks=None`, so for a reasoning-only chunk the classifier falls through to the default **text** block.

Meanwhile the delta translator `_translate_streaming_openai_chunk_to_anthropic` already has a `reasoning_content` fallback and correctly returns a `thinking_delta`. The net effect in `streaming_iterator.py`: a `content_block_start` of type `text` is opened (block type never changes, so no new block is started), and the `thinking_delta` events are emitted **inside that text block**. Anthropic streaming clients (Claude Code, SDK `.stream()`) ignore `thinking_delta` outside a `thinking` block, so the reasoning is discarded.

The non-stream translator (`_translate_openai_content_to_anthropic`) and the streaming delta translator already fall back to `reasoning_content`; only the content-block classifier was missing the same fallback.

## Fix

Add the matching `reasoning_content` fallback to the classifier so it opens a `thinking` block when `thinking_blocks` is absent. With the classifier and the delta translator now agreeing, the iterator emits a proper `thinking` `content_block_start` followed by `thinking_delta` events.

## Test

Adds `test_translate_streaming_openai_chunk_to_anthropic_reasoning_content_only_content_block`, which feeds a `reasoning_content`-only streaming chunk (`thinking_blocks=None`) and asserts the classifier returns a `thinking` block. The existing thinking-blocks tests still cover the Claude-backed path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)