### PR TITLE
Make the image-gen record/replay proxy report cache mode and per-request HIT/MISS

### DIFF
--- a/tests/_openai_record_replay_proxy.py
+++ b/tests/_openai_record_replay_proxy.py
@@ -19,6 +19,11 @@ write, never refreshed on read. A recording therefore goes stale a day after
 capture and the next run past that point re-records live and catches provider
 contract drift, exactly matching the lapse-after-write contract in
 ``tests/_vcr_redis_persister.py``.
+
+The process logs its mode at startup (REPLAY when the cassette redis is
+reachable, PASSTHROUGH or DEGRADED otherwise) and a HIT/MISS line per request,
+so a CI run shows whether it served from the cassette or went live instead of
+silently degrading.
 """
 
 from __future__ import annotations
@@ -26,8 +31,12 @@ from __future__ import annotations
 import base64
 import hashlib
 import json
+import logging
 import os
 from typing import Awaitable, Callable, List, Optional, Tuple
+
+_LOGGER = logging.getLogger("openai_record_replay")
+_LOGGER.setLevel(logging.INFO)
 
 CASSETTE_TTL_SECONDS = 24 * 60 * 60
 RECORD_KEY_PREFIX = "litellm:openai:record:"
@@ -112,12 +121,21 @@ class OpenAIRecordReplay:
         key = self.record_key(method, path, body)
         cached = self._cache_get(key)
         if cached is not None:
+            _LOGGER.info("HIT replayed from cassette: %s %s", method, path)
             return cached
 
         status, headers, resp_body = await fetch_upstream()
         sanitized = _sanitize_headers(headers)
-        if 200 <= status < 300:
-            self._cache_set(key, status, sanitized, resp_body)
+        if not (200 <= status < 300):
+            _LOGGER.info("MISS forwarded live, not cached (status=%s): %s %s", status, method, path)
+        elif self._cache_set(key, status, sanitized, resp_body):
+            _LOGGER.info("MISS forwarded live and recorded: %s %s", method, path)
+        else:
+            _LOGGER.warning(
+                "MISS forwarded live but NOT recorded (redis unset or unreachable): %s %s",
+                method,
+                path,
+            )
         return status, sanitized, resp_body
 
     def _cache_get(self, key: str) -> Optional[UpstreamResult]:
@@ -138,9 +156,9 @@ class OpenAIRecordReplay:
             return None
         return status, headers, resp_body
 
-    def _cache_set(self, key: str, status: int, headers: Headers, body: bytes) -> None:
+    def _cache_set(self, key: str, status: int, headers: Headers, body: bytes) -> bool:
         if self._redis is None:
-            return
+            return False
         payload = json.dumps(
             {
                 "status": status,
@@ -150,8 +168,31 @@ class OpenAIRecordReplay:
         )
         try:
             self._redis.set(key, payload, ex=self._ttl_seconds)
+            return True
         except Exception:
-            pass
+            return False
+
+    def log_startup_mode(self) -> None:
+        if self._redis is None:
+            _LOGGER.warning(
+                "PASSTHROUGH: %s unset, every request goes live to %s and nothing is cached",
+                RECORDER_REDIS_URL_ENV,
+                self.upstream_base_url,
+            )
+            return
+        try:
+            self._redis.ping()
+        except Exception as exc:
+            _LOGGER.warning(
+                "DEGRADED to live: %s set but cassette redis unreachable (%s); nothing is cached",
+                RECORDER_REDIS_URL_ENV,
+                type(exc).__name__,
+            )
+            return
+        _LOGGER.info(
+            "REPLAY mode: cassette redis reachable, recordings expire %ss after write (no refresh on read)",
+            self._ttl_seconds,
+        )
 
 
 def _build_default_redis_client():
@@ -186,6 +227,7 @@ def create_app(recorder: Optional[OpenAIRecordReplay] = None, http_client=None):
 
     @contextlib.asynccontextmanager
     async def lifespan(_app):
+        recorder.log_startup_mode()
         try:
             yield
         finally:
@@ -231,6 +273,7 @@ if __name__ == "__main__":
 
     import uvicorn
 
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--host", default="0.0.0.0")
     parser.add_argument("--port", type=int, default=8090)

--- a/tests/llm_translation/test_openai_record_replay_proxy.py
+++ b/tests/llm_translation/test_openai_record_replay_proxy.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 import sys
 
@@ -214,3 +215,53 @@ def test_app_lifespan_leaves_injected_http_client_open():
         pass
 
     assert client.closed is False
+
+
+def test_handle_logs_miss_then_hit(caplog):
+    """Each request self-reports so a CI run shows cassette vs live."""
+    recorder = _recorder()
+    upstream = _Upstream()
+    body_in = b'{"model":"gpt-image-1"}'
+
+    with caplog.at_level(logging.INFO, logger="openai_record_replay"):
+        _run(recorder.handle("POST", "/v1/images/generations", body_in, upstream))
+        _run(recorder.handle("POST", "/v1/images/generations", body_in, upstream))
+
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("MISS forwarded live and recorded" in m for m in messages)
+    assert any("HIT replayed from cassette" in m for m in messages)
+
+
+def test_handle_warns_when_recording_not_persisted(caplog):
+    """A redis failure must surface loudly, not look like a successful record."""
+    recorder = _recorder(_BoomRedis())
+    upstream = _Upstream()
+
+    with caplog.at_level(logging.WARNING, logger="openai_record_replay"):
+        _run(recorder.handle("POST", "/v1/images/generations", b'{"model":"gpt-image-1"}', upstream))
+
+    assert any(r.levelno == logging.WARNING and "NOT recorded" in r.getMessage() for r in caplog.records)
+
+
+def test_log_startup_mode_distinguishes_replay_from_passthrough(caplog):
+    """Startup must announce whether the recorder will actually cache."""
+    with caplog.at_level(logging.INFO, logger="openai_record_replay"):
+        OpenAIRecordReplay(None).log_startup_mode()
+        _recorder().log_startup_mode()
+
+    emitted = [(r.levelno, r.getMessage()) for r in caplog.records]
+    assert any(lvl == logging.WARNING and "PASSTHROUGH" in m for lvl, m in emitted)
+    assert any(lvl == logging.INFO and "REPLAY mode" in m for lvl, m in emitted)
+
+
+class _UnreachableRedis:
+    def ping(self):
+        raise ConnectionError("redis offline")
+
+
+def test_log_startup_mode_warns_when_redis_configured_but_unreachable(caplog):
+    """A configured-but-dead redis must warn, not look like it will cache."""
+    with caplog.at_level(logging.WARNING, logger="openai_record_replay"):
+        _recorder(_UnreachableRedis()).log_startup_mode()
+
+    assert any(r.levelno == logging.WARNING and "DEGRADED" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
## Relevant issues

Follow-up to the image-gen record/replay proxy (#29787)

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## What this fixes

The record/replay proxy that fronts api.openai.com for the dockerized image-gen spend E2E could come up pointed at a missing or unreachable cassette redis and silently forward every request live. The health check still returned ok and the process logged nothing about its mode, so a CI run looked identical whether it replayed from the cassette or paid OpenAI for a fresh image every commit. There was no way to tell from the logs whether the 24h caching was actually happening, which is exactly the question that prompted this; `CASSETTE_REDIS_URL` is set as a project-level CircleCI env var so `build_and_test` does receive it, but "it should be caching" was not something the logs could confirm or deny.

It now announces its mode at startup: REPLAY when the cassette redis is reachable, PASSTHROUGH when `CASSETTE_REDIS_URL` is unset, and DEGRADED when the variable is set but the redis is unreachable. Every request logs a HIT (served from the cassette) or MISS (forwarded live) line. `_cache_set` returns whether the write actually landed, so a mid-run redis failure surfaces as a warning instead of masquerading as a successful record. The behavior of the proxy is otherwise unchanged; this is observability only, so it stays safe to land regardless of the redis state.

## Screenshots / Proof of Fix

Ran the recorder locally against a throwaway redis, pointed upstream at the real api.openai.com, and hit it twice with a free GET that returns 200 so the proof costs nothing while still exercising a real provider round-trip.

```
$ redis-server --port 6390 --daemonize yes --save "" --appendonly no
$ CASSETTE_REDIS_URL="redis://127.0.0.1:6390" \
  RECORDER_UPSTREAM_BASE_URL="https://api.openai.com" \
  python tests/_openai_record_replay_proxy.py --host 127.0.0.1 --port 8099 &

$ curl -sS -o /dev/null -w "http=%{http_code}\n" http://127.0.0.1:8099/v1/models -H "Authorization: Bearer $OPENAI_API_KEY"
http=200
$ curl -sS -o /dev/null -w "http=%{http_code}\n" http://127.0.0.1:8099/v1/models -H "Authorization: Bearer $OPENAI_API_KEY"
http=200
```

Recorder log:

```
INFO openai_record_replay REPLAY mode: cassette redis reachable, recordings expire 86400s after write (no refresh on read)
INFO openai_record_replay MISS forwarded live and recorded: GET /v1/models
INFO openai_record_replay HIT replayed from cassette: GET /v1/models
```

And the recording landed in redis with a ~24h TTL:

```
$ redis-cli -p 6390 --scan --pattern 'litellm:openai:record:*'
litellm:openai:record:6456f67439d4b333e5f382b49267e5fa6bda46ed6d766aad43f7e78aaad45d92
$ redis-cli -p 6390 ttl litellm:openai:record:6456f6...
86399
```

In CI the same lines will appear in the "Start OpenAI image record/replay proxy" step, so the build log now states plainly whether the spend E2E replayed from the cassette or went live

## Type

🧹 Refactoring

## Changes

`tests/_openai_record_replay_proxy.py`: added a per-process logger; `handle` logs HIT/MISS/not-recorded; `_cache_set` returns a bool so a failed write is distinguishable from a successful one; new `log_startup_mode` called from the app lifespan reports REPLAY/PASSTHROUGH/DEGRADED; `__main__` configures logging so the lines reach stdout in CI

`tests/llm_translation/test_openai_record_replay_proxy.py`: tests for the three startup modes and the HIT/MISS/not-recorded request paths. The MISS-then-HIT log assertions and the not-recorded warning were mutation-checked (reverting `_cache_set` to always report success, and dropping the HIT log line, each make a test fail)