### PR TITLE
feat(moonshot): advertise json_schema response support on live models

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -25119,6 +25119,7 @@
         "source": "https://platform.moonshot.ai/docs/guide/kimi-k2-5-quickstart",
         "supports_function_calling": true,
         "supports_reasoning": true,
+        "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_video_input": true,
         "supports_vision": true
@@ -25135,6 +25136,7 @@
         "source": "https://platform.kimi.ai/docs/pricing/chat-k26",
         "supports_function_calling": true,
         "supports_reasoning": true,
+        "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_video_input": true,
         "supports_vision": true
@@ -25247,6 +25249,7 @@
         "output_cost_per_token": 5e-06,
         "source": "https://platform.moonshot.ai/docs/pricing",
         "supports_function_calling": true,
+        "supports_response_schema": true,
         "supports_tool_choice": true
     },
     "moonshot/moonshot-v1-128k-0430": {
@@ -25271,6 +25274,7 @@
         "output_cost_per_token": 5e-06,
         "source": "https://platform.moonshot.ai/docs/pricing",
         "supports_function_calling": true,
+        "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true
     },
@@ -25284,6 +25288,7 @@
         "output_cost_per_token": 3e-06,
         "source": "https://platform.moonshot.ai/docs/pricing",
         "supports_function_calling": true,
+        "supports_response_schema": true,
         "supports_tool_choice": true
     },
     "moonshot/moonshot-v1-32k-0430": {
@@ -25308,6 +25313,7 @@
         "output_cost_per_token": 3e-06,
         "source": "https://platform.moonshot.ai/docs/pricing",
         "supports_function_calling": true,
+        "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true
     },
@@ -25321,6 +25327,7 @@
         "output_cost_per_token": 2e-06,
         "source": "https://platform.moonshot.ai/docs/pricing",
         "supports_function_calling": true,
+        "supports_response_schema": true,
         "supports_tool_choice": true
     },
     "moonshot/moonshot-v1-8k-0430": {
@@ -25345,6 +25352,7 @@
         "output_cost_per_token": 2e-06,
         "source": "https://platform.moonshot.ai/docs/pricing",
         "supports_function_calling": true,
+        "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true
     },
@@ -25358,6 +25366,7 @@
         "output_cost_per_token": 5e-06,
         "source": "https://platform.moonshot.ai/docs/pricing",
         "supports_function_calling": true,
+        "supports_response_schema": true,
         "supports_tool_choice": true
     },
     "morph/morph-v3-fast": {

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -24927,6 +24927,7 @@
         "source": "https://platform.moonshot.ai/docs/guide/kimi-k2-5-quickstart",
         "supports_function_calling": true,
         "supports_reasoning": true,
+        "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_video_input": true,
         "supports_vision": true
@@ -24943,6 +24944,7 @@
         "source": "https://platform.kimi.ai/docs/pricing/chat-k26",
         "supports_function_calling": true,
         "supports_reasoning": true,
+        "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_video_input": true,
         "supports_vision": true
@@ -25055,6 +25057,7 @@
         "output_cost_per_token": 5e-06,
         "source": "https://platform.moonshot.ai/docs/pricing",
         "supports_function_calling": true,
+        "supports_response_schema": true,
         "supports_tool_choice": true
     },
     "moonshot/moonshot-v1-128k-0430": {
@@ -25079,6 +25082,7 @@
         "output_cost_per_token": 5e-06,
         "source": "https://platform.moonshot.ai/docs/pricing",
         "supports_function_calling": true,
+        "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true
     },
@@ -25092,6 +25096,7 @@
         "output_cost_per_token": 3e-06,
         "source": "https://platform.moonshot.ai/docs/pricing",
         "supports_function_calling": true,
+        "supports_response_schema": true,
         "supports_tool_choice": true
     },
     "moonshot/moonshot-v1-32k-0430": {
@@ -25116,6 +25121,7 @@
         "output_cost_per_token": 3e-06,
         "source": "https://platform.moonshot.ai/docs/pricing",
         "supports_function_calling": true,
+        "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true
     },
@@ -25129,6 +25135,7 @@
         "output_cost_per_token": 2e-06,
         "source": "https://platform.moonshot.ai/docs/pricing",
         "supports_function_calling": true,
+        "supports_response_schema": true,
         "supports_tool_choice": true
     },
     "moonshot/moonshot-v1-8k-0430": {
@@ -25153,6 +25160,7 @@
         "output_cost_per_token": 2e-06,
         "source": "https://platform.moonshot.ai/docs/pricing",
         "supports_function_calling": true,
+        "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true
     },
@@ -25166,6 +25174,7 @@
         "output_cost_per_token": 5e-06,
         "source": "https://platform.moonshot.ai/docs/pricing",
         "supports_function_calling": true,
+        "supports_response_schema": true,
         "supports_tool_choice": true
     },
     "morph/morph-v3-fast": {

--- a/tests/test_litellm/llms/moonshot/test_moonshot_chat_transformation.py
+++ b/tests/test_litellm/llms/moonshot/test_moonshot_chat_transformation.py
@@ -9,15 +9,12 @@ import os
 import sys
 from unittest.mock import patch
 
-sys.path.insert(
-    0, os.path.abspath("../../../../..")
-)  # Adds the parent directory to the system path
+sys.path.insert(0, os.path.abspath("../../../../.."))  # Adds the parent directory to the system path
 
 import pytest
 
 import litellm
 import litellm.utils
-from litellm import completion
 from litellm.litellm_core_utils.get_model_cost_map import GetModelCostMap
 from litellm.llms.moonshot.chat.transformation import MoonshotChatConfig
 
@@ -232,10 +229,7 @@ class TestMoonshotConfig:
         assert result["messages"][0]["role"] == "user"
         assert result["messages"][0]["content"] == "What's the weather like?"
         assert result["messages"][1]["role"] == "user"
-        assert (
-            result["messages"][1]["content"]
-            == "Please select a tool to handle the current issue."
-        )
+        assert result["messages"][1]["content"] == "Please select a tool to handle the current issue."
 
         # Check that tool_choice was removed but tools are preserved
         assert "tool_choice" not in result
@@ -273,10 +267,7 @@ class TestMoonshotConfig:
 
         # Check that the message was added
         assert len(result["messages"]) == 2
-        assert (
-            result["messages"][1]["content"]
-            == "Please select a tool to handle the current issue."
-        )
+        assert result["messages"][1]["content"] == "Please select a tool to handle the current issue."
 
     def test_tool_choice_non_required_preserved(self):
         """Test that non-'required' tool_choice values are preserved"""
@@ -501,9 +492,7 @@ class TestMoonshotConfig:
         assert result[0].get("reasoning_content") == "stored thinking"
         # The promoted key must be removed from provider_specific_fields to
         # avoid sending the value twice in the serialised request body
-        assert "reasoning_content" not in (
-            result[0].get("provider_specific_fields") or {}
-        )
+        assert "reasoning_content" not in (result[0].get("provider_specific_fields") or {})
 
     def test_reasoning_model_fill_called_from_transform_request(self):
         """transform_request injects reasoning_content end-to-end for reasoning models."""
@@ -603,10 +592,7 @@ class TestMoonshotConfig:
         result = config.fill_reasoning_content(messages)
 
         # reasoning_content should be preserved, not replaced with placeholder
-        assert (
-            result[0].get("reasoning_content")
-            == "<thinking>User wants weather</thinking>"
-        )
+        assert result[0].get("reasoning_content") == "<thinking>User wants weather</thinking>"
 
     def test_reasoning_content_preserved_in_multi_turn_flow(self):
         """reasoning_content is preserved through multi-turn conversation flow.
@@ -650,10 +636,7 @@ class TestMoonshotConfig:
         result = config.fill_reasoning_content(messages)
 
         # reasoning_content should be preserved in the assistant message
-        assert (
-            result[1].get("reasoning_content")
-            == "<thinking>Planning to call weather tool</thinking>"
-        )
+        assert result[1].get("reasoning_content") == "<thinking>Planning to call weather tool</thinking>"
 
 
 class TestKimiK26ModelRegistry:
@@ -695,3 +678,33 @@ class TestKimiK26ModelRegistry:
         """kimi-k2.6 should be assigned to the moonshot provider."""
         model_info = model_cost_map["moonshot/kimi-k2.6"]
         assert model_info["litellm_provider"] == "moonshot"
+
+
+class TestMoonshotResponseSchemaSupport:
+    """Every model currently live on api.moonshot.ai supports json_schema
+    response_format, which gates discovery via litellm.responses(). The flag
+    must be true so the capability is advertised honestly."""
+
+    LIVE_MODELS = [
+        "moonshot/kimi-k2.5",
+        "moonshot/kimi-k2.6",
+        "moonshot/moonshot-v1-8k",
+        "moonshot/moonshot-v1-32k",
+        "moonshot/moonshot-v1-128k",
+        "moonshot/moonshot-v1-8k-vision-preview",
+        "moonshot/moonshot-v1-32k-vision-preview",
+        "moonshot/moonshot-v1-128k-vision-preview",
+        "moonshot/moonshot-v1-auto",
+    ]
+
+    @pytest.fixture(autouse=True)
+    def model_cost_map(self):
+        return GetModelCostMap.load_local_model_cost_map()
+
+    @pytest.mark.parametrize("model", LIVE_MODELS)
+    def test_live_model_supports_response_schema(self, model, model_cost_map):
+        assert model_cost_map[model].get("supports_response_schema") is True
+
+    def test_supports_response_schema_utility_reports_true(self, model_cost_map, monkeypatch):
+        monkeypatch.setattr(litellm, "model_cost", model_cost_map)
+        assert litellm.utils.supports_response_schema(model="moonshot/kimi-k2.5") is True


### PR DESCRIPTION
## Relevant issues

Moonshot / Kimi could not be selected as a structured-output (Responses API) provider in downstream tooling because litellm never advertised json_schema support for it, even though the capability works today.

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## CI (LiteLLM team)

- [ ] Branch creation CI run
       Link:
- [ ] CI run for the last commit
       Link:
- [ ] Merge / cherry-pick CI run
       Links:

## Screenshots / Proof of Fix

`litellm.responses(model="moonshot/...")` already routes through the responses to chat-completions bridge, and Moonshot honors `response_format` json_schema on chat completions; the only gap was the missing `supports_response_schema` flag, which made capability-gated discovery drop Moonshot.

Verified against the live api.moonshot.ai endpoint that the flag now reports true and that a Responses-API call with a json_schema format returns schema-valid structured output through the bridge. To reproduce on a local proxy:

```yaml
# config.yaml
model_list:
  - model_name: kimi-k2.5
    litellm_params:
      model: moonshot/kimi-k2.5
      api_key: os.environ/MOONSHOT_API_KEY
```

```bash
python litellm/proxy/proxy_cli.py --config config.yaml --detailed_debug

curl http://localhost:4000/v1/responses \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer sk-1234" \
  -d '{
    "model": "kimi-k2.5",
    "input": "Give me a person named Ada who is 36.",
    "text": {"format": {"type": "json_schema", "name": "person", "strict": true,
      "schema": {"type": "object", "properties": {"name": {"type": "string"}, "age": {"type": "integer"}},
        "required": ["name", "age"], "additionalProperties": false}}}
  }'
```

The response output parses as `{"name": "Ada", "age": 36}`.

## Type

🆕 New Feature

## Changes

Set `supports_response_schema` on the nine Moonshot models currently live on api.moonshot.ai (kimi-k2.5, kimi-k2.6, the moonshot-v1 8k/32k/128k text and vision-preview variants, and moonshot-v1-auto) in both the root cost map and the bundled backup. Added registry tests asserting the flag on every live model and that `litellm.utils.supports_response_schema` reports true for Moonshot. Models that are no longer served on api.moonshot.ai are intentionally left untouched here and handled in a follow-up.
