### PR TITLE
feat(bedrock): add amazon.titan-embed-g1-text-02 embedding model support

### DIFF
--- a/litellm/llms/bedrock/embed/embedding.py
+++ b/litellm/llms/bedrock/embed/embedding.py
@@ -224,6 +224,10 @@ class BedrockEmbedding(BaseAWSLLM):
                 returned_response = AmazonTitanV2Config()._transform_response(
                     response_list=response_list, model=model
                 )
+            elif model == "amazon.titan-embed-g1-text-02":
+                returned_response = AmazonTitanG1Config()._transform_response(
+                    response_list=response_list, model=model
+                )
             elif provider == "twelvelabs":
                 returned_response = (
                     TwelveLabsMarengoEmbeddingConfig()._transform_response(
@@ -447,6 +451,7 @@ class BedrockEmbedding(BaseAWSLLM):
             "amazon.titan-embed-image-v1",
             "amazon.titan-embed-text-v1",
             "amazon.titan-embed-text-v2:0",
+            "amazon.titan-embed-g1-text-02",
         ]:
             batch_data = []
             for i in input:
@@ -464,6 +469,10 @@ class BedrockEmbedding(BaseAWSLLM):
                     transformed_request = AmazonTitanV2Config()._transform_request(
                         input=i, inference_params=inference_params
                     )
+                elif model == "amazon.titan-embed-g1-text-02":
+                    transformed_request = AmazonTitanG1Config()._transform_request(
+                        input=i, inference_params=inference_params
+                    )
                 else:
                     raise Exception(
                         "Unmapped model. Received={}. Expected={}".format(
@@ -472,6 +481,7 @@ class BedrockEmbedding(BaseAWSLLM):
                                 "amazon.titan-embed-image-v1",
                                 "amazon.titan-embed-text-v1",
                                 "amazon.titan-embed-text-v2:0",
+                                "amazon.titan-embed-g1-text-02",
                             ],
                         )
                     )


### PR DESCRIPTION
## Problem

`amazon.titan-embed-g1-text-02` is a Bedrock Titan G1 text embedding model not present in litellm's routing table. Any request to it fails with:

```
litellm.APIConnectionError: Unable to map Bedrock request to provider
```

## Fix

`amazon.titan-embed-g1-text-02` uses the same `inputText` / `inputTextTokenCount` JSON format as the existing `amazon.titan-embed-text-v1` (`AmazonTitanG1Config`). This PR adds the model to three spots in `litellm/llms/bedrock/embed/embedding.py`:

1. The provider routing `model in [...]` guard
2. The per-model **request** transformation branch
3. The per-model **response** transformation branch

## Test

```python
import litellm
response = litellm.embedding(
    model="bedrock/amazon.titan-embed-g1-text-02",
    input=["test embedding input"],
    aws_region_name="us-west-2",
)
print(response)
```

Before: `APIConnectionError: Unable to map Bedrock request to provider`
After: embedding vector returned successfully

Fixes #29786