### PR TITLE
chore: restore stable/1.87.x to 1.87.1 (revert premature 1.87.2 bump)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "litellm"
-version = "1.87.2"
+version = "1.87.1"
 description = "Library to easily interface with LLM API providers"
 readme = "README.md"
 requires-python = ">=3.10, <3.14"
@@ -253,7 +253,7 @@ source-exclude = [
 profile = "black"
 
 [tool.commitizen]
-version = "1.87.2"
+version = "1.87.1"
 version_files = [
     "pyproject.toml:^version",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -3269,7 +3269,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.87.2"
+version = "1.87.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## What

stable/1.87.x should sit exactly one patch above the latest GitHub release for the line. The latest 1.87.x release is v1.87.0, so the patch-to-be is 1.87.1. The GHSA-q775 backport #29636 additionally bumped 1.87.1 -> 1.87.2, cutting a version ahead of release. This reverts just that version bump and its uv.lock refresh so the line tracks 1.87.1 again; the backported fix (#29612) and the session-token hardening stay in place.

## Type

Infrastructure

## Changes

pyproject.toml and uv.lock restored to 1.87.1; no code changes