### PR TITLE
fix(safe_json_dumps): snapshot dict items before iterating

### DIFF
--- a/litellm/litellm_core_utils/safe_json_dumps.py
+++ b/litellm/litellm_core_utils/safe_json_dumps.py
@@ -34,7 +34,9 @@ def safe_dumps(data: Any, max_depth: int = DEFAULT_MAX_RECURSE_DEPTH) -> str:
         result: Union[dict, list, tuple, set, str]
         if isinstance(obj, dict):
             result = {}
-            for k, v in obj.items():
+            # Snapshot items() so a concurrent async hook mutating the same
+            # dict can't raise "dictionary changed size during iteration".
+            for k, v in list(obj.items()):
                 if isinstance(k, (str)):
                     result[strip_null_bytes(k)] = _serialize(v, seen, depth + 1)
             seen.remove(id(obj))

--- a/tests/test_litellm/litellm_core_utils/test_safe_json_dumps.py
+++ b/tests/test_litellm/litellm_core_utils/test_safe_json_dumps.py
@@ -206,3 +206,26 @@ def test_pydantic_base_model():
     assert len(result["healthy_endpoints"]) == 2
     assert result["healthy_endpoints"][0]["name"] == "test"
     assert result["healthy_endpoints"][1] == {"value": 1, "label": "one"}
+
+
+def test_dict_mutated_during_serialization_does_not_raise():
+    # Regression: safe_dumps runs on request_data / model_call_details, which a
+    # concurrent async hook can mutate while we iterate. Serializing one value
+    # here inserts a new key into the same dict (standing in for that hook). On
+    # the pre-fix code this raised "RuntimeError: dictionary changed size during
+    # iteration"; the list() snapshot must keep iteration stable.
+    class _MutateOnStr:
+        def __init__(self, target):
+            self._target = target
+
+        def __str__(self):
+            self._target["injected_by_concurrent_hook"] = "value"
+            return "mutated"
+
+    data = {}
+    data["trigger"] = _MutateOnStr(data)
+    data["after"] = 1
+
+    result = json.loads(safe_dumps(data))
+    assert result["trigger"] == "mutated"
+    assert result["after"] == 1


### PR DESCRIPTION
## Relevant issues

## Changes

`safe_dumps` is called on `request_data` and `logging_obj.model_call_details`, both of which async guardrail and logging hooks can mutate while serialization is in flight. `_serialize` iterated `obj.items()` directly over the live dict, so a concurrent insert raised `RuntimeError: dictionary changed size during iteration` and took down the request. We hit this in production as intermittent guardrail-hook failures under concurrency.

The fix wraps `obj.items()` in `list()` to take a snapshot before iterating. There is no behavior change for non-concurrent callers; the snapshot just decouples iteration from later mutation of the source dict.

## Type

🐛 Bug Fix

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Test plan

Added `test_dict_mutated_during_serialization_does_not_raise` in `tests/test_litellm/litellm_core_utils/test_safe_json_dumps.py`. It serializes a dict whose one value mutates the same dict during its own `str()` conversion, standing in for a concurrent hook. The test raises `RuntimeError: dictionary changed size during iteration` on the pre-fix code and passes once `items()` is snapshotted, so it locks in the regression