### PR TITLE
perf(anthropic_messages): remove thread hop in aanthropic_messages dispatch

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
@@ -6,8 +6,6 @@
 """
 
 import asyncio
-import contextvars
-from functools import partial
 from typing import (
     Any,
     AsyncIterator,
@@ -300,11 +298,9 @@ async def anthropic_messages(
                 **kwargs,
             )
 
-    loop = asyncio.get_event_loop()
     kwargs["is_async"] = True
 
-    func = partial(
-        anthropic_messages_handler,
+    response = anthropic_messages_handler(
         max_tokens=max_tokens,
         messages=messages,
         model=model,
@@ -330,14 +326,11 @@ async def anthropic_messages(
         _litellm_messages_presanitized=True,
         **kwargs,
     )
-    ctx = contextvars.copy_context()
-    func_with_context = partial(ctx.run, func)
-    init_response = await loop.run_in_executor(None, func_with_context)
-
-    if asyncio.iscoroutine(init_response):
-        response = await init_response
-    else:
-        response = init_response
+    # ``anthropic_messages_handler`` returns a coroutine on the async backend
+    # paths but a materialized response on the ``mock_response`` shortcut, so
+    # only await when there is something to await.
+    if asyncio.iscoroutine(response):
+        return await response
     return response
 
 

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import os
 import sys
@@ -673,3 +674,33 @@ async def test_async_wrapper_sets_presanitized_and_sanitizes_once():
     assert spy.call_count == 1
     assert captured["presanitized"] is True
     assert [b["type"] for b in captured["messages"][0]["content"]] == ["tool_use"]
+
+
+@pytest.mark.asyncio
+async def test_aanthropic_messages_does_not_use_thread_executor():
+    """The async Anthropic /messages entry must dispatch the handler directly on
+    the running event loop, never through ``loop.run_in_executor``.
+
+    Mutation control: revert handler.py to
+    ``await loop.run_in_executor(None, func_with_context)`` and this test must
+    fail with AssertionError('thread hop fired').
+    """
+    from litellm.llms.anthropic.experimental_pass_through.messages import handler
+
+    loop = asyncio.get_running_loop()
+
+    def fail_on_thread_hop(*args, **kwargs):
+        raise AssertionError("thread hop fired")
+
+    with patch.object(loop, "run_in_executor", side_effect=fail_on_thread_hop):
+        response = await handler.anthropic_messages(
+            max_tokens=8,
+            messages=[{"role": "user", "content": "hi"}],
+            model="anthropic/claude-3-5-haiku-20241022",
+            custom_llm_provider="anthropic",
+            api_key="sk-test",
+            stream=False,
+            mock_response="pong",
+        )
+
+    assert response["content"][0]["text"] == "pong"


### PR DESCRIPTION
## Relevant issues

n/a

## Linear ticket

n/a

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## What this changes

The async Anthropic `/messages` entry point (`anthropic_messages`) dispatched `anthropic_messages_handler` through `loop.run_in_executor(None, func_with_context)`, wrapping the call in a copied `contextvars` context and a `functools.partial`. This change dispatches the handler directly on the running event loop and awaits the result

## Why the thread hop was unnecessary

`anthropic_messages_handler` is `@client`-decorated. When `is_async=True` is set (which `anthropic_messages` always sets right before dispatch), the decorator's async wrapper returns a coroutine immediately rather than performing any blocking work. So `run_in_executor` was handing the default `ThreadPoolExecutor` a function whose only job was to return a coroutine, which the event loop then awaited anyway. No blocking work ever ran on the worker thread; the hop was pure scheduling overhead, and it contended for the default executor that is shared with sync logging callbacks and other blocking SDK calls

The `asyncio.iscoroutine` guard is retained on purpose. The `mock_response` shortcut inside the handler returns a materialized dict regardless of `is_async`, so a flat unconditional `await` would crash that path. The code now awaits only when the return value is actually a coroutine

## Expected impact

Less contention on the default `ThreadPoolExecutor` under concurrency, a small p50 latency reduction per request from skipping the executor round trip, and better throughput when many `/messages` calls are in flight at once. No behavior change for callers; streaming and non-streaming responses are identical

## Screenshots / Proof of Fix

Run a proxy against a real Anthropic key and confirm a normal streamed response with no thread-pool contention in the logs

1. Start the proxy

```
python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log
```

2. Hit the Anthropic `/v1/messages` pass-through with a real streaming request (this calls the live Anthropic API and costs real money)

```
curl -sN http://localhost:4000/v1/messages \
  -H "Authorization: Bearer sk-1234" \
  -H "anthropic-version: 2023-06-01" \
  -H "content-type: application/json" \
  -d '{
    "model": "claude-sonnet-4-5",
    "max_tokens": 64,
    "stream": true,
    "messages": [{"role": "user", "content": "Say hello in one short sentence."}]
  }'
```

3. Confirm a non-streaming request still returns a materialized body (this exercises the retained `iscoroutine` guard)

```
curl -s http://localhost:4000/v1/messages \
  -H "Authorization: Bearer sk-1234" \
  -H "anthropic-version: 2023-06-01" \
  -H "content-type: application/json" \
  -d '{
    "model": "claude-sonnet-4-5",
    "max_tokens": 64,
    "messages": [{"role": "user", "content": "Say hello in one short sentence."}]
  }'
```

## Regression test

`test_aanthropic_messages_does_not_use_thread_executor` patches `run_in_executor` on the running loop to raise, then drives `anthropic_messages` through the `mock_response` shortcut and asserts the response comes back without the executor ever firing. Mutation control: reverting the handler to `await loop.run_in_executor(None, func_with_context)` makes the test fail with `AssertionError('thread hop fired')`, and restoring the direct dispatch makes it pass, so the test pins the exact behavior this PR introduces

## Type

🚄 Infrastructure

## Changes

`anthropic_messages` in `litellm/llms/anthropic/experimental_pass_through/messages/handler.py` now calls `anthropic_messages_handler` directly and awaits only when the result is a coroutine; the unused `contextvars` and `functools.partial` imports are dropped. A regression test is added in `tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py`