### PR TITLE
fix: exempt zero-cost models from internal-user max_budget check

### DIFF
--- a/litellm/proxy/hooks/max_budget_limiter.py
+++ b/litellm/proxy/hooks/max_budget_limiter.py
@@ -94,7 +94,10 @@ class _PROXY_MaxBudgetLimiter(CustomLogger):
                         )
                         return
                 except ImportError:
-                    pass
+                    verbose_proxy_logger.warning(
+                        "MaxBudgetLimiter: ImportError when checking zero-cost model; "
+                        "skipping exemption and enforcing budget limit."
+                    )
 
                 raise ProxyRateLimitError(
                     detail="Max budget limit reached.",

--- a/litellm/proxy/hooks/max_budget_limiter.py
+++ b/litellm/proxy/hooks/max_budget_limiter.py
@@ -66,8 +66,9 @@ class _PROXY_MaxBudgetLimiter(CustomLogger):
 
             # CHECK IF REQUEST ALLOWED
             if curr_spend >= max_budget:
+                raw_model = data.get("model") if data else None
                 resolved_model, llm_provider = resolve_llm_provider_for_rate_limit(
-                    data.get("model") if data else None
+                    raw_model
                 )
 
                 # Zero-cost models (self-hosted / on-prem) add nothing to
@@ -79,10 +80,17 @@ class _PROXY_MaxBudgetLimiter(CustomLogger):
                     from litellm.proxy.auth.auth_checks import _is_model_cost_zero
                     from litellm.proxy.proxy_server import llm_router
 
-                    if _is_model_cost_zero(resolved_model, llm_router):
+                    # Use raw_model (the request-level model string) for the
+                    # cost lookup, not resolved_model.  _is_model_cost_zero
+                    # calls llm_router.get_model_group_info(model_group=...)
+                    # which matches on the configured model_group alias.
+                    # resolve_llm_provider_for_rate_limit returns the
+                    # underlying provider model, which may not match the
+                    # router group name when aliases are in use.
+                    if _is_model_cost_zero(raw_model, llm_router):
                         verbose_proxy_logger.debug(
                             "MaxBudgetLimiter: Skipping budget check for zero-cost model: %s",
-                            resolved_model,
+                            raw_model,
                         )
                         return
                 except ImportError:

--- a/litellm/proxy/hooks/max_budget_limiter.py
+++ b/litellm/proxy/hooks/max_budget_limiter.py
@@ -69,6 +69,25 @@ class _PROXY_MaxBudgetLimiter(CustomLogger):
                 resolved_model, llm_provider = resolve_llm_provider_for_rate_limit(
                     data.get("model") if data else None
                 )
+
+                # Zero-cost models (self-hosted / on-prem) add nothing to
+                # spend, so exempt them — matching the existing exemption in
+                # common_checks (user_api_key_auth.py) which already skips
+                # budget enforcement for zero-cost models on key, team, and
+                # end-user budget paths.
+                try:
+                    from litellm.proxy.auth.auth_checks import _is_model_cost_zero
+                    from litellm.proxy.proxy_server import llm_router
+
+                    if _is_model_cost_zero(resolved_model, llm_router):
+                        verbose_proxy_logger.debug(
+                            "MaxBudgetLimiter: Skipping budget check for zero-cost model: %s",
+                            resolved_model,
+                        )
+                        return
+                except ImportError:
+                    pass
+
                 raise ProxyRateLimitError(
                     detail="Max budget limit reached.",
                     rate_limit_type=RateLimitType.BUDGET,


### PR DESCRIPTION
## Problem

When an internal user exceeds their `max_budget`, requests to zero-cost models (self-hosted / on-prem models with no configured pricing) are rejected with `429 "Max budget limit reached."`, even though these models add nothing to spend.

Every other budget path (key, team, end-user) already exempts zero-cost models via `_is_model_cost_zero` in `common_checks()` (see `user_api_key_auth.py` lines 1355-1364 and 1773-1782). The `_PROXY_MaxBudgetLimiter` hook does not.

## Fix

Add a zero-cost model check to `_PROXY_MaxBudgetLimiter.async_pre_call_hook` before raising the rate limit error. Uses the same `_is_model_cost_zero` function that `common_checks` already uses.

## Testing

- All 6 existing `test_max_budget_limiter` tests pass
- The fix is a narrow guard: if the model is zero-cost, the hook returns early without raising
- Paid models (cost > 0) are still blocked as before

Fixes #29912
