### PR TITLE
Add litellm.cache config to litellm-backend pod

### DIFF
--- a/helm/litellm/templates/backend/configmap.yaml
+++ b/helm/litellm/templates/backend/configmap.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.backend.config.create }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "litellm.backend.fullname" . }}-config
+data:
+  config.yaml: |
+{{ .Values.backend.config.proxy_config | toYaml | indent 6 }}
+{{- end }}

--- a/helm/litellm/templates/backend/deployment.yaml
+++ b/helm/litellm/templates/backend/deployment.yaml
@@ -12,10 +12,13 @@ spec:
       {{- include "litellm.backend.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.backend.podAnnotations }}
       annotations:
+        {{- if .Values.backend.config.create }}
+        checksum/config: {{ include (print $.Template.BasePath "/backend/configmap.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.backend.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "litellm.backend.selectorLabels" . | nindent 8 }}
     spec:
@@ -35,7 +38,17 @@ spec:
               protocol: TCP
           env:
             {{- include "litellm.serverEnv" (dict "root" $ "component" .Values.backend) | nindent 12 }}
+            {{- if .Values.backend.config.create }}
+            - name: CONFIG_FILE_PATH
+              value: /app/config/config.yaml
+            {{- end }}
           {{- include "litellm.envFrom" .Values.backend | nindent 10 }}
+          {{- if .Values.backend.config.create }}
+          volumeMounts:
+            - name: backend-config
+              mountPath: /app/config/config.yaml
+              subPath: config.yaml
+          {{- end }}
           {{- with .Values.backend.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}
@@ -46,6 +59,12 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.backend.resources | nindent 12 }}
+      {{- if .Values.backend.config.create }}
+      volumes:
+        - name: backend-config
+          configMap:
+            name: {{ include "litellm.backend.fullname" . }}-config
+      {{- end }}
       {{- with .Values.backend.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/litellm/values.yaml
+++ b/helm/litellm/values.yaml
@@ -167,6 +167,9 @@ backend:
   extraEnv: []
   envConfigMaps: []
   envSecrets: []
+  config:
+    create: false
+    proxy_config: {}
   image:
     repository: ghcr.io/berriai/litellm-backend
     tag: ""


### PR DESCRIPTION
Mirrors the gateway pod's cache config on the backend pod. Clean branch off v1.88.0-rc.1.