### PR TITLE
[Lasso Guardrail] Send source.type for Used By attribution

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/lasso/lasso.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/lasso/lasso.py
@@ -829,7 +829,13 @@ class LassoGuardrail(CustomGuardrail):
             data: Request data (used for conversation_id generation and tools extraction)
             cache: Cache instance for storing conversation_id (optional for post-call)
         """
-        payload: Dict[str, Any] = {"messages": messages, "messageType": message_type}
+        payload: Dict[str, Any] = {
+            "messages": messages,
+            "messageType": message_type,
+            # Drives the "Used By" badge on Lasso Application API Keys: every call from this
+            # integration is attributed as "litellm" on the keys list.
+            "source": {"type": "litellm"},
+        }
 
         # Add optional parameters if available
         if self.user_id:

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_lasso.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_lasso.py
@@ -693,6 +693,8 @@ class TestLassoGuardrail:
         assert prompt_payload["messages"] == messages
         assert prompt_payload["userId"] == "test-user"
         assert prompt_payload["sessionId"] == "test-conversation"
+        # Every call is attributed to the "litellm" integration for the "Used By" badge.
+        assert prompt_payload["source"] == {"type": "litellm"}
 
         # Test COMPLETION payload
         completion_messages = [{"role": "assistant", "content": "Test response"}]
@@ -703,6 +705,7 @@ class TestLassoGuardrail:
         assert completion_payload["messages"] == completion_messages
         assert completion_payload["userId"] == "test-user"
         assert completion_payload["sessionId"] == "test-conversation"
+        assert completion_payload["source"] == {"type": "litellm"}
 
     def test_header_preparation(self):
         """Test header preparation."""


### PR DESCRIPTION
## Summary
The Lasso Generic Guardrail integration now stamps `source.type = "litellm"`
on every `/gateway/v3/{classify,classifix}` payload it sends. This drives
the new "Used By" badge on the customer's Application API Keys list — without
it, all LiteLLM traffic shows as "N/A" on the keys page.

Backwards compatible: `source` is an optional opaque object on the Lasso side.
Older Lasso servers ignore it.

## Test plan
- [x] Updated `test_payload_preparation_completion_vs_prompt` to assert
      `source == {type: "litellm"}` on both PROMPT and COMPLETION payloads.
- [x] No behavioral change to existing tests (payload remains a superset).