### PR TITLE
fix(mcp): don't leak server credentials in 403 'tool not allowed' error

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -2077,7 +2077,7 @@ if MCP_AVAILABLE:
             ):
                 raise HTTPException(
                     status_code=403,
-                    detail=f"User not allowed to call this tool. Allowed MCP servers: {allowed_mcp_servers}",
+                    detail=f"User not allowed to call this tool. Allowed MCP servers: {[server.name for server in allowed_mcp_servers]}",
                 )
 
         standard_logging_mcp_tool_call: StandardLoggingMCPToolCall = (


### PR DESCRIPTION
## Summary

When a key calls an MCP tool on a server it isn't allowed to use, the 403 `HTTPException` interpolates the full `List[MCPServer]` objects into the error detail. `MCPServer` is a pydantic `BaseModel` whose default repr renders every field, including the plaintext secrets `authentication_token`, `client_secret`, `aws_secret_access_key`, and `aws_session_token`. These are returned to the unauthorized caller.

This changes the message to list only the allowed server **names** — the same `[server.name for server in allowed_mcp_servers]` form already used two lines above for the permission check (`is_tool_allowed`).

## What leaks today

```
{"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text",
 "text":"Error: User not allowed to call this tool. Allowed MCP servers:
  [MCPServer(... authentication_token='sk-LEAKED-API-KEY', ...)]"}],"isError":true}}
```

## After

```
User not allowed to call this tool. Allowed MCP servers: ['server_a', 'server_b']
```

The caller still gets the actionable information (which servers they may use) without any credential material.

Fixes #29936

## Test plan

- [ ] Configure an MCP server with `authentication_token` and call a tool on a server not in the key's allowed list
- [ ] Confirm the 403 detail contains only server names, no `authentication_token` / `client_secret` / AWS secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)
