### PR TITLE
fix(logging): handle dict result.response in streaming /v1/responses spend log

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -3171,8 +3171,10 @@ class Logging(LiteLLMLoggingBaseClass):
         ):
             ## return unified Usage object
             resp = result.response
-            resp_is_dict = isinstance(resp, dict)
-            usage = resp.get("usage") if resp_is_dict else getattr(resp, "usage", None)
+            if isinstance(resp, dict):
+                usage = resp.get("usage")
+            else:
+                usage = getattr(resp, "usage", None)
             if isinstance(usage, ResponseAPIUsage):
                 transformed_usage = (
                     ResponseAPILoggingUtils._transform_response_api_usage_to_chat_usage(
@@ -3185,7 +3187,7 @@ class Logging(LiteLLMLoggingBaseClass):
                     if hasattr(transformed_usage, "model_dump")
                     else dict(transformed_usage)
                 )
-                if resp_is_dict:
+                if isinstance(resp, dict):
                     resp["usage"] = new_usage
                 else:
                     setattr(resp, "usage", new_usage)

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -3170,21 +3170,28 @@ class Logging(LiteLLMLoggingBaseClass):
             (ResponseCompletedEvent, ResponseIncompleteEvent, ResponseFailedEvent),
         ):
             ## return unified Usage object
-            if isinstance(result.response.usage, ResponseAPIUsage):
-                transformed_usage = ResponseAPILoggingUtils._transform_response_api_usage_to_chat_usage(
-                    result.response.usage
+            resp = result.response
+            resp_is_dict = isinstance(resp, dict)
+            usage = (
+                resp.get("usage") if resp_is_dict else getattr(resp, "usage", None)
+            )
+            if isinstance(usage, ResponseAPIUsage):
+                transformed_usage = (
+                    ResponseAPILoggingUtils._transform_response_api_usage_to_chat_usage(
+                        usage
+                    )
                 )
                 # Set as dict instead of Usage object so model_dump() serializes it correctly
-                setattr(
-                    result.response,
-                    "usage",
-                    (
-                        transformed_usage.model_dump()
-                        if hasattr(transformed_usage, "model_dump")
-                        else dict(transformed_usage)
-                    ),
+                new_usage = (
+                    transformed_usage.model_dump()
+                    if hasattr(transformed_usage, "model_dump")
+                    else dict(transformed_usage)
                 )
-            return result.response
+                if resp_is_dict:
+                    resp["usage"] = new_usage
+                else:
+                    setattr(resp, "usage", new_usage)
+            return resp
         else:
             return None
 

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -3172,9 +3172,7 @@ class Logging(LiteLLMLoggingBaseClass):
             ## return unified Usage object
             resp = result.response
             resp_is_dict = isinstance(resp, dict)
-            usage = (
-                resp.get("usage") if resp_is_dict else getattr(resp, "usage", None)
-            )
+            usage = resp.get("usage") if resp_is_dict else getattr(resp, "usage", None)
             if isinstance(usage, ResponseAPIUsage):
                 transformed_usage = (
                     ResponseAPILoggingUtils._transform_response_api_usage_to_chat_usage(

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -2529,6 +2529,92 @@ def test_get_assembled_streaming_response_returns_none_for_non_streaming_text_co
     assert assembled is None
 
 
+def test_get_assembled_streaming_response_dict_response_with_dict_usage_does_not_raise():
+    """
+    Regression for #29913.
+
+    Streaming `/v1/responses` builds a `ResponseCompletedEvent` whose `.response`
+    field — typed `ResponsesAPIResponse` but `extra="allow"` — is populated with a
+    plain dict at runtime. Reading `result.response.usage` then raised
+    `AttributeError: 'dict' object has no attribute 'usage'` and the spend log
+    silently never landed. The function must now read `usage` via dict-key when
+    `.response` is a dict, and return the dict unchanged.
+    """
+    import datetime
+
+    from litellm.types.llms.openai import (
+        ResponseCompletedEvent,
+        ResponsesAPIStreamEvents,
+    )
+
+    logging_obj = _make_logging_obj(stream=True)
+    response_dict = {
+        "id": "resp-1",
+        "created_at": 0,
+        "usage": {"input_tokens": 3, "output_tokens": 5, "total_tokens": 8},
+    }
+    # streaming-assembly stores a dict in `.response` via model_construct (bypass
+    # validation) — repro the runtime shape that triggered #29913.
+    event = ResponseCompletedEvent.model_construct(
+        type=ResponsesAPIStreamEvents.RESPONSE_COMPLETED,
+        response=response_dict,
+    )
+
+    assembled = logging_obj._get_assembled_streaming_response(
+        result=event,
+        start_time=datetime.datetime.now(),
+        end_time=datetime.datetime.now(),
+        is_async=True,
+        streaming_chunks=[],
+    )
+
+    assert assembled is response_dict
+    assert assembled["usage"] == {
+        "input_tokens": 3,
+        "output_tokens": 5,
+        "total_tokens": 8,
+    }
+
+
+def test_get_assembled_streaming_response_dict_response_with_responseapiusage_writes_back():
+    """
+    When `.response` is a dict but `usage` is still a `ResponseAPIUsage` instance,
+    the transformed usage must be written back into the dict (not via setattr,
+    which would fail on a plain dict).
+    """
+    import datetime
+
+    from litellm.types.llms.openai import (
+        ResponseAPIUsage,
+        ResponseCompletedEvent,
+        ResponsesAPIStreamEvents,
+    )
+
+    logging_obj = _make_logging_obj(stream=True)
+    usage = ResponseAPIUsage(input_tokens=3, output_tokens=5, total_tokens=8)
+    response_dict = {"id": "resp-1", "created_at": 0, "usage": usage}
+    # streaming-assembly stores a dict in `.response` via model_construct (bypass
+    # validation) — repro the runtime shape that triggered #29913.
+    event = ResponseCompletedEvent.model_construct(
+        type=ResponsesAPIStreamEvents.RESPONSE_COMPLETED,
+        response=response_dict,
+    )
+
+    assembled = logging_obj._get_assembled_streaming_response(
+        result=event,
+        start_time=datetime.datetime.now(),
+        end_time=datetime.datetime.now(),
+        is_async=True,
+        streaming_chunks=[],
+    )
+
+    assert assembled is response_dict
+    assert isinstance(response_dict["usage"], dict)
+    assert response_dict["usage"]["prompt_tokens"] == 3
+    assert response_dict["usage"]["completion_tokens"] == 5
+    assert response_dict["usage"]["total_tokens"] == 8
+
+
 @pytest.mark.asyncio
 async def test_non_streaming_computes_standard_logging_object_once():
     """


### PR DESCRIPTION
Fixes #29913.

Streaming `/v1/responses` was silently under-billing — the success-logging callback crashed with `AttributeError: 'dict' object has no attribute 'usage'` and no `LiteLLM_SpendLogs` row landed (200 to the client, no charge).

`ResponseCompletedEvent.response` is typed `ResponsesAPIResponse` but `extra="allow"` lets a plain dict end up in that field at runtime via the streaming-assembly path. `_get_assembled_streaming_response` accessed `result.response.usage` directly, so the dict-shape blew up.

Fix: read `usage` via dict-key when `.response` is a dict, and write the transformed usage back the same way (`setattr` on a plain dict also fails). Blocking `/v1/responses` and streaming `/v1/chat/completions` paths take different branches and are unchanged.

Two regression tests in `tests/test_litellm/litellm_core_utils/test_litellm_logging.py` — one for the dict-response + dict-usage repro from the issue, one for dict-response + `ResponseAPIUsage` instance (covers the write-back).

```
$ .venv/bin/python -m pytest tests/test_litellm/litellm_core_utils/test_litellm_logging.py -k get_assembled_streaming_response -q
.....   5 passed in 0.30s
$ .venv/bin/python -m pytest tests/test_litellm/litellm_core_utils/test_litellm_logging.py -q
94 passed in 5.62s
```

Related (different paths, kept distinct): #28943 / #29394 (Anthropic-messages bridge), #13654 (`.id` access on the `background=True` Responses path).
