### PR TITLE
feat(ui): adopt openapi-react-query as the typed data-fetching client

### DIFF
--- a/ui/litellm-dashboard/eslint-suppressions.json
+++ b/ui/litellm-dashboard/eslint-suppressions.json
@@ -4,31 +4,6 @@
       "count": 1
     }
   },
-  "src/app/(dashboard)/hooks/accessGroups/useAccessGroupDetails.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/hooks/accessGroups/useAccessGroups.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/hooks/accessGroups/useCreateAccessGroup.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/hooks/accessGroups/useDeleteAccessGroup.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/hooks/accessGroups/useEditAccessGroup.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
   "src/app/(dashboard)/hooks/blogPosts/useBlogPosts.ts": {
     "no-restricted-syntax": {
       "count": 1

--- a/ui/litellm-dashboard/package-lock.json
+++ b/ui/litellm-dashboard/package-lock.json
@@ -24,6 +24,8 @@
         "moment": "2.30.1",
         "next": "16.2.6",
         "openai": "4.104.0",
+        "openapi-fetch": "0.17.0",
+        "openapi-react-query": "0.5.4",
         "papaparse": "5.5.3",
         "react": "18.3.1",
         "react-copy-to-clipboard": "5.1.1",
@@ -10005,6 +10007,28 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "license": "MIT"
     },
+    "node_modules/openapi-fetch": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/openapi-fetch/-/openapi-fetch-0.17.0.tgz",
+      "integrity": "sha512-PsbZR1wAPcG91eEthKhN+Zn92FMHxv+/faECIwjXdxfTODGSGegYv0sc1Olz+HYPvKOuoXfp+0pA2XVt2cI0Ig==",
+      "license": "MIT",
+      "dependencies": {
+        "openapi-typescript-helpers": "^0.1.0"
+      }
+    },
+    "node_modules/openapi-react-query": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/openapi-react-query/-/openapi-react-query-0.5.4.tgz",
+      "integrity": "sha512-V9lRiozjHot19/BYSgXYoyznDxDJQhEBSdi26+SJ0UqjMANLQhkni4XG+Z7e3Ag7X46ZLMrL9VxYkghU3QvbWg==",
+      "license": "MIT",
+      "dependencies": {
+        "openapi-typescript-helpers": "^0.1.0"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.80.0",
+        "openapi-fetch": "^0.17.0"
+      }
+    },
     "node_modules/openapi-typescript": {
       "version": "7.13.0",
       "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-7.13.0.tgz",
@@ -10025,6 +10049,12 @@
       "peerDependencies": {
         "typescript": "^5.x"
       }
+    },
+    "node_modules/openapi-typescript-helpers": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/openapi-typescript-helpers/-/openapi-typescript-helpers-0.1.0.tgz",
+      "integrity": "sha512-OKTGPthhivLw/fHz6c3OPtg72vi86qaMlqbJuVJ23qOvQ+53uw1n7HdmkJFibloF7QEjDrDkzJiOJuockM/ljw==",
+      "license": "MIT"
     },
     "node_modules/openapi-typescript/node_modules/supports-color": {
       "version": "10.2.2",

--- a/ui/litellm-dashboard/package.json
+++ b/ui/litellm-dashboard/package.json
@@ -40,6 +40,8 @@
     "moment": "2.30.1",
     "next": "16.2.6",
     "openai": "4.104.0",
+    "openapi-fetch": "0.17.0",
+    "openapi-react-query": "0.5.4",
     "papaparse": "5.5.3",
     "react": "18.3.1",
     "react-copy-to-clipboard": "5.1.1",

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/accessGroups/useAccessGroupDetails.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/accessGroups/useAccessGroupDetails.ts
@@ -1,51 +1,25 @@
-import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { getProxyBaseUrl, getGlobalLitellmHeaderName, deriveErrorMessage, handleError } from "@/components/networking";
+import { useQueryClient } from "@tanstack/react-query";
+import { $api, authHeader } from "@/lib/http/api";
 import { all_admin_roles } from "@/utils/roles";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
-import { AccessGroupResponse, accessGroupKeys } from "./useAccessGroups";
-
-// ── Fetch function ───────────────────────────────────────────────────────────
-
-const fetchAccessGroupDetails = async (accessToken: string, accessGroupId: string): Promise<AccessGroupResponse> => {
-  const baseUrl = getProxyBaseUrl();
-  const url = `${baseUrl}/v1/access_group/${encodeURIComponent(accessGroupId)}`;
-
-  const response = await fetch(url, {
-    method: "GET",
-    headers: {
-      [getGlobalLitellmHeaderName()]: `Bearer ${accessToken}`,
-      "Content-Type": "application/json",
-    },
-  });
-
-  if (!response.ok) {
-    const errorData = await response.json();
-    const errorMessage = deriveErrorMessage(errorData);
-    handleError(errorMessage);
-    throw new Error(errorMessage);
-  }
-
-  return response.json();
-};
-
-// ── Hook ─────────────────────────────────────────────────────────────────────
+import { AccessGroupResponse } from "./useAccessGroups";
 
 export const useAccessGroupDetails = (accessGroupId?: string) => {
   const { accessToken, userRole } = useAuthorized();
   const queryClient = useQueryClient();
 
-  return useQuery<AccessGroupResponse>({
-    queryKey: accessGroupKeys.detail(accessGroupId!),
-    queryFn: async () => fetchAccessGroupDetails(accessToken!, accessGroupId!),
-    enabled: Boolean(accessToken && accessGroupId) && all_admin_roles.includes(userRole || ""),
-
-    // Seed from the list cache when available
-    initialData: () => {
-      if (!accessGroupId) return undefined;
-
-      const groups = queryClient.getQueryData<AccessGroupResponse[]>(accessGroupKeys.list({}));
-
-      return groups?.find((g) => g.access_group_id === accessGroupId);
+  return $api.useQuery(
+    "get",
+    "/v1/access_group/{access_group_id}",
+    { params: { path: { access_group_id: accessGroupId ?? "" } }, headers: authHeader(accessToken!) },
+    {
+      enabled: Boolean(accessToken && accessGroupId) && all_admin_roles.includes(userRole || ""),
+      initialData: () => {
+        if (!accessGroupId) return undefined;
+        const listKey = $api.queryOptions("get", "/v1/access_group", { headers: authHeader(accessToken!) }).queryKey;
+        const groups = queryClient.getQueryData<AccessGroupResponse[]>(listKey);
+        return groups?.find((g) => g.access_group_id === accessGroupId);
+      },
     },
-  });
+  );
 };

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/accessGroups/useAccessGroups.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/accessGroups/useAccessGroups.test.ts
@@ -1,242 +1,88 @@
-/* @vitest-environment jsdom */
-import React from "react";
-import { renderHook, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { useAccessGroups, AccessGroupResponse } from "./useAccessGroups";
-import * as networking from "@/components/networking";
+import React, { ReactNode } from "react";
+import { useAccessGroups } from "./useAccessGroups";
+import type { paths } from "@/lib/http/schema";
+
+type AccessGroupListResponse = paths["/v1/access_group"]["get"]["responses"][200]["content"]["application/json"];
+
+const { fetchMock } = vi.hoisted(() => {
+  const fetchMock = vi.fn();
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+  return { fetchMock };
+});
 
 vi.mock("@/components/networking", () => ({
-  getProxyBaseUrl: vi.fn(() => "http://proxy.example"),
-  getGlobalLitellmHeaderName: vi.fn(() => "Authorization"),
-  deriveErrorMessage: vi.fn((data: unknown) => (data as { detail?: string })?.detail ?? "Unknown error"),
-  handleError: vi.fn(),
+  getProxyBaseUrl: () => "http://localhost:4000",
+  getGlobalLitellmHeaderName: () => "Authorization",
 }));
 
+const mockUseAuthorized = vi.fn();
 vi.mock("@/app/(dashboard)/hooks/useAuthorized", () => ({
-  default: vi.fn(() => ({
-    accessToken: "test-token-123",
-    userRole: "Admin",
-  })),
+  default: () => mockUseAuthorized(),
 }));
 
-const createQueryClient = () =>
-  new QueryClient({
-    defaultOptions: {
-      queries: {
-        retry: false,
-        gcTime: 0,
-      },
-    },
-  });
+const DEFAULT_AUTH = { accessToken: "test-access-token", userRole: "Admin" };
 
-const wrapper = ({ children }: { children: React.ReactNode }) => {
-  const queryClient = createQueryClient();
-  return React.createElement(QueryClientProvider, { client: queryClient }, children);
-};
+const requestOf = (arg: unknown): Request => arg as Request;
+const jsonResponse = (body: unknown, status = 200): Response =>
+  new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
 
-const mockAccessToken = "test-token-123";
-const mockAccessGroups: AccessGroupResponse[] = [
+const groups: AccessGroupListResponse = [
   {
     access_group_id: "ag-1",
     access_group_name: "Group One",
-    description: "First group",
+    description: null,
     access_model_names: [],
     access_mcp_server_ids: [],
     access_agent_ids: [],
     assigned_team_ids: [],
     assigned_key_ids: [],
     created_at: "2025-01-01T00:00:00Z",
-    created_by: "user-1",
+    created_by: null,
     updated_at: "2025-01-01T00:00:00Z",
-    updated_by: "user-1",
+    updated_by: null,
   },
 ];
 
-const fetchMock = vi.fn();
-
 describe("useAccessGroups", () => {
-  beforeEach(async () => {
-    vi.clearAllMocks();
-    vi.mocked(networking.getProxyBaseUrl).mockReturnValue("http://proxy.example");
-    vi.mocked(networking.getGlobalLitellmHeaderName).mockReturnValue("Authorization");
+  let queryClient: QueryClient;
 
-    const useAuthorizedModule = await import("@/app/(dashboard)/hooks/useAuthorized");
-    vi.mocked(useAuthorizedModule.default).mockReturnValue({
-      accessToken: mockAccessToken,
-      userRole: "Admin",
-    } as any);
-
-    global.fetch = fetchMock;
+  beforeEach(() => {
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    fetchMock.mockReset();
+    mockUseAuthorized.mockReset();
+    mockUseAuthorized.mockReturnValue(DEFAULT_AUTH);
   });
 
-  it("should return hook result without errors", () => {
-    fetchMock.mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve([]),
-    } as Response);
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+  it("fetches GET /v1/access_group with the bearer header and returns typed data", async () => {
+    fetchMock.mockResolvedValue(jsonResponse(groups));
+    const { result } = renderHook(() => useAccessGroups(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const request = requestOf(fetchMock.mock.calls[0][0]);
+    expect(new URL(request.url).pathname).toBe("/v1/access_group");
+    expect(request.method).toBe("GET");
+    expect(request.headers.get("Authorization")).toBe("Bearer test-access-token");
+    expect(result.current.data?.[0].access_group_id).toBe("ag-1");
+  });
+
+  it.each([
+    ["null token", { accessToken: null }],
+    ["non-admin role", { userRole: "Internal User" }],
+  ])("does not fire a request when gated by %s", (_label, override) => {
+    fetchMock.mockResolvedValue(jsonResponse(groups));
+    mockUseAuthorized.mockReturnValue({ ...DEFAULT_AUTH, ...override });
 
     const { result } = renderHook(() => useAccessGroups(), { wrapper });
 
-    expect(result.current).toBeDefined();
-    expect(result.current).toHaveProperty("data");
-    expect(result.current).toHaveProperty("isSuccess");
-    expect(result.current).toHaveProperty("isError");
-    expect(result.current).toHaveProperty("status");
-  });
-
-  it("should return access groups when access token and admin role are present", async () => {
-    fetchMock.mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve(mockAccessGroups),
-    } as Response);
-
-    const { result } = renderHook(() => useAccessGroups(), { wrapper });
-
-    await waitFor(() => {
-      expect(result.current.isSuccess).toBe(true);
-    });
-
-    expect(fetchMock).toHaveBeenCalledWith(
-      "http://proxy.example/v1/access_group",
-      expect.objectContaining({
-        method: "GET",
-        headers: expect.objectContaining({
-          Authorization: `Bearer ${mockAccessToken}`,
-          "Content-Type": "application/json",
-        }),
-      }),
-    );
-    expect(result.current.data).toEqual(mockAccessGroups);
-  });
-
-  it("should not fetch when access token is null", async () => {
-    const useAuthorizedModule = await import("@/app/(dashboard)/hooks/useAuthorized");
-    vi.mocked(useAuthorizedModule.default).mockReturnValue({
-      accessToken: null,
-      userRole: "Admin",
-    } as any);
-
-    const { result } = renderHook(() => useAccessGroups(), { wrapper });
-
-    expect(result.current.isFetching).toBe(false);
     expect(result.current.isLoading).toBe(false);
-    expect(result.current.data).toBeUndefined();
+    expect(result.current.isFetched).toBe(false);
     expect(fetchMock).not.toHaveBeenCalled();
-  });
-
-  it("should not fetch when access token is empty string", async () => {
-    const useAuthorizedModule = await import("@/app/(dashboard)/hooks/useAuthorized");
-    vi.mocked(useAuthorizedModule.default).mockReturnValue({
-      accessToken: "",
-      userRole: "Admin",
-    } as any);
-
-    const { result } = renderHook(() => useAccessGroups(), { wrapper });
-
-    expect(result.current.isFetching).toBe(false);
-    expect(result.current.isLoading).toBe(false);
-    expect(result.current.data).toBeUndefined();
-    expect(fetchMock).not.toHaveBeenCalled();
-  });
-
-  it("should not fetch when user role is not an admin role", async () => {
-    const useAuthorizedModule = await import("@/app/(dashboard)/hooks/useAuthorized");
-    vi.mocked(useAuthorizedModule.default).mockReturnValue({
-      accessToken: mockAccessToken,
-      userRole: "Viewer",
-    } as any);
-
-    const { result } = renderHook(() => useAccessGroups(), { wrapper });
-
-    expect(result.current.isFetching).toBe(false);
-    expect(result.current.isLoading).toBe(false);
-    expect(result.current.data).toBeUndefined();
-    expect(fetchMock).not.toHaveBeenCalled();
-  });
-
-  it("should not fetch when user role is null", async () => {
-    const useAuthorizedModule = await import("@/app/(dashboard)/hooks/useAuthorized");
-    vi.mocked(useAuthorizedModule.default).mockReturnValue({
-      accessToken: mockAccessToken,
-      userRole: null,
-    } as any);
-
-    const { result } = renderHook(() => useAccessGroups(), { wrapper });
-
-    expect(result.current.isFetching).toBe(false);
-    expect(result.current.isLoading).toBe(false);
-    expect(result.current.data).toBeUndefined();
-    expect(fetchMock).not.toHaveBeenCalled();
-  });
-
-  it("should fetch when user role is proxy_admin", async () => {
-    const useAuthorizedModule = await import("@/app/(dashboard)/hooks/useAuthorized");
-    vi.mocked(useAuthorizedModule.default).mockReturnValue({
-      accessToken: mockAccessToken,
-      userRole: "proxy_admin",
-    } as any);
-
-    fetchMock.mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve(mockAccessGroups),
-    } as Response);
-
-    const { result } = renderHook(() => useAccessGroups(), { wrapper });
-
-    await waitFor(() => {
-      expect(result.current.isSuccess).toBe(true);
-    });
-
-    expect(fetchMock).toHaveBeenCalled();
-    expect(result.current.data).toEqual(mockAccessGroups);
-  });
-
-  it("should expose error state when fetch fails", async () => {
-    fetchMock.mockResolvedValue({
-      ok: false,
-      json: () => Promise.resolve({ detail: "Forbidden" }),
-    } as Response);
-    vi.mocked(networking.deriveErrorMessage).mockReturnValue("Forbidden");
-
-    const { result } = renderHook(() => useAccessGroups(), { wrapper });
-
-    await waitFor(() => {
-      expect(result.current.isError).toBe(true);
-    });
-
-    expect(result.current.error).toBeInstanceOf(Error);
-    expect((result.current.error as Error).message).toBe("Forbidden");
-    expect(result.current.data).toBeUndefined();
-    expect(networking.handleError).toHaveBeenCalledWith("Forbidden");
-  });
-
-  it("should return empty array when API returns empty list", async () => {
-    fetchMock.mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve([]),
-    } as Response);
-
-    const { result } = renderHook(() => useAccessGroups(), { wrapper });
-
-    await waitFor(() => {
-      expect(result.current.isSuccess).toBe(true);
-    });
-
-    expect(result.current.data).toEqual([]);
-  });
-
-  it("should propagate network errors", async () => {
-    const networkError = new Error("Network failure");
-    fetchMock.mockRejectedValue(networkError);
-
-    const { result } = renderHook(() => useAccessGroups(), { wrapper });
-
-    await waitFor(() => {
-      expect(result.current.isError).toBe(true);
-    });
-
-    expect(result.current.error).toEqual(networkError);
-    expect(result.current.data).toBeUndefined();
   });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/accessGroups/useAccessGroups.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/accessGroups/useAccessGroups.ts
@@ -1,62 +1,17 @@
-import { useQuery } from "@tanstack/react-query";
-import { createQueryKeys } from "../common/queryKeysFactory";
-import { getProxyBaseUrl, getGlobalLitellmHeaderName, deriveErrorMessage, handleError } from "@/components/networking";
+import type { components } from "@/lib/http/schema";
+import { $api, authHeader } from "@/lib/http/api";
 import { all_admin_roles } from "@/utils/roles";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 
-// ── Types ────────────────────────────────────────────────────────────────────
-
-export interface AccessGroupResponse {
-  access_group_id: string;
-  access_group_name: string;
-  description: string | null;
-  access_model_names: string[];
-  access_mcp_server_ids: string[];
-  access_agent_ids: string[];
-  assigned_team_ids: string[];
-  assigned_key_ids: string[];
-  created_at: string;
-  created_by: string | null;
-  updated_at: string;
-  updated_by: string | null;
-}
-
-// ── Query keys (shared across access-group hooks) ────────────────────────────
-
-export const accessGroupKeys = createQueryKeys("accessGroups");
-
-// ── Fetch function ───────────────────────────────────────────────────────────
-
-const fetchAccessGroups = async (accessToken: string): Promise<AccessGroupResponse[]> => {
-  const baseUrl = getProxyBaseUrl();
-  const url = `${baseUrl}/v1/access_group`;
-
-  const response = await fetch(url, {
-    method: "GET",
-    headers: {
-      [getGlobalLitellmHeaderName()]: `Bearer ${accessToken}`,
-      "Content-Type": "application/json",
-    },
-  });
-
-  if (!response.ok) {
-    const errorData = await response.json();
-    const errorMessage = deriveErrorMessage(errorData);
-    handleError(errorMessage);
-    throw new Error(errorMessage);
-  }
-
-  return response.json();
-};
-
-// ── Hook ─────────────────────────────────────────────────────────────────────
+export type AccessGroupResponse = components["schemas"]["AccessGroupResponse"];
 
 export const useAccessGroups = () => {
   const { accessToken, userRole } = useAuthorized();
 
-  return useQuery<AccessGroupResponse[]>({
-    queryKey: accessGroupKeys.list({}),
-    queryFn: async () => fetchAccessGroups(accessToken!),
-    enabled: Boolean(accessToken) && all_admin_roles.includes(userRole || ""),
-  });
+  return $api.useQuery(
+    "get",
+    "/v1/access_group",
+    { headers: authHeader(accessToken!) },
+    { enabled: Boolean(accessToken) && all_admin_roles.includes(userRole || "") },
+  );
 };

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/accessGroups/useCreateAccessGroup.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/accessGroups/useCreateAccessGroup.test.ts
@@ -11,7 +11,7 @@ const { fetchMock } = vi.hoisted(() => {
 });
 
 const handleError = vi.fn();
-const deriveErrorMessage = vi.fn(() => "derived message");
+const deriveErrorMessage = vi.fn((..._args: unknown[]) => "derived message");
 vi.mock("@/components/networking", () => ({
   getProxyBaseUrl: () => "http://localhost:4000",
   getGlobalLitellmHeaderName: () => "Authorization",

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/accessGroups/useCreateAccessGroup.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/accessGroups/useCreateAccessGroup.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React, { ReactNode } from "react";
+import { useCreateAccessGroup } from "./useCreateAccessGroup";
+
+const { fetchMock } = vi.hoisted(() => {
+  const fetchMock = vi.fn();
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+  return { fetchMock };
+});
+
+const handleError = vi.fn();
+const deriveErrorMessage = vi.fn(() => "derived message");
+vi.mock("@/components/networking", () => ({
+  getProxyBaseUrl: () => "http://localhost:4000",
+  getGlobalLitellmHeaderName: () => "Authorization",
+  handleError: (...args: unknown[]) => handleError(...args),
+  deriveErrorMessage: (...args: unknown[]) => deriveErrorMessage(...args),
+}));
+
+vi.mock("@/app/(dashboard)/hooks/useAuthorized", () => ({
+  default: () => ({ accessToken: "test-access-token" }),
+}));
+
+const requestOf = (arg: unknown): Request => arg as Request;
+const jsonResponse = (body: unknown, status = 200): Response =>
+  new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+
+const created = { access_group_id: "ag-new", access_group_name: "New Group" };
+
+describe("useCreateAccessGroup", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    fetchMock.mockReset();
+    handleError.mockReset();
+    deriveErrorMessage.mockClear();
+  });
+
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+  it("POSTs the body to /v1/access_group with the bearer header", async () => {
+    fetchMock.mockResolvedValue(jsonResponse(created, 201));
+    const { result } = renderHook(() => useCreateAccessGroup(), { wrapper });
+
+    result.current.mutate({ access_group_name: "New Group", access_model_names: ["gpt-4o"] });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const request = requestOf(fetchMock.mock.calls[0][0]);
+    expect(new URL(request.url).pathname).toBe("/v1/access_group");
+    expect(request.method).toBe("POST");
+    expect(request.headers.get("Authorization")).toBe("Bearer test-access-token");
+    expect(await request.json()).toEqual({ access_group_name: "New Group", access_model_names: ["gpt-4o"] });
+  });
+
+  it("invalidates the access-group list on success", async () => {
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries");
+    fetchMock.mockResolvedValue(jsonResponse(created, 201));
+    const { result } = renderHook(() => useCreateAccessGroup(), { wrapper });
+
+    result.current.mutate({ access_group_name: "New Group" });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ["get", "/v1/access_group"] });
+  });
+
+  it("routes a failed create through the global error handler", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ detail: "boom" }, 400));
+    const { result } = renderHook(() => useCreateAccessGroup(), { wrapper });
+
+    result.current.mutate({ access_group_name: "New Group" });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(deriveErrorMessage).toHaveBeenCalled();
+    expect(handleError).toHaveBeenCalledWith("derived message");
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/accessGroups/useCreateAccessGroup.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/accessGroups/useCreateAccessGroup.ts
@@ -1,63 +1,25 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { getProxyBaseUrl, getGlobalLitellmHeaderName, deriveErrorMessage, handleError } from "@/components/networking";
+import { useQueryClient } from "@tanstack/react-query";
+import type { components } from "@/lib/http/schema";
+import { $api, authHeader } from "@/lib/http/api";
+import { handleError, deriveErrorMessage } from "@/components/networking";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
-import { AccessGroupResponse, accessGroupKeys } from "./useAccessGroups";
 
-// ── Types ────────────────────────────────────────────────────────────────────
-
-export interface AccessGroupCreateParams {
-  access_group_name: string;
-  description?: string | null;
-  access_model_names?: string[];
-  access_mcp_server_ids?: string[];
-  access_agent_ids?: string[];
-  assigned_team_ids?: string[];
-  assigned_key_ids?: string[];
-}
-
-// ── Fetch function ───────────────────────────────────────────────────────────
-
-const createAccessGroup = async (
-  accessToken: string,
-  params: AccessGroupCreateParams,
-): Promise<AccessGroupResponse> => {
-  const baseUrl = getProxyBaseUrl();
-  const url = `${baseUrl}/v1/access_group`;
-
-  const response = await fetch(url, {
-    method: "POST",
-    headers: {
-      [getGlobalLitellmHeaderName()]: `Bearer ${accessToken}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(params),
-  });
-
-  if (!response.ok) {
-    const errorData = await response.json();
-    const errorMessage = deriveErrorMessage(errorData);
-    handleError(errorMessage);
-    throw new Error(errorMessage);
-  }
-
-  return response.json();
-};
-
-// ── Hook ─────────────────────────────────────────────────────────────────────
+export type AccessGroupCreateParams = components["schemas"]["AccessGroupCreateRequest"];
 
 export const useCreateAccessGroup = () => {
   const { accessToken } = useAuthorized();
   const queryClient = useQueryClient();
 
-  return useMutation<AccessGroupResponse, Error, AccessGroupCreateParams>({
-    mutationFn: async (params) => {
-      if (!accessToken) {
-        throw new Error("Access token is required");
-      }
-      return createAccessGroup(accessToken, params);
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: accessGroupKeys.all });
-    },
+  const mutation = $api.useMutation("post", "/v1/access_group", {
+    onError: (error) => handleError(deriveErrorMessage(error)),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["get", "/v1/access_group"] }),
   });
+
+  return {
+    ...mutation,
+    mutate: (body: AccessGroupCreateParams, options?: Parameters<typeof mutation.mutate>[1]) =>
+      mutation.mutate({ body, headers: authHeader(accessToken!) }, options),
+    mutateAsync: (body: AccessGroupCreateParams, options?: Parameters<typeof mutation.mutateAsync>[1]) =>
+      mutation.mutateAsync({ body, headers: authHeader(accessToken!) }, options),
+  };
 };

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/accessGroups/useDeleteAccessGroup.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/accessGroups/useDeleteAccessGroup.ts
@@ -1,47 +1,28 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { getProxyBaseUrl, getGlobalLitellmHeaderName, deriveErrorMessage, handleError } from "@/components/networking";
+import { useQueryClient } from "@tanstack/react-query";
+import { $api, authHeader } from "@/lib/http/api";
+import { handleError, deriveErrorMessage } from "@/components/networking";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
-import { accessGroupKeys } from "./useAccessGroups";
-
-// ── Fetch function ───────────────────────────────────────────────────────────
-
-const deleteAccessGroup = async (accessToken: string, accessGroupId: string): Promise<void> => {
-  const baseUrl = getProxyBaseUrl();
-  const url = `${baseUrl}/v1/access_group/${encodeURIComponent(accessGroupId)}`;
-
-  const response = await fetch(url, {
-    method: "DELETE",
-    headers: {
-      [getGlobalLitellmHeaderName()]: `Bearer ${accessToken}`,
-      "Content-Type": "application/json",
-    },
-  });
-
-  if (!response.ok) {
-    const errorData = await response.json();
-    const errorMessage = deriveErrorMessage(errorData);
-    handleError(errorMessage);
-    throw new Error(errorMessage);
-  }
-
-  // 204 No Content — nothing to parse
-};
-
-// ── Hook ─────────────────────────────────────────────────────────────────────
 
 export const useDeleteAccessGroup = () => {
   const { accessToken } = useAuthorized();
   const queryClient = useQueryClient();
 
-  return useMutation<void, Error, string>({
-    mutationFn: async (accessGroupId) => {
-      if (!accessToken) {
-        throw new Error("Access token is required");
-      }
-      return deleteAccessGroup(accessToken, accessGroupId);
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: accessGroupKeys.all });
-    },
+  const mutation = $api.useMutation("delete", "/v1/access_group/{access_group_id}", {
+    onError: (error) => handleError(deriveErrorMessage(error)),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["get", "/v1/access_group"] }),
   });
+
+  return {
+    ...mutation,
+    mutate: (accessGroupId: string, options?: Parameters<typeof mutation.mutate>[1]) =>
+      mutation.mutate(
+        { params: { path: { access_group_id: accessGroupId } }, headers: authHeader(accessToken!) },
+        options,
+      ),
+    mutateAsync: (accessGroupId: string, options?: Parameters<typeof mutation.mutateAsync>[1]) =>
+      mutation.mutateAsync(
+        { params: { path: { access_group_id: accessGroupId } }, headers: authHeader(accessToken!) },
+        options,
+      ),
+  };
 };

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/accessGroups/useEditAccessGroup.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/accessGroups/useEditAccessGroup.ts
@@ -1,72 +1,42 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { getProxyBaseUrl, getGlobalLitellmHeaderName, deriveErrorMessage, handleError } from "@/components/networking";
+import { useQueryClient } from "@tanstack/react-query";
+import type { components } from "@/lib/http/schema";
+import { $api, authHeader } from "@/lib/http/api";
+import { handleError, deriveErrorMessage } from "@/components/networking";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
-import { AccessGroupResponse, accessGroupKeys } from "./useAccessGroups";
 
-// ── Types ────────────────────────────────────────────────────────────────────
-
-export interface AccessGroupUpdateParams {
-  access_group_name?: string;
-  description?: string | null;
-  access_model_names?: string[];
-  access_mcp_server_ids?: string[];
-  access_agent_ids?: string[];
-  assigned_team_ids?: string[];
-  assigned_key_ids?: string[];
-}
+export type AccessGroupUpdateParams = components["schemas"]["AccessGroupUpdateRequest"];
 
 export interface EditAccessGroupVariables {
   accessGroupId: string;
   params: AccessGroupUpdateParams;
 }
 
-// ── Fetch function ───────────────────────────────────────────────────────────
-
-const updateAccessGroup = async (
-  accessToken: string,
-  accessGroupId: string,
-  params: AccessGroupUpdateParams,
-): Promise<AccessGroupResponse> => {
-  const baseUrl = getProxyBaseUrl();
-  const url = `${baseUrl}/v1/access_group/${encodeURIComponent(accessGroupId)}`;
-
-  const response = await fetch(url, {
-    method: "PUT",
-    headers: {
-      [getGlobalLitellmHeaderName()]: `Bearer ${accessToken}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(params),
-  });
-
-  if (!response.ok) {
-    const errorData = await response.json();
-    const errorMessage = deriveErrorMessage(errorData);
-    handleError(errorMessage);
-    throw new Error(errorMessage);
-  }
-
-  return response.json();
-};
-
-// ── Hook ─────────────────────────────────────────────────────────────────────
-
 export const useEditAccessGroup = () => {
   const { accessToken } = useAuthorized();
   const queryClient = useQueryClient();
 
-  return useMutation<AccessGroupResponse, Error, EditAccessGroupVariables>({
-    mutationFn: async ({ accessGroupId, params }) => {
-      if (!accessToken) {
-        throw new Error("Access token is required");
-      }
-      return updateAccessGroup(accessToken, accessGroupId, params);
-    },
-    onSuccess: (_data, { accessGroupId }) => {
-      queryClient.invalidateQueries({ queryKey: accessGroupKeys.all });
-      queryClient.invalidateQueries({
-        queryKey: accessGroupKeys.detail(accessGroupId),
-      });
+  const mutation = $api.useMutation("put", "/v1/access_group/{access_group_id}", {
+    onError: (error) => handleError(deriveErrorMessage(error)),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["get", "/v1/access_group"] });
+      queryClient.invalidateQueries({ queryKey: ["get", "/v1/access_group/{access_group_id}"] });
     },
   });
+
+  return {
+    ...mutation,
+    mutate: ({ accessGroupId, params }: EditAccessGroupVariables, options?: Parameters<typeof mutation.mutate>[1]) =>
+      mutation.mutate(
+        { params: { path: { access_group_id: accessGroupId } }, body: params, headers: authHeader(accessToken!) },
+        options,
+      ),
+    mutateAsync: (
+      { accessGroupId, params }: EditAccessGroupVariables,
+      options?: Parameters<typeof mutation.mutateAsync>[1],
+    ) =>
+      mutation.mutateAsync(
+        { params: { path: { access_group_id: accessGroupId } }, body: params, headers: authHeader(accessToken!) },
+        options,
+      ),
+  };
 };

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/keys/useKeys.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/keys/useKeys.ts
@@ -1,6 +1,6 @@
 import { keepPreviousData, useQuery, UseQueryResult } from "@tanstack/react-query";
 import { createQueryKeys } from "../common/queryKeysFactory";
-import { getProxyBaseUrl, getGlobalLitellmHeaderName, deriveErrorMessage, handleError } from "@/components/networking";
+import { getProxyBaseUrl, getGlobalLitellmHeaderName, deriveErrorMessage } from "@/components/networking";
 import { KeyResponse } from "@/components/key_team_helpers/key_list";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 
@@ -85,7 +85,6 @@ const keyListCall = async (accessToken: string, page: number, pageSize: number, 
     if (!response.ok) {
       const errorData = await response.json();
       const errorMessage = deriveErrorMessage(errorData);
-      handleError(errorMessage);
       throw new Error(errorMessage);
     }
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/projects/useProjectDetails.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/projects/useProjectDetails.ts
@@ -1,5 +1,5 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { getProxyBaseUrl, getGlobalLitellmHeaderName, deriveErrorMessage, handleError } from "@/components/networking";
+import { getProxyBaseUrl, getGlobalLitellmHeaderName, deriveErrorMessage } from "@/components/networking";
 import { all_admin_roles } from "@/utils/roles";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 import { ProjectResponse, projectKeys } from "./useProjects";
@@ -21,7 +21,6 @@ const fetchProjectDetails = async (accessToken: string, projectId: string): Prom
   if (!response.ok) {
     const errorData = await response.json();
     const errorMessage = deriveErrorMessage(errorData);
-    handleError(errorMessage);
     throw new Error(errorMessage);
   }
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/projects/useProjects.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/projects/useProjects.ts
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { createQueryKeys } from "../common/queryKeysFactory";
-import { getProxyBaseUrl, getGlobalLitellmHeaderName, deriveErrorMessage, handleError } from "@/components/networking";
+import { getProxyBaseUrl, getGlobalLitellmHeaderName, deriveErrorMessage } from "@/components/networking";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 import { all_admin_roles, internalUserRoles } from "@/utils/roles";
 
@@ -61,7 +61,6 @@ const fetchProjects = async (accessToken: string): Promise<ProjectResponse[]> =>
   if (!response.ok) {
     const errorData = await response.json();
     const errorMessage = deriveErrorMessage(errorData);
-    handleError(errorMessage);
     throw new Error(errorMessage);
   }
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/proxyConfig/useProxyConfig.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/proxyConfig/useProxyConfig.ts
@@ -89,7 +89,6 @@ export const getProxyConfigCall = async (accessToken: string, configType: Config
     if (!response.ok) {
       const errorData = await response.json();
       const errorMessage = deriveErrorMessage(errorData);
-      handleError(errorMessage);
       throw new Error(errorMessage);
     }
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/teams/useTeams.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/teams/useTeams.ts
@@ -4,7 +4,7 @@ import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 import { fetchTeams } from "@/app/(dashboard)/networking";
 import { createQueryKeys } from "@/app/(dashboard)/hooks/common/queryKeysFactory";
 import { teamInfoCall } from "@/components/networking";
-import { getProxyBaseUrl, getGlobalLitellmHeaderName, deriveErrorMessage, handleError } from "@/components/networking";
+import { getProxyBaseUrl, getGlobalLitellmHeaderName, deriveErrorMessage } from "@/components/networking";
 
 export interface TeamsResponse {
   teams: Team[];
@@ -72,7 +72,6 @@ export const teamListCall = async (
     if (!response.ok) {
       const errorData = await response.json();
       const errorMessage = deriveErrorMessage(errorData);
-      handleError(errorMessage);
       throw new Error(errorMessage);
     }
 
@@ -220,7 +219,6 @@ const deletedTeamListCall = async (
     if (!response.ok) {
       const errorData = await response.json();
       const errorMessage = deriveErrorMessage(errorData);
-      handleError(errorMessage);
       throw new Error(errorMessage);
     }
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/users/useUsers.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/users/useUsers.test.ts
@@ -130,6 +130,14 @@ describe("useInfiniteUsers", () => {
     expect(lastRequestUrl(mock).searchParams.has("user_email")).toBe(false);
   });
 
+  it("omits user_email when searchEmail is an empty string", async () => {
+    const mock = stubPagedFetch(1);
+    const { result } = renderHook(() => useInfiniteUsers(50, ""), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(lastRequestUrl(mock).searchParams.has("user_email")).toBe(false);
+  });
+
   it("fetches the next page with an incremented page param", async () => {
     const mock = stubPagedFetch(3);
     const { result } = renderHook(() => useInfiniteUsers(), { wrapper });

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/users/useUsers.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/users/useUsers.test.ts
@@ -3,21 +3,24 @@ import { renderHook, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import React, { ReactNode } from "react";
 import { useInfiniteUsers } from "./useUsers";
-import { userListCall } from "@/components/networking";
-import type { UserListResponse } from "@/components/networking";
+import type { paths } from "@/lib/http/schema";
 
+type UserListResponse = paths["/user/list"]["get"]["responses"][200]["content"]["application/json"];
+
+// openapi-fetch captures globalThis.fetch when the client is created (at import time), so the
+// mock must be installed before imports run — hence vi.hoisted. Per test we reconfigure its
+// implementation; the captured reference stays the same.
+const { fetchMock } = vi.hoisted(() => {
+  const fetchMock = vi.fn();
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+  return { fetchMock };
+});
+
+// api.ts only needs the base URL + auth header name from networking; mock those so the
+// test doesn't pull in the whole networking module.
 vi.mock("@/components/networking", () => ({
-  userListCall: vi.fn(),
-}));
-
-vi.mock("../common/queryKeysFactory", () => ({
-  createQueryKeys: vi.fn((resource: string) => ({
-    all: [resource],
-    lists: () => [resource, "list"],
-    list: (params?: any) => [resource, "list", { params }],
-    details: () => [resource, "detail"],
-    detail: (uid: string) => [resource, "detail", uid],
-  })),
+  getProxyBaseUrl: () => "http://localhost:4000",
+  getGlobalLitellmHeaderName: () => "Authorization",
 }));
 
 const mockUseAuthorized = vi.fn();
@@ -36,134 +39,102 @@ const DEFAULT_AUTH = {
   showSSOBanner: false,
 };
 
-const buildUserListResponse = (page: number, totalPages: number, userCount = 2): UserListResponse => ({
-  page,
-  page_size: 50,
-  total: totalPages * userCount,
-  total_pages: totalPages,
-  users: Array.from({ length: userCount }, (_, i) => ({
-    user_id: `user-${page}-${i}`,
-    user_email: `user-${page}-${i}@example.com`,
-    user_alias: null,
-    user_role: "Internal User",
-    spend: 0,
-    max_budget: null,
-    key_count: 0,
-    created_at: "2024-01-01T00:00:00Z",
-    updated_at: "2024-01-01T00:00:00Z",
-    sso_user_id: null,
-    budget_duration: null,
-  })),
-});
+const buildUserListResponse = (page: number, totalPages: number, userCount = 2): UserListResponse =>
+  ({
+    page,
+    page_size: 50,
+    total: totalPages * userCount,
+    total_pages: totalPages,
+    users: Array.from({ length: userCount }, (_, i) => ({
+      user_id: `user-${page}-${i}`,
+      user_email: `user-${page}-${i}@example.com`,
+      user_role: "internal_user",
+      key_count: 0,
+    })),
+  }) as UserListResponse;
+
+const requestOf = (arg: unknown): Request => arg as Request;
+
+const jsonResponse = (body: unknown, status = 200): Response =>
+  new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+
+/** Serve buildUserListResponse for whatever `page` the request asks for. */
+const stubPagedFetch = (totalPages: number, userCount = 2) => {
+  fetchMock.mockImplementation(async (arg: unknown) => {
+    const url = new URL(requestOf(arg).url);
+    const page = Number(url.searchParams.get("page") ?? "1");
+    return jsonResponse(buildUserListResponse(page, totalPages, userCount));
+  });
+  return fetchMock;
+};
+
+const lastRequestUrl = (mock: typeof fetchMock): URL => new URL(requestOf(mock.mock.calls.at(-1)![0]).url);
 
 describe("useInfiniteUsers", () => {
   let queryClient: QueryClient;
 
   beforeEach(() => {
-    queryClient = new QueryClient({
-      defaultOptions: {
-        queries: {
-          retry: false,
-        },
-      },
-    });
-    vi.clearAllMocks();
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    fetchMock.mockReset();
+    mockUseAuthorized.mockReset();
     mockUseAuthorized.mockReturnValue(DEFAULT_AUTH);
   });
 
   const wrapper = ({ children }: { children: ReactNode }) =>
     React.createElement(QueryClientProvider, { client: queryClient }, children);
 
-  it("should return paginated user data when query is successful", async () => {
-    const mockResponse = buildUserListResponse(1, 2);
-    (userListCall as any).mockResolvedValue(mockResponse);
-
+  it("returns the first page of typed user data on success", async () => {
+    stubPagedFetch(2);
     const { result } = renderHook(() => useInfiniteUsers(), { wrapper });
 
-    await waitFor(() => {
-      expect(result.current.isSuccess).toBe(true);
-    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(result.current.data?.pages).toHaveLength(1);
-    expect(result.current.data?.pages[0]).toEqual(mockResponse);
-    expect(userListCall).toHaveBeenCalledWith("test-access-token", null, 1, 50, null);
+    expect(result.current.data?.pages[0].users[0].user_id).toBe("user-1-0");
   });
 
-  it("should use the default page size of 50", async () => {
-    const mockResponse = buildUserListResponse(1, 1);
-    (userListCall as any).mockResolvedValue(mockResponse);
-
+  it("requests page 1 with the default page size and the bearer auth header", async () => {
+    const mock = stubPagedFetch(1);
     const { result } = renderHook(() => useInfiniteUsers(), { wrapper });
 
-    await waitFor(() => {
-      expect(result.current.isSuccess).toBe(true);
-    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(userListCall).toHaveBeenCalledWith("test-access-token", null, 1, 50, null);
+    const url = lastRequestUrl(mock);
+    expect(url.pathname).toBe("/user/list");
+    expect(url.searchParams.get("page")).toBe("1");
+    expect(url.searchParams.get("page_size")).toBe("50");
+    expect(requestOf(mock.mock.calls[0][0]).headers.get("Authorization")).toBe("Bearer test-access-token");
   });
 
-  it("should use a custom page size when provided", async () => {
-    const customPageSize = 25;
-    const mockResponse = buildUserListResponse(1, 1, 5);
-    (userListCall as any).mockResolvedValue(mockResponse);
+  it("sends a custom page size when provided", async () => {
+    const mock = stubPagedFetch(1, 5);
+    const { result } = renderHook(() => useInfiniteUsers(25), { wrapper });
 
-    const { result } = renderHook(() => useInfiniteUsers(customPageSize), {
-      wrapper,
-    });
-
-    await waitFor(() => {
-      expect(result.current.isSuccess).toBe(true);
-    });
-
-    expect(userListCall).toHaveBeenCalledWith("test-access-token", null, 1, customPageSize, null);
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(lastRequestUrl(mock).searchParams.get("page_size")).toBe("25");
   });
 
-  it("should pass searchEmail to userListCall when provided", async () => {
-    const searchEmail = "search@example.com";
-    const mockResponse = buildUserListResponse(1, 1, 1);
-    (userListCall as any).mockResolvedValue(mockResponse);
+  it("maps searchEmail to the user_email query param", async () => {
+    const mock = stubPagedFetch(1, 1);
+    const { result } = renderHook(() => useInfiniteUsers(50, "search@example.com"), { wrapper });
 
-    const { result } = renderHook(() => useInfiniteUsers(50, searchEmail), {
-      wrapper,
-    });
-
-    await waitFor(() => {
-      expect(result.current.isSuccess).toBe(true);
-    });
-
-    expect(userListCall).toHaveBeenCalledWith("test-access-token", null, 1, 50, searchEmail);
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(lastRequestUrl(mock).searchParams.get("user_email")).toBe("search@example.com");
   });
 
-  it("should pass null for searchEmail when not provided", async () => {
-    const mockResponse = buildUserListResponse(1, 1);
-    (userListCall as any).mockResolvedValue(mockResponse);
+  it("omits user_email when no searchEmail is given", async () => {
+    const mock = stubPagedFetch(1);
+    const { result } = renderHook(() => useInfiniteUsers(50), { wrapper });
 
-    const { result } = renderHook(() => useInfiniteUsers(50, undefined), {
-      wrapper,
-    });
-
-    await waitFor(() => {
-      expect(result.current.isSuccess).toBe(true);
-    });
-
-    expect(userListCall).toHaveBeenCalledWith("test-access-token", null, 1, 50, null);
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(lastRequestUrl(mock).searchParams.has("user_email")).toBe(false);
   });
 
-  it("should fetch the next page when more pages are available", async () => {
-    const page1 = buildUserListResponse(1, 3);
-    const page2 = buildUserListResponse(2, 3);
-    let callCount = 0;
-    (userListCall as any).mockImplementation(async () => {
-      callCount++;
-      return callCount === 1 ? page1 : page2;
-    });
-
+  it("fetches the next page with an incremented page param", async () => {
+    const mock = stubPagedFetch(3);
     const { result } = renderHook(() => useInfiniteUsers(), { wrapper });
 
-    await waitFor(() => {
-      expect(result.current.isSuccess).toBe(true);
-    });
-
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.hasNextPage).toBe(true);
 
     result.current.fetchNextPage();
@@ -173,115 +144,53 @@ describe("useInfiniteUsers", () => {
       expect(result.current.data?.pages).toHaveLength(2);
     });
 
-    expect(result.current.data?.pages[1]).toEqual(page2);
-    expect(userListCall).toHaveBeenCalledTimes(2);
-    expect(userListCall).toHaveBeenLastCalledWith("test-access-token", null, 2, 50, null);
+    expect(result.current.data?.pages[1].page).toBe(2);
+    expect(mock).toHaveBeenCalledTimes(2);
+    expect(lastRequestUrl(mock).searchParams.get("page")).toBe("2");
   });
 
-  it("should not have a next page when on the last page", async () => {
-    const lastPage = buildUserListResponse(2, 2);
-    (userListCall as any).mockResolvedValue(lastPage);
-
+  it("has no next page on the last page", async () => {
+    stubPagedFetch(1);
     const { result } = renderHook(() => useInfiniteUsers(), { wrapper });
 
-    await waitFor(() => {
-      expect(result.current.isSuccess).toBe(true);
-    });
-
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.hasNextPage).toBe(false);
   });
 
-  it("should not execute query when accessToken is missing", async () => {
-    mockUseAuthorized.mockReturnValue({
-      ...DEFAULT_AUTH,
-      accessToken: null,
-    });
+  it("surfaces an error when the request fails", async () => {
+    fetchMock.mockImplementation(async () => jsonResponse({ detail: "boom" }, 500));
+
+    const { result } = renderHook(() => useInfiniteUsers(), { wrapper });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it.each([
+    ["null token", { accessToken: null }],
+    ["non-admin role", { userRole: "Internal User" }],
+  ])("does not fire a request when gated by %s", async (_label, override) => {
+    const mock = stubPagedFetch(1);
+    mockUseAuthorized.mockReturnValue({ ...DEFAULT_AUTH, ...override });
 
     const { result } = renderHook(() => useInfiniteUsers(), { wrapper });
 
     expect(result.current.isLoading).toBe(false);
-    expect(result.current.data).toBeUndefined();
     expect(result.current.isFetched).toBe(false);
-    expect(userListCall).not.toHaveBeenCalled();
+    expect(mock).not.toHaveBeenCalled();
   });
 
-  it("should not execute query when userRole is not an admin role", async () => {
-    mockUseAuthorized.mockReturnValue({
-      ...DEFAULT_AUTH,
-      userRole: "Internal User",
-    });
-
-    const { result } = renderHook(() => useInfiniteUsers(), { wrapper });
-
-    expect(result.current.isLoading).toBe(false);
-    expect(result.current.data).toBeUndefined();
-    expect(result.current.isFetched).toBe(false);
-    expect(userListCall).not.toHaveBeenCalled();
-  });
-
-  it("should not execute query when both accessToken and userRole are invalid", async () => {
-    mockUseAuthorized.mockReturnValue({
-      ...DEFAULT_AUTH,
-      accessToken: null,
-      userRole: "App User",
-    });
-
-    const { result } = renderHook(() => useInfiniteUsers(), { wrapper });
-
-    expect(result.current.isLoading).toBe(false);
-    expect(result.current.data).toBeUndefined();
-    expect(result.current.isFetched).toBe(false);
-    expect(userListCall).not.toHaveBeenCalled();
-  });
-
-  it("should execute query for each admin role", async () => {
-    const adminRoles = ["Admin", "Admin Viewer", "proxy_admin", "proxy_admin_viewer", "org_admin"];
-
-    for (const role of adminRoles) {
-      vi.clearAllMocks();
-      queryClient = new QueryClient({
-        defaultOptions: { queries: { retry: false } },
-      });
-      const mockResponse = buildUserListResponse(1, 1);
-      (userListCall as any).mockResolvedValue(mockResponse);
-      mockUseAuthorized.mockReturnValue({ ...DEFAULT_AUTH, userRole: role });
+  it("runs for each admin role", async () => {
+    for (const userRole of ["Admin", "Admin Viewer", "proxy_admin", "proxy_admin_viewer", "org_admin"]) {
+      fetchMock.mockReset();
+      queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+      const mock = stubPagedFetch(1);
+      mockUseAuthorized.mockReturnValue({ ...DEFAULT_AUTH, userRole });
 
       const { result } = renderHook(() => useInfiniteUsers(), { wrapper });
 
-      await waitFor(() => {
-        expect(result.current.isSuccess).toBe(true);
-      });
-
-      expect(userListCall).toHaveBeenCalledTimes(1);
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(mock).toHaveBeenCalledTimes(1);
     }
-  });
-
-  it("should handle error when userListCall fails", async () => {
-    const testError = new Error("Failed to fetch users");
-    (userListCall as any).mockRejectedValue(testError);
-
-    const { result } = renderHook(() => useInfiniteUsers(), { wrapper });
-
-    await waitFor(() => {
-      expect(result.current.isError).toBe(true);
-    });
-
-    expect(result.current.error).toEqual(testError);
-    expect(result.current.data).toBeUndefined();
-  });
-
-  it("should pass empty string searchEmail as null", async () => {
-    const mockResponse = buildUserListResponse(1, 1);
-    (userListCall as any).mockResolvedValue(mockResponse);
-
-    const { result } = renderHook(() => useInfiniteUsers(50, ""), {
-      wrapper,
-    });
-
-    await waitFor(() => {
-      expect(result.current.isSuccess).toBe(true);
-    });
-
-    expect(userListCall).toHaveBeenCalledWith("test-access-token", null, 1, 50, null);
   });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/users/useUsers.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/users/useUsers.ts
@@ -1,38 +1,28 @@
-import { userListCall, UserListResponse } from "@/components/networking";
-import { useInfiniteQuery } from "@tanstack/react-query";
-import { createQueryKeys } from "../common/queryKeysFactory";
+import { $api, authHeader } from "@/lib/http/api";
 import { all_admin_roles } from "@/utils/roles";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
-
-const infiniteUsersKeys = createQueryKeys("infiniteUsers");
 
 const DEFAULT_PAGE_SIZE = 50;
 
 export const useInfiniteUsers = (pageSize: number = DEFAULT_PAGE_SIZE, searchEmail?: string) => {
   const { accessToken, userRole } = useAuthorized();
-  return useInfiniteQuery<UserListResponse>({
-    queryKey: infiniteUsersKeys.list({
-      filters: {
-        pageSize,
-        ...(searchEmail && { searchEmail }),
+  return $api.useInfiniteQuery(
+    "get",
+    "/user/list",
+    {
+      params: {
+        query: {
+          page_size: pageSize,
+          ...(searchEmail ? { user_email: searchEmail } : {}),
+        },
       },
-    }),
-    queryFn: async ({ pageParam }) => {
-      return await userListCall(
-        accessToken!,
-        null, // userIDs
-        pageParam as number, // page
-        pageSize, // page_size
-        searchEmail || null, // userEmail
-      );
+      headers: authHeader(accessToken!),
     },
-    initialPageParam: 1,
-    getNextPageParam: (lastPage) => {
-      if (lastPage.page < lastPage.total_pages) {
-        return lastPage.page + 1;
-      }
-      return undefined;
+    {
+      pageParamName: "page",
+      initialPageParam: 1,
+      getNextPageParam: (lastPage) => (lastPage.page < lastPage.total_pages ? lastPage.page + 1 : undefined),
+      enabled: Boolean(accessToken) && all_admin_roles.includes(userRole!),
     },
-    enabled: Boolean(accessToken) && all_admin_roles.includes(userRole!),
-  });
+  );
 };

--- a/ui/litellm-dashboard/src/contexts/ReactQueryProvider.tsx
+++ b/ui/litellm-dashboard/src/contexts/ReactQueryProvider.tsx
@@ -1,8 +1,14 @@
 "use client";
 
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClient, QueryClientProvider, QueryCache } from "@tanstack/react-query";
+import { handleError } from "@/components/networking";
+import { deriveErrorMessage } from "@/lib/http/client";
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  queryCache: new QueryCache({
+    onError: (error) => handleError(deriveErrorMessage(error)),
+  }),
+});
 
 export default function ReactQueryProvider({ children }: { children: React.ReactNode }) {
   return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;

--- a/ui/litellm-dashboard/src/lib/http/api.ts
+++ b/ui/litellm-dashboard/src/lib/http/api.ts
@@ -1,0 +1,24 @@
+import createFetchClient from "openapi-fetch";
+import createClient from "openapi-react-query";
+import type { paths } from "./schema";
+import { getProxyBaseUrl, getGlobalLitellmHeaderName } from "@/components/networking";
+
+// Placeholder origin so openapi-fetch always builds a parseable absolute URL (relative
+// Request construction throws under Node/SSR). The onRequest middleware replaces it with
+// the real, call-time base from getProxyBaseUrl on every request, so it never hits the network.
+const PLACEHOLDER_ORIGIN = "http://litellm.local";
+
+const fetchClient = createFetchClient<paths>({ baseUrl: PLACEHOLDER_ORIGIN });
+
+fetchClient.use({
+  onRequest({ request }) {
+    const tail = new URL(request.url);
+    return new Request(getProxyBaseUrl() + tail.pathname + tail.search, request);
+  },
+});
+
+export const $api = createClient(fetchClient);
+
+export const authHeader = (accessToken: string): Record<string, string> => ({
+  [getGlobalLitellmHeaderName()]: `Bearer ${accessToken}`,
+});


### PR DESCRIPTION
## Relevant issues

Builds on #29816 (the generated OpenAPI types foundation), which is already merged into `litellm_internal_staging`.

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:
- [ ] **CI run for the last commit**  
       Link:
- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Behavior is unchanged; this swaps the transport under the migrated hooks. Verification covers both migrated areas plus the consumers, which are untouched.

Live UI, user filter on the Usage page (consumer of `useInfiniteUsers`):
1. Run the proxy and open http://localhost:4000/ui/?page=usage
2. Open the per-user usage view and click the user filter dropdown
3. The dropdown populates from `/user/list`; in the Network tab confirm `/user/list?page=1&page_size=50` fires with the `Authorization: Bearer ...` header, and that scrolling pages through more users (`page=2`, ...)

Live UI, Access Groups page (consumer of the access-group hooks):
1. Open the Access Groups page in the UI
2. Create a group and confirm the list refreshes without a manual reload; in the Network tab confirm `POST /v1/access_group` with the bearer header, then the `GET /v1/access_group` refetch from the cache invalidation
3. Edit and delete the group and confirm the `PUT` / `DELETE /v1/access_group/{access_group_id}` requests and the list refresh

I'll post the screenshots once the PR is up.

## Type

🧹 Refactoring

## Changes

Introduces `openapi-react-query` (`$api`) as the typed data-fetching client on top of the generated types from #29816, then migrates the first two areas to prove the pattern for both reads and mutations.

- `src/lib/http/api.ts`: openapi-fetch client wrapped by openapi-react-query. Base URL resolves call-time via `getProxyBaseUrl` in an `onRequest` middleware, not a frozen `createClient({ baseUrl })`, so server-root-path and worker switching keep working. A placeholder origin keeps URL parsing valid under Node/SSR; the middleware always replaces it. `authHeader` passes the per-call token with the configurable header name
- `useInfiniteUsers`: now `$api.useInfiniteQuery("get", "/user/list", ...)`. Query params, response body, and user rows are typed from the spec; the 11-arg positional `userListCall` collapses into a typed query object. Return shape unchanged, so `UsagePageView` is untouched
- access groups: the five hooks (`useAccessGroups`, `useAccessGroupDetails`, `useCreateAccessGroup`, `useEditAccessGroup`, `useDeleteAccessGroup`) move onto `$api`, dropping their local fetch helpers, manual headers, manual error parsing, and the `createQueryKeys` factory. The mutation hooks keep their existing `.mutate(...)` argument shape via a thin wrapper, so the page, modals, and selector are untouched. This is the reference pattern for the read-plus-mutation case
- `ReactQueryProvider`: global `QueryCache.onError` routes into the existing `handleError`, preserving session-expiry logout
- one transitional note: `api.ts` imports `getProxyBaseUrl` / `getGlobalLitellmHeaderName` from `networking`. The base-URL resolver should move into `src/lib/http/` so the dependency points the right way; that extraction is the first step of the broader migration and is intentionally out of scope here

Greptile feedback addressed:
- the global `QueryCache.onError` made the legacy query hooks that still call `handleError` inline dispatch twice per failure (masked today only by the 60s throttle). Removed the redundant inline call from the query paths in `useKeys`, `useProjects`, `useProjectDetails`, `useProxyConfig`, and `useTeams`, leaving the global sink as the single handler. Mutation hooks keep their inline handler since there is no global mutation sink
- restored the dropped regression test for `useInfiniteUsers(50, "")` so an empty `searchEmail` is still guaranteed to send no `user_email` param

`userListCall` stays for now since `view_users` and `filter_logic` still use it; those move in the migration that follows.
