### PR TITLE
chore(moonshot): mark models retired from api.moonshot.ai as deprecated

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -25067,6 +25067,7 @@
     },
     "moonshot/kimi-k2-0711-preview": {
         "cache_read_input_token_cost": 1.5e-07,
+        "deprecation_date": "2026-05-25",
         "input_cost_per_token": 6e-07,
         "litellm_provider": "moonshot",
         "max_input_tokens": 131072,
@@ -25081,6 +25082,7 @@
     },
     "moonshot/kimi-k2-0905-preview": {
         "cache_read_input_token_cost": 1.5e-07,
+        "deprecation_date": "2026-05-25",
         "input_cost_per_token": 6e-07,
         "litellm_provider": "moonshot",
         "max_input_tokens": 262144,
@@ -25095,6 +25097,7 @@
     },
     "moonshot/kimi-k2-turbo-preview": {
         "cache_read_input_token_cost": 1.5e-07,
+        "deprecation_date": "2026-05-25",
         "input_cost_per_token": 1.15e-06,
         "litellm_provider": "moonshot",
         "max_input_tokens": 262144,
@@ -25141,6 +25144,7 @@
     },
     "moonshot/kimi-latest": {
         "cache_read_input_token_cost": 1.5e-07,
+        "deprecation_date": "2026-01-28",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "moonshot",
         "max_input_tokens": 131072,
@@ -25155,6 +25159,7 @@
     },
     "moonshot/kimi-latest-128k": {
         "cache_read_input_token_cost": 1.5e-07,
+        "deprecation_date": "2026-01-28",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "moonshot",
         "max_input_tokens": 131072,
@@ -25169,6 +25174,7 @@
     },
     "moonshot/kimi-latest-32k": {
         "cache_read_input_token_cost": 1.5e-07,
+        "deprecation_date": "2026-01-28",
         "input_cost_per_token": 1e-06,
         "litellm_provider": "moonshot",
         "max_input_tokens": 32768,
@@ -25183,6 +25189,7 @@
     },
     "moonshot/kimi-latest-8k": {
         "cache_read_input_token_cost": 1.5e-07,
+        "deprecation_date": "2026-01-28",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "moonshot",
         "max_input_tokens": 8192,
@@ -25197,6 +25204,7 @@
     },
     "moonshot/kimi-thinking-preview": {
         "cache_read_input_token_cost": 1.5e-07,
+        "deprecation_date": "2025-11-11",
         "input_cost_per_token": 6e-07,
         "litellm_provider": "moonshot",
         "max_input_tokens": 131072,
@@ -25209,6 +25217,7 @@
     },
     "moonshot/kimi-k2-thinking": {
         "cache_read_input_token_cost": 1.5e-07,
+        "deprecation_date": "2026-05-25",
         "input_cost_per_token": 6e-07,
         "litellm_provider": "moonshot",
         "max_input_tokens": 262144,
@@ -25224,6 +25233,7 @@
     },
     "moonshot/kimi-k2-thinking-turbo": {
         "cache_read_input_token_cost": 1.5e-07,
+        "deprecation_date": "2026-05-25",
         "input_cost_per_token": 1.15e-06,
         "litellm_provider": "moonshot",
         "max_input_tokens": 262144,
@@ -25250,6 +25260,7 @@
         "supports_tool_choice": true
     },
     "moonshot/moonshot-v1-128k-0430": {
+        "deprecation_date": "2024-04-30",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "moonshot",
         "max_input_tokens": 131072,
@@ -25287,6 +25298,7 @@
         "supports_tool_choice": true
     },
     "moonshot/moonshot-v1-32k-0430": {
+        "deprecation_date": "2024-04-30",
         "input_cost_per_token": 1e-06,
         "litellm_provider": "moonshot",
         "max_input_tokens": 32768,
@@ -25324,6 +25336,7 @@
         "supports_tool_choice": true
     },
     "moonshot/moonshot-v1-8k-0430": {
+        "deprecation_date": "2024-04-30",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "moonshot",
         "max_input_tokens": 8192,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -24875,6 +24875,7 @@
     },
     "moonshot/kimi-k2-0711-preview": {
         "cache_read_input_token_cost": 1.5e-07,
+        "deprecation_date": "2026-05-25",
         "input_cost_per_token": 6e-07,
         "litellm_provider": "moonshot",
         "max_input_tokens": 131072,
@@ -24889,6 +24890,7 @@
     },
     "moonshot/kimi-k2-0905-preview": {
         "cache_read_input_token_cost": 1.5e-07,
+        "deprecation_date": "2026-05-25",
         "input_cost_per_token": 6e-07,
         "litellm_provider": "moonshot",
         "max_input_tokens": 262144,
@@ -24903,6 +24905,7 @@
     },
     "moonshot/kimi-k2-turbo-preview": {
         "cache_read_input_token_cost": 1.5e-07,
+        "deprecation_date": "2026-05-25",
         "input_cost_per_token": 1.15e-06,
         "litellm_provider": "moonshot",
         "max_input_tokens": 262144,
@@ -24949,6 +24952,7 @@
     },
     "moonshot/kimi-latest": {
         "cache_read_input_token_cost": 1.5e-07,
+        "deprecation_date": "2026-01-28",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "moonshot",
         "max_input_tokens": 131072,
@@ -24963,6 +24967,7 @@
     },
     "moonshot/kimi-latest-128k": {
         "cache_read_input_token_cost": 1.5e-07,
+        "deprecation_date": "2026-01-28",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "moonshot",
         "max_input_tokens": 131072,
@@ -24977,6 +24982,7 @@
     },
     "moonshot/kimi-latest-32k": {
         "cache_read_input_token_cost": 1.5e-07,
+        "deprecation_date": "2026-01-28",
         "input_cost_per_token": 1e-06,
         "litellm_provider": "moonshot",
         "max_input_tokens": 32768,
@@ -24991,6 +24997,7 @@
     },
     "moonshot/kimi-latest-8k": {
         "cache_read_input_token_cost": 1.5e-07,
+        "deprecation_date": "2026-01-28",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "moonshot",
         "max_input_tokens": 8192,
@@ -25005,6 +25012,7 @@
     },
     "moonshot/kimi-thinking-preview": {
         "cache_read_input_token_cost": 1.5e-07,
+        "deprecation_date": "2025-11-11",
         "input_cost_per_token": 6e-07,
         "litellm_provider": "moonshot",
         "max_input_tokens": 131072,
@@ -25017,6 +25025,7 @@
     },
     "moonshot/kimi-k2-thinking": {
         "cache_read_input_token_cost": 1.5e-07,
+        "deprecation_date": "2026-05-25",
         "input_cost_per_token": 6e-07,
         "litellm_provider": "moonshot",
         "max_input_tokens": 262144,
@@ -25032,6 +25041,7 @@
     },
     "moonshot/kimi-k2-thinking-turbo": {
         "cache_read_input_token_cost": 1.5e-07,
+        "deprecation_date": "2026-05-25",
         "input_cost_per_token": 1.15e-06,
         "litellm_provider": "moonshot",
         "max_input_tokens": 262144,
@@ -25058,6 +25068,7 @@
         "supports_tool_choice": true
     },
     "moonshot/moonshot-v1-128k-0430": {
+        "deprecation_date": "2024-04-30",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "moonshot",
         "max_input_tokens": 131072,
@@ -25095,6 +25106,7 @@
         "supports_tool_choice": true
     },
     "moonshot/moonshot-v1-32k-0430": {
+        "deprecation_date": "2024-04-30",
         "input_cost_per_token": 1e-06,
         "litellm_provider": "moonshot",
         "max_input_tokens": 32768,
@@ -25132,6 +25144,7 @@
         "supports_tool_choice": true
     },
     "moonshot/moonshot-v1-8k-0430": {
+        "deprecation_date": "2024-04-30",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "moonshot",
         "max_input_tokens": 8192,


### PR DESCRIPTION
## Relevant issues

Thirteen Moonshot / Kimi models in the cost map are no longer served on api.moonshot.ai. They were surfacing as selectable in tooling that reads the model registry, even though every one returns a 404 from the live API.

## Linear ticket

N/A

## Pre-Submission checklist

- [ ] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

This is a data-only change to the model cost map (deprecation metadata); it is verified directly against the live API rather than with a unit test.

## CI (LiteLLM team)

- [ ] Branch creation CI run
       Link:
- [ ] CI run for the last commit
       Link:
- [ ] Merge / cherry-pick CI run
       Links:

## Screenshots / Proof of Fix

Each retired model returns 404 from the live endpoint:

```bash
for m in kimi-latest kimi-thinking-preview kimi-k2-thinking kimi-k2-0905-preview moonshot-v1-8k-0430; do
  printf "%-24s " "$m"
  curl -s -o /dev/null -w "%{http_code}\n" https://api.moonshot.ai/v1/chat/completions \
    -H "Authorization: Bearer $MOONSHOT_API_KEY" -H "Content-Type: application/json" \
    -d "{\"model\":\"$m\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],\"max_tokens\":1}"
done
# every line prints 404
```

Discontinuation dates are taken from the official model page at platform.kimi.ai/docs/models.

## Type

🧹 Refactoring

## Changes

Stamp a `deprecation_date` on the thirteen retired models in both the root cost map and the bundled backup, keeping the entries in place so historical cost calculation continues to resolve the names (matching how every other deprecated model in the map is handled). Dates: `kimi-thinking-preview` 2025-11-11; `kimi-latest` and its 8k/32k/128k context variants 2026-01-28; the `kimi-k2` preview, turbo, and thinking series 2026-05-25; the `moonshot-v1-*-0430` snapshots use their own 2024-04-30 snapshot date since Moonshot publishes no discontinuation date for them.
