### PR TITLE
Migrate Gemini CI test models to CI_CD_DEFAULT_GEMINI_MODEL env var

### DIFF
--- a/tests/local_testing/test_batch_completions.py
+++ b/tests/local_testing/test_batch_completions.py
@@ -72,7 +72,10 @@ def test_batch_completions_models():
 def test_batch_completion_models_all_responses():
     try:
         responses = batch_completion_models_all_responses(
-            models=["gemini/gemini-2.5-flash-lite", "claude-haiku-4-5-20251001"],
+            models=[
+                f"gemini/{os.environ.get('CI_CD_DEFAULT_GEMINI_MODEL', 'gemini-2.5-flash')}",
+                "claude-haiku-4-5-20251001",
+            ],
             messages=[{"role": "user", "content": "write a poem"}],
             max_tokens=10,
         )

--- a/tests/unified_google_tests/test_gemini_interactions.py
+++ b/tests/unified_google_tests/test_gemini_interactions.py
@@ -16,7 +16,9 @@ class TestGeminiInteractions(BaseInteractionsTest):
 
     def get_model(self) -> str:
         """Return the Gemini model string."""
-        return "gemini/gemini-2.5-flash"
+        return (
+            f"gemini/{os.environ.get('CI_CD_DEFAULT_GEMINI_MODEL', 'gemini-2.5-flash')}"
+        )
 
     def get_api_key(self) -> str:
         """Return the Gemini API key from environment."""


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Refs LIT-2650

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review

## Type

🧹 Refactoring

## Changes

Gemini slice of the per-provider migration moving hardcoded model names in the CircleCI test suite onto environment variables, so a model deprecation can be handled by changing a CircleCI project variable instead of editing code.

The live gemini (Google AI Studio) call sites now read `CI_CD_DEFAULT_GEMINI_MODEL` (falling back to `gemini-2.5-flash`), keeping the `gemini/` prefix via an f-string. Migrated files:

- `tests/unified_google_tests/test_gemini_interactions.py`
- `tests/local_testing/test_batch_completions.py` (the gemini entry only; the anthropic entry alongside it is unchanged)

This is the AI Studio `gemini/` path only; Vertex (`vertex_ai/`) is out of scope since CircleCI has no Vertex credentials, so those tests are mocked or skipped.

To make the override live, set `CI_CD_DEFAULT_GEMINI_MODEL` as a CircleCI project (or context) environment variable. Until then, tests fall back to `gemini-2.5-flash`.

## Proof

With a GEMINI_API_KEY in the environment:

1. Default fallback:
   `cd tests/unified_google_tests && python -m pytest test_gemini_interactions.py -x -s`
2. Override and confirm the new model is exercised:
   `CI_CD_DEFAULT_GEMINI_MODEL=gemini-2.5-flash-lite python -m pytest test_gemini_interactions.py -x -s`



