### PR TITLE
feat(proxy): publish /v2/model/info in Swagger OpenAPI spec

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -11742,10 +11742,8 @@ async def _find_model_by_id(
 
 @router.get(
     "/v2/model/info",
-    description="v2 - returns models available to the user based on their API key permissions. Shows model info from config.yaml (except api key and api base). Filter to just user-added models with ?user_models_only=true",
     tags=["model management"],
     dependencies=[Depends(user_api_key_auth)],
-    include_in_schema=False,
 )
 async def model_info_v2(
     user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
@@ -11781,7 +11779,49 @@ async def model_info_v2(
     ),
 ):
     """
-    BETA ENDPOINT. Might change unexpectedly. Use `/v1/model/info` for now.
+    Paginated model metadata for proxy deployments (pricing, provider, team access).
+
+    Returns configured router deployments with enriched `model_info` (costs, provider,
+    context window, etc.). Sensitive fields such as API keys and api_base are omitted.
+
+    Query parameters:
+        model: Filter to a single public `model_name`.
+        user_models_only: When true, only return models created by the calling user.
+        include_team_models: When true, populate `access_via_team_ids` and `direct_access`
+            on each model and filter to deployments the caller can use.
+        page / size: Pagination controls (defaults: page=1, size=50).
+        search: Case-insensitive partial match on model name or team public name.
+        modelId: Return a single deployment by LiteLLM model id.
+        teamId: Filter to models with direct access or team membership for this team id.
+        sortBy / sortOrder: Sort by model_name, created_at, updated_at, costs, or status.
+
+    Example request:
+    ```
+    curl -X GET 'http://localhost:4000/v2/model/info?include_team_models=true&page=1&size=50' \\
+    --header 'Authorization: Bearer sk-1234'
+    ```
+
+    Example response:
+    ```json
+    {
+        "data": [
+            {
+                "model_name": "gpt-4",
+                "litellm_params": {"model": "openai/gpt-4.1"},
+                "model_info": {
+                    "id": "abc123",
+                    "litellm_provider": "openai",
+                    "access_via_team_ids": ["team-1"],
+                    "direct_access": true
+                }
+            }
+        ],
+        "total_count": 1,
+        "current_page": 1,
+        "total_pages": 1,
+        "size": 50
+    }
+    ```
     """
     global llm_model_list, general_settings, user_config_file_path, proxy_config, llm_router
 

--- a/tests/test_litellm/proxy/proxy_server/test_routes_model_info.py
+++ b/tests/test_litellm/proxy/proxy_server/test_routes_model_info.py
@@ -60,6 +60,15 @@ def test_v2_model_info_invalid_page_returns_422(client, auth_as, empty_router):
     assert "detail" in response.json()
 
 
+def test_v2_model_info_in_openapi_schema():
+    """``GET /v2/model/info`` is published in the proxy OpenAPI/Swagger spec."""
+    from litellm.proxy.proxy_server import get_openapi_schema
+
+    schema = get_openapi_schema()
+    assert "/v2/model/info" in schema["paths"]
+    assert "get" in schema["paths"]["/v2/model/info"]
+
+
 # ---------------------------------------------------------------------------
 # GET /v1/model/info, GET /model/info
 # ---------------------------------------------------------------------------

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -18441,7 +18441,49 @@ export interface paths {
         };
         /**
          * Model Info V2
-         * @description v2 - returns models available to the user based on their API key permissions. Shows model info from config.yaml (except api key and api base). Filter to just user-added models with ?user_models_only=true
+         * @description Paginated model metadata for proxy deployments (pricing, provider, team access).
+         *
+         *     Returns configured router deployments with enriched `model_info` (costs, provider,
+         *     context window, etc.). Sensitive fields such as API keys and api_base are omitted.
+         *
+         *     Query parameters:
+         *         model: Filter to a single public `model_name`.
+         *         user_models_only: When true, only return models created by the calling user.
+         *         include_team_models: When true, populate `access_via_team_ids` and `direct_access`
+         *             on each model and filter to deployments the caller can use.
+         *         page / size: Pagination controls (defaults: page=1, size=50).
+         *         search: Case-insensitive partial match on model name or team public name.
+         *         modelId: Return a single deployment by LiteLLM model id.
+         *         teamId: Filter to models with direct access or team membership for this team id.
+         *         sortBy / sortOrder: Sort by model_name, created_at, updated_at, costs, or status.
+         *
+         *     Example request:
+         *     ```
+         *     curl -X GET 'http://localhost:4000/v2/model/info?include_team_models=true&page=1&size=50' \
+         *     --header 'Authorization: Bearer sk-1234'
+         *     ```
+         *
+         *     Example response:
+         *     ```json
+         *     {
+         *         "data": [
+         *             {
+         *                 "model_name": "gpt-4",
+         *                 "litellm_params": {"model": "openai/gpt-4.1"},
+         *                 "model_info": {
+         *                     "id": "abc123",
+         *                     "litellm_provider": "openai",
+         *                     "access_via_team_ids": ["team-1"],
+         *                     "direct_access": true
+         *                 }
+         *             }
+         *         ],
+         *         "total_count": 1,
+         *         "current_page": 1,
+         *         "total_pages": 1,
+         *         "size": 50
+         *     }
+         *     ```
          */
         get: operations["model_info_v2_v2_model_info_get"];
         put?: never;
@@ -43119,13 +43161,13 @@ export interface operations {
             /**
              * @description Unified rate-limit error.
              *
-             *     Every rate-limit condition surfaced by litellm — whether it originated from
-             *     an upstream LLM provider, a vendor batch endpoint, or one of litellm's own
-             *     proxy-side limiters (parallel-requests, dynamic-rate, batch-rate, budget,
-             *     max-iterations, etc.) — is raised as an instance of this class.
+             *         Every rate-limit condition surfaced by litellm — whether it originated from
+             *         an upstream LLM provider, a vendor batch endpoint, or one of litellm's own
+             *         proxy-side limiters (parallel-requests, dynamic-rate, batch-rate, budget,
+             *         max-iterations, etc.) — is raised as an instance of this class.
              *
-             *     The :attr:`category` attribute lets callers distinguish the source. See
-             *     :class:`RateLimitErrorCategory` for the available values.
+             *         The :attr:`category` attribute lets callers distinguish the source. See
+             *         :class:`RateLimitErrorCategory` for the available values.
              */
             429: {
                 headers: {


### PR DESCRIPTION
## Summary
- Expose `GET /v2/model/info` in the proxy Swagger/OpenAPI spec by removing `include_in_schema=False`
- Document endpoint query parameters (pagination, team access, search, sorting) in the route docstring
- Add a test asserting `/v2/model/info` is present in the generated OpenAPI schema

## Test plan
- [x] `pytest tests/test_litellm/proxy/proxy_server/test_routes_model_info.py::test_v2_model_info_in_openapi_schema -v`
- [x] `pytest tests/test_litellm/proxy/proxy_server/test_routes_model_info.py -v` (v2 model info pins)
- [ ] Restart proxy and confirm `/v2/model/info` appears under **model management** at `/docs`


<img width="1341" height="752" alt="image" src="https://github.com/user-attachments/assets/ea5342f4-bbc5-4a40-ad9d-b24710098344" />