### PR TITLE
fix(ci): authenticate git push in daily branch-creation workflows

### DIFF
--- a/.github/workflows/create_daily_oss_agent_shin_branch.yml
+++ b/.github/workflows/create_daily_oss_agent_shin_branch.yml
@@ -41,7 +41,7 @@ jobs:
             echo "Creating new branch: $BRANCH_NAME"
             # Create the new branch from main
             git checkout -b $BRANCH_NAME origin/main
-            # Push the new branch
-            git push origin $BRANCH_NAME
+            # Push the new branch (authenticate explicitly since persist-credentials is false)
+            git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$BRANCH_NAME"
             echo "Successfully created and pushed branch: $BRANCH_NAME"
           fi

--- a/.github/workflows/create_daily_staging_branch.yml
+++ b/.github/workflows/create_daily_staging_branch.yml
@@ -41,8 +41,8 @@ jobs:
             echo "Creating new branch: $BRANCH_NAME"
             # Create the new branch from main
             git checkout -b $BRANCH_NAME origin/main
-            # Push the new branch
-            git push origin $BRANCH_NAME
+            # Push the new branch (authenticate explicitly since persist-credentials is false)
+            git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$BRANCH_NAME"
             echo "Successfully created and pushed branch: $BRANCH_NAME"
           fi
 
@@ -81,7 +81,7 @@ jobs:
             echo "Creating new branch: $BRANCH_NAME"
             # Create the new branch from main
             git checkout -b $BRANCH_NAME origin/main
-            # Push the new branch
-            git push origin $BRANCH_NAME
+            # Push the new branch (authenticate explicitly since persist-credentials is false)
+            git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$BRANCH_NAME"
             echo "Successfully created and pushed branch: $BRANCH_NAME"
           fi


### PR DESCRIPTION
## Relevant issues

The "Create Daily Staging Branch" and "Create Daily oss-agent-shin Branch" scheduled workflows have been failing on every run since they were added in #29603. Example failing run: https://github.com/BerriAI/litellm/actions/runs/27062527440 (06-06 12:39 UTC, and the same failure recurs at every scheduled execution)

## Linear ticket

N/A

## Pre-Submission checklist

- [ ] I have added meaningful tests
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

There is no meaningful unit test to add here; this is a GitHub Actions workflow auth fix and the only real test is the workflow run itself going green (see the verification steps below). The change touches no Python code, so `make test-unit` is not affected.

## Root cause

Both workflows check out the repo with `persist-credentials: false`, which tells `actions/checkout` not to write the `http.https://github.com/.extraheader` auth token into git config. The push steps then ran

```
git push origin $BRANCH_NAME
```

with only `GITHUB_TOKEN` exported as an env var. Git's HTTPS transport does not read `GITHUB_TOKEN` on its own, so with no credential helper and no auth header the push fell back to prompting for a username and died:

```
Switched to a new branch 'litellm_internal_dev_06_06_2026'
fatal: could not read Username for 'https://github.com': No such device or address
##[error]Process completed with exit code 128.
```

The `create-staging-branch` job looked green only because that day's `litellm_oss_staging_<date>` branch already existed, so it took the "Skipping creation" path and never pushed. The `create-internal-dev-branch` job and the oss-agent job push on every run, so they failed every run.

## Changes

Push through an explicit token-authenticated URL instead of relying on a persisted credential, so the steps work while keeping `persist-credentials: false`

```
git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$BRANCH_NAME"
```

This is applied to all three push sites: `create-staging-branch` and `create-internal-dev-branch` in `create_daily_staging_branch.yml`, and `create-oss-agent-shin-branch` in `create_daily_oss_agent_shin_branch.yml`. `GITHUB_REPOSITORY` is a built-in Actions variable and `GITHUB_TOKEN` is masked in logs.

## Screenshots / Proof of Fix

This is a scheduled GitHub Actions workflow, so the proof is the job going green. To verify on this branch before merge, trigger each workflow manually against the PR head and confirm the push step succeeds:

1. Go to https://github.com/BerriAI/litellm/actions/workflows/create_daily_staging_branch.yml , click "Run workflow", pick branch `claude/cool-hawking-tLJtO`, run it; the `create-internal-dev-branch` job should now reach "Successfully created and pushed branch"
2. Same for https://github.com/BerriAI/litellm/actions/workflows/create_daily_oss_agent_shin_branch.yml

The previously failing run for comparison: https://github.com/BerriAI/litellm/actions/runs/27062527440

## Type

🐛 Bug Fix
