### PR TITLE
Migrate Azure CI test models to CI_CD_DEFAULT_AZURE_MODEL env var

### DIFF
--- a/tests/local_testing/test_custom_logger.py
+++ b/tests/local_testing/test_custom_logger.py
@@ -213,7 +213,9 @@ def test_async_custom_handler_stream():
         async def test_1():
             nonlocal complete_streaming_response
             response = await litellm.acompletion(
-                model="azure/gpt-4.1-mini", messages=messages, stream=True
+                model=f"azure/{os.environ.get('CI_CD_DEFAULT_AZURE_MODEL', 'gpt-4.1-mini')}",
+                messages=messages,
+                stream=True,
             )
             async for chunk in response:
                 complete_streaming_response += (
@@ -257,7 +259,9 @@ def test_azure_completion_stream():
         complete_streaming_response = ""
 
         response = litellm.completion(
-            model="azure/gpt-4.1-mini", messages=messages, stream=True
+            model=f"azure/{os.environ.get('CI_CD_DEFAULT_AZURE_MODEL', 'gpt-4.1-mini')}",
+            messages=messages,
+            stream=True,
         )
         for chunk in response:
             complete_streaming_response += chunk["choices"][0]["delta"]["content"] or ""


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Refs LIT-2650

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review

## Type

🧹 Refactoring

## Changes

Azure slice of the per-provider migration moving hardcoded model names in the CircleCI test suite onto environment variables, so a model deprecation can be handled by changing a CircleCI project variable instead of editing code.

The two live azure call sites in `tests/local_testing/test_custom_logger.py` now read `CI_CD_DEFAULT_AZURE_MODEL` (falling back to the current `gpt-4.1-mini` deployment), keeping the `azure/` prefix via an f-string.

Scope is deliberately narrow, which is why this is just one file. Almost every other `azure/gpt-4.1-mini` occurrence in the suite is a router model_list/deployment fixture inside a routing-algorithm or pure-logic unit test (lowest-latency, least-busy, get-deployments and similar) that never makes an azure call, an assertion on the deployment string, a mocked call, or commented-out code; none of those are affected by a real deprecation, so they stay pinned.

To make the override live, set `CI_CD_DEFAULT_AZURE_MODEL` as a CircleCI project (or context) environment variable to the azure deployment name you want exercised. Until then, tests fall back to `gpt-4.1-mini`.

## Proof

With azure credentials in the environment:

1. Default fallback:
   `cd tests/local_testing && python -m pytest test_custom_logger.py -k test_async_custom_handler_stream -x -s`
2. Override and confirm the new deployment is exercised:
   `CI_CD_DEFAULT_AZURE_MODEL=gpt-4o python -m pytest test_custom_logger.py -k test_async_custom_handler_stream -x -s`



