### PR TITLE
fix: correct amazon.titan-embed-text-v2 input price to $0.02/1M tokens

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -571,7 +571,7 @@
         "output_vector_size": 1536
     },
     "amazon.titan-embed-text-v2:0": {
-        "input_cost_per_token": 2e-07,
+        "input_cost_per_token": 2e-08,
         "litellm_provider": "bedrock",
         "max_input_tokens": 8192,
         "max_tokens": 8192,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -571,7 +571,7 @@
         "output_vector_size": 1536
     },
     "amazon.titan-embed-text-v2:0": {
-        "input_cost_per_token": 2e-07,
+        "input_cost_per_token": 2e-08,
         "litellm_provider": "bedrock",
         "max_input_tokens": 8192,
         "max_tokens": 8192,

--- a/tests/llm_translation/test_bedrock_embedding_pricing.py
+++ b/tests/llm_translation/test_bedrock_embedding_pricing.py
@@ -1,0 +1,36 @@
+"""
+Tests for AWS Bedrock embedding model pricing in the model cost map.
+
+Regression test for the Amazon Titan Text Embeddings V2 commercial price,
+which was previously set 10x too high (2e-07 instead of 2e-08).
+AWS lists Titan Text Embeddings V2 at $0.02 per 1M input tokens
+(= $0.00002 per 1K tokens = 2e-08 per token).
+"""
+
+import os
+
+os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"  # Load from local file
+
+import importlib
+
+import litellm.litellm_core_utils.get_model_cost_map
+import litellm
+
+# Reload modules to pick up environment variable
+importlib.reload(litellm.litellm_core_utils.get_model_cost_map)
+importlib.reload(litellm)
+
+
+class TestBedrockEmbeddingPricing:
+    """Test suite for Bedrock embedding model pricing in the cost map."""
+
+    def test_titan_embed_v2_commercial_input_cost(self):
+        """Titan Text Embeddings V2 should be priced at $0.02 / 1M tokens (2e-08)."""
+        from litellm import model_cost
+
+        model = model_cost["amazon.titan-embed-text-v2:0"]
+
+        assert model["input_cost_per_token"] == 2e-08
+        assert model["output_cost_per_token"] == 0.0
+        assert model["litellm_provider"] == "bedrock"
+        assert model["mode"] == "embedding"

--- a/tests/llm_translation/test_bedrock_embedding_pricing.py
+++ b/tests/llm_translation/test_bedrock_embedding_pricing.py
@@ -7,28 +7,26 @@ AWS lists Titan Text Embeddings V2 at $0.02 per 1M input tokens
 (= $0.00002 per 1K tokens = 2e-08 per token).
 """
 
-import os
-
-os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"  # Load from local file
-
 import importlib
-
-import litellm.litellm_core_utils.get_model_cost_map
-import litellm
-
-# Reload modules to pick up environment variable
-importlib.reload(litellm.litellm_core_utils.get_model_cost_map)
-importlib.reload(litellm)
 
 
 class TestBedrockEmbeddingPricing:
     """Test suite for Bedrock embedding model pricing in the cost map."""
 
-    def test_titan_embed_v2_commercial_input_cost(self):
+    def test_titan_embed_v2_commercial_input_cost(self, monkeypatch):
         """Titan Text Embeddings V2 should be priced at $0.02 / 1M tokens (2e-08)."""
-        from litellm import model_cost
+        # Scope the local-cost-map flag to this test only, so it does not leak
+        # into sibling tests. monkeypatch restores the environment on teardown.
+        monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
 
-        model = model_cost["amazon.titan-embed-text-v2:0"]
+        import litellm.litellm_core_utils.get_model_cost_map
+        import litellm
+
+        # Reload so the cost map is re-read from the local file with the flag set.
+        importlib.reload(litellm.litellm_core_utils.get_model_cost_map)
+        importlib.reload(litellm)
+
+        model = litellm.model_cost["amazon.titan-embed-text-v2:0"]
 
         assert model["input_cost_per_token"] == 2e-08
         assert model["output_cost_per_token"] == 0.0


### PR DESCRIPTION
## Related Issues
Fixes #29656

## What this fixes
The `amazon.titan-embed-text-v2:0` entry had `input_cost_per_token: 2e-07` ($0.20 / 1M tokens), which is 10x too high. AWS prices Amazon Titan Text Embeddings V2 at $0.02 per 1M input tokens ($0.00002 per 1K tokens = `2e-08` per token), per AWS's launch announcement and the Bedrock pricing page. This corrects cost tracking, which was inflating Titan Embed V2 spend by 10x.

## Changes
- Corrected `input_cost_per_token` for `amazon.titan-embed-text-v2:0` from `2e-07` → `2e-08` in both `model_prices_and_context_window.json` and `litellm/model_prices_and_context_window_backup.json` (kept in sync).
- Added a regression test (`tests/llm_translation/test_bedrock_embedding_pricing.py`) asserting the corrected commercial price so it can't silently regress.

## Scope note on GovCloud entries
The two GovCloud entries (`bedrock/us-gov-east-1/...` and `bedrock/us-gov-west-1/...`) also currently show `2e-07` and appear to have the same 10x error. I deliberately did **not** change them here, because `tests/llm_translation/test_bedrock_govcloud.py` encodes a ~1.2x GovCloud pricing multiplier for other Bedrock models, and I couldn't verify the correct GovCloud rate specifically for Titan Embed V2. Happy to follow up in a separate PR once a maintainer confirms whether the 1.2x applies to embeddings (making the correct value `2.4e-08`) or whether GovCloud embeddings price the same as commercial (`2e-08`).

## Testing
- `uv run pytest tests/llm_translation/test_bedrock_embedding_pricing.py -v` → passes with the fix, fails without it (verified by reverting the JSON).
- `black` and `ruff` pass on the new test file.