### PR TITLE
fix(ui): default guardrails page to the Guardrails tab

### DIFF
--- a/ui/litellm-dashboard/src/components/guardrails.test.tsx
+++ b/ui/litellm-dashboard/src/components/guardrails.test.tsx
@@ -44,6 +44,11 @@ vi.mock("./guardrails/TeamGuardrailsTab", () => ({
   TeamGuardrailsTab: () => <div>Mock Team Guardrails Tab</div>,
 }));
 
+vi.mock("./guardrails/guardrail_garden", () => ({
+  __esModule: true,
+  default: () => <div>Mock Guardrail Garden</div>,
+}));
+
 vi.mock("@/utils/roles", () => ({
   isAdminRole: vi.fn((role: string) => role === "admin"),
 }));
@@ -106,5 +111,16 @@ describe("GuardrailsPanel", () => {
     // Activate the Guardrails tab so its content (including the Add button) is rendered
     fireEvent.click(screen.getByText("Guardrails"));
     expect(screen.getByText("+ Add New Guardrail")).toBeInTheDocument();
+  });
+
+  it("defaults admins to the first tab, not Submitted Guardrails", async () => {
+    render(<GuardrailsPanel accessToken="test-token" userRole="admin" />);
+    expect(screen.getByRole("tab", { name: "Guardrail Garden" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("tab", { name: "Submitted Guardrails" })).toHaveAttribute("aria-selected", "false");
+  });
+
+  it("defaults non-admins to the Submitted Guardrails tab", async () => {
+    render(<GuardrailsPanel accessToken="test-token" userRole="internal_user" />);
+    expect(screen.getByRole("tab", { name: "Submitted Guardrails" })).toHaveAttribute("aria-selected", "true");
   });
 });

--- a/ui/litellm-dashboard/src/components/guardrails.tsx
+++ b/ui/litellm-dashboard/src/components/guardrails.tsx
@@ -133,7 +133,7 @@ const GuardrailsPanel: React.FC<GuardrailsPanelProps> = ({ accessToken, userRole
   return (
     <div className="w-full mx-auto flex-auto overflow-y-auto m-8 p-2">
       <Tabs
-        defaultActiveKey="submitted"
+        defaultActiveKey={isAdmin ? "garden" : "submitted"}
         items={[
           ...(isAdmin
             ? [


### PR DESCRIPTION
## Relevant issues

## Linear ticket

https://linear.app/litellm-ai/issue/LIT-3632/guardrails-page-defaults-to-submitted-guardrails

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

UI-only change, so the proof is in the browser. To verify on a running proxy:

1. Open http://localhost:4000/ui/ and sign in as a Proxy Admin
2. Click "Guardrails" in the left nav
3. Confirm the page now opens on the "Guardrails" tab (the configured guardrails list) rather than "Submitted Guardrails"
4. Sign in as an internal (non-admin) user and open "Guardrails"; confirm it still opens on "Submitted Guardrails", which is their only tab

## Type

🐛 Bug Fix

## Changes

The Guardrails page hardcoded `defaultActiveKey="submitted"`, so admins opened on the "Submitted Guardrails" tab, the last of their four tabs (Guardrail Garden, Guardrails, Test Playground, Submitted Guardrails), instead of the primary view.

The default is now the "Guardrails" tab. Non-admins do not have a Guardrails tab, so antd falls back to their only tab, Submitted Guardrails