### PR TITLE
feat(mcp): add TWZRD Agent Intel to mcp_servers.json

### DIFF
--- a/mcp_servers.json
+++ b/mcp_servers.json
@@ -1,23 +1,27 @@
 {
-    "zapier": {
-        "sse_url": "https://mcp.zapier.com/api/mcp"
-    },
-    "deepwiki": {
-        "http_url": "https://mcp.deepwiki.com/mcp",
-        "sse_url": "https://mcp.deepwiki.com/sse",
-        "description": "The DeepWiki MCP server provides programmatic access to DeepWiki's repository documentation (Devin Wiki) and search capabilities (Devin Search)."
-    },
-    "jira": {
-        "sse_url": "https://mcp.atlassian.com/v1/sse",
-        "description": "The Jira MCP server provides programmatic access to Jira's issue tracking capabilities."
-    },
-    "linear": {
-        "sse_url": "https://mcp.linear.app/sse",
-        "description": "The Linear MCP server provides programmatic access to Linear's issue tracking capabilities."
-    },
-    "scrapegraph": {
-        "http_url": "https://smithery.ai/api/mcp/scrapegraph-mcp",
-        "sse_url": "https://smithery.ai/api/mcp/scrapegraph-mcp/sse",
-        "description": "The ScrapeGraph MCP server provides programmatic access to ScrapeGraph AI's web scraping capabilities, including smart scraping, web crawling, search scraping, and agentic scraping workflows."
-    }
+  "zapier": {
+    "sse_url": "https://mcp.zapier.com/api/mcp"
+  },
+  "deepwiki": {
+    "http_url": "https://mcp.deepwiki.com/mcp",
+    "sse_url": "https://mcp.deepwiki.com/sse",
+    "description": "The DeepWiki MCP server provides programmatic access to DeepWiki's repository documentation (Devin Wiki) and search capabilities (Devin Search)."
+  },
+  "jira": {
+    "sse_url": "https://mcp.atlassian.com/v1/sse",
+    "description": "The Jira MCP server provides programmatic access to Jira's issue tracking capabilities."
+  },
+  "linear": {
+    "sse_url": "https://mcp.linear.app/sse",
+    "description": "The Linear MCP server provides programmatic access to Linear's issue tracking capabilities."
+  },
+  "scrapegraph": {
+    "http_url": "https://smithery.ai/api/mcp/scrapegraph-mcp",
+    "sse_url": "https://smithery.ai/api/mcp/scrapegraph-mcp/sse",
+    "description": "The ScrapeGraph MCP server provides programmatic access to ScrapeGraph AI's web scraping capabilities, including smart scraping, web crawling, search scraping, and agentic scraping workflows."
+  },
+  "twzrd-agent-intel": {
+    "http_url": "https://intel.twzrd.xyz/mcp",
+    "description": "Solana-native agent trust scoring and x402 payment verification. 4 free tools: resolve_agent, score_agent, preflight_check, verify_trust_receipt. Paid: get_trust_receipt (HTTP 402 + USDC on Solana, <1s settlement)."
+  }
 }


### PR DESCRIPTION
## Summary

Adds **TWZRD Agent Intel** to `mcp_servers.json` — a Solana-native MCP server for agent trust scoring and x402 payment verification.

### Entry

```json
"twzrd-agent-intel": {
  "http_url": "https://intel.twzrd.xyz/mcp",
  "description": "Solana-native agent trust scoring and x402 payment verification. 4 free tools: resolve_agent, score_agent, preflight_check, verify_trust_receipt. Paid: get_trust_receipt (HTTP 402 + USDC on Solana, <1s settlement)."
}
```

### Tools

| Tool | Type | Description |
|------|------|-------------|
| `resolve_agent` | Free | Resolve a Solana wallet to agent metadata |
| `score_agent` | Free | On-chain trust score (0–100) for a Solana wallet |
| `preflight_check` | Free | Pre-payment trust check for agent-to-agent transactions |
| `verify_trust_receipt` | Free | Verify a signed `twzrd.receipt.v5` trust token |
| `get_trust_receipt` | Paid (x402) | Get a signed trust receipt; HTTP 402 → USDC on Solana |

### Zero-install config

```json
{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}
```

- Website: https://intel.twzrd.xyz
- PyPI: https://pypi.org/project/twzrd-agent-intel/