### PR TITLE
feat(ui): migrate the Workflow Runs page to App Router path routing

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/workflows/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/workflows/page.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import WorkflowRuns from "@/components/workflow_runs";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+
+export default function WorkflowsPage() {
+  const { accessToken } = useAuthorized();
+  return <WorkflowRuns accessToken={accessToken} />;
+}

--- a/ui/litellm-dashboard/src/app/page.tsx
+++ b/ui/litellm-dashboard/src/app/page.tsx
@@ -40,7 +40,6 @@ import { ProjectsPage } from "@/components/Projects/ProjectsPage";
 import VectorStoreManagement from "@/components/vector_store_management";
 import ToolPoliciesView from "@/components/ToolPoliciesView";
 import { MemoryView } from "@/components/MemoryView";
-import WorkflowRuns from "@/components/workflow_runs";
 import SpendLogsTable from "@/components/view_logs";
 import ViewUserDashboard from "@/components/view_users";
 import { ThemeProvider } from "@/contexts/ThemeContext";
@@ -516,8 +515,6 @@ function CreateKeyPageContent() {
                   <VectorStoreManagement accessToken={accessToken} userRole={userRole} userID={userID} />
                 ) : page == "tool-policies" ? (
                   <ToolPoliciesView accessToken={accessToken} userRole={userRole} />
-                ) : page == "workflows" ? (
-                  <WorkflowRuns accessToken={accessToken} />
                 ) : page == "memory" ? (
                   <MemoryView accessToken={accessToken} userID={userID} userRole={userRole} />
                 ) : page == "guardrails-monitor" ? (

--- a/ui/litellm-dashboard/src/utils/migratedPages.test.ts
+++ b/ui/litellm-dashboard/src/utils/migratedPages.test.ts
@@ -67,3 +67,18 @@ describe("legacyKeyForPathname", () => {
     expect(legacyKeyForPathname("/ui/api-reference")).toBeNull();
   });
 });
+
+describe("MIGRATED_PAGES workflows", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("routes workflows to the workflows path and back", async () => {
+    vi.doMock("@/components/networking", () => ({ serverRootPath: "/" }));
+    const { MIGRATED_PAGES, legacyKeyForPathname } = await import("./migratedPages");
+
+    expect(MIGRATED_PAGES["workflows"]).toBe("workflows");
+    expect(legacyKeyForPathname("/ui/workflows")).toBe("workflows");
+    expect(legacyKeyForPathname("/ui/workflows/")).toBe("workflows");
+  });
+});

--- a/ui/litellm-dashboard/src/utils/migratedPages.ts
+++ b/ui/litellm-dashboard/src/utils/migratedPages.ts
@@ -12,6 +12,7 @@ export const MIGRATED_PAGES: Record<string, string> = {
   api_ref: "api-reference",
   // Legacy alias: older bookmarks used the hyphenated ?page=api-reference form.
   "api-reference": "api-reference",
+  workflows: "workflows",
 };
 
 function uiBase(): string {


### PR DESCRIPTION
## Relevant issues

Part of the App Router migration (Wave B). Targets `litellm_internal_staging`.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Behavior change; verify on a live proxy after building the UI into `litellm/proxy/_experimental/out`:

1. Log in at http://localhost:4000/ui/
2. Click "Workflow Runs" in the sidebar -> URL becomes http://localhost:4000/ui/workflows, the page renders, the item stays highlighted
3. Hard-refresh -> still renders (not 404)
4. Right-click "Workflow Runs" -> Open in new tab -> opens http://localhost:4000/ui/workflows directly
5. From "Workflow Runs", click a not-yet-migrated item (for example "Teams") -> returns to http://localhost:4000/ui/?page=teams
6. Visit http://localhost:4000/ui/?page=workflows directly -> redirects to http://localhost:4000/ui/workflows

## Type

🆕 New Feature

## Changes

Migrates the Workflow Runs page from the legacy `?page=workflows` switch to a real App Router route, following the same one-line pattern proven on API Reference and Playground. Adds a thin `(dashboard)/workflows/page.tsx` that pulls its data from `useAuthorized` and renders the existing component, adds `workflows -> workflows` to `MIGRATED_PAGES`, and deletes the page's arm and import from `page.tsx`. Tests pin the forward mapping and the reverse lookup used for sidebar highlighting (including the trailing-slash variant).