### PR TITLE
Litellm websocket improvements

### DIFF
--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -5528,6 +5528,7 @@ class BaseLLMHTTPHandler:
         user_api_key_dict: Optional[Any] = None,
         litellm_metadata: Optional[Dict[str, Any]] = None,
         custom_llm_provider: Optional[str] = None,
+        first_message: Optional[str] = None,
         **kwargs: Any,
     ):
         """
@@ -5559,6 +5560,7 @@ class BaseLLMHTTPHandler:
                 api_base=api_base,
                 timeout=timeout,
                 custom_llm_provider=custom_llm_provider,
+                first_message=first_message,
                 **kwargs,
             )
             await handler.run()
@@ -5624,6 +5626,7 @@ class BaseLLMHTTPHandler:
                     logging_obj=logging_obj,
                     user_api_key_dict=user_api_key_dict,
                     request_data=_request_data,
+                    first_message=first_message,
                 )
                 await streaming.bidirectional_forward()
 

--- a/litellm/proxy/hooks/proxy_track_cost_callback.py
+++ b/litellm/proxy/hooks/proxy_track_cost_callback.py
@@ -285,15 +285,15 @@ class _ProxyDBLogger(CustomLogger):
                 await _release_budget_reservation(budget_reservation=budget_reservation)
                 # Non-model call types (health checks, afile_delete) have no model or standard_logging_object.
                 # Use .get() for "stream" to avoid KeyError on health checks.
-                # WS session wrappers (_aresponses_websocket, _arealtime) fire with result=None;
-                # per-turn costs are already tracked by individual aresponses/realtime calls.
+                # WS session wrappers (_aresponses_websocket, _arealtime) also reach here with
+                # result=None; their per-turn costs are tracked on the inner aresponses/realtime calls.
                 if sl_object is None and (
                     not kwargs.get("model")
                     or kwargs.get("call_type")
                     in ("_aresponses_websocket", "_arealtime")
                 ):
                     verbose_proxy_logger.warning(
-                        "Cost tracking - skipping, no standard_logging_object and no model for call_type=%s",
+                        "Cost tracking - skipping, no standard_logging_object for call_type=%s",
                         kwargs.get("call_type", "unknown"),
                     )
                     return

--- a/litellm/proxy/hooks/proxy_track_cost_callback.py
+++ b/litellm/proxy/hooks/proxy_track_cost_callback.py
@@ -289,7 +289,8 @@ class _ProxyDBLogger(CustomLogger):
                 # per-turn costs are already tracked by individual aresponses/realtime calls.
                 if sl_object is None and (
                     not kwargs.get("model")
-                    or kwargs.get("call_type") in ("_aresponses_websocket", "_arealtime")
+                    or kwargs.get("call_type")
+                    in ("_aresponses_websocket", "_arealtime")
                 ):
                     verbose_proxy_logger.warning(
                         "Cost tracking - skipping, no standard_logging_object and no model for call_type=%s",

--- a/litellm/proxy/hooks/proxy_track_cost_callback.py
+++ b/litellm/proxy/hooks/proxy_track_cost_callback.py
@@ -285,7 +285,12 @@ class _ProxyDBLogger(CustomLogger):
                 await _release_budget_reservation(budget_reservation=budget_reservation)
                 # Non-model call types (health checks, afile_delete) have no model or standard_logging_object.
                 # Use .get() for "stream" to avoid KeyError on health checks.
-                if sl_object is None and not kwargs.get("model"):
+                # WS session wrappers (_aresponses_websocket, _arealtime) fire with result=None;
+                # per-turn costs are already tracked by individual aresponses/realtime calls.
+                if sl_object is None and (
+                    not kwargs.get("model")
+                    or kwargs.get("call_type") in ("_aresponses_websocket", "_arealtime")
+                ):
                     verbose_proxy_logger.warning(
                         "Cost tracking - skipping, no standard_logging_object and no model for call_type=%s",
                         kwargs.get("call_type", "unknown"),

--- a/litellm/proxy/response_api_endpoints/endpoints.py
+++ b/litellm/proxy/response_api_endpoints/endpoints.py
@@ -935,6 +935,60 @@ async def cancel_response(
         )
 
 
+async def _read_ws_model_from_first_frame(
+    websocket: WebSocket,
+) -> Optional[tuple]:
+    """Read the first WS frame and return (model, raw_message), or None on error.
+
+    Sends an appropriate error frame and closes the socket before returning None.
+    """
+    try:
+        first_message = await asyncio.wait_for(websocket.receive_text(), timeout=30)
+    except asyncio.TimeoutError:
+        await websocket.close(code=1008, reason="Timed out waiting for first message")
+        return None
+    except Exception:
+        await websocket.close(
+            code=1008, reason="Client disconnected before sending first message"
+        )
+        return None
+
+    try:
+        first_event = json.loads(first_message)
+    except json.JSONDecodeError:
+        await websocket.send_text(
+            json.dumps(
+                {
+                    "type": "error",
+                    "error": {
+                        "type": "invalid_request_error",
+                        "message": "First message is not valid JSON.",
+                    },
+                }
+            )
+        )
+        await websocket.close(code=1008, reason="Invalid JSON in first message")
+        return None
+
+    model = _extract_model_from_first_ws_event(first_event)
+    if not model:
+        await websocket.send_text(
+            json.dumps(
+                {
+                    "type": "error",
+                    "error": {
+                        "type": "invalid_request_error",
+                        "message": "No model provided. Supply ?model=<model> in the URL or include 'model' in the first response.create event.",
+                    },
+                }
+            )
+        )
+        await websocket.close(code=1008, reason="No model provided")
+        return None
+
+    return model, first_message
+
+
 def _extract_model_from_first_ws_event(first_event: dict) -> Optional[str]:
     """Extract model from a response.create WS event, handling flat and nested formats.
 
@@ -994,57 +1048,12 @@ async def responses_websocket_endpoint(
         accept_kwargs["subprotocol"] = requested_protocols[0]
     await websocket.accept(**accept_kwargs)
 
-    # If model was not supplied via query param, read the first frame and
-    # extract it from the response.create event. This matches OpenAI's
-    # behaviour where the bearer token scopes the connection and the model
-    # is declared inside the first message.
     first_message: Optional[str] = None
     if not model:
-        try:
-            first_message = await asyncio.wait_for(websocket.receive_text(), timeout=30)
-        except asyncio.TimeoutError:
-            await websocket.close(
-                code=1008, reason="Timed out waiting for first message"
-            )
+        result = await _read_ws_model_from_first_frame(websocket)
+        if result is None:
             return
-        except Exception:
-            await websocket.close(
-                code=1008, reason="Client disconnected before sending first message"
-            )
-            return
-
-        try:
-            first_event = json.loads(first_message)
-        except json.JSONDecodeError:
-            await websocket.send_text(
-                json.dumps(
-                    {
-                        "type": "error",
-                        "error": {
-                            "type": "invalid_request_error",
-                            "message": "First message is not valid JSON.",
-                        },
-                    }
-                )
-            )
-            await websocket.close(code=1008, reason="Invalid JSON in first message")
-            return
-
-        model = _extract_model_from_first_ws_event(first_event)
-        if not model:
-            await websocket.send_text(
-                json.dumps(
-                    {
-                        "type": "error",
-                        "error": {
-                            "type": "invalid_request_error",
-                            "message": "No model provided. Supply ?model=<model> in the URL or include 'model' in the first response.create event.",
-                        },
-                    }
-                )
-            )
-            await websocket.close(code=1008, reason="No model provided")
-            return
+        model, first_message = result
 
     data: Dict[str, Any] = {
         "model": model,

--- a/litellm/proxy/response_api_endpoints/endpoints.py
+++ b/litellm/proxy/response_api_endpoints/endpoints.py
@@ -935,6 +935,18 @@ async def cancel_response(
         )
 
 
+def _extract_model_from_first_ws_event(first_event: dict) -> Optional[str]:
+    """Extract model from a response.create WS event, handling flat and nested formats.
+
+    Flat:   {"type": "response.create", "model": "gpt-4o", ...}
+    Nested: {"type": "response.create", "response": {"model": "gpt-4o", ...}}
+    """
+    nested = first_event.get("response")
+    return (
+        nested.get("model") if isinstance(nested, dict) else None
+    ) or first_event.get("model")
+
+
 @router.websocket("/v1/responses")
 @router.websocket("/responses")
 async def responses_websocket_endpoint(
@@ -1014,12 +1026,7 @@ async def responses_websocket_endpoint(
             await websocket.close(code=1008, reason="Invalid JSON in first message")
             return
 
-        nested = first_event.get("response")
-        model = (
-            nested.get("model")
-            if isinstance(nested, dict)
-            else None
-        ) or first_event.get("model")
+        model = _extract_model_from_first_ws_event(first_event)
         if not model:
             await websocket.send_text(
                 json.dumps(

--- a/litellm/proxy/response_api_endpoints/endpoints.py
+++ b/litellm/proxy/response_api_endpoints/endpoints.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 
 import fastapi
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
-from starlette.websockets import WebSocket
+from starlette.websockets import WebSocket, WebSocketDisconnect
 
 from litellm._logging import verbose_proxy_logger
 from litellm.integrations.custom_guardrail import ModifyResponseException
@@ -947,10 +947,13 @@ async def _read_ws_model_from_first_frame(
     except asyncio.TimeoutError:
         await websocket.close(code=1008, reason="Timed out waiting for first message")
         return None
+    except WebSocketDisconnect:
+        return None
     except Exception:
-        await websocket.close(
-            code=1008, reason="Client disconnected before sending first message"
+        verbose_proxy_logger.exception(
+            "Responses WebSocket error reading first message"
         )
+        await websocket.close(code=1011, reason="Internal server error")
         return None
 
     try:

--- a/litellm/proxy/response_api_endpoints/endpoints.py
+++ b/litellm/proxy/response_api_endpoints/endpoints.py
@@ -1003,10 +1003,14 @@ async def responses_websocket_endpoint(
         try:
             first_message = await asyncio.wait_for(websocket.receive_text(), timeout=30)
         except asyncio.TimeoutError:
-            await websocket.close(code=1008, reason="Timed out waiting for first message")
+            await websocket.close(
+                code=1008, reason="Timed out waiting for first message"
+            )
             return
         except Exception:
-            await websocket.close(code=1008, reason="Client disconnected before sending first message")
+            await websocket.close(
+                code=1008, reason="Client disconnected before sending first message"
+            )
             return
 
         try:

--- a/litellm/proxy/response_api_endpoints/endpoints.py
+++ b/litellm/proxy/response_api_endpoints/endpoints.py
@@ -1014,7 +1014,12 @@ async def responses_websocket_endpoint(
             await websocket.close(code=1008, reason="Invalid JSON in first message")
             return
 
-        model = first_event.get("model")
+        nested = first_event.get("response")
+        model = (
+            nested.get("model")
+            if isinstance(nested, dict)
+            else None
+        ) or first_event.get("model")
         if not model:
             await websocket.send_text(
                 json.dumps(

--- a/litellm/proxy/response_api_endpoints/endpoints.py
+++ b/litellm/proxy/response_api_endpoints/endpoints.py
@@ -989,7 +989,10 @@ async def responses_websocket_endpoint(
     first_message: Optional[str] = None
     if not model:
         try:
-            first_message = await websocket.receive_text()
+            first_message = await asyncio.wait_for(websocket.receive_text(), timeout=30)
+        except asyncio.TimeoutError:
+            await websocket.close(code=1008, reason="Timed out waiting for first message")
+            return
         except Exception:
             await websocket.close(code=1008, reason="Client disconnected before sending first message")
             return
@@ -1045,10 +1048,10 @@ async def responses_websocket_endpoint(
     request = Request(scope=scope)
     request._url = websocket.url
 
-    _model_for_body = model
+    _body_bytes = json.dumps({"model": model}).encode()
 
     async def return_body():
-        return f'{{"model": "{_model_for_body}"}}'.encode()
+        return _body_bytes
 
     request.body = return_body  # type: ignore
 

--- a/litellm/proxy/response_api_endpoints/endpoints.py
+++ b/litellm/proxy/response_api_endpoints/endpoints.py
@@ -939,8 +939,8 @@ async def cancel_response(
 @router.websocket("/responses")
 async def responses_websocket_endpoint(
     websocket: WebSocket,
-    model: str = fastapi.Query(
-        ..., description="The model to use for the responses WebSocket session."
+    model: Optional[str] = fastapi.Query(
+        None, description="The model to use for the responses WebSocket session."
     ),
     user_api_key_dict=Depends(user_api_key_auth_websocket),
 ):
@@ -949,6 +949,10 @@ async def responses_websocket_endpoint(
 
     Keeps a persistent WebSocket connection for response.create events,
     enabling lower-latency agentic workflows with many tool-call round trips.
+
+    Follows the OpenAI split: the bearer token is validated at connection time
+    (before accept); the model is resolved either from the ?model= query param
+    or from the first response.create frame, whichever is present.
 
     See: https://developers.openai.com/api/docs/guides/websocket-mode/
     """
@@ -966,7 +970,8 @@ async def responses_websocket_endpoint(
     )
     from litellm.proxy.route_llm_request import route_request
 
-    # Accept the WebSocket handshake
+    # Accept the WebSocket handshake. Key was already validated by the Depends
+    # above; we can safely accept regardless of whether ?model= was supplied.
     requested_protocols = [
         p.strip()
         for p in (websocket.headers.get("sec-websocket-protocol") or "").split(",")
@@ -977,10 +982,57 @@ async def responses_websocket_endpoint(
         accept_kwargs["subprotocol"] = requested_protocols[0]
     await websocket.accept(**accept_kwargs)
 
+    # If model was not supplied via query param, read the first frame and
+    # extract it from the response.create event. This matches OpenAI's
+    # behaviour where the bearer token scopes the connection and the model
+    # is declared inside the first message.
+    first_message: Optional[str] = None
+    if not model:
+        try:
+            first_message = await websocket.receive_text()
+        except Exception:
+            await websocket.close(code=1008, reason="Client disconnected before sending first message")
+            return
+
+        try:
+            first_event = json.loads(first_message)
+        except json.JSONDecodeError:
+            await websocket.send_text(
+                json.dumps(
+                    {
+                        "type": "error",
+                        "error": {
+                            "type": "invalid_request_error",
+                            "message": "First message is not valid JSON.",
+                        },
+                    }
+                )
+            )
+            await websocket.close(code=1008, reason="Invalid JSON in first message")
+            return
+
+        model = first_event.get("model")
+        if not model:
+            await websocket.send_text(
+                json.dumps(
+                    {
+                        "type": "error",
+                        "error": {
+                            "type": "invalid_request_error",
+                            "message": "No model provided. Supply ?model=<model> in the URL or include 'model' in the first response.create event.",
+                        },
+                    }
+                )
+            )
+            await websocket.close(code=1008, reason="No model provided")
+            return
+
     data: Dict[str, Any] = {
         "model": model,
         "websocket": websocket,
     }
+    if first_message is not None:
+        data["first_message"] = first_message
 
     # Construct a synthetic Request for pre-call processing
     headers_list = list(websocket.scope.get("headers") or [])
@@ -993,8 +1045,10 @@ async def responses_websocket_endpoint(
     request = Request(scope=scope)
     request._url = websocket.url
 
+    _model_for_body = model
+
     async def return_body():
-        return f'{{"model": "{model}"}}'.encode()
+        return f'{{"model": "{_model_for_body}"}}'.encode()
 
     request.body = return_body  # type: ignore
 
@@ -1027,7 +1081,7 @@ async def responses_websocket_endpoint(
                     {
                         "type": "error",
                         "error": {
-                            "type": "pre_call_error",
+                            "type": "invalid_request_error",
                             "message": str(e),
                         },
                     }
@@ -1035,7 +1089,7 @@ async def responses_websocket_endpoint(
             )
         except Exception:
             pass
-        await websocket.close(code=1011, reason="Pre-call error")
+        await websocket.close(code=1008, reason="Pre-call error")
         return
 
     # Phase 2: route to upstream provider

--- a/litellm/proxy/response_api_endpoints/endpoints.py
+++ b/litellm/proxy/response_api_endpoints/endpoints.py
@@ -970,6 +970,24 @@ async def _read_ws_model_from_first_frame(
         await websocket.close(code=1008, reason="Invalid JSON in first message")
         return None
 
+    if (
+        not isinstance(first_event, dict)
+        or first_event.get("type") != "response.create"
+    ):
+        await websocket.send_text(
+            json.dumps(
+                {
+                    "type": "error",
+                    "error": {
+                        "type": "invalid_request_error",
+                        "message": "First message must be a response.create JSON object.",
+                    },
+                }
+            )
+        )
+        await websocket.close(code=1008, reason="Invalid first message")
+        return None
+
     model = _extract_model_from_first_ws_event(first_event)
     if not model:
         await websocket.send_text(
@@ -989,16 +1007,63 @@ async def _read_ws_model_from_first_frame(
     return model, first_message
 
 
-def _extract_model_from_first_ws_event(first_event: dict) -> Optional[str]:
+def _extract_model_from_first_ws_event(first_event: Any) -> Optional[str]:
     """Extract model from a response.create WS event, handling flat and nested formats.
 
     Flat:   {"type": "response.create", "model": "gpt-4o", ...}
     Nested: {"type": "response.create", "response": {"model": "gpt-4o", ...}}
     """
+    if not isinstance(first_event, dict):
+        return None
     nested = first_event.get("response")
     return (
         nested.get("model") if isinstance(nested, dict) else None
     ) or first_event.get("model")
+
+
+async def _enforce_responses_ws_first_frame_model_auth(
+    request: Request,
+    model: str,
+    user_api_key_dict: UserAPIKeyAuth,
+    llm_router: Optional[Any],
+) -> None:
+    from litellm.proxy.auth.user_api_key_auth import (
+        _enforce_key_and_fallback_model_access,
+        _run_centralized_common_checks,
+    )
+    from litellm.proxy.proxy_server import (
+        general_settings,
+        llm_model_list,
+        master_key,
+        user_custom_auth,
+    )
+
+    request_data = {"model": model}
+    route = request.scope.get("path") or "/v1/responses"
+    if master_key is None and not (
+        general_settings.get("enable_jwt_auth", False)
+        or general_settings.get("enable_oauth2_auth", False)
+        or general_settings.get("enable_oauth2_proxy_auth", False)
+    ):
+        return
+    if user_custom_auth is not None and not general_settings.get(
+        "custom_auth_run_common_checks", False
+    ):
+        return
+    await _enforce_key_and_fallback_model_access(
+        valid_token=user_api_key_dict,
+        request_data=request_data,
+        route=route,
+        request=request,
+        llm_model_list=llm_model_list,
+        llm_router=llm_router,
+    )
+    await _run_centralized_common_checks(
+        user_api_key_auth_obj=user_api_key_dict,
+        request=request,
+        request_data=request_data,
+        route=route,
+    )
 
 
 @router.websocket("/v1/responses")
@@ -1083,6 +1148,13 @@ async def responses_websocket_endpoint(
     # Phase 1: pre-call processing (auth, guardrails, rate limits)
     base_llm_response_processor = ProxyBaseLLMRequestProcessing(data=data)
     try:
+        if first_message is not None:
+            await _enforce_responses_ws_first_frame_model_auth(
+                request=request,
+                model=model,
+                user_api_key_dict=user_api_key_dict,
+                llm_router=llm_router,
+            )
         (
             data,
             litellm_logging_obj,

--- a/litellm/responses/streaming_iterator.py
+++ b/litellm/responses/streaming_iterator.py
@@ -1657,7 +1657,9 @@ class ManagedResponsesWebSocketHandler:
             # cross-connection multi-turn when spend logs are committed)
             call_kwargs["previous_response_id"] = previous_response_id
 
-    def _inject_credentials(self, call_kwargs: Dict[str, Any]) -> None:
+    def _inject_credentials(
+        self, call_kwargs: Dict[str, Any], model: Optional[str] = None
+    ) -> None:
         """Inject connection-level credentials and metadata into call_kwargs."""
         if self.api_key is not None:
             call_kwargs["api_key"] = self.api_key
@@ -1665,7 +1667,10 @@ class ManagedResponsesWebSocketHandler:
             call_kwargs["api_base"] = self.api_base
         if self.timeout is not None:
             call_kwargs["timeout"] = self.timeout
-        if self.custom_llm_provider is not None:
+        # Only force connection-level custom_llm_provider when the per-event model
+        # hasn't switched providers. If the event overrides to a different model,
+        # let litellm re-resolve the provider from the model string.
+        if self.custom_llm_provider is not None and model == self.model:
             call_kwargs["custom_llm_provider"] = self.custom_llm_provider
         if self.litellm_metadata:
             call_kwargs["litellm_metadata"] = dict(self.litellm_metadata)
@@ -1797,7 +1802,7 @@ class ManagedResponsesWebSocketHandler:
         self._apply_history(
             call_kwargs, previous_response_id, current_messages, prior_history
         )
-        self._inject_credentials(call_kwargs)
+        self._inject_credentials(call_kwargs, model=model)
         self._update_proxy_request(call_kwargs, model)
         call_kwargs.update(self.extra_kwargs)
 

--- a/litellm/responses/streaming_iterator.py
+++ b/litellm/responses/streaming_iterator.py
@@ -1459,7 +1459,7 @@ class ManagedResponsesWebSocketHandler:
         self.api_base = api_base
         self.timeout = timeout
         self.custom_llm_provider = custom_llm_provider
-        self._connection_provider = self._resolve_provider(model)
+        self._connection_provider = self._resolve_provider(model) or custom_llm_provider
         self.first_message = first_message
         # Carry through safe pass-through kwargs (e.g. extra_headers)
         self.extra_kwargs: Dict[str, Any] = {

--- a/litellm/responses/streaming_iterator.py
+++ b/litellm/responses/streaming_iterator.py
@@ -1657,6 +1657,19 @@ class ManagedResponsesWebSocketHandler:
             # cross-connection multi-turn when spend logs are committed)
             call_kwargs["previous_response_id"] = previous_response_id
 
+    def _same_provider(self, model: Optional[str]) -> bool:
+        """Return True if model uses the same LLM provider as self.model."""
+        if model is None or model == self.model:
+            return True
+        try:
+            from litellm import get_llm_provider
+
+            _, event_provider, _, _ = get_llm_provider(model=model)
+            _, conn_provider, _, _ = get_llm_provider(model=self.model)
+            return event_provider == conn_provider
+        except Exception:
+            return model == self.model
+
     def _inject_credentials(
         self, call_kwargs: Dict[str, Any], model: Optional[str] = None
     ) -> None:
@@ -1668,9 +1681,11 @@ class ManagedResponsesWebSocketHandler:
         if self.timeout is not None:
             call_kwargs["timeout"] = self.timeout
         # Only force connection-level custom_llm_provider when the per-event model
-        # hasn't switched providers. If the event overrides to a different model,
-        # let litellm re-resolve the provider from the model string.
-        if self.custom_llm_provider is not None and model == self.model:
+        # uses the same provider as the connection model. If the provider differs
+        # (e.g., connection is vertex_ai but event says openai/gpt-4), let litellm
+        # re-resolve from the model string. Same-provider model variants (e.g.,
+        # vertex_ai/gemini-2.0 -> vertex_ai/gemini-1.5) still inherit the provider.
+        if self.custom_llm_provider is not None and self._same_provider(model):
             call_kwargs["custom_llm_provider"] = self.custom_llm_provider
         if self.litellm_metadata:
             call_kwargs["litellm_metadata"] = dict(self.litellm_metadata)

--- a/litellm/responses/streaming_iterator.py
+++ b/litellm/responses/streaming_iterator.py
@@ -1251,6 +1251,7 @@ class ResponsesWebSocketStreaming:
         logging_obj: LiteLLMLoggingObj,
         user_api_key_dict: Optional[Any] = None,
         request_data: Optional[Dict] = None,
+        first_message: Optional[str] = None,
     ):
         self.websocket = websocket
         self.backend_ws = backend_ws
@@ -1259,6 +1260,7 @@ class ResponsesWebSocketStreaming:
         self.request_data: Dict = request_data or {}
         self.messages: list[Dict] = []
         self.input_messages: list[Dict[str, str]] = []
+        self.first_message = first_message
 
     def _should_store_event(self, event_obj: dict) -> bool:
         return event_obj.get("type") in RESPONSES_WS_LOGGED_EVENT_TYPES
@@ -1362,6 +1364,11 @@ class ResponsesWebSocketStreaming:
     async def client_to_backend(self) -> None:
         """Forward response.create events from client to backend."""
         try:
+            if self.first_message is not None:
+                self._store_input(self.first_message)
+                self._store_event(self.first_message)
+                await self.backend_ws.send(self.first_message)  # type: ignore[union-attr]
+
             while True:
                 message = await self.websocket.receive_text()
 
@@ -1440,6 +1447,7 @@ class ManagedResponsesWebSocketHandler:
         api_base: Optional[str] = None,
         timeout: Optional[float] = None,
         custom_llm_provider: Optional[str] = None,
+        first_message: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
         self.websocket = websocket
@@ -1451,6 +1459,7 @@ class ManagedResponsesWebSocketHandler:
         self.api_base = api_base
         self.timeout = timeout
         self.custom_llm_provider = custom_llm_provider
+        self.first_message = first_message
         # Carry through safe pass-through kwargs (e.g. extra_headers)
         self.extra_kwargs: Dict[str, Any] = {
             k: v for k, v in kwargs.items() if k not in _MANAGED_WS_SKIP_KWARGS
@@ -1819,6 +1828,9 @@ class ManagedResponsesWebSocketHandler:
         each one before waiting for the next message.
         """
         try:
+            if self.first_message is not None:
+                await self._process_response_create(self.first_message)
+
             while True:
                 try:
                     message = await self.websocket.receive_text()

--- a/litellm/responses/streaming_iterator.py
+++ b/litellm/responses/streaming_iterator.py
@@ -1459,6 +1459,7 @@ class ManagedResponsesWebSocketHandler:
         self.api_base = api_base
         self.timeout = timeout
         self.custom_llm_provider = custom_llm_provider
+        self._connection_provider = self._resolve_provider(model)
         self.first_message = first_message
         # Carry through safe pass-through kwargs (e.g. extra_headers)
         self.extra_kwargs: Dict[str, Any] = {
@@ -1657,18 +1658,27 @@ class ManagedResponsesWebSocketHandler:
             # cross-connection multi-turn when spend logs are committed)
             call_kwargs["previous_response_id"] = previous_response_id
 
-    def _same_provider(self, model: Optional[str]) -> bool:
-        """Return True if model uses the same LLM provider as self.model."""
-        if model is None or model == self.model:
-            return True
+    @staticmethod
+    def _resolve_provider(model: Optional[str]) -> Optional[str]:
+        """Resolve the LLM provider for a model string, or None if unresolvable."""
+        if not model:
+            return None
         try:
             from litellm import get_llm_provider
 
-            _, event_provider, _, _ = get_llm_provider(model=model)
-            _, conn_provider, _, _ = get_llm_provider(model=self.model)
-            return event_provider == conn_provider
+            _, provider, _, _ = get_llm_provider(model=model)
+            return provider
         except Exception:
-            return model == self.model
+            return None
+
+    def _same_provider(self, model: Optional[str]) -> bool:
+        """Return True if model uses the same LLM provider as the connection model."""
+        if model is None or model == self.model:
+            return True
+        event_provider = self._resolve_provider(model)
+        if event_provider is None:
+            return False
+        return event_provider == self._connection_provider
 
     def _inject_credentials(
         self, call_kwargs: Dict[str, Any], model: Optional[str] = None

--- a/litellm/responses/streaming_iterator.py
+++ b/litellm/responses/streaming_iterator.py
@@ -1780,8 +1780,7 @@ class ManagedResponsesWebSocketHandler:
         call_kwargs = self._build_base_call_kwargs(msg_obj)
         call_kwargs["stream"] = True
 
-        call_kwargs.pop("model", None)
-        model = self.model
+        model = call_kwargs.pop("model", None) or self.model
 
         previous_response_id: Optional[str] = call_kwargs.pop(
             "previous_response_id", None

--- a/litellm/responses/streaming_iterator.py
+++ b/litellm/responses/streaming_iterator.py
@@ -1657,9 +1657,7 @@ class ManagedResponsesWebSocketHandler:
             # cross-connection multi-turn when spend logs are committed)
             call_kwargs["previous_response_id"] = previous_response_id
 
-    def _inject_credentials(
-        self, call_kwargs: Dict[str, Any], event_model: Optional[str]
-    ) -> None:
+    def _inject_credentials(self, call_kwargs: Dict[str, Any]) -> None:
         """Inject connection-level credentials and metadata into call_kwargs."""
         if self.api_key is not None:
             call_kwargs["api_key"] = self.api_key
@@ -1667,10 +1665,7 @@ class ManagedResponsesWebSocketHandler:
             call_kwargs["api_base"] = self.api_base
         if self.timeout is not None:
             call_kwargs["timeout"] = self.timeout
-        # Only propagate custom_llm_provider when no per-request model override exists.
-        # If the payload specifies a different model, let litellm re-resolve the
-        # provider so we don't accidentally force the wrong backend.
-        if self.custom_llm_provider is not None and not event_model:
+        if self.custom_llm_provider is not None:
             call_kwargs["custom_llm_provider"] = self.custom_llm_provider
         if self.litellm_metadata:
             call_kwargs["litellm_metadata"] = dict(self.litellm_metadata)
@@ -1785,8 +1780,8 @@ class ManagedResponsesWebSocketHandler:
         call_kwargs = self._build_base_call_kwargs(msg_obj)
         call_kwargs["stream"] = True
 
-        event_model: Optional[str] = call_kwargs.pop("model", None)
-        model = event_model or self.model
+        call_kwargs.pop("model", None)
+        model = self.model
 
         previous_response_id: Optional[str] = call_kwargs.pop(
             "previous_response_id", None
@@ -1803,7 +1798,7 @@ class ManagedResponsesWebSocketHandler:
         self._apply_history(
             call_kwargs, previous_response_id, current_messages, prior_history
         )
-        self._inject_credentials(call_kwargs, event_model)
+        self._inject_credentials(call_kwargs)
         self._update_proxy_request(call_kwargs, model)
         call_kwargs.update(self.extra_kwargs)
 

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -4636,11 +4636,11 @@ class Router:
             except Exception:
                 custom_llm_provider = None
 
-            # Build response kwargs
             response_kwargs = {
                 **data,
                 "caching": self.cache_responses,
                 **kwargs,
+                "model": model_name,
             }
             # Only set custom_llm_provider if it's not None
             if custom_llm_provider is not None:

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -7126,6 +7126,9 @@ class Router:
         from litellm.types.caching import RedisPipelineIncrementOperation
 
         try:
+            # WS session wrappers fire with result=None; per-turn costs tracked by inner calls.
+            if kwargs.get("call_type") in ("_aresponses_websocket", "_arealtime"):
+                return
             standard_logging_object: Optional[StandardLoggingPayload] = kwargs.get(
                 "standard_logging_object", None
             )

--- a/litellm/router_strategy/budget_limiter.py
+++ b/litellm/router_strategy/budget_limiter.py
@@ -430,6 +430,9 @@ class RouterBudgetLimiting(CustomLogger):
     async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
         """Original method now uses helper functions"""
         verbose_router_logger.debug("in RouterBudgetLimiting.async_log_success_event")
+        # WS session wrappers fire with result=None; per-turn costs tracked by inner calls.
+        if kwargs.get("call_type") in ("_aresponses_websocket", "_arealtime"):
+            return
         standard_logging_payload: Optional[StandardLoggingPayload] = kwargs.get(
             "standard_logging_object", None
         )

--- a/tests/test_litellm/proxy/response_api_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/response_api_endpoints/test_endpoints.py
@@ -694,3 +694,20 @@ class TestManagedResponsesSameProvider:
         call_kwargs: dict = {}
         handler._inject_credentials(call_kwargs, model="vertex_ai/gemini-2.0-flash")
         assert "custom_llm_provider" not in call_kwargs
+
+    def test_unresolvable_connection_model_falls_back_to_custom_provider(self):
+        handler = self._handler(
+            "my-custom-deployment", custom_llm_provider="openai"
+        )
+        assert handler._same_provider("gpt-4o-mini") is True
+        call_kwargs: dict = {}
+        handler._inject_credentials(call_kwargs, model="gpt-4o-mini")
+        assert call_kwargs["custom_llm_provider"] == "openai"
+
+    def test_unresolvable_connection_model_still_drops_cross_provider(self):
+        handler = self._handler(
+            "my-custom-deployment", custom_llm_provider="openai"
+        )
+        call_kwargs: dict = {}
+        handler._inject_credentials(call_kwargs, model="vertex_ai/gemini-2.0-flash")
+        assert "custom_llm_provider" not in call_kwargs

--- a/tests/test_litellm/proxy/response_api_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/response_api_endpoints/test_endpoints.py
@@ -196,3 +196,110 @@ class TestResponsesAPIEndpoints(unittest.TestCase):
         assert "x-litellm-response-cost" in response.headers
         response_cost_value = float(response.headers["x-litellm-response-cost"])
         assert response_cost_value == pytest.approx(0.0005, abs=1e-10)
+
+
+import json
+
+
+class TestManagedResponsesWSFirstMessage:
+    @pytest.mark.asyncio
+    async def test_first_message_processed_before_loop(self):
+        """
+        ManagedResponsesWebSocketHandler must process first_message before
+        entering its receive loop. Regression for clients that connect without
+        ?model= (e.g. Codex) and send model inside the first response.create event.
+        """
+        from litellm.responses.streaming_iterator import ManagedResponsesWebSocketHandler
+
+        first = json.dumps(
+            {
+                "type": "response.create",
+                "model": "gpt-4o-mini",
+                "store": False,
+                "input": [
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": "hi"}],
+                    }
+                ],
+            }
+        )
+
+        ws = MagicMock()
+        ws.receive_text = AsyncMock(side_effect=Exception("disconnect"))
+        ws.send_text = AsyncMock()
+
+        processed: list = []
+
+        async def fake_process(msg: str) -> None:
+            processed.append(msg)
+
+        handler = ManagedResponsesWebSocketHandler(
+            websocket=ws,
+            model="gpt-4o-mini",
+            logging_obj=MagicMock(),
+            first_message=first,
+        )
+        handler._process_response_create = fake_process  # type: ignore[method-assign]
+
+        await handler.run()
+
+        assert processed == [first]
+
+    @pytest.mark.asyncio
+    async def test_no_first_message_falls_through_to_loop(self):
+        """When first_message is None, run() goes straight to receive_text()."""
+        from litellm.responses.streaming_iterator import ManagedResponsesWebSocketHandler
+
+        subsequent = json.dumps({"type": "response.create", "model": "gpt-4o-mini"})
+
+        ws = MagicMock()
+        ws.receive_text = AsyncMock(side_effect=[subsequent, Exception("disconnect")])
+        ws.send_text = AsyncMock()
+
+        processed: list = []
+
+        async def fake_process(msg: str) -> None:
+            processed.append(msg)
+
+        handler = ManagedResponsesWebSocketHandler(
+            websocket=ws,
+            model="gpt-4o-mini",
+            logging_obj=MagicMock(),
+            first_message=None,
+        )
+        handler._process_response_create = fake_process  # type: ignore[method-assign]
+
+        await handler.run()
+
+        assert processed == [subsequent]
+
+
+class TestResponsesWSStreamingFirstMessage:
+    @pytest.mark.asyncio
+    async def test_client_to_backend_replays_first_message(self):
+        """
+        ResponsesWebSocketStreaming.client_to_backend must send first_message to
+        the backend before entering the receive loop.
+        """
+        from litellm.responses.streaming_iterator import ResponsesWebSocketStreaming
+
+        first = json.dumps({"type": "response.create", "model": "gpt-4o-mini", "input": []})
+
+        ws = MagicMock()
+        ws.receive_text = AsyncMock(side_effect=Exception("disconnect"))
+
+        backend_ws = MagicMock()
+        backend_ws.send = AsyncMock()
+
+        streaming = ResponsesWebSocketStreaming(
+            websocket=ws,
+            backend_ws=backend_ws,
+            logging_obj=MagicMock(),
+            first_message=first,
+        )
+
+        await streaming.client_to_backend()
+
+        backend_ws.send.assert_awaited_once_with(first)

--- a/tests/test_litellm/proxy/response_api_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/response_api_endpoints/test_endpoints.py
@@ -349,33 +349,36 @@ class TestWSSessionCostTracking:
 
 
 class TestWSModelExtraction:
-    """Test that first-frame model extraction handles both flat and nested formats."""
-
-    def _extract_model(self, first_event: dict):
-        """Mirror the extraction logic from endpoints.py."""
-        nested = first_event.get("response")
-        return (
-            nested.get("model")
-            if isinstance(nested, dict)
-            else None
-        ) or first_event.get("model")
+    """Test _extract_model_from_first_ws_event for flat and nested frame formats."""
 
     def test_flat_format_extracts_model(self):
+        from litellm.proxy.response_api_endpoints.endpoints import (
+            _extract_model_from_first_ws_event,
+        )
         event = {"type": "response.create", "model": "gpt-4o", "input": "hello"}
-        assert self._extract_model(event) == "gpt-4o"
+        assert _extract_model_from_first_ws_event(event) == "gpt-4o"
 
     def test_nested_format_extracts_model(self):
+        from litellm.proxy.response_api_endpoints.endpoints import (
+            _extract_model_from_first_ws_event,
+        )
         event = {"type": "response.create", "response": {"model": "gpt-4o", "input": "hello"}}
-        assert self._extract_model(event) == "gpt-4o"
+        assert _extract_model_from_first_ws_event(event) == "gpt-4o"
 
     def test_nested_format_takes_precedence_over_flat(self):
+        from litellm.proxy.response_api_endpoints.endpoints import (
+            _extract_model_from_first_ws_event,
+        )
         event = {
             "type": "response.create",
             "model": "flat-model",
             "response": {"model": "nested-model"},
         }
-        assert self._extract_model(event) == "nested-model"
+        assert _extract_model_from_first_ws_event(event) == "nested-model"
 
     def test_no_model_returns_none(self):
+        from litellm.proxy.response_api_endpoints.endpoints import (
+            _extract_model_from_first_ws_event,
+        )
         event = {"type": "response.create", "input": "hello"}
-        assert self._extract_model(event) is None
+        assert _extract_model_from_first_ws_event(event) is None

--- a/tests/test_litellm/proxy/response_api_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/response_api_endpoints/test_endpoints.py
@@ -433,6 +433,41 @@ class TestResponsesWSFirstFrameValidation:
         ws.send_text.assert_awaited_once()
         ws.close.assert_awaited_once_with(code=1008, reason="Invalid first message")
 
+    @pytest.mark.asyncio
+    async def test_client_disconnect_first_frame_does_not_close(self):
+        from fastapi import WebSocketDisconnect
+
+        from litellm.proxy.response_api_endpoints.endpoints import (
+            _read_ws_model_from_first_frame,
+        )
+
+        ws = MagicMock()
+        ws.receive_text = AsyncMock(side_effect=WebSocketDisconnect(code=1006))
+        ws.send_text = AsyncMock()
+        ws.close = AsyncMock()
+
+        result = await _read_ws_model_from_first_frame(ws)
+
+        assert result is None
+        ws.close.assert_not_awaited()
+        ws.send_text.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_server_error_first_frame_closes_with_internal_error(self):
+        from litellm.proxy.response_api_endpoints.endpoints import (
+            _read_ws_model_from_first_frame,
+        )
+
+        ws = MagicMock()
+        ws.receive_text = AsyncMock(side_effect=RuntimeError("boom"))
+        ws.send_text = AsyncMock()
+        ws.close = AsyncMock()
+
+        result = await _read_ws_model_from_first_frame(ws)
+
+        assert result is None
+        ws.close.assert_awaited_once_with(code=1011, reason="Internal server error")
+
 
 class TestResponsesWSFirstFrameModelAuth:
     @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/response_api_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/response_api_endpoints/test_endpoints.py
@@ -572,3 +572,125 @@ class TestResponsesWSFirstFrameModelAuth:
             request_data={"model": "gpt-4o-mini"},
             route="/v1/responses",
         )
+
+
+class TestReadWSModelFromFirstFrameErrors:
+    @pytest.mark.asyncio
+    async def test_timeout_closes_without_error_frame(self):
+        import asyncio
+
+        from litellm.proxy.response_api_endpoints.endpoints import (
+            _read_ws_model_from_first_frame,
+        )
+
+        ws = MagicMock()
+        ws.receive_text = AsyncMock(side_effect=asyncio.TimeoutError())
+        ws.send_text = AsyncMock()
+        ws.close = AsyncMock()
+
+        result = await _read_ws_model_from_first_frame(ws)
+
+        assert result is None
+        ws.send_text.assert_not_awaited()
+        ws.close.assert_awaited_once_with(
+            code=1008, reason="Timed out waiting for first message"
+        )
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_sends_error_and_closes(self):
+        from litellm.proxy.response_api_endpoints.endpoints import (
+            _read_ws_model_from_first_frame,
+        )
+
+        ws = MagicMock()
+        ws.receive_text = AsyncMock(return_value="this is not json")
+        ws.send_text = AsyncMock()
+        ws.close = AsyncMock()
+
+        result = await _read_ws_model_from_first_frame(ws)
+
+        assert result is None
+        payload = json.loads(ws.send_text.await_args.args[0])
+        assert payload["error"]["message"] == "First message is not valid JSON."
+        ws.close.assert_awaited_once_with(
+            code=1008, reason="Invalid JSON in first message"
+        )
+
+    @pytest.mark.asyncio
+    async def test_missing_model_sends_error_and_closes(self):
+        from litellm.proxy.response_api_endpoints.endpoints import (
+            _read_ws_model_from_first_frame,
+        )
+
+        ws = MagicMock()
+        ws.receive_text = AsyncMock(
+            return_value=json.dumps({"type": "response.create", "input": []})
+        )
+        ws.send_text = AsyncMock()
+        ws.close = AsyncMock()
+
+        result = await _read_ws_model_from_first_frame(ws)
+
+        assert result is None
+        payload = json.loads(ws.send_text.await_args.args[0])
+        assert "No model provided" in payload["error"]["message"]
+        ws.close.assert_awaited_once_with(code=1008, reason="No model provided")
+
+    @pytest.mark.asyncio
+    async def test_valid_first_frame_returns_model_and_raw(self):
+        from litellm.proxy.response_api_endpoints.endpoints import (
+            _read_ws_model_from_first_frame,
+        )
+
+        raw = json.dumps({"type": "response.create", "model": "gpt-4o", "input": []})
+        ws = MagicMock()
+        ws.receive_text = AsyncMock(return_value=raw)
+        ws.send_text = AsyncMock()
+        ws.close = AsyncMock()
+
+        result = await _read_ws_model_from_first_frame(ws)
+
+        assert result == ("gpt-4o", raw)
+        ws.send_text.assert_not_awaited()
+        ws.close.assert_not_awaited()
+
+
+class TestManagedResponsesSameProvider:
+    def _handler(self, model, custom_llm_provider=None):
+        from litellm.responses.streaming_iterator import (
+            ManagedResponsesWebSocketHandler,
+        )
+
+        return ManagedResponsesWebSocketHandler(
+            websocket=MagicMock(),
+            model=model,
+            logging_obj=MagicMock(),
+            custom_llm_provider=custom_llm_provider,
+        )
+
+    def test_none_model_treated_as_same_provider(self):
+        assert self._handler("openai/gpt-4o")._same_provider(None) is True
+
+    def test_identical_model_is_same_provider(self):
+        assert self._handler("openai/gpt-4o")._same_provider("openai/gpt-4o") is True
+
+    def test_same_provider_different_model(self):
+        assert self._handler("gpt-4o")._same_provider("gpt-4o-mini") is True
+
+    def test_different_provider_is_not_same(self):
+        assert (
+            self._handler("gpt-4o")._same_provider("vertex_ai/gemini-2.0-flash")
+            is False
+        )
+
+    def test_inject_credentials_keeps_provider_for_same_provider_model(self):
+        handler = self._handler("gpt-4o", custom_llm_provider="openai")
+        call_kwargs: dict = {}
+        handler._inject_credentials(call_kwargs, model="gpt-4o-mini")
+        assert call_kwargs["custom_llm_provider"] == "openai"
+
+    def test_inject_credentials_drops_provider_for_cross_provider_model(self):
+        handler = self._handler("gpt-4o", custom_llm_provider="openai")
+        call_kwargs: dict = {}
+        handler._inject_credentials(call_kwargs, model="vertex_ai/gemini-2.0-flash")
+        assert "custom_llm_provider" not in call_kwargs

--- a/tests/test_litellm/proxy/response_api_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/response_api_endpoints/test_endpoints.py
@@ -346,3 +346,36 @@ class TestWSSessionCostTracking:
             start_time=None,
             end_time=None,
         )
+
+
+class TestWSModelExtraction:
+    """Test that first-frame model extraction handles both flat and nested formats."""
+
+    def _extract_model(self, first_event: dict):
+        """Mirror the extraction logic from endpoints.py."""
+        nested = first_event.get("response")
+        return (
+            nested.get("model")
+            if isinstance(nested, dict)
+            else None
+        ) or first_event.get("model")
+
+    def test_flat_format_extracts_model(self):
+        event = {"type": "response.create", "model": "gpt-4o", "input": "hello"}
+        assert self._extract_model(event) == "gpt-4o"
+
+    def test_nested_format_extracts_model(self):
+        event = {"type": "response.create", "response": {"model": "gpt-4o", "input": "hello"}}
+        assert self._extract_model(event) == "gpt-4o"
+
+    def test_nested_format_takes_precedence_over_flat(self):
+        event = {
+            "type": "response.create",
+            "model": "flat-model",
+            "response": {"model": "nested-model"},
+        }
+        assert self._extract_model(event) == "nested-model"
+
+    def test_no_model_returns_none(self):
+        event = {"type": "response.create", "input": "hello"}
+        assert self._extract_model(event) is None

--- a/tests/test_litellm/proxy/response_api_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/response_api_endpoints/test_endpoints.py
@@ -382,3 +382,158 @@ class TestWSModelExtraction:
         )
         event = {"type": "response.create", "input": "hello"}
         assert _extract_model_from_first_ws_event(event) is None
+
+    def test_non_object_returns_none(self):
+        from litellm.proxy.response_api_endpoints.endpoints import (
+            _extract_model_from_first_ws_event,
+        )
+
+        assert _extract_model_from_first_ws_event([]) is None
+
+
+class TestResponsesWSFirstFrameValidation:
+    @pytest.mark.asyncio
+    async def test_rejects_non_response_create_first_frame(self):
+        from litellm.proxy.response_api_endpoints.endpoints import (
+            _read_ws_model_from_first_frame,
+        )
+
+        ws = MagicMock()
+        ws.receive_text = AsyncMock(
+            return_value=json.dumps({"type": "session.update", "model": "gpt-4o"})
+        )
+        ws.send_text = AsyncMock()
+        ws.close = AsyncMock()
+
+        result = await _read_ws_model_from_first_frame(ws)
+
+        assert result is None
+        ws.send_text.assert_awaited_once()
+        ws.close.assert_awaited_once_with(code=1008, reason="Invalid first message")
+        error_payload = json.loads(ws.send_text.await_args.args[0])
+        assert (
+            error_payload["error"]["message"]
+            == "First message must be a response.create JSON object."
+        )
+
+    @pytest.mark.asyncio
+    async def test_rejects_non_object_json_first_frame(self):
+        from litellm.proxy.response_api_endpoints.endpoints import (
+            _read_ws_model_from_first_frame,
+        )
+
+        ws = MagicMock()
+        ws.receive_text = AsyncMock(return_value=json.dumps(["gpt-4o"]))
+        ws.send_text = AsyncMock()
+        ws.close = AsyncMock()
+
+        result = await _read_ws_model_from_first_frame(ws)
+
+        assert result is None
+        ws.send_text.assert_awaited_once()
+        ws.close.assert_awaited_once_with(code=1008, reason="Invalid first message")
+
+
+class TestResponsesWSFirstFrameModelAuth:
+    @pytest.mark.asyncio
+    async def test_endpoint_enforces_auth_after_model_from_first_frame(self):
+        from litellm.proxy.response_api_endpoints.endpoints import (
+            responses_websocket_endpoint,
+        )
+
+        ws = MagicMock()
+        ws.headers = {}
+        ws.query_params = {}
+        ws.scope = {"headers": []}
+        ws.url = "ws://testserver/v1/responses"
+        ws.accept = AsyncMock()
+        ws.receive_text = AsyncMock(
+            return_value=json.dumps(
+                {"type": "response.create", "model": "gpt-4o-mini", "input": []}
+            )
+        )
+        ws.close = AsyncMock()
+
+        processor = MagicMock()
+        processor.common_processing_pre_call_logic = AsyncMock(
+            return_value=({"model": "gpt-4o-mini"}, MagicMock())
+        )
+
+        async def fake_llm_call():
+            return None
+
+        with (
+            patch(
+                "litellm.proxy.response_api_endpoints.endpoints._enforce_responses_ws_first_frame_model_auth",
+                new_callable=AsyncMock,
+            ) as mock_model_auth,
+            patch(
+                "litellm.proxy.response_api_endpoints.endpoints.ProxyBaseLLMRequestProcessing",
+                return_value=processor,
+            ),
+            patch(
+                "litellm.proxy.route_llm_request.route_request",
+                new_callable=AsyncMock,
+                return_value=fake_llm_call(),
+            ),
+        ):
+            await responses_websocket_endpoint(
+                websocket=ws,
+                model=None,
+                user_api_key_dict=MagicMock(),
+            )
+
+        mock_model_auth.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_reruns_model_auth_for_first_frame_model(self):
+        from starlette.requests import Request
+
+        from litellm.proxy.response_api_endpoints.endpoints import (
+            _enforce_responses_ws_first_frame_model_auth,
+        )
+
+        request = Request(
+            {"type": "http", "method": "POST", "path": "/v1/responses", "headers": []}
+        )
+        user_api_key_dict = MagicMock()
+        llm_router = MagicMock()
+
+        with (
+            patch(
+                "litellm.proxy.auth.user_api_key_auth._enforce_key_and_fallback_model_access",
+                new_callable=AsyncMock,
+            ) as mock_key_check,
+            patch(
+                "litellm.proxy.auth.user_api_key_auth._run_centralized_common_checks",
+                new_callable=AsyncMock,
+            ) as mock_common_checks,
+            patch(
+                "litellm.proxy.proxy_server.llm_model_list",
+                [],
+            ),
+            patch("litellm.proxy.proxy_server.master_key", "sk-test"),
+            patch("litellm.proxy.proxy_server.user_custom_auth", None),
+            patch("litellm.proxy.proxy_server.general_settings", {}),
+        ):
+            await _enforce_responses_ws_first_frame_model_auth(
+                request=request,
+                model="gpt-4o-mini",
+                user_api_key_dict=user_api_key_dict,
+                llm_router=llm_router,
+            )
+
+        mock_key_check.assert_awaited_once_with(
+            valid_token=user_api_key_dict,
+            request_data={"model": "gpt-4o-mini"},
+            route="/v1/responses",
+            request=request,
+            llm_model_list=[],
+            llm_router=llm_router,
+        )
+        mock_common_checks.assert_awaited_once_with(
+            user_api_key_auth_obj=user_api_key_dict,
+            request=request,
+            request_data={"model": "gpt-4o-mini"},
+            route="/v1/responses",
+        )

--- a/tests/test_litellm/proxy/response_api_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/response_api_endpoints/test_endpoints.py
@@ -303,3 +303,46 @@ class TestResponsesWSStreamingFirstMessage:
         await streaming.client_to_backend()
 
         backend_ws.send.assert_awaited_once_with(first)
+
+
+class TestWSSessionCostTracking:
+    @pytest.mark.asyncio
+    async def test_router_budget_limiter_skips_aresponses_websocket_call_type(self):
+        """
+        RouterBudgetLimiting.async_log_success_event must not raise when
+        call_type='_aresponses_websocket', even when standard_logging_object is None.
+        Per-turn costs are tracked by individual aresponses calls inside the session;
+        the outer session wrapper fires with result=None.
+        """
+        from litellm.router_strategy.budget_limiter import RouterBudgetLimiting
+
+        limiter = RouterBudgetLimiting.__new__(RouterBudgetLimiting)
+        kwargs = {
+            "call_type": "_aresponses_websocket",
+            "standard_logging_object": None,
+            "litellm_params": {"custom_llm_provider": "vertex_ai"},
+        }
+        await limiter.async_log_success_event(
+            kwargs=kwargs,
+            response_obj=None,
+            start_time=None,
+            end_time=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_router_budget_limiter_skips_arealtime_call_type(self):
+        """Same guard applies to _arealtime WS session wrappers."""
+        from litellm.router_strategy.budget_limiter import RouterBudgetLimiting
+
+        limiter = RouterBudgetLimiting.__new__(RouterBudgetLimiting)
+        kwargs = {
+            "call_type": "_arealtime",
+            "standard_logging_object": None,
+            "litellm_params": {"custom_llm_provider": "openai"},
+        }
+        await limiter.async_log_success_event(
+            kwargs=kwargs,
+            response_obj=None,
+            start_time=None,
+            end_time=None,
+        )

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -982,6 +982,55 @@ async def test_router_ageneric_api_call_with_fallbacks_helper():
                     assert router.fail_calls["gpt-3.5-turbo"] == initial_fail_count + 1
 
 
+@pytest.mark.asyncio
+async def test_ageneric_api_call_deployment_model_overrides_alias():
+    """
+    Regression: when a model alias (e.g. "not-gemini-2.5-flash") maps to a deployment
+    with model="vertex_ai/gemini-2.5-flash", the underlying litellm function must receive
+    the deployment model, not the alias. Before the fix, **kwargs overwrote data["model"].
+    """
+    from unittest.mock import patch
+
+    captured: dict = {}
+
+    async def capture_model(**kwargs):
+        captured["model"] = kwargs.get("model")
+        return {"result": "ok"}
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "not-gemini-2.5-flash",
+                "litellm_params": {
+                    "model": "vertex_ai/gemini-2.5-flash",
+                    "api_key": "fake-key",
+                },
+            }
+        ]
+    )
+
+    with patch.object(router, "async_get_available_deployment") as mock_dep, \
+         patch.object(router, "_update_kwargs_with_deployment"), \
+         patch.object(router, "async_routing_strategy_pre_call_checks"), \
+         patch.object(router, "_get_client", return_value=None):
+        mock_dep.return_value = {
+            "model_name": "not-gemini-2.5-flash",
+            "litellm_params": {
+                "model": "vertex_ai/gemini-2.5-flash",
+                "api_key": "fake-key",
+            },
+        }
+
+        await router._ageneric_api_call_with_fallbacks_helper(
+            model="not-gemini-2.5-flash",
+            original_generic_function=capture_model,
+        )
+
+    assert captured["model"] == "vertex_ai/gemini-2.5-flash", (
+        f"Expected deployment model 'vertex_ai/gemini-2.5-flash', got '{captured['model']}'"
+    )
+
+
 def test_router_get_model_access_groups_team_only_models():
     """
     Test that Router.get_model_access_groups returns the correct response for team-only models

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -1009,8 +1009,14 @@ async def test_ageneric_api_call_deployment_model_overrides_alias():
         ]
     )
 
+    def inject_alias_into_kwargs(deployment, kwargs, function_name=None):
+        # Simulate the alias leaking into kwargs (as happens when
+        # _ageneric_api_call_with_fallbacks sets kwargs["model"] = alias before
+        # calling the helper through async_function_with_fallbacks).
+        kwargs["model"] = "not-gemini-2.5-flash"
+
     with patch.object(router, "async_get_available_deployment") as mock_dep, \
-         patch.object(router, "_update_kwargs_with_deployment"), \
+         patch.object(router, "_update_kwargs_with_deployment", side_effect=inject_alias_into_kwargs), \
          patch.object(router, "async_routing_strategy_pre_call_checks"), \
          patch.object(router, "_get_client", return_value=None):
         mock_dep.return_value = {


### PR DESCRIPTION
## Relevant issues

<img width="1061" height="550" alt="image" src="https://github.com/user-attachments/assets/d6ce4630-57bd-4750-a055-3e79e9bf3edd" />
## Linear ticket

<!-- if you are an internal contributor, add the Linear ticket e.g. "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or log output demonstrating that your changes work as expected.
     For bug fixes: show reproduction before the fix and passing behavior after.
     For new features: show the feature working end-to-end.
     For UI changes: include before/after screenshots. -->

## Type

🆕 New Feature
🐛 Bug Fix


## Changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches proxy auth (model allowlist after first frame), WebSocket request handling, and spend/router accounting; behavior changes for clients without `?model=` but is covered by new tests.
> 
> **Overview**
> Aligns the proxy **Responses API WebSocket** flow with OpenAI-style clients that omit `?model=` and send the model on the first `response.create` frame (e.g. Codex).
> 
> **Model resolution and first frame:** `?model=` is now optional. When it is missing, the server reads the first frame (30s timeout), validates JSON and `type: response.create`, extracts `model` from flat or nested `response` payloads, and returns structured `invalid_request_error` frames instead of silently dropping bad first messages.
> 
> **Auth and plumbing:** After the model is known from that frame, `_enforce_responses_ws_first_frame_model_auth` runs key allowlist and centralized checks. The consumed frame is passed as `first_message` through the HTTP handler, native proxy streaming, and managed WS handler so it is forwarded/processed once and not read again from the socket.
> 
> **Managed WS routing:** `custom_llm_provider` is only forced when the per-event model resolves to the **same provider** as the connection model (via `_same_provider`), so cross-provider overrides in a frame are not pinned to the wrong backend.
> 
> **Spend / router:** Session wrappers `_aresponses_websocket` and `_arealtime` are skipped in proxy cost tracking, router TPM/RPM updates, and budget limiter when there is no `standard_logging_object`, since per-turn costs are logged on inner calls.
> 
> **Router alias fix:** `_ageneric_api_call_with_fallbacks_helper` sets `model` to the deployment’s real model name so router aliases do not overwrite the resolved deployment model in kwargs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 348853e31f78a65fa9091fe1af2ee54d1c75ddfd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->