### PR TITLE
feat(helm): add extraVolumes and extraVolumeMounts for gateway and backend

### DIFF
--- a/helm/litellm/templates/backend/deployment.yaml
+++ b/helm/litellm/templates/backend/deployment.yaml
@@ -45,11 +45,16 @@ spec:
               value: /app/config/config.yaml
             {{- end }}
           {{- include "litellm.envFrom" .Values.backend | nindent 10 }}
-          {{- if .Values.gateway.config.create }}
+          {{- if or .Values.gateway.config.create .Values.backend.extraVolumeMounts }}
           volumeMounts:
+            {{- if .Values.gateway.config.create }}
             - name: gateway-config
               mountPath: /app/config/config.yaml
               subPath: config.yaml
+            {{- end }}
+            {{- with .Values.backend.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
           {{- with .Values.backend.livenessProbe }}
           livenessProbe:
@@ -61,11 +66,16 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.backend.resources | nindent 12 }}
-      {{- if .Values.gateway.config.create }}
+      {{- if or .Values.gateway.config.create .Values.backend.extraVolumes }}
       volumes:
+        {{- if .Values.gateway.config.create }}
         - name: gateway-config
           configMap:
             name: {{ include "litellm.gateway.fullname" . }}-config
+        {{- end }}
+        {{- with .Values.backend.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       {{- with .Values.backend.nodeSelector }}
       nodeSelector:

--- a/helm/litellm/templates/gateway/deployment.yaml
+++ b/helm/litellm/templates/gateway/deployment.yaml
@@ -47,11 +47,16 @@ spec:
               value: {{ .Values.gateway.numWorkers | quote }}
             {{- end }}
           {{- include "litellm.envFrom" .Values.gateway | nindent 10 }}
-          {{- if .Values.gateway.config.create }}
+          {{- if or .Values.gateway.config.create .Values.gateway.extraVolumeMounts }}
           volumeMounts:
+            {{- if .Values.gateway.config.create }}
             - name: gateway-config
               mountPath: /app/config/config.yaml
               subPath: config.yaml
+            {{- end }}
+            {{- with .Values.gateway.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
           {{- with .Values.gateway.livenessProbe }}
           livenessProbe:
@@ -63,11 +68,16 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.gateway.resources | nindent 12 }}
-      {{- if .Values.gateway.config.create }}
+      {{- if or .Values.gateway.config.create .Values.gateway.extraVolumes }}
       volumes:
+        {{- if .Values.gateway.config.create }}
         - name: gateway-config
           configMap:
             name: {{ include "litellm.gateway.fullname" . }}-config
+        {{- end }}
+        {{- with .Values.gateway.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       {{- with .Values.gateway.nodeSelector }}
       nodeSelector:

--- a/helm/litellm/values.yaml
+++ b/helm/litellm/values.yaml
@@ -186,6 +186,16 @@ backend:
   envSecrets: []
   extraVolumes: []
   extraVolumeMounts: []
+  # Example — mount a custom CA for TLS to upstream LLM providers (mirrors gateway example above):
+  # extraVolumes:
+  #   - name: custom-ca
+  #     secret:
+  #       secretName: litellm-custom-ca
+  # extraVolumeMounts:
+  #   - name: custom-ca
+  #     mountPath: /etc/ssl/certs/custom-ca.crt
+  #     subPath: ca.crt
+  #     readOnly: true
   image:
     repository: ghcr.io/berriai/litellm-backend
     tag: ""

--- a/helm/litellm/values.yaml
+++ b/helm/litellm/values.yaml
@@ -124,6 +124,23 @@ gateway:
   extraEnv: [] # Add extra environment variables to the gateway
   envConfigMaps: [] # Add extra environment variables to the gateway from config maps
   envSecrets: [] # Add extra environment variables to the gateway from secrets
+  extraVolumes: []
+  extraVolumeMounts: []
+  # Example — mount a custom CA for TLS to upstream LLM providers:
+  # extraVolumes:
+  #   - name: custom-ca
+  #     secret:
+  #       secretName: litellm-custom-ca
+  # extraVolumeMounts:
+  #   - name: custom-ca
+  #     mountPath: /etc/ssl/certs/custom-ca.crt
+  #     subPath: ca.crt
+  #     readOnly: true
+  # extraEnv:
+  #   - name: SSL_CERT_FILE
+  #     value: /etc/ssl/certs/custom-ca.crt
+  #   - name: REQUESTS_CA_BUNDLE
+  #     value: /etc/ssl/certs/custom-ca.crt
   config:
     create: true
     proxy_config: {}
@@ -167,6 +184,8 @@ backend:
   extraEnv: []
   envConfigMaps: []
   envSecrets: []
+  extraVolumes: []
+  extraVolumeMounts: []
   image:
     repository: ghcr.io/berriai/litellm-backend
     tag: ""


### PR DESCRIPTION
Allow mounting custom CA certs (or other secrets/config) via values without
forking the deployment templates.

Co-authored-by: Cursor <cursoragent@cursor.com>