### PR TITLE
Add Fireworks pricing for DeepSeek V4 Pro/Flash and Kimi K2.6

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -13916,6 +13916,30 @@
         "supports_response_schema": true,
         "supports_tool_choice": true
     },
+    "fireworks_ai/accounts/fireworks/models/deepseek-v4-pro": {
+        "input_cost_per_token": 1.74e-06,
+        "output_cost_per_token": 3.48e-06,
+        "cache_read_input_token_cost": 1.45e-07,
+        "litellm_provider": "fireworks_ai",
+        "mode": "chat",
+        "source": "https://fireworks.ai/pricing"
+    },
+    "fireworks_ai/accounts/fireworks/models/deepseek-v4-flash": {
+        "input_cost_per_token": 1.4e-07,
+        "output_cost_per_token": 2.8e-07,
+        "cache_read_input_token_cost": 2.8e-08,
+        "litellm_provider": "fireworks_ai",
+        "mode": "chat",
+        "source": "https://fireworks.ai/pricing"
+    },
+    "fireworks_ai/accounts/fireworks/models/kimi-k2p6": {
+        "input_cost_per_token": 9.5e-07,
+        "output_cost_per_token": 4e-06,
+        "cache_read_input_token_cost": 1.6e-07,
+        "litellm_provider": "fireworks_ai",
+        "mode": "chat",
+        "source": "https://fireworks.ai/pricing"
+    },
     "fireworks_ai/accounts/fireworks/models/deepseek-v3p2": {
         "input_cost_per_token": 5.6e-07,
         "litellm_provider": "fireworks_ai",


### PR DESCRIPTION
## Title
Add Fireworks serverless pricing for DeepSeek V4 Pro, DeepSeek V4 Flash, and Kimi K2.6

## Relevant issues
None — these three Fireworks serverless models resolve via the `fireworks_ai/*` route but have no entry in `model_prices_and_context_window.json`, so `usage.cost` comes back `0`/null and cost tracking is silently wrong.

## Type
🆕 New Model / Pricing

## Changes
Adds three cost-map entries (input/output + cached-input rates), matching the existing `fireworks_ai/accounts/fireworks/models/*` convention:

| key | input $/1M | output $/1M | cached input $/1M |
|---|--:|--:|--:|
| `fireworks_ai/accounts/fireworks/models/deepseek-v4-pro` | 1.74 | 3.48 | 0.145 |
| `fireworks_ai/accounts/fireworks/models/deepseek-v4-flash` | 0.14 | 0.28 | 0.028 |
| `fireworks_ai/accounts/fireworks/models/kimi-k2p6` | 0.95 | 4.00 | 0.16 |

## Source
Fireworks serverless **Standard** tier — https://fireworks.ai/pricing (captured 2026-06-06). All three were verified callable on the Fireworks serverless tier.

Only the three new keys are added; no existing entries are modified. JSON validated.