### PR TITLE
fix(otel): route per-key langfuse_host to the OTLP exporter endpoint

### DIFF
--- a/litellm/integrations/langfuse/langfuse_otel.py
+++ b/litellm/integrations/langfuse/langfuse_otel.py
@@ -283,9 +283,9 @@ class LangfuseOtelLogger(OpenTelemetry):
 
         if langfuse_host:
             # If LANGFUSE_HOST is provided, construct OTEL endpoint from it
-            endpoint = LangfuseOtelLogger._construct_langfuse_otel_endpoint(
-                langfuse_host
-            )
+            if not langfuse_host.startswith("http"):
+                langfuse_host = "https://" + langfuse_host
+            endpoint = f"{langfuse_host.rstrip('/')}/api/public/otel"
             verbose_logger.debug(f"Using Langfuse OTEL endpoint from host: {endpoint}")
         else:
             # Default to US cloud endpoint
@@ -332,9 +332,9 @@ class LangfuseOtelLogger(OpenTelemetry):
 
         if langfuse_host:
             # If LANGFUSE_HOST is provided, construct OTEL endpoint from it
-            endpoint = LangfuseOtelLogger._construct_langfuse_otel_endpoint(
-                langfuse_host
-            )
+            if not langfuse_host.startswith("http"):
+                langfuse_host = "https://" + langfuse_host
+            endpoint = f"{langfuse_host.rstrip('/')}/api/public/otel"
             verbose_logger.debug(f"Using Langfuse OTEL endpoint from host: {endpoint}")
         else:
             # Default to US cloud endpoint
@@ -364,13 +364,6 @@ class LangfuseOtelLogger(OpenTelemetry):
         auth_string = f"{public_key}:{secret_key}"
         auth_header = base64.b64encode(auth_string.encode()).decode()
         return f"Basic {auth_header}"
-
-    @staticmethod
-    def _construct_langfuse_otel_endpoint(langfuse_host: str) -> str:
-        """Build the Langfuse OTLP base endpoint from a host (scheme-tolerant)."""
-        if not langfuse_host.startswith("http"):
-            langfuse_host = "https://" + langfuse_host
-        return f"{langfuse_host.rstrip('/')}/api/public/otel"
 
     def construct_dynamic_otel_headers(
         self, standard_callback_dynamic_params: StandardCallbackDynamicParams
@@ -407,21 +400,54 @@ class LangfuseOtelLogger(OpenTelemetry):
         Construct a per-key/team Langfuse OTLP endpoint from the dynamic host.
 
         Per-key Langfuse credentials are only valid against the host that issued
-        them, so the host must travel with the credentials. Returns None when no
-        per-key host is set, falling back to the env-configured endpoint.
+        them, so the host must travel with the credentials. Returns None when the
+        dynamic host is unset or not allowed, falling back to the env-configured
+        endpoint.
 
-        Prefers ``langfuse_base_url`` (the Langfuse v3 naming) and falls back to
-        the deprecated ``langfuse_host`` for backward compatibility, mirroring the
-        SDK's own ``base_url`` -> ``host`` resolution order.
+        Security: callback vars can be supplied on requests, so a dynamic host is
+        only honored when the proxy operator has explicitly allow-listed it in the
+        ``LANGFUSE_ALLOWED_DYNAMIC_HOSTS`` env var (comma-separated base URLs, e.g.
+        ``https://us.cloud.langfuse.com,https://langfuse.internal.example``). When
+        unset, dynamic hosts are ignored entirely — the exporter destination is
+        always operator-controlled via the env.
+
+        The dynamic host must be a fully-qualified ``http(s)://`` base URL; it is
+        matched against the allowlist as-is (modulo trailing slashes) and never
+        rewritten. Prefers ``langfuse_base_url`` (the Langfuse v3 naming) and falls
+        back to the deprecated ``langfuse_host``, mirroring the SDK's own
+        ``base_url`` -> ``host`` resolution order.
         """
         dynamic_langfuse_base_url = standard_callback_dynamic_params.get(
             "langfuse_base_url"
         ) or standard_callback_dynamic_params.get("langfuse_host")
         if not dynamic_langfuse_base_url:
             return None
-        return LangfuseOtelLogger._construct_langfuse_otel_endpoint(
-            dynamic_langfuse_base_url
-        )
+
+        normalized_base_url = dynamic_langfuse_base_url.strip().rstrip("/")
+        if not normalized_base_url.startswith(("http://", "https://")):
+            verbose_logger.warning(
+                "Ignoring dynamic langfuse host %r: must be a fully-qualified "
+                "http(s):// base URL. Falling back to the env-configured Langfuse "
+                "OTEL endpoint.",
+                dynamic_langfuse_base_url,
+            )
+            return None
+
+        allowed_hosts = [
+            host.strip().rstrip("/")
+            for host in os.environ.get("LANGFUSE_ALLOWED_DYNAMIC_HOSTS", "").split(",")
+            if host.strip()
+        ]
+        if normalized_base_url not in allowed_hosts:
+            verbose_logger.warning(
+                "Ignoring dynamic langfuse host %r: not present in the "
+                "LANGFUSE_ALLOWED_DYNAMIC_HOSTS env var. Falling back to the "
+                "env-configured Langfuse OTEL endpoint.",
+                normalized_base_url,
+            )
+            return None
+
+        return f"{normalized_base_url}/api/public/otel"
 
     def create_litellm_proxy_request_started_span(
         self,

--- a/litellm/integrations/langfuse/langfuse_otel.py
+++ b/litellm/integrations/langfuse/langfuse_otel.py
@@ -409,12 +409,18 @@ class LangfuseOtelLogger(OpenTelemetry):
         Per-key Langfuse credentials are only valid against the host that issued
         them, so the host must travel with the credentials. Returns None when no
         per-key host is set, falling back to the env-configured endpoint.
+
+        Prefers ``langfuse_base_url`` (the Langfuse v3 naming) and falls back to
+        the deprecated ``langfuse_host`` for backward compatibility, mirroring the
+        SDK's own ``base_url`` -> ``host`` resolution order.
         """
-        dynamic_langfuse_host = standard_callback_dynamic_params.get("langfuse_host")
-        if not dynamic_langfuse_host:
+        dynamic_langfuse_base_url = standard_callback_dynamic_params.get(
+            "langfuse_base_url"
+        ) or standard_callback_dynamic_params.get("langfuse_host")
+        if not dynamic_langfuse_base_url:
             return None
         return LangfuseOtelLogger._construct_langfuse_otel_endpoint(
-            dynamic_langfuse_host
+            dynamic_langfuse_base_url
         )
 
     def create_litellm_proxy_request_started_span(

--- a/litellm/integrations/langfuse/langfuse_otel.py
+++ b/litellm/integrations/langfuse/langfuse_otel.py
@@ -283,9 +283,9 @@ class LangfuseOtelLogger(OpenTelemetry):
 
         if langfuse_host:
             # If LANGFUSE_HOST is provided, construct OTEL endpoint from it
-            if not langfuse_host.startswith("http"):
-                langfuse_host = "https://" + langfuse_host
-            endpoint = f"{langfuse_host.rstrip('/')}/api/public/otel"
+            endpoint = LangfuseOtelLogger._construct_langfuse_otel_endpoint(
+                langfuse_host
+            )
             verbose_logger.debug(f"Using Langfuse OTEL endpoint from host: {endpoint}")
         else:
             # Default to US cloud endpoint
@@ -332,9 +332,9 @@ class LangfuseOtelLogger(OpenTelemetry):
 
         if langfuse_host:
             # If LANGFUSE_HOST is provided, construct OTEL endpoint from it
-            if not langfuse_host.startswith("http"):
-                langfuse_host = "https://" + langfuse_host
-            endpoint = f"{langfuse_host.rstrip('/')}/api/public/otel"
+            endpoint = LangfuseOtelLogger._construct_langfuse_otel_endpoint(
+                langfuse_host
+            )
             verbose_logger.debug(f"Using Langfuse OTEL endpoint from host: {endpoint}")
         else:
             # Default to US cloud endpoint
@@ -365,6 +365,13 @@ class LangfuseOtelLogger(OpenTelemetry):
         auth_header = base64.b64encode(auth_string.encode()).decode()
         return f"Basic {auth_header}"
 
+    @staticmethod
+    def _construct_langfuse_otel_endpoint(langfuse_host: str) -> str:
+        """Build the Langfuse OTLP base endpoint from a host (scheme-tolerant)."""
+        if not langfuse_host.startswith("http"):
+            langfuse_host = "https://" + langfuse_host
+        return f"{langfuse_host.rstrip('/')}/api/public/otel"
+
     def construct_dynamic_otel_headers(
         self, standard_callback_dynamic_params: StandardCallbackDynamicParams
     ) -> Optional[dict]:
@@ -392,6 +399,23 @@ class LangfuseOtelLogger(OpenTelemetry):
             dynamic_headers["Authorization"] = auth_header
 
         return dynamic_headers
+
+    def construct_dynamic_otel_endpoint(
+        self, standard_callback_dynamic_params: StandardCallbackDynamicParams
+    ) -> Optional[str]:
+        """
+        Construct a per-key/team Langfuse OTLP endpoint from the dynamic host.
+
+        Per-key Langfuse credentials are only valid against the host that issued
+        them, so the host must travel with the credentials. Returns None when no
+        per-key host is set, falling back to the env-configured endpoint.
+        """
+        dynamic_langfuse_host = standard_callback_dynamic_params.get("langfuse_host")
+        if not dynamic_langfuse_host:
+            return None
+        return LangfuseOtelLogger._construct_langfuse_otel_endpoint(
+            dynamic_langfuse_host
+        )
 
     def create_litellm_proxy_request_started_span(
         self,

--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -858,9 +858,14 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
 
         if dynamic_headers is not None:
             # Create spans using a temporary tracer with dynamic headers
-            tracer_to_use = self._get_tracer_with_dynamic_headers(dynamic_headers)
+            dynamic_endpoint = self._get_dynamic_otel_endpoint_from_kwargs(kwargs)
+            tracer_to_use = self._get_tracer_with_dynamic_headers(
+                dynamic_headers, dynamic_endpoint=dynamic_endpoint
+            )
             verbose_logger.debug(
-                "[OTEL DEBUG] Using DYNAMIC tracer with headers: %s", dynamic_headers
+                "[OTEL DEBUG] Using DYNAMIC tracer with headers: %s endpoint: %s",
+                dynamic_headers,
+                dynamic_endpoint,
             )
         else:
             # For langfuse_otel without dynamic headers, create a provider with env var credentials
@@ -907,12 +912,29 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
 
         return dynamic_headers if dynamic_headers else None
 
-    def _get_tracer_with_dynamic_headers(self, dynamic_headers: dict):
+    def _get_dynamic_otel_endpoint_from_kwargs(self, kwargs) -> Optional[str]:
+        """Extract a dynamic OTLP endpoint from kwargs if available."""
+        standard_callback_dynamic_params: Optional[StandardCallbackDynamicParams] = (
+            kwargs.get("standard_callback_dynamic_params")
+        )
+
+        if not standard_callback_dynamic_params:
+            return None
+
+        return self.construct_dynamic_otel_endpoint(
+            standard_callback_dynamic_params=standard_callback_dynamic_params
+        )
+
+    def _get_tracer_with_dynamic_headers(
+        self, dynamic_headers: dict, dynamic_endpoint: Optional[str] = None
+    ):
         """Create a temporary tracer with dynamic headers for this request only."""
         from opentelemetry.sdk.trace import TracerProvider
 
         # Prevents thread exhaustion by reusing providers for the same credential sets (e.g. per-team keys)
         cache_key = str(sorted(dynamic_headers.items()))
+        if dynamic_endpoint:
+            cache_key = f"{cache_key}|{dynamic_endpoint}"
         if cache_key in self._tracer_provider_cache:
             return self._tracer_provider_cache[cache_key].get_tracer(
                 LITELLM_TRACER_NAME
@@ -921,7 +943,9 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
         # Create a temporary tracer provider with dynamic headers
         temp_provider = TracerProvider(resource=self._get_litellm_resource(self.config))
         temp_provider.add_span_processor(
-            self._get_span_processor(dynamic_headers=dynamic_headers)
+            self._get_span_processor(
+                dynamic_headers=dynamic_headers, dynamic_endpoint=dynamic_endpoint
+            )
         )
 
         # Store in cache for reuse
@@ -939,6 +963,17 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
 
         Returns:
             dict: A dictionary of dynamic headers
+        """
+        return None
+
+    def construct_dynamic_otel_endpoint(
+        self, standard_callback_dynamic_params: StandardCallbackDynamicParams
+    ) -> Optional[str]:
+        """
+        Construct a per-request OTLP endpoint from standard callback dynamic params.
+
+        Override in subclasses (e.g. Langfuse OTEL) where per-key/team credentials
+        are bound to a per-key host. Returning None keeps the env-configured endpoint.
         """
         return None
 
@@ -2761,7 +2796,11 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
         )
         return None, None
 
-    def _get_span_processor(self, dynamic_headers: Optional[dict] = None):
+    def _get_span_processor(
+        self,
+        dynamic_headers: Optional[dict] = None,
+        dynamic_endpoint: Optional[str] = None,
+    ):
         from opentelemetry.sdk.trace.export import (
             BatchSpanProcessor,
             ConsoleSpanExporter,
@@ -2827,7 +2866,7 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
                 self.OTEL_EXPORTER,
             )
             normalized_endpoint = self._normalize_otel_endpoint(
-                self.OTEL_ENDPOINT, "traces"
+                dynamic_endpoint or self.OTEL_ENDPOINT, "traces"
             )
             return BatchSpanProcessor(
                 OTLPSpanExporterHTTP(
@@ -2850,7 +2889,7 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
                 self.OTEL_EXPORTER,
             )
             normalized_endpoint = self._normalize_otel_endpoint(
-                self.OTEL_ENDPOINT, "traces"
+                dynamic_endpoint or self.OTEL_ENDPOINT, "traces"
             )
             return BatchSpanProcessor(
                 OTLPSpanExporterGRPC(

--- a/litellm/litellm_core_utils/initialize_dynamic_callback_params.py
+++ b/litellm/litellm_core_utils/initialize_dynamic_callback_params.py
@@ -36,6 +36,7 @@ _supported_callback_params = [
     "langfuse_secret",
     "langfuse_secret_key",
     "langfuse_host",
+    "langfuse_base_url",
     "langfuse_prompt_version",
     "langsmith_api_key",
     "langsmith_project",

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -2994,6 +2994,8 @@ class StandardCallbackDynamicParams(TypedDict, total=False):
     langfuse_secret: Optional[str]
     langfuse_secret_key: Optional[str]
     langfuse_host: Optional[str]
+    # Langfuse v3 naming for the host; preferred over langfuse_host where set
+    langfuse_base_url: Optional[str]
 
     # Langfuse prompt version
     langfuse_prompt_version: Optional[int]

--- a/tests/test_litellm/integrations/test_langfuse_otel.py
+++ b/tests/test_litellm/integrations/test_langfuse_otel.py
@@ -392,22 +392,90 @@ class TestLangfuseOtelIntegration:
         # Should return an empty dict
         assert result == {}
 
-    def test_construct_dynamic_otel_endpoint_with_host(self):
-        """Per-key langfuse_host is turned into a normalized OTLP base endpoint."""
+    def test_construct_dynamic_otel_endpoint_with_allowlisted_host(self):
+        """An allow-listed per-key langfuse_host is turned into the OTLP base endpoint."""
         from litellm.types.utils import StandardCallbackDynamicParams
 
         logger = LangfuseOtelLogger()
 
-        eu = logger.construct_dynamic_otel_endpoint(
-            StandardCallbackDynamicParams(langfuse_host="https://cloud.langfuse.com")
-        )
-        assert eu == "https://cloud.langfuse.com/api/public/otel"
+        with patch.dict(
+            os.environ,
+            {"LANGFUSE_ALLOWED_DYNAMIC_HOSTS": "https://cloud.langfuse.com"},
+        ):
+            endpoint = logger.construct_dynamic_otel_endpoint(
+                StandardCallbackDynamicParams(
+                    langfuse_host="https://cloud.langfuse.com"
+                )
+            )
+        assert endpoint == "https://cloud.langfuse.com/api/public/otel"
 
-        # scheme-less + trailing slash normalize identically to the env path
-        no_scheme = logger.construct_dynamic_otel_endpoint(
-            StandardCallbackDynamicParams(langfuse_host="us.cloud.langfuse.com/")
-        )
-        assert no_scheme == "https://us.cloud.langfuse.com/api/public/otel"
+    def test_construct_dynamic_otel_endpoint_trailing_slash_tolerated(self):
+        """Trailing slashes on the dynamic host or allowlist entries don't break matching."""
+        from litellm.types.utils import StandardCallbackDynamicParams
+
+        logger = LangfuseOtelLogger()
+
+        with patch.dict(
+            os.environ,
+            {
+                "LANGFUSE_ALLOWED_DYNAMIC_HOSTS": "https://eu.cloud.langfuse.com, https://us.cloud.langfuse.com/"
+            },
+        ):
+            endpoint = logger.construct_dynamic_otel_endpoint(
+                StandardCallbackDynamicParams(
+                    langfuse_host="https://us.cloud.langfuse.com/"
+                )
+            )
+        assert endpoint == "https://us.cloud.langfuse.com/api/public/otel"
+
+    def test_construct_dynamic_otel_endpoint_denied_when_allowlist_unset(self):
+        """No operator allowlist -> dynamic hosts are ignored (SSRF guard)."""
+        from litellm.types.utils import StandardCallbackDynamicParams
+
+        logger = LangfuseOtelLogger()
+
+        env_without_allowlist = {
+            k: v for k, v in os.environ.items() if k != "LANGFUSE_ALLOWED_DYNAMIC_HOSTS"
+        }
+        with patch.dict(os.environ, env_without_allowlist, clear=True):
+            endpoint = logger.construct_dynamic_otel_endpoint(
+                StandardCallbackDynamicParams(
+                    langfuse_host="https://attacker.internal.example"
+                )
+            )
+        assert endpoint is None
+
+    def test_construct_dynamic_otel_endpoint_denied_when_host_not_allowlisted(self):
+        """A dynamic host outside the allowlist -> ignored, env endpoint used (SSRF guard)."""
+        from litellm.types.utils import StandardCallbackDynamicParams
+
+        logger = LangfuseOtelLogger()
+
+        with patch.dict(
+            os.environ,
+            {"LANGFUSE_ALLOWED_DYNAMIC_HOSTS": "https://us.cloud.langfuse.com"},
+        ):
+            endpoint = logger.construct_dynamic_otel_endpoint(
+                StandardCallbackDynamicParams(
+                    langfuse_host="https://attacker.internal.example"
+                )
+            )
+        assert endpoint is None
+
+    def test_construct_dynamic_otel_endpoint_requires_full_url(self):
+        """Scheme-less dynamic hosts are rejected, never rewritten."""
+        from litellm.types.utils import StandardCallbackDynamicParams
+
+        logger = LangfuseOtelLogger()
+
+        with patch.dict(
+            os.environ,
+            {"LANGFUSE_ALLOWED_DYNAMIC_HOSTS": "us.cloud.langfuse.com"},
+        ):
+            endpoint = logger.construct_dynamic_otel_endpoint(
+                StandardCallbackDynamicParams(langfuse_host="us.cloud.langfuse.com")
+            )
+        assert endpoint is None
 
     def test_construct_dynamic_otel_endpoint_without_host(self):
         """No per-key host -> None, so the env endpoint is used."""
@@ -424,11 +492,15 @@ class TestLangfuseOtelIntegration:
         from litellm.types.utils import StandardCallbackDynamicParams
 
         logger = LangfuseOtelLogger()
-        endpoint = logger.construct_dynamic_otel_endpoint(
-            StandardCallbackDynamicParams(
-                langfuse_base_url="https://us.cloud.langfuse.com"
+        with patch.dict(
+            os.environ,
+            {"LANGFUSE_ALLOWED_DYNAMIC_HOSTS": "https://us.cloud.langfuse.com"},
+        ):
+            endpoint = logger.construct_dynamic_otel_endpoint(
+                StandardCallbackDynamicParams(
+                    langfuse_base_url="https://us.cloud.langfuse.com"
+                )
             )
-        )
         assert endpoint == "https://us.cloud.langfuse.com/api/public/otel"
 
     def test_construct_dynamic_otel_endpoint_base_url_preferred_over_host(self):
@@ -436,12 +508,18 @@ class TestLangfuseOtelIntegration:
         from litellm.types.utils import StandardCallbackDynamicParams
 
         logger = LangfuseOtelLogger()
-        endpoint = logger.construct_dynamic_otel_endpoint(
-            StandardCallbackDynamicParams(
-                langfuse_base_url="https://us.cloud.langfuse.com",
-                langfuse_host="https://cloud.langfuse.com",
+        with patch.dict(
+            os.environ,
+            {
+                "LANGFUSE_ALLOWED_DYNAMIC_HOSTS": "https://us.cloud.langfuse.com,https://cloud.langfuse.com"
+            },
+        ):
+            endpoint = logger.construct_dynamic_otel_endpoint(
+                StandardCallbackDynamicParams(
+                    langfuse_base_url="https://us.cloud.langfuse.com",
+                    langfuse_host="https://cloud.langfuse.com",
+                )
             )
-        )
         assert endpoint == "https://us.cloud.langfuse.com/api/public/otel"
 
     def test_get_langfuse_otel_config_with_otel_host_priority(self):

--- a/tests/test_litellm/integrations/test_langfuse_otel.py
+++ b/tests/test_litellm/integrations/test_langfuse_otel.py
@@ -392,6 +392,33 @@ class TestLangfuseOtelIntegration:
         # Should return an empty dict
         assert result == {}
 
+    def test_construct_dynamic_otel_endpoint_with_host(self):
+        """Per-key langfuse_host is turned into a normalized OTLP base endpoint."""
+        from litellm.types.utils import StandardCallbackDynamicParams
+
+        logger = LangfuseOtelLogger()
+
+        eu = logger.construct_dynamic_otel_endpoint(
+            StandardCallbackDynamicParams(langfuse_host="https://cloud.langfuse.com")
+        )
+        assert eu == "https://cloud.langfuse.com/api/public/otel"
+
+        # scheme-less + trailing slash normalize identically to the env path
+        no_scheme = logger.construct_dynamic_otel_endpoint(
+            StandardCallbackDynamicParams(langfuse_host="us.cloud.langfuse.com/")
+        )
+        assert no_scheme == "https://us.cloud.langfuse.com/api/public/otel"
+
+    def test_construct_dynamic_otel_endpoint_without_host(self):
+        """No per-key host -> None, so the env endpoint is used."""
+        from litellm.types.utils import StandardCallbackDynamicParams
+
+        logger = LangfuseOtelLogger()
+        assert (
+            logger.construct_dynamic_otel_endpoint(StandardCallbackDynamicParams())
+            is None
+        )
+
     def test_get_langfuse_otel_config_with_otel_host_priority(self):
         """LANGFUSE_OTEL_HOST should take priority over LANGFUSE_HOST."""
         with patch.dict(

--- a/tests/test_litellm/integrations/test_langfuse_otel.py
+++ b/tests/test_litellm/integrations/test_langfuse_otel.py
@@ -419,6 +419,31 @@ class TestLangfuseOtelIntegration:
             is None
         )
 
+    def test_construct_dynamic_otel_endpoint_with_base_url(self):
+        """Per-key langfuse_base_url (the Langfuse v3 naming) is honored."""
+        from litellm.types.utils import StandardCallbackDynamicParams
+
+        logger = LangfuseOtelLogger()
+        endpoint = logger.construct_dynamic_otel_endpoint(
+            StandardCallbackDynamicParams(
+                langfuse_base_url="https://us.cloud.langfuse.com"
+            )
+        )
+        assert endpoint == "https://us.cloud.langfuse.com/api/public/otel"
+
+    def test_construct_dynamic_otel_endpoint_base_url_preferred_over_host(self):
+        """When both are set, langfuse_base_url wins (mirrors the SDK's resolution order)."""
+        from litellm.types.utils import StandardCallbackDynamicParams
+
+        logger = LangfuseOtelLogger()
+        endpoint = logger.construct_dynamic_otel_endpoint(
+            StandardCallbackDynamicParams(
+                langfuse_base_url="https://us.cloud.langfuse.com",
+                langfuse_host="https://cloud.langfuse.com",
+            )
+        )
+        assert endpoint == "https://us.cloud.langfuse.com/api/public/otel"
+
     def test_get_langfuse_otel_config_with_otel_host_priority(self):
         """LANGFUSE_OTEL_HOST should take priority over LANGFUSE_HOST."""
         with patch.dict(

--- a/tests/test_litellm/integrations/test_opentelemetry.py
+++ b/tests/test_litellm/integrations/test_opentelemetry.py
@@ -1280,7 +1280,8 @@ class TestOpenTelemetry(unittest.TestCase):
             # Assertions
             mock_get_headers.assert_called_once_with(kwargs)
             mock_get_tracer.assert_called_once_with(
-                {"arize-space-id": "test-space", "api_key": "test-key"}
+                {"arize-space-id": "test-space", "api_key": "test-key"},
+                dynamic_endpoint=None,
             )
             self.assertEqual(result, mock_dynamic_tracer)
 
@@ -1374,7 +1375,7 @@ class TestOpenTelemetry(unittest.TestCase):
 
             # Assertions
             mock_get_span_processor.assert_called_once_with(
-                dynamic_headers=dynamic_headers
+                dynamic_headers=dynamic_headers, dynamic_endpoint=None
             )
             mock_provider_instance.add_span_processor.assert_called_once_with(
                 mock_span_processor
@@ -2103,6 +2104,56 @@ class TestOpenTelemetryProtocolSelection(unittest.TestCase):
 
         # Verify the exporter is the HTTP variant
         self.assertIsInstance(processor.span_exporter, OTLPSpanExporterHTTP)
+
+    def test_get_span_processor_uses_dynamic_endpoint_over_env(self):
+        """The dynamic per-key endpoint overrides self.OTEL_ENDPOINT (the core regression).
+
+        Would FAIL on current code, where the exporter is always pinned to OTEL_ENDPOINT.
+        """
+        config = OpenTelemetryConfig(
+            exporter="otlp_http", endpoint="https://cloud.langfuse.com/api/public/otel"
+        )
+        otel = OpenTelemetry(config=config)
+
+        processor = otel._get_span_processor(
+            dynamic_headers={"Authorization": "Basic abc"},
+            dynamic_endpoint="https://us.cloud.langfuse.com/api/public/otel",
+        )
+        # OTLP HTTP exporter stores the resolved endpoint on ._endpoint
+        endpoint = processor.span_exporter._endpoint
+        assert endpoint == "https://us.cloud.langfuse.com/api/public/otel/v1/traces"
+
+    def test_get_span_processor_falls_back_to_env_endpoint(self):
+        """No dynamic endpoint -> env endpoint is used (no Arize/env-only regression)."""
+        config = OpenTelemetryConfig(
+            exporter="otlp_http", endpoint="https://cloud.langfuse.com/api/public/otel"
+        )
+        otel = OpenTelemetry(config=config)
+        processor = otel._get_span_processor(
+            dynamic_headers={"Authorization": "Basic abc"}
+        )
+        assert (
+            processor.span_exporter._endpoint
+            == "https://cloud.langfuse.com/api/public/otel/v1/traces"
+        )
+
+    def test_dynamic_tracer_cache_key_separates_by_endpoint(self):
+        """Same creds + different host => distinct cached providers (cache-collision regression).
+
+        Would FAIL if the host is dropped from the cache key: the 2nd host would reuse
+        the 1st host's provider/exporter.
+        """
+        otel = OpenTelemetry()
+        headers = {"Authorization": "Basic abc"}
+        with patch.object(otel, "_get_span_processor", return_value=MagicMock()):
+            otel._get_tracer_with_dynamic_headers(
+                headers, dynamic_endpoint="https://cloud.langfuse.com/api/public/otel"
+            )
+            otel._get_tracer_with_dynamic_headers(
+                headers,
+                dynamic_endpoint="https://us.cloud.langfuse.com/api/public/otel",
+            )
+        assert len(otel._tracer_provider_cache) == 2
 
     def test_get_span_processor_uses_console_exporter_for_console(self):
         """Test that console protocol uses ConsoleSpanExporter"""


### PR DESCRIPTION
## Relevant issues

<!-- no public GitHub issue -->

## Linear ticket

Resolves LIT-3406
Resolves LIT-3404

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

**Bug:** the `langfuse_otel` dynamic-credential path threads a per-key/team `langfuse_public_key`/`langfuse_secret_key` into the OTLP exporter headers but drops the per-key `langfuse_host` — the exporter endpoint stays pinned to the proxy's env `LANGFUSE_HOST`. A key whose Langfuse project lives on a different host exports its spans to the env host carrying the other host's credentials, so Langfuse returns `401 Invalid credentials. Confirm that you've configured the correct host.` and the trace never lands.

**Setup** — proxy env `LANGFUSE_HOST=https://cloud.langfuse.com` (host A), global `langfuse_otel` callback, and the second host explicitly allow-listed by the operator:

```bash
export LANGFUSE_ALLOWED_DYNAMIC_HOSTS="https://us.cloud.langfuse.com"
```

A virtual key is bound to a project on a *different* host (host B, `https://us.cloud.langfuse.com`) with that host's own credentials:

```bash
# create a key whose project lives on a different Langfuse host
curl -s http://0.0.0.0:4000/key/generate \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{
        "models": ["gpt-4o-mini"],
        "metadata": {"logging": [{
          "callback_name": "langfuse_otel", "callback_type": "success",
          "callback_vars": {
            "langfuse_public_key": "pk-lf-<HOST_B>",
            "langfuse_secret_key": "sk-lf-<HOST_B>",
            "langfuse_host": "https://us.cloud.langfuse.com"
          }}]}}'

# fire a real completion on that key
curl -s http://0.0.0.0:4000/v1/chat/completions \
  -H "Authorization: Bearer <generated-key>" -H "Content-Type: application/json" \
  -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"otel host test"}]}'
```

**Before the fix** — exporter pinned to the env host; the per-key host is ignored, so the export carries host-B creds to host A:

```
Failed to export span batch code: 401, reason:
  {"message":"Invalid credentials. Confirm that you've configured the correct host."}
```
…and the trace never appears in the configured (host-B) project.

**After the fix** (`--detailed_debug`) — the dynamic tracer targets the per-key endpoint even though the OTEL config's env endpoint is still host A, and the trace lands in the host-B project with no 401:

```
[OTEL DEBUG] Using DYNAMIC tracer with headers: {'Authorization': 'REDACTED'}
             endpoint: https://us.cloud.langfuse.com/api/public/otel
OTEL config settings=OpenTelemetryConfig(exporter='otlp_http',
             endpoint='https://cloud.langfuse.com/api/public/otel', ...)   # env endpoint (host A)
# no "Failed to export span batch ... 401" — span lands in the host-B project
```

A key bound to a project on a second host now exports there successfully; the 401 is gone.

## Type

🐛 Bug Fix

## Changes

Adds a per-request **dynamic OTLP endpoint** channel, parallel to the existing dynamic-headers channel, so the per-key host travels with the per-key credentials — gated behind an operator-controlled allowlist so the exporter destination can never be set by request data alone.

- `litellm/integrations/opentelemetry.py`
  - New overridable `construct_dynamic_otel_endpoint()` (base returns `None`) + `_get_dynamic_otel_endpoint_from_kwargs()`.
  - Threads `dynamic_endpoint` through `get_tracer_to_use_for_request` -> `_get_tracer_with_dynamic_headers` -> `_get_span_processor`, which now uses `dynamic_endpoint or self.OTEL_ENDPOINT` in both the otlp_http and otlp_grpc branches.
  - Adds the endpoint to the tracer-provider **cache key**, so two keys that share credentials but differ by host don't collide on a cached provider.
- `litellm/integrations/langfuse/langfuse_otel.py`
  - Overrides `construct_dynamic_otel_endpoint()` to derive `{host}/api/public/otel` from the per-key host. Prefers `langfuse_base_url` (Langfuse v3 naming), falls back to the deprecated `langfuse_host`, mirroring the SDK's own resolution order.
  - **Security (SSRF guard):** because callback vars can be supplied on requests, a dynamic host is only honored when the proxy operator has explicitly allow-listed it in the `LANGFUSE_ALLOWED_DYNAMIC_HOSTS` env var (comma-separated base URLs). When unset, dynamic hosts are ignored entirely and the exporter stays on the env-configured endpoint — i.e. the destination is always operator-controlled via the env, never by request data.
  - The dynamic host must be a fully-qualified `http(s)://` base URL; it is matched against the allowlist as-is (modulo trailing slashes) and never rewritten. The pre-existing env-endpoint construction paths are untouched by this PR.

Default `None` everywhere -> no behavior change for Arize or env-only Langfuse exporters; with `LANGFUSE_ALLOWED_DYNAMIC_HOSTS` unset, behavior is identical to today.

**Tests:** 11 new (`test_langfuse_otel.py`, `test_opentelemetry.py`) covering endpoint derivation, allowlist enforcement (unset -> denied, non-allow-listed host -> denied, scheme-less URL -> denied, trailing-slash tolerance), `langfuse_base_url` preference, the env-fallback path, the dynamic-endpoint override, and cache-key separation by host; 2 existing dynamic-header assertions updated for the new signatures.
