### PR TITLE
feat(catalog): add zai/glm-5.1, zai/glm-4.7-flash, openrouter/z-ai/glm-5.1 (re-submit of #27408)

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -28791,6 +28791,22 @@
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
+    "openrouter/z-ai/glm-5.1": {
+        "input_cost_per_token": 1.05e-06,
+        "output_cost_per_token": 3.5e-06,
+        "cache_read_input_token_cost": 5.25e-07,
+        "cache_creation_input_token_cost": 0.0,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 202752,
+        "max_output_tokens": 65535,
+        "max_tokens": 65535,
+        "mode": "chat",
+        "source": "https://openrouter.ai/z-ai/glm-5.1",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
     "openrouter/minimax/minimax-m2.1": {
         "input_cost_per_token": 2.7e-07,
         "output_cost_per_token": 1.2e-06,
@@ -36733,6 +36749,21 @@
         "supports_tool_choice": true,
         "source": "https://docs.z.ai/guides/overview/pricing"
     },
+    "zai/glm-5.1": {
+        "cache_creation_input_token_cost": 0,
+        "cache_read_input_token_cost": 2.6e-07,
+        "input_cost_per_token": 1.4e-06,
+        "output_cost_per_token": 4.4e-06,
+        "litellm_provider": "zai",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "source": "https://docs.z.ai/guides/overview/pricing"
+    },
     "zai/glm-5-code": {
         "cache_creation_input_token_cost": 0,
         "cache_read_input_token_cost": 3e-07,
@@ -36753,6 +36784,21 @@
         "cache_read_input_token_cost": 1.1e-07,
         "input_cost_per_token": 6e-07,
         "output_cost_per_token": 2.2e-06,
+        "litellm_provider": "zai",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "source": "https://docs.z.ai/guides/overview/pricing"
+    },
+    "zai/glm-4.7-flash": {
+        "cache_creation_input_token_cost": 0,
+        "cache_read_input_token_cost": 0,
+        "input_cost_per_token": 0,
+        "output_cost_per_token": 0,
         "litellm_provider": "zai",
         "max_input_tokens": 200000,
         "max_output_tokens": 128000,


### PR DESCRIPTION
## What

Adds three Z.AI GLM pricing entries to `model_prices_and_context_window.json`:

| key | provider | input / cached / output ($/1M) | context |
|---|---|---|---|
| `zai/glm-5.1` | zai | 1.40 / 0.26 / 4.40 | 200K in / 128K out |
| `zai/glm-4.7-flash` | zai | free / free / free | 200K in / 128K out |
| `openrouter/z-ai/glm-5.1` | openrouter | 1.05 / 0.525 / 3.50 | 202752 in / 65535 out |

Sources: <https://docs.z.ai/guides/overview/pricing> (zai/*) and <https://openrouter.ai/z-ai/glm-5.1> (openrouter route; `max_output_tokens` from `top_provider.max_completion_tokens`).

## Why

Without these entries, direct Z.AI and OpenRouter users on these models get `response_cost = 0.0` in spend logs — the cost calculator falls back to the static catalog and finds nothing for these newer SKUs, so spend tracking and budget enforcement silently break unless every install adds per-deployment `input_cost_per_token` / `output_cost_per_token` overrides. Shipping them in the catalog fixes this globally.

`supports_vision` is intentionally **not** set: GLM-5.1 is text-only (Z.AI moved multimodality to a separate `GLM-5V-Turbo` SKU; OpenRouter and docs.z.ai both list input modality = text).

## Note

This re-submits #27408, which was auto-closed by `litellm-agent` for inactivity ("marked BLOCKED 7 days ago") even though the CLA was signed and the only reviews were Greptile **comments** (no changes requested), with the one open question — vision support — answered. Rebased cleanly onto current `litellm_internal_staging`; the diff is +46/−0 in a single file, no conflicts. Would appreciate a maintainer review. 🙏

## Test plan

- `python3 -c "import json; json.load(open('model_prices_and_context_window.json'))"` — parses.
- All three keys follow neighbour conventions (`zai/glm-5`, `zai/glm-4.7`, `openrouter/z-ai/glm-5`); no duplicate or removed fields.
- No code-path changes.
