### PR TITLE
fix(vertex_ai): use REP host for context caching on eu/us multi-region endpoints

### DIFF
--- a/litellm/llms/vertex_ai/context_caching/vertex_ai_context_caching.py
+++ b/litellm/llms/vertex_ai/context_caching/vertex_ai_context_caching.py
@@ -19,7 +19,7 @@ from litellm.types.llms.vertex_ai import (
     VertexAICachedContentResponseObject,
 )
 
-from ..common_utils import VertexAIError
+from ..common_utils import VertexAIError, get_vertex_base_url
 from ..vertex_llm_base import VertexBase
 from .transformation import (
     separate_cached_messages,
@@ -69,17 +69,13 @@ class ContextCachingEndpoints(VertexBase):
         elif custom_llm_provider == "vertex_ai":
             auth_header = vertex_auth_header
             endpoint = "cachedContents"
-            if vertex_location == "global":
-                url = f"https://aiplatform.googleapis.com/v1/projects/{vertex_project}/locations/{vertex_location}/{endpoint}"
-            else:
-                url = f"https://{vertex_location}-aiplatform.googleapis.com/v1/projects/{vertex_project}/locations/{vertex_location}/{endpoint}"
+            base_url = get_vertex_base_url(vertex_location)
+            url = f"{base_url}/v1/projects/{vertex_project}/locations/{vertex_location}/{endpoint}"
         else:
             auth_header = vertex_auth_header
             endpoint = "cachedContents"
-            if vertex_location == "global":
-                url = f"https://aiplatform.googleapis.com/v1beta1/projects/{vertex_project}/locations/{vertex_location}/{endpoint}"
-            else:
-                url = f"https://{vertex_location}-aiplatform.googleapis.com/v1beta1/projects/{vertex_project}/locations/{vertex_location}/{endpoint}"
+            base_url = get_vertex_base_url(vertex_location)
+            url = f"{base_url}/v1beta1/projects/{vertex_project}/locations/{vertex_location}/{endpoint}"
 
         return self._check_custom_proxy(
             api_base=api_base,

--- a/tests/test_litellm/llms/vertex_ai/context_caching/test_vertex_ai_context_caching.py
+++ b/tests/test_litellm/llms/vertex_ai/context_caching/test_vertex_ai_context_caching.py
@@ -86,7 +86,7 @@ class TestContextCachingEndpoints:
         cached_content = "cached_content_123"
         optional_params = self.sample_optional_params.copy()
         test_project = "test_project"
-        test_location = "test_location"
+        test_location = "us-central1"
 
         # Execute
         result = self.context_caching.check_and_create_cache(
@@ -129,7 +129,7 @@ class TestContextCachingEndpoints:
         mock_separate.return_value = ([], self.sample_messages)  # No cached messages
         optional_params = self.sample_optional_params.copy()
         test_project = "test_project"
-        test_location = "test_location"
+        test_location = "us-central1"
 
         # Execute
         result = self.context_caching.check_and_create_cache(
@@ -177,7 +177,7 @@ class TestContextCachingEndpoints:
 
         optional_params = self.sample_optional_params.copy()
         test_project = "test_project"
-        test_location = "test_location"
+        test_location = "us-central1"
 
         # Execute
         result = self.context_caching.check_and_create_cache(
@@ -251,7 +251,7 @@ class TestContextCachingEndpoints:
 
         optional_params = self.sample_optional_params.copy()
         test_project = "test_project"
-        test_location = "test_location"
+        test_location = "us-central1"
 
         # Execute
         result = self.context_caching.check_and_create_cache(
@@ -321,7 +321,7 @@ class TestContextCachingEndpoints:
 
         optional_params = self.sample_optional_params.copy()
         test_project = "test_project"
-        test_location = "test_location"
+        test_location = "us-central1"
 
         # Execute and Assert
         with pytest.raises(VertexAIError) as exc_info:
@@ -361,7 +361,7 @@ class TestContextCachingEndpoints:
         cached_content = "cached_content_123"
         optional_params = self.sample_optional_params.copy()
         test_project = "test_project"
-        test_location = "test_location"
+        test_location = "us-central1"
 
         # Execute
         result = await self.context_caching.async_check_and_create_cache(
@@ -401,7 +401,7 @@ class TestContextCachingEndpoints:
         mock_separate.return_value = ([], self.sample_messages)
         optional_params = self.sample_optional_params.copy()
         test_project = "test_project"
-        test_location = "test_location"
+        test_location = "us-central1"
 
         # Execute
         result = await self.context_caching.async_check_and_create_cache(
@@ -450,7 +450,7 @@ class TestContextCachingEndpoints:
 
         optional_params = self.sample_optional_params.copy()
         test_project = "test_project"
-        test_location = "test_location"
+        test_location = "us-central1"
 
         # Execute
         result = await self.context_caching.async_check_and_create_cache(
@@ -529,7 +529,7 @@ class TestContextCachingEndpoints:
 
         optional_params = self.sample_optional_params.copy()
         test_project = "test_project"
-        test_location = "test_location"
+        test_location = "us-central1"
 
         # Execute
         result = await self.context_caching.async_check_and_create_cache(
@@ -600,7 +600,7 @@ class TestContextCachingEndpoints:
 
         optional_params = self.sample_optional_params.copy()
         test_project = "test_project"
-        test_location = "test_location"
+        test_location = "us-central1"
 
         # Execute and Assert
         with pytest.raises(VertexAIError) as exc_info:
@@ -642,7 +642,7 @@ class TestContextCachingEndpoints:
             optional_params = self.sample_optional_params.copy()
             original_tools = optional_params["tools"].copy()
             test_project = "test_project"
-            test_location = "test_location"
+            test_location = "us-central1"
 
             # Mock the check_cache to return existing cache so we don't make HTTP calls
             with patch.object(
@@ -688,7 +688,7 @@ class TestContextCachingEndpoints:
             optional_params = self.sample_optional_params.copy()
             original_tools = optional_params["tools"].copy()
             test_project = "test_project"
-            test_location = "test_location"
+            test_location = "us-central1"
 
             # Execute
             result = self.context_caching.check_and_create_cache(
@@ -729,7 +729,7 @@ class TestContextCachingEndpoints:
             optional_params = self.sample_optional_params.copy()
             original_tools = optional_params["tools"].copy()
             test_project = "test_project"
-            test_location = "test_location"
+            test_location = "us-central1"
 
             # Execute
             result = await self.context_caching.async_check_and_create_cache(
@@ -772,7 +772,7 @@ class TestContextCachingEndpoints:
             optional_params = self.sample_optional_params.copy()
             original_tools = optional_params["tools"].copy()
             test_project = "test_project"
-            test_location = "test_location"
+            test_location = "us-central1"
 
             # Mock the async_check_cache to return existing cache so we don't make HTTP calls
             with patch.object(
@@ -1334,6 +1334,70 @@ class TestVertexAIGlobalLocation:
             assert (
                 "global-aiplatform" not in url
             ), "URL should not contain 'global-aiplatform' prefix"
+
+    @pytest.mark.parametrize("vertex_location", ["eu", "us"])
+    def test_multi_region_location_url_construction_v1(self, vertex_location):
+        """Multi-region locations (eu/us) must use the REP host for v1 API.
+
+        Regression test: previously context caching built
+        ``https://{location}-aiplatform.googleapis.com`` for every non-global
+        location, producing the invalid host ``eu-aiplatform.googleapis.com``
+        (404) for the multi-region endpoints. Inference already resolved these
+        to ``aiplatform.{geo}.rep.googleapis.com`` via ``get_vertex_base_url``;
+        context caching now uses the same helper.
+        """
+        caching = ContextCachingEndpoints()
+
+        with patch.object(
+            caching,
+            "_check_custom_proxy",
+            side_effect=lambda **kwargs: (kwargs.get("auth_header"), kwargs.get("url")),
+        ):
+            auth_header, url = caching._get_token_and_url_context_caching(
+                gemini_api_key=None,
+                custom_llm_provider="vertex_ai",
+                api_base=None,
+                vertex_project="test-project",
+                vertex_location=vertex_location,
+                vertex_auth_header="Bearer test-token",
+            )
+
+            expected_url = (
+                f"https://aiplatform.{vertex_location}.rep.googleapis.com"
+                f"/v1/projects/test-project/locations/{vertex_location}/cachedContents"
+            )
+            assert url == expected_url, f"Expected {expected_url}, got {url}"
+            assert (
+                f"{vertex_location}-aiplatform" not in url
+            ), "URL must not use the invalid '<location>-aiplatform' host for multi-region"
+
+    @pytest.mark.parametrize("vertex_location", ["eu", "us"])
+    def test_multi_region_location_url_construction_v1beta1(self, vertex_location):
+        """Multi-region locations (eu/us) must use the REP host for v1beta1 API."""
+        caching = ContextCachingEndpoints()
+
+        with patch.object(
+            caching,
+            "_check_custom_proxy",
+            side_effect=lambda **kwargs: (kwargs.get("auth_header"), kwargs.get("url")),
+        ):
+            auth_header, url = caching._get_token_and_url_context_caching(
+                gemini_api_key=None,
+                custom_llm_provider="vertex_ai_beta",
+                api_base=None,
+                vertex_project="test-project",
+                vertex_location=vertex_location,
+                vertex_auth_header="Bearer test-token",
+            )
+
+            expected_url = (
+                f"https://aiplatform.{vertex_location}.rep.googleapis.com"
+                f"/v1beta1/projects/test-project/locations/{vertex_location}/cachedContents"
+            )
+            assert url == expected_url, f"Expected {expected_url}, got {url}"
+            assert (
+                f"{vertex_location}-aiplatform" not in url
+            ), "URL must not use the invalid '<location>-aiplatform' host for multi-region"
 
     def test_gemini_context_caching_with_custom_api_base_passes_model(self):
         """Gemini context caching with custom api_base must pass model to _check_custom_proxy.


### PR DESCRIPTION
## Relevant issues

  Fixes #29571

  ## Linear ticket

  <!-- external contributor — n/a -->

  ## Pre-Submission checklist

  **Please complete all items before asking a LiteLLM maintainer to review your PR**

  - [x] I have added meaningful tests
  - [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
  - [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
  - [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5**
  before requesting a maintainer review

  ## Screenshots / Proof of Fix

  Explicit context caching (`cache_control`) was unusable on the Vertex AI **multi-region** endpoints (`eu`/`us`): the
  `cachedContents` request was sent to a non-existent host and returned a 404, even though the completion itself succeeded.

  **Before** — `vertex_location="eu"`, captured outgoing request:
  POST https://eu-aiplatform.googleapis.com/v1/projects//locations/eu/cachedContents
  → 404 (Google "Not Found" HTML page)
     litellm.NotFoundError: Vertex_aiException -  ... Error 404 (Not Found)!!1 ...
     The requested URL /v1/projects//locations/eu/cachedContents was not found on this server.
  Note the completion endpoint of the *same* call already used the correct REP host:
  POST https://aiplatform.eu.rep.googleapis.com/v1/projects//locations/eu/.../...:generateContent  → 200

  **After** — `cachedContents` now uses the same REP host as inference; the cache is created and reused:
  POST https://aiplatform.eu.rep.googleapis.com/v1/projects//locations/eu/cachedContents  → 200
  completion → 200, usage.prompt_tokens_details.cached_tokens = 12003

  Verified independently with a direct REST call that `cachedContents` is served on `aiplatform.eu.rep.googleapis.com` (the
  404 was purely the wrong host, not an unsupported feature).

  **New unit tests** (`tests/test_litellm/llms/vertex_ai/context_caching/test_vertex_ai_context_caching.py`):
  test_multi_region_location_url_construction_v1[eu]       PASSED
  test_multi_region_location_url_construction_v1[us]       PASSED
  test_multi_region_location_url_construction_v1beta1[eu]  PASSED
  test_multi_region_location_url_construction_v1beta1[us]  PASSED
  full context_caching suite: 103 passed


  ## Type

  🐛 Bug Fix

  ## Changes

  `cachedContents` URL construction in `ContextCachingEndpoints._get_token_and_url_context_caching` built the host inline as
  `https://{location}-aiplatform.googleapis.com` for any non-`global` location, producing the invalid host
  `eu-aiplatform.googleapis.com` (404) for the `eu`/`us` multi-region endpoints. Multi-region inference was already fixed
  (#27293) and global caching was fixed (#16995), but caching on multi-region fell through the gap.

  - Reuse `get_vertex_base_url()` from `vertex_ai/common_utils.py` (the helper already used by the inference path) in
  `_get_token_and_url_context_caching`, for both the `vertex_ai` (v1) and `vertex_ai_beta` (v1beta1) branches. It resolves
  `global` → `aiplatform.googleapis.com`, multi-region `eu`/`us` → `aiplatform.{geo}.rep.googleapis.com`, and regional →
  `{region}-aiplatform.googleapis.com`.
  - This preserves the existing `global` (#16995) and regional behaviour and adds correct multi-region routing — caching now
  uses the same host resolver as inference.
  - Added parametrized tests for the `eu`/`us` multi-region `cachedContents` URLs (v1 and v1beta1).
