### PR TITLE
fix(proxy): recover from cached-plan errors by reconnecting the Prisma client

### DIFF
--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -3252,40 +3252,49 @@ class PrismaClient:
         self, sql_query: str, *args
     ) -> Optional[dict]:
         """
-        Execute a query with automatic fallback for PostgreSQL cached plan errors.
+        Execute a query, recovering once from PostgreSQL's "cached plan must not
+        change result type" error.
 
-        This handles the "cached plan must not change result type" error that occurs
-        during rolling deployments when schema changes are applied while old pods
-        still have cached query plans expecting the old schema.
+        That error surfaces during rolling deployments when a schema change
+        invalidates the prepared-statement plans that pooled connections still
+        hold. Clearing only the server-side plans with DEALLOCATE ALL makes
+        things worse: Prisma's query engine keeps a per-connection client-side
+        cache of prepared-statement names, so once the server drops a plan the
+        engine re-sends a name PostgreSQL no longer recognizes and the
+        connection breaks with `prepared statement "sN" does not exist`. With a
+        small pool that connection stays poisoned and every auth lookup fails.
 
-        Args:
-            sql_query: SQL query string to execute
+        Recreating the Prisma client kills the engine subprocess and drops the
+        server-side plans and the engine's client-side name cache together, so
+        the retried query is prepared fresh. We reconnect through
+        `attempt_db_reconnect`, which is singleflight: when a schema change
+        poisons every pooled connection at once, the first cached-plan error
+        recreates the client and the concurrent waiters reuse that single
+        recreate instead of racing to kill each other's fresh engine. We then
+        retry the identical query exactly once.
 
-        Returns:
-            Query result or None
+        The retry reuses the original query byte-for-byte. Mutating the SQL
+        (e.g. injecting a unique comment) would defeat PostgreSQL's plan cache,
+        forcing a fresh plan on every request and pegging the database CPU.
 
-        Raises:
-            Original exception if not a cached plan error
+        If the reconnect is skipped because a recent reconnect is still within
+        its cooldown, the retry runs against the same connection and may fail
+        again; the get_data backoff decorator re-runs the lookup and a later
+        attempt reconnects once the cooldown elapses.
         """
         try:
             return await self.db.query_first(sql_query, *args)
         except Exception as e:
-            error_str = str(e)
-            if "cached plan must not change result type" in error_str:
-                # Force PostgreSQL to re-plan by invalidating the cache
-                # Add a unique comment to make the query different
-                sql_query_retry = sql_query.replace(
-                    "SELECT",
-                    f"SELECT /* cache_invalidated_{int(time.time() * 1000)} */",
-                )
-                verbose_proxy_logger.warning(
-                    "PostgreSQL cached plan error detected for token lookup, "
-                    "retrying with fresh plan. This may occur during rolling deployments "
-                    "when schema changes are applied."
-                )
-                return await self.db.query_first(sql_query_retry, *args)
-            else:
+            if "cached plan must not change result type" not in str(e):
                 raise
+            verbose_proxy_logger.warning(
+                "PostgreSQL cached plan error detected for token lookup; "
+                "recreating the database connection and retrying with the same "
+                "query. This may occur during rolling deployments when schema "
+                "changes are applied."
+            )
+            await self.attempt_db_reconnect(reason="postgres_cached_plan_error")
+            return await self.db.query_first(sql_query, *args)
 
     @backoff.on_exception(
         backoff.expo,

--- a/tests/test_litellm/proxy/utils/prisma_and_spend/test_prisma_client_get_data.py
+++ b/tests/test_litellm/proxy/utils/prisma_and_spend/test_prisma_client_get_data.py
@@ -193,6 +193,7 @@ async def test_query_first_with_cached_plan_fallback_happy_returns_row(
 ) -> None:
     expected = {"token": "abc", "team_spend": 1.0, "team_max_budget": 5.0}
     prisma_client.db.query_first = AsyncMock(return_value=expected)
+    prisma_client.attempt_db_reconnect = AsyncMock(return_value=True)
     result = await prisma_client._query_first_with_cached_plan_fallback(
         "SELECT * FROM x WHERE token = $1", "abc"
     )
@@ -208,35 +209,110 @@ async def test_query_first_with_cached_plan_fallback_happy_returns_row(
         "args": ("SELECT * FROM x WHERE token = $1", "abc"),
         "matches": True,
     }
+    prisma_client.attempt_db_reconnect.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_query_first_with_cached_plan_fallback_retries_on_cached_plan_error(
+async def test_query_first_with_cached_plan_fallback_reconnects_then_retries_identical_query(
     prisma_client: PrismaClient,
 ) -> None:
+    original_query = 'SELECT * FROM "LiteLLM_VerificationToken" WHERE v.token = $1'
     expected = {"token": "abc", "team_spend": 1.0, "team_max_budget": 5.0}
+    manager = MagicMock()
+    query_first = AsyncMock(
+        side_effect=[
+            RuntimeError("cached plan must not change result type"),
+            expected,
+        ]
+    )
+    reconnect = AsyncMock(return_value=True)
+    manager.attach_mock(query_first, "query_first")
+    manager.attach_mock(reconnect, "attempt_db_reconnect")
+    prisma_client.db.query_first = query_first
+    prisma_client.attempt_db_reconnect = reconnect
+
+    result = await prisma_client._query_first_with_cached_plan_fallback(
+        original_query, "abc"
+    )
+
+    assert result == expected
+    assert query_first.await_count == 2
+    first_call, retry_call = query_first.await_args_list
+    assert retry_call.args == first_call.args == (original_query, "abc")
+    reconnect.assert_awaited_once()
+    assert reconnect.await_args.kwargs.get("force", False) is False
+    assert [name for name, *_ in manager.mock_calls] == [
+        "query_first",
+        "attempt_db_reconnect",
+        "query_first",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_query_first_with_cached_plan_fallback_never_deallocates(
+    prisma_client: PrismaClient,
+) -> None:
+    expected = {"token": "abc"}
     prisma_client.db.query_first = AsyncMock(
         side_effect=[
             RuntimeError("cached plan must not change result type"),
             expected,
         ]
     )
-    result = await prisma_client._query_first_with_cached_plan_fallback(
-        "SELECT * FROM x WHERE token = $1", "abc"
+    prisma_client.db.execute_raw = AsyncMock(return_value=0)
+    prisma_client.attempt_db_reconnect = AsyncMock(return_value=True)
+
+    await prisma_client._query_first_with_cached_plan_fallback("SELECT 1")
+
+    prisma_client.db.execute_raw.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_query_first_with_cached_plan_fallback_propagates_when_retry_also_fails(
+    prisma_client: PrismaClient,
+) -> None:
+    plan_error = RuntimeError("cached plan must not change result type")
+    prisma_client.db.query_first = AsyncMock(side_effect=[plan_error, plan_error])
+    prisma_client.attempt_db_reconnect = AsyncMock(return_value=True)
+
+    with pytest.raises(RuntimeError, match="cached plan must not change result type"):
+        await prisma_client._query_first_with_cached_plan_fallback("SELECT 1")
+
+    assert prisma_client.db.query_first.await_count == 2
+    prisma_client.attempt_db_reconnect.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_query_first_with_cached_plan_fallback_retries_when_reconnect_returns_false(
+    prisma_client: PrismaClient,
+) -> None:
+    expected = {"token": "abc"}
+    prisma_client.db.query_first = AsyncMock(
+        side_effect=[
+            RuntimeError("cached plan must not change result type"),
+            expected,
+        ]
     )
+    prisma_client.attempt_db_reconnect = AsyncMock(return_value=False)
+
+    result = await prisma_client._query_first_with_cached_plan_fallback("SELECT 1")
+
     assert result == expected
     assert prisma_client.db.query_first.await_count == 2
-    second_call_sql = prisma_client.db.query_first.await_args_list[1].args[0]
-    assert "cache_invalidated_" in second_call_sql
 
 
 @pytest.mark.asyncio
 async def test_query_first_with_cached_plan_fallback_reraises_non_plan_errors(
     prisma_client: PrismaClient,
 ) -> None:
-    prisma_client.db.query_first = AsyncMock(side_effect=RuntimeError("totally unrelated"))
+    prisma_client.db.query_first = AsyncMock(
+        side_effect=RuntimeError("totally unrelated")
+    )
+    prisma_client.attempt_db_reconnect = AsyncMock(return_value=True)
     with pytest.raises(RuntimeError, match="totally unrelated"):
         await prisma_client._query_first_with_cached_plan_fallback("SELECT 1")
+    assert prisma_client.db.query_first.await_count == 1
+    prisma_client.attempt_db_reconnect.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -351,7 +427,9 @@ async def test_get_data_token_find_unique_returns_record(
 async def test_get_data_token_find_unique_missing_token_raises_401(
     prisma_client: PrismaClient,
 ) -> None:
-    prisma_client.db.litellm_verificationtoken.find_unique = AsyncMock(return_value=None)
+    prisma_client.db.litellm_verificationtoken.find_unique = AsyncMock(
+        return_value=None
+    )
     with pytest.raises(HTTPException) as excinfo:
         await prisma_client.get_data(token="sk-missing", table_name="key")
     err = excinfo.value


### PR DESCRIPTION
## Relevant issues

Relates to #19424

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Baseline for all before/after comparisons below is `litellm_internal_staging`, the base branch of this PR.

During a rolling deployment a schema change invalidates the prepared-statement plans that pooled connections still hold, and the next auth lookup fails with PostgreSQL's "cached plan must not change result type". On staging, `_query_first_with_cached_plan_fallback` recovers by retrying with a unique millisecond-timestamp comment injected into the SQL. The request succeeds, but because the retry text is unique every time, PostgreSQL can never cache a plan for it, and because nothing fixes the poisoned connection, the first attempt keeps failing on every subsequent request. Every auth lookup pays a failed attempt plus a full re-plan of the 9-table join, forever, until connections recycle. At fleet scale this pegs the database writer CPU (the production incident this PR addresses).

This PR recovers by recreating the Prisma client through the existing singleflight `attempt_db_reconnect`. Recreating the client kills the engine subprocess, which drops the server-side plans and the engine's client-side prepared-statement name cache together, so the retried query is prepared fresh. The retry reuses the SQL byte-for-byte, so PostgreSQL's plan cache keeps working and the error clears after a single reconnect instead of recurring on every request.

### Live repro setup

Postgres 17 in Docker, proxy on port 4101 with `database_connection_pool_limit: 1` for determinism. Auth results cache per key, so every DB-hitting request uses a fresh key. Keys are generated before the `ALTER` so key-generation inserts are not entangled in the repro.

```bash
docker run -d --name pg-29983 -e POSTGRES_PASSWORD=pw -e POSTGRES_DB=litellm -p 5501:5432 postgres:17

# config.yaml: one openai/gpt-4o fake-key model; general_settings.database_connection_pool_limit: 1
DATABASE_URL="postgresql://postgres:pw@localhost:5501/litellm" LITELLM_MASTER_KEY=sk-1234 \
  STORE_MODEL_IN_DB=False python litellm/proxy/proxy_cli.py --config config.yaml --port 4101

# 1. generate 14 keys (models=["gpt-4o"]) via POST /key/generate
# 2. warm 8 fresh keys on GET /v1/models (prime the prepared-statement plans)
# 3. ALTER TABLE "LiteLLM_VerificationToken" ADD COLUMN repro_col TEXT;
# 4. trigger 6 fresh keys on GET /v1/models; then 4 more for recovery
```

### Before (litellm_internal_staging): requests succeed but every post-ALTER lookup re-plans

All 6 trigger requests return HTTP 200, but the proxy log shows the cached-plan warning firing on every single one (6 warnings for 6 requests), because the timestamp-comment retry never repairs the poisoned plan and never lets PostgreSQL cache the retry:

```
WARNING utils.py:3281 - PostgreSQL cached plan error detected for token lookup, retrying with fresh plan. This may occur during rolling deployments when schema changes are applied.   # x6, one per request
```

This is the per-request failed-attempt-plus-re-plan loop that pegs the DB CPU at fleet scale.

### After (this PR, reconnect): all requests succeed and the connection recovers

```
### Trigger: 6 fresh keys on GET /v1/models ###
trigger req 1: HTTP 200
trigger req 2: HTTP 200
trigger req 3: HTTP 200
trigger req 4: HTTP 200
trigger req 5: HTTP 200
trigger req 6: HTTP 200
TRIGGER_PASS=6/6

### Recovery probe: 4 more fresh keys ###
recovery req 1: HTTP 200
recovery req 2: HTTP 200
recovery req 3: HTTP 200
recovery req 4: HTTP 200
RECOVERY_PASS=4/4
```

Exactly one cached-plan warning, one reconnect, zero 26000 errors, and no recurring warnings afterward:

```
WARNING utils.py:3290 - PostgreSQL cached plan error detected for token lookup; recreating the database connection and retrying with the same query. ...
WARNING utils.py:4730 - Attempting Prisma DB reconnect. reason=postgres_cached_plan_error
WARNING prisma_client.py:155 - Sent SIGTERM to prisma-query-engine PID 24005 during reconnect.
query-engine ac9d7041ed77bcc8a8dbd2ab6616b39013829574
INFO:     127.0.0.1 - "GET /v1/models HTTP/1.1" 200 OK   # retried lookup succeeds on the fresh engine
```

### Unit tests

```bash
python -m pytest tests/test_litellm/proxy/utils/prisma_and_spend/test_prisma_client_get_data.py -k cached_plan -q
# 6 passed
```

The cached-plan tests fail on the old DEALLOCATE ALL code (they assert `attempt_db_reconnect` is awaited and that `DEALLOCATE ALL` is never sent) and pass on this commit.

## Type

🐛 Bug Fix

## Changes

On `litellm_internal_staging`, `_query_first_with_cached_plan_fallback` retries the cached-plan error with a unique millisecond-timestamp comment injected into the SQL, which defeats PostgreSQL's plan cache on every retry and never repairs the poisoned connection (see Proof of Fix above). This PR removes the SQL mutation entirely. On the cached-plan error it logs a warning, reconnects via the existing singleflight `attempt_db_reconnect(reason="postgres_cached_plan_error")`, and retries the identical query once. Using the shared reconnect path means a schema change that poisons every pooled connection at once triggers a single client recreate that concurrent waiters reuse, rather than each request racing to kill the others' fresh engine. The retry SQL is unchanged byte-for-byte so the plan cache keeps working after recovery.

