### PR TITLE
fix(ui): keep create guardrail modal open on outside click

### DIFF
--- a/ui/litellm-dashboard/src/components/guardrails/add_guardrail_form.test.tsx
+++ b/ui/litellm-dashboard/src/components/guardrails/add_guardrail_form.test.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { fireEvent, screen } from "@testing-library/react";
+import { renderWithProviders } from "../../../tests/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import AddGuardrailForm from "./add_guardrail_form";
+
+vi.mock("@/components/networking", () => ({
+  createGuardrailCall: vi.fn(),
+  getGuardrailProviderSpecificParams: vi.fn().mockResolvedValue({}),
+  getGuardrailUISettings: vi.fn().mockResolvedValue({}),
+  modelAvailableCall: vi.fn().mockResolvedValue({ data: [] }),
+}));
+
+const renderForm = () => {
+  const onClose = vi.fn();
+  renderWithProviders(<AddGuardrailForm visible={true} onClose={onClose} accessToken={null} onSuccess={vi.fn()} />);
+  return { onClose };
+};
+
+describe("AddGuardrailForm close behavior", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not close when the user clicks outside the modal on the mask", () => {
+    const { onClose } = renderForm();
+    expect(screen.getByText("Create guardrail")).toBeInTheDocument();
+
+    const wrap = document.querySelector(".ant-modal-wrap") as HTMLElement;
+    expect(wrap).toBeTruthy();
+    fireEvent.mouseDown(wrap);
+    fireEvent.mouseUp(wrap);
+    fireEvent.click(wrap);
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("closes when the user clicks the explicit close button", () => {
+    const { onClose } = renderForm();
+    fireEvent.click(screen.getByRole("button", { name: "✕" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/litellm-dashboard/src/components/guardrails/add_guardrail_form.tsx
+++ b/ui/litellm-dashboard/src/components/guardrails/add_guardrail_form.tsx
@@ -1144,6 +1144,7 @@ const AddGuardrailForm: React.FC<AddGuardrailFormProps> = ({ visible, onClose, a
       title={null}
       open={visible}
       onCancel={handleClose}
+      maskClosable={false}
       footer={null}
       width={1000}
       closable={false}


### PR DESCRIPTION
## Relevant issues

Internally found issue: the create guardrail modal closes and discards everything the user has entered when they click outside it

## Linear ticket

LIT-3631 (https://linear.app/litellm-ai/issue/LIT-3631)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Manual verification in the dashboard:

1. Go to http://localhost:4000/ui/?page=guardrails
2. Click "Add Guardrail" to open the Create guardrail modal
3. Enter a guardrail name and pick a provider
4. Click anywhere on the dark backdrop outside the modal
5. Before this fix the modal closed and every field reset; after this fix the modal stays open with the input intact
6. Confirm the modal still closes via the X button in the header and the Cancel button

Screenshots to follow

## Type

🐛 Bug Fix

## Changes

Added `maskClosable={false}` to the create guardrail `<Modal>` in `add_guardrail_form.tsx` so an outside click no longer dismisses the modal and wipes the in-progress form. This matches the existing convention for form modals in the dashboard such as `RegenerateKeyModal` and `AddFallbacksModal`. The modal still closes through the explicit close button, Cancel, or a successful create.

Added a regression test in `add_guardrail_form.test.tsx` that asserts a backdrop click does not call `onClose`, with a control assertion that the explicit close button still does. The test fails without the fix and passes with it
