### PR TITLE
Update OpenRouter prices for Qwen3.7 and MiniMax

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -7843,6 +7843,25 @@
         "supports_tool_choice": true,
         "output_cost_per_token": 1.44e-06
     },
+    "openrouter/minimax/minimax-m3": {
+        "input_cost_per_token": 3e-07,
+        "output_cost_per_token": 1.2e-06,
+        "cache_creation_input_token_cost": 0.0,
+        "cache_read_input_token_cost": 1.5e-07,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "source": "https://openrouter.ai/minimax/minimax-m3",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true,
+        "supports_vision": false,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_computer_use": false
+    },
     "bedrock/ap-northeast-1/moonshotai.kimi-k2-thinking": {
         "input_cost_per_token": 7.3e-07,
         "litellm_provider": "bedrock",
@@ -28543,6 +28562,24 @@
         "supports_reasoning": true,
         "supports_tool_choice": true,
         "supports_vision": true
+    },
+    "openrouter/qwen/qwen3.7-plus": {
+        "input_cost_per_token": 4e-07,
+        "output_cost_per_token": 1.6e-06,
+        "cache_creation_input_token_cost": 0.0,
+        "cache_read_input_token_cost": 0.0,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "source": "https://openrouter.ai/qwen/qwen3.7-plus",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true,
+        "supports_vision": true,
+        "supports_response_schema": true,
+        "supports_prompt_caching": false
     },
     "openrouter/qwen/qwen3.5-35b-a3b": {
         "input_cost_per_token": 2.5e-07,


### PR DESCRIPTION
## Relevant issues

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests (N/A - Only JSON pricing data updated)
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review (Will request immediately after opening PR)

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

[COLE SEU PRINT DA PÁGINA DO OPENROUTER AQUI]

## Type

🧹 Refactoring
🚄 Infrastructure

## Changes
- Updated `input_cost_per_token` and `output_cost_per_token` for `openrouter/qwen/qwen3.7-plus`.
- Added comprehensive config parameters (cache costs, context windows, and schema support) for `minimax/minimax-m3` and `xiaomi/mimo-v2.5-pro` based on the official OpenRouter pricing specs.
- Updated `model_prices_and_context_window.json` and its backup file accordingly.