### PR TITLE
fix(bedrock): filter unsupported schema fields before Bedrock native structured-outputs API

### DIFF
--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -840,6 +840,7 @@ class AmazonConverseConfig(BaseConfig):
         }
         """
         if json_schema is not None:
+            json_schema = AnthropicConfig.filter_anthropic_output_schema(json_schema)
             json_schema = AmazonConverseConfig._add_additional_properties_to_schema(
                 json_schema
             )


### PR DESCRIPTION
## Summary

Closes #29168.

### Root cause

Bedrock's native structured-outputs API (the `outputConfig.textFormat.type=json_schema` path introduced for Claude 3.7+) rejects JSON schema properties that Anthropic Claude does not support:

- `minimum` / `maximum` (numeric constraints)
- `minItems` / `maxItems` (array constraints)
- `minLength` / `maxLength` (string constraints)
- `exclusiveMinimum` / `exclusiveMaximum`

The direct-Anthropic path already handles this via `AnthropicConfig.filter_anthropic_output_schema()`, which strips these fields and appends constraint notes to the `description`. However, `_create_output_config_for_response_format` in `converse_transformation.py` never called this function, so schemas containing these fields were forwarded to Bedrock verbatim and caused a 400 error:

```
output_config.format.schema: For 'number' type, properties maximum, minimum are not supported
```

This was a regression from v1.81.9, which used a synthetic-tool-call fallback for structured outputs. That path does not pass the schema to the native API, so it silently accepted the fields. After the Bedrock native structured-outputs path was introduced, the schema validation became strict.

### Fix

Call `AnthropicConfig.filter_anthropic_output_schema(json_schema)` inside `_create_output_config_for_response_format` before `_add_additional_properties_to_schema`. `AnthropicConfig` is already imported in `converse_transformation.py`.

### Example (before fix)

```python
response_format = {
    "type": "json_schema",
    "json_schema": {
        "name": "Score",
        "schema": {
            "type": "object",
            "properties": {
                "score": {
                    "type": "number",
                    "minimum": 0,
                    "maximum": 1
                }
            },
            "required": ["score"],
            "additionalProperties": False
        }
    }
}
# Before: raises BedrockException 400 for minimum/maximum
# After: minimum/maximum are stripped and noted in description; Bedrock succeeds
```
