### PR TITLE
chore(release): bump version to 1.88.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "litellm"
-version = "1.88.0"
+version = "1.88.1"
 description = "Library to easily interface with LLM API providers"
 readme = "README.md"
 requires-python = ">=3.10, <3.14"
@@ -260,7 +260,7 @@ source-exclude = [
 profile = "black"
 
 [tool.commitizen]
-version = "1.88.0"
+version = "1.88.1"
 version_files = [
     "pyproject.toml:^version",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-06-05T23:44:32.616894Z"
+exclude-newer = "2026-06-05T23:54:44.890497Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -3276,7 +3276,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.88.0"
+version = "1.88.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Relevant issues

Cuts `1.88.1` on `stable/1.88.x` on top of the pyjwt/ws dependency bumps merged in #29987

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

This is a version-number bump only; no tests apply

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

```
# pyproject.toml
[project]      version = "1.88.1"
[tool.commitizen] version = "1.88.1"

# uv.lock -> editable litellm package
name = "litellm"
version = "1.88.1"
```

## Type

🚄 Infrastructure

## Changes

Bumps the litellm version from 1.88.0 to 1.88.1 for the `stable/1.88.x` patch that carries the pyjwt 2.13.0 and ws 8.20.1 dependency bumps from #29987. Updates the `[project]` and `[tool.commitizen]` versions in `pyproject.toml` and the editable litellm entry in `uv.lock`, following the same shape as prior version-bump PRs (for example #29242). The independently-versioned `litellm-proxy-extras` and `enterprise` packages are intentionally left untouched.
