### PR TITLE
fix(fireworks_ai): pass response_format json_schema through unchanged

### DIFF
--- a/litellm/llms/fireworks_ai/chat/transformation.py
+++ b/litellm/llms/fireworks_ai/chat/transformation.py
@@ -170,11 +170,6 @@ class FireworksAIConfig(OpenAIGPTConfig):
                         is_response_format_supported=False,
                         enforce_tool_choice=False,  # tools and response_format are both set, don't enforce tool_choice
                     )
-                elif "json_schema" in value:
-                    optional_params["response_format"] = {
-                        "type": "json_object",
-                        "schema": value["json_schema"]["schema"],
-                    }
                 else:
                     optional_params["response_format"] = value
             elif param == "max_completion_tokens":

--- a/tests/llm_translation/test_fireworks_ai_translation.py
+++ b/tests/llm_translation/test_fireworks_ai_translation.py
@@ -43,12 +43,14 @@ def test_map_openai_params_tool_choice():
 
 def test_map_response_format():
     """
-    Test that the response format is translated correctly.
+    json_schema response_format is passed through to Fireworks unchanged.
 
-    h/t to https://github.com/DaveDeCaprio (@DaveDeCaprio) for the test case
+    Fireworks accepts the OpenAI strict json_schema shape natively. The earlier
+    downgrade to {type: json_object, schema: ...} silently dropped `strict` and
+    `name`, producing a request that Fireworks treats as "any valid JSON" per
+    its docs, disabling grammar-guided decoding.
 
-    Relevant Issue: https://github.com/BerriAI/litellm/issues/6797
-    Fireworks AI Ref: https://docs.fireworks.ai/structured-responses/structured-response-formatting#step-1-import-libraries
+    Ref: https://docs.fireworks.ai/structured-responses/structured-response-formatting
     """
     response_format = {
         "type": "json_schema",
@@ -65,16 +67,7 @@ def test_map_response_format():
     result = fireworks.map_openai_params(
         {"response_format": response_format}, {}, "some_model", drop_params=False
     )
-    assert result == {
-        "response_format": {
-            "type": "json_object",
-            "schema": {
-                "properties": {"result": {"type": "boolean"}},
-                "required": ["result"],
-                "type": "object",
-            },
-        }
-    }
+    assert result == {"response_format": response_format}
 
 
 class TestFireworksAIAudioTranscription(BaseLLMAudioTranscriptionTest):

--- a/tests/test_litellm/llms/fireworks_ai/chat/test_fireworks_ai_chat_transformation.py
+++ b/tests/test_litellm/llms/fireworks_ai/chat/test_fireworks_ai_chat_transformation.py
@@ -496,3 +496,59 @@ def test_transform_tools_skips_non_function_tools():
         "type": "object",
         "properties": {"id": {"type": "string"}},
     }
+
+
+def test_map_response_format_passes_json_schema_through_unchanged():
+    """
+    json_schema response_format must reach Fireworks unchanged.
+
+    Regression guard for the prior downgrade to {type: json_object, schema: ...}
+    which silently dropped `strict` and `name` and disabled grammar-guided
+    decoding on the Fireworks side.
+    """
+    config = FireworksAIConfig()
+    response_format = {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "priority_classification",
+            "strict": True,
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "priority": {
+                        "type": "string",
+                        "enum": ["high", "medium", "low"],
+                    }
+                },
+                "required": ["priority"],
+                "additionalProperties": False,
+            },
+        },
+    }
+
+    result = config.map_openai_params(
+        {"response_format": response_format},
+        {},
+        "fireworks_ai/accounts/fireworks/models/qwen3-32b",
+        drop_params=False,
+    )
+
+    rf = result["response_format"]
+    assert rf["type"] == "json_schema"
+    assert rf["json_schema"]["name"] == "priority_classification"
+    assert rf["json_schema"]["strict"] is True
+    assert rf["json_schema"]["schema"] == response_format["json_schema"]["schema"]
+
+
+def test_map_response_format_json_object_unchanged():
+    """
+    The plain json_object form keeps working as before.
+    """
+    config = FireworksAIConfig()
+    result = config.map_openai_params(
+        {"response_format": {"type": "json_object"}},
+        {},
+        "fireworks_ai/accounts/fireworks/models/qwen3-32b",
+        drop_params=False,
+    )
+    assert result == {"response_format": {"type": "json_object"}}


### PR DESCRIPTION
## Relevant issues

Fixes #29604

## Linear ticket

n/a (external contribution)

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Type

Bug fix

## Changes

Removes the `json_schema` to `json_object` rewrite in `FireworksAIConfig.map_openai_params`. Fireworks accepts the OpenAI strict `json_schema` shape natively; the rewrite added in #7085 (Dec 2024) made sense at the time but now silently drops `strict` and `name` and disables grammar guided decoding on the Fireworks side

Updates the existing `test_map_response_format` in `tests/llm_translation/test_fireworks_ai_translation.py` to assert pass through. Adds two regression tests in `tests/test_litellm/llms/fireworks_ai/chat/test_fireworks_ai_chat_transformation.py` covering preservation of `type`, `strict`, `name`, and the schema body, plus that the plain `json_object` form still works

## Screenshots / Proof of Fix

Pending. Fireworks deployments stuck scaling-up during PR prep; will add live-proxy curl output as a follow-up comment once reachable. In the meantime see the reproduction section of #29604 for the empirical 400-call matrix (1/50 schema-valid via LiteLLM versus 50/50 direct, for a Fireworks-hosted gemma-4-31b model on the same request)