### PR TITLE
perf(utils): route call_type via precomputed frozensets in the per-request wrapper

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -204,6 +204,50 @@ from litellm.types.utils import (
 
 _CALL_TYPE_ENUM_MAP: dict = {ct.value: ct for ct in CallTypes}
 
+_COMPLETION_CALL_TYPE_VALUES = frozenset(
+    {
+        CallTypes.completion.value,
+        CallTypes.acompletion.value,
+        CallTypes.anthropic_messages.value,
+    }
+)
+_COMPLETION_ACOMPLETION_CALL_TYPE_VALUES = frozenset(
+    {CallTypes.completion.value, CallTypes.acompletion.value}
+)
+_EMBEDDING_CALL_TYPE_VALUES = frozenset(
+    {CallTypes.embedding.value, CallTypes.aembedding.value}
+)
+_IMAGE_GENERATION_CALL_TYPE_VALUES = frozenset(
+    {CallTypes.image_generation.value, CallTypes.aimage_generation.value}
+)
+_MODERATION_CALL_TYPE_VALUES = frozenset(
+    {CallTypes.moderation.value, CallTypes.amoderation.value}
+)
+_TEXT_COMPLETION_CALL_TYPE_VALUES = frozenset(
+    {CallTypes.atext_completion.value, CallTypes.text_completion.value}
+)
+_RERANK_CALL_TYPE_VALUES = frozenset({CallTypes.rerank.value, CallTypes.arerank.value})
+_TRANSCRIPTION_CALL_TYPE_VALUES = frozenset(
+    {CallTypes.atranscription.value, CallTypes.transcription.value}
+)
+_SPEECH_CALL_TYPE_VALUES = frozenset({CallTypes.aspeech.value, CallTypes.speech.value})
+_RESPONSES_CALL_TYPE_VALUES = frozenset(
+    {CallTypes.aresponses.value, CallTypes.responses.value}
+)
+_GENERATE_CONTENT_CALL_TYPE_VALUES = frozenset(
+    {
+        CallTypes.generate_content.value,
+        CallTypes.agenerate_content.value,
+        CallTypes.generate_content_stream.value,
+        CallTypes.agenerate_content_stream.value,
+    }
+)
+_COMPLETION_CALL_TYPE_VALUE = CallTypes.completion.value
+_ACOMPLETION_CALL_TYPE_VALUE = CallTypes.acompletion.value
+_RESPONSES_CALL_TYPE_VALUE = CallTypes.responses.value
+_ARESPONSES_CALL_TYPE_VALUE = CallTypes.aresponses.value
+_AREALTIME_CALL_TYPE_VALUE = CallTypes.arealtime.value
+
 # +-----------------------------------------------+
 # |                                               |
 # |           Give Feedback / Get Help            |
@@ -949,11 +993,7 @@ def function_setup(
         # INIT LOGGER - for user-specified integrations
         model = args[0] if len(args) > 0 else kwargs.get("model", None)
         call_type = original_function
-        if (
-            call_type == CallTypes.completion.value
-            or call_type == CallTypes.acompletion.value
-            or call_type == CallTypes.anthropic_messages.value
-        ):
+        if call_type in _COMPLETION_CALL_TYPE_VALUES:
             messages = None
             if len(args) > 1:
                 messages = args[1]
@@ -1030,34 +1070,17 @@ def function_setup(
                     verbose_logger.warning(
                         f"Error removing thought signatures from tool call IDs: {str(e)}"
                     )
-        elif (
-            call_type == CallTypes.embedding.value
-            or call_type == CallTypes.aembedding.value
-        ):
+        elif call_type in _EMBEDDING_CALL_TYPE_VALUES:
             messages = args[1] if len(args) > 1 else kwargs.get("input", None)
-        elif (
-            call_type == CallTypes.image_generation.value
-            or call_type == CallTypes.aimage_generation.value
-        ):
+        elif call_type in _IMAGE_GENERATION_CALL_TYPE_VALUES:
             messages = args[0] if len(args) > 0 else kwargs["prompt"]
-        elif (
-            call_type == CallTypes.moderation.value
-            or call_type == CallTypes.amoderation.value
-        ):
+        elif call_type in _MODERATION_CALL_TYPE_VALUES:
             messages = args[1] if len(args) > 1 else kwargs["input"]
-        elif (
-            call_type == CallTypes.atext_completion.value
-            or call_type == CallTypes.text_completion.value
-        ):
+        elif call_type in _TEXT_COMPLETION_CALL_TYPE_VALUES:
             messages = args[0] if len(args) > 0 else kwargs["prompt"]
-        elif (
-            call_type == CallTypes.rerank.value or call_type == CallTypes.arerank.value
-        ):
+        elif call_type in _RERANK_CALL_TYPE_VALUES:
             messages = kwargs.get("query")
-        elif (
-            call_type == CallTypes.atranscription.value
-            or call_type == CallTypes.transcription.value
-        ):
+        elif call_type in _TRANSCRIPTION_CALL_TYPE_VALUES:
             _file_obj: FileTypes = args[1] if len(args) > 1 else kwargs["file"]
             # Lazy import audio_utils.utils only when needed for transcription calls
             audio_utils = _get_cached_audio_utils()
@@ -1067,14 +1090,9 @@ def function_setup(
             else:
                 kwargs["metadata"] = {"file_checksum": file_checksum}
             messages = file_checksum
-        elif (
-            call_type == CallTypes.aspeech.value or call_type == CallTypes.speech.value
-        ):
+        elif call_type in _SPEECH_CALL_TYPE_VALUES:
             messages = kwargs.get("input", "speech")
-        elif (
-            call_type == CallTypes.aresponses.value
-            or call_type == CallTypes.responses.value
-        ):
+        elif call_type in _RESPONSES_CALL_TYPE_VALUES:
             # Handle both 'input' (standard Responses API) and 'messages' (Cursor chat format)
             messages = (
                 args[0]
@@ -1082,12 +1100,7 @@ def function_setup(
                 else kwargs.get("input")
                 or kwargs.get("messages", "default-message-value")
             )
-        elif (
-            call_type == CallTypes.generate_content.value
-            or call_type == CallTypes.agenerate_content.value
-            or call_type == CallTypes.generate_content_stream.value
-            or call_type == CallTypes.agenerate_content_stream.value
-        ):
+        elif call_type in _GENERATE_CONTENT_CALL_TYPE_VALUES:
             try:
                 from litellm.google_genai.adapters.transformation import (
                     GoogleGenAIAdapter,
@@ -1317,10 +1330,7 @@ def post_call_processing(
             pass
         else:
             call_type = original_function.__name__
-            if (
-                call_type == CallTypes.completion.value
-                or call_type == CallTypes.acompletion.value
-            ):
+            if call_type in _COMPLETION_ACOMPLETION_CALL_TYPE_VALUES:
                 is_coroutine = check_coroutine(original_response)
                 if is_coroutine is True:
                     pass
@@ -1565,11 +1575,7 @@ def client(original_function):
                 and model is not None
                 and litellm.modify_params
                 is True  # user is okay with params being modified
-                and (
-                    call_type == CallTypes.acompletion.value
-                    or call_type == CallTypes.completion.value
-                    or call_type == CallTypes.anthropic_messages.value
-                )
+                and call_type in _COMPLETION_CALL_TYPE_VALUES
             ):
                 try:
                     base_model = model
@@ -1680,7 +1686,7 @@ def client(original_function):
             return result
         except Exception as e:
             call_type = original_function.__name__
-            if call_type == CallTypes.completion.value:
+            if call_type == _COMPLETION_CALL_TYPE_VALUE:
                 num_retries = (
                     kwargs.get("num_retries", None) or litellm.num_retries or None
                 )
@@ -1729,7 +1735,7 @@ def client(original_function):
                     else:
                         kwargs["model"] = context_window_fallback_dict[model]
                     return original_function(*args, **kwargs)
-            elif call_type == CallTypes.responses.value:
+            elif call_type == _RESPONSES_CALL_TYPE_VALUE:
                 num_retries = (
                     kwargs.get("num_retries", None) or litellm.num_retries or None
                 )
@@ -1867,11 +1873,7 @@ def client(original_function):
                 and model is not None
                 and litellm.modify_params
                 is True  # user is okay with params being modified
-                and (
-                    call_type == CallTypes.acompletion.value
-                    or call_type == CallTypes.completion.value
-                    or call_type == CallTypes.anthropic_messages.value
-                )
+                and call_type in _COMPLETION_CALL_TYPE_VALUES
             ):
                 try:
                     base_model = model
@@ -1923,7 +1925,7 @@ def client(original_function):
                         end_time=end_time,
                     )
                     return result
-            elif call_type == CallTypes.arealtime.value:
+            elif call_type == _AREALTIME_CALL_TYPE_VALUE:
                 return result
             ### POST-CALL RULES ###
             post_call_processing(
@@ -2029,7 +2031,7 @@ def client(original_function):
 
             call_type = original_function.__name__
             num_retries, kwargs = _get_wrapper_num_retries(kwargs=kwargs, exception=e)
-            if call_type == CallTypes.acompletion.value:
+            if call_type == _ACOMPLETION_CALL_TYPE_VALUE:
                 context_window_fallback_dict = kwargs.get(
                     "context_window_fallback_dict", {}
                 )
@@ -2067,7 +2069,7 @@ def client(original_function):
                     else:
                         kwargs["model"] = context_window_fallback_dict[model]
                     return await original_function(*args, **kwargs)
-            elif call_type == CallTypes.aresponses.value:
+            elif call_type == _ARESPONSES_CALL_TYPE_VALUE:
                 _is_litellm_router_call = "model_group" in (
                     kwargs.get("metadata") or {}
                 )  # check if call from litellm.router/proxy

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -1178,9 +1178,7 @@ def test_check_provider_match_none_value_matches_any_provider():
         is True
     )
     # When custom_llm_provider is also None nothing constrains the match.
-    assert (
-        litellm.utils._check_provider_match({"litellm_provider": None}, None) is True
-    )
+    assert litellm.utils._check_provider_match({"litellm_provider": None}, None) is True
 
 
 def test_get_provider_rerank_config():
@@ -1545,8 +1543,7 @@ class TestProxyFunctionCalling:
         assert result is True, "Resolvable model names work with fallback logic"
 
         # Documentation notes:
-        print(
-            """
+        print("""
         PROXY MODEL RESOLUTION BEHAVIOR:
         
         ✅ WORKS (with current fallback logic):
@@ -1561,8 +1558,7 @@ class TestProxyFunctionCalling:
            
         💡 SOLUTION: Use LiteLLM proxy server with proper model_list configuration
            that maps custom names to underlying models.
-        """
-        )
+        """)
 
     @pytest.mark.parametrize(
         "proxy_model_with_hints,expected_result",
@@ -1924,8 +1920,7 @@ class TestProxyFunctionCalling:
         This test provides documentation on how the proxy server configuration
         would typically map custom model names to underlying models.
         """
-        print(
-            """
+        print("""
         
         REAL-WORLD PROXY SERVER CONFIGURATION EXAMPLE:
         ===============================================
@@ -1978,8 +1973,7 @@ class TestProxyFunctionCalling:
         - Consistent request/response format
         - Enhanced streaming support for function calls
         
-        """
-        )
+        """)
 
         # Verify that direct underlying models work as expected
         bedrock_models = [
@@ -2193,8 +2187,7 @@ class TestProxyFunctionCalling:
         This test provides documentation on how the proxy server configuration
         would typically map custom model names to underlying models.
         """
-        print(
-            """
+        print("""
         
         REAL-WORLD PROXY SERVER CONFIGURATION EXAMPLE:
         ===============================================
@@ -2247,8 +2240,7 @@ class TestProxyFunctionCalling:
         - Consistent request/response format
         - Enhanced streaming support for function calls
         
-        """
-        )
+        """)
 
         # Verify that direct underlying models work as expected
         bedrock_models = [
@@ -2462,8 +2454,7 @@ class TestProxyFunctionCalling:
         This test provides documentation on how the proxy server configuration
         would typically map custom model names to underlying models.
         """
-        print(
-            """
+        print("""
         
         REAL-WORLD PROXY SERVER CONFIGURATION EXAMPLE:
         ===============================================
@@ -2516,8 +2507,7 @@ class TestProxyFunctionCalling:
         - Consistent request/response format
         - Enhanced streaming support for function calls
         
-        """
-        )
+        """)
 
         # Verify that direct underlying models work as expected
         bedrock_models = [
@@ -4178,7 +4168,9 @@ def test_deepseek_v4_models_in_cost_map():
         ("deepseek-v4-pro", 4.35e-07, 8.7e-07, 3.625e-09),
     ]:
         info = model_cost.get(key)
-        assert info is not None, f"{key} missing from model_prices_and_context_window.json"
+        assert (
+            info is not None
+        ), f"{key} missing from model_prices_and_context_window.json"
         assert info["litellm_provider"] == "deepseek"
         assert info["mode"] == "chat"
         assert info["input_cost_per_token"] == expected_input
@@ -4194,7 +4186,9 @@ def test_deepseek_v4_models_in_cost_map():
         ("deepseek/deepseek-v4-pro", 4.35e-07, 8.7e-07, 3.625e-09),
     ]:
         info = model_cost.get(key)
-        assert info is not None, f"{key} missing from model_prices_and_context_window.json"
+        assert (
+            info is not None
+        ), f"{key} missing from model_prices_and_context_window.json"
         assert info["litellm_provider"] == "deepseek"
         assert info["mode"] == "chat"
         assert info["input_cost_per_token"] == expected_input
@@ -4212,7 +4206,11 @@ def test_deepseek_v4_models_in_backup_cost_map():
     import json
     from pathlib import Path
 
-    json_path = Path(__file__).parents[2] / "litellm" / "model_prices_and_context_window_backup.json"
+    json_path = (
+        Path(__file__).parents[2]
+        / "litellm"
+        / "model_prices_and_context_window_backup.json"
+    )
     with open(json_path) as f:
         model_cost = json.load(f)
 
@@ -4309,3 +4307,100 @@ def test_aws_bedrock_project_id_excluded_from_bedrock_optional_params():
     assert "aws_bedrock_project_id" not in result
     assert result["aws_region_name"] == "us-east-1"
 
+
+class TestCallTypeMembershipSets:
+    """The per-request wrapper routes on call_type via precomputed frozensets of
+    CallTypes values (replacing chained `== CallTypes.X.value or ...` checks).
+    Each set must contain exactly the values it replaced; a dropped, added, or
+    mistyped member would silently misroute a call type, so pin them explicitly."""
+
+    def test_membership_sets_match_enum_values(self):
+        from litellm.types.utils import CallTypes
+        from litellm import utils as u
+
+        expected = {
+            "_COMPLETION_CALL_TYPE_VALUES": {
+                CallTypes.completion,
+                CallTypes.acompletion,
+                CallTypes.anthropic_messages,
+            },
+            "_COMPLETION_ACOMPLETION_CALL_TYPE_VALUES": {
+                CallTypes.completion,
+                CallTypes.acompletion,
+            },
+            "_EMBEDDING_CALL_TYPE_VALUES": {
+                CallTypes.embedding,
+                CallTypes.aembedding,
+            },
+            "_IMAGE_GENERATION_CALL_TYPE_VALUES": {
+                CallTypes.image_generation,
+                CallTypes.aimage_generation,
+            },
+            "_MODERATION_CALL_TYPE_VALUES": {
+                CallTypes.moderation,
+                CallTypes.amoderation,
+            },
+            "_TEXT_COMPLETION_CALL_TYPE_VALUES": {
+                CallTypes.text_completion,
+                CallTypes.atext_completion,
+            },
+            "_RERANK_CALL_TYPE_VALUES": {CallTypes.rerank, CallTypes.arerank},
+            "_TRANSCRIPTION_CALL_TYPE_VALUES": {
+                CallTypes.transcription,
+                CallTypes.atranscription,
+            },
+            "_SPEECH_CALL_TYPE_VALUES": {CallTypes.speech, CallTypes.aspeech},
+            "_RESPONSES_CALL_TYPE_VALUES": {
+                CallTypes.responses,
+                CallTypes.aresponses,
+            },
+            "_GENERATE_CONTENT_CALL_TYPE_VALUES": {
+                CallTypes.generate_content,
+                CallTypes.agenerate_content,
+                CallTypes.generate_content_stream,
+                CallTypes.agenerate_content_stream,
+            },
+        }
+        for name, members in expected.items():
+            assert getattr(u, name) == {m.value for m in members}, name
+
+    def test_membership_sets_use_raw_string_values(self):
+        """Routing compares against original_function (a str), so the sets must
+        hold the enum .value strings, not the enum members."""
+        from litellm import utils as u
+
+        for name in (
+            "_COMPLETION_CALL_TYPE_VALUES",
+            "_EMBEDDING_CALL_TYPE_VALUES",
+            "_GENERATE_CONTENT_CALL_TYPE_VALUES",
+        ):
+            s = getattr(u, name)
+            assert s and all(isinstance(v, str) for v in s), name
+
+    def test_scalar_call_type_values_match_enum_values(self):
+        """The single-value `==` comparisons in the sync/async exception handlers
+        (retry, context-window fallback, realtime early-return) route on these
+        scalar constants. A typo or wrong enum member would silently skip the
+        branch on error, so pin each to the exact enum value it stands in for."""
+        from litellm.types.utils import CallTypes
+        from litellm import utils as u
+
+        assert u._COMPLETION_CALL_TYPE_VALUE == CallTypes.completion.value
+        assert u._ACOMPLETION_CALL_TYPE_VALUE == CallTypes.acompletion.value
+        assert u._RESPONSES_CALL_TYPE_VALUE == CallTypes.responses.value
+        assert u._ARESPONSES_CALL_TYPE_VALUE == CallTypes.aresponses.value
+        assert u._AREALTIME_CALL_TYPE_VALUE == CallTypes.arealtime.value
+
+    def test_streaming_call_types_match_enum_members_and_values(self):
+        """`_is_streaming_request` checks membership against either the enum
+        member or its raw value, so the set must hold both forms for the two
+        streaming generate-content call types."""
+        from litellm.types.utils import CallTypes
+        from litellm import utils as u
+
+        assert u._STREAMING_CALL_TYPES == {
+            CallTypes.generate_content_stream,
+            CallTypes.agenerate_content_stream,
+            CallTypes.generate_content_stream.value,
+            CallTypes.agenerate_content_stream.value,
+        }


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests (pins each membership set to the exact enum values it replaced)
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review

## Screenshots / Proof of Fix

Measured with our internal proxy benchmark harness (not externally reproducible yet; numbers provided as claims).

In a large-context run (500K tokens across 500 messages, mock upstream, single uvicorn worker), litellm's self-measured pre-call processing dropped at p50:

| | base | this PR |
| --- | --- | --- |
| pre-call processing p50 | 34.4 ms | 7.5 ms (−78%) |

The win scales with message count because the routing checks are no longer recomputed per call; at small payloads it sits below the proxy noise floor, so the headline value is large multi-message requests.

## Type

🚄 Infrastructure

## Changes

`function_setup` and `post_call_processing` routed on `call_type` with chains of `call_type == CallTypes.X.value or call_type == CallTypes.Y.value or ...`, recomputing each enum `.value` on every request. This precomputes module-level frozensets of those values once and uses set membership instead.

Behavior is identical; a regression test pins each frozenset to the exact set of enum values it replaced, so a dropped, added or mistyped member fails the test rather than silently misrouting a call type
