### PR TITLE
perf(anthropic): serialize the /v1/messages request body with orjson

### DIFF
--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -1,5 +1,10 @@
 import json
 import ssl
+
+try:
+    import orjson
+except ImportError:  # pragma: no cover - orjson is a proxy extra, not a base SDK dep
+    orjson = None  # type: ignore[assignment]
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 from typing import (
     TYPE_CHECKING,
@@ -158,6 +163,21 @@ if TYPE_CHECKING:
     LiteLLMLoggingObj = _LiteLLMLoggingObj
 else:
     LiteLLMLoggingObj = Any
+
+
+def _dumps_request_body(request_body: Any) -> str:
+    """Serialize a request body to a JSON string with orjson (~20-25x faster than
+    the stdlib encoder on large bodies). This runs synchronously on the event
+    loop, so the GIL-held time directly caps proxy throughput under concurrent
+    long-context traffic. Falls back to the stdlib encoder for the rare payload
+    orjson rejects (e.g. ints beyond 64 bits), and when orjson is not installed
+    (SDK-only environments without the proxy extras), to preserve prior behavior."""
+    if orjson is not None:
+        try:
+            return orjson.dumps(request_body).decode("utf-8")
+        except (TypeError, orjson.JSONEncodeError):
+            pass
+    return json.dumps(request_body)
 
 
 def _google_genai_streaming_hidden_params(
@@ -1917,7 +1937,7 @@ class BaseLLMHTTPHandler:
                 response = await async_httpx_client.post(
                     url=request_url,
                     headers=headers,
-                    data=signed_json_body or json.dumps(request_body),
+                    data=signed_json_body or _dumps_request_body(request_body),
                     stream=stream or False,
                     logging_obj=logging_obj,
                 )
@@ -2098,7 +2118,7 @@ class BaseLLMHTTPHandler:
         # (e.g. Bedrock) keep their signed body untouched. The HTTP-error
         # retry path mutates + re-signs the body, so it still re-serializes
         # internally -- this only deduplicates the success path.
-        request_body_json = json.dumps(request_body)
+        request_body_json = _dumps_request_body(request_body)
 
         logging_obj.pre_call(
             input=[{"role": "user", "content": request_body_json}],

--- a/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
@@ -725,8 +725,9 @@ async def test_anthropic_post_uses_prebuilt_body_without_redumping():
 
 
 @pytest.mark.asyncio
-async def test_anthropic_post_falls_back_to_json_dumps_when_unsigned_none():
-    """signed_json_body=None keeps the exact legacy behavior."""
+async def test_anthropic_post_serializes_unsigned_body_with_orjson():
+    """signed_json_body=None -> the body is serialized for the wire (now via
+    orjson). The sent bytes must parse back to the original request body."""
     import json as _json
 
     handler = BaseLLMHTTPHandler()
@@ -756,7 +757,8 @@ async def test_anthropic_post_falls_back_to_json_dumps_when_unsigned_none():
         model="claude",
     )
     sent = http_client.post.await_args.kwargs["data"]
-    assert sent == _json.dumps(request_body)
+    assert isinstance(sent, str)
+    assert _json.loads(sent) == request_body
 
 
 @pytest.mark.asyncio
@@ -810,8 +812,9 @@ async def test_anthropic_post_retry_reserializes_mutated_body():
     assert http_client.post.await_count == 2
     first_sent = http_client.post.await_args_list[0].kwargs["data"]
     second_sent = http_client.post.await_args_list[1].kwargs["data"]
-    assert first_sent == prebuilt  # attempt 0 used prebuilt
-    assert second_sent == _json.dumps(request_body)  # attempt 1 re-serialized
+    assert first_sent == prebuilt  # attempt 0 used the prebuilt body as-is
+    assert isinstance(second_sent, str)
+    assert _json.loads(second_sent) == request_body  # attempt 1 re-serialized
     assert "MUTATED" in second_sent  # ... the mutated body
 
 
@@ -1051,3 +1054,36 @@ def test_async_compact_handler_sends_json_when_not_signed():
     )
     assert kwargs.get("json") == {"model": "openai.gpt-5.5", "input": "hi"}
     assert "data" not in kwargs
+
+
+def test_dumps_request_body_orjson_with_stdlib_fallback(monkeypatch):
+    """_dumps_request_body serializes via orjson (fast, valid JSON) and falls
+    back to the stdlib encoder for payloads orjson rejects (e.g. ints beyond
+    64 bits) and when orjson is not installed (SDK-only environments), always
+    producing a str that parses back to the input."""
+    import json as _json
+
+    from litellm.llms.custom_httpx import llm_http_handler as _h
+    from litellm.llms.custom_httpx.llm_http_handler import _dumps_request_body
+
+    body = {
+        "model": "claude",
+        "messages": [{"role": "user", "content": "café \U0001f600"}],
+        "n": 1,
+        "f": 2.5,
+        "ok": True,
+        "nil": None,
+    }
+    out = _dumps_request_body(body)
+    assert isinstance(out, str)
+    assert _json.loads(out) == body
+
+    # orjson raises on ints beyond 64 bits -> stdlib fallback handles them
+    big = {"x": 2**70}
+    assert _json.loads(_dumps_request_body(big)) == big
+
+    # orjson unavailable (SDK install without the proxy extras) -> stdlib fallback
+    monkeypatch.setattr(_h, "orjson", None)
+    out_no_orjson = _dumps_request_body(body)
+    assert isinstance(out_no_orjson, str)
+    assert _json.loads(out_no_orjson) == body


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review

## Screenshots / Proof of Fix

Measured with our internal proxy benchmark harness (mock Anthropic upstream, single uvicorn worker on the full production stack: uvloop + httptools + orjson; a tool-heavy Claude Code shaped payload of ~500K tokens across 500 tool_use/tool_result turns; not externally reproducible yet, numbers provided as claims). Median of 5 passes at concurrency 10:

| | without this fix | with this fix |
| --- | --- | --- |
| throughput | 68.5 RPS | 84.6 RPS (+23%) |
| p50 latency | 127 ms | 102 ms (-20%) |
| event-loop freezes >50ms | 2 | 2 |

Both paths serialize the same request body; the gain is throughput and latency from removing the synchronous stdlib `json.dumps` of a multi-MB body (~2.84 ms versus ~0.11 ms for orjson on a 1.9 MB body). Event-loop-lag is unchanged because the residual freeze is cold-start/inherent rather than serialization, so this is purely a per-request CPU (GIL-held) reduction that lifts the single-loop throughput ceiling.

## Type

🚄 Infrastructure

## Changes

The Anthropic `/v1/messages` handler serializes the request body to a JSON string once and reuses it for both the pre-call log input and the wire body. On long-context Claude Code traffic that body is several MB, and the stdlib json encoder is roughly 20-25x slower than orjson on it. Because the serialization holds the GIL, it directly caps proxy throughput under concurrent load.

This serializes via orjson through a small helper. orjson is a proxy extra rather than a base SDK dependency, so it is imported under try/except and the helper falls back to the stdlib encoder when orjson is unavailable (SDK-only installs) or for the rare payload orjson rejects (for example ints beyond 64 bits), preserving behavior. The same helper covers the error-retry path, which re-serializes the mutated body after a re-sign. The wire body is sent as httpx `data=<str>`, so it is not re-encoded downstream; serialization happens exactly once.

orjson emits spec-compliant `null` for non-finite floats instead of the stdlib encoder's invalid `NaN`/`Infinity` tokens, though request bodies do not carry those. The two existing serialization tests are updated to assert the sent body parses back to the request (semantic equivalence) plus a `str` type check, rather than byte-equality to the stdlib encoder, and a new test covers the helper's orjson path, big-int fallback, and orjson-unavailable fallback
