### PR TITLE
feat(ui): migrate the Budgets page to App Router path routing

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/budgets/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/budgets/page.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import BudgetPanel from "@/components/budgets/budget_panel";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+
+export default function BudgetsPage() {
+  const { accessToken } = useAuthorized();
+  return <BudgetPanel accessToken={accessToken} />;
+}

--- a/ui/litellm-dashboard/src/app/page.tsx
+++ b/ui/litellm-dashboard/src/app/page.tsx
@@ -5,7 +5,6 @@ import OldModelDashboard from "@/app/(dashboard)/models-and-endpoints/ModelsAndE
 import PlaygroundPage from "@/app/(dashboard)/playground/page";
 import AdminPanel from "@/components/AdminPanel";
 import AgentsPanel from "@/components/agents";
-import BudgetPanel from "@/components/budgets/budget_panel";
 import CacheDashboard from "@/components/cache_dashboard";
 import ClaudeCodePluginsPanel from "@/components/claude_code_plugins";
 import { teamListCall as v2TeamListCall } from "@/app/(dashboard)/hooks/teams/useTeams";
@@ -442,8 +441,6 @@ function CreateKeyPageContent() {
                   <AdminPanel proxySettings={proxySettings} />
                 ) : page == "logging-and-alerts" ? (
                   <Settings userID={userID} userRole={userRole} accessToken={accessToken} premiumUser={premiumUser} />
-                ) : page == "budgets" ? (
-                  <BudgetPanel accessToken={accessToken} />
                 ) : page == "guardrails" ? (
                   <GuardrailsPanel accessToken={accessToken} userRole={userRole} />
                 ) : page == "policies" ? (

--- a/ui/litellm-dashboard/src/utils/migratedPages.test.ts
+++ b/ui/litellm-dashboard/src/utils/migratedPages.test.ts
@@ -67,3 +67,18 @@ describe("legacyKeyForPathname", () => {
     expect(legacyKeyForPathname("/ui/api-reference")).toBeNull();
   });
 });
+
+describe("MIGRATED_PAGES budgets", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("routes budgets to the budgets path and back", async () => {
+    vi.doMock("@/components/networking", () => ({ serverRootPath: "/" }));
+    const { MIGRATED_PAGES, legacyKeyForPathname } = await import("./migratedPages");
+
+    expect(MIGRATED_PAGES["budgets"]).toBe("budgets");
+    expect(legacyKeyForPathname("/ui/budgets")).toBe("budgets");
+    expect(legacyKeyForPathname("/ui/budgets/")).toBe("budgets");
+  });
+});

--- a/ui/litellm-dashboard/src/utils/migratedPages.ts
+++ b/ui/litellm-dashboard/src/utils/migratedPages.ts
@@ -12,6 +12,7 @@ export const MIGRATED_PAGES: Record<string, string> = {
   api_ref: "api-reference",
   // Legacy alias: older bookmarks used the hyphenated ?page=api-reference form.
   "api-reference": "api-reference",
+  budgets: "budgets",
 };
 
 function uiBase(): string {


### PR DESCRIPTION
## Relevant issues

Part of the App Router migration (Wave B). Targets `litellm_internal_staging`.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Behavior change; verify on a live proxy after building the UI into `litellm/proxy/_experimental/out`:

1. Log in at http://localhost:4000/ui/
2. Click "Budgets" in the sidebar -> URL becomes http://localhost:4000/ui/budgets, the page renders, the item stays highlighted
3. Hard-refresh -> still renders (not 404)
4. Right-click "Budgets" -> Open in new tab -> opens http://localhost:4000/ui/budgets directly
5. From "Budgets", click a not-yet-migrated item (for example "Teams") -> returns to http://localhost:4000/ui/?page=teams
6. Visit http://localhost:4000/ui/?page=budgets directly -> redirects to http://localhost:4000/ui/budgets

## Type

🆕 New Feature

## Changes

Migrates the Budgets page from the legacy `?page=budgets` switch to a real App Router route, following the same one-line pattern proven on API Reference and Playground. Adds a thin `(dashboard)/budgets/page.tsx` that pulls its data from `useAuthorized` and renders the existing component, adds `budgets -> budgets` to `MIGRATED_PAGES`, and deletes the page's arm and import from `page.tsx`. Tests pin the forward mapping and the reverse lookup used for sidebar highlighting (including the trailing-slash variant).