### PR TITLE
feat: add qwen3.7-max model (Alibaba/Qwen via Anthropic protocol)

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -41865,5 +41865,23 @@
     "source": "https://soniox.com/pricing",
     "supported_endpoints": ["/v1/audio/transcriptions"],
     "supports_audio_input": true
+  },
+  "qwen3.7-max": {
+    "input_cost_per_token": 1.77e-06,
+    "cache_creation_input_token_cost": 2.21e-06,
+    "cache_read_input_token_cost": 3.54e-07,
+    "litellm_provider": "anthropic",
+    "max_input_tokens": 991000,
+    "max_output_tokens": 65536,
+    "max_tokens": 65536,
+    "mode": "chat",
+    "output_cost_per_token": 5.31e-06,
+    "source": "https://help.aliyun.com/zh/model-studio/models",
+    "supports_function_calling": true,
+    "supports_reasoning": true,
+    "supports_tool_choice": true,
+    "supports_assistant_prefill": true,
+    "supports_prompt_caching": true,
+    "supports_web_search": true
   }
  }


### PR DESCRIPTION
## Description

Add `qwen3.7-max` model entry to `model_prices_and_context_window.json`.

This model is served via DashScope's Anthropic-compatible API, with `litellm_provider` set to `"anthropic"` to match the actual protocol used.

## Model Details

| Field | Value |
|-------|-------|
| **Max Input Tokens** | 991K |
| **Max Output Tokens** | 64K (64K in thinking mode) |
| **Context Length** | 1M |
| **Max Chain of Thought Length** | 256K |

## Pricing (original price, exchange rate 1 USD = 6.78 CNY, 2026-06-08)

| Item | Price (CNY) | Price (USD) |
|------|-------------|-------------|
| Input | 12 元/百万 tokens | 1.77e-06 USD/token |
| Output | 36 元/百万 tokens | 5.31e-06 USD/token |
| Cache Creation | 15 元/百万 tokens | 2.21e-06 USD/token |
| Cache Read (hit) | 2.4 元/百万 tokens | 3.54e-07 USD/token |

## Supported Features

- Function Calling
- Reasoning (Thinking Mode)
- Tool Choice
- Assistant Prefill
- Prompt Caching
- Web Search

## Source

- [阿里云模型文档](https://help.aliyun.com/zh/model-studio/models)
- Exchange rate: 1 USD = 6.78 CNY (2026-06-08)

## Note

The `litellm_provider` is set to `"anthropic"` because this model is accessed via DashScope's **Anthropic-compatible API** (not OpenAI-compatible). The actual API endpoint routing is configured via `base_url` at runtime.