### PR TITLE
fix(responses): preserve forced-function tool_choice name in Responses to Chat transform

### DIFF
--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -148,7 +148,9 @@ class LiteLLMCompletionResponsesConfig:
                 # which is equivalent to "required" in OpenAI format
                 return "required"
             elif tool_choice_type == "function":
-                # function type without name - fall back to required
+                function_name = tool_choice.get("name")
+                if function_name:
+                    return {"type": "function", "function": {"name": function_name}}
                 return "required"
 
         # Return as-is for unknown formats

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -949,6 +949,28 @@ class TestToolChoiceTransformation:
         result = LiteLLMCompletionResponsesConfig._transform_tool_choice(tool_choice)
         assert result == tool_choice
 
+    def test_transform_tool_choice_responses_flat_function_name(self):
+        """Responses-API forced-function with a top-level name maps to the nested Chat
+        Completions shape instead of degrading to required and dropping the name"""
+        result = LiteLLMCompletionResponsesConfig._transform_tool_choice(
+            {"type": "function", "name": "get_weather"}
+        )
+        assert result == {"type": "function", "function": {"name": "get_weather"}}
+
+    def test_transform_tool_choice_function_without_name_falls_back_to_required(self):
+        """A function-type dict with no name still falls back to required"""
+        result = LiteLLMCompletionResponsesConfig._transform_tool_choice(
+            {"type": "function"}
+        )
+        assert result == "required"
+
+    def test_transform_tool_choice_function_empty_name_falls_back_to_required(self):
+        """An empty top-level name is falsy and must not produce an empty function name"""
+        result = LiteLLMCompletionResponsesConfig._transform_tool_choice(
+            {"type": "function", "name": ""}
+        )
+        assert result == "required"
+
 
 class TestContentTypeTransformation:
     """Test content type transformation from Responses API to Chat Completion format"""


### PR DESCRIPTION
## Relevant issues

No existing issue; found while testing forced-function `tool_choice` through the Responses API. Re-opens #29811, which was auto-closed when its base branch (`litellm_oss_staging_050626`) was deleted; retargeted here at the default branch

## Type

Bug Fix

## What

When a client uses the Responses API and forces a specific function, the native shape puts the name at the top level: `{"type": "function", "name": "get_weather"}`. `LiteLLMCompletionResponsesConfig._transform_tool_choice` (which converts a Responses request into a Chat Completion request) only recognized the nested Chat Completions shape `{"type": "function", "function": {"name": ...}}`. The flat Responses shape fell through to the `elif tool_choice_type == "function"` branch and returned the string `"required"`, silently dropping the function name and degrading "force this specific function" into "force any tool".

The fix maps the flat Responses shape to the nested Chat Completions shape that `ChatCompletionNamedToolChoiceParam` expects, keeping the `"required"` fallback when no name is present (so the existing Cursor-style `{"type": "tool"}` and nameless cases are unchanged). The earlier guard that passes through an already-nested `function.name` still runs first, so standard OpenAI input is unaffected.

The two formats are confirmed by OpenAI's generated SDK types: Responses uses a top-level `name` (`ToolChoiceFunctionParam`), Chat Completions nests it under `function` (`ChatCompletionNamedToolChoiceParam`).

## Proof of Fix

Live proxy against the real Gemini API (`gemini/gemini-2.5-flash`), two tools `get_weather` and `get_time`, prompt deliberately about the time so that "force any tool" would pick `get_time`, while `tool_choice` forces `get_weather`

```
curl -s http://localhost:4000/v1/responses \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"gflash","input":"What is the current time in Paris?",
       "tools":[{"type":"function","name":"get_weather","description":"Get the weather for a city","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}},
                {"type":"function","name":"get_time","description":"Get the current time for a city","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}],
       "tool_choice":{"type":"function","name":"get_weather"}}'
```

Before the fix, the forced function is dropped (`tool_choice` becomes `"required"` in the request litellm builds) and the model calls the tool that fits the prompt

```
function calls: ['get_time']   # run 1
function calls: ['get_time']   # run 2
```

After the fix, the forced function is honored end to end

```
function calls: ['get_weather']
```

The transformed `tool_choice` litellm sends to the provider goes from `'required'` before to `{'type': 'function', 'function': {'name': 'get_weather'}}` after, visible under `--detailed_debug`.

## Tests

Added three regression tests to the existing `TestToolChoiceTransformation` in `tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py`: the flat Responses forced-function form maps to the nested Chat shape, a function-type dict with no name still falls back to `"required"`, and an empty top-level name falls back to `"required"`. The first fails before this change and passes after it.
