### PR TITLE
fix(ui): save routing groups as list

### DIFF
--- a/ui/litellm-dashboard/src/components/router_settings/index.test.tsx
+++ b/ui/litellm-dashboard/src/components/router_settings/index.test.tsx
@@ -34,6 +34,7 @@ const mockCallbacksResponse = {
     routing_strategy: "simple-shuffle",
     num_retries: 3,
     timeout: 30,
+    routing_groups: [],
   },
 };
 
@@ -129,6 +130,34 @@ describe("RouterSettings", () => {
       expect.objectContaining({
         router_settings: expect.objectContaining({
           routing_strategy: "simple-shuffle",
+        }),
+      }),
+    );
+  });
+
+  it("should send routing_groups as a list when saving load balancing settings", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<RouterSettings {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("textbox", { name: /routing_groups/i })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    expect(setCallbacksCall).toHaveBeenCalledWith(
+      "test-token",
+      expect.objectContaining({
+        router_settings: expect.objectContaining({
+          routing_groups: [],
+        }),
+      }),
+    );
+    expect(setCallbacksCall).not.toHaveBeenCalledWith(
+      "test-token",
+      expect.objectContaining({
+        router_settings: expect.objectContaining({
+          routing_groups: "[]",
         }),
       }),
     );

--- a/ui/litellm-dashboard/src/components/router_settings/index.tsx
+++ b/ui/litellm-dashboard/src/components/router_settings/index.tsx
@@ -91,7 +91,7 @@ const RouterSettings: React.FC<RouterSettingsProps> = ({ accessToken, userRole, 
     console.log("router_settings", router_settings);
 
     const numberKeys = new Set(["allowed_fails", "cooldown_time", "num_retries", "timeout", "retry_after"]);
-    const jsonKeys = new Set(["model_group_alias", "retry_policy"]);
+    const jsonKeys = new Set(["model_group_alias", "retry_policy", "routing_groups"]);
 
     const parseInputValue = (key: string, raw: string | undefined, fallback: unknown) => {
       if (raw === undefined) return fallback;


### PR DESCRIPTION
## Summary
- parse `routing_groups` as JSON when saving the Load Balancing router settings
- add a regression test that verifies the dashboard sends `routing_groups: []` instead of the string `"[]"`

Fixes #29888.

## Testing
- `npm test -- --run src/components/router_settings/index.test.tsx src/components/router_settings/RouterSettingsForm.test.tsx src/components/router_settings/ReliabilityRetriesSection.test.tsx`
- `npm exec eslint -- src/components/router_settings/index.tsx src/components/router_settings/index.test.tsx` (passes with existing `no-explicit-any` warnings)
- `npm exec prettier -- --check src/components/router_settings/index.tsx src/components/router_settings/index.test.tsx`
- `git diff --check`

This PR was prepared with OpenAI Codex assistance. I reviewed the diff and ran the validation above before submitting.