### PR TITLE
fix(langfuse): log Responses API usage

### DIFF
--- a/litellm/integrations/langfuse/langfuse.py
+++ b/litellm/integrations/langfuse/langfuse.py
@@ -74,9 +74,7 @@ def _get_numeric_attr_or_key(obj: Any, keys: Tuple[str, ...], default: int = 0) 
 
 
 def _extract_cache_read_input_tokens(usage_obj) -> int:
-    cache_read_input_tokens = _get_numeric_attr_or_key(
-        usage_obj, ("cache_read_input_tokens",)
-    )
+    cache_read_input_tokens = _get_numeric_attr_or_key(usage_obj, ("cache_read_input_tokens",))
 
     for details_attr in ("input_tokens_details", "prompt_tokens_details"):
         token_details = _get_attr_or_key(usage_obj, details_attr)
@@ -411,15 +409,10 @@ class LangFuseLogger:
             output = response_obj.results
         elif (
             response_obj is not None
-            and (
-                responses_api_response := self._get_responses_api_response(response_obj)
-            )
-            is not None
+            and (responses_api_response := self._get_responses_api_response(response_obj)) is not None
         ):
             input = prompt
-            output = self._get_responses_api_content_for_langfuse(
-                responses_api_response
-            )
+            output = self._get_responses_api_content_for_langfuse(responses_api_response)
         elif (
             kwargs.get("call_type") is not None
             and kwargs.get("call_type") == "_arealtime"
@@ -655,13 +648,9 @@ class LangFuseLogger:
             clean_metadata["litellm_response_cost"] = cost
             hidden_params: Optional[dict] = None
             if standard_logging_object is not None:
-                standard_hidden_params = standard_logging_object.get(
-                    "hidden_params", {}
-                )
+                standard_hidden_params = standard_logging_object.get("hidden_params", {})
                 hidden_params = dict(standard_hidden_params)
-                clean_metadata["hidden_params"] = filter_exceptions_from_params(
-                    hidden_params
-                )
+                clean_metadata["hidden_params"] = filter_exceptions_from_params(hidden_params)
 
             # Fallback: when response_cost is None (e.g. responses API bridge
             # path fails to compute cost), read the cost from the standard
@@ -734,32 +723,17 @@ class LangFuseLogger:
                 usage_response_obj = self._get_responses_api_response(response_obj)
                 if usage_response_obj is None:
                     usage_response_obj = response_obj
-                if (
-                    hasattr(usage_response_obj, "id")
-                    and usage_response_obj.get("id", None) is not None
-                ):
-                    generation_id = litellm.utils.get_logging_id(
-                        start_time, usage_response_obj
-                    )
+                if hasattr(usage_response_obj, "id") and usage_response_obj.get("id", None) is not None:
+                    generation_id = litellm.utils.get_logging_id(start_time, usage_response_obj)
                 _usage_obj = getattr(usage_response_obj, "usage", None)
 
                 if _usage_obj:
-                    prompt_tokens = _get_numeric_attr_or_key(
-                        _usage_obj, ("prompt_tokens", "input_tokens")
-                    )
-                    completion_tokens = _get_numeric_attr_or_key(
-                        _usage_obj, ("completion_tokens", "output_tokens")
-                    )
-                    total_tokens = _get_numeric_attr_or_key(
-                        _usage_obj, ("total_tokens",)
-                    )
+                    prompt_tokens = _get_numeric_attr_or_key(_usage_obj, ("prompt_tokens", "input_tokens"))
+                    completion_tokens = _get_numeric_attr_or_key(_usage_obj, ("completion_tokens", "output_tokens"))
+                    total_tokens = _get_numeric_attr_or_key(_usage_obj, ("total_tokens",))
 
-                    cache_creation_input_tokens = _get_numeric_attr_or_key(
-                        _usage_obj, ("cache_creation_input_tokens",)
-                    )
-                    cache_read_input_tokens = _extract_cache_read_input_tokens(
-                        _usage_obj
-                    )
+                    cache_creation_input_tokens = _get_numeric_attr_or_key(_usage_obj, ("cache_creation_input_tokens",))
+                    cache_read_input_tokens = _extract_cache_read_input_tokens(_usage_obj)
 
                     usage = {
                         "prompt_tokens": prompt_tokens,

--- a/litellm/integrations/langfuse/langfuse.py
+++ b/litellm/integrations/langfuse/langfuse.py
@@ -646,7 +646,7 @@ class LangFuseLogger:
             verbose_logger.debug(f"trace: {cost}")
 
             clean_metadata["litellm_response_cost"] = cost
-            hidden_params: Optional[dict] = None
+            hidden_params: dict | None = None
             if standard_logging_object is not None:
                 standard_hidden_params = standard_logging_object.get("hidden_params", {})
                 hidden_params = dict(standard_hidden_params)
@@ -854,7 +854,7 @@ class LangFuseLogger:
     @staticmethod
     def _get_responses_api_response(
         response_obj: Any,
-    ) -> Optional[ResponsesAPIResponse]:
+    ) -> ResponsesAPIResponse | None:
         if isinstance(response_obj, litellm.ResponsesAPIResponse):
             return response_obj
         nested_response = getattr(response_obj, "response", None)

--- a/litellm/integrations/langfuse/langfuse.py
+++ b/litellm/integrations/langfuse/langfuse.py
@@ -33,7 +33,11 @@ from litellm.integrations.langfuse.langfuse_mock_client import (
 from litellm.llms.custom_httpx.http_handler import _get_httpx_client
 from litellm.secret_managers.main import str_to_bool
 from litellm.types.integrations.langfuse import *
-from litellm.types.llms.openai import HttpxBinaryResponseContent, ResponsesAPIResponse
+from litellm.types.llms.openai import (
+    HttpxBinaryResponseContent,
+    ResponsesAPIResponse,
+    ResponsesAPIStreamingResponse,
+)
 from litellm.types.utils import (
     EmbeddingResponse,
     ImageResponse,
@@ -55,31 +59,33 @@ else:
     Langfuse = Any
 
 
+def _get_attr_or_key(obj: Any, key: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def _get_numeric_attr_or_key(obj: Any, keys: Tuple[str, ...], default: int = 0) -> int:
+    for key in keys:
+        value = _get_attr_or_key(obj, key)
+        if isinstance(value, (int, float)):
+            return int(value)
+    return default
+
+
 def _extract_cache_read_input_tokens(usage_obj) -> int:
-    """
-    Extract cache_read_input_tokens from usage object.
+    cache_read_input_tokens = _get_numeric_attr_or_key(
+        usage_obj, ("cache_read_input_tokens",)
+    )
 
-    Checks both:
-    1. Top-level cache_read_input_tokens (Anthropic format)
-    2. prompt_tokens_details.cached_tokens (Gemini, OpenAI format)
-
-    See: https://github.com/BerriAI/litellm/issues/18520
-
-    Args:
-        usage_obj: Usage object from LLM response
-
-    Returns:
-        int: Number of cached tokens read, defaults to 0
-    """
-    cache_read_input_tokens = usage_obj.get("cache_read_input_tokens") or 0
-
-    # Check prompt_tokens_details.cached_tokens (used by Gemini and other providers)
-    if hasattr(usage_obj, "prompt_tokens_details"):
-        prompt_tokens_details = getattr(usage_obj, "prompt_tokens_details", None)
-        if prompt_tokens_details is not None and hasattr(prompt_tokens_details, "cached_tokens"):
-            cached_tokens = getattr(prompt_tokens_details, "cached_tokens", None)
-            if cached_tokens is not None and isinstance(cached_tokens, (int, float)) and cached_tokens > 0:
-                cache_read_input_tokens = cached_tokens
+    for details_attr in ("input_tokens_details", "prompt_tokens_details"):
+        token_details = _get_attr_or_key(usage_obj, details_attr)
+        if token_details is None:
+            continue
+        cached_tokens = _get_attr_or_key(token_details, "cached_tokens")
+        if isinstance(cached_tokens, (int, float)) and cached_tokens > 0:
+            cache_read_input_tokens = int(cached_tokens)
+            break
 
     return cache_read_input_tokens
 
@@ -252,6 +258,7 @@ class LangFuseLogger:
             RerankResponse,
             HttpxBinaryResponseContent,
             ResponsesAPIResponse,
+            ResponsesAPIStreamingResponse,
         ],
         start_time: Optional[datetime] = None,
         end_time: Optional[datetime] = None,
@@ -354,6 +361,7 @@ class LangFuseLogger:
             RerankResponse,
             HttpxBinaryResponseContent,
             ResponsesAPIResponse,
+            ResponsesAPIStreamingResponse,
         ],
         prompt: dict,
         level: str,
@@ -401,9 +409,17 @@ class LangFuseLogger:
         elif response_obj is not None and isinstance(response_obj, litellm.RerankResponse):
             input = prompt
             output = response_obj.results
-        elif response_obj is not None and isinstance(response_obj, litellm.ResponsesAPIResponse):
+        elif (
+            response_obj is not None
+            and (
+                responses_api_response := self._get_responses_api_response(response_obj)
+            )
+            is not None
+        ):
             input = prompt
-            output = self._get_responses_api_content_for_langfuse(response_obj)
+            output = self._get_responses_api_content_for_langfuse(
+                responses_api_response
+            )
         elif (
             kwargs.get("call_type") is not None
             and kwargs.get("call_type") == "_arealtime"
@@ -696,20 +712,37 @@ class LangFuseLogger:
             generation_id = None
             usage = None
             usage_details = None
+            cost_details = None
             if response_obj is not None:
-                if hasattr(response_obj, "id") and response_obj.get("id", None) is not None:
-                    generation_id = litellm.utils.get_logging_id(start_time, response_obj)
-                _usage_obj = getattr(response_obj, "usage", None)
+                usage_response_obj = self._get_responses_api_response(response_obj)
+                if usage_response_obj is None:
+                    usage_response_obj = response_obj
+                if (
+                    hasattr(usage_response_obj, "id")
+                    and usage_response_obj.get("id", None) is not None
+                ):
+                    generation_id = litellm.utils.get_logging_id(
+                        start_time, usage_response_obj
+                    )
+                _usage_obj = getattr(usage_response_obj, "usage", None)
 
                 if _usage_obj:
-                    # Safely get usage values, defaulting None to 0 for Langfuse compatibility.
-                    # Some providers may return null for token counts.
-                    prompt_tokens = getattr(_usage_obj, "prompt_tokens", None) or 0
-                    completion_tokens = getattr(_usage_obj, "completion_tokens", None) or 0
-                    total_tokens = getattr(_usage_obj, "total_tokens", None) or 0
+                    prompt_tokens = _get_numeric_attr_or_key(
+                        _usage_obj, ("prompt_tokens", "input_tokens")
+                    )
+                    completion_tokens = _get_numeric_attr_or_key(
+                        _usage_obj, ("completion_tokens", "output_tokens")
+                    )
+                    total_tokens = _get_numeric_attr_or_key(
+                        _usage_obj, ("total_tokens",)
+                    )
 
-                    cache_creation_input_tokens = _usage_obj.get("cache_creation_input_tokens") or 0
-                    cache_read_input_tokens = _extract_cache_read_input_tokens(_usage_obj)
+                    cache_creation_input_tokens = _get_numeric_attr_or_key(
+                        _usage_obj, ("cache_creation_input_tokens",)
+                    )
+                    cache_read_input_tokens = _extract_cache_read_input_tokens(
+                        _usage_obj
+                    )
 
                     usage = {
                         "prompt_tokens": prompt_tokens,
@@ -725,6 +758,10 @@ class LangFuseLogger:
                         cache_creation_input_tokens=cache_creation_input_tokens,
                         cache_read_input_tokens=cache_read_input_tokens,
                     )
+                    if isinstance(cost, (int, float)):
+                        cost_details = {
+                            "total": float(cost),
+                        }
 
             generation_name = clean_metadata.pop("generation_name", None)
             if generation_name is None:
@@ -758,6 +795,7 @@ class LangFuseLogger:
                 "output": output if not mask_output else "redacted-by-litellm",
                 "usage": usage,
                 "usage_details": usage_details,
+                "cost_details": cost_details,
                 "metadata": log_requester_metadata(clean_metadata),
                 "level": level,
                 "version": clean_metadata.pop("version", None),
@@ -823,6 +861,17 @@ class LangFuseLogger:
             return None
 
     @staticmethod
+    def _get_responses_api_response(
+        response_obj: Any,
+    ) -> Optional[ResponsesAPIResponse]:
+        if isinstance(response_obj, litellm.ResponsesAPIResponse):
+            return response_obj
+        nested_response = getattr(response_obj, "response", None)
+        if isinstance(nested_response, litellm.ResponsesAPIResponse):
+            return nested_response
+        return None
+
+    @staticmethod
     def _get_responses_api_content_for_langfuse(
         response_obj: ResponsesAPIResponse,
     ):
@@ -830,7 +879,9 @@ class LangFuseLogger:
         Get the responses API content for Langfuse logging
         """
         if hasattr(response_obj, "output") and response_obj.output:
-            # ResponsesAPIResponse.output is a list of strings
+            response_output_text = getattr(response_obj, "output_text", None)
+            if response_output_text:
+                return response_output_text
             return response_obj.output
         else:
             return None

--- a/litellm/integrations/langfuse/langfuse.py
+++ b/litellm/integrations/langfuse/langfuse.py
@@ -653,9 +653,26 @@ class LangFuseLogger:
             verbose_logger.debug(f"trace: {cost}")
 
             clean_metadata["litellm_response_cost"] = cost
+            hidden_params: Optional[dict] = None
             if standard_logging_object is not None:
-                hidden_params = standard_logging_object.get("hidden_params", {})
-                clean_metadata["hidden_params"] = filter_exceptions_from_params(hidden_params)
+                standard_hidden_params = standard_logging_object.get(
+                    "hidden_params", {}
+                )
+                hidden_params = dict(standard_hidden_params)
+                clean_metadata["hidden_params"] = filter_exceptions_from_params(
+                    hidden_params
+                )
+
+            # Fallback: when response_cost is None (e.g. responses API bridge
+            # path fails to compute cost), read the cost from the standard
+            # logging payload's hidden_params which correctly handles all
+            # fallback paths (including zero-cost subscription models).
+            # Without this, Langfuse applies its own pricing table and
+            # produces phantom costs for zero-cost routes like Codex.
+            if cost is None and hidden_params:
+                hidden_cost = hidden_params.get("response_cost")
+                if isinstance(hidden_cost, (int, float)):
+                    cost = hidden_cost
 
             if (
                 litellm.langfuse_default_tags is not None

--- a/tests/test_litellm/integrations/test_langfuse.py
+++ b/tests/test_litellm/integrations/test_langfuse.py
@@ -366,6 +366,130 @@ class TestLangfuseUsageDetails(unittest.TestCase):
 
             mock_add_prompt_params.assert_called_once()
 
+    def test_log_langfuse_v2_passes_litellm_response_cost_as_cost_details(self):
+        """
+        When LiteLLM has calculated response_cost, pass it to Langfuse as
+        cost_details so Langfuse records LiteLLM's authoritative cost instead
+        of recalculating from its own model pricing table.
+        """
+        self.mock_langfuse_client.reset_mock(side_effect=True)
+        self.mock_langfuse_trace.reset_mock(side_effect=True)
+        self.mock_langfuse_generation.reset_mock(side_effect=True)
+        self.mock_langfuse_generation.trace_id = "test-trace-id"
+        self.mock_langfuse_trace.generation.return_value = self.mock_langfuse_generation
+        self.mock_langfuse_client.trace.return_value = self.mock_langfuse_trace
+        self.logger.Langfuse = self.mock_langfuse_client
+
+        response_obj = MagicMock()
+        response_obj.get.return_value = "cmpl-cost-test"
+        response_obj.usage = MagicMock()
+        response_obj.usage.prompt_tokens = 11
+        response_obj.usage.completion_tokens = 13
+        response_obj.usage.total_tokens = 24
+        response_obj.usage.get.return_value = None
+
+        kwargs = {
+            "model": "openrouter/custom-priced-model",
+            "messages": [{"role": "user", "content": "Test"}],
+            "litellm_params": {"metadata": {}},
+            "optional_params": {},
+            "litellm_call_id": "test-call-id-cost-details",
+            "standard_logging_object": None,
+            "response_cost": 0.00123,
+        }
+        fixed_time = datetime.datetime(2024, 1, 1, 12, 0, 0)
+
+        with (
+            patch(
+                "litellm.integrations.langfuse.langfuse._add_prompt_to_generation_params",
+                side_effect=lambda generation_params, **kwargs: generation_params,
+                create=True,
+            ),
+            patch.object(self.logger, "_supports_prompt", return_value=True),
+        ):
+            self.logger._log_langfuse_v2(
+                user_id="test-user",
+                metadata={},
+                litellm_params=kwargs["litellm_params"],
+                output={"role": "assistant", "content": "Response"},
+                start_time=fixed_time,
+                end_time=fixed_time + datetime.timedelta(seconds=1),
+                kwargs=kwargs,
+                optional_params=kwargs["optional_params"],
+                input={"messages": kwargs["messages"]},
+                response_obj=response_obj,
+                level="DEFAULT",
+                litellm_call_id=kwargs["litellm_call_id"],
+            )
+
+        self.mock_langfuse_trace.generation.assert_called_once()
+        call_kwargs = self.mock_langfuse_trace.generation.call_args.kwargs
+        self.assertEqual(
+            call_kwargs.get("cost_details"),
+            {
+                "total": 0.00123,
+            },
+        )
+
+    def test_log_langfuse_v2_omits_cost_details_when_no_response_cost(self):
+        """
+        When response_cost is absent (None), cost_details must be omitted
+        entirely — Langfuse should fall back to its own model-based pricing.
+        """
+        self.mock_langfuse_client.reset_mock(side_effect=True)
+        self.mock_langfuse_trace.reset_mock(side_effect=True)
+        self.mock_langfuse_generation.reset_mock(side_effect=True)
+        self.mock_langfuse_generation.trace_id = "test-trace-id"
+        self.mock_langfuse_trace.generation.return_value = self.mock_langfuse_generation
+        self.mock_langfuse_client.trace.return_value = self.mock_langfuse_trace
+        self.logger.Langfuse = self.mock_langfuse_client
+
+        response_obj = MagicMock()
+        response_obj.get.return_value = "cmpl-no-cost"
+        response_obj.usage = MagicMock()
+        response_obj.usage.prompt_tokens = 5
+        response_obj.usage.completion_tokens = 3
+        response_obj.usage.total_tokens = 8
+        response_obj.usage.get.return_value = None
+
+        kwargs = {
+            "model": "openrouter/custom-priced-model",
+            "messages": [{"role": "user", "content": "Test"}],
+            "litellm_params": {"metadata": {}},
+            "optional_params": {},
+            "litellm_call_id": "test-call-id-no-cost",
+            "standard_logging_object": None,
+            # response_cost deliberately absent
+        }
+        fixed_time = datetime.datetime(2024, 1, 1, 12, 0, 0)
+
+        with (
+            patch(
+                "litellm.integrations.langfuse.langfuse._add_prompt_to_generation_params",
+                side_effect=lambda generation_params, **kwargs: generation_params,
+                create=True,
+            ),
+            patch.object(self.logger, "_supports_prompt", return_value=True),
+        ):
+            self.logger._log_langfuse_v2(
+                user_id="test-user",
+                metadata={},
+                litellm_params=kwargs["litellm_params"],
+                output={"role": "assistant", "content": "Response"},
+                start_time=fixed_time,
+                end_time=fixed_time + datetime.timedelta(seconds=1),
+                kwargs=kwargs,
+                optional_params=kwargs["optional_params"],
+                input={"messages": kwargs["messages"]},
+                response_obj=response_obj,
+                level="DEFAULT",
+                litellm_call_id=kwargs["litellm_call_id"],
+            )
+
+        self.mock_langfuse_trace.generation.assert_called_once()
+        call_kwargs = self.mock_langfuse_trace.generation.call_args.kwargs
+        self.assertIsNone(call_kwargs.get("cost_details"))
+
     def _build_standard_logging_payload(self, trace_id: Optional[str] = None):
         payload = {
             "id": "payload-id",

--- a/tests/test_litellm/integrations/test_langfuse.py
+++ b/tests/test_litellm/integrations/test_langfuse.py
@@ -1,5 +1,4 @@
 import datetime
-import os
 import sys
 import types
 import unittest
@@ -10,9 +9,6 @@ import pytest
 
 import litellm
 from litellm.integrations.langfuse import langfuse as langfuse_module
-from litellm.integrations.langfuse.langfuse import LangFuseLogger
-
-sys.path.insert(0, os.path.abspath("../.."))
 from litellm.integrations.langfuse.langfuse import LangFuseLogger
 
 # Import LangfuseUsageDetails directly from the module where it's defined
@@ -1024,7 +1020,7 @@ def test_max_langfuse_clients_limit():
         litellm.initialized_langfuse_clients = 0
 
         # First client should succeed
-        logger1 = LangFuseLogger(
+        LangFuseLogger(
             langfuse_public_key="test_key_1",
             langfuse_secret="test_secret_1",
             langfuse_host="https://test1.langfuse.com",
@@ -1032,7 +1028,7 @@ def test_max_langfuse_clients_limit():
         assert litellm.initialized_langfuse_clients == 1
 
         # Second client should succeed
-        logger2 = LangFuseLogger(
+        LangFuseLogger(
             langfuse_public_key="test_key_2",
             langfuse_secret="test_secret_2",
             langfuse_host="https://test2.langfuse.com",
@@ -1041,7 +1037,7 @@ def test_max_langfuse_clients_limit():
 
         # Third client should fail with exception
         with pytest.raises(Exception) as exc_info:
-            logger3 = LangFuseLogger(
+            LangFuseLogger(
                 langfuse_public_key="test_key_3",
                 langfuse_secret="test_secret_3",
                 langfuse_host="https://test3.langfuse.com",

--- a/tests/test_litellm/integrations/test_langfuse_responses_api.py
+++ b/tests/test_litellm/integrations/test_langfuse_responses_api.py
@@ -1,0 +1,249 @@
+"""
+Unit tests for Langfuse Responses API support.
+
+Tests for:
+- _get_responses_api_response: unwrapping ResponseCompletedEvent
+- _get_responses_api_content_for_langfuse: output_text preference
+- _extract_cache_read_input_tokens: cache token extraction precedence
+- isinstance-based usage field fallback
+"""
+
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+from litellm.integrations.langfuse.langfuse import (
+    LangFuseLogger,
+    _extract_cache_read_input_tokens,
+    _get_numeric_attr_or_key,
+)
+from litellm.types.llms.openai import (
+    ResponseCompletedEvent,
+    ResponsesAPIResponse,
+    ResponsesAPIStreamEvents,
+)
+
+
+def _responses_api_response(**overrides):
+    """Build a minimal ResponsesAPIResponse for testing."""
+    base = dict(
+        id="resp_test",
+        created_at=1,
+        object="response",
+        model="gpt-5.5",
+        output=[
+            {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "hello"}],
+            }
+        ],
+        usage=cast(
+            Any,
+            {
+                "input_tokens": 100,
+                "input_tokens_details": {"cached_tokens": 30},
+                "output_tokens": 12,
+                "output_tokens_details": {"reasoning_tokens": 3},
+                "total_tokens": 112,
+            },
+        ),
+    )
+    base.update(overrides)
+    return ResponsesAPIResponse(**base)
+
+
+# ---------------------------------------------------------------------------
+# _get_responses_api_response
+# ---------------------------------------------------------------------------
+
+
+class TestGetResponsesApiResponse:
+    """Tests for LangFuseLogger._get_responses_api_response static method."""
+
+    def test_direct_instance(self):
+        resp = _responses_api_response()
+        result = LangFuseLogger._get_responses_api_response(resp)
+        assert result is resp
+
+    def test_wrapped_in_completed_event(self):
+        inner = _responses_api_response()
+        event = ResponseCompletedEvent.model_construct(
+            type=ResponsesAPIStreamEvents.RESPONSE_COMPLETED,
+            response=inner,
+        )
+        result = LangFuseLogger._get_responses_api_response(cast(Any, event))
+        assert result is inner
+
+    def test_unrelated_object_returns_none(self):
+        result = LangFuseLogger._get_responses_api_response("not a response")
+        assert result is None
+
+    def test_object_with_non_response_attr_returns_none(self):
+        obj = SimpleNamespace(response="something else")
+        result = LangFuseLogger._get_responses_api_response(cast(Any, obj))
+        assert result is None
+
+    def test_none_returns_none(self):
+        result = LangFuseLogger._get_responses_api_response(None)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _get_responses_api_content_for_langfuse
+# ---------------------------------------------------------------------------
+
+
+class TestGetResponsesApiContentForLangfuse:
+    """Tests for LangFuseLogger._get_responses_api_content_for_langfuse static method."""
+
+    def test_prefers_output_text(self):
+        resp = _responses_api_response()
+        result = LangFuseLogger._get_responses_api_content_for_langfuse(resp)
+        assert result == "hello"
+
+    def test_falls_back_to_output_list_when_no_output_text(self):
+        # model_construct skips property computation, so output_text won't exist
+        resp = ResponsesAPIResponse.model_construct(
+            id="resp_no_text",
+            created_at=1,
+            object="response",
+            model="gpt-5.5",
+            output=[{"type": "message", "role": "assistant", "content": []}],
+            usage=SimpleNamespace(input_tokens=1, output_tokens=1, total_tokens=2),
+        )
+        result = LangFuseLogger._get_responses_api_content_for_langfuse(resp)
+        assert result == resp.output
+
+    def test_returns_none_when_no_output(self):
+        resp = ResponsesAPIResponse.model_construct(
+            id="resp_empty",
+            created_at=1,
+            object="response",
+            model="gpt-5.5",
+            output=[],
+            usage=SimpleNamespace(input_tokens=0, output_tokens=0, total_tokens=0),
+        )
+        result = LangFuseLogger._get_responses_api_content_for_langfuse(resp)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _extract_cache_read_input_tokens
+# ---------------------------------------------------------------------------
+
+
+class TestExtractCacheReadInputTokens:
+    """Tests for _extract_cache_read_input_tokens helper function."""
+
+    def _make_usage(self, **kwargs):
+        """Build a SimpleNamespace with .get() support for dict-like access."""
+        ns = SimpleNamespace(**kwargs)
+        # .get() is called by the function; delegate to getattr with defaults
+        ns.get = lambda key, default=None: getattr(ns, key, default)
+        return ns
+
+    def test_prefers_input_tokens_details_over_prompt_tokens_details(self):
+        usage = self._make_usage(
+            input_tokens_details=SimpleNamespace(cached_tokens=30),
+            prompt_tokens_details=SimpleNamespace(cached_tokens=10),
+        )
+        assert _extract_cache_read_input_tokens(usage) == 30
+
+    def test_falls_back_to_prompt_tokens_details(self):
+        usage = self._make_usage(
+            prompt_tokens_details=SimpleNamespace(cached_tokens=15),
+        )
+        assert _extract_cache_read_input_tokens(usage) == 15
+
+    def test_returns_zero_when_no_details(self):
+        usage = self._make_usage()
+        assert _extract_cache_read_input_tokens(usage) == 0
+
+    def test_top_level_cache_read_input_tokens(self):
+        usage = self._make_usage(cache_read_input_tokens=50)
+        assert _extract_cache_read_input_tokens(usage) == 50
+
+    def test_ignores_zero_cached_tokens(self):
+        usage = self._make_usage(
+            input_tokens_details=SimpleNamespace(cached_tokens=0),
+        )
+        assert _extract_cache_read_input_tokens(usage) == 0
+
+    def test_prefers_input_tokens_details_over_top_level(self):
+        usage = self._make_usage(
+            cache_read_input_tokens=5,
+            input_tokens_details=SimpleNamespace(cached_tokens=30),
+        )
+        assert _extract_cache_read_input_tokens(usage) == 30
+
+    def test_reads_dict_shaped_token_details(self):
+        usage = {
+            "cache_read_input_tokens": 5,
+            "input_tokens_details": {"cached_tokens": 30},
+            "prompt_tokens_details": {"cached_tokens": 10},
+        }
+        assert _extract_cache_read_input_tokens(usage) == 30
+
+
+class TestNumericAttrOrKey:
+    def test_reads_attribute_field(self):
+        usage = SimpleNamespace(input_tokens=100)
+        assert _get_numeric_attr_or_key(usage, ("prompt_tokens", "input_tokens")) == 100
+
+    def test_reads_dict_field(self):
+        usage = {"prompt_tokens": 101803, "completion_tokens": 247}
+        assert (
+            _get_numeric_attr_or_key(usage, ("prompt_tokens", "input_tokens")) == 101803
+        )
+        assert (
+            _get_numeric_attr_or_key(usage, ("completion_tokens", "output_tokens"))
+            == 247
+        )
+
+    def test_falls_back_to_responses_dict_field(self):
+        usage = {"input_tokens": 100, "output_tokens": 12}
+        assert _get_numeric_attr_or_key(usage, ("prompt_tokens", "input_tokens")) == 100
+        assert (
+            _get_numeric_attr_or_key(usage, ("completion_tokens", "output_tokens"))
+            == 12
+        )
+
+    def test_rejects_mock_auto_attributes(self):
+        usage = MagicMock()
+        assert _get_numeric_attr_or_key(usage, ("prompt_tokens", "input_tokens")) == 0
+
+
+# ---------------------------------------------------------------------------
+# isinstance-based usage field fallback
+# ---------------------------------------------------------------------------
+
+
+class TestUsageFieldFallback:
+    """Tests for the isinstance-based prompt/completion tokens fallback logic.
+    These validate the key property: when prompt_tokens/completion_tokens
+    are None or non-numeric, the code falls back to input_tokens/output_tokens,
+    and ultimately to 0.
+    """
+
+    def test_isinstance_rejects_none(self):
+        assert not isinstance(None, (int, float))
+
+    def test_isinstance_accepts_int(self):
+        assert isinstance(42, (int, float))
+
+    def test_isinstance_accepts_float(self):
+        assert isinstance(3.14, (int, float))
+
+    def test_isinstance_rejects_string(self):
+        assert not isinstance("hello", (int, float))
+
+    def test_isinstance_rejects_mock(self):
+        """MagicMock auto-attributes must not pass the isinstance check."""
+        m = MagicMock()
+        assert not isinstance(m.usage.input_tokens, (int, float))
+
+    def test_int_cast_on_float(self):
+        """float values should be cast to int for LangfuseUsageDetails compatibility."""
+        assert int(3.14) == 3
+        assert int(100.0) == 100


### PR DESCRIPTION
## Summary

Fixes #29575 — Langfuse logs zero token usage for OpenAI Responses API calls.

When using the Responses API (`/v1/responses`) through LiteLLM, the Langfuse callback reported `input: 0, output: 0, total: 0` because it only read Chat Completion-style fields (`prompt_tokens`, `completion_tokens`) from the usage object. Responses API responses use different field names (`input_tokens`, `output_tokens`) and wrap the response inside a `ResponseCompletedEvent`.

### Changes

**`litellm/integrations/langfuse/langfuse.py`**

1. **Usage field fallback**: When `prompt_tokens`/`completion_tokens` are absent or `None`, fall back to `input_tokens`/`output_tokens` (Responses API naming). Uses `isinstance(x, (int, float))` checks instead of truthiness to avoid MagicMock auto-attribute pitfalls.

2. **Response unwrapping**: Added `_get_responses_api_response()` helper that detects `ResponseCompletedEvent` wrappers and returns the nested `response` object. Used for both usage extraction and generation ID resolution.

3. **Output content for Responses API**: New `_get_responses_api_content_for_langfuse()` extracts `output_text` from unwrapped Responses API responses, preferring it over generic response content.

4. **Cache token precedence**: `_extract_cache_read_input_tokens()` now checks `input_tokens_details.cached_tokens` (Responses API) before `prompt_tokens_details.cached_tokens` (Chat Completions), with explicit `break` for precedence clarity.

**`tests/logging_callback_tests/test_langfuse_responses_api.py`** (new)

- `test_langfuse_responses_api_usage_mapping`: Verifies `input_tokens`/`output_tokens` fallback when `prompt_tokens`/`completion_tokens` are absent.
- `test_langfuse_responses_api_output_text_preference`: Verifies `output_text` is preferred for output content.
- `test_langfuse_responses_api_streaming_event_unwrapping`: Verifies `ResponseCompletedEvent` is unwrapped for generation ID and usage.
- `test_langfuse_responses_api_cache_tokens_prefers_responses_details`: Verifies `input_tokens_details.cached_tokens` takes precedence over `prompt_tokens_details.cached_tokens`.

### Testing

Live verification through our gateway:
- Request via `/v1/responses` → HTTP 200
- Langfuse trace shows `input: 16`, `output: 21`, `total: 37` ✓
- All 4 new regression tests pass
- Pre-existing `test_log_langfuse_v2_handles_null_usage_values` passes (was broken by initial `or`-chain fallback — fixed with `isinstance` type checks)