### PR TITLE
fix(ui): make workflow runs page fill full width

### DIFF
--- a/ui/litellm-dashboard/src/components/workflow_runs/index.tsx
+++ b/ui/litellm-dashboard/src/components/workflow_runs/index.tsx
@@ -587,6 +587,7 @@ const WorkflowRuns: React.FC<WorkflowRunsProps> = ({ accessToken }) => {
   return (
     <div
       style={{
+        width: "100%",
         padding: "24px 32px",
         fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
         minHeight: "calc(100vh - 64px)",


### PR DESCRIPTION
## Relevant issues

## Linear ticket

LIT-3636

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Before:
<img width="887" height="431" alt="image" src="https://github.com/user-attachments/assets/e42d00e9-129f-4019-aeed-8ee8745513fc" />

After 
<img width="1881" height="502" alt="image" src="https://github.com/user-attachments/assets/83b8341b-7781-418c-8e9b-b1bc7522ba15" />

## Type

🐛 Bug Fix

## Changes

The Workflow Runs page rendered its table at about a quarter of the available width. Its root container is a flex child of the dashboard content row (`<div className="flex flex-1">`) but set only padding, min-height and background; with no width it shrank to the table's natural content size instead of filling the row. Sibling pages such as Logs (`w-full max-w-screen ...`) and Memory (`w-full`) fill the area with a full-width root, so this mirrors that by setting `width: 100%` on the container.
