### PR TITLE
fix(ui): unify migrated-route URLs and migrate the API Reference page

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/layout.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/layout.tsx
@@ -5,51 +5,29 @@ import Navbar from "@/components/navbar";
 import { ThemeProvider } from "@/contexts/ThemeContext";
 import SidebarProvider from "@/app/(dashboard)/components/SidebarProvider";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams, usePathname } from "next/navigation";
 import { DebugWarningBanner } from "@/components/DebugWarningBanner";
-import { MIGRATED_PAGES } from "@/utils/migratedPages";
-
-/** ---- BASE URL HELPERS ---- */
-function normalizeBasePrefix(raw: string | undefined | null): string {
-  const trimmed = (raw ?? "").trim();
-  if (!trimmed) return "";
-  const core = trimmed.replace(/^\/+/, "").replace(/\/+$/, "");
-  return core ? `/${core}/` : "/";
-}
-const BASE_PREFIX = normalizeBasePrefix(process.env.NEXT_PUBLIC_BASE_URL);
-function withBase(path: string): string {
-  const body = path.startsWith("/") ? path.slice(1) : path;
-  const combined = `${BASE_PREFIX}${body}`;
-  return combined.startsWith("/") ? combined : `/${combined}`;
-}
-/** -------------------------------- */
+import { MIGRATED_PAGES, migratedHref, legacyPageHref, legacyKeyForPathname } from "@/utils/migratedPages";
 
 function LayoutContent({ children }: { children: React.ReactNode }) {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const pathname = usePathname();
   const { accessToken } = useAuthorized();
   const [sidebarCollapsed, setSidebarCollapsed] = React.useState(false);
   const [page, setPage] = useState(() => {
-    return searchParams.get("page") || "api-keys";
+    return legacyKeyForPathname(pathname) || searchParams.get("page") || "api-keys";
   });
 
   const handleSetPage = (newPage: string) => {
-    // If the page has been migrated to path routing, navigate there
     const migratedRoute = MIGRATED_PAGES[newPage];
-    if (migratedRoute) {
-      router.push(withBase(migratedRoute));
-      setPage(newPage);
-      return;
-    }
-
-    // Otherwise, navigate back to the legacy root page with query params
-    router.push(withBase(`?page=${newPage}`));
+    router.push(migratedRoute ? migratedHref(migratedRoute) : legacyPageHref(newPage));
     setPage(newPage);
   };
 
   useEffect(() => {
-    setPage(searchParams.get("page") || "api-keys");
-  }, [searchParams]);
+    setPage(legacyKeyForPathname(pathname) || searchParams.get("page") || "api-keys");
+  }, [pathname, searchParams]);
 
   const toggleSidebar = () => setSidebarCollapsed((v) => !v);
 

--- a/ui/litellm-dashboard/src/app/page.tsx
+++ b/ui/litellm-dashboard/src/app/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import APIReferenceView from "@/app/(dashboard)/api-reference/APIReferenceView";
 import SidebarProvider from "@/app/(dashboard)/components/SidebarProvider";
 import OldModelDashboard from "@/app/(dashboard)/models-and-endpoints/ModelsAndEndpointsView";
 import PlaygroundPage from "@/app/(dashboard)/playground/page";
@@ -54,7 +53,7 @@ import {
   storeReturnUrl,
 } from "@/utils/returnUrlUtils";
 import { isAdminRole } from "@/utils/roles";
-import { MIGRATED_PAGES } from "@/utils/migratedPages";
+import { MIGRATED_PAGES, migratedHref } from "@/utils/migratedPages";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useEffect, useMemo, useRef, useState } from "react";
@@ -156,15 +155,16 @@ function CreateKeyPageContent() {
     return searchParams.get("page") || "api-keys";
   });
 
-  // Custom setPage function that updates URL
   const updatePage = (newPage: string) => {
-    // Update URL without full page reload
+    const migratedRoute = MIGRATED_PAGES[newPage];
+    if (migratedRoute) {
+      router.push(migratedHref(migratedRoute));
+      setPage(newPage);
+      return;
+    }
     const newSearchParams = new URLSearchParams(searchParams);
     newSearchParams.set("page", newPage);
-
-    // Use Next.js router to update URL
     window.history.pushState(null, "", `?${newSearchParams.toString()}`);
-
     setPage(newPage);
   };
 
@@ -199,8 +199,7 @@ function CreateKeyPageContent() {
   const isLegacyRedirect = page in MIGRATED_PAGES;
   useEffect(() => {
     if (!authLoading && isLegacyRedirect) {
-      const base = (proxyBaseUrl || "") + "/ui";
-      router.replace(`${base}/${MIGRATED_PAGES[page]}`);
+      router.replace(migratedHref(MIGRATED_PAGES[page]));
     }
   }, [authLoading, isLegacyRedirect, page, router]);
 
@@ -441,8 +440,6 @@ function CreateKeyPageContent() {
                   />
                 ) : page == "admin-panel" ? (
                   <AdminPanel proxySettings={proxySettings} />
-                ) : page == "api_ref" || page == "api-reference" ? (
-                  <APIReferenceView proxySettings={proxySettings} />
                 ) : page == "logging-and-alerts" ? (
                   <Settings userID={userID} userRole={userRole} accessToken={accessToken} premiumUser={premiumUser} />
                 ) : page == "budgets" ? (

--- a/ui/litellm-dashboard/src/components/leftnav.tsx
+++ b/ui/litellm-dashboard/src/components/leftnav.tsx
@@ -43,7 +43,7 @@ import {
 import NewBadge from "./common_components/NewBadge";
 import type { Organization } from "./networking";
 import UsageIndicator from "./UsageIndicator";
-import { MIGRATED_PAGES, migratedHref } from "@/utils/migratedPages";
+import { MIGRATED_PAGES, migratedHref, legacyPageHref } from "@/utils/migratedPages";
 const { Sider } = Layout;
 
 // Define the props type
@@ -418,18 +418,9 @@ const Sidebar: React.FC<SidebarProps> = ({
   // Check if user is a team admin for any team
   const isTeamAdmin = useMemo(() => isUserTeamAdminForAnyTeam(teams ?? null, userId ?? ""), [teams, userId]);
 
-  // Navigate to page helper
-  const navigateToPage = (page: string) => {
-    // For migrated pages, just call setPage — the parent layout handles routing
-    if (MIGRATED_PAGES[page]) {
-      setPage(page);
-      return;
-    }
-    const newSearchParams = new URLSearchParams(window.location.search);
-    newSearchParams.set("page", page);
-    window.history.pushState(null, "", `?${newSearchParams.toString()}`);
-    setPage(page);
-  };
+  // The parent (legacy root page or dashboard layout) owns navigation for both
+  // migrated and legacy pages; the sidebar only reports the selected page.
+  const navigateToPage = (page: string) => setPage(page);
 
   // Wrap label in <a> so every nav item supports right-click → "Open in new tab"
   // and Ctrl/Cmd+click to open in a new tab, while preserving SPA navigation for normal clicks.
@@ -447,15 +438,8 @@ const Sidebar: React.FC<SidebarProps> = ({
         </a>
       );
     }
-    // For migrated pages, generate a path-based href for right-click "Open in new tab"
     const migratedRoute = MIGRATED_PAGES[page];
-    const href = migratedRoute
-      ? migratedHref(migratedRoute)
-      : (() => {
-          const params = new URLSearchParams(window.location.search);
-          params.set("page", page);
-          return `?${params.toString()}`;
-        })();
+    const href = migratedRoute ? migratedHref(migratedRoute) : legacyPageHref(page);
     return (
       <a
         href={href}

--- a/ui/litellm-dashboard/src/components/networking.test.ts
+++ b/ui/litellm-dashboard/src/components/networking.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { clearTokenCookies } from "@/utils/cookieUtils";
 import * as Networking from "./networking";
+import { migratedHref } from "@/utils/migratedPages";
 
 vi.mock("@/utils/cookieUtils", () => ({
   clearTokenCookies: vi.fn(),
@@ -348,6 +349,20 @@ describe("UI config and public endpoints", () => {
       (call[0] as string).includes("/litellm/.well-known/litellm-ui-config"),
     );
     expect(configCall).toBeDefined();
+  });
+
+  it("updates serverRootPath so path-based nav links carry the root path", async () => {
+    const uiConfig = {
+      server_root_path: "/litellm",
+      proxy_base_url: "https://example.com",
+    };
+
+    setupMockFetch([{ url: "/litellm/.well-known/litellm-ui-config", data: uiConfig }]);
+
+    await Networking.getUiConfig();
+
+    expect(Networking.serverRootPath).toBe("/litellm");
+    expect(migratedHref("api-reference")).toBe("/litellm/ui/api-reference");
   });
 });
 

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -404,6 +404,7 @@ export const getUiConfig = async () => {
    * Update the proxy base url and server root path
    */
   console.log("jsonData in getUiConfig:", jsonData);
+  updateServerRootPath(jsonData.server_root_path);
   updateProxyBaseUrl(jsonData.server_root_path, jsonData.proxy_base_url);
   return jsonData;
 };

--- a/ui/litellm-dashboard/src/utils/migratedPages.test.ts
+++ b/ui/litellm-dashboard/src/utils/migratedPages.test.ts
@@ -28,10 +28,42 @@ describe("migratedHref / legacyPageHref", () => {
     expect(migratedHref("/api-reference")).toBe("/ui/api-reference");
   });
 
-  it("maps the api_ref legacy id to the api-reference route", async () => {
+  it("maps both the api_ref id and the hyphenated alias to the api-reference route", async () => {
     vi.doMock("@/components/networking", () => ({ serverRootPath: "/" }));
     const { MIGRATED_PAGES } = await import("./migratedPages");
 
     expect(MIGRATED_PAGES.api_ref).toBe("api-reference");
+    expect(MIGRATED_PAGES["api-reference"]).toBe("api-reference");
+  });
+});
+
+describe("legacyKeyForPathname", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("maps a migrated path back to its legacy sidebar key (including trailing slash)", async () => {
+    vi.doMock("@/components/networking", () => ({ serverRootPath: "/" }));
+    const { legacyKeyForPathname } = await import("./migratedPages");
+
+    // Resolves to the sidebar key api_ref, not the hyphenated alias, so highlighting works.
+    expect(legacyKeyForPathname("/ui/api-reference")).toBe("api_ref");
+    expect(legacyKeyForPathname("/ui/api-reference/")).toBe("api_ref");
+  });
+
+  it("returns null for a not-yet-migrated path", async () => {
+    vi.doMock("@/components/networking", () => ({ serverRootPath: "/" }));
+    const { legacyKeyForPathname } = await import("./migratedPages");
+
+    expect(legacyKeyForPathname("/ui/")).toBeNull();
+    expect(legacyKeyForPathname("/ui/some-legacy-page")).toBeNull();
+  });
+
+  it("strips a non-root serverRootPath prefix before matching", async () => {
+    vi.doMock("@/components/networking", () => ({ serverRootPath: "/team-x/" }));
+    const { legacyKeyForPathname } = await import("./migratedPages");
+
+    expect(legacyKeyForPathname("/team-x/ui/api-reference")).toBe("api_ref");
+    expect(legacyKeyForPathname("/ui/api-reference")).toBeNull();
   });
 });

--- a/ui/litellm-dashboard/src/utils/migratedPages.test.ts
+++ b/ui/litellm-dashboard/src/utils/migratedPages.test.ts
@@ -1,43 +1,37 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
-describe("migratedHref", () => {
+describe("migratedHref / legacyPageHref", () => {
   beforeEach(() => {
     vi.resetModules();
-    vi.unstubAllEnvs();
   });
 
-  afterEach(() => {
-    vi.unstubAllEnvs();
-  });
-
-  it("returns an absolute path rooted at / when serverRootPath is /", async () => {
+  it("builds a /ui-rooted path when serverRootPath is /", async () => {
     vi.doMock("@/components/networking", () => ({ serverRootPath: "/" }));
-    const { migratedHref } = await import("./migratedPages");
+    const { migratedHref, legacyPageHref } = await import("./migratedPages");
 
-    expect(migratedHref("api-reference")).toBe("/api-reference");
-    expect(migratedHref("virtual-keys")).toBe("/virtual-keys");
+    expect(migratedHref("api-reference")).toBe("/ui/api-reference");
+    expect(legacyPageHref("models")).toBe("/ui/?page=models");
   });
 
   it("prefixes a non-root serverRootPath without duplicating slashes", async () => {
     vi.doMock("@/components/networking", () => ({ serverRootPath: "/team-x/" }));
-    const { migratedHref } = await import("./migratedPages");
+    const { migratedHref, legacyPageHref } = await import("./migratedPages");
 
-    expect(migratedHref("api-reference")).toBe("/team-x/api-reference");
+    expect(migratedHref("api-reference")).toBe("/team-x/ui/api-reference");
+    expect(legacyPageHref("models")).toBe("/team-x/ui/?page=models");
   });
 
-  it("honors NEXT_PUBLIC_BASE_URL as a base path segment", async () => {
-    vi.stubEnv("NEXT_PUBLIC_BASE_URL", "ui");
+  it("tolerates a leading slash in the route segment", async () => {
     vi.doMock("@/components/networking", () => ({ serverRootPath: "/" }));
     const { migratedHref } = await import("./migratedPages");
 
-    expect(migratedHref("api-reference")).toBe("/ui/api-reference");
+    expect(migratedHref("/api-reference")).toBe("/ui/api-reference");
   });
 
-  it("combines NEXT_PUBLIC_BASE_URL with a non-root serverRootPath", async () => {
-    vi.stubEnv("NEXT_PUBLIC_BASE_URL", "ui");
-    vi.doMock("@/components/networking", () => ({ serverRootPath: "/team-x" }));
-    const { migratedHref } = await import("./migratedPages");
+  it("maps the api_ref legacy id to the api-reference route", async () => {
+    vi.doMock("@/components/networking", () => ({ serverRootPath: "/" }));
+    const { MIGRATED_PAGES } = await import("./migratedPages");
 
-    expect(migratedHref("api-reference")).toBe("/team-x/ui/api-reference");
+    expect(MIGRATED_PAGES.api_ref).toBe("api-reference");
   });
 });

--- a/ui/litellm-dashboard/src/utils/migratedPages.ts
+++ b/ui/litellm-dashboard/src/utils/migratedPages.ts
@@ -6,20 +6,33 @@ import { serverRootPath } from "@/components/networking";
  *
  * Key = legacy page id emitted by the sidebar. Value = route segment under (dashboard)/.
  * Add an entry to route the sidebar and deep links to the new path and redirect the
- * legacy `?page=` URL; remove it to roll back. Empty until a page is migrated.
+ * legacy `?page=` URL; remove it to roll back.
  */
-export const MIGRATED_PAGES: Record<string, string> = {};
+export const MIGRATED_PAGES: Record<string, string> = {
+  api_ref: "api-reference",
+};
 
+function uiBase(): string {
+  const root = serverRootPath && serverRootPath !== "/" ? `/${serverRootPath.replace(/^\/+|\/+$/g, "")}` : "";
+  return `${root}/ui`;
+}
+
+/** Absolute (same-origin) href for a migrated route segment, e.g. "api-reference" -> "/ui/api-reference". */
 export function migratedHref(routeSegment: string): string {
-  const raw = process.env.NEXT_PUBLIC_BASE_URL ?? "";
-  const trimmed = raw.replace(/^\/+|\/+$/g, "");
-  let base = trimmed ? `/${trimmed}/` : "/";
+  return `${uiBase()}/${routeSegment.replace(/^\/+/, "")}`;
+}
 
-  if (serverRootPath && serverRootPath !== "/") {
-    const cleanRoot = serverRootPath.replace(/\/+$/, "");
-    const cleanBase = base.replace(/^\/+/, "");
-    base = `${cleanRoot}/${cleanBase}`;
+/** Href for a not-yet-migrated page, served by the legacy `?page=` switch at the UI root. */
+export function legacyPageHref(pageKey: string): string {
+  return `${uiBase()}/?page=${pageKey}`;
+}
+
+/** Reverse-maps a path-routed location back to its legacy page id, e.g. "/ui/api-reference" -> "api_ref". */
+export function legacyKeyForPathname(pathname: string): string | null {
+  const base = uiBase();
+  const rel = (pathname.startsWith(base) ? pathname.slice(base.length) : pathname).replace(/^\/+|\/+$/g, "");
+  for (const [key, segment] of Object.entries(MIGRATED_PAGES)) {
+    if (rel === segment) return key;
   }
-
-  return `${base}${routeSegment}`;
+  return null;
 }

--- a/ui/litellm-dashboard/src/utils/migratedPages.ts
+++ b/ui/litellm-dashboard/src/utils/migratedPages.ts
@@ -10,6 +10,8 @@ import { serverRootPath } from "@/components/networking";
  */
 export const MIGRATED_PAGES: Record<string, string> = {
   api_ref: "api-reference",
+  // Legacy alias: older bookmarks used the hyphenated ?page=api-reference form.
+  "api-reference": "api-reference",
 };
 
 function uiBase(): string {


### PR DESCRIPTION
## Relevant issues

Stacked on #29949 (single source of truth for migrated-page routing). Base is `litellm_ui_nav_consolidation`; please merge #29949 first, then this retargets to `litellm_internal_staging`.

## Linear ticket

Refs LIT-3687

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

This changes navigation behavior, so it wants a live-proxy check. Suggested runbook against a local proxy (`python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload`), after building the UI into `litellm/proxy/_experimental/out`:

1. Go to http://localhost:4000/ui/ and log in
2. In the left sidebar, click "API Reference". The URL should become http://localhost:4000/ui/api-reference and the API Reference content should render, with "API Reference" highlighted in the sidebar
3. Hard-refresh that page (Cmd/Ctrl-R). It should still render API Reference, not 404
4. Right-click "API Reference" -> "Open in new tab". The new tab should open http://localhost:4000/ui/api-reference directly
5. From the API Reference page, click a not-yet-migrated item (for example "Logs"). It should return to http://localhost:4000/ui/?page=logs and render Logs (this is the double-navigate fix; previously it could leave /ui)
6. Visit the old URL http://localhost:4000/ui/?page=api_ref directly. It should redirect to http://localhost:4000/ui/api-reference

If you run the proxy under a custom `server_root_path` (for example `/litellm`), the same steps should hold with the prefix in place (for example `/litellm/ui/api-reference`).

<img width="753" height="630" alt="Screenshot 2026-06-08 at 12 39 27 PM" src="https://github.com/user-attachments/assets/d7b4ac2f-deb1-4756-95ff-d5b2258fd0ad" />
<img width="1018" height="573" alt="Screenshot 2026-06-08 at 12 26 55 PM" src="https://github.com/user-attachments/assets/025194b2-430c-4ffb-906e-2ae05f6d1e72" />


## Type

🐛 Bug Fix

## Changes

Before this, three different code paths built URLs for a migrated page and disagreed: the dashboard layout's `withBase` (only `NEXT_PUBLIC_BASE_URL`), `leftnav`'s `migratedHref` (`NEXT_PUBLIC_BASE_URL` + `serverRootPath`), and the redirect in `page.tsx` (`proxyBaseUrl + "/ui"`). `NEXT_PUBLIC_BASE_URL` is unset in every build, so the first two produced URLs missing the `/ui` prefix the app is actually served under. They had never run because the migrated-pages map was empty.

This routes all migrated-page navigation through one builder in `migratedPages.ts`: `migratedHref` (a `/ui`-prefixed, `serverRootPath`-aware, same-origin path), `legacyPageHref` (back to the legacy `?page=` switch at the UI root), and `legacyKeyForPathname` (so the sidebar highlights the right item when you land on a path route). This matches the convention every other working internal link already uses (`/ui/...`).

It also removes the sidebar's own `pushState` call so the parent owns navigation, which fixes a double-navigate when crossing between a path route and a legacy `?page=` route.

Finally it cuts the API Reference page over: `api_ref -> api-reference` is added to `MIGRATED_PAGES` and the page's arm is deleted from the giant `page.tsx` switch. This is the first real page migrated under the strangler-fig plan; the pattern is now a one-line map entry plus arm removal per page

Also fixes `getUiConfig`, which set `proxyBaseUrl` but never called `updateServerRootPath`, so the module-level `serverRootPath` stayed at its `/` default and the unified builders dropped the prefix under a custom `server_root_path`; the sidebar produced `/ui/api-reference` (404) instead of `/litellm/ui/api-reference`

## Notes

Spotted while building, unrelated to this change: `ui/litellm-dashboard/out/` is not gitignored, so a contributor running `npm run build` then `git add -A` would commit the entire static export. Worth a separate one-line .gitignore fix

