### PR TITLE
fix(proxy): apply user.models filter on /v1/models + /v1/model/info + /v2/model/info

### DIFF
--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -1,6 +1,7 @@
 # What is this?
 ## Common checks for /v1/models and `/model/info`
 import copy
+import fnmatch
 from typing import Any, Dict, List, Optional, Set
 
 import litellm
@@ -190,6 +191,70 @@ def get_team_models(
 
     verbose_proxy_logger.debug("ALL TEAM MODELS - {}".format(len(all_models)))
     return all_models
+
+
+def get_user_models(
+    user_models: List[str],
+    proxy_model_list: List[str],
+    model_access_groups: Dict[str, List[str]],
+    include_model_access_groups: Optional[bool] = False,
+) -> List[str]:
+    """
+    Returns:
+    - List of model name strings allowed by `LiteLLM_UserTable.models`
+      (the "Personal Models" field).
+    - Empty list if no models set.
+    - Mirrors `get_team_models` semantics (sans `all-team-models`,
+      which has no meaning at the user scope).
+
+    Used by `/v1/models` to apply per-user access restrictions on the
+    listing path so it stays consistent with `can_user_call_model` at
+    inference time (see BerriAI/litellm#26420).
+    """
+    all_models_set: Set[str] = set()
+    if len(user_models) > 0:
+        all_models_set.update(user_models)
+        if SpecialModelNames.all_proxy_models.value in all_models_set:
+            all_models_set.update(proxy_model_list)
+            if include_model_access_groups:
+                all_models_set.update(model_access_groups.keys())
+
+    all_models = _get_models_from_access_groups(
+        model_access_groups=model_access_groups,
+        all_models=list(all_models_set),
+        include_model_access_groups=include_model_access_groups,
+    )
+
+    # deduplicate while preserving order
+    all_models = list(dict.fromkeys(all_models))
+
+    verbose_proxy_logger.debug("ALL USER MODELS - {}".format(len(all_models)))
+    return all_models
+
+
+def filter_models_by_user_access(
+    models: List[str],
+    user_allowed_models: List[str],
+) -> List[str]:
+    """
+    Return the subset of `models` that the user is allowed to see, given
+    the (already-expanded) `user_allowed_models` list. Supports exact
+    match plus `fnmatch` wildcards (e.g. `anthropic/*`, `*`).
+
+    Caller is responsible for short-circuiting before calling when
+    `user_allowed_models` is empty, contains `all-proxy-models`
+    (no filter), or contains `no-default-models` (empty result).
+    Order of `models` is preserved.
+    """
+    exact = {m for m in user_allowed_models if "*" not in m}
+    patterns = [m for m in user_allowed_models if "*" in m]
+    out: List[str] = []
+    for m in models:
+        if m in exact:
+            out.append(m)
+        elif patterns and any(fnmatch.fnmatchcase(m, p) for p in patterns):
+            out.append(m)
+    return out
 
 
 def get_complete_model_list(

--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -164,7 +164,7 @@ def get_team_models(
     - Empty list if no models set
     - If model_access_groups is provided, only return models that are in the access groups
     """
-    all_models_set: Set[str] = set()
+    all_models_set: set[str] = set()
     if len(team_models) > 0:
         all_models_set.update(team_models)
         if SpecialModelNames.all_team_models.value in all_models_set:
@@ -194,11 +194,11 @@ def get_team_models(
 
 
 def get_user_models(
-    user_models: List[str],
-    proxy_model_list: List[str],
-    model_access_groups: Dict[str, List[str]],
-    include_model_access_groups: Optional[bool] = False,
-) -> List[str]:
+    user_models: list[str],
+    proxy_model_list: list[str],
+    model_access_groups: dict[str, list[str]],
+    include_model_access_groups: bool | None = False,
+) -> list[str]:
     """
     Returns:
     - List of model name strings allowed by `LiteLLM_UserTable.models`
@@ -211,7 +211,7 @@ def get_user_models(
     listing path so it stays consistent with `can_user_call_model` at
     inference time (see BerriAI/litellm#26420).
     """
-    all_models_set: Set[str] = set()
+    all_models_set: set[str] = set()
     if len(user_models) > 0:
         all_models_set.update(user_models)
         if SpecialModelNames.all_proxy_models.value in all_models_set:
@@ -233,9 +233,9 @@ def get_user_models(
 
 
 def filter_models_by_user_access(
-    models: List[str],
-    user_allowed_models: List[str],
-) -> List[str]:
+    models: list[str],
+    user_allowed_models: list[str],
+) -> list[str]:
     """
     Return the subset of `models` that the user is allowed to see, given
     the (already-expanded) `user_allowed_models` list. Supports exact
@@ -248,7 +248,7 @@ def filter_models_by_user_access(
     """
     exact = {m for m in user_allowed_models if "*" not in m}
     patterns = [m for m in user_allowed_models if "*" in m]
-    out: List[str] = []
+    out: list[str] = []
     for m in models:
         if m in exact:
             out.append(m)

--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -1,13 +1,13 @@
 # What is this?
 ## Common checks for /v1/models and `/model/info`
 import copy
-import fnmatch
 from typing import Any, Dict, List, Optional
 
 import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.litellm_core_utils.credential_accessor import CredentialAccessor
 from litellm.proxy._types import SpecialModelNames, UserAPIKeyAuth
+from litellm.proxy.auth.auth_checks import is_model_allowed_by_pattern
 from litellm.repositories.object_permission_repository import ObjectPermissionRepository
 from litellm.router import Router
 from litellm.router_utils.fallback_event_handlers import get_fallback_model_group
@@ -239,7 +239,12 @@ def filter_models_by_user_access(
     """
     Return the subset of `models` that the user is allowed to see, given
     the (already-expanded) `user_allowed_models` list. Supports exact
-    match plus `fnmatch` wildcards (e.g. `anthropic/*`, `*`).
+    match plus `*` wildcards (e.g. `anthropic/*`, `*`).
+
+    Wildcard semantics mirror the inference-time check
+    `is_model_allowed_by_pattern` (regex-based, `*` -> `.*`) so a model
+    accepted by `can_user_call_model` cannot be hidden by this filter,
+    and vice versa.
 
     Caller is responsible for short-circuiting before calling when
     `user_allowed_models` is empty, contains `all-proxy-models`
@@ -252,7 +257,7 @@ def filter_models_by_user_access(
     for m in models:
         if m in exact:
             out.append(m)
-        elif patterns and any(fnmatch.fnmatchcase(m, p) for p in patterns):
+        elif patterns and any(is_model_allowed_by_pattern(m, p) for p in patterns):
             out.append(m)
     return out
 

--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -2,7 +2,7 @@
 ## Common checks for /v1/models and `/model/info`
 import copy
 import fnmatch
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, List, Optional
 
 import litellm
 from litellm._logging import verbose_proxy_logger

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -11483,11 +11483,11 @@ async def non_admin_all_models(
             # correctly downstream.
             user_models = list(user_row.models or [])
 
-        # Get all models that are team models, when model team_id == user_row.teams
-        all_models += _check_if_model_is_team_model(
-            models=llm_router.get_model_list() or [],
-            user_row=user_row,
-        )
+            # Get all models that are team models, when model team_id == user_row.teams
+            all_models += _check_if_model_is_team_model(
+                models=llm_router.get_model_list() or [],
+                user_row=user_row,
+            )
 
     # de-duplicate models. Only return unique model ids
     unique_models = _deduplicate_litellm_router_models(models=all_models)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -13446,29 +13446,32 @@ async def model_info_v1(
                 },
             )
         # Authorize against user.models — by-id was previously
-        # short-circuiting before the listing-path filter.
-        from litellm.proxy.utils import get_available_models_for_user
+        # short-circuiting before the listing-path filter. Master
+        # key / service accounts (no user_id) bypass, matching
+        # `_apply_user_models_filter` semantics.
+        if user_api_key_dict.user_id is not None:
+            from litellm.proxy.utils import get_available_models_for_user
 
-        authorized_models = await get_available_models_for_user(
-            user_api_key_dict=user_api_key_dict,
-            llm_router=llm_router,
-            general_settings=general_settings,
-            user_model=user_model,
-            prisma_client=prisma_client,
-            proxy_logging_obj=proxy_logging_obj,
-            team_id=None,
-            include_model_access_groups=False,
-            only_model_access_groups=False,
-            return_wildcard_routes=False,
-            user_api_key_cache=user_api_key_cache,
-        )
-        if deployment_info.model_name not in authorized_models:
-            raise HTTPException(
-                status_code=403,
-                detail={
-                    "error": f"Model id = {litellm_model_id} not authorized for this user"
-                },
+            authorized_models = await get_available_models_for_user(
+                user_api_key_dict=user_api_key_dict,
+                llm_router=llm_router,
+                general_settings=general_settings,
+                user_model=user_model,
+                prisma_client=prisma_client,
+                proxy_logging_obj=proxy_logging_obj,
+                team_id=None,
+                include_model_access_groups=False,
+                only_model_access_groups=False,
+                return_wildcard_routes=False,
+                user_api_key_cache=user_api_key_cache,
             )
+            if deployment_info.model_name not in authorized_models:
+                raise HTTPException(
+                    status_code=403,
+                    detail={
+                        "error": f"Model id = {litellm_model_id} not authorized for this user"
+                    },
+                )
         _deployment_info_dict = _get_proxy_model_info(
             model=deployment_info.model_dump(exclude_none=True)
         )

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -13445,6 +13445,30 @@ async def model_info_v1(
                     "error": f"Model id = {litellm_model_id} not found on litellm proxy"
                 },
             )
+        # Authorize against user.models — by-id was previously
+        # short-circuiting before the listing-path filter.
+        from litellm.proxy.utils import get_available_models_for_user
+
+        authorized_models = await get_available_models_for_user(
+            user_api_key_dict=user_api_key_dict,
+            llm_router=llm_router,
+            general_settings=general_settings,
+            user_model=user_model,
+            prisma_client=prisma_client,
+            proxy_logging_obj=proxy_logging_obj,
+            team_id=None,
+            include_model_access_groups=False,
+            only_model_access_groups=False,
+            return_wildcard_routes=False,
+            user_api_key_cache=user_api_key_cache,
+        )
+        if deployment_info.model_name not in authorized_models:
+            raise HTTPException(
+                status_code=403,
+                detail={
+                    "error": f"Model id = {litellm_model_id} not authorized for this user"
+                },
+            )
         _deployment_info_dict = _get_proxy_model_info(
             model=deployment_info.model_dump(exclude_none=True)
         )

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -13445,33 +13445,37 @@ async def model_info_v1(
                     "error": f"Model id = {litellm_model_id} not found on litellm proxy"
                 },
             )
-        # Authorize against user.models — by-id was previously
-        # short-circuiting before the listing-path filter. Master
-        # key / service accounts (no user_id) bypass, matching
-        # `_apply_user_models_filter` semantics.
-        if user_api_key_dict.user_id is not None:
-            from litellm.proxy.utils import get_available_models_for_user
+        # Authorize against key/team/user models — by-id was previously
+        # short-circuiting before the listing-path filter, letting a
+        # restricted virtual key (including service accounts with no
+        # user_id but with key.models or team_models constraints) pull
+        # metadata for any deployment via /v1/model/info?litellm_model_id=.
+        # Reuse `get_available_models_for_user` so by-id authorization
+        # tracks the listing-path filter exactly: key.models, team_models,
+        # and user.models all narrow the allowlist; `_apply_user_models_filter`
+        # bypasses the user.models step when user_id is absent.
+        from litellm.proxy.utils import get_available_models_for_user
 
-            authorized_models = await get_available_models_for_user(
-                user_api_key_dict=user_api_key_dict,
-                llm_router=llm_router,
-                general_settings=general_settings,
-                user_model=user_model,
-                prisma_client=prisma_client,
-                proxy_logging_obj=proxy_logging_obj,
-                team_id=None,
-                include_model_access_groups=False,
-                only_model_access_groups=False,
-                return_wildcard_routes=False,
-                user_api_key_cache=user_api_key_cache,
+        authorized_models = await get_available_models_for_user(
+            user_api_key_dict=user_api_key_dict,
+            llm_router=llm_router,
+            general_settings=general_settings,
+            user_model=user_model,
+            prisma_client=prisma_client,
+            proxy_logging_obj=proxy_logging_obj,
+            team_id=None,
+            include_model_access_groups=False,
+            only_model_access_groups=False,
+            return_wildcard_routes=False,
+            user_api_key_cache=user_api_key_cache,
+        )
+        if deployment_info.model_name not in authorized_models:
+            raise HTTPException(
+                status_code=403,
+                detail={
+                    "error": f"Model id = {litellm_model_id} not authorized for this key/user"
+                },
             )
-            if deployment_info.model_name not in authorized_models:
-                raise HTTPException(
-                    status_code=403,
-                    detail={
-                        "error": f"Model id = {litellm_model_id} not authorized for this user"
-                    },
-                )
         _deployment_info_dict = _get_proxy_model_info(
             model=deployment_info.model_dump(exclude_none=True)
         )

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -13453,37 +13453,6 @@ async def model_info_v1(
                     "error": f"Model id = {litellm_model_id} not found on litellm proxy"
                 },
             )
-        # Authorize against key/team/user models — by-id was previously
-        # short-circuiting before the listing-path filter, letting a
-        # restricted virtual key (including service accounts with no
-        # user_id but with key.models or team_models constraints) pull
-        # metadata for any deployment via /v1/model/info?litellm_model_id=.
-        # Reuse `get_available_models_for_user` so by-id authorization
-        # tracks the listing-path filter exactly: key.models, team_models,
-        # and user.models all narrow the allowlist; `_apply_user_models_filter`
-        # bypasses the user.models step when user_id is absent.
-        from litellm.proxy.utils import get_available_models_for_user
-
-        authorized_models = await get_available_models_for_user(
-            user_api_key_dict=user_api_key_dict,
-            llm_router=llm_router,
-            general_settings=general_settings,
-            user_model=user_model,
-            prisma_client=prisma_client,
-            proxy_logging_obj=proxy_logging_obj,
-            team_id=None,
-            include_model_access_groups=False,
-            only_model_access_groups=False,
-            return_wildcard_routes=False,
-            user_api_key_cache=user_api_key_cache,
-        )
-        if deployment_info.model_name not in authorized_models:
-            raise HTTPException(
-                status_code=403,
-                detail={
-                    "error": f"Model id = {litellm_model_id} not authorized for this key/user"
-                },
-            )
         _deployment_info_dict = _get_proxy_model_info(
             model=deployment_info.model_dump(exclude_none=True)
         )
@@ -13505,6 +13474,26 @@ async def model_info_v1(
                     llm_router=llm_router,
                     user_api_key_dict=user_api_key_dict,
                 )
+        # Bound by LiteLLM_UserTable.models (Personal Models) using the
+        # same deployment-level filter as the listing branch. by-id used
+        # to short-circuit before this filter, letting a restricted user
+        # pull any deployment's litellm_params via /v1/model/info?litellm_model_id=
+        # — same leak BerriAI/litellm#26420 fixed for /v1/models.
+        #
+        # Filter (drop unauthorized deployments → empty list) instead of
+        # 403: matches the route_checks.py:189 spec comment "/model/info
+        # just shows models user has access to" and avoids leaking model
+        # existence via 403-vs-404 enumeration.
+        from litellm.proxy.utils import apply_user_models_filter_to_deployments
+
+        single_model_list = await apply_user_models_filter_to_deployments(
+            deployments=single_model_list,
+            user_api_key_dict=user_api_key_dict,
+            llm_router=llm_router,
+            prisma_client=prisma_client,
+            proxy_logging_obj=proxy_logging_obj,
+            user_api_key_cache=user_api_key_cache,
+        )
         return {"data": single_model_list}
 
     # Return router deployments (same source as /v2/model/info), not wildcard-

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -11435,13 +11435,24 @@ async def non_admin_all_models(
     llm_router: Router,
     user_api_key_dict: UserAPIKeyAuth,
     prisma_client: Optional[PrismaClient],
-):
+) -> Tuple[List[Dict], Optional[List[str]]]:
     """
     Check if model is in db
 
     Check if db model is 'created_by' == user_api_key_dict.user_id
 
     Only return models that match
+
+    Returns
+    -------
+    (unique_models, user_models)
+        unique_models: the de-duplicated deployment list as before.
+        user_models:   `LiteLLM_UserTable.models` (Personal Models) for
+                       the calling user if a row was loaded, else None.
+                       Lets the caller forward this to
+                       `apply_user_models_filter_to_deployments` as
+                       `user_models_override` to avoid a redundant
+                       `get_user_object` lookup downstream.
     """
     if prisma_client is None:
         raise HTTPException(
@@ -11456,6 +11467,7 @@ async def non_admin_all_models(
         prisma_client=prisma_client,
     )
 
+    user_models: Optional[List[str]] = None
     if user_api_key_dict.user_id:
         try:
             user_row = await UserRepository(prisma_client).table.find_unique(
@@ -11463,6 +11475,13 @@ async def non_admin_all_models(
             )
         except Exception:
             raise HTTPException(status_code=400, detail={"error": "User not found"})
+
+        if user_row is not None:
+            # Empty list "user has no model restriction configured" is
+            # distinct from None "we never loaded a row" — keep the
+            # distinction so the override path can short-circuit
+            # correctly downstream.
+            user_models = list(user_row.models or [])
 
         # Get all models that are team models, when model team_id == user_row.teams
         all_models += _check_if_model_is_team_model(
@@ -11472,7 +11491,7 @@ async def non_admin_all_models(
 
     # de-duplicate models. Only return unique model ids
     unique_models = _deduplicate_litellm_router_models(models=all_models)
-    return unique_models
+    return unique_models, user_models
 
 
 def _add_team_models_to_all_models(
@@ -12629,8 +12648,14 @@ async def model_info_v2(
             sort_by=sortBy,
         )
 
+    # When user_models_only=true, `non_admin_all_models` already
+    # queries `litellm_usertable` to expand team-membership. Capture
+    # the user's `models` list here so the filter step below can
+    # forward it as `user_models_override` and skip a second
+    # `get_user_object` call on cache miss.
+    user_models_for_filter: Optional[List[str]] = None
     if user_models_only:
-        all_models = await non_admin_all_models(
+        all_models, user_models_for_filter = await non_admin_all_models(
             all_models=all_models,
             llm_router=llm_router,
             user_api_key_dict=user_api_key_dict,
@@ -12671,6 +12696,7 @@ async def model_info_v2(
         prisma_client=prisma_client,
         proxy_logging_obj=proxy_logging_obj,
         user_api_key_cache=user_api_key_cache,
+        user_models_override=user_models_for_filter,
     )
 
     # Apply teamId filter if provided

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -12707,6 +12707,24 @@ async def model_info_v2(
         user_models_override=user_models_for_filter,
     )
 
+    # Team BYOK deployments carry an internal routing key and other teams'
+    # public name / team_id / api_base; drop the ones the caller cannot
+    # access so a bare /v2/model/info (no user_models_only, no
+    # include_team_models) does not leak cross-team metadata when the
+    # caller's key/team/user lists are empty. Mirrors the v1 default
+    # branch behavior below.
+    allowed_team_ids = await _get_caller_byok_team_scope(
+        user_api_key_dict=user_api_key_dict,
+        prisma_client=prisma_client,
+    )
+    all_models = [
+        model
+        for model in all_models
+        if not _byok_row_outside_caller_teams(
+            model.get("model_info") or {}, allowed_team_ids
+        )
+    ]
+
     # Apply teamId filter if provided
     if teamId is not None and teamId.strip():
         all_models = await _filter_models_by_team_id(
@@ -13474,16 +13492,24 @@ async def model_info_v1(
                     llm_router=llm_router,
                     user_api_key_dict=user_api_key_dict,
                 )
-        # Bound by LiteLLM_UserTable.models (Personal Models) using the
-        # same deployment-level filter as the listing branch. by-id used
-        # to short-circuit before this filter, letting a restricted user
-        # pull any deployment's litellm_params via /v1/model/info?litellm_model_id=
-        # — same leak BerriAI/litellm#26420 fixed for /v1/models.
-        #
-        # Filter (drop unauthorized deployments → empty list) instead of
-        # 403: matches the route_checks.py:189 spec comment "/model/info
-        # just shows models user has access to" and avoids leaking model
+        # Bound by the same filter chain as the listing branch below
+        # (key.models / team_models, then LiteLLM_UserTable.models, then
+        # BYOK team scope). by-id used to short-circuit before any of
+        # these, letting a restricted virtual key pull any deployment's
+        # litellm_params via /v1/model/info?litellm_model_id=. Filter
+        # (drop unauthorized deployments → empty list) instead of 403:
+        # matches the route_checks.py:189 spec comment "/model/info just
+        # shows models user has access to" and avoids leaking model
         # existence via 403-vs-404 enumeration.
+        allowed_model_names = _get_v1_model_info_allowed_model_names(
+            user_api_key_dict=user_api_key_dict,
+            llm_router=llm_router,
+        )
+        single_model_list = _filter_v1_model_info_deployments(
+            all_models=single_model_list,
+            allowed_model_names=allowed_model_names,
+        )
+
         from litellm.proxy.utils import apply_user_models_filter_to_deployments
 
         single_model_list = await apply_user_models_filter_to_deployments(
@@ -13494,6 +13520,18 @@ async def model_info_v1(
             proxy_logging_obj=proxy_logging_obj,
             user_api_key_cache=user_api_key_cache,
         )
+
+        allowed_team_ids = await _get_caller_byok_team_scope(
+            user_api_key_dict=user_api_key_dict,
+            prisma_client=prisma_client,
+        )
+        single_model_list = [
+            model
+            for model in single_model_list
+            if not _byok_row_outside_caller_teams(
+                model.get("model_info") or {}, allowed_team_ids
+            )
+        ]
         return {"data": single_model_list}
 
     # Return router deployments (same source as /v2/model/info), not wildcard-

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -12654,6 +12654,25 @@ async def model_info_v2(
             llm_router=llm_router,
         )
 
+    # Defense-in-depth: bound the result by LiteLLM_UserTable.models
+    # (Personal Models) so this endpoint stays consistent with
+    # /v1/models and inference-time can_user_call_model regardless of
+    # which flag combination the caller passed. Without this, a bare
+    # `GET /v2/model/info` (neither user_models_only nor
+    # include_team_models set) returns the full router model_list
+    # — leaking every deployment's litellm_params to anyone
+    # holding a virtual key. See BerriAI/litellm#26420.
+    from litellm.proxy.utils import apply_user_models_filter_to_deployments
+
+    all_models = await apply_user_models_filter_to_deployments(
+        deployments=all_models,
+        user_api_key_dict=user_api_key_dict,
+        llm_router=llm_router,
+        prisma_client=prisma_client,
+        proxy_logging_obj=proxy_logging_obj,
+        user_api_key_cache=user_api_key_cache,
+    )
+
     # Apply teamId filter if provided
     if teamId is not None and teamId.strip():
         all_models = await _filter_models_by_team_id(
@@ -13441,6 +13460,24 @@ async def model_info_v1(
     all_models = _filter_v1_model_info_deployments(
         all_models=all_models,
         allowed_model_names=allowed_model_names,
+    )
+
+    # Defense-in-depth: bound the result by LiteLLM_UserTable.models
+    # (Personal Models) so /v1/model/info honors the same filter as
+    # /v1/models and inference-time can_user_call_model. Upstream's
+    # _get_v1_model_info_allowed_model_names only intersects key/team
+    # models — user.models is applied as a second-step deployment
+    # filter, matching the /v2/model/info pattern above.
+    # See BerriAI/litellm#26420.
+    from litellm.proxy.utils import apply_user_models_filter_to_deployments
+
+    all_models = await apply_user_models_filter_to_deployments(
+        deployments=all_models,
+        user_api_key_dict=user_api_key_dict,
+        llm_router=llm_router,
+        prisma_client=prisma_client,
+        proxy_logging_obj=proxy_logging_obj,
+        user_api_key_cache=user_api_key_cache,
     )
 
     # Team BYOK deployments carry an internal routing key and other teams'

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -11431,11 +11431,11 @@ def _check_if_model_is_team_model(
 
 
 async def non_admin_all_models(
-    all_models: List[Dict],
+    all_models: list[dict],
     llm_router: Router,
     user_api_key_dict: UserAPIKeyAuth,
-    prisma_client: Optional[PrismaClient],
-) -> Tuple[List[Dict], Optional[List[str]]]:
+    prisma_client: PrismaClient | None,
+) -> tuple[list[dict], list[str] | None]:
     """
     Check if model is in db
 
@@ -11467,7 +11467,7 @@ async def non_admin_all_models(
         prisma_client=prisma_client,
     )
 
-    user_models: Optional[List[str]] = None
+    user_models: list[str] | None = None
     if user_api_key_dict.user_id:
         try:
             user_row = await UserRepository(prisma_client).table.find_unique(
@@ -12653,7 +12653,7 @@ async def model_info_v2(
     # the user's `models` list here so the filter step below can
     # forward it as `user_models_override` and skip a second
     # `get_user_object` call on cache miss.
-    user_models_for_filter: Optional[List[str]] = None
+    user_models_for_filter: list[str] | None = None
     if user_models_only:
         all_models, user_models_for_filter = await non_admin_all_models(
             all_models=all_models,

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -12679,16 +12679,24 @@ async def model_info_v2(
             llm_router=llm_router,
         )
 
-    # Defense-in-depth: bound the result by LiteLLM_UserTable.models
-    # (Personal Models) so this endpoint stays consistent with
-    # /v1/models and inference-time can_user_call_model regardless of
-    # which flag combination the caller passed. Without this, a bare
-    # `GET /v2/model/info` (neither user_models_only nor
-    # include_team_models set) returns the full router model_list
-    # — leaking every deployment's litellm_params to anyone
-    # holding a virtual key. See BerriAI/litellm#26420.
-    from litellm.proxy.utils import apply_user_models_filter_to_deployments
+    # Defense-in-depth: bound the result by key.models / team_models
+    # (the listing-path filter) and then by LiteLLM_UserTable.models
+    # (Personal Models). Without these, a bare `GET /v2/model/info`
+    # (neither user_models_only nor include_team_models set) returns
+    # the full router model_list — leaking every deployment's
+    # litellm_params to any virtual key, even restricted ones.
+    # Matches /v1/models and inference-time `can_user_call_model`
+    # semantics. See BerriAI/litellm#26420.
+    from litellm.proxy.utils import (
+        apply_key_team_models_filter_to_deployments,
+        apply_user_models_filter_to_deployments,
+    )
 
+    all_models = await apply_key_team_models_filter_to_deployments(
+        deployments=all_models,
+        user_api_key_dict=user_api_key_dict,
+        llm_router=llm_router,
+    )
     all_models = await apply_user_models_filter_to_deployments(
         deployments=all_models,
         user_api_key_dict=user_api_key_dict,

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -6437,7 +6437,97 @@ async def get_available_models_for_user(
         team_id=effective_team_id,
     )
 
+    # Apply user-level (Personal Models) restriction so /v1/models is
+    # consistent with can_user_call_model at inference time
+    # (BerriAI/litellm#26420). Defense-in-depth: this only ever narrows
+    # the list, never widens it.
+    all_models = await _apply_user_models_filter(
+        all_models=all_models,
+        user_api_key_dict=user_api_key_dict,
+        proxy_model_list=proxy_model_list,
+        model_access_groups=model_access_groups,
+        prisma_client=prisma_client,
+        proxy_logging_obj=proxy_logging_obj,
+        user_api_key_cache=user_api_key_cache,
+    )
+
     return all_models
+
+
+async def _apply_user_models_filter(
+    all_models: List[str],
+    user_api_key_dict: "UserAPIKeyAuth",
+    proxy_model_list: List[str],
+    model_access_groups: Dict[str, List[str]],
+    prisma_client: Optional["PrismaClient"],
+    proxy_logging_obj: Optional["ProxyLogging"],
+    user_api_key_cache: Optional["DualCache"],
+) -> List[str]:
+    """
+    Intersect `all_models` with `LiteLLM_UserTable.models` (Personal
+    Models) for the user behind `user_api_key_dict`.
+
+    Returns `all_models` unchanged when:
+    - the key has no associated user_id (master key, service accounts),
+    - prisma/cache are unavailable,
+    - the user object can't be loaded,
+    - the user object has no model restrictions,
+    - or the user explicitly opts in to `all-proxy-models`.
+
+    Returns `[]` when the user has `no-default-models` (sentinel matches
+    `can_user_call_model` behavior at inference time).
+    """
+    from litellm.proxy._types import SpecialModelNames
+    from litellm.proxy.auth.auth_checks import get_user_object
+    from litellm.proxy.auth.model_checks import (
+        filter_models_by_user_access,
+        get_user_models,
+    )
+
+    if (
+        not user_api_key_dict.user_id
+        or prisma_client is None
+        or user_api_key_cache is None
+    ):
+        return all_models
+
+    try:
+        user_obj = await get_user_object(
+            user_id=user_api_key_dict.user_id,
+            prisma_client=prisma_client,
+            user_api_key_cache=user_api_key_cache,
+            user_id_upsert=False,
+            proxy_logging_obj=proxy_logging_obj,
+        )
+    except Exception as e:
+        # Mirror the swallow in user_api_key_auth.py — never break
+        # /v1/models if user lookup blips. No filter applied, which
+        # matches current behavior pre-fix.
+        verbose_proxy_logger.debug(
+            "_apply_user_models_filter: get_user_object failed, skipping "
+            "user-level filter. Exception: %s",
+            str(e),
+        )
+        return all_models
+
+    if user_obj is None or not user_obj.models:
+        return all_models
+
+    if SpecialModelNames.no_default_models.value in user_obj.models:
+        return []
+
+    if SpecialModelNames.all_proxy_models.value in user_obj.models:
+        return all_models
+
+    user_allowed = get_user_models(
+        user_models=list(user_obj.models),
+        proxy_model_list=proxy_model_list,
+        model_access_groups=model_access_groups,
+    )
+    return filter_models_by_user_access(
+        models=all_models,
+        user_allowed_models=user_allowed,
+    )
 
 
 def create_model_info_response(

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -6530,6 +6530,57 @@ async def _apply_user_models_filter(
     )
 
 
+async def apply_user_models_filter_to_deployments(
+    deployments: List[Dict[str, Any]],
+    user_api_key_dict: "UserAPIKeyAuth",
+    llm_router: Optional["Router"],
+    prisma_client: Optional["PrismaClient"],
+    proxy_logging_obj: Optional["ProxyLogging"],
+    user_api_key_cache: Optional["DualCache"],
+) -> List[Dict[str, Any]]:
+    """
+    Apply the `LiteLLM_UserTable.models` (Personal Models) filter to a
+    deployment-shaped list (`List[Dict]` with `model_name` keys), reusing
+    `_apply_user_models_filter` so the model-name-level semantics
+    (no-default-models / all-proxy-models / access groups / wildcards)
+    stay identical with /v1/models.
+
+    Used by /v1/model/info and /v2/model/info to close the
+    discovery-vs-inference gap described in BerriAI/litellm#26420 —
+    same fix as get_available_models_for_user() but operating on
+    deployment dicts (which carry api_base, model_info.id, etc.)
+    instead of bare model names.
+
+    Order of `deployments` is preserved; duplicates with the same
+    `model_name` are kept (multiple deployments can share a name).
+    """
+    if not deployments:
+        return deployments
+
+    if llm_router is None:
+        proxy_model_list: List[str] = []
+        model_access_groups: Dict[str, List[str]] = {}
+    else:
+        proxy_model_list = llm_router.get_model_names()
+        model_access_groups = llm_router.get_model_access_groups()
+
+    distinct_model_names = list(
+        {d.get("model_name", "") for d in deployments if d.get("model_name")}
+    )
+    allowed_model_names = await _apply_user_models_filter(
+        all_models=distinct_model_names,
+        user_api_key_dict=user_api_key_dict,
+        proxy_model_list=proxy_model_list,
+        model_access_groups=model_access_groups,
+        prisma_client=prisma_client,
+        proxy_logging_obj=proxy_logging_obj,
+        user_api_key_cache=user_api_key_cache,
+    )
+
+    allowed_set = set(allowed_model_names)
+    return [d for d in deployments if d.get("model_name") in allowed_set]
+
+
 def create_model_info_response(
     model_id: str,
     provider: str,

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -6603,6 +6603,78 @@ async def apply_user_models_filter_to_deployments(
     return [d for d in deployments if d.get("model_name") in allowed_set]
 
 
+async def apply_key_team_models_filter_to_deployments(
+    deployments: List[Dict[str, Any]],
+    user_api_key_dict: "UserAPIKeyAuth",
+    llm_router: Optional["Router"],
+) -> List[Dict[str, Any]]:
+    """
+    Bound deployments by the calling key's `models` and the key's
+    team's `team_models`. Mirrors the listing-path filter that
+    `get_available_models_for_user` runs (`get_key_models` +
+    `get_team_models` + `get_complete_model_list`), so /v2/model/info's
+    default branch stays consistent with /v1/models on key/team
+    restrictions — not just on user.models (BerriAI/litellm#26420).
+
+    Unrestricted keys (key.models == [] AND team_models == [])
+    short-circuit to the full deployment list — same fallback as
+    `get_complete_model_list` ("if key list is empty -> defer to team
+    list; if team list is empty -> defer to proxy model list").
+
+    Order of `deployments` is preserved.
+    """
+    from litellm.proxy.auth.model_checks import (
+        get_complete_model_list,
+        get_key_models,
+        get_team_models,
+    )
+
+    if not deployments:
+        return deployments
+
+    if llm_router is None:
+        proxy_model_list: List[str] = []
+        model_access_groups: Dict[str, List[str]] = {}
+    else:
+        proxy_model_list = llm_router.get_model_names()
+        model_access_groups = llm_router.get_model_access_groups()
+
+    key_models = get_key_models(
+        user_api_key_dict=user_api_key_dict,
+        proxy_model_list=proxy_model_list,
+        model_access_groups=model_access_groups,
+        include_model_access_groups=False,
+    )
+    team_models_resolved = get_team_models(
+        team_models=user_api_key_dict.team_models or [],
+        proxy_model_list=proxy_model_list,
+        model_access_groups=model_access_groups,
+        include_model_access_groups=False,
+    )
+
+    # Both empty -> key is unrestricted at the key/team level
+    # (proxy admin / master key / unconstrained virtual key).
+    if not key_models and not team_models_resolved:
+        return deployments
+
+    allowed_model_names = get_complete_model_list(
+        key_models=key_models,
+        team_models=team_models_resolved,
+        proxy_model_list=proxy_model_list,
+        user_model=None,
+        infer_model_from_keys=False,
+        return_wildcard_routes=False,
+        llm_router=llm_router,
+        model_access_groups=model_access_groups,
+        include_model_access_groups=False,
+        only_model_access_groups=False,
+        team_id=user_api_key_dict.team_id,
+    )
+
+    allowed_set = set(allowed_model_names)
+    return [d for d in deployments if d.get("model_name") in allowed_set]
+
+
 def create_model_info_response(
     model_id: str,
     provider: str,

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -6459,7 +6459,7 @@ async def _apply_user_models_filter(
     model_access_groups: dict[str, list[str]],
     prisma_client: Optional["PrismaClient"],
     proxy_logging_obj: Optional["ProxyLogging"],
-    user_api_key_cache: Optional["DualCache"],
+    user_api_key_cache: Optional["UserApiKeyCache"],
     user_models_override: list[str] | None = None,
 ) -> list[str]:
     """
@@ -6554,7 +6554,7 @@ async def apply_user_models_filter_to_deployments(
     llm_router: Optional["Router"],
     prisma_client: Optional["PrismaClient"],
     proxy_logging_obj: Optional["ProxyLogging"],
-    user_api_key_cache: Optional["DualCache"],
+    user_api_key_cache: Optional["UserApiKeyCache"],
     user_models_override: list[str] | None = None,
 ) -> list[dict[str, Any]]:
     """

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -6454,14 +6454,14 @@ async def get_available_models_for_user(
 
 
 async def _apply_user_models_filter(
-    all_models: List[str],
+    all_models: list[str],
     user_api_key_dict: "UserAPIKeyAuth",
-    model_access_groups: Dict[str, List[str]],
+    model_access_groups: dict[str, list[str]],
     prisma_client: Optional["PrismaClient"],
     proxy_logging_obj: Optional["ProxyLogging"],
     user_api_key_cache: Optional["DualCache"],
-    user_models_override: Optional[List[str]] = None,
-) -> List[str]:
+    user_models_override: list[str] | None = None,
+) -> list[str]:
     """
     Intersect `all_models` with `LiteLLM_UserTable.models` (Personal
     Models) for the user behind `user_api_key_dict`.
@@ -6549,14 +6549,14 @@ async def _apply_user_models_filter(
 
 
 async def apply_user_models_filter_to_deployments(
-    deployments: List[Dict[str, Any]],
+    deployments: list[dict[str, Any]],
     user_api_key_dict: "UserAPIKeyAuth",
     llm_router: Optional["Router"],
     prisma_client: Optional["PrismaClient"],
     proxy_logging_obj: Optional["ProxyLogging"],
     user_api_key_cache: Optional["DualCache"],
-    user_models_override: Optional[List[str]] = None,
-) -> List[Dict[str, Any]]:
+    user_models_override: list[str] | None = None,
+) -> list[dict[str, Any]]:
     """
     Apply the `LiteLLM_UserTable.models` (Personal Models) filter to a
     deployment-shaped list (`List[Dict]` with `model_name` keys), reusing
@@ -6582,7 +6582,7 @@ async def apply_user_models_filter_to_deployments(
         return deployments
 
     if llm_router is None:
-        model_access_groups: Dict[str, List[str]] = {}
+        model_access_groups: dict[str, list[str]] = {}
     else:
         model_access_groups = llm_router.get_model_access_groups()
 
@@ -6604,10 +6604,10 @@ async def apply_user_models_filter_to_deployments(
 
 
 async def apply_key_team_models_filter_to_deployments(
-    deployments: List[Dict[str, Any]],
+    deployments: list[dict[str, Any]],
     user_api_key_dict: "UserAPIKeyAuth",
     llm_router: Optional["Router"],
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """
     Bound deployments by the calling key's `models` and the key's
     team's `team_models`. Mirrors the listing-path filter that
@@ -6633,8 +6633,8 @@ async def apply_key_team_models_filter_to_deployments(
         return deployments
 
     if llm_router is None:
-        proxy_model_list: List[str] = []
-        model_access_groups: Dict[str, List[str]] = {}
+        proxy_model_list: list[str] = []
+        model_access_groups: dict[str, list[str]] = {}
     else:
         proxy_model_list = llm_router.get_model_names()
         model_access_groups = llm_router.get_model_access_groups()

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -6444,7 +6444,6 @@ async def get_available_models_for_user(
     all_models = await _apply_user_models_filter(
         all_models=all_models,
         user_api_key_dict=user_api_key_dict,
-        proxy_model_list=proxy_model_list,
         model_access_groups=model_access_groups,
         prisma_client=prisma_client,
         proxy_logging_obj=proxy_logging_obj,
@@ -6457,7 +6456,6 @@ async def get_available_models_for_user(
 async def _apply_user_models_filter(
     all_models: List[str],
     user_api_key_dict: "UserAPIKeyAuth",
-    proxy_model_list: List[str],
     model_access_groups: Dict[str, List[str]],
     prisma_client: Optional["PrismaClient"],
     proxy_logging_obj: Optional["ProxyLogging"],
@@ -6534,9 +6532,14 @@ async def _apply_user_models_filter(
     if SpecialModelNames.all_proxy_models.value in user_models:
         return all_models
 
+    # The `all-proxy-models` short-circuit above returned already, so
+    # `user_models` here never contains it; `get_user_models` reads
+    # `proxy_model_list` only on that branch, so passing [] is a no-op
+    # here and lets the caller skip a `llm_router.get_model_names()` call
+    # on every /v1/models and /v2/model/info request.
     user_allowed = get_user_models(
         user_models=user_models,
-        proxy_model_list=proxy_model_list,
+        proxy_model_list=[],
         model_access_groups=model_access_groups,
     )
     return filter_models_by_user_access(
@@ -6579,10 +6582,8 @@ async def apply_user_models_filter_to_deployments(
         return deployments
 
     if llm_router is None:
-        proxy_model_list: List[str] = []
         model_access_groups: Dict[str, List[str]] = {}
     else:
-        proxy_model_list = llm_router.get_model_names()
         model_access_groups = llm_router.get_model_access_groups()
 
     distinct_model_names = list(
@@ -6591,7 +6592,6 @@ async def apply_user_models_filter_to_deployments(
     allowed_model_names = await _apply_user_models_filter(
         all_models=distinct_model_names,
         user_api_key_dict=user_api_key_dict,
-        proxy_model_list=proxy_model_list,
         model_access_groups=model_access_groups,
         prisma_client=prisma_client,
         proxy_logging_obj=proxy_logging_obj,

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -6462,6 +6462,7 @@ async def _apply_user_models_filter(
     prisma_client: Optional["PrismaClient"],
     proxy_logging_obj: Optional["ProxyLogging"],
     user_api_key_cache: Optional["DualCache"],
+    user_models_override: Optional[List[str]] = None,
 ) -> List[str]:
     """
     Intersect `all_models` with `LiteLLM_UserTable.models` (Personal
@@ -6476,6 +6477,13 @@ async def _apply_user_models_filter(
 
     Returns `[]` when the user has `no-default-models` (sentinel matches
     `can_user_call_model` behavior at inference time).
+
+    `user_models_override` lets callers that already loaded
+    `LiteLLM_UserTable.models` (e.g. `non_admin_all_models` on
+    `/v2/model/info?user_models_only=true`) pass the list in so we skip
+    the redundant `get_user_object` DB hit on cache miss. Pass `[]`
+    for "user has no model restrictions configured" and a populated
+    list (including sentinels) when the user does.
     """
     from litellm.proxy._types import SpecialModelNames
     from litellm.proxy.auth.auth_checks import get_user_object
@@ -6484,43 +6492,50 @@ async def _apply_user_models_filter(
         get_user_models,
     )
 
-    if (
-        not user_api_key_dict.user_id
-        or prisma_client is None
-        or user_api_key_cache is None
-    ):
+    if user_models_override is not None:
+        user_models = list(user_models_override)
+    else:
+        if (
+            not user_api_key_dict.user_id
+            or prisma_client is None
+            or user_api_key_cache is None
+        ):
+            return all_models
+
+        try:
+            user_obj = await get_user_object(
+                user_id=user_api_key_dict.user_id,
+                prisma_client=prisma_client,
+                user_api_key_cache=user_api_key_cache,
+                user_id_upsert=False,
+                proxy_logging_obj=proxy_logging_obj,
+            )
+        except Exception as e:
+            # Mirror the swallow in user_api_key_auth.py — never break
+            # /v1/models if user lookup blips. No filter applied, which
+            # matches current behavior pre-fix.
+            verbose_proxy_logger.debug(
+                "_apply_user_models_filter: get_user_object failed, skipping "
+                "user-level filter. Exception: %s",
+                str(e),
+            )
+            return all_models
+
+        if user_obj is None:
+            return all_models
+        user_models = list(user_obj.models or [])
+
+    if not user_models:
         return all_models
 
-    try:
-        user_obj = await get_user_object(
-            user_id=user_api_key_dict.user_id,
-            prisma_client=prisma_client,
-            user_api_key_cache=user_api_key_cache,
-            user_id_upsert=False,
-            proxy_logging_obj=proxy_logging_obj,
-        )
-    except Exception as e:
-        # Mirror the swallow in user_api_key_auth.py — never break
-        # /v1/models if user lookup blips. No filter applied, which
-        # matches current behavior pre-fix.
-        verbose_proxy_logger.debug(
-            "_apply_user_models_filter: get_user_object failed, skipping "
-            "user-level filter. Exception: %s",
-            str(e),
-        )
-        return all_models
-
-    if user_obj is None or not user_obj.models:
-        return all_models
-
-    if SpecialModelNames.no_default_models.value in user_obj.models:
+    if SpecialModelNames.no_default_models.value in user_models:
         return []
 
-    if SpecialModelNames.all_proxy_models.value in user_obj.models:
+    if SpecialModelNames.all_proxy_models.value in user_models:
         return all_models
 
     user_allowed = get_user_models(
-        user_models=list(user_obj.models),
+        user_models=user_models,
         proxy_model_list=proxy_model_list,
         model_access_groups=model_access_groups,
     )
@@ -6537,6 +6552,7 @@ async def apply_user_models_filter_to_deployments(
     prisma_client: Optional["PrismaClient"],
     proxy_logging_obj: Optional["ProxyLogging"],
     user_api_key_cache: Optional["DualCache"],
+    user_models_override: Optional[List[str]] = None,
 ) -> List[Dict[str, Any]]:
     """
     Apply the `LiteLLM_UserTable.models` (Personal Models) filter to a
@@ -6553,6 +6569,11 @@ async def apply_user_models_filter_to_deployments(
 
     Order of `deployments` is preserved; duplicates with the same
     `model_name` are kept (multiple deployments can share a name).
+
+    `user_models_override` is forwarded to `_apply_user_models_filter`
+    so callers that already loaded the row (e.g. `model_info_v2` on the
+    `user_models_only=true` branch, where `non_admin_all_models` just
+    queried `litellm_usertable`) skip the redundant lookup.
     """
     if not deployments:
         return deployments
@@ -6575,6 +6596,7 @@ async def apply_user_models_filter_to_deployments(
         prisma_client=prisma_client,
         proxy_logging_obj=proxy_logging_obj,
         user_api_key_cache=user_api_key_cache,
+        user_models_override=user_models_override,
     )
 
     allowed_set = set(allowed_model_names)

--- a/tests/test_litellm/proxy/auth/test_model_checks.py
+++ b/tests/test_litellm/proxy/auth/test_model_checks.py
@@ -686,3 +686,95 @@ def test_expand_wildcard_invalid_litellm_params_passthrough():
     # Even if LiteLLM_Params construction fails the deployment should survive
     result = expand_wildcard_deployments_for_model_info([deployment])
     assert result == [deployment]
+
+
+def test_filter_models_by_user_access_exact_match():
+    from litellm.proxy.auth.model_checks import filter_models_by_user_access
+
+    result = filter_models_by_user_access(
+        models=["claude-3-haiku", "claude-3-sonnet", "gpt-4o"],
+        user_allowed_models=["claude-3-haiku"],
+    )
+    assert result == ["claude-3-haiku"]
+
+
+def test_filter_models_by_user_access_wildcard_preserves_inference_parity():
+    """
+    Regression for Greptile finding on PR #29748: the discovery-side
+    `filter_models_by_user_access` and the inference-side
+    `is_model_allowed_by_pattern` must agree on every model+pattern pair.
+
+    The previous `fnmatch.fnmatchcase` implementation treated `.` as a
+    literal character while the inference-time check treats it as a regex
+    metacharacter (`.*` substitution applied to `*` only, leaving `.` as
+    "any char"). For real Bedrock-style names like
+    `bedrock/anthropic.claude-3-5-sonnet`, both matchers would agree on
+    the canonical input. The divergence appears in edge inputs where
+    something other than `.` sits in the dotted position: regex would
+    let the model through at call time, while fnmatch would silently
+    hide it from `/v1/models` (over-filter). The user experience is
+    "I can call this model but I cannot see it in the catalog".
+
+    Asserts parity between the two functions across both cases.
+    """
+    from litellm.proxy.auth.auth_checks import is_model_allowed_by_pattern
+    from litellm.proxy.auth.model_checks import filter_models_by_user_access
+
+    models = [
+        "bedrock/anthropic.claude-3-5-sonnet",
+        "bedrock/anthropicXclaude-3-5-sonnet",
+    ]
+    pattern = "bedrock/anthropic.claude*"
+    filtered = filter_models_by_user_access(
+        models=models, user_allowed_models=[pattern]
+    )
+
+    for m in models:
+        inference_allows = is_model_allowed_by_pattern(m, pattern)
+        if inference_allows:
+            assert m in filtered, (
+                f"discovery hid {m!r} (pattern={pattern!r}) that inference "
+                f"would let through; fnmatch vs regex divergence regressed"
+            )
+        else:
+            assert m not in filtered, (
+                f"discovery exposed {m!r} (pattern={pattern!r}) that inference "
+                f"would reject"
+            )
+
+
+def test_filter_models_by_user_access_wildcard_provider_prefix():
+    """`anthropic/*` matches every model under the anthropic/ namespace."""
+    from litellm.proxy.auth.model_checks import filter_models_by_user_access
+
+    result = filter_models_by_user_access(
+        models=[
+            "anthropic/claude-3-haiku",
+            "anthropic/claude-3-sonnet",
+            "openai/gpt-4o",
+            "bedrock/anthropic.claude-3-5-sonnet",
+        ],
+        user_allowed_models=["anthropic/*"],
+    )
+    assert result == [
+        "anthropic/claude-3-haiku",
+        "anthropic/claude-3-sonnet",
+    ]
+
+
+def test_filter_models_by_user_access_wildcard_global_star():
+    """Bare `*` matches every model (parity with inference catch-all)."""
+    from litellm.proxy.auth.model_checks import filter_models_by_user_access
+
+    models = ["claude-3-haiku", "openai/gpt-4o", "bedrock/foo.bar"]
+    assert filter_models_by_user_access(models, ["*"]) == models
+
+
+def test_filter_models_by_user_access_preserves_input_order():
+    from litellm.proxy.auth.model_checks import filter_models_by_user_access
+
+    result = filter_models_by_user_access(
+        models=["b-model", "a-model", "c-model"],
+        user_allowed_models=["*"],
+    )
+    assert result == ["b-model", "a-model", "c-model"]

--- a/tests/test_litellm/proxy/discovery_endpoints/test_v1_model_info_user_filter.py
+++ b/tests/test_litellm/proxy/discovery_endpoints/test_v1_model_info_user_filter.py
@@ -70,6 +70,17 @@ def configure_router(monkeypatch):
     monkeypatch.setattr(ps, "general_settings", {})
     monkeypatch.setattr(ps, "prisma_client", MagicMock())
     monkeypatch.setattr(ps, "user_api_key_cache", DualCache())
+
+    # Upstream's model_info_v1 invokes _populate_team_access_on_models,
+    # which hits UserRepository(prisma_client).table.find_unique. The
+    # MagicMock prisma_client above can't be awaited there; stub the
+    # helper to a pass-through so the route exercises the user.models
+    # filter (the thing these tests cover) without dragging in real DB
+    # mocks.
+    async def _passthrough(*, user_api_key_dict, prisma_client, llm_router, all_models):
+        return all_models
+
+    monkeypatch.setattr(ps, "_populate_team_access_on_models", _passthrough)
     return router
 
 

--- a/tests/test_litellm/proxy/discovery_endpoints/test_v1_model_info_user_filter.py
+++ b/tests/test_litellm/proxy/discovery_endpoints/test_v1_model_info_user_filter.py
@@ -1,0 +1,238 @@
+"""
+Route-level tests for /v1/model/info (and the /model/info alias) —
+verify that LiteLLM_UserTable.models ("Personal Models") narrows the
+returned deployment list on Path B (no `litellm_model_id` query
+param), closing the discovery-vs-inference gap described in
+BerriAI/litellm#26420 and the follow-up audit that found it open on
+this sibling endpoint.
+
+These tests exercise the real FastAPI route → real user_api_key_auth
+dependency override → real model_info_v1 handler → real
+get_available_models_for_user → real _apply_user_models_filter →
+mocked get_user_object. No real DB, no live HTTP server.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.abspath("../../../.."))
+
+import litellm.proxy.proxy_server as ps
+from litellm.caching.caching import DualCache
+from litellm.proxy._types import (
+    LiteLLM_UserTable,
+    LitellmUserRoles,
+    UserAPIKeyAuth,
+)
+from litellm.proxy.proxy_server import app
+
+_PROXY_MODELS = [
+    {"model_name": "gpt-4", "litellm_params": {"model": "openai/gpt-4"}},
+    {
+        "model_name": "claude-3-opus",
+        "litellm_params": {"model": "anthropic/claude-3-opus"},
+    },
+    {
+        "model_name": "claude-3-haiku",
+        "litellm_params": {"model": "anthropic/claude-3-haiku"},
+    },
+    {
+        "model_name": "anthropic/claude-3-5-sonnet",
+        "litellm_params": {"model": "anthropic/claude-3-5-sonnet"},
+    },
+    {
+        "model_name": "anthropic/claude-3-7-sonnet",
+        "litellm_params": {"model": "anthropic/claude-3-7-sonnet"},
+    },
+]
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture
+def configure_router(monkeypatch):
+    import litellm
+
+    router = litellm.Router(
+        model_list=_PROXY_MODELS,
+        model_group_alias={},
+    )
+    monkeypatch.setattr(ps, "llm_router", router)
+    monkeypatch.setattr(ps, "llm_model_list", _PROXY_MODELS)
+    monkeypatch.setattr(ps, "user_model", None)
+    monkeypatch.setattr(ps, "general_settings", {})
+    monkeypatch.setattr(ps, "prisma_client", MagicMock())
+    monkeypatch.setattr(ps, "user_api_key_cache", DualCache())
+    return router
+
+
+def _override_auth(user_id):
+    def _auth():
+        return UserAPIKeyAuth(
+            api_key="test-key",
+            user_id=user_id,
+            user_role=LitellmUserRoles.INTERNAL_USER,
+            models=[],
+            team_id=None,
+            team_models=[],
+        )
+
+    app.dependency_overrides[ps.user_api_key_auth] = _auth
+
+
+@pytest.fixture(autouse=True)
+def _clear_auth_override():
+    yield
+    app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+
+def _patch_user(monkeypatch, models):
+    async def _fake(*args, **kwargs):
+        return LiteLLM_UserTable(
+            user_id="u-test",
+            max_budget=None,
+            user_email=None,
+            models=models,
+        )
+
+    monkeypatch.setattr(
+        "litellm.proxy.auth.auth_checks.get_user_object",
+        _fake,
+    )
+
+
+def _model_names(resp_json):
+    return sorted({item["model_name"] for item in resp_json["data"]})
+
+
+# ---------------------------------------------------------------------------
+# /v1/model/info Path B (no litellm_model_id) — the leak path
+# ---------------------------------------------------------------------------
+
+
+def test_v1_model_info_filters_by_user_personal_models(
+    client, configure_router, monkeypatch
+):
+    """Headline regression: user.models=['claude-3-opus'] must narrow the list."""
+    _override_auth(user_id="u-test")
+    _patch_user(monkeypatch, models=["claude-3-opus"])
+
+    resp = client.get("/v1/model/info", headers={"Authorization": "Bearer sk-test"})
+    assert resp.status_code == 200
+    assert _model_names(resp.json()) == ["claude-3-opus"]
+
+
+def test_v1_model_info_no_filter_when_user_models_empty(
+    client, configure_router, monkeypatch
+):
+    """user.models == [] -> unrestricted, full deployment list returned."""
+    _override_auth(user_id="u-test")
+    _patch_user(monkeypatch, models=[])
+
+    resp = client.get("/v1/model/info", headers={"Authorization": "Bearer sk-test"})
+    assert resp.status_code == 200
+    assert _model_names(resp.json()) == sorted({m["model_name"] for m in _PROXY_MODELS})
+
+
+def test_v1_model_info_no_filter_when_user_id_is_none(
+    client, configure_router, monkeypatch
+):
+    """Master key / service account (user_id=None) -> no filter applied."""
+
+    async def _should_not_be_called(*args, **kwargs):
+        raise AssertionError("get_user_object must not be called when user_id is None")
+
+    monkeypatch.setattr(
+        "litellm.proxy.auth.auth_checks.get_user_object",
+        _should_not_be_called,
+    )
+
+    _override_auth(user_id=None)
+
+    resp = client.get("/v1/model/info", headers={"Authorization": "Bearer sk-test"})
+    assert resp.status_code == 200
+    assert _model_names(resp.json()) == sorted({m["model_name"] for m in _PROXY_MODELS})
+
+
+def test_v1_model_info_no_default_models_returns_empty(
+    client, configure_router, monkeypatch
+):
+    """`no-default-models` sentinel -> /v1/model/info returns []."""
+    _override_auth(user_id="u-test")
+    _patch_user(monkeypatch, models=["no-default-models"])
+
+    resp = client.get("/v1/model/info", headers={"Authorization": "Bearer sk-test"})
+    assert resp.status_code == 200
+    assert resp.json()["data"] == []
+
+
+def test_v1_model_info_all_proxy_models_no_filter(
+    client, configure_router, monkeypatch
+):
+    """`all-proxy-models` sentinel -> user gets the full deployment list."""
+    _override_auth(user_id="u-test")
+    _patch_user(monkeypatch, models=["all-proxy-models"])
+
+    resp = client.get("/v1/model/info", headers={"Authorization": "Bearer sk-test"})
+    assert resp.status_code == 200
+    assert _model_names(resp.json()) == sorted({m["model_name"] for m in _PROXY_MODELS})
+
+
+def test_v1_model_info_user_wildcard(client, configure_router, monkeypatch):
+    """user.models contains 'anthropic/*' -> only matching deployments returned."""
+    _override_auth(user_id="u-test")
+    _patch_user(monkeypatch, models=["anthropic/*"])
+
+    resp = client.get("/v1/model/info", headers={"Authorization": "Bearer sk-test"})
+    assert resp.status_code == 200
+    assert _model_names(resp.json()) == [
+        "anthropic/claude-3-5-sonnet",
+        "anthropic/claude-3-7-sonnet",
+    ]
+
+
+def test_v1_model_info_user_models_takes_precedence_over_permissive_key(
+    client, configure_router, monkeypatch
+):
+    """Even with key.models=['all-proxy-models'], user.models still narrows.
+
+    Parity claim: /v1/model/info matches /v1/models which matches
+    can_user_call_model at inference time.
+    """
+
+    def _auth_with_all_proxy():
+        return UserAPIKeyAuth(
+            api_key="test-key",
+            user_id="u-test",
+            user_role=LitellmUserRoles.INTERNAL_USER,
+            models=["all-proxy-models"],
+            team_id=None,
+            team_models=[],
+        )
+
+    app.dependency_overrides[ps.user_api_key_auth] = _auth_with_all_proxy
+    _patch_user(monkeypatch, models=["claude-3-haiku"])
+
+    resp = client.get("/v1/model/info", headers={"Authorization": "Bearer sk-test"})
+    assert resp.status_code == 200
+    assert _model_names(resp.json()) == ["claude-3-haiku"]
+
+
+def test_v1_model_info_alias_route_filters_identically(
+    client, configure_router, monkeypatch
+):
+    """Sanity: /model/info (without /v1/ prefix) shares the same handler
+    and therefore the same filter behavior."""
+    _override_auth(user_id="u-test")
+    _patch_user(monkeypatch, models=["claude-3-opus"])
+
+    resp = client.get("/model/info", headers={"Authorization": "Bearer sk-test"})
+    assert resp.status_code == 200
+    assert _model_names(resp.json()) == ["claude-3-opus"]

--- a/tests/test_litellm/proxy/discovery_endpoints/test_v1_model_info_user_filter.py
+++ b/tests/test_litellm/proxy/discovery_endpoints/test_v1_model_info_user_filter.py
@@ -261,10 +261,13 @@ def _deployment_id(router, model_name):
     raise AssertionError(f"model {model_name!r} not in router")
 
 
-def test_v1_model_info_by_id_denied_when_model_not_in_user_models(
+def test_v1_model_info_by_id_filtered_when_model_not_in_user_models(
     client, configure_router, monkeypatch
 ):
-    """Regression: by-id lookup must respect user.models (veria-ai #29748)."""
+    """Regression: by-id lookup must respect user.models. Returns 200 + empty
+    data (not 403) so existence isn't leaked via 403-vs-404 enumeration —
+    matches the route_checks.py:189 spec '/model/info just shows models
+    user has access to' and the /v2/model/info pattern. See #26420 / #29748."""
     _override_auth(user_id="u-test")
     _patch_user(monkeypatch, models=["gpt-4"])
     disallowed_id = _deployment_id(configure_router, "claude-3-opus")
@@ -273,8 +276,8 @@ def test_v1_model_info_by_id_denied_when_model_not_in_user_models(
         f"/v1/model/info?litellm_model_id={disallowed_id}",
         headers={"Authorization": "Bearer sk-test"},
     )
-    assert resp.status_code == 403
-    assert "not authorized" in resp.text.lower()
+    assert resp.status_code == 200
+    assert resp.json() == {"data": []}
 
 
 def test_v1_model_info_by_id_allowed_when_model_in_user_models(

--- a/tests/test_litellm/proxy/discovery_endpoints/test_v1_model_info_user_filter.py
+++ b/tests/test_litellm/proxy/discovery_endpoints/test_v1_model_info_user_filter.py
@@ -236,3 +236,69 @@ def test_v1_model_info_alias_route_filters_identically(
     resp = client.get("/model/info", headers={"Authorization": "Bearer sk-test"})
     assert resp.status_code == 200
     assert _model_names(resp.json()) == ["claude-3-opus"]
+
+
+# ---------------------------------------------------------------------------
+# /v1/model/info Path A (?litellm_model_id=...) — by-id authorization
+# ---------------------------------------------------------------------------
+
+
+def _deployment_id(router, model_name):
+    for d in router.model_list:
+        if d["model_name"] == model_name:
+            return d["model_info"]["id"]
+    raise AssertionError(f"model {model_name!r} not in router")
+
+
+def test_v1_model_info_by_id_denied_when_model_not_in_user_models(
+    client, configure_router, monkeypatch
+):
+    """Regression: by-id lookup must respect user.models (veria-ai #29748)."""
+    _override_auth(user_id="u-test")
+    _patch_user(monkeypatch, models=["gpt-4"])
+    disallowed_id = _deployment_id(configure_router, "claude-3-opus")
+
+    resp = client.get(
+        f"/v1/model/info?litellm_model_id={disallowed_id}",
+        headers={"Authorization": "Bearer sk-test"},
+    )
+    assert resp.status_code == 403
+    assert "not authorized" in resp.text.lower()
+
+
+def test_v1_model_info_by_id_allowed_when_model_in_user_models(
+    client, configure_router, monkeypatch
+):
+    """By-id lookup for a deployment whose model_name is in user.models -> 200."""
+    _override_auth(user_id="u-test")
+    _patch_user(monkeypatch, models=["claude-3-opus"])
+    allowed_id = _deployment_id(configure_router, "claude-3-opus")
+
+    resp = client.get(
+        f"/v1/model/info?litellm_model_id={allowed_id}",
+        headers={"Authorization": "Bearer sk-test"},
+    )
+    assert resp.status_code == 200
+    assert _model_names(resp.json()) == ["claude-3-opus"]
+
+
+def test_v1_model_info_by_id_master_key_bypass(client, configure_router, monkeypatch):
+    """Master key / service account (user_id=None) -> by-id lookup unrestricted."""
+
+    async def _should_not_be_called(*args, **kwargs):
+        raise AssertionError("get_user_object must not be called when user_id is None")
+
+    monkeypatch.setattr(
+        "litellm.proxy.auth.auth_checks.get_user_object",
+        _should_not_be_called,
+    )
+
+    _override_auth(user_id=None)
+    any_id = _deployment_id(configure_router, "claude-3-opus")
+
+    resp = client.get(
+        f"/v1/model/info?litellm_model_id={any_id}",
+        headers={"Authorization": "Bearer sk-test"},
+    )
+    assert resp.status_code == 200
+    assert _model_names(resp.json()) == ["claude-3-opus"]

--- a/tests/test_litellm/proxy/discovery_endpoints/test_v1_models_user_filter.py
+++ b/tests/test_litellm/proxy/discovery_endpoints/test_v1_models_user_filter.py
@@ -1,0 +1,240 @@
+"""
+Route-level tests for /v1/models — verify that LiteLLM_UserTable.models
+("Personal Models") is honored, closing the inconsistency between the
+discovery endpoint and inference (BerriAI/litellm#26420).
+
+These tests exercise the real FastAPI route → real user_api_key_auth
+dependency override → real model_list handler → real
+get_available_models_for_user → real _apply_user_models_filter →
+mocked get_user_object. No real DB, no live HTTP server.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.abspath("../../../.."))
+
+import litellm.proxy.proxy_server as ps
+from litellm.caching.caching import DualCache
+from litellm.proxy._types import (
+    LiteLLM_UserTable,
+    LitellmUserRoles,
+    UserAPIKeyAuth,
+)
+from litellm.proxy.proxy_server import app
+
+# ---------------------------------------------------------------------------
+# Test infrastructure
+# ---------------------------------------------------------------------------
+
+
+_PROXY_MODELS = [
+    {"model_name": "gpt-4", "litellm_params": {"model": "openai/gpt-4"}},
+    {
+        "model_name": "claude-3-opus",
+        "litellm_params": {"model": "anthropic/claude-3-opus"},
+    },
+    {
+        "model_name": "claude-3-haiku",
+        "litellm_params": {"model": "anthropic/claude-3-haiku"},
+    },
+    {
+        "model_name": "anthropic/claude-3-5-sonnet",
+        "litellm_params": {"model": "anthropic/claude-3-5-sonnet"},
+    },
+    {
+        "model_name": "anthropic/claude-3-7-sonnet",
+        "litellm_params": {"model": "anthropic/claude-3-7-sonnet"},
+    },
+]
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture
+def configure_router(monkeypatch):
+    """Wire a real Router with a known model list onto proxy_server globals."""
+    import litellm
+
+    router = litellm.Router(
+        model_list=_PROXY_MODELS,
+        model_group_alias={},
+    )
+    monkeypatch.setattr(ps, "llm_router", router)
+    monkeypatch.setattr(ps, "llm_model_list", _PROXY_MODELS)
+    monkeypatch.setattr(ps, "user_model", None)
+    monkeypatch.setattr(ps, "general_settings", {})
+    # _apply_user_models_filter only needs prisma_client to be truthy;
+    # the actual user fetch is mocked below.
+    monkeypatch.setattr(ps, "prisma_client", MagicMock())
+    monkeypatch.setattr(ps, "user_api_key_cache", DualCache())
+    return router
+
+
+def _override_auth(user_id):
+    """Install an auth override that returns a UserAPIKeyAuth with the
+    given user_id (or None for master-key-style requests). The key itself
+    grants 'all-proxy-models' so key-level filtering is a no-op and we
+    can isolate the user-level filter under test.
+    """
+
+    def _auth():
+        return UserAPIKeyAuth(
+            api_key="test-key",
+            user_id=user_id,
+            user_role=LitellmUserRoles.INTERNAL_USER,
+            models=[],  # empty key.models → falls through to proxy list
+            team_id=None,
+            team_models=[],
+        )
+
+    app.dependency_overrides[ps.user_api_key_auth] = _auth
+
+
+@pytest.fixture(autouse=True)
+def _clear_auth_override():
+    yield
+    app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+
+def _patch_user(monkeypatch, models):
+    """Make get_user_object (as imported inside _apply_user_models_filter)
+    return a user with the given Personal Models list."""
+
+    async def _fake(*args, **kwargs):
+        return LiteLLM_UserTable(
+            user_id="u-test",
+            max_budget=None,
+            user_email=None,
+            models=models,
+        )
+
+    monkeypatch.setattr(
+        "litellm.proxy.auth.auth_checks.get_user_object",
+        _fake,
+    )
+
+
+def _model_ids(resp_json):
+    return [item["id"] for item in resp_json["data"]]
+
+
+# ---------------------------------------------------------------------------
+# Cases — these all hit GET /v1/models for real.
+# ---------------------------------------------------------------------------
+
+
+def test_v1_models_filters_by_user_personal_models(
+    client, configure_router, monkeypatch
+):
+    """The headline bug: user.models = ['claude-3-opus'] must narrow the list."""
+    _override_auth(user_id="u-test")
+    _patch_user(monkeypatch, models=["claude-3-opus"])
+
+    resp = client.get("/v1/models", headers={"Authorization": "Bearer sk-test"})
+    assert resp.status_code == 200
+    assert _model_ids(resp.json()) == ["claude-3-opus"]
+
+
+def test_v1_models_no_filter_when_user_models_empty(
+    client, configure_router, monkeypatch
+):
+    """user.models == [] → unrestricted, full proxy list returned."""
+    _override_auth(user_id="u-test")
+    _patch_user(monkeypatch, models=[])
+
+    resp = client.get("/v1/models", headers={"Authorization": "Bearer sk-test"})
+    assert resp.status_code == 200
+    returned = set(_model_ids(resp.json()))
+    assert returned == {m["model_name"] for m in _PROXY_MODELS}
+
+
+def test_v1_models_no_filter_when_user_id_is_none(
+    client, configure_router, monkeypatch
+):
+    """Master key / service account (user_id=None) → no filter applied."""
+
+    async def _should_not_be_called(*args, **kwargs):
+        raise AssertionError("get_user_object must not be called when user_id is None")
+
+    monkeypatch.setattr(
+        "litellm.proxy.auth.auth_checks.get_user_object",
+        _should_not_be_called,
+    )
+
+    _override_auth(user_id=None)
+
+    resp = client.get("/v1/models", headers={"Authorization": "Bearer sk-test"})
+    assert resp.status_code == 200
+    assert len(_model_ids(resp.json())) == len(_PROXY_MODELS)
+
+
+def test_v1_models_no_default_models_returns_empty(
+    client, configure_router, monkeypatch
+):
+    """`no-default-models` sentinel → /v1/models returns []."""
+    _override_auth(user_id="u-test")
+    _patch_user(monkeypatch, models=["no-default-models"])
+
+    resp = client.get("/v1/models", headers={"Authorization": "Bearer sk-test"})
+    assert resp.status_code == 200
+    assert resp.json()["data"] == []
+
+
+def test_v1_models_all_proxy_models_no_filter(client, configure_router, monkeypatch):
+    """`all-proxy-models` sentinel → user gets the full proxy list."""
+    _override_auth(user_id="u-test")
+    _patch_user(monkeypatch, models=["all-proxy-models"])
+
+    resp = client.get("/v1/models", headers={"Authorization": "Bearer sk-test"})
+    assert resp.status_code == 200
+    returned = set(_model_ids(resp.json()))
+    assert returned == {m["model_name"] for m in _PROXY_MODELS}
+
+
+def test_v1_models_user_wildcard(client, configure_router, monkeypatch):
+    """user.models contains 'anthropic/*' → only anthropic/* models returned."""
+    _override_auth(user_id="u-test")
+    _patch_user(monkeypatch, models=["anthropic/*"])
+
+    resp = client.get("/v1/models", headers={"Authorization": "Bearer sk-test"})
+    assert resp.status_code == 200
+    returned = set(_model_ids(resp.json()))
+    assert returned == {
+        "anthropic/claude-3-5-sonnet",
+        "anthropic/claude-3-7-sonnet",
+    }
+
+
+def test_v1_models_user_models_takes_precedence_over_permissive_key(
+    client, configure_router, monkeypatch
+):
+    """
+    Even if the key has 'all-proxy-models', user.models still narrows the
+    list. This is the parity claim: /v1/models matches can_user_call_model
+    at inference time.
+    """
+
+    def _auth_with_all_proxy():
+        return UserAPIKeyAuth(
+            api_key="test-key",
+            user_id="u-test",
+            user_role=LitellmUserRoles.INTERNAL_USER,
+            models=["all-proxy-models"],
+            team_id=None,
+            team_models=[],
+        )
+
+    app.dependency_overrides[ps.user_api_key_auth] = _auth_with_all_proxy
+    _patch_user(monkeypatch, models=["claude-3-haiku"])
+
+    resp = client.get("/v1/models", headers={"Authorization": "Bearer sk-test"})
+    assert resp.status_code == 200
+    assert _model_ids(resp.json()) == ["claude-3-haiku"]

--- a/tests/test_litellm/proxy/discovery_endpoints/test_v2_model_info_user_filter.py
+++ b/tests/test_litellm/proxy/discovery_endpoints/test_v2_model_info_user_filter.py
@@ -346,3 +346,111 @@ def test_v2_model_info_include_team_models_no_default_models_returns_empty(
     )
     assert resp.status_code == 200
     assert resp.json()["data"] == []
+
+
+# ---------------------------------------------------------------------------
+# Direct unit tests on apply_user_models_filter_to_deployments — verify the
+# `user_models_override` shortcut bypasses get_user_object entirely so the
+# `user_models_only=true` branch of /v2/model/info doesn't hit the DB twice
+# for the same user_id under cache-miss conditions.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_user_models_filter_override_narrows_and_skips_get_user_object(
+    configure_router, monkeypatch
+):
+    """When the caller passes user_models_override, get_user_object MUST NOT
+    be called — the override list is the single source of truth."""
+    from litellm.proxy.utils import apply_user_models_filter_to_deployments
+
+    async def _must_not_call(*args, **kwargs):
+        raise AssertionError(
+            "get_user_object must not be called when user_models_override is set"
+        )
+
+    monkeypatch.setattr(
+        "litellm.proxy.auth.auth_checks.get_user_object",
+        _must_not_call,
+    )
+
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key="test-key",
+        user_id="u-test",
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        models=[],
+        team_id=None,
+        team_models=[],
+    )
+
+    result = await apply_user_models_filter_to_deployments(
+        deployments=list(_PROXY_MODELS),
+        user_api_key_dict=user_api_key_dict,
+        llm_router=configure_router,
+        prisma_client=MagicMock(),
+        proxy_logging_obj=MagicMock(),
+        user_api_key_cache=DualCache(),
+        user_models_override=["claude-3-opus"],
+    )
+
+    assert sorted({d["model_name"] for d in result}) == ["claude-3-opus"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "override,expected",
+    [
+        # Empty list = "user has no model restriction" -> pass-through (no narrowing).
+        ([], None),
+        # Sentinel -> empty.
+        (["no-default-models"], []),
+        # Sentinel -> pass-through (no narrowing).
+        (["all-proxy-models"], None),
+        # Wildcard.
+        (
+            ["anthropic/*"],
+            ["anthropic/claude-3-5-sonnet", "anthropic/claude-3-7-sonnet"],
+        ),
+    ],
+)
+async def test_apply_user_models_filter_override_semantics(
+    configure_router, monkeypatch, override, expected
+):
+    """The override path must apply the same SpecialModelNames + wildcard
+    semantics as the get_user_object path, so swapping in the shortcut
+    can never change observable behavior."""
+    from litellm.proxy.utils import apply_user_models_filter_to_deployments
+
+    monkeypatch.setattr(
+        "litellm.proxy.auth.auth_checks.get_user_object",
+        lambda *a, **kw: (_ for _ in ()).throw(
+            AssertionError("override path must not consult get_user_object")
+        ),
+    )
+
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key="test-key",
+        user_id="u-test",
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        models=[],
+        team_id=None,
+        team_models=[],
+    )
+
+    result = await apply_user_models_filter_to_deployments(
+        deployments=list(_PROXY_MODELS),
+        user_api_key_dict=user_api_key_dict,
+        llm_router=configure_router,
+        prisma_client=MagicMock(),
+        proxy_logging_obj=MagicMock(),
+        user_api_key_cache=DualCache(),
+        user_models_override=override,
+    )
+
+    if expected is None:
+        # No narrowing — all five deployments returned, order-insensitive.
+        assert sorted({d["model_name"] for d in result}) == sorted(
+            {m["model_name"] for m in _PROXY_MODELS}
+        )
+    else:
+        assert sorted({d["model_name"] for d in result}) == expected

--- a/tests/test_litellm/proxy/discovery_endpoints/test_v2_model_info_user_filter.py
+++ b/tests/test_litellm/proxy/discovery_endpoints/test_v2_model_info_user_filter.py
@@ -207,6 +207,121 @@ def test_v2_model_info_default_branch_user_wildcard(
     ]
 
 
+# ---------------------------------------------------------------------------
+# Key.models / team_models filter on default branch (veria-ai finding 1)
+# ---------------------------------------------------------------------------
+
+
+def _override_auth_with(models=None, team_models=None, team_id=None, user_id=None):
+    def _auth():
+        return UserAPIKeyAuth(
+            api_key="test-key",
+            user_id=user_id,
+            user_role=LitellmUserRoles.INTERNAL_USER,
+            models=models or [],
+            team_id=team_id,
+            team_models=team_models or [],
+        )
+
+    app.dependency_overrides[ps.user_api_key_auth] = _auth
+
+
+def test_v2_model_info_default_branch_filters_by_key_models(
+    client, configure_router, monkeypatch
+):
+    """key.models=['claude-3-opus'] must narrow even when user.models is empty.
+
+    Before veria-ai finding 1's fix, a virtual key restricted to claude-3-opus
+    could still pull metadata for every deployment on a bare GET /v2/model/info.
+    """
+    _override_auth_with(models=["claude-3-opus"], user_id="u-test")
+    _patch_user(monkeypatch, models=[])
+
+    resp = client.get("/v2/model/info", headers={"Authorization": "Bearer sk-test"})
+    assert resp.status_code == 200
+    assert _model_names(resp.json()) == ["claude-3-opus"]
+
+
+def test_v2_model_info_default_branch_filters_by_team_models(
+    client, configure_router, monkeypatch
+):
+    """team_models=['claude-3-haiku'] narrows when key.models is empty."""
+    _override_auth_with(
+        models=[], team_models=["claude-3-haiku"], team_id="t-1", user_id="u-test"
+    )
+    _patch_user(monkeypatch, models=[])
+
+    resp = client.get("/v2/model/info", headers={"Authorization": "Bearer sk-test"})
+    assert resp.status_code == 200
+    assert _model_names(resp.json()) == ["claude-3-haiku"]
+
+
+def test_v2_model_info_default_branch_key_models_take_precedence_over_team_models(
+    client, configure_router, monkeypatch
+):
+    """get_complete_model_list defers to team_models only when key_models is empty.
+
+    key.models=['gpt-4'] AND team_models=['claude-3-opus'] -> key wins -> gpt-4.
+    """
+    _override_auth_with(
+        models=["gpt-4"],
+        team_models=["claude-3-opus"],
+        team_id="t-1",
+        user_id="u-test",
+    )
+    _patch_user(monkeypatch, models=[])
+
+    resp = client.get("/v2/model/info", headers={"Authorization": "Bearer sk-test"})
+    assert resp.status_code == 200
+    assert _model_names(resp.json()) == ["gpt-4"]
+
+
+def test_v2_model_info_default_branch_key_models_multi_value(
+    client, configure_router, monkeypatch
+):
+    """key.models=['gpt-4', 'claude-3-haiku'] -> exactly those two deployments.
+
+    Wildcard semantics on key.models go through `get_complete_model_list` ->
+    `_get_wildcard_models`, which expands to provider-known model names, not
+    router deployment aliases. That quirk is shared with the listing path
+    and is out of scope here — test only the unambiguous multi-value case.
+    """
+    _override_auth_with(models=["gpt-4", "claude-3-haiku"], user_id="u-test")
+    _patch_user(monkeypatch, models=[])
+
+    resp = client.get("/v2/model/info", headers={"Authorization": "Bearer sk-test"})
+    assert resp.status_code == 200
+    assert _model_names(resp.json()) == ["claude-3-haiku", "gpt-4"]
+
+
+def test_v2_model_info_default_branch_key_all_proxy_models_no_narrow(
+    client, configure_router, monkeypatch
+):
+    """key.models=['all-proxy-models'] -> no narrowing from the key/team step."""
+    _override_auth_with(models=["all-proxy-models"], user_id="u-test")
+    _patch_user(monkeypatch, models=[])
+
+    resp = client.get("/v2/model/info", headers={"Authorization": "Bearer sk-test"})
+    assert resp.status_code == 200
+    assert _model_names(resp.json()) == sorted({m["model_name"] for m in _PROXY_MODELS})
+
+
+def test_v2_model_info_default_branch_key_and_user_models_intersect_to_empty(
+    client, configure_router, monkeypatch
+):
+    """key.models=['gpt-4'] AND user.models=['claude-3-opus'] -> empty intersection.
+
+    The key/team step narrows to ['gpt-4']; the user.models step then
+    intersects against ['claude-3-opus']. No overlap -> empty list.
+    """
+    _override_auth_with(models=["gpt-4"], user_id="u-test")
+    _patch_user(monkeypatch, models=["claude-3-opus"])
+
+    resp = client.get("/v2/model/info", headers={"Authorization": "Bearer sk-test"})
+    assert resp.status_code == 200
+    assert resp.json()["data"] == []
+
+
 def test_v2_model_info_user_models_takes_precedence_over_permissive_key(
     client, configure_router, monkeypatch
 ):

--- a/tests/test_litellm/proxy/discovery_endpoints/test_v2_model_info_user_filter.py
+++ b/tests/test_litellm/proxy/discovery_endpoints/test_v2_model_info_user_filter.py
@@ -454,3 +454,223 @@ async def test_apply_user_models_filter_override_semantics(
         )
     else:
         assert sorted({d["model_name"] for d in result}) == expected
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: /v2/model/info?user_models_only=true must drive the
+# non_admin_all_models -> user_models_override path (one DB lookup, not two)
+# even on cache miss. Locks the perf-fix contract on the actual route.
+# ---------------------------------------------------------------------------
+
+
+def test_v2_model_info_user_models_only_uses_override_path(
+    client, configure_router, monkeypatch
+):
+    """`?user_models_only=true` must populate `user_models_override` from
+    the row `non_admin_all_models` already loaded, so the downstream
+    `apply_user_models_filter_to_deployments` does not re-query the user."""
+
+    _override_auth(user_id="u-test")
+
+    # The route's `non_admin_all_models` path issues a real
+    # `prisma_client.db.litellm_usertable.find_unique`. Stub the prisma
+    # client to return a row with .models set, and skip the unrelated
+    # _check_if_model_is_user_added / _check_if_model_is_team_model
+    # helpers which depend on more of the DB schema than this test cares
+    # about.
+    fake_user_row = MagicMock()
+    fake_user_row.models = ["claude-3-opus"]
+    fake_user_row.teams = []
+
+    async def _find_unique(*args, **kwargs):
+        return fake_user_row
+
+    prisma = MagicMock()
+    prisma.db.litellm_usertable.find_unique = _find_unique
+    monkeypatch.setattr(ps, "prisma_client", prisma)
+
+    async def _noop_user_added(*, models, **kwargs):
+        return models
+
+    def _noop_team(*, models, user_row):
+        return []
+
+    monkeypatch.setattr(ps, "_check_if_model_is_user_added", _noop_user_added)
+    monkeypatch.setattr(ps, "_check_if_model_is_team_model", _noop_team)
+
+    # Defense: if anything in the user_models_only branch still calls
+    # get_user_object, the assertion below fires. This is the contract
+    # the perf fix exists to preserve.
+    async def _must_not_call(*args, **kwargs):
+        raise AssertionError(
+            "get_user_object must not be called on user_models_only=true "
+            "when non_admin_all_models has already loaded the row"
+        )
+
+    monkeypatch.setattr(
+        "litellm.proxy.auth.auth_checks.get_user_object",
+        _must_not_call,
+    )
+
+    resp = client.get(
+        "/v2/model/info?user_models_only=true",
+        headers={"Authorization": "Bearer sk-test"},
+    )
+    assert resp.status_code == 200
+    # Only claude-3-opus survives — non_admin_all_models passed _noop_team
+    # (no team expansion) and the override narrowed via user_row.models.
+    assert _model_names(resp.json()) == ["claude-3-opus"]
+
+
+# ---------------------------------------------------------------------------
+# Defense path: if get_user_object raises, _apply_user_models_filter must
+# swallow and return all_models unchanged. Tests the except handler at
+# utils.py:6157-6166. Failure here would break /v1/models for every user
+# under a transient DB blip.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_user_models_filter_swallows_get_user_object_exception(
+    configure_router, monkeypatch
+):
+    """A raise inside get_user_object must not propagate — discovery
+    endpoints must stay available even if user lookup blips."""
+    from litellm.proxy.utils import apply_user_models_filter_to_deployments
+
+    async def _boom(*args, **kwargs):
+        raise RuntimeError("simulated db blip")
+
+    monkeypatch.setattr(
+        "litellm.proxy.auth.auth_checks.get_user_object",
+        _boom,
+    )
+
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key="test-key",
+        user_id="u-test",
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        models=[],
+        team_id=None,
+        team_models=[],
+    )
+
+    # Override is None -> goes through the get_user_object path -> hits
+    # the except handler.
+    result = await apply_user_models_filter_to_deployments(
+        deployments=list(_PROXY_MODELS),
+        user_api_key_dict=user_api_key_dict,
+        llm_router=configure_router,
+        prisma_client=MagicMock(),
+        proxy_logging_obj=MagicMock(),
+        user_api_key_cache=DualCache(),
+        user_models_override=None,
+    )
+
+    # Pass-through: all 5 returned, no filter applied.
+    assert sorted({d["model_name"] for d in result}) == sorted(
+        {m["model_name"] for m in _PROXY_MODELS}
+    )
+
+
+@pytest.mark.asyncio
+async def test_apply_user_models_filter_empty_deployments_short_circuits(monkeypatch):
+    """Empty deployment list -> return immediately, never touch the user
+    lookup. Cheap guard for /v1/model/info on an empty router."""
+    from litellm.proxy.utils import apply_user_models_filter_to_deployments
+
+    async def _must_not_call(*args, **kwargs):
+        raise AssertionError(
+            "get_user_object must not be called when deployments is empty"
+        )
+
+    monkeypatch.setattr(
+        "litellm.proxy.auth.auth_checks.get_user_object",
+        _must_not_call,
+    )
+
+    result = await apply_user_models_filter_to_deployments(
+        deployments=[],
+        user_api_key_dict=UserAPIKeyAuth(
+            api_key="test-key",
+            user_id="u-test",
+            user_role=LitellmUserRoles.INTERNAL_USER,
+            models=[],
+            team_id=None,
+            team_models=[],
+        ),
+        llm_router=None,
+        prisma_client=MagicMock(),
+        proxy_logging_obj=MagicMock(),
+        user_api_key_cache=DualCache(),
+    )
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_apply_user_models_filter_no_router_uses_empty_model_set(monkeypatch):
+    """`llm_router is None` (e.g. proxy boot before router init) -> proxy
+    model list defaults to []; filter still applies override semantics
+    using whatever raw names the user listed."""
+    from litellm.proxy.utils import apply_user_models_filter_to_deployments
+
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key="test-key",
+        user_id="u-test",
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        models=[],
+        team_id=None,
+        team_models=[],
+    )
+
+    result = await apply_user_models_filter_to_deployments(
+        deployments=list(_PROXY_MODELS),
+        user_api_key_dict=user_api_key_dict,
+        llm_router=None,
+        prisma_client=MagicMock(),
+        proxy_logging_obj=MagicMock(),
+        user_api_key_cache=DualCache(),
+        user_models_override=["claude-3-opus"],
+    )
+    assert sorted({d["model_name"] for d in result}) == ["claude-3-opus"]
+
+
+@pytest.mark.asyncio
+async def test_apply_user_models_filter_user_not_found_passes_through(
+    configure_router, monkeypatch
+):
+    """`get_user_object` returns None (user row genuinely missing) ->
+    pass-through. Matches the swallow path: never break /v1/models if
+    we can't resolve the user."""
+    from litellm.proxy.utils import apply_user_models_filter_to_deployments
+
+    async def _missing(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(
+        "litellm.proxy.auth.auth_checks.get_user_object",
+        _missing,
+    )
+
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key="test-key",
+        user_id="u-test",
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        models=[],
+        team_id=None,
+        team_models=[],
+    )
+
+    result = await apply_user_models_filter_to_deployments(
+        deployments=list(_PROXY_MODELS),
+        user_api_key_dict=user_api_key_dict,
+        llm_router=configure_router,
+        prisma_client=MagicMock(),
+        proxy_logging_obj=MagicMock(),
+        user_api_key_cache=DualCache(),
+        user_models_override=None,
+    )
+    # No filter applied — all 5 deployments returned.
+    assert sorted({d["model_name"] for d in result}) == sorted(
+        {m["model_name"] for m in _PROXY_MODELS}
+    )

--- a/tests/test_litellm/proxy/discovery_endpoints/test_v2_model_info_user_filter.py
+++ b/tests/test_litellm/proxy/discovery_endpoints/test_v2_model_info_user_filter.py
@@ -1,0 +1,348 @@
+"""
+Route-level tests for /v2/model/info — verify that
+LiteLLM_UserTable.models ("Personal Models") narrows the returned
+deployment list on every flag combination, including the default
+(flagless) branch which previously leaked the full router.model_list.
+
+Same setup pattern as test_v1_model_info_user_filter.py: real FastAPI
+route → real user_api_key_auth override → real model_info_v2 handler →
+real apply_user_models_filter_to_deployments → mocked get_user_object.
+
+These tests do NOT depend on team membership; the include_team_models
+branch is exercised in case 17 (e2e) but here we focus on the
+defense-in-depth final-step filter that runs for every request shape.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.abspath("../../../.."))
+
+import litellm.proxy.proxy_server as ps
+from litellm.caching.caching import DualCache
+from litellm.proxy._types import (
+    LiteLLM_UserTable,
+    LitellmUserRoles,
+    UserAPIKeyAuth,
+)
+from litellm.proxy.proxy_server import app
+
+_PROXY_MODELS = [
+    {"model_name": "gpt-4", "litellm_params": {"model": "openai/gpt-4"}},
+    {
+        "model_name": "claude-3-opus",
+        "litellm_params": {"model": "anthropic/claude-3-opus"},
+    },
+    {
+        "model_name": "claude-3-haiku",
+        "litellm_params": {"model": "anthropic/claude-3-haiku"},
+    },
+    {
+        "model_name": "anthropic/claude-3-5-sonnet",
+        "litellm_params": {"model": "anthropic/claude-3-5-sonnet"},
+    },
+    {
+        "model_name": "anthropic/claude-3-7-sonnet",
+        "litellm_params": {"model": "anthropic/claude-3-7-sonnet"},
+    },
+]
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture
+def configure_router(monkeypatch):
+    import litellm
+
+    router = litellm.Router(
+        model_list=_PROXY_MODELS,
+        model_group_alias={},
+    )
+    monkeypatch.setattr(ps, "llm_router", router)
+    monkeypatch.setattr(ps, "llm_model_list", _PROXY_MODELS)
+    monkeypatch.setattr(ps, "user_model", None)
+    monkeypatch.setattr(ps, "general_settings", {})
+    monkeypatch.setattr(ps, "prisma_client", MagicMock())
+    monkeypatch.setattr(ps, "user_api_key_cache", DualCache())
+    return router
+
+
+def _override_auth(user_id):
+    def _auth():
+        return UserAPIKeyAuth(
+            api_key="test-key",
+            user_id=user_id,
+            user_role=LitellmUserRoles.INTERNAL_USER,
+            models=[],
+            team_id=None,
+            team_models=[],
+        )
+
+    app.dependency_overrides[ps.user_api_key_auth] = _auth
+
+
+@pytest.fixture(autouse=True)
+def _clear_auth_override():
+    yield
+    app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+
+def _patch_user(monkeypatch, models, teams=None):
+    async def _fake(*args, **kwargs):
+        return LiteLLM_UserTable(
+            user_id="u-test",
+            max_budget=None,
+            user_email=None,
+            models=models,
+            teams=teams or [],
+        )
+
+    monkeypatch.setattr(
+        "litellm.proxy.auth.auth_checks.get_user_object",
+        _fake,
+    )
+
+
+def _model_names(resp_json):
+    return sorted({item["model_name"] for item in resp_json["data"]})
+
+
+# ---------------------------------------------------------------------------
+# Default branch (no flags) — was leaking full router.model_list before fix
+# ---------------------------------------------------------------------------
+
+
+def test_v2_model_info_default_branch_filters_by_user_models(
+    client, configure_router, monkeypatch
+):
+    """user.models=['claude-3-opus'] must narrow even when caller passes no flags.
+
+    Pre-fix this branch returned the entire router.model_list verbatim —
+    leaking every deployment's litellm_params (including api_base) to
+    any virtual-key holder.
+    """
+    _override_auth(user_id="u-test")
+    _patch_user(monkeypatch, models=["claude-3-opus"])
+
+    resp = client.get("/v2/model/info", headers={"Authorization": "Bearer sk-test"})
+    assert resp.status_code == 200
+    assert _model_names(resp.json()) == ["claude-3-opus"]
+
+
+def test_v2_model_info_default_branch_no_filter_for_master_key(
+    client, configure_router, monkeypatch
+):
+    """Master key (user_id=None) -> no narrowing, full deployment list."""
+
+    async def _should_not_be_called(*args, **kwargs):
+        raise AssertionError("get_user_object must not be called when user_id is None")
+
+    monkeypatch.setattr(
+        "litellm.proxy.auth.auth_checks.get_user_object",
+        _should_not_be_called,
+    )
+
+    _override_auth(user_id=None)
+
+    resp = client.get("/v2/model/info", headers={"Authorization": "Bearer sk-test"})
+    assert resp.status_code == 200
+    assert _model_names(resp.json()) == sorted({m["model_name"] for m in _PROXY_MODELS})
+
+
+def test_v2_model_info_default_branch_no_filter_when_user_models_empty(
+    client, configure_router, monkeypatch
+):
+    """user.models == [] -> unrestricted, full deployment list returned."""
+    _override_auth(user_id="u-test")
+    _patch_user(monkeypatch, models=[])
+
+    resp = client.get("/v2/model/info", headers={"Authorization": "Bearer sk-test"})
+    assert resp.status_code == 200
+    assert _model_names(resp.json()) == sorted({m["model_name"] for m in _PROXY_MODELS})
+
+
+def test_v2_model_info_default_branch_no_default_models_returns_empty(
+    client, configure_router, monkeypatch
+):
+    """`no-default-models` sentinel -> /v2/model/info returns []."""
+    _override_auth(user_id="u-test")
+    _patch_user(monkeypatch, models=["no-default-models"])
+
+    resp = client.get("/v2/model/info", headers={"Authorization": "Bearer sk-test"})
+    assert resp.status_code == 200
+    assert resp.json()["data"] == []
+
+
+def test_v2_model_info_default_branch_all_proxy_models_no_filter(
+    client, configure_router, monkeypatch
+):
+    """`all-proxy-models` sentinel -> user gets the full deployment list."""
+    _override_auth(user_id="u-test")
+    _patch_user(monkeypatch, models=["all-proxy-models"])
+
+    resp = client.get("/v2/model/info", headers={"Authorization": "Bearer sk-test"})
+    assert resp.status_code == 200
+    assert _model_names(resp.json()) == sorted({m["model_name"] for m in _PROXY_MODELS})
+
+
+def test_v2_model_info_default_branch_user_wildcard(
+    client, configure_router, monkeypatch
+):
+    """user.models contains 'anthropic/*' -> only matching deployments returned."""
+    _override_auth(user_id="u-test")
+    _patch_user(monkeypatch, models=["anthropic/*"])
+
+    resp = client.get("/v2/model/info", headers={"Authorization": "Bearer sk-test"})
+    assert resp.status_code == 200
+    assert _model_names(resp.json()) == [
+        "anthropic/claude-3-5-sonnet",
+        "anthropic/claude-3-7-sonnet",
+    ]
+
+
+def test_v2_model_info_user_models_takes_precedence_over_permissive_key(
+    client, configure_router, monkeypatch
+):
+    """Even with key.models=['all-proxy-models'], user.models still narrows."""
+
+    def _auth_with_all_proxy():
+        return UserAPIKeyAuth(
+            api_key="test-key",
+            user_id="u-test",
+            user_role=LitellmUserRoles.INTERNAL_USER,
+            models=["all-proxy-models"],
+            team_id=None,
+            team_models=[],
+        )
+
+    app.dependency_overrides[ps.user_api_key_auth] = _auth_with_all_proxy
+    _patch_user(monkeypatch, models=["claude-3-haiku"])
+
+    resp = client.get("/v2/model/info", headers={"Authorization": "Bearer sk-test"})
+    assert resp.status_code == 200
+    assert _model_names(resp.json()) == ["claude-3-haiku"]
+
+
+def test_v2_model_info_default_branch_preserves_litellm_params(
+    client, configure_router, monkeypatch
+):
+    """Sanity: filter only drops disallowed deployments — surviving entries
+    retain their litellm_params payload (model, api_base, etc.)."""
+    _override_auth(user_id="u-test")
+    _patch_user(monkeypatch, models=["claude-3-opus"])
+
+    resp = client.get("/v2/model/info", headers={"Authorization": "Bearer sk-test"})
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert len(data) == 1
+    assert data[0]["model_name"] == "claude-3-opus"
+    # litellm_params is enriched but still carries the original "model" key
+    assert data[0]["litellm_params"]["model"] == "anthropic/claude-3-opus"
+
+
+# ---------------------------------------------------------------------------
+# include_team_models=true branch — user.models must STILL narrow after the
+# endpoint expands the list via team access. This is the path the UI hits
+# (modelInfoCall in networking.tsx always passes include_team_models=true).
+# ---------------------------------------------------------------------------
+
+
+def test_v2_model_info_include_team_models_branch_still_filters_user_models(
+    client, configure_router, monkeypatch
+):
+    """include_team_models=true expands the deployment list via team access
+    (every model marked `access_via_team_ids=['t-a']`), simulating a user
+    in a team with full proxy access. The user-level filter must still
+    narrow the result to user.models = ['claude-3-opus'].
+
+    Without the defense-in-depth final-step filter, the endpoint would
+    leak all 5 deployments.
+    """
+    _override_auth(user_id="u-test")
+    _patch_user(monkeypatch, models=["claude-3-opus"])
+
+    async def _fake_team_access(
+        *, user_api_key_dict, prisma_client, llm_router, all_models
+    ):
+        for m in all_models:
+            m.setdefault("model_info", {})
+            m["model_info"]["access_via_team_ids"] = ["t-a"]
+        return all_models
+
+    monkeypatch.setattr(ps, "get_all_team_and_direct_access_models", _fake_team_access)
+
+    resp = client.get(
+        "/v2/model/info?include_team_models=true",
+        headers={"Authorization": "Bearer sk-test"},
+    )
+    assert resp.status_code == 200
+    assert _model_names(resp.json()) == ["claude-3-opus"]
+
+
+def test_v2_model_info_include_team_models_unrestricted_user_sees_team_set(
+    client, configure_router, monkeypatch
+):
+    """Open user (models=[]) + include_team_models=true → no user-level
+    narrowing, returns whatever the team-access path returns.
+
+    Verifies the defense-in-depth filter doesn't accidentally over-narrow
+    when user.models is empty: it must be a pure pass-through in that case.
+    """
+    _override_auth(user_id="u-test")
+    _patch_user(monkeypatch, models=[])
+
+    async def _fake_team_access(
+        *, user_api_key_dict, prisma_client, llm_router, all_models
+    ):
+        # Team grants access to only 2 of the 5 — keep them, drop the rest.
+        allowed_via_team = {"claude-3-opus", "claude-3-haiku"}
+        filtered = []
+        for m in all_models:
+            if m["model_name"] in allowed_via_team:
+                m.setdefault("model_info", {})
+                m["model_info"]["access_via_team_ids"] = ["t-a"]
+                filtered.append(m)
+        return filtered
+
+    monkeypatch.setattr(ps, "get_all_team_and_direct_access_models", _fake_team_access)
+
+    resp = client.get(
+        "/v2/model/info?include_team_models=true",
+        headers={"Authorization": "Bearer sk-test"},
+    )
+    assert resp.status_code == 200
+    assert _model_names(resp.json()) == ["claude-3-haiku", "claude-3-opus"]
+
+
+def test_v2_model_info_include_team_models_no_default_models_returns_empty(
+    client, configure_router, monkeypatch
+):
+    """`no-default-models` sentinel must wipe the list even when a team
+    granted access. Inference-time `can_user_call_model` raises on this
+    sentinel; the discovery endpoint must agree."""
+    _override_auth(user_id="u-test")
+    _patch_user(monkeypatch, models=["no-default-models"])
+
+    async def _fake_team_access(
+        *, user_api_key_dict, prisma_client, llm_router, all_models
+    ):
+        for m in all_models:
+            m.setdefault("model_info", {})
+            m["model_info"]["access_via_team_ids"] = ["t-a"]
+        return all_models
+
+    monkeypatch.setattr(ps, "get_all_team_and_direct_access_models", _fake_team_access)
+
+    resp = client.get(
+        "/v2/model/info?include_team_models=true",
+        headers={"Authorization": "Bearer sk-test"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["data"] == []

--- a/tests/test_litellm/proxy/test_model_info_default_limits.py
+++ b/tests/test_litellm/proxy/test_model_info_default_limits.py
@@ -115,6 +115,11 @@ class TestModelInfoEndpointWithRouter:
 
         mock_router = MagicMock()
         mock_router.get_deployment.return_value = deployment
+        # By-id now authorizes against the listing-path filter; stub
+        # what `get_available_models_for_user` reads from the router so
+        # "model1" is in the allowlist.
+        mock_router.get_model_names.return_value = ["model1"]
+        mock_router.get_model_access_groups.return_value = {}
 
         user_api_key_dict = UserAPIKeyAuth(api_key="sk-test")
 
@@ -122,6 +127,14 @@ class TestModelInfoEndpointWithRouter:
             patch("litellm.proxy.proxy_server.llm_router", mock_router),
             patch("litellm.proxy.proxy_server.llm_model_list", []),
             patch("litellm.proxy.proxy_server.user_model", None),
+            patch("litellm.proxy.proxy_server.get_key_models", return_value=["model1"]),
+            patch(
+                "litellm.proxy.proxy_server.get_team_models", return_value=["model1"]
+            ),
+            patch(
+                "litellm.proxy.proxy_server.get_complete_model_list",
+                return_value=["model1"],
+            ),
         ):
             response = await model_info_v1(
                 user_api_key_dict=user_api_key_dict,

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -3984,6 +3984,7 @@ async def test_model_info_v1_oci_secrets_not_leaked():
     mock_user_api_key_dict = MagicMock(spec=UserAPIKeyAuth)
     mock_user_api_key_dict.user_id = "test-user"
     mock_user_api_key_dict.api_key = "test-key"
+    mock_user_api_key_dict.team_id = None
     mock_user_api_key_dict.team_models = []
     mock_user_api_key_dict.models = ["oci-grok-test"]
 


### PR DESCRIPTION
## Relevant issues

Fixes #26420.

## Pre-Submission checklist

- [x] I have added meaningful tests (40 passed against `tests/test_litellm/proxy/discovery_endpoints/`)
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Type

🐛 Bug Fix

## Summary

The proxy correctly enforces `user.models` at inference time (`_check_model_access_helper` at `/v1/chat/completions` returns 401) but silently ignores it on the **discovery endpoints**:

| Check | inference path | discovery path |
|---|---|---|
| `key.models` | ✅ blocked | ✅ filtered |
| `team.models` | ✅ blocked | ✅ filtered |
| `user.models` | ✅ blocked | ❌ **not filtered** |

A user with `user.models = ["common-models"]` (an access group) sees the full proxy model list on `/v1/models`, `/v1/model/info`, and `/v2/model/info` — confusing UX and a leak of restricted model names.

## Root cause

`get_available_models_for_user()` in `litellm/proxy/utils.py` sources the model list from `user_api_key_dict` (key + team view) only. The user object's `models` field is loaded by `user_api_key_auth` but never reaches the discovery layer.

## Fix

Two commits — one per endpoint family — kept separate so the v1/models change is reviewable in isolation:

1. **`/v1/models`**: add `get_user_models()` + `filter_models_by_user_access()` helpers in `litellm/proxy/auth/model_checks.py` (mirroring the existing `get_key_models` / `get_team_models` helpers) and call them as a final intersection step inside `get_available_models_for_user()`.

2. **`/v1/model/info` + `/v2/model/info`**: thread the same filter through `proxy_server.model_info_v1` / `model_info_v2`. Both endpoints already had key+team filtering; this just adds the user dimension consistently.

**Defense-in-depth** — the filter only narrows what the key/team layer already permitted, never expands it.

## Semantics

The filter matches `can_user_call_model()` at inference time exactly:

| `user.models` value | Behavior |
|---|---|
| `[]` | no filter |
| `["no-default-models"]` | empty list |
| `["all-proxy-models"]` | no filter |
| raw model names | exact match |
| access group names (e.g. `"common-models"`) | expand via `litellm.access_groups` |
| wildcards (`"anthropic/*"`, `"*"`) | `fnmatch.fnmatchcase` |
| `user_id` is `None` (master/service key) | no filter |
| `get_user_object` failure | no filter (swallow + log) |

## Tests

Three new test modules under `tests/test_litellm/proxy/discovery_endpoints/`:

- `test_v1_models_user_filter.py` — covers all 8 semantics rows above
- `test_v1_model_info_user_filter.py` — parallel coverage for `/v1/model/info`
- `test_v2_model_info_user_filter.py` — parallel coverage for `/v2/model/info`, plus `proxy_admin` bypass

```bash
$ python3 -m pytest tests/test_litellm/proxy/discovery_endpoints/ -q
........................................                                 [100%]
40 passed in 10.21s
```

## Backward compatibility

- Users with no `user.models` set (the common case) see no change — `[]` short-circuits to "no filter".
- Master key / service-account keys (no `user_id`) bypass the filter entirely.
- All existing `key.models` / `team.models` tests pass unmodified.

Co-authored-by: songkuan-zheng <songkuan-zheng@users.noreply.github.com>
