### PR TITLE
fix(utils): copy extra_body before adding unknown params to prevent model config mutation

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -4818,7 +4818,7 @@ def add_provider_specific_params_to_optional_params(
             )
             is False
         ):
-            extra_body = passed_params.pop("extra_body", None) or {}
+            extra_body = dict(passed_params.pop("extra_body", None) or {})
             for k in passed_params.keys():
                 if k not in openai_params and passed_params[k] is not None:
                     extra_body[k] = passed_params[k]


### PR DESCRIPTION
## Summary

Closes #29615.

### Root cause

In `add_provider_specific_params_to_optional_params` (`litellm/utils.py`), the line:

```python
extra_body = passed_params.pop("extra_body", None) or {}
```

returns the **original dict reference** from the model config when `extra_body` is non-empty (truthy). The `or {}` only creates a new dict when the value is falsy (`None` or `{}`), so any model with a non-empty `extra_body` is vulnerable.

Immediately below, unknown request-level params are written into this dict:

```python
for k in passed_params.keys():
    if k not in openai_params and passed_params[k] is not None:
        extra_body[k] = passed_params[k]
```

Because `extra_body` is the same object that the router holds in `deployment["litellm_params"]["extra_body"]`, these writes mutate the shared in-memory model config. Subsequent calls to `/model/info` return the poisoned `extra_body`, and subsequent completion requests inherit the injected params.

This also explains the reporter's observation that the bug does not reproduce when `extra_body: {}` — an empty dict is falsy, so `{} or {}` returns a fresh `{}`.

### Fix

Wrap the pop result in `dict()` to always get a shallow copy:

```python
extra_body = dict(passed_params.pop("extra_body", None) or {})
```

A shallow copy is sufficient here because only top-level keys (like `thinkingConfig`) are written into `extra_body` at this call site.

### Reproduction (before fix)

```yaml
# config.yaml
model_list:
  - model_name: my-model
    litellm_params:
      model: openai/my-model
      api_base: http://127.0.0.1:9/v1
      api_key: sk-fake
      extra_body:
        marker: repro
```

```bash
# After one request with thinkingConfig in the body:
curl http://localhost:4000/model/info?model=my-model
# Returns extra_body: {marker: repro, thinkingConfig: {...}}
```

After the fix, `extra_body` remains `{marker: repro}` regardless of request content.
