### PR TITLE
fix(proxy): handle NULL DB fields in spend aggregation

### DIFF
--- a/litellm/proxy/management_endpoints/common_daily_activity.py
+++ b/litellm/proxy/management_endpoints/common_daily_activity.py
@@ -32,8 +32,6 @@ _PRISMA_TO_PG_TABLE: Dict[str, str] = {
 
 def update_metrics(existing_metrics: SpendMetrics, record: Any) -> SpendMetrics:
     """Update metrics with new record data."""
-    # Coerce nullable DB fields to 0 to prevent TypeError on None + None/int
-    # when keys have no spend data. See: #29773
     existing_metrics.spend += record.spend or 0
     existing_metrics.prompt_tokens += record.prompt_tokens or 0
     existing_metrics.completion_tokens += record.completion_tokens or 0
@@ -698,8 +696,6 @@ _GROUP_DATE_ENDPOINT_API_KEY = 30  # 0b0011110
 
 def _record_to_spend_metrics(record: Any) -> SpendMetrics:
     """Build a SpendMetrics directly from one already-aggregated rollup row."""
-    # Coerce nullable DB fields to 0 to prevent TypeError on None + None/int
-    # when keys have no spend data. See: #29773
     prompt_tokens = record.prompt_tokens or 0
     completion_tokens = record.completion_tokens or 0
     return SpendMetrics(

--- a/litellm/proxy/management_endpoints/common_daily_activity.py
+++ b/litellm/proxy/management_endpoints/common_daily_activity.py
@@ -35,9 +35,13 @@ def update_metrics(existing_metrics: SpendMetrics, record: Any) -> SpendMetrics:
     existing_metrics.spend += record.spend or 0
     existing_metrics.prompt_tokens += record.prompt_tokens or 0
     existing_metrics.completion_tokens += record.completion_tokens or 0
-    existing_metrics.total_tokens += (record.prompt_tokens or 0) + (record.completion_tokens or 0)
+    existing_metrics.total_tokens += (record.prompt_tokens or 0) + (
+        record.completion_tokens or 0
+    )
     existing_metrics.cache_read_input_tokens += record.cache_read_input_tokens or 0
-    existing_metrics.cache_creation_input_tokens += record.cache_creation_input_tokens or 0
+    existing_metrics.cache_creation_input_tokens += (
+        record.cache_creation_input_tokens or 0
+    )
     existing_metrics.api_requests += record.api_requests or 0
     existing_metrics.successful_requests += record.successful_requests or 0
     existing_metrics.failed_requests += record.failed_requests or 0
@@ -106,26 +110,24 @@ def update_breakdown_metrics(
 
         # Update API key breakdown for this model
         if record.api_key not in breakdown.models[record.model].api_key_breakdown:
-            breakdown.models[record.model].api_key_breakdown[record.api_key] = (
-                KeyMetricWithMetadata(
-                    metrics=SpendMetrics(),
-                    metadata=KeyMetadata(
-                        key_alias=api_key_metadata.get(record.api_key, {}).get(
-                            "key_alias", None
-                        ),
-                        team_id=api_key_metadata.get(record.api_key, {}).get(
-                            "team_id", None
-                        ),
+            breakdown.models[record.model].api_key_breakdown[
+                record.api_key
+            ] = KeyMetricWithMetadata(
+                metrics=SpendMetrics(),
+                metadata=KeyMetadata(
+                    key_alias=api_key_metadata.get(record.api_key, {}).get(
+                        "key_alias", None
                     ),
-                )
+                    team_id=api_key_metadata.get(record.api_key, {}).get(
+                        "team_id", None
+                    ),
+                ),
             )
-        breakdown.models[record.model].api_key_breakdown[record.api_key].metrics = (
-            update_metrics(
-                breakdown.models[record.model]
-                .api_key_breakdown[record.api_key]
-                .metrics,
-                record,
-            )
+        breakdown.models[record.model].api_key_breakdown[
+            record.api_key
+        ].metrics = update_metrics(
+            breakdown.models[record.model].api_key_breakdown[record.api_key].metrics,
+            record,
         )
 
     # Update model group breakdown
@@ -221,24 +223,22 @@ def update_breakdown_metrics(
 
     # Update API key breakdown for this provider
     if record.api_key not in breakdown.providers[provider].api_key_breakdown:
-        breakdown.providers[provider].api_key_breakdown[record.api_key] = (
-            KeyMetricWithMetadata(
-                metrics=SpendMetrics(),
-                metadata=KeyMetadata(
-                    key_alias=api_key_metadata.get(record.api_key, {}).get(
-                        "key_alias", None
-                    ),
-                    team_id=api_key_metadata.get(record.api_key, {}).get(
-                        "team_id", None
-                    ),
+        breakdown.providers[provider].api_key_breakdown[
+            record.api_key
+        ] = KeyMetricWithMetadata(
+            metrics=SpendMetrics(),
+            metadata=KeyMetadata(
+                key_alias=api_key_metadata.get(record.api_key, {}).get(
+                    "key_alias", None
                 ),
-            )
+                team_id=api_key_metadata.get(record.api_key, {}).get("team_id", None),
+            ),
         )
-    breakdown.providers[provider].api_key_breakdown[record.api_key].metrics = (
-        update_metrics(
-            breakdown.providers[provider].api_key_breakdown[record.api_key].metrics,
-            record,
-        )
+    breakdown.providers[provider].api_key_breakdown[
+        record.api_key
+    ].metrics = update_metrics(
+        breakdown.providers[provider].api_key_breakdown[record.api_key].metrics,
+        record,
     )
 
     # Update endpoint breakdown
@@ -254,18 +254,18 @@ def update_breakdown_metrics(
 
         # Update API key breakdown for this endpoint
         if record.api_key not in breakdown.endpoints[record.endpoint].api_key_breakdown:
-            breakdown.endpoints[record.endpoint].api_key_breakdown[record.api_key] = (
-                KeyMetricWithMetadata(
-                    metrics=SpendMetrics(),
-                    metadata=KeyMetadata(
-                        key_alias=api_key_metadata.get(record.api_key, {}).get(
-                            "key_alias", None
-                        ),
-                        team_id=api_key_metadata.get(record.api_key, {}).get(
-                            "team_id", None
-                        ),
+            breakdown.endpoints[record.endpoint].api_key_breakdown[
+                record.api_key
+            ] = KeyMetricWithMetadata(
+                metrics=SpendMetrics(),
+                metadata=KeyMetadata(
+                    key_alias=api_key_metadata.get(record.api_key, {}).get(
+                        "key_alias", None
                     ),
-                )
+                    team_id=api_key_metadata.get(record.api_key, {}).get(
+                        "team_id", None
+                    ),
+                ),
             )
         breakdown.endpoints[record.endpoint].api_key_breakdown[
             record.api_key
@@ -312,26 +312,24 @@ def update_breakdown_metrics(
 
         # Update API key breakdown for this entity
         if record.api_key not in breakdown.entities[entity_value].api_key_breakdown:
-            breakdown.entities[entity_value].api_key_breakdown[record.api_key] = (
-                KeyMetricWithMetadata(
-                    metrics=SpendMetrics(),
-                    metadata=KeyMetadata(
-                        key_alias=api_key_metadata.get(record.api_key, {}).get(
-                            "key_alias", None
-                        ),
-                        team_id=api_key_metadata.get(record.api_key, {}).get(
-                            "team_id", None
-                        ),
+            breakdown.entities[entity_value].api_key_breakdown[
+                record.api_key
+            ] = KeyMetricWithMetadata(
+                metrics=SpendMetrics(),
+                metadata=KeyMetadata(
+                    key_alias=api_key_metadata.get(record.api_key, {}).get(
+                        "key_alias", None
                     ),
-                )
+                    team_id=api_key_metadata.get(record.api_key, {}).get(
+                        "team_id", None
+                    ),
+                ),
             )
-        breakdown.entities[entity_value].api_key_breakdown[record.api_key].metrics = (
-            update_metrics(
-                breakdown.entities[entity_value]
-                .api_key_breakdown[record.api_key]
-                .metrics,
-                record,
-            )
+        breakdown.entities[entity_value].api_key_breakdown[
+            record.api_key
+        ].metrics = update_metrics(
+            breakdown.entities[entity_value].api_key_breakdown[record.api_key].metrics,
+            record,
         )
 
     return breakdown

--- a/litellm/proxy/management_endpoints/common_daily_activity.py
+++ b/litellm/proxy/management_endpoints/common_daily_activity.py
@@ -32,15 +32,17 @@ _PRISMA_TO_PG_TABLE: Dict[str, str] = {
 
 def update_metrics(existing_metrics: SpendMetrics, record: Any) -> SpendMetrics:
     """Update metrics with new record data."""
-    existing_metrics.spend += record.spend
-    existing_metrics.prompt_tokens += record.prompt_tokens
-    existing_metrics.completion_tokens += record.completion_tokens
-    existing_metrics.total_tokens += record.prompt_tokens + record.completion_tokens
-    existing_metrics.cache_read_input_tokens += record.cache_read_input_tokens
-    existing_metrics.cache_creation_input_tokens += record.cache_creation_input_tokens
-    existing_metrics.api_requests += record.api_requests
-    existing_metrics.successful_requests += record.successful_requests
-    existing_metrics.failed_requests += record.failed_requests
+    # Coerce nullable DB fields to 0 to prevent TypeError on None + None/int
+    # when keys have no spend data. See: #29773
+    existing_metrics.spend += record.spend or 0
+    existing_metrics.prompt_tokens += record.prompt_tokens or 0
+    existing_metrics.completion_tokens += record.completion_tokens or 0
+    existing_metrics.total_tokens += (record.prompt_tokens or 0) + (record.completion_tokens or 0)
+    existing_metrics.cache_read_input_tokens += record.cache_read_input_tokens or 0
+    existing_metrics.cache_creation_input_tokens += record.cache_creation_input_tokens or 0
+    existing_metrics.api_requests += record.api_requests or 0
+    existing_metrics.successful_requests += record.successful_requests or 0
+    existing_metrics.failed_requests += record.failed_requests or 0
     return existing_metrics
 
 
@@ -696,16 +698,20 @@ _GROUP_DATE_ENDPOINT_API_KEY = 30  # 0b0011110
 
 def _record_to_spend_metrics(record: Any) -> SpendMetrics:
     """Build a SpendMetrics directly from one already-aggregated rollup row."""
+    # Coerce nullable DB fields to 0 to prevent TypeError on None + None/int
+    # when keys have no spend data. See: #29773
+    prompt_tokens = record.prompt_tokens or 0
+    completion_tokens = record.completion_tokens or 0
     return SpendMetrics(
-        spend=record.spend,
-        prompt_tokens=record.prompt_tokens,
-        completion_tokens=record.completion_tokens,
-        total_tokens=record.prompt_tokens + record.completion_tokens,
-        cache_read_input_tokens=record.cache_read_input_tokens,
-        cache_creation_input_tokens=record.cache_creation_input_tokens,
-        api_requests=record.api_requests,
-        successful_requests=record.successful_requests,
-        failed_requests=record.failed_requests,
+        spend=record.spend or 0,
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=prompt_tokens + completion_tokens,
+        cache_read_input_tokens=record.cache_read_input_tokens or 0,
+        cache_creation_input_tokens=record.cache_creation_input_tokens or 0,
+        api_requests=record.api_requests or 0,
+        successful_requests=record.successful_requests or 0,
+        failed_requests=record.failed_requests or 0,
     )
 
 


### PR DESCRIPTION
## Linked Issue

Closes #29773

## Description

Two functions in `common_daily_activity.py` perform arithmetic on database fields without null-coalescing:

1. **`update_metrics()`** — `record.prompt_tokens + record.completion_tokens` and all `+=` operations
2. **`_record_to_spend_metrics()`** — same `prompt_tokens + completion_tokens` addition

When API keys have no spend data, PostgreSQL returns `NULL` for these numeric columns. The Prisma ORM passes `None` through, causing:

```
TypeError: unsupported operand type(s) for +: NoneType and NoneType
```

This crashes the `/user/daily/activity/aggregated` endpoint with a 500 error.

## Fix

Coerce all nullable numeric fields with `or 0` before arithmetic. Both functions now handle `None` values gracefully:

```python
# Before
total_tokens=record.prompt_tokens + record.completion_tokens,

# After
prompt_tokens = record.prompt_tokens or 0
completion_tokens = record.completion_tokens or 0
total_tokens=prompt_tokens + completion_tokens,
```

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Test Coverage

- [x] I tested manually (describe below)

Verified the fix handles `None` values correctly using standalone unit tests for both `update_metrics` and `_record_to_spend_metrics` with null-valued record fields.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code

---

*Bug identified and fix generated with [GitWire](https://gitwire.erlab.uk) — self-hosted AI governance for GitHub automation.*