### PR TITLE
fix(ui): require new expiration when regenerating an expired key

### DIFF
--- a/ui/litellm-dashboard/src/components/organisms/RegenerateKeyModal.test.tsx
+++ b/ui/litellm-dashboard/src/components/organisms/RegenerateKeyModal.test.tsx
@@ -239,19 +239,10 @@ describe("RegenerateKeyModal", () => {
     });
   });
 
-  it("should fall back to the previous expiry when duration is unparseable", async () => {
-    // Regression: if calculateNewExpiryTime returns null (unrecognised suffix),
-    // the payload should fall back to the previous expires rather than null.
+  it("should reject unparseable duration values before calling regenerate", async () => {
     const user = userEvent.setup();
-    const previousExpires = "2026-12-31T00:00:00Z";
-    mockRegenerateKeyCall.mockResolvedValue({
-      key: "sk-new-regenerated-key",
-      token: "new-token-hash",
-    });
 
-    renderWithProviders(
-      <RegenerateKeyModal {...defaultProps} selectedToken={makeToken({ expires: previousExpires })} />,
-    );
+    renderWithProviders(<RegenerateKeyModal {...defaultProps} />);
 
     const durationField = screen.getByPlaceholderText("e.g. 30s, 30h, 30d");
     await user.clear(durationField);
@@ -260,11 +251,11 @@ describe("RegenerateKeyModal", () => {
     await user.click(screen.getByRole("button", { name: /Regenerate/ }));
 
     await waitFor(() => {
-      expect(mockOnKeyUpdate).toHaveBeenCalledOnce();
+      expect(
+        screen.getByText("Must be a duration like 30s, 30m, 24h, 2d, 1w, or 1mo"),
+      ).toBeInTheDocument();
     });
-
-    const updateCall = mockOnKeyUpdate.mock.calls[0][0];
-    expect(updateCall.expires).toBe(previousExpires);
+    expect(mockRegenerateKeyCall).not.toHaveBeenCalled();
   });
 
   it("should pass form values to onKeyUpdate even when the API echoes back different limits", async () => {
@@ -335,6 +326,39 @@ describe("RegenerateKeyModal", () => {
       await user.click(regenerateBtn);
     }
 
+    expect(mockRegenerateKeyCall).not.toHaveBeenCalled();
+  });
+
+  it("should mark expiry as expired without pre-filling a duration", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-06-06T12:00:00Z"));
+
+    renderWithProviders(
+      <RegenerateKeyModal
+        {...defaultProps}
+        selectedToken={makeToken({ expires: "2026-06-01T12:00:00Z", duration: "" })}
+      />,
+    );
+
+    expect(screen.getByText(/\(expired\)/)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("e.g. 30s, 30h, 30d")).toHaveValue("");
+  });
+
+  it("should require a new expiration before regenerating an expired key", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-06-06T12:00:00Z"));
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <RegenerateKeyModal
+        {...defaultProps}
+        selectedToken={makeToken({ expires: "2026-06-01T12:00:00Z", duration: "" })}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /Regenerate/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Expiration is required for expired keys")).toBeInTheDocument();
+    });
     expect(mockRegenerateKeyCall).not.toHaveBeenCalled();
   });
 

--- a/ui/litellm-dashboard/src/components/organisms/RegenerateKeyModal.test.tsx
+++ b/ui/litellm-dashboard/src/components/organisms/RegenerateKeyModal.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { renderWithProviders, screen, waitFor } from "../../../tests/test-utils";
 import { RegenerateKeyModal } from "./RegenerateKeyModal";
 import { KeyResponse } from "../key_team_helpers/key_list";
+import * as keyExpiryUtils from "@/utils/keyExpiryUtils";
 
 // Mock the networking call
 const mockRegenerateKeyCall = vi.fn();
@@ -237,6 +238,28 @@ describe("RegenerateKeyModal", () => {
     await waitFor(() => {
       expect(screen.getByText(expected)).toBeInTheDocument();
     });
+  });
+
+  it("should fall back to the previous expiry when preview calculation returns null", async () => {
+    const user = userEvent.setup();
+    const previousExpires = "2026-12-31T00:00:00Z";
+    vi.spyOn(keyExpiryUtils, "calculateExpiryPreviewFromDuration").mockReturnValue(null);
+    mockRegenerateKeyCall.mockResolvedValue({
+      key: "sk-new-regenerated-key",
+      token: "new-token-hash",
+    });
+
+    renderWithProviders(
+      <RegenerateKeyModal {...defaultProps} selectedToken={makeToken({ expires: previousExpires, duration: "30d" })} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /Regenerate/ }));
+
+    await waitFor(() => {
+      expect(mockOnKeyUpdate).toHaveBeenCalledOnce();
+    });
+
+    expect(mockOnKeyUpdate.mock.calls[0][0].expires).toBe(previousExpires);
   });
 
   it("should reject unparseable duration values before calling regenerate", async () => {

--- a/ui/litellm-dashboard/src/components/organisms/RegenerateKeyModal.test.tsx
+++ b/ui/litellm-dashboard/src/components/organisms/RegenerateKeyModal.test.tsx
@@ -3,7 +3,6 @@ import userEvent from "@testing-library/user-event";
 import { renderWithProviders, screen, waitFor } from "../../../tests/test-utils";
 import { RegenerateKeyModal } from "./RegenerateKeyModal";
 import { KeyResponse } from "../key_team_helpers/key_list";
-import * as keyExpiryUtils from "@/utils/keyExpiryUtils";
 
 // Mock the networking call
 const mockRegenerateKeyCall = vi.fn();
@@ -240,17 +239,38 @@ describe("RegenerateKeyModal", () => {
     });
   });
 
-  it("should fall back to the previous expiry when preview calculation returns null", async () => {
+  it("should use the API response's ISO expires for the optimistic update", async () => {
+    const user = userEvent.setup();
+    const apiExpires = "2026-06-13T11:08:16.783000Z";
+    mockRegenerateKeyCall.mockResolvedValue({
+      key: "sk-new-regenerated-key",
+      token: "new-token-hash",
+      expires: apiExpires,
+    });
+
+    renderWithProviders(
+      <RegenerateKeyModal {...defaultProps} selectedToken={makeToken({ expires: "2026-12-31T00:00:00Z" })} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /Regenerate/ }));
+
+    await waitFor(() => {
+      expect(mockOnKeyUpdate).toHaveBeenCalledOnce();
+    });
+
+    expect(mockOnKeyUpdate.mock.calls[0][0].expires).toBe(apiExpires);
+  });
+
+  it("should fall back to the previous expiry when the API response omits expires", async () => {
     const user = userEvent.setup();
     const previousExpires = "2026-12-31T00:00:00Z";
-    vi.spyOn(keyExpiryUtils, "calculateExpiryPreviewFromDuration").mockReturnValue(null);
     mockRegenerateKeyCall.mockResolvedValue({
       key: "sk-new-regenerated-key",
       token: "new-token-hash",
     });
 
     renderWithProviders(
-      <RegenerateKeyModal {...defaultProps} selectedToken={makeToken({ expires: previousExpires, duration: "30d" })} />,
+      <RegenerateKeyModal {...defaultProps} selectedToken={makeToken({ expires: previousExpires })} />,
     );
 
     await user.click(screen.getByRole("button", { name: /Regenerate/ }));

--- a/ui/litellm-dashboard/src/components/organisms/RegenerateKeyModal.test.tsx
+++ b/ui/litellm-dashboard/src/components/organisms/RegenerateKeyModal.test.tsx
@@ -251,9 +251,7 @@ describe("RegenerateKeyModal", () => {
     await user.click(screen.getByRole("button", { name: /Regenerate/ }));
 
     await waitFor(() => {
-      expect(
-        screen.getByText("Must be a duration like 30s, 30m, 24h, 2d, 1w, or 1mo"),
-      ).toBeInTheDocument();
+      expect(screen.getByText("Must be a duration like 30s, 30m, 24h, 2d, 1w, or 1mo")).toBeInTheDocument();
     });
     expect(mockRegenerateKeyCall).not.toHaveBeenCalled();
   });

--- a/ui/litellm-dashboard/src/components/organisms/RegenerateKeyModal.test.tsx
+++ b/ui/litellm-dashboard/src/components/organisms/RegenerateKeyModal.test.tsx
@@ -10,6 +10,15 @@ vi.mock("../networking", () => ({
   regenerateKeyCall: (...args: unknown[]) => mockRegenerateKeyCall(...args),
 }));
 
+const mockNotificationFromBackend = vi.fn();
+const mockNotificationSuccess = vi.fn();
+vi.mock("../molecules/notifications_manager", () => ({
+  default: {
+    fromBackend: (...args: unknown[]) => mockNotificationFromBackend(...args),
+    success: (...args: unknown[]) => mockNotificationSuccess(...args),
+  },
+}));
+
 const makeToken = (overrides: Partial<KeyResponse> = {}): KeyResponse =>
   ({
     token: "token-hash-123",
@@ -297,6 +306,7 @@ describe("RegenerateKeyModal", () => {
       expect(screen.getByText("Must be a duration like 30s, 30m, 24h, 2d, 1w, or 1mo")).toBeInTheDocument();
     });
     expect(mockRegenerateKeyCall).not.toHaveBeenCalled();
+    expect(mockNotificationFromBackend).not.toHaveBeenCalled();
   });
 
   it("should pass form values to onKeyUpdate even when the API echoes back different limits", async () => {
@@ -401,6 +411,8 @@ describe("RegenerateKeyModal", () => {
       expect(screen.getByText("Expiration is required for expired keys")).toBeInTheDocument();
     });
     expect(mockRegenerateKeyCall).not.toHaveBeenCalled();
+    // Form validation rejections must not surface a backend-style toast.
+    expect(mockNotificationFromBackend).not.toHaveBeenCalled();
   });
 
   it("should pass the correct token identifier to regenerateKeyCall", async () => {

--- a/ui/litellm-dashboard/src/components/organisms/RegenerateKeyModal.tsx
+++ b/ui/litellm-dashboard/src/components/organisms/RegenerateKeyModal.tsx
@@ -1,13 +1,12 @@
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 import { CheckOutlined, CopyOutlined, SyncOutlined } from "@ant-design/icons";
 import { Alert, Button, Col, Flex, Form, Input, InputNumber, Modal, Row, Space, Typography } from "antd";
-import { add } from "date-fns";
 import { useEffect, useState } from "react";
 import { CopyToClipboard } from "react-copy-to-clipboard";
 import { KeyResponse } from "../key_team_helpers/key_list";
 import NotificationManager from "../molecules/notifications_manager";
 import { regenerateKeyCall } from "../networking";
-import { isKeyExpired } from "@/utils/keyExpiryUtils";
+import { calculateExpiryPreviewFromDuration, formatExpiresUtc, isKeyExpired } from "@/utils/keyExpiryUtils";
 
 const { Text } = Typography;
 
@@ -52,40 +51,7 @@ export function RegenerateKeyModal({ selectedToken, visible, onClose, onKeyUpdat
     }
   }, [visible, selectedToken, form, accessToken]);
 
-  const calculateNewExpiryTime = (duration: string | undefined): string | null => {
-    if (!duration) return null;
-
-    try {
-      const amount = parseInt(duration);
-      if (Number.isNaN(amount)) {
-        throw new Error("Invalid duration format");
-      }
-      const now = new Date();
-      // Check "mo" before "m" to avoid a false prefix match (e.g. "1mo" → minutes).
-      let newExpiry: Date;
-      if (duration.endsWith("mo")) {
-        newExpiry = add(now, { months: amount });
-      } else if (duration.endsWith("s")) {
-        newExpiry = add(now, { seconds: amount });
-      } else if (duration.endsWith("m")) {
-        newExpiry = add(now, { minutes: amount });
-      } else if (duration.endsWith("h")) {
-        newExpiry = add(now, { hours: amount });
-      } else if (duration.endsWith("d")) {
-        newExpiry = add(now, { days: amount });
-      } else if (duration.endsWith("w")) {
-        newExpiry = add(now, { weeks: amount });
-      } else {
-        throw new Error("Invalid duration format");
-      }
-
-      return newExpiry.toLocaleString();
-    } catch (error) {
-      return null;
-    }
-  };
-
-  const newExpiryTime = durationValue ? calculateNewExpiryTime(durationValue) : null;
+  const newExpiryTime = durationValue ? calculateExpiryPreviewFromDuration(durationValue) : null;
 
   const handleRegenerateKey = async () => {
     if (!selectedToken || !accessToken) return;
@@ -110,7 +76,7 @@ export function RegenerateKeyModal({ selectedToken, visible, onClose, onKeyUpdat
         tpm_limit: formValues.tpm_limit,
         rpm_limit: formValues.rpm_limit,
         expires: formValues.duration
-          ? calculateNewExpiryTime(formValues.duration) ?? selectedToken.expires
+          ? calculateExpiryPreviewFromDuration(formValues.duration) ?? selectedToken.expires
           : selectedToken.expires,
       };
 
@@ -232,8 +198,7 @@ export function RegenerateKeyModal({ selectedToken, visible, onClose, onKeyUpdat
                 extra={
                   <Flex vertical gap={2}>
                     <Text type={keyIsExpired ? "danger" : "secondary"} style={{ fontSize: 12 }}>
-                      Current expiry:{" "}
-                      {selectedToken?.expires ? new Date(selectedToken.expires).toLocaleString() : "Never"}
+                      Current expiry: {selectedToken?.expires ? formatExpiresUtc(selectedToken.expires) : "Never"}
                       {keyIsExpired && " (expired)"}
                     </Text>
                     {newExpiryTime && (

--- a/ui/litellm-dashboard/src/components/organisms/RegenerateKeyModal.tsx
+++ b/ui/litellm-dashboard/src/components/organisms/RegenerateKeyModal.tsx
@@ -87,9 +87,14 @@ export function RegenerateKeyModal({ selectedToken, visible, onClose, onKeyUpdat
 
       setIsRegenerating(false);
     } catch (error) {
+      setIsRegenerating(false); // Reset regenerating state on error
+      // Ant Design form validation rejections surface inline under the field;
+      // don't also raise a backend-style toast for them.
+      if (error && typeof error === "object" && "errorFields" in error) {
+        return;
+      }
       console.error("Error regenerating key:", error);
       NotificationManager.fromBackend(error);
-      setIsRegenerating(false); // Reset regenerating state on error
     }
   };
 

--- a/ui/litellm-dashboard/src/components/organisms/RegenerateKeyModal.tsx
+++ b/ui/litellm-dashboard/src/components/organisms/RegenerateKeyModal.tsx
@@ -68,6 +68,8 @@ export function RegenerateKeyModal({ selectedToken, visible, onClose, onKeyUpdat
       // fields it returns (new token, timestamps, etc.) are captured, then
       // override with the explicit form values — the user's just-submitted
       // edits must win over whatever the API echoes back.
+      // expires must come from the API (an ISO string), never the locale-
+      // formatted preview, otherwise downstream expiry parsing breaks.
       const updatedKeyData: Partial<KeyResponse> = {
         ...response,
         token: response.token || response.key_id || selectedToken.token,
@@ -75,9 +77,7 @@ export function RegenerateKeyModal({ selectedToken, visible, onClose, onKeyUpdat
         max_budget: formValues.max_budget,
         tpm_limit: formValues.tpm_limit,
         rpm_limit: formValues.rpm_limit,
-        expires: formValues.duration
-          ? calculateExpiryPreviewFromDuration(formValues.duration) ?? selectedToken.expires
-          : selectedToken.expires,
+        expires: response.expires ?? selectedToken.expires,
       };
 
       // Update the parent component with new key data

--- a/ui/litellm-dashboard/src/components/organisms/RegenerateKeyModal.tsx
+++ b/ui/litellm-dashboard/src/components/organisms/RegenerateKeyModal.tsx
@@ -7,8 +7,14 @@ import { CopyToClipboard } from "react-copy-to-clipboard";
 import { KeyResponse } from "../key_team_helpers/key_list";
 import NotificationManager from "../molecules/notifications_manager";
 import { regenerateKeyCall } from "../networking";
+import { isKeyExpired } from "@/utils/keyExpiryUtils";
 
 const { Text } = Typography;
+
+const DURATION_RULE = {
+  pattern: /^(\d+(s|m|h|d|w|mo))?$/,
+  message: "Must be a duration like 30s, 30m, 24h, 2d, 1w, or 1mo",
+};
 
 interface RegenerateKeyModalProps {
   selectedToken: KeyResponse | null;
@@ -21,10 +27,17 @@ export function RegenerateKeyModal({ selectedToken, visible, onClose, onKeyUpdat
   const { accessToken } = useAuthorized();
   const [form] = Form.useForm();
   const [regeneratedKey, setRegeneratedKey] = useState<string | null>(null);
-  const [regenerateFormData, setRegenerateFormData] = useState<any>(null);
-  const [newExpiryTime, setNewExpiryTime] = useState<string | null>(null);
   const [isRegenerating, setIsRegenerating] = useState(false);
   const [copied, setCopied] = useState(false);
+
+  const keyIsExpired = isKeyExpired(selectedToken?.expires);
+  const durationValue = Form.useWatch("duration", form);
+
+  // Expired keys must get a new duration, otherwise regeneration produces a key
+  // that inherits the old (past) expiry and is immediately unusable.
+  const durationRules = keyIsExpired
+    ? [{ required: true, message: "Expiration is required for expired keys" }, DURATION_RULE]
+    : [DURATION_RULE];
 
   useEffect(() => {
     if (visible && selectedToken && accessToken) {
@@ -72,13 +85,7 @@ export function RegenerateKeyModal({ selectedToken, visible, onClose, onKeyUpdat
     }
   };
 
-  useEffect(() => {
-    if (regenerateFormData?.duration) {
-      setNewExpiryTime(calculateNewExpiryTime(regenerateFormData.duration));
-    } else {
-      setNewExpiryTime(null);
-    }
-  }, [regenerateFormData?.duration]);
+  const newExpiryTime = durationValue ? calculateNewExpiryTime(durationValue) : null;
 
   const handleRegenerateKey = async () => {
     if (!selectedToken || !accessToken) return;
@@ -193,16 +200,7 @@ export function RegenerateKeyModal({ selectedToken, visible, onClose, onKeyUpdat
           </Flex>
         </Flex>
       ) : (
-        <Form
-          form={form}
-          layout="vertical"
-          style={{ marginTop: 4 }}
-          onValuesChange={(changedValues) => {
-            if ("duration" in changedValues) {
-              setRegenerateFormData((prev: { duration?: string }) => ({ ...prev, duration: changedValues.duration }));
-            }
-          }}
-        >
+        <Form form={form} layout="vertical" style={{ marginTop: 4 }}>
           <Form.Item name="key_alias" label="Key Alias">
             <Input disabled />
           </Form.Item>
@@ -230,11 +228,13 @@ export function RegenerateKeyModal({ selectedToken, visible, onClose, onKeyUpdat
               <Form.Item
                 name="duration"
                 label="Expire Key"
+                rules={durationRules}
                 extra={
                   <Flex vertical gap={2}>
-                    <Text type="secondary" style={{ fontSize: 12 }}>
+                    <Text type={keyIsExpired ? "danger" : "secondary"} style={{ fontSize: 12 }}>
                       Current expiry:{" "}
                       {selectedToken?.expires ? new Date(selectedToken.expires).toLocaleString() : "Never"}
+                      {keyIsExpired && " (expired)"}
                     </Text>
                     {newExpiryTime && (
                       <Text type="success" style={{ fontSize: 12 }}>
@@ -257,12 +257,7 @@ export function RegenerateKeyModal({ selectedToken, visible, onClose, onKeyUpdat
                     Recommended: 24h to 72h for production keys
                   </Text>
                 }
-                rules={[
-                  {
-                    pattern: /^(\d+(s|m|h|d|w|mo))?$/,
-                    message: "Must be a duration like 30s, 30m, 24h, 2d, 1w, or 1mo",
-                  },
-                ]}
+                rules={[DURATION_RULE]}
               >
                 <Input placeholder="e.g. 24h, 2d" />
               </Form.Item>

--- a/ui/litellm-dashboard/src/utils/keyExpiryUtils.test.ts
+++ b/ui/litellm-dashboard/src/utils/keyExpiryUtils.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { isKeyExpired, parseExpiresUtc } from "./keyExpiryUtils";
+
+describe("keyExpiryUtils", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("treats naive ISO strings as UTC", () => {
+    const ms = parseExpiresUtc("2020-01-01T12:00:00");
+    expect(ms).toBe(Date.parse("2020-01-01T12:00:00Z"));
+  });
+
+  it("parses Z-suffixed ISO strings unchanged", () => {
+    const iso = "2020-01-01T12:00:00.000Z";
+    expect(parseExpiresUtc(iso)).toBe(Date.parse(iso));
+  });
+
+  it("returns false when expires is missing", () => {
+    expect(isKeyExpired(undefined)).toBe(false);
+    expect(isKeyExpired(null)).toBe(false);
+  });
+
+  it("detects expired keys using UTC comparison", () => {
+    vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-06-06T12:00:00Z"));
+    expect(isKeyExpired("2026-06-05T12:00:00Z")).toBe(true);
+    expect(isKeyExpired("2026-06-06T12:00:00")).toBe(false);
+    expect(isKeyExpired("2026-06-07T12:00:00Z")).toBe(false);
+  });
+});

--- a/ui/litellm-dashboard/src/utils/keyExpiryUtils.test.ts
+++ b/ui/litellm-dashboard/src/utils/keyExpiryUtils.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { isKeyExpired, parseExpiresUtc } from "./keyExpiryUtils";
+import { calculateExpiryPreviewFromDuration, formatExpiresUtc, isKeyExpired, parseExpiresUtc } from "./keyExpiryUtils";
 
 describe("keyExpiryUtils", () => {
   afterEach(() => {
@@ -16,6 +16,11 @@ describe("keyExpiryUtils", () => {
     expect(parseExpiresUtc(iso)).toBe(Date.parse(iso));
   });
 
+  it("formats naive ISO strings as UTC before localizing", () => {
+    const naive = "2026-06-05T10:00:00";
+    expect(formatExpiresUtc(naive)).toBe(new Date(Date.parse(`${naive}Z`)).toLocaleString());
+  });
+
   it("returns false when expires is missing", () => {
     expect(isKeyExpired(undefined)).toBe(false);
     expect(isKeyExpired(null)).toBe(false);
@@ -26,5 +31,15 @@ describe("keyExpiryUtils", () => {
     expect(isKeyExpired("2026-06-05T12:00:00Z")).toBe(true);
     expect(isKeyExpired("2026-06-06T12:00:00")).toBe(false);
     expect(isKeyExpired("2026-06-07T12:00:00Z")).toBe(false);
+  });
+
+  it("returns a preview for supported duration strings", () => {
+    vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-06-06T12:00:00Z"));
+    expect(calculateExpiryPreviewFromDuration("30d")).toBeTruthy();
+  });
+
+  it("returns null for unparseable duration strings", () => {
+    expect(calculateExpiryPreviewFromDuration("bogus")).toBeNull();
+    expect(calculateExpiryPreviewFromDuration(undefined)).toBeNull();
   });
 });

--- a/ui/litellm-dashboard/src/utils/keyExpiryUtils.ts
+++ b/ui/litellm-dashboard/src/utils/keyExpiryUtils.ts
@@ -1,0 +1,21 @@
+const HAS_TIMEZONE_SUFFIX = /[zZ]$|[+-]\d{2}:?\d{2}$/;
+
+/**
+ * Parse a key expires timestamp as UTC, matching proxy auth behavior for naive DB values.
+ */
+export function parseExpiresUtc(expires: string): number {
+  const normalized = HAS_TIMEZONE_SUFFIX.test(expires) ? expires : `${expires}Z`;
+  return Date.parse(normalized);
+}
+
+/**
+ * Returns true when the key has an expires value in the past (UTC).
+ */
+export function isKeyExpired(expires?: string | null): boolean {
+  if (!expires) {
+    return false;
+  }
+
+  const expiryMs = parseExpiresUtc(expires);
+  return !Number.isNaN(expiryMs) && expiryMs < Date.now();
+}

--- a/ui/litellm-dashboard/src/utils/keyExpiryUtils.ts
+++ b/ui/litellm-dashboard/src/utils/keyExpiryUtils.ts
@@ -1,3 +1,5 @@
+import { add } from "date-fns";
+
 const HAS_TIMEZONE_SUFFIX = /[zZ]$|[+-]\d{2}:?\d{2}$/;
 
 /**
@@ -6,6 +8,18 @@ const HAS_TIMEZONE_SUFFIX = /[zZ]$|[+-]\d{2}:?\d{2}$/;
 export function parseExpiresUtc(expires: string): number {
   const normalized = HAS_TIMEZONE_SUFFIX.test(expires) ? expires : `${expires}Z`;
   return Date.parse(normalized);
+}
+
+/**
+ * Format an expires timestamp for display, treating naive DB values as UTC.
+ */
+export function formatExpiresUtc(expires: string): string {
+  const expiryMs = parseExpiresUtc(expires);
+  if (Number.isNaN(expiryMs)) {
+    return expires;
+  }
+
+  return new Date(expiryMs).toLocaleString();
 }
 
 /**
@@ -18,4 +32,44 @@ export function isKeyExpired(expires?: string | null): boolean {
 
   const expiryMs = parseExpiresUtc(expires);
   return !Number.isNaN(expiryMs) && expiryMs < Date.now();
+}
+
+/**
+ * Compute a human-readable preview of the new expiry from a duration string.
+ * Returns null when the duration cannot be parsed.
+ */
+export function calculateExpiryPreviewFromDuration(duration: string | undefined): string | null {
+  if (!duration) {
+    return null;
+  }
+
+  try {
+    const amount = parseInt(duration);
+    if (Number.isNaN(amount)) {
+      throw new Error("Invalid duration format");
+    }
+
+    const now = new Date();
+    // Check "mo" before "m" to avoid a false prefix match (e.g. "1mo" → minutes).
+    let newExpiry: Date;
+    if (duration.endsWith("mo")) {
+      newExpiry = add(now, { months: amount });
+    } else if (duration.endsWith("s")) {
+      newExpiry = add(now, { seconds: amount });
+    } else if (duration.endsWith("m")) {
+      newExpiry = add(now, { minutes: amount });
+    } else if (duration.endsWith("h")) {
+      newExpiry = add(now, { hours: amount });
+    } else if (duration.endsWith("d")) {
+      newExpiry = add(now, { days: amount });
+    } else if (duration.endsWith("w")) {
+      newExpiry = add(now, { weeks: amount });
+    } else {
+      throw new Error("Invalid duration format");
+    }
+
+    return newExpiry.toLocaleString();
+  } catch {
+    return null;
+  }
 }


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Linear ticket

Resolves LIT-2569

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

**Non-expired key — regenerate view (unchanged behavior, expiration optional):**

<img width="1342" height="1010" alt="image" src="https://github.com/user-attachments/assets/7e15eeda-6348-4488-86ef-501ddcf7176e" />

**Expired key — regenerate view ("(expired)" marker in red, Expire Key required):**

<img width="1766" height="1058" alt="image" src="https://github.com/user-attachments/assets/99fd786b-29a1-47db-8ca7-1dcfa31e88cd" />

<img width="657" height="513" alt="image" src="https://github.com/user-attachments/assets/06c61cc2-f639-4382-be38-22b8a53ff65a" />


**Expired key — after regenerating with a new expiration (success view):**

<img width="1350" height="1020" alt="image" src="https://github.com/user-attachments/assets/45cba5bd-2f5a-4e5c-8004-b6dcd9632242" />

## Type

🐛 Bug Fix

## Changes

### Problem
When regenerating an **already-expired** virtual key from the UI without setting the **Expire Key** field, the regenerated key inherited the original (past) `expires` value and was immediately unusable (`Authentication Error - Expired Key`). Key duration is not stored on the key (only the computed `expires` timestamp is), so the previous expiry cannot simply be reused. This is a frequent, confusing failure for self-service deployments that rotate short-lived keys.

### Fix (UI – `RegenerateKeyModal`)
- **Require a new expiration for expired keys.** When the selected key is already expired, the **Expire Key** field becomes required, so regeneration cannot produce a still-expired key.
- **Clear visual state.** The current expiry is rendered in red with an explicit `(expired)` marker (no extra banner — the required field + red text convey the state).
- **Unchanged behavior for valid keys.** Non-expired keys keep the existing "rotate the secret, preserve settings" flow; the expiration field stays optional and the previous expiry is preserved when left blank.
- **Timezone-correct expiry detection.** New `keyExpiryUtils` (`isKeyExpired` / `parseExpiresUtc`) parse `expires` as UTC, matching the proxy's auth-time comparison, so naive DB timestamps aren't misread in the browser's local timezone.

### Tests
- `keyExpiryUtils.test.ts` — UTC parsing of naive vs. `Z`-suffixed timestamps and expired/valid detection.
- `RegenerateKeyModal.test.tsx` — expired key shows `(expired)` without pre-filling a duration, and regeneration is blocked until a valid expiration is provided.

### Notes
- Scope is UI-only. An optional follow-up could add a server-side safeguard for API-only clients (expired key + no duration → apply org/team default or return a clear error).