### PR TITLE
feat(openmeter): add OPENMETER_TRUST_REQUEST_USER to prevent forged attribution

### DIFF
--- a/litellm/integrations/openmeter.py
+++ b/litellm/integrations/openmeter.py
@@ -65,7 +65,15 @@ class OpenMeterLogger(CustomLogger):
                 "total_tokens": response_obj["usage"].get("total_tokens"),
             }
 
-        user_param = kwargs.get("user", None)  # end-user passed in via 'user' param
+        # OPENMETER_TRUST_REQUEST_USER (default "true"): when set to "false",
+        # the request-supplied `user` field is ignored and the subject is
+        # resolved solely from the key-bound user_api_key_user_id. Proxies
+        # serving multi-tenant traffic enable this to prevent clients from
+        # forging attribution by setting `user` in the request body.
+        trust_request_user = (
+            os.getenv("OPENMETER_TRUST_REQUEST_USER", "true").lower() != "false"
+        )
+        user_param = kwargs.get("user", None) if trust_request_user else None
 
         # If no user provided directly, try to get it from token user_id
         if user_param is None:

--- a/tests/test_litellm/integrations/test_openmeter.py
+++ b/tests/test_litellm/integrations/test_openmeter.py
@@ -23,6 +23,7 @@ class TestOpenMeterIntegration:
         os.environ.pop("OPENMETER_API_KEY", None)
         os.environ.pop("OPENMETER_API_ENDPOINT", None)
         os.environ.pop("OPENMETER_EVENT_TYPE", None)
+        os.environ.pop("OPENMETER_TRUST_REQUEST_USER", None)
 
     def test_openmeter_logger_initialization(self):
         """Test that OpenMeterLogger initializes correctly with required env vars"""
@@ -387,6 +388,75 @@ class TestOpenMeterIntegration:
         # Verify integer user_id is converted to string
         assert isinstance(result["subject"], str)
         assert result["subject"] == "12345"
+
+    def test_common_logic_trust_request_user_false_ignores_request_user(self):
+        """OPENMETER_TRUST_REQUEST_USER=false makes the key-bound user_id win
+        over a request-supplied `user` (forge-attribution mitigation)."""
+        os.environ["OPENMETER_TRUST_REQUEST_USER"] = "false"
+        logger = OpenMeterLogger()
+
+        kwargs = {
+            "user": "forged-by-client",
+            "model": "gpt-4",
+            "response_cost": 0.002,
+            "litellm_call_id": "test-call-id",
+            "litellm_params": {
+                "metadata": {"user_api_key_user_id": "real-tenant-id"}
+            },
+        }
+
+        response_obj = {
+            "id": "test-response-id",
+            "usage": {"prompt_tokens": 20, "completion_tokens": 10, "total_tokens": 30},
+        }
+
+        result = logger._common_logic(kwargs, response_obj)
+
+        assert result["subject"] == "real-tenant-id"
+        assert result["subject"] != "forged-by-client"
+
+    def test_common_logic_trust_request_user_false_still_raises_without_key_user(self):
+        """OPENMETER_TRUST_REQUEST_USER=false still raises when no
+        user_api_key_user_id is available — the request `user` is not a
+        fallback in this mode."""
+        os.environ["OPENMETER_TRUST_REQUEST_USER"] = "false"
+        logger = OpenMeterLogger()
+
+        kwargs = {
+            "user": "would-have-worked-without-the-flag",
+            "model": "gpt-3.5-turbo",
+            "response_cost": 0.001,
+            "litellm_call_id": "test-call-id",
+        }
+
+        response_obj = {"id": "test-response-id"}
+
+        with pytest.raises(Exception, match="OpenMeter: user is required"):
+            logger._common_logic(kwargs, response_obj)
+
+    def test_common_logic_trust_request_user_default_preserves_behavior(self):
+        """Default (unset OPENMETER_TRUST_REQUEST_USER) keeps request `user`
+        taking priority — backward compatibility."""
+        # OPENMETER_TRUST_REQUEST_USER intentionally unset
+        logger = OpenMeterLogger()
+
+        kwargs = {
+            "user": "request-user",
+            "model": "gpt-4",
+            "response_cost": 0.002,
+            "litellm_call_id": "test-call-id",
+            "litellm_params": {
+                "metadata": {"user_api_key_user_id": "key-user"}
+            },
+        }
+
+        response_obj = {
+            "id": "test-response-id",
+            "usage": {"prompt_tokens": 20, "completion_tokens": 10, "total_tokens": 30},
+        }
+
+        result = logger._common_logic(kwargs, response_obj)
+        assert result["subject"] == "request-user"
 
     @patch("litellm.integrations.openmeter.HTTPHandler")
     def test_integration_token_user_id_scenario(self, mock_http_handler):


### PR DESCRIPTION
## Summary

The OpenMeter callback resolves the CloudEvent `subject` from `kwargs["user"]` first, then falls back to the key-bound `user_api_key_user_id`. For multi-tenant proxy deployments, a client can set `"user": "..."` anywhere in the request body and cause their usage to be attributed to that arbitrary string — a billing-attribution forgery risk.

This PR adds a new env var **`OPENMETER_TRUST_REQUEST_USER`** (default `"true"`, backward compatible). When set to `"false"`, the request-supplied `user` field is ignored and the OpenMeter `subject` is resolved solely from `user_api_key_user_id`.

## Motivation

Today, the only mitigation is for the proxy operator to ship a custom `pre_call_hook` that pops `user` from the request data before any callback runs (e.g. `data.pop("user", None)`). That works but is invasive — it removes the field for **all** callbacks, including ones that legitimately want the end-user value (e.g. Langfuse `trace_user_id`). An env var scoped to the OpenMeter callback keeps the mitigation localized.

## Behavior

| `OPENMETER_TRUST_REQUEST_USER` | `kwargs["user"]` set | `user_api_key_user_id` set | OpenMeter `subject` |
|---|---|---|---|
| unset / `true` (default) | yes | yes | `kwargs["user"]` (unchanged) |
| unset / `true` (default) | no | yes | `user_api_key_user_id` (unchanged) |
| `false` | yes | yes | `user_api_key_user_id` ✅ new |
| `false` | yes | no | raises `OpenMeter: user is required` ✅ new |
| `false` | no | yes | `user_api_key_user_id` |

## Tests

Added three new tests in `tests/test_litellm/integrations/test_openmeter.py`:

- `test_common_logic_trust_request_user_false_ignores_request_user` — verifies the key-bound user_id wins when the flag is `false`.
- `test_common_logic_trust_request_user_false_still_raises_without_key_user` — verifies the request `user` is not a fallback in this mode.
- `test_common_logic_trust_request_user_default_preserves_behavior` — explicit backward-compat check.

All 21 tests in the file pass locally.

## Notes

- Matches the existing env-var-driven config pattern in `openmeter.py` (`OPENMETER_API_KEY`, `OPENMETER_API_ENDPOINT`, `OPENMETER_EVENT_TYPE`). No new config schema, no type definitions to update.
- Default behavior is unchanged, so existing deployments are unaffected.