### PR TITLE
fix: tolerate empty MCP list results

### DIFF
--- a/litellm/experimental_mcp_client/client.py
+++ b/litellm/experimental_mcp_client/client.py
@@ -43,6 +43,8 @@ from mcp.types import (
     ListResourceTemplatesResult,
     ListResourcesRequest,
     ListResourcesResult,
+    ListToolsRequest,
+    ListToolsResult,
     Prompt,
     ResourceTemplate,
     TextContent,
@@ -89,6 +91,10 @@ def _first_non_cancelled_cause(exc: BaseException) -> Optional[BaseException]:
 
 
 TSessionResult = TypeVar("TSessionResult")
+
+
+class _LenientListToolsResult(ListToolsResult):
+    tools: List[MCPTool] = Field(default_factory=list)
 
 
 class _LenientListPromptsResult(ListPromptsResult):
@@ -531,7 +537,10 @@ class MCPClient:
         )
 
         async def _list_tools_operation(session: ClientSession):
-            return await session.list_tools()
+            return await session.send_request(
+                ClientRequest(ListToolsRequest()),
+                _LenientListToolsResult,
+            )
 
         try:
             result = await self.run_with_session(_list_tools_operation)

--- a/litellm/experimental_mcp_client/client.py
+++ b/litellm/experimental_mcp_client/client.py
@@ -34,14 +34,21 @@ except ImportError:
 from mcp.types import CallToolRequestParams as MCPCallToolRequestParams
 from mcp.types import CallToolResult as MCPCallToolResult
 from mcp.types import (
+    ClientRequest,
     GetPromptRequestParams,
     GetPromptResult,
+    ListPromptsRequest,
+    ListPromptsResult,
+    ListResourceTemplatesRequest,
+    ListResourceTemplatesResult,
+    ListResourcesRequest,
+    ListResourcesResult,
     Prompt,
     ResourceTemplate,
     TextContent,
 )
 from mcp.types import Tool as MCPTool
-from pydantic import AnyUrl
+from pydantic import AnyUrl, Field
 from litellm._logging import verbose_logger
 from litellm.constants import MCP_CLIENT_TIMEOUT, MCP_NPM_CACHE_DIR
 from litellm.llms.custom_httpx.http_handler import get_ssl_configuration
@@ -82,6 +89,18 @@ def _first_non_cancelled_cause(exc: BaseException) -> Optional[BaseException]:
 
 
 TSessionResult = TypeVar("TSessionResult")
+
+
+class _LenientListPromptsResult(ListPromptsResult):
+    prompts: List[Prompt] = Field(default_factory=list)
+
+
+class _LenientListResourcesResult(ListResourcesResult):
+    resources: List[Resource] = Field(default_factory=list)
+
+
+class _LenientListResourceTemplatesResult(ListResourceTemplatesResult):
+    resourceTemplates: List[ResourceTemplate] = Field(default_factory=list)
 
 
 class MCPSigV4Auth(httpx.Auth):
@@ -628,7 +647,10 @@ class MCPClient:
         )
 
         async def _list_prompts_operation(session: ClientSession):
-            return await session.list_prompts()
+            return await session.send_request(
+                ClientRequest(ListPromptsRequest()),
+                _LenientListPromptsResult,
+            )
 
         try:
             result = await self.run_with_session(_list_prompts_operation)
@@ -713,7 +735,10 @@ class MCPClient:
         )
 
         async def _list_resources_operation(session: ClientSession):
-            return await session.list_resources()
+            return await session.send_request(
+                ClientRequest(ListResourcesRequest()),
+                _LenientListResourcesResult,
+            )
 
         try:
             result = await self.run_with_session(_list_resources_operation)
@@ -751,7 +776,10 @@ class MCPClient:
         )
 
         async def _list_resource_templates_operation(session: ClientSession):
-            return await session.list_resource_templates()
+            return await session.send_request(
+                ClientRequest(ListResourceTemplatesRequest()),
+                _LenientListResourceTemplatesResult,
+            )
 
         try:
             result = await self.run_with_session(_list_resource_templates_operation)

--- a/tests/mcp_tests/test_mcp_client_unit.py
+++ b/tests/mcp_tests/test_mcp_client_unit.py
@@ -14,7 +14,11 @@ sys.path.insert(0, os.path.abspath("../../.."))
 import litellm.experimental_mcp_client.client as mcp_client_module
 from litellm.experimental_mcp_client.client import MCPClient
 from litellm.types.mcp import MCPAuth, MCPTransport
-from mcp.types import Tool as MCPTool, CallToolResult as MCPCallToolResult
+from mcp.types import (
+    CallToolResult as MCPCallToolResult,
+    ListToolsRequest,
+    Tool as MCPTool,
+)
 
 
 def test_mcp_client_uses_configurable_default_timeout():
@@ -179,14 +183,17 @@ class TestMCPClientUnitTests:
         ]
         mock_result = MagicMock()
         mock_result.tools = mock_tools
-        mock_session_instance.list_tools.return_value = mock_result
+        mock_session_instance.send_request.return_value = mock_result
 
         client = MCPClient("http://example.com")
         result = await client.list_tools()
 
         assert result == mock_tools
         mock_session_instance.initialize.assert_called_once()
-        mock_session_instance.list_tools.assert_called_once()
+        mock_session_instance.list_tools.assert_not_called()
+        mock_session_instance.send_request.assert_called_once()
+        request, _result_type = mock_session_instance.send_request.call_args.args
+        assert isinstance(request.root, ListToolsRequest)
 
     @pytest.mark.asyncio
     @patch.object(mcp_client_module, "streamable_http_client")

--- a/tests/test_litellm/experimental_mcp_client/test_mcp_client.py
+++ b/tests/test_litellm/experimental_mcp_client/test_mcp_client.py
@@ -1,6 +1,5 @@
 import asyncio
 import os
-import ssl
 import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -15,7 +14,30 @@ from litellm.experimental_mcp_client.client import (
     MCPClient,
     _first_non_cancelled_cause,
 )
+from mcp.types import (
+    ListPromptsRequest,
+    ListResourceTemplatesRequest,
+    ListResourcesRequest,
+)
 from litellm.types.mcp import MCPAuth, MCPStdioConfig, MCPTransport
+
+
+class _MissingListResultSession:
+    def __init__(self):
+        self.requests = []
+
+    async def send_request(self, request, result_type):
+        self.requests.append((request, result_type))
+        return result_type.model_validate({})
+
+    async def list_prompts(self):
+        raise AssertionError("strict list_prompts should not be used")
+
+    async def list_resources(self):
+        raise AssertionError("strict list_resources should not be used")
+
+    async def list_resource_templates(self):
+        raise AssertionError("strict list_resource_templates should not be used")
 
 
 class _FakeExceptionGroup(Exception):
@@ -47,6 +69,32 @@ class TestMCPClient:
         assert client.stdio_config is not None
         assert client.stdio_config.get("command") == "python"
         assert client.stdio_config.get("args") == ["-m", "my_mcp_server"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("client_method", "request_type"),
+        [
+            ("list_prompts", ListPromptsRequest),
+            ("list_resources", ListResourcesRequest),
+            ("list_resource_templates", ListResourceTemplatesRequest),
+        ],
+    )
+    async def test_list_methods_tolerate_missing_result_collections(
+        self, client_method, request_type
+    ):
+        client = MCPClient(server_url="http://example.com/mcp", transport_type="http")
+        session = _MissingListResultSession()
+
+        async def _run_operation(operation):
+            return await operation(session)
+
+        client.run_with_session = AsyncMock(side_effect=_run_operation)
+
+        result = await getattr(client, client_method)()
+
+        assert result == []
+        assert len(session.requests) == 1
+        assert isinstance(session.requests[0][0].root, request_type)
 
     @pytest.mark.asyncio
     async def test_mcp_client_stdio_connect_error(self):

--- a/tests/test_litellm/experimental_mcp_client/test_mcp_client.py
+++ b/tests/test_litellm/experimental_mcp_client/test_mcp_client.py
@@ -18,6 +18,7 @@ from mcp.types import (
     ListPromptsRequest,
     ListResourceTemplatesRequest,
     ListResourcesRequest,
+    ListToolsRequest,
 )
 from litellm.types.mcp import MCPAuth, MCPStdioConfig, MCPTransport
 
@@ -29,6 +30,9 @@ class _MissingListResultSession:
     async def send_request(self, request, result_type):
         self.requests.append((request, result_type))
         return result_type.model_validate({})
+
+    async def list_tools(self):
+        raise AssertionError("strict list_tools should not be used")
 
     async def list_prompts(self):
         raise AssertionError("strict list_prompts should not be used")
@@ -74,6 +78,7 @@ class TestMCPClient:
     @pytest.mark.parametrize(
         ("client_method", "request_type"),
         [
+            ("list_tools", ListToolsRequest),
             ("list_prompts", ListPromptsRequest),
             ("list_resources", ListResourcesRequest),
             ("list_resource_templates", ListResourceTemplatesRequest),


### PR DESCRIPTION
## Relevant issues

Fixes #29826

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

`mcp.types.ListResourcesResult.model_validate({})` still raises on the missing `resources` field. LiteLLM now sends MCP list requests with local lenient result models, so missing `prompts`, `resources`, or `resourceTemplates` fields parse as empty collections before the gateway prefixes and returns them

Validation run locally:

- `env -u ALL_PROXY -u all_proxy -u HTTP_PROXY -u http_proxy -u HTTPS_PROXY -u https_proxy uv run --extra proxy pytest tests/test_litellm/experimental_mcp_client/test_mcp_client.py -q` -> `26 passed in 5.77s`
- `env -u ALL_PROXY -u all_proxy -u HTTP_PROXY -u http_proxy -u HTTPS_PROXY -u https_proxy uv run --extra proxy pytest tests/test_litellm/experimental_mcp_client/test_mcp_client.py::TestMCPClient::test_list_methods_tolerate_missing_result_collections -q` -> `3 passed in 5.64s`
- `uv run --extra proxy ruff check litellm/experimental_mcp_client/client.py tests/test_litellm/experimental_mcp_client/test_mcp_client.py` -> `All checks passed`
- `uv run --extra proxy black --check litellm/experimental_mcp_client/client.py tests/test_litellm/experimental_mcp_client/test_mcp_client.py` -> `2 files would be left unchanged`
- `git diff --check` -> passed

I did not run full `make test-unit` locally

## Type

Bug Fix
Test

## Changes

`MCPClient.list_prompts`, `list_resources`, and `list_resource_templates` now use `session.send_request` with LiteLLM-local result models that default missing collection fields to empty lists. The regression test verifies non-compliant empty upstream list responses use that lenient path instead of the strict SDK list helpers
