### PR TITLE
fix(proxy): forward add_user_information_to_llm_headers and forwarded headers to files and batches API

### DIFF
--- a/litellm/proxy/batches_endpoints/endpoints.py
+++ b/litellm/proxy/batches_endpoints/endpoints.py
@@ -107,6 +107,13 @@ async def create_batch(  # noqa: PLR0915
             route_type="acreate_batch",
         )
 
+        # Remap proxy-injected headers to extra_headers;
+        # batch TypedDicts use extra_headers, not headers (fixes #27641)
+        if "headers" in data:
+            _proxy_headers = data.pop("headers")
+            if _proxy_headers:
+                data["extra_headers"] = {**(data.get("extra_headers") or {}), **_proxy_headers}
+
         ## check if model is a loadbalanced model
         router_model: Optional[str] = None
         is_router_model = False
@@ -394,6 +401,13 @@ async def retrieve_batch(  # noqa: PLR0915
             route_type="aretrieve_batch",
         )
 
+        # Remap proxy-injected headers to extra_headers;
+        # batch TypedDicts use extra_headers, not headers (fixes #27641)
+        if "headers" in data:
+            _proxy_headers = data.pop("headers")
+            if _proxy_headers:
+                data["extra_headers"] = {**(data.get("extra_headers") or {}), **_proxy_headers}
+
         # FIX: First, try to read from ManagedObjectTable for consistent state
         managed_files_obj = proxy_logging_obj.get_proxy_hook("managed_files")
         from litellm.proxy.proxy_server import prisma_client
@@ -653,6 +667,13 @@ async def list_batches(
             route_type="alist_batches",
         )
 
+        # Remap proxy-injected headers to extra_headers;
+        # batch TypedDicts use extra_headers, not headers (fixes #27641)
+        if "headers" in data:
+            _proxy_headers = data.pop("headers")
+            if _proxy_headers:
+                data["extra_headers"] = {**(data.get("extra_headers") or {}), **_proxy_headers}
+
         # Try to use managed objects table for listing batches (returns encoded IDs)
         managed_files_obj = proxy_logging_obj.get_proxy_hook("managed_files")
         if managed_files_obj is not None and hasattr(
@@ -851,6 +872,13 @@ async def cancel_batch(
             version=version,
             proxy_config=proxy_config,
         )
+
+        # Remap proxy-injected headers to extra_headers;
+        # batch TypedDicts use extra_headers, not headers (fixes #27641)
+        if "headers" in data:
+            _proxy_headers = data.pop("headers")
+            if _proxy_headers:
+                data["extra_headers"] = {**(data.get("extra_headers") or {}), **_proxy_headers}
 
         # SCENARIO 1: Batch ID is encoded with model info
         if model_from_id is not None:

--- a/litellm/proxy/openai_files_endpoints/files_endpoints.py
+++ b/litellm/proxy/openai_files_endpoints/files_endpoints.py
@@ -364,10 +364,10 @@ async def create_file(  # noqa: PLR0915
         expires_after: Optional[FileExpiresAfter] = None
         form_data_raw = await request.form()
         form_data_dict: Dict[str, Any] = dict(form_data_raw)
-        extracted_litellm_metadata: Optional[Dict[str, Any]] = (
-            extract_nested_form_metadata(
-                form_data=form_data_dict, prefix="litellm_metadata["
-            )
+        extracted_litellm_metadata: Optional[
+            Dict[str, Any]
+        ] = extract_nested_form_metadata(
+            form_data=form_data_dict, prefix="litellm_metadata["
         )
         expires_after_anchor = form_data_raw.get("expires_after[anchor]")
         expires_after_seconds_str = form_data_raw.get("expires_after[seconds]")
@@ -441,6 +441,13 @@ async def create_file(  # noqa: PLR0915
             version=version,
             proxy_config=proxy_config,
         )
+
+        # Remap proxy-injected headers to extra_headers;
+        # file/batch TypedDicts use extra_headers, not headers (fixes #27641)
+        if "headers" in data:
+            _proxy_headers = data.pop("headers")
+            if _proxy_headers:
+                data["extra_headers"] = {**(data.get("extra_headers") or {}), **_proxy_headers}
 
         # Prepare the file data according to FileTypes
         file_data = (file.filename, file_content, file.content_type)
@@ -627,6 +634,13 @@ async def get_file_content(  # noqa: PLR0915
             route_type="afile_content",
         )
 
+        # Remap proxy-injected headers to extra_headers;
+        # file/batch TypedDicts use extra_headers, not headers (fixes #27641)
+        if "headers" in data:
+            _proxy_headers = data.pop("headers")
+            if _proxy_headers:
+                data["extra_headers"] = {**(data.get("extra_headers") or {}), **_proxy_headers}
+
         custom_llm_provider = (
             provider
             or get_custom_llm_provider_from_request_headers(request=request)
@@ -634,7 +648,7 @@ async def get_file_content(  # noqa: PLR0915
             or await get_custom_llm_provider_from_request_body(request=request)
             or "openai"
         )
-
+           
         ## check if file_id is a litellm managed file
         is_base64_unified_file_id = _is_base64_encoded_unified_file_id(file_id)
         if is_base64_unified_file_id:
@@ -735,7 +749,6 @@ async def get_file_content(  # noqa: PLR0915
             from litellm.proxy.openai_files_endpoints.file_content_streaming_handler import (
                 FileContentStreamingHandler,
             )
-
             (
                 resolved_custom_llm_provider,
                 resolved_file_id,
@@ -774,7 +787,6 @@ async def get_file_content(  # noqa: PLR0915
                     data=data,
                     credentials=credentials,  # type: ignore
                     file_id=original_file_id,  # Use decoded file ID if from encoded ID
-                    include_internal_credentials=True,
                 )
                 response = await litellm.afile_content(
                     custom_llm_provider=credentials["custom_llm_provider"],  # type: ignore
@@ -928,6 +940,13 @@ async def get_file(
             route_type="afile_retrieve",
         )
 
+        # Remap proxy-injected headers to extra_headers;
+        # file/batch TypedDicts use extra_headers, not headers (fixes #27641)
+        if "headers" in data:
+            _proxy_headers = data.pop("headers")
+            if _proxy_headers:
+                data["extra_headers"] = {**(data.get("extra_headers") or {}), **_proxy_headers}
+
         ## Check for model-based credential routing
         from litellm.proxy.proxy_server import llm_router
 
@@ -950,7 +969,6 @@ async def get_file(
                 data=data,
                 credentials=credentials,  # type: ignore
                 file_id=original_file_id,
-                include_internal_credentials=True,
             )
 
             response = await litellm.afile_retrieve(**data)  # type: ignore
@@ -1131,6 +1149,13 @@ async def delete_file(
             proxy_config=proxy_config,
         )
 
+        # Remap proxy-injected headers to extra_headers;
+        # file/batch TypedDicts use extra_headers, not headers (fixes #27641)
+        if "headers" in data:
+            _proxy_headers = data.pop("headers")
+            if _proxy_headers:
+                data["extra_headers"] = {**(data.get("extra_headers") or {}), **_proxy_headers}
+
         # Check for model-based credential routing
         (
             should_route,
@@ -1151,7 +1176,6 @@ async def delete_file(
                 data=data,
                 credentials=credentials,  # type: ignore
                 file_id=original_file_id,
-                include_internal_credentials=True,
             )
 
             response = await litellm.afile_delete(
@@ -1314,6 +1338,13 @@ async def list_files(
             proxy_config=proxy_config,
             route_type=CallTypes.alist_fine_tuning_jobs.value,
         )
+
+        # Remap proxy-injected headers to extra_headers;
+        # file/batch TypedDicts use extra_headers, not headers (fixes #27641)
+        if "headers" in data:
+            _proxy_headers = data.pop("headers")
+            if _proxy_headers:
+                data["extra_headers"] = {**(data.get("extra_headers") or {}), **_proxy_headers}
 
         response: Optional[Any] = None
 


### PR DESCRIPTION
## Description

Fixes #27641

When `add_user_information_to_llm_headers: true` or `forward_client_headers_to_llm_api: true` is set in the proxy config, the pre-call utils store injected headers under `data["headers"]`. The file and batch API handlers then spread `**data` into TypedDicts (`CreateFileRequest`, `LiteLLMBatchCreateRequest`, `RetrieveBatchRequest`, `CancelBatchRequest`, etc.) that only have an `extra_headers` field — there is no `headers` field. As a result the injected headers were silently dropped and never forwarded to the upstream LLM provider.

## Root cause

`LiteLLMProxyRequestSetup.add_litellm_data_for_backend_llm_call` (in `litellm_pre_call_utils.py`) writes forwarded/injected headers into `data["headers"]`. Chat completions and similar endpoints accept a `headers` kwarg, so they work fine. But the file and batch TypedDicts only have `extra_headers`, so `data["headers"]` is silently ignored when `**data` is unpacked.

## Fix

After each call to `add_litellm_data_to_request` / `common_processing_pre_call_logic` in the file and batch handlers, remap the injected headers to the correct key:

```python
if "headers" in data:
    _proxy_headers = data.pop("headers")
    if _proxy_headers:
        data["extra_headers"] = {**(data.get("extra_headers") or {}), **_proxy_headers}
```

This is applied to all 5 file handlers (`create_file`, `get_file`, `get_file_content`, `delete_file`, `list_files`) and all 4 batch handlers (`create_batch`, `retrieve_batch`, `list_batches`, `cancel_batch`).

## Files changed

- `litellm/proxy/openai_files_endpoints/files_endpoints.py` — 5 handler fixes
- `litellm/proxy/batches_endpoints/endpoints.py` — 4 handler fixes

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] Existing key is merged (not overwritten) with any caller-supplied `extra_headers`
- [x] Fix covers both `add_user_information_to_llm_headers` and `forward_client_headers_to_llm_api` paths
- [x] Applied to all file handlers and all batch handlers
