### PR TITLE
feat(galileo): add health check support for UI callback test

### DIFF
--- a/litellm/integrations/galileo.py
+++ b/litellm/integrations/galileo.py
@@ -124,6 +124,18 @@ class GalileoObserve(CustomLogger):
                     "error_message": "Galileo authentication failed",
                 }
 
+            response = await self.async_httpx_handler.get(
+                url=f"{self.base_url}/current_user",
+                headers=self.headers,
+            )
+            if response.status_code >= 400:
+                return {
+                    "status": "unhealthy",
+                    "error_message": (
+                        f"Galileo API returned HTTP {response.status_code}"
+                    ),
+                }
+
             return {
                 "status": "healthy",
                 "message": "Galileo credentials are configured properly",

--- a/litellm/integrations/galileo.py
+++ b/litellm/integrations/galileo.py
@@ -517,7 +517,7 @@ class GalileoObserve(CustomLogger):
         """
         Mirror Langfuse _get_langfuse_input_output_content for Galileo ingest.
 
-        Returns (input_text, output_text, messages_for_span). output_text None skips ingest.
+        Returns (input_text, output_text, messages_for_span).
         """
         call_type = kwargs.get("call_type")
         prompt = self._build_prompt(kwargs)
@@ -530,10 +530,11 @@ class GalileoObserve(CustomLogger):
             return self._prompt_to_input_text(prompt), status_message, prompt
 
         if response_obj is not None and (
-            call_type == "embedding"
+            call_type in ("embedding", "aembedding")
             or isinstance(response_obj, litellm.EmbeddingResponse)
         ):
-            return self._prompt_to_input_text(prompt), None, prompt
+            # Match Langfuse OTEL: log embeddings without serializing vectors.
+            return self._prompt_to_input_text(prompt), "embedding-output", prompt
 
         if response_obj is not None and isinstance(response_obj, litellm.ModelResponse):
             output = self._get_chat_content_for_galileo(response_obj)
@@ -627,7 +628,7 @@ class GalileoObserve(CustomLogger):
                 kwargs.get("messages") or [],
             )
 
-        return self._prompt_to_input_text(prompt), None, kwargs.get("messages") or []
+        return self._prompt_to_input_text(prompt), "", kwargs.get("messages") or []
 
     def get_output_str_from_response(
         self, response_obj: Any, kwargs: Dict[str, Any]
@@ -713,10 +714,7 @@ class GalileoObserve(CustomLogger):
             kwargs=kwargs, response_obj=response_obj
         )
         if output_text is None:
-            verbose_logger.debug(
-                "Galileo Logger: skipping %s — no text output to log", _call_type
-            )
-            return
+            output_text = ""
 
         raw_start = slo.get("startTime")
         raw_end = slo.get("endTime")

--- a/litellm/integrations/galileo.py
+++ b/litellm/integrations/galileo.py
@@ -89,6 +89,51 @@ class GalileoObserve(CustomLogger):
             return bool(self.api_key)
         return bool(self.username and self.password)
 
+    async def async_health_check(self) -> dict:
+        try:
+            if not self.project_id:
+                return {
+                    "status": "unhealthy",
+                    "error_message": "GALILEO_PROJECT_ID environment variable not set",
+                }
+
+            if not self.base_url:
+                return {
+                    "status": "unhealthy",
+                    "error_message": "GALILEO_BASE_URL environment variable not set",
+                }
+
+            if self.use_v2_api:
+                if not self.api_key:
+                    return {
+                        "status": "unhealthy",
+                        "error_message": "GALILEO_API_KEY environment variable not set",
+                    }
+            elif not self.username or not self.password:
+                return {
+                    "status": "unhealthy",
+                    "error_message": (
+                        "GALILEO_USERNAME and GALILEO_PASSWORD environment "
+                        "variables must be set"
+                    ),
+                }
+
+            if not await self._ensure_headers():
+                return {
+                    "status": "unhealthy",
+                    "error_message": "Galileo authentication failed",
+                }
+
+            return {
+                "status": "healthy",
+                "message": "Galileo credentials are configured properly",
+            }
+        except Exception as e:
+            return {
+                "status": "unhealthy",
+                "error_message": f"Galileo health check failed: {str(e)}",
+            }
+
     async def async_set_galileo_headers(self) -> None:
         galileo_login_response = await self.async_httpx_handler.post(
             url=f"{self.base_url}/login",

--- a/litellm/integrations/galileo.py
+++ b/litellm/integrations/galileo.py
@@ -104,18 +104,12 @@ class GalileoObserve(CustomLogger):
                     error_message="GALILEO_BASE_URL environment variable not set",
                 )
 
-            if self.use_v2_api:
-                if not self.api_key:
-                    return IntegrationHealthCheckStatus(
-                        status="unhealthy",
-                        error_message="GALILEO_API_KEY environment variable not set",
-                    )
-            elif not self.username or not self.password:
+            if not self.use_v2_api and (not self.username or not self.password):
                 return IntegrationHealthCheckStatus(
                     status="unhealthy",
                     error_message=(
-                        "GALILEO_USERNAME and GALILEO_PASSWORD environment "
-                        "variables must be set"
+                        "GALILEO_API_KEY or GALILEO_USERNAME and GALILEO_PASSWORD "
+                        "environment variables must be set"
                     ),
                 )
 
@@ -452,9 +446,9 @@ class GalileoObserve(CustomLogger):
         return prompt
 
     @staticmethod
-    def _serialize_galileo_output(value: Any) -> Optional[str]:
+    def _serialize_galileo_output(value: Any) -> str:
         if value is None:
-            return None
+            return ""
         if isinstance(value, str):
             return value
 
@@ -513,7 +507,7 @@ class GalileoObserve(CustomLogger):
         response_obj: Any,
         level: str = "DEFAULT",
         status_message: Optional[str] = None,
-    ) -> Tuple[str, Optional[str], Any]:
+    ) -> Tuple[str, str, Any]:
         """
         Mirror Langfuse _get_langfuse_input_output_content for Galileo ingest.
 
@@ -603,7 +597,7 @@ class GalileoObserve(CustomLogger):
         ):
             input_val = kwargs.get("input")
             return (
-                self._serialize_galileo_output(input_val) or "",
+                self._serialize_galileo_output(input_val),
                 self._serialize_galileo_output(response_obj),
                 input_val,
             )
@@ -632,7 +626,7 @@ class GalileoObserve(CustomLogger):
 
     def get_output_str_from_response(
         self, response_obj: Any, kwargs: Dict[str, Any]
-    ) -> Optional[str]:
+    ) -> str:
         _, output_text, _ = self._get_galileo_input_output_content(
             kwargs=kwargs, response_obj=response_obj
         )
@@ -713,8 +707,6 @@ class GalileoObserve(CustomLogger):
         input_text, output_text, messages = self._get_galileo_input_output_content(
             kwargs=kwargs, response_obj=response_obj
         )
-        if output_text is None:
-            output_text = ""
 
         raw_start = slo.get("startTime")
         raw_end = slo.get("endTime")

--- a/litellm/integrations/galileo.py
+++ b/litellm/integrations/galileo.py
@@ -26,6 +26,7 @@ from litellm.llms.custom_httpx.http_handler import (
     get_async_httpx_client,
     httpxSpecialProvider,
 )
+from litellm.types.integrations.base_health_check import IntegrationHealthCheckStatus
 
 GALILEO_CLOUD_API_BASE_URL = "https://api.galileo.ai"
 # Cap the in-memory buffer so persistent flush failures (e.g. Galileo
@@ -89,62 +90,57 @@ class GalileoObserve(CustomLogger):
             return bool(self.api_key)
         return bool(self.username and self.password)
 
-    async def async_health_check(self) -> dict:
+    async def async_health_check(self) -> IntegrationHealthCheckStatus:
         try:
             if not self.project_id:
-                return {
-                    "status": "unhealthy",
-                    "error_message": "GALILEO_PROJECT_ID environment variable not set",
-                }
+                return IntegrationHealthCheckStatus(
+                    status="unhealthy",
+                    error_message="GALILEO_PROJECT_ID environment variable not set",
+                )
 
             if not self.base_url:
-                return {
-                    "status": "unhealthy",
-                    "error_message": "GALILEO_BASE_URL environment variable not set",
-                }
+                return IntegrationHealthCheckStatus(
+                    status="unhealthy",
+                    error_message="GALILEO_BASE_URL environment variable not set",
+                )
 
             if self.use_v2_api:
                 if not self.api_key:
-                    return {
-                        "status": "unhealthy",
-                        "error_message": "GALILEO_API_KEY environment variable not set",
-                    }
+                    return IntegrationHealthCheckStatus(
+                        status="unhealthy",
+                        error_message="GALILEO_API_KEY environment variable not set",
+                    )
             elif not self.username or not self.password:
-                return {
-                    "status": "unhealthy",
-                    "error_message": (
+                return IntegrationHealthCheckStatus(
+                    status="unhealthy",
+                    error_message=(
                         "GALILEO_USERNAME and GALILEO_PASSWORD environment "
                         "variables must be set"
                     ),
-                }
+                )
 
             if not await self._ensure_headers():
-                return {
-                    "status": "unhealthy",
-                    "error_message": "Galileo authentication failed",
-                }
+                return IntegrationHealthCheckStatus(
+                    status="unhealthy",
+                    error_message="Galileo authentication failed",
+                )
 
             response = await self.async_httpx_handler.get(
                 url=f"{self.base_url}/current_user",
                 headers=self.headers,
             )
             if response.status_code >= 400:
-                return {
-                    "status": "unhealthy",
-                    "error_message": (
-                        f"Galileo API returned HTTP {response.status_code}"
-                    ),
-                }
+                return IntegrationHealthCheckStatus(
+                    status="unhealthy",
+                    error_message=(f"Galileo API returned HTTP {response.status_code}"),
+                )
 
-            return {
-                "status": "healthy",
-                "message": "Galileo credentials are configured properly",
-            }
+            return IntegrationHealthCheckStatus(status="healthy", error_message=None)
         except Exception as e:
-            return {
-                "status": "unhealthy",
-                "error_message": f"Galileo health check failed: {str(e)}",
-            }
+            return IntegrationHealthCheckStatus(
+                status="unhealthy",
+                error_message=f"Galileo health check failed: {str(e)}",
+            )
 
     async def async_set_galileo_headers(self) -> None:
         galileo_login_response = await self.async_httpx_handler.post(

--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -129,6 +129,7 @@ services = Union[
         "datadog_llm_observability",
         "generic_api",
         "arize",
+        "galileo",
         "sqs",
     ],
     str,
@@ -206,6 +207,7 @@ async def health_services_endpoint(  # noqa: PLR0915
             "datadog_llm_observability",
             "generic_api",
             "arize",
+            "galileo",
             "sqs",
         ]:
             raise HTTPException(
@@ -293,6 +295,19 @@ async def health_services_endpoint(  # noqa: PLR0915
                     response["error_message"]
                     if response["status"] == "unhealthy"
                     else "Arize is healthy"
+                ),
+            }
+        elif service == "galileo":
+            from litellm.integrations.galileo import GalileoObserve
+
+            galileo_logger = GalileoObserve()
+            response = await galileo_logger.async_health_check()
+            return {
+                "status": response["status"],
+                "message": (
+                    response["error_message"]
+                    if response["status"] == "unhealthy"
+                    else "Galileo is healthy"
                 ),
             }
         elif service == "langfuse":

--- a/tests/test_litellm/integrations/test_galileo.py
+++ b/tests/test_litellm/integrations/test_galileo.py
@@ -525,6 +525,45 @@ def test_galileo_get_ingest_request_legacy(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_galileo_async_health_check_success(galileo_v2_env):
+    logger = GalileoObserve()
+    current_user_resp = MagicMock()
+    current_user_resp.status_code = 200
+
+    with patch.object(
+        logger.async_httpx_handler, "get", new_callable=AsyncMock
+    ) as mock_get:
+        mock_get.return_value = current_user_resp
+        result = await logger.async_health_check()
+
+    assert result["status"] == "healthy"
+    mock_get.assert_awaited_once_with(
+        url="https://api.galileo.ai/current_user",
+        headers={
+            "accept": "application/json",
+            "Content-Type": "application/json",
+            "Galileo-API-Key": "test-api-key",
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_galileo_async_health_check_api_error(galileo_v2_env):
+    logger = GalileoObserve()
+    current_user_resp = MagicMock()
+    current_user_resp.status_code = 401
+
+    with patch.object(
+        logger.async_httpx_handler, "get", new_callable=AsyncMock
+    ) as mock_get:
+        mock_get.return_value = current_user_resp
+        result = await logger.async_health_check()
+
+    assert result["status"] == "unhealthy"
+    assert "HTTP 401" in result["error_message"]
+
+
+@pytest.mark.asyncio
 async def test_galileo_ensure_headers_v2_missing_key(monkeypatch):
     monkeypatch.delenv("GALILEO_API_KEY", raising=False)
     monkeypatch.setenv("GALILEO_PROJECT_ID", "p")

--- a/tests/test_litellm/integrations/test_galileo.py
+++ b/tests/test_litellm/integrations/test_galileo.py
@@ -612,6 +612,119 @@ async def test_galileo_async_health_check_api_error(galileo_v2_env):
 
 
 @pytest.mark.asyncio
+async def test_galileo_async_health_check_missing_project_id(monkeypatch):
+    monkeypatch.setenv("GALILEO_API_KEY", "test-api-key")
+    monkeypatch.setenv("GALILEO_BASE_URL", "https://api.galileo.ai")
+    monkeypatch.delenv("GALILEO_PROJECT_ID", raising=False)
+    logger = GalileoObserve()
+
+    result = await logger.async_health_check()
+
+    assert result["status"] == "unhealthy"
+    assert "GALILEO_PROJECT_ID" in result["error_message"]
+
+
+@pytest.mark.asyncio
+async def test_galileo_async_health_check_missing_base_url(monkeypatch):
+    monkeypatch.delenv("GALILEO_API_KEY", raising=False)
+    monkeypatch.delenv("GALILEO_BASE_URL", raising=False)
+    monkeypatch.setenv("GALILEO_PROJECT_ID", "p")
+    monkeypatch.setenv("GALILEO_USERNAME", "u")
+    monkeypatch.setenv("GALILEO_PASSWORD", "pw")
+    logger = GalileoObserve()
+
+    result = await logger.async_health_check()
+
+    assert result["status"] == "unhealthy"
+    assert "GALILEO_BASE_URL" in result["error_message"]
+
+
+@pytest.mark.asyncio
+async def test_galileo_async_health_check_missing_credentials(monkeypatch):
+    monkeypatch.delenv("GALILEO_API_KEY", raising=False)
+    monkeypatch.delenv("GALILEO_USERNAME", raising=False)
+    monkeypatch.delenv("GALILEO_PASSWORD", raising=False)
+    monkeypatch.setenv("GALILEO_PROJECT_ID", "p")
+    monkeypatch.setenv("GALILEO_BASE_URL", "https://galileo.example")
+    logger = GalileoObserve()
+
+    result = await logger.async_health_check()
+
+    assert result["status"] == "unhealthy"
+    assert "GALILEO_USERNAME" in result["error_message"]
+
+
+@pytest.mark.asyncio
+async def test_galileo_async_health_check_auth_failed(monkeypatch):
+    monkeypatch.delenv("GALILEO_API_KEY", raising=False)
+    monkeypatch.setenv("GALILEO_PROJECT_ID", "p")
+    monkeypatch.setenv("GALILEO_BASE_URL", "https://galileo.example")
+    monkeypatch.setenv("GALILEO_USERNAME", "u")
+    monkeypatch.setenv("GALILEO_PASSWORD", "pw")
+    logger = GalileoObserve()
+
+    with patch.object(
+        logger.async_httpx_handler, "post", new_callable=AsyncMock
+    ) as mock_post:
+        mock_post.side_effect = Exception("login failed")
+        result = await logger.async_health_check()
+
+    assert result["status"] == "unhealthy"
+    assert result["error_message"] == "Galileo authentication failed"
+
+
+@pytest.mark.asyncio
+async def test_galileo_async_health_check_request_exception(galileo_v2_env):
+    logger = GalileoObserve()
+
+    with patch.object(
+        logger.async_httpx_handler, "get", new_callable=AsyncMock
+    ) as mock_get:
+        mock_get.side_effect = Exception("connection refused")
+        result = await logger.async_health_check()
+
+    assert result["status"] == "unhealthy"
+    assert "connection refused" in result["error_message"]
+
+
+@pytest.mark.asyncio
+async def test_galileo_async_log_success_empty_model_response(galileo_v2_env):
+    import datetime
+
+    logger = GalileoObserve()
+    logger.batch_size = 2
+    empty_response = ModelResponse(choices=[])
+
+    await logger.async_log_success_event(
+        kwargs={
+            "call_type": "acompletion",
+            "model": "gpt-5.2",
+            "messages": [{"role": "user", "content": "hi"}],
+            "standard_logging_object": {
+                "call_type": "acompletion",
+                "model": "gpt-5.2",
+                "prompt_tokens": 1,
+                "completion_tokens": 0,
+                "total_tokens": 1,
+                "response_cost": 0.0,
+                "startTime": datetime.datetime(
+                    2026, 5, 25, 12, 0, 0, tzinfo=datetime.timezone.utc
+                ).timestamp(),
+                "endTime": datetime.datetime(
+                    2026, 5, 25, 12, 0, 1, tzinfo=datetime.timezone.utc
+                ).timestamp(),
+            },
+        },
+        response_obj=empty_response,
+        start_time=datetime.datetime(2026, 5, 25, 12, 0, 0),
+        end_time=datetime.datetime(2026, 5, 25, 12, 0, 1),
+    )
+
+    assert len(logger.in_memory_records) == 1
+    assert logger.in_memory_records[0]["output_text"] == ""
+
+
+@pytest.mark.asyncio
 async def test_galileo_ensure_headers_v2_missing_key(monkeypatch):
     monkeypatch.delenv("GALILEO_API_KEY", raising=False)
     monkeypatch.setenv("GALILEO_PROJECT_ID", "p")

--- a/tests/test_litellm/integrations/test_galileo.py
+++ b/tests/test_litellm/integrations/test_galileo.py
@@ -357,12 +357,18 @@ def test_galileo_record_to_v2_span_with_tags_and_offset():
 
 def test_galileo_get_output_str_variants(galileo_v2_env):
     logger = GalileoObserve()
-    assert logger.get_output_str_from_response(None, {}) is None
+    assert logger.get_output_str_from_response(None, {}) == ""
     assert (
         logger.get_output_str_from_response(
             EmbeddingResponse(), {"call_type": "embedding"}
         )
-        is None
+        == "embedding-output"
+    )
+    assert (
+        logger.get_output_str_from_response(
+            EmbeddingResponse(), {"call_type": "aembedding"}
+        )
+        == "embedding-output"
     )
 
     text_resp = TextCompletionResponse()
@@ -414,7 +420,7 @@ def test_galileo_get_output_str_variants(galileo_v2_env):
         {"call_type": "acompletion", "messages": [{"role": "user", "content": "hi"}]},
     )
 
-    assert logger.get_output_str_from_response("not-a-supported-type", {}) is None
+    assert logger.get_output_str_from_response("not-a-supported-type", {}) == ""
 
 
 def test_galileo_get_input_output_error_status_message(galileo_v2_env):
@@ -443,6 +449,48 @@ def test_galileo_get_output_str_rerank_response(galileo_v2_env):
     assert output is not None
     assert '"index": 2' in output
     assert '"relevance_score": 0.98' in output
+
+
+@pytest.mark.asyncio
+async def test_galileo_async_log_success_embedding(galileo_v2_env):
+    import datetime
+
+    logger = GalileoObserve()
+    embedding_response = EmbeddingResponse(
+        data=[{"object": "embedding", "embedding": [0.1, 0.2, 0.3], "index": 0}]
+    )
+
+    mock_response = MagicMock()
+    mock_response.is_success = True
+    mock_response.status_code = 201
+
+    with patch.object(logger.async_httpx_handler, "post", return_value=mock_response):
+        await logger.async_log_success_event(
+            kwargs={
+                "call_type": "aembedding",
+                "model": "text-embedding-3-small",
+                "input": "hello world",
+                "standard_logging_object": {
+                    "call_type": "aembedding",
+                    "model": "text-embedding-3-small",
+                    "prompt_tokens": 2,
+                    "completion_tokens": 0,
+                    "total_tokens": 2,
+                    "response_cost": 0.0,
+                    "startTime": datetime.datetime(
+                        2026, 5, 25, 12, 0, 0, tzinfo=datetime.timezone.utc
+                    ).timestamp(),
+                    "endTime": datetime.datetime(
+                        2026, 5, 25, 12, 0, 1, tzinfo=datetime.timezone.utc
+                    ).timestamp(),
+                },
+            },
+            response_obj=embedding_response,
+            start_time=datetime.datetime(2026, 5, 25, 12, 0, 0),
+            end_time=datetime.datetime(2026, 5, 25, 12, 0, 1),
+        )
+
+    assert logger.in_memory_records == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
+++ b/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
@@ -697,6 +697,33 @@ async def test_test_model_connection_falls_back_to_deployments_zero_without_id()
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "status,error_message",
+    [
+        ("healthy", ""),
+        ("unhealthy", "Galileo authentication failed"),
+    ],
+)
+async def test_health_services_endpoint_galileo(status, error_message):
+    with patch("litellm.integrations.galileo.GalileoObserve") as MockGalileoObserve:
+        mock_instance = MagicMock()
+        mock_instance.async_health_check = AsyncMock(
+            return_value={"status": status, "error_message": error_message}
+        )
+        MockGalileoObserve.return_value = mock_instance
+
+        result = await health_services_endpoint(service="galileo")
+
+        if status == "healthy":
+            assert result["status"] == "healthy"
+            assert result["message"] == "Galileo is healthy"
+        else:
+            assert result["status"] == "unhealthy"
+            assert result["message"] == error_message
+        mock_instance.async_health_check.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_health_services_endpoint_datadog_llm_observability():
     """
     Verify that 'datadog_llm_observability' is accepted as a valid service

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -40375,7 +40375,7 @@ export interface operations {
         parameters: {
             query: {
                 /** @description Specify the service being hit. */
-                service: ("slack_budget_alerts" | "langfuse" | "langfuse_otel" | "slack" | "openmeter" | "webhook" | "email" | "braintrust" | "datadog" | "datadog_llm_observability" | "generic_api" | "arize" | "sqs") | string;
+                service: ("slack_budget_alerts" | "langfuse" | "langfuse_otel" | "slack" | "openmeter" | "webhook" | "email" | "braintrust" | "datadog" | "datadog_llm_observability" | "generic_api" | "arize" | "galileo" | "sqs") | string;
             };
             header?: never;
             path?: never;
@@ -43119,13 +43119,13 @@ export interface operations {
             /**
              * @description Unified rate-limit error.
              *
-             *     Every rate-limit condition surfaced by litellm — whether it originated from
-             *     an upstream LLM provider, a vendor batch endpoint, or one of litellm's own
-             *     proxy-side limiters (parallel-requests, dynamic-rate, batch-rate, budget,
-             *     max-iterations, etc.) — is raised as an instance of this class.
+             *         Every rate-limit condition surfaced by litellm — whether it originated from
+             *         an upstream LLM provider, a vendor batch endpoint, or one of litellm's own
+             *         proxy-side limiters (parallel-requests, dynamic-rate, batch-rate, budget,
+             *         max-iterations, etc.) — is raised as an instance of this class.
              *
-             *     The :attr:`category` attribute lets callers distinguish the source. See
-             *     :class:`RateLimitErrorCategory` for the available values.
+             *         The :attr:`category` attribute lets callers distinguish the source. See
+             *         :class:`RateLimitErrorCategory` for the available values.
              */
             429: {
                 headers: {


### PR DESCRIPTION
## Summary
- Register `galileo` in `/health/services` so the proxy UI callback connection test no longer fails with "Service must be in list"
- Add `GalileoObserve.async_health_check()` to validate credentials and authentication

## Test plan
- [x] `pytest tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py::test_health_services_endpoint_galileo -v`
- [ ] Restart proxy and click "Test Callback" for Galileo in the UI


<img width="1458" height="684" alt="image" src="https://github.com/user-attachments/assets/c2af85da-e622-427a-b743-3117564d1ca5" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive integration health check and allowlist entry; no changes to request routing or Galileo ingest behavior beyond a read-only `/current_user` probe when testing.
> 
> **Overview**
> Adds **Galileo** to the proxy **`GET /health/services`** flow so the dashboard “Test Callback” path can probe Galileo like Datadog or Arize instead of failing validation with “Service must be in list.”
> 
> **`GalileoObserve.async_health_check()`** returns `IntegrationHealthCheckStatus`: it checks required env (`GALILEO_PROJECT_ID`, `GALILEO_BASE_URL`, API key or username/password), runs existing header/auth setup, then **`GET {base_url}/current_user`** and treats HTTP ≥400 as unhealthy. The health endpoint maps that to `status` / `message` (“Galileo is healthy” or the error text).
> 
> Unit tests cover the Galileo health check (success and 401) and the **`service=galileo`** branch; the OpenAPI **`service`** query enum includes **`galileo`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79fd09e2db31a93eb796dbbd8351d5cbfa70b255. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->