### PR TITLE
Migrate Anthropic CI test models to CI_CD_DEFAULT_ANTHROPIC_MODEL env var

### DIFF
--- a/tests/local_testing/test_router_budget_limiter.py
+++ b/tests/local_testing/test_router_budget_limiter.py
@@ -153,7 +153,7 @@ async def test_provider_budgets_e2e_test_expect_to_fail():
 
     response = await router.acompletion(
         messages=[{"role": "user", "content": "Hello, how are you?"}],
-        model="anthropic/claude-sonnet-4-5-20250929",
+        model=f"anthropic/{os.environ.get('CI_CD_DEFAULT_ANTHROPIC_MODEL', 'claude-haiku-4-5-20251001')}",
     )
     print(response)
 
@@ -163,7 +163,7 @@ async def test_provider_budgets_e2e_test_expect_to_fail():
         with pytest.raises(Exception) as exc_info:
             response = await router.acompletion(
                 messages=[{"role": "user", "content": "Hello, how are you?"}],
-                model="anthropic/claude-sonnet-4-5-20250929",
+                model=f"anthropic/{os.environ.get('CI_CD_DEFAULT_ANTHROPIC_MODEL', 'claude-haiku-4-5-20251001')}",
             )
             print(response)
             print("response.hidden_params", response._hidden_params)

--- a/tests/openai_endpoints_tests/test_e2e_openai_responses_api.py
+++ b/tests/openai_endpoints_tests/test_e2e_openai_responses_api.py
@@ -1,3 +1,5 @@
+import os
+
 import httpx
 from openai import OpenAI, BadRequestError
 import pytest
@@ -124,7 +126,7 @@ def test_bad_request_bad_param_error():
 def test_anthropic_with_responses_api():
     client = get_test_client()
     response = client.responses.create(
-        model="anthropic/claude-sonnet-4-5-20250929",
+        model=f"anthropic/{os.environ.get('CI_CD_DEFAULT_ANTHROPIC_MODEL', 'claude-haiku-4-5-20251001')}",
         input="just respond with the word 'ping'",
         previous_response_id="hi",
     )

--- a/tests/pass_through_tests/test_anthropic_passthrough_basic.py
+++ b/tests/pass_through_tests/test_anthropic_passthrough_basic.py
@@ -1,3 +1,5 @@
+import os
+
 from base_anthropic_messages_test import BaseAnthropicMessagesTest
 import anthropic
 
@@ -21,7 +23,7 @@ class TestAnthropicMessagesEndpoint(BaseAnthropicMessagesTest):
     def test_anthropic_messages_to_wildcard_model(self):
         client = self.get_client()
         response = client.messages.create(
-            model="anthropic/claude-haiku-4-5-20251001",
+            model=f"anthropic/{os.environ.get('CI_CD_DEFAULT_ANTHROPIC_MODEL', 'claude-haiku-4-5-20251001')}",
             messages=[{"role": "user", "content": "Hello, world!"}],
             max_tokens=100,
         )


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Refs LIT-2650

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review

## Type

🧹 Refactoring

## Changes

First slice of a per-provider migration moving hardcoded model names in the CircleCI test suite onto environment variables, so a model deprecation can be handled by changing a CircleCI project variable instead of editing code.

This PR covers Anthropic. The live-call CI tests now read `CI_CD_DEFAULT_ANTHROPIC_MODEL` (with the current default as the fallback), extending the convention already used in `tests/local_testing/test_router.py` and friends:

- `tests/openai_endpoints_tests/test_e2e_openai_responses_api.py`
- `tests/pass_through_tests/test_anthropic_passthrough_basic.py`
- `tests/local_testing/test_router_budget_limiter.py`

Scope is deliberately narrow. Only sites that make a real Anthropic call are migrated. Tests that assert on a specific model (metadata lookups via `supports_prompt_caching`, dict-to-ChatCompletion conversion, route-URL parsing) stay pinned, and so does `test_anthropic_messages_tool_search.py`, since tool search is only supported on Sonnet/Opus 4.5 and would break under the haiku default. No `.circleci/config.yml` change is needed; pytest runs on the job executor where CircleCI project variables are already present, and the proxy container routes `anthropic/*` by prefix regardless of the specific model.

To make the override live, set `CI_CD_DEFAULT_ANTHROPIC_MODEL` as a CircleCI project (or context) environment variable. Until then, tests fall back to the hardcoded default and behavior is unchanged.

## Proof

With a proxy running locally against the real Anthropic API:

1. `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug`
2. Default (no env var set), the passthrough call uses the fallback model:
   `cd tests/pass_through_tests && python -m pytest test_anthropic_passthrough_basic.py -k wildcard -x -s`
3. Override and confirm the new model is exercised end to end:
   `CI_CD_DEFAULT_ANTHROPIC_MODEL=claude-sonnet-4-5-20250929 python -m pytest test_anthropic_passthrough_basic.py -k wildcard -x -s`



