### PR TITLE
fix(key_generate): scope session-token team-key budget exemption to caller-supplied team_id

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -691,10 +691,12 @@ async def _common_key_generation_helper(  # noqa: PLR0915
             prisma_client=prisma_client,
         )
 
-    # Capture the caller-supplied max_budget before any defaults or upperbound
-    # params can fill it, so the ceiling check only fires when the caller
-    # explicitly requested a budget.
+    # Capture caller-supplied max_budget and team_id before any defaults or
+    # upperbound params can fill them, so the ceiling check and its team-key
+    # exemption key off what the caller explicitly requested, not a value that
+    # default_key_generate_params injected.
     _requested_max_budget = data.max_budget
+    _requested_team_id = data.team_id
 
     # check if user set default key/generate params on config.yaml
     if litellm.default_key_generate_params is not None:
@@ -728,7 +730,7 @@ async def _common_key_generation_helper(  # noqa: PLR0915
     # at request time. Personal keys keep the ceiling; nothing else bounds them.
     is_ui_session_team_key = (
         user_api_key_dict.team_id == UI_SESSION_TOKEN_TEAM_ID
-        and data.team_id is not None
+        and _requested_team_id is not None
     )
     if (
         user_api_key_dict.user_role != LitellmUserRoles.PROXY_ADMIN.value

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -11623,3 +11623,48 @@ async def test_ghsa_q775_ui_session_token_personal_key_still_capped():
         msg = str(getattr(err, "detail", "")) + str(getattr(err, "message", ""))
         assert str(code) == "400"
         assert "cannot exceed" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_ghsa_q775_default_team_id_does_not_grant_session_token_exemption():
+    """
+    Security regression for GHSA-q775: the team-key exemption must key off the
+    team_id the CALLER supplied, not one injected by default_key_generate_params.
+    With default_key_generate_params.team_id set, a UI session token's personal-key
+    request (no team_id) would otherwise have team_id auto-filled before the ceiling
+    check, flipping is_ui_session_team_key to True and bypassing the ceiling. The
+    request must still be rejected. Mirrors how _requested_max_budget is captured
+    before defaults run.
+    """
+    from litellm.constants import UI_SESSION_TOKEN_TEAM_ID
+
+    data = GenerateKeyRequest(max_budget=500)
+    assert data.team_id is None
+    user_api_key_dict = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        api_key="sk-ui-session",
+        user_id="user-1",
+        team_id=UI_SESSION_TOKEN_TEAM_ID,
+        max_budget=0.25,
+    )
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", AsyncMock()),
+        patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
+        patch("litellm.proxy.proxy_server.llm_router", None),
+        patch("litellm.proxy.proxy_server.premium_user", False),
+        patch("litellm.proxy.proxy_server.litellm_proxy_admin_name", "default_user_id"),
+        patch("litellm.default_key_generate_params", {"team_id": "injected-team"}),
+    ):
+        with pytest.raises((HTTPException, ProxyException)) as exc_info:
+            await _common_key_generation_helper(
+                data=data,
+                user_api_key_dict=user_api_key_dict,
+                litellm_changed_by=None,
+                team_table=None,
+            )
+        err = exc_info.value
+        code = getattr(err, "status_code", None) or getattr(err, "code", None)
+        msg = str(getattr(err, "detail", "")) + str(getattr(err, "message", ""))
+        assert str(code) == "400"
+        assert "cannot exceed" in msg.lower()


### PR DESCRIPTION
## Relevant issues

Follow-up to #29612 (merged). That PR exempted UI/CLI session tokens from the key budget ceiling when creating a team key; this tightens how that exemption is decided.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

`_common_key_generation_helper` skips the budget ceiling for a UI/CLI session token only when it is creating a team key. That decision read `data.team_id`, which is populated a few lines earlier by the `default_key_generate_params` loop. So on a proxy configured with `default_key_generate_params.team_id`, a request the caller did not scope to a team gets a `team_id` filled in and is treated as a team key, skipping the ceiling. The fix captures `_requested_team_id` before the defaults loop runs, next to the existing `_requested_max_budget`, and keys the exemption off that.

Reproduced against a local proxy whose config sets `default_key_generate_params.team_id` to a team the session user is not a member of:

```
litellm_settings:
  default_key_generate_params:
    team_id: "<team-the-session-user-is-not-in>"
```

A) A UI session token (the $0.25 `max_ui_session_budget` chat cap) creating a personal key (no `team_id`) with a $999 budget. On `litellm_internal_staging` today this returns `200` and mints the key under the default team; with this change it is rejected.

```
$ curl -s -X POST localhost:4000/key/generate -H "Authorization: Bearer $UI_SESSION_KEY" \
    -H 'Content-Type: application/json' -d '{"max_budget":999}'
HTTP 400
{'error': "max_budget (999.0) cannot exceed the caller's own max_budget (0.25)."}
```

B) The same session token creating a team key it administers still works.

```
$ curl -s -X POST localhost:4000/key/generate -H "Authorization: Bearer $UI_SESSION_KEY" \
    -H 'Content-Type: application/json' -d "{\"team_id\":\"$TEAM\",\"max_budget\":999}"
HTTP 200
created team key: team_id=a4de10b9-... max_budget=999.0
```

C) A normal non-session non-admin key still cannot set a budget above its own.

```
$ curl -s -X POST localhost:4000/key/generate -H "Authorization: Bearer $PLAIN_KEY" \
    -H 'Content-Type: application/json' -d '{"max_budget":999}'
HTTP 400
{'error': "max_budget (999.0) cannot exceed the caller's own max_budget (0.25)."}
```

Adjacent flows confirmed unchanged on the fixed build: session token + within-cap personal key -> 200, session token + no-budget key -> 200, non-session within its own budget -> 200, session token creating a key for a team it is not a member of -> 400 (membership error, not budget), proxy admin any budget -> 200.

## Type

🐛 Bug Fix

## Changes

`_common_key_generation_helper` captured `_requested_max_budget` before `default_key_generate_params` and `_enforce_upperbound_key_params` could mutate the request, but the team-key exemption added in #29612 read `data.team_id` after those mutations. On a deployment that configures `default_key_generate_params.team_id`, a request with no caller-supplied `team_id` has one auto-filled, so the exemption treats it as a team key and skips the ceiling that bounds personal keys.

This change captures `_requested_team_id = data.team_id` alongside `_requested_max_budget`, before the defaults loop, and the exemption now keys off `_requested_team_id`. The exemption fires only for keys the caller explicitly scoped to a team; anything else keeps the ceiling.

A regression test, `test_ghsa_q775_default_team_id_does_not_grant_session_token_exemption`, sets `default_key_generate_params={"team_id": ...}`, drives the helper with a session token and no caller-supplied `team_id`, and asserts the request is still rejected. It fails if the exemption is keyed off `data.team_id` again.
