### PR TITLE
fix(ui): stop MCP playground tool calls from sending twice

### DIFF
--- a/ui/litellm-dashboard/src/components/mcp_tools/ToolTestPanel.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/ToolTestPanel.test.tsx
@@ -151,4 +151,19 @@ describe("ToolTestPanel defaults", () => {
     expect(screen.getByPlaceholderText("Enter input for this tool")).toBeInTheDocument();
     expect(screen.queryByText("No parameters required")).not.toBeInTheDocument();
   });
+
+  it("renders the call button as type=button so a click never also triggers native form submission", () => {
+    const schema: InputSchema = {
+      type: "object",
+      properties: {
+        message: { type: "string", description: "Prompt text" },
+      },
+    };
+
+    renderPanel(schema);
+
+    const callButton = screen.getByRole("button", { name: "Call Tool" });
+    expect(callButton.closest("form")).not.toBeNull();
+    expect(callButton).toHaveAttribute("type", "button");
+  });
 });

--- a/ui/litellm-dashboard/src/components/mcp_tools/ToolTestPanel.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/ToolTestPanel.tsx
@@ -521,6 +521,7 @@ export function ToolTestPanel({
 
               <div className="pt-3 border-t border-gray-100">
                 <Button
+                  type="button"
                   onClick={() => form.submit()}
                   disabled={isLoading}
                   variant="primary"


### PR DESCRIPTION
## Problem
- MCP Playground tools are doing duplicate actions.
- Eg: using slack_send_message tool on MCP Playground sends a duplicate message into the slack channel
- Its a UI issue where on the Submit button, we didnt specify it to be a button, thus it sends a request on the submit action as well as onClick() it sends the same request again. Thus theres a duplicate

## Fix
- Added a Type Button to prevent duplicate action

## Linear ticket
Resolves LIT-3601

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Open the MCP playground for a server with a side-effecting tool (e.g. a Slack server with `slack_send_message`), at http://localhost:4000/ui/?page=mcp-servers -> pick the server -> Tools/Playground tab. Select `slack_send_message`, fill in `channel_id` and `message`, and click "Call Tool" once. Before this change two identical messages arrive in the channel even though the Tool Result pane shows a single response; after this change exactly one message is sent per click.

## Type

🐛 Bug Fix

## Changes

The tool-test panel's call button rendered without an explicit `type`, so inside the Ant `Form` it acted as a submit button. The button also has `onClick={() => form.submit()}`, so a single click ran the form's `onFinish` twice; once from the programmatic `form.submit()` and once from native form submission. Each `onFinish` fires the `executeTool` mutation, so two identical requests were sent upstream. For tools with side effects like `slack_send_message` this delivered the message twice while the UI only displayed the last (identical) response, which is why the duplicate was easy to miss.

Setting `type="button"` keeps the explicit `form.submit()` as the only submit path, so one click sends one request. The added test asserts the call button renders as `type="button"` inside the form; reverting the fix makes it fail.
