### PR TITLE
[Bug Fix] Do not leak MCP server credentials in the 403 'tool not allowed' error

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -2161,7 +2161,11 @@ if MCP_AVAILABLE:
             ):
                 raise HTTPException(
                     status_code=403,
-                    detail=f"User not allowed to call this tool. Allowed MCP servers: {allowed_mcp_servers}",
+                    # Do not include the allowed-server configs here: they carry
+                    # credential material (authentication_token, client_secret,
+                    # AWS secrets) that must not leak to the caller. The caller
+                    # only needs to know they lack permission.
+                    detail="User not allowed to call this tool.",
                 )
 
         standard_logging_mcp_tool_call: StandardLoggingMCPToolCall = (

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -1637,6 +1637,39 @@ async def test_call_mcp_tool_user_unauthorized_access():
 
 
 @pytest.mark.asyncio
+async def test_execute_mcp_tool_unauthorized_does_not_leak_server_credentials():
+    """The 403 for an unauthorized tool must not leak server credentials.
+
+    Regression test: the 403 detail used to interpolate the full list of allowed
+    ``MCPServer`` configs into the error returned to the caller, exposing
+    ``authentication_token`` / ``client_secret`` / AWS secrets in plaintext.
+    """
+    from litellm.proxy._experimental.mcp_server.server import execute_mcp_tool
+
+    secret = "sk-super-secret-mcp-token"
+    allowed_server = MCPServer(
+        server_id="allowed_server",
+        name="allowed_server",
+        transport="http",
+        authentication_token=secret,
+    )
+
+    # Call a tool whose server prefix is not in the allowed list.
+    with pytest.raises(HTTPException) as exc_info:
+        await execute_mcp_tool(
+            name="restricted_server-some_tool",
+            arguments={},
+            allowed_mcp_servers=[allowed_server],
+            start_time=datetime.now(),
+        )
+
+    assert exc_info.value.status_code == 403
+    assert "not allowed" in str(exc_info.value.detail).lower()
+    # The credential must not appear anywhere in the response detail.
+    assert secret not in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
 async def test_list_tools_filters_by_key_team_permissions():
     """Test that list_tools filters tools based on key/team mcp_tool_permissions"""
     try:


### PR DESCRIPTION
## Relevant issues

Fixes #29936

## Type

🐛 Bug Fix · 🔒 Security

## Changes

When a key calls an MCP tool on a server it is not allowed to use,
`execute_mcp_tool` raised a `403` whose `detail` interpolated the full list of
allowed `MCPServer` config objects:

```python
detail=f"User not allowed to call this tool. Allowed MCP servers: {allowed_mcp_servers}"
```

`MCPServer` carries credential material (`authentication_token`,
`client_secret`, `aws_secret_access_key`, `aws_session_token`), so these were
returned **in plaintext to the caller** of a tool they don't even have access
to. The caller only needs to know it lacks permission, so this drops the server
list from the error detail (matching the other `403`s in this file, e.g. the
`"User not allowed to call this tool."` raised a few lines down).

## Testing

- Added `test_execute_mcp_tool_unauthorized_does_not_leak_server_credentials`,
  which constructs an allowed `MCPServer` with an `authentication_token`, calls a
  tool whose server prefix is not allowed, and asserts the `403` detail does not
  contain the secret.
- Verified before/after locally: before, the `403` detail contains the full
  `MCPServer(... authentication_token='...')` repr; after, it is just
  `"User not allowed to call this tool."`.
- `black --check`, `ruff check`, and `mypy` pass on the changed source file.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
