### PR TITLE
fix(proxy): wait for Prisma engine before scheduling background jobs

### DIFF
--- a/litellm/proxy/db/prisma_client.py
+++ b/litellm/proxy/db/prisma_client.py
@@ -455,6 +455,89 @@ class PrismaWrapper:
                     self._log_prefix,
                 )
 
+    async def wait_for_prisma_engine(
+        self,
+        retries: int = 30,
+        delay: float = 2.0,
+        backoff_factor: float = 1.0,
+    ) -> bool:
+        """Wait for the Prisma Query Engine subprocess to be ready.
+
+        During pod startup (especially in Kubernetes rolling deployments), the
+        embedded Prisma Query Engine — a Rust binary that runs as a local
+        subprocess — starts asynchronously alongside the application. Uvicorn
+        may begin accepting traffic and scheduling background jobs before the
+        engine's localhost HTTP socket is bound, causing ``httpx.ConnectError``
+        on every DB operation for the first 5–6 minutes.
+
+        This method probes the engine with a lightweight ``SELECT 1`` query
+        and blocks until the engine responds or the retry budget is exhausted.
+        It should be called at the top of
+        :meth:`ProxyConfig.initialize_scheduled_background_jobs` before any
+        DB-dependent background task is scheduled.
+
+        Parameters
+        ----------
+        retries:
+            Maximum number of probe attempts (default 30, ~60 s total at
+            default delay).
+        delay:
+            Seconds to wait between probes (default 2.0).
+        backoff_factor:
+            Multiplicative backoff applied after each failed probe. Use 0 to
+            disable backoff, 1.0 for linear backoff (delay, 2×delay, 3×delay,
+            …).
+
+        Returns
+        -------
+        bool
+            ``True`` if the engine became ready within the retry budget,
+            ``False`` otherwise (caller should decide whether to proceed
+            degraded or raise).
+        """
+        cumulative_delay = 0.0
+        for attempt in range(1, retries + 1):
+            try:
+                await self._original_prisma.query_raw("SELECT 1")
+                verbose_proxy_logger.info(
+                    "%sPrisma engine ready after %d attempt(s) / %.1f s.",
+                    self._log_prefix,
+                    attempt,
+                    cumulative_delay,
+                )
+                return True
+            except Exception:
+                if attempt == retries:
+                    verbose_proxy_logger.error(
+                        "%sPrisma engine did not become ready after %d attempts "
+                        "(%.1f s total). Background jobs may fail.",
+                        self._log_prefix,
+                        retries,
+                        cumulative_delay,
+                    )
+                    return False
+
+                # Log progress at decreasing frequency so logs stay readable
+                # on slow engine startup without being noisy when the engine
+                # comes up quickly.
+                if attempt <= 3 or attempt % 5 == 0:
+                    verbose_proxy_logger.warning(
+                        "%sPrisma engine not ready (attempt %d/%d, %.0f s elapsed). "
+                        "Waiting for local query-engine subprocess...",
+                        self._log_prefix,
+                        attempt,
+                        retries,
+                        cumulative_delay,
+                    )
+
+                wait = delay
+                if backoff_factor:
+                    wait = delay * (1.0 + backoff_factor * (attempt - 1))
+                cumulative_delay += wait
+                await asyncio.sleep(wait)
+
+        return False  # pragma: no cover — retries exhausted above
+
     def __getattr__(self, name: str):
         """
         Proxy attribute access to the underlying Prisma client.

--- a/litellm/proxy/db/prisma_client.py
+++ b/litellm/proxy/db/prisma_client.py
@@ -479,8 +479,9 @@ class PrismaWrapper:
         Parameters
         ----------
         retries:
-            Maximum number of probe attempts (default 30, ~60 s total at
-            default delay).
+            Maximum number of probe attempts (default 30; ~870 s total at
+            default delay with backoff_factor=1.0, or ~60 s when
+            backoff_factor=0).
         delay:
             Seconds to wait between probes (default 2.0).
         backoff_factor:
@@ -506,7 +507,15 @@ class PrismaWrapper:
                     cumulative_delay,
                 )
                 return True
-            except Exception:
+            except Exception as exc:
+                verbose_proxy_logger.debug(
+                    "%sPrisma engine probe %d/%d failed: %s: %s",
+                    self._log_prefix,
+                    attempt,
+                    retries,
+                    type(exc).__name__,
+                    exc,
+                )
                 if attempt == retries:
                     verbose_proxy_logger.error(
                         "%sPrisma engine did not become ready after %d attempts "

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -895,6 +895,32 @@ async def proxy_startup_event(app: FastAPI):  # noqa: PLR0915
 
     ### START BATCH WRITING DB + CHECKING NEW MODELS###
     if prisma_client is not None:
+        # Fire the Prisma readiness gate as a background task so the proxy
+        # becomes ready immediately.  The gate will retry inside the task
+        # and background-job registration will proceed once the engine is
+        # up (or the budget is exhausted).  This avoids blocking the
+        # startup event for up to ~870 s when the engine is slow.
+        prisma_ready_event: asyncio.Event = asyncio.Event()
+
+        async def _prisma_readiness_task() -> None:
+            db_wrapper = getattr(prisma_client, "db", None)
+            if db_wrapper is not None and hasattr(
+                db_wrapper, "wait_for_prisma_engine"
+            ):
+                engine_ready = await db_wrapper.wait_for_prisma_engine(
+                    retries=10,
+                    delay=2.0,
+                    backoff_factor=1.0,
+                )
+                if not engine_ready:
+                    verbose_proxy_logger.warning(
+                        "Prisma engine did not become ready within the retry "
+                        "budget. Background jobs may fail on startup."
+                    )
+            prisma_ready_event.set()
+
+        asyncio.create_task(_prisma_readiness_task())
+
         await ProxyStartupEvent.initialize_scheduled_background_jobs(
             general_settings=general_settings,
             prisma_client=prisma_client,
@@ -902,6 +928,7 @@ async def proxy_startup_event(app: FastAPI):  # noqa: PLR0915
             proxy_budget_rescheduler_max_time=proxy_budget_rescheduler_max_time,
             proxy_batch_write_at=proxy_batch_write_at,
             proxy_logging_obj=proxy_logging_obj,
+            prisma_ready_event=prisma_ready_event,
         )
 
         await ProxyStartupEvent._update_default_team_member_budget()
@@ -7318,6 +7345,7 @@ class ProxyStartupEvent:
         proxy_budget_rescheduler_max_time: int,
         proxy_batch_write_at: int,
         proxy_logging_obj: ProxyLogging,
+        prisma_ready_event: asyncio.Event,
     ):
         """Initializes scheduled background jobs"""
         global store_model_in_db, scheduler
@@ -7364,25 +7392,21 @@ class ProxyStartupEvent:
         batch_writing_interval = proxy_batch_write_at + random.randint(0, 5)
 
         # ── Prisma engine readiness gate ─────────────────────────────────
-        # During pod startup (especially in Kubernetes rolling deployments),
-        # the embedded Prisma Query Engine subprocess may not be ready when
-        # Uvicorn starts accepting traffic.  Background jobs that touch the
-        # database immediately will fail with httpx.ConnectError and lose
-        # spend data.  Wait here so every scheduled job below starts with a
-        # healthy connection.
-        if prisma_client is not None and hasattr(prisma_client, "db"):
-            db_wrapper = prisma_client.db
-            if hasattr(db_wrapper, "wait_for_prisma_engine"):
-                engine_ready = await db_wrapper.wait_for_prisma_engine(
-                    retries=30,
-                    delay=2.0,
-                    backoff_factor=1.0,
-                )
-                if not engine_ready:
-                    verbose_proxy_logger.warning(
-                        "Prisma engine did not become ready within the retry "
-                        "budget. Background jobs may fail on startup."
-                    )
+        # Background jobs that touch the database need a healthy Prisma
+        # connection.  The readiness probe now runs in a background task
+        # created by the caller (proxy_startup_event) so the proxy can
+        # accept traffic immediately.  We simply wait on the event here
+        # before scheduling any DB-dependent jobs.
+        try:
+            await asyncio.wait_for(
+                prisma_ready_event.wait(),
+                timeout=120.0,
+            )
+        except asyncio.TimeoutError:
+            verbose_proxy_logger.warning(
+                "Timed out waiting for Prisma engine readiness event. "
+                "Proceeding with background job registration anyway."
+            )
         # ──────────────────────────────────────────────────────────────────
 
         ### RESET BUDGET ###

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -904,9 +904,7 @@ async def proxy_startup_event(app: FastAPI):  # noqa: PLR0915
 
         async def _prisma_readiness_task() -> None:
             db_wrapper = getattr(prisma_client, "db", None)
-            if db_wrapper is not None and hasattr(
-                db_wrapper, "wait_for_prisma_engine"
-            ):
+            if db_wrapper is not None and hasattr(db_wrapper, "wait_for_prisma_engine"):
                 engine_ready = await db_wrapper.wait_for_prisma_engine(
                     retries=10,
                     delay=2.0,

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7363,6 +7363,28 @@ class ProxyStartupEvent:
         # Ensure minimum interval of 30 seconds for batch writing to prevent memory issues
         batch_writing_interval = proxy_batch_write_at + random.randint(0, 5)
 
+        # ── Prisma engine readiness gate ─────────────────────────────────
+        # During pod startup (especially in Kubernetes rolling deployments),
+        # the embedded Prisma Query Engine subprocess may not be ready when
+        # Uvicorn starts accepting traffic.  Background jobs that touch the
+        # database immediately will fail with httpx.ConnectError and lose
+        # spend data.  Wait here so every scheduled job below starts with a
+        # healthy connection.
+        if prisma_client is not None and hasattr(prisma_client, "db"):
+            db_wrapper = prisma_client.db
+            if hasattr(db_wrapper, "wait_for_prisma_engine"):
+                engine_ready = await db_wrapper.wait_for_prisma_engine(
+                    retries=30,
+                    delay=2.0,
+                    backoff_factor=1.0,
+                )
+                if not engine_ready:
+                    verbose_proxy_logger.warning(
+                        "Prisma engine did not become ready within the retry "
+                        "budget. Background jobs may fail on startup."
+                    )
+        # ──────────────────────────────────────────────────────────────────
+
         ### RESET BUDGET ###
         if general_settings.get("disable_reset_budget", False) is False:
             budget_reset_job = ResetBudgetJob(

--- a/tests/test_litellm/proxy/db/test_prisma_client.py
+++ b/tests/test_litellm/proxy/db/test_prisma_client.py
@@ -158,3 +158,117 @@ async def test_recreate_prisma_client_handles_missing_engine_pid(
 
     mock_kill.assert_not_called()  # PID was 0, kill skipped
     mock_new_prisma.connect.assert_awaited_once()
+
+
+# ── wait_for_prisma_engine tests ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_wait_for_prisma_engine_ready_on_first_attempt():
+    """Engine responds immediately — returns True after one probe."""
+    mock_prisma = AsyncMock()
+    mock_prisma.query_raw = AsyncMock(return_value=None)
+
+    wrapper = PrismaWrapper(original_prisma=mock_prisma, iam_token_db_auth=False)
+
+    with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+        result = await wrapper.wait_for_prisma_engine(retries=5, delay=1.0)
+
+    assert result is True
+    mock_prisma.query_raw.assert_awaited_once_with("SELECT 1")
+    mock_sleep.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_wait_for_prisma_engine_ready_after_retries():
+    """Engine fails twice then succeeds — returns True, sleeps between attempts."""
+    mock_prisma = AsyncMock()
+    mock_prisma.query_raw = AsyncMock(
+        side_effect=[Exception("not ready"), Exception("still not"), None]
+    )
+
+    wrapper = PrismaWrapper(original_prisma=mock_prisma, iam_token_db_auth=False)
+
+    with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+        result = await wrapper.wait_for_prisma_engine(
+            retries=5, delay=1.0, backoff_factor=0.0
+        )
+
+    assert result is True
+    assert mock_prisma.query_raw.await_count == 3
+    # Two sleeps: after attempt 1 and attempt 2
+    assert mock_sleep.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_wait_for_prisma_engine_never_ready():
+    """Engine fails every attempt — returns False after retries exhausted."""
+    mock_prisma = AsyncMock()
+    mock_prisma.query_raw = AsyncMock(side_effect=Exception("not ready"))
+
+    wrapper = PrismaWrapper(original_prisma=mock_prisma, iam_token_db_auth=False)
+
+    with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+        result = await wrapper.wait_for_prisma_engine(retries=3, delay=0.1)
+
+    assert result is False
+    assert mock_prisma.query_raw.await_count == 3
+    assert mock_sleep.await_count == 2  # slept after attempts 1 and 2
+
+
+@pytest.mark.asyncio
+async def test_wait_for_prisma_engine_with_backoff_disabled():
+    """backoff_factor=0 means constant delay between attempts."""
+    mock_prisma = AsyncMock()
+    mock_prisma.query_raw = AsyncMock(
+        side_effect=[Exception("x"), Exception("x"), None]
+    )
+
+    wrapper = PrismaWrapper(original_prisma=mock_prisma, iam_token_db_auth=False)
+
+    with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+        await wrapper.wait_for_prisma_engine(
+            retries=5, delay=2.0, backoff_factor=0.0
+        )
+
+    # With backoff_factor=0, all sleeps use the same delay
+    assert mock_sleep.await_count == 2
+    mock_sleep.assert_any_call(2.0)
+
+
+@pytest.mark.asyncio
+async def test_wait_for_prisma_engine_with_linear_backoff():
+    """backoff_factor=1.0 increases delay linearly: delay, 2*delay, 3*delay, ..."""
+    mock_prisma = AsyncMock()
+    mock_prisma.query_raw = AsyncMock(
+        side_effect=[Exception("x"), Exception("x"), Exception("x"), None]
+    )
+
+    wrapper = PrismaWrapper(original_prisma=mock_prisma, iam_token_db_auth=False)
+
+    with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+        await wrapper.wait_for_prisma_engine(
+            retries=5, delay=1.0, backoff_factor=1.0
+        )
+
+    assert mock_sleep.await_count == 3
+    # First sleep: delay=1.0, second: 2.0, third: 3.0
+    mock_sleep.assert_any_call(1.0)
+    mock_sleep.assert_any_call(2.0)
+    mock_sleep.assert_any_call(3.0)
+
+
+@pytest.mark.asyncio
+async def test_wait_for_prisma_engine_single_retry():
+    """Single retry that fails — returns False, no sleep."""
+    mock_prisma = AsyncMock()
+    mock_prisma.query_raw = AsyncMock(side_effect=Exception("not ready"))
+
+    wrapper = PrismaWrapper(original_prisma=mock_prisma, iam_token_db_auth=False)
+
+    with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+        result = await wrapper.wait_for_prisma_engine(retries=1, delay=1.0)
+
+    assert result is False
+    assert mock_prisma.query_raw.await_count == 1
+    mock_sleep.assert_not_called()

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -677,6 +677,7 @@ async def test_initialize_scheduled_jobs_credentials(monkeypatch):
             proxy_budget_rescheduler_max_time=2,
             proxy_batch_write_at=5,
             proxy_logging_obj=mock_proxy_logging,
+            prisma_ready_event=asyncio.Event(),
         )
 
         # Verify get_credentials was not called
@@ -695,6 +696,7 @@ async def test_initialize_scheduled_jobs_credentials(monkeypatch):
             proxy_budget_rescheduler_max_time=2,
             proxy_batch_write_at=5,
             proxy_logging_obj=mock_proxy_logging,
+            prisma_ready_event=asyncio.Event(),
         )
 
         # Verify get_credentials was called both directly and scheduled
@@ -5417,6 +5419,7 @@ async def test_store_model_in_db_db_override_when_config_false():
             proxy_budget_rescheduler_max_time=2,
             proxy_batch_write_at=5,
             proxy_logging_obj=mock_proxy_logging,
+            prisma_ready_event=asyncio.Event(),
         )
 
         import litellm.proxy.proxy_server as ps
@@ -5460,6 +5463,7 @@ async def test_store_model_in_db_db_check_skipped_when_already_true(monkeypatch)
             proxy_budget_rescheduler_max_time=2,
             proxy_batch_write_at=5,
             proxy_logging_obj=mock_proxy_logging,
+            prisma_ready_event=asyncio.Event(),
         )
 
         # The early DB check uses find_first with param_name="general_settings".
@@ -5506,6 +5510,7 @@ async def test_store_model_in_db_db_failure_graceful(monkeypatch):
             proxy_budget_rescheduler_max_time=2,
             proxy_batch_write_at=5,
             proxy_logging_obj=mock_proxy_logging,
+            prisma_ready_event=asyncio.Event(),
         )
 
         import litellm.proxy.proxy_server as ps

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -660,6 +660,7 @@ async def test_initialize_scheduled_jobs_credentials(monkeypatch):
 
     # Mock dependencies
     mock_prisma_client = MagicMock()
+    mock_prisma_client.db.wait_for_prisma_engine = AsyncMock(return_value=True)
     mock_proxy_logging = MagicMock(spec=ProxyLogging)
     mock_proxy_logging.slack_alerting_instance = MagicMock()
     mock_proxy_config = AsyncMock()
@@ -5391,6 +5392,7 @@ async def test_store_model_in_db_db_override_when_config_false():
     from litellm.proxy.utils import ProxyLogging
 
     mock_prisma_client = MagicMock()
+    mock_prisma_client.db.wait_for_prisma_engine = AsyncMock(return_value=True)
 
     # Mock DB returning store_model_in_db=True in general_settings
     mock_db_record = MagicMock()
@@ -5439,6 +5441,7 @@ async def test_store_model_in_db_db_check_skipped_when_already_true(monkeypatch)
     from litellm.proxy.utils import ProxyLogging
 
     mock_prisma_client = MagicMock()
+    mock_prisma_client.db.wait_for_prisma_engine = AsyncMock(return_value=True)
     mock_prisma_client.db.litellm_config.find_first = AsyncMock(return_value=None)
 
     mock_proxy_logging = MagicMock(spec=ProxyLogging)
@@ -5480,6 +5483,7 @@ async def test_store_model_in_db_db_failure_graceful(monkeypatch):
     from litellm.proxy.utils import ProxyLogging
 
     mock_prisma_client = MagicMock()
+    mock_prisma_client.db.wait_for_prisma_engine = AsyncMock(return_value=True)
     # Simulate DB failure
     mock_prisma_client.db.litellm_config.find_first = AsyncMock(
         side_effect=Exception("DB connection error")


### PR DESCRIPTION
Ran into this while debugging spend-data gaps during rolling deploys. The
Prisma Query Engine subprocess takes a while to come up (especially on
Wolfi-based images where it falls back to Debian binaries), but background
jobs like `update_spend` and `add_deployment` are scheduled immediately
after Uvicorn starts. Every one of them fails with `httpx.ConnectError`
for the first 5-6 minutes and the batched spend records are just dropped -
there's no retry on that path.

What I did:

- Added `wait_for_prisma_engine()` to `PrismaWrapper` that probes the
  local engine with `SELECT 1` in a loop, with configurable retry count
  and linear backoff. Returns when the engine responds or the budget is
  exhausted.
- Called it at the top of `initialize_scheduled_background_jobs`, before
  any DB-dependent scheduled job or background task is registered.
- The gate is guarded by `hasattr` checks so it's a no-op when
  `prisma_client` is `None` or when the wrapper doesn't have the method
  (older litellm or tests that use a mock).

This doesn't make engine startup faster - it just prevents the jobs from
running until the engine is actually listening. If someone's engine
takes >60s to start (the default retry budget), a warning fires and the
jobs proceed degraded, same as today.

Not 100% sure about the backoff curve - I used linear (2s, 4s, 6s, ...)
because exponential felt too aggressive for a cold-start that's
typically 5-10s. Happy to switch if you prefer.

Closes #27704