### PR TITLE
fix(mcp): mirror upstream token lifetime instead of forcing a 1h OBO expiry

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
@@ -512,12 +512,13 @@ async def exchange_token_with_server(
     result = {
         "access_token": access_token,
         "token_type": token_response.get("token_type", "Bearer"),
-        "expires_in": token_response.get("expires_in", 3600),
     }
 
-    if "refresh_token" in token_response and token_response["refresh_token"]:
+    if token_response.get("expires_in") is not None:
+        result["expires_in"] = token_response["expires_in"]
+    if token_response.get("refresh_token"):
         result["refresh_token"] = token_response["refresh_token"]
-    if "scope" in token_response and token_response["scope"]:
+    if token_response.get("scope"):
         result["scope"] = token_response["scope"]
 
     # RFC 6749 §5.1: token responses must not be cached.

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
@@ -1,5 +1,6 @@
 """Tests for MCP OAuth discoverable endpoints"""
 
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -2661,3 +2662,74 @@ async def test_token_endpoint_sets_no_store_cache_control():
 
     assert response.headers["cache-control"] == "no-store"
     assert response.headers["pragma"] == "no-cache"
+
+
+async def _exchange_with_upstream_token_response(upstream_body):
+    from fastapi import Request
+
+    from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+        exchange_token_with_server,
+    )
+    from litellm.proxy._types import MCPTransport
+    from litellm.types.mcp import MCPAuth
+    from litellm.types.mcp_server.mcp_server_manager import MCPServer
+
+    server = MCPServer(
+        server_id="t",
+        name="t",
+        server_name="t",
+        alias="t",
+        transport=MCPTransport.http,
+        auth_type=MCPAuth.oauth2,
+        client_id="cid",
+        client_secret="cs",
+        authorization_url="https://provider.com/oauth/authorize",
+        token_url="https://provider.com/oauth/token",
+    )
+    mock_request = MagicMock(spec=Request)
+    mock_request.base_url = "https://litellm.example.com/"
+    mock_request.headers = {}
+
+    fake_http_response = MagicMock()
+    fake_http_response.json.return_value = upstream_body
+    fake_http_response.raise_for_status = MagicMock()
+    fake_http_client = MagicMock()
+    fake_http_client.post = AsyncMock(return_value=fake_http_response)
+
+    with patch(
+        "litellm.proxy._experimental.mcp_server.discoverable_endpoints.get_async_httpx_client",
+        return_value=fake_http_client,
+    ):
+        response = await exchange_token_with_server(
+            request=mock_request,
+            mcp_server=server,
+            grant_type="authorization_code",
+            code="c",
+            redirect_uri="http://127.0.0.1:3000/cb",
+            client_id="cid",
+            client_secret=None,
+            code_verifier=None,
+        )
+    return json.loads(response.body)
+
+
+@pytest.mark.asyncio
+async def test_token_exchange_omits_expires_in_when_upstream_omits_it():
+    """A provider that issues a non-expiring token (e.g. Slack without token
+    rotation) returns no ``expires_in``. The exchange must mirror that and omit
+    ``expires_in`` rather than fabricate a 1-hour TTL, so the stored credential
+    is treated as non-expiring instead of dying after an hour."""
+    body = await _exchange_with_upstream_token_response(
+        {"access_token": "tok", "token_type": "Bearer"}
+    )
+    assert "expires_in" not in body
+
+
+@pytest.mark.asyncio
+async def test_token_exchange_passes_through_upstream_expires_in():
+    """When the provider does send ``expires_in`` (e.g. Slack with token
+    rotation), the exchange forwards the real value unchanged."""
+    body = await _exchange_with_upstream_token_response(
+        {"access_token": "tok", "token_type": "Bearer", "expires_in": 43200}
+    )
+    assert body["expires_in"] == 43200


### PR DESCRIPTION
## Problem
- We hardcode a default 3600 TTL on any access_token we receive from external MCP servers.
- So even though access_token is valid, our gateway would return no tools found because our backend logic thinks its expired

## Fix
- Remove default 3600 TTL logic and use the actual expiry timeline that is returned from slack
- So if slack returns an access_token with no expiry, we mirror that same token lifetime in our database.

## Linear ticket
Resolves LIT-3579

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix
<img width="497" height="89" alt="Screenshot 2026-06-08 at 4 35 07 PM" src="https://github.com/user-attachments/assets/21df9cac-5920-4db0-bb12-ddad645cfe4f" />

Deploy this branch, then on the Tools page connect (OBO mode) to a Slack MCP server that has token rotation off (Slack issues a non-expiring token with no `expires_in` and no `refresh_token`), and confirm the tools list keeps working past an hour rather than going empty.

1. Connect `slack_obo` from the Tools page so a fresh credential is written.
2. Inspect the stored payload and confirm it carries no `expires_at` (mirrors the non-expiring Slack token) instead of `now + 1h`.
3. List tools and confirm they return:

```
curl -s -X POST "$PROXY/v1/mcp/server/$SERVER_ID/tools/list" \
  -H "Authorization: Bearer $LITELLM_KEY" | jq '.tools | length'
```

Before the fix the same flow stamped `expires_at = now + 1h`, so once that hour passed `resolve_valid_user_oauth_token` treated the (still valid) token as expired with no refresh token to recover from, the upstream call went out unauthenticated, and the page showed "No tools available".

## Type

🐛 Bug Fix

## Changes

The OBO token exchange (`exchange_token_with_server`) hardcoded `expires_in` to `3600` when the provider's token response omitted it. For a provider that issues non-expiring tokens; Slack without token rotation, which sends no `expires_in` and no `refresh_token`; that fabricated a 1-hour TTL on a token that never actually expires. The credential got stored with `expires_at = now + 1h` and no refresh token, so `resolve_valid_user_oauth_token` treated it as expired with nothing to refresh from, and tools silently vanished about an hour after connecting.

The exchange now passes `expires_in` through only when the provider sends it, matching how `refresh_token` and `scope` are already handled. With no `expires_in` upstream, the stored credential carries no `expires_at` and `is_oauth_credential_expired` treats it as non-expiring, mirroring the provider. When the provider does send `expires_in` (Slack with token rotation on), the real value flows through unchanged and the existing refresh path keeps it alive; that case is unaffected since the `3600` default never fired when `expires_in` was present.

Added two regression tests on `exchange_token_with_server`: one asserts the response omits `expires_in` when upstream omits it (fails on the old `3600` default), the other asserts a real upstream `expires_in` passes through unchanged.

Note: this prevents the bad expiry from being written going forward; it does not retroactively repair credential rows already stored with the fabricated `expires_at`. Reconnecting the server writes a correct, non-expiring credential.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to MCP OAuth token response shaping with regression tests; affects credential expiry behavior but not auth logic broadly.
> 
> **Overview**
> Fixes MCP OBO token exchange so **`expires_in` is only returned when the upstream OAuth provider sends it**, instead of defaulting to **3600** seconds.
> 
> `exchange_token_with_server` now mirrors upstream lifetime for optional token fields (`expires_in`, `refresh_token`, `scope`), matching how credentials are stored. Providers like Slack without token rotation that omit `expires_in` no longer get a fabricated 1-hour TTL, so stored credentials stay **non-expiring** and tools keep working past an hour.
> 
> Regression tests cover upstream responses **with** and **without** `expires_in`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fcbc74cff83872327b759309f4047d5eb0f849f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->