### PR TITLE
fix(responses): map namespace tools as functions

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -683,7 +683,11 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
             elif tool.get("type") == "namespace" and (
                 not tool.get("description") or not tool.get("parameters")
             ):
-                raise ValueError("Namespace tools require description and parameters")
+                verbose_logger.warning(
+                    "Skipping namespace tool without description or parameters: %s",
+                    tool.get("name"),
+                )
+                continue
             # Handle tools with 'type' field (OpenAI spec compliance) Ignore this field -> https://github.com/BerriAI/litellm/issues/14644#issuecomment-3342061838
             elif "type" in tool:
                 tool = {k: tool[k] for k in tool if k != "type"}

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -680,6 +680,13 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                     f"Gemini: Transforming OpenAI-style '{tool['type']}' tool to googleSearch"
                 )
                 tool = {VertexToolName.GOOGLE_SEARCH.value: {}}
+            elif tool.get("type") == "namespace" and (
+                not tool.get("description") or not tool.get("parameters")
+            ):
+                raise ValueError(
+                    "Namespace tools require description and parameters before "
+                    "converting to Gemini function declarations"
+                )
             # Handle tools with 'type' field (OpenAI spec compliance) Ignore this field -> https://github.com/BerriAI/litellm/issues/14644#issuecomment-3342061838
             elif "type" in tool:
                 tool = {k: tool[k] for k in tool if k != "type"}

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -683,10 +683,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
             elif tool.get("type") == "namespace" and (
                 not tool.get("description") or not tool.get("parameters")
             ):
-                raise ValueError(
-                    "Namespace tools require description and parameters before "
-                    "converting to Gemini function declarations"
-                )
+                raise ValueError("Namespace tools require description and parameters")
             # Handle tools with 'type' field (OpenAI spec compliance) Ignore this field -> https://github.com/BerriAI/litellm/issues/14644#issuecomment-3342061838
             elif "type" in tool:
                 tool = {k: tool[k] for k in tool if k != "type"}

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -1388,6 +1388,14 @@ class LiteLLMCompletionResponsesConfig:
                 )
             elif tool.get("type") in ("function", "namespace"):
                 typed_tool = cast(FunctionToolParam, tool)
+                if tool.get("type") == "namespace" and (
+                    not typed_tool.get("description")
+                    or not typed_tool.get("parameters")
+                ):
+                    raise ValueError(
+                        "Responses API namespace tools require description and "
+                        "parameters before converting to Chat Completion tools"
+                    )
                 # Ensure parameters has "type": "object" as required by providers like Anthropic
                 parameters = dict(typed_tool.get("parameters", {}) or {})
                 if not parameters or "type" not in parameters:

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -1393,8 +1393,7 @@ class LiteLLMCompletionResponsesConfig:
                     or not typed_tool.get("parameters")
                 ):
                     raise ValueError(
-                        "Responses API namespace tools require description and "
-                        "parameters before converting to Chat Completion tools"
+                        "Namespace tools require description and parameters"
                     )
                 # Ensure parameters has "type": "object" as required by providers like Anthropic
                 parameters = dict(typed_tool.get("parameters", {}) or {})

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -1392,9 +1392,7 @@ class LiteLLMCompletionResponsesConfig:
                     not typed_tool.get("description")
                     or not typed_tool.get("parameters")
                 ):
-                    raise ValueError(
-                        "Namespace tools require description and parameters"
-                    )
+                    continue
                 # Ensure parameters has "type": "object" as required by providers like Anthropic
                 parameters = dict(typed_tool.get("parameters", {}) or {})
                 if not parameters or "type" not in parameters:

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -1386,7 +1386,7 @@ class LiteLLMCompletionResponsesConfig:
                     search_context_size=_search_context_size,
                     user_location=_user_location,
                 )
-            elif tool.get("type") == "function":
+            elif tool.get("type") in ("function", "namespace"):
                 typed_tool = cast(FunctionToolParam, tool)
                 # Ensure parameters has "type": "object" as required by providers like Anthropic
                 parameters = dict(typed_tool.get("parameters", {}) or {})

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -2917,14 +2917,15 @@ def test_vertex_ai_function_declarations_with_other_tools_separate():
     assert func_tool["function_declarations"][0]["name"] == "get_weather"
 
 
-def test_vertex_ai_namespace_tool_without_schema_raises():
+def test_vertex_ai_namespace_tool_without_schema_skips():
     v = VertexGeminiConfig()
 
-    with pytest.raises(ValueError, match="Namespace tools require description"):
-        v._map_function(
-            value=[{"type": "namespace", "name": "mcp__node_repl"}],
-            optional_params={},
-        )
+    tools = v._map_function(
+        value=[{"type": "namespace", "name": "mcp__node_repl"}],
+        optional_params={},
+    )
+
+    assert tools == []
 
 
 def test_vertex_ai_single_tool_type_still_works():

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -2917,6 +2917,16 @@ def test_vertex_ai_function_declarations_with_other_tools_separate():
     assert func_tool["function_declarations"][0]["name"] == "get_weather"
 
 
+def test_vertex_ai_namespace_tool_without_schema_raises():
+    v = VertexGeminiConfig()
+
+    with pytest.raises(ValueError, match="Namespace tools require description"):
+        v._map_function(
+            value=[{"type": "namespace", "name": "mcp__node_repl"}],
+            optional_params={},
+        )
+
+
 def test_vertex_ai_single_tool_type_still_works():
     """
     Test that single tool type usage still works correctly (backward compatibility).

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -1228,17 +1228,49 @@ class TestToolTransformation:
         )
         assert result_tool["function"]["parameters"] == namespace_tool["parameters"]
 
-    def test_transform_namespace_tools_without_schema_raises(self):
-        """Name-only namespace tools cannot be converted into usable functions."""
+    def test_transform_namespace_tools_without_schema_skips(self):
+        """Name-only namespace tools are skipped instead of becoming hollow functions."""
         namespace_tool = {
             "type": "namespace",
             "name": "mcp__node_repl",
         }
 
-        with pytest.raises(ValueError, match="Namespace tools require description"):
-            LiteLLMCompletionResponsesConfig.transform_responses_api_tools_to_chat_completion_tools(
-                tools=[namespace_tool]
-            )
+        (
+            result_tools,
+            web_search_options,
+        ) = LiteLLMCompletionResponsesConfig.transform_responses_api_tools_to_chat_completion_tools(
+            tools=[namespace_tool]
+        )
+
+        assert result_tools == []
+        assert web_search_options is None
+
+    def test_transform_namespace_tools_without_schema_keeps_other_tools(self):
+        """Skipping name-only namespace tools should not abort the whole request."""
+        function_tool = {
+            "type": "function",
+            "name": "get_weather",
+            "description": "Get weather",
+            "parameters": {
+                "type": "object",
+                "properties": {"location": {"type": "string"}},
+            },
+        }
+        namespace_tool = {
+            "type": "namespace",
+            "name": "mcp__node_repl",
+        }
+
+        (
+            result_tools,
+            web_search_options,
+        ) = LiteLLMCompletionResponsesConfig.transform_responses_api_tools_to_chat_completion_tools(
+            tools=[namespace_tool, function_tool]
+        )
+
+        assert web_search_options is None
+        assert len(result_tools) == 1
+        assert result_tools[0]["function"]["name"] == "get_weather"
 
     def test_transform_code_execution_tools(self):
         """Test that code_execution tools are passed through as-is"""

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -1228,13 +1228,19 @@ class TestToolTransformation:
         )
         assert result_tool["function"]["parameters"] == namespace_tool["parameters"]
 
-    def test_transform_namespace_tools_without_schema_skips(self):
-        """Name-only namespace tools are skipped instead of becoming hollow functions."""
-        namespace_tool = {
-            "type": "namespace",
-            "name": "mcp__node_repl",
-        }
-
+    @pytest.mark.parametrize(
+        "namespace_tool",
+        [
+            {"type": "namespace", "name": "mcp__node_repl"},
+            {
+                "type": "namespace",
+                "name": "mcp__node_repl",
+                "description": "Runtime namespace exposed by MCP",
+            },
+        ],
+    )
+    def test_transform_namespace_tools_without_schema_skips(self, namespace_tool):
+        """Namespace tools without parameters are skipped instead of becoming hollow functions."""
         (
             result_tools,
             web_search_options,

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -1189,6 +1189,44 @@ class TestToolTransformation:
         assert "allowed_callers" not in result_tool
         assert "input_examples" not in result_tool
 
+    def test_transform_namespace_tools_to_function_tools(self):
+        """Test that Responses API namespace tools keep their schema."""
+        namespace_tool = {
+            "type": "namespace",
+            "name": "mcp__node_repl",
+            "description": "Run JavaScript in the node REPL",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "code": {
+                        "type": "string",
+                        "description": "JavaScript source to evaluate",
+                    }
+                },
+                "required": ["code"],
+            },
+        }
+
+        tools = [namespace_tool]
+
+        (
+            result_tools,
+            web_search_options,
+        ) = LiteLLMCompletionResponsesConfig.transform_responses_api_tools_to_chat_completion_tools(
+            tools=tools
+        )
+
+        assert web_search_options is None
+        assert len(result_tools) == 1
+        result_tool = result_tools[0]
+        assert result_tool["type"] == "function"
+        assert result_tool["function"]["name"] == "mcp__node_repl"
+        assert (
+            result_tool["function"]["description"]
+            == "Run JavaScript in the node REPL"
+        )
+        assert result_tool["function"]["parameters"] == namespace_tool["parameters"]
+
     def test_transform_code_execution_tools(self):
         """Test that code_execution tools are passed through as-is"""
         code_execution_tool = {

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -1,6 +1,8 @@
 import os
 import sys
 
+import pytest
+
 sys.path.insert(
     0, os.path.abspath("../../..")
 )  # Adds the parent directory to the system path
@@ -1222,10 +1224,21 @@ class TestToolTransformation:
         assert result_tool["type"] == "function"
         assert result_tool["function"]["name"] == "mcp__node_repl"
         assert (
-            result_tool["function"]["description"]
-            == "Run JavaScript in the node REPL"
+            result_tool["function"]["description"] == "Run JavaScript in the node REPL"
         )
         assert result_tool["function"]["parameters"] == namespace_tool["parameters"]
+
+    def test_transform_namespace_tools_without_schema_raises(self):
+        """Name-only namespace tools cannot be converted into usable functions."""
+        namespace_tool = {
+            "type": "namespace",
+            "name": "mcp__node_repl",
+        }
+
+        with pytest.raises(ValueError, match="namespace tools require description"):
+            LiteLLMCompletionResponsesConfig.transform_responses_api_tools_to_chat_completion_tools(
+                tools=[namespace_tool]
+            )
 
     def test_transform_code_execution_tools(self):
         """Test that code_execution tools are passed through as-is"""

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -1235,7 +1235,7 @@ class TestToolTransformation:
             "name": "mcp__node_repl",
         }
 
-        with pytest.raises(ValueError, match="namespace tools require description"):
+        with pytest.raises(ValueError, match="Namespace tools require description"):
             LiteLLMCompletionResponsesConfig.transform_responses_api_tools_to_chat_completion_tools(
                 tools=[namespace_tool]
             )


### PR DESCRIPTION
## What
- map Responses API `type=namespace` tools through the existing chat function-tool normalization
- preserve `name`, `description`, and `parameters` before Gemini converts tools to function declarations
- add a regression for namespace tool schema preservation

Fixes #29854

## Tests
- `PYTHONPATH=/tmp/litellm-mcp-inspect:. python3 -m pytest tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py::TestToolTransformation -q`
- `git diff --check`

Note: local `python3 -m black --check ...` could not run because this Python environment does not have `black` installed.