### PR TITLE
feat: declarative fallback generalizations for unknown models

### DIFF
--- a/litellm/litellm_core_utils/fallback_generalizations.py
+++ b/litellm/litellm_core_utils/fallback_generalizations.py
@@ -1,0 +1,87 @@
+"""
+Declarative fallback generalizations for unknown / newly-released models.
+
+The ``fallback_generalizations`` block in ``model_prices_and_context_window.json``
+holds an ordered list of rules. Each rule pairs a single case-insensitive regex
+with the metadata to apply when a model name has no exact entry in the cost map.
+The metadata is a partial cost-map entry: ``litellm_provider`` drives provider
+routing, and the remaining fields (``mode``, ``supports_*``, context window,
+pricing, ...) drive ``get_model_info`` / ``supports_*``.
+
+Precedence: rules are evaluated in file order and the first match wins. They are
+consulted only after exact and case-insensitive lookups miss, so an exact entry
+always takes precedence over a rule.
+
+The compiled-regex list is built once and cached. ``match_fallback_generalization``
+is O(number of rules); callers must only invoke it on a cache miss.
+"""
+
+import re
+from typing import Dict, List, Optional, Pattern, Tuple
+
+from litellm._logging import verbose_logger
+
+PATTERN_FIELD = "pattern"
+MODEL_INFO_FIELD = "model_info"
+
+_rules: List[dict] = []
+_compiled_rules: Optional[List[Tuple[Pattern, Dict]]] = None
+
+
+def set_fallback_generalizations(rules: Optional[List[dict]]) -> None:
+    """Install the active rule list and invalidate the compiled-regex cache.
+
+    Called once when the model cost map is loaded (and again on any reload).
+    """
+    global _rules, _compiled_rules
+    _rules = rules if isinstance(rules, list) else []
+    _compiled_rules = None
+
+
+def get_fallback_generalization_rules() -> List[dict]:
+    """Return the raw rule list (read-only view for callers/tests)."""
+    return _rules
+
+
+def _compile_rules() -> List[Tuple[Pattern, Dict]]:
+    compiled: List[Tuple[Pattern, Dict]] = []
+    for rule in _rules:
+        if not isinstance(rule, dict):
+            continue
+        pattern = rule.get(PATTERN_FIELD)
+        model_info = rule.get(MODEL_INFO_FIELD)
+        if not isinstance(pattern, str) or not isinstance(model_info, dict):
+            verbose_logger.warning(
+                "LiteLLM: skipping malformed fallback generalization rule %s "
+                "(needs string '%s' and dict '%s').",
+                rule.get("name", pattern),
+                PATTERN_FIELD,
+                MODEL_INFO_FIELD,
+            )
+            continue
+        try:
+            compiled.append((re.compile(pattern, re.IGNORECASE), model_info))
+        except re.error as e:
+            verbose_logger.warning(
+                "LiteLLM: skipping fallback generalization rule with invalid "
+                "regex %r: %s",
+                pattern,
+                e,
+            )
+    return compiled
+
+
+def match_fallback_generalization(model: str) -> Optional[Dict]:
+    """Return the ``model_info`` of the first rule whose regex matches ``model``.
+
+    O(number of rules). Only call this once exact lookups have missed.
+    """
+    global _compiled_rules
+    if not model:
+        return None
+    if _compiled_rules is None:
+        _compiled_rules = _compile_rules()
+    for pattern, model_info in _compiled_rules:
+        if pattern.search(model) is not None:
+            return model_info
+    return None

--- a/litellm/litellm_core_utils/get_llm_provider_logic.py
+++ b/litellm/litellm_core_utils/get_llm_provider_logic.py
@@ -1,9 +1,11 @@
-import re
 from typing import Optional, Tuple
 from urllib.parse import urlparse
 
 import litellm
 from litellm.constants import REPLICATE_MODEL_NAME_WITH_ID_LENGTH
+from litellm.litellm_core_utils.fallback_generalizations import (
+    match_fallback_generalization,
+)
 from litellm.llms.openai_like.json_loader import JSONProviderRegistry
 from litellm.secret_managers.main import get_secret, get_secret_str
 
@@ -70,25 +72,6 @@ def _is_azure_claude_model(model: str) -> bool:
         return "claude" in model_lower or model_lower.startswith("claude")
     except Exception:
         return False
-
-
-_CLAUDE_PATTERN = re.compile(r"^claude-[a-z]+-\d+-\d+(?:-\d{8})?$", re.IGNORECASE)
-
-
-def _matches_claude_model_pattern(model: str) -> bool:
-    """
-    Check if a model string matches the Claude model naming pattern.
-
-    Matches patterns like:
-    - claude-opus-4-7
-    - claude-sonnet-4-6
-    - claude-haiku-4-5
-    - claude-opus-5-1-20270101 (with optional date suffix)
-
-    This allows future Claude models to be routed to the Anthropic provider
-    without requiring updates to model_prices_and_context_window.json.
-    """
-    return _CLAUDE_PATTERN.match(model) is not None
 
 
 def handle_cohere_chat_model_custom_llm_provider(
@@ -421,9 +404,6 @@ def get_llm_provider(  # noqa: PLR0915
                 custom_llm_provider = "anthropic_text"
             else:
                 custom_llm_provider = "anthropic"
-        ## anthropic - pattern-based matching for future Claude models
-        elif _matches_claude_model_pattern(model):
-            custom_llm_provider = "anthropic"
         ## cohere
         elif model in litellm.cohere_models or model in litellm.cohere_embedding_models:
             custom_llm_provider = "cohere"
@@ -524,6 +504,15 @@ def get_llm_provider(  # noqa: PLR0915
             custom_llm_provider = "amazon_nova"
         elif model.startswith("sap/"):
             custom_llm_provider = "sap"
+
+        # Last resort for an otherwise-unknown model: a declarative
+        # fallback-generalization rule (e.g. routes future claude-* to anthropic).
+        # Exact provider matches above always win; this only runs on a miss.
+        if not custom_llm_provider:
+            generalization = match_fallback_generalization(model)
+            if generalization is not None:
+                custom_llm_provider = generalization.get("litellm_provider") or None
+
         if not custom_llm_provider:
             if litellm.suppress_debug_info is False:
                 print()  # noqa

--- a/litellm/litellm_core_utils/get_model_cost_map.py
+++ b/litellm/litellm_core_utils/get_model_cost_map.py
@@ -20,6 +20,20 @@ from litellm.constants import (
     MODEL_COST_MAP_MAX_SHRINK_RATIO,
     MODEL_COST_MAP_MIN_MODEL_COUNT,
 )
+from litellm.litellm_core_utils.fallback_generalizations import (
+    set_fallback_generalizations,
+)
+
+FALLBACK_GENERALIZATIONS_KEY = "fallback_generalizations"
+
+# Reserved top-level keys that are not model entries. They must be excluded
+# from the model-count integrity check so a real upstream shrink can't be masked.
+RESERVED_TOP_LEVEL_KEYS = frozenset({"sample_spec", FALLBACK_GENERALIZATIONS_KEY})
+
+
+def _count_model_entries(model_cost: dict) -> int:
+    """Count actual model entries, excluding reserved meta keys."""
+    return sum(1 for key in model_cost if key not in RESERVED_TOP_LEVEL_KEYS)
 
 
 class GetModelCostMap:
@@ -48,7 +62,7 @@ class GetModelCostMap:
         """Return the number of models in the local backup (cached int)."""
         if cls._backup_model_count < 0:
             backup = cls.load_local_model_cost_map()
-            cls._backup_model_count = len(backup)
+            cls._backup_model_count = _count_model_entries(backup)
         return cls._backup_model_count
 
     @staticmethod
@@ -80,7 +94,7 @@ class GetModelCostMap:
         max_shrink_ratio: float = MODEL_COST_MAP_MAX_SHRINK_RATIO,
     ) -> bool:
         """Check 2: model count has not reduced significantly vs backup."""
-        fetched_count = len(fetched_map)
+        fetched_count = _count_model_entries(fetched_map)
 
         if fetched_count < min_model_count:
             verbose_logger.warning(
@@ -241,6 +255,18 @@ def _expand_model_aliases(model_cost: dict) -> dict:
     return model_cost
 
 
+def _finalize_model_cost_map(model_cost: dict) -> dict:
+    """Extract fallback generalizations out of the raw map, then expand aliases.
+
+    The ``fallback_generalizations`` block is installed into the generalizations
+    module and removed from the map so it is never treated as a model entry.
+    """
+    raw = model_cost.pop(FALLBACK_GENERALIZATIONS_KEY, None)
+    rules = raw.get("rules") if isinstance(raw, dict) else None
+    set_fallback_generalizations(rules)
+    return _expand_model_aliases(model_cost)
+
+
 def get_model_cost_map(url: str) -> dict:
     """
     Public entry point — returns the model cost map dict.
@@ -260,7 +286,7 @@ def get_model_cost_map(url: str) -> dict:
         _cost_map_source_info.url = None
         _cost_map_source_info.is_env_forced = True
         _cost_map_source_info.fallback_reason = None
-        return _expand_model_aliases(GetModelCostMap.load_local_model_cost_map())
+        return _finalize_model_cost_map(GetModelCostMap.load_local_model_cost_map())
 
     _cost_map_source_info.url = url
     _cost_map_source_info.is_env_forced = False
@@ -276,7 +302,7 @@ def get_model_cost_map(url: str) -> dict:
         )
         _cost_map_source_info.source = "local"
         _cost_map_source_info.fallback_reason = f"Remote fetch failed: {str(e)}"
-        return _expand_model_aliases(GetModelCostMap.load_local_model_cost_map())
+        return _finalize_model_cost_map(GetModelCostMap.load_local_model_cost_map())
 
     # Validate using cached count (cheap int comparison, no file I/O)
     if not GetModelCostMap.validate_model_cost_map(
@@ -292,8 +318,8 @@ def get_model_cost_map(url: str) -> dict:
         _cost_map_source_info.fallback_reason = (
             "Remote data failed integrity validation"
         )
-        return _expand_model_aliases(GetModelCostMap.load_local_model_cost_map())
+        return _finalize_model_cost_map(GetModelCostMap.load_local_model_cost_map())
 
     _cost_map_source_info.source = "remote"
     _cost_map_source_info.fallback_reason = None
-    return _expand_model_aliases(content)
+    return _finalize_model_cost_map(content)

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -41539,5 +41539,30 @@
         "supports_vision": true,
         "supports_native_structured_output": true,
         "supports_pdf_input": true
+    },
+    "fallback_generalizations": {
+        "rules": [
+            {
+                "name": "anthropic-claude",
+                "pattern": "^claude-[a-z]+-\\d+-\\d+(?:-\\d{8})?$",
+                "model_info": {
+                    "litellm_provider": "anthropic",
+                    "mode": "chat",
+                    "max_input_tokens": 200000,
+                    "max_output_tokens": 64000,
+                    "max_tokens": 64000,
+                    "supports_function_calling": true,
+                    "supports_parallel_function_calling": true,
+                    "supports_vision": true,
+                    "supports_tool_choice": true,
+                    "supports_assistant_prefill": true,
+                    "supports_prompt_caching": true,
+                    "supports_response_schema": true,
+                    "supports_reasoning": true,
+                    "supports_pdf_input": true,
+                    "supports_system_messages": true
+                }
+            }
+        ]
     }
 }

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -60,6 +60,9 @@ from litellm._lazy_imports import (
     _get_token_counter_new,
 )
 from litellm._uuid import uuid
+from litellm.litellm_core_utils.fallback_generalizations import (
+    match_fallback_generalization,
+)
 from litellm.constants import (
     DEFAULT_CHAT_COMPLETION_PARAM_VALUES,
     DEFAULT_EMBEDDING_PARAM_VALUES,
@@ -5618,6 +5621,34 @@ class PotentialModelNamesAndCustomLLMProvider(TypedDict):
     custom_llm_provider: str
 
 
+def _get_model_info_from_generalization(
+    model: str,
+    potential_model_names: PotentialModelNamesAndCustomLLMProvider,
+    custom_llm_provider: Optional[str],
+) -> Optional[Tuple[str, dict]]:
+    """Resolve an unmapped model via a declarative fallback-generalization rule.
+
+    Tries the same name candidates as the exact lookups, in the same order, and
+    returns ``(matched_name, model_info)`` for the first candidate whose rule also
+    satisfies the provider constraint. O(number of rules); only call after the
+    exact lookups have missed.
+    """
+    candidates = [
+        potential_model_names["combined_model_name"],
+        model,
+        potential_model_names["combined_stripped_model_name"],
+        potential_model_names["stripped_model_name"],
+        potential_model_names["split_model"],
+    ]
+    for candidate in candidates:
+        generalized_info = match_fallback_generalization(candidate)
+        if generalized_info is not None and _check_provider_match(
+            model_info=generalized_info, custom_llm_provider=custom_llm_provider
+        ):
+            return candidate, generalized_info
+    return None
+
+
 def _get_potential_model_names(
     model: str, custom_llm_provider: Optional[str]
 ) -> PotentialModelNamesAndCustomLLMProvider:
@@ -5879,6 +5910,15 @@ def _get_model_info_helper(  # noqa: PLR0915
                         model_info=_model_info, custom_llm_provider=custom_llm_provider
                     ):
                         _model_info = None
+
+            if _model_info is None:
+                generalization = _get_model_info_from_generalization(
+                    model=model,
+                    potential_model_names=potential_model_names,
+                    custom_llm_provider=custom_llm_provider,
+                )
+                if generalization is not None:
+                    key, _model_info = generalization
 
             if _model_info is None or key is None:
                 raise ValueError(

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -41748,6 +41748,30 @@
     "output_cost_per_token": 0.0,
     "litellm_provider": "snowflake",
     "mode": "embedding"
-  }
- }
-
+  },
+    "fallback_generalizations": {
+        "rules": [
+            {
+                "name": "anthropic-claude",
+                "pattern": "^claude-[a-z]+-\\d+-\\d+(?:-\\d{8})?$",
+                "model_info": {
+                    "litellm_provider": "anthropic",
+                    "mode": "chat",
+                    "max_input_tokens": 200000,
+                    "max_output_tokens": 64000,
+                    "max_tokens": 64000,
+                    "supports_function_calling": true,
+                    "supports_parallel_function_calling": true,
+                    "supports_vision": true,
+                    "supports_tool_choice": true,
+                    "supports_assistant_prefill": true,
+                    "supports_prompt_caching": true,
+                    "supports_response_schema": true,
+                    "supports_reasoning": true,
+                    "supports_pdf_input": true,
+                    "supports_system_messages": true
+                }
+            }
+        ]
+    }
+}

--- a/tests/local_testing/conftest.py
+++ b/tests/local_testing/conftest.py
@@ -29,9 +29,14 @@ import litellm
 # was added on this branch).  Backfill any entries that are missing from the
 # remote-fetched map so cost-calculator lookups in tests succeed against the
 # cassette state the branch is being tested with.
-from litellm.litellm_core_utils.get_model_cost_map import GetModelCostMap
+from litellm.litellm_core_utils.get_model_cost_map import (
+    RESERVED_TOP_LEVEL_KEYS,
+    GetModelCostMap,
+)
 
 for _k, _v in GetModelCostMap.load_local_model_cost_map().items():
+    if _k in RESERVED_TOP_LEVEL_KEYS:
+        continue
     litellm.model_cost.setdefault(_k, _v)
 
 from tests._vcr_conftest_common import (  # noqa: E402,F401

--- a/tests/local_testing/test_get_llm_provider.py
+++ b/tests/local_testing/test_get_llm_provider.py
@@ -480,107 +480,94 @@ def test_get_llm_provider_use_proxy_arg_true_with_direct_args():
     assert base == arg_api_base  # Should use the argument base
 
 
-# -------- Tests for Claude model pattern matching ---------
+# -------- Tests for the anthropic-claude fallback generalization rule ---------
+
+
+@pytest.fixture
+def shipped_generalizations():
+    """Install the rules shipped in the bundled backup, then restore.
+
+    The remote-fetched cost map pinned to ``main`` may not yet carry the rule
+    added on this branch, so these tests install the rule the branch actually
+    ships rather than depending on whatever the live URL returns.
+    """
+    from litellm.litellm_core_utils.fallback_generalizations import (
+        get_fallback_generalization_rules,
+        set_fallback_generalizations,
+    )
+    from litellm.litellm_core_utils.get_model_cost_map import GetModelCostMap
+
+    previous = list(get_fallback_generalization_rules())
+    backup = GetModelCostMap.load_local_model_cost_map()
+    rules = backup.get("fallback_generalizations", {}).get("rules", [])
+    set_fallback_generalizations(rules)
+    try:
+        yield rules
+    finally:
+        set_fallback_generalizations(previous)
 
 
 class TestClaudeModelPatternMatching:
     """
-    Tests for _matches_claude_model_pattern which routes future Claude models
-    to the Anthropic provider without requiring model_prices_and_context_window.json updates.
+    The ``anthropic-claude`` fallback generalization rule routes future Claude
+    models to the Anthropic provider without requiring a
+    model_prices_and_context_window.json entry. These tests exercise the rule
+    end-to-end through ``get_llm_provider`` and ``match_fallback_generalization``.
     """
 
-    def test_matches_claude_opus_pattern(self):
-        """Test claude-opus-X-Y pattern matching."""
-        from litellm.litellm_core_utils.get_llm_provider_logic import (
-            _matches_claude_model_pattern,
-        )
-
-        assert _matches_claude_model_pattern("claude-opus-4-7") is True
-        assert _matches_claude_model_pattern("claude-opus-4-9") is True
-        assert _matches_claude_model_pattern("claude-opus-5-1") is True
-
-    def test_matches_claude_sonnet_pattern(self):
-        """Test claude-sonnet-X-Y pattern matching."""
-        from litellm.litellm_core_utils.get_llm_provider_logic import (
-            _matches_claude_model_pattern,
-        )
-
-        assert _matches_claude_model_pattern("claude-sonnet-4-6") is True
-        assert _matches_claude_model_pattern("claude-sonnet-5-0") is True
-
-    def test_matches_claude_haiku_pattern(self):
-        """Test claude-haiku-X-Y pattern matching."""
-        from litellm.litellm_core_utils.get_llm_provider_logic import (
-            _matches_claude_model_pattern,
-        )
-
-        assert _matches_claude_model_pattern("claude-haiku-4-5") is True
-        assert _matches_claude_model_pattern("claude-haiku-5-0") is True
-
-    def test_matches_claude_with_date_suffix(self):
-        """Test claude model pattern with date suffix."""
-        from litellm.litellm_core_utils.get_llm_provider_logic import (
-            _matches_claude_model_pattern,
-        )
-
-        assert _matches_claude_model_pattern("claude-opus-5-1-20270101") is True
-        assert _matches_claude_model_pattern("claude-sonnet-4-7-20260601") is True
-        assert _matches_claude_model_pattern("claude-haiku-4-6-20251201") is True
-
-    def test_matches_unknown_tier_name(self):
-        """A tier segment we don't know about today should still route to anthropic.
-
-        The pattern intentionally accepts any ``[a-z]+`` tier rather than a
-        hard-coded ``opus|sonnet|haiku`` list so a future tier (e.g. a new
-        "mini" line) is covered without a code change. This guards against a
-        regression back to hard-coded tier names.
-        """
-        from litellm.litellm_core_utils.get_llm_provider_logic import (
-            _matches_claude_model_pattern,
-        )
-
-        assert _matches_claude_model_pattern("claude-mini-4-5") is True
-        assert _matches_claude_model_pattern("claude-neptune-6-0") is True
-
-    def test_rejects_non_claude_models(self):
-        """Test that non-Claude models are not matched."""
-        from litellm.litellm_core_utils.get_llm_provider_logic import (
-            _matches_claude_model_pattern,
-        )
-
-        assert _matches_claude_model_pattern("gpt-4") is False
-        assert _matches_claude_model_pattern("mistral-large") is False
-        assert _matches_claude_model_pattern("llama-3") is False
-
-    def test_rejects_invalid_claude_patterns(self):
-        """Test that invalid Claude model patterns are not matched."""
-        from litellm.litellm_core_utils.get_llm_provider_logic import (
-            _matches_claude_model_pattern,
-        )
-
-        # Wrong order (variant before name)
-        assert _matches_claude_model_pattern("claude-4-opus") is False
-        # Missing version numbers
-        assert _matches_claude_model_pattern("claude-opus") is False
-        # Old format (claude-3-opus instead of claude-opus-3)
-        assert _matches_claude_model_pattern("claude-3-opus-20240229") is False
-
-    def test_get_llm_provider_future_claude_model(self):
-        """Test that get_llm_provider routes future Claude models to anthropic."""
-        model, custom_llm_provider, dynamic_api_key, api_base = (
-            litellm.get_llm_provider(
-                model="claude-opus-4-9",
-            )
-        )
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "claude-opus-4-9",
+            "claude-opus-5-1",
+            "claude-sonnet-4-6",
+            "claude-sonnet-5-0",
+            "claude-haiku-4-5",
+            "claude-haiku-5-0",
+            "claude-opus-5-1-20270101",
+            "claude-sonnet-4-7-20260601",
+            "claude-haiku-4-6-20251201",
+            # A tier segment we don't know about today still routes: the regex
+            # accepts any [a-z]+ tier rather than a hard-coded opus|sonnet|haiku
+            # list, so a future tier is covered without a code change.
+            "claude-mini-4-5",
+            "claude-neptune-6-0",
+        ],
+    )
+    def test_unknown_claude_routes_to_anthropic(self, model, shipped_generalizations):
+        _, custom_llm_provider, _, _ = litellm.get_llm_provider(model=model)
         assert custom_llm_provider == "anthropic"
-        assert model == "claude-opus-4-9"
 
-    def test_get_llm_provider_future_claude_model_with_date(self):
-        """Test that get_llm_provider routes future Claude models with date suffix."""
-        model, custom_llm_provider, dynamic_api_key, api_base = (
-            litellm.get_llm_provider(
-                model="claude-opus-5-1-20270101",
-            )
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "gpt-4",
+            "mistral-large",
+            "llama-3",
+            # Wrong order (variant before name)
+            "claude-4-opus",
+            # Missing version numbers
+            "claude-opus",
+            # Old format (claude-3-opus instead of claude-opus-3)
+            "claude-3-opus-20240229",
+        ],
+    )
+    def test_non_matching_models_do_not_match_rule(
+        self, model, shipped_generalizations
+    ):
+        from litellm.litellm_core_utils.fallback_generalizations import (
+            match_fallback_generalization,
         )
-        assert custom_llm_provider == "anthropic"
-        assert model == "claude-opus-5-1-20270101"
+
+        assert match_fallback_generalization(model) is None
+
+    def test_routing_comes_from_the_rule_not_python(self, shipped_generalizations):
+        """With the rule cleared, an unknown claude must no longer route to
+        anthropic; this guards against re-introducing a hard-coded Python regex."""
+        from litellm.litellm_core_utils.fallback_generalizations import (
+            set_fallback_generalizations,
+        )
+
+        set_fallback_generalizations([])
+        with pytest.raises(Exception):
+            litellm.get_llm_provider(model="claude-opus-4-9")

--- a/tests/test_litellm/litellm_core_utils/test_fallback_generalizations.py
+++ b/tests/test_litellm/litellm_core_utils/test_fallback_generalizations.py
@@ -1,0 +1,183 @@
+"""
+Tests for the declarative fallback-generalizations mechanism.
+
+Covers both the pure module (litellm.litellm_core_utils.fallback_generalizations)
+and its end-to-end wiring into provider routing (get_llm_provider) and model-info
+resolution (get_model_info / supports_*).
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../.."))
+
+import litellm
+from litellm.litellm_core_utils.fallback_generalizations import (
+    get_fallback_generalization_rules,
+    match_fallback_generalization,
+    set_fallback_generalizations,
+)
+
+
+@pytest.fixture
+def restore_generalizations():
+    """Save the active rules, let the test install its own, then restore."""
+    previous = list(get_fallback_generalization_rules())
+    try:
+        yield set_fallback_generalizations
+    finally:
+        set_fallback_generalizations(previous)
+
+
+# --------------------------------------------------------------------------- #
+# Pure module behaviour
+# --------------------------------------------------------------------------- #
+
+
+def test_match_returns_model_info_of_first_matching_rule(restore_generalizations):
+    restore_generalizations(
+        [
+            {
+                "name": "first",
+                "pattern": r"^acme-",
+                "model_info": {"litellm_provider": "openai", "tag": "first"},
+            },
+            {
+                "name": "second",
+                "pattern": r"^acme-pro-",
+                "model_info": {"litellm_provider": "anthropic", "tag": "second"},
+            },
+        ]
+    )
+    # Both rules match "acme-pro-1"; first-in-list wins (documented precedence).
+    matched = match_fallback_generalization("acme-pro-1")
+    assert matched is not None
+    assert matched["tag"] == "first"
+
+
+def test_match_is_case_insensitive(restore_generalizations):
+    restore_generalizations(
+        [{"name": "r", "pattern": r"^claude-opus", "model_info": {"ok": True}}]
+    )
+    assert match_fallback_generalization("CLAUDE-OPUS-9-9") == {"ok": True}
+
+
+def test_no_match_returns_none(restore_generalizations):
+    restore_generalizations(
+        [{"name": "r", "pattern": r"^claude-", "model_info": {"ok": True}}]
+    )
+    assert match_fallback_generalization("gpt-4o") is None
+    assert match_fallback_generalization("") is None
+
+
+def test_empty_rules_match_nothing(restore_generalizations):
+    restore_generalizations([])
+    assert match_fallback_generalization("claude-opus-9-9") is None
+
+
+def test_malformed_rules_are_skipped_not_fatal(restore_generalizations):
+    restore_generalizations(
+        [
+            {"name": "no-pattern", "model_info": {"x": 1}},
+            {"name": "bad-info", "pattern": r"^a", "model_info": "not-a-dict"},
+            {"name": "bad-regex", "pattern": r"^claude-(", "model_info": {"x": 1}},
+            {"name": "good", "pattern": r"^claude-", "model_info": {"good": True}},
+        ]
+    )
+    # The three malformed rules are skipped; the valid one still matches.
+    assert match_fallback_generalization("claude-opus-9-9") == {"good": True}
+
+
+def test_setting_rules_invalidates_compiled_cache(restore_generalizations):
+    restore_generalizations([{"name": "r", "pattern": r"^aaa", "model_info": {"v": 1}}])
+    assert match_fallback_generalization("aaa-1") == {"v": 1}
+    # Re-install different rules; the compiled cache must be rebuilt.
+    set_fallback_generalizations(
+        [{"name": "r", "pattern": r"^bbb", "model_info": {"v": 2}}]
+    )
+    assert match_fallback_generalization("aaa-1") is None
+    assert match_fallback_generalization("bbb-1") == {"v": 2}
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end: provider routing + model-info resolution
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def myco_rule(restore_generalizations):
+    """A self-contained rule carrying provider, pricing, context and capabilities."""
+    restore_generalizations(
+        [
+            {
+                "name": "myco",
+                "pattern": r"^myco-[a-z]+-\d+$",
+                "model_info": {
+                    "litellm_provider": "openai",
+                    "mode": "chat",
+                    "input_cost_per_token": 1e-06,
+                    "output_cost_per_token": 2e-06,
+                    "max_input_tokens": 12345,
+                    "max_output_tokens": 678,
+                    "supports_vision": True,
+                    "supports_function_calling": True,
+                },
+            }
+        ]
+    )
+    return "myco-fast-1"
+
+
+def test_unknown_model_routes_via_rule(myco_rule):
+    _, provider, _, _ = litellm.get_llm_provider(model=myco_rule)
+    assert provider == "openai"
+
+
+def test_unknown_model_gets_pricing_context_and_capabilities(myco_rule):
+    info = litellm.get_model_info(myco_rule)
+    assert info["litellm_provider"] == "openai"
+    assert info["input_cost_per_token"] == 1e-06
+    assert info["output_cost_per_token"] == 2e-06
+    assert info["max_input_tokens"] == 12345
+    assert info["supports_vision"] is True
+
+
+def test_supports_helper_reads_through_generalization(myco_rule):
+    assert litellm.supports_vision(myco_rule) is True
+    assert litellm.supports_function_calling(myco_rule) is True
+
+
+def test_exact_entry_takes_precedence_over_rule(restore_generalizations):
+    """An exact cost-map entry must win over a rule that also matches it."""
+    restore_generalizations(
+        [
+            {
+                "name": "shadow-gpt4o",
+                "pattern": r"^gpt-4o$",
+                "model_info": {
+                    "litellm_provider": "anthropic",
+                    "input_cost_per_token": 999.0,
+                },
+            }
+        ]
+    )
+    info = litellm.get_model_info("gpt-4o")
+    # Resolved from the real exact entry, not the shadowing rule.
+    assert info["litellm_provider"] == "openai"
+    assert info["input_cost_per_token"] != 999.0
+
+
+def test_unknown_model_without_matching_rule_still_unmapped(restore_generalizations):
+    restore_generalizations(
+        [
+            {
+                "name": "claude",
+                "pattern": r"^claude-",
+                "model_info": {"litellm_provider": "anthropic"},
+            }
+        ]
+    )
+    with pytest.raises(Exception):
+        litellm.get_model_info("totally-unknown-model-xyz")

--- a/tests/test_litellm/litellm_core_utils/test_get_model_cost_map.py
+++ b/tests/test_litellm/litellm_core_utils/test_get_model_cost_map.py
@@ -1,0 +1,141 @@
+"""
+Tests for model-cost-map loading: the model-count integrity check (which must
+count actual model entries, not reserved meta keys) and the extraction of the
+``fallback_generalizations`` block out of the raw map.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../.."))
+
+from litellm.litellm_core_utils.fallback_generalizations import (
+    get_fallback_generalization_rules,
+    match_fallback_generalization,
+    set_fallback_generalizations,
+)
+from litellm.litellm_core_utils.get_model_cost_map import (
+    FALLBACK_GENERALIZATIONS_KEY,
+    GetModelCostMap,
+    _count_model_entries,
+    _finalize_model_cost_map,
+)
+
+
+def _make_models(n: int) -> dict:
+    return {
+        f"model-{i}": {"litellm_provider": "openai", "mode": "chat"} for i in range(n)
+    }
+
+
+def test_count_model_entries_excludes_reserved_keys():
+    m = _make_models(3)
+    m["sample_spec"] = {"foo": "bar"}
+    m[FALLBACK_GENERALIZATIONS_KEY] = {"rules": []}
+    assert _count_model_entries(m) == 3
+
+
+def test_validation_rejects_truly_shrunk_file_even_with_meta_keys():
+    """A file with only a handful of real models must be rejected as corrupt,
+    and the extra meta keys must not inflate the count past the minimum."""
+    shrunk = _make_models(5)
+    shrunk["sample_spec"] = {"foo": "bar"}
+    shrunk[FALLBACK_GENERALIZATIONS_KEY] = {"rules": [{"name": "x"}]}
+
+    assert (
+        GetModelCostMap.validate_model_cost_map(
+            fetched_map=shrunk,
+            backup_model_count=2000,
+            min_model_count=50,
+        )
+        is False
+    )
+
+
+def test_validation_accepts_healthy_file_with_meta_keys():
+    healthy = _make_models(2000)
+    healthy["sample_spec"] = {"foo": "bar"}
+    healthy[FALLBACK_GENERALIZATIONS_KEY] = {"rules": []}
+
+    assert (
+        GetModelCostMap.validate_model_cost_map(
+            fetched_map=healthy,
+            backup_model_count=2000,
+            min_model_count=50,
+        )
+        is True
+    )
+
+
+def test_validation_rejects_significant_shrink_vs_backup():
+    # 600 real models vs a 2000-model backup is below the 50% shrink threshold.
+    shrunk = _make_models(600)
+    shrunk[FALLBACK_GENERALIZATIONS_KEY] = {"rules": []}
+    assert (
+        GetModelCostMap.validate_model_cost_map(
+            fetched_map=shrunk,
+            backup_model_count=2000,
+            min_model_count=50,
+            max_shrink_ratio=0.5,
+        )
+        is False
+    )
+
+
+def test_finalize_pops_key_and_installs_rules():
+    previous = list(get_fallback_generalization_rules())
+    try:
+        raw = _make_models(2)
+        raw[FALLBACK_GENERALIZATIONS_KEY] = {
+            "rules": [
+                {
+                    "name": "rule",
+                    "pattern": r"^widget-",
+                    "model_info": {"litellm_provider": "openai"},
+                }
+            ]
+        }
+        finalized = _finalize_model_cost_map(raw)
+
+        # The reserved key is removed from the returned model map ...
+        assert FALLBACK_GENERALIZATIONS_KEY not in finalized
+        # ... and its rules are installed into the generalizations module.
+        assert match_fallback_generalization("widget-9") == {
+            "litellm_provider": "openai"
+        }
+    finally:
+        set_fallback_generalizations(previous)
+
+
+def test_finalize_with_no_block_clears_rules():
+    previous = list(get_fallback_generalization_rules())
+    try:
+        set_fallback_generalizations(
+            [{"name": "stale", "pattern": r"^x", "model_info": {"a": 1}}]
+        )
+        _finalize_model_cost_map(_make_models(2))
+        assert match_fallback_generalization("x-1") is None
+    finally:
+        set_fallback_generalizations(previous)
+
+
+def test_shipped_backup_carries_the_anthropic_claude_rule():
+    """The bundled backup must ship the anthropic-claude rule so a fresh install
+    (or an offline fallback) routes unknown Claude models without code changes."""
+    backup = GetModelCostMap.load_local_model_cost_map()
+    rules = backup.get(FALLBACK_GENERALIZATIONS_KEY, {}).get("rules", [])
+    names = {r.get("name") for r in rules}
+    assert "anthropic-claude" in names
+
+    rule = next(r for r in rules if r.get("name") == "anthropic-claude")
+    assert rule["model_info"]["litellm_provider"] == "anthropic"
+
+    previous = list(get_fallback_generalization_rules())
+    try:
+        set_fallback_generalizations(rules)
+        matched = match_fallback_generalization("claude-opus-4-9")
+        assert matched is not None and matched["litellm_provider"] == "anthropic"
+    finally:
+        set_fallback_generalizations(previous)

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -970,6 +970,9 @@ def test_aaamodel_prices_and_context_window_json_is_valid():
     actual_json.pop(
         "sample_spec", None
     )  # remove the sample, whose schema is inconsistent with the real data
+    actual_json.pop(
+        "fallback_generalizations", None
+    )  # reserved meta key, not a model entry
 
     # Validate schema
     validate(actual_json, INTENDED_SCHEMA)
@@ -1170,9 +1173,7 @@ def test_check_provider_match_none_value_matches_any_provider():
         is True
     )
     # When custom_llm_provider is also None nothing constrains the match.
-    assert (
-        litellm.utils._check_provider_match({"litellm_provider": None}, None) is True
-    )
+    assert litellm.utils._check_provider_match({"litellm_provider": None}, None) is True
 
 
 def test_get_provider_rerank_config():
@@ -1537,8 +1538,7 @@ class TestProxyFunctionCalling:
         assert result is True, "Resolvable model names work with fallback logic"
 
         # Documentation notes:
-        print(
-            """
+        print("""
         PROXY MODEL RESOLUTION BEHAVIOR:
         
         ✅ WORKS (with current fallback logic):
@@ -1553,8 +1553,7 @@ class TestProxyFunctionCalling:
            
         💡 SOLUTION: Use LiteLLM proxy server with proper model_list configuration
            that maps custom names to underlying models.
-        """
-        )
+        """)
 
     @pytest.mark.parametrize(
         "proxy_model_with_hints,expected_result",
@@ -1916,8 +1915,7 @@ class TestProxyFunctionCalling:
         This test provides documentation on how the proxy server configuration
         would typically map custom model names to underlying models.
         """
-        print(
-            """
+        print("""
         
         REAL-WORLD PROXY SERVER CONFIGURATION EXAMPLE:
         ===============================================
@@ -1970,8 +1968,7 @@ class TestProxyFunctionCalling:
         - Consistent request/response format
         - Enhanced streaming support for function calls
         
-        """
-        )
+        """)
 
         # Verify that direct underlying models work as expected
         bedrock_models = [
@@ -2185,8 +2182,7 @@ class TestProxyFunctionCalling:
         This test provides documentation on how the proxy server configuration
         would typically map custom model names to underlying models.
         """
-        print(
-            """
+        print("""
         
         REAL-WORLD PROXY SERVER CONFIGURATION EXAMPLE:
         ===============================================
@@ -2239,8 +2235,7 @@ class TestProxyFunctionCalling:
         - Consistent request/response format
         - Enhanced streaming support for function calls
         
-        """
-        )
+        """)
 
         # Verify that direct underlying models work as expected
         bedrock_models = [
@@ -2454,8 +2449,7 @@ class TestProxyFunctionCalling:
         This test provides documentation on how the proxy server configuration
         would typically map custom model names to underlying models.
         """
-        print(
-            """
+        print("""
         
         REAL-WORLD PROXY SERVER CONFIGURATION EXAMPLE:
         ===============================================
@@ -2508,8 +2502,7 @@ class TestProxyFunctionCalling:
         - Consistent request/response format
         - Enhanced streaming support for function calls
         
-        """
-        )
+        """)
 
         # Verify that direct underlying models work as expected
         bedrock_models = [


### PR DESCRIPTION
## Relevant issues

Follow-up to the pattern shown in #29238, where shipping one new model (claude-opus-4-8) meant touching a hardcoded `BEDROCK_CONVERSE_MODELS` list, two structures in the setup wizard, a capability-gating refactor, and nine JSON entries duplicated across two in-sync files. This makes unknown/newly-released models degrade gracefully from a single declarative source instead of scattered Python.

## Linear ticket

N/A

## The problem

When a brand-new model ships before we add a JSON entry, litellm degrades: cost lookup misses, `supports_*` flags are wrong, and provider routing fails. We patched each case with one-off hardcoded regexes in Python; for example `_CLAUDE_PATTERN` / `_matches_claude_model_pattern` in `get_llm_provider_logic.py` routed unknown `claude-*` to anthropic, separate from the `supports_*` / model-info fallback in `utils.py`. There was no single source of truth.

## What this does

It adds a declarative `fallback_generalizations` block to `model_prices_and_context_window.json`. Each rule pairs a single case-insensitive regex (use alternation inside the regex rather than a list of patterns) with the `model_info` to apply when a model name has no exact entry. `model_info.litellm_provider` drives provider routing, and the rest (`mode`, `supports_*`, context window, pricing) drives `get_model_info` / `supports_*`, so one rule subsumes both the provider-routing case and the capability/model-info case.

```json
"fallback_generalizations": {
  "rules": [
    {
      "name": "anthropic-claude",
      "pattern": "^claude-[a-z]+-\\d+-\\d+(?:-\\d{8})?$",
      "model_info": { "litellm_provider": "anthropic", "mode": "chat", "supports_function_calling": true, "...": "..." }
    }
  ]
}
```

Precedence is documented and simple: rules are an ordered list, first match wins, and they are consulted only after every exact and case-insensitive lookup misses, so an exact entry always beats a rule. A new `fallback_generalizations` module owns the rules and a compiled-regex cache that is built once and invalidated on reload; the O(n) scan runs only on a cache miss, and `_get_model_cost_key()` stays untouched and O(1) on the hot router path.

`get_llm_provider` now routes an otherwise-unknown model via the first matching rule's `litellm_provider` as a last resort after the exact provider checks, and the hardcoded `_CLAUDE_PATTERN` / `_matches_claude_model_pattern` are deleted. `_get_model_info_helper` falls back to a matching rule's `model_info` after the five exact lookups miss, so `get_model_info` and the `supports_*` helpers resolve unknown models from the same rule.

## Migration and back-compat (the tradeoff)

I pushed back on nesting every model under a `"models"` key. The file is fetched live by every installed litellm version; if models moved under a nested key, every existing release would see zero top-level models, fail the shrink-count check, freeze on its bundled backup, and silently miss lookups. Instead the top level stays a flat map of models (a strict superset) with one added reserved key, exactly like the existing `sample_spec`, so old clients keep working unchanged and keep receiving updates while new clients pop the reserved keys and read the rules. One file, one source of truth, no v2 mirror to keep in sync. The block is a dict wrapper (`{"rules": [...]}`) rather than a bare list so old `add_known_models`, which calls `.get("litellm_provider")` on every top-level value, does not choke on it. The block ships in both the root file and the bundled `*_backup.json`, and `LITELLM_LOCAL_MODEL_COST_MAP` keeps working. The one window where unknown-claude routing is inert is this branch before merge, because the remote file pinned to main does not carry the rule yet; the tests inject the rule rather than depend on the live URL.

The count validation in `get_model_cost_map.py` now counts actual model entries (top-level keys minus reserved meta keys) for both fetched and backup, so the new key cannot inflate the count and mask a genuinely shrunk upstream file.

## What I deliberately did not do

I left `BEDROCK_CONVERSE_MODELS` in place. It selects the converse-vs-invoke sub-route (not `litellm_provider`) and has a dedicated guard test, so subsuming it is a separate, riskier change; the mechanism here is general enough to absorb it later. I also kept the bare-model-name capability fallback from #20885 in `_supports_factory`; that is a prefixed-to-bare delegation for known models, orthogonal to generalizations, so it is not dead code.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## CI (LiteLLM team)

- [ ] Branch creation CI run
       Link:
- [ ] CI run for the last commit
       Link:
- [ ] Merge / cherry-pick CI run
       Links:

## Screenshots / Proof of Fix

Run against a live proxy on localhost:4000 with the branch checked out. `LITELLM_LOCAL_MODEL_COST_MAP=True` makes the proxy load the bundled backup, which ships the `anthropic-claude` rule (the remote file pinned to main does not have it until this merges).

1. Start the proxy

```
LITELLM_LOCAL_MODEL_COST_MAP=True python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log
```

2. Confirm an unmapped Claude name resolves via the rule (provider anthropic, capability flags, context window) without any JSON entry for it

```
python -c "import litellm, json; print(json.dumps(litellm.get_model_info('claude-opus-4-9'), default=str, indent=2))"
```

Expect `litellm_provider: anthropic`, `supports_function_calling: true`, `supports_vision: true`, `max_input_tokens: 200000`.

3. Confirm provider routing reaches the real Anthropic API (this costs real money). Calling a not-yet-real name proves routing: the request reaches Anthropic and Anthropic itself rejects the unknown model, whereas before the change litellm failed earlier with "LLM Provider NOT provided". Swap in any real Anthropic model name that litellm has not mapped yet to get a 200

```
curl -s http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model": "claude-opus-4-9", "messages": [{"role": "user", "content": "hi"}]}' | jq .
```

## Type

🆕 New Feature

## Changes

New `litellm/litellm_core_utils/fallback_generalizations.py` (rules plus compiled-regex cache and matcher). `get_model_cost_map.py` extracts the block and counts real model entries for the integrity check. `get_llm_provider_logic.py` routes unknown models via the rule and drops the hardcoded claude regex. `utils.py` adds the generalization fallback in `_get_model_info_helper`. The `fallback_generalizations` block (with an `anthropic-claude` rule) is added to both `model_prices_and_context_window.json` and the bundled backup. Tests cover provider routing through the rule, `supports_*` / context / pricing resolution, exact-entry precedence, malformed-rule resilience, compiled-cache invalidation, and the count validation still rejecting a truly-shrunk upstream file.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G8Jro8dPLktwnaaSJwVDpo)_