### PR TITLE
fix(terraform/gcp): abandon SQL user on destroy

### DIFF
--- a/terraform/litellm/gcp/cloudsql.tf
+++ b/terraform/litellm/gcp/cloudsql.tf
@@ -108,6 +108,8 @@ resource "google_sql_user" "app" {
   name     = var.db_username
   instance = google_sql_database_instance.writer.name
   password = random_password.db_password.result
+
+  deletion_policy = "ABANDON"
 }
 
 resource "google_secret_manager_secret" "db_password" {


### PR DESCRIPTION
## Relevant issues

Follow-up to #29852.

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [\`make test-unit\`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting \`@greptileai\` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

Caught while tearing down the stack I deployed to verify #29852. After the four \`deletion_protection=false\` fixes from #29852 landed, the next \`terraform destroy\` got further but failed on:

\`\`\`
Error: Error, failed to deleteuser litellm_app in instance ykortam-litellm-dev:
googleapi: Error 400: Invalid request: failed to delete user litellm_app: .
role "litellm_app" cannot be dropped because some objects depend on it
Details: 75 objects in database litellm.
\`\`\`

#29852 set \`deletion_policy = "ABANDON"\` on \`google_sql_database.this\` so the database survives destroy and the connection-draining race goes away. That leaves the role still owning all the tables prisma created, so the subsequent \`DROP ROLE litellm_app\` fails. Same pattern, fixed the same way: abandon the user; the instance deletion takes both the database and the role with it.

## Type

🐛 Bug Fix

## Changes

One line on \`google_sql_user.app\` in \`cloudsql.tf\`. Companion to the \`deletion_policy = "ABANDON"\` already set on \`google_sql_database.this\` in #29852.