### PR TITLE
fix(proxy): handle multipart/form-data in Mistral passthrough route (Fixes #29926)

### DIFF
--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -425,12 +425,10 @@ async def mistral_proxy_route(
     )
 
     ## check for streaming
-    is_streaming_request = False
-    # anthropic is streaming when 'stream' = True is in the body
-    if request.method == "POST":
-        _request_body = await request.json()
-        if _request_body.get("stream"):
-            is_streaming_request = True
+    # Use the shared helper so multipart/form-data uploads (e.g. file uploads to
+    # `/mistral/v1/files`) are not parsed as JSON, which previously raised a 500
+    # before the request was ever forwarded to Mistral.
+    is_streaming_request = await is_streaming_request_fn(request)
 
     ## CREATE PASS-THROUGH
     endpoint_func = create_pass_through_route(

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
@@ -2890,3 +2890,225 @@ class TestCursorProxyRoute:
             assert call_args["target"] == "https://api.cursor.com/v0/agents"
             assert result["id"] == "bc_abc123"
             assert result["status"] == "CREATING"
+
+
+class TestMistralProxyRoute:
+    """Regression tests for the Mistral pass-through route.
+
+    See https://github.com/BerriAI/litellm/issues/29926 — multipart/form-data
+    uploads to `/mistral/v1/files` previously crashed with a 500 because the
+    route called `await request.json()` on every POST. The route now relies on
+    the shared `is_streaming_request_fn` helper, which parses form data for
+    multipart requests instead of forcing JSON parsing.
+    """
+
+    def _make_multipart_request(self):
+        """Build a mock multipart/form-data file-upload request.
+
+        `request.json()` is wired to raise like Starlette does for a non-JSON
+        body, so any code path that calls it will surface as a failure.
+        """
+        mock_request = MagicMock(spec=Request)
+        mock_request.method = "POST"
+        mock_request.query_params = {}
+        mock_request.headers = {
+            "content-type": "multipart/form-data; boundary=----abc123"
+        }
+        mock_request.form = AsyncMock(
+            return_value={"purpose": "ocr", "file": "<binary>"}
+        )
+        mock_request.json = AsyncMock(
+            side_effect=json.JSONDecodeError("Expecting value", "", 0)
+        )
+        return mock_request
+
+    @pytest.mark.asyncio
+    async def test_mistral_multipart_upload_does_not_parse_json(self):
+        """A multipart upload must not be JSON-parsed and must reach the target."""
+        from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
+            mistral_proxy_route,
+        )
+
+        mock_request = self._make_multipart_request()
+        mock_response = MagicMock(spec=Response)
+        mock_user_api_key_dict = MagicMock()
+
+        with (
+            patch(
+                "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.passthrough_endpoint_router.get_credentials",
+                return_value="test-mistral-key",
+            ),
+            patch(
+                "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.create_pass_through_route"
+            ) as mock_create_route,
+        ):
+            mock_endpoint_func = AsyncMock(return_value={"id": "file-123"})
+            mock_create_route.return_value = mock_endpoint_func
+
+            result = await mistral_proxy_route(
+                endpoint="v1/files",
+                request=mock_request,
+                fastapi_response=mock_response,
+                user_api_key_dict=mock_user_api_key_dict,
+            )
+
+        # The bug: `request.json()` was called on the multipart body and raised.
+        mock_request.json.assert_not_called()
+        mock_create_route.assert_called_once()
+        call_args = mock_create_route.call_args[1]
+        assert call_args["target"] == "https://api.mistral.ai/v1/files"
+        assert call_args["is_streaming_request"] is False
+        assert call_args["custom_headers"]["Authorization"] == "Bearer test-mistral-key"
+        assert result == {"id": "file-123"}
+
+    @pytest.mark.asyncio
+    async def test_mistral_multipart_upload_streaming_flag(self):
+        """A multipart form carrying `stream=true` is detected as streaming."""
+        from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
+            mistral_proxy_route,
+        )
+
+        mock_request = self._make_multipart_request()
+        mock_request.form = AsyncMock(return_value={"purpose": "ocr", "stream": "true"})
+        mock_response = MagicMock(spec=Response)
+        mock_user_api_key_dict = MagicMock()
+
+        with (
+            patch(
+                "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.passthrough_endpoint_router.get_credentials",
+                return_value="test-mistral-key",
+            ),
+            patch(
+                "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.create_pass_through_route"
+            ) as mock_create_route,
+        ):
+            mock_create_route.return_value = AsyncMock(return_value={"ok": True})
+
+            await mistral_proxy_route(
+                endpoint="v1/files",
+                request=mock_request,
+                fastapi_response=mock_response,
+                user_api_key_dict=mock_user_api_key_dict,
+            )
+
+        mock_request.json.assert_not_called()
+        assert mock_create_route.call_args[1]["is_streaming_request"] is True
+
+    @pytest.mark.asyncio
+    async def test_mistral_json_post_streaming_detected(self):
+        """A JSON POST with `stream=true` is still detected as streaming."""
+        from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
+            mistral_proxy_route,
+        )
+
+        mock_request = MagicMock(spec=Request)
+        mock_request.method = "POST"
+        mock_request.query_params = {}
+        mock_request.headers = {"content-type": "application/json"}
+        mock_request.body = AsyncMock(
+            return_value=json.dumps(
+                {"model": "mistral-large-latest", "stream": True}
+            ).encode("utf-8")
+        )
+        mock_response = MagicMock(spec=Response)
+        mock_user_api_key_dict = MagicMock()
+
+        with (
+            patch(
+                "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.passthrough_endpoint_router.get_credentials",
+                return_value="test-mistral-key",
+            ),
+            patch(
+                "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.create_pass_through_route"
+            ) as mock_create_route,
+        ):
+            mock_create_route.return_value = AsyncMock(return_value={"ok": True})
+
+            await mistral_proxy_route(
+                endpoint="v1/chat/completions",
+                request=mock_request,
+                fastapi_response=mock_response,
+                user_api_key_dict=mock_user_api_key_dict,
+            )
+
+        assert mock_create_route.call_args[1]["is_streaming_request"] is True
+        assert (
+            mock_create_route.call_args[1]["target"]
+            == "https://api.mistral.ai/v1/chat/completions"
+        )
+
+    @pytest.mark.asyncio
+    async def test_mistral_json_post_non_streaming(self):
+        """A JSON POST without `stream` is non-streaming."""
+        from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
+            mistral_proxy_route,
+        )
+
+        mock_request = MagicMock(spec=Request)
+        mock_request.method = "POST"
+        mock_request.query_params = {}
+        mock_request.headers = {"content-type": "application/json"}
+        mock_request.body = AsyncMock(
+            return_value=json.dumps({"model": "mistral-large-latest"}).encode("utf-8")
+        )
+        mock_response = MagicMock(spec=Response)
+        mock_user_api_key_dict = MagicMock()
+
+        with (
+            patch(
+                "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.passthrough_endpoint_router.get_credentials",
+                return_value="test-mistral-key",
+            ),
+            patch(
+                "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.create_pass_through_route"
+            ) as mock_create_route,
+        ):
+            mock_create_route.return_value = AsyncMock(return_value={"ok": True})
+
+            await mistral_proxy_route(
+                endpoint="v1/chat/completions",
+                request=mock_request,
+                fastapi_response=mock_response,
+                user_api_key_dict=mock_user_api_key_dict,
+            )
+
+        assert mock_create_route.call_args[1]["is_streaming_request"] is False
+
+    @pytest.mark.asyncio
+    async def test_mistral_get_request_does_not_read_body(self):
+        """A GET request must never attempt to read/parse the body."""
+        from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
+            mistral_proxy_route,
+        )
+
+        mock_request = MagicMock(spec=Request)
+        mock_request.method = "GET"
+        mock_request.query_params = {}
+        mock_request.headers = {}
+        mock_request.json = AsyncMock(
+            side_effect=AssertionError("json() must not be called for GET")
+        )
+        mock_response = MagicMock(spec=Response)
+        mock_user_api_key_dict = MagicMock()
+
+        with (
+            patch(
+                "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.passthrough_endpoint_router.get_credentials",
+                return_value="test-mistral-key",
+            ),
+            patch(
+                "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.create_pass_through_route"
+            ) as mock_create_route,
+        ):
+            mock_create_route.return_value = AsyncMock(return_value={"data": []})
+
+            result = await mistral_proxy_route(
+                endpoint="v1/models",
+                request=mock_request,
+                fastapi_response=mock_response,
+                user_api_key_dict=mock_user_api_key_dict,
+            )
+
+        mock_request.json.assert_not_called()
+        assert mock_create_route.call_args[1]["is_streaming_request"] is False
+        assert result == {"data": []}


### PR DESCRIPTION
## Relevant issues

Fixes #29926

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests for the touched module
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Type

🐛 Bug Fix
✅ Test

## Changes

### Root cause

`mistral_proxy_route()` in `litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py` detected streaming by calling `await request.json()` on **every** POST:

```python
## check for streaming
is_streaming_request = False
if request.method == "POST":
    _request_body = await request.json()      # <-- crashes on multipart bodies
    if _request_body.get("stream"):
        is_streaming_request = True
```

For a `multipart/form-data` upload (the format the OpenAI/Mistral SDKs use for `POST /mistral/v1/files`), the body is not JSON, so `request.json()` raises `JSONDecodeError`. The exception propagates out of the route and the proxy returns a generic **HTTP 500** — the request never reaches Mistral.

The fix is already encoded in this same file: `is_streaming_request_fn()` branches on `content-type` and reads form data via `get_form_data()` for multipart requests, falling back to JSON otherwise. `anthropic_proxy_route()` already uses it. This PR makes the Mistral route do the same.

### Minimal repro

```bash
curl -X POST "http://localhost:4000/mistral/v1/files" \
  -H "Authorization: Bearer sk-1234" \
  -F "purpose=ocr" \
  -F "file=@document.pdf"
```

### Before / After

| Scenario | Before | After |
|---|---|---|
| `POST /mistral/v1/files` (multipart upload) | **500 Internal Server Error** (`JSONDecodeError`, never forwarded) | Forwarded to Mistral ✅ |
| Multipart form with `stream=true` | 500 | Detected as streaming ✅ |
| JSON POST with `"stream": true` | streaming ✅ | streaming ✅ (unchanged) |
| JSON POST without `stream` | non-streaming ✅ | non-streaming ✅ (unchanged) |
| `GET /mistral/v1/models` | ✅ | ✅ (no body read) |

### The fix

```diff
 ## check for streaming
-is_streaming_request = False
-if request.method == "POST":
-    _request_body = await request.json()
-    if _request_body.get("stream"):
-        is_streaming_request = True
+is_streaming_request = await is_streaming_request_fn(request)
```

### Architecture note

The passthrough routes share a single streaming-detection contract: a request is "streaming" iff its parsed body carries a truthy `stream` field. `is_streaming_request_fn()` is the canonical implementation of that contract and is content-type aware — it never assumes JSON. By routing Mistral through the same helper as Anthropic, streaming detection stays correct while multipart, form-urlencoded, and empty bodies all parse safely instead of throwing. No behavior changes for existing JSON traffic; the only difference is that non-JSON bodies are now handled instead of crashing.

## Tests

Added `TestMistralProxyRoute` to `tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py` (5 cases):

1. `test_mistral_multipart_upload_does_not_parse_json` — multipart upload reaches the target, `request.json()` is never called *(fails without the fix)*
2. `test_mistral_multipart_upload_streaming_flag` — multipart form with `stream=true` is detected as streaming *(fails without the fix)*
3. `test_mistral_json_post_streaming_detected` — JSON POST with `stream=true` still streams
4. `test_mistral_json_post_non_streaming` — JSON POST without `stream` is non-streaming *(fails without the fix)*
5. `test_mistral_get_request_does_not_read_body` — GET never reads the body

All 5 pass with the fix; the three marked above fail on `main` (the two multipart cases raise the original 500).

```
$ pytest tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py::TestMistralProxyRoute
5 passed
```
