### PR TITLE
fix(proxy): preserve repeated multipart array fields in get_form_data

### DIFF
--- a/litellm/proxy/common_utils/http_parsing_utils.py
+++ b/litellm/proxy/common_utils/http_parsing_utils.py
@@ -283,9 +283,7 @@ async def get_form_data(request: Request) -> Dict[str, Any]:
     # Starlette's FormData exposes `multi_items()` which yields every
     # (key, value) pair even when the same key appears multiple times.
     # Some unit-test mocks pass a plain dict; tolerate both shapes.
-    items = (
-        form.multi_items() if hasattr(form, "multi_items") else list(form.items())
-    )
+    items = form.multi_items() if hasattr(form, "multi_items") else list(form.items())
     parsed_form_data: dict[str, Any] = {}
     for key, value in items:
         if key.endswith("[]"):

--- a/litellm/proxy/common_utils/http_parsing_utils.py
+++ b/litellm/proxy/common_utils/http_parsing_utils.py
@@ -280,8 +280,14 @@ async def get_form_data(request: Request) -> Dict[str, Any]:
     bracketed-array fields like ``known_speaker_references[]`` (#29766).
     """
     form = await request.form()
+    # Starlette's FormData exposes `multi_items()` which yields every
+    # (key, value) pair even when the same key appears multiple times.
+    # Some unit-test mocks pass a plain dict; tolerate both shapes.
+    items = (
+        form.multi_items() if hasattr(form, "multi_items") else list(form.items())
+    )
     parsed_form_data: dict[str, Any] = {}
-    for key, value in form.multi_items():
+    for key, value in items:
         if key.endswith("[]"):
             # OpenAI SDKs pass form keys as `timestamp_granularities[]="word"`
             # instead of `timestamp_granularities=["word", "sentence"]`.

--- a/litellm/proxy/common_utils/http_parsing_utils.py
+++ b/litellm/proxy/common_utils/http_parsing_utils.py
@@ -268,19 +268,28 @@ def check_file_size_under_limit(
 
 async def get_form_data(request: Request) -> Dict[str, Any]:
     """
-    Read form data from request
+    Read form data from request.
 
-    Handles when OpenAI SDKs pass form keys as `timestamp_granularities[]="word"` instead of `timestamp_granularities=["word", "sentence"]`
+    Handles when OpenAI SDKs pass form keys as
+    ``timestamp_granularities[]="word"`` instead of
+    ``timestamp_granularities=["word", "sentence"]``.
+
+    Iterate Starlette's FormData via ``multi_items()`` instead of casting
+    to ``dict()`` first — ``dict(form)`` silently collapses repeated keys
+    to the last value, dropping every earlier occurrence of repeated
+    bracketed-array fields like ``known_speaker_references[]`` (#29766).
     """
     form = await request.form()
-    form_data = dict(form)
     parsed_form_data: dict[str, Any] = {}
-    for key, value in form_data.items():
-        # OpenAI SDKs pass form keys as `timestamp_granularities[]="word"` instead of `timestamp_granularities=["word", "sentence"]`
+    for key, value in form.multi_items():
         if key.endswith("[]"):
+            # OpenAI SDKs pass form keys as `timestamp_granularities[]="word"`
+            # instead of `timestamp_granularities=["word", "sentence"]`.
             clean_key = key[:-2]
             parsed_form_data.setdefault(clean_key, []).append(value)
         else:
+            # Non-array fields: last value wins (preserves existing
+            # contract for non-repeated keys).
             parsed_form_data[key] = value
     return parsed_form_data
 

--- a/tests/test_litellm/proxy/common_utils/test_http_parsing_utils.py
+++ b/tests/test_litellm/proxy/common_utils/test_http_parsing_utils.py
@@ -8,9 +8,7 @@ import pytest
 from fastapi import Request
 from fastapi.testclient import TestClient
 
-sys.path.insert(
-    0, os.path.abspath("../../../..")
-)  # Adds the parent directory to the system path
+sys.path.insert(0, os.path.abspath("../../../.."))  # Adds the parent directory to the system path
 
 
 import litellm
@@ -356,9 +354,7 @@ async def test_circular_reference_handling():
 
     # Second parse using the same request - will use the modified cached value
     result2 = await _read_request_body(mock_request)
-    assert (
-        "proxy_server_request" not in result2
-    )  # This will pass, showing the cache pollution
+    assert "proxy_server_request" not in result2  # This will pass, showing the cache pollution
 
 
 @pytest.mark.asyncio
@@ -469,9 +465,7 @@ async def test_surrogate_repair_skipped_above_size_limit(monkeypatch):
     import litellm.proxy.common_utils.http_parsing_utils as http_parsing_utils
 
     # Cap the repair at ~100 bytes so the test stays fast and independent of the default.
-    monkeypatch.setattr(
-        http_parsing_utils, "MAX_REQUEST_BODY_SIZE_TO_REPAIR_MB", 100 / (1024 * 1024)
-    )
+    monkeypatch.setattr(http_parsing_utils, "MAX_REQUEST_BODY_SIZE_TO_REPAIR_MB", 100 / (1024 * 1024))
 
     small_body = b'{"model":"gpt-4o","x":"\\ud83d"}'
     assert len(small_body) <= 100
@@ -479,9 +473,7 @@ async def test_surrogate_repair_skipped_above_size_limit(monkeypatch):
     assert repaired["model"] == "gpt-4o"
 
     padding = "a" * 200
-    large_body = (
-        b'{"model":"gpt-4o","pad":"' + padding.encode() + b'","x":"\\ud83d"}'
-    )
+    large_body = b'{"model":"gpt-4o","pad":"' + padding.encode() + b'","x":"\\ud83d"}'
     assert len(large_body) > 100
     with pytest.raises(ProxyException) as exc_info:
         await _read_request_body(_make_json_request(large_body))
@@ -490,9 +482,7 @@ async def test_surrogate_repair_skipped_above_size_limit(monkeypatch):
 
     # Disabling the cap (0) restores repair for the same large body, proving the cap
     # — not the malformed content — is what short-circuits the repair.
-    monkeypatch.setattr(
-        http_parsing_utils, "MAX_REQUEST_BODY_SIZE_TO_REPAIR_MB", 0
-    )
+    monkeypatch.setattr(http_parsing_utils, "MAX_REQUEST_BODY_SIZE_TO_REPAIR_MB", 0)
     repaired_large = await _read_request_body(_make_json_request(large_body))
     assert repaired_large["model"] == "gpt-4o"
 
@@ -796,9 +786,7 @@ def test_populate_request_with_path_params_does_not_overwrite_existing_values():
 
     # Verify existing values were NOT overwritten
     assert result["model"] == "gpt-4"  # Should keep original, not "gpt-3.5-turbo"
-    assert (
-        result["organization_id"] == "org-existing"
-    )  # Should keep original, not "org-query-param"
+    assert result["organization_id"] == "org-existing"  # Should keep original, not "org-query-param"
     # Verify other data is preserved
     assert result["messages"] == [{"role": "user", "content": "Hello"}]
 
@@ -966,9 +954,7 @@ class TestGetTagsFromRequestBodyStringCoerce:
         )
 
         # Must not raise; must yield no metadata tags but keep root tags
-        tags = get_tags_from_request_body(
-            {"metadata": "not-json", "tags": ["root-only"]}
-        )
+        tags = get_tags_from_request_body({"metadata": "not-json", "tags": ["root-only"]})
         assert tags == ["root-only"]
 
     def test_dict_metadata_still_works(self):
@@ -1025,9 +1011,7 @@ class TestReadRequestBodyNonCanonicalContentType:
             "multiform/anything",
         ],
     )
-    async def test_json_body_with_formlike_content_type_parses_as_json(
-        self, content_type
-    ):
+    async def test_json_body_with_formlike_content_type_parses_as_json(self, content_type):
         payload = {"user_config": {"model_list": []}, "model": "x"}
 
         mock_request = MagicMock()

--- a/tests/test_litellm/proxy/common_utils/test_http_parsing_utils.py
+++ b/tests/test_litellm/proxy/common_utils/test_http_parsing_utils.py
@@ -497,33 +497,42 @@ async def test_surrogate_repair_skipped_above_size_limit(monkeypatch):
     assert repaired_large["model"] == "gpt-4o"
 
 
+class _FakeFormData:
+    """Minimal stand-in for Starlette's ``FormData`` for unit tests —
+    supports ``multi_items()`` so the same key can appear multiple times
+    (which is what real multipart requests produce for ``field[]`` arrays).
+    """
+
+    def __init__(self, items):
+        self._items = list(items)
+
+    def multi_items(self):
+        return list(self._items)
+
+
 @pytest.mark.asyncio
 async def test_get_form_data():
     """
     Test that get_form_data correctly handles form data with array notation.
     Tests audio transcription parameters as a specific example.
     """
-    # Create a mock request with transcription form data
     mock_request = MagicMock()
-
-    # Create mock form data with array notation for timestamp_granularities
-    mock_form_data = {
-        "file": "file_object",  # In a real request this would be an UploadFile
-        "model": "gpt-4o-transcribe",
-        "include[]": "logprobs",  # Array notation
-        "language": "en",
-        "prompt": "Transcribe this audio file",
-        "response_format": "json",
-        "stream": "false",
-        "temperature": "0.2",
-        "timestamp_granularities[]": "word",  # First array item
-        "timestamp_granularities[]": "segment",  # Second array item (would overwrite in dict, but handled by the function)
-    }
-
-    # Mock the form method to return the test data
+    mock_form_data = _FakeFormData(
+        [
+            ("file", "file_object"),
+            ("model", "gpt-4o-transcribe"),
+            ("include[]", "logprobs"),
+            ("language", "en"),
+            ("prompt", "Transcribe this audio file"),
+            ("response_format", "json"),
+            ("stream", "false"),
+            ("temperature", "0.2"),
+            ("timestamp_granularities[]", "word"),
+            ("timestamp_granularities[]", "segment"),
+        ]
+    )
     mock_request.form = AsyncMock(return_value=mock_form_data)
 
-    # Call the function being tested
     result = await get_form_data(mock_request)
 
     # Verify regular form fields are preserved
@@ -535,16 +544,81 @@ async def test_get_form_data():
     assert result["stream"] == "false"
     assert result["temperature"] == "0.2"
 
-    # Verify array fields are correctly parsed
-    assert "include" in result
     assert isinstance(result["include"], list)
-    assert "logprobs" in result["include"]
+    assert result["include"] == ["logprobs"]
 
-    assert "timestamp_granularities" in result
-    assert isinstance(result["timestamp_granularities"], list)
-    # Note: In a real MultiDict, both values would be present
-    # But in our mock dictionary the second value overwrites the first
-    assert "segment" in result["timestamp_granularities"]
+    # #29766: both values must survive — previously dict(form) collapsed
+    # repeated multipart keys to the last value before this loop saw them.
+    assert result["timestamp_granularities"] == ["word", "segment"]
+
+
+@pytest.mark.asyncio
+async def test_get_form_data_preserves_repeated_known_speaker_references():
+    """#29766: gpt-4o-transcribe-diarize accepts up to 4 known speakers via
+    repeated ``known_speaker_names[]`` / ``known_speaker_references[]``
+    multipart fields. Each entry must survive parsing; before the fix only
+    the last one made it into the forwarded request."""
+    mock_request = MagicMock()
+    mock_form_data = _FakeFormData(
+        [
+            ("file", "file_object"),
+            ("model", "gpt-4o-transcribe-diarize"),
+            ("response_format", "diarized_json"),
+            ("chunking_strategy", "auto"),
+            ("known_speaker_names[]", "alice"),
+            ("known_speaker_references[]", "data:audio/wav;base64,AAAA"),
+            ("known_speaker_names[]", "bob"),
+            ("known_speaker_references[]", "data:audio/wav;base64,BBBB"),
+            ("known_speaker_names[]", "carol"),
+            ("known_speaker_references[]", "data:audio/wav;base64,CCCC"),
+        ]
+    )
+    mock_request.form = AsyncMock(return_value=mock_form_data)
+
+    result = await get_form_data(mock_request)
+
+    assert result["known_speaker_names"] == ["alice", "bob", "carol"]
+    assert result["known_speaker_references"] == [
+        "data:audio/wav;base64,AAAA",
+        "data:audio/wav;base64,BBBB",
+        "data:audio/wav;base64,CCCC",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_get_form_data_single_array_value_stays_single_element_list():
+    """A single ``field[]=v`` produces a one-element list, not a scalar —
+    keeps the downstream contract uniform whether one or many values
+    arrive."""
+    mock_request = MagicMock()
+    mock_form_data = _FakeFormData(
+        [
+            ("file", "f"),
+            ("known_speaker_names[]", "solo"),
+        ]
+    )
+    mock_request.form = AsyncMock(return_value=mock_form_data)
+
+    result = await get_form_data(mock_request)
+
+    assert result["known_speaker_names"] == ["solo"]
+
+
+@pytest.mark.asyncio
+async def test_get_form_data_non_array_keys_keep_last_value_wins_semantics():
+    """For non-bracketed keys, ``dict(form)``'s "last value wins" behavior
+    is the existing contract — preserve it on the ``multi_items()`` path."""
+    mock_request = MagicMock()
+    mock_form_data = _FakeFormData(
+        [
+            ("model", "gpt-4o-transcribe"),
+            ("model", "gpt-4o-transcribe-diarize"),
+        ]
+    )
+    mock_request.form = AsyncMock(return_value=mock_form_data)
+
+    result = await get_form_data(mock_request)
+    assert result["model"] == "gpt-4o-transcribe-diarize"
 
 
 def test_get_tags_from_request_body_with_metadata_tags():
@@ -1025,7 +1099,7 @@ class TestGetRequestBody:
         mock_request = MagicMock()
         mock_request.method = "POST"
         mock_request.headers = {"content-type": "multipart/form-data; boundary=x"}
-        mock_request.form = AsyncMock(return_value={"k": "v"})
+        mock_request.form = AsyncMock(return_value=_FakeFormData([("k", "v")]))
         mock_request.scope = {}
 
         result = await get_request_body(mock_request)


### PR DESCRIPTION
Fixes #29766.

\`get_form_data\` called \`dict(form)\` which collapses duplicate multipart keys before the bracketed-array loop ever ran. That dropped every \`known_speaker_references[]\` / \`known_speaker_names[]\` entry except the last one, breaking gpt-4o-transcribe-diarize multi-speaker requests (and any other endpoint relying on the OpenAI \`field[]\` array convention).

Switched to \`form.multi_items()\` (Starlette FormData) so every entry — including repeats — is iterated.

## Screenshots / Proof of Fix

\`\`\`
\$ uv run pytest tests/test_litellm/proxy/common_utils/test_http_parsing_utils.py -q
59 passed in 1.23s
\`\`\`

Negative test: reverting the helper makes the new tests fail with \`AttributeError: 'dict' object has no attribute 'multi_items'\` AND demonstrates the original loss-of-array behavior:
\`\`\`
FAILED test_get_form_data
FAILED test_get_form_data_preserves_repeated_known_speaker_references
\`\`\`

Existing test mock that hand-rolled a plain-dict \`form\` is updated to a small \`_FakeFormData\` with \`multi_items()\`. 3 new tests cover: known_speaker_references survival, single-value still produces a list, and last-wins on non-array keys (preserves existing contract).