### PR TITLE
fix(otel): capture 401 error details in management endpoint spans

### DIFF
--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -3287,6 +3287,32 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
             value=int(status_code),
         )
 
+    def record_error_attributes_on_span(
+        self,
+        span: Optional[Span],
+        exception: Optional[Exception],
+        status_code: int,
+    ) -> None:
+        """Stamp structured ``error.*`` attributes on the SERVER span from the
+        exception returned to the client, with ``error.code`` pinned to the real
+        response status. Idempotent (overwrites); emits no exception event."""
+        if span is None or exception is None:
+            return
+        from litellm.litellm_core_utils.litellm_logging import (
+            StandardLoggingPayloadSetup,
+        )
+
+        error_information = StandardLoggingPayloadSetup.get_error_information(
+            original_exception=exception
+        )
+        error_information["error_code"] = str(status_code)
+        self._record_exception_on_span(
+            span=span,
+            kwargs={
+                "standard_logging_object": {"error_information": error_information}
+            },
+        )
+
     def set_preprocessing_duration_attribute(
         self, span: Optional[Span], container: Any
     ) -> None:

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -5300,8 +5300,12 @@ class StandardLoggingPayloadSetup:
                     tb_lines[:MAXIMUM_TRACEBACK_LINES_TO_LOG]
                 )  # Limit to first 100 lines
 
-        # Get additional error details
-        error_message = str(original_exception)
+        explicit_message = getattr(original_exception, "message", None)
+        error_message = (
+            explicit_message
+            if isinstance(explicit_message, str) and explicit_message
+            else str(original_exception)
+        )
 
         return StandardLoggingPayloadErrorInformation(
             error_code=error_status,

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -3673,6 +3673,7 @@ class ProxyException(Exception):
         provider_specific_fields: Optional[dict] = None,
     ):
         self.message = str(message)
+        super().__init__(self.message)
         self.type = type
         self.param = param
         self.openai_code = openai_code or code

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1265,7 +1265,7 @@ async def openai_exception_handler(request: Request, exc: ProxyException):
     headers = exc.headers
     error_dict = exc.to_dict()
     status_code = int(exc.code) if exc.code else status.HTTP_500_INTERNAL_SERVER_ERROR
-    _close_dangling_otel_server_span(request, status_code)
+    _close_dangling_otel_server_span(request, status_code, exc=exc)
     return JSONResponse(
         status_code=status_code,
         content={"error": error_dict},
@@ -1273,7 +1273,9 @@ async def openai_exception_handler(request: Request, exc: ProxyException):
     )
 
 
-def _close_dangling_otel_server_span(request: Request, status_code: int) -> None:
+def _close_dangling_otel_server_span(
+    request: Request, status_code: int, exc: Optional[Exception] = None
+) -> None:
     parent_otel_span = getattr(request.state, "parent_otel_span", None)
     if parent_otel_span is None:
         return
@@ -1296,6 +1298,10 @@ def _close_dangling_otel_server_span(request: Request, status_code: int) -> None
         open_telemetry_logger.set_response_status_code_attribute(
             parent_otel_span, status_code
         )
+        if status_code >= 400:
+            open_telemetry_logger.record_error_attributes_on_span(
+                parent_otel_span, exc, status_code
+            )
         parent_otel_span.set_status(
             Status(StatusCode.ERROR if status_code >= 400 else StatusCode.OK)
         )
@@ -1312,7 +1318,7 @@ def _close_dangling_otel_server_span(request: Request, status_code: int) -> None
 async def otel_request_validation_exception_handler(
     request: Request, exc: RequestValidationError
 ):
-    _close_dangling_otel_server_span(request, 422)
+    _close_dangling_otel_server_span(request, 422, exc=exc)
     return JSONResponse(
         status_code=422,
         content={"detail": jsonable_encoder(exc.errors())},
@@ -1326,7 +1332,7 @@ async def otel_unhandled_exception_handler(request: Request, exc: Exception):
     verbose_proxy_logger.exception(
         "Unhandled exception in request: %s", type(exc).__name__
     )
-    _close_dangling_otel_server_span(request, 500)
+    _close_dangling_otel_server_span(request, 500, exc=exc)
     return JSONResponse(
         status_code=500,
         content={

--- a/tests/test_litellm/integrations/open_telemetry/test_otel_exception_handler.py
+++ b/tests/test_litellm/integrations/open_telemetry/test_otel_exception_handler.py
@@ -18,7 +18,9 @@ from litellm.proxy.proxy_server import (
     otel_unhandled_exception_handler,
 )
 
-from ._helpers import assert_server_span_attrs
+from litellm.integrations._types.open_inference import ErrorAttributes
+
+from ._helpers import assert_server_span_attrs, get_server_span
 
 
 def _fake_request(parent_otel_span=None):
@@ -90,6 +92,33 @@ def test_exception_handler_closes_span(
         expected_url_path=path,
         where=f"{handler.__name__} ({type(exc).__name__})",
     )
+
+
+@pytest.mark.parametrize("path", ["/team/list", "/organization/list"])
+def test_openai_exception_handler_stamps_structured_error_on_span(
+    wired_otel, server_span_factory, path
+):
+    """A ProxyException 401 (invalid/expired key on a management endpoint) must
+    leave error.type, error.code AND error.message on the SERVER span. Pre-fix,
+    ProxyException stringified to "" so error.message was dropped — the span
+    showed an error with no message."""
+    msg = "Authentication Error, Invalid proxy server token passed."
+    request = _fake_request(parent_otel_span=server_span_factory(path))
+    exc = ProxyException(message=msg, type="auth_error", param="key", code=401)
+
+    response = asyncio.run(openai_exception_handler(request, exc))
+    assert response.status_code == 401
+
+    assert_server_span_attrs(
+        wired_otel,
+        expected_status=401,
+        expected_url_path=path,
+        where=f"openai_exception_handler ({path})",
+    )
+    attrs = get_server_span(wired_otel).attributes
+    assert attrs.get(ErrorAttributes.ERROR_MESSAGE) == msg
+    assert attrs.get(ErrorAttributes.ERROR_TYPE) == "ProxyException"
+    assert attrs.get(ErrorAttributes.ERROR_CODE) == "401"
 
 
 def test_unhandled_handler_reraises_known_exceptions(wired_otel, server_span_factory):

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -3078,3 +3078,39 @@ class TestFirstApiCallStartTimeSetOnce:
         assert obj.model_call_details["api_call_start_time"] > first
         assert obj.model_call_details["first_api_call_start_time"] == first
         assert user_meta == {}
+
+
+def test_get_error_information_proxy_exception_preserves_message():
+    """ProxyException keeps its text in ``.message`` (str() was empty pre-fix),
+    so error_information must still surface the message and code."""
+    from litellm.litellm_core_utils.litellm_logging import StandardLoggingPayloadSetup
+    from litellm.proxy._types import ProxyException
+
+    msg = "Authentication Error, Invalid proxy server token passed."
+    exc = ProxyException(message=msg, type="auth_error", param="key", code=401)
+
+    info = StandardLoggingPayloadSetup.get_error_information(original_exception=exc)
+    assert info["error_message"] == msg
+    assert info["error_class"] == "ProxyException"
+    assert info["error_code"] == "401"
+
+
+def test_get_error_information_prefers_message_attribute_over_empty_str():
+    """error_message must come from a populated ``.message`` even when the
+    exception's __str__ is empty — guards classes that store the text on
+    ``.message`` without forwarding it to ``Exception.__init__``."""
+    from litellm.litellm_core_utils.litellm_logging import StandardLoggingPayloadSetup
+
+    class _SilentExc(Exception):
+        def __init__(self):
+            self.message = "real failure detail"
+            self.code = 401
+
+        def __str__(self):
+            return ""
+
+    info = StandardLoggingPayloadSetup.get_error_information(
+        original_exception=_SilentExc()
+    )
+    assert info["error_message"] == "real failure detail"
+    assert info["error_code"] == "401"

--- a/tests/test_litellm/proxy/test_proxy_types.py
+++ b/tests/test_litellm/proxy/test_proxy_types.py
@@ -87,3 +87,22 @@ def test_user_api_key_auth_hashes_authorization_header_form_of_key():
         assert from_header.api_key == baseline.api_key
         assert from_header.token == baseline.token
         assert not from_header.api_key.lower().startswith("bearer")
+
+
+def test_proxy_exception_str_returns_message():
+    """ProxyException must stringify to its message: OTEL's
+    ``span.record_exception`` and ``str(exc)``-based logging read the string
+    form, which was empty pre-fix. The OpenAI-mapped fields must stay intact."""
+    from litellm.proxy._types import ProxyException
+
+    msg = "Authentication Error, Invalid proxy server token passed."
+    exc = ProxyException(message=msg, type="auth_error", param="key", code=401)
+
+    assert str(exc) == msg
+    assert exc.message == msg
+    assert exc.to_dict() == {
+        "message": msg,
+        "type": "auth_error",
+        "param": "key",
+        "code": "401",
+    }


### PR DESCRIPTION
## Relevant issues

## Linear ticket
Resolves LIT-3515

## Pre-Submission checklist
- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type
Bug Fix

## Changes
On v1 (legacy) OpenTelemetry, a 401 from a management endpoint such as `team/list` or `organization/list` (invalid or expired key) is raised as a `ProxyException`. `ProxyException.__init__` never forwarded its message to `Exception.__init__`, so `str(exc)` was empty; `get_error_information` derived the message from `str(exc)`, and OTEL's `span.record_exception` also reads `str(exc)`. The SERVER span (`litellm_request`) therefore recorded `error.type` and `error.code` but dropped `error.message`, and the recorded exception event carried an empty `exception.message`. Plain `Exception` auth failures kept their message but lacked the code, so which detail survived flipped per exception class; that is the inconsistency reported (sometimes an error with no message, sometimes a message with no code)

Three changes make the span error record consistent. `ProxyException` now calls `super().__init__(self.message)` so it stringifies to its message. `get_error_information` prefers an explicit `.message` attribute and falls back to `str()`. A new `record_error_attributes_on_span` is invoked from the proxy exception handlers via `_close_dangling_otel_server_span`, stamping `error.type`, `error.code` and `error.message` authoritatively from the exception returned to the client, with `error.code` pinned to the real response status; writes are idempotent so it converges with the failure-callback path rather than racing it

## Test plan
- [x] `tests/test_litellm/proxy/test_proxy_types.py::test_proxy_exception_str_returns_message`
- [x] `tests/test_litellm/litellm_core_utils/test_litellm_logging.py` — `test_get_error_information_proxy_exception_preserves_message`, `test_get_error_information_prefers_message_attribute_over_empty_str`
- [x] `tests/test_litellm/integrations/open_telemetry/test_otel_exception_handler.py::test_openai_exception_handler_stamps_structured_error_on_span` (parametrized over `/team/list` and `/organization/list`)
- [x] Mutation-checked: reverting any one of the three fixes fails its corresponding test

## Screenshots / Proof of Fix
Live proxy on `:4000` with the v1 OTEL console exporter (`OTEL_EXPORTER=console`), hitting management endpoints with bad credentials. These are auth-path failures on management endpoints, so no LLM call is involved; the user-visible artifact is the SERVER span. The same scenario was run with the fix stashed (before) and applied (after)


before 
<img width="1501" height="332" alt="Screenshot 2026-06-02 at 3 59 57 PM" src="https://github.com/user-attachments/assets/cb1b55a7-8950-4237-8ce9-fbe6739b74da" />

after 
<img width="1502" height="317" alt="Screenshot 2026-06-02 at 4 00 05 PM" src="https://github.com/user-attachments/assets/ae59e54a-1317-4b98-b415-52e36456734f" />


Commands:
```
OTEL_EXPORTER=console litellm --config config.yaml   # legacy v1 OTEL, console exporter

# invalid key
curl -s -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer sk-invalid-demo-key" http://localhost:4000/team/list
curl -s -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer sk-invalid-demo-key" http://localhost:4000/organization/list

# expired key
K=$(curl -s -X POST http://localhost:4000/key/generate -H "Authorization: Bearer $MASTER_KEY" -H 'content-type: application/json' -d '{"duration":"3s"}' | jq -r .key); sleep 6
curl -s -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer $K" http://localhost:4000/team/list
```

SERVER span (`litellm_request`) attributes, all responses HTTP 401:

| scenario | `error.message` before | `error.message` after | `exception.message` before -> after |
| --- | --- | --- | --- |
| invalid key, `/team/list` | absent | present | `""` -> present |
| invalid key, `/organization/list` | absent | present | `""` -> present |
| expired key, `/team/list` | absent | present | `""` -> present |

`error.type=ProxyException` and `error.code=401` were already present in both runs. After the fix the span carries, for the invalid-key case, `error.message = "Authentication Error, Invalid proxy server token passed. ... Unable to find token in cache or LiteLLM_VerificationTokenTable"`, and for the expired-key case `error.message = "Authentication Error - Expired Key. Key Expiry time ... and current time ..."`

Resolves LIT-3515