### PR TITLE
fix: raise HTTPException(400) instead of CustomCodeExecutionError in custom code guardrail

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/custom_code/custom_code_guardrail.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/custom_code/custom_code_guardrail.py
@@ -257,11 +257,11 @@ class CustomCodeGuardrail(CustomGuardrail):
             verbose_proxy_logger.error(
                 f"Custom code guardrail '{self.guardrail_name}' execution error: {e}"
             )
-            raise CustomCodeExecutionError(
-                f"Custom code guardrail execution failed: {e}",
-                details={
-                    "guardrail_name": self.guardrail_name,
-                    "input_type": input_type,
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": f"Custom code guardrail execution failed: {e}",
+                    "guardrail": self.guardrail_name,
                 },
             ) from e
 


### PR DESCRIPTION
## Summary

Closes #29436.

When a custom code guardrail's `apply_guardrail` call fails at execution time (for example, user-provided code raises inside the sandbox), the `except Exception` handler wraps it in `CustomCodeExecutionError`. That class is a plain Python `Exception` with no HTTP status attribute, so FastAPI's default exception handler returns **500 Internal Server Error** instead of the intended **400 Bad Request**.

The fix is straightforward: replace the `raise CustomCodeExecutionError(...)` with `raise HTTPException(status_code=400, detail=...)`. `HTTPException` is already imported at the top of the file and is the correct mechanism for returning client-facing error codes through FastAPI.

## Changes

- `litellm/proxy/guardrails/guardrail_hooks/custom_code/custom_code_guardrail.py`
  - In `apply_guardrail`, changed the `except Exception as e` handler to raise `HTTPException(status_code=400)` instead of `CustomCodeExecutionError`.
  - The log line (`verbose_proxy_logger.error(...)`) is preserved so operator logs still show the failure.
  - `HTTPException` and `ModifyResponseException` are already re-raised above this block, so no existing behavior changes.

## How to reproduce (before fix)

```python
# config.yaml custom code that raises inside the sandbox
def guardrail_function(input, config):
    raise ValueError("policy violation")
```

Before: proxy returns `500 Internal Server Error`.
After: proxy returns `400 Bad Request` with `{"error": "Custom code guardrail execution failed: policy violation", "guardrail": "<name>"}`.

## Testing

- Existing `CustomCodeGuardrail` tests should pass unchanged.
- A guardrail that raises inside the sandbox now produces a 400 response code.
