### PR TITLE
fix(proxy): persist oauth2_flow on MCP server registration

### DIFF
--- a/litellm-proxy-extras/litellm_proxy_extras/migrations/20260604120000_add_oauth2_flow_to_mcp_servers/migration.sql
+++ b/litellm-proxy-extras/litellm_proxy_extras/migrations/20260604120000_add_oauth2_flow_to_mcp_servers/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "LiteLLM_MCPServerTable" ADD COLUMN IF NOT EXISTS "oauth2_flow" TEXT;

--- a/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
+++ b/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
@@ -322,6 +322,7 @@ model LiteLLM_MCPServerTable {
   authorization_url  String?
   token_url          String?
   registration_url   String?
+  oauth2_flow        String?
   allow_all_keys Boolean @default(false)
   available_on_public_internet Boolean @default(true)
   delegate_auth_to_upstream Boolean @default(false)

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1376,6 +1376,7 @@ class UpdateMCPServerRequest(LiteLLMPydanticObjectBase):
     authorization_url: Optional[str] = None
     token_url: Optional[str] = None
     registration_url: Optional[str] = None
+    oauth2_flow: Optional[Literal["client_credentials", "authorization_code"]] = None
     allow_all_keys: bool = False
     available_on_public_internet: bool = True
     delegate_auth_to_upstream: bool = False
@@ -1449,6 +1450,7 @@ class LiteLLM_MCPServerTable(LiteLLMPydanticObjectBase):
     authorization_url: Optional[str] = None
     token_url: Optional[str] = None
     registration_url: Optional[str] = None
+    oauth2_flow: Optional[Literal["client_credentials", "authorization_code"]] = None
     allow_all_keys: bool = False
     available_on_public_internet: bool = True
     delegate_auth_to_upstream: bool = False

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -322,6 +322,7 @@ model LiteLLM_MCPServerTable {
   authorization_url  String?
   token_url          String?
   registration_url   String?
+  oauth2_flow        String?
   allow_all_keys Boolean @default(false)
   available_on_public_internet Boolean @default(true)
   delegate_auth_to_upstream Boolean @default(false)

--- a/schema.prisma
+++ b/schema.prisma
@@ -322,6 +322,7 @@ model LiteLLM_MCPServerTable {
   authorization_url  String?
   token_url          String?
   registration_url   String?
+  oauth2_flow        String?
   allow_all_keys Boolean @default(false)
   available_on_public_internet Boolean @default(true)
   delegate_auth_to_upstream Boolean @default(false)

--- a/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
@@ -3317,3 +3317,55 @@ def test_sanitize_mcp_server_for_non_admin_clears_credential_fields():
     # server without exposing secrets.
     assert sanitized.server_id == server.server_id
     assert sanitized.alias == server.alias
+
+
+def test_oauth2_flow_accepted_on_create_request():
+    """NewMCPServerRequest carries oauth2_flow through to the persisted dict."""
+    from litellm.proxy._experimental.mcp_server.db import _prepare_mcp_server_data
+
+    payload = NewMCPServerRequest(
+        server_name="m2m-server",
+        url="https://example.com/mcp",
+        transport="http",
+        auth_type="oauth2",
+        token_url="https://idp.example.com/oauth/token",
+        oauth2_flow="client_credentials",
+    )
+    data_dict = _prepare_mcp_server_data(payload)
+    assert data_dict["oauth2_flow"] == "client_credentials"
+
+
+def test_oauth2_flow_round_trips_on_update_and_response_models():
+    """oauth2_flow survives UpdateMCPServerRequest and the LiteLLM_MCPServerTable
+    response model. Before the fix these models dropped the field (no attribute),
+    which is why a persisted value never round-tripped."""
+    from litellm.proxy._types import (
+        LiteLLM_MCPServerTable,
+        UpdateMCPServerRequest,
+    )
+
+    update = UpdateMCPServerRequest(
+        server_id="srv-1", oauth2_flow="client_credentials"
+    )
+    assert update.oauth2_flow == "client_credentials"
+
+    row = LiteLLM_MCPServerTable(
+        server_id="srv-1",
+        transport="http",
+        oauth2_flow="client_credentials",
+    )
+    assert row.oauth2_flow == "client_credentials"
+
+
+def test_oauth2_flow_defaults_to_none_when_omitted():
+    """Omitting oauth2_flow is valid and resolves to None (runtime infers it)."""
+    from litellm.proxy._types import (
+        LiteLLM_MCPServerTable,
+        UpdateMCPServerRequest,
+    )
+
+    assert UpdateMCPServerRequest(server_id="srv-1").oauth2_flow is None
+    assert (
+        LiteLLM_MCPServerTable(server_id="srv-1", transport="http").oauth2_flow
+        is None
+    )


### PR DESCRIPTION
## Relevant issues

No filed issue. Related open PRs in this area: #25535 and #24941 (M2M OAuth / `oauth2_flow` mapping). This PR is a minimal, isolated fix for the registration 500 and intentionally omits their broader UI/inference scope.

## Linear ticket

<!-- none -->

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

**Bug**: registering an MCP server with an explicit `oauth2_flow` via the REST API returned HTTP 500, because `oauth2_flow` existed on the request model but had no column in `LiteLLM_MCPServerTable`.

Before the fix:

```
POST /v1/mcp/server  {"oauth2_flow": "client_credentials", ...}
-> HTTP 500
   Error creating mcp server: Could not find field at
   'createOneLiteLLM_MCPServerTable.data.oauth2_flow'
```

After the fix — create succeeds and the value round-trips on read-back:

```bash
curl -sS -X POST http://localhost:4000/v1/mcp/server \
  -H "Authorization: Bearer sk-..." -H "Content-Type: application/json" \
  -d '{"server_name":"m2m-test","url":"https://mcp.example.com/mcp",
       "transport":"http","auth_type":"oauth2","oauth2_flow":"client_credentials",
       "token_url":"https://idp.example.com/oauth/token"}'
# -> HTTP 200, body includes  "oauth2_flow": "client_credentials"

curl -sS http://localhost:4000/v1/mcp/server/<server_id> -H "Authorization: Bearer sk-..."
# -> "oauth2_flow": "client_credentials"   (read back from DB)
```

Unit tests: 3 new regression tests added; related MCP management/update/custom-field suites pass (91 passed); `ruff` clean.

## Type

🐛 Bug Fix

## Changes

- Added `oauth2_flow String?` to `LiteLLM_MCPServerTable` in all three `schema.prisma` copies, plus a migration (`ADD COLUMN IF NOT EXISTS "oauth2_flow" TEXT`).
- Added `oauth2_flow` to `UpdateMCPServerRequest` and the `LiteLLM_MCPServerTable` response model in `litellm/proxy/_types.py` (the create model `NewMCPServerRequest` already had it), so the field persists and round-trips.
- No logic changes — the create/read paths and runtime resolver already referenced the field; the column was the only gap. Additive and nullable: existing rows read back `null` and continue to be inferred at runtime.
- Added 3 regression tests in `test_mcp_management_endpoints.py`.
