### PR TITLE
chore: ignore prettier dashboard reformat in git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -8,3 +8,6 @@
 
 # Update pydantic code to fix warnings (GH-3600)
 876840e9957bc7e9f7d6a2b58c4d7c53dad16481
+
+# style(ui): run prettier --write across the dashboard (#29622)
+7edf3a9cb55548b143df1692f4ed7c4681d7fcf7


### PR DESCRIPTION
## Relevant issues

Follow-up to #29622

## Linear ticket

## Pre-Submission checklist

- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Screenshots / Proof of Fix

#29622 ran `prettier --write` across the dashboard and rewrote 608 files, which made `git blame` (and the GitHub blame UI) attribute all of those lines to the formatting commit instead of the real authors. This adds the squash-merged SHA of that PR to `.git-blame-ignore-revs` so blame skips it.

Verified on `ui/litellm-dashboard/src/app/(dashboard)/playground/page.tsx`:

```
$ git blame "$f" | grep -c '^7edf3a9cb5'                 # without ignore
37
$ git blame --ignore-rev 7edf3a9cb5 "$f" | grep -c '^7edf3a9cb5'   # with ignore
0
```

All 37 lines that were blamed to the prettier commit get reattributed to their original authors once the SHA is ignored. GitHub's blame UI reads `.git-blame-ignore-revs` automatically; locally, `git config blame.ignoreRevsFile .git-blame-ignore-revs` opts in

## Type

🚄 Infrastructure

## Changes

Append the squash SHA `7edf3a9cb55548b143df1692f4ed7c4681d7fcf7` of #29622 to `.git-blame-ignore-revs`, with a comment naming the PR
