### PR TITLE
fix: call failure handler on mid-stream timeout in async_data_generator

### DIFF
--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -2068,8 +2068,8 @@ class ProxyBaseLLMRequestProcessing:
                     target=_litellm_logging_obj.failure_handler,
                     args=(e, traceback_exception),
                 ).start()
-                asyncio.create_task(
-                    _litellm_logging_obj.async_failure_handler(e, traceback_exception)
+                await _litellm_logging_obj.async_failure_handler(
+                    e, traceback_exception
                 )
 
             transformed_exception = await proxy_logging_obj.post_call_failure_hook(

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import logging
+import threading
 import time
 import traceback
 from datetime import datetime
@@ -2060,6 +2061,17 @@ class ProxyBaseLLMRequestProcessing:
                     str(e)
                 )
             )
+            _litellm_logging_obj = request_data.get("litellm_logging_obj")
+            if _litellm_logging_obj is not None:
+                traceback_exception = traceback.format_exc()
+                threading.Thread(
+                    target=_litellm_logging_obj.failure_handler,
+                    args=(e, traceback_exception),
+                ).start()
+                asyncio.create_task(
+                    _litellm_logging_obj.async_failure_handler(e, traceback_exception)
+                )
+
             transformed_exception = await proxy_logging_obj.post_call_failure_hook(
                 user_api_key_dict=user_api_key_dict,
                 original_exception=e,

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -2068,9 +2068,7 @@ class ProxyBaseLLMRequestProcessing:
                     target=_litellm_logging_obj.failure_handler,
                     args=(e, traceback_exception),
                 ).start()
-                await _litellm_logging_obj.async_failure_handler(
-                    e, traceback_exception
-                )
+                await _litellm_logging_obj.async_failure_handler(e, traceback_exception)
 
             transformed_exception = await proxy_logging_obj.post_call_failure_hook(
                 user_api_key_dict=user_api_key_dict,

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -2317,3 +2317,49 @@ class TestAsyncStreamingDataGeneratorFastPath:
         hook_spy.assert_awaited_once()
 
         ProxyLogging._callback_capabilities_cache.clear()
+
+    @pytest.mark.asyncio
+    async def test_async_streaming_data_generator_calls_failure_handlers_on_timeout(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(litellm, "callbacks", [])
+        ProxyLogging._callback_capabilities_cache.clear()
+
+        proxy_logging_obj = ProxyLogging(user_api_key_cache=MagicMock())
+        proxy_logging_obj.post_call_failure_hook = AsyncMock(return_value=None)
+
+        async def _raise_iter():
+            yield b"event: a\ndata: {}\n\n"
+            raise httpx.ReadTimeout("Request timed out")
+
+        async def _iterator_hook(*args, **kwargs):
+            return _raise_iter()
+
+        monkeypatch.setattr(
+            proxy_logging_obj,
+            "async_post_call_streaming_iterator_hook",
+            _iterator_hook,
+        )
+
+        logging_obj = MagicMock()
+        logging_obj.async_failure_handler = AsyncMock()
+        logging_obj.failure_handler = MagicMock()
+        logging_obj.dispatch_success_handlers = AsyncMock()
+
+        out = [
+            c
+            async for c in ProxyBaseLLMRequestProcessing.async_streaming_data_generator(
+                response=MagicMock(),
+                user_api_key_dict=MagicMock(spec=UserAPIKeyAuth),
+                request_data={"model": "gpt-4", "litellm_logging_obj": logging_obj},
+                proxy_logging_obj=proxy_logging_obj,
+                serialize_chunk=lambda chunk: chunk,
+                serialize_error=lambda exc: f"err:{exc}",
+            )
+        ]
+
+        assert out[0] == b"event: a\ndata: {}\n\n"
+        assert out[1].startswith("err:")
+        logging_obj.async_failure_handler.assert_awaited_once()
+        logging_obj.failure_handler.assert_called_once()
+        logging_obj.dispatch_success_handlers.assert_not_called()

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -2332,14 +2332,11 @@ class TestAsyncStreamingDataGeneratorFastPath:
             yield b"event: a\ndata: {}\n\n"
             raise httpx.ReadTimeout("Request timed out")
 
-        async def _iterator_hook(*args, **kwargs):
-            return _raise_iter()
+        async def mock_hook(response, *args, **kwargs):
+            async for chunk in response:
+                yield chunk
 
-        monkeypatch.setattr(
-            proxy_logging_obj,
-            "async_post_call_streaming_iterator_hook",
-            _iterator_hook,
-        )
+        proxy_logging_obj.async_post_call_streaming_iterator_hook = mock_hook
 
         logging_obj = MagicMock()
         logging_obj.async_failure_handler = AsyncMock()


### PR DESCRIPTION
## Summary
When a streaming request times out mid-stream, the exception is caught 
inside `async_data_generator` but the failure handler is never called — 
causing the success callback to fire and `litellm_proxy_failed_requests_metric` 
to not increment.

## Root Cause
In `common_request_processing.py`, the `except` block in `async_data_generator` 
logs the exception and yields an error chunk to the client but does not call 
`proxy_logging_obj.async_failure_handler()`. Since the HTTP `200` status line 
is already committed at this point, the request falls through to the success 
logging path.

## Fix
Added a call to `proxy_logging_obj.async_failure_handler()` in the `except` 
block of `async_data_generator`, passing the caught exception so that:
- The failure logging callback fires correctly
- `litellm_proxy_failed_requests_metric` is incremented
- The error chunk yield to the client is unchanged

## Before
- Mid-stream timeout → success callback fires → failed_requests not incremented
- ~11,500 real timeouts logged as ~1,300 failures (9x undercount in production)

## After
- Mid-stream timeout → failure callback fires → failed_requests incremented correctly

## Testing
- Existing streaming tests pass
- Added test simulating mid-stream timeout and asserting failure handler is called

Fixes: #29602