### PR TITLE
fix(proxy): disable proxy buffering on streaming SSE responses

### DIFF
--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -249,6 +249,13 @@ async def create_response(  # noqa: PLR0915
     If the first chunk is an error, return a standard JSON error response.
     Otherwise, return StreamingResponse and stream all content.
     """
+    # Tell buffering reverse proxies (nginx, ingress-nginx, Envoy) to flush SSE
+    # immediately instead of releasing the whole stream in one batch (issue #28384).
+    streaming_headers = {
+        **headers,
+        "Cache-Control": "no-cache",
+        "X-Accel-Buffering": "no",
+    }
     first_chunk_value: Optional[str] = None
     final_status_code = default_status_code
 
@@ -300,7 +307,7 @@ async def create_response(  # noqa: PLR0915
         return StreamingResponse(
             empty_gen(),
             media_type=media_type,
-            headers=headers,
+            headers=streaming_headers,
             status_code=default_status_code,
         )
     except Exception as e:
@@ -338,7 +345,7 @@ async def create_response(  # noqa: PLR0915
         return StreamingResponse(
             error_gen_message(),
             media_type=media_type,
-            headers=headers,
+            headers=streaming_headers,
             status_code=error_status,
         )
 
@@ -360,7 +367,7 @@ async def create_response(  # noqa: PLR0915
     return StreamingResponse(
         combined_generator(),
         media_type=media_type,
-        headers=headers,
+        headers=streaming_headers,
         status_code=final_status_code,
     )
 

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -1258,6 +1258,31 @@ class TestCommonRequestProcessingHelpers:
         )
         assert response.headers["x-custom-header"] == "TestValue"
 
+    async def test_create_streaming_response_disables_proxy_buffering(self):
+        """Regression for #28384: every StreamingResponse create_response returns
+        must carry the headers that stop nginx/ingress/Envoy from buffering the
+        SSE stream into one batch, while preserving caller-supplied headers."""
+
+        async def normal_stream():
+            yield 'data: {"content": "part"}\n\n'
+            yield "data: [DONE]\n\n"
+
+        async def empty_stream():
+            if False:  # never yields -> StopAsyncIteration
+                yield
+
+        error_stream = AsyncMock()
+        error_stream.__anext__.side_effect = ValueError("boom")
+
+        for generator in (normal_stream(), empty_stream(), error_stream):
+            response = await create_response(
+                generator, "text/event-stream", {"X-Custom-Header": "keep"}
+            )
+            assert isinstance(response, StreamingResponse)
+            assert response.headers["x-accel-buffering"] == "no"
+            assert response.headers["cache-control"] == "no-cache"
+            assert response.headers["x-custom-header"] == "keep"
+
     async def test_create_streaming_response_non_default_status_code(self):
         async def mock_generator():
             yield 'data: {"content": "data"}\n\n'


### PR DESCRIPTION
## Relevant issues

Fixes #28384

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

The reporter streams Anthropic responses through the proxy's `/v1/messages` endpoint behind an nginx reverse proxy in k8s and sees the whole SSE stream arrive in one buffered batch, while OpenAI streams fine. litellm itself yields the Anthropic chunks incrementally (verified below), so the buffering is introduced by an intermediary that was never told to leave the SSE stream alone. The proxy now sends `X-Accel-Buffering: no` and `Cache-Control: no-cache` on its streaming responses so nginx / ingress-nginx / Envoy flush immediately.

Against a live proxy hitting the real Anthropic API, the header is now present on the streaming response:

```
$ curl -sN -D - -o /dev/null http://localhost:4000/v1/messages \
    -H "Authorization: Bearer sk-1234" -H "anthropic-version: 2023-06-01" \
    -d '{"model":"claude-4-haiku","max_tokens":64,"stream":true,"messages":[{"role":"user","content":"hi"}]}'

HTTP/1.1 200 OK
cache-control: no-cache
x-accel-buffering: no
content-type: text/event-stream; charset=utf-8
Transfer-Encoding: chunked
```

The same header is now emitted for `/chat/completions` and `/v1/responses`, which share the same `create_response()` return path.

Streaming throughput is unchanged; chunks still arrive incrementally across the whole generation (timestamps are seconds from request start, against the real Anthropic API):

```
$ curl -sN http://localhost:4000/v1/messages -H "Authorization: Bearer sk-1234" \
    -H "anthropic-version: 2023-06-01" \
    -d '{"model":"claude-4-haiku","max_tokens":512,"stream":true,"messages":[{"role":"user","content":"Write a 200 word essay on the history of the internet."}]}'

[  0.424s] chunk#1: event: message_start
[  0.424s] chunk#3: event: content_block_start
[  2.314s] chunk#25: event: content_block_delta
... 40 SSE lines, first@0.424s, last@3.047s
```

## Type

🐛 Bug Fix

## Changes

`/chat/completions`, `/v1/messages`, `/v1/responses`, and the assistants streaming endpoint all return their SSE through the shared `create_response()` helper, which set `media_type=text/event-stream` but never sent the headers that disable buffering in front-end proxies. A reverse proxy with default buffering (nginx without `proxy_buffering off` on every hop, k8s ingress-nginx, an Envoy/Istio sidecar) then accumulates the whole response and releases it in one batch, which presents to the client as a broken or buffered stream even though litellm is yielding chunks incrementally.

`create_response()` now adds `Cache-Control: no-cache` and `X-Accel-Buffering: no` to every `StreamingResponse` it returns, merged over any caller-supplied headers. This matches what the proxy already does for its own usage and policy SSE endpoints. Added a regression test in the mapped `test_common_request_processing.py` that asserts both headers are present on the normal, empty, and error streaming paths and that caller headers are preserved; it fails before the change with `KeyError: 'x-accel-buffering'`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: response-header-only change on the existing streaming helper, with regression tests; first-chunk JSON errors still use the original headers (non-SSE).
> 
> **Overview**
> Fixes **buffered SSE** behind reverse proxies (nginx, ingress-nginx, Envoy) by having the shared `create_response()` helper merge **`Cache-Control: no-cache`** and **`X-Accel-Buffering: no`** into every **`StreamingResponse`** it returns, on top of caller headers.
> 
> That central path covers proxy streaming routes such as **`/chat/completions`**, **`/v1/messages`**, **`/v1/responses`**, and assistants streaming—aligned with headers already used on some management SSE endpoints. A regression test asserts those headers on normal, empty, and early-error streaming branches while preserving custom headers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec137311af67893135303327cd844c750edf0430. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->