### PR TITLE
perf(core): fast-path SafeAttributeModel.__delattr__ for declared fields

### DIFF
--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -91,6 +91,16 @@ class SafeAttributeModel:
     """
 
     def __delattr__(self, name):
+        # Dropping an unset optional field stored in __dict__ goes straight to
+        # object.__delattr__, skipping pydantic's __delattr__ whose per-call
+        # class getattr lookup and _check_frozen dominate response construction.
+        if (
+            name in type(self).__pydantic_fields__
+            and name in self.__dict__
+            and not type(self).model_config.get("frozen")
+        ):
+            object.__delattr__(self, name)
+            return
         try:
             super().__delattr__(name)
         except AttributeError:

--- a/tests/test_litellm/types/test_types_utils.py
+++ b/tests/test_litellm/types/test_types_utils.py
@@ -348,3 +348,37 @@ def test_delta_maps_reasoning_to_reasoning_content():
     # When neither is present, reasoning_content is not set (OpenAI spec)
     delta4 = Delta(content="hello")
     assert not hasattr(delta4, "reasoning_content")
+
+
+def test_safe_attribute_model_delattr():
+    """
+    SafeAttributeModel.__delattr__ must remove a field from the instance so it
+    is omitted from model_dump (OpenAI spec), whether the field is a declared
+    model field or an extra, and deleting a missing attribute must be a no-op.
+    """
+    from litellm.types.utils import Message
+
+    # Unset optional declared fields are dropped during __init__ -> absent from dump
+    msg = Message(content="hi", role="assistant")
+    assert not hasattr(msg, "audio")
+    assert not hasattr(msg, "reasoning_content")
+    assert "audio" not in msg.model_dump()
+    assert "reasoning_content" not in msg.model_dump()
+
+    # Explicitly deleting a present declared field removes it from the dump
+    msg2 = Message(content="hi", role="assistant", reasoning_content="because")
+    assert msg2.reasoning_content == "because"
+    del msg2.reasoning_content
+    assert not hasattr(msg2, "reasoning_content")
+    assert "reasoning_content" not in msg2.model_dump()
+
+    # Extra fields (extra='allow') are still deletable via the fallback path
+    msg3 = Message(content="hi", role="assistant", custom_field=123)
+    assert msg3.custom_field == 123
+    del msg3.custom_field
+    assert not hasattr(msg3, "custom_field")
+    assert "custom_field" not in msg3.model_dump()
+
+    # Deleting a non-existent attribute is a silent no-op
+    msg4 = Message(content="hi", role="assistant")
+    del msg4.does_not_exist


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review

## Screenshots / Proof of Fix

Measured with our internal proxy benchmark harness (not externally reproducible yet; numbers provided as claims).

Construction microbenchmark (median of 200k calls, base = current `litellm_internal_staging`):

| construction | base | this PR |
| --- | --- | --- |
| `Message(content, role)` | 5.31 us/call | 2.37 us/call (−55%) |

Response models delete unset optional fields during construction, so this is on the per-request and per-chunk path.

## Type

🚄 Infrastructure

## Changes

Response models (Message, Choices, Usage, and the legacy Delta path) delete unset optional fields in `__init__` so `model_dump` matches the OpenAI spec. Each delete routed through pydantic's `BaseModel.__delattr__`, whose per-call `ModelMetaclass.__getattr__` lookup and `_check_frozen` dominate construction.

When the target is a declared field already present in `__dict__` on a non-frozen model, this deletes it with `object.__delattr__` directly; that matches exactly what pydantic does for that case while skipping the metaclass getattr and the frozen check. It falls back to the previous `super().__delattr__` path for extras, private attributes, cached properties and missing names, so behavior is unchanged; a regression test covers declared-field, extra-field and missing-attribute deletion
