### PR TITLE
bump: version 1.84.6 (backport CrowdStrike AIDR metadata capture + identity fix)

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/crowdstrike_aidr/crowdstrike_aidr.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/crowdstrike_aidr/crowdstrike_aidr.py
@@ -1,4 +1,5 @@
 import os
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Optional, Type
 from typing_extensions import Any, override
 
@@ -310,10 +311,26 @@ class CrowdStrikeAIDRHandler(CustomGuardrail):
             event_type = "output"
             hook_name = "apply_guardrail (response)"
 
-        ai_guard_payload = {
+        ai_guard_payload: dict[str, Any] = {
             "guard_input": guard_input,
             "event_type": event_type,
         }
+
+        model = inputs.get("model")
+        if model:
+            ai_guard_payload["model"] = model
+
+        metadata = request_data.get("litellm_metadata", request_data.get("metadata"))
+        if isinstance(metadata, Mapping):
+            user_id = metadata.get("user_api_key_user_id")
+            if user_id:
+                ai_guard_payload["user_id"] = user_id
+
+            extra_info: dict[str, str] = {}
+            user_email = metadata.get("user_api_key_user_email")
+            if user_email:
+                extra_info["user_name"] = user_email
+            ai_guard_payload["extra_info"] = extra_info
 
         ai_guard_response = await self._call_crowdstrike_aidr_guard(
             ai_guard_payload, hook_name

--- a/litellm/proxy/guardrails/guardrail_hooks/crowdstrike_aidr/crowdstrike_aidr.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/crowdstrike_aidr/crowdstrike_aidr.py
@@ -30,6 +30,16 @@ class CrowdStrikeAIDRGuardrailMissingSecrets(Exception):
     pass
 
 
+def _merge_metadata_bags(request_data: Mapping[str, Any]) -> Optional[dict[str, Any]]:
+    merged: dict[str, Any] = {}
+    present = False
+    for bag in (request_data.get("metadata"), request_data.get("litellm_metadata")):
+        if isinstance(bag, Mapping):
+            present = True
+            merged.update(bag)
+    return merged if present else None
+
+
 class CrowdStrikeAIDRHandler(CustomGuardrail):
     """
     CrowdStrike AIDR AI Guardrail handler to interact with the CrowdStrike AIDR
@@ -320,8 +330,8 @@ class CrowdStrikeAIDRHandler(CustomGuardrail):
         if model:
             ai_guard_payload["model"] = model
 
-        metadata = request_data.get("litellm_metadata", request_data.get("metadata"))
-        if isinstance(metadata, Mapping):
+        metadata = _merge_metadata_bags(request_data)
+        if metadata is not None:
             user_id = metadata.get("user_api_key_user_id")
             if user_id:
                 ai_guard_payload["user_id"] = user_id

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "litellm"
-version = "1.84.5"
+version = "1.84.6"
 description = "Library to easily interface with LLM API providers"
 readme = "README.md"
 requires-python = ">=3.10, <3.14"
@@ -242,7 +242,7 @@ source-exclude = [
 profile = "black"
 
 [tool.commitizen]
-version = "1.84.5"
+version = "1.84.6"
 version_files = [
     "pyproject.toml:^version",
 ]

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_crowdstrike_aidr.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_crowdstrike_aidr.py
@@ -41,7 +41,8 @@ def test_crowdstrike_aidr_guardrail_config() -> None:
     )
 
 
-def test_crowdstrike_aidr_guardrail_config_no_api_key() -> None:
+def test_crowdstrike_aidr_guardrail_config_no_api_key(monkeypatch) -> None:
+    monkeypatch.delenv("CS_AIDR_TOKEN", raising=False)
     with pytest.raises(CrowdStrikeAIDRGuardrailMissingSecrets):
         init_guardrails_v2(
             all_guardrails=[
@@ -59,7 +60,8 @@ def test_crowdstrike_aidr_guardrail_config_no_api_key() -> None:
         )
 
 
-def test_crowdstrike_aidr_guardrail_config_no_api_base() -> None:
+def test_crowdstrike_aidr_guardrail_config_no_api_base(monkeypatch) -> None:
+    monkeypatch.delenv("CS_AIDR_BASE_URL", raising=False)
     with pytest.raises(CrowdStrikeAIDRGuardrailMissingSecrets):
         init_guardrails_v2(
             all_guardrails=[
@@ -428,3 +430,118 @@ async def test_apply_guardrail_response_ok(
     )
     # Should return original inputs when not transformed
     assert result["texts"] == inputs["texts"]
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_sends_user_id_model_and_extra_info(
+    crowdstrike_aidr_guardrail: CrowdStrikeAIDRHandler,
+) -> None:
+    inputs: GenericGuardrailAPIInputs = {
+        "texts": ["Hello"],
+        "structured_messages": [{"role": "user", "content": "Hello"}],
+        "model": "gpt-4o",
+    }
+    request_data = {
+        "messages": inputs["structured_messages"],
+        "model": "gpt-4o",
+        "litellm_metadata": {
+            "user_api_key_user_id": "uid-abc",
+            "user_api_key_user_email": "alice@example.com",
+        },
+    }
+    guardrail_endpoint = (
+        f"{crowdstrike_aidr_guardrail.api_base}/v1/guard_chat_completions"
+    )
+
+    with patch(
+        "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+        return_value=httpx.Response(
+            status_code=200,
+            json={"result": {"blocked": False, "transformed": False}},
+            request=httpx.Request(method="POST", url=guardrail_endpoint),
+        ),
+    ) as mock_method:
+        await crowdstrike_aidr_guardrail.apply_guardrail(
+            inputs=inputs,
+            request_data=request_data,
+            input_type="request",
+        )
+
+    payload = mock_method.call_args.kwargs["json"]
+    assert payload["user_id"] == "uid-abc"
+    assert payload["model"] == "gpt-4o"
+    assert payload["extra_info"] == {"user_name": "alice@example.com"}
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_empty_extra_info_when_no_email(
+    crowdstrike_aidr_guardrail: CrowdStrikeAIDRHandler,
+) -> None:
+    inputs: GenericGuardrailAPIInputs = {
+        "texts": ["Hello"],
+        "structured_messages": [{"role": "user", "content": "Hello"}],
+        "model": "gemini-flash",
+    }
+    request_data = {
+        "messages": inputs["structured_messages"],
+        "model": "gemini-flash",
+        "litellm_metadata": {
+            "user_api_key_user_id": "uid-no-email",
+            "user_api_key_user_email": None,
+        },
+    }
+    guardrail_endpoint = (
+        f"{crowdstrike_aidr_guardrail.api_base}/v1/guard_chat_completions"
+    )
+
+    with patch(
+        "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+        return_value=httpx.Response(
+            status_code=200,
+            json={"result": {"blocked": False, "transformed": False}},
+            request=httpx.Request(method="POST", url=guardrail_endpoint),
+        ),
+    ) as mock_method:
+        await crowdstrike_aidr_guardrail.apply_guardrail(
+            inputs=inputs,
+            request_data=request_data,
+            input_type="request",
+        )
+
+    payload = mock_method.call_args.kwargs["json"]
+    assert payload["user_id"] == "uid-no-email"
+    assert payload["model"] == "gemini-flash"
+    assert payload["extra_info"] == {}
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_no_metadata_skips_user_fields(
+    crowdstrike_aidr_guardrail: CrowdStrikeAIDRHandler,
+) -> None:
+    inputs: GenericGuardrailAPIInputs = {
+        "texts": ["Hello"],
+        "structured_messages": [{"role": "user", "content": "Hello"}],
+    }
+    request_data = {"messages": inputs["structured_messages"]}
+    guardrail_endpoint = (
+        f"{crowdstrike_aidr_guardrail.api_base}/v1/guard_chat_completions"
+    )
+
+    with patch(
+        "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+        return_value=httpx.Response(
+            status_code=200,
+            json={"result": {"blocked": False, "transformed": False}},
+            request=httpx.Request(method="POST", url=guardrail_endpoint),
+        ),
+    ) as mock_method:
+        await crowdstrike_aidr_guardrail.apply_guardrail(
+            inputs=inputs,
+            request_data=request_data,
+            input_type="request",
+        )
+
+    payload = mock_method.call_args.kwargs["json"]
+    assert "user_id" not in payload
+    assert "model" not in payload
+    assert "extra_info" not in payload

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_crowdstrike_aidr.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_crowdstrike_aidr.py
@@ -545,3 +545,53 @@ async def test_apply_guardrail_no_metadata_skips_user_fields(
     assert "user_id" not in payload
     assert "model" not in payload
     assert "extra_info" not in payload
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "litellm_metadata, metadata",
+    [
+        (None, {"user_api_key_user_id": "uid-abc", "user_api_key_user_email": "alice@example.com"}),
+        ({"trace_id": "t1"}, {"user_api_key_user_id": "uid-abc", "user_api_key_user_email": "alice@example.com"}),
+        (["unexpected"], {"user_api_key_user_id": "uid-abc", "user_api_key_user_email": "alice@example.com"}),
+        ({"user_api_key_user_id": "uid-abc", "user_api_key_user_email": "alice@example.com"}, {"trace_id": "t1"}),
+    ],
+    ids=["identity_in_metadata_llm_none", "identity_in_metadata_llm_user_dict", "identity_in_metadata_llm_non_mapping", "identity_in_litellm_metadata"],
+)
+async def test_apply_guardrail_reads_identity_from_either_metadata_bag(
+    crowdstrike_aidr_guardrail: CrowdStrikeAIDRHandler,
+    litellm_metadata,
+    metadata,
+) -> None:
+    inputs: GenericGuardrailAPIInputs = {
+        "texts": ["Hello"],
+        "structured_messages": [{"role": "user", "content": "Hello"}],
+        "model": "gpt-4o",
+    }
+    request_data = {
+        "messages": inputs["structured_messages"],
+        "model": "gpt-4o",
+        "litellm_metadata": litellm_metadata,
+        "metadata": metadata,
+    }
+    guardrail_endpoint = (
+        f"{crowdstrike_aidr_guardrail.api_base}/v1/guard_chat_completions"
+    )
+
+    with patch(
+        "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+        return_value=httpx.Response(
+            status_code=200,
+            json={"result": {"blocked": False, "transformed": False}},
+            request=httpx.Request(method="POST", url=guardrail_endpoint),
+        ),
+    ) as mock_method:
+        await crowdstrike_aidr_guardrail.apply_guardrail(
+            inputs=inputs,
+            request_data=request_data,
+            input_type="request",
+        )
+
+    payload = mock_method.call_args.kwargs["json"]
+    assert payload["user_id"] == "uid-abc"
+    assert payload["extra_info"] == {"user_name": "alice@example.com"}

--- a/uv.lock
+++ b/uv.lock
@@ -3083,7 +3083,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.84.5"
+version = "1.84.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Relevant issues

Backports the CrowdStrike AIDR user/model metadata capture (#29517, authored by Kenan Yildirim) plus the follow-up metadata-bag fix to `stable/1.84.x`, and bumps the patch version to 1.84.6 for a release.

The fix corrects a bug in #29517: it resolved the request metadata from a single bag with `request_data.get("litellm_metadata", request_data.get("metadata"))`. Because `dict.get` returns the stored value when the key is present, a present `litellm_metadata` (an explicit `null`, or a caller-supplied dict) shadowed `metadata`, where `/chat/completions` places the authenticated identity. So `user_id` and `extra_info.user_name` were silently dropped from the outbound guard payload for any request that carried a `litellm_metadata` field. The fix reads identity from both bags.

## Adaptation note (not a clean cherry-pick)

`stable/1.84.x` carries an older CrowdStrike implementation than #29517 was written against, so the cherry-pick required three deliberate adaptations, each preserved here:

- `guard_input` is a plain `dict` on this branch, so the payload keeps `"guard_input": guard_input` rather than `guard_input.model_dump(mode="json")` (the latter would `AttributeError` on a dict). Kenan's `dict[str, Any]` annotation is kept.
- Added `from collections.abc import Mapping`, which this branch did not import but the metadata code needs.
- The cherry-pick's test hunk pulled in an unrelated test (`test_apply_guardrail_request_skipped_messages_stay_aligned`) from a different change that is not on this branch; only Kenan's three new tests were taken.

Kenan's authorship is preserved on his commit.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Screenshots / Proof of Fix

Full CrowdStrike guardrail suite on this branch (stable's 9 tests + Kenan's 3 + the regression test's 4 parametrizations):

```shell
$ python -m pytest -q tests/test_litellm/proxy/guardrails/guardrail_hooks/test_crowdstrike_aidr.py
16 passed
```

The regression test `test_apply_guardrail_reads_identity_from_either_metadata_bag` fails on the pre-fix single-bag read (3 of 4 parametrizations drop `user_id`) and passes after. Black, Ruff, and MyPy pass on the changed module, and `uv lock --check` is consistent with the 1.84.6 bump.

## Type

🐛 Bug Fix

## Changes

Three commits on top of `stable/1.84.x`: Kenan's #29517 feature (adapted to this branch as above), the metadata-bag fix with a `_merge_metadata_bags` helper plus a parametrized regression test, and the 1.84.5 -> 1.84.6 version bump in `pyproject.toml` and `uv.lock`.
