### PR TITLE
fix(redis): apply namespace prefix in delete_cache and async_delete_cache

### DIFF
--- a/litellm/caching/redis_cache.py
+++ b/litellm/caching/redis_cache.py
@@ -1322,10 +1322,11 @@ class RedisCache(BaseCache):
     async def async_delete_cache(self, key: str):
         # typed as Any, redis python lib has incomplete type stubs for RedisCluster and does not include `delete`
         _redis_client: Any = self.init_async_client()
-        # keys is str
+        key = self.check_and_fix_namespace(key=key)
         return await _redis_client.delete(key)
 
     def delete_cache(self, key):
+        key = self.check_and_fix_namespace(key=key)
         self.redis_client.delete(key)
 
     async def _pipeline_increment_helper(

--- a/tests/test_litellm/caching/test_redis_cache.py
+++ b/tests/test_litellm/caching/test_redis_cache.py
@@ -3,7 +3,6 @@ import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
-from fastapi.testclient import TestClient
 
 sys.path.insert(
     0, os.path.abspath("../../..")
@@ -92,6 +91,42 @@ async def test_redis_cache_async_increment_default_does_not_bump_existing_ttl(
         await redis_cache.async_increment(key="rate_limit:window", value=1)
 
     mock_redis_instance.expire.assert_not_awaited()
+
+
+@pytest.mark.parametrize("namespace", [None, "litellm"])
+@pytest.mark.asyncio
+async def test_async_delete_cache_applies_namespace(
+    namespace, monkeypatch, redis_no_ping
+):
+    """async_delete_cache must prefix keys with the namespace, matching every
+    other cache operation. Without this, Redis NOPERM errors occur when an
+    ACL restricts DEL to the litellm:* pattern."""
+    monkeypatch.setenv("REDIS_HOST", "https://my-test-host")
+    redis_cache = RedisCache(namespace=namespace)
+    mock_redis_instance = AsyncMock()
+
+    with patch.object(
+        redis_cache, "init_async_client", return_value=mock_redis_instance
+    ):
+        await redis_cache.async_delete_cache(key="3997c4abcdef")
+
+    expected_key = "litellm:3997c4abcdef" if namespace else "3997c4abcdef"
+    mock_redis_instance.delete.assert_awaited_once_with(expected_key)
+
+
+@pytest.mark.parametrize("namespace", [None, "litellm"])
+def test_delete_cache_applies_namespace(namespace, monkeypatch, redis_no_ping):
+    """delete_cache must prefix keys with the namespace, matching every other
+    cache operation."""
+    monkeypatch.setenv("REDIS_HOST", "https://my-test-host")
+    redis_cache = RedisCache(namespace=namespace)
+    mock_redis_client = MagicMock()
+    redis_cache.redis_client = mock_redis_client
+
+    redis_cache.delete_cache(key="3997c4abcdef")
+
+    expected_key = "litellm:3997c4abcdef" if namespace else "3997c4abcdef"
+    mock_redis_client.delete.assert_called_once_with(expected_key)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement**
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

Bug Fix

## Changes

`delete_cache` and `async_delete_cache` in `RedisCache` were the only cache operations that skipped `check_and_fix_namespace`. Every other operation (get, set, increment) already calls it, so keys are stored and read as `litellm:<hash>`. The delete path was passing the raw SHA256 hash directly to Redis, causing two problems:

1. On deployments with a Redis ACL restricting DEL to the `litellm:*` pattern, the command was rejected with NOPERM.
2. On all other deployments, the DEL was a silent no-op — the un-prefixed key was never stored, so nothing was actually evicted from the cache.

The fix is two lines: call `check_and_fix_namespace` in both delete methods, matching the behavior of every other cache operation.

## Screenshots / Proof of Fix

Start the proxy and update a key on a deployment with `namespace: litellm` in the Redis cache config. Before this fix, the update either returns NOPERM or silently fails to evict the stale cache entry. After the fix, the delete targets `litellm:<hash>`, matching the stored key.