### PR TITLE
fix(ui): create keys for bulk invited users

### DIFF
--- a/ui/litellm-dashboard/src/components/bulk_create_users_button.test.tsx
+++ b/ui/litellm-dashboard/src/components/bulk_create_users_button.test.tsx
@@ -62,7 +62,7 @@ describe("BulkCreateUsersButton", () => {
 
     fireEvent.click(screen.getByText("+ Bulk Invite Users"));
 
-    uploadCsv("user_email,user_role\nuser@example.com,internal_user\n");
+    uploadCsv("user_email,user_role\n@evil.example.com,internal_user\n");
 
     const createButtons = await screen.findAllByRole("button", { name: "Create 1 Users" });
     fireEvent.click(createButtons[0]);
@@ -72,7 +72,7 @@ describe("BulkCreateUsersButton", () => {
         "test-token",
         null,
         expect.objectContaining({
-          user_email: "user@example.com",
+          user_email: "@evil.example.com",
           user_role: "internal_user",
           auto_create_key: true,
           models: ["no-default-models"],
@@ -83,14 +83,16 @@ describe("BulkCreateUsersButton", () => {
     await screen.findByText("User creation complete");
     fireEvent.click(screen.getByRole("button", { name: /Download User Credentials/i }));
 
-    expect(unparseSpy).toHaveBeenLastCalledWith([
+    const lastUnparseCall = unparseSpy.mock.calls[unparseSpy.mock.calls.length - 1];
+    expect(lastUnparseCall[0]).toEqual([
       expect.objectContaining({
-        user_email: "user@example.com",
+        user_email: "@evil.example.com",
         status: "success",
         key: "sk-test-key",
       }),
     ]);
-    expect(unparseSpy).not.toHaveBeenLastCalledWith([
+    expect(lastUnparseCall[1]).toEqual({ escapeFormulae: true });
+    expect(lastUnparseCall[0]).not.toEqual([
       expect.objectContaining({
         key: "user-1",
       }),

--- a/ui/litellm-dashboard/src/components/bulk_create_users_button.test.tsx
+++ b/ui/litellm-dashboard/src/components/bulk_create_users_button.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, it, expect, vi } from "vitest";
+import Papa from "papaparse";
 import BulkCreateUsersButton from "./bulk_create_users_button";
 import * as networking from "./networking";
 
@@ -26,14 +27,33 @@ describe("BulkCreateUsersButton", () => {
     vi.clearAllMocks();
   });
 
+  const uploadCsv = (csv: string) => {
+    const file = new File([csv], "users.csv", {
+      type: "text/csv",
+    });
+    const dialog = screen.getByRole("dialog", { name: "Bulk Invite Users" });
+    const fileInput = dialog.querySelector("input[type='file']");
+    expect(fileInput).not.toBeNull();
+    fireEvent.change(fileInput!, { target: { files: [file] } });
+  };
+
   it("should render", () => {
     const { getByText } = render(<BulkCreateUsersButton accessToken="test-token" teams={[]} possibleUIRoles={null} />);
     expect(getByText("+ Bulk Invite Users")).toBeInTheDocument();
   });
 
-  it("should request virtual key creation for bulk invited users", async () => {
+  it("should request virtual key creation and export returned keys for bulk invited users", async () => {
     const userCreateCall = vi.mocked(networking.userCreateCall);
     const invitationCreateCall = vi.mocked(networking.invitationCreateCall);
+    const unparseSpy = vi.spyOn(Papa, "unparse");
+    Object.defineProperty(window.URL, "createObjectURL", {
+      writable: true,
+      value: vi.fn(() => "blob:test-results"),
+    });
+    Object.defineProperty(window.URL, "revokeObjectURL", {
+      writable: true,
+      value: vi.fn(),
+    });
 
     userCreateCall.mockResolvedValue({ user_id: "user-1", key: "sk-test-key" });
     invitationCreateCall.mockResolvedValue({ id: "invite-1" });
@@ -42,12 +62,7 @@ describe("BulkCreateUsersButton", () => {
 
     fireEvent.click(screen.getByText("+ Bulk Invite Users"));
 
-    const file = new File(["user_email,user_role\nuser@example.com,internal_user\n"], "users.csv", {
-      type: "text/csv",
-    });
-    const fileInput = document.body.querySelector("input[type='file']");
-    expect(fileInput).not.toBeNull();
-    fireEvent.change(fileInput!, { target: { files: [file] } });
+    uploadCsv("user_email,user_role\nuser@example.com,internal_user\n");
 
     const createButtons = await screen.findAllByRole("button", { name: "Create 1 Users" });
     fireEvent.click(createButtons[0]);
@@ -64,6 +79,22 @@ describe("BulkCreateUsersButton", () => {
         }),
       );
     });
+
+    await screen.findByText("User creation complete");
+    fireEvent.click(screen.getByRole("button", { name: /Download User Credentials/i }));
+
+    expect(unparseSpy).toHaveBeenLastCalledWith([
+      expect.objectContaining({
+        user_email: "user@example.com",
+        status: "success",
+        key: "sk-test-key",
+      }),
+    ]);
+    expect(unparseSpy).not.toHaveBeenLastCalledWith([
+      expect.objectContaining({
+        key: "user-1",
+      }),
+    ]);
   });
 
   it("should restrict non-admin users when models csv value parses to empty", async () => {
@@ -77,12 +108,7 @@ describe("BulkCreateUsersButton", () => {
 
     fireEvent.click(screen.getByText("+ Bulk Invite Users"));
 
-    const file = new File(['user_email,user_role,models\nuser@example.com,internal_user,", ,"\n'], "users.csv", {
-      type: "text/csv",
-    });
-    const fileInput = document.body.querySelector("input[type='file']");
-    expect(fileInput).not.toBeNull();
-    fireEvent.change(fileInput!, { target: { files: [file] } });
+    uploadCsv('user_email,user_role,models\nuser@example.com,internal_user,", ,"\n');
 
     const createButtons = await screen.findAllByRole("button", { name: "Create 1 Users" });
     fireEvent.click(createButtons[0]);
@@ -111,12 +137,7 @@ describe("BulkCreateUsersButton", () => {
 
     fireEvent.click(screen.getByText("+ Bulk Invite Users"));
 
-    const file = new File(["user_email,user_role\nuser@example.com,internal_user\n"], "users.csv", {
-      type: "text/csv",
-    });
-    const fileInput = document.body.querySelector("input[type='file']");
-    expect(fileInput).not.toBeNull();
-    fireEvent.change(fileInput!, { target: { files: [file] } });
+    uploadCsv("user_email,user_role\nuser@example.com,internal_user\n");
 
     const createButtons = await screen.findAllByRole("button", { name: "Create 1 Users" });
     fireEvent.click(createButtons[0]);

--- a/ui/litellm-dashboard/src/components/bulk_create_users_button.test.tsx
+++ b/ui/litellm-dashboard/src/components/bulk_create_users_button.test.tsx
@@ -1,6 +1,7 @@
-import { render } from "@testing-library/react";
-import { describe, it, expect, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, it, expect, vi } from "vitest";
 import BulkCreateUsersButton from "./bulk_create_users_button";
+import * as networking from "./networking";
 
 vi.mock("./networking", () => ({
   userCreateCall: vi.fn(),
@@ -21,8 +22,106 @@ vi.mock("./molecules/notifications_manager", () => ({
 }));
 
 describe("BulkCreateUsersButton", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("should render", () => {
     const { getByText } = render(<BulkCreateUsersButton accessToken="test-token" teams={[]} possibleUIRoles={null} />);
     expect(getByText("+ Bulk Invite Users")).toBeInTheDocument();
+  });
+
+  it("should request virtual key creation for bulk invited users", async () => {
+    const userCreateCall = vi.mocked(networking.userCreateCall);
+    const invitationCreateCall = vi.mocked(networking.invitationCreateCall);
+
+    userCreateCall.mockResolvedValue({ user_id: "user-1", key: "sk-test-key" });
+    invitationCreateCall.mockResolvedValue({ id: "invite-1" });
+
+    render(<BulkCreateUsersButton accessToken="test-token" teams={[]} possibleUIRoles={null} />);
+
+    fireEvent.click(screen.getByText("+ Bulk Invite Users"));
+
+    const file = new File(["user_email,user_role\nuser@example.com,internal_user\n"], "users.csv", {
+      type: "text/csv",
+    });
+    const fileInput = document.body.querySelector("input[type='file']");
+    expect(fileInput).not.toBeNull();
+    fireEvent.change(fileInput!, { target: { files: [file] } });
+
+    const createButtons = await screen.findAllByRole("button", { name: "Create 1 Users" });
+    fireEvent.click(createButtons[0]);
+
+    await waitFor(() => {
+      expect(userCreateCall).toHaveBeenCalledWith(
+        "test-token",
+        null,
+        expect.objectContaining({
+          user_email: "user@example.com",
+          user_role: "internal_user",
+          auto_create_key: true,
+          models: ["no-default-models"],
+        }),
+      );
+    });
+  });
+
+  it("should restrict non-admin users when models csv value parses to empty", async () => {
+    const userCreateCall = vi.mocked(networking.userCreateCall);
+    const invitationCreateCall = vi.mocked(networking.invitationCreateCall);
+
+    userCreateCall.mockResolvedValue({ user_id: "user-1", key: "sk-test-key" });
+    invitationCreateCall.mockResolvedValue({ id: "invite-1" });
+
+    render(<BulkCreateUsersButton accessToken="test-token" teams={[]} possibleUIRoles={null} />);
+
+    fireEvent.click(screen.getByText("+ Bulk Invite Users"));
+
+    const file = new File(['user_email,user_role,models\nuser@example.com,internal_user,", ,"\n'], "users.csv", {
+      type: "text/csv",
+    });
+    const fileInput = document.body.querySelector("input[type='file']");
+    expect(fileInput).not.toBeNull();
+    fireEvent.change(fileInput!, { target: { files: [file] } });
+
+    const createButtons = await screen.findAllByRole("button", { name: "Create 1 Users" });
+    fireEvent.click(createButtons[0]);
+
+    await waitFor(() => {
+      expect(userCreateCall).toHaveBeenCalledWith(
+        "test-token",
+        null,
+        expect.objectContaining({
+          user_email: "user@example.com",
+          user_role: "internal_user",
+          auto_create_key: true,
+          models: ["no-default-models"],
+        }),
+      );
+    });
+  });
+
+  it("should fail the row when user creation returns no virtual key", async () => {
+    const userCreateCall = vi.mocked(networking.userCreateCall);
+    const invitationCreateCall = vi.mocked(networking.invitationCreateCall);
+
+    userCreateCall.mockResolvedValue({ user_id: "user-1" });
+
+    render(<BulkCreateUsersButton accessToken="test-token" teams={[]} possibleUIRoles={null} />);
+
+    fireEvent.click(screen.getByText("+ Bulk Invite Users"));
+
+    const file = new File(["user_email,user_role\nuser@example.com,internal_user\n"], "users.csv", {
+      type: "text/csv",
+    });
+    const fileInput = document.body.querySelector("input[type='file']");
+    expect(fileInput).not.toBeNull();
+    fireEvent.change(fileInput!, { target: { files: [file] } });
+
+    const createButtons = await screen.findAllByRole("button", { name: "Create 1 Users" });
+    fireEvent.click(createButtons[0]);
+
+    await screen.findByText(JSON.stringify("User created but no virtual key was returned"));
+    expect(invitationCreateCall).not.toHaveBeenCalled();
   });
 });

--- a/ui/litellm-dashboard/src/components/bulk_create_users_button.tsx
+++ b/ui/litellm-dashboard/src/components/bulk_create_users_button.tsx
@@ -450,7 +450,7 @@ const BulkCreateUsersButton: React.FC<BulkCreateUsersProps> = ({
       error: user.error || "",
     }));
 
-    const csv = Papa.unparse(results);
+    const csv = Papa.unparse(results, { escapeFormulae: true });
     const blob = new Blob([csv], { type: "text/csv" });
     const url = window.URL.createObjectURL(blob);
     const a = document.createElement("a");

--- a/ui/litellm-dashboard/src/components/bulk_create_users_button.tsx
+++ b/ui/litellm-dashboard/src/components/bulk_create_users_button.tsx
@@ -38,6 +38,10 @@ interface UserData {
   invitation_link?: string;
 }
 
+type BulkCreateUserPayload = Partial<UserData> & {
+  auto_create_key: boolean;
+};
+
 // Define an interface for the UI settings
 interface UISettings {
   PROXY_BASE_URL: string | null;
@@ -302,9 +306,10 @@ const BulkCreateUsersButton: React.FC<BulkCreateUsersProps> = ({
       const user = updatedData[index];
       try {
         // Create a clean user object with only non-empty values
-        const cleanUser: Partial<UserData> = {
+        const cleanUser: BulkCreateUserPayload = {
           user_email: user.user_email,
           user_role: user.user_role,
+          auto_create_key: true,
         };
 
         // Only add optional fields if they have values
@@ -321,14 +326,16 @@ const BulkCreateUsersButton: React.FC<BulkCreateUsersProps> = ({
 
         // Only add models if provided and non-empty
         if (user.models && typeof user.models === "string" && user.models.trim() !== "") {
-          cleanUser.models = user.models
+          const models = user.models
             .split(",")
             .map((model) => model.trim())
             .filter(Boolean);
-          // Only include models if there's at least one valid model
-          if (cleanUser.models.length === 0) {
-            delete cleanUser.models;
+          if (models.length > 0) {
+            cleanUser.models = models;
           }
+        }
+        if ((!cleanUser.models || cleanUser.models.length === 0) && user.user_role !== "proxy_admin") {
+          cleanUser.models = ["no-default-models"];
         }
 
         // Only add max_budget if it's a valid number
@@ -351,10 +358,12 @@ const BulkCreateUsersButton: React.FC<BulkCreateUsersProps> = ({
 
         const response = await userCreateCall(accessToken, null, cleanUser);
 
-        // Check if response has key or user_id, indicating success
-        if (response && (response.key || response.user_id)) {
+        const user_id = response?.data?.user_id || response?.user_id;
+        const virtualKey = response?.key;
+
+        // Check if response has key and user_id, indicating success
+        if (response && user_id && virtualKey) {
           anySuccessful = true;
-          const user_id = response.data?.user_id || response.user_id;
 
           // Create invitation link for the user
           try {
@@ -369,7 +378,7 @@ const BulkCreateUsersButton: React.FC<BulkCreateUsersProps> = ({
                     ? {
                         ...u,
                         status: "success",
-                        key: response.key || response.user_id,
+                        key: virtualKey,
                         invitation_link: invitationUrl,
                       }
                     : u,
@@ -385,7 +394,7 @@ const BulkCreateUsersButton: React.FC<BulkCreateUsersProps> = ({
                     ? {
                         ...u,
                         status: "success",
-                        key: response.key || response.user_id,
+                        key: virtualKey,
                         invitation_link: invitationUrl,
                       }
                     : u,
@@ -400,7 +409,7 @@ const BulkCreateUsersButton: React.FC<BulkCreateUsersProps> = ({
                   ? {
                       ...u,
                       status: "success",
-                      key: response.key || response.user_id,
+                      key: virtualKey,
                       error: "User created but failed to generate invitation link",
                     }
                   : u,
@@ -408,7 +417,8 @@ const BulkCreateUsersButton: React.FC<BulkCreateUsersProps> = ({
             );
           }
         } else {
-          const errorMessage = response?.error || "Failed to create user";
+          const errorMessage =
+            response?.error || (user_id ? "User created but no virtual key was returned" : "Failed to create user");
           setParsedData((current) =>
             current.map((u, i) => (i === index ? { ...u, status: "failed", error: errorMessage } : u)),
           );

--- a/ui/litellm-dashboard/src/components/networking.test.ts
+++ b/ui/litellm-dashboard/src/components/networking.test.ts
@@ -113,6 +113,62 @@ describe("loginCall - storeLoginToken integration", () => {
   });
 });
 
+describe("userCreateCall", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("preserves explicit auto_create_key values", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ user_id: "user-1", key: "sk-test" }),
+    } as any);
+    global.fetch = mockFetch as any;
+
+    await Networking.userCreateCall("token", null, {
+      user_email: "user@example.com",
+      user_role: "internal_user",
+      auto_create_key: true,
+    });
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [, options] = mockFetch.mock.calls[0];
+    expect(JSON.parse(options.body)).toEqual(
+      expect.objectContaining({
+        user_email: "user@example.com",
+        user_role: "internal_user",
+        auto_create_key: true,
+      }),
+    );
+  });
+
+  it("defaults auto_create_key to false when callers omit it", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ user_id: "user-2" }),
+    } as any);
+    global.fetch = mockFetch as any;
+
+    await Networking.userCreateCall("token", null, {
+      user_email: "user@example.com",
+      user_role: "internal_user",
+    });
+
+    const [, options] = mockFetch.mock.calls[0];
+    expect(JSON.parse(options.body)).toEqual(
+      expect.objectContaining({
+        auto_create_key: false,
+      }),
+    );
+  });
+});
+
 describe("daily activity helpers", () => {
   const startTime = new Date("2025-02-12T00:00:00.000Z");
   const endTime = new Date("2025-02-19T00:00:00.000Z");

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -849,7 +849,9 @@ export const userCreateCall = async (
       formValues.metadata = JSON.stringify(formValues.metadata);
     }
 
-    formValues.auto_create_key = false;
+    if (formValues.auto_create_key === undefined) {
+      formValues.auto_create_key = false;
+    }
     // if formValues.metadata is not undefined, make it a valid dict
     if (formValues.metadata) {
       // if there's an exception JSON.parse, show it in the message


### PR DESCRIPTION
## Relevant issues

Fixes #27849

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review and received a Confidence Score of at least 4/5

## Screenshots / Proof of Fix

Manual UI path:

1. Run the proxy with the dashboard enabled.
2. Open `/ui`, sign in as an admin, and open the user management view.
3. Click `+ Bulk Invite Users`.
4. Upload a CSV with `user_email,user_role` and a valid user row.
5. Click `Create 1 Users`, then download the credentials CSV.
6. Confirm the `key` column contains the generated virtual key from `/user/new`, beginning with `sk-`, rather than the created `user_id`.

## Type

Bug Fix

## Changes

- Bulk invite explicitly requests virtual key creation from `/user/new`.
- `userCreateCall` still defaults `auto_create_key` to false for callers that omit it, but preserves explicit caller values.
- A response with a user id but no virtual key is surfaced as a failed row instead of a successful row with a blank or invalid credential.
- Non-admin bulk-created users retain the single-user flow's `no-default-models` fallback.
- Downloaded credential CSVs use the returned virtual key and enable Papa Parse formula escaping.
- Regression coverage verifies payload defaults, returned-key export, missing-key failure, empty model normalization, and formula escaping.

## Current staging refresh

Rebased onto `litellm_internal_staging@3e9e5204` as exact head `939af901` after confirming the issue still reproduces upstream:

- `userCreateCall` still overwrites `auto_create_key` with false.
- Bulk invite still accepts `user_id` as a successful key fallback.
- No competing PR implements the same fix.

Validation on the rebased head:

- `npm test -- --run src/components/networking.test.ts src/components/bulk_create_users_button.test.tsx` -> 29 passed
- focused ESLint -> 0 errors
- focused Prettier check -> passed
- `git diff --check origin/litellm_internal_staging...HEAD` -> passed
