### PR TITLE
fix: handle None token fields in daily activity aggregation

### DIFF
--- a/litellm/proxy/management_endpoints/common_daily_activity.py
+++ b/litellm/proxy/management_endpoints/common_daily_activity.py
@@ -32,15 +32,15 @@ _PRISMA_TO_PG_TABLE: Dict[str, str] = {
 
 def update_metrics(existing_metrics: SpendMetrics, record: Any) -> SpendMetrics:
     """Update metrics with new record data."""
-    existing_metrics.spend += record.spend
-    existing_metrics.prompt_tokens += record.prompt_tokens
-    existing_metrics.completion_tokens += record.completion_tokens
-    existing_metrics.total_tokens += record.prompt_tokens + record.completion_tokens
-    existing_metrics.cache_read_input_tokens += record.cache_read_input_tokens
-    existing_metrics.cache_creation_input_tokens += record.cache_creation_input_tokens
-    existing_metrics.api_requests += record.api_requests
-    existing_metrics.successful_requests += record.successful_requests
-    existing_metrics.failed_requests += record.failed_requests
+    existing_metrics.spend += record.spend or 0.0
+    existing_metrics.prompt_tokens += record.prompt_tokens or 0
+    existing_metrics.completion_tokens += record.completion_tokens or 0
+    existing_metrics.total_tokens += (record.prompt_tokens or 0) + (record.completion_tokens or 0)
+    existing_metrics.cache_read_input_tokens += record.cache_read_input_tokens or 0
+    existing_metrics.cache_creation_input_tokens += record.cache_creation_input_tokens or 0
+    existing_metrics.api_requests += record.api_requests or 0
+    existing_metrics.successful_requests += record.successful_requests or 0
+    existing_metrics.failed_requests += record.failed_requests or 0
     return existing_metrics
 
 
@@ -696,16 +696,18 @@ _GROUP_DATE_ENDPOINT_API_KEY = 30  # 0b0011110
 
 def _record_to_spend_metrics(record: Any) -> SpendMetrics:
     """Build a SpendMetrics directly from one already-aggregated rollup row."""
+    prompt_tokens = record.prompt_tokens or 0
+    completion_tokens = record.completion_tokens or 0
     return SpendMetrics(
-        spend=record.spend,
-        prompt_tokens=record.prompt_tokens,
-        completion_tokens=record.completion_tokens,
-        total_tokens=record.prompt_tokens + record.completion_tokens,
-        cache_read_input_tokens=record.cache_read_input_tokens,
-        cache_creation_input_tokens=record.cache_creation_input_tokens,
-        api_requests=record.api_requests,
-        successful_requests=record.successful_requests,
-        failed_requests=record.failed_requests,
+        spend=record.spend or 0.0,
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=prompt_tokens + completion_tokens,
+        cache_read_input_tokens=record.cache_read_input_tokens or 0,
+        cache_creation_input_tokens=record.cache_creation_input_tokens or 0,
+        api_requests=record.api_requests or 0,
+        successful_requests=record.successful_requests or 0,
+        failed_requests=record.failed_requests or 0,
     )
 
 


### PR DESCRIPTION
## Problem

When a virtual key has never been used, the GROUPING SETS rollup query returns `NULL` for `prompt_tokens`, `completion_tokens`, and other numeric fields. Both `_record_to_spend_metrics` and `update_metrics` then crash with:

```
TypeError: unsupported operand type(s) for +: 'NoneType' and 'NoneType'
```

causing a 500 on `GET /user/daily/activity/aggregated` for any key with zero spend.

## Fix

Coerce `NULL → 0` (int) or `NULL → 0.0` (float) for every numeric field in both functions using `or 0` / `or 0.0`.

## Changes

- `litellm/proxy/management_endpoints/common_daily_activity.py`
  - `update_metrics`: all `+= record.x` → `+= record.x or 0`
  - `_record_to_spend_metrics`: all `record.x` → `record.x or 0`, extracted `prompt_tokens`/`completion_tokens` locals to avoid double `or 0` on `total_tokens`

## Test

1. Create a fresh virtual key
2. Call `/user/daily/activity/aggregated?start_date=...&end_date=...` with that key's bearer token
3. Before: 500 `TypeError: unsupported operand type(s) for +: 'NoneType' and 'NoneType'`
4. After: 200 with zeroed metrics

Fixes #29773