### PR TITLE
fix(bedrock): preserve cache_control for ARN models in /v1/messages adapter

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -332,7 +332,14 @@ class LiteLLMAnthropicMessagesAdapter:
             if isinstance(source, dict)
             else getattr(source, "cache_control", None)
         )
-        if cache_control and model and self.is_anthropic_claude_model(model):
+        if (
+            cache_control
+            and model
+            and (
+                self.is_anthropic_claude_model(model)
+                or self.is_bedrock_arn_model(model)
+            )
+        ):
             # TypedDict objects support dict operations at runtime
             # Use type ignore consistent with codebase pattern (see anthropic/chat/transformation.py:432)
             if isinstance(target, dict):
@@ -751,6 +758,18 @@ class LiteLLMAnthropicMessagesAdapter:
         """
         model_lower = model.lower()
         return "anthropic" in model_lower or "claude" in model_lower
+
+    @staticmethod
+    def is_bedrock_arn_model(model: str) -> bool:
+        """
+        Check if the model string is a Bedrock ARN, such as an Application
+        Inference Profile (e.g. arn:aws:bedrock:us-east-1:123:application-inference-profile/id).
+
+        These ARNs contain neither "anthropic" nor "claude", so is_anthropic_claude_model
+        cannot identify them even though, on the /v1/messages endpoint, they point at Claude.
+        """
+        model_lower = model.lower()
+        return "arn:" in model_lower and "bedrock" in model_lower
 
     @staticmethod
     def translate_thinking_for_model(

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -1295,6 +1295,12 @@ CACHE_CONTROL_BEDROCK_CONVERSE_MODEL = (
     "bedrock/converse/global.anthropic.claude-opus-4-5-20251101-v1:0"
 )
 CACHE_CONTROL_NON_ANTHROPIC_MODEL = "gpt-4"
+# Bedrock Application Inference Profile ARN: the string contains neither
+# "anthropic" nor "claude", so the model can only be recognized via its ARN shape
+CACHE_CONTROL_BEDROCK_ARN_MODEL = (
+    "bedrock/converse/arn:aws:bedrock:us-east-1:123456789012:"
+    "application-inference-profile/abcdef123456"
+)
 
 
 def test_should_add_cache_control_for_anthropic_model():
@@ -1409,6 +1415,67 @@ def test_cache_control_not_preserved_for_non_claude_model():
 
     assert len(result) == 1
     assert "cache_control" not in result[0]["content"][0]
+
+
+@pytest.mark.parametrize(
+    "model, expected",
+    [
+        (CACHE_CONTROL_BEDROCK_ARN_MODEL, True),
+        (
+            "arn:aws-us-gov:bedrock:us-gov-west-1:123:application-inference-profile/x",
+            True,
+        ),
+        ("bedrock/amazon.titan-text-express-v1", False),
+        ("arn:aws:sagemaker:us-east-1:123:endpoint/my-endpoint", False),
+        (CACHE_CONTROL_NON_ANTHROPIC_MODEL, False),
+    ],
+)
+def test_is_bedrock_arn_model(model, expected):
+    """is_bedrock_arn_model requires both an ARN and the bedrock service in the string."""
+    assert LiteLLMAnthropicMessagesAdapter.is_bedrock_arn_model(model) is expected
+
+
+def test_cache_control_preserved_for_bedrock_arn_inference_profile():
+    """
+    Regression for https://github.com/BerriAI/litellm/issues/26625
+
+    Bedrock Application Inference Profile ARNs hide the underlying Claude model
+    name, so cache_control must still be preserved through the /v1/messages adapter.
+    """
+    anthropic_messages = [
+        AnthropicMessagesUserMessageParam(
+            role="user",
+            content=[
+                {
+                    "type": "text",
+                    "text": "This is cached content",
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+        )
+    ]
+
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    result = adapter.translate_anthropic_messages_to_openai(
+        messages=anthropic_messages, model=CACHE_CONTROL_BEDROCK_ARN_MODEL
+    )
+
+    assert len(result) == 1
+    assert result[0]["content"][0]["cache_control"] == {"type": "ephemeral"}
+
+
+def test_cache_control_fix_does_not_broaden_claude_detection():
+    """
+    The cache_control fix is scoped to _add_cache_control_if_applicable; it must not
+    make is_anthropic_claude_model treat ARN profiles as Claude, which would route
+    thinking params through unmodified and break non-Claude Bedrock profiles.
+    """
+    assert (
+        LiteLLMAnthropicMessagesAdapter.is_anthropic_claude_model(
+            CACHE_CONTROL_BEDROCK_ARN_MODEL
+        )
+        is False
+    )
 
 
 def test_cache_control_preserved_in_image_content_for_claude():


### PR DESCRIPTION
## Relevant issues

Fixes #26625

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

I don't have Bedrock credentials in this environment to hit a real Application Inference Profile, so here is a runbook to confirm the fix against a live proxy. Point a profile at any Claude model and run both endpoints; only the `/v1/messages` path was broken before.

1. Configure a Bedrock Application Inference Profile in your config

```yaml
model_list:
  - model_name: my-claude-model
    litellm_params:
      model: bedrock/converse/arn:aws:bedrock:us-east-1:ACCOUNT:application-inference-profile/PROFILE_ID
```

2. Start the proxy

```bash
python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log
```

3. Send a large cached prompt through the Anthropic endpoint (the previously broken path). Use enough text to clear Bedrock's minimum cache token threshold

```bash
BIG=$(python -c "print('the quick brown fox jumps over the lazy dog. ' * 3000)")
curl -s -X POST http://localhost:4000/v1/messages \
  -H "x-api-key: $LITELLM_KEY" \
  -H "anthropic-version: 2023-06-01" \
  -H "content-type: application/json" \
  -d "{\"model\":\"my-claude-model\",\"max_tokens\":16,\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"$BIG\",\"cache_control\":{\"type\":\"ephemeral\"}}]}]}" \
  | python -c "import sys,json; u=json.load(sys.stdin)['usage']; print(u)"
```

4. Before this fix the response usage shows `cache_creation_input_tokens: 0` and `cache_read_input_tokens: 0`. After this fix the first call returns a non-zero `cache_creation_input_tokens`, and an immediate identical second call returns a non-zero `cache_read_input_tokens`, matching what `/v1/chat/completions` already returned for the same profile

## Type

🐛 Bug Fix

## Changes

When a Bedrock Application Inference Profile is called through the Anthropic `/v1/messages` endpoint (the path Claude Code uses), `cache_control` was silently dropped during the Anthropic to OpenAI message translation, so prompt caching never activated. Several users reported large unexpected Bedrock bills from this since the same profile cached correctly through `/v1/chat/completions`.

The root cause is in `litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py`. `_add_cache_control_if_applicable()` only preserves `cache_control` when `is_anthropic_claude_model()` returns true, and that helper looks for the substrings `anthropic` or `claude` in the model string. An Application Inference Profile model is an ARN like `bedrock/converse/arn:aws:bedrock:us-east-1:ACCOUNT:application-inference-profile/ID`, which contains neither substring, so the check failed and the directive was dropped before reaching the Bedrock Converse `cachePoint` conversion.

The fix adds a small `is_bedrock_arn_model()` helper and uses it as an additional condition in `_add_cache_control_if_applicable()` only. I deliberately did not broaden `is_anthropic_claude_model()` itself, because that helper also gates `thinking` to `reasoning_effort` translation; widening it would let `thinking` pass through unmodified for a genuinely non-Claude Bedrock profile and break that request. Scoping the change to cache control keeps the blast radius to the one path that was broken, and preserving `cache_control` is safe even for the rare non-Claude ARN since Bedrock Converse ignores `cachePoint` blocks it doesn't support rather than rejecting the request.

Tests live in the mapped file `tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py`. `test_cache_control_preserved_for_bedrock_arn_inference_profile` is the regression for this issue and fails on `main` with a `KeyError` on the missing `cache_control`. `test_is_bedrock_arn_model` pins the ARN-plus-bedrock detection including the GovCloud partition and rejects non-ARN bedrock model ids and non-bedrock ARNs. `test_cache_control_fix_does_not_broaden_claude_detection` guards the scoping decision so a future change can't quietly widen `is_anthropic_claude_model` and regress thinking translation.

This is the same problem and approach validated in the discussion on the stale community PR #26627; this revives it on top of current internal staging with added regression coverage so it can land


---
_Generated by [Claude Code](https://claude.ai/code/session_01UbJjX9nGYFP16LzTwbHgHN)_