### PR TITLE
feat(provider): add AGIone provider

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -825,6 +825,7 @@ openai_compatible_providers: List = [
     "novita",
     "meta_llama",
     "publicai",  # PublicAI - JSON-configured provider
+    "agione",  # AGIone - JSON-configured provider
     "synthetic",  # Synthetic - JSON-configured provider
     "tensormesh",  # Tensormesh - JSON-configured provider
     "apertis",  # Apertis - JSON-configured provider

--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -107,6 +107,12 @@
     "api_key_env": "AIHUBMIX_API_KEY",
     "api_base_env": "AIHUBMIX_API_BASE"
   },
+  "agione": {
+    "base_url": "https://agione.pro/hyperone/xapi/api/v1",
+    "api_key_env": "AGIONE_API_KEY",
+    "api_base_env": "AGIONE_API_BASE",
+    "supported_endpoints": ["/v1/chat/completions", "/v1/messages", "/v1/responses"]
+  },
   "crusoe": {
     "base_url": "https://managed-inference-api-proxy.crusoecloud.com/v1",
     "api_key_env": "CRUSOE_API_KEY",

--- a/litellm/provider_endpoints_support_backup.json
+++ b/litellm/provider_endpoints_support_backup.json
@@ -66,6 +66,23 @@
         "a2a": false
       }
     },
+    "agione": {
+      "display_name": "AGIone (`agione`)",
+      "url": "https://agione.pro",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": true,
+        "responses": true,
+        "embeddings": false,
+        "image_generations": false,
+        "audio_transcriptions": false,
+        "audio_speech": false,
+        "moderations": false,
+        "batches": false,
+        "rerank": false,
+        "a2a": false
+      }
+    },
     "aiml": {
       "display_name": "AI/ML API (`aiml`)",
       "url": "https://docs.litellm.ai/docs/providers/aiml",

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3299,6 +3299,7 @@ class LlmProviders(str, Enum):
     DASHSCOPE = "dashscope"
     MOONSHOT = "moonshot"
     PUBLICAI = "publicai"
+    AGIONE = "agione"
     V0 = "v0"
     MORPH = "morph"
     LAMBDA_AI = "lambda_ai"

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -66,6 +66,23 @@
         "a2a": false
       }
     },
+    "agione": {
+      "display_name": "AGIone (`agione`)",
+      "url": "https://agione.pro",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": true,
+        "responses": true,
+        "embeddings": false,
+        "image_generations": false,
+        "audio_transcriptions": false,
+        "audio_speech": false,
+        "moderations": false,
+        "batches": false,
+        "rerank": false,
+        "a2a": false
+      }
+    },
     "aiml": {
       "display_name": "AI/ML API (`aiml`)",
       "url": "https://docs.litellm.ai/docs/providers/aiml",

--- a/tests/test_litellm/llms/openai_like/test_agione_provider.py
+++ b/tests/test_litellm/llms/openai_like/test_agione_provider.py
@@ -1,0 +1,115 @@
+"""Tests for AGIone provider configuration and integration."""
+
+import os
+
+import pytest
+
+import litellm
+
+
+class TestAGIoneProviderConfig:
+    """Test AGIone provider configuration."""
+
+    def test_agione_in_provider_list(self):
+        from litellm import LlmProviders
+
+        assert hasattr(LlmProviders, "AGIONE")
+        assert LlmProviders.AGIONE.value == "agione"
+        assert "agione" in litellm.provider_list
+
+    def test_agione_json_config_exists(self):
+        from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+
+        assert JSONProviderRegistry.exists("agione")
+
+        agione = JSONProviderRegistry.get("agione")
+        assert agione is not None
+        assert agione.base_url == "https://agione.pro/hyperone/xapi/api/v1"
+        assert agione.api_key_env == "AGIONE_API_KEY"
+        assert agione.api_base_env == "AGIONE_API_BASE"
+        assert agione.supported_endpoints == [
+            "/v1/chat/completions",
+            "/v1/messages",
+            "/v1/responses",
+        ]
+        assert JSONProviderRegistry.supports_responses_api("agione") is True
+
+    def test_agione_responses_url(self):
+        from litellm.llms.openai_like.dynamic_config import create_responses_config_class
+        from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+
+        agione = JSONProviderRegistry.get("agione")
+        assert agione is not None
+
+        config_cls = create_responses_config_class(agione)
+        config = config_cls()
+
+        assert config.get_complete_url(api_base=None, litellm_params={}) == "https://agione.pro/hyperone/xapi/api/v1/responses"
+
+    def test_agione_provider_resolution(self):
+        from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+
+        model, provider, api_key, api_base = get_llm_provider(
+            model="agione/deepseek/deepseek-v3.2/0000n",
+            custom_llm_provider=None,
+            api_base=None,
+            api_key=None,
+        )
+
+        assert model == "deepseek/deepseek-v3.2/0000n"
+        assert provider == "agione"
+        assert api_base == "https://agione.pro/hyperone/xapi/api/v1"
+
+    def test_agione_api_base_override(self):
+        from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+
+        model, provider, api_key, api_base = get_llm_provider(
+            model="agione/deepseek/deepseek-v3.2/0000n",
+            custom_llm_provider=None,
+            api_base="https://custom.example.com/v1",
+            api_key="test-key",
+        )
+
+        assert provider == "agione"
+        assert api_base == "https://custom.example.com/v1"
+        assert api_key == "test-key"
+
+    def test_agione_router_config(self):
+        from litellm import Router
+
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "agione-chat",
+                    "litellm_params": {
+                        "model": "agione/deepseek/deepseek-v3.2/0000n",
+                        "api_key": "test-key",
+                    },
+                }
+            ]
+        )
+
+        assert len(router.model_list) == 1
+        assert router.model_list[0]["model_name"] == "agione-chat"
+
+
+def test_agione_completion_live():
+    """Optional live smoke test. Runs only when AGIONE_API_KEY is set."""
+    api_key = os.environ.get("AGIONE_API_KEY")
+    if not api_key or api_key == "PASTE_YOUR_NEW_KEY_HERE":
+        pytest.skip("AGIONE_API_KEY not set")
+
+    response = litellm.completion(
+        model="agione/deepseek/deepseek-v3.2/0000n",
+        messages=[
+            {
+                "role": "user",
+                "content": "Reply exactly: litellm-agione-ok",
+            }
+        ],
+        max_tokens=20,
+    )
+
+    assert response is not None
+    assert response.choices
+    assert response.choices[0].message.content is not None

--- a/tests/test_litellm/llms/openai_like/test_agione_provider.py
+++ b/tests/test_litellm/llms/openai_like/test_agione_provider.py
@@ -1,9 +1,5 @@
 """Tests for AGIone provider configuration and integration."""
 
-import os
-
-import pytest
-
 import litellm
 
 
@@ -91,25 +87,3 @@ class TestAGIoneProviderConfig:
 
         assert len(router.model_list) == 1
         assert router.model_list[0]["model_name"] == "agione-chat"
-
-
-def test_agione_completion_live():
-    """Optional live smoke test. Runs only when AGIONE_API_KEY is set."""
-    api_key = os.environ.get("AGIONE_API_KEY")
-    if not api_key or api_key == "PASTE_YOUR_NEW_KEY_HERE":
-        pytest.skip("AGIONE_API_KEY not set")
-
-    response = litellm.completion(
-        model="agione/deepseek/deepseek-v3.2/0000n",
-        messages=[
-            {
-                "role": "user",
-                "content": "Reply exactly: litellm-agione-ok",
-            }
-        ],
-        max_tokens=20,
-    )
-
-    assert response is not None
-    assert response.choices
-    assert response.choices[0].message.content is not None


### PR DESCRIPTION
## Relevant issues

N/A — adds AGIone as an OpenAI-compatible provider.

## Linear ticket

<!-- if you are an internal contributor, add the Linear ticket e.g. "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or log output demonstrating that your changes work as expected.
     For bug fixes: show reproduction before the fix and passing behavior after.
     For new features: show the feature working end-to-end.
     For UI changes: include before/after screenshots. -->

Added AGIone as a JSON-configured OpenAI-compatible provider and covered provider registration/resolution with targeted unit tests.

```bash
python -m pytest tests/test_litellm/llms/openai_like/test_agione_provider.py tests/test_litellm/llms/openai_like/test_json_providers.py tests/test_litellm/llms/openai_like/responses/test_openai_like_responses.py -q -k 'not Integration and not completion_basic and not streaming'
```

Output:

```text
34 passed, 4 deselected, 2 warnings in 0.97s
```

Manual live smoke test:

```python
import os
import litellm

response = litellm.completion(
    model="agione/deepseek/deepseek-v3.2/0000n",
    messages=[{"role": "user", "content": "Reply exactly: litellm-agione-ok"}],
    api_key=os.environ["AGIONE_API_KEY"],
    max_tokens=20,
    temperature=0,
)
print(response.choices[0].message.content)
```

Output:

```text
litellm-agione-ok
```

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes

Adds AGIone (`agione`) as an OpenAI-compatible provider using LiteLLM's JSON provider configuration.

The provider is registered with:

- Base URL: `https://agione.pro/hyperone/xapi/api/v1`
- API key env var: `AGIONE_API_KEY`
- Optional base URL override env var: `AGIONE_API_BASE`
- Supported endpoints: `/v1/chat/completions`, `/v1/messages`, `/v1/responses`

The PR also adds a focused mock-only test file for provider registration, JSON config loading, provider resolution, API base override behavior, Router configuration, and Responses URL support. The live smoke test remains manual proof in this PR body and is not part of the committed unit tests.

