### PR TITLE
fix(ui): label default key type as "Full Access" on key edit page

### DIFF
--- a/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
@@ -394,11 +394,11 @@ export function KeyEditView({
                   }
                 }}
               >
-                <Select.Option value="default" label="Default">
+                <Select.Option value="default" label="Full Access">
                   <div style={{ padding: "4px 0" }}>
-                    <div style={{ fontWeight: 500 }}>Default</div>
+                    <div style={{ fontWeight: 500 }}>Full Access</div>
                     <div style={{ fontSize: "11px", color: "#6b7280", marginTop: "2px" }}>
-                      Can call AI APIs + Management routes
+                      Can call all routes (AI APIs, Management, and read-only)
                     </div>
                   </div>
                 </Select.Option>


### PR DESCRIPTION
## Relevant issues

Internally found UI inconsistency in the key type selector

## Linear ticket

LIT-3634: https://linear.app/litellm-ai/issue/LIT-3634/key-settings-page-still-defaults-key-type-to-default-instead-of-full

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

Bug Fix

## Changes

The key edit page and the key creation form disagreed on what to call the key type that has no allowed_routes restriction. The create form labels that value "Full Access" with the description "Can call all routes (AI APIs, Management, and read-only)", while the edit page labeled the same value "Default" with a narrower description "Can call AI APIs + Management routes". Same underlying value, two different names in the UI

This aligns the edit page to the create form so both surfaces read "Full Access" with the same description. The create form is treated as the source of truth, so only the edit page changed

No behavior change beyond the label and description text; the option value stays `default` and the allowed_routes mapping is untouched

## Screenshots / Proof of Fix

This is a UI label change. To verify on a local proxy build:

1. Go to http://localhost:4000/ui/?page=api-keys
2. Click "Create New Key" and open the "Key Type" dropdown; confirm the broadest option reads "Full Access"
3. Close the modal, click an existing key that has no allowed_routes restriction, then "Edit"
4. Open the "Key Type" dropdown on the edit view and confirm it now also reads "Full Access" (previously "Default") with the description "Can call all routes (AI APIs, Management, and read-only)"
