### PR TITLE
feat(ui): migrate the self-contained leaf pages to App Router path routing

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/access-groups/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/access-groups/page.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { AccessGroupsPage } from "@/components/AccessGroups/AccessGroupsPage";
+
+export default function AccessGroupsRoute() {
+  return <AccessGroupsPage />;
+}

--- a/ui/litellm-dashboard/src/app/(dashboard)/budgets/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/budgets/page.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import BudgetPanel from "@/components/budgets/budget_panel";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+
+export default function BudgetsRoute() {
+  const { accessToken } = useAuthorized();
+  return <BudgetPanel accessToken={accessToken} />;
+}

--- a/ui/litellm-dashboard/src/app/(dashboard)/caching/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/caching/page.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import CacheDashboard from "@/components/cache_dashboard";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+
+export default function CachingRoute() {
+  const { accessToken, userId, userRole, token, premiumUser } = useAuthorized();
+  return (
+    <CacheDashboard
+      userID={userId}
+      userRole={userRole}
+      token={token}
+      accessToken={accessToken}
+      premiumUser={premiumUser}
+    />
+  );
+}

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-tracking/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-tracking/page.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import { CostTrackingSettings } from "@/components/CostTrackingSettings";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+
+export default function CostTrackingRoute() {
+  const { accessToken, userId, userRole } = useAuthorized();
+  return <CostTrackingSettings userID={userId} userRole={userRole} accessToken={accessToken} />;
+}

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails-monitor/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails-monitor/page.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import GuardrailsMonitorView from "@/components/GuardrailsMonitor/GuardrailsMonitorView";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+
+export default function GuardrailsMonitorRoute() {
+  const { accessToken } = useAuthorized();
+  return <GuardrailsMonitorView accessToken={accessToken} />;
+}

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/page.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import GuardrailsPanel from "@/components/guardrails";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+
+export default function GuardrailsRoute() {
+  const { accessToken, userRole } = useAuthorized();
+  return <GuardrailsPanel accessToken={accessToken} userRole={userRole} />;
+}

--- a/ui/litellm-dashboard/src/app/(dashboard)/logs/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/logs/page.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import SpendLogsTable from "@/components/view_logs";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+
+export default function LogsRoute() {
+  const { accessToken, userId, userRole, token, premiumUser } = useAuthorized();
+  return (
+    <SpendLogsTable
+      userID={userId}
+      userRole={userRole}
+      token={token}
+      accessToken={accessToken}
+      premiumUser={premiumUser}
+    />
+  );
+}

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/page.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import { MCPServers } from "@/components/mcp_tools";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+
+export default function McpServersRoute() {
+  const { accessToken, userId, userRole } = useAuthorized();
+  return <MCPServers accessToken={accessToken} userRole={userRole} userID={userId} />;
+}

--- a/ui/litellm-dashboard/src/app/(dashboard)/memory/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/memory/page.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import { MemoryView } from "@/components/MemoryView";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+
+export default function MemoryRoute() {
+  const { accessToken, userId, userRole } = useAuthorized();
+  return <MemoryView accessToken={accessToken} userID={userId} userRole={userRole} />;
+}

--- a/ui/litellm-dashboard/src/app/(dashboard)/policies/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/policies/page.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import PoliciesPanel from "@/components/policies";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+
+export default function PoliciesRoute() {
+  const { accessToken, userRole } = useAuthorized();
+  return <PoliciesPanel accessToken={accessToken} userRole={userRole} />;
+}

--- a/ui/litellm-dashboard/src/app/(dashboard)/projects/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/projects/page.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { ProjectsPage } from "@/components/Projects/ProjectsPage";
+
+export default function ProjectsRoute() {
+  return <ProjectsPage />;
+}

--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/page.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import PromptsPanel from "@/components/prompts";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+
+export default function PromptsRoute() {
+  const { accessToken, userRole } = useAuthorized();
+  return <PromptsPanel accessToken={accessToken} userRole={userRole} />;
+}

--- a/ui/litellm-dashboard/src/app/(dashboard)/search-tools/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/search-tools/page.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import { SearchTools } from "@/components/SearchTools";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+
+export default function SearchToolsRoute() {
+  const { accessToken, userId, userRole } = useAuthorized();
+  return <SearchTools accessToken={accessToken} userRole={userRole} userID={userId} />;
+}

--- a/ui/litellm-dashboard/src/app/(dashboard)/skills/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/skills/page.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import ClaudeCodePluginsPanel from "@/components/claude_code_plugins";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+
+export default function SkillsRoute() {
+  const { accessToken, userRole } = useAuthorized();
+  return <ClaudeCodePluginsPanel accessToken={accessToken} userRole={userRole} />;
+}

--- a/ui/litellm-dashboard/src/app/(dashboard)/tag-management/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/tag-management/page.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import TagManagement from "@/components/tag_management";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+
+export default function TagManagementRoute() {
+  const { accessToken, userId, userRole } = useAuthorized();
+  return <TagManagement accessToken={accessToken} userRole={userRole} userID={userId} />;
+}

--- a/ui/litellm-dashboard/src/app/(dashboard)/tool-policies/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/tool-policies/page.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import ToolPoliciesView from "@/components/ToolPoliciesView";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+
+export default function ToolPoliciesRoute() {
+  const { accessToken, userRole } = useAuthorized();
+  return <ToolPoliciesView accessToken={accessToken} userRole={userRole} />;
+}

--- a/ui/litellm-dashboard/src/app/(dashboard)/transform-request/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/transform-request/page.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import TransformRequestPanel from "@/components/transform_request";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+
+export default function TransformRequestRoute() {
+  const { accessToken } = useAuthorized();
+  return <TransformRequestPanel accessToken={accessToken} />;
+}

--- a/ui/litellm-dashboard/src/app/(dashboard)/ui-theme/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/ui-theme/page.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import UIThemeSettings from "@/components/ui_theme_settings";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+
+export default function UiThemeRoute() {
+  const { accessToken, userId, userRole } = useAuthorized();
+  return <UIThemeSettings userID={userId} userRole={userRole} accessToken={accessToken} />;
+}

--- a/ui/litellm-dashboard/src/app/(dashboard)/vector-stores/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/vector-stores/page.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import VectorStoreManagement from "@/components/vector_store_management";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+
+export default function VectorStoresRoute() {
+  const { accessToken, userId, userRole } = useAuthorized();
+  return <VectorStoreManagement accessToken={accessToken} userRole={userRole} userID={userId} />;
+}

--- a/ui/litellm-dashboard/src/app/(dashboard)/workflows/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/workflows/page.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import WorkflowRuns from "@/components/workflow_runs";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+
+export default function WorkflowsRoute() {
+  const { accessToken } = useAuthorized();
+  return <WorkflowRuns accessToken={accessToken} />;
+}

--- a/ui/litellm-dashboard/src/app/page.tsx
+++ b/ui/litellm-dashboard/src/app/page.tsx
@@ -5,18 +5,10 @@ import OldModelDashboard from "@/app/(dashboard)/models-and-endpoints/ModelsAndE
 import PlaygroundPage from "@/app/(dashboard)/playground/page";
 import AdminPanel from "@/components/AdminPanel";
 import AgentsPanel from "@/components/agents";
-import BudgetPanel from "@/components/budgets/budget_panel";
-import CacheDashboard from "@/components/cache_dashboard";
-import ClaudeCodePluginsPanel from "@/components/claude_code_plugins";
 import { teamListCall as v2TeamListCall } from "@/app/(dashboard)/hooks/teams/useTeams";
 import LoadingScreen from "@/components/common_components/LoadingScreen";
-import { CostTrackingSettings } from "@/components/CostTrackingSettings";
 import GeneralSettings from "@/components/general_settings";
-import GuardrailsMonitorView from "@/components/GuardrailsMonitor/GuardrailsMonitorView";
-import GuardrailsPanel from "@/components/guardrails";
-import PoliciesPanel from "@/components/policies";
 import { Team } from "@/components/key_team_helpers/key_list";
-import { MCPServers } from "@/components/mcp_tools";
 import ModelHubTable from "@/components/AIHub/ModelHubTable";
 import Navbar from "@/components/navbar";
 import { Organization, proxyBaseUrl, getInProductNudgesCall } from "@/components/networking";
@@ -25,23 +17,11 @@ import OldTeams from "@/components/OldTeams";
 import { fetchUserModels, CreateKeyPrefillData } from "@/components/organisms/create_key_button";
 import Organizations, { fetchOrganizations } from "@/components/organizations";
 import PassThroughSettings from "@/components/pass_through_settings";
-import PromptsPanel from "@/components/prompts";
 import PublicModelHub from "@/components/public_model_hub";
-import { SearchTools } from "@/components/SearchTools";
 import Settings from "@/components/settings";
 import { SurveyPrompt, SurveyModal, ClaudeCodePrompt, ClaudeCodeModal } from "@/components/survey";
-import TagManagement from "@/components/tag_management";
-import TransformRequestPanel from "@/components/transform_request";
-import UIThemeSettings from "@/components/ui_theme_settings";
 import Usage from "@/components/usage";
 import UserDashboard from "@/components/user_dashboard";
-import { AccessGroupsPage } from "@/components/AccessGroups/AccessGroupsPage";
-import { ProjectsPage } from "@/components/Projects/ProjectsPage";
-import VectorStoreManagement from "@/components/vector_store_management";
-import ToolPoliciesView from "@/components/ToolPoliciesView";
-import { MemoryView } from "@/components/MemoryView";
-import WorkflowRuns from "@/components/workflow_runs";
-import SpendLogsTable from "@/components/view_logs";
 import ViewUserDashboard from "@/components/view_users";
 import { ThemeProvider } from "@/contexts/ThemeContext";
 import { useAuth } from "@/contexts/AuthContext";
@@ -442,18 +422,8 @@ function CreateKeyPageContent() {
                   <AdminPanel proxySettings={proxySettings} />
                 ) : page == "logging-and-alerts" ? (
                   <Settings userID={userID} userRole={userRole} accessToken={accessToken} premiumUser={premiumUser} />
-                ) : page == "budgets" ? (
-                  <BudgetPanel accessToken={accessToken} />
-                ) : page == "guardrails" ? (
-                  <GuardrailsPanel accessToken={accessToken} userRole={userRole} />
-                ) : page == "policies" ? (
-                  <PoliciesPanel accessToken={accessToken} userRole={userRole} />
                 ) : page == "agents" ? (
                   <AgentsPanel accessToken={accessToken} userRole={userRole} teams={teams} />
-                ) : page == "prompts" ? (
-                  <PromptsPanel accessToken={accessToken} userRole={userRole} />
-                ) : page == "transform-request" ? (
-                  <TransformRequestPanel accessToken={accessToken} />
                 ) : page == "router-settings" ? (
                   <GeneralSettings
                     userID={userID}
@@ -461,10 +431,6 @@ function CreateKeyPageContent() {
                     accessToken={accessToken}
                     modelData={modelData}
                   />
-                ) : page == "ui-theme" ? (
-                  <UIThemeSettings userID={userID} userRole={userRole} accessToken={accessToken} />
-                ) : page == "cost-tracking" ? (
-                  <CostTrackingSettings userID={userID} userRole={userRole} accessToken={accessToken} />
                 ) : page == "model-hub-table" ? (
                   isAdminRole(userRole) ? (
                     <ModelHubTable
@@ -476,14 +442,6 @@ function CreateKeyPageContent() {
                   ) : (
                     <PublicModelHub accessToken={accessToken} isEmbedded={true} />
                   )
-                ) : page == "caching" ? (
-                  <CacheDashboard
-                    userID={userID}
-                    userRole={userRole}
-                    token={token}
-                    accessToken={accessToken}
-                    premiumUser={premiumUser}
-                  />
                 ) : page == "pass-through-settings" ? (
                   <PassThroughSettings
                     userID={userID}
@@ -492,36 +450,6 @@ function CreateKeyPageContent() {
                     modelData={modelData}
                     premiumUser={premiumUser}
                   />
-                ) : page == "logs" ? (
-                  <SpendLogsTable
-                    userID={userID}
-                    userRole={userRole}
-                    token={token}
-                    accessToken={accessToken}
-                    premiumUser={premiumUser}
-                  />
-                ) : page == "mcp-servers" ? (
-                  <MCPServers accessToken={accessToken} userRole={userRole} userID={userID} />
-                ) : page == "search-tools" ? (
-                  <SearchTools accessToken={accessToken} userRole={userRole} userID={userID} />
-                ) : page == "tag-management" ? (
-                  <TagManagement accessToken={accessToken} userRole={userRole} userID={userID} />
-                ) : page == "skills" || page == "claude-code-plugins" ? (
-                  <ClaudeCodePluginsPanel accessToken={accessToken} userRole={userRole} />
-                ) : page == "access-groups" ? (
-                  <AccessGroupsPage />
-                ) : page == "projects" ? (
-                  <ProjectsPage />
-                ) : page == "vector-stores" ? (
-                  <VectorStoreManagement accessToken={accessToken} userRole={userRole} userID={userID} />
-                ) : page == "tool-policies" ? (
-                  <ToolPoliciesView accessToken={accessToken} userRole={userRole} />
-                ) : page == "workflows" ? (
-                  <WorkflowRuns accessToken={accessToken} />
-                ) : page == "memory" ? (
-                  <MemoryView accessToken={accessToken} userID={userID} userRole={userRole} />
-                ) : page == "guardrails-monitor" ? (
-                  <GuardrailsMonitorView accessToken={accessToken} />
                 ) : page == "new_usage" ? (
                   <NewUsagePage
                     teams={(teams as Team[]) ?? []}

--- a/ui/litellm-dashboard/src/utils/migratedPages.test.ts
+++ b/ui/litellm-dashboard/src/utils/migratedPages.test.ts
@@ -67,3 +67,47 @@ describe("legacyKeyForPathname", () => {
     expect(legacyKeyForPathname("/ui/api-reference")).toBeNull();
   });
 });
+
+describe("MIGRATED_PAGES leaf cutover", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("routes every migrated leaf page to its segment and back to a sidebar key", async () => {
+    vi.doMock("@/components/networking", () => ({ serverRootPath: "/" }));
+    const { MIGRATED_PAGES, legacyKeyForPathname } = await import("./migratedPages");
+
+    const cases: [string, string][] = [
+      ["budgets", "budgets"],
+      ["caching", "caching"],
+      ["cost-tracking", "cost-tracking"],
+      ["guardrails", "guardrails"],
+      ["guardrails-monitor", "guardrails-monitor"],
+      ["logs", "logs"],
+      ["mcp-servers", "mcp-servers"],
+      ["memory", "memory"],
+      ["policies", "policies"],
+      ["projects", "projects"],
+      ["prompts", "prompts"],
+      ["search-tools", "search-tools"],
+      ["skills", "skills"],
+      ["claude-code-plugins", "skills"],
+      ["tag-management", "tag-management"],
+      ["tool-policies", "tool-policies"],
+      ["transform-request", "transform-request"],
+      ["ui-theme", "ui-theme"],
+      ["vector-stores", "vector-stores"],
+      ["workflows", "workflows"],
+      ["access-groups", "access-groups"],
+    ];
+    for (const [key, seg] of cases) {
+      expect(MIGRATED_PAGES[key]).toBe(seg);
+      expect(legacyKeyForPathname(`/ui/${seg}`)).not.toBeNull();
+      expect(legacyKeyForPathname(`/ui/${seg}/`)).not.toBeNull();
+    }
+
+    // The skills alias resolves to the "skills" sidebar key, not "claude-code-plugins".
+    expect(legacyKeyForPathname("/ui/skills")).toBe("skills");
+    expect(legacyKeyForPathname("/ui/budgets")).toBe("budgets");
+  });
+});

--- a/ui/litellm-dashboard/src/utils/migratedPages.ts
+++ b/ui/litellm-dashboard/src/utils/migratedPages.ts
@@ -12,6 +12,27 @@ export const MIGRATED_PAGES: Record<string, string> = {
   api_ref: "api-reference",
   // Legacy alias: older bookmarks used the hyphenated ?page=api-reference form.
   "api-reference": "api-reference",
+  budgets: "budgets",
+  caching: "caching",
+  "cost-tracking": "cost-tracking",
+  guardrails: "guardrails",
+  "guardrails-monitor": "guardrails-monitor",
+  logs: "logs",
+  "mcp-servers": "mcp-servers",
+  memory: "memory",
+  policies: "policies",
+  projects: "projects",
+  prompts: "prompts",
+  "search-tools": "search-tools",
+  skills: "skills",
+  "claude-code-plugins": "skills",
+  "tag-management": "tag-management",
+  "tool-policies": "tool-policies",
+  "transform-request": "transform-request",
+  "ui-theme": "ui-theme",
+  "vector-stores": "vector-stores",
+  workflows: "workflows",
+  "access-groups": "access-groups",
 };
 
 function uiBase(): string {

--- a/ui/litellm-dashboard/src/utils/migratedPages.ts
+++ b/ui/litellm-dashboard/src/utils/migratedPages.ts
@@ -24,6 +24,7 @@ export const MIGRATED_PAGES: Record<string, string> = {
   projects: "projects",
   prompts: "prompts",
   "search-tools": "search-tools",
+  // Canonical sidebar key first, alias after: legacyKeyForPathname returns the first match.
   skills: "skills",
   "claude-code-plugins": "skills",
   "tag-management": "tag-management",
@@ -50,7 +51,11 @@ export function legacyPageHref(pageKey: string): string {
   return `${uiBase()}/?page=${pageKey}`;
 }
 
-/** Reverse-maps a path-routed location back to its legacy page id, e.g. "/ui/api-reference" -> "api_ref". */
+/**
+ * Reverse-maps a path-routed location back to its legacy page id, e.g. "/ui/api-reference" -> "api_ref".
+ * Returns the first key whose segment matches, so when several keys share a segment (aliases) the
+ * canonical sidebar key must be listed before its aliases in MIGRATED_PAGES.
+ */
 export function legacyKeyForPathname(pathname: string): string | null {
   const base = uiBase();
   const rel = (pathname.startsWith(base) ? pathname.slice(base.length) : pathname).replace(/^\/+|\/+$/g, "");


### PR DESCRIPTION
## Relevant issues

App Router migration, Wave B (the self-contained leaf pages). Targets `litellm_internal_staging`. Supersedes the single-page PRs #29967, #29968, #29969, #29970, #29971, which are being closed in favor of this batch.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Behavior change; verify on a live proxy after building the UI into `litellm/proxy/_experimental/out`. For any of the migrated items (for example Budgets, Logs, Memory, Vector Stores):

1. Log in at http://localhost:4000/ui/
2. Click the item in the sidebar -> URL becomes http://localhost:4000/ui/<segment>, the page renders, the item stays highlighted
3. Hard-refresh -> still renders (not 404)
4. Right-click -> Open in new tab -> opens the path route directly
5. Click a not-yet-migrated item (for example Teams) -> returns to http://localhost:4000/ui/?page=teams
6. Visit an old URL such as http://localhost:4000/ui/?page=logs -> redirects to http://localhost:4000/ui/logs

## Type

🆕 New Feature

## Changes

Bulk cutover of the 20 self-contained leaf pages from the legacy `?page=` switch to real App Router routes, following the pattern proven on API Reference and Playground. Each page becomes a thin `(dashboard)/<segment>/page.tsx` that pulls its data from `useAuthorized` and renders the existing component; the corresponding arm and import are removed from the giant `page.tsx` switch, and entries are added to `MIGRATED_PAGES` (`skills` and `claude-code-plugins` both route to `/ui/skills`). A data-driven test asserts every forward mapping and reverse lookup, so adding future pages keeps the same coverage.

These are routing-only cutovers; the heavier shared-state pages (organizations, models, agents, the settings group, users, teams, virtual-keys, usage) will follow in their own PRs.