### PR TITLE
Fix encrypted content affinity priority over deployment affinity

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -1658,11 +1658,102 @@ class Router:
                     f"Dictionary '{fallback_dict}' must have exactly one key, but has {len(fallback_dict)} keys."
                 )
 
+    @staticmethod
+    def _insert_callback_before_type(
+        callback_list: List[Any],
+        callback: Any,
+        before_type: Any,
+    ) -> None:
+        insert_index = next(
+            (
+                index
+                for index, existing_callback in enumerate(callback_list)
+                if isinstance(existing_callback, before_type)
+            ),
+            len(callback_list),
+        )
+        callback_list.insert(insert_index, callback)
+
+    @staticmethod
+    def _move_callback_before_type(
+        callback_list: List[Any],
+        callback: Any,
+        callback_type: Any,
+        before_type: Any,
+    ) -> None:
+        callback_to_move = None
+        for existing_callback in callback_list:
+            if existing_callback is callback:
+                callback_to_move = existing_callback
+                break
+
+        if callback_to_move is None:
+            for existing_callback in callback_list:
+                if isinstance(existing_callback, callback_type):
+                    callback_to_move = existing_callback
+                    break
+
+        if callback_to_move is None:
+            return
+
+        callback_list.remove(callback_to_move)
+        Router._insert_callback_before_type(
+            callback_list=callback_list,
+            callback=callback_to_move,
+            before_type=before_type,
+        )
+
+    def _add_encrypted_content_affinity_check(self) -> None:
+        from litellm.router_utils.pre_call_checks.encrypted_content_affinity_check import (
+            EncryptedContentAffinityCheck,
+        )
+
+        if self.optional_callbacks is None:
+            self.optional_callbacks = []
+
+        ec_callback = next(
+            (
+                cb
+                for cb in self.optional_callbacks
+                if isinstance(cb, EncryptedContentAffinityCheck)
+            ),
+            None,
+        )
+        if ec_callback is None:
+            ec_callback = EncryptedContentAffinityCheck(router=self)
+            self._insert_callback_before_type(
+                callback_list=self.optional_callbacks,
+                callback=ec_callback,
+                before_type=DeploymentAffinityCheck,
+            )
+        else:
+            ec_callback.router = self
+            self._move_callback_before_type(
+                callback_list=self.optional_callbacks,
+                callback=ec_callback,
+                callback_type=EncryptedContentAffinityCheck,
+                before_type=DeploymentAffinityCheck,
+            )
+
+        litellm.logging_callback_manager.add_litellm_callback(ec_callback)
+        self._move_callback_before_type(
+            callback_list=litellm.callbacks,
+            callback=ec_callback,
+            callback_type=EncryptedContentAffinityCheck,
+            before_type=DeploymentAffinityCheck,
+        )
+
     def add_optional_pre_call_checks(
         self, optional_pre_call_checks: Optional[OptionalPreCallChecks]
     ):
         if optional_pre_call_checks is None:
             return
+
+        # ---------------------------------------------------------------------
+        # Encrypted content affinity
+        # ---------------------------------------------------------------------
+        if "encrypted_content_affinity" in optional_pre_call_checks:
+            self._add_encrypted_content_affinity_check()
 
         # ---------------------------------------------------------------------
         # Unified deployment affinity (session stickiness)
@@ -1718,27 +1809,6 @@ class Router:
                 self.optional_callbacks.append(affinity_callback)
                 litellm.logging_callback_manager.add_litellm_callback(affinity_callback)
 
-        # ---------------------------------------------------------------------
-        # Encrypted content affinity
-        # ---------------------------------------------------------------------
-        if "encrypted_content_affinity" in optional_pre_call_checks:
-            from litellm.router_utils.pre_call_checks.encrypted_content_affinity_check import (
-                EncryptedContentAffinityCheck,
-            )
-
-            if self.optional_callbacks is None:
-                self.optional_callbacks = []
-
-            already_registered = any(
-                isinstance(cb, EncryptedContentAffinityCheck)
-                for cb in self.optional_callbacks
-            )
-            if not already_registered:
-                ec_callback = EncryptedContentAffinityCheck(router=self)
-                self.optional_callbacks.append(ec_callback)
-                litellm.logging_callback_manager.add_litellm_callback(ec_callback)
-
-        # ---------------------------------------------------------------------
         # Remaining optional pre-call checks
         # ---------------------------------------------------------------------
         for pre_call_check in optional_pre_call_checks:

--- a/tests/router_unit_tests/test_router_endpoints.py
+++ b/tests/router_unit_tests/test_router_endpoints.py
@@ -772,6 +772,78 @@ def test_apply_default_settings():
         mock_add_checks.assert_called_once_with([])
 
 
+def test_router_encrypted_content_affinity_callback_ordering():
+    from litellm.router_utils.pre_call_checks.deployment_affinity_check import (
+        DeploymentAffinityCheck,
+    )
+    from litellm.router_utils.pre_call_checks.encrypted_content_affinity_check import (
+        EncryptedContentAffinityCheck,
+    )
+
+    original_callbacks = litellm.callbacks
+    litellm.callbacks = []
+    router = Router(
+        model_list=[
+            {
+                "model_name": "openai.gpt-5.1-codex",
+                "litellm_params": {
+                    "model": "openai/gpt-5.1-codex",
+                    "api_key": "mock-api-key",
+                },
+                "model_info": {"id": "deployment-a"},
+            }
+        ],
+        optional_pre_call_checks=["deployment_affinity"],
+    )
+
+    try:
+        deployment_callback = next(
+            cb
+            for cb in router.optional_callbacks or []
+            if isinstance(cb, DeploymentAffinityCheck)
+        )
+        encrypted_callback = EncryptedContentAffinityCheck(router=router)
+
+        callbacks = [deployment_callback]
+        Router._insert_callback_before_type(
+            callback_list=callbacks,
+            callback=encrypted_callback,
+            before_type=DeploymentAffinityCheck,
+        )
+        assert callbacks == [encrypted_callback, deployment_callback]
+
+        callbacks = [deployment_callback, encrypted_callback]
+        Router._move_callback_before_type(
+            callback_list=callbacks,
+            callback=encrypted_callback,
+            callback_type=EncryptedContentAffinityCheck,
+            before_type=DeploymentAffinityCheck,
+        )
+        assert callbacks == [encrypted_callback, deployment_callback]
+
+        router.optional_callbacks = [deployment_callback]
+        litellm.callbacks = [deployment_callback]
+        router._add_encrypted_content_affinity_check()
+
+        assert [
+            type(callback)
+            for callback in router.optional_callbacks or []
+            if isinstance(
+                callback, (EncryptedContentAffinityCheck, DeploymentAffinityCheck)
+            )
+        ] == [EncryptedContentAffinityCheck, DeploymentAffinityCheck]
+        assert [
+            type(callback)
+            for callback in litellm.callbacks
+            if isinstance(
+                callback, (EncryptedContentAffinityCheck, DeploymentAffinityCheck)
+            )
+        ] == [EncryptedContentAffinityCheck, DeploymentAffinityCheck]
+    finally:
+        router.discard()
+        litellm.callbacks = original_callbacks
+
+
 def test_initialize_core_endpoints():
     """
     Test that _initialize_core_endpoints correctly sets up all core router endpoints.

--- a/tests/test_litellm/router_utils/pre_call_checks/test_encrypted_content_affinity_check.py
+++ b/tests/test_litellm/router_utils/pre_call_checks/test_encrypted_content_affinity_check.py
@@ -26,6 +26,12 @@ import pytest
 sys.path.insert(0, os.path.abspath("../.."))
 
 import litellm
+from litellm.router_utils.pre_call_checks.deployment_affinity_check import (
+    DeploymentAffinityCheck,
+)
+from litellm.router_utils.pre_call_checks.encrypted_content_affinity_check import (
+    EncryptedContentAffinityCheck,
+)
 from litellm.responses.utils import ResponsesAPIRequestUtils
 from litellm.types.llms.openai import ResponsesAPIResponse
 
@@ -60,6 +66,46 @@ def _extract_encoded_item_id(response) -> str:
         if item_id.startswith("encitem_"):
             return item_id
     return ""
+
+
+def _build_two_deployment_router(optional_pre_call_checks):
+    return litellm.Router(
+        model_list=[
+            {
+                "model_name": "openai.gpt-5.1-codex",
+                "litellm_params": {
+                    "model": "openai/gpt-5.1-codex",
+                    "api_key": "mock-api-key-1",
+                },
+                "model_info": {"id": "deployment-a"},
+            },
+            {
+                "model_name": "openai.gpt-5.1-codex",
+                "litellm_params": {
+                    "model": "openai/gpt-5.1-codex",
+                    "api_key": "mock-api-key-2",
+                },
+                "model_info": {"id": "deployment-b"},
+            },
+        ],
+        optional_pre_call_checks=optional_pre_call_checks,
+        num_retries=0,
+    )
+
+
+def _affinity_callback_order():
+    return [
+        type(callback).__name__
+        for callback in litellm.callbacks
+        if isinstance(
+            callback,
+            (EncryptedContentAffinityCheck, DeploymentAffinityCheck),
+        )
+    ]
+
+
+def _deployment_ids(deployments):
+    return [deployment["model_info"]["id"] for deployment in deployments]
 
 
 # ---------------------------------------------------------------------------
@@ -266,6 +312,131 @@ class TestRestoreEncryptedContentItemIds:
 # ---------------------------------------------------------------------------
 # Integration tests (router-level)
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "optional_pre_call_checks",
+    [
+        ["deployment_affinity", "encrypted_content_affinity"],
+        ["encrypted_content_affinity", "deployment_affinity"],
+    ],
+)
+async def test_encrypted_content_affinity_wins_over_deployment_affinity(
+    optional_pre_call_checks,
+):
+    """
+    If user-key affinity points to deployment A but encrypted content was produced
+    by deployment B, the encrypted-content routing constraint should win.
+    """
+    original_callbacks = litellm.callbacks
+    litellm.callbacks = []
+    router = None
+
+    try:
+        router = _build_two_deployment_router(
+            optional_pre_call_checks=optional_pre_call_checks,
+        )
+        assert _affinity_callback_order() == [
+            "EncryptedContentAffinityCheck",
+            "DeploymentAffinityCheck",
+        ]
+
+        user_key = "test-user-key"
+        affinity_cache_key = DeploymentAffinityCheck.get_affinity_cache_key(
+            model_group="openai.gpt-5.1-codex",
+            user_key=user_key,
+        )
+        await router.cache.async_set_cache(
+            affinity_cache_key,
+            {"model_id": "deployment-a"},
+            ttl=3600,
+        )
+
+        wrapped_content = (
+            ResponsesAPIRequestUtils._wrap_encrypted_content_with_model_id(
+                "gAAAAABpnW_yEYmSNEyOG_original_content",
+                "deployment-b",
+            )
+        )
+        request_kwargs = {
+            "input": [
+                {
+                    "type": "reasoning",
+                    "encrypted_content": wrapped_content,
+                }
+            ],
+            "litellm_metadata": {"user_api_key_hash": user_key},
+        }
+
+        deployments = await router.async_callback_filter_deployments(
+            model="openai.gpt-5.1-codex",
+            healthy_deployments=router.model_list,
+            messages=None,
+            request_kwargs=request_kwargs,
+            parent_otel_span=None,
+        )
+
+        assert _deployment_ids(deployments) == ["deployment-b"]
+        assert request_kwargs["_encrypted_content_affinity_pinned"] is True
+    finally:
+        if router is not None:
+            router.discard()
+        litellm.callbacks = original_callbacks
+
+
+@pytest.mark.asyncio
+async def test_deployment_affinity_still_applies_without_encrypted_content_marker():
+    """
+    EncryptedContentAffinityCheck should be a no-op for ordinary requests, so
+    deployment_affinity should still apply when no encrypted marker is present.
+    """
+    original_callbacks = litellm.callbacks
+    litellm.callbacks = []
+    router = None
+
+    try:
+        router = _build_two_deployment_router(
+            optional_pre_call_checks=[
+                "deployment_affinity",
+                "encrypted_content_affinity",
+            ],
+        )
+        assert _affinity_callback_order() == [
+            "EncryptedContentAffinityCheck",
+            "DeploymentAffinityCheck",
+        ]
+
+        user_key = "test-user-key"
+        affinity_cache_key = DeploymentAffinityCheck.get_affinity_cache_key(
+            model_group="openai.gpt-5.1-codex",
+            user_key=user_key,
+        )
+        await router.cache.async_set_cache(
+            affinity_cache_key,
+            {"model_id": "deployment-a"},
+            ttl=3600,
+        )
+
+        request_kwargs = {
+            "input": "plain follow-up without encrypted content",
+            "litellm_metadata": {"user_api_key_hash": user_key},
+        }
+
+        deployments = await router.async_callback_filter_deployments(
+            model="openai.gpt-5.1-codex",
+            healthy_deployments=router.model_list,
+            messages=None,
+            request_kwargs=request_kwargs,
+            parent_otel_span=None,
+        )
+
+        assert _deployment_ids(deployments) == ["deployment-a"]
+        assert "_encrypted_content_affinity_pinned" not in request_kwargs
+    finally:
+        if router is not None:
+            router.discard()
+        litellm.callbacks = original_callbacks
 
 
 @pytest.mark.asyncio
@@ -710,10 +881,6 @@ def test_encrypted_content_wrapping_with_multiple_semicolons():
 # ---------------------------------------------------------------------------
 # Regression tests: affinity check must not break tag-based routing
 # ---------------------------------------------------------------------------
-
-from litellm.router_utils.pre_call_checks.encrypted_content_affinity_check import (
-    EncryptedContentAffinityCheck,
-)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Relevant issues

Addresses #29733

## Problem / scenario

`encrypted_content_affinity` is documented as the routing mechanism for Responses API encrypted content in multi-region / multi-key load balancing: https://docs.litellm.ai/docs/response_api#encrypted-content-affinity-multi-region-load-balancing

The failure mode this PR fixes is:

1. A LiteLLM model group has multiple deployments, for example deployment A and deployment B, backed by different upstream API keys / orgs / regions.
2. A Codex / Responses API session receives encrypted content produced by deployment B.
3. The same LiteLLM user key is later associated with deployment A through `deployment_affinity`.
4. A follow-up request sends the encrypted content from deployment B.
5. Before this PR, `DeploymentAffinityCheck` could run first and reduce `healthy_deployments` to deployment A.
6. `EncryptedContentAffinityCheck` would then decode deployment B from the encrypted content, but deployment B had already been filtered out.
7. The request could be sent to a deployment that cannot decrypt the content, resulting in upstream `invalid_encrypted_content`.

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
  - Attempted locally on the rebased branch: `PATH="$HOME/.local/bin:$PATH" make test-unit`
  - Result: failed in local environment. The stable failure is the DB-backed key-rotation E2E test, `tests/test_litellm/proxy/common_utils/test_key_rotation_e2e.py::TestDeprecatedKeyLookupDbE2E::test_deprecated_key_grace_period_cache_hit_path`, because local Prisma could not connect with the current `DATABASE_URL` setup. In the same xdist run, `tests/test_litellm/integrations/test_rubrik.py::TestInitialization::test_init_success` also failed once, but passed when run standalone.
  - Full-run summary before stop: `2 failed, 7810 passed, 80 skipped`.
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Local verification:

```shell
PATH="$HOME/.local/bin:$PATH" poetry run pytest tests/test_litellm/router_utils/pre_call_checks/test_encrypted_content_affinity_check.py tests/test_litellm/router_utils/pre_call_checks/test_deployment_affinity_check.py -vv
# 50 passed

PATH="$HOME/.local/bin:$PATH" poetry run ruff check litellm/router.py tests/test_litellm/router_utils/pre_call_checks/test_encrypted_content_affinity_check.py
# passed

PATH="$HOME/.local/bin:$PATH" poetry run black --check litellm/router.py tests/test_litellm/router_utils/pre_call_checks/test_encrypted_content_affinity_check.py
# passed

PATH="$HOME/.local/bin:$PATH" make lint-ruff
# passed

PATH="$HOME/.local/bin:$PATH" poetry run pytest tests/test_litellm/integrations/test_rubrik.py::TestInitialization::test_init_success -vv
# 1 passed
```

## Type

🐛 Bug Fix
✅ Test

## Changes

- Registers `EncryptedContentAffinityCheck` before `DeploymentAffinityCheck` whenever both checks are enabled, independent of the YAML order in `optional_pre_call_checks`.
- Keeps the current `DeploymentAffinityCheck` behavior for ordinary requests that do not contain encrypted-content markers.
- Preserves the `router=self` reference when constructing `EncryptedContentAffinityCheck`, so existing same-encryption-boundary fallback behavior still works.
- Cleans up the redundant callback repositioning noted by Greptile in the earlier review.
- Adds regression tests for both `optional_pre_call_checks` orderings where user-key affinity points to deployment A but encrypted content points to deployment B, plus a no-marker test showing deployment affinity still applies.

