### PR TITLE
refactor(bedrock): build Converse toolSpec via a BedrockToolSpec dict subclass

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -5550,14 +5550,17 @@ def _bedrock_tools_pt(
         normalize_json_schema_custom_types_to_object(parameters)
         if parameters.get("type") not in _valid_json_schema_root_types:
             parameters["type"] = "object"
-        tool_block = BedrockToolSpec(
-            name=name,
-            description=description,
-            parameters=parameters,
-            strict=tool.get("function", {}).get("strict", None),
-            supports_strict_tools=supports_strict_tools,
+        tool_block = cast(
+            BedrockToolBlock,
+            BedrockToolSpec(
+                name=name,
+                description=description,
+                parameters=parameters,
+                strict=tool.get("function", {}).get("strict", None),
+                supports_strict_tools=supports_strict_tools,
+            ),
         )
-        tool_block_list.append(tool_block)  # type: ignore[arg-type]
+        tool_block_list.append(tool_block)
 
         ## ADD CACHE POINT TOOL BLOCK ##
         cache_point_tool_block = add_cache_point_tool_block(tool, model=model)

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -5550,14 +5550,14 @@ def _bedrock_tools_pt(
         normalize_json_schema_custom_types_to_object(parameters)
         if parameters.get("type") not in _valid_json_schema_root_types:
             parameters["type"] = "object"
-        tool_block = BedrockToolSpec.from_openai_tool(
+        tool_block = BedrockToolSpec(
             name=name,
             description=description,
             parameters=parameters,
             strict=tool.get("function", {}).get("strict", None),
             supports_strict_tools=supports_strict_tools,
-        ).to_tool_block()
-        tool_block_list.append(tool_block)
+        )
+        tool_block_list.append(tool_block)  # type: ignore[arg-type]
 
         ## ADD CACHE POINT TOOL BLOCK ##
         cache_point_tool_block = add_cache_point_tool_block(tool, model=model)

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -3653,17 +3653,13 @@ from litellm.types.llms.bedrock import ContentBlock as BedrockContentBlock
 from litellm.types.llms.bedrock import DocumentBlock as BedrockDocumentBlock
 from litellm.types.llms.bedrock import ImageBlock as BedrockImageBlock
 from litellm.types.llms.bedrock import SourceBlock as BedrockSourceBlock
+from litellm.types.llms.bedrock import BedrockToolSpec
 from litellm.types.llms.bedrock import ToolBlock as BedrockToolBlock
-from litellm.types.llms.bedrock import (
-    ToolInputSchemaBlock as BedrockToolInputSchemaBlock,
-)
-from litellm.types.llms.bedrock import ToolJsonSchemaBlock as BedrockToolJsonSchemaBlock
 from litellm.types.llms.bedrock import SearchResultBlock
 from litellm.types.llms.bedrock import ToolResultBlock as BedrockToolResultBlock
 from litellm.types.llms.bedrock import (
     ToolResultContentBlock as BedrockToolResultContentBlock,
 )
-from litellm.types.llms.bedrock import ToolSpecBlock as BedrockToolSpecBlock
 from litellm.types.llms.bedrock import ToolUseBlock as BedrockToolUseBlock
 from litellm.types.llms.bedrock import VideoBlock as BedrockVideoBlock
 
@@ -5554,22 +5550,13 @@ def _bedrock_tools_pt(
         normalize_json_schema_custom_types_to_object(parameters)
         if parameters.get("type") not in _valid_json_schema_root_types:
             parameters["type"] = "object"
-        json_schema = BedrockToolJsonSchemaBlock(
-            type=parameters["type"],
-            properties=parameters.get("properties", {}),
-            required=parameters.get("required", []),
-        )
-        additional_properties = parameters.get("additionalProperties", None)
-        if supports_strict_tools and additional_properties is not None:
-            json_schema["additionalProperties"] = additional_properties
-        tool_input_schema = BedrockToolInputSchemaBlock(json=json_schema)
-        tool_spec = BedrockToolSpecBlock(
-            inputSchema=tool_input_schema, name=name, description=description
-        )
-        strict = tool.get("function", {}).get("strict", None)
-        if supports_strict_tools and strict is not None:
-            tool_spec["strict"] = strict
-        tool_block = BedrockToolBlock(toolSpec=tool_spec)
+        tool_block = BedrockToolSpec.from_openai_tool(
+            name=name,
+            description=description,
+            parameters=parameters,
+            strict=tool.get("function", {}).get("strict", None),
+            supports_strict_tools=supports_strict_tools,
+        ).to_tool_block()
         tool_block_list.append(tool_block)
 
         ## ADD CACHE POINT TOOL BLOCK ##

--- a/litellm/types/llms/bedrock.py
+++ b/litellm/types/llms/bedrock.py
@@ -1,4 +1,5 @@
 import json
+from dataclasses import dataclass
 from typing import Any, Dict, List, Literal, Optional, Union
 
 from typing_extensions import TYPE_CHECKING, Required, TypedDict, override
@@ -283,6 +284,60 @@ class ToolBlock(TypedDict, total=False):
     toolSpec: Optional[ToolSpecBlock]
     systemTool: Optional[SystemToolBlock]
     cachePoint: Optional[CachePointBlock]
+
+
+@dataclass
+class BedrockToolSpec:
+    name: str
+    description: str
+    json_type: str
+    properties: dict
+    required: List[str]
+    additional_properties: Optional[bool] = None
+    strict: Optional[bool] = None
+
+    @classmethod
+    def from_openai_tool(
+        cls,
+        *,
+        name: str,
+        description: str,
+        parameters: dict,
+        strict: Optional[bool],
+        supports_strict_tools: bool,
+    ) -> "BedrockToolSpec":
+        return cls(
+            name=name,
+            description=description,
+            json_type=parameters["type"],
+            properties=parameters.get("properties", {}),
+            required=parameters.get("required", []),
+            additional_properties=(
+                parameters.get("additionalProperties")
+                if supports_strict_tools
+                else None
+            ),
+            strict=strict if supports_strict_tools else None,
+        )
+
+    def to_tool_block(self) -> ToolBlock:
+        json_schema: ToolJsonSchemaBlock = {
+            "type": self.json_type,  # type: ignore[typeddict-item]
+            "properties": self.properties,
+            "required": self.required,
+        }
+        if self.additional_properties is not None:
+            json_schema["additionalProperties"] = self.additional_properties
+
+        tool_spec: ToolSpecBlock = {
+            "inputSchema": {"json": json_schema},
+            "name": self.name,
+            "description": self.description,
+        }
+        if self.strict is not None:
+            tool_spec["strict"] = self.strict
+
+        return ToolBlock(toolSpec=tool_spec)
 
 
 class SpecificToolChoiceBlock(TypedDict):

--- a/litellm/types/llms/bedrock.py
+++ b/litellm/types/llms/bedrock.py
@@ -296,7 +296,7 @@ class BedrockToolSpec(dict):
         supports_strict_tools: bool,
     ) -> None:
         json_schema: ToolJsonSchemaBlock = {
-            "type": parameters["type"],  # type: ignore[typeddict-item]
+            "type": parameters["type"],
             "properties": parameters.get("properties", {}),
             "required": parameters.get("required", []),
         }

--- a/litellm/types/llms/bedrock.py
+++ b/litellm/types/llms/bedrock.py
@@ -286,8 +286,6 @@ class ToolBlock(TypedDict, total=False):
 
 
 class BedrockToolSpec(dict):
-    """A ``toolSpec`` ToolBlock; the instance is the wire dict itself."""
-
     def __init__(
         self,
         *,

--- a/litellm/types/llms/bedrock.py
+++ b/litellm/types/llms/bedrock.py
@@ -1,5 +1,4 @@
 import json
-from dataclasses import dataclass
 from typing import Any, Dict, List, Literal, Optional, Union
 
 from typing_extensions import TYPE_CHECKING, Required, TypedDict, override
@@ -286,58 +285,36 @@ class ToolBlock(TypedDict, total=False):
     cachePoint: Optional[CachePointBlock]
 
 
-@dataclass
-class BedrockToolSpec:
-    name: str
-    description: str
-    json_type: str
-    properties: dict
-    required: List[str]
-    additional_properties: Optional[bool] = None
-    strict: Optional[bool] = None
+class BedrockToolSpec(dict):
+    """A ``toolSpec`` ToolBlock; the instance is the wire dict itself."""
 
-    @classmethod
-    def from_openai_tool(
-        cls,
+    def __init__(
+        self,
         *,
         name: str,
         description: str,
         parameters: dict,
         strict: Optional[bool],
         supports_strict_tools: bool,
-    ) -> "BedrockToolSpec":
-        return cls(
-            name=name,
-            description=description,
-            json_type=parameters["type"],
-            properties=parameters.get("properties", {}),
-            required=parameters.get("required", []),
-            additional_properties=(
-                parameters.get("additionalProperties")
-                if supports_strict_tools
-                else None
-            ),
-            strict=strict if supports_strict_tools else None,
-        )
-
-    def to_tool_block(self) -> ToolBlock:
+    ) -> None:
         json_schema: ToolJsonSchemaBlock = {
-            "type": self.json_type,  # type: ignore[typeddict-item]
-            "properties": self.properties,
-            "required": self.required,
+            "type": parameters["type"],  # type: ignore[typeddict-item]
+            "properties": parameters.get("properties", {}),
+            "required": parameters.get("required", []),
         }
-        if self.additional_properties is not None:
-            json_schema["additionalProperties"] = self.additional_properties
+        additional_properties = parameters.get("additionalProperties")
+        if supports_strict_tools and additional_properties is not None:
+            json_schema["additionalProperties"] = additional_properties
 
         tool_spec: ToolSpecBlock = {
             "inputSchema": {"json": json_schema},
-            "name": self.name,
-            "description": self.description,
+            "name": name,
+            "description": description,
         }
-        if self.strict is not None:
-            tool_spec["strict"] = self.strict
+        if supports_strict_tools and strict is not None:
+            tool_spec["strict"] = strict
 
-        return ToolBlock(toolSpec=tool_spec)
+        super().__init__(toolSpec=tool_spec)
 
 
 class SpecificToolChoiceBlock(TypedDict):


### PR DESCRIPTION
## Relevant issues

Follow-up refactor to the strict tool support landed via #29814 (now in `litellm_internal_staging`). In review, the concern was that `_bedrock_tools_pt` constructed the `toolSpec` TypedDicts and then item-assigned the optional `strict` / `additionalProperties` keys afterward, which read like sidestepping the type and mutating the dict directly. This explores pushing that logic into a small class so the conditional gating lives in one place

## Linear ticket

## Pre-Submission checklist

- [ ] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

No new test is added because this is a behavior-preserving refactor; the existing `test_bedrock_tools_pt_strict_parameter` (already in staging) is the regression guard and still passes unchanged, asserting the serialized `toolSpec` is identical for Claude (strict + additionalProperties forwarded), Nova (both stripped), and Claude-without-strict (both absent)

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:
- [ ] **CI run for the last commit**
       Link:
- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

Behavior is unchanged from the merged feature, so the same live reproduction against a real Bedrock Claude deployment holds; the returned `unit` stays `celsius` (the only enum member) after the refactor

```bash
curl -s http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer $LITELLM_KEY" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0",
    "messages": [{"role": "user", "content": "What is the weather in Dallas in Fahrenheit? Call the tool."}],
    "tool_choice": "required",
    "tools": [{
      "type": "function",
      "function": {
        "name": "get_weather",
        "strict": true,
        "description": "Get the weather for a city",
        "parameters": {
          "type": "object",
          "properties": {
            "city": {"type": "string"},
            "unit": {"type": "string", "enum": ["celsius"]}
          },
          "required": ["city", "unit"],
          "additionalProperties": false
        }
      }
    }]
  }' | jq '.choices[0].message.tool_calls[0].function.arguments'
```

I have not run this against live Bedrock from this environment; the unit test confirms the emitted payload is byte-identical to the pre-refactor path

## Type

🧹 Refactoring

## Changes

`litellm/types/llms/bedrock.py`: add `BedrockToolSpec` as a `dict` subclass whose `__init__` owns the whole transformation. The Claude-only gating and the omit-when-absent serialization both live in the constructor, and the instance is the `toolSpec` `ToolBlock` wire dict itself, so there is no separate `from_openai_tool` / `to_tool_block` round-trip and `__repr__` comes for free from `dict`. The TypedDicts stay as the typed construction target inside `__init__`

`litellm/litellm_core_utils/prompt_templates/factory.py`: replace the construct-then-item-assign block in `_bedrock_tools_pt` with a single `BedrockToolSpec(...)` construction that is appended directly

Tradeoff worth calling out: this unifies the conditional logic in one place and is more compact than both the original inline code and the earlier dataclass sketch, but subclassing `dict` is a slightly unusual idiom and the instance is not statically a `ToolBlock`, so the call site casts it to `ToolBlock`. That cast is a true structural assertion since the instance is `{"toolSpec": {...}}`, and it keeps the precise `List[ToolBlock]` return type rather than widening it to `List[dict]`; a plain inline builder returning `ToolBlock` would need neither the subclass nor the cast

https://claude.ai/code/session_017oXxjg6J3FH4YTifKx8zJg