### PR TITLE
Migrate Bedrock CI test models to CI_CD_DEFAULT_BEDROCK_MODEL env var

### DIFF
--- a/tests/llm_translation/test_bedrock_invoke_tests.py
+++ b/tests/llm_translation/test_bedrock_invoke_tests.py
@@ -3,7 +3,6 @@ import pytest
 import sys
 import os
 
-
 sys.path.insert(
     0, os.path.abspath("../..")
 )  # Adds the parent directory to the system path
@@ -16,7 +15,7 @@ class TestBedrockInvokeClaudeJson(BaseLLMChatTest):
     def get_base_completion_call_args(self) -> dict:
         litellm._turn_on_debug()
         return {
-            "model": "bedrock/invoke/us.anthropic.claude-haiku-4-5-20251001-v1:0",
+            "model": f"bedrock/invoke/us.{os.environ.get('CI_CD_DEFAULT_BEDROCK_MODEL', 'anthropic.claude-haiku-4-5-20251001-v1:0')}",
         }
 
     def test_tool_call_no_arguments(self, tool_call_no_arguments):

--- a/tests/pass_through_unit_tests/messages_api_structured_output/test_bedrock_converse_structured_output.py
+++ b/tests/pass_through_unit_tests/messages_api_structured_output/test_bedrock_converse_structured_output.py
@@ -26,4 +26,4 @@ class TestBedrockConverseStructuredOutput(BaseAnthropicMessagesStructuredOutputT
     """
 
     def get_model(self) -> str:
-        return "bedrock/converse/us.anthropic.claude-haiku-4-5-20251001-v1:0"
+        return f"bedrock/converse/us.{os.environ.get('CI_CD_DEFAULT_BEDROCK_MODEL', 'anthropic.claude-haiku-4-5-20251001-v1:0')}"

--- a/tests/pass_through_unit_tests/test_anthropic_messages_prompt_caching.py
+++ b/tests/pass_through_unit_tests/test_anthropic_messages_prompt_caching.py
@@ -31,7 +31,7 @@ class TestBedrockConversePromptCaching(BaseAnthropicMessagesPromptCachingTest):
     """
 
     def get_model(self) -> str:
-        return "bedrock/converse/us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+        return f"bedrock/converse/us.{os.environ.get('CI_CD_DEFAULT_BEDROCK_MODEL', 'anthropic.claude-haiku-4-5-20251001-v1:0')}"
 
 
 class TestBedrockInvokePromptCaching(BaseAnthropicMessagesPromptCachingTest):
@@ -43,4 +43,4 @@ class TestBedrockInvokePromptCaching(BaseAnthropicMessagesPromptCachingTest):
     """
 
     def get_model(self) -> str:
-        return "bedrock/invoke/us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+        return f"bedrock/invoke/us.{os.environ.get('CI_CD_DEFAULT_BEDROCK_MODEL', 'anthropic.claude-haiku-4-5-20251001-v1:0')}"

--- a/tests/pass_through_unit_tests/test_bedrock_tool_use_beta_header.py
+++ b/tests/pass_through_unit_tests/test_bedrock_tool_use_beta_header.py
@@ -24,7 +24,7 @@ async def test_bedrock_sonnet_4_5_with_advanced_tool_use_beta_header():
     """
     litellm._turn_on_debug()
     response = await litellm.anthropic.messages.acreate(
-        model="bedrock/invoke/us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        model=f"bedrock/invoke/us.{os.environ.get('CI_CD_DEFAULT_BEDROCK_MODEL', 'anthropic.claude-haiku-4-5-20251001-v1:0')}",
         messages=[{"role": "user", "content": "What is 2+2?"}],
         max_tokens=100,
         provider_specific_header={


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Refs LIT-2650

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review

## Type

🧹 Refactoring

## Changes

Bedrock slice of the per-provider migration moving hardcoded model names in the CircleCI test suite onto environment variables, so a model deprecation can be handled by changing a CircleCI project variable instead of editing code.

The live anthropic-on-bedrock call sites now read `CI_CD_DEFAULT_BEDROCK_MODEL` (falling back to `anthropic.claude-haiku-4-5-20251001-v1:0`). The bedrock routing prefix (`invoke/`, `converse/`) and the region/inference-profile prefix (`us.`) stay literal because they are what these tests exercise; only the base model id comes from the env var, composed with an f-string. Migrated files:

- `tests/llm_translation/test_bedrock_invoke_tests.py`
- `tests/pass_through_unit_tests/messages_api_structured_output/test_bedrock_converse_structured_output.py`
- `tests/pass_through_unit_tests/test_anthropic_messages_prompt_caching.py`
- `tests/pass_through_unit_tests/test_bedrock_tool_use_beta_header.py`

Left pinned on purpose: `test_bedrock_common_utils.py` (a string-parsing unit test whose model strings are input/expected fixtures), `reasoning_effort_grid` (asserts a specific model is "not available for this account"), the skipped invoke-structured-output class, the Nova-specific sites, and `test_bedrock_batches_api.py` (its model id must match a static `model_name` in the e2e proxy config, so it cannot be parametrized without also editing that config).

To make the override live, set `CI_CD_DEFAULT_BEDROCK_MODEL` as a CircleCI project (or context) environment variable to a base bedrock model id (no routing or region prefix). Until then, tests fall back to the current default.

## Proof

With AWS bedrock credentials in the environment:

1. Default fallback:
   `cd tests/llm_translation && python -m pytest test_bedrock_invoke_tests.py -k Json -x -s`
2. Override and confirm the new base model is exercised (prefix preserved):
   `CI_CD_DEFAULT_BEDROCK_MODEL=us.anthropic.claude-sonnet-4-5-20250929-v1:0 python -m pytest test_bedrock_invoke_tests.py -k Json -x -s`



