### PR TITLE
fix(anthropic-messages): hoist role=system entries from messages[] into top-level system field

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
@@ -303,9 +303,7 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
                     if isinstance(content, str) and content:
                         hoisted_system.append({"type": "text", "text": content})
                     elif isinstance(content, list):
-                        hoisted_system.extend(
-                            c for c in content if isinstance(c, dict)
-                        )
+                        hoisted_system.extend(c for c in content if isinstance(c, dict))
                     # Drop empty/None system entries silently.
                 else:
                     remaining_messages.append(m)

--- a/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
@@ -286,6 +286,49 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
             optional_params=anthropic_messages_optional_request_params,
         )
 
+        # Hoist role="system" entries from messages[] into the top-level
+        # system field. Anthropic's Messages API recently added support for
+        # system entries inside the messages array (Claude 4.8 announcement),
+        # but Bedrock and other downstream providers still expect system on
+        # the top-level field. Normalize here so every adapter sees the same
+        # canonical layout (#29698).
+        if isinstance(messages, list) and any(
+            isinstance(m, dict) and m.get("role") == "system" for m in messages
+        ):
+            hoisted_system: List[Dict[str, Any]] = []
+            remaining_messages: List[Any] = []
+            for m in messages:
+                if isinstance(m, dict) and m.get("role") == "system":
+                    content = m.get("content")
+                    if isinstance(content, str) and content:
+                        hoisted_system.append({"type": "text", "text": content})
+                    elif isinstance(content, list):
+                        hoisted_system.extend(
+                            c for c in content if isinstance(c, dict)
+                        )
+                    # Drop empty/None system entries silently.
+                else:
+                    remaining_messages.append(m)
+            messages = remaining_messages
+            if hoisted_system:
+                existing_system = anthropic_messages_optional_request_params.get(
+                    "system"
+                )
+                if existing_system is None:
+                    anthropic_messages_optional_request_params["system"] = (
+                        hoisted_system
+                    )
+                elif isinstance(existing_system, str):
+                    anthropic_messages_optional_request_params["system"] = [
+                        {"type": "text", "text": existing_system},
+                        *hoisted_system,
+                    ]
+                elif isinstance(existing_system, list):
+                    anthropic_messages_optional_request_params["system"] = [
+                        *existing_system,
+                        *hoisted_system,
+                    ]
+
         # Filter out x-anthropic-billing-header from system messages
         system_param = anthropic_messages_optional_request_params.get("system")
         if system_param is not None:

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_messages_system_role_hoisting.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_messages_system_role_hoisting.py
@@ -1,0 +1,116 @@
+"""
+Regression tests for #29698 — Anthropic Messages API now accepts
+role="system" entries inside the messages[] array, but Bedrock and other
+downstream providers still expect system on the top-level field. Verify
+that AnthropicMessagesConfig.transform_anthropic_messages_request hoists
+any in-messages system entries into the top-level system field before the
+adapter forwards downstream.
+"""
+
+import pytest
+
+from litellm.llms.anthropic.experimental_pass_through.messages.transformation import (
+    AnthropicMessagesConfig,
+)
+
+
+def _transform(messages, optional_params=None):
+    config = AnthropicMessagesConfig()
+    optional_params = {**(optional_params or {})}
+    optional_params.setdefault("max_tokens", 100)
+    return config.transform_anthropic_messages_request(
+        model="claude-sonnet-4-8",
+        messages=messages,
+        anthropic_messages_optional_request_params=optional_params,
+        litellm_params={},
+        headers={},
+    )
+
+
+def test_system_role_in_messages_hoisted_to_top_level_system_field():
+    result = _transform(
+        [
+            {"role": "user", "content": "hi"},
+            {"role": "system", "content": "you are helpful"},
+        ]
+    )
+    system = result.get("system")
+    assert isinstance(system, list)
+    assert {"type": "text", "text": "you are helpful"} in system
+    assert all(m["role"] != "system" for m in result["messages"])
+
+
+def test_system_role_merged_after_existing_top_level_string_system():
+    result = _transform(
+        [
+            {"role": "system", "content": "also be concise"},
+            {"role": "user", "content": "hi"},
+        ],
+        optional_params={"system": "you are helpful"},
+    )
+    system = result["system"]
+    assert isinstance(system, list)
+    assert system[0] == {"type": "text", "text": "you are helpful"}
+    assert system[1] == {"type": "text", "text": "also be concise"}
+
+
+def test_system_role_merged_after_existing_top_level_list_system():
+    result = _transform(
+        [
+            {"role": "system", "content": "also be concise"},
+            {"role": "user", "content": "hi"},
+        ],
+        optional_params={
+            "system": [{"type": "text", "text": "you are helpful"}],
+        },
+    )
+    system = result["system"]
+    assert system == [
+        {"type": "text", "text": "you are helpful"},
+        {"type": "text", "text": "also be concise"},
+    ]
+
+
+def test_system_role_with_list_content_extends_system_blocks():
+    result = _transform(
+        [
+            {
+                "role": "system",
+                "content": [
+                    {"type": "text", "text": "be terse"},
+                    {"type": "text", "text": "use markdown"},
+                ],
+            },
+            {"role": "user", "content": "hi"},
+        ]
+    )
+    system = result["system"]
+    assert {"type": "text", "text": "be terse"} in system
+    assert {"type": "text", "text": "use markdown"} in system
+
+
+def test_system_role_empty_or_none_content_dropped_silently():
+    result = _transform(
+        [
+            {"role": "system", "content": None},
+            {"role": "system", "content": ""},
+            {"role": "user", "content": "hi"},
+        ]
+    )
+    # No new system entries, but the user message survives.
+    assert result.get("system") is None
+    assert result["messages"] == [{"role": "user", "content": "hi"}]
+
+
+def test_no_system_role_in_messages_is_a_noop():
+    result = _transform(
+        [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ],
+        optional_params={"system": "you are helpful"},
+    )
+    # System field is preserved through the existing _filter_billing path,
+    # messages are untouched.
+    assert "system" in result
+    assert len(result["messages"]) == 2


### PR DESCRIPTION
Fixes #29698.

Anthropic's Messages API recently added support for \`role: "system"\` entries inside the \`messages[]\` array (Claude 4.8 announcement). Bedrock and other downstream adapters still only accept \`system\` on the top-level field, so a client following the new Anthropic spec gets a 400 \`"input is in incorrect format"\` from Bedrock.

Normalize early in \`AnthropicMessagesConfig.transform_anthropic_messages_request\`: scan messages[] for role=system, extract content (str → text block, list → spread), drop from messages[], merge into the top-level system field (preserving any existing system content). Every adapter that inherits from this base — Anthropic, Bedrock, Vertex Anthropic, Azure AI Anthropic, Deepseek — now sees the canonical layout regardless of which API spec the client used.

## Screenshots / Proof of Fix

\`\`\`
$ uv run pytest tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_messages_system_role_hoisting.py -v
6 passed in 0.24s

$ uv run pytest tests/test_litellm/llms/anthropic/experimental_pass_through/messages/ -q
129 passed in 20.92s
\`\`\`

Negative test verified: stashing the transformation change makes the new tests fail with \`AssertionError: isinstance(None, list)\` (the system field is None because nothing got hoisted).

Tests cover: basic hoist, merge after existing str system, merge after existing list system, list-content extension, empty/None content dropped silently, no-op when no system in messages.