### PR TITLE
fix(vantage-export): surface upstream errors and prevent blank ServiceName rejection

### DIFF
--- a/.github/workflows/test-unit-proxy-db.yml
+++ b/.github/workflows/test-unit-proxy-db.yml
@@ -172,6 +172,7 @@ jobs:
               tests/proxy_unit_tests/test_skills_db.py
               tests/proxy_unit_tests/test_update_daily_tag_spend.py
               tests/proxy_unit_tests/test_update_spend.py
+              tests/proxy_unit_tests/test_vantage_endpoints.py
               tests/proxy_unit_tests/test_proxy_encrypt_decrypt.py
             workers: 4
             dist: loadscope

--- a/litellm/integrations/focus/transformer.py
+++ b/litellm/integrations/focus/transformer.py
@@ -125,7 +125,18 @@ class FocusTransformer:
             pl.col("model").cast(pl.String).alias("ResourceType"),
             pl.lit("AI and Machine Learning").alias("ServiceCategory"),
             pl.lit("Generative AI").alias("ServiceSubcategory"),
-            pl.col("model_group").cast(pl.String).alias("ServiceName"),
+            # Vantage requires ServiceName on every row. model_group can be
+            # null/empty (e.g. direct calls that bypass the router), so fall
+            # back to model, then to a literal placeholder.
+            pl.coalesce(
+                pl.when(pl.col("model_group").cast(pl.String).str.len_chars() > 0)
+                .then(pl.col("model_group").cast(pl.String))
+                .otherwise(None),
+                pl.when(pl.col("model").cast(pl.String).str.len_chars() > 0)
+                .then(pl.col("model").cast(pl.String))
+                .otherwise(None),
+                pl.lit("unknown"),
+            ).alias("ServiceName"),
             pl.col("team_id").cast(pl.String).alias("SubAccountId"),
             pl.col("team_alias").cast(pl.String).alias("SubAccountName"),
             none_str.alias("SubAccountType"),

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -485,6 +485,10 @@ class MaskedHTTPStatusError(httpx.HTTPStatusError):
             if k.lower() not in ("content-encoding", "content-length")
         }
 
+        # Requests built with `files=` (multipart) have a streaming body, so
+        # `.content` raises httpx.RequestNotRead. Guard the access so the
+        # masked error can still be constructed when the original upload used
+        # multipart — otherwise the real HTTPStatusError gets swallowed.
         try:
             request_content = original_error.request.content
         except httpx.RequestNotRead:

--- a/litellm/proxy/spend_tracking/vantage_endpoints.py
+++ b/litellm/proxy/spend_tracking/vantage_endpoints.py
@@ -287,6 +287,16 @@ def is_vantage_setup_in_config() -> bool:
     return False
 
 
+def _get_upstream_status_code(exception: Exception) -> int:
+    """Return the upstream HTTP status code when the export client exposes one."""
+    status_code = getattr(exception, "status_code", None)
+    if status_code is None:
+        response = getattr(exception, "response", None)
+        status_code = getattr(response, "status_code", None)
+
+    return status_code if isinstance(status_code, int) else 500
+
+
 async def is_vantage_setup() -> bool:
     """Check if Vantage is setup in either config or database."""
     try:
@@ -518,10 +528,14 @@ async def vantage_export(
     except HTTPException:
         raise
     except Exception as e:
-        verbose_proxy_logger.error(f"Error performing Vantage export: {str(e)}")
+        body = getattr(e, "text", None) or getattr(
+            getattr(e, "response", None), "text", None
+        )
+        detail = f"{str(e)} | response body: {body}" if body else str(e)
+        verbose_proxy_logger.error(f"Error performing Vantage export: {detail}")
         raise HTTPException(
-            status_code=500,
-            detail={"error": f"Failed to perform Vantage export: {str(e)}"},
+            status_code=_get_upstream_status_code(e),
+            detail={"error": f"Failed to perform Vantage export: {detail}"},
         )
 
 

--- a/tests/proxy_unit_tests/test_vantage_endpoints.py
+++ b/tests/proxy_unit_tests/test_vantage_endpoints.py
@@ -1,0 +1,77 @@
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from fastapi import HTTPException
+
+from litellm.llms.custom_httpx.http_handler import MaskedHTTPStatusError
+from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+from litellm.proxy.spend_tracking import vantage_endpoints
+from litellm.types.proxy.vantage_endpoints import VantageExportRequest
+
+
+@pytest.mark.parametrize(
+    ("exception", "expected_status_code"),
+    [
+        (type("StatusCodeError", (Exception,), {"status_code": 422})(), 422),
+        (
+            type(
+                "ResponseStatusCodeError",
+                (Exception,),
+                {"response": httpx.Response(409)},
+            )(),
+            409,
+        ),
+        (Exception("unexpected failure"), 500),
+    ],
+)
+def test_get_upstream_status_code_uses_upstream_status_when_available(
+    exception, expected_status_code
+):
+    assert (
+        vantage_endpoints._get_upstream_status_code(exception) == expected_status_code
+    )
+
+
+@pytest.mark.asyncio
+async def test_vantage_export_preserves_upstream_http_status(monkeypatch):
+    request = httpx.Request(
+        "POST",
+        "https://api.vantage.sh/costs",
+        content=b"usage-data",
+    )
+    response = httpx.Response(
+        422,
+        request=request,
+        content=b'{"error":"ServiceName is required"}',
+    )
+    upstream_error = httpx.HTTPStatusError(
+        "Unprocessable Entity",
+        request=request,
+        response=response,
+    )
+    masked_error = MaskedHTTPStatusError(
+        upstream_error,
+        message='{"error":"ServiceName is required"}',
+        text='{"error":"ServiceName is required"}',
+    )
+
+    fake_logger = AsyncMock()
+    fake_logger.export_usage_data.side_effect = masked_error
+    monkeypatch.setattr(
+        vantage_endpoints,
+        "_get_registered_vantage_logger",
+        lambda: fake_logger,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await vantage_endpoints.vantage_export(
+            request=VantageExportRequest(),
+            user_api_key_dict=UserAPIKeyAuth(
+                user_role=LitellmUserRoles.PROXY_ADMIN,
+                api_key="sk-test",
+            ),
+        )
+
+    assert exc_info.value.status_code == 422
+    assert "ServiceName is required" in exc_info.value.detail["error"]


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Run against a live proxy with a configured Vantage integration (`POST /vantage/init` first), then trigger an export:

```bash
curl -sS -X POST http://localhost:4000/vantage/export \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
  -H "Content-Type: application/json" \
  -d '{}' | jq
```

Before this change, any upstream rejection from Vantage came back as a flat `500` with the upstream body discarded, so the caller could not tell that the real cause was a blank `ServiceName` (Vantage requires it on every row). After this change two things hold: rows whose `model_group` is null/empty no longer produce a blank `ServiceName` (it falls back to `model`, then to `unknown`), so that specific rejection stops happening; and when Vantage does reject for some other reason, the proxy returns the upstream status code and includes the upstream response body in the error detail instead of masking everything as `500`.

## Type

🐛 Bug Fix

## Changes

Two independent failure modes in the Vantage usage export are addressed.

`litellm/integrations/focus/transformer.py` now coalesces `ServiceName` from `model_group` to `model` to a literal `unknown`, guarding each candidate with a non-empty check. Direct calls that bypass the router can leave `model_group` null or empty, which Vantage rejects because it requires `ServiceName` on every row; the fallback guarantees a value.

`litellm/proxy/spend_tracking/vantage_endpoints.py` stops collapsing every export failure into a generic `500`. A small helper, `_get_upstream_status_code`, reads the status from the exception (directly via `status_code`, then via `response.status_code`) and only defaults to `500` when no usable integer status exists. The handler also appends the upstream response body to the error detail so the real cause is visible to the caller. The existing `except HTTPException: raise` passthrough and the success path are untouched.

`litellm/llms/custom_httpx/http_handler.py` gains a comment only; it documents why the pre-existing `httpx.RequestNotRead` guard around `request.content` matters for multipart uploads. There is no behavior change in that file.

Tests live in `tests/proxy_unit_tests/test_vantage_endpoints.py` and cover the status-code helper across the direct, nested, and default cases, plus an end-to-end check that a masked upstream `422` is preserved through `vantage_export` rather than rewritten to `500`.
