### PR TITLE
fix(responses-bridge): map system-only chat request to system input item

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -402,6 +402,20 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
             instructions,
         ) = self.convert_chat_completion_messages_to_responses_api(messages)
 
+        # OpenAI's Responses API rejects an empty input. For a system-only
+        # request, carry the system message as a system-role input item instead
+        # of instructions, mirroring how non-string system content is already
+        # handled in convert_chat_completion_messages_to_responses_api.
+        if not input_items and instructions is not None:
+            input_items = [
+                {
+                    "type": "message",
+                    "role": "system",
+                    "content": [{"type": "input_text", "text": instructions}],
+                }
+            ]
+            instructions = None
+
         optional_params = self._extract_extra_body_params(optional_params)
 
         # Build responses API request using the reverse transformation logic

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -13,6 +13,9 @@ sys.path.insert(
     0, os.path.abspath("../../..")
 )  # Adds the parent directory to the system-path
 import litellm
+from litellm.completion_extras.litellm_responses_transformation.transformation import (
+    LiteLLMResponsesTransformationHandler,
+)
 
 
 def test_convert_chat_completion_messages_to_responses_api_image_input():
@@ -858,6 +861,39 @@ def test_extract_extra_body_params_reasoning_effort_override():
 
     # extra_body should no longer be in optional_params (it was popped)
     assert "extra_body" not in result
+
+
+def test_transform_request_system_only_message_maps_to_system_input_item():
+    """System-only requests must not send input=[] to the Responses API.
+
+    OpenAI rejects both input=[] and input="". When the only message is a
+    system message, carry it as a system-role input item (single copy, correct
+    role) rather than leaving input empty or duplicating it into instructions.
+    """
+    handler = LiteLLMResponsesTransformationHandler()
+    logging_obj = Mock()
+    messages = [{"role": "system", "content": "You are a helpful assistant."}]
+
+    result = handler.transform_request(
+        model="gpt-5.3-codex",
+        messages=messages,
+        optional_params={},
+        litellm_params={},
+        headers={},
+        litellm_logging_obj=logging_obj,
+    )
+
+    assert result["input"] == [
+        {
+            "type": "message",
+            "role": "system",
+            "content": [
+                {"type": "input_text", "text": "You are a helpful assistant."}
+            ],
+        }
+    ]
+    # System content lives in input only; not duplicated into instructions.
+    assert not result.get("instructions")
 
 
 def test_transform_request_single_char_keys_not_matched():


### PR DESCRIPTION
## Relevant issues

Fixes a bug where `mode: responses` Codex models (`gpt-5.3-codex`, `gpt-5.1-codex`, `gpt-5-codex`, `codex-mini-latest`) reject system-only `completion()` requests with `missing_required_parameter` for `input`. Open WebUI and similar clients send only a system message on new conversations.

## Linear ticket

Resolves LIT-3609

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes targeted unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code) scope — `pytest tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py -v` (44 passed)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Steps to Reproduce

1. Call `litellm.completion()` with a Codex responses model and only a system message:
   ```python
   litellm.completion(
       model="gpt-5.3-codex",
       messages=[{"role": "system", "content": "You are a helpful assistant."}],
   )
   ```
2. On staging, the completions→responses bridge maps the system message to `instructions` and leaves `input=[]`.
3. OpenAI returns HTTP 400: `missing_required_parameter` — one of `input`, `previous_response_id`, `prompt`, or `conversation_id` must be provided.

## Screenshots / Proof of Fix

**Before — `litellm_internal_staging`:** bridge sends `input=[]`; live `completion()` fails with `missing_required_parameter`.

<img width="505" height="325" alt="image" src="https://github.com/user-attachments/assets/f746f5df-a678-461e-a7d5-16716d5602e6" />


**After — `litellm_fix_responses_bridge_empty_input`:** bridge carries the system message as a `role: "system"` input item; live `completion()` succeeds.

<img width="1080" height="436" alt="image" src="https://github.com/user-attachments/assets/02c4aeb2-3257-4a3a-bba7-dee7d2946c8b" />

## Type

🐛 Bug Fix

## Changes

- In `transform_request()`, when `input_items` is empty (only system messages were present), carry the system message as a `role: "system"` input item and leave `instructions` unset:
  ```python
  if not input_items and instructions is not None:
      input_items = [{
          "type": "message",
          "role": "system",
          "content": [{"type": "input_text", "text": instructions}],
      }]
      instructions = None
  ```
- Add regression test `test_transform_request_system_only_message_maps_to_system_input_item`.

**Why this mapping:** Live API testing against `gpt-5.3-codex` confirmed OpenAI rejects both `input=[]` and `input=""`. Carrying the system message as a system-role input item keeps the content in a single place, preserves system semantics (the model treats it as a system instruction, not a user turn), and avoids duplicating it into both `instructions` and `input`. This mirrors how the bridge already handles non-string system content in `convert_chat_completion_messages_to_responses_api`. The `" "` fallback only applies to the impossible edge case of no messages at all.

## Regression safety

The new branch only runs when `input_items` is empty **and** `instructions` is set — the system-only case, which currently returns HTTP 400. Any request containing a user/assistant/tool message is unchanged. Only `transform_request()` is touched (not the shared `convert_...` helper). Full file suite: 44 passed.
