### PR TITLE
fix(cohere): support max_completion_tokens on cohere v2 chat (default route)

### DIFF
--- a/litellm/llms/cohere/chat/v2_transformation.py
+++ b/litellm/llms/cohere/chat/v2_transformation.py
@@ -120,6 +120,7 @@ class CohereV2ChatConfig(OpenAIGPTConfig):
             "stream",
             "temperature",
             "max_tokens",
+            "max_completion_tokens",
             "top_p",
             "frequency_penalty",
             "presence_penalty",
@@ -144,6 +145,8 @@ class CohereV2ChatConfig(OpenAIGPTConfig):
             if param == "temperature":
                 optional_params["temperature"] = value
             if param == "max_tokens":
+                optional_params["max_tokens"] = value
+            if param == "max_completion_tokens":
                 optional_params["max_tokens"] = value
             if param == "n":
                 optional_params["num_generations"] = value

--- a/litellm/llms/cohere/chat/v2_transformation.py
+++ b/litellm/llms/cohere/chat/v2_transformation.py
@@ -144,7 +144,10 @@ class CohereV2ChatConfig(OpenAIGPTConfig):
                 optional_params["stream"] = value
             if param == "temperature":
                 optional_params["temperature"] = value
-            if param == "max_tokens":
+            if (
+                param == "max_tokens"
+                and "max_completion_tokens" not in non_default_params
+            ):
                 optional_params["max_tokens"] = value
             if param == "max_completion_tokens":
                 optional_params["max_tokens"] = value

--- a/tests/test_litellm/llms/cohere/chat/test_cohere_transformation.py
+++ b/tests/test_litellm/llms/cohere/chat/test_cohere_transformation.py
@@ -64,6 +64,17 @@ class TestCohereV2Transform:
             self.model
         )
 
+    def test_v2_max_tokens_only_still_maps(self):
+        """max_tokens alone maps to cohere max_tokens when max_completion_tokens is absent"""
+        result = self.config.map_openai_params(
+            non_default_params={"temperature": 0.7, "max_tokens": 200},
+            optional_params={},
+            model=self.model,
+            drop_params=False,
+        )
+
+        assert result == {"temperature": 0.7, "max_tokens": 200}
+
     def test_v2_map_max_completion_tokens_overrides_max_tokens(self):
         """max_completion_tokens maps to cohere max_tokens and overrides max_tokens, matching v1"""
         result = self.config.map_openai_params(
@@ -78,6 +89,24 @@ class TestCohereV2Transform:
         )
 
         assert result == {"temperature": 0.7, "max_tokens": 256}
+
+    def test_v2_max_completion_tokens_precedence_is_order_independent(self):
+        """max_completion_tokens wins over max_tokens regardless of dict ordering"""
+        max_tokens_first = self.config.map_openai_params(
+            non_default_params={"max_tokens": 200, "max_completion_tokens": 256},
+            optional_params={},
+            model=self.model,
+            drop_params=False,
+        )
+        max_completion_first = self.config.map_openai_params(
+            non_default_params={"max_completion_tokens": 256, "max_tokens": 200},
+            optional_params={},
+            model=self.model,
+            drop_params=False,
+        )
+
+        assert max_tokens_first == {"max_tokens": 256}
+        assert max_completion_first == {"max_tokens": 256}
 
     def test_v2_default_route_accepts_max_completion_tokens(self):
         """The default cohere_chat route resolves to v2; max_completion_tokens must not raise"""

--- a/tests/test_litellm/llms/cohere/chat/test_cohere_transformation.py
+++ b/tests/test_litellm/llms/cohere/chat/test_cohere_transformation.py
@@ -6,7 +6,9 @@ sys.path.insert(
     0, os.path.abspath("../../../../..")
 )  # Adds the parent directory to the system path
 
+import litellm
 from litellm.llms.cohere.chat.transformation import CohereChatConfig
+from litellm.llms.cohere.chat.v2_transformation import CohereV2ChatConfig
 
 
 class TestCohereTransform:
@@ -49,3 +51,40 @@ class TestCohereTransform:
 
         # The function should properly map max_tokens if max_completion_tokens is not provided
         assert result == {"temperature": 0.7, "max_tokens": 200}
+
+
+class TestCohereV2Transform:
+    def setup_method(self):
+        self.config = CohereV2ChatConfig()
+        self.model = "command-r"
+
+    def test_v2_supports_max_completion_tokens(self):
+        """max_completion_tokens must be advertised so get_optional_params does not reject it"""
+        assert "max_completion_tokens" in self.config.get_supported_openai_params(
+            self.model
+        )
+
+    def test_v2_map_max_completion_tokens_overrides_max_tokens(self):
+        """max_completion_tokens maps to cohere max_tokens and overrides max_tokens, matching v1"""
+        result = self.config.map_openai_params(
+            non_default_params={
+                "temperature": 0.7,
+                "max_tokens": 200,
+                "max_completion_tokens": 256,
+            },
+            optional_params={},
+            model=self.model,
+            drop_params=False,
+        )
+
+        assert result == {"temperature": 0.7, "max_tokens": 256}
+
+    def test_v2_default_route_accepts_max_completion_tokens(self):
+        """The default cohere_chat route resolves to v2; max_completion_tokens must not raise"""
+        optional_params = litellm.get_optional_params(
+            model=self.model,
+            custom_llm_provider="cohere_chat",
+            max_completion_tokens=256,
+        )
+
+        assert optional_params["max_tokens"] == 256


### PR DESCRIPTION
## Relevant issues

No existing issue; found while testing the default `cohere_chat` route with the OpenAI-compatible `max_completion_tokens` parameter

## Type

Bug Fix

## What

`get_cohere_route` defaults to `v2` for any model without a `v1/` prefix, so a plain model like `command-r` is handled by `CohereV2ChatConfig`. That config never advertised or mapped `max_completion_tokens`: it was missing from `get_supported_openai_params`, and `map_openai_params` had no branch for it. So an OpenAI-compatible request that uses `max_completion_tokens` (the modern replacement for the deprecated `max_tokens`) against the default Cohere route fails with `litellm.UnsupportedParamsError`, while the same request explicitly routed to v1 (`model="v1/command-r"`) succeeds and maps to Cohere's `max_tokens`

The v1 config (`CohereChatConfig`) already lists `max_completion_tokens` and maps it onto `max_tokens`, and the existing `test_map_cohere_params` asserts that mapping, so this was a v1/v2 divergence rather than intended behavior. The fix adds `max_completion_tokens` to `get_supported_openai_params` and maps it to `optional_params["max_tokens"]`. When both `max_tokens` and `max_completion_tokens` are supplied, `max_completion_tokens` takes precedence explicitly (it is the canonical replacement for the deprecated `max_tokens`), so the result no longer depends on dict iteration order

Before, on the default route:

```
>>> litellm.get_optional_params(model="command-r", custom_llm_provider="cohere_chat", max_completion_tokens=256)
litellm.UnsupportedParamsError: cohere_chat does not support parameters: ['max_completion_tokens'], for model=command-r
```

After:

```
>>> litellm.get_optional_params(model="command-r", custom_llm_provider="cohere_chat", max_completion_tokens=256)
{'stream': False, 'max_tokens': 256}
```

## Tests

Added `TestCohereV2Transform` to `tests/test_litellm/llms/cohere/chat/test_cohere_transformation.py`: that `max_completion_tokens` is advertised by `get_supported_openai_params`, that `map_openai_params` maps it onto `max_tokens` and overrides a supplied `max_tokens`, that precedence holds regardless of dict ordering, and that the default `cohere_chat` route accepts it through `get_optional_params` without raising. Each fails before the corresponding change and passes after it


## Proof of Fix

Ran a live proxy locally with a single Cohere model and called it with `max_completion_tokens` against the real Cohere API. Config used

```yaml
model_list:
  - model_name: command-a
    litellm_params:
      model: cohere/command-a-03-2025
      api_key: os.environ/COHERE_API_KEY
general_settings:
  master_key: sk-1234
```

Before the fix, the default cohere route (v2 config) rejects the request

```
$ curl -s http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"command-a","messages":[{"role":"user","content":"Write one sentence about the ocean."}],"max_completion_tokens":16}'

HTTP 400
litellm.UnsupportedParamsError: cohere_chat does not support parameters: ['max_completion_tokens'], for model=command-a-03-2025
```

After the fix, the same request succeeds and the cap is honored (completion_tokens is 16)

```
$ curl -s http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"command-a","messages":[{"role":"user","content":"Write one sentence about the ocean."}],"max_completion_tokens":16}'

HTTP 200
{
  "model": "command-a",
  "choices": [
    {"finish_reason": "stop", "index": 0,
     "message": {"role": "assistant", "content": "The ocean, covering over 70% of Earth's surface, is"}}
  ],
  "usage": {"completion_tokens": 16, "prompt_tokens": 502, "total_tokens": 518}
}
```
