### PR TITLE
fix(anthropic): route Claude Opus 4.8 through adaptive thinking

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -394,6 +394,7 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
         if effort == "max" and not (
             AnthropicConfig._is_claude_4_6_model(model)
             or AnthropicConfig._is_claude_4_7_model(model)
+            or AnthropicConfig._is_claude_4_8_model(model)
             or AnthropicConfig._supports_effort_level(model, "max")
         ):
             return f"effort='max' is not supported by this model. Got model: {model}"
@@ -468,6 +469,7 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             "claude-3-7-sonnet" in model
             or AnthropicConfig._is_claude_4_6_model(model)
             or AnthropicConfig._is_claude_4_7_model(model)
+            or AnthropicConfig._is_claude_4_8_model(model)
             or supports_reasoning(
                 model=model,
                 custom_llm_provider=self.custom_llm_provider,

--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -81,7 +81,6 @@ from litellm.types.utils import (
 from litellm.utils import (
     ModelResponse,
     Usage,
-    _supports_factory,
     add_dummy_tool,
     any_assistant_message_has_thinking_blocks,
     get_max_tokens,
@@ -338,50 +337,6 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
         )
 
     @staticmethod
-    def _supports_model_capability(model: str, key: str) -> bool:
-        """Check a boolean capability ``key`` in the model map.
-
-        Strips bedrock/vertex prefixes so a provider-routed Claude still
-        resolves to the Anthropic model-map entry.
-        """
-        try:
-            if _supports_factory(
-                model=model,
-                custom_llm_provider="anthropic",
-                key=key,
-            ):
-                return True
-        except Exception:
-            pass
-        candidates = [model]
-        for prefix in (
-            "bedrock/converse/",
-            "bedrock/invoke/",
-            "bedrock/",
-            "vertex_ai/",
-        ):
-            if model.startswith(prefix):
-                candidates.append(model[len(prefix) :])
-        try:
-            from litellm.llms.bedrock.common_utils import BedrockModelInfo
-
-            base = BedrockModelInfo.get_base_model(model)
-            if base:
-                candidates.append(base)
-                candidates.append(f"bedrock/{base}")
-        except Exception:
-            pass
-        try:
-            for cand in candidates:
-                if cand in litellm.model_cost and (
-                    litellm.model_cost[cand].get(key) is True
-                ):
-                    return True
-        except Exception:
-            pass
-        return False
-
-    @staticmethod
     def _supports_effort_level(model: str, level: str) -> bool:
         """Check ``supports_{level}_reasoning_effort`` in the model map."""
         return AnthropicConfig._supports_model_capability(
@@ -394,7 +349,6 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
         if effort == "max" and not (
             AnthropicConfig._is_claude_4_6_model(model)
             or AnthropicConfig._is_claude_4_7_model(model)
-            or AnthropicConfig._is_claude_4_8_model(model)
             or AnthropicConfig._supports_effort_level(model, "max")
         ):
             return f"effort='max' is not supported by this model. Got model: {model}"
@@ -469,7 +423,6 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             "claude-3-7-sonnet" in model
             or AnthropicConfig._is_claude_4_6_model(model)
             or AnthropicConfig._is_claude_4_7_model(model)
-            or AnthropicConfig._is_claude_4_8_model(model)
             or supports_reasoning(
                 model=model,
                 custom_llm_provider=self.custom_llm_provider,

--- a/litellm/llms/anthropic/common_utils.py
+++ b/litellm/llms/anthropic/common_utils.py
@@ -272,38 +272,66 @@ class AnthropicModelInfo(BaseLLMModelInfo):
         )
 
     @staticmethod
-    def _is_claude_4_8_model(model: str) -> bool:
-        """Check if the model is a Claude 4.8 model (Opus 4.8)."""
-        model_lower = model.lower()
-        return any(
-            v in model_lower
-            for v in (
-                "opus-4-8",
-                "opus_4_8",
-                "opus-4.8",
-                "opus_4.8",
-            )
-        )
+    def _supports_model_capability(model: str, key: str) -> bool:
+        """Check a boolean capability ``key`` in the model map.
 
-    @staticmethod
-    def _is_adaptive_thinking_model(model: str) -> bool:
-        """Claude 4.6+ models use adaptive thinking with ``output_config.effort``."""
+        Strips bedrock/vertex prefixes so a provider-routed Claude still
+        resolves to the Anthropic model-map entry.
+        """
         from litellm.utils import _supports_factory
 
         try:
             if _supports_factory(
                 model=model,
-                custom_llm_provider=None,
-                key="supports_adaptive_thinking",
+                custom_llm_provider="anthropic",
+                key=key,
             ):
                 return True
         except Exception:
             pass
-        return (
-            AnthropicModelInfo._is_claude_4_6_model(model)
-            or AnthropicModelInfo._is_claude_4_7_model(model)
-            or AnthropicModelInfo._is_claude_4_8_model(model)
-        )
+        candidates = [model]
+        for prefix in (
+            "bedrock/converse/",
+            "bedrock/invoke/",
+            "bedrock/",
+            "vertex_ai/",
+        ):
+            if model.startswith(prefix):
+                candidates.append(model[len(prefix) :])
+        try:
+            from litellm.llms.bedrock.common_utils import BedrockModelInfo
+
+            base = BedrockModelInfo.get_base_model(model)
+            if base:
+                candidates.append(base)
+                candidates.append(f"bedrock/{base}")
+        except Exception:
+            pass
+        try:
+            for cand in candidates:
+                if cand in litellm.model_cost and (
+                    litellm.model_cost[cand].get(key) is True
+                ):
+                    return True
+        except Exception:
+            pass
+        return False
+
+    @staticmethod
+    def _is_adaptive_thinking_model(model: str) -> bool:
+        """Claude 4.6+ models use adaptive thinking with ``output_config.effort``.
+
+        Driven by the ``supports_adaptive_thinking`` flag in the model map; the
+        4.6/4.7 name checks remain only as a fallback for provider-routed ids
+        whose map entries predate the flag.
+        """
+        if AnthropicModelInfo._supports_model_capability(
+            model, "supports_adaptive_thinking"
+        ):
+            return True
+        return AnthropicModelInfo._is_claude_4_6_model(
+            model
+        ) or AnthropicModelInfo._is_claude_4_7_model(model)
 
     def is_effort_used(
         self, optional_params: Optional[dict], model: Optional[str] = None

--- a/litellm/llms/anthropic/common_utils.py
+++ b/litellm/llms/anthropic/common_utils.py
@@ -272,6 +272,20 @@ class AnthropicModelInfo(BaseLLMModelInfo):
         )
 
     @staticmethod
+    def _is_claude_4_8_model(model: str) -> bool:
+        """Check if the model is a Claude 4.8 model (Opus 4.8)."""
+        model_lower = model.lower()
+        return any(
+            v in model_lower
+            for v in (
+                "opus-4-8",
+                "opus_4_8",
+                "opus-4.8",
+                "opus_4.8",
+            )
+        )
+
+    @staticmethod
     def _is_adaptive_thinking_model(model: str) -> bool:
         """Claude 4.6+ models use adaptive thinking with ``output_config.effort``."""
         from litellm.utils import _supports_factory
@@ -285,9 +299,11 @@ class AnthropicModelInfo(BaseLLMModelInfo):
                 return True
         except Exception:
             pass
-        return AnthropicModelInfo._is_claude_4_6_model(
-            model
-        ) or AnthropicModelInfo._is_claude_4_7_model(model)
+        return (
+            AnthropicModelInfo._is_claude_4_6_model(model)
+            or AnthropicModelInfo._is_claude_4_7_model(model)
+            or AnthropicModelInfo._is_claude_4_8_model(model)
+        )
 
     def is_effort_used(
         self, optional_params: Optional[dict], model: Optional[str] = None

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -1319,6 +1319,7 @@
             "search_context_size_low": 0.01,
             "search_context_size_medium": 0.01
         },
+        "supports_adaptive_thinking": true,
         "supports_assistant_prefill": false,
         "supports_computer_use": true,
         "supports_function_calling": true,
@@ -1350,6 +1351,7 @@
             "search_context_size_low": 0.01,
             "search_context_size_medium": 0.01
         },
+        "supports_adaptive_thinking": true,
         "supports_assistant_prefill": false,
         "supports_computer_use": true,
         "supports_function_calling": true,
@@ -1381,6 +1383,7 @@
             "search_context_size_low": 0.01,
             "search_context_size_medium": 0.01
         },
+        "supports_adaptive_thinking": true,
         "supports_assistant_prefill": false,
         "supports_computer_use": true,
         "supports_function_calling": true,
@@ -1412,6 +1415,7 @@
             "search_context_size_low": 0.01,
             "search_context_size_medium": 0.01
         },
+        "supports_adaptive_thinking": true,
         "supports_assistant_prefill": false,
         "supports_computer_use": true,
         "supports_function_calling": true,
@@ -1443,6 +1447,7 @@
             "search_context_size_low": 0.01,
             "search_context_size_medium": 0.01
         },
+        "supports_adaptive_thinking": true,
         "supports_assistant_prefill": false,
         "supports_computer_use": true,
         "supports_function_calling": true,
@@ -2194,6 +2199,7 @@
         "cache_creation_input_token_cost": 6.25e-06,
         "cache_creation_input_token_cost_above_1hr": 1e-05,
         "cache_read_input_token_cost": 5e-07,
+        "supports_adaptive_thinking": true,
         "supports_assistant_prefill": false,
         "supports_computer_use": true,
         "supports_function_calling": true,
@@ -33927,6 +33933,7 @@
             "search_context_size_low": 0.01,
             "search_context_size_medium": 0.01
         },
+        "supports_adaptive_thinking": true,
         "supports_assistant_prefill": false,
         "supports_computer_use": true,
         "supports_function_calling": true,
@@ -33955,6 +33962,7 @@
             "search_context_size_low": 0.01,
             "search_context_size_medium": 0.01
         },
+        "supports_adaptive_thinking": true,
         "supports_assistant_prefill": false,
         "supports_computer_use": true,
         "supports_function_calling": true,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -1319,6 +1319,7 @@
             "search_context_size_low": 0.01,
             "search_context_size_medium": 0.01
         },
+        "supports_adaptive_thinking": true,
         "supports_assistant_prefill": false,
         "supports_computer_use": true,
         "supports_function_calling": true,
@@ -1350,6 +1351,7 @@
             "search_context_size_low": 0.01,
             "search_context_size_medium": 0.01
         },
+        "supports_adaptive_thinking": true,
         "supports_assistant_prefill": false,
         "supports_computer_use": true,
         "supports_function_calling": true,
@@ -1381,6 +1383,7 @@
             "search_context_size_low": 0.01,
             "search_context_size_medium": 0.01
         },
+        "supports_adaptive_thinking": true,
         "supports_assistant_prefill": false,
         "supports_computer_use": true,
         "supports_function_calling": true,
@@ -1412,6 +1415,7 @@
             "search_context_size_low": 0.01,
             "search_context_size_medium": 0.01
         },
+        "supports_adaptive_thinking": true,
         "supports_assistant_prefill": false,
         "supports_computer_use": true,
         "supports_function_calling": true,
@@ -1443,6 +1447,7 @@
             "search_context_size_low": 0.01,
             "search_context_size_medium": 0.01
         },
+        "supports_adaptive_thinking": true,
         "supports_assistant_prefill": false,
         "supports_computer_use": true,
         "supports_function_calling": true,
@@ -2194,6 +2199,7 @@
         "cache_creation_input_token_cost": 6.25e-06,
         "cache_creation_input_token_cost_above_1hr": 1e-05,
         "cache_read_input_token_cost": 5e-07,
+        "supports_adaptive_thinking": true,
         "supports_assistant_prefill": false,
         "supports_computer_use": true,
         "supports_function_calling": true,
@@ -33962,6 +33968,7 @@
             "search_context_size_low": 0.01,
             "search_context_size_medium": 0.01
         },
+        "supports_adaptive_thinking": true,
         "supports_assistant_prefill": false,
         "supports_computer_use": true,
         "supports_function_calling": true,
@@ -33990,6 +33997,7 @@
             "search_context_size_low": 0.01,
             "search_context_size_medium": 0.01
         },
+        "supports_adaptive_thinking": true,
         "supports_assistant_prefill": false,
         "supports_computer_use": true,
         "supports_function_calling": true,

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_reasoning_effort_translation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_reasoning_effort_translation.py
@@ -299,6 +299,38 @@ def test_legacy_thinking_high_budget_keeps_xhigh_when_supported():
 
 
 @pytest.mark.parametrize(
+    "model",
+    [
+        "claude-opus-4-8",
+        "bedrock/us.anthropic.claude-opus-4-8",
+        "bedrock/invoke/us.anthropic.claude-opus-4-8",
+    ],
+)
+def test_legacy_thinking_translates_to_adaptive_for_opus_48(model):
+    """Regression for issue #29188: Opus 4.8 requires adaptive thinking, but the
+    legacy ``thinking.type='enabled'`` shape was passed through unchanged for
+    Bedrock 4.8 (its cost-map entry lacks ``supports_adaptive_thinking`` and the
+    name matcher didn't know 4.8), so Bedrock rejected the request. The reporter's
+    reproducer used ``budget_tokens=24000``, which lands in the ``xhigh`` bucket."""
+    config = AnthropicMessagesConfig()
+    optional_params = {
+        "max_tokens": 100,
+        "thinking": {"type": "enabled", "budget_tokens": 24000},
+    }
+
+    result = config.transform_anthropic_messages_request(
+        model=model,
+        messages=[{"role": "user", "content": "ping"}],
+        anthropic_messages_optional_request_params=optional_params,
+        litellm_params={},
+        headers={},
+    )
+
+    assert result.get("thinking") == {"type": "adaptive"}
+    assert result.get("output_config") == {"effort": "xhigh"}
+
+
+@pytest.mark.parametrize(
     "budget_tokens,expected_effort",
     [
         (31999, "high"),

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_reasoning_effort_translation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_reasoning_effort_translation.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+import litellm
 from litellm.llms.anthropic.common_utils import AnthropicError
 from litellm.llms.anthropic.experimental_pass_through.messages.transformation import (
     AnthropicMessagesConfig,
@@ -9,6 +10,22 @@ from litellm.llms.anthropic.experimental_pass_through.messages.transformation im
 from litellm.llms.bedrock.messages.invoke_transformations.anthropic_claude3_transformation import (
     AmazonAnthropicClaudeMessagesConfig,
 )
+
+
+@pytest.fixture
+def local_model_cost_map(monkeypatch):
+    """Force the bundled backup cost map so Opus 4.8 adaptive detection (driven
+    by the ``supports_adaptive_thinking`` flag) doesn't depend on the
+    network-fetched ``main`` copy, which lacks the flag until this branch merges."""
+    original = litellm.model_cost
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+    litellm.get_model_info.cache_clear()
+    try:
+        yield
+    finally:
+        litellm.model_cost = original
+        litellm.get_model_info.cache_clear()
 
 
 @pytest.mark.parametrize(
@@ -306,12 +323,14 @@ def test_legacy_thinking_high_budget_keeps_xhigh_when_supported():
         "bedrock/invoke/us.anthropic.claude-opus-4-8",
     ],
 )
-def test_legacy_thinking_translates_to_adaptive_for_opus_48(model):
+def test_legacy_thinking_translates_to_adaptive_for_opus_48(
+    model, local_model_cost_map
+):
     """Regression for issue #29188: Opus 4.8 requires adaptive thinking, but the
     legacy ``thinking.type='enabled'`` shape was passed through unchanged for
-    Bedrock 4.8 (its cost-map entry lacks ``supports_adaptive_thinking`` and the
-    name matcher didn't know 4.8), so Bedrock rejected the request. The reporter's
-    reproducer used ``budget_tokens=24000``, which lands in the ``xhigh`` bucket."""
+    Bedrock 4.8 (its cost-map entry lacked ``supports_adaptive_thinking`` and the
+    lookup didn't strip the provider prefix), so Bedrock rejected the request. The
+    reporter's reproducer used ``budget_tokens=24000``, the ``xhigh`` bucket."""
     config = AnthropicMessagesConfig()
     optional_params = {
         "max_tokens": 100,

--- a/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
+++ b/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
@@ -14,6 +14,8 @@ import os
 import sys
 from unittest.mock import patch
 
+import pytest
+
 sys.path.insert(
     0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../.."))
 )
@@ -1380,53 +1382,71 @@ class TestAnthropicThinkingSignatureSelfHeal:
         assert data["messages"] == []
 
 
+@pytest.fixture
+def local_model_cost_map(monkeypatch):
+    """Force the bundled backup cost map so detection doesn't depend on the
+    network-fetched ``main`` copy (which lacks this branch's flags until merge)."""
+    import litellm
+
+    original = litellm.model_cost
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+    litellm.get_model_info.cache_clear()
+    try:
+        yield
+    finally:
+        litellm.model_cost = original
+        litellm.get_model_info.cache_clear()
+
+
 class TestClaudeOpus48AdaptiveThinking:
     """Opus 4.8 requires adaptive thinking (``thinking.type='adaptive'`` +
-    ``output_config.effort``). The Bedrock/Vertex/Azure cost-map entries do not
-    carry ``supports_adaptive_thinking``, so detection has to fall back to the
-    name matcher; before this fix that matcher only knew 4.6/4.7, so a
+    ``output_config.effort``). Detection is driven by the
+    ``supports_adaptive_thinking`` cost-map flag, resolved through provider
+    prefixes. Before the fix the Bedrock entries lacked the flag and the lookup
+    didn't strip the ``us.anthropic.``/``invoke/`` prefixes, so a
     ``bedrock/us.anthropic.claude-opus-4-8`` call sent the legacy
     ``thinking.type='enabled'`` shape and Bedrock rejected it (issue #29188)."""
 
-    def test_is_claude_4_8_model_matches_name_variants(self):
-        from litellm.llms.anthropic.common_utils import AnthropicModelInfo
-
-        for model in (
+    @pytest.mark.parametrize(
+        "model",
+        [
             "claude-opus-4-8",
-            "claude-opus-4-8-20260601",
-            "claude-opus_4_8",
-            "claude-opus-4.8",
-            "claude-opus_4.8",
             "anthropic/claude-opus-4-8",
-            "bedrock/us.anthropic.claude-opus-4-8",
-            "vertex_ai/claude-opus-4-8",
-            "azure_ai/claude-opus-4-8",
-        ):
-            assert AnthropicModelInfo._is_claude_4_8_model(model) is True, model
-
-    def test_is_claude_4_8_model_rejects_other_models(self):
-        from litellm.llms.anthropic.common_utils import AnthropicModelInfo
-
-        for model in (
-            "claude-opus-4-7",
-            "claude-opus-4-6",
-            "claude-sonnet-4-6",
-            "claude-opus-4-5",
-            "claude-3-7-sonnet",
-            "gpt-4.8",
-        ):
-            assert AnthropicModelInfo._is_claude_4_8_model(model) is False, model
-
-    def test_adaptive_thinking_detected_without_cost_map_flag(self):
-        """The decisive regression: these names are absent from the cost map (or
-        their entry lacks ``supports_adaptive_thinking``), so a True result can
-        only come from the 4.8 name matcher, not ``_supports_factory``."""
-        from litellm.llms.anthropic.common_utils import AnthropicModelInfo
-
-        for model in (
-            "claude-opus-4.8",
-            "claude-opus-4-8-20260601",
+            "anthropic.claude-opus-4-8",
             "bedrock/us.anthropic.claude-opus-4-8",
             "bedrock/invoke/us.anthropic.claude-opus-4-8",
-        ):
-            assert AnthropicModelInfo._is_adaptive_thinking_model(model) is True, model
+            "bedrock/eu.anthropic.claude-opus-4-8",
+            "vertex_ai/claude-opus-4-8",
+            "azure_ai/claude-opus-4-8",
+        ],
+    )
+    def test_adaptive_thinking_detected_for_opus_4_8(self, local_model_cost_map, model):
+        from litellm.llms.anthropic.common_utils import AnthropicModelInfo
+
+        assert AnthropicModelInfo._is_adaptive_thinking_model(model) is True
+
+    def test_resolver_reads_flag_through_bedrock_invoke_prefix(
+        self, local_model_cost_map
+    ):
+        """The resolver fix: ``bedrock/invoke/...`` resolves to the flagged
+        Bedrock entry. Pure ``_supports_factory`` without prefix-stripping
+        returns False here, which is why the data-only fix alone was not enough."""
+        from litellm.llms.anthropic.common_utils import AnthropicModelInfo
+
+        assert (
+            AnthropicModelInfo._supports_model_capability(
+                "bedrock/invoke/us.anthropic.claude-opus-4-8",
+                "supports_adaptive_thinking",
+            )
+            is True
+        )
+
+    @pytest.mark.parametrize(
+        "model",
+        ["claude-opus-4-5", "claude-3-7-sonnet", "claude-3-5-haiku-20241022"],
+    )
+    def test_non_adaptive_models_not_detected(self, local_model_cost_map, model):
+        from litellm.llms.anthropic.common_utils import AnthropicModelInfo
+
+        assert AnthropicModelInfo._is_adaptive_thinking_model(model) is False

--- a/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
+++ b/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
@@ -1378,3 +1378,55 @@ class TestAnthropicThinkingSignatureSelfHeal:
         config.transform_anthropic_messages_request_on_http_error(err, data)
         assert "thinking" not in data
         assert data["messages"] == []
+
+
+class TestClaudeOpus48AdaptiveThinking:
+    """Opus 4.8 requires adaptive thinking (``thinking.type='adaptive'`` +
+    ``output_config.effort``). The Bedrock/Vertex/Azure cost-map entries do not
+    carry ``supports_adaptive_thinking``, so detection has to fall back to the
+    name matcher; before this fix that matcher only knew 4.6/4.7, so a
+    ``bedrock/us.anthropic.claude-opus-4-8`` call sent the legacy
+    ``thinking.type='enabled'`` shape and Bedrock rejected it (issue #29188)."""
+
+    def test_is_claude_4_8_model_matches_name_variants(self):
+        from litellm.llms.anthropic.common_utils import AnthropicModelInfo
+
+        for model in (
+            "claude-opus-4-8",
+            "claude-opus-4-8-20260601",
+            "claude-opus_4_8",
+            "claude-opus-4.8",
+            "claude-opus_4.8",
+            "anthropic/claude-opus-4-8",
+            "bedrock/us.anthropic.claude-opus-4-8",
+            "vertex_ai/claude-opus-4-8",
+            "azure_ai/claude-opus-4-8",
+        ):
+            assert AnthropicModelInfo._is_claude_4_8_model(model) is True, model
+
+    def test_is_claude_4_8_model_rejects_other_models(self):
+        from litellm.llms.anthropic.common_utils import AnthropicModelInfo
+
+        for model in (
+            "claude-opus-4-7",
+            "claude-opus-4-6",
+            "claude-sonnet-4-6",
+            "claude-opus-4-5",
+            "claude-3-7-sonnet",
+            "gpt-4.8",
+        ):
+            assert AnthropicModelInfo._is_claude_4_8_model(model) is False, model
+
+    def test_adaptive_thinking_detected_without_cost_map_flag(self):
+        """The decisive regression: these names are absent from the cost map (or
+        their entry lacks ``supports_adaptive_thinking``), so a True result can
+        only come from the 4.8 name matcher, not ``_supports_factory``."""
+        from litellm.llms.anthropic.common_utils import AnthropicModelInfo
+
+        for model in (
+            "claude-opus-4.8",
+            "claude-opus-4-8-20260601",
+            "bedrock/us.anthropic.claude-opus-4-8",
+            "bedrock/invoke/us.anthropic.claude-opus-4-8",
+        ):
+            assert AnthropicModelInfo._is_adaptive_thinking_model(model) is True, model

--- a/tests/test_litellm/test_claude_opus_4_8_config.py
+++ b/tests/test_litellm/test_claude_opus_4_8_config.py
@@ -182,3 +182,24 @@ def test_opus_4_8_provider_resolves_via_model_info(local_model_cost_map):
     assert info["litellm_provider"] == "anthropic"
     assert info["max_input_tokens"] == 1000000
     assert info["max_output_tokens"] == 128000
+
+
+@pytest.mark.parametrize(
+    "cost_map",
+    [_load_root_cost_map(), GetModelCostMap.load_local_model_cost_map()],
+    ids=["root", "bundled_backup"],
+)
+def test_opus_4_8_all_variants_carry_adaptive_thinking_flag(cost_map):
+    """Every Opus 4.8 entry must advertise ``supports_adaptive_thinking``.
+
+    Adaptive-thinking detection is cost-map driven, so a single variant missing
+    the flag silently sends the legacy ``thinking.type='enabled'`` shape and the
+    provider 400s (issue #29188, which the Bedrock/Vertex/Azure variants hit
+    because only the bare ``claude-opus-4-8`` entry carried the flag). This guards
+    against a future variant being added without it."""
+    variants = [k for k in cost_map if "claude-opus-4-8" in k]
+    assert variants, "no claude-opus-4-8 entries found in cost map"
+    missing = [
+        k for k in variants if cost_map[k].get("supports_adaptive_thinking") is not True
+    ]
+    assert not missing, f"missing supports_adaptive_thinking: {missing}"


### PR DESCRIPTION
## Relevant issues

Fixes #29188 (the adaptive-thinking breakage reported by @seanturner-zh)

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Run a proxy with an Opus 4.8 Bedrock deployment and send the reproducer from the issue. Before this change the request 400s with "thinking.type.enabled is not supported for this model"; after it, the legacy `thinking.type=enabled` payload is rewritten to `thinking.type=adaptive` + `output_config.effort` and the call succeeds.

```bash
python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log
```

```bash
curl -s http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer $LITELLM_KEY" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "bedrock/us.anthropic.claude-opus-4-8",
    "messages": [{"role": "user", "content": "ping"}],
    "thinking": {"type": "enabled", "budget_tokens": 24000},
    "max_tokens": 100
  }' | jq
```

## Type

🐛 Bug Fix

## Changes

Opus 4.8 uses the same adaptive thinking contract as 4.6/4.7: `thinking.type=adaptive` plus `output_config.effort`, with the legacy `thinking.type=enabled` shape rejected by the provider. Whether a model is on that contract is decided by `AnthropicModelInfo._is_adaptive_thinking_model`, which reads the `supports_adaptive_thinking` cost-map flag and falls back to name matchers. The direct Anthropic `claude-opus-4-8` entry carries the flag, but the Bedrock, Vertex, and Azure entries did not, so `bedrock/us.anthropic.claude-opus-4-8` resolved to an entry without the flag and the name fallback didn't recognize 4.8; the legacy payload went out and Bedrock 400'd with exactly the error in the issue.

The first version of this PR added an `_is_claude_4_8_model` name matcher next to the 4.6/4.7 ones. Greptile and Mateo both flagged that as the wrong layer: model capabilities belong in the cost map, and hardcoding a matcher per model is the very pattern that produced the `_is_claude_4_7_model` debt. This revision moves the fix to the data.

`supports_adaptive_thinking: true` is now set on every Opus 4.8 provider variant (Bedrock regional and global, Vertex, Azure) in both the root and bundled cost maps. The matcher and its three wiring sites are gone. The one thing data alone doesn't cover is that the existing `_supports_factory` lookup doesn't strip the `us.anthropic.`/`invoke/` prefixes, so `bedrock/invoke/us.anthropic.claude-opus-4-8` would still miss the flag; to handle that, the prefix-resolving `_supports_model_capability` helper (already used by the effort-level checks) moves down to `AnthropicModelInfo` and `_is_adaptive_thinking_model` now goes through it. The 4.6/4.7 name checks stay only as a fallback, since those providers' entries don't carry the flag yet; they can migrate the same way later.

To stop this from recurring, a cost-map guardrail test asserts that every `claude-opus-4-8` entry in both maps carries `supports_adaptive_thinking`, so adding a future variant without it fails CI rather than silently shipping the broken shape. The rest of the coverage exercises detection across all provider prefixes (including the `invoke/` form that the resolver change specifically fixes) and the issue's end-to-end `budget_tokens=24000 -> effort=xhigh` translation on bare and Bedrock-prefixed ids. Reverting the cost-map flags while keeping the tests fails ten of them across the Bedrock, Vertex, Azure, resolver, guardrail, and end-to-end cases, confirming the coverage is real.
