### PR TITLE
feat(dashscope): add Anthropic Messages support

### DIFF
--- a/litellm/llms/dashscope/messages/__init__.py
+++ b/litellm/llms/dashscope/messages/__init__.py
@@ -1,0 +1,3 @@
+from .transformation import DashScopeAnthropicMessagesConfig
+
+__all__ = ["DashScopeAnthropicMessagesConfig"]

--- a/litellm/llms/dashscope/messages/transformation.py
+++ b/litellm/llms/dashscope/messages/transformation.py
@@ -1,0 +1,101 @@
+"""
+DashScope Anthropic transformation config - extends AnthropicMessagesConfig for
+DashScope's Anthropic-compatible Messages API.
+"""
+
+from typing import Any, List, Optional, Tuple
+
+from litellm.llms.anthropic.experimental_pass_through.messages.transformation import (
+    AnthropicMessagesConfig,
+)
+from litellm.secret_managers.main import get_secret_str
+
+DEFAULT_DASHSCOPE_ANTHROPIC_MESSAGES_API_BASE = (
+    "https://dashscope.aliyuncs.com/apps/anthropic/v1/messages"
+)
+_COMPATIBLE_MODE_CHAT_COMPLETIONS_SUFFIX = "/compatible-mode/v1/chat/completions"
+_COMPATIBLE_MODE_SUFFIX = "/compatible-mode/v1"
+_ANTHROPIC_MESSAGES_SUFFIX = "/apps/anthropic"
+_MESSAGES_SUFFIX = "/v1/messages"
+
+
+class DashScopeAnthropicMessagesConfig(AnthropicMessagesConfig):
+    """
+    DashScope Anthropic configuration that extends AnthropicMessagesConfig.
+
+    DashScope (Alibaba Cloud) exposes an Anthropic-compatible Messages API at:
+    - China:         https://dashscope.aliyuncs.com/apps/anthropic/v1/messages
+    - International: https://dashscope-intl.aliyuncs.com/apps/anthropic/v1/messages
+
+    The OpenAI-compatible base URLs (``.../compatible-mode/v1`` and
+    ``.../compatible-mode/v1/chat/completions``) are also recognized and
+    rewritten to the Anthropic Messages endpoint, since callers commonly reuse
+    the chat-completions base URL.
+
+    Supported models: any DashScope-hosted model that is exposed via the
+    Anthropic Messages endpoint (e.g. ``qwen3-max``, ``qwen-plus``,
+    ``qwen-max``).
+    """
+
+    @property
+    def custom_llm_provider(self) -> Optional[str]:
+        return "dashscope"
+
+    @staticmethod
+    def _get_api_key(api_key: Optional[str] = None) -> Optional[str]:
+        return api_key or get_secret_str("DASHSCOPE_API_KEY")
+
+    @staticmethod
+    def _get_anthropic_messages_api_base(api_base: Optional[str] = None) -> str:
+        if not api_base:
+            return DEFAULT_DASHSCOPE_ANTHROPIC_MESSAGES_API_BASE
+
+        base_url = api_base.rstrip("/")
+        if base_url.endswith(_MESSAGES_SUFFIX):
+            return base_url
+        if base_url.endswith(_COMPATIBLE_MODE_CHAT_COMPLETIONS_SUFFIX):
+            root = base_url[: -len(_COMPATIBLE_MODE_CHAT_COMPLETIONS_SUFFIX)]
+            return f"{root}{_ANTHROPIC_MESSAGES_SUFFIX}{_MESSAGES_SUFFIX}"
+        if base_url.endswith(_COMPATIBLE_MODE_SUFFIX):
+            root = base_url[: -len(_COMPATIBLE_MODE_SUFFIX)]
+            return f"{root}{_ANTHROPIC_MESSAGES_SUFFIX}{_MESSAGES_SUFFIX}"
+        if base_url.endswith(f"{_ANTHROPIC_MESSAGES_SUFFIX}/v1"):
+            return f"{base_url}/messages"
+        if base_url.endswith(_ANTHROPIC_MESSAGES_SUFFIX):
+            return f"{base_url}{_MESSAGES_SUFFIX}"
+
+        return f"{base_url}{_MESSAGES_SUFFIX}"
+
+    def get_complete_url(
+        self,
+        api_base: Optional[str],
+        api_key: Optional[str],
+        model: str,
+        optional_params: dict,
+        litellm_params: dict,
+        stream: Optional[bool] = None,
+    ) -> str:
+        return self._get_anthropic_messages_api_base(api_base=api_base)
+
+    def validate_anthropic_messages_environment(
+        self,
+        headers: dict,
+        model: str,
+        messages: List[Any],
+        optional_params: dict,
+        litellm_params: dict,
+        api_key: Optional[str] = None,
+        api_base: Optional[str] = None,
+    ) -> Tuple[dict, Optional[str]]:
+        dynamic_api_key = self._get_api_key(api_key=api_key)
+        if dynamic_api_key and "x-api-key" not in headers:
+            headers["x-api-key"] = dynamic_api_key
+        if "content-type" not in headers:
+            headers["content-type"] = "application/json"
+
+        # DashScope's Anthropic-compatible endpoint does not accept Anthropic
+        # version/beta headers. Keep this provider-specific so other Anthropic
+        # Messages providers retain their existing behavior.
+        headers.pop("anthropic-version", None)
+        headers.pop("anthropic-beta", None)
+        return headers, api_base

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -8643,6 +8643,12 @@ class ProviderConfigManager:
             )
 
             return DeepSeekAnthropicMessagesConfig()
+        elif litellm.LlmProviders.DASHSCOPE == provider:
+            from litellm.llms.dashscope.messages.transformation import (
+                DashScopeAnthropicMessagesConfig,
+            )
+
+            return DashScopeAnthropicMessagesConfig()
         return None
 
     @staticmethod

--- a/tests/test_litellm/llms/dashscope/test_dashscope_messages_transformation.py
+++ b/tests/test_litellm/llms/dashscope/test_dashscope_messages_transformation.py
@@ -1,0 +1,92 @@
+"""
+Unit tests for DashScope Anthropic-compatible Messages support.
+"""
+
+from litellm.llms.dashscope.messages.transformation import (
+    DEFAULT_DASHSCOPE_ANTHROPIC_MESSAGES_API_BASE,
+    DashScopeAnthropicMessagesConfig,
+)
+from litellm.types.utils import LlmProviders
+from litellm.utils import ProviderConfigManager
+
+
+def test_should_map_dashscope_compatible_base_to_anthropic_messages_endpoint():
+    config = DashScopeAnthropicMessagesConfig()
+
+    assert (
+        config.get_complete_url(
+            api_base=None,
+            api_key=None,
+            model="qwen3-max",
+            optional_params={},
+            litellm_params={},
+        )
+        == DEFAULT_DASHSCOPE_ANTHROPIC_MESSAGES_API_BASE
+    )
+    assert (
+        config.get_complete_url(
+            api_base="https://dashscope.aliyuncs.com/compatible-mode/v1",
+            api_key=None,
+            model="qwen3-max",
+            optional_params={},
+            litellm_params={},
+        )
+        == "https://dashscope.aliyuncs.com/apps/anthropic/v1/messages"
+    )
+    assert (
+        config.get_complete_url(
+            api_base="https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions",
+            api_key=None,
+            model="qwen3-max",
+            optional_params={},
+            litellm_params={},
+        )
+        == "https://dashscope-intl.aliyuncs.com/apps/anthropic/v1/messages"
+    )
+    assert (
+        config.get_complete_url(
+            api_base="https://dashscope.aliyuncs.com/apps/anthropic",
+            api_key=None,
+            model="qwen3-max",
+            optional_params={},
+            litellm_params={},
+        )
+        == "https://dashscope.aliyuncs.com/apps/anthropic/v1/messages"
+    )
+
+
+def test_should_prepare_dashscope_anthropic_messages_headers():
+    config = DashScopeAnthropicMessagesConfig()
+
+    headers, api_base = config.validate_anthropic_messages_environment(
+        headers={
+            "anthropic-version": "2023-06-01",
+            "anthropic-beta": "prompt-caching-2024-07-31",
+        },
+        model="qwen3-max",
+        messages=[{"role": "user", "content": "hello"}],
+        optional_params={},
+        litellm_params={},
+        api_key="dashscope-key",
+        api_base="https://dashscope.aliyuncs.com/compatible-mode/v1",
+    )
+
+    assert headers["x-api-key"] == "dashscope-key"
+    assert headers["content-type"] == "application/json"
+    assert "anthropic-version" not in headers
+    assert "anthropic-beta" not in headers
+    assert api_base == "https://dashscope.aliyuncs.com/compatible-mode/v1"
+
+
+def test_should_route_dashscope_provider_to_native_messages_config():
+    qwen_max_config = ProviderConfigManager.get_provider_anthropic_messages_config(
+        model="qwen3-max",
+        provider=LlmProviders.DASHSCOPE,
+    )
+    qwen_plus_config = ProviderConfigManager.get_provider_anthropic_messages_config(
+        model="qwen-plus",
+        provider=LlmProviders.DASHSCOPE,
+    )
+
+    assert isinstance(qwen_max_config, DashScopeAnthropicMessagesConfig)
+    assert isinstance(qwen_plus_config, DashScopeAnthropicMessagesConfig)


### PR DESCRIPTION
## Relevant issues

No existing issue — new provider integration.

## Changes

Adds `DashScopeAnthropicMessagesConfig` so `/v1/messages` calls with `dashscope/<model>` route to DashScope's Anthropic-compatible endpoint:

- China:         `https://dashscope.aliyuncs.com/apps/anthropic/v1/messages`
- International: `https://dashscope-intl.aliyuncs.com/apps/anthropic/v1/messages`

The config extends `AnthropicMessagesConfig`, mirroring the existing `MinimaxMessagesConfig` and `DeepSeekAnthropicMessagesConfig` patterns, and is wired into `ProviderConfigManager.get_provider_anthropic_messages_config` for the already-present `LlmProviders.DASHSCOPE` enum.

Two DashScope-specific behaviors:

1. **URL rewriting.** Callers commonly reuse the OpenAI-compatible base URL (`.../compatible-mode/v1` or `.../compatible-mode/v1/chat/completions`). The config recognizes these (and the `.../apps/anthropic` / `.../apps/anthropic/v1` shorthand) and rewrites them to the Anthropic Messages endpoint, so existing DashScope configuration keeps working.
2. **Header normalization.** DashScope's Anthropic-compatible endpoint does not accept the `anthropic-version` or `anthropic-beta` headers — they are stripped here so other Anthropic Messages providers keep their existing behavior. `api_key` falls back to `DASHSCOPE_API_KEY` when not supplied.

Example usage:

```python
import litellm

response = await litellm.anthropic_messages(
    model="dashscope/qwen3-max",
    messages=[{"role": "user", "content": "hello"}],
    max_tokens=100,
)
```

## Testing

- Added `tests/test_litellm/llms/dashscope/test_dashscope_messages_transformation.py` with 3 tests covering:
  - URL rewriting for the 4 base-URL shapes (no `api_base`, `compatible-mode/v1`, `compatible-mode/v1/chat/completions`, `apps/anthropic`)
  - Header preparation (api_key injection, content-type default, anthropic-version/beta stripping)
  - \`ProviderConfigManager\` returns \`DashScopeAnthropicMessagesConfig\` for \`LlmProviders.DASHSCOPE\`
- Reverse-verified by temporarily removing the new module + \`utils.py\` branch — tests fail with \`ModuleNotFoundError\`, restored and pass again
- Ran \`uv run pytest tests/test_litellm/llms/dashscope/\` — 42 passed (all existing DashScope tests still green)

## Type

🆕 New Feature