### PR TITLE
test(token_counter): skip test_tokenizers when the HuggingFace hub is unreachable

### DIFF
--- a/tests/test_litellm/litellm_core_utils/test_token_counter.py
+++ b/tests/test_litellm/litellm_core_utils/test_token_counter.py
@@ -173,6 +173,32 @@ class NeedsToleranceUpdateError(Exception):
     pass
 
 
+def _hf_hub_unreachable(exc: Exception) -> bool:
+    """Whether ``exc`` looks like a HuggingFace hub connectivity failure.
+
+    The llama tokenizers and ``create_pretrained_tokenizer`` download from the
+    HuggingFace hub, which is frequently unreachable or rate-limited in CI.
+    """
+    message = str(exc).lower()
+    return any(
+        marker in message
+        for marker in (
+            "couldn't reach",
+            "could not reach",
+            "connection",
+            "max retries",
+            "timed out",
+            "timeout",
+            "temporarily unavailable",
+            "failed to resolve",
+            "name or service not known",
+            "502 server error",
+            "503 server error",
+            "504 server error",
+        )
+    )
+
+
 def test_tokenizers():
     try:
         ### test the openai, claude, cohere and llama2 tokenizers.
@@ -225,6 +251,12 @@ def test_tokenizers():
 
         print("test tokenizer: It worked!")
     except Exception as e:
+        # The llama2/llama3 token counts and create_pretrained_tokenizer fetch
+        # tokenizers from the HuggingFace hub, which is often unreachable or
+        # rate-limited in CI. Skip rather than fail on those connectivity errors
+        # so this test only fails on real tokenizer regressions.
+        if _hf_hub_unreachable(e):
+            pytest.skip(f"HuggingFace hub unreachable; skipping tokenizer test ({e})")
         pytest.fail(f"An exception occured: {e}")
 
 
@@ -517,7 +549,6 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from litellm.utils import _select_tokenizer_helper, claude_json_str, encoding
-
 
 # Clear the cache at module load to ensure clean state
 _select_tokenizer_helper.cache_clear()


### PR DESCRIPTION
## Relevant issues

N/A (CI flakiness)

## Linear ticket

N/A (external contribution)

## Pre-Submission checklist

- [x] I have added/updated testing in the `tests/test_litellm/` directory
- [x] My PR passes the relevant unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves one specific problem
- [ ] I have requested a Greptile review

## What this fixes

`tests/test_litellm/litellm_core_utils/test_token_counter.py::test_tokenizers` downloads tokenizers from the HuggingFace hub (`meta-llama/Llama-2-7b-chat`, `meta-llama/llama-3-70b-instruct`, and `create_pretrained_tokenizer("Xenova/llama-3-tokenizer")`). The HF hub is frequently unreachable or rate-limited in CI, so those downloads raise and the test fails through its outer `except Exception` even though nothing about the tokenizer logic regressed.

There is already a partial guard for the case where llama2 falls back to tiktoken, but it does not cover a connectivity error raised during `create_pretrained_tokenizer` or the llama fetches. This change extends that same "skip on HF-hub unreachability" approach to the connectivity-error path so the test only fails on real tokenizer regressions, not on transient network conditions.

## Changes

- Add a small `_hf_hub_unreachable(exc)` helper that recognizes HuggingFace-hub connectivity failures by message (connection / timeout / max-retries / 5xx / DNS markers).
- In `test_tokenizers`, when the body raises, `pytest.skip` if the error is a HF-hub connectivity failure; otherwise `pytest.fail` as before. Real assertion failures and logic errors still fail the test.

## Screenshots / Proof of Fix

This is a CI-flakiness fix, so the "proof" is behavioral:

- With the HF hub reachable, the test runs and asserts exactly as before (no behavior change on the happy path).
- When a tokenizer download raises a connectivity error (the CI failure mode), the test now reports `SKIPPED` with `HuggingFace hub unreachable; skipping tokenizer test (...)` instead of `FAILED`.
- A genuine tokenizer regression still raises a non-connectivity error and fails the test, so coverage is preserved.

Black and Ruff are clean on the changed file.

## Type

✅ Test



---
Raised by [Dinesh Girbide](mailto:dinesh@incubyte.co) from [Incubyte](https://incubyte.co)