### PR TITLE
fix(ui): preserve configured model in connection test

### DIFF
--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -1843,7 +1843,9 @@ async def test_model_connection(
     Note: 
     - If the model is configured in proxy_config.yaml, credentials (api_key, api_base, etc.) 
       will be automatically loaded from the config (with resolved environment variables).
-    - You can override specific params by including them in the request.
+    - You can override specific params by including them in the request. If the
+      model is configured in proxy_config.yaml, the configured provider model is
+      used for the connection test.
     - You can use `os.environ/VARIABLE_NAME` syntax to reference environment variables,
       which will be resolved automatically (same as in proxy_config.yaml).
     

--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -1932,6 +1932,8 @@ async def test_model_connection(
         # Merge: config params (from proxy config) as base, request params override
         # This allows users to override specific params while using config for credentials
         litellm_params = {**config_litellm_params, **request_litellm_params}
+        if config_litellm_params.get("model") is not None:
+            litellm_params["model"] = config_litellm_params["model"]
 
         ## Auth check
         await ModelManagementAuthChecks.can_user_make_model_call(

--- a/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
+++ b/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
@@ -450,20 +450,83 @@ async def test_test_model_connection_loads_config_from_router():
         model_params = ahealth_check_call_args.kwargs.get("model_params", {})
 
         # Verify that config params were loaded and merged
-        # Note: request params override config params, so model from request is used
         assert model_params.get("api_key") == "resolved-api-key-from-env"
         assert (
             model_params.get("api_base")
             == "https://resolved-endpoint.openai.azure.com/"
         )
         assert model_params.get("api_version") == "2024-10-21"
-        assert (
-            model_params.get("model") == "gpt-4o"
-        )  # Request param overrides config param
+        assert model_params.get("model") == "azure/gpt-4o"
 
         # Verify result
         assert result["status"] == "success"
         assert "result" in result
+
+
+@pytest.mark.asyncio
+async def test_test_model_connection_preserves_configured_provider_model():
+    from litellm.types.router import Deployment, LiteLLM_Params
+
+    mock_router = MagicMock()
+    mock_router.get_deployment.return_value = Deployment(
+        model_name="claude-haiku-4.5",
+        litellm_params=LiteLLM_Params(
+            model="bedrock/converse/eu.anthropic.claude-haiku-4-5-20251001-v1:0",
+            aws_region_name="eu-central-1",
+            drop_params=True,
+            additional_drop_params=["extra_headers"],
+        ),
+        model_info={"id": "bedrock-deployment-id", "mode": "chat"},
+    )
+
+    mock_ahealth_check = AsyncMock(return_value={"status": "healthy"})
+    mock_run_with_timeout = AsyncMock(return_value={"status": "healthy"})
+
+    def mock_update_params(model_info, litellm_params):
+        params = litellm_params.copy()
+        params["messages"] = [{"role": "user", "content": "test"}]
+        return params
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
+        patch("litellm.proxy.proxy_server.llm_router", mock_router),
+        patch("litellm.proxy.proxy_server.premium_user", False),
+        patch(
+            "litellm.proxy.management_endpoints.model_management_endpoints.ModelManagementAuthChecks.can_user_make_model_call",
+            AsyncMock(),
+        ),
+        patch(
+            "litellm.proxy.health_endpoints._health_endpoints.litellm.ahealth_check",
+            mock_ahealth_check,
+        ),
+        patch(
+            "litellm.proxy.health_endpoints._health_endpoints.run_with_timeout",
+            mock_run_with_timeout,
+        ),
+        patch(
+            "litellm.proxy.health_endpoints._health_endpoints._update_litellm_params_for_health_check",
+            mock_update_params,
+        ),
+        patch(
+            "litellm.proxy.health_endpoints._health_endpoints._reject_os_environ_references",
+            lambda params: None,
+        ),
+    ):
+        result = await health_test_model_connection(
+            request=MagicMock(),
+            mode="chat",
+            litellm_params={"model": "claude-haiku-4.5"},
+            model_info={"id": "bedrock-deployment-id", "mode": "chat"},
+            user_api_key_dict=MagicMock(),
+        )
+
+    assert result["status"] == "success"
+    model_params = mock_ahealth_check.call_args.kwargs["model_params"]
+    assert (
+        model_params["model"]
+        == "bedrock/converse/eu.anthropic.claude-haiku-4-5-20251001-v1:0"
+    )
+    assert model_params["aws_region_name"] == "eu-central-1"
 
 
 @pytest.mark.asyncio

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -43119,13 +43119,13 @@ export interface operations {
             /**
              * @description Unified rate-limit error.
              *
-             *     Every rate-limit condition surfaced by litellm — whether it originated from
-             *     an upstream LLM provider, a vendor batch endpoint, or one of litellm's own
-             *     proxy-side limiters (parallel-requests, dynamic-rate, batch-rate, budget,
-             *     max-iterations, etc.) — is raised as an instance of this class.
+             *         Every rate-limit condition surfaced by litellm — whether it originated from
+             *         an upstream LLM provider, a vendor batch endpoint, or one of litellm's own
+             *         proxy-side limiters (parallel-requests, dynamic-rate, batch-rate, budget,
+             *         max-iterations, etc.) — is raised as an instance of this class.
              *
-             *     The :attr:`category` attribute lets callers distinguish the source. See
-             *     :class:`RateLimitErrorCategory` for the available values.
+             *         The :attr:`category` attribute lets callers distinguish the source. See
+             *         :class:`RateLimitErrorCategory` for the available values.
              */
             429: {
                 headers: {

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -5880,7 +5880,9 @@ export interface paths {
          *     Note:
          *     - If the model is configured in proxy_config.yaml, credentials (api_key, api_base, etc.)
          *       will be automatically loaded from the config (with resolved environment variables).
-         *     - You can override specific params by including them in the request.
+         *     - You can override specific params by including them in the request. If the
+         *       model is configured in proxy_config.yaml, the configured provider model is
+         *       used for the connection test.
          *     - You can use `os.environ/VARIABLE_NAME` syntax to reference environment variables,
          *       which will be resolved automatically (same as in proxy_config.yaml).
          *


### PR DESCRIPTION
## Relevant issues

Fixes #29785

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Delays in PR merge?

N/A

## CI (LiteLLM team)

- [ ] Branch creation CI run
       Link:

- [ ] CI run for the last commit
       Link:

- [ ] Merge / cherry-pick CI run
       Links:

## Screenshots / Proof of Fix

Targeted local validation:

```bash
env -u ALL_PROXY -u HTTPS_PROXY -u HTTP_PROXY -u all_proxy -u https_proxy -u http_proxy uv run --extra proxy --group proxy-dev pytest tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py -q -k test_model_connection
```

Result: 4 passed, 41 deselected. Pytest reported two existing AsyncMock unawaited-coroutine warnings in neighboring health endpoint tests

Additional checks:

```bash
uv run black --check litellm/proxy/health_endpoints/_health_endpoints.py tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
git diff --check
uv run ruff check litellm/proxy/health_endpoints/_health_endpoints.py
```

All passed

## Type

Bug Fix
Test

## Changes

`/health/test_connection` already loads deployment config from the proxy router before calling `litellm.ahealth_check`. The merge order let the request body's `litellm_params.model` overwrite the configured deployment model, so the UI could send a public model name like `claude-haiku-4.5` and the backend would test that string instead of the configured provider model like `bedrock/converse/...`. That reproduces the "LLM Provider NOT provided" failure from #29785 even though normal routed traffic works.

This keeps the configured deployment model when router config is found, while still allowing direct ad-hoc tests to use the request model when no matching deployment config exists. I also updated the existing router-config test and added a Bedrock Converse regression covering the public-name to provider-model case
