### PR TITLE
fix(latency-routing): prevent lost-update race in latency tracker

### DIFF
--- a/litellm/router_strategy/lowest_latency.py
+++ b/litellm/router_strategy/lowest_latency.py
@@ -1,7 +1,9 @@
 #### What this does ####
 #   picks based on response time (for streaming, this is time to first token)
+import asyncio
 import random
 from datetime import datetime, timedelta
+from threading import Lock
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 import litellm
@@ -34,6 +36,25 @@ class LowestLatencyLoggingHandler(CustomLogger):
     def __init__(self, router_cache: DualCache, routing_args: dict = {}):
         self.router_cache = router_cache
         self.routing_args = RoutingArgs(**routing_args)
+        # Per-key locks to prevent lost-update race between concurrent
+        # completions on the same model group (#24720).
+        self._latency_key_locks: Dict[str, Lock] = {}
+        self._async_latency_key_locks: Dict[str, asyncio.Lock] = {}
+        self._lock_factory_lock = Lock()
+
+    def _get_lock(self, latency_key: str) -> Lock:
+        """Return a threading.Lock for *latency_key*, creating it lazily."""
+        if latency_key not in self._latency_key_locks:
+            with self._lock_factory_lock:
+                if latency_key not in self._latency_key_locks:
+                    self._latency_key_locks[latency_key] = Lock()
+        return self._latency_key_locks[latency_key]
+
+    def _get_async_lock(self, latency_key: str) -> "asyncio.Lock":
+        """Return an asyncio.Lock for *latency_key*, creating it lazily."""
+        if latency_key not in self._async_latency_key_locks:
+            self._async_latency_key_locks[latency_key] = asyncio.Lock()
+        return self._async_latency_key_locks[latency_key]
 
     def log_success_event(  # noqa: PLR0915
         self, kwargs, response_obj, start_time, end_time
@@ -123,6 +144,10 @@ class LowestLatencyLoggingHandler(CustomLogger):
                 # ------------
                 # Update usage
                 # ------------
+                # Acquire per-key lock to serialise read-modify-write
+                # and prevent lost-update race (#24720).
+                lock = self._get_lock(latency_key)
+                lock.acquire()
                 parent_otel_span = _get_parent_otel_span_from_kwargs(kwargs)
                 request_count_dict = (
                     self.router_cache.get_cache(
@@ -176,6 +201,7 @@ class LowestLatencyLoggingHandler(CustomLogger):
                 self.router_cache.set_cache(
                     key=latency_key, value=request_count_dict, ttl=self.routing_args.ttl
                 )  # reset map within window
+                lock.release()
 
                 ### TESTING ###
                 if self.test_flag:
@@ -225,6 +251,8 @@ class LowestLatencyLoggingHandler(CustomLogger):
                     }
                     """
                     latency_key = f"{model_group}_map"
+                    async_lock = self._get_async_lock(latency_key)
+                    await async_lock.acquire()
                     request_count_dict = (
                         await self.router_cache.async_get_cache(key=latency_key) or {}
                     )
@@ -248,6 +276,7 @@ class LowestLatencyLoggingHandler(CustomLogger):
                         value=request_count_dict,
                         ttl=self.routing_args.ttl,
                     )  # reset map within window
+                    async_lock.release()
             else:
                 # do nothing if it's not a timeout error
                 return
@@ -346,6 +375,8 @@ class LowestLatencyLoggingHandler(CustomLogger):
                 # ------------
                 # Update usage
                 # ------------
+                async_lock = self._get_async_lock(latency_key)
+                await async_lock.acquire()
                 parent_otel_span = _get_parent_otel_span_from_kwargs(kwargs)
                 request_count_dict = (
                     await self.router_cache.async_get_cache(
@@ -401,6 +432,7 @@ class LowestLatencyLoggingHandler(CustomLogger):
                 await self.router_cache.async_set_cache(
                     key=latency_key, value=request_count_dict, ttl=self.routing_args.ttl
                 )  # reset map within window
+                async_lock.release()
 
                 ### TESTING ###
                 if self.test_flag:


### PR DESCRIPTION
## Summary

Fixes the lost-update race condition in latency-based routing (#24720).

### Problem

`log_success_event` / `async_log_success_event` perform a non-atomic read-modify-write on the shared latency cache key (`{model_group}_map`). When concurrent completions complete at the same time:

1. Request A reads the cache → gets `{deploy_1: {latency: [0.5]}}`
2. Request B reads the cache → gets the same stale snapshot
3. Request A writes its update
4. Request B writes its update — **overwrites A's data**

This causes latency data to be constantly lost. Deployments with lost data fall back to `latency: [0]` (treated as fastest), causing traffic to distribute proportionally to deployment count rather than actual latency.

### Fix

Add per-latency-key locks to serialise the read-modify-write:

- **Sync path** (`log_success_event`): `threading.Lock` acquired before `get_cache`, released after `set_cache`
- **Async path** (`async_log_success_event`): `asyncio.Lock` acquired before `async_get_cache`, released after `async_set_cache`

Locks are created lazily per `model_group` so unrelated model groups never contend.

### Files changed

| File | Change |
|------|--------|
| `router_strategy/lowest_latency.py` | +32 lines: import lock types, lock dicts in `__init__`, lock helpers, wrap 3 RMW sites |

### Verification

- Locks are per-model-group: `medium_map` and `fast_map` are independent
- Read-only path (`_get_available_deployments`) is unaffected
- Existing tests exercise the same code paths (lock overhead is negligible — modify is pure in-memory dict ops)

Closes #24720