### PR TITLE
fix(responses): recover streamed output before logging

### DIFF
--- a/litellm/responses/streaming_iterator.py
+++ b/litellm/responses/streaming_iterator.py
@@ -25,6 +25,10 @@ from litellm.litellm_core_utils.llm_response_utils.response_metadata import (
 )
 from litellm.litellm_core_utils.thread_pool_executor import executor
 from litellm.llms.base_llm.responses.transformation import BaseResponsesAPIConfig
+from litellm.responses.sse_output_recovery import (
+    record_output_item_chunk,
+    record_output_text_chunk,
+)
 from litellm.responses.utils import ResponsesAPIRequestUtils
 from litellm.types.llms.openai import ResponsesAPIStreamEvents
 from litellm.types.utils import CallTypes
@@ -77,6 +81,8 @@ class BaseResponsesAPIStreamingIterator:
         self._completed_response_cache_hit: Optional[bool] = None
         self._persist_completed_response_before_logging = True
         self._stream_created_time: float = time.time()
+        self._recovered_output_items: Dict[int, Dict[str, Any]] = {}
+        self._recovered_text_only_items: Dict[int, Dict[str, Any]] = {}
 
         # track request context for hooks
         self.litellm_metadata = litellm_metadata
@@ -116,6 +122,33 @@ class BaseResponsesAPIStreamingIterator:
                 llm_provider=self.custom_llm_provider or "",
             )
 
+    def _record_recoverable_output_chunk(self, parsed_chunk: Dict[str, Any]) -> None:
+        event_type = parsed_chunk.get("type")
+        if event_type == ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE:
+            record_output_item_chunk(
+                parsed_chunk=parsed_chunk,
+                output_items=self._recovered_output_items,
+            )
+        elif event_type == ResponsesAPIStreamEvents.OUTPUT_TEXT_DONE:
+            record_output_text_chunk(
+                parsed_chunk=parsed_chunk,
+                output_items=self._recovered_output_items,
+                text_only_items=self._recovered_text_only_items,
+            )
+
+    def _recover_output_on_completed_response(self, response_obj: Any) -> None:
+        existing_output = getattr(response_obj, "output", None)
+        if existing_output:
+            return
+
+        merged_items: Dict[int, Dict[str, Any]] = {**self._recovered_text_only_items}
+        merged_items.update(self._recovered_output_items)
+        if not merged_items:
+            return
+
+        recovered_output = [item for _, item in sorted(merged_items.items())]
+        setattr(response_obj, "output", recovered_output)
+
     def _process_chunk(self, chunk) -> Optional[Any]:
         """Process a single chunk of data from the stream"""
         if not chunk:
@@ -137,6 +170,7 @@ class BaseResponsesAPIStreamingIterator:
 
             # Format as ResponsesAPIStreamingResponse
             if isinstance(parsed_chunk, dict):
+                self._record_recoverable_output_chunk(parsed_chunk)
                 if self.responses_api_provider_config is None:
                     raise ValueError(
                         "responses_api_provider_config is required to process live streaming chunks"
@@ -245,6 +279,13 @@ class BaseResponsesAPIStreamingIterator:
                     openai_types.ResponsesAPIStreamEvents.RESPONSE_INCOMPLETE,
                     openai_types.ResponsesAPIStreamEvents.RESPONSE_FAILED,
                 ):
+                    response_obj_for_recovery = getattr(
+                        openai_responses_api_chunk, "response", None
+                    )
+                    if response_obj_for_recovery is not None:
+                        self._recover_output_on_completed_response(
+                            response_obj_for_recovery
+                        )
                     self.completed_response = openai_responses_api_chunk
                     # Add cost to usage object if include_cost_in_streaming_usage is True
                     if (

--- a/tests/llm_responses_api_testing/test_responses_hooks.py
+++ b/tests/llm_responses_api_testing/test_responses_hooks.py
@@ -422,6 +422,213 @@ def test_process_chunk_recovers_output_from_stream_events_before_logging(monkeyp
     completion_handler.assert_called_once()
 
 
+def test_record_recoverable_output_chunk_handles_output_item_done(monkeypatch):
+    """OUTPUT_ITEM_DONE chunks populate _recovered_output_items (takes precedence
+    over any synthetic text-only recovery at the same output_index)."""
+
+    class _NoopConfig:
+        def transform_streaming_response(self, **kwargs):
+            return None
+
+    iterator = ResponsesAPIStreamingIterator(
+        response=httpx.Response(200),
+        model="test-model",
+        responses_api_provider_config=_NoopConfig(),
+        logging_obj=_FakeLoggingObj(),
+        request_data={"foo": "bar"},
+        call_type=CallTypes.responses.value,
+    )
+
+    real_item = {
+        "type": "message",
+        "id": "msg_real",
+        "role": "assistant",
+        "status": "completed",
+        "content": [
+            {
+                "type": "output_text",
+                "text": "real-item-text",
+                "annotations": [],
+            }
+        ],
+    }
+    iterator._process_chunk(
+        json.dumps(
+            {
+                "type": "response.output_item.done",
+                "output_index": 0,
+                "item": real_item,
+            }
+        )
+    )
+
+    assert iterator._recovered_output_items[0] == real_item
+    # Pre-seed a synthetic text-only item at the same index to verify the
+    # OUTPUT_ITEM_DONE branch overwrites it on the next pass.
+    iterator._recovered_text_only_items[0] = {
+        "type": "message",
+        "id": "msg_synthetic",
+        "role": "assistant",
+        "status": "completed",
+        "content": [{"type": "output_text", "text": "synthetic", "annotations": []}],
+    }
+    iterator._process_chunk(
+        json.dumps(
+            {
+                "type": "response.output_item.done",
+                "output_index": 0,
+                "item": real_item,
+            }
+        )
+    )
+    assert iterator._recovered_output_items[0] == real_item
+
+
+def test_recover_output_on_completed_response_skips_when_existing_output_present():
+    """If the terminal response already carries output, recovery is a no-op."""
+    iterator = ResponsesAPIStreamingIterator(
+        response=httpx.Response(200),
+        model="test-model",
+        responses_api_provider_config=SimpleNamespace(),
+        logging_obj=_FakeLoggingObj(),
+        request_data={"foo": "bar"},
+        call_type=CallTypes.responses.value,
+    )
+    # Seed the recovery buffers — these should be ignored when the response
+    # object already has output.
+    iterator._recovered_output_items[0] = {
+        "type": "message",
+        "id": "msg_real",
+        "role": "assistant",
+        "status": "completed",
+        "content": [{"type": "output_text", "text": "real", "annotations": []}],
+    }
+
+    response_obj = ResponsesAPIResponse(
+        id="resp_skip",
+        created_at=int(datetime.now().timestamp()),
+        status="completed",
+        model="test-model",
+        object="response",
+        output=[
+            {
+                "type": "message",
+                "id": "msg_provider",
+                "role": "assistant",
+                "status": "completed",
+                "content": [
+                    {
+                        "type": "output_text",
+                        "text": "provider-supplied",
+                        "annotations": [],
+                    }
+                ],
+            }
+        ],
+    )
+
+    iterator._recover_output_on_completed_response(response_obj)
+
+    # Existing output is untouched.
+    assert len(response_obj.output) == 1
+    assert response_obj.output[0].id == "msg_provider"
+
+
+def test_recover_output_on_completed_response_noop_when_buffers_empty():
+    """No recoverable items + empty response.output → no mutation, no crash."""
+    iterator = ResponsesAPIStreamingIterator(
+        response=httpx.Response(200),
+        model="test-model",
+        responses_api_provider_config=SimpleNamespace(),
+        logging_obj=_FakeLoggingObj(),
+        request_data={"foo": "bar"},
+        call_type=CallTypes.responses.value,
+    )
+
+    response_obj = ResponsesAPIResponse(
+        id="resp_empty",
+        created_at=int(datetime.now().timestamp()),
+        status="completed",
+        model="test-model",
+        object="response",
+        output=[],
+    )
+
+    iterator._recover_output_on_completed_response(response_obj)
+
+    assert response_obj.output == []
+
+
+def test_process_chunk_recovers_output_for_incomplete_terminal_event(monkeypatch):
+    """RESPONSE_INCOMPLETE with empty output should also trigger recovery
+    (the iterator recovery path runs before logging for incomplete/failed
+    terminal events, not just RESPONSE_COMPLETED)."""
+    openai_types = streaming_module._get_openai_response_types()
+
+    class _IncompleteConfig:
+        def transform_streaming_response(self, **kwargs):
+            parsed_chunk = kwargs["parsed_chunk"]
+            event_type = parsed_chunk.get("type")
+            if event_type == openai_types.ResponsesAPIStreamEvents.OUTPUT_TEXT_DONE:
+                return openai_types.OutputTextDoneEvent(
+                    type=openai_types.ResponsesAPIStreamEvents.OUTPUT_TEXT_DONE,
+                    item_id="msg_inc",
+                    output_index=0,
+                    content_index=0,
+                    text="partial",
+                )
+            return openai_types.ResponseIncompleteEvent(
+                type=openai_types.ResponsesAPIStreamEvents.RESPONSE_INCOMPLETE,
+                response=ResponsesAPIResponse(
+                    id="resp_inc",
+                    created_at=int(datetime.now().timestamp()),
+                    status="incomplete",
+                    model="test-model",
+                    object="response",
+                    output=[],
+                    incomplete_details={"reason": "max_output_tokens"},
+                ),
+            )
+
+    iterator = ResponsesAPIStreamingIterator(
+        response=httpx.Response(200),
+        model="test-model",
+        responses_api_provider_config=_IncompleteConfig(),
+        logging_obj=_FakeLoggingObj(),
+        request_data={"foo": "bar"},
+        call_type=CallTypes.responses.value,
+    )
+    completion_handler = MagicMock()
+    monkeypatch.setattr(
+        iterator, "_handle_logging_completed_response", completion_handler
+    )
+
+    iterator._process_chunk(
+        json.dumps(
+            {
+                "type": "response.output_text.done",
+                "item_id": "msg_inc",
+                "output_index": 0,
+                "content_index": 0,
+                "text": "partial",
+            }
+        )
+    )
+    event = iterator._process_chunk(
+        json.dumps(
+            {
+                "type": "response.incomplete",
+                "response": {"id": "resp_inc", "output": []},
+            }
+        )
+    )
+
+    assert event.response.output != []
+    assert event.response.output[0]["content"][0]["text"] == "partial"
+    assert iterator.completed_response is event
+    completion_handler.assert_called_once()
+
+
 def test_process_chunk_completed_response_updates_id_and_usage_cost(monkeypatch):
     original_include_cost = litellm.include_cost_in_streaming_usage
     litellm.include_cost_in_streaming_usage = True

--- a/tests/llm_responses_api_testing/test_responses_hooks.py
+++ b/tests/llm_responses_api_testing/test_responses_hooks.py
@@ -342,6 +342,86 @@ def test_process_chunk_wraps_encrypted_content_with_model_id():
     assert event.item.encrypted_content.endswith(";ciphertext")
 
 
+def test_process_chunk_recovers_output_from_stream_events_before_logging(monkeypatch):
+    openai_types = streaming_module._get_openai_response_types()
+
+    class _RecoveringConfig:
+        def transform_streaming_response(self, **kwargs):
+            parsed_chunk = kwargs["parsed_chunk"]
+            event_type = parsed_chunk.get("type")
+            if event_type == openai_types.ResponsesAPIStreamEvents.OUTPUT_TEXT_DONE:
+                return openai_types.OutputTextDoneEvent(
+                    type=openai_types.ResponsesAPIStreamEvents.OUTPUT_TEXT_DONE,
+                    item_id="msg_1",
+                    output_index=0,
+                    content_index=0,
+                    text="bridge-ok",
+                )
+            return openai_types.ResponseCompletedEvent(
+                type=openai_types.ResponsesAPIStreamEvents.RESPONSE_COMPLETED,
+                response=ResponsesAPIResponse(
+                    id="resp_live",
+                    created_at=int(datetime.now().timestamp()),
+                    status="completed",
+                    model="test-model",
+                    object="response",
+                    output=[],
+                    usage=openai_types.ResponseAPIUsage(
+                        input_tokens=10,
+                        output_tokens=3,
+                        total_tokens=13,
+                    ),
+                ),
+            )
+
+    iterator = ResponsesAPIStreamingIterator(
+        response=httpx.Response(200),
+        model="test-model",
+        responses_api_provider_config=_RecoveringConfig(),
+        logging_obj=_FakeLoggingObj(),
+        request_data={"foo": "bar"},
+        call_type=CallTypes.responses.value,
+    )
+    completion_handler = MagicMock()
+    monkeypatch.setattr(
+        iterator, "_handle_logging_completed_response", completion_handler
+    )
+
+    iterator._process_chunk(
+        json.dumps(
+            {
+                "type": "response.output_text.done",
+                "item_id": "msg_1",
+                "output_index": 0,
+                "content_index": 0,
+                "text": "bridge-ok",
+            }
+        )
+    )
+    event = iterator._process_chunk(
+        json.dumps(
+            {
+                "type": "response.completed",
+                "response": {
+                    "id": "resp_live",
+                    "output": [],
+                    "usage": {
+                        "input_tokens": 10,
+                        "output_tokens": 3,
+                        "total_tokens": 13,
+                    },
+                },
+            }
+        )
+    )
+
+    assert event.response.output != []
+    output_item = event.response.output[0]
+    assert output_item["content"][0]["text"] == "bridge-ok"
+    assert iterator.completed_response is event
+    completion_handler.assert_called_once()
+
+
 def test_process_chunk_completed_response_updates_id_and_usage_cost(monkeypatch):
     original_include_cost = litellm.include_cost_in_streaming_usage
     litellm.include_cost_in_streaming_usage = True
@@ -387,9 +467,7 @@ def test_process_chunk_completed_response_updates_id_and_usage_cost(monkeypatch)
         # Chunk must include a top-level "response" key so BaseResponsesAPIStreamingIterator
         # runs _update_responses_api_response_id_with_model_id (see streaming_iterator.py).
         event = iterator._process_chunk(
-            json.dumps(
-                {"type": "response.completed", "response": {"id": "resp_live"}}
-            )
+            json.dumps({"type": "response.completed", "response": {"id": "resp_live"}})
         )
     finally:
         litellm.include_cost_in_streaming_usage = original_include_cost


### PR DESCRIPTION
## Relevant issues

Follow-up to #29574 and #29666

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## CI (LiteLLM team)

- [ ] Branch creation CI run
       Link:

- [ ] CI run for the last commit
       Link:

- [ ] Merge / cherry-pick CI run
       Links:

## Screenshots / Proof of Fix

A focused regression test now covers the failure mode where a streaming Responses API provider emits useful `response.output_text.done` chunks, but the final `response.completed` payload has an empty `response.output`. Before the fix, the completed response stayed empty and downstream logging callbacks received no output content. After the fix, the streaming iterator reconstructs the output before the completed response is logged

```bash
PYTEST_XDIST_WORKER=gw0 python -m pytest tests/llm_responses_api_testing/test_responses_hooks.py -q
```

Output:

```text
31 passed in 2.60s
```

Additional checks run:

```bash
python -m black litellm/responses/streaming_iterator.py tests/llm_responses_api_testing/test_responses_hooks.py
python -m compileall litellm/responses/streaming_iterator.py tests/llm_responses_api_testing/test_responses_hooks.py
python -m ruff check litellm/responses/streaming_iterator.py tests/llm_responses_api_testing/test_responses_hooks.py
```

## Type

Bug Fix
Test

## Changes

The Responses API streaming iterator now records recoverable output from `response.output_item.done` and `response.output_text.done` SSE chunks while the stream is being consumed. When a terminal `response.completed`, `response.incomplete`, or `response.failed` event arrives with an empty `response.output`, the iterator fills that output from the recovered stream items before invoking the normal success or failure logging path

This keeps the fix local to the streaming iterator and reuses the existing `sse_output_recovery` helpers rather than duplicating output reconstruction logic. Real `output_item.done` payloads take precedence over synthetic text-only recovery at the same `output_index`
