### PR TITLE
fix(dashscope-image): construct full generation path from base /v1 URL

### DIFF
--- a/litellm/llms/dashscope/image_generation/transformation.py
+++ b/litellm/llms/dashscope/image_generation/transformation.py
@@ -97,9 +97,11 @@ class DashScopeImageGenerationConfig(BaseImageGenerationConfig):
         litellm_params: dict,
         stream: Optional[bool] = None,
     ) -> str:
-        return (
-            api_base or get_secret_str("DASHSCOPE_API_BASE_IMAGE") or DEFAULT_API_BASE
-        )
+        base = api_base or get_secret_str("DASHSCOPE_API_BASE_IMAGE") or DEFAULT_API_BASE
+        cleaned = base.rstrip("/")
+        if cleaned.endswith("/v1"):
+            return f"{cleaned}/services/aigc/multimodal-generation/generation"
+        return cleaned
 
     def validate_environment(
         self,


### PR DESCRIPTION
## Summary

  Update `DashScopeImageGenerationConfig.get_complete_url()` to handle both DashScope
  base API URLs (ending with `/v1`) and full endpoint URLs for image generation.

  Previously, only the full default URL was supported:
  `https://dashscope-intl.aliyuncs.com/api/v1/services/aigc/multimodal-generation/generation`

  Now users can also set `api_base` or `DASHSCOPE_API_BASE_IMAGE` to just:
  `https://dashscope-intl.aliyuncs.com/api/v1`
  and the code will automatically append the image generation path.

  ## Changes

  - **`litellm/llms/dashscope/image_generation/transformation.py`** — trim trailing
  `https://dashscope-intl.aliyuncs.com/api/v1/services/aigc/multimodal-generation/generation`

  Now users can also set `api_base` or `DASHSCOPE_API_BASE_IMAGE` to just:
  `https://dashscope-intl.aliyuncs.com/api/v1`
  and the code will automatically append the image generation path.

  ## Changes

  - **`litellm/llms/dashscope/image_generation/transformation.py`** — trim trailing
    slashes from the base URL; if it ends with `/v1`, append the full generation path.
  - **`.gitignore`** — ignore `litellm/proxy/_experimental/*` (build output).

  ## Test plan

  - [x] Existing unit tests in `test_dashscope_image_generation.py` pass:
    - `test_get_complete_url_default` — no custom URL, returns `DEFAULT_API_BASE`
    - `test_get_complete_url_custom` — custom non-`/v1` URL, returned as-is
  - [ ] New behavior: `https://dashscope-intl.aliyuncs.com/api/v1` →
        `https://dashscope-intl.aliyuncs.com/api/v1/services/aigc/multimodal-generation/generation` (tested manually)