### PR TITLE
fix(huggingface): handle special token text in embedding usage

### DIFF
--- a/litellm/llms/huggingface/embedding/handler.py
+++ b/litellm/llms/huggingface/embedding/handler.py
@@ -239,7 +239,7 @@ class HuggingFaceEmbedding(BaseLLM):
         model_response.model = model
         input_tokens = 0
         for text in input:
-            input_tokens += len(encoding.encode(text))
+            input_tokens += len(encoding.encode(text, disallowed_special=()))
 
         setattr(
             model_response,

--- a/tests/test_litellm/llms/huggingface/embedding/test_huggingface_embedding_handler.py
+++ b/tests/test_litellm/llms/huggingface/embedding/test_huggingface_embedding_handler.py
@@ -104,6 +104,23 @@ class TestHuggingFaceEmbedding:
         assert "source_sentence" not in str(request_data)
         assert "sentences" not in str(request_data)
 
+    def test_embedding_allows_special_token_looking_input(self):
+        input_text = ["hello <|fim_prefix|> world"]
+
+        response = litellm.embedding(
+            model=self.model,
+            input=input_text,
+            input_type="embed",
+        )
+
+        self.mock_http.assert_called_once()
+        post_call_args = self.mock_http.call_args
+        request_data = json.loads(post_call_args[1]["data"])
+
+        assert request_data["inputs"] == input_text
+        assert response.usage.prompt_tokens > 0
+        assert response.usage.total_tokens == response.usage.prompt_tokens
+
     def test_embedding_with_sentence_similarity_task(self):
         """Test embedding when task type is sentence-similarity (requires 2+ sentences)"""
 


### PR DESCRIPTION
## Title

Fix HuggingFace embedding usage counting for special-token-looking input

## Relevant issues

Related prior fixes, but this HuggingFace embedding path was still unfixed:
- Related: #9574
- Related: #9640
- Related: #13374
- Related: #3170

## Changes

HuggingFace embedding responses can fail after the provider has already returned embeddings if the original input contains text that matches a tiktoken special token, for example `<|fim_prefix|>` or `<|endoftext|>`.

The failure happens while LiteLLM calculates local embedding usage:

```python
encoding.encode(text)
```

This PR treats those special-token-looking strings as normal text during usage counting by passing `disallowed_special=()`, matching LiteLLM's shared token counting behavior.

## Testing

Added a regression test for HuggingFace embedding input containing `<|fim_prefix|>`:

```bash
python -m pytest tests/test_litellm/llms/huggingface/embedding/test_huggingface_embedding_handler.py::TestHuggingFaceEmbedding::test_embedding_allows_special_token_looking_input -q
```

Result:

```text
1 passed
```

Also verified against a local Qwen3 TEI embedding backend via LiteLLM proxy.

Before this fix, same backend/config:

```text
normal embedding text -> HTTP 200, dims 2560
hello <|fim_prefix|> world -> HTTP 500
hello <|endoftext|> world -> HTTP 500
```

After this fix, same backend/config:

```text
normal embedding text -> HTTP 200, dims 2560, prompt_tokens 3
hello <|fim_prefix|> world -> HTTP 200, dims 2560, prompt_tokens 8
hello <|endoftext|> world -> HTTP 200, dims 2560, prompt_tokens 8
```

## Type

🐛 Bug Fix