### PR TITLE
test(ci): record/replay OpenAI image gen so the spend E2E isn't outage-bound

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1626,6 +1626,25 @@ jobs:
             zstd -d litellm-docker-database.tar.zst --stdout | docker load
             docker tag litellm-docker-database:ci my-app:latest
       - run:
+          name: Start OpenAI image record/replay proxy
+          background: true
+          command: |
+            CASSETTE_REDIS_URL="$CASSETTE_REDIS_URL" \
+            RECORDER_UPSTREAM_BASE_URL="https://api.openai.com" \
+              uv run --no-sync python tests/_openai_record_replay_proxy.py --host 0.0.0.0 --port 8090
+      - run:
+          name: Wait for record/replay proxy
+          command: |
+            for i in $(seq 1 30); do
+              if curl -sf http://localhost:8090/__recorder_health >/dev/null 2>&1; then
+                echo "record/replay proxy is up"
+                exit 0
+              fi
+              sleep 1
+            done
+            echo "record/replay proxy did not become ready" >&2
+            exit 1
+      - run:
           name: Run Docker container
           command: |
             docker run -d \
@@ -1655,6 +1674,7 @@ jobs:
               -e LANGFUSE_PROJECT2_PUBLIC=$LANGFUSE_PROJECT2_PUBLIC \
               -e LANGFUSE_PROJECT1_SECRET=$LANGFUSE_PROJECT1_SECRET \
               -e LANGFUSE_PROJECT2_SECRET=$LANGFUSE_PROJECT2_SECRET \
+              -e IMAGE_GEN_RECORDER_BASE_URL=http://host.docker.internal:8090/v1 \
               --add-host host.docker.internal:host-gateway \
               --name my-app \
               -v $(pwd)/proxy_server_config.yaml:/app/config.yaml \

--- a/proxy_server_config.yaml
+++ b/proxy_server_config.yaml
@@ -44,6 +44,15 @@ model_list:
   - model_name: openai-dall-e-3 # dall-e-3 deprecated 2026-05-12; underlying now gpt-image-1
     litellm_params:
       model: gpt-image-1
+  # In CI, IMAGE_GEN_RECORDER_BASE_URL points this at the record/replay proxy
+  # (tests/_openai_record_replay_proxy.py) so the image spend E2E doesn't depend
+  # on OpenAI's uptime every commit. Unset elsewhere, so it resolves to None and
+  # falls back to api.openai.com.
+  - model_name: gpt-image-1
+    litellm_params:
+      model: openai/gpt-image-1
+      api_key: os.environ/OPENAI_API_KEY
+      api_base: os.environ/IMAGE_GEN_RECORDER_BASE_URL
   - model_name: fake-openai-endpoint
     litellm_params:
       model: openai/gpt-5-mini

--- a/tests/_openai_record_replay_proxy.py
+++ b/tests/_openai_record_replay_proxy.py
@@ -1,0 +1,238 @@
+"""Record/replay reverse proxy for the dockerized image-gen spend E2E.
+
+The spend-accuracy test ``tests/test_keys.py::
+test_key_info_spend_values_image_generation`` runs the litellm proxy in its own
+container and curls it over real HTTP, then asserts the proxy tracked a nonzero
+spend for a ``gpt-image-1`` call. That call wildcard-routes to ``openai/*`` on
+the real key, so every commit run hit api.openai.com for a paid image and was
+exposed to OpenAI outages (the 401 that started this).
+
+This process sits between the proxy and api.openai.com. The proxy points only
+its image model's ``api_base`` here; nothing else about the topology changes.
+The first request (or the first after a recording lapses) is forwarded live to
+OpenAI and recorded; subsequent requests within the TTL replay the recorded
+response, so the per-commit run no longer depends on OpenAI being up.
+
+Recordings live in the same Redis cassette store as the VCR persister
+(``CASSETTE_REDIS_URL``) and expire ``CASSETTE_TTL_SECONDS`` after their last
+write, never refreshed on read. A recording therefore goes stale a day after
+capture and the next run past that point re-records live and catches provider
+contract drift, exactly matching the lapse-after-write contract in
+``tests/_vcr_redis_persister.py``.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+from typing import Awaitable, Callable, List, Optional, Tuple
+
+CASSETTE_TTL_SECONDS = 24 * 60 * 60
+RECORD_KEY_PREFIX = "litellm:openai:record:"
+RECORDER_REDIS_URL_ENV = "CASSETTE_REDIS_URL"
+UPSTREAM_BASE_URL_ENV = "RECORDER_UPSTREAM_BASE_URL"
+DEFAULT_UPSTREAM_BASE_URL = "https://api.openai.com"
+
+Headers = List[Tuple[str, str]]
+UpstreamResult = Tuple[int, Headers, bytes]
+FetchUpstream = Callable[[], Awaitable[UpstreamResult]]
+
+# Headers the re-serving layer owns and must set itself. Replaying an upstream
+# framing header verbatim onto a freshly built response is the same class of bug
+# as the Bedrock content-length: 0 regression (#29549): a stale header rides
+# along and contradicts the real body. The serving server recomputes
+# content-length and sets its own date/server; the stored body is already
+# content-decoded so content-encoding must not claim otherwise.
+_STRIPPED_RESPONSE_HEADERS = frozenset(
+    {
+        "content-length",
+        "content-encoding",
+        "transfer-encoding",
+        "connection",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailer",
+        "upgrade",
+        "date",
+        "server",
+    }
+)
+
+
+def _canonical_body(body: bytes) -> bytes:
+    if not body:
+        return b""
+    try:
+        return json.dumps(
+            json.loads(body), sort_keys=True, separators=(",", ":")
+        ).encode("utf-8")
+    except (ValueError, TypeError):
+        return body
+
+
+def _sanitize_headers(headers: Headers) -> Headers:
+    return [(k, v) for (k, v) in headers if k.lower() not in _STRIPPED_RESPONSE_HEADERS]
+
+
+class OpenAIRecordReplay:
+    """Record-once / replay-from-Redis for upstream OpenAI HTTP calls.
+
+    ``redis_client`` is injected so the process wiring and the tests share one
+    code path; pass ``None`` to run as a pure live passthrough (local dev with
+    no cassette Redis).
+    """
+
+    def __init__(
+        self,
+        redis_client,
+        *,
+        upstream_base_url: str = DEFAULT_UPSTREAM_BASE_URL,
+        ttl_seconds: int = CASSETTE_TTL_SECONDS,
+    ) -> None:
+        self._redis = redis_client
+        self.upstream_base_url = upstream_base_url.rstrip("/")
+        self._ttl_seconds = ttl_seconds
+
+    @staticmethod
+    def record_key(method: str, path: str, body: bytes) -> str:
+        digest = hashlib.sha256(
+            b"\n".join(
+                [
+                    method.upper().encode("utf-8"),
+                    path.encode("utf-8"),
+                    _canonical_body(body),
+                ]
+            )
+        ).hexdigest()
+        return f"{RECORD_KEY_PREFIX}{digest}"
+
+    async def handle(
+        self, method: str, path: str, body: bytes, fetch_upstream: FetchUpstream
+    ) -> UpstreamResult:
+        key = self.record_key(method, path, body)
+        cached = self._cache_get(key)
+        if cached is not None:
+            return cached
+
+        status, headers, resp_body = await fetch_upstream()
+        sanitized = _sanitize_headers(headers)
+        if 200 <= status < 300:
+            self._cache_set(key, status, sanitized, resp_body)
+        return status, sanitized, resp_body
+
+    def _cache_get(self, key: str) -> Optional[UpstreamResult]:
+        if self._redis is None:
+            return None
+        try:
+            raw = self._redis.get(key)
+        except Exception:
+            return None
+        if raw is None:
+            return None
+        try:
+            payload = json.loads(raw)
+            status = int(payload["status"])
+            headers = [(str(k), str(v)) for k, v in payload["headers"]]
+            resp_body = base64.b64decode(payload["body_b64"])
+        except Exception:
+            return None
+        return status, headers, resp_body
+
+    def _cache_set(self, key: str, status: int, headers: Headers, body: bytes) -> None:
+        if self._redis is None:
+            return
+        payload = json.dumps(
+            {
+                "status": status,
+                "headers": [[k, v] for (k, v) in headers],
+                "body_b64": base64.b64encode(body).decode("ascii"),
+            }
+        )
+        try:
+            self._redis.set(key, payload, ex=self._ttl_seconds)
+        except Exception:
+            pass
+
+
+def _build_default_redis_client():
+    url = os.environ.get(RECORDER_REDIS_URL_ENV)
+    if not url:
+        return None
+    import redis
+
+    return redis.Redis.from_url(
+        url,
+        socket_timeout=5,
+        socket_connect_timeout=5,
+        decode_responses=False,
+    )
+
+
+def create_app(recorder: Optional[OpenAIRecordReplay] = None, http_client=None):
+    import httpx
+    from starlette.applications import Starlette
+    from starlette.responses import PlainTextResponse, Response
+    from starlette.routing import Route
+
+    if recorder is None:
+        recorder = OpenAIRecordReplay(
+            redis_client=_build_default_redis_client(),
+            upstream_base_url=os.environ.get(
+                UPSTREAM_BASE_URL_ENV, DEFAULT_UPSTREAM_BASE_URL
+            ),
+        )
+    client = http_client or httpx.AsyncClient(timeout=httpx.Timeout(120.0))
+
+    async def health(_request):
+        return PlainTextResponse("ok")
+
+    async def proxy(request):
+        body = await request.body()
+        path = request.url.path
+        full_path = f"{path}?{request.url.query}" if request.url.query else path
+
+        async def fetch_upstream() -> UpstreamResult:
+            fwd_headers = {
+                k: v for k, v in request.headers.items() if k.lower() != "host"
+            }
+            upstream = await client.request(
+                request.method,
+                f"{recorder.upstream_base_url}{full_path}",
+                content=body,
+                headers=fwd_headers,
+            )
+            return (
+                upstream.status_code,
+                list(upstream.headers.items()),
+                upstream.content,
+            )
+
+        status, headers, resp_body = await recorder.handle(
+            request.method, full_path, body, fetch_upstream
+        )
+        return Response(content=resp_body, status_code=status, headers=dict(headers))
+
+    return Starlette(
+        routes=[
+            Route("/__recorder_health", health, methods=["GET"]),
+            Route(
+                "/{path:path}", proxy, methods=["GET", "POST", "PUT", "PATCH", "DELETE"]
+            ),
+        ]
+    )
+
+
+if __name__ == "__main__":
+    import argparse
+
+    import uvicorn
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--port", type=int, default=8090)
+    args = parser.parse_args()
+    uvicorn.run(create_app(), host=args.host, port=args.port)

--- a/tests/_openai_record_replay_proxy.py
+++ b/tests/_openai_record_replay_proxy.py
@@ -67,9 +67,7 @@ def _canonical_body(body: bytes) -> bytes:
     if not body:
         return b""
     try:
-        return json.dumps(
-            json.loads(body), sort_keys=True, separators=(",", ":")
-        ).encode("utf-8")
+        return json.dumps(json.loads(body), sort_keys=True, separators=(",", ":")).encode("utf-8")
     except (ValueError, TypeError):
         return body
 
@@ -110,9 +108,7 @@ class OpenAIRecordReplay:
         ).hexdigest()
         return f"{RECORD_KEY_PREFIX}{digest}"
 
-    async def handle(
-        self, method: str, path: str, body: bytes, fetch_upstream: FetchUpstream
-    ) -> UpstreamResult:
+    async def handle(self, method: str, path: str, body: bytes, fetch_upstream: FetchUpstream) -> UpstreamResult:
         key = self.record_key(method, path, body)
         cached = self._cache_get(key)
         if cached is not None:
@@ -173,6 +169,8 @@ def _build_default_redis_client():
 
 
 def create_app(recorder: Optional[OpenAIRecordReplay] = None, http_client=None):
+    import contextlib
+
     import httpx
     from starlette.applications import Starlette
     from starlette.responses import PlainTextResponse, Response
@@ -181,11 +179,18 @@ def create_app(recorder: Optional[OpenAIRecordReplay] = None, http_client=None):
     if recorder is None:
         recorder = OpenAIRecordReplay(
             redis_client=_build_default_redis_client(),
-            upstream_base_url=os.environ.get(
-                UPSTREAM_BASE_URL_ENV, DEFAULT_UPSTREAM_BASE_URL
-            ),
+            upstream_base_url=os.environ.get(UPSTREAM_BASE_URL_ENV, DEFAULT_UPSTREAM_BASE_URL),
         )
+    owns_client = http_client is None
     client = http_client or httpx.AsyncClient(timeout=httpx.Timeout(120.0))
+
+    @contextlib.asynccontextmanager
+    async def lifespan(_app):
+        try:
+            yield
+        finally:
+            if owns_client:
+                await client.aclose()
 
     async def health(_request):
         return PlainTextResponse("ok")
@@ -196,9 +201,7 @@ def create_app(recorder: Optional[OpenAIRecordReplay] = None, http_client=None):
         full_path = f"{path}?{request.url.query}" if request.url.query else path
 
         async def fetch_upstream() -> UpstreamResult:
-            fwd_headers = {
-                k: v for k, v in request.headers.items() if k.lower() != "host"
-            }
+            fwd_headers = {k: v for k, v in request.headers.items() if k.lower() != "host"}
             upstream = await client.request(
                 request.method,
                 f"{recorder.upstream_base_url}{full_path}",
@@ -211,18 +214,15 @@ def create_app(recorder: Optional[OpenAIRecordReplay] = None, http_client=None):
                 upstream.content,
             )
 
-        status, headers, resp_body = await recorder.handle(
-            request.method, full_path, body, fetch_upstream
-        )
+        status, headers, resp_body = await recorder.handle(request.method, full_path, body, fetch_upstream)
         return Response(content=resp_body, status_code=status, headers=dict(headers))
 
     return Starlette(
         routes=[
             Route("/__recorder_health", health, methods=["GET"]),
-            Route(
-                "/{path:path}", proxy, methods=["GET", "POST", "PUT", "PATCH", "DELETE"]
-            ),
-        ]
+            Route("/{path:path}", proxy, methods=["GET", "POST", "PUT", "PATCH", "DELETE"]),
+        ],
+        lifespan=lifespan,
     )
 
 

--- a/tests/llm_translation/test_openai_record_replay_proxy.py
+++ b/tests/llm_translation/test_openai_record_replay_proxy.py
@@ -23,9 +23,7 @@ class _Upstream:
     def __init__(self, status=200, headers=None, body=_OK_BODY):
         self.calls = 0
         self._status = status
-        self._headers = (
-            headers if headers is not None else [("content-type", "application/json")]
-        )
+        self._headers = headers if headers is not None else [("content-type", "application/json")]
         self._body = body
 
     async def __call__(self):
@@ -34,9 +32,7 @@ class _Upstream:
 
 
 def _recorder(client=None):
-    return OpenAIRecordReplay(
-        client if client is not None else fakeredis.FakeStrictRedis()
-    )
+    return OpenAIRecordReplay(client if client is not None else fakeredis.FakeStrictRedis())
 
 
 def _run(coro):
@@ -49,17 +45,13 @@ def test_miss_forwards_to_upstream_and_records():
     upstream = _Upstream()
 
     status, headers, body = _run(
-        recorder.handle(
-            "POST", "/v1/images/generations", b'{"model":"gpt-image-1"}', upstream
-        )
+        recorder.handle("POST", "/v1/images/generations", b'{"model":"gpt-image-1"}', upstream)
     )
 
     assert upstream.calls == 1
     assert status == 200
     assert body == _OK_BODY
-    key = OpenAIRecordReplay.record_key(
-        "POST", "/v1/images/generations", b'{"model":"gpt-image-1"}'
-    )
+    key = OpenAIRecordReplay.record_key("POST", "/v1/images/generations", b'{"model":"gpt-image-1"}')
     assert key.startswith(RECORD_KEY_PREFIX)
     assert fake.get(key) is not None
 
@@ -81,27 +73,15 @@ def test_different_body_is_a_separate_recording():
     recorder = _recorder()
     upstream = _Upstream()
 
-    _run(
-        recorder.handle(
-            "POST", "/v1/images/generations", b'{"prompt":"otter"}', upstream
-        )
-    )
-    _run(
-        recorder.handle(
-            "POST", "/v1/images/generations", b'{"prompt":"seal"}', upstream
-        )
-    )
+    _run(recorder.handle("POST", "/v1/images/generations", b'{"prompt":"otter"}', upstream))
+    _run(recorder.handle("POST", "/v1/images/generations", b'{"prompt":"seal"}', upstream))
 
     assert upstream.calls == 2
 
 
 def test_record_key_ignores_json_key_order():
-    a = OpenAIRecordReplay.record_key(
-        "POST", "/v1/images/generations", b'{"model":"x","prompt":"y"}'
-    )
-    b = OpenAIRecordReplay.record_key(
-        "POST", "/v1/images/generations", b'{"prompt":"y","model":"x"}'
-    )
+    a = OpenAIRecordReplay.record_key("POST", "/v1/images/generations", b'{"model":"x","prompt":"y"}')
+    b = OpenAIRecordReplay.record_key("POST", "/v1/images/generations", b'{"prompt":"y","model":"x"}')
     assert a == b
 
 
@@ -145,12 +125,8 @@ def test_replay_drops_framing_headers_so_server_recomputes():
     )
     body_in = b'{"model":"gpt-image-1"}'
 
-    _, live_headers, _ = _run(
-        recorder.handle("POST", "/v1/images/generations", body_in, upstream)
-    )
-    _, replay_headers, _ = _run(
-        recorder.handle("POST", "/v1/images/generations", body_in, upstream)
-    )
+    _, live_headers, _ = _run(recorder.handle("POST", "/v1/images/generations", body_in, upstream))
+    _, replay_headers, _ = _run(recorder.handle("POST", "/v1/images/generations", body_in, upstream))
 
     for headers in (live_headers, replay_headers):
         names = {k.lower() for k, _ in headers}
@@ -174,9 +150,7 @@ def test_non_2xx_response_is_not_cached():
     body_in = b'{"model":"gpt-image-1"}'
     key = OpenAIRecordReplay.record_key("POST", "/v1/images/generations", body_in)
 
-    status, _, _ = _run(
-        recorder.handle("POST", "/v1/images/generations", body_in, upstream)
-    )
+    status, _, _ = _run(recorder.handle("POST", "/v1/images/generations", body_in, upstream))
     assert status == 500
     assert fake.get(key) is None
 
@@ -213,3 +187,30 @@ def test_passthrough_when_no_redis_client_configured():
     _run(recorder.handle("POST", "/v1/images/generations", body_in, upstream))
 
     assert upstream.calls == 2
+
+
+class _StubClient:
+    def __init__(self):
+        self.closed = False
+
+    async def aclose(self):
+        self.closed = True
+
+
+def test_app_lifespan_leaves_injected_http_client_open():
+    """The app must only close the client it created, never a caller's.
+
+    A caller that injects its own client owns that client's lifecycle; the
+    app closing it would break reuse across multiple ``create_app`` calls.
+    """
+    from starlette.testclient import TestClient
+
+    from tests._openai_record_replay_proxy import create_app
+
+    client = _StubClient()
+    app = create_app(recorder=_recorder(), http_client=client)
+
+    with TestClient(app):
+        pass
+
+    assert client.closed is False

--- a/tests/llm_translation/test_openai_record_replay_proxy.py
+++ b/tests/llm_translation/test_openai_record_replay_proxy.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+
+import fakeredis
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from tests._openai_record_replay_proxy import (  # noqa: E402
+    CASSETTE_TTL_SECONDS,
+    RECORD_KEY_PREFIX,
+    OpenAIRecordReplay,
+)
+
+_OK_BODY = b'{"data":[{"b64_json":"aW1n"}],"usage":{"total_tokens":42}}'
+
+
+class _Upstream:
+    """Stub live upstream; counts calls so replays can be proven offline."""
+
+    def __init__(self, status=200, headers=None, body=_OK_BODY):
+        self.calls = 0
+        self._status = status
+        self._headers = (
+            headers if headers is not None else [("content-type", "application/json")]
+        )
+        self._body = body
+
+    async def __call__(self):
+        self.calls += 1
+        return self._status, list(self._headers), self._body
+
+
+def _recorder(client=None):
+    return OpenAIRecordReplay(
+        client if client is not None else fakeredis.FakeStrictRedis()
+    )
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_miss_forwards_to_upstream_and_records():
+    fake = fakeredis.FakeStrictRedis()
+    recorder = _recorder(fake)
+    upstream = _Upstream()
+
+    status, headers, body = _run(
+        recorder.handle(
+            "POST", "/v1/images/generations", b'{"model":"gpt-image-1"}', upstream
+        )
+    )
+
+    assert upstream.calls == 1
+    assert status == 200
+    assert body == _OK_BODY
+    key = OpenAIRecordReplay.record_key(
+        "POST", "/v1/images/generations", b'{"model":"gpt-image-1"}'
+    )
+    assert key.startswith(RECORD_KEY_PREFIX)
+    assert fake.get(key) is not None
+
+
+def test_hit_replays_without_calling_upstream():
+    recorder = _recorder()
+    upstream = _Upstream()
+    body_in = b'{"model":"gpt-image-1","prompt":"otter"}'
+
+    first = _run(recorder.handle("POST", "/v1/images/generations", body_in, upstream))
+    second = _run(recorder.handle("POST", "/v1/images/generations", body_in, upstream))
+
+    assert upstream.calls == 1
+    assert first == second
+    assert second[2] == _OK_BODY
+
+
+def test_different_body_is_a_separate_recording():
+    recorder = _recorder()
+    upstream = _Upstream()
+
+    _run(
+        recorder.handle(
+            "POST", "/v1/images/generations", b'{"prompt":"otter"}', upstream
+        )
+    )
+    _run(
+        recorder.handle(
+            "POST", "/v1/images/generations", b'{"prompt":"seal"}', upstream
+        )
+    )
+
+    assert upstream.calls == 2
+
+
+def test_record_key_ignores_json_key_order():
+    a = OpenAIRecordReplay.record_key(
+        "POST", "/v1/images/generations", b'{"model":"x","prompt":"y"}'
+    )
+    b = OpenAIRecordReplay.record_key(
+        "POST", "/v1/images/generations", b'{"prompt":"y","model":"x"}'
+    )
+    assert a == b
+
+
+def test_ttl_set_on_write_and_not_refreshed_on_read():
+    """A replay must not slide the recording's expiry forward.
+
+    The recording counts down from its last write so it lapses
+    ``CASSETTE_TTL_SECONDS`` after capture and the next run re-records live,
+    catching provider drift. Refreshing the TTL on a replay would keep an
+    actively-replayed recording alive forever and that drift check would never
+    run. This mirrors the VCR persister's lapse-after-write contract.
+    """
+    fake = fakeredis.FakeStrictRedis()
+    recorder = _recorder(fake)
+    upstream = _Upstream()
+    body_in = b'{"model":"gpt-image-1"}'
+    key = OpenAIRecordReplay.record_key("POST", "/v1/images/generations", body_in)
+
+    _run(recorder.handle("POST", "/v1/images/generations", body_in, upstream))
+    assert CASSETTE_TTL_SECONDS - 5 <= fake.ttl(key) <= CASSETTE_TTL_SECONDS
+
+    fake.expire(key, 60)
+    _run(recorder.handle("POST", "/v1/images/generations", body_in, upstream))
+
+    assert fake.ttl(key) <= 60
+
+
+def test_replay_drops_framing_headers_so_server_recomputes():
+    fake = fakeredis.FakeStrictRedis()
+    recorder = _recorder(fake)
+    upstream = _Upstream(
+        headers=[
+            ("content-type", "application/json"),
+            ("content-length", "9999"),
+            ("transfer-encoding", "chunked"),
+            ("content-encoding", "gzip"),
+            ("date", "Mon, 01 Jan 2024 00:00:00 GMT"),
+            ("server", "cloudflare"),
+            ("x-request-id", "req_abc"),
+        ]
+    )
+    body_in = b'{"model":"gpt-image-1"}'
+
+    _, live_headers, _ = _run(
+        recorder.handle("POST", "/v1/images/generations", body_in, upstream)
+    )
+    _, replay_headers, _ = _run(
+        recorder.handle("POST", "/v1/images/generations", body_in, upstream)
+    )
+
+    for headers in (live_headers, replay_headers):
+        names = {k.lower() for k, _ in headers}
+        assert names.isdisjoint(
+            {
+                "content-length",
+                "transfer-encoding",
+                "content-encoding",
+                "date",
+                "server",
+            }
+        )
+        assert ("content-type", "application/json") in headers
+        assert ("x-request-id", "req_abc") in headers
+
+
+def test_non_2xx_response_is_not_cached():
+    fake = fakeredis.FakeStrictRedis()
+    recorder = _recorder(fake)
+    upstream = _Upstream(status=500, body=b'{"error":"boom"}')
+    body_in = b'{"model":"gpt-image-1"}'
+    key = OpenAIRecordReplay.record_key("POST", "/v1/images/generations", body_in)
+
+    status, _, _ = _run(
+        recorder.handle("POST", "/v1/images/generations", body_in, upstream)
+    )
+    assert status == 500
+    assert fake.get(key) is None
+
+    _run(recorder.handle("POST", "/v1/images/generations", body_in, upstream))
+    assert upstream.calls == 2
+
+
+class _BoomRedis:
+    def get(self, *args, **kwargs):
+        raise ConnectionError("redis offline")
+
+    def set(self, *args, **kwargs):
+        raise ConnectionError("redis offline")
+
+
+def test_redis_outage_degrades_to_live_passthrough():
+    recorder = _recorder(_BoomRedis())
+    upstream = _Upstream()
+    body_in = b'{"model":"gpt-image-1"}'
+
+    first = _run(recorder.handle("POST", "/v1/images/generations", body_in, upstream))
+    second = _run(recorder.handle("POST", "/v1/images/generations", body_in, upstream))
+
+    assert first[0] == 200 and second[0] == 200
+    assert upstream.calls == 2
+
+
+def test_passthrough_when_no_redis_client_configured():
+    recorder = OpenAIRecordReplay(None)
+    upstream = _Upstream()
+    body_in = b'{"model":"gpt-image-1"}'
+
+    _run(recorder.handle("POST", "/v1/images/generations", body_in, upstream))
+    _run(recorder.handle("POST", "/v1/images/generations", body_in, upstream))
+
+    assert upstream.calls == 2


### PR DESCRIPTION
## Relevant issues

The dockerized spend test `tests/test_keys.py::test_key_info_spend_values_image_generation` curls the proxy for a `gpt-image-1` image and asserts a nonzero tracked spend. In `proxy_server_config.yaml` `gpt-image-1` has no explicit route, so it falls through the `model_name: "*"` wildcard to `openai/*` on the real `OPENAI_API_KEY`; every commit run hit api.openai.com for a paid image and depended on OpenAI being up. That is the same class of failure as the OpenAI 401 outage that reddened unrelated PRs.

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## What this does

Adds an in-repo record/replay reverse proxy (`tests/_openai_record_replay_proxy.py`) that sits between the litellm proxy and api.openai.com. The proxy keeps its full real separate-process HTTP topology; the test still curls `localhost:4000/v1/images/generations` and the proxy still runs auth, routing, the openai provider, a real HTTP round-trip, and the whole spend-accounting -> Redis buffer -> Postgres pipeline unmocked. The only hop that changes is proxy -> "OpenAI": in CI the image model's `api_base` is pointed at the recorder via `IMAGE_GEN_RECORDER_BASE_URL`. The first run, and the first after the recording lapses, forwards live to OpenAI and records; subsequent runs replay the recorded response, so the per-commit run no longer depends on OpenAI's uptime and no longer pays per image.

`IMAGE_GEN_RECORDER_BASE_URL` is only set in the `build_and_test` CircleCI job. Unset everywhere else it resolves to `None`, so the shared config falls back to api.openai.com and local/dev behavior is unchanged.

Recordings live in the same Redis cassette store as the VCR persister (`CASSETTE_REDIS_URL`) and expire 24h after their last write, never refreshed on read, so a recording goes stale a day after capture and the next run re-records live and catches provider contract drift. This matches the lapse-after-write contract in `tests/_vcr_redis_persister.py`. If `CASSETTE_REDIS_URL` is not present in the job, the recorder degrades to a pure live passthrough (current behavior), so this is safe to land before the secret is wired.

Replayed responses drop upstream framing/server headers (`content-length`, `transfer-encoding`, `content-encoding`, `date`, `server`) so the re-serving layer recomputes them; replaying a stale `content-length` is exactly the Bedrock `content-length: 0` regression, so that lesson is baked into a test here.

## Why an in-repo recorder instead of mitmproxy

Same point in the topology, same record/replay behavior, but no third-party binary added to CI (no supply-chain pinning/checksums) and no TLS-MITM CA trust to install in the container. The image path builds an `httpx.AsyncClient` whose `api_base` is overridable per-model, so a plain-HTTP reverse recorder is enough; on a replay run neither approach exercises the literal TLS handshake to OpenAI anyway.

## CI (LiteLLM team)

- [ ] Branch creation CI run  
       Link:
- [ ] CI run for the last commit  
       Link:
- [ ] Merge / cherry-pick CI run  
       Links:

To actually cache across runs, `CASSETTE_REDIS_URL` needs to be present in the `build_and_test` job's context (same dedicated cassette Redis the VCR persister uses). Without it the job still works, just always live.

## Screenshots / Proof of Fix

Local end-to-end, no real OpenAI needed to show record then replay. Run in order:

1. Start a stub that stands in for api.openai.com and counts hits, plus a Redis:

```bash
docker run -d --name rr-redis -p 6380:6379 redis:7
cat > /tmp/stub_openai.py <<'PY'
from starlette.applications import Starlette
from starlette.responses import JSONResponse
from starlette.routing import Route
hits = {"n": 0}
async def gen(r):
    hits["n"] += 1
    print("UPSTREAM HIT", hits["n"], flush=True)
    return JSONResponse({"data":[{"b64_json":"aW1n"}],"usage":{"total_tokens":7}},
                        headers={"transfer-encoding":"chunked","x-request-id":"req_1"})
app = Starlette(routes=[Route("/v1/images/generations", gen, methods=["POST"])])
PY
python -m uvicorn --app-dir /tmp stub_openai:app --host 127.0.0.1 --port 9099 &
```

2. Start the recorder pointed at the stub, backed by Redis:

```bash
CASSETTE_REDIS_URL=redis://127.0.0.1:6380/0 \
RECORDER_UPSTREAM_BASE_URL=http://127.0.0.1:9099 \
  python tests/_openai_record_replay_proxy.py --host 127.0.0.1 --port 8090 &
```

3. First call records (watch the stub log print one UPSTREAM HIT); second identical call replays from Redis with no new UPSTREAM HIT, and the returned headers show a single freshly computed `content-length`, no `transfer-encoding`:

```bash
for i in 1 2; do
  curl -s -D - -o /dev/null -X POST http://127.0.0.1:8090/v1/images/generations \
    -H 'content-type: application/json' \
    -d '{"model":"gpt-image-1","prompt":"A cute baby sea otter"}'
done
```

For the real run, set `RECORDER_UPSTREAM_BASE_URL=https://api.openai.com`, point a local proxy's `gpt-image-1` `api_base` at `http://127.0.0.1:8090/v1`, then run `test_key_info_spend_values_image_generation` twice; the second run hits no OpenAI quota and still asserts `spend > 0`.

## Type

✅ Test

## Changes

- `tests/_openai_record_replay_proxy.py`: record-once/replay-from-Redis reverse proxy (DI-friendly core class plus a Starlette app and a `__main__` runner)
- `tests/llm_translation/test_openai_record_replay_proxy.py`: unit tests for miss/hit, key canonicalization, 24h lapse-after-write (no refresh-on-read), framing-header stripping, non-2xx not cached, and Redis-outage passthrough
- `.circleci/config.yml`: start the recorder in `build_and_test`, wait for readiness, point the container's image model at it
- `proxy_server_config.yaml`: explicit `gpt-image-1` route whose `api_base` is the env-injected recorder, falling back to OpenAI when unset

---
_Generated by [Claude Code](https://claude.ai/code/session_01MZbuvUySMysdhHHwXV1pQF)_