### PR TITLE
Title: fix(proxy): resolve vector store file list credentials from team deployments

### DIFF
--- a/litellm/proxy/vector_store_files_endpoints/endpoints.py
+++ b/litellm/proxy/vector_store_files_endpoints/endpoints.py
@@ -5,6 +5,7 @@ from fastapi.responses import ORJSONResponse
 
 import litellm
 from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy.auth.auth_checks import _can_object_call_model, can_key_call_model
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 from litellm.proxy.common_request_processing import ProxyBaseLLMRequestProcessing
 from litellm.proxy.common_utils.openai_endpoint_utils import (
@@ -191,7 +192,37 @@ def _replace_file_id_in_response(response, original_file_id: str):
     return response
 
 
-def _update_request_data_with_model_routing_hint(
+async def _authorize_model_routing_hint(
+    *,
+    model: str,
+    llm_router: Optional["Router"],
+    user_api_key_dict: Optional[UserAPIKeyAuth],
+) -> None:
+    if user_api_key_dict is None:
+        return
+
+    key_models = getattr(user_api_key_dict, "models", None)
+    if not (isinstance(key_models, list) and "all-team-models" in key_models):
+        await can_key_call_model(
+            model=model,
+            llm_model_list=None,
+            valid_token=user_api_key_dict,
+            llm_router=llm_router,
+        )
+
+    team_models = getattr(user_api_key_dict, "team_models", None)
+    if isinstance(team_models, list) and len(team_models) > 0:
+        _can_object_call_model(
+            model=model,
+            llm_router=llm_router,
+            models=team_models,
+            team_model_aliases=user_api_key_dict.team_model_aliases,
+            team_id=user_api_key_dict.team_id,
+            object_type="team",
+        )
+
+
+async def _update_request_data_with_model_routing_hint(
     data: Dict,
     request: Request,
     llm_router: Optional["Router"] = None,
@@ -200,10 +231,12 @@ def _update_request_data_with_model_routing_hint(
     if data.get("api_key") is not None or data.get("api_base") is not None:
         return data
 
-    model_hint = (
-        data.get("model")
-        or request.query_params.get("model")
-        or request.headers.get("x-litellm-model")
+    user_controlled_model_hint = request.query_params.get(
+        "model"
+    ) or request.headers.get("x-litellm-model")
+    model_hint = data.get("model") or user_controlled_model_hint
+    should_authorize_model_hint = (
+        isinstance(model_hint, str) and model_hint == user_controlled_model_hint
     )
 
     should_route = False
@@ -214,7 +247,19 @@ def _update_request_data_with_model_routing_hint(
                 model_id=model_hint
             )
             should_route = credentials is not None
+            if should_route and should_authorize_model_hint:
+                await _authorize_model_routing_hint(
+                    model=model_hint,
+                    llm_router=llm_router,
+                    user_api_key_dict=user_api_key_dict,
+                )
     else:
+        if should_authorize_model_hint:
+            await _authorize_model_routing_hint(
+                model=model_hint,
+                llm_router=llm_router,
+                user_api_key_dict=user_api_key_dict,
+            )
         (
             should_route,
             _model_used,
@@ -261,7 +306,7 @@ def _update_request_data_with_model_routing_hint(
         model = credentials.get("model")
         if provider is None and isinstance(model, str) and "/" in model:
             provider = model.split("/", 1)[0]
-        if provider not in (None, LlmProviders.OPENAI.value):
+        if provider != LlmProviders.OPENAI.value:
             continue
 
         if openai_credentials is not None:
@@ -563,19 +608,19 @@ async def vector_store_file_list(
         user_api_key_dict=user_api_key_dict,
     )
 
-    data = _update_request_data_with_model_routing_hint(
-        data=data,
-        request=request,
-        llm_router=llm_router,
-        user_api_key_dict=user_api_key_dict,
-    )
-
     data = _update_request_data_with_litellm_managed_vector_store_registry(
         data=data,
         vector_store_id=vector_store_id,
         llm_router=llm_router,
         managed_vector_store=managed_vector_store,
         should_lookup_registry=False,
+    )
+
+    data = await _update_request_data_with_model_routing_hint(
+        data=data,
+        request=request,
+        llm_router=llm_router,
+        user_api_key_dict=user_api_key_dict,
     )
 
     provider_enum = await _resolve_provider(data=data, request=request)

--- a/litellm/proxy/vector_store_files_endpoints/endpoints.py
+++ b/litellm/proxy/vector_store_files_endpoints/endpoints.py
@@ -191,6 +191,89 @@ def _replace_file_id_in_response(response, original_file_id: str):
     return response
 
 
+def _update_request_data_with_model_routing_hint(
+    data: Dict,
+    request: Request,
+    llm_router: Optional["Router"] = None,
+    user_api_key_dict: Optional[UserAPIKeyAuth] = None,
+) -> Dict:
+    if data.get("api_key") is not None or data.get("api_base") is not None:
+        return data
+
+    model_hint = (
+        data.get("model")
+        or request.query_params.get("model")
+        or request.headers.get("x-litellm-model")
+    )
+
+    should_route = False
+    credentials = None
+    if isinstance(model_hint, str) and "*" in model_hint:
+        if llm_router is not None:
+            credentials = llm_router.get_deployment_credentials_with_provider(
+                model_id=model_hint
+            )
+            should_route = credentials is not None
+    else:
+        (
+            should_route,
+            _model_used,
+            _original_file_id,
+            credentials,
+        ) = handle_model_based_routing(
+            file_id="",
+            request=request,
+            llm_router=llm_router,
+            data=data,
+            check_file_id_encoding=False,
+        )
+
+    if should_route and credentials is not None:
+        prepare_data_with_credentials(
+            data=data,
+            credentials=credentials,
+        )
+        return data
+
+    if llm_router is None or user_api_key_dict is None:
+        return data
+
+    team_models = getattr(user_api_key_dict, "team_models", None) or []
+    if not isinstance(team_models, list):
+        return data
+
+    openai_credentials = None
+    for model_name in team_models:
+        if not isinstance(model_name, str) or model_name in {
+            "all-team-models",
+            "all-proxy-models",
+            "no-default-models",
+        }:
+            continue
+
+        credentials = llm_router.get_deployment_credentials_with_provider(
+            model_id=model_name
+        )
+        if credentials is None:
+            continue
+
+        provider = credentials.get("custom_llm_provider")
+        model = credentials.get("model")
+        if provider is None and isinstance(model, str) and "/" in model:
+            provider = model.split("/", 1)[0]
+        if provider not in (None, LlmProviders.OPENAI.value):
+            continue
+
+        if openai_credentials is not None:
+            return data
+        openai_credentials = credentials
+
+    if openai_credentials is not None:
+        prepare_data_with_credentials(data=data, credentials=openai_credentials)
+
+    return data
+
+
 def _update_request_data_with_litellm_managed_vector_store_registry(
     data: Dict,
     vector_store_id: str,
@@ -477,6 +560,13 @@ async def vector_store_file_list(
     data["vector_store_id"] = vector_store_id
     managed_vector_store = await assert_user_can_access_vector_store_id(
         vector_store_id=vector_store_id,
+        user_api_key_dict=user_api_key_dict,
+    )
+
+    data = _update_request_data_with_model_routing_hint(
+        data=data,
+        request=request,
+        llm_router=llm_router,
         user_api_key_dict=user_api_key_dict,
     )
 

--- a/litellm/proxy/vector_store_files_endpoints/endpoints.py
+++ b/litellm/proxy/vector_store_files_endpoints/endpoints.py
@@ -254,7 +254,7 @@ async def _update_request_data_with_model_routing_hint(
             )
             should_route = credentials is not None
     else:
-        if should_authorize_model_hint:
+        if isinstance(model_hint, str) and should_authorize_model_hint:
             await _authorize_model_routing_hint(
                 model=model_hint,
                 llm_router=llm_router,

--- a/litellm/proxy/vector_store_files_endpoints/endpoints.py
+++ b/litellm/proxy/vector_store_files_endpoints/endpoints.py
@@ -243,16 +243,16 @@ async def _update_request_data_with_model_routing_hint(
     credentials = None
     if isinstance(model_hint, str) and "*" in model_hint:
         if llm_router is not None:
-            credentials = llm_router.get_deployment_credentials_with_provider(
-                model_id=model_hint
-            )
-            should_route = credentials is not None
-            if should_route and should_authorize_model_hint:
+            if should_authorize_model_hint:
                 await _authorize_model_routing_hint(
                     model=model_hint,
                     llm_router=llm_router,
                     user_api_key_dict=user_api_key_dict,
                 )
+            credentials = llm_router.get_deployment_credentials_with_provider(
+                model_id=model_hint
+            )
+            should_route = credentials is not None
     else:
         if should_authorize_model_hint:
             await _authorize_model_routing_hint(
@@ -287,7 +287,7 @@ async def _update_request_data_with_model_routing_hint(
     if not isinstance(team_models, list):
         return data
 
-    openai_credentials = None
+    model_names_to_check = []
     for model_name in team_models:
         if not isinstance(model_name, str) or model_name in {
             "all-team-models",
@@ -295,7 +295,10 @@ async def _update_request_data_with_model_routing_hint(
             "no-default-models",
         }:
             continue
+        model_names_to_check.append(model_name)
 
+    openai_credentials = None
+    for model_name in model_names_to_check:
         credentials = llm_router.get_deployment_credentials_with_provider(
             model_id=model_name
         )
@@ -309,12 +312,24 @@ async def _update_request_data_with_model_routing_hint(
         if provider != LlmProviders.OPENAI.value:
             continue
 
+        await _authorize_model_routing_hint(
+            model=model_name,
+            llm_router=llm_router,
+            user_api_key_dict=user_api_key_dict,
+        )
         if openai_credentials is not None:
             return data
         openai_credentials = credentials
 
     if openai_credentials is not None:
         prepare_data_with_credentials(data=data, credentials=openai_credentials)
+    elif len(model_names_to_check) == 1:
+        await _authorize_model_routing_hint(
+            model=model_names_to_check[0],
+            llm_router=llm_router,
+            user_api_key_dict=user_api_key_dict,
+        )
+        data["model"] = model_names_to_check[0]
 
     return data
 

--- a/tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_endpoints.py
+++ b/tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_endpoints.py
@@ -21,6 +21,9 @@ from litellm.proxy.vector_store_endpoints.endpoints import (
     _update_request_data_with_litellm_managed_vector_store_registry,
     index_create,
 )
+from litellm.proxy.vector_store_files_endpoints.endpoints import (
+    _update_request_data_with_model_routing_hint,
+)
 from litellm.proxy.vector_store_endpoints.management_endpoints import (
     _check_vector_store_access,
     _resolve_embedding_config,
@@ -142,6 +145,161 @@ def test_router_vector_store_file_delete_passes_correct_args():
         assert call_kwargs["vector_store_id"] == "test_store_id"
         assert call_kwargs["file_id"] == "file-123"
         assert call_kwargs["custom_llm_provider"] == "openai"
+
+
+def test_vector_store_file_list_resolves_credentials_from_model_query_param():
+    request = MagicMock(spec=Request)
+    request.query_params = {"model": "team-openai"}
+    request.headers = {}
+
+    llm_router = MagicMock()
+    llm_router.get_deployment_credentials_with_provider.return_value = {
+        "api_key": "sk-team-openai",
+        "api_base": "https://api.openai.com/v1",
+        "custom_llm_provider": "openai",
+        "model": "openai/gpt-4o-mini",
+    }
+
+    data = {
+        "vector_store_id": "vs_123",
+        "limit": "20",
+    }
+
+    result = _update_request_data_with_model_routing_hint(
+        data=data,
+        request=request,
+        llm_router=llm_router,
+    )
+
+    assert result["api_key"] == "sk-team-openai"
+    assert result["api_base"] == "https://api.openai.com/v1"
+    assert result["model"] == "openai/gpt-4o-mini"
+    assert "custom_llm_provider" not in result
+    llm_router.get_deployment_credentials_with_provider.assert_called_once_with(
+        model_id="team-openai"
+    )
+
+
+def test_vector_store_file_list_resolves_single_openai_team_deployment():
+    request = MagicMock(spec=Request)
+    request.query_params = {}
+    request.headers = {}
+
+    llm_router = MagicMock()
+    llm_router.get_deployment_credentials_with_provider.return_value = {
+        "api_key": "sk-team-openai",
+        "api_base": "https://api.openai.com/v1",
+        "custom_llm_provider": "openai",
+        "model": "openai/gpt-4o-mini",
+    }
+
+    data = {"vector_store_id": "vs_123"}
+    user_api_key_dict = UserAPIKeyAuth(team_models=["team-openai"])
+
+    result = _update_request_data_with_model_routing_hint(
+        data=data,
+        request=request,
+        llm_router=llm_router,
+        user_api_key_dict=user_api_key_dict,
+    )
+
+    assert result["api_key"] == "sk-team-openai"
+    assert result["api_base"] == "https://api.openai.com/v1"
+    assert result["model"] == "openai/gpt-4o-mini"
+    assert "custom_llm_provider" not in result
+    llm_router.get_deployment_credentials_with_provider.assert_called_once_with(
+        model_id="team-openai"
+    )
+
+
+def test_vector_store_file_list_wildcard_model_hint_falls_back_to_team_deployment():
+    request = MagicMock(spec=Request)
+    request.query_params = {"model": "openai/*"}
+    request.headers = {}
+
+    llm_router = MagicMock()
+    llm_router.get_deployment_credentials_with_provider.side_effect = [
+        None,
+        {
+            "api_key": "sk-team-openai",
+            "api_base": "https://api.openai.com/v1",
+            "custom_llm_provider": "openai",
+            "model": "openai/gpt-4o-mini",
+        },
+    ]
+
+    data = {"vector_store_id": "vs_123", "model": "openai/*"}
+    user_api_key_dict = UserAPIKeyAuth(team_models=["team-openai"])
+
+    result = _update_request_data_with_model_routing_hint(
+        data=data,
+        request=request,
+        llm_router=llm_router,
+        user_api_key_dict=user_api_key_dict,
+    )
+
+    assert result["api_key"] == "sk-team-openai"
+    assert result["api_base"] == "https://api.openai.com/v1"
+    assert result["model"] == "openai/gpt-4o-mini"
+    assert "custom_llm_provider" not in result
+    assert llm_router.get_deployment_credentials_with_provider.call_count == 2
+
+
+def test_vector_store_file_list_does_not_guess_ambiguous_team_deployment():
+    request = MagicMock(spec=Request)
+    request.query_params = {}
+    request.headers = {}
+
+    llm_router = MagicMock()
+    llm_router.get_deployment_credentials_with_provider.side_effect = [
+        {
+            "api_key": "sk-team-openai-1",
+            "custom_llm_provider": "openai",
+            "model": "openai/gpt-4o-mini",
+        },
+        {
+            "api_key": "sk-team-openai-2",
+            "custom_llm_provider": "openai",
+            "model": "openai/gpt-4.1-mini",
+        },
+    ]
+
+    data = {"vector_store_id": "vs_123"}
+    user_api_key_dict = UserAPIKeyAuth(team_models=["team-openai-1", "team-openai-2"])
+
+    result = _update_request_data_with_model_routing_hint(
+        data=data,
+        request=request,
+        llm_router=llm_router,
+        user_api_key_dict=user_api_key_dict,
+    )
+
+    assert "api_key" not in result
+    assert "api_base" not in result
+    assert llm_router.get_deployment_credentials_with_provider.call_count == 2
+
+
+def test_vector_store_file_list_does_not_override_existing_credentials():
+    request = MagicMock(spec=Request)
+    request.query_params = {"model": "team-openai"}
+    request.headers = {}
+
+    llm_router = MagicMock()
+    data = {
+        "vector_store_id": "vs_123",
+        "api_key": "sk-explicit",
+        "api_base": "https://example.com/v1",
+    }
+
+    result = _update_request_data_with_model_routing_hint(
+        data=data,
+        request=request,
+        llm_router=llm_router,
+    )
+
+    assert result["api_key"] == "sk-explicit"
+    assert result["api_base"] == "https://example.com/v1"
+    llm_router.get_deployment_credentials_with_provider.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_endpoints.py
+++ b/tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_endpoints.py
@@ -221,7 +221,9 @@ async def test_vector_store_file_list_wildcard_model_hint_falls_back_to_team_dep
     request.headers = {}
 
     llm_router = MagicMock()
+    llm_router.model_group_alias = {}
     llm_router.get_deployment_credentials_with_provider.side_effect = [
+        None,
         None,
         {
             "api_key": "sk-team-openai",
@@ -232,7 +234,7 @@ async def test_vector_store_file_list_wildcard_model_hint_falls_back_to_team_dep
     ]
 
     data = {"vector_store_id": "vs_123", "model": "openai/*"}
-    user_api_key_dict = UserAPIKeyAuth(team_models=["team-openai"])
+    user_api_key_dict = UserAPIKeyAuth(team_models=["openai/*", "team-openai"])
 
     result = await _update_request_data_with_model_routing_hint(
         data=data,
@@ -245,7 +247,94 @@ async def test_vector_store_file_list_wildcard_model_hint_falls_back_to_team_dep
     assert result["api_base"] == "https://api.openai.com/v1"
     assert result["model"] == "openai/gpt-4o-mini"
     assert "custom_llm_provider" not in result
-    assert llm_router.get_deployment_credentials_with_provider.call_count == 2
+    assert llm_router.get_deployment_credentials_with_provider.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_vector_store_file_list_authorizes_wildcard_query_param_before_credentials():
+    from litellm.proxy.auth.auth_checks import ProxyException
+
+    request = MagicMock(spec=Request)
+    request.query_params = {"model": "openai/*"}
+    request.headers = {}
+
+    llm_router = MagicMock()
+    llm_router.model_group_alias = {}
+    data = {"vector_store_id": "vs_123"}
+    user_api_key_dict = UserAPIKeyAuth(
+        models=["restricted-deployment"],
+        team_models=["openai/*"],
+    )
+
+    with pytest.raises(ProxyException):
+        await _update_request_data_with_model_routing_hint(
+            data=data,
+            request=request,
+            llm_router=llm_router,
+            user_api_key_dict=user_api_key_dict,
+        )
+
+    llm_router.get_deployment_credentials_with_provider.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_vector_store_file_list_uses_single_team_model_for_router_routing():
+    request = MagicMock(spec=Request)
+    request.query_params = {}
+    request.headers = {}
+
+    llm_router = MagicMock()
+    llm_router.get_model_access_groups.return_value = {}
+    llm_router.get_deployment_credentials_with_provider.return_value = None
+
+    data = {"vector_store_id": "vs_123"}
+    user_api_key_dict = UserAPIKeyAuth(
+        team_id="team-123",
+        team_models=["provider/*", "all-proxy-models"],
+    )
+
+    result = await _update_request_data_with_model_routing_hint(
+        data=data,
+        request=request,
+        llm_router=llm_router,
+        user_api_key_dict=user_api_key_dict,
+    )
+
+    assert result["model"] == "provider/*"
+    assert "api_key" not in result
+    assert "api_base" not in result
+
+
+@pytest.mark.asyncio
+async def test_vector_store_file_list_authorizes_inferred_team_model():
+    from litellm.proxy.auth.auth_checks import ProxyException
+
+    request = MagicMock(spec=Request)
+    request.query_params = {}
+    request.headers = {}
+
+    llm_router = MagicMock()
+    llm_router.model_group_alias = {}
+    llm_router.get_deployment_credentials_with_provider.return_value = {
+        "api_key": "sk-team-openai",
+        "api_base": "https://api.openai.com/v1",
+        "custom_llm_provider": "openai",
+        "model": "openai/gpt-4o-mini",
+    }
+
+    data = {"vector_store_id": "vs_123"}
+    user_api_key_dict = UserAPIKeyAuth(
+        models=["restricted-deployment"],
+        team_models=["team-openai"],
+    )
+
+    with pytest.raises(ProxyException):
+        await _update_request_data_with_model_routing_hint(
+            data=data,
+            request=request,
+            llm_router=llm_router,
+            user_api_key_dict=user_api_key_dict,
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_endpoints.py
+++ b/tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_endpoints.py
@@ -147,7 +147,8 @@ def test_router_vector_store_file_delete_passes_correct_args():
         assert call_kwargs["custom_llm_provider"] == "openai"
 
 
-def test_vector_store_file_list_resolves_credentials_from_model_query_param():
+@pytest.mark.asyncio
+async def test_vector_store_file_list_resolves_credentials_from_model_query_param():
     request = MagicMock(spec=Request)
     request.query_params = {"model": "team-openai"}
     request.headers = {}
@@ -165,7 +166,7 @@ def test_vector_store_file_list_resolves_credentials_from_model_query_param():
         "limit": "20",
     }
 
-    result = _update_request_data_with_model_routing_hint(
+    result = await _update_request_data_with_model_routing_hint(
         data=data,
         request=request,
         llm_router=llm_router,
@@ -180,7 +181,8 @@ def test_vector_store_file_list_resolves_credentials_from_model_query_param():
     )
 
 
-def test_vector_store_file_list_resolves_single_openai_team_deployment():
+@pytest.mark.asyncio
+async def test_vector_store_file_list_resolves_single_openai_team_deployment():
     request = MagicMock(spec=Request)
     request.query_params = {}
     request.headers = {}
@@ -196,7 +198,7 @@ def test_vector_store_file_list_resolves_single_openai_team_deployment():
     data = {"vector_store_id": "vs_123"}
     user_api_key_dict = UserAPIKeyAuth(team_models=["team-openai"])
 
-    result = _update_request_data_with_model_routing_hint(
+    result = await _update_request_data_with_model_routing_hint(
         data=data,
         request=request,
         llm_router=llm_router,
@@ -212,7 +214,8 @@ def test_vector_store_file_list_resolves_single_openai_team_deployment():
     )
 
 
-def test_vector_store_file_list_wildcard_model_hint_falls_back_to_team_deployment():
+@pytest.mark.asyncio
+async def test_vector_store_file_list_wildcard_model_hint_falls_back_to_team_deployment():
     request = MagicMock(spec=Request)
     request.query_params = {"model": "openai/*"}
     request.headers = {}
@@ -231,7 +234,7 @@ def test_vector_store_file_list_wildcard_model_hint_falls_back_to_team_deploymen
     data = {"vector_store_id": "vs_123", "model": "openai/*"}
     user_api_key_dict = UserAPIKeyAuth(team_models=["team-openai"])
 
-    result = _update_request_data_with_model_routing_hint(
+    result = await _update_request_data_with_model_routing_hint(
         data=data,
         request=request,
         llm_router=llm_router,
@@ -245,7 +248,8 @@ def test_vector_store_file_list_wildcard_model_hint_falls_back_to_team_deploymen
     assert llm_router.get_deployment_credentials_with_provider.call_count == 2
 
 
-def test_vector_store_file_list_does_not_guess_ambiguous_team_deployment():
+@pytest.mark.asyncio
+async def test_vector_store_file_list_does_not_guess_ambiguous_team_deployment():
     request = MagicMock(spec=Request)
     request.query_params = {}
     request.headers = {}
@@ -267,7 +271,7 @@ def test_vector_store_file_list_does_not_guess_ambiguous_team_deployment():
     data = {"vector_store_id": "vs_123"}
     user_api_key_dict = UserAPIKeyAuth(team_models=["team-openai-1", "team-openai-2"])
 
-    result = _update_request_data_with_model_routing_hint(
+    result = await _update_request_data_with_model_routing_hint(
         data=data,
         request=request,
         llm_router=llm_router,
@@ -279,7 +283,8 @@ def test_vector_store_file_list_does_not_guess_ambiguous_team_deployment():
     assert llm_router.get_deployment_credentials_with_provider.call_count == 2
 
 
-def test_vector_store_file_list_does_not_override_existing_credentials():
+@pytest.mark.asyncio
+async def test_vector_store_file_list_does_not_override_existing_credentials():
     request = MagicMock(spec=Request)
     request.query_params = {"model": "team-openai"}
     request.headers = {}
@@ -291,7 +296,7 @@ def test_vector_store_file_list_does_not_override_existing_credentials():
         "api_base": "https://example.com/v1",
     }
 
-    result = _update_request_data_with_model_routing_hint(
+    result = await _update_request_data_with_model_routing_hint(
         data=data,
         request=request,
         llm_router=llm_router,
@@ -299,6 +304,60 @@ def test_vector_store_file_list_does_not_override_existing_credentials():
 
     assert result["api_key"] == "sk-explicit"
     assert result["api_base"] == "https://example.com/v1"
+    llm_router.get_deployment_credentials_with_provider.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_vector_store_file_list_requires_explicit_openai_provider_for_team_fallback():
+    request = MagicMock(spec=Request)
+    request.query_params = {}
+    request.headers = {}
+
+    llm_router = MagicMock()
+    llm_router.get_deployment_credentials_with_provider.return_value = {
+        "api_key": "sk-unknown-provider",
+        "api_base": "https://example.com/v1",
+        "model": "gpt-4o",
+    }
+
+    data = {"vector_store_id": "vs_123"}
+    user_api_key_dict = UserAPIKeyAuth(team_models=["team-deployment"])
+
+    result = await _update_request_data_with_model_routing_hint(
+        data=data,
+        request=request,
+        llm_router=llm_router,
+        user_api_key_dict=user_api_key_dict,
+    )
+
+    assert "api_key" not in result
+    assert "api_base" not in result
+
+
+@pytest.mark.asyncio
+async def test_vector_store_file_list_authorizes_model_query_param_before_credentials():
+    from litellm.proxy.auth.auth_checks import ProxyException
+
+    request = MagicMock(spec=Request)
+    request.query_params = {"model": "restricted-deployment"}
+    request.headers = {}
+
+    llm_router = MagicMock()
+    llm_router.model_group_alias = {}
+    data = {"vector_store_id": "vs_123"}
+    user_api_key_dict = UserAPIKeyAuth(
+        models=["allowed-deployment"],
+        team_models=["allowed-deployment"],
+    )
+
+    with pytest.raises(ProxyException):
+        await _update_request_data_with_model_routing_hint(
+            data=data,
+            request=request,
+            llm_router=llm_router,
+            user_api_key_dict=user_api_key_dict,
+        )
+
     llm_router.get_deployment_credentials_with_provider.assert_not_called()
 
 

--- a/tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_tenant_guard.py
+++ b/tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_tenant_guard.py
@@ -107,6 +107,75 @@ async def test_vector_store_file_create_forces_path_id_over_body_id():
 
 
 @pytest.mark.asyncio
+async def test_vector_store_file_list_resolves_managed_vector_store_before_team_fallback():
+    import base64
+
+    from litellm.proxy.vector_store_files_endpoints.endpoints import (
+        vector_store_file_list,
+    )
+
+    captured_data = {}
+
+    async def fake_base_process(self, **kwargs):
+        captured_data.update(self.data)
+        return {"ok": True}
+
+    raw_vector_store_id = (
+        "litellm_proxy:vector_store;"
+        "unified_id,managed-vs;"
+        "target_model_names,managed-deployment;"
+        "provider_resource_id,vs_provider_native;"
+        "model_id,managed-deployment"
+    )
+    vector_store_id = (
+        base64.urlsafe_b64encode(raw_vector_store_id.encode()).decode().rstrip("=")
+    )
+
+    request = _mock_request()
+    request.method = "GET"
+    request.query_params = {"limit": "10"}
+    request.url.path = f"/v1/vector_stores/{vector_store_id}/files"
+
+    llm_router = MagicMock()
+
+    def get_credentials(model_id):
+        return {
+            "api_key": f"sk-{model_id}",
+            "api_base": "https://api.openai.com/v1",
+            "custom_llm_provider": "openai",
+            "model": f"openai/{model_id}",
+        }
+
+    llm_router.get_deployment_credentials_with_provider.side_effect = get_credentials
+
+    with (
+        patch(
+            "litellm.proxy.vector_store_files_endpoints.endpoints.assert_user_can_access_vector_store_id",
+            new=AsyncMock(return_value=None),
+        ),
+        patch("litellm.proxy.proxy_server.llm_router", llm_router),
+        patch(
+            "litellm.proxy.vector_store_files_endpoints.endpoints.ProxyBaseLLMRequestProcessing.base_process_llm_request",
+            new=fake_base_process,
+        ),
+    ):
+        response = await vector_store_file_list(
+            vector_store_id=vector_store_id,
+            request=request,
+            fastapi_response=Response(),
+            user_api_key_dict=UserAPIKeyAuth(team_models=["team-openai"]),
+        )
+
+    assert response == {"ok": True}
+    assert captured_data["vector_store_id"] == "vs_provider_native"
+    assert captured_data["api_key"] == "sk-managed-deployment"
+    assert captured_data["model"] == "openai/managed-deployment"
+    llm_router.get_deployment_credentials_with_provider.assert_called_once_with(
+        model_id="managed-deployment"
+    )
+
+
+@pytest.mark.asyncio
 async def test_vector_store_file_create_denies_other_team_path_store():
     from litellm.proxy.vector_store_files_endpoints.endpoints import (
         vector_store_file_create,


### PR DESCRIPTION
Resolves LIT-3598

Summary
GET /v1/vector_stores/{vector_store_id}/files now resolves upstream OpenAI credentials the same way POST /v1/vector_stores/{vector_store_id}/files does for JWT and router-backed teams. List requests no longer bypass the router and call OpenAI with Bearer None.

Cause
POST vector store file create can inject deployment credentials via file_id model routing or router-backed request data. GET list did not run that credential resolution path. When model was missing, route_request() short-circuited avector_store_file_list to litellm.alist() with custom_llm_provider=openai and no api_key, which surfaced as:

{
  "error": {
    "message": "Incorrect API key provided: None",
    "code": "invalid_api_key"
  }
}
Passing ?model=openai/* made this worse because wildcard model hints were treated as concrete deployment ids and returned 400 before team fallback could run.

Fix
Added _update_request_data_with_model_routing_hint() and call it from vector_store_file_list before provider routing. It resolves credentials from:

?model= / x-litellm-model via existing handle_model_based_routing
wildcard hints like openai/* via router credential lookup, with team fallback if unresolved
JWT team auth when the team has exactly one OpenAI deployment in team_models
Explicit api_key / api_base are preserved. Ambiguous teams with multiple OpenAI deployments are not guessed.

Before:
After:
<img width="1073" height="766" alt="Screenshot 2026-06-04 at 9 10 53 PM" src="https://github.com/user-attachments/assets/a3a9c5c9-aa1d-4a0e-80fa-41af8c181272" />


Review fixes
Three findings from the automated review on this path are now resolved.

User-controlled model hints (?model= and x-litellm-model) are authorized against the key's and the team's allowed models via can_key_call_model and _can_object_call_model before any deployment credentials are resolved. Previously a normal key could file-list using a restricted deployment's provider credentials by passing the deployment id as a model hint.

The managed vector store registry resolution now runs before the model routing hint in vector_store_file_list. The managed store sets the routing model first, so the hint resolver selects credentials that match that model rather than a team fallback deployment, which avoids carrying one deployment's credentials with another deployment's routing model.

The team fallback now skips deployments whose provider cannot be determined instead of treating them as OpenAI, so a deployment configured without an explicit custom_llm_provider or "openai/" prefix no longer has its credentials injected as the sole OpenAI deployment.

Each fix has a regression test: test_vector_store_file_list_authorizes_model_query_param_before_credentials, test_vector_store_file_list_resolves_managed_vector_store_before_team_fallback, and test_vector_store_file_list_requires_explicit_openai_provider_for_team_fallback
