### PR TITLE
fix(openrouter): expose the model routed by openrouter/auto

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -170,6 +170,7 @@ LITELLM_UI_ALLOW_HEADERS = [
     "x-litellm-semantic-filter",
     "x-litellm-semantic-filter-tools",
     "x-litellm-adaptive-router-model",
+    "x-litellm-routed-model",
 ]
 
 # Gemini model-specific minimal thinking budget constants

--- a/litellm/llms/openrouter/chat/transformation.py
+++ b/litellm/llms/openrouter/chat/transformation.py
@@ -192,10 +192,10 @@ class OpenrouterConfig(OpenAIGPTConfig):
         """
         Transform the response from OpenRouter API.
 
-        Extracts cost information from response headers if available.
+        Extracts cost and the routed model from the response body when available.
 
         Returns:
-            ModelResponse: The transformed response with cost information.
+            ModelResponse: The transformed response.
         """
         # Call parent transform_response to get the standard ModelResponse
         model_response = super().transform_response(
@@ -227,6 +227,15 @@ class OpenrouterConfig(OpenAIGPTConfig):
                     model_response._hidden_params["additional_headers"][
                         "llm_provider-x-litellm-response-cost"
                     ] = float(response_cost)
+            # Surface the model OpenRouter actually routed to when it differs from the
+            # requested model (openrouter/auto resolves server-side), exposed by the
+            # proxy as the x-litellm-routed-model header.
+            routed_model = response_json.get("model")
+            requested_model = model.split("openrouter/", 1)[-1]
+            if routed_model and routed_model != requested_model:
+                if not hasattr(model_response, "_hidden_params"):
+                    model_response._hidden_params = {}
+                model_response._hidden_params["routed_model"] = routed_model
         except Exception:
             # If we can't extract cost, continue without it - don't fail the response
             pass

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -590,6 +590,7 @@ class ProxyBaseLLMRequestProcessing:
         headers = {
             "x-litellm-call-id": call_id,
             "x-litellm-model-id": model_id,
+            "x-litellm-routed-model": hidden_params.get("routed_model"),
             "x-litellm-cache-key": cache_key,
             "x-litellm-model-api-base": (
                 api_base.split("?")[0] if api_base else None

--- a/tests/test_litellm/llms/openrouter/chat/test_openrouter_chat_transformation.py
+++ b/tests/test_litellm/llms/openrouter/chat/test_openrouter_chat_transformation.py
@@ -455,6 +455,124 @@ def test_openrouter_cost_tracking_non_streaming():
     )
 
 
+def test_openrouter_exposes_routed_model_in_headers():
+    """
+    Regression test for https://github.com/BerriAI/litellm/issues/29406
+
+    When calling openrouter/auto, OpenRouter resolves the request to a concrete
+    model and returns it in the response body's top-level "model" field. The proxy
+    reports only the requested model group ("openrouter/auto"), so the actually
+    routed model must be captured into _hidden_params["routed_model"], which the proxy
+    surfaces as the x-litellm-routed-model response header.
+    """
+    from unittest.mock import Mock, patch
+    from litellm.types.utils import ModelResponse, Choices, Message, Usage
+
+    config = OpenrouterConfig()
+
+    requested_model = "openrouter/auto"
+    routed_model = "anthropic/claude-sonnet-4"
+
+    mock_response = Mock(spec=httpx.Response)
+    mock_response.json.return_value = {
+        "id": "gen-123",
+        "model": routed_model,
+        "choices": [
+            {
+                "message": {"role": "assistant", "content": "Hello!"},
+                "finish_reason": "stop",
+                "index": 0,
+            }
+        ],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30},
+    }
+    mock_response.headers = {}
+
+    model_response = ModelResponse(
+        id="gen-123",
+        choices=[
+            Choices(
+                finish_reason="stop",
+                index=0,
+                message=Message(content="Hello!", role="assistant"),
+            )
+        ],
+        created=1234567890,
+        model=requested_model,
+        object="chat.completion",
+        usage=Usage(prompt_tokens=10, completion_tokens=20, total_tokens=30),
+    )
+
+    with patch.object(
+        OpenAIGPTConfig, "transform_response", return_value=model_response
+    ):
+        result = config.transform_response(
+            model=requested_model,
+            raw_response=mock_response,
+            model_response=model_response,
+            logging_obj=Mock(),
+            request_data={},
+            messages=[{"role": "user", "content": "Hello"}],
+            optional_params={},
+            litellm_params={},
+            encoding=None,
+        )
+
+    assert result._hidden_params["routed_model"] == routed_model
+    # the routed model must differ from the requested group, otherwise the header adds nothing
+    assert result._hidden_params["routed_model"] != requested_model
+
+    # A non-auto request whose response echoes the requested model must NOT set the
+    # header, so plain (non-auto) OpenRouter traffic is left untagged
+    echoed_model = "anthropic/claude-sonnet-4"
+    mock_echo = Mock(spec=httpx.Response)
+    mock_echo.json.return_value = {
+        "id": "gen-456",
+        "model": echoed_model,
+        "choices": [
+            {
+                "message": {"role": "assistant", "content": "Hi"},
+                "finish_reason": "stop",
+                "index": 0,
+            }
+        ],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    }
+    mock_echo.headers = {}
+
+    echo_response = ModelResponse(
+        id="gen-456",
+        choices=[
+            Choices(
+                finish_reason="stop",
+                index=0,
+                message=Message(content="Hi", role="assistant"),
+            )
+        ],
+        created=1234567890,
+        model=f"openrouter/{echoed_model}",
+        object="chat.completion",
+        usage=Usage(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+    )
+
+    with patch.object(
+        OpenAIGPTConfig, "transform_response", return_value=echo_response
+    ):
+        echo_result = config.transform_response(
+            model=f"openrouter/{echoed_model}",
+            raw_response=mock_echo,
+            model_response=echo_response,
+            logging_obj=Mock(),
+            request_data={},
+            messages=[{"role": "user", "content": "Hi"}],
+            optional_params={},
+            litellm_params={},
+            encoding=None,
+        )
+
+    assert "routed_model" not in echo_result._hidden_params
+
+
 def test_openrouter_cost_tracking_streaming():
     """
     Test OpenRouter cost tracking for streaming completions.

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -569,6 +569,34 @@ class TestProxyBaseLLMRequestProcessing:
         assert "x-litellm-response-cost-original" not in headers
         assert "x-litellm-response-cost-discount-amount" not in headers
 
+    def test_get_custom_headers_includes_routed_model(self):
+        """
+        Regression test for https://github.com/BerriAI/litellm/issues/29406
+
+        When a provider resolves the request to a different model (e.g. openrouter/auto),
+        the adapter stores it in hidden_params["routed_model"] and the proxy must expose
+        it as the x-litellm-routed-model header. When absent, the header is omitted.
+        """
+        mock_user_api_key_dict = MagicMock(spec=UserAPIKeyAuth)
+        mock_user_api_key_dict.tpm_limit = None
+        mock_user_api_key_dict.rpm_limit = None
+        mock_user_api_key_dict.max_budget = None
+        mock_user_api_key_dict.spend = 0
+
+        headers = ProxyBaseLLMRequestProcessing.get_custom_headers(
+            user_api_key_dict=mock_user_api_key_dict,
+            call_id="test-call-id",
+            hidden_params={"routed_model": "anthropic/claude-sonnet-4"},
+        )
+        assert headers["x-litellm-routed-model"] == "anthropic/claude-sonnet-4"
+
+        headers_without = ProxyBaseLLMRequestProcessing.get_custom_headers(
+            user_api_key_dict=mock_user_api_key_dict,
+            call_id="test-call-id",
+            hidden_params={},
+        )
+        assert "x-litellm-routed-model" not in headers_without
+
     def test_get_custom_headers_with_margin_info(self):
         """
         Test that margin headers are included when margin is applied.


### PR DESCRIPTION
## Relevant issues

Fixes #29406

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Type

Bug Fix

## Changes

OpenRouter's `openrouter/auto` resolves a request to a concrete model on its side and returns that model in the response body `model` field. The proxy previously reported only the requested model group, so a caller had no way to tell which model actually served an auto-routed request

`OpenrouterConfig.transform_response` now records the resolved model in `model_response._hidden_params["routed_model"]`, and `ProxyBaseLLMRequestProcessing.get_custom_headers` exposes it as the `x-litellm-routed-model` response header. The header is added to `LITELLM_UI_ALLOW_HEADERS` so browser clients can read it through CORS, mirroring the existing `x-litellm-adaptive-router-model` header used for adaptive routing. The value is recorded only when the resolved model differs from the requested model, so plain non-auto OpenRouter requests stay untagged and the header is omitted

Streaming is already covered: `OpenRouterChatCompletionStreamingHandler.chunk_parser` preserves the resolved `model` on every chunk, and a response header cannot carry it for streaming since headers are flushed before the body

Tests: a transformation unit test asserts the resolved model is captured from the response body, and a proxy test asserts the `x-litellm-routed-model` header is emitted when the value is present and omitted when it is absent

## Screenshots / Proof of Fix

Live curl proof against a local proxy configured with `openrouter/auto`, showing the `x-litellm-routed-model` response header, will be attached shortly
