### PR TITLE
test(pass-through): move Gemini pass-through tests to gemini-3.1-flash-lite

### DIFF
--- a/tests/pass_through_tests/test_gemini_with_spend.test.js
+++ b/tests/pass_through_tests/test_gemini_with_spend.test.js
@@ -32,7 +32,7 @@ describe('Gemini AI Tests', () => {
         };
 
         const model = genAI.getGenerativeModel({
-            model: 'gemini-2.5-flash-lite'
+            model: 'gemini-3.1-flash-lite'
         }, requestOptions);
 
         const prompt = 'Say "hello test" and nothing else';
@@ -83,7 +83,7 @@ describe('Gemini AI Tests', () => {
         };
 
         const model = genAI.getGenerativeModel({
-            model: 'gemini-2.5-flash-lite'
+            model: 'gemini-3.1-flash-lite'
         }, requestOptions);
 
         const prompt = 'Say "hello test" and nothing else';

--- a/tests/pass_through_tests/test_local_gemini.js
+++ b/tests/pass_through_tests/test_local_gemini.js
@@ -1,13 +1,13 @@
 const { GoogleGenerativeAI, ModelParams, RequestOptions } = require("@google/generative-ai");
 
 const modelParams = {
-    model: 'gemini-2.5-flash-lite',
+    model: 'gemini-3.1-flash-lite',
 };
   
 const requestOptions = {
     baseUrl: 'http://127.0.0.1:4000/gemini',
     customHeaders: {
-        "tags": "gemini-js-sdk,gemini-2.5-flash-lite"
+        "tags": "gemini-js-sdk,gemini-3.1-flash-lite"
     }
 };
   

--- a/tests/pass_through_tests/test_local_vertex.js
+++ b/tests/pass_through_tests/test_local_vertex.js
@@ -20,7 +20,7 @@ const requestOptions = {
 };
 
 const generativeModel = vertexAI.getGenerativeModel(
-    { model: 'gemini-2.5-flash-lite' },
+    { model: 'gemini-3.1-flash-lite' },
     requestOptions
 );
 

--- a/tests/pass_through_tests/test_local_vertex.js
+++ b/tests/pass_through_tests/test_local_vertex.js
@@ -4,7 +4,7 @@ const { VertexAI, RequestOptions } = require('@google-cloud/vertexai');
 
 const vertexAI = new VertexAI({
     project: 'litellm-ci-cd',
-    location: 'us-central1',
+    location: 'global',
     apiEndpoint: "127.0.0.1:4000/vertex-ai"
 });
 

--- a/tests/pass_through_tests/test_vertex.test.js
+++ b/tests/pass_through_tests/test_vertex.test.js
@@ -68,7 +68,7 @@ describe('Vertex AI Tests', () => {
         async () => {
             const vertexAI = new VertexAI({
                 project: 'litellm-ci-cd',
-                location: 'us-central1',
+                location: 'global',
                 apiEndpoint: "localhost:4000/vertex-ai"
             });
 
@@ -111,7 +111,7 @@ describe('Vertex AI Tests', () => {
         async () => {
             const vertexAI = new VertexAI({
                 project: 'litellm-ci-cd',
-                location: 'us-central1',
+                location: 'global',
                 apiEndpoint: "localhost:4000/vertex-ai"
             });
             const customHeaders = new Headers({"x-litellm-api-key": "sk-1234"});

--- a/tests/pass_through_tests/test_vertex.test.js
+++ b/tests/pass_through_tests/test_vertex.test.js
@@ -56,6 +56,9 @@ beforeAll(() => {
     loadVertexAiCredentials();
 });
 
+// Configure Jest to retry flaky tests up to 3 times (useful for 429 rate limiting)
+jest.retryTimes(3);
+
 // Non-streaming Vertex generateContent can exceed 5s in CI / under load
 const VERTEX_TEST_TIMEOUT_MS = 30000;
 
@@ -78,7 +81,7 @@ describe('Vertex AI Tests', () => {
             };
 
             const generativeModel = vertexAI.getGenerativeModel(
-                { model: 'gemini-2.5-flash-lite' },
+                { model: 'gemini-3.1-flash-lite' },
                 requestOptions
             );
 
@@ -114,7 +117,7 @@ describe('Vertex AI Tests', () => {
             const customHeaders = new Headers({"x-litellm-api-key": "sk-1234"});
             const requestOptions = {customHeaders: customHeaders};
             const generativeModel = vertexAI.getGenerativeModel(
-                {model: 'gemini-2.5-flash-lite'},
+                {model: 'gemini-3.1-flash-lite'},
                 requestOptions
             );
             const request = {contents: [{role: 'user', parts: [{text: 'What is 2+2?'}]}]};

--- a/tests/pass_through_tests/test_vertex_ai.py
+++ b/tests/pass_through_tests/test_vertex_ai.py
@@ -108,7 +108,7 @@ async def test_basic_vertex_ai_pass_through_with_spendlog():
         api_transport="rest",
     )
 
-    model = GenerativeModel(model_name="gemini-2.5-flash-lite")
+    model = GenerativeModel(model_name="gemini-3.1-flash-lite")
     response = model.generate_content("hi")
 
     print("response", response)
@@ -148,7 +148,7 @@ async def test_basic_vertex_ai_pass_through_streaming_with_spendlog():
         api_transport="rest",
     )
 
-    model = GenerativeModel(model_name="gemini-2.5-flash-lite")
+    model = GenerativeModel(model_name="gemini-3.1-flash-lite")
     response = model.generate_content("hi", stream=True)
 
     for chunk in response:
@@ -204,7 +204,7 @@ async def test_vertex_ai_pass_through_endpoint_context_caching():
     ]
 
     cached_content = caching.CachedContent.create(
-        model_name="gemini-2.5-flash-lite-001",
+        model_name="gemini-3.1-flash-lite",
         system_instruction=system_instruction,
         contents=contents,
         ttl=datetime.timedelta(minutes=60),

--- a/tests/pass_through_tests/test_vertex_ai.py
+++ b/tests/pass_through_tests/test_vertex_ai.py
@@ -103,7 +103,7 @@ async def test_basic_vertex_ai_pass_through_with_spendlog():
 
     vertexai.init(
         project="litellm-ci-cd",
-        location="us-central1",
+        location="global",
         api_endpoint=f"{LITE_LLM_ENDPOINT}/vertex_ai",
         api_transport="rest",
     )
@@ -143,7 +143,7 @@ async def test_basic_vertex_ai_pass_through_streaming_with_spendlog():
 
     vertexai.init(
         project="litellm-ci-cd",
-        location="us-central1",
+        location="global",
         api_endpoint=f"{LITE_LLM_ENDPOINT}/vertex_ai",
         api_transport="rest",
     )
@@ -182,7 +182,7 @@ async def test_vertex_ai_pass_through_endpoint_context_caching():
 
     vertexai.init(
         project="litellm-ci-cd",
-        location="us-central1",
+        location="global",
         api_endpoint=f"{LITE_LLM_ENDPOINT}/vertex_ai",
         api_transport="rest",
     )

--- a/tests/pass_through_tests/test_vertex_with_spend.test.js
+++ b/tests/pass_through_tests/test_vertex_with_spend.test.js
@@ -71,7 +71,7 @@ describe('Vertex AI Tests', () => {
     test('should successfully generate non-streaming content with tags', async () => {
         const vertexAI = new VertexAI({
             project: 'litellm-ci-cd',
-            location: 'us-central1',
+            location: 'global',
             apiEndpoint: "127.0.0.1:4000/vertex_ai"
         });
 
@@ -130,7 +130,7 @@ describe('Vertex AI Tests', () => {
     test('should successfully generate streaming content with tags', async () => {
         const vertexAI = new VertexAI({
             project: 'litellm-ci-cd',
-            location: 'us-central1',
+            location: 'global',
             apiEndpoint: "127.0.0.1:4000/vertex_ai"
         });
 

--- a/tests/pass_through_tests/test_vertex_with_spend.test.js
+++ b/tests/pass_through_tests/test_vertex_with_spend.test.js
@@ -85,7 +85,7 @@ describe('Vertex AI Tests', () => {
         };
 
         const generativeModel = vertexAI.getGenerativeModel(
-            { model: 'gemini-2.5-flash-lite' },
+            { model: 'gemini-3.1-flash-lite' },
             requestOptions
         );
 
@@ -144,7 +144,7 @@ describe('Vertex AI Tests', () => {
         };
 
         const generativeModel = vertexAI.getGenerativeModel(
-            { model: 'gemini-2.5-flash-lite' },
+            { model: 'gemini-3.1-flash-lite' },
             requestOptions
         );
 


### PR DESCRIPTION
## Relevant issues

None

## Linear ticket

N/A

## What and why

The Vertex / Gemini pass-through tests under `tests/pass_through_tests/` were all pinned to `gemini-2.5-flash-lite`. That model is a generation behind now (Gemini 3.1 Flash-Lite is GA) and on Vertex AI the 2.5 family is slated for discontinuation no earlier than October 16, 2026, so the suite was exercising an aging model that will eventually hard-fail when Google pulls it. This moves every reference to `gemini-3.1-flash-lite`, which is GA and already priced in `model_prices_and_context_window.json` for both the `gemini/` and `vertex_ai/` providers, so the `*_with_spend` assertions still compute a real, non-zero cost

`gemini-3.1-flash-lite` is not served on the Vertex `us-central1` regional endpoint for the CI project (the pass-through returned a deterministic 404 "Publisher Model ... was not found or your project does not have access to it"), so the Vertex test clients now use the `global` location, which the pass-through router maps to `aiplatform.googleapis.com`, where the 3.1 family is served. The Gemini API side already works on 3.1-flash-lite

While here, `test_vertex.test.js` gains `jest.retryTimes(3)` to match its sibling `test_vertex_with_spend.test.js` and `test_gemini_with_spend.test.js`. The original recurring CI failures were intermittent `429 RESOURCE_EXHAUSTED` from Vertex quota pressure, not a credentials problem; that file was the only one in the directory without a retry, so a single rate-limited request was failing the whole job

## Pre-Submission checklist

- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have added meaningful tests (this PR refreshes existing tests rather than adding new ones)
- [ ] My PR passes all unit tests on `make test-unit`
- [ ] I have requested a Greptile review and received a Confidence Score of at least 4/5

## Screenshots / Proof of Fix

Pass-through tests hit real provider APIs, so the proof is a live proxy call. With a config that has the `gemini` and `vertex_ai` pass-through credentials set, run the proxy and then:

1. Start the proxy
```
python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log
```

2. Hit the Gemini pass-through endpoint with the new model and confirm a 200 with a real completion
```
curl -sS -X POST "http://localhost:4000/gemini/v1beta/models/gemini-3.1-flash-lite:generateContent" \
  -H "x-litellm-api-key: sk-1234" \
  -H "Content-Type: application/json" \
  -d '{"contents":[{"role":"user","parts":[{"text":"Say hello in 3 words"}]}]}'
```

3. Hit the Vertex pass-through against the global endpoint and confirm a 200
```
curl -sS -X POST "http://localhost:4000/vertex-ai/v1/projects/<PROJECT>/locations/global/publishers/google/models/gemini-3.1-flash-lite:generateContent" \
  -H "x-litellm-api-key: sk-1234" \
  -H "Content-Type: application/json" \
  -d '{"contents":[{"role":"user","parts":[{"text":"What is 2+2?"}]}]}'
```

4. Optionally run the node pass-through suite the way CI does
```
cd tests/pass_through_tests && NODE_OPTIONS=--experimental-vm-modules npx jest . --verbose
```

## CI (LiteLLM team)

- [ ] Branch creation CI run
       Link:
- [ ] CI run for the last commit
       Link:
- [ ] Merge / cherry-pick CI run
       Links:

## Type

✅ Test

## Changes

Replaced `gemini-2.5-flash-lite` (and the lone `gemini-2.5-flash-lite-001` in the skipped context-caching test) with `gemini-3.1-flash-lite` across `test_vertex.test.js`, `test_vertex_with_spend.test.js`, `test_gemini_with_spend.test.js`, `test_local_vertex.js`, `test_local_gemini.js`, and `test_vertex_ai.py`. Switched the Vertex test clients from `us-central1` to the `global` location so the 3.1 model resolves. Added `jest.retryTimes(3)` to `test_vertex.test.js`