### PR TITLE
fix(anthropic): omit thinking blocks from Responses API message history replay

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
@@ -166,11 +166,9 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
                                 }
                             )
                         elif btype == "thinking":
-                            thinking_text = block.get("thinking", "")
-                            if thinking_text:
-                                asst_parts.append(
-                                    {"type": "output_text", "text": thinking_text}
-                                )
+                            # Thinking blocks are internal model reasoning and must not be
+                            # forwarded as output_text in replayed history (fixes #26916).
+                            pass
                     if asst_parts:
                         input_items.append(
                             {


### PR DESCRIPTION
## Description

Fixes #26916

When `anthropic_messages()` is called with a prior assistant `thinking` block in the conversation history, the Responses-API adapter was serializing the thinking content as an `output_text` block:

**Before (broken):**
```python
elif btype == "thinking":
    thinking_text = block.get("thinking", "")
    if thinking_text:
        asst_parts.append({"type": "output_text", "text": thinking_text})
```

This caused the model's internal reasoning to be replayed to OpenAI as regular assistant-visible text, potentially:
- Leaking private reasoning into normal conversation history
- Altering subsequent model behavior (since the model sees its own prior thinking as ordinary output)

## Fix

Thinking blocks represent private internal reasoning that has no equivalent history item in the OpenAI Responses API, so they are silently dropped during history replay:

```python
elif btype == "thinking":
    # Thinking blocks are internal model reasoning and must not be
    # forwarded as output_text in replayed history (fixes #26916).
    pass
```

This matches the behavior of the Anthropic API itself, which strips `thinking` blocks on replay when extended thinking is enabled.

## File changed

- `litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py` — drop the `btype == "thinking"` → `output_text` conversion in `translate_messages_to_input`

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] Text blocks and tool_use blocks in assistant history are unchanged
- [x] The fix removes the content leak without affecting any other block type
