### PR TITLE
fix(router): clean pattern_router state on upsert/delete

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -8733,7 +8733,7 @@ class Router:
         except Exception:
             return None
 
-    def _remove_deployment_from_wildcard_state(self, model_id: str) -> None:
+    def _remove_deployment_from_wildcard_state(self, model_id: Optional[str]) -> None:
         """
         Drop every reference to model_id from the wildcard-routing data
         structures. Without this, upsert/delete leaves stale credentials in

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -8686,6 +8686,9 @@ class Router:
                         self._update_deployment_indices_after_removal(
                             model_id=deployment_id, removal_idx=removal_idx
                         )
+                        self._remove_deployment_from_wildcard_state(
+                            model_id=deployment_id
+                        )
 
             # if the model_id is not in router
             self.add_deployment(deployment=deployment)
@@ -8721,6 +8724,7 @@ class Router:
                 self._update_deployment_indices_after_removal(
                     model_id=id, removal_idx=deployment_idx
                 )
+                self._remove_deployment_from_wildcard_state(model_id=id)
                 _budget_limiter = self._get_router_deployment_budget_limiter()
                 if _budget_limiter is not None:
                     _budget_limiter.unregister_deployment_budget(model_id=id)
@@ -8729,6 +8733,28 @@ class Router:
                 return None
         except Exception:
             return None
+
+    def _remove_deployment_from_wildcard_state(self, model_id: str) -> None:
+        """
+        Drop every reference to model_id from the wildcard-routing data
+        structures. Without this, upsert/delete leaves stale credentials in
+        pattern_router which silently defeats key rotation for wildcard
+        deployments.
+        """
+        if not model_id:
+            return
+        self.pattern_router.remove_deployment(model_id)
+        empty_team_ids: List[str] = []
+        for team_id, team_router in self.team_pattern_routers.items():
+            team_router.remove_deployment(model_id)
+            if not team_router.patterns:
+                empty_team_ids.append(team_id)
+        for team_id in empty_team_ids:
+            del self.team_pattern_routers[team_id]
+        if model_id in self.provider_default_deployment_ids:
+            self.provider_default_deployment_ids = [
+                i for i in self.provider_default_deployment_ids if i != model_id
+            ]
 
     def _get_router_deployment_budget_limiter(
         self,

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -8715,6 +8715,9 @@ class Router:
             deployment_idx = self.model_id_to_deployment_index_map[id]
 
         try:
+            # Idempotent and symmetric with upsert_deployment, so a desynced
+            # index_map cannot leave stale wildcard credentials behind.
+            self._remove_deployment_from_wildcard_state(model_id=id)
             if deployment_idx is not None:
                 # Pop the item from the list first
                 item = self.model_list.pop(deployment_idx)
@@ -8723,7 +8726,6 @@ class Router:
                 self._update_deployment_indices_after_removal(
                     model_id=id, removal_idx=deployment_idx
                 )
-                self._remove_deployment_from_wildcard_state(model_id=id)
                 _budget_limiter = self._get_router_deployment_budget_limiter()
                 if _budget_limiter is not None:
                     _budget_limiter.unregister_deployment_budget(model_id=id)

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -8686,9 +8686,8 @@ class Router:
                         self._update_deployment_indices_after_removal(
                             model_id=deployment_id, removal_idx=removal_idx
                         )
-                        self._remove_deployment_from_wildcard_state(
-                            model_id=deployment_id
-                        )
+
+                self._remove_deployment_from_wildcard_state(model_id=deployment_id)
 
             # if the model_id is not in router
             self.add_deployment(deployment=deployment)

--- a/litellm/router_utils/pattern_match_deployments.py
+++ b/litellm/router_utils/pattern_match_deployments.py
@@ -75,6 +75,34 @@ class PatternMatchRouter:
             self.patterns[regex] = []
         self.patterns[regex].append(llm_deployment)
 
+    def remove_deployment(self, model_id: str) -> int:
+        """
+        Remove every stored entry whose model_info.id equals model_id.
+
+        Returns the number of entries removed. A regex whose deployment list
+        becomes empty is dropped so the patterns dict does not grow unboundedly.
+
+        Empty / falsy model_id is a no-op so callers cannot accidentally wipe
+        entries whose model_info.id is missing.
+        """
+        if not model_id:
+            return 0
+        removed_total = 0
+        for regex in list(self.patterns.keys()):
+            original = self.patterns[regex]
+            filtered = [
+                d for d in original if (d.get("model_info") or {}).get("id") != model_id
+            ]
+            removed_here = len(original) - len(filtered)
+            if removed_here == 0:
+                continue
+            removed_total += removed_here
+            if filtered:
+                self.patterns[regex] = filtered
+            else:
+                del self.patterns[regex]
+        return removed_total
+
     def _pattern_to_regex(self, pattern: str) -> str:
         """
         Convert a wildcard pattern to a regex pattern

--- a/litellm/router_utils/pattern_match_deployments.py
+++ b/litellm/router_utils/pattern_match_deployments.py
@@ -75,7 +75,7 @@ class PatternMatchRouter:
             self.patterns[regex] = []
         self.patterns[regex].append(llm_deployment)
 
-    def remove_deployment(self, model_id: str) -> int:
+    def remove_deployment(self, model_id: Optional[str]) -> int:
         """
         Remove every stored entry whose model_info.id equals model_id.
 

--- a/tests/local_testing/test_router_pattern_matching.py
+++ b/tests/local_testing/test_router_pattern_matching.py
@@ -395,3 +395,90 @@ def test_wildcard_priority_over_deployment_names():
     assert (
         deployments[0]["litellm_params"]["api_base"] == "http://localhost:8081/openai"
     ), f"Expected '*' wildcard deployment (8081), got {deployments[0]['litellm_params']['api_base']}"
+
+
+def _make_wildcard_entry(model_id: str, api_key: str) -> dict:
+    """Build a dict shaped like Deployment(...).to_json(exclude_none=True)."""
+    return Deployment(
+        model_name="openai/*",
+        litellm_params=LiteLLM_Params(model="openai/*", api_key=api_key),
+        model_info=ModelInfo(id=model_id),
+    ).to_json(exclude_none=True)
+
+
+def test_remove_deployment_drops_matching_id_only():
+    router = PatternMatchRouter()
+    router.add_pattern("openai/*", _make_wildcard_entry("id-A", "key-A"))
+    router.add_pattern("openai/*", _make_wildcard_entry("id-B", "key-B"))
+
+    removed = router.remove_deployment("id-A")
+
+    assert removed == 1
+    survivors = router.patterns["openai/(.*)"]
+    assert len(survivors) == 1
+    assert survivors[0]["model_info"]["id"] == "id-B"
+    assert survivors[0]["litellm_params"]["api_key"] == "key-B"
+
+
+def test_remove_deployment_drops_regex_key_when_list_empties():
+    router = PatternMatchRouter()
+    router.add_pattern("openai/*", _make_wildcard_entry("id-A", "key-A"))
+
+    router.remove_deployment("id-A")
+
+    assert router.patterns == {}
+
+
+def test_remove_deployment_spans_multiple_regexes():
+    router = PatternMatchRouter()
+    router.add_pattern("openai/*", _make_wildcard_entry("id-A", "key-A"))
+    router.add_pattern("anthropic/*", _make_wildcard_entry("id-A", "key-A"))
+    router.add_pattern("openai/*", _make_wildcard_entry("id-B", "key-B"))
+
+    removed = router.remove_deployment("id-A")
+
+    assert removed == 2
+    assert "anthropic/(.*)" not in router.patterns
+    assert [d["model_info"]["id"] for d in router.patterns["openai/(.*)"]] == ["id-B"]
+
+
+def test_remove_deployment_noop_for_unknown_id():
+    router = PatternMatchRouter()
+    router.add_pattern("openai/*", _make_wildcard_entry("id-A", "key-A"))
+    before = {k: list(v) for k, v in router.patterns.items()}
+
+    removed = router.remove_deployment("id-DOES-NOT-EXIST")
+
+    assert removed == 0
+    assert router.patterns == before
+
+
+def test_remove_deployment_with_falsy_id_is_noop_even_when_entries_have_no_id():
+    """
+    An entry without model_info.id has '' / None as its id. remove_deployment('')
+    must NOT match those entries; otherwise a stray empty-string call would
+    wipe every id-less wildcard deployment in the router.
+    """
+    router = PatternMatchRouter()
+    router.patterns["openai/(.*)"] = [
+        {"model_name": "openai/*", "litellm_params": {"api_key": "key-X"}}
+    ]
+
+    for falsy in ("", None):
+        removed = router.remove_deployment(falsy)
+        assert removed == 0
+        assert len(router.patterns["openai/(.*)"]) == 1
+
+
+def test_remove_deployment_tolerates_missing_model_info():
+    router = PatternMatchRouter()
+    router.patterns["openai/(.*)"] = [
+        {"model_name": "openai/*", "litellm_params": {"api_key": "X"}},
+        _make_wildcard_entry("id-A", "key-A"),
+    ]
+
+    router.remove_deployment("id-A")
+
+    survivors = router.patterns["openai/(.*)"]
+    assert len(survivors) == 1
+    assert "model_info" not in survivors[0]

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -4448,3 +4448,24 @@ def test_remove_deployment_from_wildcard_state_is_noop_for_empty_id():
 
     assert router.pattern_router.patterns == snapshot_patterns
     assert router.provider_default_deployment_ids == snapshot_ids
+
+
+def test_delete_deployment_cleans_wildcard_state_even_when_index_is_desynced():
+    """
+    Symmetric with the upsert path: delete_deployment must clean wildcard
+    state from the model_id regardless of whether the fast-mapping index
+    still knows about it. Simulates index corruption / partial-failure by
+    removing the entry from model_id_to_deployment_index_map while leaving
+    pattern_router intact, then calls delete and asserts pattern_router is
+    cleaned.
+    """
+    router, _ = _build_wildcard_router(api_key="key-A")
+    model_id = "wildcard-deployment-1"
+
+    assert router.pattern_router.patterns
+    del router.model_id_to_deployment_index_map[model_id]
+
+    router.delete_deployment(id=model_id)
+
+    assert router.pattern_router.patterns == {}
+    assert model_id not in router.provider_default_deployment_ids

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -4231,3 +4231,172 @@ def test_is_deployment_blocked_static_helper_reflects_blocked_flag():
         )
         is True
     )
+
+
+def _build_wildcard_router(api_key: str, model_id: str = "wildcard-deployment-1"):
+    from litellm.router import Deployment
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "openai/*",
+                "litellm_params": {"model": "openai/*", "api_key": api_key},
+                "model_info": {"id": model_id},
+            },
+        ],
+    )
+    return router, Deployment
+
+
+def test_upsert_wildcard_deployment_removes_stale_api_key():
+    """
+    Regression: rotating the api_key on a wildcard deployment must NOT leave
+    the previous credential in pattern_router. Before the fix, the old entry
+    survived in pattern_router.patterns[regex] and was still selected on
+    roughly half of wildcard traffic.
+    """
+    router, Deployment = _build_wildcard_router(api_key="OLD-KEY")
+    model_id = "wildcard-deployment-1"
+
+    router.upsert_deployment(
+        Deployment(
+            model_name="openai/*",
+            litellm_params={"model": "openai/*", "api_key": "NEW-KEY"},
+            model_info={"id": model_id},
+        )
+    )
+
+    entries = router.pattern_router.patterns["openai/(.*)"]
+    assert (
+        len(entries) == 1
+    ), f"pattern_router accumulated stale entries: {len(entries)} present"
+    assert entries[0]["litellm_params"]["api_key"] == "NEW-KEY"
+    assert all(
+        e["litellm_params"]["api_key"] != "OLD-KEY" for e in entries
+    ), "Rotated-out api_key is still resident in pattern_router"
+
+
+def test_upsert_wildcard_deployment_is_idempotent_in_pattern_router():
+    """
+    Repeated upserts of the same wildcard deployment must not grow the
+    pattern_router unboundedly.
+    """
+    router, Deployment = _build_wildcard_router(api_key="key-0")
+    model_id = "wildcard-deployment-1"
+
+    for i in range(1, 6):
+        router.upsert_deployment(
+            Deployment(
+                model_name="openai/*",
+                litellm_params={"model": "openai/*", "api_key": f"key-{i}"},
+                model_info={"id": model_id},
+            )
+        )
+
+    entries = router.pattern_router.patterns["openai/(.*)"]
+    assert len(entries) == 1
+    assert entries[0]["litellm_params"]["api_key"] == "key-5"
+    assert router.provider_default_deployment_ids.count(model_id) == 1
+
+
+def test_delete_wildcard_deployment_clears_pattern_router():
+    router, _ = _build_wildcard_router(api_key="OLD-KEY")
+    model_id = "wildcard-deployment-1"
+
+    assert router.pattern_router.patterns  # sanity
+
+    router.delete_deployment(id=model_id)
+
+    assert router.pattern_router.patterns == {}
+    assert model_id not in router.provider_default_deployment_ids
+
+
+def test_upsert_wildcard_to_concrete_model_removes_old_wildcard_entry():
+    """
+    Changing model_name from a wildcard to a concrete name must drop the
+    old wildcard entry. Otherwise traffic to openai/<anything> still routes
+    to a model the operator believes they renamed.
+    """
+    router, Deployment = _build_wildcard_router(api_key="key-A")
+    model_id = "wildcard-deployment-1"
+
+    router.upsert_deployment(
+        Deployment(
+            model_name="openai/gpt-4o",
+            litellm_params={"model": "openai/gpt-4o", "api_key": "key-A"},
+            model_info={"id": model_id},
+        )
+    )
+
+    assert router.pattern_router.patterns == {}
+    assert model_id not in router.provider_default_deployment_ids
+
+
+def test_upsert_team_wildcard_deployment_does_not_leak_old_key():
+    from litellm.router import Deployment
+
+    team_id = "team-acme"
+    model_id = "team-wildcard-1"
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "openai/team-foo-*",
+                "litellm_params": {"model": "openai/*", "api_key": "OLD-KEY"},
+                "model_info": {
+                    "id": model_id,
+                    "team_id": team_id,
+                    "team_public_model_name": "team-foo-*",
+                },
+            },
+        ],
+    )
+
+    assert team_id in router.team_pattern_routers
+    assert router.team_pattern_routers[team_id].patterns
+
+    router.upsert_deployment(
+        Deployment(
+            model_name="openai/team-foo-*",
+            litellm_params={"model": "openai/*", "api_key": "NEW-KEY"},
+            model_info={
+                "id": model_id,
+                "team_id": team_id,
+                "team_public_model_name": "team-foo-*",
+            },
+        )
+    )
+
+    team_router = router.team_pattern_routers[team_id]
+    assert len(team_router.patterns) == 1
+    team_entries = next(iter(team_router.patterns.values()))
+    assert len(team_entries) == 1
+    assert team_entries[0]["litellm_params"]["api_key"] == "NEW-KEY"
+
+
+def test_delete_team_wildcard_removes_empty_team_router():
+    """
+    When the last wildcard deployment for a team is deleted, its dedicated
+    team_pattern_router entry should be discarded too, not left as an empty
+    PatternMatchRouter holding the team_id forever.
+    """
+    team_id = "team-acme"
+    model_id = "team-wildcard-1"
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "openai/team-foo-*",
+                "litellm_params": {"model": "openai/*", "api_key": "key-A"},
+                "model_info": {
+                    "id": model_id,
+                    "team_id": team_id,
+                    "team_public_model_name": "team-foo-*",
+                },
+            },
+        ],
+    )
+
+    router.delete_deployment(id=model_id)
+
+    assert team_id not in router.team_pattern_routers

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -4400,3 +4400,51 @@ def test_delete_team_wildcard_removes_empty_team_router():
     router.delete_deployment(id=model_id)
 
     assert team_id not in router.team_pattern_routers
+
+
+def test_remove_deployment_from_wildcard_state_cleans_all_three_structures():
+    """
+    Pin the contract of Router._remove_deployment_from_wildcard_state: a single
+    call must strip model_id from the global pattern router, from every per-team
+    pattern router (dropping the team entry when its router empties out), and
+    from provider_default_deployment_ids. Exercised directly so the helper's
+    behavior is locked in independently of the upsert/delete code paths.
+    """
+    from litellm.router_utils.pattern_match_deployments import PatternMatchRouter
+
+    router, _ = _build_wildcard_router(api_key="key-A")
+    model_id = "wildcard-deployment-1"
+
+    router.team_pattern_routers["team-x"] = PatternMatchRouter()
+    router.team_pattern_routers["team-x"].add_pattern(
+        "openai/team-x-*",
+        {
+            "model_name": "openai/team-x-*",
+            "litellm_params": {"model": "openai/*", "api_key": "key-A"},
+            "model_info": {"id": model_id},
+        },
+    )
+    assert router.pattern_router.patterns
+    assert "team-x" in router.team_pattern_routers
+    assert model_id in router.provider_default_deployment_ids
+
+    router._remove_deployment_from_wildcard_state(model_id=model_id)
+
+    assert router.pattern_router.patterns == {}
+    assert "team-x" not in router.team_pattern_routers
+    assert model_id not in router.provider_default_deployment_ids
+
+
+def test_remove_deployment_from_wildcard_state_is_noop_for_empty_id():
+    """
+    A falsy model_id must not touch any wildcard-routing state; otherwise an
+    accidental empty-string call could wipe deployments that lack model_info.id.
+    """
+    router, _ = _build_wildcard_router(api_key="key-A")
+    snapshot_patterns = {k: list(v) for k, v in router.pattern_router.patterns.items()}
+    snapshot_ids = list(router.provider_default_deployment_ids)
+
+    router._remove_deployment_from_wildcard_state(model_id="")
+
+    assert router.pattern_router.patterns == snapshot_patterns
+    assert router.provider_default_deployment_ids == snapshot_ids


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Linear ticket

<!-- if you are an internal contributor, add the Linear ticket e.g. "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

The bug lives in internal router state, so the user-visible symptom is "the api_key I just rotated still works for my wildcard models." The runbook below reproduces it on `litellm_internal_staging` and shows it gone on this branch.

The original draft of this runbook called for two real OpenAI keys and revoking one of them on the dashboard, but the demonstration only needs a controllable revocation event, not a real provider; I swapped OpenAI for a 50-line local fake-OpenAI server whose set of accepted bearer tokens can be mutated at runtime via a tiny `/admin/revoke` endpoint. Same shape of traffic, same shape of failure, no real keys spent

One thing I learned while building the proof: with LiteLLM's internal retry layer in front of the wildcard router, a single rotation against a fresh DB hides the bug from customers entirely. Every customer request still comes back 200, because when round-robin lands on the stale OLD entry the proxy quietly retries against the surviving NEW entry. The leak only becomes customer-visible when stale entries accumulate over multiple rotations. So the unambiguous signal isn't the customer-facing status code; it's the upstream traffic. On staging the fake server logs a wave of REJECTs against the rotated-out key for every rotation; on this branch it sees none

### Setup

Local Postgres (any reachable instance works; the proxy just needs `DATABASE_URL` so `/model/update` is exercised):

```bash
brew install postgresql@16 && brew services start postgresql@16
createuser -s litellm 2>/dev/null
createdb -O litellm litellm 2>/dev/null
psql -U litellm -d litellm -c "ALTER USER litellm WITH PASSWORD 'litellm';"
export DATABASE_URL="postgresql://litellm:litellm@127.0.0.1:5432/litellm"
```

A `tools/fake_openai_server.py` that holds a mutable `valid_keys` set, returns 200 for accepted bearer tokens and 401 for everything else, and exposes `POST /admin/revoke {"key":"..."}` so we can simulate dashboard revocation:

```python
import json, os, sys
from http.server import BaseHTTPRequestHandler, HTTPServer
from threading import Lock

valid_keys = set(k for k in os.environ.get("VALID_KEYS", "").split(",") if k)
lock = Lock()

class H(BaseHTTPRequestHandler):
    def _json(self, s, b):
        p = json.dumps(b).encode()
        self.send_response(s); self.send_header("Content-Type", "application/json")
        self.send_header("Content-Length", str(len(p))); self.end_headers(); self.wfile.write(p)
    def _body(self):
        n = int(self.headers.get("Content-Length", "0") or "0")
        return json.loads(self.rfile.read(n)) if n > 0 else {}
    def do_POST(self):
        if self.path == "/admin/revoke":
            with lock: valid_keys.discard(self._body().get("key", ""))
            return self._json(200, {"valid": sorted(valid_keys)})
        if self.path == "/admin/reset":
            with lock: valid_keys.clear(); valid_keys.update(self._body().get("keys", []))
            return self._json(200, {"valid": sorted(valid_keys)})
        if self.path.endswith("/chat/completions"):
            tok = self.headers.get("Authorization", "")[7:]
            with lock: ok = tok in valid_keys
            sys.stderr.write(("ACCEPT" if ok else "REJECT") + f" key=...{tok[-8:]}\n")
            return self._json(
                200 if ok else 401,
                {"id":"x","object":"chat.completion","created":0,"model":"f","choices":[{"index":0,"message":{"role":"assistant","content":"hi"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}} if ok else {"error":{"message":"Invalid Authorization header"}}
            )
        self._json(404, {"error":"not found"})
    def log_message(self, *a, **k): return

if __name__ == "__main__":
    HTTPServer(("127.0.0.1", 8765), H).serve_forever()
```

```bash
VALID_KEYS="sk-OLD-FAKE-1111,sk-NEW-FAKE-2222" python3 tools/fake_openai_server.py 2> /tmp/fake.err &
```

Minimal `litellm/proxy/dev_config.yaml` (no models declared in config so `/model/update` actually reaches the upsert path):

```yaml
general_settings:
  master_key: sk-1234
  store_model_in_db: true
  database_url: os.environ/DATABASE_URL

model_list: []
```

```bash
python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml \
  --detailed_debug --use_v2_migration_resolver > litellm.log 2>&1 &
```

Wipe the model table between branch swaps so each run starts from a known state:

```bash
psql "$DATABASE_URL" -c 'TRUNCATE "LiteLLM_ProxyModelTable" CASCADE;'
```

### The demo

```bash
PROXY=http://localhost:4000; FAKE=http://127.0.0.1:8765; MASTER=sk-1234
OLD=sk-OLD-FAKE-1111; NEW=sk-NEW-FAKE-2222; ID=wildcard-deployment-1

curl -sS -X POST $FAKE/admin/reset -H "Content-Type: application/json" \
  -d "{\"keys\":[\"$OLD\",\"$NEW\"]}"

curl -sS -X POST $PROXY/model/new -H "Authorization: Bearer $MASTER" \
  -H "Content-Type: application/json" -d "{
    \"model_name\":\"openai/*\",
    \"litellm_params\":{\"model\":\"openai/*\",\"api_key\":\"$OLD\",\"api_base\":\"$FAKE/v1\"},
    \"model_info\":{\"id\":\"$ID\"}
  }"

curl -sS -o /dev/null -w "sanity: %{http_code}\n" \
  -X POST $PROXY/v1/chat/completions \
  -H "Authorization: Bearer $MASTER" -H "Content-Type: application/json" \
  -d '{"model":"openai/gpt-4o-mini","messages":[{"role":"user","content":"hi"}]}'

curl -sS -X POST $FAKE/admin/revoke -H "Content-Type: application/json" \
  -d "{\"key\":\"$OLD\"}"

curl -sS -X POST $PROXY/model/update -H "Authorization: Bearer $MASTER" \
  -H "Content-Type: application/json" -d "{
    \"model_info\":{\"id\":\"$ID\"},
    \"litellm_params\":{\"model\":\"openai/*\",\"api_key\":\"$NEW\",\"api_base\":\"$FAKE/v1\"}
  }"

for i in $(seq 1 20); do
  curl -sS -o /dev/null -w "%{http_code}\n" \
    -X POST $PROXY/v1/chat/completions \
    -H "Authorization: Bearer $MASTER" -H "Content-Type: application/json" \
    -d '{"model":"openai/gpt-4o-mini","messages":[{"role":"user","content":"hi"}]}'
done | sort | uniq -c

echo "--- upstream traffic on fake server ---"
sort /tmp/fake.err | uniq -c
```

### `litellm_internal_staging` (bug present)

```
sanity: 200

  20 200

--- upstream traffic on fake server ---
   1 ACCEPT key=...AKE-1111
  20 ACCEPT key=...AKE-2222
   9 REJECT key=...AKE-1111
```

Customer-side everything looks fine, because LiteLLM's retry layer quietly swaps the wildcard request onto the surviving NEW entry whenever round-robin lands on the stale OLD entry. The upstream is where the leak is loud: 9 wasted round-trips to the revoked key in a single 20-request loop. Every one of those would be a real billed call in production, plus the added retry-latency on the customer's request. The single OLD-ACCEPT is the pre-rotation sanity check, which is expected

(A second consecutive rotation against the same proxy instance compounds the leak as more stale entries pile into `pattern_router.patterns`, and the customer-visible 401s start to appear once retries can no longer rescue every request. The single-rotation case above is the conservative read of the bug)

### `litellm_fix_pattern_router_leak` (this PR)

```
sanity: 200

  20 200

--- upstream traffic on fake server ---
   1 ACCEPT key=...AKE-1111
  20 ACCEPT key=...AKE-2222
```

20/20 customer-side, exactly 20 upstream calls to NEW, zero calls to OLD after rotation, zero wasted retries. The pre-rotation sanity-check ACCEPT for OLD is expected. No stale credential left in `pattern_router.patterns`

## Type

🐛 Bug Fix

## Changes

`PatternMatchRouter.add_pattern` was append-only, and neither `Router.upsert_deployment` nor `delete_deployment` ever removed the existing entry. So every time an admin edited or deleted a wildcard model, the old deployment dict (including its old `api_key`) just sat there in `pattern_router.patterns`, and the load balancer kept round-robining onto it until proxy restart. The same leak hit `provider_default_deployment_ids` and the per-team `team_pattern_routers`

Added `PatternMatchRouter.remove_deployment(model_id)` and a private `Router._remove_deployment_from_wildcard_state(model_id)` that cleans up across all three. Wired into `upsert_deployment` and `delete_deployment` right alongside the existing index-map cleanup so the change stays narrow

Six unit tests in `tests/local_testing/test_router_pattern_matching.py` pin the new method's contract, and six integration tests in `tests/test_litellm/test_router.py` cover the actual upsert/delete paths, including team-scoped wildcards and api_key rotation as the regression test
