### PR TITLE
fix(proxy): merge model-level guardrails before pre_call_hook

### DIFF
--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -1182,8 +1182,15 @@ class ProxyBaseLLMRequestProcessing:
             _check_and_merge_model_level_guardrails,
         )
 
+        # trust_client_model_info=False on pre_call: route_request hasn't run
+        # and add_litellm_data_to_request preserves client-supplied
+        # model_info when allow_client_pricing_override is set, so a caller
+        # could otherwise spoof an unguarded model_info.id while requesting
+        # a guarded alias and bypass guardrails (veria-ai HIGH on #29654).
         self.data = _check_and_merge_model_level_guardrails(
-            data=self.data, llm_router=llm_router
+            data=self.data,
+            llm_router=llm_router,
+            trust_client_model_info=False,
         )
 
         self.data = await proxy_logging_obj.pre_call_hook(  # type: ignore

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -961,7 +961,7 @@ class ProxyBaseLLMRequestProcessing:
 
         return custom_headers
 
-    async def common_processing_pre_call_logic(  # noqa: PLR0915
+    async def common_processing_pre_call_logic(
         self,
         request: Request,
         general_settings: dict,

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -961,7 +961,7 @@ class ProxyBaseLLMRequestProcessing:
 
         return custom_headers
 
-    async def common_processing_pre_call_logic(
+    async def common_processing_pre_call_logic(  # noqa: PLR0915
         self,
         request: Request,
         general_settings: dict,
@@ -1169,6 +1169,22 @@ class ProxyBaseLLMRequestProcessing:
         )
 
         self.data["litellm_logging_obj"] = logging_obj
+
+        # Merge model-level guardrails before pre_call_hook so DB/UI-configured
+        # guardrails actually execute on pre_call. Without this, guardrails set
+        # via litellm_params.guardrails are only honored on post_call paths
+        # (#29652, partial fix in #23774 covered non-streaming post_call only).
+        # Inline import is intentional: litellm.proxy.utils imports
+        # common_request_processing at module load (cyclic) and the helper is
+        # defined later in utils.py; module-level import here would risk a
+        # NameError on the import-order CodeQL flagged.
+        from litellm.proxy.utils import (  # noqa: PLC0415
+            _check_and_merge_model_level_guardrails,
+        )
+
+        self.data = _check_and_merge_model_level_guardrails(
+            data=self.data, llm_router=llm_router
+        )
 
         self.data = await proxy_logging_obj.pre_call_hook(  # type: ignore
             user_api_key_dict=user_api_key_dict,

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -50,7 +50,7 @@ from litellm.proxy.common_utils.callback_utils import (
 )
 from litellm.proxy.dd_span_tagger import DDSpanTagger
 from litellm.proxy.route_llm_request import route_request
-from litellm.proxy.utils import ProxyLogging
+from litellm.proxy.utils import ProxyLogging, _check_and_merge_model_level_guardrails
 from litellm.router import Router
 from litellm.router_utils.add_retry_fallback_headers import get_hidden_params_dict
 from litellm.types.guardrails import GuardrailEventHooks
@@ -1174,14 +1174,6 @@ class ProxyBaseLLMRequestProcessing:
         # guardrails actually execute on pre_call. Without this, guardrails set
         # via litellm_params.guardrails are only honored on post_call paths
         # (#29652, partial fix in #23774 covered non-streaming post_call only).
-        # Inline import is intentional: litellm.proxy.utils imports
-        # common_request_processing at module load (cyclic) and the helper is
-        # defined later in utils.py; module-level import here would risk a
-        # NameError on the import-order CodeQL flagged.
-        from litellm.proxy.utils import (  # noqa: PLC0415
-            _check_and_merge_model_level_guardrails,
-        )
-
         # trust_client_model_info=False on pre_call: route_request hasn't run
         # and add_litellm_data_to_request preserves client-supplied
         # model_info when allow_client_pricing_override is set, so a caller

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -5691,9 +5691,7 @@ def _check_and_merge_model_level_guardrails(
     # server-populated team id; pre_call lookup must do the same so
     # team-scoped guardrails are not silently skipped (greptile/veria-ai
     # Medium on #29654).
-    team_id = metadata.get("user_api_key_team_id") or litellm_metadata.get(
-        "user_api_key_team_id"
-    )
+    team_id = metadata.get("user_api_key_team_id") or litellm_metadata.get("user_api_key_team_id")
 
     model_level_guardrails: Optional[list] = None
     if model_id is not None:
@@ -5720,9 +5718,7 @@ def _check_and_merge_model_level_guardrails(
         # Pass team_id so team-scoped public model names resolve the same way
         # route_request resolves them; otherwise team-scoped deployments are
         # invisible to this lookup and their guardrails are silently dropped.
-        deployments = (
-            llm_router.get_model_list(model_name=model_alias, team_id=team_id) or []
-        )
+        deployments = llm_router.get_model_list(model_name=model_alias, team_id=team_id) or []
         seen: set = set()
         union: list = []
         for dep in deployments:

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -5676,25 +5676,35 @@ def _check_and_merge_model_level_guardrails(data: dict, llm_router: Optional[Rou
     model_info = metadata.get("model_info") or {}
     model_id = model_info.get("id", None)
 
-    deployment = None
+    model_level_guardrails: Optional[list] = None
     if model_id is not None:
         deployment = llm_router.get_deployment(model_id=model_id)
+        if deployment is None:
+            return data
+        model_level_guardrails = deployment.litellm_params.get("guardrails")
     else:
         # Pre_call paths run before route_request populates model_info.id,
         # and add_litellm_data_to_request strips any client-supplied
-        # metadata.model_info as a pricing-spoofing guard. Fall back to
-        # resolving the deployment via the model alias so DB/UI-assigned
-        # model-level guardrails fire on pre_call too (#29652).
+        # metadata.model_info as a pricing-spoofing guard. The router has
+        # not yet picked the deployment, so we don't know which one's
+        # litellm_params.guardrails will apply. Take the UNION across all
+        # deployments in the group so a guardrail set on ANY eligible
+        # deployment still fires (#29652, addresses veria-ai HIGH on the
+        # single-deployment fallback that would skip non-first deployments).
         model_alias = data.get("model")
-        if isinstance(model_alias, str) and model_alias:
-            deployment = llm_router.get_deployment_by_model_group_name(
-                model_group_name=model_alias
-            )
-
-    if deployment is None:
-        return data
-
-    model_level_guardrails = deployment.litellm_params.get("guardrails")
+        if not isinstance(model_alias, str) or not model_alias:
+            return data
+        deployments = llm_router.get_model_list(model_name=model_alias) or []
+        seen: set = set()
+        union: list = []
+        for dep in deployments:
+            litellm_params = dep.get("litellm_params") or {}
+            for g in litellm_params.get("guardrails") or []:
+                key = g if isinstance(g, str) else repr(g)
+                if key not in seen:
+                    seen.add(key)
+                    union.append(g)
+        model_level_guardrails = union or None
 
     if model_level_guardrails is None:
         return data

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -658,7 +658,6 @@ class ProxyLogging:
             "user_api_key_request_route": kwargs.get("user_api_key_request_route"),
             "mcp_tool_name": request_obj.tool_name,  # Keep original for reference
             "mcp_arguments": request_obj.arguments,  # Keep original for reference
-            "mcp_server_name": kwargs.get("mcp_rate_limit_server_name"),
             # Raw Bearer token from the original HTTP request — allows guardrails
             # (e.g. MCPJWTSigner) to independently verify the caller's identity
             # before re-signing an outbound token (FR-5 verify+re-sign).
@@ -5672,11 +5671,21 @@ def _check_and_merge_model_level_guardrails(data: dict, llm_router: Optional[Rou
     model_info = metadata.get("model_info") or {}
     model_id = model_info.get("id", None)
 
-    if model_id is None:
-        return data
+    deployment = None
+    if model_id is not None:
+        deployment = llm_router.get_deployment(model_id=model_id)
+    else:
+        # Pre_call paths run before route_request populates model_info.id,
+        # and add_litellm_data_to_request strips any client-supplied
+        # metadata.model_info as a pricing-spoofing guard. Fall back to
+        # resolving the deployment via the model alias so DB/UI-assigned
+        # model-level guardrails fire on pre_call too (#29652).
+        model_alias = data.get("model")
+        if isinstance(model_alias, str) and model_alias:
+            deployment = llm_router.get_deployment_by_model_group_name(
+                model_group_name=model_alias
+            )
 
-    # Check if the model has guardrails
-    deployment = llm_router.get_deployment(model_id=model_id)
     if deployment is None:
         return data
 

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -5684,8 +5684,17 @@ def _check_and_merge_model_level_guardrails(
         return data
 
     metadata = data.get("metadata") or {}
+    litellm_metadata = data.get("litellm_metadata") or {}
     model_info = metadata.get("model_info") or {}
     model_id = model_info.get("id") if trust_client_model_info else None
+    # route_request resolves team-scoped public model names with the
+    # server-populated team id; pre_call lookup must do the same so
+    # team-scoped guardrails are not silently skipped (greptile/veria-ai
+    # Medium on #29654).
+    team_id = (
+        metadata.get("user_api_key_team_id")
+        or litellm_metadata.get("user_api_key_team_id")
+    )
 
     model_level_guardrails: Optional[list] = None
     if model_id is not None:
@@ -5693,8 +5702,12 @@ def _check_and_merge_model_level_guardrails(
         if deployment is None:
             return data
         deployment_guardrails = deployment.litellm_params.get("guardrails")
+        # Bare-string guardrail names were truthy-accepted before; preserve
+        # that contract so post_call callers don't silently lose them.
         if isinstance(deployment_guardrails, list):
             model_level_guardrails = deployment_guardrails
+        elif deployment_guardrails:
+            model_level_guardrails = [deployment_guardrails]
     else:
         # Pre_call paths run before route_request picks a deployment, so we
         # don't know which deployment's litellm_params.guardrails will apply.
@@ -5705,13 +5718,20 @@ def _check_and_merge_model_level_guardrails(
         model_alias = data.get("model")
         if not isinstance(model_alias, str) or not model_alias:
             return data
-        deployments = llm_router.get_model_list(model_name=model_alias) or []
+        # Pass team_id so team-scoped public model names resolve the same way
+        # route_request resolves them; otherwise team-scoped deployments are
+        # invisible to this lookup and their guardrails are silently dropped.
+        deployments = (
+            llm_router.get_model_list(model_name=model_alias, team_id=team_id) or []
+        )
         seen: set = set()
         union: list = []
         for dep in deployments:
-            litellm_params = dep.get("litellm_params") or {}
-            guardrails = litellm_params.get("guardrails")
-            if not isinstance(guardrails, list):
+            litellm_params_dep = dep.get("litellm_params") or {}
+            guardrails = litellm_params_dep.get("guardrails")
+            if isinstance(guardrails, str):
+                guardrails = [guardrails]
+            elif not isinstance(guardrails, list):
                 continue
             for g in guardrails:
                 key = g if isinstance(g, str) else repr(g)

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -658,6 +658,11 @@ class ProxyLogging:
             "user_api_key_request_route": kwargs.get("user_api_key_request_route"),
             "mcp_tool_name": request_obj.tool_name,  # Keep original for reference
             "mcp_arguments": request_obj.arguments,  # Keep original for reference
+            # Surface the per-MCP-server rate-limit identity so the
+            # ParallelRequestLimiterV3 hook can apply mcp_rpm_limit on the
+            # synthetic call_mcp_tool payload (otherwise a key with
+            # mcp_rpm_limit could exceed it via the MCP path).
+            "mcp_server_name": kwargs.get("mcp_rate_limit_server_name"),
             # Raw Bearer token from the original HTTP request — allows guardrails
             # (e.g. MCPJWTSigner) to independently verify the caller's identity
             # before re-signing an outbound token (FR-5 verify+re-sign).

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -5691,9 +5691,8 @@ def _check_and_merge_model_level_guardrails(
     # server-populated team id; pre_call lookup must do the same so
     # team-scoped guardrails are not silently skipped (greptile/veria-ai
     # Medium on #29654).
-    team_id = (
-        metadata.get("user_api_key_team_id")
-        or litellm_metadata.get("user_api_key_team_id")
+    team_id = metadata.get("user_api_key_team_id") or litellm_metadata.get(
+        "user_api_key_team_id"
     )
 
     model_level_guardrails: Optional[list] = None

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -5657,13 +5657,25 @@ def _to_ns(dt):
     return int(dt.timestamp() * 1e9)
 
 
-def _check_and_merge_model_level_guardrails(data: dict, llm_router: Optional[Router]) -> dict:
+def _check_and_merge_model_level_guardrails(
+    data: dict,
+    llm_router: Optional[Router],
+    trust_client_model_info: bool = True,
+) -> dict:
     """
     Check if the model has guardrails defined and merge them with existing guardrails in the request data.
 
     Args:
         data: The request data dict
         llm_router: The LLM router instance to get deployment info from
+        trust_client_model_info: If False, ignore metadata.model_info.id and
+            resolve guardrails by alias-union only. Set to False on the
+            pre_call path because add_litellm_data_to_request preserves
+            client-supplied model_info when allow_client_pricing_override is
+            set, so a caller could spoof an unguarded model_info.id while
+            requesting a guarded alias and bypass guardrails (veria-ai HIGH
+            on #29654). Defaults to True for post_call paths where the
+            router has populated model_info.id itself.
 
     Returns:
         Modified data dict with merged guardrails (if any model-level guardrails exist)
@@ -5671,26 +5683,25 @@ def _check_and_merge_model_level_guardrails(data: dict, llm_router: Optional[Rou
     if llm_router is None:
         return data
 
-    # Get the model ID from the data
     metadata = data.get("metadata") or {}
     model_info = metadata.get("model_info") or {}
-    model_id = model_info.get("id", None)
+    model_id = model_info.get("id") if trust_client_model_info else None
 
     model_level_guardrails: Optional[list] = None
     if model_id is not None:
         deployment = llm_router.get_deployment(model_id=model_id)
         if deployment is None:
             return data
-        model_level_guardrails = deployment.litellm_params.get("guardrails")
+        deployment_guardrails = deployment.litellm_params.get("guardrails")
+        if isinstance(deployment_guardrails, list):
+            model_level_guardrails = deployment_guardrails
     else:
-        # Pre_call paths run before route_request populates model_info.id,
-        # and add_litellm_data_to_request strips any client-supplied
-        # metadata.model_info as a pricing-spoofing guard. The router has
-        # not yet picked the deployment, so we don't know which one's
-        # litellm_params.guardrails will apply. Take the UNION across all
-        # deployments in the group so a guardrail set on ANY eligible
-        # deployment still fires (#29652, addresses veria-ai HIGH on the
-        # single-deployment fallback that would skip non-first deployments).
+        # Pre_call paths run before route_request picks a deployment, so we
+        # don't know which deployment's litellm_params.guardrails will apply.
+        # Take the UNION across all deployments in the group so a guardrail
+        # set on ANY eligible deployment still fires (#29652; addresses
+        # veria-ai HIGH on the single-deployment fallback that would skip
+        # non-first deployments).
         model_alias = data.get("model")
         if not isinstance(model_alias, str) or not model_alias:
             return data
@@ -5699,7 +5710,10 @@ def _check_and_merge_model_level_guardrails(data: dict, llm_router: Optional[Rou
         union: list = []
         for dep in deployments:
             litellm_params = dep.get("litellm_params") or {}
-            for g in litellm_params.get("guardrails") or []:
+            guardrails = litellm_params.get("guardrails")
+            if not isinstance(guardrails, list):
+                continue
+            for g in guardrails:
                 key = g if isinstance(g, str) else repr(g)
                 if key not in seen:
                     seen.add(key)

--- a/tests/test_litellm/proxy/test_model_level_guardrails.py
+++ b/tests/test_litellm/proxy/test_model_level_guardrails.py
@@ -599,18 +599,17 @@ async def test_pre_call_merges_model_level_guardrails_before_pre_call_hook():
     """
     from litellm.proxy.common_request_processing import ProxyBaseLLMRequestProcessing
 
-    # Stub router that reports a deployment with one model-level guardrail.
-    # Mirrors the real proxy: at pre_call_hook time model_info has been
-    # stripped by add_litellm_data_to_request (see veria-ai review on PR
-    # #29654) and route_request hasn't yet populated model_info.id — so
-    # the resolver has to fall back to the model alias.
+    # Stub router that reports one deployment in the group with one
+    # model-level guardrail. Mirrors the real proxy: at pre_call_hook time
+    # model_info has been stripped by add_litellm_data_to_request (see
+    # veria-ai review on PR #29654) and route_request hasn't yet populated
+    # model_info.id — so the resolver has to fall back to the model alias
+    # and union guardrails across all deployments in the group.
     mock_router = MagicMock()
-    mock_deployment = MagicMock()
-    mock_deployment.litellm_params.get.return_value = ["my-pre-call-guardrail"]
-    # get_deployment(model_id=...) returns None (no model_info.id yet).
     mock_router.get_deployment.return_value = None
-    # get_deployment_by_model_group_name(model_alias) resolves the alias.
-    mock_router.get_deployment_by_model_group_name.return_value = mock_deployment
+    mock_router.get_model_list.return_value = [
+        {"litellm_params": {"guardrails": ["my-pre-call-guardrail"]}}
+    ]
 
     processing = ProxyBaseLLMRequestProcessing(
         data={

--- a/tests/test_litellm/proxy/test_model_level_guardrails.py
+++ b/tests/test_litellm/proxy/test_model_level_guardrails.py
@@ -10,7 +10,7 @@ import os
 import sys
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
 
@@ -93,9 +93,14 @@ class TestCheckAndMergeModelLevelGuardrails:
         assert result is data
 
     def test_returns_data_unchanged_when_no_model_info(self):
-        """Returns data unchanged when metadata has no model_info."""
+        """Returns data unchanged when metadata has no model_info AND the
+        model alias does not resolve to a deployment."""
         data = {"model": "gpt-4", "metadata": {}}
         mock_router = MagicMock()
+        # Neither the model_id lookup nor the alias-fallback lookup
+        # finds a deployment.
+        mock_router.get_deployment.return_value = None
+        mock_router.get_deployment_by_model_group_name.return_value = None
         result = _check_and_merge_model_level_guardrails(
             data=data, llm_router=mock_router
         )
@@ -575,3 +580,111 @@ async def test_streaming_iterator_hook_skips_guardrail_not_on_model():
 
         assert guardrail.was_called is False
         assert chunks == ["chunk-1"]
+
+
+# ---------------------------------------------------------------------------
+# Regression: pre_call ordering — _check_and_merge_model_level_guardrails
+# must run BEFORE pre_call_hook so DB/UI-configured guardrails fire on
+# pre_call paths (#29652; #23774 only covered post_call).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pre_call_merges_model_level_guardrails_before_pre_call_hook():
+    """
+    common_processing_pre_call_logic must merge model-level guardrails into
+    data BEFORE proxy_logging_obj.pre_call_hook is invoked. Otherwise
+    pre_call guardrails (e.g. apply_guardrail event) never see the
+    UI/DB-assigned guardrail name.
+    """
+    from litellm.proxy.common_request_processing import ProxyBaseLLMRequestProcessing
+
+    # Stub router that reports a deployment with one model-level guardrail.
+    # Mirrors the real proxy: at pre_call_hook time model_info has been
+    # stripped by add_litellm_data_to_request (see veria-ai review on PR
+    # #29654) and route_request hasn't yet populated model_info.id — so
+    # the resolver has to fall back to the model alias.
+    mock_router = MagicMock()
+    mock_deployment = MagicMock()
+    mock_deployment.litellm_params.get.return_value = ["my-pre-call-guardrail"]
+    # get_deployment(model_id=...) returns None (no model_info.id yet).
+    mock_router.get_deployment.return_value = None
+    # get_deployment_by_model_group_name(model_alias) resolves the alias.
+    mock_router.get_deployment_by_model_group_name.return_value = mock_deployment
+
+    processing = ProxyBaseLLMRequestProcessing(
+        data={
+            "model": "my-model",
+            "metadata": {},  # model_info already stripped
+        }
+    )
+
+    captured_pre_call_data: dict = {}
+
+    async def fake_pre_call_hook(*, user_api_key_dict, data, call_type):
+        captured_pre_call_data.update(data)
+        return data
+
+    proxy_logging = MagicMock()
+    proxy_logging.pre_call_hook = fake_pre_call_hook
+
+    # Minimal stubs for the surrounding setup steps in
+    # common_processing_pre_call_logic. We only care about the ordering
+    # between _check_and_merge_model_level_guardrails and pre_call_hook.
+    async def passthrough_add_litellm_data(*, data, **kwargs):
+        return data
+
+    proxy_config = MagicMock()
+    proxy_config._get_hierarchical_router_settings = AsyncMock(return_value=None)
+
+    # Stop the function before any post-pre_call_hook logic so we can keep
+    # the test focused. Raising _StopAfterPreCall in the next await fires
+    # right after the guardrail merge + pre_call_hook complete.
+    class _StopAfterPreCall(Exception):
+        pass
+
+    proxy_config._get_hierarchical_router_settings.side_effect = _StopAfterPreCall()
+
+    with (
+        patch(
+            "litellm.proxy.common_request_processing.add_litellm_data_to_request",
+            side_effect=passthrough_add_litellm_data,
+        ),
+        patch(
+            "litellm.proxy.common_request_processing.litellm.utils.function_setup",
+            return_value=(MagicMock(), processing.data),
+        ),
+        patch(
+            "litellm.proxy.proxy_server.prisma_client",
+            None,
+        ),
+    ):
+        from litellm.proxy._types import UserAPIKeyAuth
+
+        try:
+            await processing.common_processing_pre_call_logic(
+                request=MagicMock(headers={}, url=MagicMock(path="/v1/chat/completions")),
+                general_settings={},
+                user_api_key_dict=UserAPIKeyAuth(api_key="test-key"),
+                proxy_logging_obj=proxy_logging,
+                proxy_config=proxy_config,
+                route_type="acompletion",
+                version=None,
+                user_model=None,
+                user_temperature=None,
+                user_request_timeout=None,
+                user_max_tokens=None,
+                user_api_base=None,
+                model=None,
+                llm_router=mock_router,
+            )
+        except _StopAfterPreCall:
+            pass
+
+    # The pre_call_hook must have received data with the model-level
+    # guardrail already merged in. Before the fix, this assertion fails
+    # because pre_call_hook saw the original data without merge.
+    merged = (captured_pre_call_data.get("metadata") or {}).get("guardrails") or (
+        captured_pre_call_data.get("guardrails") or []
+    )
+    assert "my-pre-call-guardrail" in merged

--- a/tests/test_litellm/proxy/test_model_level_guardrails.py
+++ b/tests/test_litellm/proxy/test_model_level_guardrails.py
@@ -38,9 +38,7 @@ class TestCheckAndMergeModelLevelGuardrails:
         mock_deployment.litellm_params.get.return_value = ["openai-moderation"]
         mock_router.get_deployment.return_value = mock_deployment
 
-        result = _check_and_merge_model_level_guardrails(
-            data=data, llm_router=mock_router
-        )
+        result = _check_and_merge_model_level_guardrails(data=data, llm_router=mock_router)
 
         assert "openai-moderation" in result["metadata"]["guardrails"]
         mock_router.get_deployment.assert_called_once_with(model_id="model-uuid-123")
@@ -59,9 +57,7 @@ class TestCheckAndMergeModelLevelGuardrails:
         mock_deployment.litellm_params.get.return_value = ["model-guardrail"]
         mock_router.get_deployment.return_value = mock_deployment
 
-        result = _check_and_merge_model_level_guardrails(
-            data=data, llm_router=mock_router
-        )
+        result = _check_and_merge_model_level_guardrails(data=data, llm_router=mock_router)
 
         assert "existing-guardrail" in result["metadata"]["guardrails"]
         assert "model-guardrail" in result["metadata"]["guardrails"]
@@ -80,9 +76,7 @@ class TestCheckAndMergeModelLevelGuardrails:
         mock_deployment.litellm_params.get.return_value = ["openai-moderation"]
         mock_router.get_deployment.return_value = mock_deployment
 
-        result = _check_and_merge_model_level_guardrails(
-            data=data, llm_router=mock_router
-        )
+        result = _check_and_merge_model_level_guardrails(data=data, llm_router=mock_router)
 
         assert result["metadata"]["guardrails"].count("openai-moderation") == 1
 
@@ -101,9 +95,7 @@ class TestCheckAndMergeModelLevelGuardrails:
         # finds a deployment.
         mock_router.get_deployment.return_value = None
         mock_router.get_deployment_by_model_group_name.return_value = None
-        result = _check_and_merge_model_level_guardrails(
-            data=data, llm_router=mock_router
-        )
+        result = _check_and_merge_model_level_guardrails(data=data, llm_router=mock_router)
         assert result is data
 
     def test_returns_data_unchanged_when_deployment_has_no_guardrails(self):
@@ -117,9 +109,7 @@ class TestCheckAndMergeModelLevelGuardrails:
         mock_deployment.litellm_params.get.return_value = None
         mock_router.get_deployment.return_value = mock_deployment
 
-        result = _check_and_merge_model_level_guardrails(
-            data=data, llm_router=mock_router
-        )
+        result = _check_and_merge_model_level_guardrails(data=data, llm_router=mock_router)
 
         assert result is data
 
@@ -132,9 +122,7 @@ class TestCheckAndMergeModelLevelGuardrails:
         mock_router = MagicMock()
         mock_router.get_deployment.return_value = None
 
-        result = _check_and_merge_model_level_guardrails(
-            data=data, llm_router=mock_router
-        )
+        result = _check_and_merge_model_level_guardrails(data=data, llm_router=mock_router)
 
         assert result is data
 
@@ -152,9 +140,7 @@ class TestCheckAndMergeModelLevelGuardrails:
         mock_deployment.litellm_params.get.return_value = ["new-guardrail"]
         mock_router.get_deployment.return_value = mock_deployment
 
-        result = _check_and_merge_model_level_guardrails(
-            data=data, llm_router=mock_router
-        )
+        result = _check_and_merge_model_level_guardrails(data=data, llm_router=mock_router)
 
         # Result is a different top-level dict
         assert result is not data
@@ -477,9 +463,7 @@ async def test_streaming_iterator_hook_runs_model_level_guardrail():
             )
             self.was_called = False
 
-        async def async_post_call_streaming_iterator_hook(
-            self, user_api_key_dict, response, request_data
-        ):
+        async def async_post_call_streaming_iterator_hook(self, user_api_key_dict, response, request_data):
             self.was_called = True
             async for chunk in response:
                 yield chunk
@@ -540,9 +524,7 @@ async def test_streaming_iterator_hook_skips_guardrail_not_on_model():
             )
             self.was_called = False
 
-        async def async_post_call_streaming_iterator_hook(
-            self, user_api_key_dict, response, request_data
-        ):
+        async def async_post_call_streaming_iterator_hook(self, user_api_key_dict, response, request_data):
             self.was_called = True
             async for chunk in response:
                 yield chunk
@@ -607,9 +589,7 @@ async def test_pre_call_merges_model_level_guardrails_before_pre_call_hook():
     # and union guardrails across all deployments in the group.
     mock_router = MagicMock()
     mock_router.get_deployment.return_value = None
-    mock_router.get_model_list.return_value = [
-        {"litellm_params": {"guardrails": ["my-pre-call-guardrail"]}}
-    ]
+    mock_router.get_model_list.return_value = [{"litellm_params": {"guardrails": ["my-pre-call-guardrail"]}}]
 
     processing = ProxyBaseLLMRequestProcessing(
         data={

--- a/tests/test_litellm/proxy/utils/helpers/test_guardrail_merge.py
+++ b/tests/test_litellm/proxy/utils/helpers/test_guardrail_merge.py
@@ -13,16 +13,24 @@ def normalize(value):
     return value
 
 
-def _router_with_deployment(guardrails):
+def _router_with_deployment(guardrails, *, by_alias: bool = False):
+    """Build a stub router whose `get_deployment(model_id=...)` returns a
+    deployment with the given guardrails. ``by_alias=True`` also stubs the
+    `get_deployment_by_model_group_name(...)` fallback used by the pre_call
+    path (#29652) where ``metadata.model_info.id`` isn't yet populated."""
     deployment = SimpleNamespace(litellm_params={"guardrails": guardrails})
     router = MagicMock()
     router.get_deployment.return_value = deployment
+    router.get_deployment_by_model_group_name.return_value = (
+        deployment if by_alias else None
+    )
     return router
 
 
 def _router_without_deployment():
     router = MagicMock()
     router.get_deployment.return_value = None
+    router.get_deployment_by_model_group_name.return_value = None
     return router
 
 
@@ -59,8 +67,10 @@ def test_check_and_merge_model_level_guardrails_returns_data_when_router_none():
     }
 
 
-def test_check_and_merge_model_level_guardrails_returns_data_when_model_id_missing():
-    router = _router_with_deployment(["pii"])
+def test_check_and_merge_model_level_guardrails_returns_data_when_model_id_missing_and_alias_unknown():
+    """When model_id is missing AND the model alias doesn't resolve to a
+    deployment (router returns None for both lookups), data is unchanged."""
+    router = _router_with_deployment(["pii"])  # by_alias=False by default
     data = {"metadata": {"model_info": {}}, "model": "m", "extra": "v"}
     result = _check_and_merge_model_level_guardrails(data, router)
     snapshot = {
@@ -76,6 +86,20 @@ def test_check_and_merge_model_level_guardrails_returns_data_when_model_id_missi
         "extra": "v",
     }
     router.get_deployment.assert_not_called()
+    # Alias fallback was attempted; it just didn't find a deployment.
+    router.get_deployment_by_model_group_name.assert_called_once()
+
+
+def test_check_and_merge_model_level_guardrails_falls_back_to_model_alias_when_model_id_missing():
+    """Pre_call path: model_info.id isn't populated yet because route_request
+    hasn't run. The helper must fall back to looking up the deployment by
+    the model alias (#29652) so DB/UI-assigned guardrails still fire."""
+    router = _router_with_deployment(["pii"], by_alias=True)
+    data = {"metadata": {"model_info": {}}, "model": "m", "extra": "v"}
+    result = _check_and_merge_model_level_guardrails(data, router)
+    # Merge happened via the alias fallback.
+    assert "pii" in result["metadata"]["guardrails"]
+    router.get_deployment_by_model_group_name.assert_called_once()
 
 
 def test_check_and_merge_model_level_guardrails_returns_data_when_deployment_none():
@@ -93,7 +117,8 @@ def test_check_and_merge_model_level_guardrails_returns_data_when_guardrails_non
 
 
 def test_check_and_merge_model_level_guardrails_handles_missing_metadata():
-    router = _router_with_deployment(["pii"])
+    """No metadata at all + alias unknown to the router → data unchanged."""
+    router = _router_with_deployment(["pii"])  # by_alias=False
     data = {"model": "m"}
     result = _check_and_merge_model_level_guardrails(data, router)
     snapshot = {

--- a/tests/test_litellm/proxy/utils/helpers/test_guardrail_merge.py
+++ b/tests/test_litellm/proxy/utils/helpers/test_guardrail_merge.py
@@ -15,22 +15,37 @@ def normalize(value):
 
 def _router_with_deployment(guardrails, *, by_alias: bool = False):
     """Build a stub router whose `get_deployment(model_id=...)` returns a
-    deployment with the given guardrails. ``by_alias=True`` also stubs the
-    `get_deployment_by_model_group_name(...)` fallback used by the pre_call
-    path (#29652) where ``metadata.model_info.id`` isn't yet populated."""
+    deployment with the given guardrails. ``by_alias=True`` also stubs
+    `get_model_list(model_name=...)` to return one matching deployment so the
+    pre_call alias fallback (#29652) resolves."""
     deployment = SimpleNamespace(litellm_params={"guardrails": guardrails})
     router = MagicMock()
     router.get_deployment.return_value = deployment
-    router.get_deployment_by_model_group_name.return_value = (
-        deployment if by_alias else None
+    router.get_model_list.return_value = (
+        [{"litellm_params": {"guardrails": guardrails}}] if by_alias else []
     )
+    return router
+
+
+def _router_with_deployments(group_guardrails):
+    """Stub a router whose `get_model_list(model_name=...)` returns multiple
+    deployments — each entry of `group_guardrails` is the guardrails list for
+    one deployment in the group (use None for a deployment with no guardrails).
+    Used to pin the UNION-across-deployments fallback (veria-ai Medium on
+    #29654)."""
+    router = MagicMock()
+    router.get_deployment.return_value = None
+    router.get_model_list.return_value = [
+        {"litellm_params": {"guardrails": g} if g is not None else {}}
+        for g in group_guardrails
+    ]
     return router
 
 
 def _router_without_deployment():
     router = MagicMock()
     router.get_deployment.return_value = None
-    router.get_deployment_by_model_group_name.return_value = None
+    router.get_model_list.return_value = []
     return router
 
 
@@ -87,19 +102,49 @@ def test_check_and_merge_model_level_guardrails_returns_data_when_model_id_missi
     }
     router.get_deployment.assert_not_called()
     # Alias fallback was attempted; it just didn't find a deployment.
-    router.get_deployment_by_model_group_name.assert_called_once()
+    router.get_model_list.assert_called_once()
 
 
 def test_check_and_merge_model_level_guardrails_falls_back_to_model_alias_when_model_id_missing():
     """Pre_call path: model_info.id isn't populated yet because route_request
-    hasn't run. The helper must fall back to looking up the deployment by
-    the model alias (#29652) so DB/UI-assigned guardrails still fire."""
+    hasn't run. The helper must fall back to looking up deployments by the
+    model alias (#29652) so DB/UI-assigned guardrails still fire."""
     router = _router_with_deployment(["pii"], by_alias=True)
     data = {"metadata": {"model_info": {}}, "model": "m", "extra": "v"}
     result = _check_and_merge_model_level_guardrails(data, router)
     # Merge happened via the alias fallback.
     assert "pii" in result["metadata"]["guardrails"]
-    router.get_deployment_by_model_group_name.assert_called_once()
+    router.get_model_list.assert_called_once()
+
+
+def test_check_and_merge_model_level_guardrails_unions_guardrails_across_group_deployments():
+    """veria-ai Medium on #29654: when model_id is missing, the router has not
+    yet picked the deployment, so taking the FIRST deployment's guardrails
+    would silently drop a guardrail defined only on a non-first deployment.
+    The fix is to union the guardrails from all deployments in the group."""
+    router = _router_with_deployments([["pii"], ["secret-scan"], None])
+    data = {"metadata": {"model_info": {}}, "model": "m"}
+    result = _check_and_merge_model_level_guardrails(data, router)
+    assert sorted(result["metadata"]["guardrails"]) == ["pii", "secret-scan"]
+
+
+def test_check_and_merge_model_level_guardrails_dedups_guardrails_across_group_deployments():
+    """Two deployments with the same guardrail must not produce duplicate
+    entries in the merged guardrails list."""
+    router = _router_with_deployments([["pii"], ["pii", "secret-scan"]])
+    data = {"metadata": {"model_info": {}}, "model": "m"}
+    result = _check_and_merge_model_level_guardrails(data, router)
+    assert sorted(result["metadata"]["guardrails"]) == ["pii", "secret-scan"]
+
+
+def test_check_and_merge_model_level_guardrails_group_with_no_guardrails_returns_data():
+    """If all deployments in the group have no guardrails (or empty lists),
+    the helper returns the data unchanged."""
+    router = _router_with_deployments([None, None, []])
+    data = {"metadata": {"model_info": {}}, "model": "m"}
+    result = _check_and_merge_model_level_guardrails(data, router)
+    assert result is data
+    assert "guardrails" not in result["metadata"]
 
 
 def test_check_and_merge_model_level_guardrails_returns_data_when_deployment_none():

--- a/tests/test_litellm/proxy/utils/helpers/test_guardrail_merge.py
+++ b/tests/test_litellm/proxy/utils/helpers/test_guardrail_merge.py
@@ -147,6 +147,50 @@ def test_check_and_merge_model_level_guardrails_group_with_no_guardrails_returns
     assert "guardrails" not in result["metadata"]
 
 
+def test_check_and_merge_model_level_guardrails_ignores_client_model_info_id_when_distrusted():
+    """veria-ai HIGH on #29654: when allow_client_pricing_override is set,
+    add_litellm_data_to_request preserves the client-supplied
+    metadata.model_info, so a caller could spoof an unknown/unguarded
+    model_info.id while requesting a guarded alias and bypass the merge.
+    On the pre_call path (trust_client_model_info=False), the helper must
+    ignore the spoofed id and fall back to the alias-union path.
+    """
+    router = MagicMock()
+    # Spoofed id resolves to an unguarded deployment.
+    spoofed_deployment = SimpleNamespace(litellm_params={"guardrails": []})
+    router.get_deployment.return_value = spoofed_deployment
+    # The real alias group has a guarded deployment.
+    router.get_model_list.return_value = [
+        {"litellm_params": {"guardrails": ["alias-secret-scan"]}}
+    ]
+
+    data = {
+        "model": "guarded-alias",
+        "metadata": {"model_info": {"id": "spoofed-unguarded-deployment"}},
+    }
+    result = _check_and_merge_model_level_guardrails(
+        data, router, trust_client_model_info=False
+    )
+    assert "alias-secret-scan" in result["metadata"]["guardrails"]
+    # The model_id lookup must NOT have been used.
+    router.get_deployment.assert_not_called()
+    router.get_model_list.assert_called_once()
+
+
+def test_check_and_merge_model_level_guardrails_trusts_client_model_info_id_by_default():
+    """Post_call paths (default trust_client_model_info=True) still use the
+    model_id route because route_request has populated model_info.id by then.
+    """
+    router = _router_with_deployment(["post-call-guardrail"])
+    data = {
+        "model": "any",
+        "metadata": {"model_info": {"id": "deployment-123"}},
+    }
+    result = _check_and_merge_model_level_guardrails(data, router)
+    assert "post-call-guardrail" in result["metadata"]["guardrails"]
+    router.get_deployment.assert_called_once_with(model_id="deployment-123")
+
+
 def test_check_and_merge_model_level_guardrails_returns_data_when_deployment_none():
     router = _router_without_deployment()
     data = {"metadata": {"model_info": {"id": "x"}}, "model": "m"}

--- a/tests/test_litellm/proxy/utils/helpers/test_guardrail_merge.py
+++ b/tests/test_litellm/proxy/utils/helpers/test_guardrail_merge.py
@@ -21,9 +21,7 @@ def _router_with_deployment(guardrails, *, by_alias: bool = False):
     deployment = SimpleNamespace(litellm_params={"guardrails": guardrails})
     router = MagicMock()
     router.get_deployment.return_value = deployment
-    router.get_model_list.return_value = (
-        [{"litellm_params": {"guardrails": guardrails}}] if by_alias else []
-    )
+    router.get_model_list.return_value = [{"litellm_params": {"guardrails": guardrails}}] if by_alias else []
     return router
 
 
@@ -36,8 +34,7 @@ def _router_with_deployments(group_guardrails):
     router = MagicMock()
     router.get_deployment.return_value = None
     router.get_model_list.return_value = [
-        {"litellm_params": {"guardrails": g} if g is not None else {}}
-        for g in group_guardrails
+        {"litellm_params": {"guardrails": g} if g is not None else {}} for g in group_guardrails
     ]
     return router
 
@@ -160,17 +157,13 @@ def test_check_and_merge_model_level_guardrails_ignores_client_model_info_id_whe
     spoofed_deployment = SimpleNamespace(litellm_params={"guardrails": []})
     router.get_deployment.return_value = spoofed_deployment
     # The real alias group has a guarded deployment.
-    router.get_model_list.return_value = [
-        {"litellm_params": {"guardrails": ["alias-secret-scan"]}}
-    ]
+    router.get_model_list.return_value = [{"litellm_params": {"guardrails": ["alias-secret-scan"]}}]
 
     data = {
         "model": "guarded-alias",
         "metadata": {"model_info": {"id": "spoofed-unguarded-deployment"}},
     }
-    result = _check_and_merge_model_level_guardrails(
-        data, router, trust_client_model_info=False
-    )
+    result = _check_and_merge_model_level_guardrails(data, router, trust_client_model_info=False)
     assert "alias-secret-scan" in result["metadata"]["guardrails"]
     # The model_id lookup must NOT have been used.
     router.get_deployment.assert_not_called()
@@ -208,9 +201,7 @@ def test_check_and_merge_model_level_guardrails_alias_union_accepts_bare_string_
     """Same scalar-string contract on the pre_call alias-union path."""
     router = MagicMock()
     router.get_deployment.return_value = None
-    router.get_model_list.return_value = [
-        {"litellm_params": {"guardrails": "scalar-alias-guardrail"}}
-    ]
+    router.get_model_list.return_value = [{"litellm_params": {"guardrails": "scalar-alias-guardrail"}}]
     data = {"model": "alias-m", "metadata": {"model_info": {}}}
     result = _check_and_merge_model_level_guardrails(data, router)
     assert "scalar-alias-guardrail" in result["metadata"]["guardrails"]
@@ -223,9 +214,7 @@ def test_check_and_merge_model_level_guardrails_alias_fallback_passes_team_id():
     deployments are invisible and their guardrails are silently dropped."""
     router = MagicMock()
     router.get_deployment.return_value = None
-    router.get_model_list.return_value = [
-        {"litellm_params": {"guardrails": ["team-guardrail"]}}
-    ]
+    router.get_model_list.return_value = [{"litellm_params": {"guardrails": ["team-guardrail"]}}]
     data = {
         "model": "team-scoped-alias",
         "metadata": {
@@ -233,13 +222,9 @@ def test_check_and_merge_model_level_guardrails_alias_fallback_passes_team_id():
             "user_api_key_team_id": "team-abc",
         },
     }
-    result = _check_and_merge_model_level_guardrails(
-        data, router, trust_client_model_info=False
-    )
+    result = _check_and_merge_model_level_guardrails(data, router, trust_client_model_info=False)
     assert "team-guardrail" in result["metadata"]["guardrails"]
-    router.get_model_list.assert_called_once_with(
-        model_name="team-scoped-alias", team_id="team-abc"
-    )
+    router.get_model_list.assert_called_once_with(model_name="team-scoped-alias", team_id="team-abc")
 
 
 def test_check_and_merge_model_level_guardrails_alias_fallback_reads_team_id_from_litellm_metadata():
@@ -253,12 +238,8 @@ def test_check_and_merge_model_level_guardrails_alias_fallback_reads_team_id_fro
         "metadata": {"model_info": {}},
         "litellm_metadata": {"user_api_key_team_id": "team-xyz"},
     }
-    _check_and_merge_model_level_guardrails(
-        data, router, trust_client_model_info=False
-    )
-    router.get_model_list.assert_called_once_with(
-        model_name="alias-m", team_id="team-xyz"
-    )
+    _check_and_merge_model_level_guardrails(data, router, trust_client_model_info=False)
+    router.get_model_list.assert_called_once_with(model_name="alias-m", team_id="team-xyz")
 
 
 def test_check_and_merge_model_level_guardrails_returns_data_when_deployment_none():

--- a/tests/test_litellm/proxy/utils/helpers/test_guardrail_merge.py
+++ b/tests/test_litellm/proxy/utils/helpers/test_guardrail_merge.py
@@ -191,6 +191,76 @@ def test_check_and_merge_model_level_guardrails_trusts_client_model_info_id_by_d
     router.get_deployment.assert_called_once_with(model_id="deployment-123")
 
 
+def test_check_and_merge_model_level_guardrails_post_call_accepts_bare_string_guardrail():
+    """greptile P1 on #29654: the mypy-narrowing isinstance(list) guard must
+    not silently drop bare-string guardrail values that were truthy-accepted
+    before. Wrap a scalar into a one-element list so post_call merge keeps
+    working with single-guardrail configs."""
+    deployment = SimpleNamespace(litellm_params={"guardrails": "scalar-guardrail"})
+    router = MagicMock()
+    router.get_deployment.return_value = deployment
+    data = {"model": "any", "metadata": {"model_info": {"id": "deployment-x"}}}
+    result = _check_and_merge_model_level_guardrails(data, router)
+    assert "scalar-guardrail" in result["metadata"]["guardrails"]
+
+
+def test_check_and_merge_model_level_guardrails_alias_union_accepts_bare_string_guardrail():
+    """Same scalar-string contract on the pre_call alias-union path."""
+    router = MagicMock()
+    router.get_deployment.return_value = None
+    router.get_model_list.return_value = [
+        {"litellm_params": {"guardrails": "scalar-alias-guardrail"}}
+    ]
+    data = {"model": "alias-m", "metadata": {"model_info": {}}}
+    result = _check_and_merge_model_level_guardrails(data, router)
+    assert "scalar-alias-guardrail" in result["metadata"]["guardrails"]
+
+
+def test_check_and_merge_model_level_guardrails_alias_fallback_passes_team_id():
+    """veria-ai Medium on #29654: route_request resolves team-scoped public
+    model names with metadata.user_api_key_team_id. The pre_call alias
+    lookup must pass that team_id to get_model_list, or team-scoped
+    deployments are invisible and their guardrails are silently dropped."""
+    router = MagicMock()
+    router.get_deployment.return_value = None
+    router.get_model_list.return_value = [
+        {"litellm_params": {"guardrails": ["team-guardrail"]}}
+    ]
+    data = {
+        "model": "team-scoped-alias",
+        "metadata": {
+            "model_info": {},
+            "user_api_key_team_id": "team-abc",
+        },
+    }
+    result = _check_and_merge_model_level_guardrails(
+        data, router, trust_client_model_info=False
+    )
+    assert "team-guardrail" in result["metadata"]["guardrails"]
+    router.get_model_list.assert_called_once_with(
+        model_name="team-scoped-alias", team_id="team-abc"
+    )
+
+
+def test_check_and_merge_model_level_guardrails_alias_fallback_reads_team_id_from_litellm_metadata():
+    """Backstop: some call sites stash the team id on litellm_metadata
+    instead of metadata. The alias fallback should accept either."""
+    router = MagicMock()
+    router.get_deployment.return_value = None
+    router.get_model_list.return_value = []
+    data = {
+        "model": "alias-m",
+        "metadata": {"model_info": {}},
+        "litellm_metadata": {"user_api_key_team_id": "team-xyz"},
+    }
+    _check_and_merge_model_level_guardrails(
+        data, router, trust_client_model_info=False
+    )
+    router.get_model_list.assert_called_once_with(
+        model_name="alias-m", team_id="team-xyz"
+    )
+
+
 def test_check_and_merge_model_level_guardrails_returns_data_when_deployment_none():
     router = _router_without_deployment()
     data = {"metadata": {"model_info": {"id": "x"}}, "model": "m"}


### PR DESCRIPTION
## Title

fix(proxy): merge model-level guardrails before pre_call_hook

## Relevant issues

Closes #29652. Builds on #23774 (which covered post_call only).

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

`common_request_processing.py:963` — \`pre_call_hook\` was called without first merging deployment-level guardrails. \`_check_and_merge_model_level_guardrails\` was already being used in three post_call sites (\`utils.py:2234\`, \`utils.py:2498\`, \`common_request_processing.py:1663\`) but the pre_call path was skipped — so DB/UI-assigned \`litellm_params.guardrails\` only fired on post_call and were silently dropped on pre_call.

PR #23774 fixed the non-streaming post_call case; this PR fixes the remaining pre_call gap, which #29652 narrowed down to the exact line.

Added a single import-and-call right before \`pre_call_hook\`, reusing the existing helper. Uses the local \`llm_router\` parameter already in scope at that point.

Test added: \`test_pre_call_merges_model_level_guardrails_before_pre_call_hook\` in \`tests/test_litellm/proxy/test_model_level_guardrails.py\` — patches \`pre_call_hook\` to capture data, asserts the model-level guardrail name is present.

Verified locally:
- \`uv run pytest tests/test_litellm/proxy/test_model_level_guardrails.py -q\` → 13 passed
- Negative test: revert the 4 added lines in \`common_request_processing.py\` and the new test fails with \`AssertionError: 'my-pre-call-guardrail' in []\` — confirms the new test catches the bug