### PR TITLE
test(ui): data-driven App Router migration E2E smoke (default + server-root-path)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2683,53 +2683,117 @@ jobs:
             LITELLM_LICENSE="$LITELLM_LICENSE" \
               npx playwright test --config e2e_tests/playwright.config.ts
           no_output_timeout: 10m
+      - store_artifacts:
+          path: ui/litellm-dashboard/test-results
+          destination: e2e-test-results
+      - store_artifacts:
+          path: ui/litellm-dashboard/playwright-report
+          destination: e2e-playwright-report
+
+  e2e_ui_testing_server_root_path:
+    docker:
+      - image: cimg/python:3.12-browsers@sha256:b432899af01c9a311bf74f4f22e9ada2e5306d4b1b4383f8d29e1228a5844ef2
+        auth:
+          username: ${DOCKERHUB_USERNAME}
+          password: ${DOCKERHUB_PASSWORD}
+      - image: cimg/postgres:16.0@sha256:b125148bc76e8e8eee5eb3ad6020a3a14110a14e8192f1c645128afebe2e2f84
+        environment:
+          POSTGRES_USER: e2euser
+          POSTGRES_PASSWORD: e2epassword
+          POSTGRES_DB: litellm_e2e
+    resource_class: large
+    working_directory: ~/project
+    environment:
+      DATABASE_URL: "postgresql://e2euser:e2epassword@localhost:5432/litellm_e2e"
+      CI: "true"
+      # The whole job exercises the proxy mounted under a prefix. SERVER_ROOT_PATH
+      # is read both by the proxy at boot (to rewrite the built UI bundle in place)
+      # and by migration.serverRootPath.config.ts, which refuses to run without it.
+      SERVER_ROOT_PATH: "/litellm"
+    steps:
+      - checkout
+      - setup_google_dns
+      - install_uv
+      - restore_cache:
+          keys:
+            - v1-uv-cache-{{ checksum "uv.lock" }}
       - run:
-          name: Reboot proxy under a server root path
+          name: Install Python dependencies
+          command: |
+            uv sync --frozen --all-groups --all-extras --python 3.12
+            uv run --no-sync python -m prisma generate --schema litellm/proxy/schema.prisma
+      - save_cache:
+          key: v1-uv-cache-{{ checksum "uv.lock" }}
+          paths:
+            - ~/.cache/uv
+      - restore_cache:
+          keys:
+            - ui-e2e-node-deps-v2-{{ checksum "ui/litellm-dashboard/package-lock.json" }}
+      - run:
+          name: Install Node dependencies and Playwright
+          command: |
+            cd ui/litellm-dashboard
+            npm ci
+            npx playwright install chromium
+      - save_cache:
+          key: ui-e2e-node-deps-v2-{{ checksum "ui/litellm-dashboard/package-lock.json" }}
+          paths:
+            - ui/litellm-dashboard/node_modules
+            - ~/.cache/ms-playwright
+      - run:
+          name: Build UI from source
+          command: |
+            cd ui/litellm-dashboard
+            npm run build
+            rm -rf ../../litellm/proxy/_experimental/out
+            mv out ../../litellm/proxy/_experimental/out
+            find ../../litellm/proxy/_experimental/out -name '*.html' ! -name 'index.html' | while read -r f; do
+              d="${f%.html}"; mkdir -p "$d"; mv "$f" "$d/index.html"
+            done
+      - wait_for_service:
+          url: tcp://localhost:5432
+          timeout: "30"
+      - run:
+          name: Push Prisma schema
+          command: uv run --no-sync python -m prisma db push --schema litellm/proxy/schema.prisma --accept-data-loss
+      - run:
+          name: Seed database
+          command: |
+            PGPASSWORD=e2epassword psql -h localhost -p 5432 -U e2euser -d litellm_e2e \
+              -f ui/litellm-dashboard/e2e_tests/fixtures/seed.sql
+      - run:
+          name: Start mock LLM server
+          command: uv run --no-sync python ui/litellm-dashboard/e2e_tests/fixtures/mock_llm_server/server.py
+          background: true
+      - run:
+          name: Start LiteLLM proxy under a server root path
           environment:
             LITELLM_MASTER_KEY: "sk-1234"
             MOCK_LLM_URL: "http://127.0.0.1:8090/v1"
             DISABLE_SCHEMA_UPDATE: "true"
-            SERVER_ROOT_PATH: "/litellm"
+          # Output flows to this step's own log, so a boot crash is visible here
+          # rather than swallowed by a downstream readiness probe.
           command: |
-            pkill -9 -f "litellm.proxy.proxy_cli" || true
-            for i in $(seq 1 15); do
-              curl -s -o /dev/null --max-time 2 http://127.0.0.1:4000/health 2>/dev/null || break
-              sleep 1
-            done
             LITELLM_LICENSE="$LITELLM_LICENSE" \
               uv run --no-sync python -m litellm.proxy.proxy_cli \
                 --config ui/litellm-dashboard/e2e_tests/fixtures/config.yml \
-                --port 4000 > /tmp/proxy_root.log 2>&1
+                --port 4000
           background: true
       - run:
           name: Wait for prefixed proxy to be ready
           command: |
-            live=""
-            for i in $(seq 1 90); do
-              code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 -H "Authorization: Bearer sk-1234" http://127.0.0.1:4000/litellm/health 2>/dev/null || true)
-              if [ "$code" = "200" ]; then live="yes"; echo "Prefixed proxy live after ${i} tries"; break; fi
-              sleep 2
-            done
-            for i in $(seq 1 30); do
-              content=$(curl -sL --max-time 5 -H "Authorization: Bearer sk-1234" http://127.0.0.1:4000/litellm/ui/ 2>/dev/null || true)
-              if echo "$content" | grep -qE "(<!DOCTYPE|<html|<head)"; then
-                echo "Prefixed proxy is serving the UI"
+            for i in $(seq 1 60); do
+              HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 -H "Authorization: Bearer sk-1234" http://127.0.0.1:4000/litellm/health 2>/dev/null || true)
+              if [ "$HTTP_CODE" = "200" ]; then
+                echo "Prefixed proxy is ready"
                 exit 0
               fi
               sleep 2
             done
-            echo "=== Prefixed proxy did not serve /litellm/ui/ (health_live=${live:-no}) ==="
-            echo "--- curl -v /litellm/health ---"
-            curl -sv --max-time 5 -H "Authorization: Bearer sk-1234" http://127.0.0.1:4000/litellm/health 2>&1 | tail -20
-            echo "--- curl -v /litellm/ui/ ---"
-            curl -sv --max-time 5 -H "Authorization: Bearer sk-1234" http://127.0.0.1:4000/litellm/ui/ 2>&1 | tail -30
-            echo "--- proxy boot log tail ---"
-            tail -100 /tmp/proxy_root.log 2>/dev/null || echo "(no proxy log)"
+            echo "Prefixed proxy failed to start; see the 'Start LiteLLM proxy under a server root path' step for the boot log"
             exit 1
       - run:
           name: Run migration smoke under SERVER_ROOT_PATH
-          environment:
-            SERVER_ROOT_PATH: "/litellm"
           command: |
             cd ui/litellm-dashboard
             LITELLM_LICENSE="$LITELLM_LICENSE" \
@@ -2737,10 +2801,10 @@ jobs:
           no_output_timeout: 10m
       - store_artifacts:
           path: ui/litellm-dashboard/test-results
-          destination: e2e-test-results
+          destination: e2e-server-root-path-test-results
       - store_artifacts:
           path: ui/litellm-dashboard/playwright-report
-          destination: e2e-playwright-report
+          destination: e2e-server-root-path-playwright-report
 
   build_docker_database_image:
     machine:
@@ -2846,6 +2910,8 @@ workflows:
       - build_docker_database_image:
           filters: *main_branches
       - e2e_ui_testing:
+          filters: *main_branches
+      - e2e_ui_testing_server_root_path:
           filters: *main_branches
       - build_and_test:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2683,6 +2683,43 @@ jobs:
             LITELLM_LICENSE="$LITELLM_LICENSE" \
               npx playwright test --config e2e_tests/playwright.config.ts
           no_output_timeout: 10m
+      - run:
+          name: Reboot proxy under a server root path
+          environment:
+            LITELLM_MASTER_KEY: "sk-1234"
+            MOCK_LLM_URL: "http://127.0.0.1:8090/v1"
+            DISABLE_SCHEMA_UPDATE: "true"
+            SERVER_ROOT_PATH: "/litellm"
+          command: |
+            pkill -f "litellm.proxy.proxy_cli" || true
+            sleep 3
+            LITELLM_LICENSE="$LITELLM_LICENSE" \
+              uv run --no-sync python -m litellm.proxy.proxy_cli \
+                --config ui/litellm-dashboard/e2e_tests/fixtures/config.yml \
+                --port 4000
+          background: true
+      - run:
+          name: Wait for prefixed proxy to be ready
+          command: |
+            for i in $(seq 1 60); do
+              content=$(curl -sL --max-time 5 -H "Authorization: Bearer sk-1234" http://127.0.0.1:4000/litellm/ui/ 2>/dev/null || true)
+              if echo "$content" | grep -qE "(<!DOCTYPE|<html|<head)"; then
+                echo "Prefixed proxy is serving the UI"
+                exit 0
+              fi
+              sleep 2
+            done
+            echo "Prefixed proxy failed to serve /litellm/ui/"
+            exit 1
+      - run:
+          name: Run migration smoke under SERVER_ROOT_PATH
+          environment:
+            SERVER_ROOT_PATH: "/litellm"
+          command: |
+            cd ui/litellm-dashboard
+            LITELLM_LICENSE="$LITELLM_LICENSE" \
+              npx playwright test --config e2e_tests/migration.serverRootPath.config.ts
+          no_output_timeout: 10m
       - store_artifacts:
           path: ui/litellm-dashboard/test-results
           destination: e2e-test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2691,17 +2691,26 @@ jobs:
             DISABLE_SCHEMA_UPDATE: "true"
             SERVER_ROOT_PATH: "/litellm"
           command: |
-            pkill -f "litellm.proxy.proxy_cli" || true
-            sleep 3
+            pkill -9 -f "litellm.proxy.proxy_cli" || true
+            for i in $(seq 1 15); do
+              curl -s -o /dev/null --max-time 2 http://127.0.0.1:4000/health 2>/dev/null || break
+              sleep 1
+            done
             LITELLM_LICENSE="$LITELLM_LICENSE" \
               uv run --no-sync python -m litellm.proxy.proxy_cli \
                 --config ui/litellm-dashboard/e2e_tests/fixtures/config.yml \
-                --port 4000
+                --port 4000 > /tmp/proxy_root.log 2>&1
           background: true
       - run:
           name: Wait for prefixed proxy to be ready
           command: |
-            for i in $(seq 1 60); do
+            live=""
+            for i in $(seq 1 90); do
+              code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 -H "Authorization: Bearer sk-1234" http://127.0.0.1:4000/litellm/health 2>/dev/null || true)
+              if [ "$code" = "200" ]; then live="yes"; echo "Prefixed proxy live after ${i} tries"; break; fi
+              sleep 2
+            done
+            for i in $(seq 1 30); do
               content=$(curl -sL --max-time 5 -H "Authorization: Bearer sk-1234" http://127.0.0.1:4000/litellm/ui/ 2>/dev/null || true)
               if echo "$content" | grep -qE "(<!DOCTYPE|<html|<head)"; then
                 echo "Prefixed proxy is serving the UI"
@@ -2709,7 +2718,13 @@ jobs:
               fi
               sleep 2
             done
-            echo "Prefixed proxy failed to serve /litellm/ui/"
+            echo "=== Prefixed proxy did not serve /litellm/ui/ (health_live=${live:-no}) ==="
+            echo "--- curl -v /litellm/health ---"
+            curl -sv --max-time 5 -H "Authorization: Bearer sk-1234" http://127.0.0.1:4000/litellm/health 2>&1 | tail -20
+            echo "--- curl -v /litellm/ui/ ---"
+            curl -sv --max-time 5 -H "Authorization: Bearer sk-1234" http://127.0.0.1:4000/litellm/ui/ 2>&1 | tail -30
+            echo "--- proxy boot log tail ---"
+            tail -100 /tmp/proxy_root.log 2>/dev/null || echo "(no proxy log)"
             exit 1
       - run:
           name: Run migration smoke under SERVER_ROOT_PATH

--- a/ui/litellm-dashboard/e2e_tests/fixtures/migratedPages.ts
+++ b/ui/litellm-dashboard/e2e_tests/fixtures/migratedPages.ts
@@ -1,0 +1,16 @@
+/**
+ * Source of truth for the App Router migration smoke (tests/migration/migratedPages.spec.ts).
+ *
+ * Add a route segment here once its migration has MERGED to the branch under test.
+ * Both suites pick it up automatically:
+ *   - default mount:           npm run e2e:migration
+ *   - server-root-path mount:  SERVER_ROOT_PATH=/<root> npm run e2e:migration:root
+ *
+ * Keep this in lockstep with MIGRATED_PAGES in src/utils/migratedPages.ts.
+ * Pending (uncomment as each PR lands): playground, and the leaf-pages batch
+ * (budgets, caching, cost-tracking, guardrails, guardrails-monitor, logs,
+ * mcp-servers, memory, policies, projects, prompts, search-tools, skills,
+ * tag-management, tool-policies, transform-request, ui-theme, vector-stores,
+ * workflows, access-groups).
+ */
+export const MIGRATED_E2E_SEGMENTS: string[] = ["api-reference"];

--- a/ui/litellm-dashboard/e2e_tests/globalSetup.ts
+++ b/ui/litellm-dashboard/e2e_tests/globalSetup.ts
@@ -4,17 +4,18 @@ import * as fs from "fs";
 
 async function globalSetup() {
   const browser = await chromium.launch();
+  const rootPath = process.env.SERVER_ROOT_PATH ?? "";
 
   for (const role of Object.values(Role)) {
     const { email, password } = users[role];
     const storagePath = STORAGE_PATHS[role];
     const page = await browser.newPage();
     try {
-      await page.goto("http://localhost:4000/ui/login");
+      await page.goto(`http://localhost:4000${rootPath}/ui/login`);
       await page.getByPlaceholder("Enter your username").fill(email);
       await page.getByPlaceholder("Enter your password").fill(password);
       await page.getByRole("button", { name: "Login", exact: true }).click();
-      await page.waitForURL((url) => url.pathname.startsWith("/ui") && !url.pathname.includes("/login"), {
+      await page.waitForURL((url) => url.pathname.startsWith(`${rootPath}/ui`) && !url.pathname.includes("/login"), {
         timeout: 30_000,
       });
       await expect(page.locator("a", { hasText: "Virtual Keys" })).toBeVisible({ timeout: 30_000 });

--- a/ui/litellm-dashboard/e2e_tests/migration.serverRootPath.config.ts
+++ b/ui/litellm-dashboard/e2e_tests/migration.serverRootPath.config.ts
@@ -6,6 +6,14 @@ import { defineConfig, devices } from "@playwright/test";
  * running. globalSetup logs in at `${SERVER_ROOT_PATH}/ui/login` so the admin
  * storage state is valid under the prefix.
  */
+if (!process.env.SERVER_ROOT_PATH) {
+  throw new Error(
+    "migration.serverRootPath.config.ts requires SERVER_ROOT_PATH to be set (e.g. SERVER_ROOT_PATH=/litellm). " +
+      "Without it this config silently re-runs the default mount and never exercises the prefix. " +
+      "For the root-less run use the default playwright.config.ts (npm run e2e:migration).",
+  );
+}
+
 export default defineConfig({
   testDir: "./tests/migration",
   testMatch: ["migratedPages.spec.ts"],

--- a/ui/litellm-dashboard/e2e_tests/migration.serverRootPath.config.ts
+++ b/ui/litellm-dashboard/e2e_tests/migration.serverRootPath.config.ts
@@ -19,6 +19,9 @@ export default defineConfig({
     trace: "on-first-retry",
     actionTimeout: 15 * 1000,
     navigationTimeout: 30 * 1000,
+    launchOptions: {
+      slowMo: process.env.SLOWMO ? parseInt(process.env.SLOWMO, 10) || 0 : 0,
+    },
   },
   projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
   timeout: 3 * 60 * 1000,

--- a/ui/litellm-dashboard/e2e_tests/migration.serverRootPath.config.ts
+++ b/ui/litellm-dashboard/e2e_tests/migration.serverRootPath.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * App Router migration smoke under a non-root mount. Boot the proxy with the same
+ * SERVER_ROOT_PATH (e.g. SERVER_ROOT_PATH=/litellm) and a UI built for it before
+ * running. globalSetup logs in at `${SERVER_ROOT_PATH}/ui/login` so the admin
+ * storage state is valid under the prefix.
+ */
+export default defineConfig({
+  testDir: "./tests/migration",
+  testMatch: ["migratedPages.spec.ts"],
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: "list",
+  use: {
+    baseURL: "http://localhost:4000",
+    trace: "on-first-retry",
+    actionTimeout: 15 * 1000,
+    navigationTimeout: 30 * 1000,
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  timeout: 3 * 60 * 1000,
+  expect: { timeout: 10 * 1000 },
+  globalSetup: require.resolve("./globalSetup"),
+});

--- a/ui/litellm-dashboard/e2e_tests/tests/migration/README.md
+++ b/ui/litellm-dashboard/e2e_tests/tests/migration/README.md
@@ -1,0 +1,33 @@
+# App Router migration smoke
+
+A growing E2E smoke for pages migrated from the legacy `?page=` switch to App
+Router path routes. For each migrated page it deep-links to the path route, checks
+the URL and that the page renders, then clicks off to a legacy page and checks
+that navigation still works. It runs in two situations: the default mount and a
+non-root `SERVER_ROOT_PATH` mount.
+
+## Adding a page
+
+When a page's migration merges, add its route segment to
+`e2e_tests/fixtures/migratedPages.ts` (keep it in lockstep with `MIGRATED_PAGES`
+in `src/utils/migratedPages.ts`). Both suites pick it up automatically.
+
+## Running
+
+Build the UI into the proxy and start the proxy first (the suite runs against
+`http://localhost:4000`).
+
+Default mount:
+
+```
+npm run e2e:migration
+```
+
+Non-root mount (build and boot the proxy with the same root path, e.g. `/litellm`):
+
+```
+SERVER_ROOT_PATH=/litellm npm run e2e:migration:root
+```
+
+`globalSetup` logs in once per role; the admin storage state is reused for these
+tests. Under a non-root mount it logs in at `${SERVER_ROOT_PATH}/ui/login`.

--- a/ui/litellm-dashboard/e2e_tests/tests/migration/README.md
+++ b/ui/litellm-dashboard/e2e_tests/tests/migration/README.md
@@ -1,10 +1,10 @@
 # App Router migration smoke
 
 A growing E2E smoke for pages migrated from the legacy `?page=` switch to App
-Router path routes. For each migrated page it deep-links to the path route, checks
-the URL and that the page renders, then clicks off to a legacy page and checks
-that navigation still works. It runs in two situations: the default mount and a
-non-root `SERVER_ROOT_PATH` mount.
+Router path routes. For each migrated page it clicks the page's sidebar link, checks
+the URL is the path route and the page renders, reloads it, then clicks off to a
+legacy page and back to confirm navigation still works. It runs in two situations:
+the default mount and a non-root `SERVER_ROOT_PATH` mount.
 
 ## Adding a page
 

--- a/ui/litellm-dashboard/e2e_tests/tests/migration/migratedPages.spec.ts
+++ b/ui/litellm-dashboard/e2e_tests/tests/migration/migratedPages.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from "@playwright/test";
+import { MIGRATED_E2E_SEGMENTS } from "../../fixtures/migratedPages";
+import { ADMIN_STORAGE_PATH } from "../../constants";
+import { dismissFeedbackPopup } from "../../helpers/navigation";
+
+/**
+ * App Router migration smoke. For each migrated page we deep-link to its path
+ * route and then navigate away, asserting no failure in either situation. Driven
+ * by MIGRATED_E2E_SEGMENTS, so it grows as pages are migrated.
+ *
+ * SERVER_ROOT_PATH (e.g. "/litellm") exercises the non-root mount; leave it unset
+ * for the default mount. Boot the proxy with the matching value before running.
+ */
+const ROOT = process.env.SERVER_ROOT_PATH ?? "";
+
+test.use({ storageState: ADMIN_STORAGE_PATH });
+
+test.describe("App Router migrated pages", () => {
+  for (const segment of MIGRATED_E2E_SEGMENTS) {
+    test(`${segment}: deep-links to its path route and navigates away cleanly`, async ({ page }) => {
+      const pageErrors: string[] = [];
+      page.on("pageerror", (e) => pageErrors.push(String(e)));
+
+      // 1. The migrated page is served at its own path (this is what a wrong
+      //    server_root_path breaks: the static export must serve <root>/ui/<segment>).
+      await page.goto(`${ROOT}/ui/${segment}`);
+      await dismissFeedbackPopup(page);
+
+      await expect(page).toHaveURL(new RegExp(`${ROOT}/ui/${segment}/?($|\\?)`));
+      // The dashboard shell rendered and the route did not 404 / crash.
+      await expect(page.locator("a", { hasText: "Virtual Keys" })).toBeVisible({ timeout: 20_000 });
+      expect(pageErrors, `page errors on ${ROOT}/ui/${segment}`).toEqual([]);
+
+      // 2. Clicking off to a not-yet-migrated page returns to the legacy switch
+      //    (the migrated -> ?page= transition that used to double-navigate).
+      await page.locator("a", { hasText: "Virtual Keys" }).click();
+      await expect(page).toHaveURL(new RegExp(`${ROOT}/ui/\\?page=api-keys`));
+      await dismissFeedbackPopup(page);
+      expect(pageErrors, `page errors after leaving ${ROOT}/ui/${segment}`).toEqual([]);
+    });
+  }
+});

--- a/ui/litellm-dashboard/e2e_tests/tests/migration/migratedPages.spec.ts
+++ b/ui/litellm-dashboard/e2e_tests/tests/migration/migratedPages.spec.ts
@@ -12,6 +12,9 @@ import { dismissFeedbackPopup } from "../../helpers/navigation";
  * for the default mount. Boot the proxy with the matching value before running.
  */
 const ROOT = process.env.SERVER_ROOT_PATH ?? "";
+// Optional: linger on each state so a human can watch a headed run. No-op (0) by default.
+const WATCH_MS = Number(process.env.E2E_WATCH_MS ?? 0);
+const watch = (page: import("@playwright/test").Page) => (WATCH_MS ? page.waitForTimeout(WATCH_MS) : Promise.resolve());
 
 test.use({ storageState: ADMIN_STORAGE_PATH });
 
@@ -30,6 +33,7 @@ test.describe("App Router migrated pages", () => {
       // The dashboard shell rendered and the route did not 404 / crash.
       await expect(page.locator("a", { hasText: "Virtual Keys" })).toBeVisible({ timeout: 20_000 });
       expect(pageErrors, `page errors on ${ROOT}/ui/${segment}`).toEqual([]);
+      await watch(page);
 
       // 2. Clicking off to a not-yet-migrated page returns to the legacy switch
       //    (the migrated -> ?page= transition that used to double-navigate).
@@ -37,6 +41,7 @@ test.describe("App Router migrated pages", () => {
       await expect(page).toHaveURL(new RegExp(`${ROOT}/ui/\\?page=api-keys`));
       await dismissFeedbackPopup(page);
       expect(pageErrors, `page errors after leaving ${ROOT}/ui/${segment}`).toEqual([]);
+      await watch(page);
     });
   }
 });

--- a/ui/litellm-dashboard/e2e_tests/tests/migration/migratedPages.spec.ts
+++ b/ui/litellm-dashboard/e2e_tests/tests/migration/migratedPages.spec.ts
@@ -7,22 +7,19 @@ import { dismissFeedbackPopup } from "../../helpers/navigation";
  * App Router migration smoke as a user journey: start where the proxy lands you,
  * click a migrated page in the sidebar, confirm it routed and rendered, reload it
  * (the check a wrong server_root_path breaks), bounce to a legacy page and back,
- * and — once two pages are migrated — navigate directly between two migrated pages.
+ * and, once two pages are migrated, navigate directly between two migrated pages.
  *
  * Driven by MIGRATED_E2E_SEGMENTS, so it grows as pages are migrated. Set
  * SERVER_ROOT_PATH (e.g. "/litellm") to exercise the non-root mount; leave it
  * unset for the default mount. Boot the proxy with the matching value first.
  */
 const ROOT = process.env.SERVER_ROOT_PATH ?? "";
-// Optional: linger on each state so a human can watch a headed run. No-op (0) by default.
-const WATCH_MS = Number(process.env.E2E_WATCH_MS ?? 0);
-const watch = (page: Page) => (WATCH_MS ? page.waitForTimeout(WATCH_MS) : Promise.resolve());
 
 const esc = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 const pathRe = (segment: string) => new RegExp(`${esc(ROOT)}/ui/${esc(segment)}/?($|\\?)`);
 const legacyAnchor = (page: Page) => page.locator("a", { hasText: "Virtual Keys" });
 
-/** The dashboard shell is present (sidebar rendered) — page didn't 404 / crash. */
+/** The dashboard shell is present (sidebar rendered); page didn't 404 / crash. */
 async function expectRendered(page: Page) {
   await expect(legacyAnchor(page)).toBeVisible({ timeout: 20_000 });
 }
@@ -61,28 +58,20 @@ test.describe("App Router migrated pages", () => {
       await clickSidebar(page, segment);
       await expect(page).toHaveURL(pathRe(segment));
       await expectRendered(page);
-      await watch(page);
-
-      // 3. Reload the path route directly — a wrong server_root_path 404s here.
+      // 3. Reload the path route directly; a wrong server_root_path 404s here.
       await page.reload();
       await dismissFeedbackPopup(page);
       await expect(page).toHaveURL(pathRe(segment));
       await expectRendered(page);
-      await watch(page);
-
       // 4. Click off to a legacy (not-yet-migrated) page.
       await legacyAnchor(page).click();
       await expect(page).toHaveURL(new RegExp(`${esc(ROOT)}/ui/\\?page=api-keys`));
       await dismissFeedbackPopup(page);
       await expectRendered(page);
-      await watch(page);
-
       // 5. Click back to the migrated page.
       await clickSidebar(page, segment);
       await expect(page).toHaveURL(pathRe(segment));
       await expectRendered(page);
-      await watch(page);
-
       expect(pageErrors, `page errors during ${segment} journey`).toEqual([]);
     });
   }
@@ -99,13 +88,9 @@ test.describe("App Router migrated pages", () => {
     await clickSidebar(page, first);
     await expect(page).toHaveURL(pathRe(first));
     await expectRendered(page);
-    await watch(page);
-
     await clickSidebar(page, second);
     await expect(page).toHaveURL(pathRe(second));
     await expectRendered(page);
-    await watch(page);
-
     // Back to the first migrated page.
     await clickSidebar(page, first);
     await expect(page).toHaveURL(pathRe(first));

--- a/ui/litellm-dashboard/e2e_tests/tests/migration/migratedPages.spec.ts
+++ b/ui/litellm-dashboard/e2e_tests/tests/migration/migratedPages.spec.ts
@@ -18,7 +18,8 @@ const ROOT = process.env.SERVER_ROOT_PATH ?? "";
 const WATCH_MS = Number(process.env.E2E_WATCH_MS ?? 0);
 const watch = (page: Page) => (WATCH_MS ? page.waitForTimeout(WATCH_MS) : Promise.resolve());
 
-const pathRe = (segment: string) => new RegExp(`${ROOT}/ui/${segment}/?($|\\?)`);
+const esc = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+const pathRe = (segment: string) => new RegExp(`${esc(ROOT)}/ui/${esc(segment)}/?($|\\?)`);
 const legacyAnchor = (page: Page) => page.locator("a", { hasText: "Virtual Keys" });
 
 /** The dashboard shell is present (sidebar rendered) — page didn't 404 / crash. */
@@ -71,7 +72,7 @@ test.describe("App Router migrated pages", () => {
 
       // 4. Click off to a legacy (not-yet-migrated) page.
       await legacyAnchor(page).click();
-      await expect(page).toHaveURL(new RegExp(`${ROOT}/ui/\\?page=api-keys`));
+      await expect(page).toHaveURL(new RegExp(`${esc(ROOT)}/ui/\\?page=api-keys`));
       await dismissFeedbackPopup(page);
       await expectRendered(page);
       await watch(page);

--- a/ui/litellm-dashboard/e2e_tests/tests/migration/migratedPages.spec.ts
+++ b/ui/litellm-dashboard/e2e_tests/tests/migration/migratedPages.spec.ts
@@ -1,47 +1,115 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 import { MIGRATED_E2E_SEGMENTS } from "../../fixtures/migratedPages";
 import { ADMIN_STORAGE_PATH } from "../../constants";
 import { dismissFeedbackPopup } from "../../helpers/navigation";
 
 /**
- * App Router migration smoke. For each migrated page we deep-link to its path
- * route and then navigate away, asserting no failure in either situation. Driven
- * by MIGRATED_E2E_SEGMENTS, so it grows as pages are migrated.
+ * App Router migration smoke as a user journey: start where the proxy lands you,
+ * click a migrated page in the sidebar, confirm it routed and rendered, reload it
+ * (the check a wrong server_root_path breaks), bounce to a legacy page and back,
+ * and — once two pages are migrated — navigate directly between two migrated pages.
  *
- * SERVER_ROOT_PATH (e.g. "/litellm") exercises the non-root mount; leave it unset
- * for the default mount. Boot the proxy with the matching value before running.
+ * Driven by MIGRATED_E2E_SEGMENTS, so it grows as pages are migrated. Set
+ * SERVER_ROOT_PATH (e.g. "/litellm") to exercise the non-root mount; leave it
+ * unset for the default mount. Boot the proxy with the matching value first.
  */
 const ROOT = process.env.SERVER_ROOT_PATH ?? "";
 // Optional: linger on each state so a human can watch a headed run. No-op (0) by default.
 const WATCH_MS = Number(process.env.E2E_WATCH_MS ?? 0);
-const watch = (page: import("@playwright/test").Page) => (WATCH_MS ? page.waitForTimeout(WATCH_MS) : Promise.resolve());
+const watch = (page: Page) => (WATCH_MS ? page.waitForTimeout(WATCH_MS) : Promise.resolve());
+
+const pathRe = (segment: string) => new RegExp(`${ROOT}/ui/${segment}/?($|\\?)`);
+const legacyAnchor = (page: Page) => page.locator("a", { hasText: "Virtual Keys" });
+
+/** The dashboard shell is present (sidebar rendered) — page didn't 404 / crash. */
+async function expectRendered(page: Page) {
+  await expect(legacyAnchor(page)).toBeVisible({ timeout: 20_000 });
+}
+
+/**
+ * Click a migrated page's sidebar link. Migrated items render as <a href=".../ui/<segment>">;
+ * nested ones live under collapsible submenus, so expand submenus until the link is clickable.
+ */
+async function clickSidebar(page: Page, segment: string) {
+  const link = page.locator(`a[href$="/ui/${segment}"]`).first();
+  for (let i = 0; i < 8 && !(await link.isVisible().catch(() => false)); i++) {
+    const collapsedSubmenu = page
+      .locator(".ant-menu-submenu:not(.ant-menu-submenu-open) > .ant-menu-submenu-title")
+      .first();
+    if (!(await collapsedSubmenu.isVisible().catch(() => false))) break;
+    await collapsedSubmenu.click();
+    await page.waitForTimeout(250);
+  }
+  await link.click();
+}
 
 test.use({ storageState: ADMIN_STORAGE_PATH });
 
 test.describe("App Router migrated pages", () => {
   for (const segment of MIGRATED_E2E_SEGMENTS) {
-    test(`${segment}: deep-links to its path route and navigates away cleanly`, async ({ page }) => {
+    test(`${segment}: sidebar nav, reload, and round-trip with a legacy page`, async ({ page }) => {
       const pageErrors: string[] = [];
       page.on("pageerror", (e) => pageErrors.push(String(e)));
 
-      // 1. The migrated page is served at its own path (this is what a wrong
-      //    server_root_path breaks: the static export must serve <root>/ui/<segment>).
-      await page.goto(`${ROOT}/ui/${segment}`);
+      // 1. Start where the proxy lands us.
+      await page.goto(`${ROOT}/ui/`);
       await dismissFeedbackPopup(page);
+      await expectRendered(page);
 
-      await expect(page).toHaveURL(new RegExp(`${ROOT}/ui/${segment}/?($|\\?)`));
-      // The dashboard shell rendered and the route did not 404 / crash.
-      await expect(page.locator("a", { hasText: "Virtual Keys" })).toBeVisible({ timeout: 20_000 });
-      expect(pageErrors, `page errors on ${ROOT}/ui/${segment}`).toEqual([]);
+      // 2. Click the migrated page in the sidebar -> path route + rendered.
+      await clickSidebar(page, segment);
+      await expect(page).toHaveURL(pathRe(segment));
+      await expectRendered(page);
       await watch(page);
 
-      // 2. Clicking off to a not-yet-migrated page returns to the legacy switch
-      //    (the migrated -> ?page= transition that used to double-navigate).
-      await page.locator("a", { hasText: "Virtual Keys" }).click();
+      // 3. Reload the path route directly — a wrong server_root_path 404s here.
+      await page.reload();
+      await dismissFeedbackPopup(page);
+      await expect(page).toHaveURL(pathRe(segment));
+      await expectRendered(page);
+      await watch(page);
+
+      // 4. Click off to a legacy (not-yet-migrated) page.
+      await legacyAnchor(page).click();
       await expect(page).toHaveURL(new RegExp(`${ROOT}/ui/\\?page=api-keys`));
       await dismissFeedbackPopup(page);
-      expect(pageErrors, `page errors after leaving ${ROOT}/ui/${segment}`).toEqual([]);
+      await expectRendered(page);
       await watch(page);
+
+      // 5. Click back to the migrated page.
+      await clickSidebar(page, segment);
+      await expect(page).toHaveURL(pathRe(segment));
+      await expectRendered(page);
+      await watch(page);
+
+      expect(pageErrors, `page errors during ${segment} journey`).toEqual([]);
     });
   }
+
+  test("navigates directly between two migrated pages", async ({ page }) => {
+    test.skip(MIGRATED_E2E_SEGMENTS.length < 2, "needs >= 2 migrated pages");
+    const [first, second] = MIGRATED_E2E_SEGMENTS;
+    const pageErrors: string[] = [];
+    page.on("pageerror", (e) => pageErrors.push(String(e)));
+
+    await page.goto(`${ROOT}/ui/`);
+    await dismissFeedbackPopup(page);
+
+    await clickSidebar(page, first);
+    await expect(page).toHaveURL(pathRe(first));
+    await expectRendered(page);
+    await watch(page);
+
+    await clickSidebar(page, second);
+    await expect(page).toHaveURL(pathRe(second));
+    await expectRendered(page);
+    await watch(page);
+
+    // Back to the first migrated page.
+    await clickSidebar(page, first);
+    await expect(page).toHaveURL(pathRe(first));
+    await expectRendered(page);
+
+    expect(pageErrors, "page errors during migrated -> migrated nav").toEqual([]);
+  });
 });

--- a/ui/litellm-dashboard/package.json
+++ b/ui/litellm-dashboard/package.json
@@ -16,6 +16,8 @@
     "format:check": "prettier --check .",
     "e2e": "playwright test --config e2e_tests/playwright.config.ts",
     "e2e:ui": "playwright test --ui --config e2e_tests/playwright.config.ts",
+    "e2e:migration": "playwright test e2e_tests/tests/migration/migratedPages.spec.ts --config e2e_tests/playwright.config.ts",
+    "e2e:migration:root": "playwright test --config e2e_tests/migration.serverRootPath.config.ts",
     "knip": "knip",
     "knip:fix": "knip --fix",
     "gen:api": "node scripts/gen-api-types.mjs"


### PR DESCRIPTION
## Relevant issues

Supports the App Router migration (the harness the per-page PRs plug into). Targets `litellm_internal_staging`.

## Linear ticket

None

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

✅ Test

## Changes

Adds a data-driven Playwright smoke for the App Router migration so each migrated page is covered the same way in two mounts: the default mount and a non-root `SERVER_ROOT_PATH` mount.

For every segment in `e2e_tests/fixtures/migratedPages.ts` the test runs a user journey: it lands where the proxy drops you, clicks the migrated page in the sidebar, asserts the URL is the path route (not the legacy `?page=` form) and the dashboard shell rendered without a page error, reloads the path route directly (the step a wrong `server_root_path` breaks, since the static export must serve the prefixed path), then clicks off to a not-yet-migrated page and back to confirm navigation round-trips. Adding a page is a one-line append to the fixture, so the suite grows with the migration; it is seeded with `api-reference` (the only page merged so far) to stay green, with the pending segments listed in a comment.

`globalSetup` now builds its login URL as `${SERVER_ROOT_PATH}/ui/login` (and the post-login wait honors the prefix), so the admin storage state is valid under a non-root mount; behavior is unchanged when the var is unset. Two npm scripts wire it up for local runs:

- `npm run e2e:migration` (default mount)
- `SERVER_ROOT_PATH=/litellm npm run e2e:migration:root` (non-root mount)

Both mounts run in CI on every PR rather than only when someone runs the scripts by hand. The default mount is picked up by the suite's glob in the existing `e2e_ui_testing` job. The prefixed mount runs in its own `e2e_ui_testing_server_root_path` job that boots the proxy once with `SERVER_ROOT_PATH=/litellm` and runs `e2e_tests/migration.serverRootPath.config.ts`, so the prefixed path serving and prefixed login are exercised. A dedicated job matches how every other proxy variant in the config is set up and avoids killing and relaunching the live proxy mid-job, which was racy and hid boot failures.

## Screenshots / Proof of Fix

This is exercised in CI by two CircleCI jobs that build the UI and boot a live proxy. The `e2e_ui_testing` job runs the smoke at the default mount as part of the full Playwright suite. The `e2e_ui_testing_server_root_path` job boots the proxy under `SERVER_ROOT_PATH=/litellm` and runs `migration.serverRootPath.config.ts`; watch its "Run migration smoke under SERVER_ROOT_PATH" step for the prefixed run.

