### PR TITLE
feat(streaming): add inactivity timeout for stalled provider streams

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -57,6 +57,19 @@ LITELLM_MAX_STREAMING_DURATION_SECONDS = (
     float(_max_stream_duration_env) if _max_stream_duration_env is not None else None
 )
 
+# Max seconds to wait for the next chunk from a streaming provider before
+# raising a Timeout. Guards against a provider that keeps the socket warm
+# (keepalive bytes) but stops sending content, which httpx's read timeout
+# cannot detect. None (default) = disabled. Async streaming only.
+_stream_inactivity_timeout_env = os.getenv(
+    "LITELLM_STREAM_INACTIVITY_TIMEOUT_SECONDS", None
+)
+LITELLM_STREAM_INACTIVITY_TIMEOUT_SECONDS = (
+    float(_stream_inactivity_timeout_env)
+    if _stream_inactivity_timeout_env is not None
+    else None
+)
+
 # Maximum number of base64 characters to keep in logging payloads.
 # Data URIs exceeding this are replaced with a size placeholder.
 # Set to 0 to disable truncation.

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -95,6 +95,38 @@ def print_verbose(print_statement):
         pass
 
 
+class _StreamInactivityGuard:
+    """Async-iterator wrapper that raises litellm.Timeout when the upstream
+    provider sends no chunk within ``timeout`` seconds (inter-chunk inactivity).
+    """
+
+    def __init__(self, inner, timeout, model, custom_llm_provider):
+        self._inner = inner.__aiter__() if hasattr(inner, "__aiter__") else inner
+        self._timeout = timeout
+        self._model = model
+        self._custom_llm_provider = custom_llm_provider
+        self._started = False
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        # First chunk carries connect + time-to-first-token, already bounded by
+        # the request timeout, so only the gaps between later chunks are guarded.
+        if not self._started:
+            chunk = await self._inner.__anext__()
+            self._started = True
+            return chunk
+        try:
+            return await asyncio.wait_for(self._inner.__anext__(), self._timeout)
+        except (asyncio.TimeoutError, TimeoutError) as e:
+            raise litellm.Timeout(
+                message=f"Stream inactivity timeout: no chunk received within {self._timeout}s",
+                model=self._model or "",
+                llm_provider=self._custom_llm_provider or "",
+            ) from e
+
+
 class CustomStreamWrapper:
     def __init__(
         self,
@@ -114,6 +146,7 @@ class CustomStreamWrapper:
         self.sent_first_chunk = False
         self.sent_last_chunk = False
         self._stream_created_time: float = time.time()
+        self._inactivity_source: Optional[Any] = None
 
         litellm_params: GenericLiteLLMParams = GenericLiteLLMParams(
             **self.logging_obj.model_call_details.get("litellm_params", {})
@@ -180,6 +213,28 @@ class CustomStreamWrapper:
         self.is_function_call = self.check_is_function_call(logging_obj=logging_obj)
         self.created: Optional[int] = None
         self._last_returned_hidden_params: Optional[dict] = None
+
+    def _async_inactivity_source(self, completion_stream: Any) -> Any:
+        """Return *completion_stream* wrapped so a mid-stream provider stall
+        raises litellm.Timeout, or the raw stream when the guard is disabled.
+
+        Catches the case where a provider keeps the socket warm (keepalive/SSE
+        comment bytes) but emits no chunks, which httpx's read timeout cannot
+        see. Opt-in via LITELLM_STREAM_INACTIVITY_TIMEOUT_SECONDS; cached so the
+        first-chunk exemption persists across __anext__ calls.
+        """
+        from litellm.constants import LITELLM_STREAM_INACTIVITY_TIMEOUT_SECONDS
+
+        if LITELLM_STREAM_INACTIVITY_TIMEOUT_SECONDS is None:
+            return completion_stream
+        if self._inactivity_source is None:
+            self._inactivity_source = _StreamInactivityGuard(
+                completion_stream,
+                LITELLM_STREAM_INACTIVITY_TIMEOUT_SECONDS,
+                self.model,
+                self.custom_llm_provider,
+            )
+        return self._inactivity_source
 
     def _check_max_streaming_duration(self) -> None:
         """Raise litellm.Timeout if the stream has exceeded LITELLM_MAX_STREAMING_DURATION_SECONDS."""
@@ -2031,7 +2086,7 @@ class CustomStreamWrapper:
                 await self.fetch_stream()
 
             if is_async_iterable(self.completion_stream):
-                async for chunk in self.completion_stream:  # type: ignore[union-attr]
+                async for chunk in self._async_inactivity_source(self.completion_stream):  # type: ignore[union-attr]
                     if chunk == "None" or chunk is None:
                         continue  # skip None chunks
 

--- a/tests/test_litellm/litellm_core_utils/test_stream_inactivity_timeout.py
+++ b/tests/test_litellm/litellm_core_utils/test_stream_inactivity_timeout.py
@@ -1,0 +1,101 @@
+import asyncio
+import os
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../.."))
+
+import litellm
+from litellm.litellm_core_utils.streaming_handler import (
+    CustomStreamWrapper,
+    _StreamInactivityGuard,
+)
+
+
+class _FakeAsyncStream:
+    """Async iterator driven by (delay_seconds, value_or_exception) steps."""
+
+    def __init__(self, steps):
+        self._steps = list(steps)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._steps:
+            raise StopAsyncIteration
+        delay, item = self._steps.pop(0)
+        if delay:
+            await asyncio.sleep(delay)
+        if isinstance(item, BaseException):
+            raise item
+        return item
+
+
+async def _drain(aiterable):
+    out = []
+    async for item in aiterable:
+        out.append(item)
+    return out
+
+
+def test_first_chunk_is_not_guarded():
+    # First chunk carries time-to-first-token, so a slow first chunk must not trip.
+    guard = _StreamInactivityGuard(
+        _FakeAsyncStream([(0.3, "a"), (0.0, "b")]), 0.05, "m", "openai"
+    )
+    assert asyncio.run(_drain(guard)) == ["a", "b"]
+
+
+def test_mid_stream_stall_raises_timeout():
+    guard = _StreamInactivityGuard(
+        _FakeAsyncStream([(0.0, "a"), (0.3, "b")]), 0.05, "m", "openai"
+    )
+
+    async def _run():
+        seen = []
+        agen = guard.__aiter__()
+        seen.append(await agen.__anext__())
+        await agen.__anext__()
+        return seen
+
+    with pytest.raises(litellm.Timeout):
+        asyncio.run(_run())
+
+
+def test_fast_stream_passes_through():
+    guard = _StreamInactivityGuard(
+        _FakeAsyncStream([(0.0, "a"), (0.0, "b"), (0.0, "c")]), 0.5, "m", "openai"
+    )
+    assert asyncio.run(_drain(guard)) == ["a", "b", "c"]
+
+
+def test_exhaustion_propagates_stop_async_iteration():
+    guard = _StreamInactivityGuard(_FakeAsyncStream([(0.0, "a")]), 0.5, "m", "openai")
+    assert asyncio.run(_drain(guard)) == ["a"]
+
+
+def test_source_disabled_returns_raw_stream(monkeypatch):
+    monkeypatch.setattr(
+        "litellm.constants.LITELLM_STREAM_INACTIVITY_TIMEOUT_SECONDS", None
+    )
+    wrapper = CustomStreamWrapper(
+        completion_stream=None, model=None, logging_obj=MagicMock(), custom_llm_provider=None
+    )
+    raw = _FakeAsyncStream([(0.0, "a")])
+    assert wrapper._async_inactivity_source(raw) is raw
+
+
+def test_source_enabled_wraps_and_caches(monkeypatch):
+    monkeypatch.setattr(
+        "litellm.constants.LITELLM_STREAM_INACTIVITY_TIMEOUT_SECONDS", 1.0
+    )
+    wrapper = CustomStreamWrapper(
+        completion_stream=None, model=None, logging_obj=MagicMock(), custom_llm_provider=None
+    )
+    raw = _FakeAsyncStream([(0.0, "a")])
+    first = wrapper._async_inactivity_source(raw)
+    assert isinstance(first, _StreamInactivityGuard)
+    assert wrapper._async_inactivity_source(raw) is first


### PR DESCRIPTION
## Relevant issues

No linked external issue. This fixes a class of mid-stream hang on streaming completions (details below).

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on `make test-unit` (ran the streaming_handler unit tests locally, see Proof of Fix)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review

## Type

🆕 New Feature

## Changes

### Problem

An async streaming completion can hang until the request times out (or never) when a provider keeps the TCP/SSE connection warm with keepalive bytes (for example SSE comment lines) but stops emitting content chunks. In that state:

- httpx's read timeout never fires, because bytes are still arriving.
- The existing `LITELLM_MAX_STREAMING_DURATION_SECONDS` guard does not help, because `_check_max_streaming_duration()` is only evaluated at the top of `__anext__`; while the inner read loop is blocked waiting for the next chunk, the check is never reached.

So there is no mechanism that bounds the gap between chunks once the first token has arrived.

### Fix

Add an opt-in inter-chunk inactivity timeout.

- New env var `LITELLM_STREAM_INACTIVITY_TIMEOUT_SECONDS` (float, default `None` = disabled), defined next to `LITELLM_MAX_STREAMING_DURATION_SECONDS` in `litellm/constants.py`.
- New `_StreamInactivityGuard` async-iterator wrapper in `streaming_handler.py`. When enabled it wraps the provider stream and raises `litellm.Timeout` if no chunk is received within the configured window. The first chunk is not guarded, so time-to-first-token stays bounded by the request `timeout` (this matters for reasoning models). `litellm.Timeout` is status 408, so it surfaces as a normal timeout through the existing error path rather than being wrapped.
- Disabled by default, so behaviour is unchanged unless the env var is set.

Scope is intentionally limited to the async SSE path (`__anext__`, the common provider path). The sync `__next__` path and the async bedrock `to_thread` branch are left for a follow-up, since interrupting a blocking `next()` is a separate problem.

## Proof of Fix

New tests in `tests/test_litellm/litellm_core_utils/test_stream_inactivity_timeout.py` (6 tests, all passing):

- first chunk is not guarded (slow first token does not trip)
- a mid-stream stall raises `litellm.Timeout`
- a fast stream passes through unchanged
- normal exhaustion still raises `StopAsyncIteration`
- the guard is disabled when the env var is unset (returns the raw stream)
- the guard is wrapped and cached when enabled

Existing `tests/test_litellm/litellm_core_utils/test_streaming_handler.py`: 54 passed, 2 failed. The 2 failures (`test_gemini_legacy_vertex_*`) are a pre-existing missing-module error in my environment and fail identically without this change.
