### PR TITLE
fix(files): decode x-litellm-model encoded file_id in chat + responses

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -504,17 +504,13 @@ def update_messages_with_model_file_ids(
                             if not provider_file_id and _is_base64_encoded_unified_file_id(file_id):
                                 unified_file_id = convert_b64_uid_to_unified_uid(file_id)
                                 if "llm_output_file_id," in unified_file_id:
-                                    provider_file_id = unified_file_id.split(
-                                        "llm_output_file_id,"
-                                    )[1].split(";")[0]
+                                    provider_file_id = unified_file_id.split("llm_output_file_id,")[1].split(";")[0]
                             if not provider_file_id and is_model_embedded_id(file_id):
                                 # `litellm:<raw_id>;model,<m>` encoding from the
                                 # x-litellm-model upload path. Strip the wrapper
                                 # so the provider sees its own ID.
                                 provider_file_id = get_original_file_id(file_id)
-                            file_object_file_field["file_id"] = (
-                                provider_file_id or file_id
-                            )
+                            file_object_file_field["file_id"] = provider_file_id or file_id
                         if format:
                             file_object_file_field["format"] = format
     return messages
@@ -591,9 +587,7 @@ def update_responses_input_with_model_file_ids(
                                 # x-litellm-model upload path. Strip the wrapper
                                 # so the provider sees its own ID.
                                 updated_content_item = content_item.copy()
-                                updated_content_item["file_id"] = get_original_file_id(
-                                    file_id
-                                )
+                                updated_content_item["file_id"] = get_original_file_id(file_id)
                                 updated_content.append(updated_content_item)
                             else:
                                 # Not a managed file, keep as-is

--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -465,6 +465,8 @@ def update_messages_with_model_file_ids(
     from litellm.proxy.openai_files_endpoints.common_utils import (
         _is_base64_encoded_unified_file_id,
         convert_b64_uid_to_unified_uid,
+        get_original_file_id,
+        is_model_embedded_id,
     )
 
     for message in messages:
@@ -502,8 +504,17 @@ def update_messages_with_model_file_ids(
                             if not provider_file_id and _is_base64_encoded_unified_file_id(file_id):
                                 unified_file_id = convert_b64_uid_to_unified_uid(file_id)
                                 if "llm_output_file_id," in unified_file_id:
-                                    provider_file_id = unified_file_id.split("llm_output_file_id,")[1].split(";")[0]
-                            file_object_file_field["file_id"] = provider_file_id or file_id
+                                    provider_file_id = unified_file_id.split(
+                                        "llm_output_file_id,"
+                                    )[1].split(";")[0]
+                            if not provider_file_id and is_model_embedded_id(file_id):
+                                # `litellm:<raw_id>;model,<m>` encoding from the
+                                # x-litellm-model upload path. Strip the wrapper
+                                # so the provider sees its own ID.
+                                provider_file_id = get_original_file_id(file_id)
+                            file_object_file_field["file_id"] = (
+                                provider_file_id or file_id
+                            )
                         if format:
                             file_object_file_field["format"] = format
     return messages
@@ -530,6 +541,8 @@ def update_responses_input_with_model_file_ids(
     from litellm.proxy.openai_files_endpoints.common_utils import (
         _is_base64_encoded_unified_file_id,
         convert_b64_uid_to_unified_uid,
+        get_original_file_id,
+        is_model_embedded_id,
     )
 
     if isinstance(input, str):
@@ -572,6 +585,15 @@ def update_responses_input_with_model_file_ids(
 
                                 updated_content_item = content_item.copy()
                                 updated_content_item["file_id"] = provider_file_id
+                                updated_content.append(updated_content_item)
+                            elif is_model_embedded_id(file_id):
+                                # `litellm:<raw_id>;model,<m>` encoding from the
+                                # x-litellm-model upload path. Strip the wrapper
+                                # so the provider sees its own ID.
+                                updated_content_item = content_item.copy()
+                                updated_content_item["file_id"] = get_original_file_id(
+                                    file_id
+                                )
                                 updated_content.append(updated_content_item)
                             else:
                                 # Not a managed file, keep as-is

--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -470,6 +470,8 @@ def update_messages_with_model_file_ids(
     from litellm.proxy.openai_files_endpoints.common_utils import (
         _is_base64_encoded_unified_file_id,
         convert_b64_uid_to_unified_uid,
+        get_original_file_id,
+        is_model_embedded_id,
     )
 
     for message in messages:
@@ -508,6 +510,11 @@ def update_messages_with_model_file_ids(
                                 unified_file_id = convert_b64_uid_to_unified_uid(file_id)
                                 if "llm_output_file_id," in unified_file_id:
                                     provider_file_id = unified_file_id.split("llm_output_file_id,")[1].split(";")[0]
+                            if not provider_file_id and is_model_embedded_id(file_id):
+                                # `litellm:<raw_id>;model,<m>` encoding from the
+                                # x-litellm-model upload path. Strip the wrapper
+                                # so the provider sees its own ID.
+                                provider_file_id = get_original_file_id(file_id)
                             file_object_file_field["file_id"] = provider_file_id or file_id
                         if format:
                             file_object_file_field["format"] = format
@@ -535,6 +542,8 @@ def update_responses_input_with_model_file_ids(
     from litellm.proxy.openai_files_endpoints.common_utils import (
         _is_base64_encoded_unified_file_id,
         convert_b64_uid_to_unified_uid,
+        get_original_file_id,
+        is_model_embedded_id,
     )
 
     if isinstance(input, str):
@@ -577,6 +586,13 @@ def update_responses_input_with_model_file_ids(
 
                                 updated_content_item = content_item.copy()
                                 updated_content_item["file_id"] = provider_file_id
+                                updated_content.append(updated_content_item)
+                            elif is_model_embedded_id(file_id):
+                                # `litellm:<raw_id>;model,<m>` encoding from the
+                                # x-litellm-model upload path. Strip the wrapper
+                                # so the provider sees its own ID.
+                                updated_content_item = content_item.copy()
+                                updated_content_item["file_id"] = get_original_file_id(file_id)
                                 updated_content.append(updated_content_item)
                             else:
                                 # Not a managed file, keep as-is

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_common_utils.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_common_utils.py
@@ -721,3 +721,80 @@ class TestUnpackLegacyDefs:
         out = unpack_legacy_defs(schema)
         assert "components" not in out
         assert out["properties"]["r0"]["properties"]["p0"] == {"type": "string"}
+
+
+# --- x-litellm-model upload-path decoding (litellm #29830) -------------------
+
+
+def _xlitellm_encoded(raw_id: str, model: str) -> str:
+    from litellm.proxy.openai_files_endpoints.common_utils import (
+        encode_file_id_with_model,
+    )
+
+    return encode_file_id_with_model(raw_id, model)
+
+
+def test_update_messages_with_model_file_ids_decodes_xlitellm_encoded_id():
+    """x-litellm-model upload returns `file-<b64(litellm:<raw>;model,<m>)>`.
+    Without decoding, the encoded id leaks to upstream OpenAI and errors as
+    'Files [...] were not found'. Decode it back to raw provider id."""
+    raw_id = "file-ExTuCawUqxEMjVFK6xwR9B"
+    encoded_id = _xlitellm_encoded(raw_id, "gpt-5.1")
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Summarize this."},
+                {"type": "file", "file": {"file_id": encoded_id}},
+            ],
+        }
+    ]
+
+    updated = update_messages_with_model_file_ids(messages, "model-A", {})
+
+    assert updated[0]["content"][1]["file"]["file_id"] == raw_id
+
+
+def test_update_responses_input_with_model_file_ids_decodes_xlitellm_encoded_id():
+    """Same bug on /v1/responses path. Without decoding the encoded id (>64
+    chars), OpenAI rejects with 'string too long. Expected ... maximum length
+    64'."""
+    from litellm.litellm_core_utils.prompt_templates.common_utils import (
+        update_responses_input_with_model_file_ids,
+    )
+
+    raw_id = "file-ExTuCawUqxEMjVFK6xwR9B"
+    encoded_id = _xlitellm_encoded(raw_id, "gpt-5.1")
+    input_items = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "input_text", "text": "Summarize."},
+                {"type": "input_file", "file_id": encoded_id},
+            ],
+        }
+    ]
+
+    updated = update_responses_input_with_model_file_ids(input_items)
+
+    assert updated[0]["content"][1]["file_id"] == raw_id
+
+
+def test_update_messages_xlitellm_decode_does_not_override_mapping():
+    """If the call-site already resolved a provider id via the mapping, that
+    wins. The new decode fallback runs only when no mapping match."""
+    raw_id = "file-ExTuCawUqxEMjVFK6xwR9B"
+    encoded_id = _xlitellm_encoded(raw_id, "gpt-5.1")
+    mapping = {encoded_id: {"model-A": "provider-explicit-id"}}
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "file", "file": {"file_id": encoded_id}},
+            ],
+        }
+    ]
+
+    updated = update_messages_with_model_file_ids(messages, "model-A", mapping)
+
+    assert updated[0]["content"][0]["file"]["file_id"] == "provider-explicit-id"

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_common_utils.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_common_utils.py
@@ -5,9 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-sys.path.insert(
-    0, os.path.abspath("../../..")
-)  # Adds the parent directory to the system path
+sys.path.insert(0, os.path.abspath("../../.."))  # Adds the parent directory to the system path
 
 from litellm.litellm_core_utils.prompt_templates.common_utils import (
     add_system_prompt_to_messages,
@@ -20,9 +18,7 @@ from litellm.litellm_core_utils.prompt_templates.common_utils import (
 
 
 def test_get_format_from_file_id():
-    unified_file_id = (
-        "litellm_proxy:application/pdf;unified_id,cbbe3534-8bf8-4386-af00-f5f6b7e370bf"
-    )
+    unified_file_id = "litellm_proxy:application/pdf;unified_id,cbbe3534-8bf8-4386-af00-f5f6b7e370bf"
 
     format = get_format_from_file_id(unified_file_id)
 
@@ -49,9 +45,7 @@ def test_update_messages_with_model_file_ids():
 
     model_file_id_mapping = {file_id: {"my_model_id": "provider_file_id"}}
 
-    updated_messages = update_messages_with_model_file_ids(
-        messages, model_id, model_file_id_mapping
-    )
+    updated_messages = update_messages_with_model_file_ids(messages, model_id, model_file_id_mapping)
 
     assert updated_messages == [
         {
@@ -157,9 +151,7 @@ def test_add_system_prompt_to_messages_merge_with_first_system():
         {"role": "system", "content": "Existing system prompt."},
         {"role": "user", "content": "Hello"},
     ]
-    result = add_system_prompt_to_messages(
-        messages, "You are helpful.", merge_with_first_system=True
-    )
+    result = add_system_prompt_to_messages(messages, "You are helpful.", merge_with_first_system=True)
     assert result == [
         {"role": "system", "content": "You are helpful.\n\nExisting system prompt."},
         {"role": "user", "content": "Hello"},
@@ -169,9 +161,7 @@ def test_add_system_prompt_to_messages_merge_with_first_system():
 def test_add_system_prompt_to_messages_merge_with_first_system_adds_new_when_no_system():
     """When merge_with_first_system=True but no system message, adds new one at start."""
     messages = [{"role": "user", "content": "Hello"}]
-    result = add_system_prompt_to_messages(
-        messages, "You are helpful.", merge_with_first_system=True
-    )
+    result = add_system_prompt_to_messages(messages, "You are helpful.", merge_with_first_system=True)
     assert result == [
         {"role": "system", "content": "You are helpful."},
         {"role": "user", "content": "Hello"},
@@ -484,14 +474,8 @@ def test_update_messages_with_model_file_ids_tolerates_non_dict_content_items():
     messages_token_ids_batch = [{"role": "user", "content": [[15496, 995], [9906, 0]]}]
 
     # Both should pass through unchanged without raising.
-    assert (
-        update_messages_with_model_file_ids(messages_token_ids, "model-A", {})
-        == messages_token_ids
-    )
-    assert (
-        update_messages_with_model_file_ids(messages_token_ids_batch, "model-A", {})
-        == messages_token_ids_batch
-    )
+    assert update_messages_with_model_file_ids(messages_token_ids, "model-A", {}) == messages_token_ids
+    assert update_messages_with_model_file_ids(messages_token_ids_batch, "model-A", {}) == messages_token_ids_batch
 
 
 class TestExtractFileDataBareStr:
@@ -637,9 +621,7 @@ class TestUnpackLegacyDefs:
         definitions = {
             f"L{i}": {
                 "type": "object",
-                "properties": {
-                    f"x{j}": {"$ref": f"#/definitions/L{i + 1}"} for j in range(fanout)
-                },
+                "properties": {f"x{j}": {"$ref": f"#/definitions/L{i + 1}"} for j in range(fanout)},
             }
             for i in range(depth)
         }
@@ -704,9 +686,7 @@ class TestUnpackLegacyDefs:
 
         schema = {
             "type": "object",
-            "properties": {
-                f"r{i}": {"$ref": f"#/components/schemas/T{i}"} for i in range(50)
-            },
+            "properties": {f"r{i}": {"$ref": f"#/components/schemas/T{i}"} for i in range(50)},
             "components": {
                 "schemas": {
                     f"T{i}": {

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_common_utils.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_common_utils.py
@@ -19,9 +19,7 @@ from litellm.litellm_core_utils.prompt_templates.common_utils import (
 
 
 def test_get_format_from_file_id():
-    unified_file_id = (
-        "litellm_proxy:application/pdf;unified_id,cbbe3534-8bf8-4386-af00-f5f6b7e370bf"
-    )
+    unified_file_id = "litellm_proxy:application/pdf;unified_id,cbbe3534-8bf8-4386-af00-f5f6b7e370bf"
 
     format = get_format_from_file_id(unified_file_id)
 
@@ -48,9 +46,7 @@ def test_update_messages_with_model_file_ids():
 
     model_file_id_mapping = {file_id: {"my_model_id": "provider_file_id"}}
 
-    updated_messages = update_messages_with_model_file_ids(
-        messages, model_id, model_file_id_mapping
-    )
+    updated_messages = update_messages_with_model_file_ids(messages, model_id, model_file_id_mapping)
 
     assert updated_messages == [
         {
@@ -143,9 +139,7 @@ def test_add_system_prompt_to_messages_merge_with_first_system():
         {"role": "system", "content": "Existing system prompt."},
         {"role": "user", "content": "Hello"},
     ]
-    result = add_system_prompt_to_messages(
-        messages, "You are helpful.", merge_with_first_system=True
-    )
+    result = add_system_prompt_to_messages(messages, "You are helpful.", merge_with_first_system=True)
     assert result == [
         {"role": "system", "content": "You are helpful.\n\nExisting system prompt."},
         {"role": "user", "content": "Hello"},
@@ -155,9 +149,7 @@ def test_add_system_prompt_to_messages_merge_with_first_system():
 def test_add_system_prompt_to_messages_merge_with_first_system_adds_new_when_no_system():
     """When merge_with_first_system=True but no system message, adds new one at start."""
     messages = [{"role": "user", "content": "Hello"}]
-    result = add_system_prompt_to_messages(
-        messages, "You are helpful.", merge_with_first_system=True
-    )
+    result = add_system_prompt_to_messages(messages, "You are helpful.", merge_with_first_system=True)
     assert result == [
         {"role": "system", "content": "You are helpful."},
         {"role": "user", "content": "Hello"},
@@ -492,14 +484,8 @@ def test_update_messages_with_model_file_ids_tolerates_non_dict_content_items():
     messages_token_ids_batch = [{"role": "user", "content": [[15496, 995], [9906, 0]]}]
 
     # Both should pass through unchanged without raising.
-    assert (
-        update_messages_with_model_file_ids(messages_token_ids, "model-A", {})
-        == messages_token_ids
-    )
-    assert (
-        update_messages_with_model_file_ids(messages_token_ids_batch, "model-A", {})
-        == messages_token_ids_batch
-    )
+    assert update_messages_with_model_file_ids(messages_token_ids, "model-A", {}) == messages_token_ids
+    assert update_messages_with_model_file_ids(messages_token_ids_batch, "model-A", {}) == messages_token_ids_batch
 
 
 class TestExtractFileDataBareStr:
@@ -645,9 +631,7 @@ class TestUnpackLegacyDefs:
         definitions = {
             f"L{i}": {
                 "type": "object",
-                "properties": {
-                    f"x{j}": {"$ref": f"#/definitions/L{i + 1}"} for j in range(fanout)
-                },
+                "properties": {f"x{j}": {"$ref": f"#/definitions/L{i + 1}"} for j in range(fanout)},
             }
             for i in range(depth)
         }
@@ -712,9 +696,7 @@ class TestUnpackLegacyDefs:
 
         schema = {
             "type": "object",
-            "properties": {
-                f"r{i}": {"$ref": f"#/components/schemas/T{i}"} for i in range(50)
-            },
+            "properties": {f"r{i}": {"$ref": f"#/components/schemas/T{i}"} for i in range(50)},
             "components": {
                 "schemas": {
                     f"T{i}": {
@@ -739,9 +721,7 @@ class TestTextCompletionPromptToMessages:
             text_completion_prompt_to_messages,
         )
 
-        assert text_completion_prompt_to_messages("summarize this") == (
-            {"role": "user", "content": "summarize this"},
-        )
+        assert text_completion_prompt_to_messages("summarize this") == ({"role": "user", "content": "summarize this"},)
 
     def test_list_of_strings_becomes_one_message_each(self):
         from litellm.litellm_core_utils.prompt_templates.common_utils import (
@@ -970,3 +950,80 @@ class TestCustomToolFormatShapeConversion:
         for weird in ({}, {"type": "grammar"}, {"type": "future_format", "x": 1}):
             assert convert_custom_tool_format_to_chat_shape(dict(weird)) in (weird, {"type": "grammar", "grammar": {}})
             assert convert_custom_tool_format_to_responses_shape(dict(weird)) == weird
+
+
+# --- x-litellm-model upload-path decoding (litellm #29830) -------------------
+
+
+def _xlitellm_encoded(raw_id: str, model: str) -> str:
+    from litellm.proxy.openai_files_endpoints.common_utils import (
+        encode_file_id_with_model,
+    )
+
+    return encode_file_id_with_model(raw_id, model)
+
+
+def test_update_messages_with_model_file_ids_decodes_xlitellm_encoded_id():
+    """x-litellm-model upload returns `file-<b64(litellm:<raw>;model,<m>)>`.
+    Without decoding, the encoded id leaks to upstream OpenAI and errors as
+    'Files [...] were not found'. Decode it back to raw provider id."""
+    raw_id = "file-ExTuCawUqxEMjVFK6xwR9B"
+    encoded_id = _xlitellm_encoded(raw_id, "gpt-5.1")
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Summarize this."},
+                {"type": "file", "file": {"file_id": encoded_id}},
+            ],
+        }
+    ]
+
+    updated = update_messages_with_model_file_ids(messages, "model-A", {})
+
+    assert updated[0]["content"][1]["file"]["file_id"] == raw_id
+
+
+def test_update_responses_input_with_model_file_ids_decodes_xlitellm_encoded_id():
+    """Same bug on /v1/responses path. Without decoding the encoded id (>64
+    chars), OpenAI rejects with 'string too long. Expected ... maximum length
+    64'."""
+    from litellm.litellm_core_utils.prompt_templates.common_utils import (
+        update_responses_input_with_model_file_ids,
+    )
+
+    raw_id = "file-ExTuCawUqxEMjVFK6xwR9B"
+    encoded_id = _xlitellm_encoded(raw_id, "gpt-5.1")
+    input_items = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "input_text", "text": "Summarize."},
+                {"type": "input_file", "file_id": encoded_id},
+            ],
+        }
+    ]
+
+    updated = update_responses_input_with_model_file_ids(input_items)
+
+    assert updated[0]["content"][1]["file_id"] == raw_id
+
+
+def test_update_messages_xlitellm_decode_does_not_override_mapping():
+    """If the call-site already resolved a provider id via the mapping, that
+    wins. The new decode fallback runs only when no mapping match."""
+    raw_id = "file-ExTuCawUqxEMjVFK6xwR9B"
+    encoded_id = _xlitellm_encoded(raw_id, "gpt-5.1")
+    mapping = {encoded_id: {"model-A": "provider-explicit-id"}}
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "file", "file": {"file_id": encoded_id}},
+            ],
+        }
+    ]
+
+    updated = update_messages_with_model_file_ids(messages, "model-A", mapping)
+
+    assert updated[0]["content"][0]["file"]["file_id"] == "provider-explicit-id"


### PR DESCRIPTION
## TLDR

Problem this solves:

- `POST /v1/files` with `x-litellm-model` returns a 71-char wrapped id
- That wrapped id was sent to the provider unchanged on chat and responses
- OpenAI rejects it (404 not found; 400 too long); Gemini errors on mime type

How it solves it:

- Decode the wrapped id back to the raw provider id before the request
- Runs only as a fallback after mapping and managed-file paths
- Explicit `model_file_id_mapping` still takes precedence

## User Flow

Before: a developer who uploaded a PDF through the gateway's model-routed file endpoint gets an error the moment they reference that file in a chat or responses request

1. They POST https://litellm-domain/v1/files with header `x-litellm-model: gpt-5.2`, the PDF, and `purpose=user_data`, and get 200 back with an id like `file-bGl0ZWxsbTpmaWxl...` that is 71 characters, not the provider's own shorter `file-...`
2. They POST https://litellm-domain/v1/chat/completions referencing that id as `{"type":"file","file":{"file_id":"file-bGl0..."}}` and get 404 `Files [file-bGl0...] were not found`
3. They instead POST https://litellm-domain/v1/responses referencing that id as `{"type":"input_file","file_id":"file-bGl0..."}` and get 400 `string too long. Expected a string with maximum length 64, but got a string with length 71`
4. Either way the id the gateway just handed them is rejected by the provider, so the upload is unusable

After: the same id now works on both endpoints, returning a real answer grounded in the PDF

1. They POST https://litellm-domain/v1/files with header `x-litellm-model: gpt-5.2`, the PDF, and `purpose=user_data`, and get 200 back with the same 71-character id
2. They POST https://litellm-domain/v1/chat/completions referencing that id and get 200 with an answer that quotes the PDF's contents
3. They POST https://litellm-domain/v1/responses referencing that id and get 200 (`status: completed`) with an answer that quotes the PDF's contents
4. The id the gateway handed them is now accepted on both endpoints

## Relevant issues

Fixes #29830

## Linear ticket

Resolves LIT-6056

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup (same for Before and After):

- Proxy booted with no DB on a random high port, master key `sk-1234`, real OpenAI key, config:
  ```yaml
  model_list:
    - model_name: gpt-5.2
      litellm_params:
        model: openai/gpt-5.2
        api_key: os.environ/OPENAI_API_KEY
  ```
- A one-page PDF that plants the codeword `PLATYPUS-42` (so the After read-back proves a real file read, not a mock)
- Upload once per run: `curl -X POST $PROXY/v1/files -H "Authorization: Bearer sk-1234" -H "x-litellm-model: gpt-5.2" -F purpose=user_data -F file=@doc.pdf` returns a 71-char `file-<b64>` id, used in both cases below

### Before (f1f6d83)

Upload returned `file-bGl0ZWxsbTpmaWxlLTJoVEpxUTdDR0JYNm9jRm0zNUE0VUs7bW9kZWwsZ3B0LTUuMg` (71 chars).

#### /v1/chat/completions

1. `curl -X POST $PROXY/v1/chat/completions -H "Authorization: Bearer sk-1234" -d '{"model":"gpt-5.2","messages":[{"role":"user","content":[{"type":"text","text":"Summarize this document in one sentence."},{"type":"file","file":{"file_id":"file-bGl0ZWxsbTpmaWxlLTJoVEpxUTdDR0JYNm9jRm0zNUE0VUs7bW9kZWwsZ3B0LTUuMg"}}]}]}'`
2. HTTP 404: `litellm.BadRequestError: OpenAIException - Files [file-bGl0ZWxsbTpmaWxlLTJoVEpxUTdDR0JYNm9jRm0zNUE0VUs7bW9kZWwsZ3B0LTUuMg] were not found. Received Model Group=gpt-5.2`

#### /v1/responses

1. `curl -X POST $PROXY/v1/responses -H "Authorization: Bearer sk-1234" -d '{"model":"gpt-5.2","input":[{"role":"user","content":[{"type":"input_text","text":"Summarize this document in one sentence."},{"type":"input_file","file_id":"file-bGl0ZWxsbTpmaWxlLTJoVEpxUTdDR0JYNm9jRm0zNUE0VUs7bW9kZWwsZ3B0LTUuMg"}]}]}'`
2. HTTP 400: `litellm.BadRequestError: OpenAIException - Invalid 'input[0].content[1].file_id': string too long. Expected a string with maximum length 64, but got a string with length 71 instead.`

### After (b7aefba)

Upload returned `file-bGl0ZWxsbTpmaWxlLTI2Nzl6cFIzOGVXU0JlMVJxamp4WHM7bW9kZWwsZ3B0LTUuMg` (71 chars).

#### /v1/chat/completions

1. `curl -X POST $PROXY/v1/chat/completions -H "Authorization: Bearer sk-1234" -d '{"model":"gpt-5.2","messages":[{"role":"user","content":[{"type":"text","text":"Summarize this document in one sentence."},{"type":"file","file":{"file_id":"file-bGl0ZWxsbTpmaWxlLTI2Nzl6cFIzOGVXU0JlMVJxamp4WHM7bW9kZWwsZ3B0LTUuMg"}}]}]}'`
2. HTTP 200: assistant answers `The one-page 'LiteLLM QA Test Document' states that the Andean spectacled bear is the only bear native to South America and includes the secret QA codeword 'PLATYPUS-42.'`

#### /v1/responses

1. `curl -X POST $PROXY/v1/responses -H "Authorization: Bearer sk-1234" -d '{"model":"gpt-5.2","input":[{"role":"user","content":[{"type":"input_text","text":"Summarize this document in one sentence."},{"type":"input_file","file_id":"file-bGl0ZWxsbTpmaWxlLTI2Nzl6cFIzOGVXU0JlMVJxamp4WHM7bW9kZWwsZ3B0LTUuMg"}]}]}'`
2. HTTP 200 (`status: completed`): `This brief QA test document notes that the Andean spectacled bear is the only bear native to South America and includes the secret codeword 'PLATYPUS-42.'`

## Type

🐛 Bug Fix

## Caveats (if any)

- [x] b7aefba passes /live-pr-risk (SAFE): live A/B at base vs head confirms plain and non-litellm base64 file ids forward byte-identical on both endpoints; the decode branch fires only on genuine model-embedded ids

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow fallback in existing file-ID remapping paths; mapping precedence is unchanged and behavior is covered by new tests.
> 
> **Overview**
> Fixes **#29830** by decoding `x-litellm-model` upload file IDs before requests go to upstream providers.
> 
> Uploads with that header return IDs wrapped as `file-<b64(litellm:<raw>;model,<m>)>` (often **>64 chars**). Chat and Responses message prep only handled unified/managed IDs, so the wrapped ID was forwarded and broke OpenAI (length / not found) and Gemini (mime type).
> 
> **`update_messages_with_model_file_ids`** and **`update_responses_input_with_model_file_ids`** now call **`is_model_embedded_id`** / **`get_original_file_id`** when mapping and unified decode do not apply, stripping the wrapper so providers see the raw ID. Explicit **`model_file_id_mapping`** still wins.
> 
> Three regression tests cover chat, Responses, and mapping precedence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7aefbad0838ed2808c7e39a3d5deabb566d2a30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
