### PR TITLE
feat(cli): add `litellm-proxy claude-code` to launch Claude Code through the proxy

### DIFF
--- a/litellm/proxy/client/cli/README.md
+++ b/litellm/proxy/client/cli/README.md
@@ -438,6 +438,27 @@ litellm-proxy http request POST /chat/completions -j '{"model": "gpt-4", "messag
 litellm-proxy http request GET /health/test_connection -H "X-Custom-Header:value"
 ```
 
+### Claude Code
+
+Launch [Claude Code](https://docs.claude.com/en/docs/claude-code) routed through your LiteLLM proxy. The wrapper resolves your LiteLLM key (logging in via SSO if you are not authenticated), exports the Anthropic environment variables Claude Code reads, then hands off to the `claude` binary. As long as you start Claude Code this way, it always talks to your proxy:
+
+```bash
+litellm-proxy claude-code
+```
+
+Options:
+
+- `--model`, `-m`: Model Claude Code should request (sets `ANTHROPIC_MODEL`). The name must resolve on your proxy.
+- `--small-fast-model`: Model for background tasks (sets `ANTHROPIC_SMALL_FAST_MODEL`).
+
+Any extra arguments are forwarded to `claude`. Use `--` to pass flags that `claude` owns:
+
+```bash
+litellm-proxy claude-code --model claude-sonnet-proxy -- --resume
+```
+
+Under the hood this sets `ANTHROPIC_BASE_URL` to your proxy URL and `ANTHROPIC_AUTH_TOKEN` to your LiteLLM key, and clears any stray `ANTHROPIC_API_KEY` so the proxy token always wins. Requests land on the proxy's Anthropic-compatible `/v1/messages` endpoint, so the models you reference (default Claude model names or your `--model` override) must exist on the proxy.
+
 ## Environment Variables
 
 The CLI respects the following environment variables:

--- a/litellm/proxy/client/cli/commands/claude_code.py
+++ b/litellm/proxy/client/cli/commands/claude_code.py
@@ -1,0 +1,141 @@
+import os
+import shutil
+from typing import Callable, Dict, Mapping, Optional, Sequence
+
+import click
+
+from .auth import get_stored_api_key, login
+
+ANTHROPIC_BASE_URL_ENV = "ANTHROPIC_BASE_URL"
+ANTHROPIC_AUTH_TOKEN_ENV = "ANTHROPIC_AUTH_TOKEN"
+ANTHROPIC_API_KEY_ENV = "ANTHROPIC_API_KEY"
+ANTHROPIC_MODEL_ENV = "ANTHROPIC_MODEL"
+ANTHROPIC_SMALL_FAST_MODEL_ENV = "ANTHROPIC_SMALL_FAST_MODEL"
+
+CLAUDE_BINARY = "claude"
+CLAUDE_INSTALL_DOCS = "https://docs.claude.com/en/docs/claude-code/setup"
+
+
+class ClaudeCodeNotFoundError(Exception):
+    """Raised when the Claude Code `claude` executable cannot be located."""
+
+
+def build_claude_env(
+    base_env: Mapping[str, str],
+    base_url: str,
+    api_key: str,
+    model: Optional[str] = None,
+    small_fast_model: Optional[str] = None,
+) -> Dict[str, str]:
+    """Return a copy of base_env wired to route Claude Code through the LiteLLM proxy.
+
+    Claude Code sends requests to ``{ANTHROPIC_BASE_URL}/v1/messages`` with the
+    LiteLLM key as a bearer token. ANTHROPIC_API_KEY is dropped so a stray
+    Anthropic key in the environment cannot win over the proxy token.
+    """
+    env = dict(base_env)
+    env[ANTHROPIC_BASE_URL_ENV] = base_url.rstrip("/")
+    env[ANTHROPIC_AUTH_TOKEN_ENV] = api_key
+    env.pop(ANTHROPIC_API_KEY_ENV, None)
+    if model:
+        env[ANTHROPIC_MODEL_ENV] = model
+    if small_fast_model:
+        env[ANTHROPIC_SMALL_FAST_MODEL_ENV] = small_fast_model
+    return env
+
+
+def _exec_claude(claude_path: str, args: Sequence[str], env: Mapping[str, str]) -> None:
+    os.execvpe(claude_path, [claude_path, *args], dict(env))
+
+
+def launch_claude_code(
+    base_url: str,
+    api_key: str,
+    *,
+    model: Optional[str] = None,
+    small_fast_model: Optional[str] = None,
+    claude_args: Sequence[str] = (),
+    base_env: Optional[Mapping[str, str]] = None,
+    which: Callable[[str], Optional[str]] = shutil.which,
+    launcher: Callable[[str, Sequence[str], Mapping[str, str]], None] = _exec_claude,
+) -> None:
+    """Wire the Anthropic environment to the LiteLLM proxy and hand off to `claude`.
+
+    On success this replaces the current process with Claude Code and never
+    returns. Raises ClaudeCodeNotFoundError when `claude` is not on PATH.
+    """
+    claude_path = which(CLAUDE_BINARY)
+    if claude_path is None:
+        raise ClaudeCodeNotFoundError(
+            f"Could not find the `{CLAUDE_BINARY}` executable on your PATH. "
+            f"Install Claude Code first: {CLAUDE_INSTALL_DOCS}"
+        )
+
+    env = build_claude_env(
+        base_env if base_env is not None else os.environ,
+        base_url,
+        api_key,
+        model,
+        small_fast_model,
+    )
+    launcher(claude_path, claude_args, env)
+
+
+@click.command(
+    name="claude-code",
+    context_settings={"ignore_unknown_options": True},
+)
+@click.option(
+    "--model",
+    "-m",
+    default=None,
+    help="Model Claude Code should request (sets ANTHROPIC_MODEL). Must exist on your proxy.",
+)
+@click.option(
+    "--small-fast-model",
+    default=None,
+    help="Model for background tasks (sets ANTHROPIC_SMALL_FAST_MODEL). Must exist on your proxy.",
+)
+@click.argument("claude_args", nargs=-1, type=click.UNPROCESSED)
+@click.pass_context
+def claude_code(
+    ctx: click.Context,
+    model: Optional[str],
+    small_fast_model: Optional[str],
+    claude_args: Sequence[str],
+):
+    """Launch Claude Code pointed at your LiteLLM proxy.
+
+    Logs in with LiteLLM if needed, exports the Anthropic environment variables
+    Claude Code reads, then hands off to the `claude` binary. Any extra
+    arguments are forwarded to `claude` (use `--` to pass flags claude owns,
+    e.g. `litellm-proxy claude-code -- --resume`).
+    """
+    base_url = ctx.obj["base_url"]
+    api_key = ctx.obj.get("api_key")
+
+    if not api_key:
+        click.echo("No LiteLLM credentials found; starting login...")
+        ctx.invoke(login)
+        api_key = get_stored_api_key(expected_base_url=base_url)
+
+    if not api_key:
+        raise click.ClickException(
+            "Could not obtain a LiteLLM API key. Run `litellm-proxy login` and try again."
+        )
+
+    click.echo(f"Launching Claude Code through LiteLLM proxy at {base_url.rstrip('/')}")
+
+    try:
+        launch_claude_code(
+            base_url,
+            api_key,
+            model=model,
+            small_fast_model=small_fast_model,
+            claude_args=claude_args,
+        )
+    except ClaudeCodeNotFoundError as e:
+        raise click.ClickException(str(e))
+
+
+__all__ = ["claude_code", "launch_claude_code", "build_claude_env"]

--- a/litellm/proxy/client/cli/interface.py
+++ b/litellm/proxy/client/cli/interface.py
@@ -91,6 +91,7 @@ def show_commands():
         ("keys", "Manage API keys"),
         ("teams", "Manage teams and team assignments"),
         ("users", "Manage users"),
+        ("claude-code", "Launch Claude Code routed through the proxy"),
         ("version", "Show version information"),
         ("help", "Show this help message"),
         ("quit", "Exit the interactive session"),

--- a/litellm/proxy/client/cli/main.py
+++ b/litellm/proxy/client/cli/main.py
@@ -9,6 +9,7 @@ from litellm.proxy.client.health import HealthManagementClient
 
 from .commands.auth import get_stored_api_key, login, logout, whoami
 from .commands.chat import chat
+from .commands.claude_code import claude_code
 from .commands.credentials import credentials
 from .commands.http import http
 from .commands.keys import keys
@@ -98,6 +99,8 @@ def version(ctx: click.Context):
 cli.add_command(login)
 cli.add_command(logout)
 cli.add_command(whoami)
+# Add the claude-code launcher command
+cli.add_command(claude_code)
 # Add the models command group
 cli.add_command(models)
 # Add the credentials command group

--- a/tests/test_litellm/proxy/client/cli/test_claude_code_commands.py
+++ b/tests/test_litellm/proxy/client/cli/test_claude_code_commands.py
@@ -1,0 +1,216 @@
+import os
+import sys
+from unittest.mock import patch
+
+import click
+import pytest
+from click.testing import CliRunner
+
+sys.path.insert(
+    0, os.path.abspath("../../..")
+)  # Adds the parent directory to the system path
+
+
+from litellm.proxy.client.cli.commands.claude_code import (
+    ClaudeCodeNotFoundError,
+    build_claude_env,
+    claude_code,
+    launch_claude_code,
+)
+
+CLAUDE_CODE_MODULE = "litellm.proxy.client.cli.commands.claude_code"
+
+
+class TestBuildClaudeEnv:
+    def test_sets_base_url_and_bearer_token(self):
+        env = build_claude_env({}, "http://localhost:4000/", "sk-litellm-123")
+
+        assert env["ANTHROPIC_BASE_URL"] == "http://localhost:4000"
+        assert env["ANTHROPIC_AUTH_TOKEN"] == "sk-litellm-123"
+
+    def test_drops_existing_anthropic_api_key(self):
+        env = build_claude_env(
+            {"ANTHROPIC_API_KEY": "real-anthropic-key"},
+            "http://localhost:4000",
+            "sk-litellm-123",
+        )
+
+        assert "ANTHROPIC_API_KEY" not in env
+
+    def test_omits_model_overrides_by_default(self):
+        env = build_claude_env({}, "http://localhost:4000", "sk-litellm-123")
+
+        assert "ANTHROPIC_MODEL" not in env
+        assert "ANTHROPIC_SMALL_FAST_MODEL" not in env
+
+    def test_sets_model_overrides_when_provided(self):
+        env = build_claude_env(
+            {},
+            "http://localhost:4000",
+            "sk-litellm-123",
+            model="claude-sonnet-proxy",
+            small_fast_model="claude-haiku-proxy",
+        )
+
+        assert env["ANTHROPIC_MODEL"] == "claude-sonnet-proxy"
+        assert env["ANTHROPIC_SMALL_FAST_MODEL"] == "claude-haiku-proxy"
+
+    def test_preserves_unrelated_env_and_does_not_mutate_input(self):
+        base = {"PATH": "/usr/bin", "ANTHROPIC_API_KEY": "real-anthropic-key"}
+
+        env = build_claude_env(base, "http://localhost:4000", "sk-litellm-123")
+
+        assert env["PATH"] == "/usr/bin"
+        assert base == {"PATH": "/usr/bin", "ANTHROPIC_API_KEY": "real-anthropic-key"}
+
+
+class TestLaunchClaudeCode:
+    def test_launches_resolved_binary_with_wired_env(self):
+        calls = {}
+
+        def fake_launcher(path, args, env):
+            calls["path"] = path
+            calls["args"] = tuple(args)
+            calls["env"] = dict(env)
+
+        launch_claude_code(
+            "http://localhost:4000/",
+            "sk-litellm-123",
+            model="claude-sonnet-proxy",
+            small_fast_model="claude-haiku-proxy",
+            claude_args=["--resume"],
+            base_env={"PATH": "/usr/bin", "ANTHROPIC_API_KEY": "leaked"},
+            which=lambda name: "/usr/local/bin/claude",
+            launcher=fake_launcher,
+        )
+
+        assert calls["path"] == "/usr/local/bin/claude"
+        assert calls["args"] == ("--resume",)
+        env = calls["env"]
+        assert env["ANTHROPIC_BASE_URL"] == "http://localhost:4000"
+        assert env["ANTHROPIC_AUTH_TOKEN"] == "sk-litellm-123"
+        assert env["ANTHROPIC_MODEL"] == "claude-sonnet-proxy"
+        assert env["ANTHROPIC_SMALL_FAST_MODEL"] == "claude-haiku-proxy"
+        assert "ANTHROPIC_API_KEY" not in env
+        assert env["PATH"] == "/usr/bin"
+
+    def test_resolves_binary_by_name(self):
+        seen = {}
+
+        def fake_which(name):
+            seen["name"] = name
+            return "/usr/local/bin/claude"
+
+        launch_claude_code(
+            "http://localhost:4000",
+            "sk-litellm-123",
+            base_env={},
+            which=fake_which,
+            launcher=lambda *a: None,
+        )
+
+        assert seen["name"] == "claude"
+
+    def test_raises_when_binary_missing(self):
+        launched = []
+
+        with pytest.raises(ClaudeCodeNotFoundError):
+            launch_claude_code(
+                "http://localhost:4000",
+                "sk-litellm-123",
+                base_env={},
+                which=lambda name: None,
+                launcher=lambda *a: launched.append(a),
+            )
+
+        assert launched == []
+
+
+class TestClaudeCodeCommand:
+    def setup_method(self):
+        self.runner = CliRunner()
+
+    def test_launches_with_stored_key_and_forwards_args(self):
+        captured = {}
+
+        def fake_launch(base_url, api_key, *, model, small_fast_model, claude_args):
+            captured["base_url"] = base_url
+            captured["api_key"] = api_key
+            captured["model"] = model
+            captured["small_fast_model"] = small_fast_model
+            captured["claude_args"] = tuple(claude_args)
+
+        with patch(f"{CLAUDE_CODE_MODULE}.launch_claude_code", side_effect=fake_launch):
+            result = self.runner.invoke(
+                claude_code,
+                ["--model", "claude-sonnet-proxy", "--", "--resume"],
+                obj={"base_url": "http://localhost:4000", "api_key": "sk-litellm-123"},
+            )
+
+        assert result.exit_code == 0, result.output
+        assert captured["api_key"] == "sk-litellm-123"
+        assert captured["base_url"] == "http://localhost:4000"
+        assert captured["model"] == "claude-sonnet-proxy"
+        assert captured["claude_args"] == ("--resume",)
+
+    def test_logs_in_when_no_key_then_launches(self):
+        captured = {}
+
+        @click.command()
+        def fake_login():
+            pass
+
+        def fake_launch(base_url, api_key, *, model, small_fast_model, claude_args):
+            captured["api_key"] = api_key
+
+        with (
+            patch(f"{CLAUDE_CODE_MODULE}.login", fake_login),
+            patch(
+                f"{CLAUDE_CODE_MODULE}.get_stored_api_key",
+                return_value="sk-after-login",
+            ) as mock_get,
+            patch(f"{CLAUDE_CODE_MODULE}.launch_claude_code", side_effect=fake_launch),
+        ):
+            result = self.runner.invoke(
+                claude_code,
+                [],
+                obj={"base_url": "http://localhost:4000", "api_key": None},
+            )
+
+        assert result.exit_code == 0, result.output
+        assert captured["api_key"] == "sk-after-login"
+        mock_get.assert_called_once_with(expected_base_url="http://localhost:4000")
+
+    def test_errors_when_login_does_not_yield_key(self):
+        @click.command()
+        def fake_login():
+            pass
+
+        with (
+            patch(f"{CLAUDE_CODE_MODULE}.login", fake_login),
+            patch(f"{CLAUDE_CODE_MODULE}.get_stored_api_key", return_value=None),
+            patch(f"{CLAUDE_CODE_MODULE}.launch_claude_code") as mock_launch,
+        ):
+            result = self.runner.invoke(
+                claude_code,
+                [],
+                obj={"base_url": "http://localhost:4000", "api_key": None},
+            )
+
+        assert result.exit_code != 0
+        assert "Could not obtain a LiteLLM API key" in result.output
+        mock_launch.assert_not_called()
+
+    def test_reports_missing_binary_as_click_error(self):
+        with patch(
+            f"{CLAUDE_CODE_MODULE}.launch_claude_code",
+            side_effect=ClaudeCodeNotFoundError("claude not on PATH"),
+        ):
+            result = self.runner.invoke(
+                claude_code,
+                [],
+                obj={"base_url": "http://localhost:4000", "api_key": "sk-litellm-123"},
+            )
+
+        assert result.exit_code != 0
+        assert "claude not on PATH" in result.output


### PR DESCRIPTION
Superseded by #29850, which moves this to a `litellm_`-prefixed branch and generalizes the wrapper into `litellm-proxy run -- <agent>` (Claude Code, Codex, OpenCode, ...) with agent-vault-style DX: auto-login, container/CI "agent mode", and a fail-fast key check. `litellm-proxy claude-code` is kept there as a shortcut for `run -- claude`.

Closing in favor of #29850.