### PR TITLE
test(vcr): stop refreshing cassette TTL on read so cassettes lapse after 24h

### DIFF
--- a/tests/_vcr_redis_persister.py
+++ b/tests/_vcr_redis_persister.py
@@ -174,21 +174,13 @@ def make_redis_persister(
                 _log.warning(msg)
                 warnings.warn(msg, VCRCassetteCacheWarning, stacklevel=2)
                 raise CassetteNotFoundError() from exc
-            # Slide the expiry forward on every successful read. A plain GET
-            # does not touch the key's TTL, so a cassette that is only ever
-            # replayed (HIT/NOOP, never re-recorded) expires exactly
-            # ``ttl_seconds`` after its last *write* no matter how often it is
-            # read — and whichever CI run happens to cross that boundary
-            # re-records it live, surfacing as a spurious VCR MISS that no
-            # amount of matcher tolerance can prevent. Refreshing the TTL on
-            # read keeps any cassette used at least once per TTL window alive
-            # indefinitely, so the second/third run of a day replays cleanly.
-            # Best-effort: a failed refresh must never turn a successful load
-            # into a miss.
-            try:
-                redis_client.expire(key, ttl_seconds)
-            except RedisError:
-                pass
+            # TTL is intentionally not refreshed on read. The cassette must
+            # lapse ``ttl_seconds`` after its last *write*, so the next run
+            # past that point re-records live and catches provider request or
+            # response contract drift instead of replaying a frozen response
+            # forever. Sliding the expiry forward on read would keep an
+            # actively-used cassette alive indefinitely and that drift check
+            # would never run.
             return result
 
         @staticmethod

--- a/tests/llm_translation/test_vcr_redis_persister.py
+++ b/tests/llm_translation/test_vcr_redis_persister.py
@@ -79,57 +79,27 @@ def test_load_missing_key_raises_cassette_not_found():
         persister.load_cassette("never/recorded", yamlserializer)
 
 
-def test_load_refreshes_ttl_so_replayed_cassettes_do_not_expire():
-    """A successful read must slide the cassette's expiry forward.
+def test_load_does_not_refresh_ttl_so_cassettes_lapse_after_write():
+    """A successful read must not slide the cassette's expiry forward.
 
-    Regression: ``load_cassette`` used a plain ``GET``, which does not
-    touch the key's TTL. A cassette that is only ever replayed (HIT/NOOP,
-    never re-recorded) therefore expired exactly ``CASSETTE_TTL_SECONDS``
-    after its last *write* no matter how often it was read, and whichever
-    CI run crossed that 24h boundary re-recorded it live — a spurious VCR
-    MISS on otherwise-deterministic cassettes. Reading must refresh the
-    TTL so an actively-used cassette never expires.
+    The TTL deliberately counts down from the last *write*: a cassette that
+    is only ever replayed must still lapse ``CASSETTE_TTL_SECONDS`` after it
+    was recorded, so the next run past that point re-records live and catches
+    provider request/response contract drift. Refreshing the TTL on read
+    would keep an actively-used cassette alive forever and that drift check
+    would never run.
     """
     fake, persister = _persister_with_fake_redis()
-    cassette_id = "tests/llm_translation/test_x/test_ttl_refresh"
+    cassette_id = "tests/llm_translation/test_x/test_ttl_no_refresh"
     key = redis_key_for(cassette_id)
 
     persister.save_cassette(cassette_id, _sample_cassette_dict(), yamlserializer)
     # Simulate a cassette written ~most-of-a-day ago: only a little TTL left.
     fake.expire(key, 60)
-    assert fake.ttl(key) <= 60
 
     persister.load_cassette(cassette_id, yamlserializer)
 
-    refreshed = fake.ttl(key)
-    assert CASSETTE_TTL_SECONDS - 5 <= refreshed <= CASSETTE_TTL_SECONDS
-
-
-def test_load_ttl_refresh_failure_does_not_break_load():
-    """A failed TTL refresh must never turn a successful load into a miss."""
-
-    class _RefreshFailsRedis:
-        def __init__(self, inner):
-            self._inner = inner
-
-        def get(self, *args, **kwargs):
-            return self._inner.get(*args, **kwargs)
-
-        def set(self, *args, **kwargs):
-            return self._inner.set(*args, **kwargs)
-
-        def expire(self, *args, **kwargs):
-            raise RedisConnectionError("simulated outage")
-
-    client = _RefreshFailsRedis(fakeredis.FakeStrictRedis())
-    persister = make_redis_persister(client=client)
-    cassette_id = "tests/llm_translation/test_x/test_ttl_refresh_fail"
-
-    persister.save_cassette(cassette_id, _sample_cassette_dict(), yamlserializer)
-    requests, responses = persister.load_cassette(cassette_id, yamlserializer)
-
-    assert len(requests) == 1
-    assert len(responses) == 1
+    assert fake.ttl(key) <= 60
 
 
 def test_redis_key_normalizes_path_passed_by_pytest_recording():


### PR DESCRIPTION
## Relevant issues

The Redis-backed VCR cassette persister (`tests/_vcr_redis_persister.py`) slid the 24h TTL forward on every successful read (`redis_client.expire(key, ttl_seconds)` in `load_cassette`). A cassette that is only ever replayed therefore never expired as long as it was read at least once per 24h window. With CI running more than once a day, a recorded provider response is replayed indefinitely and the suite never re-hits the real provider, so a changed request shape or response contract on the provider side goes undetected until someone manually deletes the key

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Background

Refresh-on-read was added to avoid a "spurious" VCR MISS: without it, the cassette expires exactly 24h after its last write, so whichever run crosses that boundary re-records live. The trade it made to get that stability was giving up the only point at which the cassette is ever re-validated against the provider, which turns the cache from a freshness window into a permanent freeze. For a cache whose whole purpose includes catching provider drift, that is the wrong side of the trade

This drops the refresh. The TTL now counts down from the last write, so a cassette lapses 24h after it was recorded and the next run past that point re-records live and catches drift. Every per-commit run in between still replays from cache at zero cost; only the single boundary-crossing run goes live, which is an acceptable once-per-day hit. The request-body matcher is strict (the suite matches on a byte-level body matcher, not just method and URL), so a changed request body misses and re-records rather than falsely replaying a stale response, which is what makes the periodic live re-record meaningful

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:
- [ ] **CI run for the last commit**  
       Link:
- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

This changes test infrastructure, so there is no live-proxy curl that demonstrates it. The proof is that the persister test pins the new contract and fails against the old behavior. `test_load_does_not_refresh_ttl_so_cassettes_lapse_after_write` writes a cassette, shrinks its TTL to 60s to simulate one recorded most of a day ago, reads it, and asserts the TTL is still at or under 60s

With refresh-on-read removed:

```
$ python -m pytest tests/llm_translation/test_vcr_redis_persister.py -q
37 passed
```

After temporarily re-adding `redis_client.expire(key, ttl_seconds)` on the read path and re-running just that test:

```
>       assert fake.ttl(key) <= 60
E       AssertionError: assert 86400 <= 60
1 failed
```

## Type

🧹 Refactoring
✅ Test

## Changes

`tests/_vcr_redis_persister.py`: removed the `expire(key, ttl_seconds)` refresh from `load_cassette` (and the comment explaining it), leaving a short comment that records why the TTL is deliberately not refreshed so it does not get re-added by mistake

`tests/llm_translation/test_vcr_redis_persister.py`: replaced `test_load_refreshes_ttl_so_replayed_cassettes_do_not_expire` with `test_load_does_not_refresh_ttl_so_cassettes_lapse_after_write`, which asserts the inverted contract, and removed `test_load_ttl_refresh_failure_does_not_break_load`, which only existed to cover the now-deleted refresh call

---
_Generated by [Claude Code](https://claude.ai/code/session_01MZbuvUySMysdhHHwXV1pQF)_