### PR TITLE
fix(ui): key Agent Builder agent selection on model_info.id

### DIFF
--- a/ui/litellm-dashboard/src/components/playground/chat_ui/AgentBuilderView.tsx
+++ b/ui/litellm-dashboard/src/components/playground/chat_ui/AgentBuilderView.tsx
@@ -335,7 +335,7 @@ export default function AgentBuilderView({
       const createdId: string | null = response?.model_id ?? response?.model_info?.id ?? null;
       const list = await loadAgents();
       const created = createdId
-        ? list.find((a) => getAgentModelId(a) === createdId)
+        ? list.find((a) => getAgentModelId(a) === createdId) ?? list.find((a) => a.model_name === draftName.trim())
         : list.find((a) => a.model_name === draftName.trim());
       setSelectedId(created ? getAgentSelectionKey(created) : list[0] ? getAgentSelectionKey(list[0]) : null);
       setActiveTab("chat");

--- a/ui/litellm-dashboard/src/components/playground/chat_ui/AgentBuilderView.tsx
+++ b/ui/litellm-dashboard/src/components/playground/chat_ui/AgentBuilderView.tsx
@@ -131,6 +131,14 @@ function getAgentModelId(agent: AgentModel): string | null {
   return info?.id ?? null;
 }
 
+// Selection key that always resolves to a non-null string. Prefers the DB
+// id (stable across renames and unique across teams) but falls back to
+// `model_name` so config-file-defined agents — which have no `model_info.id`
+// — remain selectable.
+function getAgentSelectionKey(agent: AgentModel): string {
+  return getAgentModelId(agent) ?? agent.model_name;
+}
+
 function parseUnderlyingModel(litellmModel: string | undefined): string | undefined {
   if (!litellmModel || !litellmModel.startsWith("litellm_agent/")) return undefined;
   return litellmModel.slice("litellm_agent/".length) || undefined;
@@ -196,22 +204,24 @@ export default function AgentBuilderView({
 
   const effectiveApiKey = apiKey || accessToken || "";
   const selectedAgent =
-    selectedId === NEW_AGENT_ID ? null : agentModels.find((a) => a.model_name === selectedId) ?? null;
+    selectedId === NEW_AGENT_ID ? null : agentModels.find((a) => getAgentSelectionKey(a) === selectedId) ?? null;
   const isNewAgent = selectedId === NEW_AGENT_ID;
   const selectedAgentModelId = selectedAgent ? getAgentModelId(selectedAgent) : null;
 
-  const loadAgents = useCallback(async () => {
-    if (!accessToken || !userID || !userRole) return;
+  const loadAgents = useCallback(async (): Promise<AgentModel[]> => {
+    if (!accessToken || !userID || !userRole) return [];
     setLoadingAgents(true);
     try {
       const list = await fetchAvailableAgentModels(accessToken, userID, userRole);
       setAgentModels(list);
-      if (!selectedId || (selectedId !== NEW_AGENT_ID && !list.some((a) => a.model_name === selectedId))) {
-        setSelectedId(list.length > 0 ? list[0].model_name : null);
+      if (!selectedId || (selectedId !== NEW_AGENT_ID && !list.some((a) => getAgentSelectionKey(a) === selectedId))) {
+        setSelectedId(list.length > 0 ? getAgentSelectionKey(list[0]) : null);
       }
+      return list;
     } catch (e) {
       console.error(e);
       NotificationsManager.fromBackend("Failed to load agents");
+      return [];
     } finally {
       setLoadingAgents(false);
     }
@@ -308,7 +318,7 @@ export default function AgentBuilderView({
     }
     setSaving(true);
     try {
-      await modelCreateCall(accessToken, {
+      const response = await modelCreateCall(accessToken, {
         model_name: draftName.trim(),
         litellm_params: {
           model: `litellm_agent/${draftUnderlyingModel}`,
@@ -319,9 +329,15 @@ export default function AgentBuilderView({
         },
         model_info: {},
       });
-      const newName = draftName.trim();
-      await loadAgents();
-      setSelectedId(newName);
+      // /model/new returns the row with `model_id` at the top level.
+      // Prefer that id over name-matching so we land on the just-created
+      // agent even when its public name collides with another team's.
+      const createdId: string | null = response?.model_id ?? response?.model_info?.id ?? null;
+      const list = await loadAgents();
+      const created = createdId
+        ? list.find((a) => getAgentModelId(a) === createdId)
+        : list.find((a) => a.model_name === draftName.trim());
+      setSelectedId(created ? getAgentSelectionKey(created) : list[0] ? getAgentSelectionKey(list[0]) : null);
       setActiveTab("chat");
     } catch (e) {
       NotificationsManager.fromBackend("Failed to save agent");
@@ -353,8 +369,10 @@ export default function AgentBuilderView({
         selectedAgentModelId,
       );
       NotificationsManager.success("Agent updated successfully");
-      await loadAgents();
-      setSelectedId(draftName.trim());
+      const list = await loadAgents();
+      const stillSelected = list.find((a) => getAgentModelId(a) === selectedAgentModelId);
+      const target = stillSelected ?? list[0];
+      setSelectedId(target ? getAgentSelectionKey(target) : null);
     } catch (e) {
       NotificationsManager.fromBackend("Failed to update agent");
     } finally {
@@ -398,9 +416,9 @@ export default function AgentBuilderView({
         try {
           await modelDeleteCall(accessToken, selectedAgentModelId);
           NotificationsManager.success("Agent deleted");
-          await loadAgents();
-          const remaining = agentModels.filter((a) => a.model_name !== selectedAgent.model_name);
-          setSelectedId(remaining.length > 0 ? remaining[0].model_name : null);
+          const list = await loadAgents();
+          const remaining = list.filter((a) => getAgentModelId(a) !== selectedAgentModelId);
+          setSelectedId(remaining.length > 0 ? getAgentSelectionKey(remaining[0]) : null);
         } catch (e) {
           NotificationsManager.fromBackend("Failed to delete agent");
         } finally {
@@ -462,21 +480,24 @@ export default function AgentBuilderView({
               </div>
             ) : (
               <>
-                {agentModels.map((agent) => (
-                  <button
-                    key={agent.model_name}
-                    type="button"
-                    onClick={() => setSelectedId(agent.model_name)}
-                    className={`mb-1 w-full rounded-md border-l-2 px-3 py-2 text-left text-sm transition-colors ${
-                      selectedId === agent.model_name
-                        ? "border-blue-500 bg-blue-50 text-blue-800"
-                        : "border-transparent hover:bg-gray-50"
-                    }`}
-                  >
-                    <div className="font-medium truncate">{agent.model_name}</div>
-                    <div className="text-[10px] text-gray-500 truncate">litellm_agent</div>
-                  </button>
-                ))}
+                {agentModels.map((agent) => {
+                  const key = getAgentSelectionKey(agent);
+                  return (
+                    <button
+                      key={key}
+                      type="button"
+                      onClick={() => setSelectedId(key)}
+                      className={`mb-1 w-full rounded-md border-l-2 px-3 py-2 text-left text-sm transition-colors ${
+                        selectedId === key
+                          ? "border-blue-500 bg-blue-50 text-blue-800"
+                          : "border-transparent hover:bg-gray-50"
+                      }`}
+                    >
+                      <div className="font-medium truncate">{agent.model_name}</div>
+                      <div className="text-[10px] text-gray-500 truncate">litellm_agent</div>
+                    </button>
+                  );
+                })}
                 <button
                   type="button"
                   onClick={handleAddAgent}


### PR DESCRIPTION
## Relevant issues

Builds on the team BYOK model-name corruption fix (#28382, backend landed via #29001, already on this branch). This is the UI half of #27376, cherry-picked on top.

## Background

For team-scoped BYOK models the backend stores an internal routing key `model_name_{team_id}_{uuid}` and keeps the user-facing public name in `model_info.team_public_model_name`. With #29001 on this branch, `/v1` and `/v2/model/info` now return the public name instead of the internal key. A side effect is that two team-scoped agents can legitimately share the same public `model_name`, so the Agent Builder can no longer use `model_name` as a selection identity; it collides.

## Changes

`AgentBuilderView.tsx` now keys agent selection on the stable `model_info.id` via a small `getAgentSelectionKey` helper, falling back to `model_name` only for config-file-defined agents that have no id. Create, update, delete and the sidebar list all resolve the selected agent by id, so the right agent is selected even when two share a public name. `loadAgents` returns the fetched list so the post-create/post-update/post-delete selection can target the just-affected row by id rather than by name.

No backend changes; the diff is one UI file.

## Pre-Submission checklist

- [ ] I have added meaningful tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

A note on tests: this change is not covered by a new vitest yet. The backend behavior it depends on is covered by #29001's Python tests. A component test asserting that selection resolves by `model_info.id` when two agents share a public name would be a good follow-up; happy to add it if you want it in this PR

## Screenshots / Proof of Fix

The diff is UI-only and not curl-reproducible. Suggested manual smoke once this is deployed to a UI build:

1. As proxy admin, create two team-scoped BYOK models in two different teams that share the same public name (for example `gpt-4o`), each with `litellm_agent/...` so they show up in the Agent Builder
2. Go to http://localhost:4000/ui/?page=llm-playground and open the Agent Builder tab
3. Confirm both agents render as separate rows in the left list (before this change they would have collapsed onto one key)
4. Select the first, rename it, save; confirm the selection stays on that same agent and the second is untouched
5. Delete one; confirm the remaining one stays selectable and correct

For context, the backend corruption fix on this branch (#29001) was verified end-to-end against a live proxy with a team BYOK model and a team-scoped key (real provider calls). A non-rename PATCH that echoes the internal `model_name_{team_id}_{uuid}` no longer overwrites `team_public_model_name` or the team `models[]` ACL, genuine renames still work, routing by the public name returns 200, and non-team models are untouched

## Type

🐛 Bug Fix
