### PR TITLE
feat(helm): support configurable httpGet scheme on health probes

### DIFF
--- a/deploy/charts/litellm-helm/Chart.yaml
+++ b/deploy/charts/litellm-helm/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.0
+version: 1.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deploy/charts/litellm-helm/templates/deployment.yaml
+++ b/deploy/charts/litellm-helm/templates/deployment.yaml
@@ -183,6 +183,7 @@ spec:
             httpGet:
               path: {{ .Values.livenessProbe.path | quote }}
               port: "http"
+              scheme: {{ .Values.livenessProbe.scheme | default "HTTP" }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
@@ -192,6 +193,7 @@ spec:
             httpGet:
               path: {{ .Values.readinessProbe.path | quote }}
               port: "http"
+              scheme: {{ .Values.readinessProbe.scheme | default "HTTP" }}
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
@@ -201,6 +203,7 @@ spec:
             httpGet:
               path: {{ .Values.startupProbe.path | quote }}
               port: "http"
+              scheme: {{ .Values.startupProbe.scheme | default "HTTP" }}
             initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.startupProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}

--- a/deploy/charts/litellm-helm/templates/deployment.yaml
+++ b/deploy/charts/litellm-helm/templates/deployment.yaml
@@ -183,7 +183,7 @@ spec:
             httpGet:
               path: {{ .Values.livenessProbe.path | quote }}
               port: "http"
-              scheme: {{ .Values.livenessProbe.scheme | default "HTTP" }}
+              scheme: {{ .Values.livenessProbe.scheme | default "HTTP" | upper }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
@@ -193,7 +193,7 @@ spec:
             httpGet:
               path: {{ .Values.readinessProbe.path | quote }}
               port: "http"
-              scheme: {{ .Values.readinessProbe.scheme | default "HTTP" }}
+              scheme: {{ .Values.readinessProbe.scheme | default "HTTP" | upper }}
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
@@ -203,7 +203,7 @@ spec:
             httpGet:
               path: {{ .Values.startupProbe.path | quote }}
               port: "http"
-              scheme: {{ .Values.startupProbe.scheme | default "HTTP" }}
+              scheme: {{ .Values.startupProbe.scheme | default "HTTP" | upper }}
             initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.startupProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}

--- a/deploy/charts/litellm-helm/tests/deployment_tests.yaml
+++ b/deploy/charts/litellm-helm/tests/deployment_tests.yaml
@@ -402,3 +402,34 @@ tests:
       - equal:
           path: spec.template.metadata.annotations["example.com/literal"]
           value: "plain-string-value"
+  - it: should default probe httpGet scheme to HTTP
+    template: deployment.yaml
+    set:
+      image.tag: test
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.scheme
+          value: HTTP
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.scheme
+          value: HTTP
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.scheme
+          value: HTTP
+  - it: should set probe httpGet scheme to HTTPS when configured
+    template: deployment.yaml
+    set:
+      image.tag: test
+      livenessProbe.scheme: HTTPS
+      readinessProbe.scheme: HTTPS
+      startupProbe.scheme: HTTPS
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.scheme
+          value: HTTPS
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.scheme
+          value: HTTPS
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.scheme
+          value: HTTPS

--- a/deploy/charts/litellm-helm/tests/deployment_tests.yaml
+++ b/deploy/charts/litellm-helm/tests/deployment_tests.yaml
@@ -433,3 +433,20 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].startupProbe.httpGet.scheme
           value: HTTPS
+  - it: should upper-case a lowercase probe scheme
+    template: deployment.yaml
+    set:
+      image.tag: test
+      livenessProbe.scheme: https
+      readinessProbe.scheme: https
+      startupProbe.scheme: https
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.scheme
+          value: HTTPS
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.scheme
+          value: HTTPS
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.scheme
+          value: HTTPS

--- a/deploy/charts/litellm-helm/values.yaml
+++ b/deploy/charts/litellm-helm/values.yaml
@@ -91,6 +91,10 @@ service:
 # Probes for LiteLLM gateway container
 livenessProbe:
   path: /health/liveliness
+  # Scheme for the probe request: HTTP (default) or HTTPS. Set to HTTPS when the
+  # proxy terminates TLS on the container port (ssl_keyfile_path/ssl_certfile_path),
+  # otherwise the kubelet's plain-HTTP probe fails the TLS handshake.
+  scheme: HTTP
   initialDelaySeconds: 0
   periodSeconds: 15
   timeoutSeconds: 5
@@ -99,6 +103,8 @@ livenessProbe:
 
 readinessProbe:
   path: /health/readiness
+  # See livenessProbe.scheme. HTTP (default) or HTTPS.
+  scheme: HTTP
   initialDelaySeconds: 0
   periodSeconds: 10
   timeoutSeconds: 5
@@ -107,6 +113,8 @@ readinessProbe:
 
 startupProbe:
   path: /health/readiness
+  # See livenessProbe.scheme. HTTP (default) or HTTPS.
+  scheme: HTTP
   initialDelaySeconds: 0
   periodSeconds: 10
   timeoutSeconds: 5

--- a/deploy/charts/litellm-helm/values.yaml
+++ b/deploy/charts/litellm-helm/values.yaml
@@ -94,6 +94,7 @@ livenessProbe:
   # Scheme for the probe request: HTTP (default) or HTTPS. Set to HTTPS when the
   # proxy terminates TLS on the container port (ssl_keyfile_path/ssl_certfile_path),
   # otherwise the kubelet's plain-HTTP probe fails the TLS handshake.
+  # Case-insensitive — the value is upper-cased before rendering.
   scheme: HTTP
   initialDelaySeconds: 0
   periodSeconds: 15


### PR DESCRIPTION
## Title

feat(helm): support configurable httpGet scheme on health probes

## Relevant issues

None filed — gap discovered while running the chart with TLS terminated at the proxy.

## What

Adds an optional `scheme` field (`HTTP` / `HTTPS`) to `livenessProbe`, `readinessProbe`, and `startupProbe`, wired into each probe's `httpGet.scheme`. Defaults to `HTTP`.

## Why

When the proxy serves TLS directly on the container port (`--ssl_keyfile_path` / `--ssl_certfile_path`), the kubelet's probes currently issue plain-HTTP `GET`s against the TLS socket. The handshake fails (`EOF`), the probe never succeeds, and the pod never becomes `Ready`. The probe template previously hardcoded the scheme with no override, so there was no way to run HTTPS health checks.

## Backward compatibility

Default is `HTTP`. Rendered output is unchanged for existing users (kubelet also defaults `httpGet.scheme` to `HTTP`, so even the explicit field is a no-op for current deployments). `appVersion` is untouched; only the chart `version` is bumped `1.1.0` → `1.2.0`.

## Changes

- `templates/deployment.yaml`: add `scheme: {{ .Values.<probe>.scheme | default "HTTP" }}` to the three probes.
- `values.yaml`: document the new `scheme` key (default `HTTP`) on each probe.
- `Chart.yaml`: bump chart `version` to `1.2.0`.
- `tests/deployment_tests.yaml`: add helm-unittest cases for the `HTTP` default and the `HTTPS` override on all three probes.

## Testing

```
helm unittest -f 'tests/*.yaml' deploy/charts/litellm-helm
# Charts: 1 passed | Test Suites: 8 passed | Tests: 56 passed
helm lint deploy/charts/litellm-helm   # 0 failed
```

## Type

🆕 New Feature

## Checklist

- [x] My PR is an isolated change addressing one problem
- [x] I have added at least one test (helm-unittest cases)
- [x] My PR passes the chart's helm unit tests and `helm lint`