### PR TITLE
fix: respect NO_COLOR env var in logging format

### DIFF
--- a/litellm/_logging.py
+++ b/litellm/_logging.py
@@ -249,7 +249,7 @@ if json_logs:
     handler.setFormatter(JsonFormatter())
     _setup_json_exception_handlers(JsonFormatter())
 else:
-    if os.environ.get("NO_COLOR") is None:
+    if sys.stdout.isatty() and os.environ.get("NO_COLOR") is None:
         _format_str = "\033[92m%(asctime)s - %(name)s:%(levelname)s\033[0m: %(filename)s:%(lineno)s - %(message)s"
     else:
         _format_str = "%(asctime)s - %(name)s:%(levelname)s: %(filename)s:%(lineno)s - %(message)s"

--- a/litellm/_logging.py
+++ b/litellm/_logging.py
@@ -249,8 +249,12 @@ if json_logs:
     handler.setFormatter(JsonFormatter())
     _setup_json_exception_handlers(JsonFormatter())
 else:
+    if os.environ.get("NO_COLOR") is None:
+        _format_str = "\033[92m%(asctime)s - %(name)s:%(levelname)s\033[0m: %(filename)s:%(lineno)s - %(message)s"
+    else:
+        _format_str = "%(asctime)s - %(name)s:%(levelname)s: %(filename)s:%(lineno)s - %(message)s"
     formatter = logging.Formatter(
-        "\033[92m%(asctime)s - %(name)s:%(levelname)s\033[0m: %(filename)s:%(lineno)s - %(message)s",
+        _format_str,
         datefmt="%H:%M:%S",
     )
 


### PR DESCRIPTION
## Summary

ANSI escape codes were hardcoded into the logging format string at , producing garbled output when piped to files or when the  env var is set.

Now checks  and emits a plain format string when set, matching the existing convention in .

## Linked Issue

Fixes #29799

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Verified without : ANSI codes present in log output (existing behavior preserved)
- Verified with : plain text output, no escape codes
- All 10 existing tests pass