### PR TITLE
fix(router): stamp actual retry count on exception when retry_policy sets retries to 0

### DIFF
--- a/litellm/exceptions.py
+++ b/litellm/exceptions.py
@@ -60,17 +60,17 @@ class AuthenticationError(openai.AuthenticationError):  # type: ignore
 
     def __str__(self):
         _message = self.message
-        if self.num_retries:
+        if self.num_retries is not None:
             _message += f" LiteLLM Retried: {self.num_retries} times"
-        if self.max_retries:
+        if self.max_retries is not None:
             _message += f", LiteLLM Max Retries: {self.max_retries}"
         return _message
 
     def __repr__(self):
         _message = self.message
-        if self.num_retries:
+        if self.num_retries is not None:
             _message += f" LiteLLM Retried: {self.num_retries} times"
-        if self.max_retries:
+        if self.max_retries is not None:
             _message += f", LiteLLM Max Retries: {self.max_retries}"
         return _message
 
@@ -106,17 +106,17 @@ class NotFoundError(openai.NotFoundError):  # type: ignore
 
     def __str__(self):
         _message = self.message
-        if self.num_retries:
+        if self.num_retries is not None:
             _message += f" LiteLLM Retried: {self.num_retries} times"
-        if self.max_retries:
+        if self.max_retries is not None:
             _message += f", LiteLLM Max Retries: {self.max_retries}"
         return _message
 
     def __repr__(self):
         _message = self.message
-        if self.num_retries:
+        if self.num_retries is not None:
             _message += f" LiteLLM Retried: {self.num_retries} times"
-        if self.max_retries:
+        if self.max_retries is not None:
             _message += f", LiteLLM Max Retries: {self.max_retries}"
         return _message
 
@@ -157,17 +157,17 @@ class BadRequestError(openai.BadRequestError):  # type: ignore
 
     def __str__(self):
         _message = self.message
-        if self.num_retries:
+        if self.num_retries is not None:
             _message += f" LiteLLM Retried: {self.num_retries} times"
-        if self.max_retries:
+        if self.max_retries is not None:
             _message += f", LiteLLM Max Retries: {self.max_retries}"
         return _message
 
     def __repr__(self):
         _message = self.message
-        if self.num_retries:
+        if self.num_retries is not None:
             _message += f" LiteLLM Retried: {self.num_retries} times"
-        if self.max_retries:
+        if self.max_retries is not None:
             _message += f", LiteLLM Max Retries: {self.max_retries}"
         return _message
 
@@ -220,17 +220,17 @@ class UnprocessableEntityError(openai.UnprocessableEntityError):  # type: ignore
 
     def __str__(self):
         _message = self.message
-        if self.num_retries:
+        if self.num_retries is not None:
             _message += f" LiteLLM Retried: {self.num_retries} times"
-        if self.max_retries:
+        if self.max_retries is not None:
             _message += f", LiteLLM Max Retries: {self.max_retries}"
         return _message
 
     def __repr__(self):
         _message = self.message
-        if self.num_retries:
+        if self.num_retries is not None:
             _message += f" LiteLLM Retried: {self.num_retries} times"
-        if self.max_retries:
+        if self.max_retries is not None:
             _message += f", LiteLLM Max Retries: {self.max_retries}"
         return _message
 
@@ -266,17 +266,17 @@ class Timeout(openai.APITimeoutError):  # type: ignore
     # custom function to convert to str
     def __str__(self):
         _message = self.message
-        if self.num_retries:
+        if self.num_retries is not None:
             _message += f" LiteLLM Retried: {self.num_retries} times"
-        if self.max_retries:
+        if self.max_retries is not None:
             _message += f", LiteLLM Max Retries: {self.max_retries}"
         return _message
 
     def __repr__(self):
         _message = self.message
-        if self.num_retries:
+        if self.num_retries is not None:
             _message += f" LiteLLM Retried: {self.num_retries} times"
-        if self.max_retries:
+        if self.max_retries is not None:
             _message += f", LiteLLM Max Retries: {self.max_retries}"
         return _message
 
@@ -305,17 +305,17 @@ class PermissionDeniedError(openai.PermissionDeniedError):  # type: ignore
 
     def __str__(self):
         _message = self.message
-        if self.num_retries:
+        if self.num_retries is not None:
             _message += f" LiteLLM Retried: {self.num_retries} times"
-        if self.max_retries:
+        if self.max_retries is not None:
             _message += f", LiteLLM Max Retries: {self.max_retries}"
         return _message
 
     def __repr__(self):
         _message = self.message
-        if self.num_retries:
+        if self.num_retries is not None:
             _message += f" LiteLLM Retried: {self.num_retries} times"
-        if self.max_retries:
+        if self.max_retries is not None:
             _message += f", LiteLLM Max Retries: {self.max_retries}"
         return _message
 
@@ -357,17 +357,17 @@ class RateLimitError(openai.RateLimitError):  # type: ignore
 
     def __str__(self):
         _message = self.message
-        if self.num_retries:
+        if self.num_retries is not None:
             _message += f" LiteLLM Retried: {self.num_retries} times"
-        if self.max_retries:
+        if self.max_retries is not None:
             _message += f", LiteLLM Max Retries: {self.max_retries}"
         return _message
 
     def __repr__(self):
         _message = self.message
-        if self.num_retries:
+        if self.num_retries is not None:
             _message += f" LiteLLM Retried: {self.num_retries} times"
-        if self.max_retries:
+        if self.max_retries is not None:
             _message += f", LiteLLM Max Retries: {self.max_retries}"
         return _message
 
@@ -399,17 +399,17 @@ class ContextWindowExceededError(BadRequestError):  # type: ignore
 
     def __str__(self):
         _message = self.message
-        if self.num_retries:
+        if self.num_retries is not None:
             _message += f" LiteLLM Retried: {self.num_retries} times"
-        if self.max_retries:
+        if self.max_retries is not None:
             _message += f", LiteLLM Max Retries: {self.max_retries}"
         return _message
 
     def __repr__(self):
         _message = self.message
-        if self.num_retries:
+        if self.num_retries is not None:
             _message += f" LiteLLM Retried: {self.num_retries} times"
-        if self.max_retries:
+        if self.max_retries is not None:
             _message += f", LiteLLM Max Retries: {self.max_retries}"
         return _message
 
@@ -442,17 +442,17 @@ class RejectedRequestError(BadRequestError):  # type: ignore
 
     def __str__(self):
         _message = self.message
-        if self.num_retries:
+        if self.num_retries is not None:
             _message += f" LiteLLM Retried: {self.num_retries} times"
-        if self.max_retries:
+        if self.max_retries is not None:
             _message += f", LiteLLM Max Retries: {self.max_retries}"
         return _message
 
     def __repr__(self):
         _message = self.message
-        if self.num_retries:
+        if self.num_retries is not None:
             _message += f" LiteLLM Retried: {self.num_retries} times"
-        if self.max_retries:
+        if self.max_retries is not None:
             _message += f", LiteLLM Max Retries: {self.max_retries}"
         return _message
 
@@ -495,9 +495,9 @@ class ContentPolicyViolationError(BadRequestError):  # type: ignore
         Transform the error to a string
         """
         _message = self.message
-        if self.num_retries:
+        if self.num_retries is not None:
             _message += f" LiteLLM Retried: {self.num_retries} times"
-        if self.max_retries:
+        if self.max_retries is not None:
             _message += f", LiteLLM Max Retries: {self.max_retries}"
         return _message
 
@@ -537,17 +537,17 @@ class ServiceUnavailableError(openai.APIStatusError):  # type: ignore
 
     def __str__(self):
         _message = self.message
-        if self.num_retries:
+        if self.num_retries is not None:
             _message += f" LiteLLM Retried: {self.num_retries} times"
-        if self.max_retries:
+        if self.max_retries is not None:
             _message += f", LiteLLM Max Retries: {self.max_retries}"
         return _message
 
     def __repr__(self):
         _message = self.message
-        if self.num_retries:
+        if self.num_retries is not None:
             _message += f" LiteLLM Retried: {self.num_retries} times"
-        if self.max_retries:
+        if self.max_retries is not None:
             _message += f", LiteLLM Max Retries: {self.max_retries}"
         return _message
 
@@ -587,17 +587,17 @@ class BadGatewayError(openai.APIStatusError):  # type: ignore
 
     def __str__(self):
         _message = self.message
-        if self.num_retries:
+        if self.num_retries is not None:
             _message += f" LiteLLM Retried: {self.num_retries} times"
-        if self.max_retries:
+        if self.max_retries is not None:
             _message += f", LiteLLM Max Retries: {self.max_retries}"
         return _message
 
     def __repr__(self):
         _message = self.message
-        if self.num_retries:
+        if self.num_retries is not None:
             _message += f" LiteLLM Retried: {self.num_retries} times"
-        if self.max_retries:
+        if self.max_retries is not None:
             _message += f", LiteLLM Max Retries: {self.max_retries}"
         return _message
 
@@ -637,17 +637,17 @@ class InternalServerError(openai.InternalServerError):  # type: ignore
 
     def __str__(self):
         _message = self.message
-        if self.num_retries:
+        if self.num_retries is not None:
             _message += f" LiteLLM Retried: {self.num_retries} times"
-        if self.max_retries:
+        if self.max_retries is not None:
             _message += f", LiteLLM Max Retries: {self.max_retries}"
         return _message
 
     def __repr__(self):
         _message = self.message
-        if self.num_retries:
+        if self.num_retries is not None:
             _message += f" LiteLLM Retried: {self.num_retries} times"
-        if self.max_retries:
+        if self.max_retries is not None:
             _message += f", LiteLLM Max Retries: {self.max_retries}"
         return _message
 
@@ -678,17 +678,17 @@ class APIError(openai.APIError):  # type: ignore
 
     def __str__(self):
         _message = self.message
-        if self.num_retries:
+        if self.num_retries is not None:
             _message += f" LiteLLM Retried: {self.num_retries} times"
-        if self.max_retries:
+        if self.max_retries is not None:
             _message += f", LiteLLM Max Retries: {self.max_retries}"
         return _message
 
     def __repr__(self):
         _message = self.message
-        if self.num_retries:
+        if self.num_retries is not None:
             _message += f" LiteLLM Retried: {self.num_retries} times"
-        if self.max_retries:
+        if self.max_retries is not None:
             _message += f", LiteLLM Max Retries: {self.max_retries}"
         return _message
 
@@ -717,17 +717,17 @@ class APIConnectionError(openai.APIConnectionError):  # type: ignore
 
     def __str__(self):
         _message = self.message
-        if self.num_retries:
+        if self.num_retries is not None:
             _message += f" LiteLLM Retried: {self.num_retries} times"
-        if self.max_retries:
+        if self.max_retries is not None:
             _message += f", LiteLLM Max Retries: {self.max_retries}"
         return _message
 
     def __repr__(self):
         _message = self.message
-        if self.num_retries:
+        if self.num_retries is not None:
             _message += f" LiteLLM Retried: {self.num_retries} times"
-        if self.max_retries:
+        if self.max_retries is not None:
             _message += f", LiteLLM Max Retries: {self.max_retries}"
         return _message
 
@@ -755,17 +755,17 @@ class APIResponseValidationError(openai.APIResponseValidationError):  # type: ig
 
     def __str__(self):
         _message = self.message
-        if self.num_retries:
+        if self.num_retries is not None:
             _message += f" LiteLLM Retried: {self.num_retries} times"
-        if self.max_retries:
+        if self.max_retries is not None:
             _message += f", LiteLLM Max Retries: {self.max_retries}"
         return _message
 
     def __repr__(self):
         _message = self.message
-        if self.num_retries:
+        if self.num_retries is not None:
             _message += f" LiteLLM Retried: {self.num_retries} times"
-        if self.max_retries:
+        if self.max_retries is not None:
             _message += f", LiteLLM Max Retries: {self.max_retries}"
         return _message
 
@@ -1005,9 +1005,9 @@ class MidStreamFallbackError(ServiceUnavailableError):  # type: ignore
 
     def __str__(self):
         _message = self.message
-        if self.num_retries:
+        if self.num_retries is not None:
             _message += f" LiteLLM Retried: {self.num_retries} times"
-        if self.max_retries:
+        if self.max_retries is not None:
             _message += f", LiteLLM Max Retries: {self.max_retries}"
         if self.original_exception:
             _message += f" Original exception: {type(self.original_exception).__name__}: {str(self.original_exception)}"

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -5796,8 +5796,8 @@ class Router:
                 # (0) before raising so error messages reflect reality instead of
                 # carrying a stale value injected by the @client decorator.
                 if type(original_exception) in litellm.LITELLM_EXCEPTION_TYPES:
-                    setattr(original_exception, "max_retries", 0)
-                    setattr(original_exception, "num_retries", 0)
+                    setattr(original_exception, "max_retries", num_retries)
+                    setattr(original_exception, "num_retries", num_retries)
                 raise
 
             verbose_router_logger.debug(

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -5792,6 +5792,12 @@ class Router:
             if num_retries > 0:
                 kwargs = self.log_retry(kwargs=kwargs, e=original_exception)
             else:
+                # No retries will occur; stamp the exception with the actual counts
+                # (0) before raising so error messages reflect reality instead of
+                # carrying a stale value injected by the @client decorator.
+                if type(original_exception) in litellm.LITELLM_EXCEPTION_TYPES:
+                    setattr(original_exception, "max_retries", 0)
+                    setattr(original_exception, "num_retries", 0)
                 raise
 
             verbose_router_logger.debug(

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -2088,9 +2088,19 @@ def client(original_function):  # noqa: PLR0915
                     except Exception:
                         pass
 
-            setattr(
-                e, "num_retries", num_retries
-            )  ## IMPORTANT: returns the deployment's num_retries to the router
+            # Only set num_retries on the exception for non-router calls.
+            # When the router is in use, it manages retry counts itself and stamps
+            # the actual attempted count via setattr after the retry loop completes.
+            # Injecting litellm.num_retries here for router calls causes misleading
+            # "LiteLLM Retried: N times" in error messages even when zero retries
+            # occurred (e.g. TimeoutErrorRetries=0 in retry_policy).
+            _is_router_or_proxy_call = "model_group" in (
+                kwargs.get("metadata") or {}
+            )
+            if not _is_router_or_proxy_call:
+                setattr(
+                    e, "num_retries", num_retries
+                )  ## returns the deployment's num_retries for non-router retry logic
 
             timeout = _get_wrapper_timeout(kwargs=kwargs, exception=e)
             setattr(e, "timeout", timeout)

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -2094,9 +2094,7 @@ def client(original_function):  # noqa: PLR0915
             # Injecting litellm.num_retries here for router calls causes misleading
             # "LiteLLM Retried: N times" in error messages even when zero retries
             # occurred (e.g. TimeoutErrorRetries=0 in retry_policy).
-            _is_router_or_proxy_call = "model_group" in (
-                kwargs.get("metadata") or {}
-            )
+            _is_router_or_proxy_call = "model_group" in (kwargs.get("metadata") or {})
             if not _is_router_or_proxy_call:
                 setattr(
                     e, "num_retries", num_retries

--- a/tests/test_litellm/test_retry_count_in_exception_messages.py
+++ b/tests/test_litellm/test_retry_count_in_exception_messages.py
@@ -178,8 +178,9 @@ async def test_decorator_does_not_inject_global_num_retries_for_router_calls():
                 )
 
         raised = exc_info.value
-        assert raised.num_retries != 99, (
-            "Decorator injected litellm.num_retries=99 into a router-managed exception. "
+        assert raised.num_retries == 0, (
+            f"Expected num_retries=0 (router stamped actual count), "
+            f"got {raised.num_retries}. "
             "Router calls should not be polluted by the global litellm.num_retries value."
         )
     finally:

--- a/tests/test_litellm/test_retry_count_in_exception_messages.py
+++ b/tests/test_litellm/test_retry_count_in_exception_messages.py
@@ -1,0 +1,186 @@
+"""
+Tests for accurate retry count stamping in exception messages.
+
+Verifies that:
+1. retry_policy with TimeoutErrorRetries=0 stamps num_retries=0 / max_retries=0
+   on the exception — not a stale value from litellm.num_retries.
+2. exceptions.py __str__ displays 0 retries (is-not-None check, not truthy).
+3. The @client decorator does not inject litellm.num_retries into exceptions
+   that come from router/proxy calls.
+
+Regression tests for https://github.com/BerriAI/litellm/pull/29903
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import litellm
+from litellm import Router
+from litellm.exceptions import Timeout, InternalServerError
+from litellm.types.router import RetryPolicy
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_timeout(message="Connection timed out"):
+    return Timeout(
+        message=message,
+        model="claude-opus-4-6",
+        llm_provider="vertex_ai",
+    )
+
+
+def _make_internal_server_error(message="vLLM connection refused"):
+    return InternalServerError(
+        message=message,
+        model="hosted_vllm/llama-3.1",
+        llm_provider="hosted_vllm",
+    )
+
+
+def _make_router(retry_policy: dict) -> Router:
+    return Router(
+        model_list=[
+            {
+                "model_name": "test-model",
+                "litellm_params": {
+                    "model": "openai/gpt-4o",
+                    "api_key": "fake-key",
+                },
+            }
+        ],
+        retry_policy=RetryPolicy(**retry_policy),
+        num_retries=3,
+    )
+
+
+# ---------------------------------------------------------------------------
+# exceptions.py: is-not-None check
+# ---------------------------------------------------------------------------
+
+class TestExceptionStrFormat:
+    def test_zero_num_retries_is_displayed(self):
+        """num_retries=0 should appear in __str__, not be silently suppressed."""
+        exc = _make_timeout()
+        exc.num_retries = 0
+        exc.max_retries = 0
+        s = str(exc)
+        assert "LiteLLM Retried: 0 times" in s
+        assert "LiteLLM Max Retries: 0" in s
+
+    def test_none_num_retries_is_not_displayed(self):
+        """num_retries=None (unset) should not produce any retry text."""
+        exc = _make_timeout()
+        exc.num_retries = None
+        exc.max_retries = None
+        s = str(exc)
+        assert "LiteLLM Retried" not in s
+        assert "LiteLLM Max Retries" not in s
+
+    def test_nonzero_num_retries_displayed_normally(self):
+        """num_retries=3 should display as before."""
+        exc = _make_internal_server_error()
+        exc.num_retries = 3
+        exc.max_retries = 3
+        s = str(exc)
+        assert "LiteLLM Retried: 3 times" in s
+        assert "LiteLLM Max Retries: 3" in s
+
+
+# ---------------------------------------------------------------------------
+# router.py: TimeoutErrorRetries=0 stamps 0 on exception
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_timeout_zero_retries_stamps_zero_on_exception():
+    """
+    With TimeoutErrorRetries=0, the router should stamp num_retries=0 and
+    max_retries=0 on the exception before raising — not leave a stale value.
+    """
+    router = _make_router({"TimeoutErrorRetries": 0})
+
+    timeout_exc = _make_timeout()
+
+    with patch.object(router, "_acompletion", new_callable=AsyncMock) as mock_call:
+        mock_call.side_effect = timeout_exc
+
+        with pytest.raises(Timeout) as exc_info:
+            await router.acompletion(
+                model="test-model",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+    raised = exc_info.value
+    assert raised.num_retries == 0, (
+        f"Expected num_retries=0, got {raised.num_retries}. "
+        "TimeoutErrorRetries=0 should stamp 0 retries, not litellm.num_retries."
+    )
+    assert raised.max_retries == 0, (
+        f"Expected max_retries=0, got {raised.max_retries}."
+    )
+
+
+@pytest.mark.asyncio
+async def test_internal_server_error_three_retries_stamps_correctly():
+    """
+    With InternalServerErrorRetries=3, the router should retry 3 times and
+    stamp num_retries=3 / max_retries=3 on the final exception.
+    """
+    router = _make_router({"InternalServerErrorRetries": 3})
+
+    with patch.object(router, "_acompletion", new_callable=AsyncMock) as mock_call:
+        mock_call.side_effect = _make_internal_server_error()
+
+        with pytest.raises(InternalServerError) as exc_info:
+            await router.acompletion(
+                model="test-model",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+    raised = exc_info.value
+    assert raised.num_retries == 3, (
+        f"Expected num_retries=3, got {raised.num_retries}."
+    )
+    assert raised.max_retries == 3, (
+        f"Expected max_retries=3, got {raised.max_retries}."
+    )
+    assert mock_call.call_count == 4  # 1 initial + 3 retries
+
+
+# ---------------------------------------------------------------------------
+# utils.py: decorator does not inject litellm.num_retries for router calls
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_decorator_does_not_inject_global_num_retries_for_router_calls():
+    """
+    When a call comes from the router (metadata contains model_group),
+    the @client decorator must not stamp litellm.num_retries onto the
+    exception. The router manages its own retry counts.
+    """
+    original_num_retries = litellm.num_retries
+    litellm.num_retries = 99  # set a clearly wrong global value
+
+    try:
+        router = _make_router({"TimeoutErrorRetries": 0})
+        timeout_exc = _make_timeout()
+
+        with patch.object(router, "_acompletion", new_callable=AsyncMock) as mock_call:
+            mock_call.side_effect = timeout_exc
+
+            with pytest.raises(Timeout) as exc_info:
+                await router.acompletion(
+                    model="test-model",
+                    messages=[{"role": "user", "content": "hi"}],
+                )
+
+        raised = exc_info.value
+        assert raised.num_retries != 99, (
+            "Decorator injected litellm.num_retries=99 into a router-managed exception. "
+            "Router calls should not be polluted by the global litellm.num_retries value."
+        )
+    finally:
+        litellm.num_retries = original_num_retries

--- a/tests/test_litellm/test_retry_count_in_exception_messages.py
+++ b/tests/test_litellm/test_retry_count_in_exception_messages.py
@@ -20,10 +20,10 @@ from litellm import Router
 from litellm.exceptions import Timeout, InternalServerError
 from litellm.types.router import RetryPolicy
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _make_timeout(message="Connection timed out"):
     return Timeout(
@@ -61,6 +61,7 @@ def _make_router(retry_policy: dict) -> Router:
 # exceptions.py: is-not-None check
 # ---------------------------------------------------------------------------
 
+
 class TestExceptionStrFormat:
     def test_zero_num_retries_is_displayed(self):
         """num_retries=0 should appear in __str__, not be silently suppressed."""
@@ -94,6 +95,7 @@ class TestExceptionStrFormat:
 # router.py: TimeoutErrorRetries=0 stamps 0 on exception
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 async def test_timeout_zero_retries_stamps_zero_on_exception():
     """
@@ -118,9 +120,7 @@ async def test_timeout_zero_retries_stamps_zero_on_exception():
         f"Expected num_retries=0, got {raised.num_retries}. "
         "TimeoutErrorRetries=0 should stamp 0 retries, not litellm.num_retries."
     )
-    assert raised.max_retries == 0, (
-        f"Expected max_retries=0, got {raised.max_retries}."
-    )
+    assert raised.max_retries == 0, f"Expected max_retries=0, got {raised.max_retries}."
 
 
 @pytest.mark.asyncio
@@ -141,18 +141,15 @@ async def test_internal_server_error_three_retries_stamps_correctly():
             )
 
     raised = exc_info.value
-    assert raised.num_retries == 3, (
-        f"Expected num_retries=3, got {raised.num_retries}."
-    )
-    assert raised.max_retries == 3, (
-        f"Expected max_retries=3, got {raised.max_retries}."
-    )
+    assert raised.num_retries == 3, f"Expected num_retries=3, got {raised.num_retries}."
+    assert raised.max_retries == 3, f"Expected max_retries=3, got {raised.max_retries}."
     assert mock_call.call_count == 4  # 1 initial + 3 retries
 
 
 # ---------------------------------------------------------------------------
 # utils.py: decorator does not inject litellm.num_retries for router calls
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.asyncio
 async def test_decorator_does_not_inject_global_num_retries_for_router_calls():


### PR DESCRIPTION
## Relevant issues

<!-- Fixes #XXXXX if applicable -->

## Pre-Submission checklist

- [x] I have added tests in [`tests/test_litellm/test_retry_count_in_exception_messages.py`](https://github.com/jungraekim-gif/litellm/blob/fix/misleading-retry-count-in-exception-messages/tests/test_litellm/test_retry_count_in_exception_messages.py)
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai`

## Type

🐛 Bug Fix

## Changes

Fix misleading "LiteLLM Retried: N times" in error messages when `retry_policy` sets retries to 0 (e.g. `TimeoutErrorRetries: 0`).

### Root Cause

Three separate issues interact:

1. **`utils.py`**: The `@client` decorator unconditionally stamps `e.num_retries = litellm.num_retries` on every exception — including router-managed calls where the router controls its own retry logic.
2. **`router.py`**: The `setattr` that records the actual retry count only runs *after* the retry loop. When `num_retries=0` (retry_policy short-circuits), the `else: raise` path exits before that code is reached, leaving the decorator's stale value intact.
3. **`exceptions.py`**: `if self.num_retries:` is a truthy check — `0` evaluates to `False` and is silently suppressed, so even if the correct count were stamped, it would not appear in the message.

### Fix

- **`utils.py`**: Skip `num_retries` injection for router/proxy calls (detected via `"model_group" in metadata`). The router manages its own retry counts.
- **`router.py`**: In the `else: raise` branch (0 retries), stamp `num_retries=0` and `max_retries=0` on the exception before raising.
- **`exceptions.py`**: Change `if self.num_retries:` / `if self.max_retries:` to `is not None` checks across all exception classes so a count of `0` is displayed rather than suppressed.

## Screenshots / Proof of Fix

**Before (TimeoutErrorRetries=0, litellm_settings.num_retries=3):**
```
litellm.Timeout: ... LiteLLM Retried: 3 times LiteLLM Retried: 3 times
```
Zero actual retries occurred, but the stale global value (3) was displayed.

**After:**
```
litellm.Timeout: ... LiteLLM Retried: 0 times, LiteLLM Max Retries: 0
```

**InternalServerErrorRetries=3 (real retries — unchanged):**
```
litellm.InternalServerError: ... LiteLLM Retried: 3 times, LiteLLM Max Retries: 3
```
