### PR TITLE
fix(managed-files): use end_user_id as managed-resource owner when user_id is unset

### DIFF
--- a/enterprise/litellm_enterprise/proxy/hooks/managed_files.py
+++ b/enterprise/litellm_enterprise/proxy/hooks/managed_files.py
@@ -19,6 +19,7 @@ from litellm.llms.base_llm.managed_resources.isolation import (
     build_list_page,
     build_owner_filter,
     can_access_resource,
+    get_managed_resource_owner_id,
 )
 from litellm.proxy._types import (
     CallTypes,
@@ -97,15 +98,16 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
         verbose_logger.info(
             f"Storing LiteLLM Managed File object with id={file_id} in cache"
         )
+        owner_id = get_managed_resource_owner_id(user_api_key_dict)
         if file_object is not None:
             litellm_managed_file_object = LiteLLM_ManagedFileTable(
                 unified_file_id=file_id,
                 file_object=file_object,
                 model_mappings=model_mappings,
                 flat_model_file_ids=list(model_mappings.values()),
-                created_by=user_api_key_dict.user_id,
+                created_by=owner_id,
                 team_id=user_api_key_dict.team_id,
-                updated_by=user_api_key_dict.user_id,
+                updated_by=owner_id,
             )
             await self.internal_usage_cache.async_set_cache(
                 key=file_id,
@@ -119,9 +121,9 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
             "unified_file_id": file_id,
             "model_mappings": json.dumps(model_mappings),
             "flat_model_file_ids": list(model_mappings.values()),
-            "created_by": user_api_key_dict.user_id,
+            "created_by": owner_id,
             "team_id": user_api_key_dict.team_id,
-            "updated_by": user_api_key_dict.user_id,
+            "updated_by": owner_id,
         }
 
         if file_object is not None:
@@ -169,6 +171,7 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
             litellm_parent_otel_span=litellm_parent_otel_span,
         )
 
+        owner_id = get_managed_resource_owner_id(user_api_key_dict)
         await self.prisma_client.db.litellm_managedobjecttable.upsert(
             where={"unified_object_id": unified_object_id},
             data={
@@ -177,15 +180,15 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
                     "file_object": file_object.model_dump_json(),
                     "model_object_id": model_object_id,
                     "file_purpose": file_purpose,
-                    "created_by": user_api_key_dict.user_id,
+                    "created_by": owner_id,
                     "team_id": user_api_key_dict.team_id,
-                    "updated_by": user_api_key_dict.user_id,
+                    "updated_by": owner_id,
                     "status": file_object.status,
                 },
                 "update": {
                     "file_object": file_object.model_dump_json(),
                     "status": file_object.status,
-                    "updated_by": user_api_key_dict.user_id,
+                    "updated_by": owner_id,
                 },  # FIX: Update status and file_object on every operation to keep state in sync
             },
         )

--- a/litellm/llms/base_llm/managed_resources/base_managed_resource.py
+++ b/litellm/llms/base_llm/managed_resources/base_managed_resource.py
@@ -22,6 +22,7 @@ from litellm.llms.base_llm.managed_resources.isolation import (
     build_list_page,
     build_owner_filter,
     can_access_resource,
+    get_managed_resource_owner_id,
 )
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.types.utils import SpecialEnums
@@ -168,14 +169,15 @@ class BaseManagedResource(ABC, Generic[ResourceObjectType]):
         )
 
         # Prepare cache data
+        owner_id = get_managed_resource_owner_id(user_api_key_dict)
         cache_data = {
             "unified_resource_id": unified_resource_id,
             "resource_object": resource_object,
             "model_mappings": model_mappings,
             "flat_model_resource_ids": list(model_mappings.values()),
-            "created_by": user_api_key_dict.user_id,
+            "created_by": owner_id,
             "team_id": user_api_key_dict.team_id,
-            "updated_by": user_api_key_dict.user_id,
+            "updated_by": owner_id,
         }
 
         # Add additional fields if provided
@@ -195,9 +197,9 @@ class BaseManagedResource(ABC, Generic[ResourceObjectType]):
             "unified_resource_id": unified_resource_id,
             "model_mappings": json.dumps(model_mappings),
             "flat_model_resource_ids": list(model_mappings.values()),
-            "created_by": user_api_key_dict.user_id,
+            "created_by": owner_id,
             "team_id": user_api_key_dict.team_id,
-            "updated_by": user_api_key_dict.user_id,
+            "updated_by": owner_id,
         }
 
         # Add resource object if available

--- a/litellm/llms/base_llm/managed_resources/isolation.py
+++ b/litellm/llms/base_llm/managed_resources/isolation.py
@@ -17,6 +17,22 @@ from litellm.proxy._types import (
 )
 
 
+def get_managed_resource_owner_id(
+    user_api_key_dict: UserAPIKeyAuth,
+) -> Optional[str]:
+    """Identity used to tag (``created_by``) and scope managed resources.
+
+    Falls back to ``end_user_id`` when ``user_id`` is unset. Custom-auth /
+    end-user-scoped deployments return only ``end_user_id`` from their auth
+    callback (no ``user_id`` / ``team_id``); without this fallback their
+    created batches/files are stored ownerless (``created_by=None``) and
+    every retrieve/poll is denied. Using ``end_user_id`` as the owner lets
+    the same end user read back what they created, while an identity-less
+    caller (no user_id, team_id, or end_user_id) stays denied.
+    """
+    return user_api_key_dict.user_id or user_api_key_dict.end_user_id
+
+
 def build_list_page(items: List[Any], has_more: bool = False) -> Dict[str, Any]:
     """Build the OpenAI-style paginated list response shape used by managed
     file/batch/vector-store listings. ``first_id`` and ``last_id`` are
@@ -37,7 +53,8 @@ def build_owner_filter(
     to records the caller is allowed to see.
 
     - ``{}`` means no scoping (proxy admins).
-    - ``{"created_by": <user_id>}`` for user-keyed callers.
+    - ``{"created_by": <user_id or end_user_id>}`` for user-keyed and
+      end-user-scoped (custom-auth) callers.
     - ``{"team_id": <team_id>}`` for service-account callers
       that have a team but no user_id.
     - ``{"OR": [...]}`` when the caller has both — listing must include
@@ -49,19 +66,21 @@ def build_owner_filter(
     if _user_has_admin_view(user_api_key_dict):
         return {}
 
-    user_id = user_api_key_dict.user_id
+    # ``user_id`` falls back to ``end_user_id`` for custom-auth / end-user
+    # deployments so listings mirror the ownership stamped at create time.
+    owner_id = get_managed_resource_owner_id(user_api_key_dict)
     team_id = user_api_key_dict.team_id
 
-    if user_id is not None and team_id is not None:
+    if owner_id is not None and team_id is not None:
         return {
             "OR": [
-                {"created_by": user_id},
+                {"created_by": owner_id},
                 {"team_id": team_id},
             ]
         }
 
-    if user_id is not None:
-        return {"created_by": user_id}
+    if owner_id is not None:
+        return {"created_by": owner_id}
 
     if team_id is not None:
         return {"team_id": team_id}
@@ -84,8 +103,11 @@ def can_access_resource(
     if _user_has_admin_view(user_api_key_dict):
         return True
 
-    user_id = user_api_key_dict.user_id
-    if user_id is not None and created_by is not None and created_by == user_id:
+    # ``user_id`` falls back to ``end_user_id`` so custom-auth callers can
+    # read resources they created. ``created_by`` must be non-None to match,
+    # preserving the deny on the ``None == None`` bypass.
+    owner_id = get_managed_resource_owner_id(user_api_key_dict)
+    if owner_id is not None and created_by is not None and created_by == owner_id:
         return True
 
     team_id = user_api_key_dict.team_id

--- a/tests/test_litellm/llms/base_llm/test_managed_resource_isolation.py
+++ b/tests/test_litellm/llms/base_llm/test_managed_resource_isolation.py
@@ -7,6 +7,7 @@ import pytest
 from litellm.llms.base_llm.managed_resources.isolation import (
     build_owner_filter,
     can_access_resource,
+    get_managed_resource_owner_id,
 )
 from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
 
@@ -54,6 +55,47 @@ def test_owner_filter_no_identity_returns_none():
     assert build_owner_filter(UserAPIKeyAuth()) is None
 
 
+def test_owner_filter_falls_back_to_end_user_id():
+    """Custom-auth callers (only end_user_id set) scope to their end-user id,
+    matching the ownership stamped at create time."""
+    end_user = UserAPIKeyAuth(end_user_id="customer-1")
+    assert build_owner_filter(end_user) == {"created_by": "customer-1"}
+
+
+def test_owner_filter_user_id_takes_precedence_over_end_user_id():
+    user = UserAPIKeyAuth(user_id="alice", end_user_id="customer-1")
+    assert build_owner_filter(user) == {"created_by": "alice"}
+
+
+def test_owner_filter_end_user_with_team_returns_or_filter():
+    end_user = UserAPIKeyAuth(end_user_id="customer-1", team_id="team-eng")
+    assert build_owner_filter(end_user) == {
+        "OR": [
+            {"created_by": "customer-1"},
+            {"team_id": "team-eng"},
+        ]
+    }
+
+
+# ---------------------------------------------------------------------------
+# get_managed_resource_owner_id
+# ---------------------------------------------------------------------------
+
+
+def test_owner_id_prefers_user_id():
+    auth = UserAPIKeyAuth(user_id="alice", end_user_id="customer-1")
+    assert get_managed_resource_owner_id(auth) == "alice"
+
+
+def test_owner_id_falls_back_to_end_user_id():
+    auth = UserAPIKeyAuth(end_user_id="customer-1")
+    assert get_managed_resource_owner_id(auth) == "customer-1"
+
+
+def test_owner_id_none_when_no_identity():
+    assert get_managed_resource_owner_id(UserAPIKeyAuth()) is None
+
+
 # ---------------------------------------------------------------------------
 # can_access_resource
 # ---------------------------------------------------------------------------
@@ -90,6 +132,34 @@ def test_access_user_id_match(user_id, created_by, expected):
     assert (
         can_access_resource(user, created_by=created_by, resource_team_id=None)
         is expected
+    )
+
+
+@pytest.mark.parametrize(
+    "end_user_id,created_by,expected",
+    [
+        ("customer-1", "customer-1", True),
+        ("customer-1", "customer-2", False),
+        ("customer-1", None, False),
+    ],
+)
+def test_access_end_user_id_match_when_no_user_id(end_user_id, created_by, expected):
+    """Custom-auth callers (only end_user_id) can read resources they
+    created (created_by == end_user_id), but not others' or ownerless rows."""
+    caller = UserAPIKeyAuth(end_user_id=end_user_id)
+    assert (
+        can_access_resource(caller, created_by=created_by, resource_team_id=None)
+        is expected
+    )
+
+
+def test_access_user_id_match_ignores_end_user_id():
+    """When user_id is set it is the owner identity; a created_by that only
+    matches end_user_id must NOT grant access."""
+    caller = UserAPIKeyAuth(user_id="alice", end_user_id="customer-1")
+    assert (
+        can_access_resource(caller, created_by="customer-1", resource_team_id=None)
+        is False
     )
 
 


### PR DESCRIPTION
## Relevant issues

Custom-auth deployments that return a `UserAPIKeyAuth` with only `end_user_id` (no `user_id` / `team_id`) can **create** managed batches/files via the `target_model_names` path, but every **retrieve/poll** is rejected with `User None does not have access to the object ...`. Because polling fails, the batch poller and cost/completion callbacks (`aretrieve_batch` with `response_cost`) never run, so end-user spend is never tracked.

## Linear ticket

Resolves LIT-3602

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code) — targeted: `tests/test_litellm/llms/base_llm/test_managed_resource_isolation.py` (32 passed)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Live proxy repro against Postgres. Identical setup on both runs: custom auth returns a `UserAPIKeyAuth` with **only `end_user_id`** (no `user_id` / `team_id`), managed path via `target_model_names=gpt-4o-mini`, real OpenAI batch.

**Before — `litellm_internal_staging`:** owner retrieve → HTTP **403** (`User None does not have access`); `created_by` stored as `NULL` → poller/cost callbacks never run.

<img width="1040" height="304" alt="image" src="https://github.com/user-attachments/assets/347d3908-9d2d-41a8-8728-26fd5997e8df" />

**After — this branch:** owner (`customer-1`) retrieve → HTTP **200**; a different tenant (`customer-2`) retrieving the same batch → HTTP **403** (isolation preserved); `created_by` stamped with the end-user id.

<img width="1040" height="326" alt="image" src="https://github.com/user-attachments/assets/47a78208-f661-4f03-9d6e-d9311d799037" />

## Type

🐛 Bug Fix

## Changes

Managed batch/file objects are stamped with ownership taken from `user_api_key_dict.user_id` and `team_id`, and `can_access_resource()` enforces those on retrieve/poll. Custom-auth callers that set only `end_user_id` therefore stored `created_by = NULL` and were denied on retrieve (the deliberate `None == None` isolation guard).

**Fix (`litellm/llms/base_llm/managed_resources/isolation.py`):**
- Add `get_managed_resource_owner_id(user_api_key_dict)` → `user_id or end_user_id`.
- Use it in `can_access_resource()` and `build_owner_filter()` so an end-user can read/list the resources they created.

**Store sites** now stamp `created_by` / `updated_by` via the same helper:
- `enterprise/litellm_enterprise/proxy/hooks/managed_files.py` (`store_unified_file_id`, `store_unified_object_id`)
- `litellm/llms/base_llm/managed_resources/base_managed_resource.py` (`store_unified_resource_id`)

**Isolation preserved:** a caller with no `user_id`, `team_id`, *and* no `end_user_id` is still denied against every resource — the `None == None` bypass is not reintroduced (verified by the live cross-tenant 403 and by `test_access_identity_less_caller_always_denied`).

**Tests added** in `tests/test_litellm/llms/base_llm/test_managed_resource_isolation.py`: `end_user_id` owner fallback for `get_managed_resource_owner_id`, `build_owner_filter` (incl. OR with team), and `can_access_resource` (match / mismatch / NULL / `user_id` precedence).

> Note: this is the managed (`target_model_names`) path fix only. It does not change the model-embedded (`model=`) batch path.
