### PR TITLE
Fix incorrect agent API request example payload structure

### DIFF
--- a/litellm/proxy/agent_endpoints/endpoints.py
+++ b/litellm/proxy/agent_endpoints/endpoints.py
@@ -288,36 +288,34 @@ async def create_agent(
 
     Example Request:
     ```bash
-    curl -X POST "http://localhost:4000/agents" \\
+    curl -X POST "http://localhost:4000/v1/agents" \\
         -H "Authorization: Bearer <your_api_key>" \\
         -H "Content-Type: application/json" \\
         -d '{
-            "agent": {
-                "agent_name": "my-custom-agent",
-                "agent_card_params": {
-                    "protocolVersion": "1.0",
-                    "name": "Hello World Agent",
-                    "description": "Just a hello world agent",
-                    "url": "http://localhost:9999/",
-                    "version": "1.0.0",
-                    "defaultInputModes": ["text"],
-                    "defaultOutputModes": ["text"],
-                    "capabilities": {
-                        "streaming": true
-                    },
-                    "skills": [
-                        {
-                            "id": "hello_world",
-                            "name": "Returns hello world",
-                            "description": "just returns hello world",
-                            "tags": ["hello world"],
-                            "examples": ["hi", "hello world"]
-                        }
-                    ]
+            "agent_name": "my-custom-agent",
+            "agent_card_params": {
+                "protocolVersion": "1.0",
+                "name": "Hello World Agent",
+                "description": "Just a hello world agent",
+                "url": "http://localhost:9999/",
+                "version": "1.0.0",
+                "defaultInputModes": ["text"],
+                "defaultOutputModes": ["text"],
+                "capabilities": {
+                    "streaming": true
                 },
-                "litellm_params": {
-                    "make_public": true
-                }
+                "skills": [
+                    {
+                        "id": "hello_world",
+                        "name": "Returns hello world",
+                        "description": "just returns hello world",
+                        "tags": ["hello world"],
+                        "examples": ["hi", "hello world"]
+                    }
+                ]
+            },
+            "litellm_params": {
+                "make_public": true
             }
         }'
     ```
@@ -387,7 +385,7 @@ async def get_agent_by_id(
 
     Example Request:
     ```bash
-    curl -X GET "http://localhost:4000/agents/123e4567-e89b-12d3-a456-426614174000" \\
+    curl -X GET "http://localhost:4000/v1/agents/123e4567-e89b-12d3-a456-426614174000" \\
         -H "Authorization: Bearer <your_api_key>"
     ```
     """
@@ -480,28 +478,26 @@ async def update_agent(
 
     Example Request:
     ```bash
-    curl -X PUT "http://localhost:4000/agents/123e4567-e89b-12d3-a456-426614174000" \\
+    curl -X PUT "http://localhost:4000/v1/agents/123e4567-e89b-12d3-a456-426614174000" \\
         -H "Authorization: Bearer <your_api_key>" \\
         -H "Content-Type: application/json" \\
         -d '{
-            "agent": {
-                "agent_name": "updated-agent",
-                "agent_card_params": {
-                    "protocolVersion": "1.0",
-                    "name": "Updated Agent",
-                    "description": "Updated description",
-                    "url": "http://localhost:9999/",
-                    "version": "1.1.0",
-                    "defaultInputModes": ["text"],
-                    "defaultOutputModes": ["text"],
-                    "capabilities": {
-                        "streaming": true
-                    },
-                    "skills": []
+            "agent_name": "updated-agent",
+            "agent_card_params": {
+                "protocolVersion": "1.0",
+                "name": "Updated Agent",
+                "description": "Updated description",
+                "url": "http://localhost:9999/",
+                "version": "1.1.0",
+                "defaultInputModes": ["text"],
+                "defaultOutputModes": ["text"],
+                "capabilities": {
+                    "streaming": true
                 },
-                "litellm_params": {
-                    "make_public": false
-                }
+                "skills": []
+            },
+            "litellm_params": {
+                "make_public": false
             }
         }'
     ```
@@ -573,28 +569,26 @@ async def patch_agent(
 
     Example Request:
     ```bash
-    curl -X PUT "http://localhost:4000/agents/123e4567-e89b-12d3-a456-426614174000" \\
+    curl -X PATCH "http://localhost:4000/v1/agents/123e4567-e89b-12d3-a456-426614174000" \\
         -H "Authorization: Bearer <your_api_key>" \\
         -H "Content-Type: application/json" \\
         -d '{
-            "agent": {
-                "agent_name": "updated-agent",
-                "agent_card_params": {
-                    "protocolVersion": "1.0",
-                    "name": "Updated Agent",
-                    "description": "Updated description",
-                    "url": "http://localhost:9999/",
-                    "version": "1.1.0",
-                    "defaultInputModes": ["text"],
-                    "defaultOutputModes": ["text"],
-                    "capabilities": {
-                        "streaming": true
-                    },
-                    "skills": []
+            "agent_name": "updated-agent",
+            "agent_card_params": {
+                "protocolVersion": "1.0",
+                "name": "Updated Agent",
+                "description": "Updated description",
+                "url": "http://localhost:9999/",
+                "version": "1.1.0",
+                "defaultInputModes": ["text"],
+                "defaultOutputModes": ["text"],
+                "capabilities": {
+                    "streaming": true
                 },
-                "litellm_params": {
-                    "make_public": false
-                }
+                "skills": []
+            },
+            "litellm_params": {
+                "make_public": false
             }
         }'
     ```
@@ -664,7 +658,7 @@ async def delete_agent(
 
     Example Request:
     ```bash
-    curl -X DELETE "http://localhost:4000/agents/123e4567-e89b-12d3-a456-426614174000" \\
+    curl -X DELETE "http://localhost:4000/v1/agents/123e4567-e89b-12d3-a456-426614174000" \\
         -H "Authorization: Bearer <your_api_key>"
     ```
 


### PR DESCRIPTION
Relevant issues
N/A

Linear ticket
N/A

Pre-Submission checklist
 My PR's scope is as isolated as possible, it only solves 1 specific problem
Screenshots / Proof of Fix - Attached SS with and without agent wrapper with its respective response.
Before
The documented Swagger/OpenAPI examples for agent endpoints wrapped request payloads inside:

{
  "agent": {
    ...
  }
}
Sending the documented payload resulted in:

422 validation error
loc: ["body", "agent_name"]
After
Updated examples to use root-level request bodies:

{
  "agent_name": "...",
  "agent_card_params": { ... },
  "litellm_params": { ... }
}
Verified locally:

Nested payload → 422 validation error
Root-level payload → 200 success
Verified updated examples through /openapi.json
Verified formatting with Black
Type
📖 Documentation
🐛 Bug Fix

Changes
Fix incorrect Agent API request examples in OpenAPI/Swagger documentation.

Root cause:
Agent endpoints accept request models directly (request: AgentConfig, request: PatchAgentRequest) and therefore expect root-level request fields rather than an outer agent object.

Updated examples for:

POST /v1/agents
PUT /v1/agents/{agent_id}
PATCH /v1/agents/{agent_id}
Also updated related example URLs for consistency:

GET /v1/agents/{agent_id}
DELETE /v1/agents/{agent_id}
Changes made:

- Removed outer "agent" wrapper from example payloads
- Updated /agents → /v1/agents
- Corrected PATCH curl example to use the appropriate HTTP method
- Cleaned example indentation

<img width="1071" height="566" alt="image" src="https://github.com/user-attachments/assets/5b04752d-a257-4e9f-93ff-d051f1966550" />
<img width="1366" height="680" alt="image" src="https://github.com/user-attachments/assets/177b3898-9305-4938-a96d-704e85149999" />
<img width="1082" height="460" alt="image" src="https://github.com/user-attachments/assets/b951dc23-9653-4ffe-87c0-76fcacc7aaa2" />
