### PR TITLE
Fix 500 on first SSO login: LiteLLM_UserTable validator crashes on BaseModel input

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2931,6 +2931,9 @@ class LiteLLM_UserTable(LiteLLMPydanticObjectBase):
     @model_validator(mode="before")
     @classmethod
     def set_model_info(cls, values):
+        if isinstance(values, BaseModel):
+            values = values.model_dump()
+
         if values.get("spend") is None:
             values.update({"spend": 0.0})
         if values.get("models") is None:

--- a/tests/test_litellm/proxy/test_proxy_types.py
+++ b/tests/test_litellm/proxy/test_proxy_types.py
@@ -69,3 +69,30 @@ def test_internal_jobs_user_has_proxy_admin_role():
     assert system_user.user_id == "system"
     assert system_user.team_id == "system"
     assert system_user.team_alias == "system"
+
+
+def test_litellm_usertable_validate_from_pydantic_model():
+    """
+    LiteLLM_UserTable.model_validate must accept another BaseModel instance, not
+    only a dict.
+
+    Regression test for the SSO first-login 500. On the first login the user does
+    not exist yet, so new_user() returns a NewUserResponse object which is then
+    cached with model_type=LiteLLM_UserTable (see _sync_user_role_from_jwt_role_map
+    in litellm/proxy/management_endpoints/ui_sso.py). Pydantic runs the
+    set_model_info (mode="before") validator with that model instance, which used
+    to call .get() on it and raise `AttributeError: 'NewUserResponse' object has
+    no attribute 'get'`. The second login worked only because the user was then
+    fetched from the DB as a real LiteLLM_UserTable, which Pydantic returns as-is
+    (revalidate_instances="never"), skipping the validator.
+    """
+    from litellm.proxy._types import LiteLLM_UserTable, NewUserResponse
+
+    new_user_response = NewUserResponse(user_id="test-user-id", key="sk-test")
+
+    validated = LiteLLM_UserTable.model_validate(new_user_response)
+
+    assert validated.user_id == "test-user-id"
+    assert validated.spend == 0.0
+    assert validated.models == []
+    assert validated.teams == []


### PR DESCRIPTION
## What
`LiteLLM_UserTable.set_model_info` (a `mode="before"` validator) calls `values.get(...)` assuming a dict. When a `BaseModel` instance is passed to `model_validate`, it raises `AttributeError: '...' object has no attribute 'get'`.

## Why it happens on the *first* SSO login only
`_sync_user_role_from_jwt_role_map` (ui_sso.py) caches the user via `async_set_cache(value=user_info, model_type=LiteLLM_UserTable)`. On first login the user doesn't exist, so `user_info` is a `NewUserResponse` → the validator receives a model instance → 500. On the second login the user is read from the DB as a real `LiteLLM_UserTable`; Pydantic's default `revalidate_instances="never"` returns it as-is and skips the validator, so it succeeds. This is exactly the reported "fails the first time, works the second time" behavior.

## Fix
Normalize `values` to a dict when a `BaseModel` is passed — the same guard already present in `LiteLLM_TeamTable.set_model_info`.

## Testing
Added `test_litellm_usertable_validate_from_pydantic_model` in `tests/test_litellm/proxy/test_proxy_types.py`. It fails without the fix (AttributeError) and passes with it. `black --check`, `ruff check litellm/`, and `mypy litellm/proxy/_types.py` are clean.

---
<sub>Investigated and authored with assistance from Claude Opus 4.8.</sub>