### PR TITLE
fix(cache): log hashed cache keys

### DIFF
--- a/litellm/caching/caching.py
+++ b/litellm/caching/caching.py
@@ -309,9 +309,13 @@ class Cache:
                     param_value = kwargs[param]
                     cache_key += f"{str(param)}: {str(param_value)}"
 
-        verbose_logger.debug("\nCreated cache key: %s", cache_key)
         hashed_cache_key = Cache._get_hashed_cache_key(cache_key)
         hashed_cache_key = self._add_namespace_to_cache_key(hashed_cache_key, **kwargs)
+        verbose_logger.debug(
+            "\nCreated cache key: %s (source material length: %d)",
+            hashed_cache_key,
+            len(cache_key),
+        )
         # Remove preset_cache_key from kwargs to avoid "got multiple values" TypeError
         # when kwargs already contains preset_cache_key from upstream callers
         kwargs_for_preset = {k: v for k, v in kwargs.items() if k != "preset_cache_key"}

--- a/tests/test_litellm/caching/test_caching.py
+++ b/tests/test_litellm/caching/test_caching.py
@@ -1,0 +1,48 @@
+import logging
+import re
+
+from litellm.caching.caching import Cache
+from litellm.types.caching import LiteLLMCacheType
+
+
+def test_cache_key_debug_log_does_not_include_prompt_material(caplog):
+    cache = Cache(type=LiteLLMCacheType.LOCAL)
+    prompt_marker = "secret prompt material "
+
+    with caplog.at_level(logging.DEBUG, logger="LiteLLM"):
+        cache_key = cache.get_cache_key(
+            model="gpt-4.1-mini",
+            messages=[
+                {"role": "system", "content": prompt_marker * 100},
+                {"role": "user", "content": "hello"},
+            ],
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "lookup",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"query": {"type": "string"}},
+                        },
+                    },
+                }
+            ],
+            response_format={
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "lookup_response",
+                    "schema": {"type": "object"},
+                },
+            },
+            stream=True,
+        )
+
+    assert re.fullmatch(r"[0-9a-f]{64}", cache_key)
+
+    created_cache_key_logs = [
+        record.getMessage() for record in caplog.records if "Created cache key:" in record.getMessage()
+    ]
+    assert created_cache_key_logs
+    assert all(prompt_marker not in message for message in created_cache_key_logs)
+    assert any(cache_key in message for message in created_cache_key_logs)


### PR DESCRIPTION
## Relevant issues

Fixes #29414

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Delays in PR merge?

N/A

## CI (LiteLLM team)

- [ ] Branch creation CI run
       Link:

- [ ] CI run for the last commit
       Link:

- [ ] Merge / cherry-pick CI run
       Links:

## Screenshots / Proof of Fix

I reproduced the reported debug-log shape by calling `Cache.get_cache_key()` with a long system prompt, tools, response_format, and messages. The returned cache key was already a 64-character SHA-256 key, but the `Created cache key` debug log printed the unhashed source material before this change

After this change, the same script shows the log line contains the final hashed key and the source material length, while the prompt marker is absent from logs

```text
cache_key_len= 64
prompt_marker_in_logs= False
Created cache key: af820855c8cf25649dea1d7decef5da2401d6019181a39ae3a881f78bde3d1ef (source material length: 2559)
```

Validation run locally:

```text
uv run python -m pytest tests/test_litellm/test_model_param_helper.py tests/test_litellm/caching/test_caching.py -q
5 passed in 0.10s

uv run ruff check litellm/caching/caching.py tests/test_litellm/caching/test_caching.py
All checks passed!

uv run ruff format --check tests/test_litellm/caching/test_caching.py
1 file already formatted

git diff --check
```

I did not run `make test-unit` locally because this is a focused cache logging change and the targeted cache-key regression passed

## Type

Bug Fix
Test

## Changes

`Cache.get_cache_key()` now emits the final hashed cache key in the `Created cache key` debug log instead of the raw source material used to derive the hash. The log keeps `source material length` so operators can still spot unexpectedly large cache-key inputs without writing prompt content, tool schemas, or response schemas into debug logs

A regression test covers long prompt material with tools and response_format. It asserts the returned key remains a SHA-256 value and the `Created cache key` debug log does not contain prompt material
