### PR TITLE
chore: restore stable/1.86.x to 1.86.4 (revert premature 1.86.5 bump)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "litellm"
-version = "1.86.5"
+version = "1.86.4"
 description = "Library to easily interface with LLM API providers"
 readme = "README.md"
 requires-python = ">=3.10, <3.14"
@@ -251,7 +251,7 @@ source-exclude = [
 profile = "black"
 
 [tool.commitizen]
-version = "1.86.5"
+version = "1.86.4"
 version_files = [
     "pyproject.toml:^version",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -3189,7 +3189,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.86.5"
+version = "1.86.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## What

stable/1.86.x should sit exactly one patch above the latest GitHub release for the line. The latest 1.86.x release is v1.86.3, so the patch-to-be is 1.86.4. The GHSA-q775 backport #29635 additionally bumped 1.86.4 -> 1.86.5, cutting a version ahead of release. This reverts just that version bump and its uv.lock refresh so the line tracks 1.86.4 again; the backported fix (#29612) and the session-token hardening stay in place.

## Type

Infrastructure

## Changes

pyproject.toml and uv.lock restored to 1.86.4; no code changes