### PR TITLE
fix(model-management): allow deleting a BYOK model after its team is deleted

### DIFF
--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -857,6 +857,7 @@ class ModelManagementAuthChecks:
         user_api_key_dict: UserAPIKeyAuth,
         prisma_client: PrismaClient,
         premium_user: bool,
+        allow_missing_team: bool = False,
     ) -> Literal[True]:
         ## Check team model auth
         if (
@@ -867,6 +868,18 @@ class ModelManagementAuthChecks:
                 where={"team_id": model_params.model_info.team_id}
             )
             if team_obj_row is None:
+                # The team was deleted. Callers that opt in (e.g. model deletion) may
+                # act on the orphaned model, but only as a proxy admin -- without the
+                # team there is no team-admin membership left to verify.
+                if allow_missing_team:
+                    if user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN:
+                        return True
+                    raise HTTPException(
+                        status_code=403,
+                        detail={
+                            "error": "Only a proxy admin can delete a model whose team has been deleted."
+                        },
+                    )
                 raise HTTPException(
                     status_code=400,
                     detail={
@@ -947,31 +960,13 @@ async def delete_model(
             )
 
         model_params = Deployment(**model_in_db.model_dump())
-
-        team_id = model_params.model_info.team_id if model_params.model_info else None
-        team_exists = team_id is None or (
-            await prisma_client.db.litellm_teamtable.find_unique(
-                where={"team_id": team_id}
-            )
-            is not None
+        await ModelManagementAuthChecks.can_user_make_model_call(
+            model_params=model_params,
+            user_api_key_dict=user_api_key_dict,
+            prisma_client=prisma_client,
+            premium_user=premium_user,
+            allow_missing_team=True,
         )
-
-        if team_exists:
-            await ModelManagementAuthChecks.can_user_make_model_call(
-                model_params=model_params,
-                user_api_key_dict=user_api_key_dict,
-                prisma_client=prisma_client,
-                premium_user=premium_user,
-            )
-        elif user_api_key_dict.user_role != LitellmUserRoles.PROXY_ADMIN:
-            # The model's team was deleted; without it team-admin membership can't be
-            # verified, so only a proxy admin may delete the orphaned model.
-            raise HTTPException(
-                status_code=403,
-                detail={
-                    "error": "Only a proxy admin can delete a model whose team has been deleted."
-                },
-            )
 
         # update DB
         if store_model_in_db is True:

--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -947,12 +947,31 @@ async def delete_model(
             )
 
         model_params = Deployment(**model_in_db.model_dump())
-        await ModelManagementAuthChecks.can_user_make_model_call(
-            model_params=model_params,
-            user_api_key_dict=user_api_key_dict,
-            prisma_client=prisma_client,
-            premium_user=premium_user,
+
+        team_id = model_params.model_info.team_id if model_params.model_info else None
+        team_exists = team_id is None or (
+            await prisma_client.db.litellm_teamtable.find_unique(
+                where={"team_id": team_id}
+            )
+            is not None
         )
+
+        if team_exists:
+            await ModelManagementAuthChecks.can_user_make_model_call(
+                model_params=model_params,
+                user_api_key_dict=user_api_key_dict,
+                prisma_client=prisma_client,
+                premium_user=premium_user,
+            )
+        elif user_api_key_dict.user_role != LitellmUserRoles.PROXY_ADMIN:
+            # The model's team was deleted; without it team-admin membership can't be
+            # verified, so only a proxy admin may delete the orphaned model.
+            raise HTTPException(
+                status_code=403,
+                detail={
+                    "error": "Only a proxy admin can delete a model whose team has been deleted."
+                },
+            )
 
         # update DB
         if store_model_in_db is True:

--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -1915,15 +1915,16 @@ class TestDeleteTeamBYOKModelGhost:
         mock_refresh.assert_not_awaited()
 
 
-class TestDeleteOrphanedTeamModel:
-    """Deleting a team BYOK model whose team was deleted.
+class TestDeleteModelTeamAuth:
+    """Team auth on the /model/delete path.
 
     A model added via /model/new with model_info.team_id is orphaned once its
     team is deleted: can_user_make_model_call looked the team up and raised
     'Team id=... does not exist in db' before the delete could run, so the model
     was undeletable from the Models + Endpoints page. Without the team, team-admin
     membership can't be verified, so a proxy admin (and only a proxy admin) may
-    delete the orphan; a missing team must never let a non-admin through.
+    delete the orphan; a missing team must never let a non-admin through. The team
+    is also looked up exactly once -- the auth check must not add a second query.
     """
 
     def _orphaned_model_mocks(self, team_id, model_id):
@@ -2026,6 +2027,75 @@ class TestDeleteOrphanedTeamModel:
                 )
 
         assert str(exc_info.value.code) == "403"
+        mock_prisma.db.litellm_proxymodeltable.delete.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_live_team_delete_looks_up_team_once(self):
+        """The auth check must not add a redundant team query on the live-team path."""
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            ModelInfoDelete,
+            delete_model as delete_model_endpoint,
+        )
+        from litellm.proxy.proxy_server import ProxyException
+
+        team_id = "live-team-1"
+        model_id = "live-byok-1"
+        db_row = LiteLLM_ProxyModelTable(
+            model_id=model_id,
+            model_name=f"model_name_{team_id}_abc-uuid",
+            litellm_params={"model": "openai/gpt-4.1-nano"},
+            model_info={
+                "id": model_id,
+                "team_id": team_id,
+                "team_public_model_name": "live-gpt",
+            },
+            created_by="admin",
+            updated_by="admin",
+        )
+        team_row = LiteLLM_TeamTable(
+            team_id=team_id,
+            team_alias="live-team",
+            members_with_roles=[Member(user_id="admin", role="admin")],
+            models=["live-gpt"],
+        )
+        mock_prisma = MagicMock()
+        mock_prisma.db = MagicMock()
+        mock_prisma.db.litellm_proxymodeltable = AsyncMock()
+        mock_prisma.db.litellm_proxymodeltable.find_unique = AsyncMock(
+            return_value=db_row
+        )
+        mock_prisma.db.litellm_proxymodeltable.delete = AsyncMock(return_value=db_row)
+        mock_prisma.db.litellm_proxymodeltable.find_many = AsyncMock(return_value=[])
+        mock_prisma.db.litellm_teamtable = AsyncMock()
+        mock_prisma.db.litellm_teamtable.find_unique = AsyncMock(return_value=team_row)
+        mock_prisma.db.litellm_modeltable = AsyncMock()
+        mock_prisma.db.litellm_modeltable.find_many = AsyncMock(return_value=[])
+
+        # A team member who is not the team admin: rejected before the delete runs,
+        # so the only team lookup is the single one inside the auth check.
+        non_admin = UserAPIKeyAuth(
+            user_id="someone", user_role=LitellmUserRoles.INTERNAL_USER
+        )
+
+        _PS = "litellm.proxy.proxy_server"
+        _MOD = "litellm.proxy.management_endpoints.model_management_endpoints"
+        with (
+            patch(f"{_PS}.prisma_client", mock_prisma),
+            patch(f"{_PS}.store_model_in_db", True),
+            patch(f"{_PS}.premium_user", True),
+            patch(f"{_PS}.llm_router", MagicMock()),
+            patch(f"{_PS}.proxy_logging_obj", MagicMock()),
+            patch(f"{_PS}.user_api_key_cache", MagicMock()),
+            patch(f"{_MOD}._refresh_cached_team", new=AsyncMock()),
+        ):
+            with pytest.raises(ProxyException) as exc_info:
+                await delete_model_endpoint(
+                    model_info=ModelInfoDelete(id=model_id),
+                    user_api_key_dict=non_admin,
+                )
+
+        assert str(exc_info.value.code) == "403"
+        assert mock_prisma.db.litellm_teamtable.find_unique.await_count == 1
         mock_prisma.db.litellm_proxymodeltable.delete.assert_not_awaited()
 
 

--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -1915,6 +1915,120 @@ class TestDeleteTeamBYOKModelGhost:
         mock_refresh.assert_not_awaited()
 
 
+class TestDeleteOrphanedTeamModel:
+    """Deleting a team BYOK model whose team was deleted.
+
+    A model added via /model/new with model_info.team_id is orphaned once its
+    team is deleted: can_user_make_model_call looked the team up and raised
+    'Team id=... does not exist in db' before the delete could run, so the model
+    was undeletable from the Models + Endpoints page. Without the team, team-admin
+    membership can't be verified, so a proxy admin (and only a proxy admin) may
+    delete the orphan; a missing team must never let a non-admin through.
+    """
+
+    def _orphaned_model_mocks(self, team_id, model_id):
+        db_row = LiteLLM_ProxyModelTable(
+            model_id=model_id,
+            model_name=f"model_name_{team_id}_abc-uuid",
+            litellm_params={"model": "openai/gpt-4.1-nano"},
+            model_info={
+                "id": model_id,
+                "team_id": team_id,
+                "team_public_model_name": "orphaned-gpt",
+            },
+            created_by="admin",
+            updated_by="admin",
+        )
+        mock_prisma = MagicMock()
+        mock_prisma.db = MagicMock()
+        mock_prisma.db.litellm_proxymodeltable = AsyncMock()
+        mock_prisma.db.litellm_proxymodeltable.find_unique = AsyncMock(
+            return_value=db_row
+        )
+        mock_prisma.db.litellm_proxymodeltable.delete = AsyncMock(return_value=db_row)
+        mock_prisma.db.litellm_proxymodeltable.find_many = AsyncMock(return_value=[])
+        # The team is gone -> every team lookup returns None.
+        mock_prisma.db.litellm_teamtable = AsyncMock()
+        mock_prisma.db.litellm_teamtable.find_unique = AsyncMock(return_value=None)
+        mock_prisma.db.litellm_teamtable.update = AsyncMock()
+        mock_prisma.db.litellm_modeltable = AsyncMock()
+        mock_prisma.db.litellm_modeltable.find_many = AsyncMock(return_value=[])
+        return mock_prisma
+
+    @pytest.mark.asyncio
+    async def test_proxy_admin_can_delete_model_when_team_deleted(self):
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            ModelInfoDelete,
+            delete_model as delete_model_endpoint,
+        )
+
+        team_id = "deleted-team-xyz"
+        model_id = "orphaned-byok-1"
+        mock_prisma = self._orphaned_model_mocks(team_id, model_id)
+
+        admin_user = UserAPIKeyAuth(
+            user_id="admin", user_role=LitellmUserRoles.PROXY_ADMIN
+        )
+
+        _PS = "litellm.proxy.proxy_server"
+        _MOD = "litellm.proxy.management_endpoints.model_management_endpoints"
+        with (
+            patch(f"{_PS}.prisma_client", mock_prisma),
+            patch(f"{_PS}.store_model_in_db", True),
+            patch(f"{_PS}.premium_user", True),
+            patch(f"{_PS}.llm_router", MagicMock()),
+            patch(f"{_PS}.proxy_logging_obj", MagicMock()),
+            patch(f"{_PS}.user_api_key_cache", MagicMock()),
+            patch(f"{_MOD}._refresh_cached_team", new=AsyncMock()),
+        ):
+            result = await delete_model_endpoint(
+                model_info=ModelInfoDelete(id=model_id),
+                user_api_key_dict=admin_user,
+            )
+
+        assert "deleted successfully" in result["message"]
+        mock_prisma.db.litellm_proxymodeltable.delete.assert_awaited_once()
+        # Team is gone -> no team.models cleanup to do.
+        mock_prisma.db.litellm_teamtable.update.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_non_admin_cannot_delete_model_when_team_deleted(self):
+        """A missing team must never let a non-admin delete the orphan (no fail-open)."""
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            ModelInfoDelete,
+            delete_model as delete_model_endpoint,
+        )
+        from litellm.proxy.proxy_server import ProxyException
+
+        team_id = "deleted-team-abc"
+        model_id = "orphaned-byok-2"
+        mock_prisma = self._orphaned_model_mocks(team_id, model_id)
+
+        non_admin = UserAPIKeyAuth(
+            user_id="someone", user_role=LitellmUserRoles.INTERNAL_USER
+        )
+
+        _PS = "litellm.proxy.proxy_server"
+        _MOD = "litellm.proxy.management_endpoints.model_management_endpoints"
+        with (
+            patch(f"{_PS}.prisma_client", mock_prisma),
+            patch(f"{_PS}.store_model_in_db", True),
+            patch(f"{_PS}.premium_user", True),
+            patch(f"{_PS}.llm_router", MagicMock()),
+            patch(f"{_PS}.proxy_logging_obj", MagicMock()),
+            patch(f"{_PS}.user_api_key_cache", MagicMock()),
+            patch(f"{_MOD}._refresh_cached_team", new=AsyncMock()),
+        ):
+            with pytest.raises(ProxyException) as exc_info:
+                await delete_model_endpoint(
+                    model_info=ModelInfoDelete(id=model_id),
+                    user_api_key_dict=non_admin,
+                )
+
+        assert str(exc_info.value.code) == "403"
+        mock_prisma.db.litellm_proxymodeltable.delete.assert_not_awaited()
+
+
 class TestGetTeamDeployments:
     """Tests for _get_team_deployments which filters by model_name prefix + Python-side team_id check."""
 


### PR DESCRIPTION
## Relevant issues

## Linear ticket

LIT-3635

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

A BYOK model added to a team stores `model_info.team_id`. Once the team is deleted the model is orphaned, and `POST /model/delete` used to reject it with `Team id=... does not exist in db`, so it lingered on the Models + Endpoints page with no way to remove it.

Reproduction against a live proxy (master key is proxy admin):

```bash
# 1) create a team
TID=$(curl -s "http://localhost:4000/team/new" -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" -d '{"team_alias":"demo"}' | jq -r .team_id)

# 2) add a BYOK model scoped to that team
MID=$(curl -s "http://localhost:4000/model/new" -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d "{\"model_name\":\"demo-byok\",\"litellm_params\":{\"model\":\"openai/gpt-4o-mini\",\"api_key\":\"sk-fake\"},\"model_info\":{\"team_id\":\"$TID\"}}" | jq -r .model_id)

# 3) delete the team
curl -s "http://localhost:4000/team/delete" -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" -d "{\"team_ids\":[\"$TID\"]}"

# 4) delete the now-orphaned model
curl -s -w "\nHTTP %{http_code}\n" "http://localhost:4000/model/delete" \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d "{\"id\":\"$MID\"}"
```

Before the fix, step 4 returned:

```
{"error":{"message":"{'error': 'Team id=... does not exist in db'}","type":"auth_error","code":"400"}}
HTTP 400
```

After the fix, the proxy admin can remove the orphan:

```
{"message":"Model: 39134476-6198-4965-b122-a9c92f746f94 deleted successfully"}
HTTP 200
```

The check is fail-closed; a non-admin key attempting the same delete is rejected rather than allowed through:

```
{"error":{"message":"{'error': 'Only a proxy admin can delete a model whose team has been deleted.'}","type":"auth_error","code":"403"}}
HTTP 403
```

Deleting a model whose team still exists, deleting a non-team model, and the team-admin auth path are all unchanged, and adding a model that references a non-existent team is still rejected.

## Type

🐛 Bug Fix

## Changes

`delete_model` no longer treats team existence as a prerequisite. It resolves the model's `team_id` and, when the team still exists, runs the existing `can_user_make_model_call` auth check unchanged. When the team is gone the model is orphaned, so a proxy admin may delete it and any other caller gets a 403. This is a positive authorization requirement rather than a skipped check, so a `None` or errored team lookup can only block the delete or require an admin, never grant a non-admin access. The add, update, and health paths keep their team-existence validation

Tests cover both the proxy-admin success and the non-admin rejection (asserting the row is not deleted), and both fail on the pre-fix code with the original `Team id=... does not exist in db` error
