### PR TITLE
Migrate OpenAI CI test models to CI_CD_DEFAULT_OPENAI_MODEL env var

### DIFF
--- a/tests/local_testing/test_router_auto_router.py
+++ b/tests/local_testing/test_router_auto_router.py
@@ -47,7 +47,9 @@ async def test_router_auto_router():
             {
                 "model_name": "litellm-gpt-4.1",
                 "litellm_params": {
-                    "model": "gpt-4.1",
+                    "model": os.environ.get(
+                        "CI_CD_DEFAULT_OPENAI_MODEL", "gpt-4o-mini"
+                    ),
                 },
                 "model_info": {"id": "openai-id"},
             },

--- a/tests/local_testing/test_router_budget_limiter.py
+++ b/tests/local_testing/test_router_budget_limiter.py
@@ -522,7 +522,7 @@ async def test_deployment_budget_limits_e2e_test():
             {
                 "model_name": "gpt-4o",  # openai model name
                 "litellm_params": {  # params for litellm completion/embedding call
-                    "model": "openai/gpt-4o",
+                    "model": f"openai/{os.environ.get('CI_CD_DEFAULT_OPENAI_MODEL', 'gpt-4o-mini')}",
                     "api_key": os.getenv("OPENAI_API_KEY"),
                     "max_budget": 0.000000000001,
                     "budget_duration": "1d",

--- a/tests/logging_callback_tests/test_pagerduty_alerting.py
+++ b/tests/logging_callback_tests/test_pagerduty_alerting.py
@@ -93,7 +93,7 @@ async def test_pagerduty_hanging_request_alerting():
     )
 
     await litellm.acompletion(
-        model="gpt-5.5",
+        model=os.environ.get("CI_CD_DEFAULT_OPENAI_MODEL", "gpt-4o-mini"),
         messages=[{"role": "user", "content": "hi"}],
     )
 

--- a/tests/logging_callback_tests/test_token_counting.py
+++ b/tests/logging_callback_tests/test_token_counting.py
@@ -55,7 +55,7 @@ async def test_stream_token_counting_gpt_4o():
     litellm.logging_callback_manager.add_litellm_callback(custom_logger)
 
     response = await litellm.acompletion(
-        model="gpt-5.5",
+        model=os.environ.get("CI_CD_DEFAULT_OPENAI_MODEL", "gpt-4o-mini"),
         messages=[{"role": "user", "content": "Hello, how are you?" * 100}],
         stream=True,
         stream_options={"include_usage": True},
@@ -95,7 +95,7 @@ async def test_stream_token_counting_without_include_usage():
     litellm.logging_callback_manager.add_litellm_callback(custom_logger)
 
     response = await litellm.acompletion(
-        model="gpt-5.5",
+        model=os.environ.get("CI_CD_DEFAULT_OPENAI_MODEL", "gpt-4o-mini"),
         messages=[{"role": "user", "content": "Hello, how are you?" * 100}],
         stream=True,
     )
@@ -133,7 +133,7 @@ async def test_stream_token_counting_with_redaction():
     litellm.logging_callback_manager.add_litellm_callback(custom_logger)
 
     response = await litellm.acompletion(
-        model="gpt-5.5",
+        model=os.environ.get("CI_CD_DEFAULT_OPENAI_MODEL", "gpt-4o-mini"),
         messages=[{"role": "user", "content": "Hello, how are you?" * 100}],
         stream=True,
     )

--- a/tests/openai_endpoints_tests/test_e2e_openai_responses_api.py
+++ b/tests/openai_endpoints_tests/test_e2e_openai_responses_api.py
@@ -76,7 +76,8 @@ def validate_stream_chunk(chunk):
 def test_basic_response():
     client = get_test_client()
     response = client.responses.create(
-        model="gpt-5.5", input="just respond with the word 'ping'"
+        model=os.environ.get("CI_CD_DEFAULT_OPENAI_MODEL", "gpt-4o-mini"),
+        input="just respond with the word 'ping'",
     )
     print("basic response=", response)
 
@@ -96,7 +97,9 @@ def test_basic_response():
 def test_streaming_response():
     client = get_test_client()
     stream = client.responses.create(
-        model="gpt-5.5", input="just respond with the word 'ping'", stream=True
+        model=os.environ.get("CI_CD_DEFAULT_OPENAI_MODEL", "gpt-4o-mini"),
+        input="just respond with the word 'ping'",
+        stream=True,
     )
 
     collected_chunks = []
@@ -119,7 +122,9 @@ def test_bad_request_bad_param_error():
     with pytest.raises(BadRequestError):
         # Trigger error with invalid model name
         client.responses.create(
-            model="gpt-5.5", input="This should fail", temperature=2000
+            model=os.environ.get("CI_CD_DEFAULT_OPENAI_MODEL", "gpt-4o-mini"),
+            input="This should fail",
+            temperature=2000,
         )
 
 
@@ -139,7 +144,9 @@ def test_cancel_response():
         from litellm.types.llms.openai import ResponsesAPIResponse
 
         response = client.responses.create(
-            model="gpt-5.5", input="just respond with the word 'ping'", background=True
+            model=os.environ.get("CI_CD_DEFAULT_OPENAI_MODEL", "gpt-4o-mini"),
+            input="just respond with the word 'ping'",
+            background=True,
         )
         print("basic response=", response)
 
@@ -162,7 +169,7 @@ def test_cancel_streaming_response():
         from litellm.types.llms.openai import ResponsesAPIResponse
 
         stream = client.responses.create(
-            model="gpt-5.5",
+            model=os.environ.get("CI_CD_DEFAULT_OPENAI_MODEL", "gpt-4o-mini"),
             input="just respond with the word 'ping'",
             stream=True,
             background=True,

--- a/tests/pass_through_tests/test_anthropic_passthrough.py
+++ b/tests/pass_through_tests/test_anthropic_passthrough.py
@@ -2,6 +2,8 @@
 This test ensures that the proxy can passthrough anthropic requests
 """
 
+import os
+
 import pytest
 import anthropic
 import aiohttp
@@ -407,7 +409,7 @@ async def test_anthropic_messages_openai_model_streaming_cost_injection():
     }
 
     payload = {
-        "model": "openai/gpt-4o",
+        "model": f"openai/{os.environ.get('CI_CD_DEFAULT_OPENAI_MODEL', 'gpt-4o-mini')}",
         "max_tokens": 20,
         "stream": True,
         "messages": [{"role": "user", "content": "Say 'Hi'"}],

--- a/tests/pass_through_tests/test_openai_assistants_passthrough.py
+++ b/tests/pass_through_tests/test_openai_assistants_passthrough.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 import openai
 import aiohttp
@@ -5,7 +7,6 @@ import asyncio
 import tempfile
 from typing_extensions import override
 from openai import AssistantEventHandler
-
 
 client = openai.OpenAI(base_url="http://0.0.0.0:4000/openai", api_key="sk-1234")
 
@@ -35,7 +36,7 @@ def test_openai_assistants_e2e_operations():
         name="Math Tutor",
         instructions="You are a personal math tutor. Write and run code to answer math questions.",
         tools=[{"type": "code_interpreter"}],
-        model="gpt-4o",
+        model=os.environ.get("CI_CD_DEFAULT_OPENAI_MODEL", "gpt-4o-mini"),
     )
     print("assistant created", assistant)
 
@@ -75,7 +76,7 @@ def test_openai_assistants_e2e_operations_stream():
         name="Math Tutor",
         instructions="You are a personal math tutor. Write and run code to answer math questions.",
         tools=[{"type": "code_interpreter"}],
-        model="gpt-4o",
+        model=os.environ.get("CI_CD_DEFAULT_OPENAI_MODEL", "gpt-4o-mini"),
     )
     print("assistant created", assistant)
 

--- a/tests/store_model_in_db_tests/test_team_models.py
+++ b/tests/store_model_in_db_tests/test_team_models.py
@@ -31,7 +31,7 @@ async def test_team_model_alias():
         json={
             "model_name": "gpt-4o-team1",
             "litellm_params": {
-                "model": "gpt-4o",
+                "model": os.environ.get("CI_CD_DEFAULT_OPENAI_MODEL", "gpt-4o-mini"),
                 "api_key": os.getenv("OPENAI_API_KEY"),
             },
         },

--- a/tests/unified_google_tests/test_litellm_responses_bridge.py
+++ b/tests/unified_google_tests/test_litellm_responses_bridge.py
@@ -21,7 +21,7 @@ class TestLiteLLMResponsesBridge(BaseInteractionsTest):
         The bridge provider uses litellm.responses() internally, so we can
         use any model that litellm.responses() supports (e.g., gpt-5.5).
         """
-        return "gpt-5.5"
+        return os.environ.get("CI_CD_DEFAULT_OPENAI_MODEL", "gpt-4o-mini")
 
     def get_api_key(self) -> str:
         """Return the OpenAI API key from environment."""


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Refs LIT-2650

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review

## Type

🧹 Refactoring

## Changes

OpenAI slice of the per-provider migration moving hardcoded model names in the CircleCI test suite onto environment variables, so a model deprecation can be handled by changing a CircleCI project variable instead of editing code.

This PR stacks on the Anthropic PR (#29543); it targets that branch so the diff stays scoped to OpenAI. Merge #29543 first.

Live-call sites now read `CI_CD_DEFAULT_OPENAI_MODEL` (falling back to `gpt-4o-mini`), keeping any `openai/` routing prefix via an f-string. Migrated files:

- `tests/openai_endpoints_tests/test_e2e_openai_responses_api.py`
- `tests/pass_through_tests/test_openai_assistants_passthrough.py` (the OpenAI sites only; the Azure variant is left pinned)
- `tests/pass_through_tests/test_anthropic_passthrough.py`
- `tests/logging_callback_tests/test_token_counting.py`
- `tests/logging_callback_tests/test_pagerduty_alerting.py` (the live acompletion only, not the hook payload dict)
- `tests/local_testing/test_router_budget_limiter.py`
- `tests/local_testing/test_router_auto_router.py`
- `tests/store_model_in_db_tests/test_team_models.py`
- `tests/unified_google_tests/test_litellm_responses_bridge.py`

Scope is deliberately narrow. Legacy pins (`gpt-4`, `gpt-3.5-turbo`) stay hardcoded; so do router/routing-algorithm config fixtures (lowest-latency, least-busy, get-deployments), dict-conversion and VCR tests, spend/token payload fixtures, and model-access tests that assert on the model string. The bare-model sites in the responses API test are safe because the e2e proxy config routes `*` to `openai/*`, so any current OpenAI model is accepted.

To make the override live, set `CI_CD_DEFAULT_OPENAI_MODEL` as a CircleCI project (or context) environment variable. Until then, tests fall back to `gpt-4o-mini`.

## Proof

With a proxy running locally against the real OpenAI API (oai_misc_config.yaml):

1. `python litellm/proxy/proxy_cli.py --config litellm/proxy/example_config_yaml/oai_misc_config.yaml --detailed_debug`
2. Default fallback:
   `cd tests/openai_endpoints_tests && python -m pytest test_e2e_openai_responses_api.py::test_basic_response -x -s`
3. Override and confirm the new model is exercised:
   `CI_CD_DEFAULT_OPENAI_MODEL=gpt-4.1-mini python -m pytest test_e2e_openai_responses_api.py::test_basic_response -x -s`



