### PR TITLE
fix(key_generate): exempt UI/CLI session tokens from the budget ceiling for team keys

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -722,8 +722,17 @@ async def _common_key_generation_helper(  # noqa: PLR0915
     # Delegated-authority ceiling (GHSA-q775-qw9r-2r4g): a non-admin caller
     # with an explicit budget cannot grant a key a higher budget than their own.
     # Callers with max_budget=None (unlimited) can delegate any budget.
+    # A UI/CLI session token's max_budget is a per-session chat spend cap
+    # (max_ui_session_budget), not a delegation authority, so it is exempt only
+    # when creating a team key - that key's spend is bounded by the team budget
+    # at request time. Personal keys keep the ceiling; nothing else bounds them.
+    is_ui_session_team_key = (
+        user_api_key_dict.team_id == UI_SESSION_TOKEN_TEAM_ID
+        and data.team_id is not None
+    )
     if (
         user_api_key_dict.user_role != LitellmUserRoles.PROXY_ADMIN.value
+        and not is_ui_session_team_key
         and _requested_max_budget is not None
         and user_api_key_dict.max_budget is not None
         and _requested_max_budget > user_api_key_dict.max_budget

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -11539,3 +11539,87 @@ async def test_ghsa_q775_admin_bypasses_budget_ceiling():
             litellm_changed_by=None,
         )
         assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_ghsa_q775_ui_session_token_team_key_exempt_from_budget_ceiling():
+    """
+    Regression: a UI/CLI session token (team_id=litellm-dashboard) creating a
+    TEAM key (data.team_id set) is exempt from the delegated-authority ceiling.
+    The session max_budget is a per-session chat spend cap (max_ui_session_budget,
+    default $0.25), not a delegation authority, and the team key's spend is bounded
+    by the team budget at request time. This is the team-admin key-creation flow
+    blocked since v1.86.x. Calls the helper directly so the ceiling runs (mocking
+    out _common_key_generation_helper would mock out the check under test).
+    """
+    from litellm.constants import UI_SESSION_TOKEN_TEAM_ID
+
+    data = GenerateKeyRequest(max_budget=500, team_id="team-abc")
+    user_api_key_dict = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        api_key="sk-ui-session",
+        user_id="user-1",
+        team_id=UI_SESSION_TOKEN_TEAM_ID,
+        max_budget=0.25,
+    )
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", AsyncMock()),
+        patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
+        patch("litellm.proxy.proxy_server.llm_router", None),
+        patch("litellm.proxy.proxy_server.premium_user", False),
+        patch("litellm.proxy.proxy_server.litellm_proxy_admin_name", "default_user_id"),
+    ):
+        try:
+            await _common_key_generation_helper(
+                data=data,
+                user_api_key_dict=user_api_key_dict,
+                litellm_changed_by=None,
+                team_table=MagicMock(),
+            )
+        except (HTTPException, ProxyException) as err:
+            msg = str(getattr(err, "detail", "")) + str(getattr(err, "message", ""))
+            assert (
+                "cannot exceed" not in msg.lower()
+            ), "UI/CLI session token creating a team key must be exempt from the ceiling"
+
+
+@pytest.mark.asyncio
+async def test_ghsa_q775_ui_session_token_personal_key_still_capped():
+    """
+    Security regression for GHSA-q775: the session-token exemption must NOT extend
+    to personal keys. A UI/CLI session token (team_id=litellm-dashboard) creating a
+    key with no data.team_id is still bound by the ceiling; otherwise a session
+    token - or a leaked one, whose blast radius is the $0.25 chat cap - could mint
+    an arbitrary-budget personal key, the exact escalation GHSA-q775 closed. Unlike
+    a team key, nothing else bounds a personal key's spend.
+    """
+    from litellm.constants import UI_SESSION_TOKEN_TEAM_ID
+
+    data = GenerateKeyRequest(max_budget=500)
+    user_api_key_dict = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        api_key="sk-ui-session",
+        user_id="user-1",
+        team_id=UI_SESSION_TOKEN_TEAM_ID,
+        max_budget=0.25,
+    )
+
+    mock_prisma_client = AsyncMock()
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client),
+        patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
+        patch("litellm.proxy.proxy_server.user_custom_key_generate", None),
+    ):
+        with pytest.raises((HTTPException, ProxyException)) as exc_info:
+            await generate_key_fn(
+                data=data,
+                user_api_key_dict=user_api_key_dict,
+                litellm_changed_by=None,
+            )
+        err = exc_info.value
+        code = getattr(err, "status_code", None) or getattr(err, "code", None)
+        msg = str(getattr(err, "detail", "")) + str(getattr(err, "message", ""))
+        assert str(code) == "400"
+        assert "cannot exceed" in msg.lower()


### PR DESCRIPTION
## Relevant issues

Fixes #29073

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Run against a local proxy. Create an internal user, a team they admin (budget 1000), and a key shaped like the token the UI issues on login (`team_id=litellm-dashboard`, `max_budget=0.25`, the `max_ui_session_budget` chat cap).

```
USERID=$(curl -s localhost:4000/user/new -H "Authorization: Bearer sk-1234" \
  -H 'Content-Type: application/json' -d '{"user_role":"internal_user"}' | jq -r .user_id)

TEAM=$(curl -s localhost:4000/team/new -H "Authorization: Bearer sk-1234" \
  -H 'Content-Type: application/json' \
  -d "{\"team_alias\":\"acme\",\"max_budget\":1000,\"members_with_roles\":[{\"user_id\":\"$USERID\",\"role\":\"admin\"}]}" | jq -r .team_id)

UI_SESSION_KEY=$(curl -s localhost:4000/key/generate -H "Authorization: Bearer sk-1234" \
  -H 'Content-Type: application/json' \
  -d "{\"user_id\":\"$USERID\",\"team_id\":\"litellm-dashboard\",\"max_budget\":0.25}" | jq -r .key)
```

1) The reported failure: a team admin acting through the UI session token creates a team key with a $100 budget. Before this change it returned `400 max_budget (100.0) cannot exceed the caller's own max_budget (0.25)`. Now it succeeds.

```
$ curl -s -X POST localhost:4000/key/generate -H "Authorization: Bearer $UI_SESSION_KEY" \
    -H 'Content-Type: application/json' -d "{\"team_id\":\"$TEAM\",\"max_budget\":100}"
HTTP 200
{ "max_budget": 100.0, "team_id": "e4020a18-baef-46b1-ae17-a52f4ee73c97" }
```

2) The exemption is scoped to team keys. The same session token creating a personal key (no `team_id`) above its cap is still rejected, so a session token cannot mint an arbitrary-budget personal key.

```
$ curl -s -X POST localhost:4000/key/generate -H "Authorization: Bearer $UI_SESSION_KEY" \
    -H 'Content-Type: application/json' -d '{"max_budget":500}'
HTTP 400
{'error': "max_budget (500.0) cannot exceed the caller's own max_budget (0.25)."}
```

3) Non-session non-admin keys are unchanged: the budget ceiling still applies.

```
$ curl -s -X POST localhost:4000/key/generate -H "Authorization: Bearer $PLAIN_KEY" \
    -H 'Content-Type: application/json' -d '{"max_budget":100}'
HTTP 400
{'error': "max_budget (100.0) cannot exceed the caller's own max_budget (0.25)."}
```

## Type

🐛 Bug Fix

## Changes

The key budget ceiling in `_common_key_generation_helper` rejects a non-admin caller whose requested `max_budget` is higher than the caller's own `max_budget`. The UI and CLI authenticate every request with a session token whose `max_budget` is `max_ui_session_budget` (default $0.25), a per-session chat spend cap rather than a delegation budget. As a result a team admin acting through the UI was blocked from creating a team key with a budget above $0.25, while creating the key without a budget and then editing it to add one still worked because `/key/update` has no such ceiling.

This change skips the ceiling only when a session token (identified by `team_id == UI_SESSION_TOKEN_TEAM_ID`) creates a team key (`data.team_id` set). That key's spend is bounded by the team budget at request time, so the team budget is the real ceiling. Personal-key creation and every other non-admin caller keep the ceiling, so a session token (or a leaked one, whose blast radius is the $0.25 chat cap) cannot mint an arbitrary-budget personal key, which is the escalation GHSA-q775 closed.

Two regression tests sit next to the existing ceiling tests: one confirming a session token creating a team key bypasses the ceiling, one confirming a session token creating a personal key above the cap is still rejected. The personal-key test fails if the exemption is widened back to all session tokens.
