### PR TITLE
cookbook: add TWZRD Agent Intel trust-gated LiteLLM example

### DIFF
--- a/cookbook/TWZRD_Agent_Intel_Trust_Gated_LiteLLM.ipynb
+++ b/cookbook/TWZRD_Agent_Intel_Trust_Gated_LiteLLM.ipynb
@@ -1,0 +1,157 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# TWZRD Agent Intel + LiteLLM: Trust-Gated Agent Calls\n",
+    "\n",
+    "This cookbook shows how to use [TWZRD Agent Intel](https://intel.twzrd.xyz) with LiteLLM to:\n",
+    "1. Score a Solana agent wallet before routing LLM calls to it\n",
+    "2. Gate LiteLLM completion requests based on agent trust score\n",
+    "3. Verify x402 payment receipts from agent-to-agent transactions\n",
+    "\n",
+    "TWZRD Agent Intel is a zero-install remote MCP server — no API key required for trust scoring."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Install dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install litellm mcp twzrd-agent-intel"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Option 1: Direct MCP client (no additional API key needed)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import asyncio\n",
+    "from mcp import ClientSession\n",
+    "from mcp.client.streamable_http import streamablehttp_client\n",
+    "import litellm\n",
+    "\n",
+    "TWZRD_MCP_URL = \"https://intel.twzrd.xyz/mcp\"\n",
+    "TRUST_SCORE_THRESHOLD = 50  # minimum trust score to allow LLM call\n",
+    "\n",
+    "async def get_agent_trust_score(wallet_address: str) -> dict:\n",
+    "    \"\"\"Score a Solana agent wallet using TWZRD Agent Intel.\"\"\"\n",
+    "    async with streamablehttp_client(TWZRD_MCP_URL) as (read, write, _):\n",
+    "        async with ClientSession(read, write) as session:\n",
+    "            await session.initialize()\n",
+    "            result = await session.call_tool(\"score_agent\", {\"wallet\": wallet_address})\n",
+    "            return result.content[0].text\n",
+    "\n",
+    "async def trust_gated_completion(agent_wallet: str, prompt: str) -> str:\n",
+    "    \"\"\"\n",
+    "    Run a LiteLLM completion only if the agent wallet meets the trust threshold.\n",
+    "    Returns the LLM response or a rejection message if trust score is too low.\n",
+    "    \"\"\"\n",
+    "    # Step 1: Check trust score\n",
+    "    score_data = await get_agent_trust_score(agent_wallet)\n",
+    "    print(f\"Trust data for {agent_wallet}: {score_data}\")\n",
+    "    \n",
+    "    # Parse trust score (score_data is a JSON string)\n",
+    "    import json\n",
+    "    data = json.loads(score_data) if isinstance(score_data, str) else score_data\n",
+    "    trust_score = data.get(\"trust_score\", 0)\n",
+    "    \n",
+    "    if trust_score < TRUST_SCORE_THRESHOLD:\n",
+    "        return f\"Rejected: agent trust score {trust_score} below threshold {TRUST_SCORE_THRESHOLD}\"\n",
+    "    \n",
+    "    # Step 2: Trust gate passed — run LiteLLM completion\n",
+    "    response = litellm.completion(\n",
+    "        model=\"gpt-4o-mini\",\n",
+    "        messages=[{\"role\": \"user\", \"content\": prompt}]\n",
+    "    )\n",
+    "    return response.choices[0].message.content\n",
+    "\n",
+    "# Example usage\n",
+    "agent_wallet = \"D1QkbFJKiPsymJ65RKHhF6DFB8sPMfpBaFBzuHKfJGWi\"  # example Solana wallet\n",
+    "result = asyncio.run(trust_gated_completion(agent_wallet, \"What is 2+2?\"))\n",
+    "print(result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Option 2: Preflight check before sending x402 payment to an agent"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def preflight_before_payment(agent_wallet: str) -> bool:\n",
+    "    \"\"\"Run a preflight trust check before initiating an x402 payment to an agent.\"\"\"\n",
+    "    async with streamablehttp_client(TWZRD_MCP_URL) as (read, write, _):\n",
+    "        async with ClientSession(read, write) as session:\n",
+    "            await session.initialize()\n",
+    "            result = await session.call_tool(\"preflight_check\", {\"wallet\": agent_wallet})\n",
+    "            import json\n",
+    "            data = json.loads(result.content[0].text)\n",
+    "            print(f\"Preflight result: {data}\")\n",
+    "            return data.get(\"safe_to_transact\", False)\n",
+    "\n",
+    "# Only proceed with payment if agent passes preflight\n",
+    "is_safe = asyncio.run(preflight_before_payment(agent_wallet))\n",
+    "print(f\"Safe to transact: {is_safe}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## MCP Server Configuration\n",
+    "\n",
+    "To use TWZRD Agent Intel as an MCP server in Claude Desktop or other MCP clients:\n",
+    "\n",
+    "```json\n",
+    "{\"mcpServers\": {\"twzrd-agent-intel\": {\"url\": \"https://intel.twzrd.xyz/mcp\"}}}\n",
+    "```\n",
+    "\n",
+    "No installation required — it's a remote MCP server (Streamable HTTP transport).\n",
+    "\n",
+    "**Available tools:**\n",
+    "- `score_agent(wallet)` — trust score + reputation data\n",
+    "- `resolve_agent(wallet)` — agent identity resolution\n",
+    "- `preflight_check(wallet)` — pre-transaction safety check\n",
+    "- `verify_trust_receipt(receipt)` — verify x402 payment receipt\n",
+    "- `get_trust_receipt(wallet)` — paid endpoint (x402 micropayment)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Description

Adds a cookbook notebook demonstrating how to use [TWZRD Agent Intel](https://intel.twzrd.xyz) with LiteLLM to implement trust-gated agent calls.

**File:** `cookbook/TWZRD_Agent_Intel_Trust_Gated_LiteLLM.ipynb`

## What it shows

1. **Trust-gated completions** — score a Solana agent wallet via TWZRD MCP, then only run the LiteLLM completion if the trust score exceeds a threshold
2. **Preflight checks** — verify agent safety before initiating x402 micropayments
3. **x402 receipt verification** — validate payment receipts from agent-to-agent transactions

## TWZRD Agent Intel

- Zero-install remote MCP server (Streamable HTTP)
- No API key needed for trust scoring
- Returns trust score (0-100) + reputation data for Solana wallets
- MCP config: `{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}`
- PyPI: `pip install twzrd-agent-intel`

## Testing

```bash
pip install litellm mcp twzrd-agent-intel
# Run the notebook cells
```

The notebook is self-contained and doesn't require real API keys to test the trust scoring (TWZRD tools are free). An OpenAI key is needed only for the LiteLLM completion cells.