### PR TITLE
perf(openai): skip the SDK request transform on the chat completions path

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -352,6 +352,9 @@ enable_preview_features: bool = False
 return_response_headers: bool = (
     False  # get response headers from LLM Api providers - example x-remaining-requests,
 )
+skip_openai_chat_transform: bool = (
+    True  # post chat/completions directly, skipping the OpenAI SDK request transform; set False to use chat.completions.create
+)
 enable_json_schema_validation: bool = False
 enable_model_config_credential_overrides: bool = False
 enable_key_alias_format_validation: bool = (

--- a/litellm/llms/openai/openai.py
+++ b/litellm/llms/openai/openai.py
@@ -22,7 +22,16 @@ if TYPE_CHECKING:
     from aiohttp import ClientSession
 
 import openai
-from openai import AsyncOpenAI, OpenAI
+from openai import AsyncOpenAI, AsyncStream, OpenAI, Stream
+from openai.types.chat import ChatCompletion, ChatCompletionChunk
+
+try:
+    from openai._base_client import make_request_options
+    from openai._constants import RAW_RESPONSE_HEADER
+
+    _OPENAI_CHAT_TRANSFORM_BYPASS_AVAILABLE = True
+except ImportError:  # pragma: no cover - private SDK symbols moved or renamed
+    _OPENAI_CHAT_TRANSFORM_BYPASS_AVAILABLE = False
 from openai.types.beta.assistant_deleted import AssistantDeleted
 from openai.types.file_deleted import FileDeleted
 from pydantic import BaseModel
@@ -419,6 +428,35 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
             )
             return client
 
+    @staticmethod
+    def _chat_completion_post_kwargs(
+        data: dict, timeout: Union[float, httpx.Timeout]
+    ) -> dict:
+        """Reach /chat/completions identically to
+        chat.completions.with_raw_response.create(**data), but skip the SDK's
+        async_maybe_transform. That transform recurses the message-param union and
+        runs uncached typing introspection per field, which dominates CPU on large
+        multi-message requests; the chat-completion request types declare no field
+        aliases and no format converters, so it is pure overhead for this body.
+        extra_headers/extra_body/extra_query are extracted and forwarded the same
+        way create() forwards them."""
+        body = dict(data)
+        extra_headers = body.pop("extra_headers", None) or {}
+        extra_body = body.pop("extra_body", None)
+        extra_query = body.pop("extra_query", None)
+        body.pop("timeout", None)
+        return {
+            "body": body,
+            "cast_to": ChatCompletion,
+            "options": make_request_options(
+                extra_headers={RAW_RESPONSE_HEADER: "true", **extra_headers},
+                extra_query=extra_query,
+                extra_body=extra_body,
+                timeout=timeout,
+            ),
+            "stream": bool(body.get("stream", False)),
+        }
+
     @track_llm_api_timing()
     async def make_openai_chat_completion_request(
         self,
@@ -428,17 +466,32 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
         logging_obj: LiteLLMLoggingObj,
     ) -> Tuple[dict, BaseModel]:
         """
-        Helper to:
-        - call chat.completions.create.with_raw_response when litellm.return_response_headers is True
-        - call chat.completions.create by default
+        Send the chat completion request and return (headers, parsed response).
+
+        By default this posts to /chat/completions directly, skipping the OpenAI
+        SDK request transform (pure overhead for this body; see
+        _chat_completion_post_kwargs). Falls back to
+        chat.completions.with_raw_response.create when
+        litellm.skip_openai_chat_transform is False or the SDK request-option
+        internals are unavailable.
         """
         start_time = time.time()
         try:
-            raw_response = (
-                await openai_aclient.chat.completions.with_raw_response.create(
-                    **data, timeout=timeout
+            if (
+                litellm.skip_openai_chat_transform
+                and _OPENAI_CHAT_TRANSFORM_BYPASS_AVAILABLE
+            ):
+                raw_response = await openai_aclient.post(
+                    "/chat/completions",
+                    stream_cls=AsyncStream[ChatCompletionChunk],
+                    **self._chat_completion_post_kwargs(data, timeout),
                 )
-            )
+            else:
+                raw_response = (
+                    await openai_aclient.chat.completions.with_raw_response.create(
+                        **data, timeout=timeout
+                    )
+                )
             end_time = time.time()
 
             if hasattr(raw_response, "headers"):
@@ -469,15 +522,30 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
         logging_obj: LiteLLMLoggingObj,
     ) -> Tuple[dict, BaseModel]:
         """
-        Helper to:
-        - call chat.completions.create.with_raw_response when litellm.return_response_headers is True
-        - call chat.completions.create by default
+        Send the chat completion request and return (headers, parsed response).
+
+        By default this posts to /chat/completions directly, skipping the OpenAI
+        SDK request transform (pure overhead for this body; see
+        _chat_completion_post_kwargs). Falls back to
+        chat.completions.with_raw_response.create when
+        litellm.skip_openai_chat_transform is False or the SDK request-option
+        internals are unavailable.
         """
         raw_response = None
         try:
-            raw_response = openai_client.chat.completions.with_raw_response.create(
-                **data, timeout=timeout
-            )
+            if (
+                litellm.skip_openai_chat_transform
+                and _OPENAI_CHAT_TRANSFORM_BYPASS_AVAILABLE
+            ):
+                raw_response = openai_client.post(
+                    "/chat/completions",
+                    stream_cls=Stream[ChatCompletionChunk],
+                    **self._chat_completion_post_kwargs(data, timeout),
+                )
+            else:
+                raw_response = openai_client.chat.completions.with_raw_response.create(
+                    **data, timeout=timeout
+                )
 
             if hasattr(raw_response, "headers"):
                 headers = dict(raw_response.headers)

--- a/tests/test_litellm/llms/openai/test_openai_empty_response.py
+++ b/tests/test_litellm/llms/openai/test_openai_empty_response.py
@@ -30,9 +30,7 @@ class TestEmptyResponseHandling:
         mock_raw_response.parse.return_value = ""  # Empty string response
 
         mock_client = MagicMock()
-        mock_client.chat.completions.with_raw_response.create.return_value = (
-            mock_raw_response
-        )
+        mock_client.post.return_value = mock_raw_response
 
         with pytest.raises(OpenAIError) as exc_info:
             openai_chat.make_sync_openai_chat_completion_request(
@@ -56,9 +54,7 @@ class TestEmptyResponseHandling:
         mock_raw_response.parse.return_value = None
 
         mock_client = MagicMock()
-        mock_client.chat.completions.with_raw_response.create.return_value = (
-            mock_raw_response
-        )
+        mock_client.post.return_value = mock_raw_response
 
         with pytest.raises(OpenAIError) as exc_info:
             openai_chat.make_sync_openai_chat_completion_request(
@@ -83,9 +79,7 @@ class TestEmptyResponseHandling:
         mock_raw_response.parse.return_value = mock_response
 
         mock_client = MagicMock()
-        mock_client.chat.completions.with_raw_response.create.return_value = (
-            mock_raw_response
-        )
+        mock_client.post.return_value = mock_raw_response
 
         headers, response = openai_chat.make_sync_openai_chat_completion_request(
             openai_client=mock_client,
@@ -112,9 +106,7 @@ class TestEmptyResponseHandling:
         mock_raw_response.parse.return_value = mock_stream
 
         mock_client = MagicMock()
-        mock_client.chat.completions.with_raw_response.create.return_value = (
-            mock_raw_response
-        )
+        mock_client.post.return_value = mock_raw_response
 
         # Key: data has stream=True - this should bypass the model_dump check
         headers, response = openai_chat.make_sync_openai_chat_completion_request(

--- a/tests/test_litellm/llms/openai/test_openai_request_post_bypass.py
+++ b/tests/test_litellm/llms/openai/test_openai_request_post_bypass.py
@@ -1,0 +1,213 @@
+"""
+The OpenAI chat handler sends the request via client.post(body=data) instead of
+chat.completions.create(**data), skipping the SDK's async_maybe_transform whose
+per-field typing introspection over the message-param union dominates CPU on large
+multi-message requests. That is only correct if the transform is a no-op for the
+chat-completion request body. These tests lock that assumption and the request-option
+extraction so a future SDK change can never silently corrupt outbound requests.
+"""
+
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock
+
+sys.path.insert(0, os.path.abspath("../../../.."))
+
+from openai._constants import RAW_RESPONSE_HEADER
+from openai._utils import async_maybe_transform
+from openai.types.chat import completion_create_params
+
+from litellm.llms.openai.openai import OpenAIChatCompletion
+
+REPRESENTATIVE_BODY = {
+    "model": "gpt-4o",
+    "messages": [
+        {"role": "system", "content": "you are helpful"},
+        {"role": "user", "content": "hi"},
+        {
+            "role": "assistant",
+            "content": "hello",
+            "tool_calls": [
+                {
+                    "id": "c1",
+                    "type": "function",
+                    "function": {"name": "f", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "c1", "content": "result"},
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "describe"},
+                {"type": "image_url", "image_url": {"url": "http://x/y.png"}},
+            ],
+        },
+    ],
+    "temperature": 0.5,
+    "max_tokens": 64,
+    "tools": [
+        {
+            "type": "function",
+            "function": {"name": "f", "parameters": {"type": "object"}},
+        }
+    ],
+    "response_format": {"type": "json_object"},
+    "stream": False,
+}
+
+
+async def test_bypass_body_matches_sdk_transform():
+    transformed = await async_maybe_transform(
+        dict(REPRESENTATIVE_BODY),
+        completion_create_params.CompletionCreateParamsNonStreaming,
+    )
+    kwargs = OpenAIChatCompletion._chat_completion_post_kwargs(
+        dict(REPRESENTATIVE_BODY), timeout=30.0
+    )
+    assert kwargs["body"] == transformed
+
+
+def test_bypass_extracts_request_options_and_sets_raw_header():
+    data = {
+        "model": "gpt-4o",
+        "messages": [{"role": "user", "content": "hi"}],
+        "extra_headers": {"x-custom": "1"},
+        "extra_body": {"vendor_flag": True},
+        "extra_query": {"q": "1"},
+    }
+    kwargs = OpenAIChatCompletion._chat_completion_post_kwargs(dict(data), timeout=12.0)
+    body = kwargs["body"]
+    options = kwargs["options"]
+
+    for k in ("extra_headers", "extra_body", "extra_query"):
+        assert k not in body
+    assert options["headers"][RAW_RESPONSE_HEADER] == "true"
+    assert options["headers"]["x-custom"] == "1"
+    assert options["extra_json"] == {"vendor_flag": True}
+    assert options["params"] == {"q": "1"}
+    assert options["timeout"] == 12.0
+
+
+async def test_async_request_posts_to_chat_completions_and_returns_headers():
+    openai_chat = OpenAIChatCompletion()
+    mock_response = MagicMock()
+    mock_response.model_dump.return_value = {"choices": []}
+    mock_raw = MagicMock()
+    mock_raw.headers = {"x-request-id": "abc"}
+    mock_raw.parse.return_value = mock_response
+
+    mock_client = MagicMock()
+    mock_client.post = AsyncMock(return_value=mock_raw)
+
+    headers, response = await openai_chat.make_openai_chat_completion_request(
+        openai_aclient=mock_client,
+        data={"messages": [{"role": "user", "content": "hi"}]},
+        timeout=30,
+        logging_obj=MagicMock(),
+    )
+
+    assert response is mock_response
+    assert headers == {"x-request-id": "abc"}
+    assert mock_client.post.await_args.args[0] == "/chat/completions"
+    assert mock_client.post.await_args.kwargs["body"]["messages"] == [
+        {"role": "user", "content": "hi"}
+    ]
+
+
+def test_bypass_keeps_stream_in_body_and_flags_post():
+    data = {
+        "model": "gpt-4o",
+        "messages": [{"role": "user", "content": "hi"}],
+        "stream": True,
+    }
+    kwargs = OpenAIChatCompletion._chat_completion_post_kwargs(dict(data), timeout=30.0)
+    assert kwargs["body"]["stream"] is True
+    assert kwargs["stream"] is True
+
+    no_stream = OpenAIChatCompletion._chat_completion_post_kwargs(
+        {"model": "gpt-4o", "messages": []}, timeout=30.0
+    )
+    assert no_stream["stream"] is False
+
+
+def test_bypass_options_match_sdk_make_request_options():
+    from openai._base_client import make_request_options
+
+    data = {
+        "model": "gpt-4o",
+        "messages": [{"role": "user", "content": "hi"}],
+        "extra_headers": {"x-custom": "1"},
+        "extra_body": {"vendor_flag": True},
+        "extra_query": {"q": "1"},
+    }
+    options = OpenAIChatCompletion._chat_completion_post_kwargs(
+        dict(data), timeout=7.0
+    )["options"]
+    expected = make_request_options(
+        extra_headers={RAW_RESPONSE_HEADER: "true", "x-custom": "1"},
+        extra_query={"q": "1"},
+        extra_body={"vendor_flag": True},
+        timeout=7.0,
+    )
+    assert options == expected
+
+
+def _mock_client_with_both_paths():
+    raw = MagicMock()
+    raw.headers = {}
+    raw.parse.return_value = MagicMock()
+    client = MagicMock()
+    client.post.return_value = raw
+    client.chat.completions.with_raw_response.create.return_value = raw
+    return client
+
+
+def test_escape_hatch_uses_create_when_flag_disabled(monkeypatch):
+    import litellm
+
+    monkeypatch.setattr(litellm, "skip_openai_chat_transform", False)
+    client = _mock_client_with_both_paths()
+    OpenAIChatCompletion().make_sync_openai_chat_completion_request(
+        openai_client=client,
+        data={"messages": [{"role": "user", "content": "hi"}]},
+        timeout=30,
+        logging_obj=MagicMock(),
+    )
+    client.chat.completions.with_raw_response.create.assert_called_once()
+    client.post.assert_not_called()
+
+
+def test_falls_back_to_create_when_bypass_symbols_unavailable(monkeypatch):
+    from litellm.llms.openai import openai as openai_mod
+
+    monkeypatch.setattr(openai_mod, "_OPENAI_CHAT_TRANSFORM_BYPASS_AVAILABLE", False)
+    client = _mock_client_with_both_paths()
+    openai_mod.OpenAIChatCompletion().make_sync_openai_chat_completion_request(
+        openai_client=client,
+        data={"messages": [{"role": "user", "content": "hi"}]},
+        timeout=30,
+        logging_obj=MagicMock(),
+    )
+    client.chat.completions.with_raw_response.create.assert_called_once()
+    client.post.assert_not_called()
+
+
+async def test_async_escape_hatch_uses_create_when_flag_disabled(monkeypatch):
+    import litellm
+
+    monkeypatch.setattr(litellm, "skip_openai_chat_transform", False)
+    raw = MagicMock()
+    raw.headers = {}
+    raw.parse.return_value = MagicMock()
+    client = MagicMock()
+    client.post = AsyncMock(return_value=raw)
+    client.chat.completions.with_raw_response.create = AsyncMock(return_value=raw)
+    await OpenAIChatCompletion().make_openai_chat_completion_request(
+        openai_aclient=client,
+        data={"messages": [{"role": "user", "content": "hi"}]},
+        timeout=30,
+        logging_obj=MagicMock(),
+    )
+    client.chat.completions.with_raw_response.create.assert_awaited_once()
+    client.post.assert_not_awaited()

--- a/tests/test_litellm/llms/openai/test_use_chat_completions_api_no_leak.py
+++ b/tests/test_litellm/llms/openai/test_use_chat_completions_api_no_leak.py
@@ -55,9 +55,7 @@ def test_completion_does_not_leak_flag_into_provider_request_body():
     mock_raw_response.parse.return_value = mock_response
 
     mock_client = MagicMock()
-    mock_client.chat.completions.with_raw_response.create.return_value = (
-        mock_raw_response
-    )
+    mock_client.post.return_value = mock_raw_response
 
     litellm.completion(
         model="openai/gpt-4o-mini",
@@ -67,8 +65,8 @@ def test_completion_does_not_leak_flag_into_provider_request_body():
         client=mock_client,
     )
 
-    create_kwargs = (
-        mock_client.chat.completions.with_raw_response.create.call_args.kwargs
-    )
-    assert "use_chat_completions_api" not in create_kwargs
-    assert "use_chat_completions_api" not in (create_kwargs.get("extra_body") or {})
+    post_kwargs = mock_client.post.call_args.kwargs
+    body = post_kwargs["body"]
+    extra_json = (post_kwargs.get("options") or {}).get("extra_json") or {}
+    assert "use_chat_completions_api" not in body
+    assert "use_chat_completions_api" not in extra_json

--- a/tests/test_litellm/llms/volcengine/test_volcengine.py
+++ b/tests/test_litellm/llms/volcengine/test_volcengine.py
@@ -126,9 +126,7 @@ class TestVolcEngineConfig:
         }
         mock_raw_response.parse.return_value = ModelResponse()
 
-        with patch.object(
-            client.chat.completions.with_raw_response, "create", mock_raw_response
-        ) as mock_create:
+        with patch.object(client, "post", mock_raw_response) as mock_create:
             completion(
                 model="volcengine/doubao-seed-1.6",
                 messages=[
@@ -145,10 +143,9 @@ class TestVolcEngineConfig:
 
             mock_create.assert_called_once()
             print(mock_create.call_args.kwargs)
-            # Fixed: thinking disabled should appear in extra_body with original structure
-            assert (
-                "extra_body" in mock_create.call_args.kwargs
-                and "thinking" in mock_create.call_args.kwargs.get("extra_body", {})
-                and mock_create.call_args.kwargs.get("extra_body", {})["thinking"]
-                == {"type": "disabled"}
+            # thinking disabled is forwarded via extra_body, which the post bypass
+            # passes through request options as extra_json
+            extra_json = mock_create.call_args.kwargs.get("options", {}).get(
+                "extra_json", {}
             )
+            assert extra_json.get("thinking") == {"type": "disabled"}

--- a/tests/test_litellm/test_main.py
+++ b/tests/test_litellm/test_main.py
@@ -110,9 +110,7 @@ def test_completion_missing_role(openai_api_response):
 
     print(f"openai_api_response: {openai_api_response}")
 
-    with patch.object(
-        client.chat.completions.with_raw_response, "create", mock_raw_response
-    ) as mock_create:
+    with patch.object(client, "post", return_value=mock_raw_response) as mock_create:
         litellm.completion(
             model="gpt-4o-mini",
             messages=[
@@ -298,9 +296,7 @@ async def test_url_with_format_param_openai(model, sync_mode):
             }
         ],
     }
-    with patch.object(
-        client.chat.completions.with_raw_response, "create"
-    ) as mock_client:
+    with patch.object(client, "post") as mock_client:
         try:
             if sync_mode:
                 response = completion(**args, client=client)
@@ -314,7 +310,7 @@ async def test_url_with_format_param_openai(model, sync_mode):
 
         print(mock_client.call_args.kwargs)
 
-        json_str = json.dumps(mock_client.call_args.kwargs)
+        json_str = json.dumps(mock_client.call_args.kwargs["body"])
 
         assert "format" not in json_str
 


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests (a regression test pinning the bypass body to the SDK transform output; the existing openai handler tests updated for the new call path)
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review

## Screenshots / Proof of Fix

Measured with our internal proxy benchmark harness (mock OpenAI upstream, single uvicorn worker, payload of 500K tokens spread across 500 messages; not externally reproducible yet, numbers provided as claims). Median of 3 repeats.

| scenario | base RPS | this PR RPS | p50 | event-loop freezes >50ms |
| --- | --- | --- | --- | --- |
| non-stream, concurrency 1 | 25.2 | 74.8 (+197%) | 40 -> 13 ms | n/a |
| non-stream, concurrency 5 | 27.7 | 101.5 (+267%) | 180 -> 48 ms | 44 -> 15 |
| streaming (full), concurrency 5 | 9.5 | 12.5 (+32%) | 526 -> 398 ms | 398 -> 346 |

Isolated, the SDK transform costs about 26.6 ms/call at 500 messages (0.10 ms at a single message), so it scales with message count. At concurrency 1 the bypass removes roughly 27 ms from a 40 ms request; at concurrency 5 the effect compounds because the transform is synchronous work on the event loop, so the baseline barely scales with added workers (25 -> 28 RPS from 1 to 5) while the bypass keeps scaling (75 -> 101).

## Type

🚄 Infrastructure

## Changes

The OpenAI chat handler builds the request as a plain dict and sends it via `chat.completions.with_raw_response.create(**data)`. That entry point first runs the SDK's `async_maybe_transform` over the body, which recurses the `messages` annotation (`Iterable[Union[...6 message TypedDicts...]]`) and runs uncached typing introspection (`typing.get_origin` plus the `is_*_type` helpers) per field, per message. On a 500-message request that is roughly 68k `get_origin` calls and tens of milliseconds of synchronous CPU on the event loop, scaling with message count.

The chat-completion request param types declare no field aliases and no format converters, so this transform produces the same body it was given; it is pure overhead for this path. This switches to `client.post("/chat/completions", body=data, ...)`, which is exactly what `create()` calls after the transform, replicating its behavior: the raw-response header so header capture still works, extraction of `extra_headers`/`extra_body`/`extra_query`, the `ChatCompletion` cast, and the `stream_cls` wiring for streaming. Response handling is unchanged, and output is identical for both streaming and non-streaming.

A regression test asserts the bypass body equals `async_maybe_transform`'s output for a representative request (system, user, assistant, and tool messages, tool calls, multimodal content, tools, and response_format), so a future SDK release that begins aliasing or formatting a chat request field fails the test rather than silently sending a malformed request. The body serialization itself still goes through the SDK's `openapi_dumps`, so non-JSON values are encoded as before
