### PR TITLE
refactor(ui): centralize proxy base URL resolution into tested resolver

### DIFF
--- a/ui/litellm-dashboard/e2e_tests/tests/login/serverRootPathRedirect.spec.ts
+++ b/ui/litellm-dashboard/e2e_tests/tests/login/serverRootPathRedirect.spec.ts
@@ -28,5 +28,11 @@ test("unauth redirect preserves SERVER_ROOT_PATH prefix", async ({ page }) => {
 
   await page.waitForURL((url) => url.pathname.includes("/ui/login"), { timeout: 15_000 });
 
-  expect(page.url()).toContain(`${ROOT_PATH}/ui/login`);
+  // The redirect target is built by joining proxyBaseUrl (assembled by
+  // resolveApiBase from the origin + SERVER_ROOT_PATH) with "/ui/login". A
+  // regression in that join surfaces as a doubled separator, which the loose
+  // toContain above would still accept, so assert the prefix joins exactly once.
+  const { pathname } = new URL(page.url());
+  expect(pathname.startsWith(`${ROOT_PATH}/ui/login`)).toBe(true);
+  expect(pathname).not.toContain("//");
 });

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -77,6 +77,7 @@ import { EmailEventSettingsResponse, EmailEventSettingsUpdateRequest } from "./e
 import { jsonFields } from "./common_components/check_openapi_schema";
 import NotificationsManager from "./molecules/notifications_manager";
 import { createApiClient, deriveErrorMessage } from "@/lib/http/client";
+import { resolveApiBase } from "@/lib/http/resolveApiBase";
 
 export { deriveErrorMessage };
 export { ApiError } from "@/lib/http/client";
@@ -84,11 +85,13 @@ export { ApiError } from "@/lib/http/client";
 const isLocal = process.env.NODE_ENV === "development";
 // In dev, if NEXT_PUBLIC_USE_REWRITES=true the Next.js dev server proxies API calls
 // to the backend — use relative URLs (null) so rewrites can intercept them.
-const defaultProxyBaseUrl = process.env.NEXT_PUBLIC_BASE_URL
-  ? process.env.NEXT_PUBLIC_BASE_URL
-  : isLocal && process.env.NEXT_PUBLIC_USE_REWRITES !== "true"
-    ? "http://localhost:4000"
-    : null;
+const resolveDefaultBase = (fallback: string | null): string | null =>
+  process.env.NEXT_PUBLIC_BASE_URL
+    ? process.env.NEXT_PUBLIC_BASE_URL
+    : isLocal && process.env.NEXT_PUBLIC_USE_REWRITES !== "true"
+      ? "http://localhost:4000"
+      : fallback;
+const defaultProxyBaseUrl = resolveDefaultBase(null);
 const defaultServerRootPath = "/";
 export let serverRootPath = defaultServerRootPath;
 const WORKER_URL_KEY = "litellm_worker_url";
@@ -128,28 +131,10 @@ const updateProxyBaseUrl = (serverRootPath: string, receivedProxyBaseUrl: string
   if (typeof window !== "undefined" && window.localStorage.getItem(WORKER_URL_KEY)) {
     return;
   }
-  const browserLocation = getWindowLocation();
-  const resolvedDefaultProxyBaseUrl = process.env.NEXT_PUBLIC_BASE_URL
-    ? process.env.NEXT_PUBLIC_BASE_URL
-    : isLocal && process.env.NEXT_PUBLIC_USE_REWRITES !== "true"
-      ? "http://localhost:4000"
-      : browserLocation?.origin ?? null;
-  let initialProxyBaseUrl = receivedProxyBaseUrl || resolvedDefaultProxyBaseUrl;
-  console.log("proxyBaseUrl:", proxyBaseUrl);
-  console.log("serverRootPath:", serverRootPath);
-
-  if (!initialProxyBaseUrl) {
-    proxyBaseUrl = proxyBaseUrl ?? null;
-    console.log("Updated proxyBaseUrl:", proxyBaseUrl);
-    return;
-  }
-
-  if (serverRootPath.length > 0 && !initialProxyBaseUrl.endsWith(serverRootPath) && serverRootPath != "/") {
-    initialProxyBaseUrl += serverRootPath;
-  }
-
-  proxyBaseUrl = initialProxyBaseUrl;
-  console.log("Updated proxyBaseUrl:", proxyBaseUrl);
+  proxyBaseUrl = resolveApiBase({
+    explicitBase: receivedProxyBaseUrl || resolveDefaultBase(getWindowLocation()?.origin ?? null),
+    serverRootPath,
+  });
 };
 
 const updateServerRootPath = (receivedServerRootPath: string) => {

--- a/ui/litellm-dashboard/src/lib/http/resolveApiBase.test.ts
+++ b/ui/litellm-dashboard/src/lib/http/resolveApiBase.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { resolveApiBase } from "./resolveApiBase";
+
+describe("resolveApiBase", () => {
+  describe("same-origin (no explicit base)", () => {
+    it("returns an empty base so requests stay relative", () => {
+      expect(resolveApiBase({})).toBe("");
+      expect(resolveApiBase({ explicitBase: null, serverRootPath: "/" })).toBe("");
+      expect(resolveApiBase({ explicitBase: "", serverRootPath: undefined })).toBe("");
+    });
+
+    it("prefixes a relative base with the server root path", () => {
+      expect(resolveApiBase({ serverRootPath: "/litellm" })).toBe("/litellm");
+    });
+  });
+
+  describe("explicit base (split-origin / dev)", () => {
+    it("uses the explicit base verbatim when root path is mounted at /", () => {
+      expect(resolveApiBase({ explicitBase: "http://localhost:4000", serverRootPath: "/" })).toBe(
+        "http://localhost:4000",
+      );
+    });
+
+    it("appends the server root path to the explicit base", () => {
+      expect(resolveApiBase({ explicitBase: "http://localhost:4000", serverRootPath: "/litellm" })).toBe(
+        "http://localhost:4000/litellm",
+      );
+    });
+  });
+
+  describe("dedup — base already includes the root path", () => {
+    it("does not double the root path", () => {
+      expect(resolveApiBase({ explicitBase: "http://localhost:4000/litellm", serverRootPath: "/litellm" })).toBe(
+        "http://localhost:4000/litellm",
+      );
+    });
+  });
+
+  describe("normalization", () => {
+    it("trims a trailing slash from the explicit base before appending", () => {
+      expect(resolveApiBase({ explicitBase: "http://localhost:4000/", serverRootPath: "/litellm" })).toBe(
+        "http://localhost:4000/litellm",
+      );
+    });
+
+    it("trims a trailing slash from the explicit base when there is no root path", () => {
+      expect(resolveApiBase({ explicitBase: "http://localhost:4000/", serverRootPath: "/" })).toBe(
+        "http://localhost:4000",
+      );
+    });
+
+    it("adds a leading slash to a root path that lacks one", () => {
+      expect(resolveApiBase({ explicitBase: "http://localhost:4000", serverRootPath: "litellm" })).toBe(
+        "http://localhost:4000/litellm",
+      );
+    });
+
+    it("trims a trailing slash from the root path", () => {
+      expect(resolveApiBase({ explicitBase: "http://localhost:4000", serverRootPath: "/litellm/" })).toBe(
+        "http://localhost:4000/litellm",
+      );
+    });
+
+    it("ignores whitespace around inputs", () => {
+      expect(resolveApiBase({ explicitBase: "  http://localhost:4000  ", serverRootPath: "  /litellm  " })).toBe(
+        "http://localhost:4000/litellm",
+      );
+    });
+  });
+
+  describe("multi-segment root paths", () => {
+    it("appends a nested root path", () => {
+      expect(resolveApiBase({ explicitBase: "http://localhost:4000", serverRootPath: "/team/litellm" })).toBe(
+        "http://localhost:4000/team/litellm",
+      );
+    });
+
+    it("dedups a nested root path", () => {
+      expect(
+        resolveApiBase({ explicitBase: "http://localhost:4000/team/litellm", serverRootPath: "/team/litellm" }),
+      ).toBe("http://localhost:4000/team/litellm");
+    });
+  });
+});

--- a/ui/litellm-dashboard/src/lib/http/resolveApiBase.ts
+++ b/ui/litellm-dashboard/src/lib/http/resolveApiBase.ts
@@ -1,0 +1,35 @@
+export interface ApiBaseInputs {
+  /**
+   * Absolute API origin to target instead of same-origin. Comes from the
+   * NEXT_PUBLIC_BASE_URL build env (dev / split-origin) or the proxy_base_url
+   * the backend reports in its UI config. Empty/unset means same-origin.
+   */
+  explicitBase?: string | null;
+  /**
+   * The proxy's mount path when it sits under a sub-path (e.g. "/litellm"
+   * behind a reverse proxy). "/" or empty means mounted at the root.
+   */
+  serverRootPath?: string | null;
+}
+
+const normalizeRootPath = (serverRootPath: string | null | undefined): string => {
+  const trimmed = (serverRootPath ?? "").trim();
+  if (trimmed === "" || trimmed === "/") return "";
+  const withLeadingSlash = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+  return withLeadingSlash.replace(/\/+$/, "");
+};
+
+/**
+ * Resolve the single API base string that every request is prefixed with.
+ *
+ * Same-origin is represented as "" so requests stay relative and work behind
+ * any domain or reverse proxy without hardcoding an origin. An explicit base is
+ * used verbatim (trailing slash trimmed). The server root path is appended
+ * unless the base already ends with it.
+ */
+export const resolveApiBase = ({ explicitBase, serverRootPath }: ApiBaseInputs): string => {
+  const base = (explicitBase ?? "").trim().replace(/\/+$/, "");
+  const rootPath = normalizeRootPath(serverRootPath);
+  if (rootPath === "" || base.endsWith(rootPath)) return base;
+  return `${base}${rootPath}`;
+};


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Summary

The UI's API base URL was assembled by hand-rolled logic inside `networking.tsx` and re-derived inline at hundreds of call sites, with no test coverage. The join had a latent double-slash bug (a base with a trailing slash plus a server root path produced `host//root`) and the env precedence ladder was copied in two places. This pulls the join into a single pure `resolveApiBase()` with full unit coverage and routes the existing resolution through it, with no change to runtime behavior for the already-correct cases.

Refs LIT-3128

## Changes

`src/lib/http/resolveApiBase.ts` is a new pure function that resolves the one base string every request is prefixed with: same-origin becomes `""` (relative), an explicit base is used verbatim with its trailing slash trimmed, and the server root path is appended unless the base already ends with it. `networking.tsx`'s `updateProxyBaseUrl` now delegates the join to it, and the duplicated `NEXT_PUBLIC_BASE_URL -> localhost:4000 -> fallback` ladder is collapsed into one `resolveDefaultBase()` helper. The mutable module symbol and the worker flow are deliberately left untouched; this is the first step toward removing them, scoped narrowly so it can be reviewed and shipped on its own.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review and received a Confidence Score of at least 4/5

## Screenshots / Proof of Fix

No user-visible change; this is a behavior-preserving refactor of frontend URL-building logic that additionally fixes a latent join bug. There is no proxy endpoint or UI surface to curl or screenshot. The guarantee is the new unit suite plus the unchanged existing suite.

## Test plan

- [x] `src/lib/http/resolveApiBase.test.ts` — 12 cases covering same-origin relative, explicit base, sub-path append, dedup when the base already includes the root path, trailing/leading slash normalization, whitespace, and nested multi-segment root paths (the first-ever coverage of this logic; the dedup and trailing-slash cases pin the double-slash bug)
- [x] `src/components/networking.test.ts` and `useUIConfig.test.ts` pass unchanged as the regression oracle for no collateral behavior change
- [x] `e2e_tests/tests/login/serverRootPathRedirect.spec.ts` — tightened to a strict prefix match plus a no-double-slash assertion, so the resolveApiBase origin+SERVER_ROOT_PATH join is guarded end-to-end (runs in the `test_server_root_path` workflow)

## Type

🧹 Refactoring
