### PR TITLE
feat(proxy): add option to disable server-side prepared statements for DB lookups

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2177,6 +2177,17 @@ class ConfigGeneralSettings(LiteLLMPydanticObjectBase):
             "`statement_cache_size`). Keys here override any default LiteLLM sets."
         ),
     )
+    database_disable_prepared_statements: Optional[bool] = Field(
+        None,
+        description=(
+            "Disable server-side prepared statements by setting Prisma's "
+            "`pgbouncer=true` URL param. Use this for pgbouncer transaction-pooling "
+            "deployments, or to prevent the 'cached plan must not change result "
+            "type' error that pooled connections hit during rolling schema "
+            "migrations. An explicit `pgbouncer` in `database_extra_connection_params` "
+            "takes precedence."
+        ),
+    )
     database_type: Optional[Literal["dynamo_db"]] = Field(
         None, description="to use dynamodb instead of postgres db"
     )

--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -44,15 +44,19 @@ def _build_db_connection_url_params(
     pool_timeout: Optional[Union[int, float]],
     connect_timeout: Optional[Union[int, float]] = None,
     socket_timeout: Optional[Union[int, float]] = None,
+    disable_prepared_statements: bool = False,
     extra_params: Optional[dict] = None,
 ) -> dict:
     """Build the Prisma DATABASE_URL query params controlling connection pool behavior.
 
     `connect_timeout` / `socket_timeout` map to the Prisma URL params of the same
     name (https://www.prisma.io/docs/orm/overview/databases/postgresql) and are
-    omitted when None so Prisma's defaults apply. `extra_params` is an
-    untyped passthrough — keys it provides win over the named arguments above,
-    so it can be used to override any default we set here.
+    omitted when None so Prisma's defaults apply. `disable_prepared_statements`
+    sets `pgbouncer=true`, which makes Prisma stop using server-side prepared
+    statements (pgbouncer transaction-pool compatible; also sidesteps the
+    "cached plan must not change result type" error during rolling migrations).
+    `extra_params` is an untyped passthrough — keys it provides win over the
+    named arguments above, so it can be used to override any default we set here.
     """
     params: dict = {
         "connection_limit": connection_limit,
@@ -63,6 +67,8 @@ def _build_db_connection_url_params(
         params["connect_timeout"] = connect_timeout
     if socket_timeout is not None:
         params["socket_timeout"] = socket_timeout
+    if disable_prepared_statements:
+        params["pgbouncer"] = "true"
     if extra_params:
         params.update(extra_params)
     return params
@@ -963,6 +969,7 @@ def run_server(  # noqa: PLR0915
         db_connection_timeout: Optional[Union[int, float]] = 60
         db_connect_timeout: Optional[Union[int, float]] = None
         db_socket_timeout: Optional[Union[int, float]] = None
+        db_disable_prepared_statements: bool = False
         db_extra_connection_params: Optional[dict] = None
         general_settings = {}
         ### GET DB TOKEN FOR IAM AUTH ###
@@ -1083,6 +1090,17 @@ def run_server(  # noqa: PLR0915
                 )
             db_connect_timeout = general_settings.get("database_connect_timeout")
             db_socket_timeout = general_settings.get("database_socket_timeout")
+            _disable_prepared_statements = general_settings.get(
+                "database_disable_prepared_statements", False
+            )
+            if isinstance(_disable_prepared_statements, str):
+                from litellm.secret_managers.main import str_to_bool
+
+                db_disable_prepared_statements = (
+                    str_to_bool(_disable_prepared_statements) is True
+                )
+            else:
+                db_disable_prepared_statements = bool(_disable_prepared_statements)
             db_extra_connection_params = general_settings.get(
                 "database_extra_connection_params"
             )
@@ -1130,6 +1148,7 @@ def run_server(  # noqa: PLR0915
                     pool_timeout=db_connection_timeout,
                     connect_timeout=db_connect_timeout,
                     socket_timeout=db_socket_timeout,
+                    disable_prepared_statements=db_disable_prepared_statements,
                     extra_params=db_extra_connection_params,
                 )
                 if os.getenv("DATABASE_URL", None) is not None:

--- a/tests/test_litellm/proxy/test_proxy_cli.py
+++ b/tests/test_litellm/proxy/test_proxy_cli.py
@@ -795,6 +795,127 @@ class TestProxyInitializationHelpers:
             assert appended_params["pgbouncer"] == "true"
             assert appended_params["statement_cache_size"] == 0
 
+    def test_build_db_connection_url_params_disable_prepared_statements(self):
+        from litellm.proxy.proxy_cli import _build_db_connection_url_params
+
+        params = _build_db_connection_url_params(
+            connection_limit=10,
+            pool_timeout=60,
+            disable_prepared_statements=True,
+        )
+        assert params["pgbouncer"] == "true"
+
+    def test_build_db_connection_url_params_no_pgbouncer_by_default(self):
+        from litellm.proxy.proxy_cli import _build_db_connection_url_params
+
+        params = _build_db_connection_url_params(
+            connection_limit=10,
+            pool_timeout=60,
+        )
+        assert "pgbouncer" not in params
+
+    def test_build_db_connection_url_params_extra_pgbouncer_overrides_flag(self):
+        from litellm.proxy.proxy_cli import _build_db_connection_url_params
+
+        params = _build_db_connection_url_params(
+            connection_limit=10,
+            pool_timeout=60,
+            disable_prepared_statements=True,
+            extra_params={"pgbouncer": "false"},
+        )
+        assert params["pgbouncer"] == "false"
+
+    @pytest.mark.parametrize(
+        "config_value, expect_pgbouncer",
+        [
+            (True, True),
+            (False, False),
+            ("true", True),
+            ("false", False),
+            ("not-a-bool", False),
+        ],
+    )
+    @patch("subprocess.run")
+    @patch("atexit.register")
+    @patch("litellm.proxy.db.prisma_client.PrismaManager.setup_database")
+    @patch(
+        "litellm.proxy.db.prisma_client.should_update_prisma_schema", return_value=False
+    )
+    def test_disable_prepared_statements_forwarded_to_url(
+        self,
+        mock_should_update,
+        mock_setup_db,
+        mock_atexit_register,
+        mock_subprocess_run,
+        config_value,
+        expect_pgbouncer,
+    ):
+        from click.testing import CliRunner
+
+        from litellm.proxy.proxy_cli import run_server
+
+        runner = CliRunner()
+        mock_subprocess_run.return_value = MagicMock(returncode=0)
+
+        mock_proxy_module = MagicMock(
+            app=MagicMock(),
+            ProxyConfig=MagicMock(),
+            KeyManagementSettings=MagicMock(),
+            save_worker_config=MagicMock(),
+        )
+        mock_proxy_module.ProxyConfig.return_value.get_config = AsyncMock(
+            return_value={
+                "general_settings": {
+                    "database_url": "postgresql://test:test@localhost:5432/test",
+                    "database_disable_prepared_statements": config_value,
+                }
+            }
+        )
+
+        clean_env = {
+            k: v
+            for k, v in os.environ.items()
+            if k not in ("DATABASE_URL", "DIRECT_URL")
+        }
+
+        with (
+            patch.dict(os.environ, clean_env, clear=True),
+            patch.dict(
+                "sys.modules",
+                {
+                    "proxy_server": mock_proxy_module,
+                    "litellm.proxy.proxy_server": mock_proxy_module,
+                },
+            ),
+            patch(
+                "litellm.proxy.proxy_cli.ProxyInitializationHelpers._get_default_unvicorn_init_args"
+            ) as mock_get_args,
+            patch(
+                "litellm.proxy.proxy_cli.append_query_params",
+                side_effect=lambda url, params: str(url),
+            ) as mock_append_query_params,
+        ):
+            mock_get_args.return_value = {
+                "app": "litellm.proxy.proxy_server:app",
+                "host": "localhost",
+                "port": 8000,
+            }
+
+            result = runner.invoke(
+                run_server,
+                ["--local", "--config", "test-config.yaml", "--skip_server_startup"],
+            )
+
+            assert (
+                result.exit_code == 0
+            ), f"exit_code={result.exit_code}, output={result.output}"
+            mock_append_query_params.assert_called()
+            appended_params = mock_append_query_params.call_args.args[1]
+            if expect_pgbouncer:
+                assert appended_params["pgbouncer"] == "true"
+            else:
+                assert "pgbouncer" not in appended_params
+
     @patch("uvicorn.run")
     @patch("atexit.register")
     @patch("litellm.proxy.db.prisma_client.PrismaManager.setup_database")

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -22013,6 +22013,11 @@ export interface components {
              */
             database_connection_timeout: number | null;
             /**
+             * Database Disable Prepared Statements
+             * @description Disable server-side prepared statements by setting Prisma's `pgbouncer=true` URL param. Use this for pgbouncer transaction-pooling deployments, or to prevent the 'cached plan must not change result type' error that pooled connections hit during rolling schema migrations. An explicit `pgbouncer` in `database_extra_connection_params` takes precedence.
+             */
+            database_disable_prepared_statements?: boolean | null;
+            /**
              * Database Extra Connection Params
              * @description Escape hatch: extra key/value pairs appended verbatim to the Prisma DATABASE_URL / DIRECT_URL query string (e.g. `sslmode`, `pgbouncer`, `statement_cache_size`). Keys here override any default LiteLLM sets.
              */


### PR DESCRIPTION
## Relevant issues

Preventative complement to the cached-plan retry fix. During rolling deployments, pooled Postgres connections can hold prepared-statement plans that a concurrent schema migration invalidates, producing `cached plan must not change result type`. The retry path recovers after the fact; this PR lets operators turn the failure mode off entirely for deployments where it is a known problem (pgbouncer transaction pooling, frequent migrations)

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Verified live against a real Postgres 16 instance with the new flag enabled, making real requests to the OpenAI API. Every database read and write went through the connection that has `pgbouncer=true` appended.

Config used (`/tmp/pr29984_live_config.yaml`):

```yaml
model_list:
  - model_name: gpt-4.1-mini
    litellm_params:
      model: openai/gpt-4.1-mini
      api_key: os.environ/OPENAI_API_KEY

general_settings:
  master_key: sk-1234
  database_url: postgresql://litellm:litellm@localhost:5433/litellm
  database_disable_prepared_statements: true
```

1. Start a dedicated Postgres and the proxy on port 4010

```bash
docker run -d --name litellm-pr29984-live -e POSTGRES_USER=litellm -e POSTGRES_PASSWORD=litellm -e POSTGRES_DB=litellm -p 5433:5432 postgres:16

python litellm/proxy/proxy_cli.py --config /tmp/pr29984_live_config.yaml --port 4010 --detailed_debug
```

The proxy boots, runs migrations against the real DB, and starts serving:

```
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:4010 (Press CTRL+C to quit)
```

2. Health check

```bash
curl -s http://localhost:4010/health/liveliness
```
```
"I'm alive!"
```

3. Real chat completion through the proxy (hits the live OpenAI API)

```bash
curl -s http://localhost:4010/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model": "gpt-4.1-mini", "messages": [{"role": "user", "content": "Say hello in 5 words"}]}'
```
```json
{"id":"chatcmpl-DpKWjfc1NfZMK7IqjKhJfCu0wQkvV","model":"gpt-4.1-mini","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"Hello! Hope you’re doing well!","role":"assistant"}}],"usage":{"completion_tokens":8,"prompt_tokens":13,"total_tokens":21}}
```

4. Generate a virtual key (a DB write through the pgbouncer-mode connection)

```bash
curl -s http://localhost:4010/key/generate \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"models": ["gpt-4.1-mini"], "key_alias": "pr29984-live-test"}'
```
```json
{"key_alias":"pr29984-live-test","key":"sk-lDmw_pCGLtgS7jL-pCglog","token_id":"ea5e107a0b6a35427b05598677c29ae165bcd51aff3e0da1500f6c646aad8ee0","created_at":"2026-06-10T21:13:33.407000Z"}
```

5. Use the generated key (a DB read; auth lookup resolves the key from Postgres, then the request hits OpenAI)

```bash
curl -s http://localhost:4010/v1/chat/completions \
  -H "Authorization: Bearer sk-lDmw_pCGLtgS7jL-pCglog" -H "Content-Type: application/json" \
  -d '{"model": "gpt-4.1-mini", "messages": [{"role": "user", "content": "Reply with the single word: pong"}]}'
```
```json
{"id":"chatcmpl-DpKWr7W1YFLKA62gu2dVN7XaXXHeH","model":"gpt-4.1-mini","choices":[{"finish_reason":"stop","message":{"content":"pong","role":"assistant"}}],"usage":{"completion_tokens":1,"prompt_tokens":14,"total_tokens":15}}
```

6. Confirm the key was actually persisted in the real Postgres

```bash
docker exec litellm-pr29984-live psql -U litellm -d litellm -t -A \
  -c "SELECT key_alias, key_name FROM \"LiteLLM_VerificationToken\" WHERE key_alias='pr29984-live-test';"
```
```
pr29984-live-test|sk-...glog
```

7. Confirm the flag actually appends `pgbouncer=true` to the Prisma DATABASE_URL, using the exact functions the proxy runs at startup

```bash
python3 - <<'PY'
import yaml
from litellm.proxy.proxy_cli import _build_db_connection_url_params, append_query_params
from litellm.secret_managers.main import str_to_bool
gs = yaml.safe_load(open("/tmp/pr29984_live_config.yaml"))["general_settings"]
raw = gs.get("database_disable_prepared_statements", False)
flag = (str_to_bool(raw) is True) if isinstance(raw, str) else bool(raw)
params = _build_db_connection_url_params(connection_limit=10, pool_timeout=60, disable_prepared_statements=flag)
print("resolved flag:", flag)
print("params:", params)
print("flag ON  ->", append_query_params(gs["database_url"], params))
off = _build_db_connection_url_params(connection_limit=10, pool_timeout=60, disable_prepared_statements=False)
print("flag OFF ->", append_query_params(gs["database_url"], off))
PY
```
```
resolved flag: True
params: {'connection_limit': 10, 'pool_timeout': 60, 'pgbouncer': 'true'}
flag ON  -> postgresql://litellm:litellm@localhost:5433/litellm?connection_limit=10&pool_timeout=60&pgbouncer=true
flag OFF -> postgresql://litellm:litellm@localhost:5433/litellm?connection_limit=10&pool_timeout=60
```

With the flag on, `pgbouncer=true` is appended; with it off, it is absent. The live proxy above ran with the flag on and successfully served completions and performed DB reads and writes against the real database, confirming the assembled URL is valid and fully functional.

### Migration scenario: reproducing and eliminating "cached plan must not change result type"

This demonstrates, on a live proxy against a real Postgres, the behavioral difference the flag introduces. The flag-off runs double as the before baseline: `database_disable_prepared_statements` does not exist on `litellm_internal_staging`, and with the flag off (the default) this branch builds the exact same DATABASE_URL and exhibits the exact same prepared-statement behavior as staging. The same schema migration that takes a proxy down with the flag off is harmless with it on.

Postgres 16 in Docker, with statement logging on so we can see exactly what Prisma sends:

```bash
docker run -d --name litellm-pr29984-mig -e POSTGRES_USER=litellm -e POSTGRES_PASSWORD=litellm -e POSTGRES_DB=litellm -p 5434:5432 postgres:16
docker exec litellm-pr29984-mig psql -U litellm -d litellm -c "ALTER SYSTEM SET log_statement = 'all';"
docker exec litellm-pr29984-mig psql -U litellm -d litellm -c "SELECT pg_reload_conf();"
```

Two configs, identical except for the flag:

```yaml
# /tmp/litellm_pr29984_off.yaml
general_settings:
  master_key: sk-1234
  database_url: postgresql://litellm:litellm@localhost:5434/litellm
  database_disable_prepared_statements: false

# /tmp/litellm_pr29984_on.yaml  (only this line differs)
  database_disable_prepared_statements: true
```

Proxy launched on port 4020 via the CLI so the DATABASE_URL rewrite in proxy_cli.py runs:

```bash
DISABLE_SCHEMA_UPDATE=true python litellm/proxy/proxy_cli.py \
  --config /tmp/litellm_pr29984_off.yaml --port 4020 --num_workers 1 --detailed_debug
```

DB-backed traffic is a virtual key plus repeated authenticated reads. Key auth issues a SELECT against `LiteLLM_VerificationToken` on every call, which is the query Prisma keeps as a server-side prepared statement:

```bash
GEN=$(curl -s http://localhost:4020/key/generate -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"key_alias":"pr29984"}')
NEWKEY=$(echo "$GEN" | python3 -c "import sys,json;print(json.load(sys.stdin)['key'])")
for i in $(seq 1 N); do curl -s "http://localhost:4020/key/info?key=$NEWKEY" -H "Authorization: Bearer $NEWKEY"; done
```

**What the flag actually changes.** The flag is not "prepared statements on vs off entirely". With it off, Prisma keeps one persistent named prepared statement per query and reuses it across requests on a pooled connection. With it on (pgbouncer=true), Prisma issues a fresh, uniquely named prepared statement per query and does not reuse a cached plan. The reused plan is the thing a migration invalidates, so removing the reuse removes the failure mode.

Statement names seen in the Postgres log for the same `LiteLLM_VerificationToken` SELECT, counted by name. Flag OFF (one plan reused):

```
1066 execute s25
   1 execute s30
   1 execute s28
   1 execute s27
```

Flag ON (every execution is a distinct, single-use statement):

```
   1 execute s68
   1 execute s67
   1 execute s66
   1 execute s65
   1 execute s64
   1 execute s63
   1 execute s62
```

A 60-request burst added 60 reused executions of `s25` with the flag off, and 60 distinct one-shot statements (s62, s63, ...) with the flag on.

**The migration failure (flag OFF).** The error fires when the result type of a column inside a cached plan changes under DDL. `LiteLLM_VerificationTokenView` references the base-table columns, so it was dropped first to allow the column type change (the view is unrelated to Prisma's cached statement, which reads the base table directly):

```bash
docker exec litellm-pr29984-mig psql -U litellm -d litellm -c 'DROP VIEW IF EXISTS "LiteLLM_VerificationTokenView";'
# warm the reused cached plan
for i in $(seq 1 120); do curl -s "http://localhost:4020/key/info?key=$NEWKEY" -H "Authorization: Bearer $NEWKEY" -o /dev/null; done
# the migration: a column inside the cached SELECT changes result type
docker exec litellm-pr29984-mig psql -U litellm -d litellm -c 'ALTER TABLE "LiteLLM_VerificationToken" ALTER COLUMN rotation_count TYPE BIGINT;'
# subsequent traffic on the same pooled connections
for i in $(seq 1 200); do curl -s -o /dev/null -w "%{http_code}\n" "http://localhost:4020/key/info?key=$NEWKEY" -H "Authorization: Bearer $NEWKEY"; done
```

Result with the flag off:

```
post-migration hammer: ok=0 fail=200        # every request returns HTTP 500
NEW cached-plan errors in POSTGRES log: 200
proxy log: ConnectorError(... QueryError(PostgresError { code: "0A000",
           message: "cached plan must not change result type", severity: "ERROR" ...
```

Every request after the migration fails until the stale plans are gone (connection recycling). This is the production symptom during a rolling deploy: old pods hold cached plans, a migration lands, and their pooled connections start returning errors.

**Same migration, flag ON.** Identical sequence (drop view, warm traffic, `ALTER COLUMN rotation_count TYPE BIGINT`, 200 follow-up requests), against the proxy started with `database_disable_prepared_statements: true`:

```
post-migration hammer (flag ON): ok=200 fail=0
NEW cached-plan errors in POSTGRES log: 0
NEW cached-plan errors in PROXY log: 0
```

No request fails, and Postgres logs no error. Because each query re-prepares against the current schema, there is no stale cached plan to break.

A note on migration shapes: a plain `ALTER TABLE ADD COLUMN` of an unrelated column did not trigger the error here, because Prisma selects an explicit column list rather than `SELECT *`, so adding a trailing column does not change the result type of those cached plans. The error needs the result type of a selected column to change (for example INT to BIGINT), or it bites raw `SELECT *` style queries and views. The flag protects the general case by never reusing a cached plan, so any of these migration shapes becomes safe.

Cleanup:

```bash
docker rm -f litellm-pr29984-mig
```

## Type

🆕 New Feature

## Changes

Adds `database_disable_prepared_statements` to `general_settings`. When true it appends Prisma's `pgbouncer=true` param to the proxy's `DATABASE_URL` / `DIRECT_URL`, which puts Prisma in pgbouncer transaction-pool compatible mode and stops the query engine from using server-side prepared statements. That also sidesteps the `cached plan must not change result type` error during rolling schema migrations.

The flag is threaded through `_build_db_connection_url_params` alongside the existing `connection_limit` / `pool_timeout` / `connect_timeout` / `socket_timeout` knobs, so it follows the same path every other DB connection setting already uses. An explicit `pgbouncer` value in `database_extra_connection_params` still wins, preserving the existing override precedence. String values for the flag (e.g. from `os.environ/` substitution) are coerced through `str_to_bool`, so `"false"` resolves to disabled rather than silently enabling; non-boolean strings also resolve to disabled, covered by a regression test.

Tests cover the param builder in isolation (flag on sets `pgbouncer=true`, flag off leaves it out, operator `pgbouncer=false` override wins) and a parametrized end-to-end assertion that `database_disable_prepared_statements` reaches the URL params during proxy startup for boolean, string, and non-boolean string config values.

