### PR TITLE
fix(vertex_ai/context_caching): use get_vertex_base_url for cachedContents host

### DIFF
--- a/tests/test_litellm/llms/vertex_ai/context_caching/test_vertex_ai_context_caching.py
+++ b/tests/test_litellm/llms/vertex_ai/context_caching/test_vertex_ai_context_caching.py
@@ -1917,3 +1917,57 @@ class TestVertexAIGlobalLocation:
 
         assert "generativelanguage.googleapis.com" in url
         assert "cachedContents" in url
+
+
+class TestContextCachingMultiRegionUrls:
+    """Regression coverage for #29571: multi-region vertex_location values
+    (`eu`, `us`) must resolve to the REP host (`aiplatform.{geo}.rep.googleapis.com`)
+    on the cachedContents endpoint, matching the inference path (already
+    fixed in #27293). Previously the URL was hardcoded to
+    `{location}-aiplatform.googleapis.com`, which doesn't exist for
+    multi-region locations and 404'd."""
+
+    def setup_method(self):
+        self.caching = ContextCachingEndpoints()
+
+    @pytest.mark.parametrize("location", ["eu", "us"])
+    def test_vertex_ai_multi_region_uses_rep_host(self, location):
+        _, url = self.caching._get_token_and_url_context_caching(
+            gemini_api_key=None,
+            custom_llm_provider="vertex_ai",
+            api_base=None,
+            vertex_project="my-project",
+            vertex_location=location,
+            vertex_auth_header="Bearer token",
+        )
+
+        assert url.startswith(f"https://aiplatform.{location}.rep.googleapis.com/")
+        assert f"/locations/{location}/cachedContents" in url
+        # Old broken host must no longer appear.
+        assert f"{location}-aiplatform.googleapis.com" not in url
+
+    def test_vertex_ai_regional_still_uses_regional_host(self):
+        _, url = self.caching._get_token_and_url_context_caching(
+            gemini_api_key=None,
+            custom_llm_provider="vertex_ai",
+            api_base=None,
+            vertex_project="my-project",
+            vertex_location="us-central1",
+            vertex_auth_header="Bearer token",
+        )
+
+        assert url.startswith("https://us-central1-aiplatform.googleapis.com/")
+        assert "/locations/us-central1/cachedContents" in url
+
+    def test_vertex_ai_global_still_uses_global_host(self):
+        _, url = self.caching._get_token_and_url_context_caching(
+            gemini_api_key=None,
+            custom_llm_provider="vertex_ai",
+            api_base=None,
+            vertex_project="my-project",
+            vertex_location="global",
+            vertex_auth_header="Bearer token",
+        )
+
+        assert url.startswith("https://aiplatform.googleapis.com/")
+        assert "/locations/global/cachedContents" in url


### PR DESCRIPTION
## Summary

Closes #29571.

`ContextCachingEndpoints._get_token_and_url_context_caching` hardcoded `{location}-aiplatform.googleapis.com` for non-global Vertex AI locations. That host pattern only exists for **regional** endpoints (e.g. `us-central1`). **Multi-region** locations (`eu`, `us`) live on the REP host `aiplatform.{geo}.rep.googleapis.com`, so context-cache creation 404'd on those endpoints even though the inference path (already fixed for multi-region in #27293) succeeded.

| `vertex_location` | Required host | Before this PR | After |
|---|---|---|---|
| `global` | `aiplatform.googleapis.com` | ✅ | ✅ |
| `eu` (multi-region) | `aiplatform.eu.rep.googleapis.com` | ❌ `eu-aiplatform.googleapis.com` (404) | ✅ |
| `us` (multi-region) | `aiplatform.us.rep.googleapis.com` | ❌ `us-aiplatform.googleapis.com` (404) | ✅ |
| `us-central1` (regional) | `us-central1-aiplatform.googleapis.com` | ✅ | ✅ |

## Fix shape

Route through `get_vertex_base_url(vertex_location)` (the helper introduced in #27293), which already encodes the full host policy. Both the `vertex_ai` and the `else` branch (`v1beta1`) now use the same resolver.

## Test plan

- [x] New `TestContextCachingMultiRegionUrls`:
  - parametrized `test_vertex_ai_multi_region_uses_rep_host` for `eu` and `us` — URL starts with `aiplatform.{geo}.rep.googleapis.com` and the old broken `{geo}-aiplatform.googleapis.com` host is gone
  - `test_vertex_ai_regional_still_uses_regional_host` — `us-central1` keeps the regional host (no regression)
  - `test_vertex_ai_global_still_uses_global_host` — `global` keeps `aiplatform.googleapis.com` (no regression)
- [x] Full `test_vertex_ai_context_caching.py` collects 108 tests; the 4 new ones added.