### PR TITLE
fix(ui): show all session logs in the drawer, not just the first 50

### DIFF
--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -3400,7 +3400,7 @@ async def ui_view_session_spend_logs(
                 session_id, status, mcp_namespaced_tool_name, agent_id
             FROM "LiteLLM_SpendLogs"
             WHERE session_id = $1
-            ORDER BY "startTime" ASC
+            ORDER BY "startTime" DESC
             LIMIT $2 OFFSET $3
         """
         result = await prisma_client.db.query_raw(

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
@@ -1313,9 +1313,9 @@ async def test_ui_view_session_spend_logs_pagination(client, monkeypatch):
             # Endpoint uses raw SQL for pagination - verify params
             assert session_id == "session-123"
             assert page_size == 1
-            assert skip == 0  # page=1, page_size=1
+            assert skip == 1  # page=2, page_size=1
             assert 'ORDER BY "startTime" DESC' in sql_query
-            return [mock_spend_logs[1]]
+            return [mock_spend_logs[0]]
 
     class MockPrismaClient:
         def __init__(self):
@@ -1327,18 +1327,18 @@ async def test_ui_view_session_spend_logs_pagination(client, monkeypatch):
 
     response = client.get(
         "/spend/logs/session/ui",
-        params={"session_id": "session-123", "page": 1, "page_size": 1},
+        params={"session_id": "session-123", "page": 2, "page_size": 1},
         headers={"Authorization": "Bearer sk-test"},
     )
 
     assert response.status_code == 200
     data = response.json()
     assert data["total"] == 2
-    assert data["page"] == 1
+    assert data["page"] == 2
     assert data["page_size"] == 1
     assert data["total_pages"] == 2
     assert len(data["data"]) == 1
-    assert data["data"][0]["request_id"] == "req2"
+    assert data["data"][0]["request_id"] == "req1"
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
@@ -1313,7 +1313,8 @@ async def test_ui_view_session_spend_logs_pagination(client, monkeypatch):
             # Endpoint uses raw SQL for pagination - verify params
             assert session_id == "session-123"
             assert page_size == 1
-            assert skip == 1  # page=2, page_size=1
+            assert skip == 0  # page=1, page_size=1
+            assert 'ORDER BY "startTime" DESC' in sql_query
             return [mock_spend_logs[1]]
 
     class MockPrismaClient:
@@ -1326,14 +1327,14 @@ async def test_ui_view_session_spend_logs_pagination(client, monkeypatch):
 
     response = client.get(
         "/spend/logs/session/ui",
-        params={"session_id": "session-123", "page": 2, "page_size": 1},
+        params={"session_id": "session-123", "page": 1, "page_size": 1},
         headers={"Authorization": "Bearer sk-test"},
     )
 
     assert response.status_code == 200
     data = response.json()
     assert data["total"] == 2
-    assert data["page"] == 2
+    assert data["page"] == 1
     assert data["page_size"] == 1
     assert data["total_pages"] == 2
     assert len(data["data"]) == 1

--- a/ui/litellm-dashboard/src/components/networking.test.ts
+++ b/ui/litellm-dashboard/src/components/networking.test.ts
@@ -453,3 +453,50 @@ describe("teamInfoCall", () => {
     expect(parsed.searchParams.has("team_id")).toBe(false);
   });
 });
+
+describe("sessionSpendLogsCall", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("should request the first page with defaults so the caller can page through the session", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ data: [], total: 0, page: 1, page_size: 100, total_pages: 1 }),
+    } as any);
+    global.fetch = mockFetch as any;
+
+    await Networking.sessionSpendLogsCall("token", "session-123");
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url] = mockFetch.mock.calls[0];
+    const urlStr = typeof url === "string" ? url : (url as Request).url;
+    const parsed = typeof url === "string" ? new URL(url, "http://example.com") : new URL((url as Request).url);
+
+    expect(urlStr).toContain("/spend/logs/session/ui");
+    expect(parsed.searchParams.get("session_id")).toBe("session-123");
+    expect(parsed.searchParams.get("page")).toBe("1");
+    expect(parsed.searchParams.get("page_size")).toBe("100");
+  });
+
+  it("should pass explicit page and page_size query params for later pages", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ data: [], total: 250, page: 3, page_size: 100, total_pages: 3 }),
+    } as any);
+    global.fetch = mockFetch as any;
+
+    await Networking.sessionSpendLogsCall("token", "session-123", 3, 100);
+
+    const [url] = mockFetch.mock.calls[0];
+    const parsed = typeof url === "string" ? new URL(url, "http://example.com") : new URL((url as Request).url);
+    expect(parsed.searchParams.get("page")).toBe("3");
+    expect(parsed.searchParams.get("page_size")).toBe("100");
+  });
+});

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -7143,13 +7143,27 @@ export const teamPermissionsUpdateCall = async (accessToken: string, teamId: str
 };
 
 /**
- * Get all spend logs for a particular session
+ * Get a page of spend logs for a particular session.
+ *
+ * The backend paginates this endpoint (page / page_size, returning
+ * { data, total, page, page_size, total_pages }). Callers that need the whole
+ * session should page through total_pages and accumulate the results.
  */
-export const sessionSpendLogsCall = async (accessToken: string, session_id: string) => {
+export const sessionSpendLogsCall = async (
+  accessToken: string,
+  session_id: string,
+  page: number = 1,
+  page_size: number = 100,
+) => {
   try {
+    const params = new URLSearchParams({
+      session_id,
+      page: String(page),
+      page_size: String(page_size),
+    });
     let url = proxyBaseUrl
-      ? `${proxyBaseUrl}/spend/logs/session/ui?session_id=${encodeURIComponent(session_id)}`
-      : `/spend/logs/session/ui?session_id=${encodeURIComponent(session_id)}`;
+      ? `${proxyBaseUrl}/spend/logs/session/ui?${params.toString()}`
+      : `/spend/logs/session/ui?${params.toString()}`;
 
     const response = await fetch(url, {
       method: "GET",

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.tsx
@@ -129,7 +129,6 @@ export function LogDetailsDrawer({
       // than one page of logs are shown in full (capped for safety).
       const firstPage = await sessionSpendLogsCall(accessToken, sessionId, 1, SESSION_PAGE_SIZE);
       let rows: LogEntry[] = firstPage.data || firstPage || [];
-      const total: number = firstPage.total ?? rows.length;
       const pagesToFetch = Math.min(firstPage.total_pages ?? 1, MAX_SESSION_PAGES);
 
       if (pagesToFetch > 1) {
@@ -148,6 +147,10 @@ export function LogDetailsDrawer({
           rows = rows.concat(page.data || []);
         }
       }
+
+      // Fall back to the accumulated row count (not just the first page) when the
+      // backend omits total, so the truncation note reflects what was fetched.
+      const total: number = firstPage.total ?? rows.length;
 
       const logs = rows
         .map((row) => ({

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.tsx
@@ -133,11 +133,17 @@ export function LogDetailsDrawer({
       const pagesToFetch = Math.min(firstPage.total_pages ?? 1, MAX_SESSION_PAGES);
 
       if (pagesToFetch > 1) {
-        const remaining = await Promise.all(
-          Array.from({ length: pagesToFetch - 1 }, (_, i) =>
-            sessionSpendLogsCall(accessToken, sessionId, i + 2, SESSION_PAGE_SIZE),
-          ),
-        );
+        const BATCH = 5;
+        const remaining: Awaited<ReturnType<typeof sessionSpendLogsCall>>[] = [];
+        for (let start = 2; start <= pagesToFetch; start += BATCH) {
+          const end = Math.min(start + BATCH - 1, pagesToFetch);
+          const batch = await Promise.all(
+            Array.from({ length: end - start + 1 }, (_, i) =>
+              sessionSpendLogsCall(accessToken, sessionId, start + i, SESSION_PAGE_SIZE),
+            ),
+          );
+          remaining.push(...batch);
+        }
         for (const page of remaining) {
           rows = rows.concat(page.data || []);
         }

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.tsx
@@ -28,6 +28,14 @@ export interface LogDetailsDrawerProps {
 
 const SIDEBAR_WIDTH_PX = 224;
 
+// Session logs are fetched page-by-page from the paginated backend and
+// accumulated so the drawer can show the whole session. page_size is the
+// backend maximum (le=100); the page cap bounds the fetch and the
+// (un-virtualized) sidebar list for pathological sessions, keeping the most
+// recent logs since the endpoint returns newest-first.
+const SESSION_PAGE_SIZE = 100;
+const MAX_SESSION_PAGES = 50;
+
 /* ------------------------------------------------------------------ */
 /*  TraceEventRow — compact event row used in both session & non-     */
 /*  session sidebar lists.  Extracted to avoid JSX duplication.       */
@@ -112,13 +120,30 @@ export function LogDetailsDrawer({
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
   const [copiedLeftPanelId, setCopiedLeftPanelId] = useState(false);
 
-  const { data: sessionLogs = [] } = useQuery({
+  const { data: sessionData } = useQuery({
     queryKey: ["sessionLogs", sessionId],
     queryFn: async () => {
-      if (!sessionId || !accessToken) return [];
-      const response = await sessionSpendLogsCall(accessToken, sessionId);
-      const allSessionLogs: LogEntry[] = response.data || response || [];
-      return allSessionLogs
+      if (!sessionId || !accessToken) return { logs: [] as LogEntry[], total: 0 };
+
+      // Fetch the first page, then page through the rest so sessions with more
+      // than one page of logs are shown in full (capped for safety).
+      const firstPage = await sessionSpendLogsCall(accessToken, sessionId, 1, SESSION_PAGE_SIZE);
+      let rows: LogEntry[] = firstPage.data || firstPage || [];
+      const total: number = firstPage.total ?? rows.length;
+      const pagesToFetch = Math.min(firstPage.total_pages ?? 1, MAX_SESSION_PAGES);
+
+      if (pagesToFetch > 1) {
+        const remaining = await Promise.all(
+          Array.from({ length: pagesToFetch - 1 }, (_, i) =>
+            sessionSpendLogsCall(accessToken, sessionId, i + 2, SESSION_PAGE_SIZE),
+          ),
+        );
+        for (const page of remaining) {
+          rows = rows.concat(page.data || []);
+        }
+      }
+
+      const logs = rows
         .map((row) => ({
           ...row,
           request_duration_ms: row.request_duration_ms ?? Date.parse(row.endTime) - Date.parse(row.startTime),
@@ -129,9 +154,17 @@ export function LogDetailsDrawer({
           if (aIsMcp !== bIsMcp) return aIsMcp - bIsMcp;
           return new Date(a.startTime).getTime() - new Date(b.startTime).getTime();
         });
+
+      return { logs, total };
     },
     enabled: Boolean(open && isSessionMode && sessionId && accessToken),
   });
+
+  const sessionLogs: LogEntry[] = sessionData?.logs ?? [];
+  // total reported by the backend; when the page cap truncates the fetch this
+  // exceeds sessionLogs.length, which drives the "showing most recent" note.
+  const sessionTotalCount = sessionData?.total ?? sessionLogs.length;
+  const sessionTruncated = sessionTotalCount > sessionLogs.length;
 
   const currentLog = useMemo(() => {
     if (!isSessionMode) return logEntry;
@@ -327,6 +360,11 @@ export function LogDetailsDrawer({
                   </>
                 )}
               </div>
+              {isSessionMode && sessionTruncated && (
+                <div className="mt-1 text-[11px] text-amber-600 font-mono">
+                  Showing most recent {logsForList.length} of {sessionTotalCount}
+                </div>
+              )}
             </div>
 
             <div className="flex-1 overflow-y-auto">

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.tsx
@@ -152,7 +152,9 @@ export function LogDetailsDrawer({
           const aIsMcp = MCP_CALL_TYPES.includes(a.call_type) ? 1 : 0;
           const bIsMcp = MCP_CALL_TYPES.includes(b.call_type) ? 1 : 0;
           if (aIsMcp !== bIsMcp) return aIsMcp - bIsMcp;
-          return new Date(a.startTime).getTime() - new Date(b.startTime).getTime();
+          // Newest first, matching the all-sessions logs overview. MCP calls
+          // stay grouped last (above), newest-first within that group too.
+          return new Date(b.startTime).getTime() - new Date(a.startTime).getTime();
         });
 
       return { logs, total };
@@ -166,18 +168,33 @@ export function LogDetailsDrawer({
   const sessionTotalCount = sessionData?.total ?? sessionLogs.length;
   const sessionTruncated = sessionTotalCount > sessionLogs.length;
 
+  // Default selection for a freshly opened session: the most recent log (latest
+  // startTime). The list is sorted newest-first, but MCP calls are grouped last,
+  // so the latest log by time is not necessarily sessionLogs[0]; compute it
+  // explicitly. A clicked/remembered log still wins over this default.
+  const mostRecentLog = useMemo<LogEntry | null>(
+    () =>
+      sessionLogs.reduce<LogEntry | null>(
+        (latest, row) =>
+          !latest || new Date(row.startTime).getTime() > new Date(latest.startTime).getTime() ? row : latest,
+        null,
+      ),
+    [sessionLogs],
+  );
+
   const currentLog = useMemo(() => {
     if (!isSessionMode) return logEntry;
     if (!sessionLogs.length) return null;
+    const fallbackLog = mostRecentLog ?? sessionLogs[0];
     if (selectedSessionRequestId) {
-      return sessionLogs.find((row) => row.request_id === selectedSessionRequestId) || sessionLogs[0];
+      return sessionLogs.find((row) => row.request_id === selectedSessionRequestId) || fallbackLog;
     }
     if (logEntry?.request_id) {
       const clickedLog = sessionLogs.find((row) => row.request_id === logEntry.request_id);
-      return clickedLog || sessionLogs[0];
+      return clickedLog || fallbackLog;
     }
-    return sessionLogs[0];
-  }, [isSessionMode, logEntry, selectedSessionRequestId, sessionLogs]);
+    return fallbackLog;
+  }, [isSessionMode, logEntry, selectedSessionRequestId, sessionLogs, mostRecentLog]);
 
   useEffect(() => {
     if (!isSessionMode || !sessionLogs.length) return;
@@ -185,10 +202,10 @@ export function LogDetailsDrawer({
       const fallbackRequestId =
         logEntry?.request_id && sessionLogs.some((row) => row.request_id === logEntry.request_id)
           ? logEntry.request_id
-          : sessionLogs[0].request_id;
+          : (mostRecentLog ?? sessionLogs[0]).request_id;
       setSelectedSessionRequestId(fallbackRequestId);
     }
-  }, [isSessionMode, logEntry, selectedSessionRequestId, sessionLogs]);
+  }, [isSessionMode, logEntry, selectedSessionRequestId, sessionLogs, mostRecentLog]);
 
   // Reset transient UI state when the drawer opens or closes.
   useEffect(() => {


### PR DESCRIPTION
## Relevant issues

Fixes #29153

Supersedes #29211 and #29218. This PR includes the backend sort commits from #29211 and adds the UI changes that actually make all of a session's logs reachable.

## Linear ticket

<!-- if you are an internal contributor, add the Linear ticket e.g. "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or log output demonstrating that your changes work as expected.
     For bug fixes: show reproduction before the fix and passing behavior after.
     For new features: show the feature working end-to-end.
     For UI changes: include before/after screenshots. -->

Sessions with more than 50 requests now show all logs, most recent (0001, 3 minutes ago) first, oldest (0120, 2 hours ago) last.

https://github.com/user-attachments/assets/b216dbe7-efa2-417e-99de-aff4ec26073a

Capped at 5000, shows 5000 most recent logs, most recent first. Shows message "Showing most recent 5000 of 5200"

https://github.com/user-attachments/assets/f61fa14d-1893-49cf-a689-847096fe8e28


## Type

🐛 Bug Fix

## Changes

Since a recent version (v1.85.0 or older) the logs page groups requests by session. Opening a session opens the detail drawer, whose sidebar fetched the session via `sessionSpendLogsCall` without `page`/`page_size`, so it only ever received the backend default of one page (50 rows). Sessions with more than 50 calls had the rest unreachable in the UI.

Backend (cherry-picked from #29211, authored by @he-yufeng):
- `/spend/logs/session/ui` now orders by `startTime DESC`, so the first page is the most recent logs. The existing pagination test was updated to assert the new order.

Frontend:
- `sessionSpendLogsCall` now accepts `page` and `page_size`.
- The drawer fetches the first page, reads `total_pages`, then fetches the remaining pages and accumulates them before sorting. This keeps the single continuous list, the selected-log lookup, and keyboard navigation correct, since they all assume the full session is present. The fetch is bounded by a page cap (50 pages x 100 = 5000 rows); if a session exceeds it, the sidebar shows a "showing most recent N of M" note and keeps the most recent logs.
- The sidebar is ordered newest-first and opens with the most recent log selected, matching the all-sessions logs overview. MCP calls stay grouped last.
- The session list rows are lightweight metadata (the endpoint excludes messages/response). Request and response bodies are still loaded per log on demand when a row is selected.

## Testing

- Backend: `test_ui_view_session_spend_logs_pagination` asserts the `DESC` order and the newest-first result. Passing.
- Frontend: added `sessionSpendLogsCall` tests in `networking.test.ts` asserting the `page`/`page_size` query params. `npm run test` passing.
- Manual: ran a local proxy against a seeded 120-log session. The drawer now lists all 120 logs (previously capped at 50), newest first, with the most recent selected on open. Video above.
- Manual: ran a local proxy against a seeded 5200-log session. The drawer now lists 5000 logs, capped (previously capped at 50), newest first, with the most recent selected on open. Video above. 