### PR TITLE
Fix daily activity aggregated endpoint crash for keys with no spend

### DIFF
--- a/litellm/proxy/management_endpoints/common_daily_activity.py
+++ b/litellm/proxy/management_endpoints/common_daily_activity.py
@@ -32,15 +32,17 @@ _PRISMA_TO_PG_TABLE: Dict[str, str] = {
 
 def update_metrics(existing_metrics: SpendMetrics, record: Any) -> SpendMetrics:
     """Update metrics with new record data."""
-    existing_metrics.spend += record.spend
-    existing_metrics.prompt_tokens += record.prompt_tokens
-    existing_metrics.completion_tokens += record.completion_tokens
-    existing_metrics.total_tokens += record.prompt_tokens + record.completion_tokens
-    existing_metrics.cache_read_input_tokens += record.cache_read_input_tokens
-    existing_metrics.cache_creation_input_tokens += record.cache_creation_input_tokens
-    existing_metrics.api_requests += record.api_requests
-    existing_metrics.successful_requests += record.successful_requests
-    existing_metrics.failed_requests += record.failed_requests
+    prompt_tokens = record.prompt_tokens or 0
+    completion_tokens = record.completion_tokens or 0
+    existing_metrics.spend += record.spend or 0
+    existing_metrics.prompt_tokens += prompt_tokens
+    existing_metrics.completion_tokens += completion_tokens
+    existing_metrics.total_tokens += prompt_tokens + completion_tokens
+    existing_metrics.cache_read_input_tokens += record.cache_read_input_tokens or 0
+    existing_metrics.cache_creation_input_tokens += record.cache_creation_input_tokens or 0
+    existing_metrics.api_requests += record.api_requests or 0
+    existing_metrics.successful_requests += record.successful_requests or 0
+    existing_metrics.failed_requests += record.failed_requests or 0
     return existing_metrics
 
 
@@ -696,16 +698,18 @@ _GROUP_DATE_ENDPOINT_API_KEY = 30  # 0b0011110
 
 def _record_to_spend_metrics(record: Any) -> SpendMetrics:
     """Build a SpendMetrics directly from one already-aggregated rollup row."""
+    prompt_tokens = record.prompt_tokens or 0
+    completion_tokens = record.completion_tokens or 0
     return SpendMetrics(
-        spend=record.spend,
-        prompt_tokens=record.prompt_tokens,
-        completion_tokens=record.completion_tokens,
-        total_tokens=record.prompt_tokens + record.completion_tokens,
-        cache_read_input_tokens=record.cache_read_input_tokens,
-        cache_creation_input_tokens=record.cache_creation_input_tokens,
-        api_requests=record.api_requests,
-        successful_requests=record.successful_requests,
-        failed_requests=record.failed_requests,
+        spend=record.spend or 0,
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=prompt_tokens + completion_tokens,
+        cache_read_input_tokens=record.cache_read_input_tokens or 0,
+        cache_creation_input_tokens=record.cache_creation_input_tokens or 0,
+        api_requests=record.api_requests or 0,
+        successful_requests=record.successful_requests or 0,
+        failed_requests=record.failed_requests or 0,
     )
 
 

--- a/tests/test_litellm/proxy/management_endpoints/test_common_daily_activity.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_common_daily_activity.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -10,10 +11,13 @@ sys.path.insert(
 
 from litellm.proxy.management_endpoints.common_daily_activity import (
     _is_user_agent_tag,
+    _record_to_spend_metrics,
     get_api_key_metadata,
     get_daily_activity,
     get_daily_activity_aggregated,
+    update_metrics,
 )
+from litellm.types.proxy.management_endpoints.common_daily_activity import SpendMetrics
 
 
 @pytest.mark.asyncio
@@ -585,3 +589,38 @@ async def test_aggregated_activity_preserves_metadata_for_deleted_keys():
     assert key_data.metadata.key_alias == "toto-test-2"
     assert key_data.metadata.team_id == "69cd4b77-b095-4489-8c46-4f2f31d840a2"
     assert key_data.metrics.spend == 10.0
+
+
+def _no_spend_record():
+    """A rollup row for a key with no spend, where SUM() returns NULL (None)."""
+    return SimpleNamespace(
+        spend=None,
+        prompt_tokens=None,
+        completion_tokens=None,
+        cache_read_input_tokens=None,
+        cache_creation_input_tokens=None,
+        api_requests=None,
+        successful_requests=None,
+        failed_requests=None,
+    )
+
+
+def test_record_to_spend_metrics_handles_none_values():
+    """Keys with no spend produce NULL aggregates; treat them as zero, not a crash."""
+    metrics = _record_to_spend_metrics(_no_spend_record())
+    assert metrics.spend == 0
+    assert metrics.prompt_tokens == 0
+    assert metrics.completion_tokens == 0
+    assert metrics.total_tokens == 0
+    assert metrics.api_requests == 0
+    assert metrics.successful_requests == 0
+    assert metrics.failed_requests == 0
+
+
+def test_update_metrics_handles_none_values():
+    """update_metrics should ignore NULL aggregates instead of raising TypeError."""
+    metrics = update_metrics(SpendMetrics(), _no_spend_record())
+    assert metrics.spend == 0
+    assert metrics.prompt_tokens == 0
+    assert metrics.completion_tokens == 0
+    assert metrics.total_tokens == 0


### PR DESCRIPTION
## Description

`/user/daily/activity/aggregated` returns HTTP 500 for any key that has no spend. The aggregated rollup query uses SQL `SUM()`, which returns `NULL` (Python `None`) when a key has no matching rows. `_record_to_spend_metrics` and `update_metrics` then add those `None` values directly, raising:

```
TypeError: unsupported operand type(s) for +: 'NoneType' and 'NoneType'
```

This coalesces the per-record numeric fields to `0` in both functions, so a key with no spend reports zeros instead of crashing the endpoint.

Fixes #29773

## Testing

Added two unit tests to `tests/test_litellm/proxy/management_endpoints/test_common_daily_activity.py`:

- `test_record_to_spend_metrics_handles_none_values`
- `test_update_metrics_handles_none_values`

Both reproduce the `TypeError` on the current code and pass with the fix. The full test file passes (13 tests) locally with no regressions.
