### PR TITLE
feat(langfuse_otel): emit gen_ai.usage.cost span attribute

### DIFF
--- a/litellm/integrations/langfuse/langfuse_otel.py
+++ b/litellm/integrations/langfuse/langfuse_otel.py
@@ -50,6 +50,20 @@ class LangfuseOtelLogger(OpenTelemetry):
         LangfuseOtelLogger._set_langfuse_specific_attributes(
             span=span, kwargs=kwargs, response_obj=response_obj
         )
+
+        #########################################################
+        # Set cost on the span
+        #########################################################
+        # LiteLLM computes the request cost but emits it only as the
+        # `gen_ai.client.token.cost` metric, which a trace consumer like Langfuse
+        # does not ingest. Set it on the span as `gen_ai.usage.cost` so cost is
+        # recorded without re-deriving it from a model price table.
+        # (`langfuse.observation.cost_details` is not ingested over OTEL:
+        # https://github.com/langfuse/langfuse/issues/11030)
+        standard_logging_payload = kwargs.get("standard_logging_object") or {}
+        response_cost = standard_logging_payload.get("response_cost")
+        if response_cost is not None:
+            _utils.safe_set_attribute(span, "gen_ai.usage.cost", float(response_cost))
         return
 
     @staticmethod

--- a/tests/test_litellm/integrations/test_langfuse_otel.py
+++ b/tests/test_litellm/integrations/test_langfuse_otel.py
@@ -115,6 +115,44 @@ class TestLangfuseOtelIntegration:
                 mock_span, mock_kwargs, mock_response, LangfuseLLMObsOTELAttributes
             )
 
+    def test_set_langfuse_otel_attributes_sets_cost(self):
+        """response_cost should be emitted as a numeric gen_ai.usage.cost span attribute."""
+        mock_span = MagicMock()
+        kwargs = {"standard_logging_object": {"response_cost": 0.001234}}
+
+        with patch("litellm.integrations.arize._utils.set_attributes"):
+            LangfuseOtelLogger.set_langfuse_otel_attributes(mock_span, kwargs, {})
+
+        mock_span.set_attribute.assert_any_call("gen_ai.usage.cost", 0.001234)
+        cost_calls = [
+            c for c in mock_span.set_attribute.call_args_list
+            if c.args[0] == "gen_ai.usage.cost"
+        ]
+        assert len(cost_calls) == 1
+        assert isinstance(cost_calls[0].args[1], float)
+
+    def test_set_langfuse_otel_attributes_allows_zero_cost(self):
+        """An explicit zero cost is valid and should be emitted; only None is skipped."""
+        mock_span = MagicMock()
+        kwargs = {"standard_logging_object": {"response_cost": 0}}
+
+        with patch("litellm.integrations.arize._utils.set_attributes"):
+            LangfuseOtelLogger.set_langfuse_otel_attributes(mock_span, kwargs, {})
+
+        mock_span.set_attribute.assert_any_call("gen_ai.usage.cost", 0.0)
+
+    def test_set_langfuse_otel_attributes_skips_missing_cost(self):
+        """No cost attribute is set when response_cost is absent."""
+        for kwargs in ({"standard_logging_object": {}}, {}):
+            mock_span = MagicMock()
+            with patch("litellm.integrations.arize._utils.set_attributes"):
+                LangfuseOtelLogger.set_langfuse_otel_attributes(mock_span, kwargs, {})
+            cost_calls = [
+                c for c in mock_span.set_attribute.call_args_list
+                if c.args[0] == "gen_ai.usage.cost"
+            ]
+            assert cost_calls == []
+
     def test_set_langfuse_environment_attribute(self):
         """Test that Langfuse environment is set correctly when environment variable is present."""
         mock_span = MagicMock()


### PR DESCRIPTION
## Relevant issues

The `langfuse_otel` integration emits token usage but no cost. It reuses the Arize/OpenInference attribute setter (`_utils.set_attributes`), which has no cost attribute, and LiteLLM otherwise routes the computed request cost only to the `gen_ai.client.token.cost` **metric**. Trace consumers such as Langfuse ingest spans, not metrics — so cost never reaches them and has to be re-derived from a model price table (fragile when the logged model string doesn't match a priced catalog entry).

## What this PR does

Sets LiteLLM's already-computed cost on the span as the standard `gen_ai.usage.cost` attribute, read from `standard_logging_object.response_cost` (already in scope in this call path). Langfuse ingests this attribute directly, so cost is recorded without any model-price-table matching.

- Uses `gen_ai.usage.cost` (numeric double via `float(...)`).
- `langfuse.observation.cost_details` is intentionally **not** used — it does not ingest over OTEL (langfuse/langfuse#11030).
- `is not None` guard lets an explicit `0.0` through while skipping calls with no computed cost.

Scope is isolated to `langfuse_otel.py` (the metric path and other integrations are unchanged).

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Testing

Added 3 unit tests in `tests/test_litellm/integrations/test_langfuse_otel.py`:
- cost is emitted as a numeric `gen_ai.usage.cost`,
- an explicit `0.0` cost is emitted,
- missing `response_cost` emits no cost attribute.

```
$ pytest tests/test_litellm/integrations/test_langfuse_otel.py -k "cost or set_langfuse_otel_attributes or responses_api"
9 passed
```