### PR TITLE
fix(mcp): tolerate missing list results (fix #29826)

### DIFF
--- a/litellm/experimental_mcp_client/client.py
+++ b/litellm/experimental_mcp_client/client.py
@@ -86,6 +86,10 @@ class _LenientListPromptsResult(types.ListPromptsResult):
     prompts: List[Prompt] = Field(default_factory=list)
 
 
+class _LenientListToolsResult(types.ListToolsResult):
+    tools: List[MCPTool] = Field(default_factory=list)
+
+
 class _LenientListResourcesResult(types.ListResourcesResult):
     resources: List[Resource] = Field(default_factory=list)
 
@@ -521,7 +525,10 @@ class MCPClient:
         )
 
         async def _list_tools_operation(session: ClientSession):
-            return await session.list_tools()
+            return await session.send_request(
+                types.ClientRequest(types.ListToolsRequest(params=None)),
+                _LenientListToolsResult,
+            )
 
         try:
             result = await self.run_with_session(_list_tools_operation)

--- a/litellm/experimental_mcp_client/client.py
+++ b/litellm/experimental_mcp_client/client.py
@@ -18,6 +18,7 @@ from typing import (
     Union,
 )
 import httpx
+import mcp.types as types
 from mcp import ClientSession, ReadResourceResult, Resource, StdioServerParameters
 from mcp.client.sse import sse_client
 from mcp.client.stdio import stdio_client
@@ -41,7 +42,7 @@ from mcp.types import (
     TextContent,
 )
 from mcp.types import Tool as MCPTool
-from pydantic import AnyUrl
+from pydantic import AnyUrl, Field
 from litellm._logging import verbose_logger
 from litellm.constants import MCP_CLIENT_TIMEOUT, MCP_NPM_CACHE_DIR
 from litellm.llms.custom_httpx.http_handler import get_ssl_configuration
@@ -79,6 +80,14 @@ def _first_non_cancelled_cause(exc: BaseException) -> Optional[BaseException]:
         elif not isinstance(current, asyncio.CancelledError):
             return current
     return None
+
+
+class _LenientListPromptsResult(types.ListPromptsResult):
+    prompts: List[Prompt] = Field(default_factory=list)
+
+
+class _LenientListResourcesResult(types.ListResourcesResult):
+    resources: List[Resource] = Field(default_factory=list)
 
 
 TSessionResult = TypeVar("TSessionResult")
@@ -628,7 +637,10 @@ class MCPClient:
         )
 
         async def _list_prompts_operation(session: ClientSession):
-            return await session.list_prompts()
+            return await session.send_request(
+                types.ClientRequest(types.ListPromptsRequest(params=None)),
+                _LenientListPromptsResult,
+            )
 
         try:
             result = await self.run_with_session(_list_prompts_operation)
@@ -713,7 +725,10 @@ class MCPClient:
         )
 
         async def _list_resources_operation(session: ClientSession):
-            return await session.list_resources()
+            return await session.send_request(
+                types.ClientRequest(types.ListResourcesRequest(params=None)),
+                _LenientListResourcesResult,
+            )
 
         try:
             result = await self.run_with_session(_list_resources_operation)

--- a/tests/mcp_tests/test_mcp_client_unit.py
+++ b/tests/mcp_tests/test_mcp_client_unit.py
@@ -179,14 +179,19 @@ class TestMCPClientUnitTests:
         ]
         mock_result = MagicMock()
         mock_result.tools = mock_tools
-        mock_session_instance.list_tools.return_value = mock_result
+
+        async def send_request(_request, result_type):
+            assert result_type is mcp_client_module._LenientListToolsResult
+            return mock_result
+
+        mock_session_instance.send_request = AsyncMock(side_effect=send_request)
 
         client = MCPClient("http://example.com")
         result = await client.list_tools()
 
         assert result == mock_tools
         mock_session_instance.initialize.assert_called_once()
-        mock_session_instance.list_tools.assert_called_once()
+        mock_session_instance.send_request.assert_awaited_once()
 
     @pytest.mark.asyncio
     @patch.object(mcp_client_module, "streamable_http_client")

--- a/tests/mcp_tests/test_mcp_client_unit.py
+++ b/tests/mcp_tests/test_mcp_client_unit.py
@@ -194,6 +194,28 @@ class TestMCPClientUnitTests:
         mock_session_instance.send_request.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_list_tools_tolerates_missing_tools_field(self):
+        """Test listing tools when the upstream response omits empty tools."""
+        client = MCPClient("http://example.com")
+        mock_session = AsyncMock()
+
+        async def send_request(_request, result_type):
+            assert result_type is mcp_client_module._LenientListToolsResult
+            return result_type.model_validate({})
+
+        mock_session.send_request = AsyncMock(side_effect=send_request)
+
+        async def run_with_session(operation):
+            return await operation(mock_session)
+
+        client.run_with_session = AsyncMock(side_effect=run_with_session)
+
+        result = await client.list_tools()
+
+        assert result == []
+        mock_session.send_request.assert_awaited_once()
+
+    @pytest.mark.asyncio
     @patch.object(mcp_client_module, "streamable_http_client")
     @patch.object(mcp_client_module, "ClientSession")
     async def test_call_tool(self, mock_session_class, mock_transport):

--- a/tests/test_litellm/experimental_mcp_client/test_mcp_client.py
+++ b/tests/test_litellm/experimental_mcp_client/test_mcp_client.py
@@ -426,6 +426,53 @@ class TestMCPClientInstructionsCapture:
 
 
 # ---------------------------------------------------------------------------
+# MCP list result tolerance
+# ---------------------------------------------------------------------------
+
+
+class TestMCPListOperations:
+    """MCP list operations should tolerate omitted empty list fields."""
+
+    async def _run_list_operation(self, method_name, result_type):
+        client = MCPClient(server_url="http://example.com/mcp", transport_type="http")
+        session = AsyncMock()
+
+        async def send_request(_request, actual_result_type):
+            assert actual_result_type is result_type
+            return actual_result_type.model_validate({})
+
+        session.send_request = AsyncMock(side_effect=send_request)
+
+        async def run_with_session(operation):
+            return await operation(session)
+
+        client.run_with_session = AsyncMock(side_effect=run_with_session)
+
+        result = await getattr(client, method_name)()
+
+        assert result == []
+        session.send_request.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_list_tools_tolerates_missing_tools_field(self):
+        await self._run_list_operation(
+            "list_tools", mcp_client_module._LenientListToolsResult
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_resources_tolerates_missing_resources_field(self):
+        await self._run_list_operation(
+            "list_resources", mcp_client_module._LenientListResourcesResult
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_prompts_tolerates_missing_prompts_field(self):
+        await self._run_list_operation(
+            "list_prompts", mcp_client_module._LenientListPromptsResult
+        )
+
+
+# ---------------------------------------------------------------------------
 # Transport error surfacing
 # ---------------------------------------------------------------------------
 
@@ -541,44 +588,6 @@ class TestExecuteSessionOperationSurfacesTransportError:
 
         result = await client._execute_session_operation(transport_ctx, _op)
         assert result == "done"
-
-    @pytest.mark.asyncio
-    async def test_list_resources_tolerates_missing_resources_field(self):
-        client = MCPClient(server_url="http://example.com/mcp", transport_type="http")
-        session = AsyncMock()
-
-        async def send_request(_request, result_type):
-            assert result_type is mcp_client_module._LenientListResourcesResult
-            return result_type.model_validate({})
-
-        session.send_request = AsyncMock(side_effect=send_request)
-
-        async def run_with_session(operation):
-            return await operation(session)
-
-        client.run_with_session = AsyncMock(side_effect=run_with_session)
-
-        assert await client.list_resources() == []
-        session.send_request.assert_awaited_once()
-
-    @pytest.mark.asyncio
-    async def test_list_prompts_tolerates_missing_prompts_field(self):
-        client = MCPClient(server_url="http://example.com/mcp", transport_type="http")
-        session = AsyncMock()
-
-        async def send_request(_request, result_type):
-            assert result_type is mcp_client_module._LenientListPromptsResult
-            return result_type.model_validate({})
-
-        session.send_request = AsyncMock(side_effect=send_request)
-
-        async def run_with_session(operation):
-            return await operation(session)
-
-        client.run_with_session = AsyncMock(side_effect=run_with_session)
-
-        assert await client.list_prompts() == []
-        session.send_request.assert_awaited_once()
 
 
 if __name__ == "__main__":

--- a/tests/test_litellm/experimental_mcp_client/test_mcp_client.py
+++ b/tests/test_litellm/experimental_mcp_client/test_mcp_client.py
@@ -542,6 +542,44 @@ class TestExecuteSessionOperationSurfacesTransportError:
         result = await client._execute_session_operation(transport_ctx, _op)
         assert result == "done"
 
+    @pytest.mark.asyncio
+    async def test_list_resources_tolerates_missing_resources_field(self):
+        client = MCPClient(server_url="http://example.com/mcp", transport_type="http")
+        session = AsyncMock()
+
+        async def send_request(_request, result_type):
+            assert result_type is mcp_client_module._LenientListResourcesResult
+            return result_type.model_validate({})
+
+        session.send_request = AsyncMock(side_effect=send_request)
+
+        async def run_with_session(operation):
+            return await operation(session)
+
+        client.run_with_session = AsyncMock(side_effect=run_with_session)
+
+        assert await client.list_resources() == []
+        session.send_request.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_list_prompts_tolerates_missing_prompts_field(self):
+        client = MCPClient(server_url="http://example.com/mcp", transport_type="http")
+        session = AsyncMock()
+
+        async def send_request(_request, result_type):
+            assert result_type is mcp_client_module._LenientListPromptsResult
+            return result_type.model_validate({})
+
+        session.send_request = AsyncMock(side_effect=send_request)
+
+        async def run_with_session(operation):
+            return await operation(session)
+
+        client.run_with_session = AsyncMock(side_effect=run_with_session)
+
+        assert await client.list_prompts() == []
+        session.send_request.assert_awaited_once()
+
 
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
## Relevant issues

Fixes #29826

## Problem

Some upstream MCP servers return `{}` for `resources/list` when they have no resources. The MCP SDK model requires `resources`, so LiteLLM treats the response as a parse failure and drops the upstream list result. `prompts/list` has the same required-list shape.

## Fix

Use LiteLLM-local lenient result models for `list_resources` and `list_prompts`, with empty-list defaults for missing `resources` / `prompts`. This keeps the tolerance scoped to LiteLLM federation without patching the upstream MCP package globally.

## Test

- `PYTHONPATH=/tmp/litellm-mcp-inspect:. python3 -m pytest tests/test_litellm/experimental_mcp_client/test_mcp_client.py -q`
- Result: `25 passed in 1.45s`

Full `make test-unit` was not run in this local cron environment.

## Risk

Low. The change only affects MCP list operations and preserves the existing response shape when upstreams include the fields. Missing fields now become empty lists instead of parse failures.

## Type

🐛 Bug Fix
✅ Test

## Changes

- Added lenient local result models for MCP prompt/resource list responses.
- Added regression tests for missing `resources` and missing `prompts` fields.