### PR TITLE
fix(guardrails): read CrowdStrike AIDR identity from both metadata bags

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/crowdstrike_aidr/crowdstrike_aidr.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/crowdstrike_aidr/crowdstrike_aidr.py
@@ -105,6 +105,16 @@ def _extract_text_from_content(content: object) -> str:
     return ""
 
 
+def _merge_metadata_bags(request_data: Mapping[str, Any]) -> Optional[dict[str, Any]]:
+    merged: dict[str, Any] = {}
+    present = False
+    for bag in (request_data.get("metadata"), request_data.get("litellm_metadata")):
+        if isinstance(bag, Mapping):
+            present = True
+            merged.update(bag)
+    return merged if present else None
+
+
 class CrowdStrikeAIDRHandler(CustomGuardrail):
     """
     CrowdStrike AIDR AI Guardrail handler to interact with the CrowdStrike AIDR
@@ -321,8 +331,8 @@ class CrowdStrikeAIDRHandler(CustomGuardrail):
         if model:
             ai_guard_payload["model"] = model
 
-        metadata = request_data.get("litellm_metadata", request_data.get("metadata"))
-        if isinstance(metadata, Mapping):
+        metadata = _merge_metadata_bags(request_data)
+        if metadata is not None:
             user_id = metadata.get("user_api_key_user_id")
             if user_id:
                 ai_guard_payload["user_id"] = user_id

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_crowdstrike_aidr.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_crowdstrike_aidr.py
@@ -530,6 +530,56 @@ async def test_apply_guardrail_no_metadata_skips_user_fields(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "litellm_metadata, metadata",
+    [
+        (None, {"user_api_key_user_id": "uid-abc", "user_api_key_user_email": "alice@example.com"}),
+        ({"trace_id": "t1"}, {"user_api_key_user_id": "uid-abc", "user_api_key_user_email": "alice@example.com"}),
+        (["unexpected"], {"user_api_key_user_id": "uid-abc", "user_api_key_user_email": "alice@example.com"}),
+        ({"user_api_key_user_id": "uid-abc", "user_api_key_user_email": "alice@example.com"}, {"trace_id": "t1"}),
+    ],
+    ids=["identity_in_metadata_llm_none", "identity_in_metadata_llm_user_dict", "identity_in_metadata_llm_non_mapping", "identity_in_litellm_metadata"],
+)
+async def test_apply_guardrail_reads_identity_from_either_metadata_bag(
+    crowdstrike_aidr_guardrail: CrowdStrikeAIDRHandler,
+    litellm_metadata,
+    metadata,
+) -> None:
+    inputs: GenericGuardrailAPIInputs = {
+        "texts": ["Hello"],
+        "structured_messages": [{"role": "user", "content": "Hello"}],
+        "model": "gpt-4o",
+    }
+    request_data = {
+        "messages": inputs["structured_messages"],
+        "model": "gpt-4o",
+        "litellm_metadata": litellm_metadata,
+        "metadata": metadata,
+    }
+    guardrail_endpoint = (
+        f"{crowdstrike_aidr_guardrail.api_base}/v1/guard_chat_completions"
+    )
+
+    with patch(
+        "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+        return_value=httpx.Response(
+            status_code=200,
+            json={"result": {"blocked": False, "transformed": False}},
+            request=httpx.Request(method="POST", url=guardrail_endpoint),
+        ),
+    ) as mock_method:
+        await crowdstrike_aidr_guardrail.apply_guardrail(
+            inputs=inputs,
+            request_data=request_data,
+            input_type="request",
+        )
+
+    payload = mock_method.call_args.kwargs["json"]
+    assert payload["user_id"] == "uid-abc"
+    assert payload["extra_info"] == {"user_name": "alice@example.com"}
+
+
+@pytest.mark.asyncio
 async def test_apply_guardrail_request_skipped_messages_stay_aligned(
     crowdstrike_aidr_guardrail: CrowdStrikeAIDRHandler,
 ) -> None:


### PR DESCRIPTION
## Relevant issues

Follow-up to #29517, which added user and model metadata capture to the CrowdStrike AIDR guardrail. That change resolved the metadata from a single bag with `request_data.get("litellm_metadata", request_data.get("metadata"))`. Because `dict.get` returns the stored value when the key is present, a present `litellm_metadata` (an explicit `null`, or a caller-supplied dict used for tracing) shadows `metadata`, which is where `/chat/completions` actually places the authenticated identity. The result is that `user_id` and `extra_info.user_name` were silently dropped from the outbound guard payload for any request that carried a `litellm_metadata` field. The common case (no `litellm_metadata` in the body) still worked, so the original tests passed

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Verified end to end against a live proxy. The chat completion hits real Anthropic; a local HTTP server stands in for the CrowdStrike AIDR endpoint (we have no CrowdStrike account) and records the exact JSON the proxy sends, which is the only thing this change affects. A virtual key is bound to a user that has an email so `user_api_key_user_id` and `user_api_key_user_email` are populated.

Three request shapes, run once before the fix and once after:

```bash
KEY=...   # key bound to a user with email alice@example.com
for BODY in \
  '{"model":"e2e-haiku","messages":[{"role":"user","content":"hello"}]}' \
  '{"model":"e2e-haiku","messages":[{"role":"user","content":"hello"}],"litellm_metadata":null}' \
  '{"model":"e2e-haiku","messages":[{"role":"user","content":"hello"}],"litellm_metadata":{"trace_id":"t1"}}'; do
  curl -s http://localhost:4001/v1/chat/completions \
    -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" -d "$BODY" -o /dev/null
done
# then read the request-side payloads the proxy POSTed to the CrowdStrike endpoint
```

What the proxy sent to CrowdStrike (request-side guard call), before the fix:

```
no litellm_metadata        -> user_id=cs-e2e-user  extra_info={"user_name":"alice@example.com"}
litellm_metadata: null     -> user_id=null         extra_info absent        # identity dropped
litellm_metadata: {trace}  -> user_id=null         extra_info={}            # identity dropped
```

After the fix:

```
no litellm_metadata        -> user_id=cs-e2e-user  extra_info={"user_name":"alice@example.com"}
litellm_metadata: null     -> user_id=cs-e2e-user  extra_info={"user_name":"alice@example.com"}
litellm_metadata: {trace}  -> user_id=cs-e2e-user  extra_info={"user_name":"alice@example.com"}
```

Unit tests on the touched file:

```shell
$ poetry run pytest -q tests/test_litellm/proxy/guardrails/guardrail_hooks/test_crowdstrike_aidr.py
17 passed
```

The new parametrized test `test_apply_guardrail_reads_identity_from_either_metadata_bag` fails on the pre-fix code (KeyError on `user_id`) for the `null`, user-dict, and non-mapping `litellm_metadata` cases, and passes after

## Type

🐛 Bug Fix

## Changes

The guardrail now reads identity from both metadata bags instead of choosing one by presence. It merges `metadata` and `litellm_metadata` (each only when it is a Mapping) and reads `user_api_key_user_id` and `user_api_key_user_email` from the merged view, so the identity is found regardless of which bag the proxy wrote it to. This is safe against caller forgery because the proxy strips every `user_api_key_*` key from caller-supplied metadata before guardrails run and writes the authenticated values into exactly one bag, so there is no collision and no way for a caller to inject an identity. Behavior is unchanged when neither bag is present (no `user_id`, `model`, or `extra_info` added) and when only one bag carries the identity
