### PR TITLE
fix(model_prices): correct max_input_tokens for minimax/MiniMax-M3 (512K → 1M)

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -24132,7 +24132,7 @@
         "supports_reasoning": true,
         "supports_system_messages": true,
         "supports_vision": true,
-        "max_input_tokens": 512000,
+        "max_input_tokens": 1048576,
         "max_output_tokens": 128000
     },
     "mistral.devstral-2-123b": {

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -24132,7 +24132,7 @@
         "supports_reasoning": true,
         "supports_system_messages": true,
         "supports_vision": true,
-        "max_input_tokens": 512000,
+        "max_input_tokens": 1048576,
         "max_output_tokens": 128000
     },
     "mistral.devstral-2-123b": {


### PR DESCRIPTION
## Title
Corrects `max_input_tokens` for `minimax/MiniMax-M3` from `512000` to `1048576`.

## Relevant issues
Follow-up to #29412 (merged with the 512K value) — see my review comment there: https://github.com/BerriAI/litellm/pull/29412#issuecomment-4602629967

## Type
🐛 Bug Fix

## Changes
Per MiniMax's official specs, **MiniMax-M3 ships a 1,048,576-token (1M) context window** (MSA architecture). The 512K figure is MiniMax's *long-context billing threshold* — requests at or below 512K input tokens are billed at the base rate — not the model's context window.

With `512000`, LiteLLM's context-window checks (and routing/fallback logic based on `max_input_tokens`) would reject or misroute valid requests between 512K and 1M tokens.

- `model_prices_and_context_window.json`: `512000` → `1048576`
- `litellm/model_prices_and_context_window_backup.json`: same

Sources:
- MiniMax official model page / API docs (M3: 1M context)
- OpenRouter listing for MiniMax-M3 (1,048,576 context)
- Consistency with sibling `minimax/MiniMax-M2.x` entries in this file, which all use `1000000`

Pricing fields are untouched ($0.60/M input, $2.40/M output are correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)