### PR TITLE
fix(passthrough): use Responses API config for /v1/responses logging

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -4285,6 +4285,7 @@ PassThroughEndpointLoggingResultValues = Union[
     EmbeddingResponse,
     VideoObject,
     StandardPassThroughResponseObject,
+    ResponsesAPIResponse,
 ]
 
 

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/openai_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/openai_passthrough_logging_handler.py
@@ -1,7 +1,8 @@
 """
 OpenAI Passthrough Logging Handler
 
-Handles cost tracking and logging for OpenAI passthrough endpoints, specifically /chat/completions.
+Handles cost tracking and logging for OpenAI passthrough endpoints, specifically /chat/completions,
+/v1/responses, /v1/images/generations, and /v1/images/edits.
 """
 
 from datetime import datetime
@@ -18,6 +19,7 @@ from litellm.litellm_core_utils.litellm_logging import (
 )
 from litellm.llms.openai.openai import OpenAIConfig
 from litellm.llms.openai.openai import OpenAIConfig as OpenAIConfigType
+from litellm.llms.openai.responses.transformation import OpenAIResponsesAPIConfig
 from litellm.proxy._types import PassThroughEndpointLoggingTypedDict
 from litellm.proxy.pass_through_endpoints.llm_provider_handlers.base_passthrough_logging_handler import (
     BasePassthroughLoggingHandler,
@@ -253,7 +255,12 @@ class OpenAIPassthroughLoggingHandler(BasePassthroughLoggingHandler):
         try:
             response_cost = 0.0
             litellm_model_response: Optional[
-                Union[ModelResponse, TextCompletionResponse, ImageResponse]
+                Union[
+                    ModelResponse,
+                    TextCompletionResponse,
+                    ImageResponse,
+                    litellm.ResponsesAPIResponse,
+                ]
             ] = None
             handler_instance = OpenAIPassthroughLoggingHandler()
 
@@ -336,21 +343,16 @@ class OpenAIPassthroughLoggingHandler(BasePassthroughLoggingHandler):
                     litellm_model_response._hidden_params = {}
                 litellm_model_response._hidden_params["response_cost"] = response_cost
             elif is_responses:
-                # Handle responses API cost calculation
-                provider_config = handler_instance.get_provider_config(model=model)
-                existing_litellm_params = kwargs.get("litellm_params", {}) or {}
-                litellm_model_response = provider_config.transform_response(
-                    raw_response=httpx_response,
-                    model_response=litellm.ModelResponse(),
-                    model=model,
-                    messages=request_body.get("messages", []),
-                    logging_obj=logging_obj,
-                    optional_params=request_body.get("optional_params", {}),
-                    api_key="",
-                    request_data=request_body,
-                    encoding=litellm.encoding,
-                    json_mode=False,
-                    litellm_params=existing_litellm_params,
+                # Handle responses API cost calculation using the Responses API config
+                # which correctly parses Responses API JSON (output/usage) instead of
+                # Chat Completions JSON (choices/prompt_tokens/completion_tokens).
+                responses_provider_config = OpenAIResponsesAPIConfig()
+                litellm_model_response = (
+                    responses_provider_config.transform_response_api_response(
+                        model=model,
+                        raw_response=httpx_response,
+                        logging_obj=logging_obj,
+                    )
                 )
 
                 # Calculate cost using LiteLLM's cost calculator with responses call type
@@ -398,7 +400,15 @@ class OpenAIPassthroughLoggingHandler(BasePassthroughLoggingHandler):
             endpoint_type = (
                 "chat_completions"
                 if is_chat_completions
-                else "image_generation" if is_image_generation else "image_editing"
+                else (
+                    "image_generation"
+                    if is_image_generation
+                    else (
+                        "image_editing"
+                        if is_image_editing
+                        else "responses" if is_responses else "unknown"
+                    )
+                )
             )
             verbose_proxy_logger.debug(
                 f"OpenAI passthrough cost tracking - Endpoint: {endpoint_type}, Model: {model}, Cost: ${response_cost:.6f}"

--- a/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_openai_passthrough_logging_handler.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_openai_passthrough_logging_handler.py
@@ -624,46 +624,36 @@ class TestOpenAIPassthroughLoggingHandler:
     @patch(
         "litellm.litellm_core_utils.litellm_logging.get_standard_logging_object_payload"
     )
-    @patch(
-        "litellm.proxy.pass_through_endpoints.llm_provider_handlers.openai_passthrough_logging_handler.OpenAIPassthroughLoggingHandler.get_provider_config"
-    )
     def test_responses_api_cost_tracking(
-        self, mock_get_provider_config, mock_get_standard_logging, mock_completion_cost
+        self, mock_get_standard_logging, mock_completion_cost
     ):
-        """Test cost tracking for responses API route"""
+        """Test cost tracking for responses API route using OpenAIResponsesAPIConfig"""
         # Arrange
         mock_completion_cost.return_value = 0.000050
         mock_get_standard_logging.return_value = {"test": "logging_payload"}
 
-        # Mock the provider config's transform_response to return a valid ModelResponse
-        from litellm import ModelResponse
-
-        mock_model_response = ModelResponse(
-            id="resp_abc123",
-            model="gpt-4o-2024-08-06",
-            choices=[
-                {
-                    "message": {
-                        "role": "assistant",
-                        "content": "Hello! How can I help you today?",
-                    }
-                }
-            ],
-            usage={"prompt_tokens": 20, "completion_tokens": 15, "total_tokens": 35},
-        )
-
-        mock_provider_config = MagicMock()
-        mock_provider_config.transform_response.return_value = mock_model_response
-        mock_get_provider_config.return_value = mock_provider_config
-
-        # Mock responses API response
+        # Mock responses API response with realistic structure
         mock_responses_response = {
             "id": "resp_abc123",
             "object": "response",
-            "created": 1677652288,
+            "created_at": 1677652288,
             "model": "gpt-4o-2024-08-06",
-            "output": [{"type": "text", "text": "Hello! How can I help you today?"}],
-            "usage": {"input_tokens": 20, "output_tokens": 15},
+            "output": [
+                {
+                    "type": "message",
+                    "id": "msg_001",
+                    "status": "completed",
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "Hello! How can I help you today?",
+                        }
+                    ],
+                }
+            ],
+            "usage": {"input_tokens": 20, "output_tokens": 15, "total_tokens": 35},
+            "status": "completed",
         }
 
         mock_httpx_response = self._create_mock_httpx_response(mock_responses_response)
@@ -698,6 +688,21 @@ class TestOpenAIPassthroughLoggingHandler:
         assert result["kwargs"]["model"] == "gpt-4o"
         assert result["kwargs"]["custom_llm_provider"] == "openai"
 
+        # Verify the result is a ResponsesAPIResponse (not an empty ModelResponse)
+        from litellm.types.llms.openai import ResponsesAPIResponse
+
+        assert isinstance(result["result"], ResponsesAPIResponse)
+        usage = result["result"].usage
+        assert usage is not None
+        # With valid JSON, strict ResponsesAPIResponse() construction should always
+        # produce a proper ResponseAPIUsage model — never a plain dict.
+        # Asserting this catches unexpected model_construct fallbacks early.
+        assert not isinstance(
+            usage, dict
+        ), "usage should be a ResponseAPIUsage model, not a dict"
+        assert usage.input_tokens == 20
+        assert usage.output_tokens == 15
+
         # Verify cost calculation was called with responses call type
         mock_completion_cost.assert_called_once()
         call_args = mock_completion_cost.call_args
@@ -709,6 +714,84 @@ class TestOpenAIPassthroughLoggingHandler:
         assert mock_logging_obj.model_call_details["response_cost"] == 0.000050
         assert mock_logging_obj.model_call_details["model"] == "gpt-4o"
         assert mock_logging_obj.model_call_details["custom_llm_provider"] == "openai"
+
+    @patch("litellm.completion_cost")
+    @patch(
+        "litellm.litellm_core_utils.litellm_logging.get_standard_logging_object_payload"
+    )
+    def test_responses_api_returns_usage_not_zero(
+        self, mock_get_standard_logging, mock_completion_cost
+    ):
+        """Regression test: Responses API passthrough must produce non-zero usage.
+
+        Previously the is_responses branch used OpenAIConfig().transform_response()
+        (chat completions parser) which expects 'choices' in the response. Responses API
+        responses have 'output'/'usage' instead, causing APIError → empty ModelResponse
+        → Langfuse logs input=0, output=0.
+        """
+        mock_completion_cost.return_value = 0.001
+        mock_get_standard_logging.return_value = {"test": "logging_payload"}
+
+        mock_responses_response = {
+            "id": "resp_usage_test",
+            "object": "response",
+            "created_at": 1677652288,
+            "model": "gpt-5.5",
+            "output": [
+                {
+                    "type": "message",
+                    "id": "msg_001",
+                    "status": "completed",
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "langfuse-responses-ok",
+                        }
+                    ],
+                }
+            ],
+            "usage": {
+                "input_tokens": 110009,
+                "output_tokens": 759,
+                "total_tokens": 110768,
+            },
+            "status": "completed",
+        }
+
+        mock_httpx_response = self._create_mock_httpx_response(mock_responses_response)
+        mock_logging_obj = self._create_mock_logging_obj()
+        passthrough_payload = self._create_passthrough_logging_payload()
+
+        kwargs = {
+            "passthrough_logging_payload": passthrough_payload,
+            "model": "gpt-5.5",
+            "custom_llm_provider": "openai",
+        }
+
+        result = OpenAIPassthroughLoggingHandler.openai_passthrough_handler(
+            httpx_response=mock_httpx_response,
+            response_body=mock_responses_response,
+            logging_obj=mock_logging_obj,
+            url_route="https://api.openai.com/v1/responses",
+            result="",
+            start_time=self.start_time,
+            end_time=self.end_time,
+            cache_hit=False,
+            request_body={"model": "gpt-5.5", "input": "test"},
+            **kwargs,
+        )
+
+        from litellm.types.llms.openai import ResponsesAPIResponse
+
+        assert isinstance(result["result"], ResponsesAPIResponse)
+        usage = result["result"].usage
+        assert usage is not None
+        assert not isinstance(
+            usage, dict
+        ), "usage should be a ResponseAPIUsage model, not a dict"
+        assert usage.input_tokens > 0
+        assert usage.output_tokens > 0
 
 
 class TestOpenAIPassthroughIntegration:


### PR DESCRIPTION
## Problem

The `is_responses` branch in `openai_passthrough_logging_handler.py` calls `OpenAIConfig().transform_response()` — the **chat completions** parser — for Responses API passthrough requests. This parser expects a `choices` key in the response JSON, but Responses API responses have `output`/`usage` instead, causing an `APIError` and producing an empty `ModelResponse`.

Downstream, Langfuse reads the empty `ModelResponse` and logs `input_tokens=0, output_tokens=0, total_tokens=0` even though LiteLLM's internal spend tracker has the correct token counts (tracked via a separate billing path).

## Fix

Use `OpenAIResponsesAPIConfig().transform_response_api_response()` for the `is_responses` branch, which correctly parses Responses API JSON (`output`, `usage` with `input_tokens`/`output_tokens`) and returns a proper `ResponsesAPIResponse`.

Also:
- Added `ResponsesAPIResponse` to the `PassThroughEndpointLoggingResultValues` union type
- Fixed the `endpoint_type` debug log to include `"responses"`
- Updated the existing `test_responses_api_cost_tracking` test to exercise the real code path (removed mock of `get_provider_config` that was papering over the bug)
- Added `test_responses_api_returns_usage_not_zero` regression test documenting the root cause

## Relationship to PR #29574

This PR is a **separate, complementary fix** to #29574:
- **#29574** fixes the Langfuse *callback* (`langfuse.py`) to correctly read usage from `ResponsesAPIResponse` objects
- **This PR** fixes the *passthrough handler* to actually *produce* `ResponsesAPIResponse` objects instead of empty `ModelResponse` objects

Both fixes are needed for complete Langfuse observability of Responses API traffic through passthrough endpoints.

Refs: #29575