### PR TITLE
fix(realtime): allow null transcripts in stream logging payloads

### DIFF
--- a/litellm/types/llms/openai.py
+++ b/litellm/types/llms/openai.py
@@ -1892,7 +1892,7 @@ class OpenAIRealtimeStreamResponseOutputItemContent(TypedDict, total=False):
     """The ID of the previous conversation item for reference"""
     text: str
     """The text content, used for 'input_text' / 'text' / 'output_text' content types"""
-    transcript: str
+    transcript: Optional[str]
     """The transcript content, used for 'input_audio' / 'audio' content types"""
     type: Literal[
         "input_audio",
@@ -1998,7 +1998,7 @@ class OpenAIRealtimeResponseContentPart(TypedDict, total=False):
     text: str
     """The text content, if type is 'text' or 'output_text'"""
 
-    transcript: str
+    transcript: Optional[str]
     """The transcript content, if type is 'audio' or 'output_audio'"""
 
     type: Union[

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel
 
 import litellm
 from litellm.cost_calculator import (
+    RealtimeAPITokenUsageProcessor,
     completion_cost,
     cost_per_token,
     handle_realtime_stream_cost_calculation,
@@ -383,6 +384,43 @@ def test_handle_realtime_stream_cost_calculation():
         litellm_model_name="gpt-3.5-turbo",
     )
     assert cost == 0.0  # No usage, no cost
+
+
+def test_realtime_logging_object_allows_null_transcript_in_conversation_item_added():
+    results: OpenAIRealtimeStreamList = [
+        {
+            "type": "conversation.item.added",
+            "event_id": "event_added",
+            "item": {
+                "id": "item_123",
+                "type": "message",
+                "role": "assistant",
+                "status": "in_progress",
+                "content": [{"type": "audio", "transcript": None}],
+            },
+        },
+        {
+            "type": "response.done",
+            "event_id": "event_done",
+            "response": {
+                "id": "resp_123",
+                "object": "realtime.response",
+                "status": "completed",
+                "usage": {"input_tokens": 11, "output_tokens": 7, "total_tokens": 18},
+            },
+        },
+    ]
+
+    usage = RealtimeAPITokenUsageProcessor.collect_and_combine_usage_from_realtime_stream_results(
+        results=results
+    )
+    logging_result = RealtimeAPITokenUsageProcessor.create_logging_realtime_object(
+        usage=usage,
+        results=results,
+    )
+
+    assert logging_result.usage.total_tokens == 18
+    assert logging_result.results[0]["item"]["content"][0]["transcript"] is None
 
 
 def test_custom_pricing_with_router_model_id():


### PR DESCRIPTION
## Relevant issues

Fixes realtime logging validation failures where `conversation.item.added` / `conversation.item.done` can include `content[].transcript = null`, causing `LiteLLMRealtimeStreamLoggingObject` creation to fail and preventing success callbacks from firing.

Resolves LIT-3555

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes targeted unit tests on `make test-unit` equivalent scope (`poetry run pytest tests/test_litellm/test_cost_calculator.py -k "realtime_logging_object_allows_null_transcript_in_conversation_item_added or handle_realtime_stream_cost_calculation" -v`)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Steps to Reproduce

1. Start fake upstream that emits `conversation.item.added` and `conversation.item.done` with `item.content[0].transcript = null`.
2. Start LiteLLM proxy with realtime logging enabled for all default GA realtime event types.
3. Connect to `/v1/realtime?model=fake-realtime-mini` and send `response.create`.
4. Observe proxy logs:
   - before fix: `Task exception was never retrieved` + `[Non-Blocking] LiteLLM.Success_Call Error` + `ValidationError` for `LiteLLMRealtimeStreamLoggingObject` (includes `item.content.0.transcript` string-type failure).
   - after fix: no validation exception in logging path for the same event sequence.

## Screenshots / Proof of Fix

**Before — validation error path triggered (`transcript: null` fails type checks):**

<img width="980" height="700" alt="before" src="https://github.com/user-attachments/assets/57f2e3de-c5e2-4c0f-a220-a9d05b31331a" />

**After — same flow succeeds without logging validation error:**

<img width="980" height="480" alt="after" src="https://github.com/user-attachments/assets/65993916-dab9-4f41-899f-dcbe79b4fece" />

## Type

🐛 Bug Fix

## Changes

- Update realtime OpenAI typed payloads to allow nullable transcript fields:
  - `OpenAIRealtimeStreamResponseOutputItemContent.transcript: Optional[str]`
  - `OpenAIRealtimeResponseContentPart.transcript: Optional[str]`
- Add regression coverage:
  - `test_realtime_logging_object_allows_null_transcript_in_conversation_item_added`
  - validates `RealtimeAPITokenUsageProcessor.create_logging_realtime_object()` accepts `transcript=None` and still produces usage.

## Why this fixes the customer issue

`normalize_logging_result()` for realtime converts collected events into `LiteLLMRealtimeStreamLoggingObject`. With strict `transcript: str`, GA realtime events containing `transcript: null` raise Pydantic validation errors and short-circuit success callback handling. Making transcript nullable aligns schema with observed provider payloads and removes this failure path while preserving existing event parsing behavior.
