### PR TITLE
perf(proxy): cache per-request optional imports on non-streaming hot path

### DIFF
--- a/litellm/integrations/otel/runtime.py
+++ b/litellm/integrations/otel/runtime.py
@@ -2,13 +2,39 @@
 
 Proxy code may run without the OpenTelemetry SDK installed, so it must not import
 ``litellm.integrations.otel.logger`` (which imports the SDK at module scope) at
-module load. These wrappers import it lazily and no-op when the SDK is absent or
-V2 is not the active logger — so a call site can wrap a request phase or seed
-identity unconditionally.
+module load. These wrappers resolve it lazily on first use and no-op when the SDK
+is absent or V2 is not the active logger -- so a call site can wrap a request
+phase or seed identity unconditionally.
+
+The resolution is cached after the first attempt. A failed ``import`` is never
+recorded in ``sys.modules``, so re-attempting it per request re-runs the full
+import finder/loader machinery; on a proxy without the SDK that costs hundreds of
+microseconds on every request. Caching the outcome makes the steady-state cost a
+single attribute load.
 """
 
 from contextlib import contextmanager
-from typing import Any, Iterator
+from typing import Any, Callable, Iterator, Optional
+
+_resolved = False
+_phase_span_impl: Optional[Callable[[str], Any]] = None
+_seed_request_identity_impl: Optional[Callable[..., None]] = None
+
+
+def _resolve() -> None:
+    global _resolved, _phase_span_impl, _seed_request_identity_impl
+    try:
+        from litellm.integrations.otel.logger import (
+            phase_span as _phase_span,
+            seed_request_identity as _seed,
+        )
+
+        _phase_span_impl = _phase_span
+        _seed_request_identity_impl = _seed
+    except Exception:
+        _phase_span_impl = None
+        _seed_request_identity_impl = None
+    _resolved = True
 
 
 @contextmanager
@@ -18,21 +44,19 @@ def phase_span(name: str) -> "Iterator[Any]":
     Yields ``None`` (a plain no-op) when the OTel SDK is unavailable or V2 is not
     the active logger.
     """
-    try:
-        from litellm.integrations.otel.logger import phase_span as _phase_span
-    except Exception:
+    if not _resolved:
+        _resolve()
+    if _phase_span_impl is None:
         yield None
         return
-    with _phase_span(name) as span:
+    with _phase_span_impl(name) as span:
         yield span
 
 
 def seed_request_identity(user_api_key_dict: Any, model: Any = None) -> None:
     """Seed request-identity Baggage at the auth boundary (no-op without V2)."""
-    try:
-        from litellm.integrations.otel.logger import (
-            seed_request_identity as _seed_request_identity,
-        )
-    except Exception:
+    if not _resolved:
+        _resolve()
+    if _seed_request_identity_impl is None:
         return
-    _seed_request_identity(user_api_key_dict, model=model)
+    _seed_request_identity_impl(user_api_key_dict, model=model)

--- a/litellm/proxy/db/log_db_metrics.py
+++ b/litellm/proxy/db/log_db_metrics.py
@@ -121,14 +121,14 @@ def _db_exception_types_cached() -> Tuple[type, ...]:
     if _db_exception_types is None:
         import httpx
 
-        types: Tuple[type, ...] = (httpx.ConnectError, httpx.TimeoutException)
+        exc_types: Tuple[type, ...] = (httpx.ConnectError, httpx.TimeoutException)
         try:
             from prisma.errors import PrismaError
 
-            types = (PrismaError, *types)
+            exc_types = (PrismaError, *exc_types)
         except Exception:
             pass
-        _db_exception_types = types
+        _db_exception_types = exc_types
     return _db_exception_types
 
 

--- a/litellm/proxy/db/log_db_metrics.py
+++ b/litellm/proxy/db/log_db_metrics.py
@@ -106,15 +106,37 @@ def log_db_metrics(func):
     return wrapper
 
 
+_db_exception_types: Optional[Tuple[type, ...]] = None
+
+
+def _db_exception_types_cached() -> Tuple[type, ...]:
+    """Exception types that mark a DB failure, resolved once.
+
+    ``prisma`` is an optional dependency, so a proxy without it must not re-run
+    (and re-fail) ``from prisma.errors import PrismaError`` on every handled
+    exception -- a failed import is never cached in ``sys.modules`` and re-runs
+    the whole finder/loader machinery each call.
+    """
+    global _db_exception_types
+    if _db_exception_types is None:
+        import httpx
+
+        types: Tuple[type, ...] = (httpx.ConnectError, httpx.TimeoutException)
+        try:
+            from prisma.errors import PrismaError
+
+            types = (PrismaError, *types)
+        except Exception:
+            pass
+        _db_exception_types = types
+    return _db_exception_types
+
+
 def _is_exception_related_to_db(e: Exception) -> bool:
     """
     Returns True if the exception is related to the DB
     """
-
-    import httpx
-    from prisma.errors import PrismaError
-
-    return isinstance(e, (PrismaError, httpx.ConnectError, httpx.TimeoutException))
+    return isinstance(e, _db_exception_types_cached())
 
 
 async def _handle_logging_db_exception(

--- a/tests/test_litellm/integrations/otel/test_otel_runtime.py
+++ b/tests/test_litellm/integrations/otel/test_otel_runtime.py
@@ -1,0 +1,76 @@
+"""Regression tests for ``litellm.integrations.otel.runtime``.
+
+These guard the per-request hot path: the SDK-free wrappers must resolve the
+optional ``litellm.integrations.otel.logger`` import exactly once and cache the
+outcome. Re-attempting the import on every call re-runs the whole import
+finder/loader machinery (a failed import is never recorded in ``sys.modules``),
+which on a proxy without the OTel SDK cost hundreds of microseconds per request.
+"""
+
+import builtins
+import contextlib
+
+import litellm.integrations.otel.runtime as rt
+
+
+def _reset_runtime_cache():
+    rt._resolved = False
+    rt._phase_span_impl = None
+    rt._seed_request_identity_impl = None
+
+
+def test_resolves_logger_import_at_most_once(monkeypatch):
+    _reset_runtime_cache()
+
+    real_import = builtins.__import__
+    attempts = {"n": 0}
+
+    def counting_import(name, *args, **kwargs):
+        if name == "litellm.integrations.otel.logger":
+            attempts["n"] += 1
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", counting_import)
+
+    for _ in range(25):
+        with rt.phase_span("auth /v1/chat/completions"):
+            pass
+        rt.seed_request_identity(object(), model="gpt-4o")
+
+    assert attempts["n"] <= 1
+
+
+def test_phase_span_and_seed_noop_when_logger_unavailable():
+    rt._resolved = True
+    rt._phase_span_impl = None
+    rt._seed_request_identity_impl = None
+
+    with rt.phase_span("auth /v1/messages") as span:
+        assert span is None
+
+    rt.seed_request_identity(object(), model="claude-3-5")
+
+
+def test_phase_span_and_seed_use_resolved_impl_when_available():
+    calls = {"phase": [], "seed": []}
+
+    @contextlib.contextmanager
+    def fake_phase_span(name):
+        calls["phase"].append(name)
+        yield "live-span"
+
+    def fake_seed(user_api_key_dict, model=None):
+        calls["seed"].append((user_api_key_dict, model))
+
+    rt._resolved = True
+    rt._phase_span_impl = fake_phase_span
+    rt._seed_request_identity_impl = fake_seed
+
+    with rt.phase_span("auth /chat") as span:
+        assert span == "live-span"
+    rt.seed_request_identity("key-obj", model="gpt-4o")
+
+    assert calls["phase"] == ["auth /chat"]
+    assert calls["seed"] == [("key-obj", "gpt-4o")]
+
+    _reset_runtime_cache()

--- a/tests/test_litellm/integrations/otel/test_otel_runtime.py
+++ b/tests/test_litellm/integrations/otel/test_otel_runtime.py
@@ -9,6 +9,8 @@ which on a proxy without the OTel SDK cost hundreds of microseconds per request.
 
 import builtins
 import contextlib
+import sys
+import types
 
 import litellm.integrations.otel.runtime as rt
 
@@ -72,5 +74,46 @@ def test_phase_span_and_seed_use_resolved_impl_when_available():
 
     assert calls["phase"] == ["auth /chat"]
     assert calls["seed"] == [("key-obj", "gpt-4o")]
+
+    _reset_runtime_cache()
+
+
+def test_resolve_wires_up_logger_when_importable(monkeypatch):
+    """When the OTel logger is importable, ``_resolve`` caches its callables.
+
+    Simulates the SDK-present deployment by injecting a fake logger module, so
+    the import-success branch is exercised even though this environment has no
+    OTel SDK. Triggering resolution via ``seed_request_identity`` first also
+    covers the lazy-resolve path on that entrypoint.
+    """
+    seen = {}
+
+    @contextlib.contextmanager
+    def logger_phase_span(name):
+        seen["phase"] = name
+        yield "real-span"
+
+    def logger_seed(user_api_key_dict, model=None):
+        seen["seed"] = (user_api_key_dict, model)
+
+    fake_logger = types.ModuleType("litellm.integrations.otel.logger")
+    fake_logger.phase_span = logger_phase_span
+    fake_logger.seed_request_identity = logger_seed
+    monkeypatch.setitem(sys.modules, "litellm.integrations.otel.logger", fake_logger)
+
+    _reset_runtime_cache()
+
+    rt.seed_request_identity("key-obj", model="claude-3-5")
+    assert rt._resolved is True
+    assert rt._phase_span_impl is logger_phase_span
+    assert rt._seed_request_identity_impl is logger_seed
+
+    with rt.phase_span("auth /v1/chat/completions") as span:
+        assert span == "real-span"
+
+    assert seen == {
+        "seed": ("key-obj", "claude-3-5"),
+        "phase": "auth /v1/chat/completions",
+    }
 
     _reset_runtime_cache()

--- a/tests/test_litellm/integrations/otel/test_otel_runtime.py
+++ b/tests/test_litellm/integrations/otel/test_otel_runtime.py
@@ -12,6 +12,8 @@ import contextlib
 import sys
 import types
 
+import pytest
+
 import litellm.integrations.otel.runtime as rt
 
 
@@ -21,9 +23,14 @@ def _reset_runtime_cache():
     rt._seed_request_identity_impl = None
 
 
-def test_resolves_logger_import_at_most_once(monkeypatch):
+@pytest.fixture(autouse=True)
+def _isolate_runtime_cache():
+    _reset_runtime_cache()
+    yield
     _reset_runtime_cache()
 
+
+def test_resolves_logger_import_at_most_once(monkeypatch):
     real_import = builtins.__import__
     attempts = {"n": 0}
 
@@ -75,8 +82,6 @@ def test_phase_span_and_seed_use_resolved_impl_when_available():
     assert calls["phase"] == ["auth /chat"]
     assert calls["seed"] == [("key-obj", "gpt-4o")]
 
-    _reset_runtime_cache()
-
 
 def test_resolve_wires_up_logger_when_importable(monkeypatch):
     """When the OTel logger is importable, ``_resolve`` caches its callables.
@@ -115,5 +120,3 @@ def test_resolve_wires_up_logger_when_importable(monkeypatch):
         "seed": ("key-obj", "claude-3-5"),
         "phase": "auth /v1/chat/completions",
     }
-
-    _reset_runtime_cache()

--- a/tests/test_litellm/proxy/db/test_log_db_metrics.py
+++ b/tests/test_litellm/proxy/db/test_log_db_metrics.py
@@ -8,6 +8,9 @@ re-ran the import finder/loader machinery every time. The classification is now
 resolved once and degrades gracefully when prisma is absent.
 """
 
+import sys
+import types
+
 import httpx
 
 import litellm.proxy.db.log_db_metrics as m
@@ -39,17 +42,26 @@ def test_exception_types_resolved_once_and_cached():
     assert httpx.TimeoutException in first
 
 
-def test_prisma_error_classified_as_db_when_available():
+def test_prisma_error_classified_as_db_when_available(monkeypatch):
+    """With prisma installed, ``PrismaError`` is treated as a DB failure.
+
+    prisma is optional and absent in this environment, so inject a fake
+    ``prisma.errors`` module to exercise the import-success branch deterministically.
+    """
+
+    class FakePrismaError(Exception):
+        pass
+
+    fake_errors = types.ModuleType("prisma.errors")
+    fake_errors.PrismaError = FakePrismaError
+    fake_prisma = types.ModuleType("prisma")
+    fake_prisma.errors = fake_errors
+    monkeypatch.setitem(sys.modules, "prisma", fake_prisma)
+    monkeypatch.setitem(sys.modules, "prisma.errors", fake_errors)
+
     _reset_cache()
-    try:
-        from prisma.errors import PrismaError
-    except Exception:
-        import pytest
+    assert FakePrismaError in m._db_exception_types_cached()
+    assert m._is_exception_related_to_db(FakePrismaError()) is True
+    assert m._is_exception_related_to_db(httpx.ConnectError("x")) is True
 
-        pytest.skip("prisma not installed")
-
-    class _FakePrismaError(PrismaError):
-        def __init__(self):
-            pass
-
-    assert m._is_exception_related_to_db(_FakePrismaError()) is True
+    _reset_cache()

--- a/tests/test_litellm/proxy/db/test_log_db_metrics.py
+++ b/tests/test_litellm/proxy/db/test_log_db_metrics.py
@@ -1,0 +1,55 @@
+"""Regression tests for ``litellm.proxy.db.log_db_metrics`` exception classification.
+
+``_is_exception_related_to_db`` runs inside the DB failure handler on the request
+path. It used to ``from prisma.errors import PrismaError`` on every call; prisma
+is an optional dependency, so on a proxy without it that import raised
+``ImportError`` straight out of the failure handler (masking the real error) and
+re-ran the import finder/loader machinery every time. The classification is now
+resolved once and degrades gracefully when prisma is absent.
+"""
+
+import httpx
+
+import litellm.proxy.db.log_db_metrics as m
+
+
+def _reset_cache():
+    m._db_exception_types = None
+
+
+def test_httpx_connection_errors_classified_as_db():
+    _reset_cache()
+    assert m._is_exception_related_to_db(httpx.ConnectError("boom")) is True
+    assert m._is_exception_related_to_db(httpx.TimeoutException("slow")) is True
+
+
+def test_non_db_exception_returns_false_without_raising():
+    _reset_cache()
+    # Must not raise even when prisma is not installed.
+    assert m._is_exception_related_to_db(ValueError("nope")) is False
+    assert m._is_exception_related_to_db(KeyError("nope")) is False
+
+
+def test_exception_types_resolved_once_and_cached():
+    _reset_cache()
+    first = m._db_exception_types_cached()
+    second = m._db_exception_types_cached()
+    assert first is second
+    assert httpx.ConnectError in first
+    assert httpx.TimeoutException in first
+
+
+def test_prisma_error_classified_as_db_when_available():
+    _reset_cache()
+    try:
+        from prisma.errors import PrismaError
+    except Exception:
+        import pytest
+
+        pytest.skip("prisma not installed")
+
+    class _FakePrismaError(PrismaError):
+        def __init__(self):
+            pass
+
+    assert m._is_exception_related_to_db(_FakePrismaError()) is True

--- a/tests/test_litellm/proxy/db/test_log_db_metrics.py
+++ b/tests/test_litellm/proxy/db/test_log_db_metrics.py
@@ -12,6 +12,7 @@ import sys
 import types
 
 import httpx
+import pytest
 
 import litellm.proxy.db.log_db_metrics as m
 
@@ -20,21 +21,25 @@ def _reset_cache():
     m._db_exception_types = None
 
 
-def test_httpx_connection_errors_classified_as_db():
+@pytest.fixture(autouse=True)
+def _isolate_exception_type_cache():
     _reset_cache()
+    yield
+    _reset_cache()
+
+
+def test_httpx_connection_errors_classified_as_db():
     assert m._is_exception_related_to_db(httpx.ConnectError("boom")) is True
     assert m._is_exception_related_to_db(httpx.TimeoutException("slow")) is True
 
 
 def test_non_db_exception_returns_false_without_raising():
-    _reset_cache()
     # Must not raise even when prisma is not installed.
     assert m._is_exception_related_to_db(ValueError("nope")) is False
     assert m._is_exception_related_to_db(KeyError("nope")) is False
 
 
 def test_exception_types_resolved_once_and_cached():
-    _reset_cache()
     first = m._db_exception_types_cached()
     second = m._db_exception_types_cached()
     assert first is second
@@ -59,9 +64,6 @@ def test_prisma_error_classified_as_db_when_available(monkeypatch):
     monkeypatch.setitem(sys.modules, "prisma", fake_prisma)
     monkeypatch.setitem(sys.modules, "prisma.errors", fake_errors)
 
-    _reset_cache()
     assert FakePrismaError in m._db_exception_types_cached()
     assert m._is_exception_related_to_db(FakePrismaError()) is True
     assert m._is_exception_related_to_db(httpx.ConnectError("x")) is True
-
-    _reset_cache()


### PR DESCRIPTION
## Relevant issues

Improves RPS and overhead latency for non-streaming `POST /chat/completions` and `POST /v1/messages`

## Linear ticket

Resolves LIT-3540
Resolves LIT-3314

## What this changes

Profiling the proxy under load (py-spy) showed a large slice of per-request CPU going into Python's import finder/loader machinery on the request hot path. Two optional-dependency imports were being attempted on every request inside `try/except` blocks. A failed import is never recorded in `sys.modules`, so Python re-runs the entire finder/loader chain on each call; on a proxy without the OTel SDK (and without prisma) that is hundreds of microseconds burned per request.

`litellm/integrations/otel/runtime.py`: `phase_span` and `seed_request_identity` (auth calls one of each per request) did `from litellm.integrations.otel.logger import ...` on every call. Measured at ~298us per failed import, ~0.6ms per request combined. They now resolve the import once and cache the callables, or a disabled sentinel when the SDK is absent.

`litellm/proxy/db/log_db_metrics.py`: `_is_exception_related_to_db` did `from prisma.errors import PrismaError` on every handled DB exception. With prisma absent this re-ran the import machinery and raised `ImportError` straight out of the failure handler, masking the real error. It now resolves the DB exception-type tuple once and degrades gracefully when prisma is not installed (a genuine correctness fix on top of the perf win).

## Benchmark setup

Single-worker uvicorn so the measurement is CPU-bound on one event loop (this is the regime where per-request overhead maps directly to RPS; at concurrency 64 the baseline RPS equals concurrency-1 RPS, confirming the proxy is CPU-bound and `RPS ~= 1000 / overhead_ms`). A mock model (`mock_response` in the deployment) isolates proxy overhead from provider network latency. Load generated with an aiohttp client. Numbers are the mean of two 10s runs each, measured A/B on the same box by stashing/unstashing the change.

Overhead latency is the mean request latency at concurrency 1 (no queueing), i.e. the pure per-request work the proxy adds.

## RPS and Overhead latency, before vs after

| Endpoint | Metric | Before | After | Delta |
|---|---|---:|---:|---:|
| /chat/completions | RPS (conc 1) | 190.5 | 233.2 | +22.4% |
| /chat/completions | Overhead latency (conc 1) | 5.25 ms | 4.28 ms | -18.5% |
| /chat/completions | RPS (conc 64) | 213.4 | 249.6 | +17.0% |
| /v1/messages | RPS (conc 1) | 175.0 | 210.4 | +20.2% |
| /v1/messages | Overhead latency (conc 1) | 5.71 ms | 4.75 ms | -16.8% |
| /v1/messages | RPS (conc 64) | 185.5 | 222.6 | +20.0% |

## Flamegraph

py-spy flamegraphs captured under sustained `/chat/completions` load at concurrency 32. The import frames that dominated per-request overhead drop to zero after the change:

| Frame | Before (% samples) | After (% samples) |
|---|---:|---:|
| `phase_span` (otel/runtime) | 8.1% | 0.0% |
| `seed_request_identity` (otel/runtime) | 6.0% | 0.0% |
| `_is_exception_related_to_db` | 2.3% | 0.0% |
| `_handle_logging_db_exception` | 2.3% | 0.1% |

Before and after SVG flamegraphs are attached below.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Type

🚄 Infrastructure

## Changes

`litellm/integrations/otel/runtime.py` and `litellm/proxy/db/log_db_metrics.py` resolve their optional imports once and cache the result. Regression tests in `tests/test_litellm/integrations/otel/test_otel_runtime.py` and `tests/test_litellm/proxy/db/test_log_db_metrics.py` assert the logger import is attempted at most once across many calls and that DB-exception classification no longer raises when prisma is absent; both fail on the pre-change code.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RuBwwU7NjrGt7MDvQGAGaY)_