### PR TITLE
fix(proxy): exempt zero-cost models from internal-user budget hook

### DIFF
--- a/litellm/proxy/hooks/max_budget_limiter.py
+++ b/litellm/proxy/hooks/max_budget_limiter.py
@@ -36,6 +36,21 @@ class _PROXY_MaxBudgetLimiter(CustomLogger):
             if user_api_key_dict.team_id is not None:
                 return
 
+            # Zero-cost models (e.g. free / on-prem models configured with
+            # input+output cost == 0) bypass budget enforcement, matching
+            # common_checks()/_should_skip_budget_checks(). Without this, an
+            # over-budget user is incorrectly blocked from free models even
+            # though those requests add nothing to spend.
+            # Imported lazily to avoid a circular import via proxy.utils.
+            from litellm.proxy.auth.auth_checks import _is_model_cost_zero
+            from litellm.proxy.proxy_server import llm_router
+
+            if _is_model_cost_zero(
+                model=data.get("model") if data else None,
+                llm_router=llm_router,
+            ):
+                return
+
             # The reservation path admits at the strict-`<` boundary and
             # atomically pre-fills the same counter we'd read here. Re-checking
             # with `>=` would reject a request the reservation already admitted

--- a/tests/test_litellm/proxy/hooks/test_max_budget_limiter.py
+++ b/tests/test_litellm/proxy/hooks/test_max_budget_limiter.py
@@ -206,3 +206,85 @@ async def test_no_max_budget_passes():
 
     assert result is None
     mock_get_spend.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Regression: zero-cost (free / on-prem) models must NOT be blocked by the
+# personal-budget hook when the user is over budget.
+#
+# common_checks already exempts zero-cost models via skip_budget_checks
+# (_is_model_cost_zero). This hook is a *separate* enforcement point that
+# currently ignores model cost, so it blocks free models too. These tests pin
+# the intended behavior: free model -> allowed, paid model -> still blocked.
+# ---------------------------------------------------------------------------
+
+
+def _zero_and_paid_router():
+    from litellm import Router
+
+    return Router(
+        model_list=[
+            {
+                "model_name": "free-model",
+                "litellm_params": {
+                    "model": "openai/free",
+                    "api_key": "x",
+                    "input_cost_per_token": 0,
+                    "output_cost_per_token": 0,
+                },
+            },
+            {
+                "model_name": "paid-model",
+                "litellm_params": {
+                    "model": "openai/paid",
+                    "api_key": "x",
+                    "input_cost_per_token": 0.00001,
+                    "output_cost_per_token": 0.00001,
+                },
+            },
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_zero_cost_model_exempt_from_personal_budget():
+    """Over-budget user requesting a ZERO-COST model must be allowed (regression)."""
+    handler = _PROXY_MaxBudgetLimiter()
+    user_api_key_dict = _make_user_api_key_auth(user_max_budget=10.0)
+    router = _zero_and_paid_router()
+
+    with patch(
+        "litellm.proxy.proxy_server.get_current_spend",
+        new=AsyncMock(return_value=10.0),
+    ), patch("litellm.proxy.proxy_server.llm_router", router):
+        result = await handler.async_pre_call_hook(
+            user_api_key_dict=user_api_key_dict,
+            cache=DualCache(),
+            data={"model": "free-model"},
+            call_type="completion",
+        )
+
+    assert result is None  # zero-cost model is exempt despite over-budget
+
+
+@pytest.mark.asyncio
+async def test_paid_model_still_blocked_when_over_budget():
+    """Over-budget user requesting a PAID model must still be blocked (guard)."""
+    handler = _PROXY_MaxBudgetLimiter()
+    user_api_key_dict = _make_user_api_key_auth(user_max_budget=10.0)
+    router = _zero_and_paid_router()
+
+    with patch(
+        "litellm.proxy.proxy_server.get_current_spend",
+        new=AsyncMock(return_value=10.0),
+    ), patch("litellm.proxy.proxy_server.llm_router", router):
+        with pytest.raises(HTTPException) as exc_info:
+            await handler.async_pre_call_hook(
+                user_api_key_dict=user_api_key_dict,
+                cache=DualCache(),
+                data={"model": "paid-model"},
+                call_type="completion",
+            )
+
+    assert exc_info.value.status_code == 429
+    assert "Max budget limit reached." in exc_info.value.detail


### PR DESCRIPTION
## Relevant issues

Fixes #29912

<!-- e.g. "Fixes #000" -->

## Linear ticket

N/A (external contributor)

<!-- if you are an internal contributor, add the Linear ticket e.g. "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

### Unit Tests

**File:** `tests/test_litellm/proxy/hooks/test_max_budget_limiter.py`

#### Before the Fix
(Over-budget user accessing a zero-cost model)

```text
test_zero_cost_model_exempt_from_personal_budget   FAILED
    -> ProxyHTTPRateLimitError: 429: Max budget limit reached.
       (max_budget_limiter.py:73)
```

#### After the Fix

```text
test_zero_cost_model_exempt_from_personal_budget   PASSED   # free model allowed
test_paid_model_still_blocked_when_over_budget     PASSED   # paid model still blocked

... 8 passed
```

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->
🐛 Bug Fix
✅ Test

## Changes

  #### `litellm/proxy/hooks/max_budget_limiter.py`

In `_PROXY_MaxBudgetLimiter.async_pre_call_hook()`, add a zero-cost model guard before enforcing the personal budget. If the requested model is zero-cost (`_is_model_cost_zero(data.get("model"), llm_router)`), return early and skip the budget check.

This aligns the internal-user budget path with the existing behavior in `common_checks()` / `_should_skip_budget_checks()`, where zero-cost models are exempt from budget enforcement for key, team, and end-user budget checks.

To avoid circular imports, `_is_model_cost_zero` and `llm_router` should be imported lazily using the same pattern already used for `get_current_spend`. The check should fail safe: if the router is unavailable or model cost cannot be determined, budget enforcement should continue as normal.

#### `tests/test_litellm/proxy/hooks/test_max_budget_limiter.py`

Add regression test coverage for the internal-user budget path:

- `test_zero_cost_model_exempt_from_personal_budget`
  - Verifies that an over-budget internal user can still access a zero-cost model.

- `test_paid_model_still_blocked_when_over_budget`
  - Verifies that an over-budget internal user continues to be blocked when accessing a paid model.

- `_zero_and_paid_router()`
  - Helper that constructs a `Router` containing one zero-cost model and one paid model for test scenarios.
