### PR TITLE
feat(bedrock): forward strict and additionalProperties to Converse toolSpec

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -5548,15 +5548,25 @@ def _bedrock_tools_pt(
         normalize_json_schema_custom_types_to_object(parameters)
         if parameters.get("type") not in _valid_json_schema_root_types:
             parameters["type"] = "object"
+        additional_properties = parameters.get("additionalProperties", None)
         tool_input_schema = BedrockToolInputSchemaBlock(
             json=BedrockToolJsonSchemaBlock(
                 type=parameters["type"],
                 properties=parameters.get("properties", {}),
                 required=parameters.get("required", []),
+                **(
+                    {"additionalProperties": additional_properties}
+                    if additional_properties is not None
+                    else {}
+                ),
             )
         )
+        strict = tool.get("function", {}).get("strict", None)
         tool_spec = BedrockToolSpecBlock(
-            inputSchema=tool_input_schema, name=name, description=description
+            inputSchema=tool_input_schema,
+            name=name,
+            description=description,
+            **({"strict": strict} if strict is not None else {}),
         )
         tool_block = BedrockToolBlock(toolSpec=tool_spec)
         tool_block_list.append(tool_block)

--- a/litellm/types/llms/bedrock.py
+++ b/litellm/types/llms/bedrock.py
@@ -250,6 +250,7 @@ class ToolJsonSchemaBlock(TypedDict, total=False):
     type: Literal["object"]
     properties: dict
     required: List[str]
+    additionalProperties: bool
 
 
 class ToolInputSchemaBlock(TypedDict):
@@ -260,6 +261,7 @@ class ToolSpecBlock(TypedDict, total=False):
     inputSchema: Required[ToolInputSchemaBlock]
     name: Required[str]
     description: str
+    strict: bool
 
 
 class SystemToolBlock(TypedDict, total=False):

--- a/tests/llm_translation/test_bedrock_completion.py
+++ b/tests/llm_translation/test_bedrock_completion.py
@@ -1182,6 +1182,52 @@ def test_bedrock_tools_transformation_valid_params():
     assert "test" in result[0]["toolSpec"]["inputSchema"]["json"]["required"]
 
 
+def test_bedrock_tools_pt_strict_parameter():
+    """Regression for strict tools silently dropped on the Bedrock Converse path.
+
+    Bedrock Converse supports strict in toolSpec since 2026-02; without forwarding
+    strict (and additionalProperties, which Bedrock requires alongside strict) the
+    model ignores the enum constraint the caller asked for.
+    """
+    tools_with_strict = [
+        {
+            "type": "function",
+            "function": {
+                "name": "generate_sql",
+                "strict": True,
+                "description": "Generate a SQL query",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                    "required": ["query"],
+                    "additionalProperties": False,
+                },
+            },
+        }
+    ]
+    result = _bedrock_tools_pt(tools_with_strict)
+    assert result[0]["toolSpec"]["strict"] is True
+    assert result[0]["toolSpec"]["inputSchema"]["json"]["additionalProperties"] is False
+
+    tools_without_strict = [
+        {
+            "type": "function",
+            "function": {
+                "name": "generate_sql",
+                "description": "Generate a SQL query",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                    "required": ["query"],
+                },
+            },
+        }
+    ]
+    result = _bedrock_tools_pt(tools_without_strict)
+    assert "strict" not in result[0]["toolSpec"]
+    assert "additionalProperties" not in result[0]["toolSpec"]["inputSchema"]["json"]
+
+
 def test_not_found_error():
     with pytest.raises(litellm.NotFoundError):
         completion(


### PR DESCRIPTION
## Relevant issues

A customer reported that `strict: true` on tools is silently ignored for Claude on Bedrock: give a tool an enum and ask for a value outside it, and GPT and direct-Anthropic stay inside the enum while Claude-on-Bedrock returns the out-of-enum value. This re-applies the fix from #25209, which was correct and approved (Greptile 5/5) but went stale with merge conflicts since April after unrelated refactors landed in `_bedrock_tools_pt`. The hunks no longer applied, but the change itself was still valid, so this is a clean rebase onto current staging rather than a rewrite. Related: #10062, #16725, #6136

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:
- [ ] **CI run for the last commit**
       Link:
- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

Reproduce against a live proxy hitting real Bedrock (Claude). Define a tool whose only enum value is `celsius` and ask for Fahrenheit; before this change the call comes back with `additionalProperties`/`strict` dropped and the model free to pick an out-of-enum value, after it the schema reaches Bedrock intact.

```bash
curl -s http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer $LITELLM_KEY" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0",
    "messages": [{"role": "user", "content": "What is the weather in Dallas in Fahrenheit? Call the tool."}],
    "tool_choice": "required",
    "tools": [{
      "type": "function",
      "function": {
        "name": "get_weather",
        "strict": true,
        "description": "Get the weather for a city",
        "parameters": {
          "type": "object",
          "properties": {
            "city": {"type": "string"},
            "unit": {"type": "string", "enum": ["celsius"]}
          },
          "required": ["city", "unit"],
          "additionalProperties": false
        }
      }
    }]
  }' | jq '.choices[0].message.tool_calls[0].function.arguments'
```

With the fix the returned `unit` stays `"celsius"` (the only enum member) instead of `"fahrenheit"`.

## Type

🐛 Bug Fix

## Changes

`litellm/types/llms/bedrock.py`: add `additionalProperties: bool` to `ToolJsonSchemaBlock` and `strict: bool` to `ToolSpecBlock` (both `total=False`, so the keys stay optional).

`litellm/litellm_core_utils/prompt_templates/factory.py`: in `_bedrock_tools_pt`, forward `strict` from the OpenAI `function` and `additionalProperties` from the schema, each only when present. Bedrock requires `additionalProperties: false` alongside `strict: true` or it rejects the request, so both have to travel together.

`tests/llm_translation/test_bedrock_completion.py`: add `test_bedrock_tools_pt_strict_parameter` covering both the pass-through and the absent-by-default cases. It fails (KeyError on `strict`) without the factory change and passes with it.