### PR TITLE
test(vertex passthrough): key spend test off the request's own log row

### DIFF
--- a/tests/pass_through_tests/test_vertex_ai.py
+++ b/tests/pass_through_tests/test_vertex_ai.py
@@ -163,7 +163,13 @@ async def get_request_spend_log(
             if float(row.get("spend") or 0.0) <= 0:
                 continue
             row_start = _parse_spend_log_start_time(row.get("startTime"))
-            if row_start is not None and row_start >= after_time:
+            if row_start is None:
+                print(
+                    f"matching row has unparseable startTime {row.get('startTime')!r}",
+                    row,
+                )
+                continue
+            if row_start >= after_time:
                 print(f"found spend log (elapsed={elapsed}s)", row)
                 return row
     return None

--- a/tests/pass_through_tests/test_vertex_ai.py
+++ b/tests/pass_through_tests/test_vertex_ai.py
@@ -103,10 +103,76 @@ def _is_vertex_quota_error(exc: Exception) -> bool:
     )
 
 
+def _parse_spend_log_start_time(value):
+    import datetime
+
+    if not value:
+        return None
+    try:
+        parsed = datetime.datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=datetime.timezone.utc)
+    return parsed
+
+
+async def get_request_spend_log(
+    model_name: str,
+    after_time,
+    max_wait: int = 120,
+    poll_interval: int = 10,
+):
+    """Poll /spend/logs for the individual row produced by this request: one for
+    ``model_name``, started at/after ``after_time``, with spend > 0.
+
+    Asserting on this request's own row instead of a shared daily spend total is what
+    keeps the test deterministic. The total is mutated by every other passthrough test
+    on the same key and is bucketed by UTC day, so a strict "total went up" check races
+    both of those; a request that lands on the far side of midnight UTC or whose tiny
+    delta is masked by a concurrent write would flake. Spend logging is async and
+    batched, so the row still shows up a few seconds after the response returns; poll
+    until it does.
+    """
+    import datetime
+    import requests
+
+    after_date = after_time.date()
+    start_date = (after_date - datetime.timedelta(days=1)).strftime("%Y-%m-%d")
+    end_date = (after_date + datetime.timedelta(days=1)).strftime("%Y-%m-%d")
+    url = f"{LITE_LLM_ENDPOINT}/spend/logs"
+    params = {
+        "api_key": "best-api-key-ever",
+        "start_date": start_date,
+        "end_date": end_date,
+        "summarize": "false",
+    }
+    headers = {"Authorization": "Bearer sk-1234"}
+
+    elapsed = 0
+    while elapsed < max_wait:
+        await asyncio.sleep(poll_interval)
+        elapsed += poll_interval
+        response = requests.get(url, headers=headers, params=params)
+        if response.status_code != 200:
+            print(f"/spend/logs returned {response.status_code}: {response.text}")
+            continue
+        for row in response.json():
+            if model_name not in (row.get("model") or ""):
+                continue
+            if float(row.get("spend") or 0.0) <= 0:
+                continue
+            row_start = _parse_spend_log_start_time(row.get("startTime"))
+            if row_start is not None and row_start >= after_time:
+                print(f"found spend log (elapsed={elapsed}s)", row)
+                return row
+    return None
+
+
 @pytest.mark.asyncio()
 async def test_basic_vertex_ai_pass_through_with_spendlog():
+    import datetime
 
-    spend_before = await call_spend_logs_endpoint() or 0.0
     load_vertex_ai_credentials()
 
     vertexai.init(
@@ -117,6 +183,11 @@ async def test_basic_vertex_ai_pass_through_with_spendlog():
     )
 
     model = GenerativeModel(model_name="gemini-3.1-flash-lite")
+    # Capture the request time before the call (with a small buffer for clock skew) so
+    # we only match the spend log this request produces, not an earlier one.
+    request_time = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
+        seconds=5
+    )
     try:
         response = model.generate_content("hi")
     except Exception as exc:
@@ -126,23 +197,14 @@ async def test_basic_vertex_ai_pass_through_with_spendlog():
 
     print("response", response)
 
-    # Poll for spend update instead of fixed sleep - spend logging is async/batched
-    max_wait = 120  # total seconds to wait
-    poll_interval = 10  # seconds between checks
-    elapsed = 0
-    spend_after = spend_before
-    while elapsed < max_wait:
-        await asyncio.sleep(poll_interval)
-        elapsed += poll_interval
-        spend_after = await call_spend_logs_endpoint() or 0.0
-        print(f"spend_after (elapsed={elapsed}s)", spend_after)
-        if spend_after > spend_before:
-            break
+    spend_log = await get_request_spend_log(
+        model_name="gemini-3.1-flash-lite", after_time=request_time
+    )
 
-    assert (
-        spend_after > spend_before
-    ), "Spend should be greater than before after {}s. spend_before: {}, spend_after: {}".format(
-        elapsed, spend_before, spend_after
+    assert spend_log is not None, (
+        "No spend log with spend > 0 was recorded for the vertex passthrough request "
+        "within 120s. The request itself succeeded, so its cost-tracking write was lost "
+        "or its cost was computed as zero."
     )
 
 


### PR DESCRIPTION
## Relevant issues

`tests/pass_through_tests/test_vertex_ai.py::test_basic_vertex_ai_pass_through_with_spendlog` is flaky in the `proxy_pass_through_endpoint_tests` CircleCI job. It fails intermittently (seen on `litellm_internal_staging` itself, roughly 1 run in 5) with `spend_before == spend_after` even though the Vertex call succeeds, so it is unrelated to whatever PR happens to be running

## Linear ticket

## What was wrong

The test made one real Vertex call and then asserted that the shared daily spend total for the key `best-api-key-ever` strictly increased within 120s. That total is the wrong thing to assert on: it is fed by every other passthrough test writing to the same key, and the `MonthlyGlobalSpendPerKey` view buckets it by `DATE(startTime)` in UTC. So the "total went up" check races two independent things; a request that lands on the far side of midnight UTC (these CI runs start just after 00:00 UTC), or whose tiny ~$0.00001 delta is masked relative to a concurrent write, produces `spend_before == spend_after` and fails. The spend write is also fire-and-forget (`asyncio.create_task` in the passthrough success handler with no awaiter), so a lost or zero-cost write surfaced only as this silent flake

## The fix

Key off this request's own spend log row instead of a shared aggregate. After the call, poll `GET /spend/logs?...&summarize=false` for an individual row whose `model` is `gemini-3.1-flash-lite`, whose `startTime` is at or after the call (captured with a small clock-skew buffer), and whose `spend > 0`. This removes the shared-baseline race and the midnight-UTC bucket race in one move, and it converts a genuinely lost or zero-cost write into a deterministic, well-labelled failure instead of a flake that hides a real bug. The polling stays (spend logging is async and batched), but it now waits for the correct, request-specific signal

The two new helpers' matching logic was unit-checked against simulated `/spend/logs` payloads: it matches the request's own row (including a `vertex_ai/` model prefix), and rejects `spend == 0`, a different model, a row older than the request, an unparseable `startTime`, and the empty case

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:
- [ ] **CI run for the last commit**
       Link:
- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

This is a change to an e2e test that needs a live proxy plus real Vertex credentials, so the proof is the exact `/spend/logs` query the test now makes. With the proxy running and the `best-api-key-ever` passthrough key configured (as in CI), run a real Vertex passthrough call and then read that request's own row:

1. Start the proxy: `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log`
2. Make a real Vertex passthrough `generateContent` call to `gemini-3.1-flash-lite` through `/vertex_ai` (the test drives this via the `vertexai` SDK pointed at the proxy)
3. Read the request's own spend log row (today plus the day boundaries), exactly what the test now asserts on:
```
curl -s -G "http://0.0.0.0:4000/spend/logs" \
  -H "Authorization: Bearer sk-1234" \
  --data-urlencode "api_key=best-api-key-ever" \
  --data-urlencode "start_date=$(date -u -d yesterday +%F)" \
  --data-urlencode "end_date=$(date -u -d tomorrow +%F)" \
  --data-urlencode "summarize=false" \
  | python3 -c "import sys,json;[print(r['startTime'], r['model'], r['spend']) for r in json.load(sys.stdin) if 'gemini-3.1-flash-lite' in (r.get('model') or '') and float(r.get('spend') or 0) > 0]"
```
The fix is working when that prints a `gemini-3.1-flash-lite` row with a positive spend for the call just made

## Type

✅ Test

## Changes

`tests/pass_through_tests/test_vertex_ai.py`: replaces the shared daily-spend-total assertion in `test_basic_vertex_ai_pass_through_with_spendlog` with a lookup of the request's own spend log row via `get_request_spend_log` (new), backed by a small `_parse_spend_log_start_time` timestamp helper. The unrelated, already-skipped streaming and context-caching tests are untouched