### PR TITLE
docs: remove webhook-test callback example

### DIFF
--- a/litellm/litellm_core_utils/logging_callback_manager.py
+++ b/litellm/litellm_core_utils/logging_callback_manager.py
@@ -206,7 +206,7 @@ class LoggingCallbackManager:
         callback_settings:
             custom_callback_name:
                 callback_type: generic_api
-                endpoint: https://webhook-test.com/30343bc33591bc5e6dc44217ceae3e0a
+                endpoint: https://example.com/litellm-webhook
                 headers:
                 Authorization: Bearer sk-1234
         """


### PR DESCRIPTION
## Summary
- replace the `webhook-test.com` success callback example with an `example.com` placeholder
- avoid pointing users at a third-party test endpoint in callback configuration examples

Closes #18722

## Validation
- `python3 -m py_compile litellm/litellm_core_utils/logging_callback_manager.py`
- `rg "webhook-test\.com|webhook-test" .` returned no matches

Note: `make lint` was not run successfully because the local environment has `uv 0.9.29` while this repo requires `uv >=0.10.9`.
