### PR TITLE
fix(proxy): harden request-body/metadata/header trust boundary against param injection

### DIFF
--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -304,6 +304,13 @@ _BANNED_REQUEST_BODY_PARAMS: Tuple[str, ...] = (
     "aws_profile_name",
     "base_model",
     "oci_key_file",
+    # OCI serving-mode / endpoint / compartment selectors are read off
+    # optional_params by the OCI transform; a client could flip the serving mode
+    # to DEDICATED and retarget the served model/endpoint, or point at another
+    # compartment, using the operator's stored OCI credentials.
+    "oci_serving_mode",
+    "oci_endpoint_id",
+    "oci_compartment_id",
     # Observability credentials, hosts, and project identifiers: derived
     # from the canonical ``_supported_callback_params`` allowlist so new
     # integrations are covered automatically. Sorted for stable iteration

--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -105,9 +105,15 @@ def check_complete_credentials(request_body: dict) -> bool:
 
 def check_regex_or_str_match(request_body_value: Any, regex_str: str) -> bool:
     """
-    Check if request_body_value matches the regex_str or is equal to param
+    Check if request_body_value matches the regex_str or is equal to param.
+
+    Uses ``re.fullmatch`` (not ``re.match``): an unanchored match lets an
+    admin allowlist entry like ``https://api\\.openai\\.com`` accept
+    ``https://api.openai.com.attacker.com/...`` (the regex only had to match a
+    prefix), turning the clientside-``api_base`` opt-in into an SSRF /
+    credential-exfil bypass. The full value must match.
     """
-    if re.match(regex_str, request_body_value) or regex_str == request_body_value:
+    if re.fullmatch(regex_str, request_body_value) or regex_str == request_body_value:
         return True
     return False
 
@@ -177,7 +183,15 @@ def _allow_model_level_clientside_configurable_parameters(
 # ``extra_body.aws_web_identity_token``) without re-validating, so the
 # banned-key check has to descend into it the same way it descends into
 # ``litellm_embedding_config``.
-_NESTED_CONFIG_KEYS: Tuple[str, ...] = ("litellm_embedding_config", "extra_body")
+_NESTED_CONFIG_KEYS: Tuple[str, ...] = (
+    "litellm_embedding_config",
+    "extra_body",
+    # Merged into the outbound request by the Gemini/Vertex Agents endpoints
+    # (``data.pop("litellm_params_template")`` spread over ``data`` for any key
+    # not already present), so an ``api_base`` smuggled here reaches the
+    # handler unvalidated the same way ``extra_body`` does.
+    "litellm_params_template",
+)
 
 # Metadata containers that carry per-request configuration consumed by the
 # observability callbacks. The same banned-param list applies — a value
@@ -279,6 +293,30 @@ _BANNED_REQUEST_BODY_PARAMS: Tuple[str, ...] = (
     "s3_endpoint_url",
     "sagemaker_base_url",
     "deployment_url",
+    # Routing / credential-selection / config-shaped fields a client must not
+    # supply: each retargets the request to another tenant's deployment, swaps
+    # in a server-side credential, or smuggles config past the model-authz layer.
+    #  - ``model_list``: array of deployment dicts (own ``litellm_params``/
+    #    ``api_base``) processed by batch_completion, smuggling arbitrary
+    #    deployments past authorization (only the root ``model`` is authorized).
+    #  - ``vertex_ai_credentials``: alias of the already-banned
+    #    ``vertex_credentials``; the ``external_account`` ``executable``
+    #    credential source is an RCE sink.
+    #  - ``vertex_project``: selects the GCP project the proxy SA acts on
+    #    (cross-tenant impersonation).
+    #  - ``litellm_credential_name``: resolves a globally-stored credential by
+    #    name with no ownership model.
+    #  - ``aws_profile_name``: selects a server-side AWS profile/credential.
+    #  - ``base_model``: redirects the cost-lookup model (spend spoofing).
+    #  - ``oci_key_file``: a server file path the OCI handler opens and reads
+    #    unbounded (arbitrary-file-path DoS).
+    "model_list",
+    "vertex_ai_credentials",
+    "vertex_project",
+    "litellm_credential_name",
+    "aws_profile_name",
+    "base_model",
+    "oci_key_file",
     # Observability credentials, hosts, and project identifiers: derived
     # from the canonical ``_supported_callback_params`` allowlist so new
     # integrations are covered automatically. Sorted for stable iteration
@@ -368,6 +406,18 @@ def is_request_body_safe(
         metadata = _coerce_metadata_to_dict(request_body.get(metadata_key))
         if metadata is not None:
             _check_banned_params(metadata, general_settings, llm_router, model)
+    # Each entry in ``tools`` is a caller-supplied dict; provider integrations
+    # (e.g. the Advisor orchestration tool) read endpoint/credential fields
+    # straight off the tool object (``tool["api_base"]``) without re-validating,
+    # so an ``api_base`` smuggled here is an SSRF / master-key-exfil primitive.
+    # Check each tool object the same way — one level, no descent into the
+    # JSON-schema ``function.parameters`` where an ``api_base`` is just data.
+    tools = request_body.get("tools")
+    if isinstance(tools, list):
+        for tool in tools:
+            tool_dict = _coerce_metadata_to_dict(tool)
+            if tool_dict is not None:
+                _check_banned_params(tool_dict, general_settings, llm_router, model)
     return True
 
 

--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -295,21 +295,8 @@ _BANNED_REQUEST_BODY_PARAMS: Tuple[str, ...] = (
     "deployment_url",
     # Routing / credential-selection / config-shaped fields a client must not
     # supply: each retargets the request to another tenant's deployment, swaps
-    # in a server-side credential, or smuggles config past the model-authz layer.
-    #  - ``model_list``: array of deployment dicts (own ``litellm_params``/
-    #    ``api_base``) processed by batch_completion, smuggling arbitrary
-    #    deployments past authorization (only the root ``model`` is authorized).
-    #  - ``vertex_ai_credentials``: alias of the already-banned
-    #    ``vertex_credentials``; the ``external_account`` ``executable``
-    #    credential source is an RCE sink.
-    #  - ``vertex_project``: selects the GCP project the proxy SA acts on
-    #    (cross-tenant impersonation).
-    #  - ``litellm_credential_name``: resolves a globally-stored credential by
-    #    name with no ownership model.
-    #  - ``aws_profile_name``: selects a server-side AWS profile/credential.
-    #  - ``base_model``: redirects the cost-lookup model (spend spoofing).
-    #  - ``oci_key_file``: a server file path the OCI handler opens and reads
-    #    unbounded (arbitrary-file-path DoS).
+    # in a server-side credential, or smuggles config past the model-authz layer
+    # (vertex_ai_credentials is the alias of the already-banned vertex_credentials).
     "model_list",
     "vertex_ai_credentials",
     "vertex_project",
@@ -324,6 +311,9 @@ _BANNED_REQUEST_BODY_PARAMS: Tuple[str, ...] = (
     *sorted(_build_banned_observability_params()),
     *sorted(CustomPricingLiteLLMParams.model_fields.keys()),
 )
+# Membership set for the per-request check, which iterates the (small) body
+# keys against it rather than scanning the (large, still-growing) ban list.
+_BANNED_REQUEST_BODY_PARAMS_SET: FrozenSet[str] = frozenset(_BANNED_REQUEST_BODY_PARAMS)
 
 
 def _check_banned_params(
@@ -337,12 +327,11 @@ def _check_banned_params(
     Shared between the root-level check and the nested-config check so a
     new banned param only needs to be added in one place.
     """
-    for param in _BANNED_REQUEST_BODY_PARAMS:
-        if param not in body:
+    for param in body:
+        if param not in _BANNED_REQUEST_BODY_PARAMS_SET:
             continue
         if general_settings.get("allow_client_side_credentials") is True:
-            # Proxy-wide opt-in: every banned param is permitted, exit
-            # entirely so the rest of the loop doesn't waste work.
+            # Proxy-wide opt-in: every banned param is permitted.
             return
         if (
             _allow_model_level_clientside_configurable_parameters(
@@ -353,11 +342,9 @@ def _check_banned_params(
             )
             is True
         ):
-            # Per-param opt-in: only THIS param is permitted by the
-            # deployment's ``configurable_clientside_auth_params``. Skip
-            # to the next banned param so a body that pairs an allowed
-            # ``api_base`` with an unallowed ``langfuse_host`` is still
-            # rejected for the second field.
+            # Per-param opt-in via the deployment's
+            # ``configurable_clientside_auth_params``: only THIS param is
+            # permitted, so keep checking the remaining body keys.
             continue
         raise ValueError(
             f"Rejected Request: {param} is not allowed in request body. "
@@ -398,20 +385,14 @@ def is_request_body_safe(
     recursion-depth DoS surface.
     """
     _check_banned_params(request_body, general_settings, llm_router, model)
-    for nested_key in _NESTED_CONFIG_KEYS:
+    for nested_key in (*_NESTED_CONFIG_KEYS, *_NESTED_METADATA_KEYS):
         nested = _coerce_metadata_to_dict(request_body.get(nested_key))
         if nested is not None:
             _check_banned_params(nested, general_settings, llm_router, model)
-    for metadata_key in _NESTED_METADATA_KEYS:
-        metadata = _coerce_metadata_to_dict(request_body.get(metadata_key))
-        if metadata is not None:
-            _check_banned_params(metadata, general_settings, llm_router, model)
-    # Each entry in ``tools`` is a caller-supplied dict; provider integrations
-    # (e.g. the Advisor orchestration tool) read endpoint/credential fields
-    # straight off the tool object (``tool["api_base"]``) without re-validating,
-    # so an ``api_base`` smuggled here is an SSRF / master-key-exfil primitive.
-    # Check each tool object the same way — one level, no descent into the
-    # JSON-schema ``function.parameters`` where an ``api_base`` is just data.
+    # Each ``tools`` entry is a caller-supplied dict that integrations (e.g. the
+    # Advisor tool) read endpoint/credential fields straight off of, so check
+    # each one level deep — not into ``function.parameters``, where an
+    # ``api_base`` is just schema data.
     tools = request_body.get("tools")
     if isinstance(tools, list):
         for tool in tools:

--- a/litellm/proxy/google_endpoints/agents_endpoints.py
+++ b/litellm/proxy/google_endpoints/agents_endpoints.py
@@ -15,17 +15,22 @@ These are distinct from the A2A agent registry at /v1/agents.
 """
 
 import json
+from typing import TYPE_CHECKING, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from fastapi.responses import ORJSONResponse
 
 from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+from litellm.proxy.auth.auth_utils import is_request_body_safe
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 from litellm.proxy.common_request_processing import ProxyBaseLLMRequestProcessing
 from litellm.proxy.common_utils.http_parsing_utils import (
     _read_request_body,
     _safe_get_request_query_params,
 )
+
+if TYPE_CHECKING:
+    from litellm.router import Router
 
 router = APIRouter(tags=["gemini managed agents"])
 
@@ -69,7 +74,12 @@ def _enforce_caller_supplied_provider_key(
     )
 
 
-def _merge_query_params_into_data(data: dict, request: Request) -> dict:
+def _merge_query_params_into_data(
+    data: dict,
+    request: Request,
+    general_settings: dict,
+    llm_router: Optional["Router"],
+) -> dict:
     """
     For GET/DELETE endpoints that cannot carry a JSON body, read a
     JSON-encoded ``litellm_params_template`` query parameter and merge its
@@ -106,6 +116,21 @@ def _merge_query_params_into_data(data: dict, request: Request) -> dict:
         except (json.JSONDecodeError, ValueError):
             template = {}
         if isinstance(template, dict):
+            # This template skips the auth-time is_request_body_safe() bouncer
+            # that guards POST bodies, so a banned param smuggled here (e.g.
+            # api_base alongside litellm_credential_name) would otherwise reach
+            # the agents client unchecked. Apply the same gate before merging;
+            # legitimate per-request fields like api_key / custom_llm_provider
+            # are not on the blocklist and still pass through.
+            try:
+                is_request_body_safe(
+                    request_body=template,
+                    general_settings=general_settings,
+                    llm_router=llm_router,
+                    model="",
+                )
+            except ValueError as e:
+                raise HTTPException(status_code=400, detail={"error": str(e)})
             for key, value in template.items():
                 data.setdefault(key, value)
 
@@ -239,7 +264,9 @@ async def list_gemini_agents(
     """
     srv = _proxy_server_imports()
     data: dict = {"custom_llm_provider": "gemini"}
-    _merge_query_params_into_data(data, request)
+    _merge_query_params_into_data(
+        data, request, srv["general_settings"], srv["llm_router"]
+    )
     _enforce_caller_supplied_provider_key(data, user_api_key_dict)
 
     processor = ProxyBaseLLMRequestProcessing(data=data)
@@ -297,7 +324,9 @@ async def get_gemini_agent(
     """
     srv = _proxy_server_imports()
     data = {"name": name, "custom_llm_provider": "gemini"}
-    _merge_query_params_into_data(data, request)
+    _merge_query_params_into_data(
+        data, request, srv["general_settings"], srv["llm_router"]
+    )
     _enforce_caller_supplied_provider_key(data, user_api_key_dict)
 
     processor = ProxyBaseLLMRequestProcessing(data=data)
@@ -355,7 +384,9 @@ async def delete_gemini_agent(
     """
     srv = _proxy_server_imports()
     data = {"name": name, "custom_llm_provider": "gemini"}
-    _merge_query_params_into_data(data, request)
+    _merge_query_params_into_data(
+        data, request, srv["general_settings"], srv["llm_router"]
+    )
     _enforce_caller_supplied_provider_key(data, user_api_key_dict)
 
     processor = ProxyBaseLLMRequestProcessing(data=data)
@@ -413,7 +444,9 @@ async def list_gemini_agent_versions(
     """
     srv = _proxy_server_imports()
     data = {"name": name, "custom_llm_provider": "gemini"}
-    _merge_query_params_into_data(data, request)
+    _merge_query_params_into_data(
+        data, request, srv["general_settings"], srv["llm_router"]
+    )
     _enforce_caller_supplied_provider_key(data, user_api_key_dict)
 
     processor = ProxyBaseLLMRequestProcessing(data=data)

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -140,6 +140,25 @@ _UNTRUSTED_ROOT_CONTROL_FIELDS = (
     "service_callback",
     "logger_fn",
     "litellm_disabled_callbacks",
+    # ``success_callback`` / ``failure_callback`` from the request body register
+    # a dynamic logging callback (e.g. a Langsmith/Langfuse base_url the proxy
+    # then POSTs prompts+responses to) — request-payload exfil. The legitimate
+    # values are set from key/team config later in this pipeline, so the
+    # client-supplied ones are stripped here.
+    "success_callback",
+    "failure_callback",
+    # ``cache_key`` lets a caller pin the cache slot and write an attacker
+    # response under another tenant's predictable key (cross-tenant poisoning).
+    # The proxy derives the key deterministically; a client must not supply it.
+    "cache_key",
+    # ``model_group_retry_policy`` is coerced into a RetryPolicy with unbounded
+    # retry counts → request amplification / cost drain. Config-only.
+    "model_group_retry_policy",
+    # ``deployment_id`` (Azure) / ``model_id`` (Bedrock) override the resolved
+    # target after the model-name authorization ran against ``model``; routing
+    # by them bypasses that gate, so a client must not supply them.
+    "deployment_id",
+    "model_id",
 )
 
 _UNTRUSTED_METADATA_CONTROL_FIELDS = (
@@ -161,6 +180,22 @@ _UNTRUSTED_METADATA_CONTROL_FIELDS = (
     "secret_fields",
     "_guardrail_pipelines",
     "_pipeline_managed_guardrails",
+    # ``standard_logging_guardrail_information`` in client metadata spoofs the
+    # recorded guardrail verdict (makes a blocked request look allowed in logs).
+    "standard_logging_guardrail_information",
+    # ``usage_object`` overwrites the server-computed token counts, corrupting
+    # spend/analytics aggregates (and a non-dict value silently drops the row).
+    "usage_object",
+    # Internal rate-limiter stash sentinels (mirrors STASH_KEYS in
+    # litellm/proxy/hooks/parallel_request_limiter_v3.py). A client that injects
+    # these into metadata, then errors before the pre-call hook strips them, has
+    # the failure hook refund/replay another tenant's TPM reservation. Stripping
+    # at ingestion closes every channel, not just the pre-call path.
+    "_litellm_tpm_reserved_tokens",
+    "_litellm_tpm_reserved_model",
+    "_litellm_tpm_reserved_scopes",
+    "_litellm_tpm_reservation_released",
+    "_litellm_rate_limit_descriptors",
 )
 
 _UNTRUSTED_REQUEST_HEADER_CONTROL_FIELDS = frozenset(
@@ -173,6 +208,10 @@ _ALLOW_CLIENT_MOCK_RESPONSE_METADATA_KEY = "allow_client_mock_response"
 _ALLOW_CLIENT_MESSAGE_REDACTION_OPT_OUT_METADATA_KEY = (
     "allow_client_message_redaction_opt_out"
 )
+
+# Upper bound on a client-supplied ``x-litellm-num-retries``. Applied verbatim,
+# a large value amplifies one request into many upstream calls (cost/DoS).
+_MAX_CLIENT_NUM_RETRIES = 5
 
 # Per-request pricing parameters mutate cost-tracking output and (via
 # ``litellm.completion`` → ``register_model``) the process-wide
@@ -662,11 +701,20 @@ class LiteLLMProxyRequestSetup:
     def _get_num_retries_from_request(headers: dict) -> Optional[int]:
         """
         Workaround for client request from Vercel's AI SDK.
+
+        Clamped to ``[0, _MAX_CLIENT_NUM_RETRIES]``: the value was applied
+        verbatim, so a client could set ``x-litellm-num-retries`` to a huge
+        number and amplify one request into hundreds of thousands of upstream
+        calls (cost drain / DoS). A malformed (non-integer) value is ignored.
         """
         num_retries_header = headers.get("x-litellm-num-retries", None)
-        if num_retries_header is not None:
-            return int(num_retries_header)
-        return None
+        if num_retries_header is None:
+            return None
+        try:
+            requested = int(num_retries_header)
+        except (TypeError, ValueError):
+            return None
+        return max(0, min(requested, _MAX_CLIENT_NUM_RETRIES))
 
     @staticmethod
     def _get_spend_logs_metadata_from_request_headers(headers: dict) -> Optional[dict]:

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -148,6 +148,11 @@ _UNTRUSTED_ROOT_CONTROL_FIELDS = (
     # client-supplied ones are stripped here.
     "success_callback",
     "failure_callback",
+    # ``no-log`` is honored by default (only ``litellm.global_disable_no_log_param``
+    # turns it off) and suppresses every operator-configured audit/observability
+    # sink that isn't a ``_PROXY_`` cost callback; a client must not be able to
+    # silence the operator's logging for its own requests.
+    "no-log",
     # ``cache_key`` lets a caller pin the cache slot and write an attacker
     # response under another tenant's predictable key (cross-tenant poisoning).
     # The proxy derives the key deterministically; a client must not supply it.

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -13,6 +13,7 @@ from starlette.datastructures import Headers
 import litellm
 from litellm._logging import verbose_logger, verbose_proxy_logger
 from litellm._service_logger import ServiceLogging
+from litellm.constants import X_LITELLM_DISABLE_CALLBACKS
 from litellm.litellm_core_utils.credential_accessor import CredentialAccessor
 from litellm.litellm_core_utils.safe_json_loads import safe_json_loads
 from litellm.litellm_core_utils.url_utils import is_url_destination_allowed_by_host
@@ -199,9 +200,16 @@ _UNTRUSTED_METADATA_CONTROL_FIELDS = (
     *_LITELLM_STASH_KEYS,
 )
 
+_CLIENT_MESSAGE_REDACTION_HEADER = "litellm-disable-message-redaction"
+# ``x-litellm-disable-callbacks`` lets the caller switch off operator-configured
+# audit/observability callbacks for its own request (honored by default whenever
+# ``litellm.allow_dynamic_callback_disabling`` is set). The legitimate way to
+# disable callbacks is key/team metadata (``litellm_disabled_callbacks``); the
+# client-supplied header is an observability-bypass and is always stripped.
 _UNTRUSTED_REQUEST_HEADER_CONTROL_FIELDS = frozenset(
     {
-        "litellm-disable-message-redaction",
+        _CLIENT_MESSAGE_REDACTION_HEADER,
+        X_LITELLM_DISABLE_CALLBACKS,
     }
 )
 _CLIENT_MOCK_CONTROL_FIELDS = frozenset({"mock_response", "mock_tool_calls"})
@@ -288,13 +296,16 @@ def _strip_untrusted_request_header_controls(
         return
 
     for header_name in list(headers.keys()):
-        if (
-            isinstance(header_name, str)
-            and header_name.lower() in _UNTRUSTED_REQUEST_HEADER_CONTROL_FIELDS
+        if not isinstance(header_name, str):
+            continue
+        lowered = header_name.lower()
+        if lowered not in _UNTRUSTED_REQUEST_HEADER_CONTROL_FIELDS:
+            continue
+        if allow_client_message_redaction_opt_out and (
+            lowered == _CLIENT_MESSAGE_REDACTION_HEADER
         ):
-            if allow_client_message_redaction_opt_out:
-                continue
-            headers.pop(header_name, None)
+            continue
+        headers.pop(header_name, None)
 
 
 def _is_false_like(value: Any) -> bool:

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -30,6 +30,7 @@ from litellm.proxy.common_utils.callback_utils import (
     get_metadata_variable_name_from_kwargs,
 )
 from litellm.proxy.common_utils.http_parsing_utils import _safe_get_request_headers
+from litellm.proxy.hooks.parallel_request_limiter_v3 import _LITELLM_STASH_KEYS
 
 # Cache special headers as a frozenset for O(1) lookup performance
 _SPECIAL_HEADERS_CACHE = frozenset(
@@ -186,16 +187,11 @@ _UNTRUSTED_METADATA_CONTROL_FIELDS = (
     # ``usage_object`` overwrites the server-computed token counts, corrupting
     # spend/analytics aggregates (and a non-dict value silently drops the row).
     "usage_object",
-    # Internal rate-limiter stash sentinels (mirrors STASH_KEYS in
-    # litellm/proxy/hooks/parallel_request_limiter_v3.py). A client that injects
-    # these into metadata, then errors before the pre-call hook strips them, has
-    # the failure hook refund/replay another tenant's TPM reservation. Stripping
-    # at ingestion closes every channel, not just the pre-call path.
-    "_litellm_tpm_reserved_tokens",
-    "_litellm_tpm_reserved_model",
-    "_litellm_tpm_reserved_scopes",
-    "_litellm_tpm_reservation_released",
-    "_litellm_rate_limit_descriptors",
+    # Internal rate-limiter stash sentinels: a client that injects these into
+    # metadata, then errors before the pre-call hook strips them, has the failure
+    # hook refund/replay another tenant's TPM reservation. Stripping at ingestion
+    # closes every channel, not just the pre-call path.
+    *_LITELLM_STASH_KEYS,
 )
 
 _UNTRUSTED_REQUEST_HEADER_CONTROL_FIELDS = frozenset(
@@ -209,9 +205,20 @@ _ALLOW_CLIENT_MESSAGE_REDACTION_OPT_OUT_METADATA_KEY = (
     "allow_client_message_redaction_opt_out"
 )
 
-# Upper bound on a client-supplied ``x-litellm-num-retries``. Applied verbatim,
-# a large value amplifies one request into many upstream calls (cost/DoS).
+# Upper bound on a client-supplied num_retries (header or body). Applied
+# verbatim, a large value amplifies one request into many upstream calls (DoS).
 _MAX_CLIENT_NUM_RETRIES = 5
+
+
+def _clamp_client_num_retries(value: Any) -> Optional[int]:
+    """Clamp a client-supplied num_retries to ``[0, _MAX_CLIENT_NUM_RETRIES]``;
+    return None if it isn't a valid integer."""
+    try:
+        requested = int(value)
+    except (TypeError, ValueError):
+        return None
+    return max(0, min(requested, _MAX_CLIENT_NUM_RETRIES))
+
 
 # Per-request pricing parameters mutate cost-tracking output and (via
 # ``litellm.completion`` → ``register_model``) the process-wide
@@ -710,11 +717,7 @@ class LiteLLMProxyRequestSetup:
         num_retries_header = headers.get("x-litellm-num-retries", None)
         if num_retries_header is None:
             return None
-        try:
-            requested = int(num_retries_header)
-        except (TypeError, ValueError):
-            return None
-        return max(0, min(requested, _MAX_CLIENT_NUM_RETRIES))
+        return _clamp_client_num_retries(num_retries_header)
 
     @staticmethod
     def _get_spend_logs_metadata_from_request_headers(headers: dict) -> Optional[dict]:
@@ -1346,6 +1349,14 @@ async def add_litellm_data_to_request(  # noqa: PLR0915
         if _allow_client_mock_response and _internal_key in _CLIENT_MOCK_CONTROL_FIELDS:
             continue
         data.pop(_internal_key, None)
+    # A body-supplied ``num_retries`` bypasses the header clamp but still reaches
+    # the router via ``**data``; clamp it here (drop if non-integer).
+    if data.get("num_retries") is not None:
+        _clamped_retries = _clamp_client_num_retries(data["num_retries"])
+        if _clamped_retries is None:
+            data.pop("num_retries", None)
+        else:
+            data["num_retries"] = _clamped_retries
     _reject_url_valued_destinations(data)
     # Strip spoofable auth metadata from user-supplied metadata dict
     _user_metadata = data.get("metadata")

--- a/tests/proxy_unit_tests/test_gemini_agents_endpoints.py
+++ b/tests/proxy_unit_tests/test_gemini_agents_endpoints.py
@@ -3,9 +3,11 @@ Unit tests for litellm/proxy/google_endpoints/agents_endpoints.py
 
 Focus: verify that list_gemini_agents, get_gemini_agent, delete_gemini_agent,
 and list_gemini_agent_versions correctly forward per-request credentials
-(api_key, api_base, …) supplied via the JSON-encoded litellm_params_template
-query parameter.  Flat credential query params (e.g. ?api_key=…) are no
-longer accepted — they would appear in server logs.
+(e.g. api_key) supplied via the JSON-encoded litellm_params_template query
+parameter.  Endpoint-targeting / credential-selection params (api_base,
+litellm_credential_name, vertex_project, …) are rejected by the same
+banned-param gate that guards POST bodies.  Flat credential query params
+(e.g. ?api_key=…) are not accepted — they would appear in server logs.
 """
 
 import json
@@ -22,7 +24,6 @@ sys.path.insert(0, os.path.abspath("../.."))
 from litellm.proxy.google_endpoints.agents_endpoints import (
     _merge_query_params_into_data,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -46,14 +47,18 @@ class TestMergeQueryParamsIntoData:
     def test_no_query_params_leaves_data_unchanged(self):
         data = {"custom_llm_provider": "gemini"}
         request = _make_request("")
-        result = _merge_query_params_into_data(data, request)
+        result = _merge_query_params_into_data(
+            data, request, general_settings={}, llm_router=None
+        )
         assert result == {"custom_llm_provider": "gemini"}
 
     def test_flat_api_key_is_ignored(self):
         """Flat credential params must NOT be merged (they leak into server logs)."""
         data = {"custom_llm_provider": "gemini"}
         request = _make_request("api_key=AIzaSyTest123")
-        _merge_query_params_into_data(data, request)
+        _merge_query_params_into_data(
+            data, request, general_settings={}, llm_router=None
+        )
         assert "api_key" not in data
         assert data["custom_llm_provider"] == "gemini"
 
@@ -61,23 +66,44 @@ class TestMergeQueryParamsIntoData:
         """Flat params (including name injection attempts) are ignored entirely."""
         data = {"name": "my-agent", "custom_llm_provider": "gemini"}
         request = _make_request("name=INJECTED&api_key=AIzaSyTest")
-        _merge_query_params_into_data(data, request)
+        _merge_query_params_into_data(
+            data, request, general_settings={}, llm_router=None
+        )
         assert data["name"] == "my-agent"
         assert "api_key" not in data
 
     def test_litellm_params_template_json_is_expanded(self):
-        template = json.dumps(
-            {"api_key": "AIzaFromTemplate", "api_base": "https://example.com"}
-        )
+        """An allowed field in the JSON template expands into data; the raw
+        template key itself never leaks through."""
+        template = json.dumps({"api_key": "AIzaFromTemplate"})
         from urllib.parse import quote
 
         request = _make_request(f"litellm_params_template={quote(template)}")
         data = {"custom_llm_provider": "gemini"}
-        _merge_query_params_into_data(data, request)
+        _merge_query_params_into_data(
+            data, request, general_settings={}, llm_router=None
+        )
         assert data["api_key"] == "AIzaFromTemplate"
-        assert data["api_base"] == "https://example.com"
         # The raw template key itself must NOT appear in data
         assert "litellm_params_template" not in data
+
+    def test_litellm_params_template_banned_key_is_rejected(self):
+        """An endpoint-targeting field smuggled via the query template (the
+        api_base + named-credential SSRF/exfil vector) is rejected with a 400
+        and never merged into data."""
+        from fastapi import HTTPException
+
+        template = json.dumps({"api_base": "https://attacker.example", "api_key": "x"})
+        from urllib.parse import quote
+
+        request = _make_request(f"litellm_params_template={quote(template)}")
+        data = {"custom_llm_provider": "gemini"}
+        with pytest.raises(HTTPException) as exc_info:
+            _merge_query_params_into_data(
+                data, request, general_settings={}, llm_router=None
+            )
+        assert exc_info.value.status_code == 400
+        assert "api_base" not in data
 
     def test_litellm_params_template_does_not_overwrite_existing(self):
         template = json.dumps(
@@ -87,7 +113,9 @@ class TestMergeQueryParamsIntoData:
 
         request = _make_request(f"litellm_params_template={quote(template)}")
         data = {"custom_llm_provider": "gemini"}
-        _merge_query_params_into_data(data, request)
+        _merge_query_params_into_data(
+            data, request, general_settings={}, llm_router=None
+        )
         # custom_llm_provider was already set; template must not override it
         assert data["custom_llm_provider"] == "gemini"
         assert data["api_key"] == "FromTemplate"
@@ -95,7 +123,9 @@ class TestMergeQueryParamsIntoData:
     def test_invalid_litellm_params_template_json_is_ignored(self):
         request = _make_request("litellm_params_template=NOT_VALID_JSON")
         data = {"custom_llm_provider": "gemini"}
-        _merge_query_params_into_data(data, request)
+        _merge_query_params_into_data(
+            data, request, general_settings={}, llm_router=None
+        )
         # Bad JSON is silently skipped; other data stays intact
         assert data == {"custom_llm_provider": "gemini"}
 
@@ -107,7 +137,9 @@ class TestMergeQueryParamsIntoData:
         qs = f"litellm_params_template={quote(template)}&vertex_project=my-project"
         request = _make_request(qs)
         data = {"custom_llm_provider": "gemini"}
-        _merge_query_params_into_data(data, request)
+        _merge_query_params_into_data(
+            data, request, general_settings={}, llm_router=None
+        )
         assert data["api_key"] == "FromTemplate"
         # flat vertex_project is ignored since it wasn't in litellm_params_template
         assert "vertex_project" not in data
@@ -318,11 +350,11 @@ async def test_get_gemini_agent_name_not_overwritten_by_query_param(
 
 @pytest.mark.asyncio
 async def test_list_agents_template_via_query_param(mock_srv, user_api_key_dict):
-    """litellm_params_template in query string is expanded."""
+    """litellm_params_template in query string is expanded (allowed fields)."""
     from litellm.proxy.google_endpoints.agents_endpoints import list_gemini_agents
     from urllib.parse import quote
 
-    template = json.dumps({"api_key": "TemplateKey", "vertex_project": "proj-x"})
+    template = json.dumps({"api_key": "TemplateKey"})
 
     with patch(
         "litellm.proxy.google_endpoints.agents_endpoints.ProxyBaseLLMRequestProcessing"
@@ -339,7 +371,6 @@ async def test_list_agents_template_via_query_param(mock_srv, user_api_key_dict)
 
         init_data = MockProcessor.call_args[1]["data"]
         assert init_data["api_key"] == "TemplateKey"
-        assert init_data["vertex_project"] == "proj-x"
         assert "litellm_params_template" not in init_data
 
 

--- a/tests/test_litellm/proxy/auth/test_banned_params_extra_body.py
+++ b/tests/test_litellm/proxy/auth/test_banned_params_extra_body.py
@@ -94,3 +94,110 @@ def test_banned_param_under_stringified_extra_body_is_rejected():
             llm_router=None,
             model="bedrock/anthropic.claude-v2",
         )
+
+
+# --- Cluster: nested-container + alias + regex-anchor hardening ---
+
+from litellm.proxy.auth.auth_utils import check_regex_or_str_match  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    "banned_param",
+    [
+        "model_list",  # deployment-dict smuggling past model authz
+        "vertex_ai_credentials",  # alias of vertex_credentials (executable-cred RCE sink)
+        "vertex_project",  # cross-tenant project impersonation
+        "litellm_credential_name",  # globally-stored credential by name, no ownership
+        "aws_profile_name",  # server-side AWS profile selection
+        "base_model",  # cost-lookup model spoofing
+        "oci_key_file",  # arbitrary server file path read (DoS)
+    ],
+)
+def test_newly_banned_root_param_is_rejected(banned_param):
+    body = {
+        "model": "openai/gpt-4",
+        "messages": [{"role": "user", "content": "x"}],
+        banned_param: "attacker-chosen",
+    }
+    with pytest.raises(ValueError, match="not allowed in request body"):
+        is_request_body_safe(
+            request_body=body,
+            general_settings={},
+            llm_router=None,
+            model="openai/gpt-4",
+        )
+
+
+def test_banned_param_under_litellm_params_template_is_rejected():
+    # The Gemini/Vertex Agents endpoints spread litellm_params_template into the
+    # outbound request, so an api_base smuggled there must be caught.
+    body = {
+        "model": "gemini/gemini-1.5-pro",
+        "messages": [{"role": "user", "content": "x"}],
+        "litellm_params_template": {
+            "api_base": "http://169.254.169.254/",
+            "api_key": "dummy",
+        },
+    }
+    with pytest.raises(ValueError, match="not allowed in request body"):
+        is_request_body_safe(
+            request_body=body,
+            general_settings={},
+            llm_router=None,
+            model="gemini/gemini-1.5-pro",
+        )
+
+
+def test_banned_param_in_a_tool_object_is_rejected():
+    # The Advisor orchestration tool reads api_base straight off the tool dict;
+    # an attacker endpoint there exfiltrates the proxy's provider key.
+    body = {
+        "model": "anthropic/claude-3-5-sonnet",
+        "messages": [{"role": "user", "content": "x"}],
+        "tools": [{"type": "advisor_20260301", "api_base": "https://attacker.example"}],
+    }
+    with pytest.raises(ValueError, match="not allowed in request body"):
+        is_request_body_safe(
+            request_body=body,
+            general_settings={},
+            llm_router=None,
+            model="anthropic/claude-3-5-sonnet",
+        )
+
+
+def test_legit_function_tool_with_api_base_param_is_allowed():
+    # A real function tool whose JSON-schema parameters happen to define an
+    # "api_base" property is data, not a top-level override — must NOT be rejected.
+    body = {
+        "model": "openai/gpt-4",
+        "messages": [{"role": "user", "content": "x"}],
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "fetch",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"api_base": {"type": "string"}},
+                    },
+                },
+            }
+        ],
+    }
+    assert is_request_body_safe(
+        request_body=body,
+        general_settings={},
+        llm_router=None,
+        model="openai/gpt-4",
+    )
+
+
+def test_clientside_api_base_regex_is_fully_anchored():
+    # An allowlist regex must match the WHOLE value: a prefix-only match would
+    # accept a look-alike host with an attacker suffix.
+    allow = r"https://api\.openai\.com"
+    assert check_regex_or_str_match("https://api.openai.com", allow) is True
+    assert (
+        check_regex_or_str_match("https://api.openai.com.attacker.com/v1", allow)
+        is False
+    )

--- a/tests/test_litellm/proxy/auth/test_banned_params_extra_body.py
+++ b/tests/test_litellm/proxy/auth/test_banned_params_extra_body.py
@@ -74,6 +74,24 @@ def test_admin_opt_in_still_permits_extra_body_credentials():
     )
 
 
+def test_admin_opt_in_still_permits_oci_routing_params():
+    # The OCI serving-mode/endpoint/compartment selectors are banned by default
+    # but, like every other credential/routing field, remain available behind the
+    # ``allow_client_side_credentials`` admin opt-in.
+    body = {
+        "model": "oci/some-model",
+        "messages": [{"role": "user", "content": "x"}],
+        "oci_serving_mode": "DEDICATED",
+        "oci_endpoint_id": "ocid1.generativeaiendpoint...",
+    }
+    assert is_request_body_safe(
+        request_body=body,
+        general_settings={"allow_client_side_credentials": True},
+        llm_router=None,
+        model="oci/some-model",
+    )
+
+
 def test_banned_param_under_stringified_extra_body_is_rejected():
     # Raw-HTTP and multipart/form-data clients can send ``extra_body`` as
     # a JSON-encoded string rather than an object. An ``isinstance(...,
@@ -111,6 +129,9 @@ from litellm.proxy.auth.auth_utils import check_regex_or_str_match  # noqa: E402
         "aws_profile_name",  # server-side AWS profile selection
         "base_model",  # cost-lookup model spoofing
         "oci_key_file",  # arbitrary server file path read (DoS)
+        "oci_serving_mode",  # flip ON_DEMAND->DEDICATED to retarget the model
+        "oci_endpoint_id",  # retarget the OCI dedicated endpoint
+        "oci_compartment_id",  # retarget the OCI compartment
     ],
 )
 def test_newly_banned_root_param_is_rejected(banned_param):

--- a/tests/test_litellm/proxy/google_endpoints/test_managed_agents_model_param.py
+++ b/tests/test_litellm/proxy/google_endpoints/test_managed_agents_model_param.py
@@ -9,6 +9,7 @@ non-existent model deployment.  The agent name is already carried in
 ``data["name"]`` and must not pollute the ``model`` slot.
 """
 
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -42,9 +43,10 @@ def _build_agents_client():
     return TestClient(app)
 
 
-def _patch_proxy_server_imports(client=None):
+def _patch_proxy_server_imports(client=None, **overrides):
     """Return a context-manager that stubs _proxy_server_imports so tests
-    don't need a running proxy."""
+    don't need a running proxy. ``overrides`` replaces individual srv entries
+    (e.g. ``general_settings`` / ``llm_router``)."""
     mock_srv = {
         "general_settings": {},
         "llm_router": MagicMock(),
@@ -58,6 +60,7 @@ def _patch_proxy_server_imports(client=None):
         "user_temperature": None,
         "version": "0.0.0",
     }
+    mock_srv.update(overrides)
     return patch(
         "litellm.proxy.google_endpoints.agents_endpoints._proxy_server_imports",
         return_value=mock_srv,
@@ -197,3 +200,91 @@ class TestManagedAgentsModelParam:
         kwargs = mock_process.call_args.kwargs
         assert kwargs["model"] is None
         assert kwargs["route_type"] == "alist_agents"
+
+
+class TestManagedAgentsQueryTemplateBoundary:
+    """The GET/DELETE ``litellm_params_template`` query parameter skips the
+    auth-time is_request_body_safe() bouncer that guards POST bodies, so it must
+    be run through the same banned-param gate before it is merged into data."""
+
+    @pytest.mark.parametrize(
+        "template",
+        [
+            {"api_base": "https://attacker.example"},
+            {
+                "api_base": "https://attacker.example",
+                "litellm_credential_name": "shared-gemini",
+            },
+            {"vertex_credentials": "stolen"},
+        ],
+    )
+    def test_merge_query_template_rejects_banned_params(self, template):
+        """A banned param smuggled via the query template is rejected with a 400
+        and never reaches ``data``."""
+        from fastapi import HTTPException
+
+        from litellm.proxy.google_endpoints.agents_endpoints import (
+            _merge_query_params_into_data,
+        )
+
+        data = {"custom_llm_provider": "gemini"}
+        with patch(
+            "litellm.proxy.google_endpoints.agents_endpoints._safe_get_request_query_params",
+            return_value={"litellm_params_template": json.dumps(template)},
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                _merge_query_params_into_data(
+                    data, MagicMock(), general_settings={}, llm_router=None
+                )
+
+        assert exc_info.value.status_code == 400
+        for banned_key in template:
+            assert banned_key not in data
+
+    def test_merge_query_template_allows_legit_params(self):
+        """Non-blocklisted fields (api_key, custom_llm_provider) are the supported
+        per-request credential path and must still merge into data."""
+        from litellm.proxy.google_endpoints.agents_endpoints import (
+            _merge_query_params_into_data,
+        )
+
+        data = {"custom_llm_provider": "gemini"}
+        template = {"api_key": "AIza-test", "custom_llm_provider": "openai"}
+        with patch(
+            "litellm.proxy.google_endpoints.agents_endpoints._safe_get_request_query_params",
+            return_value={"litellm_params_template": json.dumps(template)},
+        ):
+            result = _merge_query_params_into_data(
+                data, MagicMock(), general_settings={}, llm_router=None
+            )
+
+        assert result["api_key"] == "AIza-test"
+        # pre-existing keys (path/provider) are never overwritten by the template
+        assert result["custom_llm_provider"] == "gemini"
+
+    def test_get_agent_rejects_banned_query_template_end_to_end(self):
+        """The 400 surfaces through the GET endpoint and base_process is skipped."""
+        try:
+            client = _build_agents_client()
+        except ImportError as exc:
+            pytest.skip(f"Skipping: missing dependency {exc}")
+
+        with (
+            _patch_proxy_server_imports(llm_router=None),
+            _patch_base_process() as mock_process,
+            _patch_auth(),
+        ):
+            resp = client.get(
+                "/v1beta/agents/my-custom-slides-agent",
+                params={
+                    "litellm_params_template": json.dumps(
+                        {
+                            "api_base": "https://attacker.example",
+                            "litellm_credential_name": "shared-gemini",
+                        }
+                    )
+                },
+            )
+
+        assert resp.status_code == 400
+        mock_process.assert_not_called()

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -820,14 +820,15 @@ async def test_add_litellm_data_to_request_strips_new_metadata_control_fields():
     """Spend/guardrail/rate-limiter sentinels injected via client metadata corrupt
     analytics, spoof guardrail verdicts, or refund another tenant's TPM
     reservation on the failure path; strip them at ingestion."""
+    from litellm.proxy.hooks.parallel_request_limiter_v3 import _LITELLM_STASH_KEYS
+
+    stripped = {
+        "usage_object",
+        "standard_logging_guardrail_information",
+        *_LITELLM_STASH_KEYS,
+    }
     malicious_metadata = {
-        "usage_object": {"total_tokens": 0},
-        "standard_logging_guardrail_information": {"status": "success"},
-        "_litellm_tpm_reserved_tokens": 999999,
-        "_litellm_tpm_reserved_model": "victim",
-        "_litellm_tpm_reserved_scopes": ["victim"],
-        "_litellm_tpm_reservation_released": True,
-        "_litellm_rate_limit_descriptors": [{"key": "victim"}],
+        **{key: "victim" for key in stripped},
         "safe_user_metadata": "kept",
     }
     data = {
@@ -844,20 +845,41 @@ async def test_add_litellm_data_to_request_strips_new_metadata_control_fields():
         general_settings={},
         version="test-version",
     )
-    stripped = {
-        "usage_object",
-        "standard_logging_guardrail_information",
-        "_litellm_tpm_reserved_tokens",
-        "_litellm_tpm_reserved_model",
-        "_litellm_tpm_reserved_scopes",
-        "_litellm_tpm_reservation_released",
-        "_litellm_rate_limit_descriptors",
-    }
     for metadata_key in ("metadata", "litellm_metadata"):
         cleaned = updated.get(metadata_key) or {}
         for key in stripped:
             assert key not in cleaned
         assert cleaned.get("safe_user_metadata") == "kept"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "body_value,expected",
+    [
+        (999999, 5),  # huge body-supplied num_retries is capped
+        ("999999", 5),  # string form is also capped
+        (-1, 0),  # negative clamped to 0
+        ("not-int", None),  # non-integer is dropped, not applied
+    ],
+)
+async def test_add_litellm_data_to_request_clamps_body_num_retries(
+    body_value, expected
+):
+    """A num_retries supplied in the request body (not the header) still reaches
+    the router via **data, so it must be clamped at ingestion too."""
+    updated = await add_litellm_data_to_request(
+        data={
+            "model": "gpt-3.5-turbo",
+            "messages": [{"role": "user", "content": "hi"}],
+            "num_retries": body_value,
+        },
+        request=_strip_request_mock(),
+        user_api_key_dict=UserAPIKeyAuth(api_key="hashed-key"),
+        proxy_config=MagicMock(),
+        general_settings={},
+        version="test-version",
+    )
+    assert updated.get("num_retries") == expected
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -787,6 +787,7 @@ def _strip_request_mock():
     [
         ("success_callback", ["https://attacker.example"]),  # dynamic-callback exfil
         ("failure_callback", ["https://attacker.example"]),
+        ("no-log", True),  # silences operator audit/observability sinks
         ("cache_key", "victim-predicted-key"),  # cross-tenant cache poisoning
         ("model_group_retry_policy", {"RateLimitErrorRetries": 100000}),  # retry DoS
         ("deployment_id", "premium-deployment"),  # post-auth model override

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -1041,6 +1041,56 @@ async def test_add_litellm_data_to_request_allows_redaction_opt_out_with_admin_o
     }
 
 
+@pytest.mark.parametrize(
+    "auth_kwargs,redaction_kept",
+    [
+        ({}, False),
+        ({"metadata": {"allow_client_message_redaction_opt_out": True}}, True),
+        ({"team_metadata": {"allow_client_message_redaction_opt_out": True}}, True),
+    ],
+)
+@pytest.mark.asyncio
+async def test_add_litellm_data_to_request_strips_disable_callbacks_header(
+    auth_kwargs, redaction_kept
+):
+    """The client-supplied ``x-litellm-disable-callbacks`` header silences
+    operator-configured audit/observability callbacks for the caller's own
+    request. It is always stripped at the boundary, even when the key is allowed
+    to opt out of message redaction; the redaction opt-out must not double as a
+    license to disable callbacks."""
+    request_mock = MagicMock(spec=Request)
+    request_mock.url.path = "/v1/chat/completions"
+    request_mock.url = MagicMock()
+    request_mock.url.__str__.return_value = "http://localhost/v1/chat/completions"
+    request_mock.method = "POST"
+    request_mock.query_params = {}
+    request_mock.headers = {
+        "Content-Type": "application/json",
+        "litellm-disable-message-redaction": "true",
+        "x-litellm-disable-callbacks": "datadog,langfuse",
+    }
+    request_mock.client = MagicMock()
+    request_mock.client.host = "127.0.0.1"
+
+    updated = await add_litellm_data_to_request(
+        data={
+            "model": "gpt-3.5-turbo",
+            "messages": [{"role": "user", "content": "hello"}],
+        },
+        request=request_mock,
+        user_api_key_dict=UserAPIKeyAuth(api_key="hashed-key", **auth_kwargs),
+        proxy_config=MagicMock(),
+        general_settings={},
+        version="test-version",
+    )
+
+    proxy_headers = {
+        header.lower() for header in updated["proxy_server_request"]["headers"]
+    }
+    assert "x-litellm-disable-callbacks" not in proxy_headers
+    assert ("litellm-disable-message-redaction" in proxy_headers) is redaction_kept
+
+
 @pytest.mark.asyncio
 async def test_add_litellm_data_to_request_honors_header_tags():
     """Header-supplied tags flow through to request metadata."""

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -768,6 +768,98 @@ async def test_add_litellm_data_to_request_strips_callback_control_fields(
     assert control_field not in snapshot_body
 
 
+def _strip_request_mock():
+    request_mock = MagicMock(spec=Request)
+    request_mock.url.path = "/v1/chat/completions"
+    request_mock.url = MagicMock()
+    request_mock.url.__str__.return_value = "http://localhost/v1/chat/completions"
+    request_mock.method = "POST"
+    request_mock.query_params = {}
+    request_mock.headers = {"Content-Type": "application/json"}
+    request_mock.client = MagicMock()
+    request_mock.client.host = "127.0.0.1"
+    return request_mock
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "control_field,value",
+    [
+        ("success_callback", ["https://attacker.example"]),  # dynamic-callback exfil
+        ("failure_callback", ["https://attacker.example"]),
+        ("cache_key", "victim-predicted-key"),  # cross-tenant cache poisoning
+        ("model_group_retry_policy", {"RateLimitErrorRetries": 100000}),  # retry DoS
+        ("deployment_id", "premium-deployment"),  # post-auth model override
+        ("model_id", "premium-bedrock-model"),
+    ],
+)
+async def test_add_litellm_data_to_request_strips_new_root_control_fields(
+    control_field, value
+):
+    """Routing/cache/retry/callback control fields supplied in the request body
+    bypass authorization, poison the cache, or amplify retries; none has a
+    documented per-request client use, so all are stripped at the boundary."""
+    updated = await add_litellm_data_to_request(
+        data={
+            "model": "gpt-3.5-turbo",
+            "messages": [{"role": "user", "content": "hi"}],
+            control_field: value,
+        },
+        request=_strip_request_mock(),
+        user_api_key_dict=UserAPIKeyAuth(api_key="hashed-key"),
+        proxy_config=MagicMock(),
+        general_settings={},
+        version="test-version",
+    )
+    assert control_field not in updated
+    assert control_field not in updated["proxy_server_request"]["body"]
+
+
+@pytest.mark.asyncio
+async def test_add_litellm_data_to_request_strips_new_metadata_control_fields():
+    """Spend/guardrail/rate-limiter sentinels injected via client metadata corrupt
+    analytics, spoof guardrail verdicts, or refund another tenant's TPM
+    reservation on the failure path; strip them at ingestion."""
+    malicious_metadata = {
+        "usage_object": {"total_tokens": 0},
+        "standard_logging_guardrail_information": {"status": "success"},
+        "_litellm_tpm_reserved_tokens": 999999,
+        "_litellm_tpm_reserved_model": "victim",
+        "_litellm_tpm_reserved_scopes": ["victim"],
+        "_litellm_tpm_reservation_released": True,
+        "_litellm_rate_limit_descriptors": [{"key": "victim"}],
+        "safe_user_metadata": "kept",
+    }
+    data = {
+        "model": "gpt-3.5-turbo",
+        "messages": [{"role": "user", "content": "hi"}],
+        "metadata": copy.deepcopy(malicious_metadata),
+        "litellm_metadata": copy.deepcopy(malicious_metadata),
+    }
+    updated = await add_litellm_data_to_request(
+        data=data,
+        request=_strip_request_mock(),
+        user_api_key_dict=UserAPIKeyAuth(api_key="hashed-key"),
+        proxy_config=MagicMock(),
+        general_settings={},
+        version="test-version",
+    )
+    stripped = {
+        "usage_object",
+        "standard_logging_guardrail_information",
+        "_litellm_tpm_reserved_tokens",
+        "_litellm_tpm_reserved_model",
+        "_litellm_tpm_reserved_scopes",
+        "_litellm_tpm_reservation_released",
+        "_litellm_rate_limit_descriptors",
+    }
+    for metadata_key in ("metadata", "litellm_metadata"):
+        cleaned = updated.get(metadata_key) or {}
+        for key in stripped:
+            assert key not in cleaned
+        assert cleaned.get("safe_user_metadata") == "kept"
+
+
 @pytest.mark.asyncio
 async def test_add_litellm_data_to_request_allows_client_mock_response_with_admin_opt_in():
     request_mock = MagicMock(spec=Request)
@@ -1765,12 +1857,12 @@ def test_get_num_retries_from_request():
     result = LiteLLMProxyRequestSetup._get_num_retries_from_request(headers_with_zero)
     assert result == 0
 
-    # Test case 5: Header present with large number
+    # Test case 5: large number is clamped to the cap (no retry amplification)
     headers_with_large_number = {"x-litellm-num-retries": "100"}
     result = LiteLLMProxyRequestSetup._get_num_retries_from_request(
         headers_with_large_number
     )
-    assert result == 100
+    assert result == 5
 
     # Test case 6: Multiple headers with num retries header
     headers_multiple = {
@@ -1781,22 +1873,26 @@ def test_get_num_retries_from_request():
     result = LiteLLMProxyRequestSetup._get_num_retries_from_request(headers_multiple)
     assert result == 5
 
-    # Test case 7: Header present with invalid value (should raise ValueError when int() is called)
+    # Test case 7: invalid value is ignored (treated as unset), not applied
     headers_with_invalid = {"x-litellm-num-retries": "invalid"}
-    with pytest.raises(ValueError):
+    assert (
         LiteLLMProxyRequestSetup._get_num_retries_from_request(headers_with_invalid)
+        is None
+    )
 
-    # Test case 8: Header present with float string (should raise ValueError when int() is called)
+    # Test case 8: float string is ignored (treated as unset)
     headers_with_float = {"x-litellm-num-retries": "3.5"}
-    with pytest.raises(ValueError):
+    assert (
         LiteLLMProxyRequestSetup._get_num_retries_from_request(headers_with_float)
+        is None
+    )
 
-    # Test case 9: Header present with negative number
+    # Test case 9: negative number is clamped to 0
     headers_with_negative = {"x-litellm-num-retries": "-1"}
     result = LiteLLMProxyRequestSetup._get_num_retries_from_request(
         headers_with_negative
     )
-    assert result == -1
+    assert result == 0
 
 
 def test_add_user_api_key_auth_to_request_metadata():


### PR DESCRIPTION
## Type

🐛 Bug Fix

## Changes

The proxy authorizes a request and runs its SSRF / logging / rate-limit checks against one view of the body, then forwards a different payload, so several caller-supplied fields slipped past the request-body trust boundary. This tightens that boundary in the two places it lives, `litellm/proxy/auth/auth_utils.py` and `litellm/proxy/litellm_pre_call_utils.py`.

`is_request_body_safe` now descends the banned-param check into each `tools[]` object (provider integrations such as the advisor tool read an endpoint and credential straight off the tool dict, so an `api_base` smuggled there was an SSRF / key-exfil primitive) and into `litellm_params_template` (spread into the outbound Gemini/Vertex Agents request the same way `extra_body` is). The Gemini Agents GET/DELETE endpoints additionally accept `litellm_params_template` as a JSON query parameter that is merged into the request *after* the auth-time body check runs, so those endpoints now run the parsed query template through the same banned-param gate before merging (an `api_base` + `litellm_credential_name` smuggled in the query string would otherwise have sent credential-backed traffic to an attacker host); non-blocklisted fields like `api_key` still pass through. The blocklist gains `model_list` (an array of deployment dicts that smuggled arbitrary `api_base`/credentials past the model-authz layer, since only the root `model` is authorized), the `vertex_ai_credentials` alias of the already-banned `vertex_credentials`, `vertex_project`, `litellm_credential_name`, `aws_profile_name`, `base_model`, `oci_key_file`, and the OCI routing selectors `oci_serving_mode`/`oci_endpoint_id`/`oci_compartment_id` (read off `optional_params` by the OCI transform, so a client could flip the serving mode to DEDICATED and retarget the served model/endpoint or compartment using the operator's stored OCI credentials). The clientside `api_base` allowlist is matched with `re.fullmatch` so an entry like `https://api\.openai\.com` no longer accepts `https://api.openai.com.attacker.com/...`. Every banned field still honors the existing admin opt-ins (`general_settings.allow_client_side_credentials` proxy-wide, or `configurable_clientside_auth_params` per deployment).

On the pre-call path, client-supplied control fields that change routing, caching, retries, logging, spend, or rate-limiting are stripped before guardrails/logging/headers read them: root `success_callback`/`failure_callback` (dynamic-callback exfil), `no-log` (silences every operator-configured audit/observability sink that isn't a `_PROXY_` cost callback, and is honored by default), `cache_key` (cross-tenant cache poisoning), `model_group_retry_policy` (retry amplification), `deployment_id`/`model_id` (post-auth model override); metadata `usage_object` (spend/analytics corruption), `standard_logging_guardrail_information` (verdict spoofing), and the rate-limiter stash sentinels (so a request that errors before the pre-call hook can't refund or replay another tenant's TPM reservation on the failure path). A client-supplied `num_retries`, from either the `x-litellm-num-retries` header or the request body, is clamped to a small cap so one request can't be amplified into many upstream calls. The `x-litellm-disable-callbacks` header is dropped too; like `no-log` it otherwise silences operator-configured callbacks for the caller's own request, and it was honored by default while its body twin `litellm_disabled_callbacks` was already stripped. The message-redaction opt-out is scoped so it only spares the redaction header rather than re-enabling every controlled header.

## Upgrade notes

These default to deny, with admin escapes preserved:

- The newly-banned fields (`model_list`, `vertex_ai_credentials`, `vertex_project`, `litellm_credential_name`, `aws_profile_name`, `base_model`, `oci_key_file`, `oci_serving_mode`, `oci_endpoint_id`, `oci_compartment_id`) are rejected from client request bodies unless allowed via `general_settings.allow_client_side_credentials` or the deployment's `configurable_clientside_auth_params`, the same opt-ins that already gate `api_base`. Deployment-configured OCI routing (set server-side in `litellm_params`) is unaffected; only client-supplied request-body values are blocked.
- A `configurable_clientside_auth_params` `api_base` regex is now matched in full. An entry that previously relied on prefix matching (e.g. `https://api.example.com`) must anchor the rest itself (e.g. `https://api\.example\.com/.*`).
- A client `num_retries` (header or body) above the cap is reduced to it rather than honored.
- A request-body `no-log` is dropped rather than honored. Operators that genuinely want per-request log suppression should set it server-side; the global off-switch `litellm.global_disable_no_log_param` is unaffected.
- The `x-litellm-disable-callbacks` request header is dropped. Disabling callbacks for specific keys or teams still works through their metadata (`litellm_disabled_callbacks`); only the client-supplied header is rejected.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Screenshots / Proof of Fix

Run a proxy locally and exercise the boundary with curl against a real key.

1. Start the proxy: `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug`
2. A normal request still works: `curl -sS http://localhost:4000/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'content-type: application/json' -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hi"}]}'` returns a completion.
3. Each smuggled field is rejected (expect HTTP 400 "not allowed in request body"), run as a `for` loop:
   ```
   for p in '"model_list":[{"litellm_params":{"api_base":"http://169.254.169.254/"}}]' '"vertex_ai_credentials":"x"' '"base_model":"gpt-3.5-turbo"' '"tools":[{"type":"advisor_20260301","api_base":"https://attacker.example"}]'; do
     curl -sS -o /dev/null -w "%{http_code} for $p\n" http://localhost:4000/v1/chat/completions \
       -H "Authorization: Bearer $KEY" -H 'content-type: application/json' \
       -d "{\"model\":\"gpt-4o-mini\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],$p}"
   done
   ```
4. A look-alike `api_base` does not satisfy a `configurable_clientside_auth_params` allowlist of `https://api\.openai\.com`: send `"api_base":"https://api.openai.com.attacker.example/v1"` and confirm HTTP 400.
5. Retry amplification is capped: send `-H "x-litellm-num-retries: 100000"` (and separately `"num_retries":100000` in the body) and confirm the effective retries are clamped (visible in `--detailed_debug` logs as the small cap, not the requested value).
6. `no-log` no longer silences logging: with any logging callback configured (`litellm_settings.success_callback`, e.g. a langfuse/datadog sink, or just watch the `--detailed_debug` logging output), send `"no-log":true` in the body and confirm the request is still logged. Before this change the `--detailed_debug` output shows `no-log request, skipping logging for ... event`; after, that line is gone and the event is logged.
7. The `x-litellm-disable-callbacks` header no longer silences a callback: with a callback configured (e.g. `success_callback: ["datadog"]`), send `-H "x-litellm-disable-callbacks: datadog"` and confirm the callback still fires (before this change the `--detailed_debug` output shows the callback being skipped via the header).

## Changes

Hardens the proxy request-body / metadata / header trust boundary against nested and aliased parameter injection. A focused follow-up will cover the provider-handler `extra_body` merge order and the residual Vertex executable-credential sink.
