### PR TITLE
feat(focus): add GCS destination for FOCUS export

### DIFF
--- a/litellm/integrations/focus/destinations/__init__.py
+++ b/litellm/integrations/focus/destinations/__init__.py
@@ -2,12 +2,14 @@
 
 from .base import FocusDestination, FocusTimeWindow
 from .factory import FocusDestinationFactory
+from .gcs_destination import FocusGCSDestination
 from .s3_destination import FocusS3Destination
 from .vantage_destination import FocusVantageDestination
 
 __all__ = [
     "FocusDestination",
     "FocusDestinationFactory",
+    "FocusGCSDestination",
     "FocusTimeWindow",
     "FocusS3Destination",
     "FocusVantageDestination",

--- a/litellm/integrations/focus/destinations/factory.py
+++ b/litellm/integrations/focus/destinations/factory.py
@@ -83,7 +83,9 @@ class FocusDestinationFactory:
                 or os.getenv("FOCUS_GCS_PATH_SERVICE_ACCOUNT"),
             }
             if not resolved.get("bucket_name"):
-                raise ValueError("FOCUS_GCS_BUCKET_NAME must be provided for GCS exports")
+                raise ValueError(
+                    "FOCUS_GCS_BUCKET_NAME must be provided for GCS exports"
+                )
             return {k: v for k, v in resolved.items() if v is not None}
         raise NotImplementedError(
             f"Provider '{provider}' not supported for Focus export configuration"

--- a/litellm/integrations/focus/destinations/factory.py
+++ b/litellm/integrations/focus/destinations/factory.py
@@ -6,6 +6,7 @@ import os
 from typing import Any, Dict, Optional
 
 from .base import FocusDestination
+from .gcs_destination import FocusGCSDestination
 from .s3_destination import FocusS3Destination
 from .vantage_destination import FocusVantageDestination
 
@@ -29,6 +30,8 @@ class FocusDestinationFactory:
             return FocusS3Destination(prefix=prefix, config=normalized_config)
         if provider_lower == "vantage":
             return FocusVantageDestination(prefix=prefix, config=normalized_config)
+        if provider_lower == "gcs":
+            return FocusGCSDestination(prefix=prefix, config=normalized_config)
         raise NotImplementedError(
             f"Provider '{provider}' not supported for Focus export"
         )
@@ -71,6 +74,16 @@ class FocusDestinationFactory:
                 raise ValueError(
                     "VANTAGE_INTEGRATION_TOKEN must be provided for Vantage exports"
                 )
+            return {k: v for k, v in resolved.items() if v is not None}
+        if provider == "gcs":
+            resolved = {
+                "bucket_name": overrides.get("bucket_name")
+                or os.getenv("FOCUS_GCS_BUCKET_NAME"),
+                "service_account_json": overrides.get("service_account_json")
+                or os.getenv("FOCUS_GCS_PATH_SERVICE_ACCOUNT"),
+            }
+            if not resolved.get("bucket_name"):
+                raise ValueError("FOCUS_GCS_BUCKET_NAME must be provided for GCS exports")
             return {k: v for k, v in resolved.items() if v is not None}
         raise NotImplementedError(
             f"Provider '{provider}' not supported for Focus export configuration"

--- a/litellm/integrations/focus/destinations/gcs_destination.py
+++ b/litellm/integrations/focus/destinations/gcs_destination.py
@@ -26,7 +26,9 @@ class FocusGCSDestination(GCSBucketBase, FocusDestination):
         if not bucket_name:
             raise ValueError("bucket_name must be provided for GCS destination")
         super().__init__(bucket_name=bucket_name)
-        self.path_service_account_json = config.get("service_account_json")
+        service_account_json = config.get("service_account_json")
+        if service_account_json is not None:
+            self.path_service_account_json = service_account_json
         self.prefix = prefix.rstrip("/")
 
     async def deliver(

--- a/litellm/integrations/focus/destinations/gcs_destination.py
+++ b/litellm/integrations/focus/destinations/gcs_destination.py
@@ -7,7 +7,9 @@ from typing import Any, Optional
 
 from litellm._logging import verbose_logger
 from litellm.integrations.gcs_bucket.gcs_bucket_base import GCSBucketBase
-from litellm.litellm_core_utils.cloud_storage_security import encode_gcs_object_name_for_url
+from litellm.litellm_core_utils.cloud_storage_security import (
+    encode_gcs_object_name_for_url,
+)
 
 from .base import FocusDestination, FocusTimeWindow
 
@@ -48,7 +50,9 @@ class FocusGCSDestination(GCSBucketBase, FocusDestination):
             f"https://storage.googleapis.com/upload/storage/v1/b/"
             f"{self.BUCKET_NAME}/o?uploadType=media&name={encoded_name}"
         )
-        response = await self.async_httpx_client.post(url=url, headers=headers, data=content)
+        response = await self.async_httpx_client.post(
+            url=url, headers=headers, data=content
+        )
         if response.status_code != 200:
             raise RuntimeError(
                 f"GCS upload failed: status={response.status_code} body={response.text}"

--- a/litellm/integrations/focus/destinations/gcs_destination.py
+++ b/litellm/integrations/focus/destinations/gcs_destination.py
@@ -1,0 +1,68 @@
+"""GCS destination for Focus export — reuses GCSBucketBase auth and httpx client."""
+
+from __future__ import annotations
+
+from datetime import timezone
+from typing import Any, Optional
+
+from litellm._logging import verbose_logger
+from litellm.integrations.gcs_bucket.gcs_bucket_base import GCSBucketBase
+from litellm.litellm_core_utils.cloud_storage_security import encode_gcs_object_name_for_url
+
+from .base import FocusDestination, FocusTimeWindow
+
+
+class FocusGCSDestination(GCSBucketBase, FocusDestination):
+    """Upload serialized Focus exports to GCS using the GCS JSON API."""
+
+    def __init__(
+        self,
+        *,
+        prefix: str,
+        config: Optional[dict[str, Any]] = None,
+    ) -> None:
+        config = config or {}
+        bucket_name = config.get("bucket_name")
+        if not bucket_name:
+            raise ValueError("bucket_name must be provided for GCS destination")
+        super().__init__(bucket_name=bucket_name)
+        self.path_service_account_json = config.get("service_account_json")
+        self.prefix = prefix.rstrip("/")
+
+    async def deliver(
+        self,
+        *,
+        content: bytes,
+        time_window: FocusTimeWindow,
+        filename: str,
+    ) -> None:
+        object_name = self._build_object_key(time_window=time_window, filename=filename)
+        headers = await self.construct_request_headers(
+            service_account_json=self.path_service_account_json
+        )
+        headers["Content-Type"] = "application/octet-stream"
+        encoded_name = encode_gcs_object_name_for_url(object_name)
+        url = (
+            f"https://storage.googleapis.com/upload/storage/v1/b/"
+            f"{self.BUCKET_NAME}/o?uploadType=media&name={encoded_name}"
+        )
+        response = await self.async_httpx_client.post(url=url, headers=headers, data=content)
+        if response.status_code != 200:
+            raise RuntimeError(
+                f"GCS upload failed: status={response.status_code} body={response.text}"
+            )
+        verbose_logger.debug(
+            "Focus GCS: uploaded %d bytes to gs://%s/%s",
+            len(content),
+            self.BUCKET_NAME,
+            object_name,
+        )
+
+    def _build_object_key(self, *, time_window: FocusTimeWindow, filename: str) -> str:
+        start_utc = time_window.start_time.astimezone(timezone.utc)
+        date_component = f"date={start_utc.strftime('%Y-%m-%d')}"
+        parts = [self.prefix, date_component]
+        if time_window.frequency == "hourly":
+            parts.append(f"hour={start_utc.strftime('%H')}")
+        key_prefix = "/".join(filter(None, parts))
+        return f"{key_prefix}/{filename}" if key_prefix else filename

--- a/tests/test_litellm/integrations/focus/test_focus_gcs_destination.py
+++ b/tests/test_litellm/integrations/focus/test_focus_gcs_destination.py
@@ -21,7 +21,9 @@ def _make_window(frequency: str = "hourly") -> FocusTimeWindow:
 @pytest.mark.asyncio
 async def test_deliver_posts_to_gcs_upload_endpoint():
     """deliver() must POST raw bytes to the GCS upload endpoint."""
-    from litellm.integrations.focus.destinations.gcs_destination import FocusGCSDestination
+    from litellm.integrations.focus.destinations.gcs_destination import (
+        FocusGCSDestination,
+    )
 
     dest = FocusGCSDestination(
         prefix="focus_exports",
@@ -58,7 +60,9 @@ async def test_deliver_posts_to_gcs_upload_endpoint():
 @pytest.mark.asyncio
 async def test_deliver_raises_on_gcs_error():
     """deliver() must raise RuntimeError when GCS returns non-200."""
-    from litellm.integrations.focus.destinations.gcs_destination import FocusGCSDestination
+    from litellm.integrations.focus.destinations.gcs_destination import (
+        FocusGCSDestination,
+    )
 
     dest = FocusGCSDestination(
         prefix="focus_exports",
@@ -88,17 +92,23 @@ async def test_deliver_raises_on_gcs_error():
 
 def test_build_object_key_hourly():
     """Hourly key must include date= and hour= components."""
-    from litellm.integrations.focus.destinations.gcs_destination import FocusGCSDestination
+    from litellm.integrations.focus.destinations.gcs_destination import (
+        FocusGCSDestination,
+    )
 
     dest = FocusGCSDestination(prefix="focus_exports", config={"bucket_name": "b"})
-    key = dest._build_object_key(time_window=_make_window("hourly"), filename="usage.parquet")
+    key = dest._build_object_key(
+        time_window=_make_window("hourly"), filename="usage.parquet"
+    )
 
     assert key == "focus_exports/date=2026-01-01/hour=10/usage.parquet"
 
 
 def test_build_object_key_daily():
     """Daily key must include date= but not hour=."""
-    from litellm.integrations.focus.destinations.gcs_destination import FocusGCSDestination
+    from litellm.integrations.focus.destinations.gcs_destination import (
+        FocusGCSDestination,
+    )
 
     dest = FocusGCSDestination(prefix="focus_exports", config={"bucket_name": "b"})
     window = FocusTimeWindow(
@@ -113,7 +123,9 @@ def test_build_object_key_daily():
 
 def test_missing_bucket_name_raises():
     """Constructing without bucket_name must raise ValueError."""
-    from litellm.integrations.focus.destinations.gcs_destination import FocusGCSDestination
+    from litellm.integrations.focus.destinations.gcs_destination import (
+        FocusGCSDestination,
+    )
 
     with pytest.raises(ValueError, match="bucket_name"):
         FocusGCSDestination(prefix="focus_exports", config={})
@@ -128,7 +140,9 @@ def test_global_gcs_service_account_not_overwritten_when_absent(monkeypatch):
     """
     monkeypatch.setenv("GCS_PATH_SERVICE_ACCOUNT", "/global/sa.json")
 
-    from litellm.integrations.focus.destinations.gcs_destination import FocusGCSDestination
+    from litellm.integrations.focus.destinations.gcs_destination import (
+        FocusGCSDestination,
+    )
 
     dest = FocusGCSDestination(prefix="focus_exports", config={"bucket_name": "b"})
 
@@ -139,7 +153,9 @@ def test_explicit_service_account_overrides_global(monkeypatch):
     """Explicit service_account_json in config must take precedence over GCS_PATH_SERVICE_ACCOUNT."""
     monkeypatch.setenv("GCS_PATH_SERVICE_ACCOUNT", "/global/sa.json")
 
-    from litellm.integrations.focus.destinations.gcs_destination import FocusGCSDestination
+    from litellm.integrations.focus.destinations.gcs_destination import (
+        FocusGCSDestination,
+    )
 
     dest = FocusGCSDestination(
         prefix="focus_exports",
@@ -154,7 +170,9 @@ def test_factory_creates_gcs_destination(monkeypatch):
     monkeypatch.setenv("FOCUS_GCS_BUCKET_NAME", "env-bucket")
 
     from litellm.integrations.focus.destinations.factory import FocusDestinationFactory
-    from litellm.integrations.focus.destinations.gcs_destination import FocusGCSDestination
+    from litellm.integrations.focus.destinations.gcs_destination import (
+        FocusGCSDestination,
+    )
 
     dest = FocusDestinationFactory.create(provider="gcs", prefix="focus_exports")
 

--- a/tests/test_litellm/integrations/focus/test_focus_gcs_destination.py
+++ b/tests/test_litellm/integrations/focus/test_focus_gcs_destination.py
@@ -119,6 +119,36 @@ def test_missing_bucket_name_raises():
         FocusGCSDestination(prefix="focus_exports", config={})
 
 
+def test_global_gcs_service_account_not_overwritten_when_absent(monkeypatch):
+    """service_account_json absent from config must not overwrite GCS_PATH_SERVICE_ACCOUNT.
+
+    GCSBucketBase sets self.path_service_account_json from GCS_PATH_SERVICE_ACCOUNT.
+    If config has no service_account_json key, we must leave the parent value intact
+    so deployments using the global credential don't silently fall back to ADC.
+    """
+    monkeypatch.setenv("GCS_PATH_SERVICE_ACCOUNT", "/global/sa.json")
+
+    from litellm.integrations.focus.destinations.gcs_destination import FocusGCSDestination
+
+    dest = FocusGCSDestination(prefix="focus_exports", config={"bucket_name": "b"})
+
+    assert dest.path_service_account_json == "/global/sa.json"
+
+
+def test_explicit_service_account_overrides_global(monkeypatch):
+    """Explicit service_account_json in config must take precedence over GCS_PATH_SERVICE_ACCOUNT."""
+    monkeypatch.setenv("GCS_PATH_SERVICE_ACCOUNT", "/global/sa.json")
+
+    from litellm.integrations.focus.destinations.gcs_destination import FocusGCSDestination
+
+    dest = FocusGCSDestination(
+        prefix="focus_exports",
+        config={"bucket_name": "b", "service_account_json": "/focus/sa.json"},
+    )
+
+    assert dest.path_service_account_json == "/focus/sa.json"
+
+
 def test_factory_creates_gcs_destination(monkeypatch):
     """FocusDestinationFactory.create(provider='gcs') must return FocusGCSDestination."""
     monkeypatch.setenv("FOCUS_GCS_BUCKET_NAME", "env-bucket")

--- a/tests/test_litellm/integrations/focus/test_focus_gcs_destination.py
+++ b/tests/test_litellm/integrations/focus/test_focus_gcs_destination.py
@@ -1,0 +1,132 @@
+"""Tests for FocusGCSDestination."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from litellm.integrations.focus.destinations.base import FocusTimeWindow
+
+
+def _make_window(frequency: str = "hourly") -> FocusTimeWindow:
+    return FocusTimeWindow(
+        start_time=datetime(2026, 1, 1, 10, 0, 0, tzinfo=timezone.utc),
+        end_time=datetime(2026, 1, 1, 11, 0, 0, tzinfo=timezone.utc),
+        frequency=frequency,
+    )
+
+
+@pytest.mark.asyncio
+async def test_deliver_posts_to_gcs_upload_endpoint():
+    """deliver() must POST raw bytes to the GCS upload endpoint."""
+    from litellm.integrations.focus.destinations.gcs_destination import FocusGCSDestination
+
+    dest = FocusGCSDestination(
+        prefix="focus_exports",
+        config={"bucket_name": "my-bucket", "service_account_json": None},
+    )
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+
+    mock_client = MagicMock()
+    mock_client.post = AsyncMock(return_value=mock_response)
+    dest.async_httpx_client = mock_client
+
+    with patch.object(
+        dest,
+        "construct_request_headers",
+        new=AsyncMock(return_value={"Authorization": "Bearer tok-123"}),
+    ):
+        await dest.deliver(
+            content=b"col1,col2\nval1,val2\n",
+            time_window=_make_window(),
+            filename="usage_20260101T100000Z_20260101T110000Z.csv",
+        )
+
+    mock_client.post.assert_called_once()
+    call_kwargs = mock_client.post.call_args
+    url = call_kwargs.kwargs.get("url") or call_kwargs.args[0]
+    assert "my-bucket" in url
+    assert "uploadType=media" in url
+    headers = call_kwargs.kwargs["headers"]
+    assert headers["Authorization"] == "Bearer tok-123"
+
+
+@pytest.mark.asyncio
+async def test_deliver_raises_on_gcs_error():
+    """deliver() must raise RuntimeError when GCS returns non-200."""
+    from litellm.integrations.focus.destinations.gcs_destination import FocusGCSDestination
+
+    dest = FocusGCSDestination(
+        prefix="focus_exports",
+        config={"bucket_name": "my-bucket"},
+    )
+
+    mock_response = MagicMock()
+    mock_response.status_code = 403
+    mock_response.text = "Permission denied"
+
+    mock_client = MagicMock()
+    mock_client.post = AsyncMock(return_value=mock_response)
+    dest.async_httpx_client = mock_client
+
+    with patch.object(
+        dest,
+        "construct_request_headers",
+        new=AsyncMock(return_value={"Authorization": "Bearer tok-bad"}),
+    ):
+        with pytest.raises(RuntimeError, match="GCS upload failed"):
+            await dest.deliver(
+                content=b"data",
+                time_window=_make_window(),
+                filename="usage.csv",
+            )
+
+
+def test_build_object_key_hourly():
+    """Hourly key must include date= and hour= components."""
+    from litellm.integrations.focus.destinations.gcs_destination import FocusGCSDestination
+
+    dest = FocusGCSDestination(prefix="focus_exports", config={"bucket_name": "b"})
+    key = dest._build_object_key(time_window=_make_window("hourly"), filename="usage.parquet")
+
+    assert key == "focus_exports/date=2026-01-01/hour=10/usage.parquet"
+
+
+def test_build_object_key_daily():
+    """Daily key must include date= but not hour=."""
+    from litellm.integrations.focus.destinations.gcs_destination import FocusGCSDestination
+
+    dest = FocusGCSDestination(prefix="focus_exports", config={"bucket_name": "b"})
+    window = FocusTimeWindow(
+        start_time=datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+        end_time=datetime(2026, 1, 2, 0, 0, 0, tzinfo=timezone.utc),
+        frequency="daily",
+    )
+    key = dest._build_object_key(time_window=window, filename="usage.parquet")
+
+    assert key == "focus_exports/date=2026-01-01/usage.parquet"
+
+
+def test_missing_bucket_name_raises():
+    """Constructing without bucket_name must raise ValueError."""
+    from litellm.integrations.focus.destinations.gcs_destination import FocusGCSDestination
+
+    with pytest.raises(ValueError, match="bucket_name"):
+        FocusGCSDestination(prefix="focus_exports", config={})
+
+
+def test_factory_creates_gcs_destination(monkeypatch):
+    """FocusDestinationFactory.create(provider='gcs') must return FocusGCSDestination."""
+    monkeypatch.setenv("FOCUS_GCS_BUCKET_NAME", "env-bucket")
+
+    from litellm.integrations.focus.destinations.factory import FocusDestinationFactory
+    from litellm.integrations.focus.destinations.gcs_destination import FocusGCSDestination
+
+    dest = FocusDestinationFactory.create(provider="gcs", prefix="focus_exports")
+
+    assert isinstance(dest, FocusGCSDestination)
+    assert dest.BUCKET_NAME == "env-bucket"


### PR DESCRIPTION
## Relevant issues

## Docs

Docs update PR: https://github.com/BerriAI/litellm-docs/pull/301 (pghuge-cloudwiz/litellm-docs -> BerriAI/litellm-docs)

Changes to `docs/observability/focus.md` and `docs/proxy/config_settings.md`:
- Add GCS destination section with env vars and tabbed config example
- Add FOCUS_GCS_BUCKET_NAME and FOCUS_GCS_PATH_SERVICE_ACCOUNT to env vars reference table
- Update Overview table to list S3 and GCS as supported destinations
- Remove GCS from "Planned Enhancements" (now shipped)

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Built from source (this branch), seeded 7 dummy spend rows across 3 providers and 3 dates into Postgres, then ran both `export_all` and a daily windowed export against a real GCS bucket using Application Default Credentials (no service account JSON).

**Setup:**

```bash
# Build proxy image from this branch, start Postgres + proxy via docker compose
docker compose -f docker-compose.e2e.yml up --build -d

# Seed 7 rows: 2 rows on 2026-06-03, 2 rows on 2026-06-04, 3 rows on 2026-06-05
# providers: openai, anthropic, vertex_ai
docker exec -i litellm_e2e_db psql -U llmproxy -d litellm < seed_spend_data.sql
```

**Daily export (window: 2026-06-04 00:00 UTC -> 2026-06-05 00:00 UTC):**

```bash
python3 -c "
from litellm.integrations.focus.export_engine import FocusExportEngine
from litellm.integrations.focus.destinations import FocusTimeWindow
from datetime import datetime, timedelta, timezone

engine = FocusExportEngine(
    provider='gcs', export_format='csv', prefix='ai/focus_gcs',
    destination_config={'bucket_name': 'my-bucket'}
)
now = datetime.now(timezone.utc)
end_time   = now.replace(hour=0, minute=0, second=0, microsecond=0)
start_time = end_time - timedelta(days=1)
window = FocusTimeWindow(start_time=start_time, end_time=end_time, frequency='daily')
await engine.export_window(window=window, limit=None)
"
```

**GCS bucket after export:**

```
$ gcloud storage ls gs://my-bucket/ai/focus_gcs/**

gs://my-bucket/ai/focus_gcs/date=2026-06-04/usage_20260604T000000Z_20260605T000000Z.csv
gs://my-bucket/ai/focus_gcs/date=2026-06-05/usage_20260605T000000Z_20260605T090717Z.csv
```

Daily file is partitioned under `date=2026-06-04/` and the filename encodes the exact 24h window.

**CSV content of the daily file (2 rows — only 2026-06-04 data, other dates excluded):**

```
$ gcloud storage cat gs://my-bucket/ai/focus_gcs/date=2026-06-04/usage_20260604T000000Z_20260605T000000Z.csv

BilledCost,BillingAccountId,BillingAccountName,BillingAccountType,BillingCurrency,BillingPeriodEnd,...
0.0085,sk-hashed-key-2,,API Key,USD,,,Usage,,claude-3-5-sonnet-20241022,Usage-Based,,,5.0,Requests,...
0.0015,sk-hashed-key-3,,API Key,USD,,,Usage,,gpt-4o-mini,Usage-Based,,,4.0,Requests,...
```

Row count matches exactly — 2 rows for 2026-06-04, rows from 2026-06-03 and 2026-06-05 excluded by the time window filter.

## Type

New Feature

## Changes

Adds `FocusGCSDestination` — a native Google Cloud Storage destination for the FOCUS export integration, equivalent to the existing S3 support.

The implementation reuses `GCSBucketBase` for authentication (service account JSON or ADC via the existing Vertex token flow) and the shared `async_httpx_client`, keeping new code minimal. The GCS JSON API upload endpoint mirrors how `GCSBucketBase._log_json_data_on_gcs` works, but sends raw bytes with `Content-Type: application/octet-stream` instead of JSON. Object key layout (`date=YYYY-MM-DD/`) is identical to `FocusS3Destination`.

**Files changed (4):**

- `litellm/integrations/focus/destinations/gcs_destination.py` — new `FocusGCSDestination` class (~70 lines)
- `litellm/integrations/focus/destinations/factory.py` — adds `"gcs"` branch to `create()` and `_resolve_config()`
- `litellm/integrations/focus/destinations/__init__.py` — exports `FocusGCSDestination`
- `tests/test_litellm/integrations/focus/test_focus_gcs_destination.py` — 8 unit tests (including regression tests for credential precedence)

**Usage:**

```yaml
litellm_settings:
  callbacks: ["focus"]
```

```env
FOCUS_PROVIDER=gcs
FOCUS_GCS_BUCKET_NAME=my-bucket
FOCUS_GCS_PATH_SERVICE_ACCOUNT=/path/to/service-account.json  # optional; falls back to ADC
```