### PR TITLE
fix(otel/v2): set error.type on server spans via http semconv opt-in

### DIFF
--- a/litellm/integrations/otel/README.md
+++ b/litellm/integrations/otel/README.md
@@ -100,7 +100,13 @@ becomes the global, so server spans export to that backend too.
    scrapes, and asset fetches don't flood traces. Entries are substring-matched, so
    `/metrics` also drops the `/model/metrics` admin-analytics spans. Set
    `OTEL_PYTHON_FASTAPI_EXCLUDED_URLS` to override the whole set (e.g. `""` to trace
-   everything, or your own comma-separated path list).
+   everything, or your own comma-separated path list). Before instrumenting, the mount
+   also opts the instrumentation into the new HTTP semantic conventions
+   (`mount._ensure_http_semconv_opt_in`) by appending `http` to
+   `OTEL_SEMCONV_STABILITY_OPT_IN` if no http mode is set, so server spans carry
+   `http.response.status_code` and an `error.type` on 5xx (the default mode emits the
+   legacy `http.status_code` and no error attribute). Set that env var to `http/dup`
+   to keep the legacy attribute alongside the new ones.
 2. **Startup** (`proxy_server.proxy_startup_event`): after the config (and
    callbacks) is loaded, the already-registered preset `OpenTelemetryV2` logger
    is reused — or a generic one reading `OTEL_*` envs is built when no preset is

--- a/litellm/integrations/otel/mount.py
+++ b/litellm/integrations/otel/mount.py
@@ -15,7 +15,16 @@ import os
 from typing import Any
 
 from litellm._logging import verbose_logger
+from litellm.integrations.opentelemetry_utils.gen_ai_semconv import (
+    OTEL_SEMCONV_STABILITY_OPT_IN_ENV,
+)
 from litellm.integrations.otel.model.config import is_otel_v2_enabled
+
+# Tokens that put the HTTP instrumentation on the new (stable) HTTP semantic
+# conventions. ``http`` switches fully to the new attributes; ``http/dup`` emits
+# both new and legacy. Either one makes ``_report_new`` true, which is what gates
+# the ``error.type`` (and ``http.response.status_code``) attributes on server spans.
+_HTTP_SEMCONV_OPT_IN_TOKENS = ("http", "http/dup")
 
 # Routes excluded from server-span tracing by default: high-frequency pollers and
 # static UI/docs assets, none of which are LLM traffic. Entries are substring-matched
@@ -88,6 +97,29 @@ def _passthrough_span_name_hook(span: Any, scope: dict) -> None:
         pass
 
 
+def _ensure_http_semconv_opt_in() -> None:
+    """Opt the FastAPI/ASGI instrumentation into the new HTTP semantic conventions.
+
+    The instrumentation only stamps ``error.type`` (and the new
+    ``http.response.status_code``) on a server span when the HTTP semconv opt-in
+    is active; in the default mode it emits the legacy ``http.status_code`` and no
+    error attribute, so failed requests (5xx) carry no machine-readable error
+    marker. LiteLLM's own otel spans already use the new names, so aligning the
+    instrumentation keeps every server-span attribute consistent.
+
+    The opt-in lives in ``OTEL_SEMCONV_STABILITY_OPT_IN``, a comma-separated,
+    multi-category flag that also carries the gen-ai opt-in, so append rather than
+    overwrite, and leave an operator who has already chosen an http mode untouched.
+    This MUST run before ``instrument_app``, which reads the flag once.
+    """
+    raw = os.environ.get(OTEL_SEMCONV_STABILITY_OPT_IN_ENV, "")
+    tokens = [token.strip() for token in raw.split(",") if token.strip()]
+    if any(token in _HTTP_SEMCONV_OPT_IN_TOKENS for token in tokens):
+        return
+    tokens.append("http")
+    os.environ[OTEL_SEMCONV_STABILITY_OPT_IN_ENV] = ",".join(tokens)
+
+
 def instrument_fastapi_app(app: Any) -> None:
     """Attach OTel server-span instrumentation to the proxy FastAPI app.
 
@@ -111,6 +143,8 @@ def instrument_fastapi_app(app: Any) -> None:
         # ``proxy_server``'s unconditional ``import`` of this module crash when the
         # package is absent, even with the gate off.
         from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+
+        _ensure_http_semconv_opt_in()
 
         excluded_urls = (
             os.environ.get("OTEL_PYTHON_FASTAPI_EXCLUDED_URLS")

--- a/tests/test_litellm/integrations/otel/test_otel_v2_mount.py
+++ b/tests/test_litellm/integrations/otel/test_otel_v2_mount.py
@@ -23,13 +23,17 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import (  # noqa: E4
 )
 from opentelemetry.trace import SpanKind  # noqa: E402
 
+from litellm.integrations.opentelemetry_utils.gen_ai_semconv import (  # noqa: E402
+    OTEL_SEMCONV_STABILITY_OPT_IN_ENV,
+)
+from litellm.integrations.otel.logger import OpenTelemetryV2  # noqa: E402
 from litellm.integrations.otel.model.config import (  # noqa: E402
     OpenTelemetryV2Config,
     is_otel_v2_enabled,
 )
-from litellm.integrations.otel.logger import OpenTelemetryV2  # noqa: E402
 from litellm.integrations.otel.mount import (  # noqa: E402
     PASSTHROUGH_PREFIXES,
+    _ensure_http_semconv_opt_in,
     _passthrough_span_name_hook,
     instrument_fastapi_app,
 )
@@ -149,3 +153,104 @@ def test_instrument_fastapi_app_attaches_when_gate_on(monkeypatch):
         assert getattr(app, "_is_instrumented_by_opentelemetry", False) is True
     finally:
         FastAPIInstrumentor.uninstrument_app(app)
+
+
+def test_ensure_http_semconv_opt_in_appends_when_unset(monkeypatch):
+    monkeypatch.delenv(OTEL_SEMCONV_STABILITY_OPT_IN_ENV, raising=False)
+    _ensure_http_semconv_opt_in()
+    assert os.environ[OTEL_SEMCONV_STABILITY_OPT_IN_ENV] == "http"
+
+
+def test_ensure_http_semconv_opt_in_preserves_other_categories(monkeypatch):
+    """The flag is shared with the gen-ai opt-in, so appending must not clobber it."""
+    monkeypatch.setenv(OTEL_SEMCONV_STABILITY_OPT_IN_ENV, "gen_ai_latest_experimental")
+    _ensure_http_semconv_opt_in()
+    tokens = os.environ[OTEL_SEMCONV_STABILITY_OPT_IN_ENV].split(",")
+    assert "gen_ai_latest_experimental" in tokens
+    assert "http" in tokens
+
+
+@pytest.mark.parametrize("existing", ["http", "http/dup", "gen_ai,http/dup"])
+def test_ensure_http_semconv_opt_in_respects_operator_http_mode(monkeypatch, existing):
+    """An operator who already picked an http mode is left untouched (no double-add)."""
+    monkeypatch.setenv(OTEL_SEMCONV_STABILITY_OPT_IN_ENV, existing)
+    _ensure_http_semconv_opt_in()
+    assert os.environ[OTEL_SEMCONV_STABILITY_OPT_IN_ENV] == existing
+
+
+def _reset_semconv_stability():
+    """Snapshot and clear the once-initialized HTTP semconv mode so an
+    ``instrument_app`` call re-reads the env var as a fresh process would.
+    Returns a restore callable for teardown."""
+    from opentelemetry.instrumentation import _semconv
+
+    cls = _semconv._OpenTelemetrySemanticConventionStability
+    prev_initialized = cls._initialized
+    prev_mapping = dict(cls._OTEL_SEMCONV_STABILITY_SIGNAL_MAPPING)
+
+    cls._initialized = False
+    cls._OTEL_SEMCONV_STABILITY_SIGNAL_MAPPING = {}
+
+    def restore():
+        cls._initialized = prev_initialized
+        cls._OTEL_SEMCONV_STABILITY_SIGNAL_MAPPING = prev_mapping
+
+    return restore
+
+
+def _server_span_for_status(app, exporter, path):
+    TestClient(app, raise_server_exceptions=False).get(path)
+    server_spans = [
+        s for s in exporter.get_finished_spans() if s.kind is SpanKind.SERVER
+    ]
+    assert server_spans, "expected a SERVER span for the failing request"
+    return server_spans[0].attributes or {}
+
+
+def _failing_app_with_exporter():
+    app = fastapi.FastAPI()
+
+    @app.get("/boom")
+    def boom():
+        return fastapi.Response(status_code=503)
+
+    from opentelemetry.sdk.trace import TracerProvider
+
+    provider = TracerProvider()
+    exporter = InMemorySpanExporter()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    return app, provider, exporter
+
+
+def test_server_span_carries_error_type_on_5xx(monkeypatch):
+    """The fix: with the http semconv opt-in active (which the mount applies),
+    a 5xx server span carries the OTel ``error.type`` attribute."""
+    monkeypatch.delenv(OTEL_SEMCONV_STABILITY_OPT_IN_ENV, raising=False)
+    _ensure_http_semconv_opt_in()
+    restore = _reset_semconv_stability()
+    app, provider, exporter = _failing_app_with_exporter()
+    FastAPIInstrumentor.instrument_app(app, tracer_provider=provider)
+    try:
+        attrs = _server_span_for_status(app, exporter, "/boom")
+        assert attrs.get("error.type") == "503"
+        assert attrs.get("http.response.status_code") == 503
+    finally:
+        FastAPIInstrumentor.uninstrument_app(app)
+        restore()
+
+
+def test_server_span_missing_error_type_without_opt_in(monkeypatch):
+    """Negative control: in the default semconv mode the same 5xx carries no
+    ``error.type`` and only the legacy ``http.status_code`` - exactly the gap
+    the opt-in closes."""
+    monkeypatch.delenv(OTEL_SEMCONV_STABILITY_OPT_IN_ENV, raising=False)
+    restore = _reset_semconv_stability()
+    app, provider, exporter = _failing_app_with_exporter()
+    FastAPIInstrumentor.instrument_app(app, tracer_provider=provider)
+    try:
+        attrs = _server_span_for_status(app, exporter, "/boom")
+        assert "error.type" not in attrs
+        assert attrs.get("http.status_code") == 503
+    finally:
+        FastAPIInstrumentor.uninstrument_app(app)
+        restore()


### PR DESCRIPTION
## Relevant issues

otelv2 server spans are missing the HTTP `error.type` attribute on failures

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:
- [ ] **CI run for the last commit**
       Link:
- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

With the proxy running under the V2 gate (`LITELLM_OTEL_V2=1`) and an OTLP collector attached, send a request that the proxy rejects so it returns a 5xx, then inspect the exported SERVER span. Before this change the span has only the legacy `http.status_code` and no error marker; after it, the span carries `http.response.status_code` plus `error.type`.

```
# a request that fails server-side (e.g. an unconfigured model -> 5xx)
curl -sS -o /dev/null -w "%{http_code}\n" http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer $LITELLM_KEY" \
  -H "Content-Type: application/json" \
  -d '{"model":"does-not-exist","messages":[{"role":"user","content":"hi"}]}'
```

In the collector, the proxy SERVER span for that request now shows `error.type` set to the response status (e.g. `"500"`) alongside `http.response.status_code`. I will attach the collector output once a live instance is up.

## Type

🐛 Bug Fix

## Changes

The proxy's SERVER spans come from `FastAPIInstrumentor`. Whether that instrumentation stamps the HTTP `error.type` attribute is decided in `opentelemetry.instrumentation._semconv._set_status`, which only sets `error.type` (and the new `http.response.status_code`) when the HTTP semantic-convention opt-in mode is `http` or `http/dup`. That mode defaults to `DEFAULT`, under which the instrumentation emits the legacy `http.status_code` and never sets `error.type`. So failed requests carried no machine-readable error marker, and the status-code attribute on server spans (`http.status_code`) disagreed with the new-semconv names otelv2 uses everywhere else (`http.response.status_code`, `error.type`, `url.path`, `http.route`).

The opt-in is read once from `OTEL_SEMCONV_STABILITY_OPT_IN` by the instrumentation's `_initialize`, which `instrument_app` triggers. `instrument_fastapi_app` is litellm's only HTTP instrumentation and the single mount site, so the fix opts in there before `instrument_app` runs: `_ensure_http_semconv_opt_in` appends `http` to the flag when no http mode is present. The flag is comma-separated and shared with the gen-ai opt-in, so the append preserves any existing categories (e.g. `gen_ai_latest_experimental`) and leaves an operator who already chose `http` / `http/dup` untouched. Operators who want the legacy attribute kept alongside the new ones can set `OTEL_SEMCONV_STABILITY_OPT_IN=http/dup`.

Result: server spans now carry `http.response.status_code` on every traced request and `error.type` on 5xx, consistent with the rest of otelv2.

Tests in `test_otel_v2_mount.py` cover the env-flag merge (append when unset, preserve other categories, respect an operator-set http mode) and the end-to-end span behavior: a 5xx server span carries `error.type` with the opt-in active, and a negative-control test asserts that without the opt-in the same 5xx has no `error.type` and only the legacy `http.status_code`, pinning the exact gap this closes.

https://claude.ai/code/session_01L4eUykxq7brxBzbbgVfLY5

---
_Generated by [Claude Code](https://claude.ai/code/session_01L4eUykxq7brxBzbbgVfLY5)_