### PR TITLE
fix(guardrails): scan Anthropic tool_result content blocks

### DIFF
--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -242,7 +242,10 @@ class AnthropicMessagesHandler(BaseTranslation):
                 # outputs (file reads, API responses) bypass guardrail scanning.
                 # The block index is tracked so sanitized text is written back to
                 # the correct location (see _apply_guardrail_responses_to_input).
-                if content_item.get("type") == "tool_result":
+                # Honor skip_tool_message here as well: Anthropic tool outputs are
+                # tool_result blocks nested inside a user message (not a role="tool"
+                # message), so the role check above does not cover them.
+                if content_item.get("type") == "tool_result" and not skip_tool_message:
                     tool_result_content = content_item.get("content")
                     if isinstance(tool_result_content, str):
                         texts_to_check.append(tool_result_content)

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -251,9 +251,7 @@ class AnthropicMessagesHandler(BaseTranslation):
                                 block_text = block.get("text")
                                 if block_text is not None:
                                     texts_to_check.append(block_text)
-                                    task_mappings.append(
-                                        (msg_idx, int(content_idx))
-                                    )
+                                    task_mappings.append((msg_idx, int(content_idx)))
 
                 # Extract images
                 if content_item.get("type") == "image":

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -128,7 +128,7 @@ class AnthropicMessagesHandler(BaseTranslation):
         tools_to_check: List[ChatCompletionToolParam] = (
             chat_completion_compatible_request.get("tools", [])
         )
-        task_mappings: List[Tuple[int, Optional[int]]] = []
+        task_mappings: List[Tuple[int, Optional[int], Optional[int]]] = []
 
         # Step 1: Extract all text content and images
         for msg_idx, message in enumerate(messages):
@@ -202,7 +202,7 @@ class AnthropicMessagesHandler(BaseTranslation):
         msg_idx: int,
         texts_to_check: List[str],
         images_to_check: List[str],
-        task_mappings: List[Tuple[int, Optional[int]]],
+        task_mappings: List[Tuple[int, Optional[int], Optional[int]]],
         skip_system_message: bool = False,
         skip_tool_message: bool = False,
     ) -> None:
@@ -226,7 +226,7 @@ class AnthropicMessagesHandler(BaseTranslation):
         if content is not None and isinstance(content, str):
             # Simple string content
             texts_to_check.append(content)
-            task_mappings.append((msg_idx, None))
+            task_mappings.append((msg_idx, None, None))
 
         elif content is not None and isinstance(content, list):
             # List content (e.g., multimodal with text and images)
@@ -235,23 +235,27 @@ class AnthropicMessagesHandler(BaseTranslation):
                 text_str = content_item.get("text", None)
                 if text_str is not None:
                     texts_to_check.append(text_str)
-                    task_mappings.append((msg_idx, int(content_idx)))
+                    task_mappings.append((msg_idx, int(content_idx), None))
 
                 # Anthropic tool_result blocks carry their text under "content"
                 # (string or list of blocks), not "text". Without this, tool
                 # outputs (file reads, API responses) bypass guardrail scanning.
+                # The block index is tracked so sanitized text is written back to
+                # the correct location (see _apply_guardrail_responses_to_input).
                 if content_item.get("type") == "tool_result":
                     tool_result_content = content_item.get("content")
                     if isinstance(tool_result_content, str):
                         texts_to_check.append(tool_result_content)
-                        task_mappings.append((msg_idx, int(content_idx)))
+                        task_mappings.append((msg_idx, int(content_idx), None))
                     elif isinstance(tool_result_content, list):
-                        for block in tool_result_content:
+                        for block_idx, block in enumerate(tool_result_content):
                             if isinstance(block, dict):
                                 block_text = block.get("text")
                                 if block_text is not None:
                                     texts_to_check.append(block_text)
-                                    task_mappings.append((msg_idx, int(content_idx)))
+                                    task_mappings.append(
+                                        (msg_idx, int(content_idx), int(block_idx))
+                                    )
 
                 # Extract images
                 if content_item.get("type") == "image":
@@ -282,7 +286,7 @@ class AnthropicMessagesHandler(BaseTranslation):
         self,
         messages: List[Dict[str, Any]],
         responses: List[str],
-        task_mappings: List[Tuple[int, Optional[int]]],
+        task_mappings: List[Tuple[int, Optional[int], Optional[int]]],
     ) -> None:
         """
         Apply guardrail responses back to input messages.
@@ -293,6 +297,7 @@ class AnthropicMessagesHandler(BaseTranslation):
             mapping = task_mappings[task_idx]
             msg_idx = cast(int, mapping[0])
             content_idx_optional = cast(Optional[int], mapping[1])
+            block_idx_optional = cast(Optional[int], mapping[2])
 
             content = messages[msg_idx].get("content", None)
             if content is None:
@@ -303,10 +308,24 @@ class AnthropicMessagesHandler(BaseTranslation):
                 messages[msg_idx]["content"] = guardrail_response
 
             elif isinstance(content, list) and content_idx_optional is not None:
-                # Replace specific text item in list content
-                messages[msg_idx]["content"][content_idx_optional][
-                    "text"
-                ] = guardrail_response
+                content_item = content[content_idx_optional]
+                if content_item.get("type") == "tool_result":
+                    # tool_result text lives under "content" (string or list of
+                    # blocks), not "text" — write the sanitized text back there so
+                    # redactions are actually applied to the outgoing tool output.
+                    tool_result_content = content_item.get("content")
+                    if isinstance(tool_result_content, str):
+                        content_item["content"] = guardrail_response
+                    elif (
+                        isinstance(tool_result_content, list)
+                        and block_idx_optional is not None
+                    ):
+                        tool_result_content[block_idx_optional][
+                            "text"
+                        ] = guardrail_response
+                else:
+                    # Replace specific text item in list content
+                    content_item["text"] = guardrail_response
 
     async def process_output_response(
         self,

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -237,6 +237,24 @@ class AnthropicMessagesHandler(BaseTranslation):
                     texts_to_check.append(text_str)
                     task_mappings.append((msg_idx, int(content_idx)))
 
+                # Anthropic tool_result blocks carry their text under "content"
+                # (string or list of blocks), not "text". Without this, tool
+                # outputs (file reads, API responses) bypass guardrail scanning.
+                if content_item.get("type") == "tool_result":
+                    tool_result_content = content_item.get("content")
+                    if isinstance(tool_result_content, str):
+                        texts_to_check.append(tool_result_content)
+                        task_mappings.append((msg_idx, int(content_idx)))
+                    elif isinstance(tool_result_content, list):
+                        for block in tool_result_content:
+                            if isinstance(block, dict):
+                                block_text = block.get("text")
+                                if block_text is not None:
+                                    texts_to_check.append(block_text)
+                                    task_mappings.append(
+                                        (msg_idx, int(content_idx))
+                                    )
+
                 # Extract images
                 if content_item.get("type") == "image":
                     source = content_item.get("source", {})

--- a/tests/test_litellm/llms/anthropic/chat/guardrail_translation/test_anthropic_guardrail_handler.py
+++ b/tests/test_litellm/llms/anthropic/chat/guardrail_translation/test_anthropic_guardrail_handler.py
@@ -294,6 +294,52 @@ class TestAnthropicMessagesHandlerInputProcessing:
         assert tools[1]["description"] == "Get the weather at a specific location"
         assert "input_schema" in tools[1]
 
+    def test_extract_input_skips_anthropic_tool_result_when_skip_tool_message(self):
+        """When skip_tool_message=True, Anthropic tool_result blocks must be skipped.
+
+        Anthropic tool outputs are tool_result blocks nested inside a user message
+        (not a role="tool" message), so the role-based early-return does not cover
+        them. Guardrail scanning must skip those blocks while still scanning the
+        user's own text in the same message.
+        """
+        handler = AnthropicMessagesHandler()
+        message = {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "user typed text"},
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "abc",
+                    "content": "secret tool output",
+                },
+            ],
+        }
+
+        # skip_tool_message=True -> tool_result text is NOT scanned, user text is
+        texts: List[str] = []
+        handler._extract_input_text_and_images(
+            message=message,
+            msg_idx=0,
+            texts_to_check=texts,
+            images_to_check=[],
+            task_mappings=[],
+            skip_tool_message=True,
+        )
+        assert "user typed text" in texts
+        assert "secret tool output" not in texts
+
+        # skip_tool_message=False -> tool_result text IS scanned (default behavior)
+        texts_default: List[str] = []
+        handler._extract_input_text_and_images(
+            message=message,
+            msg_idx=0,
+            texts_to_check=texts_default,
+            images_to_check=[],
+            task_mappings=[],
+            skip_tool_message=False,
+        )
+        assert "secret tool output" in texts_default
+
 
 if __name__ == "__main__":
     # Run the tests


### PR DESCRIPTION
## Summary

Fixes #29593.

The Generic Guardrail API's `_extract_input_text_and_images()` (in `litellm/llms/anthropic/chat/guardrail_translation/handler.py`) only reads the `"text"` key when iterating list content blocks. Anthropic **`tool_result`** blocks carry their text under `"content"` (not `"text"`), so tool outputs were silently skipped and never added to `texts_to_check`.

This means content returned by tools — file reads, API responses, database rows, etc. — bypassed **all** guardrails built on the Generic Guardrail API. In agentic workflows (Cursor, coding agents, MCP file reads) this is a PII/secret-leak gap: a tool result containing an API key or PII would never be scanned.

## Change

In the list-content branch, after the existing `text` extraction, also handle `tool_result` blocks:

- `content` as a **string** → appended directly.
- `content` as a **list of blocks** → each `text` block's text is appended.

Both forms are part of the Anthropic tool_result spec. Images and other block types are untouched. 18 lines added, no existing behavior changed.

## Test plan

- [ ] Guardrail with a `tool_result` (string `content`) now scans the tool output.
- [ ] Guardrail with a `tool_result` whose `content` is a list of text blocks scans each block.
- [ ] Plain text / image blocks behave exactly as before (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
