### PR TITLE
fix(bedrock): stop base_model label from stripping tools/tool_choice

### DIFF
--- a/litellm/litellm_core_utils/get_supported_openai_params.py
+++ b/litellm/litellm_core_utils/get_supported_openai_params.py
@@ -22,9 +22,11 @@ def get_supported_openai_params(  # noqa: PLR0915
     ```
 
     Args:
-        base_model: For Azure, the true underlying model (e.g. ``"azure/gpt-5.2"``)
-            when the deployment name differs. Used for model-type detection so that
-            non-standard deployment names route to the correct config.
+        base_model: An optional capability hint for deployments whose ``model``
+            label isn't recognized on its own (e.g. an Azure deployment name, or a
+            friendly Bedrock alias). It is additive: the result is the union of the
+            params supported by ``model`` and by ``base_model``, so a hint can only
+            add capabilities, never strip ones the real model already supports.
 
     Returns:
     - List if custom_llm_provider is mapped
@@ -52,7 +54,15 @@ def get_supported_openai_params(  # noqa: PLR0915
         provider_config = None
 
     if provider_config and request_type == "chat_completion":
-        return provider_config.get_supported_openai_params(model=base_model or model)
+        supported_params = provider_config.get_supported_openai_params(model=model)
+        if base_model and base_model != model:
+            base_model_params = provider_config.get_supported_openai_params(
+                model=base_model
+            )
+            supported_params = list(
+                dict.fromkeys([*supported_params, *base_model_params])
+            )
+        return supported_params
 
     if custom_llm_provider == "bedrock":
         return litellm.AmazonConverseConfig().get_supported_openai_params(model=model)

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -1319,7 +1319,9 @@ def completion(  # type: ignore # noqa: PLR0915
     preset_cache_key = kwargs.get("preset_cache_key", None)
     hf_model_name = kwargs.get("hf_model_name", None)
     supports_system_message = kwargs.get("supports_system_message", None)
-    base_model = kwargs.get("base_model", None)
+    base_model = kwargs.get("base_model", None) or (
+        model_info.get("base_model") if isinstance(model_info, dict) else None
+    )
     ### DISABLE FLAGS ###
     disable_add_transform_inline_image_block = kwargs.get(
         "disable_add_transform_inline_image_block", None
@@ -1531,11 +1533,7 @@ def completion(  # type: ignore # noqa: PLR0915
             "logit_bias": logit_bias,
             "user": user,
             # params to identify the model
-            "model": (
-                model_info.get("base_model")
-                if isinstance(model_info, dict) and model_info.get("base_model")
-                else model
-            ),
+            "model": model,
             "custom_llm_provider": custom_llm_provider,
             "response_format": response_format,
             "seed": seed,

--- a/tests/test_litellm/litellm_core_utils/test_get_supported_openai_params.py
+++ b/tests/test_litellm/litellm_core_utils/test_get_supported_openai_params.py
@@ -1,0 +1,134 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../.."))
+
+from litellm.litellm_core_utils.get_supported_openai_params import (
+    get_supported_openai_params,
+)
+
+BEDROCK_REAL_MODEL = "eu.anthropic.claude-haiku-4-5-20251001-v1:0"
+BEDROCK_LABEL = "claude-haiku-4-5"
+
+
+def test_base_model_label_does_not_strip_bedrock_tools():
+    """Regression for #29618.
+
+    A Bedrock deployment whose ``model_info.base_model`` is a friendly label
+    (``claude-haiku-4-5``) must still advertise ``tools``/``tool_choice``. The label
+    on its own resolves to no tool support, so before the fix it stripped the
+    capability the real model id exposes, silently dropping function calling under
+    ``drop_params``."""
+    params = get_supported_openai_params(
+        model=BEDROCK_REAL_MODEL,
+        custom_llm_provider="bedrock",
+        base_model=BEDROCK_LABEL,
+    )
+
+    assert params is not None
+    assert "tools" in params
+    assert "tool_choice" in params
+
+
+def test_base_model_label_alone_lacks_bedrock_tools():
+    """The label by itself does not advertise tools; this is what made the union
+    necessary. Guards against the discrepancy disappearing (and the regression test
+    above silently passing for the wrong reason)."""
+    params = get_supported_openai_params(
+        model=BEDROCK_LABEL, custom_llm_provider="bedrock"
+    )
+
+    assert params is not None
+    assert "tools" not in params
+
+
+def test_base_model_is_additive_not_replacement():
+    """``base_model`` may only add capabilities, never remove ones the real model has.
+
+    Bedrock: real id supports ``tools`` but not the label's reasoning hint; the union
+    must contain the real model's ``tools`` regardless of the label being a subset."""
+    real_only = set(
+        get_supported_openai_params(
+            model=BEDROCK_REAL_MODEL, custom_llm_provider="bedrock"
+        )
+    )
+    label_only = set(
+        get_supported_openai_params(model=BEDROCK_LABEL, custom_llm_provider="bedrock")
+    )
+    combined = set(
+        get_supported_openai_params(
+            model=BEDROCK_REAL_MODEL,
+            custom_llm_provider="bedrock",
+            base_model=BEDROCK_LABEL,
+        )
+    )
+
+    assert combined == real_only | label_only
+    assert real_only - label_only  # the label really is a strict subset here
+    assert real_only <= combined
+
+
+def test_base_model_adds_capabilities_the_real_model_lacks():
+    """Regression for #27717 (the behavior the union must preserve).
+
+    ``gemini-3.1-pro`` isn't in the cost map so it advertises no reasoning support,
+    but the registered ``gemini-3.1-pro-preview`` base_model does. The hint must add
+    ``reasoning_effort``/``thinking`` without the call erroring."""
+    real_only = set(
+        get_supported_openai_params(
+            model="gemini-3.1-pro", custom_llm_provider="gemini"
+        )
+    )
+    assert "reasoning_effort" not in real_only
+
+    combined = set(
+        get_supported_openai_params(
+            model="gemini-3.1-pro",
+            custom_llm_provider="gemini",
+            base_model="gemini-3.1-pro-preview",
+        )
+    )
+    assert "reasoning_effort" in combined
+    assert "thinking" in combined
+
+
+def test_no_base_model_is_unchanged():
+    """Omitting ``base_model`` must resolve purely from ``model``."""
+    with_none = get_supported_openai_params(
+        model=BEDROCK_REAL_MODEL, custom_llm_provider="bedrock", base_model=None
+    )
+    plain = get_supported_openai_params(
+        model=BEDROCK_REAL_MODEL, custom_llm_provider="bedrock"
+    )
+
+    assert with_none == plain
+
+
+def test_base_model_equal_to_model_is_unchanged():
+    """A ``base_model`` identical to ``model`` must not double-resolve or reorder."""
+    plain = get_supported_openai_params(
+        model=BEDROCK_REAL_MODEL, custom_llm_provider="bedrock"
+    )
+    same = get_supported_openai_params(
+        model=BEDROCK_REAL_MODEL,
+        custom_llm_provider="bedrock",
+        base_model=BEDROCK_REAL_MODEL,
+    )
+
+    assert same == plain
+
+
+def test_azure_base_model_detection_preserved():
+    """Azure relies on ``base_model`` for model-type detection when the deployment
+    name is opaque; the union must keep advertising the gpt-5 capabilities."""
+    params = get_supported_openai_params(
+        model="my-opaque-deployment",
+        custom_llm_provider="azure",
+        base_model="azure/gpt-5.2",
+    )
+
+    assert params is not None
+    assert "reasoning_effort" in params
+    assert "tools" in params

--- a/tests/test_litellm/test_main.py
+++ b/tests/test_litellm/test_main.py
@@ -849,9 +849,9 @@ def test_gpt_5_4_responses_bridge_preserves_reasoning_summary_dict(
 
 
 @pytest.mark.parametrize(
-    "model, model_info, expected_model_param",
+    "model, model_info, expected_base_model_param",
     [
-        ("gemini/gemini-3.1-pro", None, "gemini-3.1-pro"),
+        ("gemini/gemini-3.1-pro", None, None),
         (
             "gemini/gemini-3.1-pro",
             {"base_model": "gemini-3.1-pro-preview"},
@@ -862,8 +862,13 @@ def test_gpt_5_4_responses_bridge_preserves_reasoning_summary_dict(
 def test_completion_optional_params_base_model(
     model: str,
     model_info: dict | None,
-    expected_model_param: str,
+    expected_base_model_param: str | None,
 ):
+    """``model_info.base_model`` must reach ``get_optional_params`` as ``base_model``
+    (an additive capability hint), without overwriting ``model`` with the label.
+
+    Regression for #29618: overwriting ``model`` with a friendly ``base_model``
+    label made Bedrock drop ``tools``/``tool_choice`` under ``drop_params``."""
     with patch("litellm.main.get_optional_params") as mock_get_optional_params:
         mock_get_optional_params.return_value = MagicMock()
 
@@ -881,10 +886,9 @@ def test_completion_optional_params_base_model(
         litellm.completion(**kwargs)
 
         assert mock_get_optional_params.called is True
-        get_optional_params_model_param = mock_get_optional_params.call_args.kwargs[
-            "model"
-        ]
-        assert get_optional_params_model_param == expected_model_param
+        call_kwargs = mock_get_optional_params.call_args.kwargs
+        assert call_kwargs["model"] == "gemini-3.1-pro"
+        assert call_kwargs["base_model"] == expected_base_model_param
 
 
 @patch("litellm.completion_extras.responses_api_bridge.completion")

--- a/tests/test_litellm/test_main.py
+++ b/tests/test_litellm/test_main.py
@@ -849,12 +849,13 @@ def test_gpt_5_4_responses_bridge_preserves_reasoning_summary_dict(
 
 
 @pytest.mark.parametrize(
-    "model, model_info, expected_base_model_param",
+    "model, model_info, expected_model_param, expected_base_model_param",
     [
-        ("gemini/gemini-3.1-pro", None, None),
+        ("gemini/gemini-3.1-pro", None, "gemini-3.1-pro", None),
         (
             "gemini/gemini-3.1-pro",
             {"base_model": "gemini-3.1-pro-preview"},
+            "gemini-3.1-pro",
             "gemini-3.1-pro-preview",
         ),
     ],
@@ -862,6 +863,7 @@ def test_gpt_5_4_responses_bridge_preserves_reasoning_summary_dict(
 def test_completion_optional_params_base_model(
     model: str,
     model_info: dict | None,
+    expected_model_param: str,
     expected_base_model_param: str | None,
 ):
     """``model_info.base_model`` must reach ``get_optional_params`` as ``base_model``
@@ -887,7 +889,7 @@ def test_completion_optional_params_base_model(
 
         assert mock_get_optional_params.called is True
         call_kwargs = mock_get_optional_params.call_args.kwargs
-        assert call_kwargs["model"] == "gemini-3.1-pro"
+        assert call_kwargs["model"] == expected_model_param
         assert call_kwargs["base_model"] == expected_base_model_param
 
 

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -4144,3 +4144,51 @@ class TestValidateAndFixThinkingParam:
         validate_and_fix_thinking_param(thinking=thinking)
         assert "budgetTokens" in thinking
         assert "budget_tokens" not in thinking
+
+
+class TestBedrockBaseModelLabelKeepsTools:
+    """Regression for #29618: a Bedrock deployment whose ``base_model`` is a friendly
+    label must not silently drop ``tools``/``tool_choice`` under ``drop_params``."""
+
+    TOOLS = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                },
+            },
+        }
+    ]
+
+    def test_base_model_label_keeps_tools_with_drop_params(self):
+        from litellm.utils import get_optional_params
+
+        result = get_optional_params(
+            model="eu.anthropic.claude-haiku-4-5-20251001-v1:0",
+            custom_llm_provider="bedrock",
+            base_model="claude-haiku-4-5",
+            tools=self.TOOLS,
+            tool_choice="auto",
+            drop_params=True,
+        )
+
+        assert "tools" in result
+        assert "tool_choice" in result
+
+    def test_base_model_label_alone_drops_tools(self):
+        """Without the real model id the label resolves to no tool support, so passing
+        the label as ``model`` is exactly what dropped tools before the fix."""
+        from litellm.utils import get_optional_params
+
+        result = get_optional_params(
+            model="claude-haiku-4-5",
+            custom_llm_provider="bedrock",
+            tools=self.TOOLS,
+            tool_choice="auto",
+            drop_params=True,
+        )
+
+        assert "tools" not in result


### PR DESCRIPTION
## Relevant issues

Fixes #29618

A Router/proxy Bedrock deployment whose `model_info.base_model` is a friendly label (e.g. `claude-haiku-4-5`) silently lost `tools` and `tool_choice`. The outgoing Bedrock Converse request was built without `toolConfig`, so the model behaved as if no tools were provided. This worked in v1.84.0 and regressed in v1.85.0; with `drop_params: true` it failed silently rather than surfacing an error

## Linear ticket

## Root cause

Two changes compound into the bug. `completion()` passed `model_info.base_model` as the `model` argument to `get_optional_params` (introduced in #27720), so the real Bedrock model id never reached supported-param resolution. Separately, `get_supported_openai_params` resolved the provider config's params from `base_model or model` (#28582), letting the label fully replace the real model. For Bedrock the label resolves to no tool support (Bedrock gates tools on recognizing the Converse model id), so `tools`/`tool_choice` were stripped before transformation and never reached `toolConfig`. Azure was unaffected because its deployment names are opaque, so `base_model` is the only signal it has

## Fix

`completion()` now keeps `model` as the real deployment model and threads the resolved `base_model` (the kwarg, falling back to `model_info`) through separately. `get_supported_openai_params` treats `base_model` as additive: it returns the union of the params supported by `model` and by `base_model`. A hint can only add capabilities, never strip ones the real model already exposes. That keeps the original `base_model` behavior from #27717 (a registered base_model adding `reasoning_effort`/`thinking` for an unregistered model) and Azure's `base_model` driven model-type detection working, while restoring Bedrock tool support

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

Verified against a live proxy hitting real Bedrock (real, billable calls)

### The fix: a friendly `base_model` label no longer strips tools

This is the configuration from the issue, a Bedrock deployment whose `model_info.base_model` is the label `claude-haiku-4-5`, with `drop_params: true`

```yaml
model_list:
  - model_name: claude-haiku-4-5
    litellm_params:
      model: bedrock/eu.anthropic.claude-haiku-4-5-20251001-v1:0
    model_info:
      base_model: claude-haiku-4-5

litellm_settings:
  drop_params: true

general_settings:
  master_key: sk-1234
```

```bash
python litellm/proxy/proxy_cli.py --config bedrock_basemodel_test.yaml --port 4000
```

```bash
curl -s http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "claude-haiku-4-5",
    "messages": [{"role": "user", "content": "What is the weather in Copenhagen?"}],
    "tools": [{"type": "function", "function": {"name": "get_weather", "description": "Get the weather for a city", "parameters": {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]}}}],
    "tool_choice": "auto"
  }' | jq '{model, finish_reason: .choices[0].finish_reason, tool_calls: .choices[0].message.tool_calls, usage}'
```

Response on this branch:

```json
{
  "model": "claude-haiku-4-5",
  "finish_reason": "tool_calls",
  "tool_calls": [
    {
      "index": 0,
      "function": { "arguments": "{\"city\": \"Copenhagen\"}", "name": "get_weather" },
      "id": "tooluse_bBi2LpRSJZixywecGRb5MV",
      "type": "function"
    }
  ],
  "usage": { "completion_tokens": 54, "prompt_tokens": 564, "total_tokens": 618 }
}
```

The model selects `get_weather` with `{"city": "Copenhagen"}`, so `tools`/`tool_choice` reach Bedrock Converse. On the pre-fix code the same request drops both params before transformation, so no `toolConfig` is sent and the model cannot call the tool

### No regression for the common pattern (no `base_model`)

The same model registered the usual way, without `model_info.base_model`, which was never affected but is worth confirming stays correct

```yaml
model_list:
  - model_name: claude-haiku-4-5
    litellm_params:
      model: bedrock/eu.anthropic.claude-haiku-4-5-20251001-v1:0
      aws_region_name: eu-west-1

litellm_settings:
  drop_params: true
```

Same curl, response on this branch:

```json
{
  "model": "claude-haiku-4-5",
  "finish_reason": "tool_calls",
  "tool_calls": [
    {
      "index": 0,
      "function": { "arguments": "{\"city\": \"Copenhagen\"}", "name": "get_weather" },
      "id": "tooluse_OGbWS86RtufrlCBmBiZhC3",
      "type": "function"
    }
  ],
  "usage": { "completion_tokens": 54, "prompt_tokens": 564, "total_tokens": 618 }
}
```

## Type

Bug Fix

## Changes

`litellm/main.py`: in `completion()`, resolve `base_model` from the kwarg or `model_info`, and stop overwriting the `model` passed to `get_optional_params` with the `base_model` label so the real model reaches capability resolution

`litellm/litellm_core_utils/get_supported_openai_params.py`: make `base_model` additive for the provider-config path by returning the union of the params supported by `model` and by `base_model`, instead of letting `base_model` replace `model`

Tests: a `get_supported_openai_params` suite covering the union both directions (Bedrock label that would strip `tools`, gemini base_model that adds `reasoning_effort`, Azure detection preserved, no-base_model and base_model==model unchanged); a `get_optional_params` regression asserting `tools`/`tool_choice` survive `drop_params` with the label; and an update to `test_completion_optional_params_base_model` to assert per case that `model` stays the real deployment model while `base_model` is threaded through as the additive hint
