### PR TITLE
fix(helm): mount gateway config.yaml on backend Deployment

### DIFF
--- a/helm/litellm/templates/backend/deployment.yaml
+++ b/helm/litellm/templates/backend/deployment.yaml
@@ -12,6 +12,7 @@ spec:
       {{- include "litellm.backend.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      {{- if or .Values.gateway.config.create .Values.backend.podAnnotations }}
       annotations:
         {{- if .Values.gateway.config.create }}
         checksum/config: {{ include (print $.Template.BasePath "/gateway/configmap.yaml") . | sha256sum }}
@@ -19,6 +20,7 @@ spec:
         {{- with .Values.backend.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- end }}
       labels:
         {{- include "litellm.backend.selectorLabels" . | nindent 8 }}
     spec:

--- a/helm/litellm/templates/backend/deployment.yaml
+++ b/helm/litellm/templates/backend/deployment.yaml
@@ -12,10 +12,13 @@ spec:
       {{- include "litellm.backend.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.backend.podAnnotations }}
       annotations:
+        {{- if .Values.gateway.config.create }}
+        checksum/config: {{ include (print $.Template.BasePath "/gateway/configmap.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.backend.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "litellm.backend.selectorLabels" . | nindent 8 }}
     spec:
@@ -35,7 +38,17 @@ spec:
               protocol: TCP
           env:
             {{- include "litellm.serverEnv" (dict "root" $ "component" .Values.backend) | nindent 12 }}
+            {{- if .Values.gateway.config.create }}
+            - name: CONFIG_FILE_PATH
+              value: /app/config/config.yaml
+            {{- end }}
           {{- include "litellm.envFrom" .Values.backend | nindent 10 }}
+          {{- if .Values.gateway.config.create }}
+          volumeMounts:
+            - name: gateway-config
+              mountPath: /app/config/config.yaml
+              subPath: config.yaml
+          {{- end }}
           {{- with .Values.backend.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}
@@ -46,6 +59,12 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.backend.resources | nindent 12 }}
+      {{- if .Values.gateway.config.create }}
+      volumes:
+        - name: gateway-config
+          configMap:
+            name: {{ include "litellm.gateway.fullname" . }}-config
+      {{- end }}
       {{- with .Values.backend.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
## Summary

- The componentized chart's `backend` Deployment never mounted `{fullname}-gateway-config` or set `CONFIG_FILE_PATH`, so anything declared in `gateway.config.proxy_config.litellm_settings` (callbacks, cache, guardrails, ...) only loaded on the gateway process — even though the backend runs the same proxy code and needs the same callbacks to fire for management-API and proxy-level OTel spans.
- Reuse the existing `gateway.config.create` toggle and the existing ConfigMap: when true, the backend now also gets `CONFIG_FILE_PATH=/app/config/config.yaml`, the `gateway-config` volume + volumeMount, and a `checksum/config` pod annotation so ConfigMap edits roll backend pods alongside gateway pods.
- No `values.yaml` change. No new toggle. When `gateway.config.create=false`, the backend Deployment is byte-identical to before.

## Why reuse the gateway ConfigMap?

The litellm proxy reads a single `config.yaml`; splitting per-component would let the two drift and break shared settings (callbacks, cache, guardrails) on whichever side forgets to set them. Reusing keeps a single source of truth and matches runtime reality.

## Test plan

- [x] `helm template` with `gateway.config.create=true` shows the backend Deployment now contains `CONFIG_FILE_PATH`, the `gateway-config` volumeMount + volume, and a `checksum/config` annotation pointing at `{release}-litellm-gateway-config`.
- [x] `helm template` with `gateway.config.create=false` produces a backend Deployment with no `CONFIG_FILE_PATH`, no `volumeMounts`, no `volumes`, and no `checksum/config` annotation (identical to `main`).
- [ ] Deploy to a cluster, edit `litellm-gateway-config` to add a callback, confirm backend pods roll and the new callback is registered in backend logs.