### PR TITLE
fix(attachment_registry): preserve config-loaded policies across DB sync

### DIFF
--- a/litellm/proxy/policy_engine/attachment_registry.py
+++ b/litellm/proxy/policy_engine/attachment_registry.py
@@ -41,6 +41,7 @@ class AttachmentRegistry:
 
     def __init__(self):
         self._attachments: List[PolicyAttachment] = []
+        self._config_attachments: List[PolicyAttachment] = []
         self._initialized: bool = False
 
     def load_attachments(self, attachments_config: List[Dict[str, Any]]) -> None:
@@ -51,11 +52,13 @@ class AttachmentRegistry:
             attachments_config: List of attachment dictionaries from YAML.
         """
         self._attachments = []
+        self._config_attachments = []
 
         for attachment_data in attachments_config:
             try:
                 attachment = self._parse_attachment(attachment_data)
                 self._attachments.append(attachment)
+                self._config_attachments.append(attachment)
                 verbose_proxy_logger.debug(
                     f"Loaded attachment for policy: {attachment.policy}"
                 )
@@ -210,6 +213,7 @@ class AttachmentRegistry:
         Clear all attachments from the registry.
         """
         self._attachments = []
+        self._config_attachments = []
         self._initialized = False
 
     def add_attachment(self, attachment: PolicyAttachment) -> None:
@@ -452,14 +456,17 @@ class AttachmentRegistry:
         """
         Sync policy attachments from the database to in-memory registry.
 
+        Preserves config-loaded attachments so a DB sync with no results does not
+        wipe them. DB entries are merged on top of config attachments.
+
         Args:
             prisma_client: The Prisma client instance
         """
         try:
             attachments = await self.get_all_attachments_from_db(prisma_client)
 
-            # Clear existing attachments and reload from DB
-            self._attachments = []
+            # Start with config-loaded attachments (preserve YAML-defined ones)
+            self._attachments = list(self._config_attachments)
 
             for attachment_response in attachments:
                 attachment = PolicyAttachment(
@@ -480,7 +487,8 @@ class AttachmentRegistry:
 
             self._initialized = True
             verbose_proxy_logger.info(
-                f"Synced {len(attachments)} attachments from DB to in-memory registry"
+                f"Synced {len(attachments)} DB attachments + "
+                f"{len(self._config_attachments)} config attachments to in-memory registry"
             )
         except Exception as e:
             verbose_proxy_logger.exception(f"Error syncing attachments from DB: {e}")


### PR DESCRIPTION
## Relevant issues

This update will fix [issue](https://github.com/BerriAI/litellm/issues/29416) in addition of [this](https://github.com/BerriAI/litellm/pull/29500) pull request.


## Working instruction
Create some models using config.yaml file
```yaml
model_list:
  - model_name: brain-Qwen3.5
    litellm_params:
      model: openai/Qwen3.5
      api_base: https://my-custom-model.youpi.fr/v1
      api_key: os.environ/BRAIN_API_KEY
  - model_name: DeepSeek-V4-Pro
    litellm_params:
      model: together_ai/deepseek-ai/DeepSeek-V4-Pro
  - model_name: kimi-k2.6
    litellm_params:
      model: moonshot/kimi-k2.6
  - model_name: Qwen3.6-27B
    litellm_params:
      model: ovhcloud/Qwen3.6-27B
```

Create some policies
```yaml
policies:
  gdpr-external-providers:
    guardrails:
      add:
        - gdpr-eu-contact-information
        - gdpr-eu-financial-data
        - gdpr-eu-national-identifiers
        - secrets-protection
    condition:
      model:
        - DeepSeek-V4-Pro
        - kimi-k2.6

  gdpr-eu-providers:
    guardrails:
      add:
        - secrets-protection
    condition:
      model:
        - Qwen3.6-27B

policy_attachments:
  - policy: gdpr-external-providers
    scope: '*'
  - policy: gdpr-eu-providers
    scope: '*'
```

Guardrails will now work correctly:
- gdpr-eu-contact-information, gdpr-eu-financial-data, gdpr-eu-national-identifiers and secrets-protection for DeepSeek-V4-Pro and kimi-k2.6
- secrets-protection for Qwen3.6-27B
- no guardrail for brain-Qwen3.5

## Screenshots / Proof of Fix

The patch preserves YAML-loaded policy attachments during periodic database synchronization.

Problem: When store_model_in_db: true is set, LiteLLM periodically calls sync_attachments_from_db() (~every 10s). The upstream code does self._attachments = [] then reloads only from the database. Since policy attachments defined in config.yaml are never stored in the DB, they get wiped — causing all guardrails to silently stop being enforced.

Fix: The patch introduces a _config_attachments field that stores a copy of attachments loaded from YAML config. During DB sync, instead of starting from an empty list, it starts from list(self._config_attachments), then appends any DB-sourced attachments on top. This ensures config-defined attachments are never lost.

This mirrors the same fix already applied to [policy_registry.py](https://github.com/BerriAI/litellm/pull/29500) (which had the identical bug for policies themselves).

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix

## Changes
