### PR TITLE
feat(openrouter): expose actual routed model on openrouter/auto

### DIFF
--- a/litellm/llms/openrouter/chat/transformation.py
+++ b/litellm/llms/openrouter/chat/transformation.py
@@ -227,6 +227,22 @@ class OpenrouterConfig(OpenAIGPTConfig):
                     model_response._hidden_params["additional_headers"][
                         "llm_provider-x-litellm-response-cost"
                     ] = float(response_cost)
+
+            # When the request used OpenRouter Auto (`openrouter/auto`), the
+            # response body's `model` field carries the model OpenRouter
+            # actually routed to (e.g. `anthropic/claude-3.7-sonnet`). Expose
+            # it so callers can track routing decisions without re-calling
+            # OpenRouter's REST API directly (#29406).
+            routed_model = response_json.get("model")
+            if routed_model and isinstance(routed_model, str) and routed_model != model:
+                if not hasattr(model_response, "_hidden_params"):
+                    model_response._hidden_params = {}
+                model_response._hidden_params["routed_model"] = routed_model
+                if "additional_headers" not in model_response._hidden_params:
+                    model_response._hidden_params["additional_headers"] = {}
+                model_response._hidden_params["additional_headers"][
+                    "llm_provider-x-litellm-routed-model"
+                ] = routed_model
         except Exception:
             # If we can't extract cost, continue without it - don't fail the response
             pass

--- a/tests/test_litellm/llms/openrouter/chat/test_openrouter_chat_transformation.py
+++ b/tests/test_litellm/llms/openrouter/chat/test_openrouter_chat_transformation.py
@@ -553,3 +553,131 @@ def test_openrouter_non_reasoning_models_do_not_add_reasoning_effort():
     )
 
     assert "reasoning_effort" not in supported_params
+
+
+def test_openrouter_auto_exposes_routed_model_in_hidden_params():
+    """Regression for #29406.
+
+    When the request used `openrouter/auto`, OpenRouter returns the actual
+    routed model in the response body's `model` field. `transform_response`
+    must surface it via `_hidden_params["routed_model"]` (and an
+    `llm_provider-x-litellm-routed-model` additional header) so callers
+    can track routing decisions, audit costs, and debug auto-routing
+    without re-calling OpenRouter's REST API.
+    """
+    from unittest.mock import Mock, patch
+    from litellm.types.utils import Choices, Message, ModelResponse, Usage
+
+    config = OpenrouterConfig()
+
+    routed = "anthropic/claude-sonnet-4"
+    mock_response = Mock(spec=httpx.Response)
+    mock_response.json.return_value = {
+        "id": "gen-auto-1",
+        "model": routed,
+        "choices": [
+            {
+                "message": {"role": "assistant", "content": "hi"},
+                "finish_reason": "stop",
+                "index": 0,
+            }
+        ],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    }
+    mock_response.headers = {}
+
+    model_response = ModelResponse(
+        id="gen-auto-1",
+        choices=[
+            Choices(
+                finish_reason="stop",
+                index=0,
+                message=Message(content="hi", role="assistant"),
+            )
+        ],
+        created=1234567890,
+        model="openrouter/auto",
+        object="chat.completion",
+        usage=Usage(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+    )
+
+    with patch.object(
+        OpenAIGPTConfig, "transform_response", return_value=model_response
+    ):
+        result = config.transform_response(
+            model="openrouter/auto",
+            raw_response=mock_response,
+            model_response=model_response,
+            logging_obj=Mock(),
+            request_data={},
+            messages=[{"role": "user", "content": "hi"}],
+            optional_params={},
+            litellm_params={},
+            encoding=None,
+        )
+
+    assert result._hidden_params["routed_model"] == routed
+    assert (
+        result._hidden_params["additional_headers"][
+            "llm_provider-x-litellm-routed-model"
+        ]
+        == routed
+    )
+
+
+def test_openrouter_non_auto_does_not_set_routed_model_when_model_matches():
+    """When the caller requested a specific model and OpenRouter echoes it
+    back unchanged, no `routed_model` hint is added (avoids noise on
+    non-auto calls)."""
+    from unittest.mock import Mock, patch
+    from litellm.types.utils import Choices, Message, ModelResponse, Usage
+
+    config = OpenrouterConfig()
+
+    same_model = "openrouter/anthropic/claude-sonnet-4.5"
+    mock_response = Mock(spec=httpx.Response)
+    mock_response.json.return_value = {
+        "id": "gen-non-auto-1",
+        "model": same_model,
+        "choices": [
+            {
+                "message": {"role": "assistant", "content": "hi"},
+                "finish_reason": "stop",
+                "index": 0,
+            }
+        ],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    }
+    mock_response.headers = {}
+
+    model_response = ModelResponse(
+        id="gen-non-auto-1",
+        choices=[
+            Choices(
+                finish_reason="stop",
+                index=0,
+                message=Message(content="hi", role="assistant"),
+            )
+        ],
+        created=1234567890,
+        model=same_model,
+        object="chat.completion",
+        usage=Usage(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+    )
+
+    with patch.object(
+        OpenAIGPTConfig, "transform_response", return_value=model_response
+    ):
+        result = config.transform_response(
+            model=same_model,
+            raw_response=mock_response,
+            model_response=model_response,
+            logging_obj=Mock(),
+            request_data={},
+            messages=[{"role": "user", "content": "hi"}],
+            optional_params={},
+            litellm_params={},
+            encoding=None,
+        )
+
+    assert "routed_model" not in (result._hidden_params or {})


### PR DESCRIPTION
## Summary

Closes #29406.

When the caller requested `openrouter/auto`, OpenRouter's response body carries the model it actually routed to in the `model` field (e.g. `anthropic/claude-sonnet-4`). LiteLLM previously discarded this — callers using auto-routing only saw `openrouter/auto` come back and had no way to:

- track which model handled the request
- audit per-route costs
- debug auto-routing decisions
- analyze per-model latency / quality without re-calling OpenRouter's REST API

## Fix shape

Inside `OpenrouterConfig.transform_response`, read the response body's `model` field and surface it via:

- `model_response._hidden_params["routed_model"]`
- `model_response._hidden_params["additional_headers"]["llm_provider-x-litellm-routed-model"]` (so it propagates downstream through the existing `additional_headers` plumbing the cost-tracking PR uses)

The new fields are only set when the body's `model` differs from the requested model, so non-auto calls don't pick up noise.

## Test plan

- [x] `test_openrouter_auto_exposes_routed_model_in_hidden_params` — `openrouter/auto` request, OpenRouter returns `model: "anthropic/claude-sonnet-4"`; result exposes routed model via both `_hidden_params["routed_model"]` and the `llm_provider-x-litellm-routed-model` header.
- [x] `test_openrouter_non_auto_does_not_set_routed_model_when_model_matches` — control: when the request model equals the response model, no `routed_model` hint is added.
- [x] Existing 13 openrouter chat-transformation tests still pass (cost tracking, cache control, etc.).