### PR TITLE
fix(mcp): highlight MCP cards red when the logged-in user is missing per-user env vars

### DIFF
--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -879,6 +879,32 @@ if MCP_AVAILABLE:
 
         return _redact_mcp_credentials_list(servers)
 
+    async def _resolve_accessible_mcp_servers(
+        user_api_key_dict: UserAPIKeyAuth,
+    ) -> List[LiteLLM_MCPServerTable]:
+        """The server set the dashboard grid shows (GET /v1/mcp/server, no team
+        filter), returned unredacted. Callers that surface this to a client must
+        apply their own redaction; the per-user env-var status endpoint relies on
+        the raw env_vars and only ever returns is_set booleans, never secrets.
+
+        Sharing this resolution keeps the red "missing user fields" card status
+        aligned with the cards actually rendered: an admin in view_all mode sees
+        every server even when their key carries no per-server MCP grant.
+        """
+        if (
+            _get_user_mcp_management_mode() == "view_all"
+            and not _is_restricted_virtual_key_request(user_api_key_dict)
+        ):
+            return await global_mcp_server_manager.get_all_mcp_servers_unfiltered()
+
+        aggregated: Dict[str, LiteLLM_MCPServerTable] = {}
+        for auth_context in await build_effective_auth_contexts(user_api_key_dict):
+            for server in await global_mcp_server_manager.get_all_allowed_mcp_servers(
+                user_api_key_auth=auth_context
+            ):
+                aggregated.setdefault(server.server_id, server)
+        return list(aggregated.values())
+
     @router.get(
         "/server",
         description="Returns the mcp server list with associated teams",
@@ -950,30 +976,8 @@ if MCP_AVAILABLE:
                 sanitized_team_id
             )
         else:
-            user_mcp_management_mode = _get_user_mcp_management_mode()
-
-            if user_mcp_management_mode == "view_all" and not is_restricted_virtual_key:
-                servers = (
-                    await global_mcp_server_manager.get_all_mcp_servers_unfiltered()
-                )
-                redacted_mcp_servers = _redact_mcp_credentials_list(servers)
-            else:
-                auth_contexts = await build_effective_auth_contexts(user_api_key_dict)
-
-                aggregated_servers: Dict[str, LiteLLM_MCPServerTable] = {}
-                for auth_context in auth_contexts:
-                    servers = (
-                        await global_mcp_server_manager.get_all_allowed_mcp_servers(
-                            user_api_key_auth=auth_context
-                        )
-                    )
-                    for server in servers:
-                        if server.server_id not in aggregated_servers:
-                            aggregated_servers[server.server_id] = server
-
-                redacted_mcp_servers = _redact_mcp_credentials_list(
-                    aggregated_servers.values()
-                )
+            servers = await _resolve_accessible_mcp_servers(user_api_key_dict)
+            redacted_mcp_servers = _redact_mcp_credentials_list(servers)
 
         # augment the mcp servers with public status
         if litellm.public_mcp_servers is not None:
@@ -2391,9 +2395,7 @@ if MCP_AVAILABLE:
         user_id = user_api_key_dict.user_id or ""
         if not user_id:
             return []
-        accessible = await get_all_mcp_servers_for_user(
-            prisma_client, user_api_key_dict
-        )
+        accessible = await _resolve_accessible_mcp_servers(user_api_key_dict)
         if not accessible:
             return []
         server_ids = [s.server_id for s in accessible]

--- a/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
@@ -4249,11 +4249,6 @@ class TestListMCPUserEnvVarStatus:
             ),
             patch.object(
                 mgmt_endpoints,
-                "get_all_mcp_servers_for_user",
-                AsyncMock(return_value=[]),
-            ),
-            patch.object(
-                mgmt_endpoints,
                 "get_user_env_vars_bulk",
                 AsyncMock(return_value={}),
             ),

--- a/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
@@ -4146,7 +4146,7 @@ class TestListMCPUserEnvVarStatus:
             ),
             patch.object(
                 mgmt_endpoints,
-                "get_all_mcp_servers_for_user",
+                "_resolve_accessible_mcp_servers",
                 AsyncMock(return_value=[]),
             ),
         ):
@@ -4174,7 +4174,7 @@ class TestListMCPUserEnvVarStatus:
             ),
             patch.object(
                 mgmt_endpoints,
-                "get_all_mcp_servers_for_user",
+                "_resolve_accessible_mcp_servers",
                 AsyncMock(return_value=[server_with, server_without]),
             ),
             patch.object(
@@ -4204,7 +4204,7 @@ class TestListMCPUserEnvVarStatus:
             ),
             patch.object(
                 mgmt_endpoints,
-                "get_all_mcp_servers_for_user",
+                "_resolve_accessible_mcp_servers",
                 AsyncMock(return_value=[server]),
             ),
             patch.object(
@@ -4220,6 +4220,56 @@ class TestListMCPUserEnvVarStatus:
         assert by_name["CORP_USERNAME"].is_set is True
         assert by_name["CORP_PASSWORD"].is_set is False
         assert "alice" not in result[0].model_dump_json()
+
+    @pytest.mark.asyncio
+    async def test_admin_view_all_flags_missing_fields_without_key_grants(self):
+        """Regression: the red "user fields missing" card must light up for an
+        admin in view_all mode even when their key carries no per-server MCP
+        grant. The bulk status feed has to resolve the same server set the
+        dashboard grid renders; the old narrow key-scoped listing returned
+        nothing for such an admin, leaving every card un-highlighted."""
+        server = _make_env_var_server(
+            server_id="srv-with",
+            env_vars=_ENV_VARS_MIXED,
+            static_headers=_STATIC_HEADERS_MIXED,
+        )
+        with (
+            patch.object(
+                mgmt_endpoints, "get_prisma_client_or_throw", return_value=MagicMock()
+            ),
+            patch.object(
+                mgmt_endpoints,
+                "_get_user_mcp_management_mode",
+                return_value="view_all",
+            ),
+            patch.object(
+                mgmt_endpoints.global_mcp_server_manager,
+                "get_all_mcp_servers_unfiltered",
+                AsyncMock(return_value=[server]),
+            ),
+            patch.object(
+                mgmt_endpoints,
+                "get_all_mcp_servers_for_user",
+                AsyncMock(return_value=[]),
+            ),
+            patch.object(
+                mgmt_endpoints,
+                "get_user_env_vars_bulk",
+                AsyncMock(return_value={}),
+            ),
+        ):
+            result = await mgmt_endpoints.list_mcp_user_env_var_status(
+                user_api_key_dict=generate_mock_user_api_key_auth(
+                    user_id="admin",
+                    user_role=LitellmUserRoles.PROXY_ADMIN,
+                )
+            )
+        assert [s.server_id for s in result] == ["srv-with"]
+        assert result[0].missing_count == 2
+        assert {f.name for f in result[0].required} == {
+            "CORP_USERNAME",
+            "CORP_PASSWORD",
+        }
 
 
 class TestMCPUserEnvVarsAccessControl:


### PR DESCRIPTION
## Relevant issues

The MCP server card grid is supposed to highlight a card red with a "Set" button when the logged-in user has not filled in all of that server's per-user variables. In practice the card never turned red, even for the admin who created the server, when per-user variables were left unset.

## Linear ticket

## Root cause

The card grid and the red-highlight status feed resolved their server lists through two different code paths. The grid (`GET /v1/mcp/server`) lists servers via the registry-backed manager: `get_all_mcp_servers_unfiltered` for an admin in `view_all` mode, and the allowed-auth-context aggregation otherwise. The per-user env-var status endpoint (`GET /v1/mcp/user-env-vars/status`) instead resolved servers through `get_all_mcp_servers_for_user`, which only returns servers explicitly granted on the calling key. A dashboard session key for an admin carries no per-server MCP grant, so that path returned an empty set; the status feed came back empty and no card ever turned red even though the user was missing required variables. The single-server modal path already special-cased admins, which is why clicking into a server and filling fields worked while the at-a-glance red highlight did not.

## Changes

Both surfaces now share one `_resolve_accessible_mcp_servers` helper, so the status feed is computed over exactly the set of cards the user sees. The grid endpoint is refactored onto the helper with no behavior change, and the bulk status endpoint switches from `get_all_mcp_servers_for_user` to the shared helper, which is the fix. The helper returns servers unredacted; the status endpoint needs the raw `env_vars` to know which per-user fields are required and still only ever reports `is_set` booleans, never the stored secret values.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## CI (LiteLLM team)

- [ ] Branch creation CI run
       Link:
- [ ] CI run for the last commit
       Link:
- [ ] Merge / cherry-pick CI run
       Links:

## Screenshots / Proof of Fix

The new regression test `test_admin_view_all_flags_missing_fields_without_key_grants` fails before the fix (the status feed returns `[]` for the admin, so no card highlights) and passes after.

To verify end to end against a live proxy, with a server that declares a per-user variable referenced in a static header and with no value stored for your user yet:

1. As an admin, create an MCP server whose `env_vars` includes an entry with `scope: "user"` (for example `CORP_PASSWORD`) and reference it in a static header, e.g. `Authorization: Bearer ${CORP_PASSWORD}`
2. `curl -s -H "Authorization: Bearer $LITELLM_KEY" http://localhost:4000/v1/mcp/user-env-vars/status | jq` and confirm the response now contains that server with `CORP_PASSWORD` and `is_set: false` (before the fix this returned `[]` for an admin)
3. Open http://localhost:4000/ui/?page=mcp-servers and confirm the server's card is outlined red with the count of missing user fields and a "Set" button
4. Click "Set", fill in the value, save, then re-run the curl in step 2 and confirm `is_set: true` and the card is no longer red

## Type

🐛 Bug Fix


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xg4JGiHmti18bSGCT5cirP)_