### PR TITLE
Litellm cache creation usage

### DIFF
--- a/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
+++ b/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
@@ -7,6 +7,7 @@ from litellm.types.llms.openai import (
     ChatCompletionAudioDelta,
 )
 from litellm.types.utils import (
+    CacheCreationTokenDetails,
     ChatCompletionAudioResponse,
     ChatCompletionMessageToolCall,
     Choices,
@@ -470,6 +471,7 @@ class ChunkProcessor:
         ## anthropic prompt caching information ##
         cache_creation_input_tokens: Optional[int] = None
         cache_read_input_tokens: Optional[int] = None
+        cache_creation: Optional[CacheCreationTokenDetails] = None
         completion_tokens_details: Optional[CompletionTokensDetails] = None
         prompt_tokens_details: Optional[PromptTokensDetailsWrapper] = None
 
@@ -481,6 +483,12 @@ class ChunkProcessor:
             cache_creation_input_tokens = usage_chunk.get("cache_creation_input_tokens")
         if "cache_read_input_tokens" in usage_chunk:
             cache_read_input_tokens = usage_chunk.get("cache_read_input_tokens")
+        if "cache_creation" in usage_chunk:
+            usage_cache_creation = usage_chunk.get("cache_creation")
+            if isinstance(usage_cache_creation, dict):
+                cache_creation = CacheCreationTokenDetails(**usage_cache_creation)
+            elif isinstance(usage_cache_creation, CacheCreationTokenDetails):
+                cache_creation = usage_cache_creation
         if hasattr(usage_chunk, "completion_tokens_details"):
             if isinstance(usage_chunk.completion_tokens_details, dict):
                 completion_tokens_details = CompletionTokensDetails(
@@ -505,6 +513,7 @@ class ChunkProcessor:
             "completion_tokens": completion_tokens,
             "cache_creation_input_tokens": cache_creation_input_tokens,
             "cache_read_input_tokens": cache_read_input_tokens,
+            "cache_creation": cache_creation,
             "completion_tokens_details": completion_tokens_details,
             "prompt_tokens_details": prompt_tokens_details,
         }
@@ -539,6 +548,7 @@ class ChunkProcessor:
         ## anthropic prompt caching information ##
         cache_creation_input_tokens: Optional[int] = None
         cache_read_input_tokens: Optional[int] = None
+        cache_creation: Optional[CacheCreationTokenDetails] = None
 
         server_tool_use: Optional[ServerToolUse] = None
         web_search_requests: Optional[int] = None
@@ -580,6 +590,8 @@ class ChunkProcessor:
                     cache_read_input_tokens = usage_chunk_dict[
                         "cache_read_input_tokens"
                     ]
+                if usage_chunk_dict["cache_creation"] is not None:
+                    cache_creation = usage_chunk_dict["cache_creation"]
                 if usage_chunk_dict["completion_tokens_details"] is not None:
                     completion_tokens_details = usage_chunk_dict[
                         "completion_tokens_details"
@@ -610,6 +622,7 @@ class ChunkProcessor:
             completion_tokens=completion_tokens,
             cache_creation_input_tokens=cache_creation_input_tokens,
             cache_read_input_tokens=cache_read_input_tokens,
+            cache_creation=cache_creation,
             server_tool_use=server_tool_use,
             web_search_requests=web_search_requests,
             completion_tokens_details=completion_tokens_details,
@@ -639,6 +652,9 @@ class ChunkProcessor:
         ]
         cache_read_input_tokens: Optional[int] = calculated_usage_per_chunk[
             "cache_read_input_tokens"
+        ]
+        cache_creation: Optional[CacheCreationTokenDetails] = calculated_usage_per_chunk[
+            "cache_creation"
         ]
 
         server_tool_use: Optional[ServerToolUse] = calculated_usage_per_chunk[
@@ -684,6 +700,8 @@ class ChunkProcessor:
             setattr(
                 returned_usage, "cache_read_input_tokens", cache_read_input_tokens
             )  # for anthropic
+        if cache_creation is not None:
+            returned_usage.cache_creation = cache_creation
         if completion_tokens_details is not None:
             if isinstance(completion_tokens_details, CompletionTokensDetails):
                 returned_usage.completion_tokens_details = (

--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -2266,6 +2266,7 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             completion_tokens=completion_tokens,
             total_tokens=total_tokens,
             prompt_tokens_details=prompt_tokens_details,
+            cache_creation=cache_creation_token_details,
             cache_creation_input_tokens=cache_creation_input_tokens,
             cache_read_input_tokens=cache_read_input_tokens,
             completion_tokens_details=completion_token_details,

--- a/litellm/types/litellm_core_utils/streaming_chunk_builder_utils.py
+++ b/litellm/types/litellm_core_utils/streaming_chunk_builder_utils.py
@@ -2,7 +2,12 @@ from typing import TYPE_CHECKING, Optional
 
 from typing_extensions import TypedDict
 
-from ..utils import CompletionTokensDetails, PromptTokensDetailsWrapper, ServerToolUse
+from ..utils import (
+    CacheCreationTokenDetails,
+    CompletionTokensDetails,
+    PromptTokensDetailsWrapper,
+    ServerToolUse,
+)
 
 
 class UsagePerChunk(TypedDict):
@@ -10,6 +15,7 @@ class UsagePerChunk(TypedDict):
     completion_tokens: int
     cache_creation_input_tokens: Optional[int]
     cache_read_input_tokens: Optional[int]
+    cache_creation: Optional[CacheCreationTokenDetails]
     server_tool_use: Optional[ServerToolUse]
     web_search_requests: Optional[int]
     completion_tokens_details: Optional[CompletionTokensDetails]

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -1559,6 +1559,9 @@ class Usage(SafeAttributeModel, CompletionUsage):
     prompt_tokens_details: Optional[PromptTokensDetailsWrapper] = None
     """Breakdown of tokens used in the prompt."""
 
+    cache_creation: Optional[CacheCreationTokenDetails] = None
+    """Anthropic cache creation token breakdown by TTL."""
+
     def __init__(  # noqa: PLR0915
         self,
         prompt_tokens: Optional[int] = None,
@@ -1670,6 +1673,7 @@ class Usage(SafeAttributeModel, CompletionUsage):
             total_tokens=total_tokens or 0,
             completion_tokens_details=_completion_tokens_details or None,
             prompt_tokens_details=_prompt_tokens_details or None,
+            cache_creation=params.get("cache_creation"),
         )
 
         if server_tool_use is not None:
@@ -1700,7 +1704,12 @@ class Usage(SafeAttributeModel, CompletionUsage):
             self._cache_read_input_tokens = params["prompt_cache_hit_tokens"]
 
         for k, v in params.items():
+            if k == "cache_creation":
+                continue
             setattr(self, k, v)
+
+        if self.cache_creation is None:
+            del self.cache_creation
 
     def __contains__(self, key):
         # Define custom behavior for the 'in' operator

--- a/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
@@ -11,6 +11,7 @@ sys.path.insert(
 from litellm import stream_chunk_builder
 from litellm.litellm_core_utils.streaming_chunk_builder_utils import ChunkProcessor
 from litellm.types.utils import (
+    CacheCreationTokenDetails,
     ChatCompletionDeltaToolCall,
     ChatCompletionMessageToolCall,
     Delta,
@@ -271,6 +272,10 @@ def test_cache_read_input_tokens_retained():
             ),
             cache_creation_input_tokens=4,
             cache_read_input_tokens=11775,
+            cache_creation=CacheCreationTokenDetails(
+                ephemeral_5m_input_tokens=1,
+                ephemeral_1h_input_tokens=3,
+            ),
         ),
     )
 
@@ -322,6 +327,12 @@ def test_cache_read_input_tokens_retained():
 
     assert usage.cache_creation_input_tokens == 4
     assert usage.cache_read_input_tokens == 11775
+    assert usage.cache_creation.ephemeral_5m_input_tokens == 1
+    assert usage.cache_creation.ephemeral_1h_input_tokens == 3
+    assert usage.model_dump()["cache_creation"] == {
+        "ephemeral_5m_input_tokens": 1,
+        "ephemeral_1h_input_tokens": 3,
+    }
     assert usage.prompt_tokens_details.cached_tokens == 11775
 
 

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_handler.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_handler.py
@@ -1378,6 +1378,40 @@ def test_container_in_provider_specific_fields_streaming():
     assert container_field["skills"][0]["version"] == "20251013", "version should match"
 
 
+def test_anthropic_streaming_usage_preserves_cache_creation_details():
+    iterator = ModelResponseIterator(
+        streaming_response=MagicMock(), sync_stream=True, json_mode=False
+    )
+    chunk = {
+        "type": "message_delta",
+        "delta": {
+            "stop_reason": "end_turn",
+            "stop_sequence": None,
+        },
+        "usage": {
+            "input_tokens": 48,
+            "cache_creation_input_tokens": 14055,
+            "cache_read_input_tokens": 0,
+            "output_tokens": 832,
+            "cache_creation": {
+                "ephemeral_5m_input_tokens": 56,
+                "ephemeral_1h_input_tokens": 13999,
+            },
+        },
+    }
+
+    parsed = iterator.chunk_parser(chunk)
+    usage = getattr(parsed, "usage")
+
+    assert usage.cache_creation_input_tokens == 14055
+    assert usage.cache_creation.ephemeral_5m_input_tokens == 56
+    assert usage.cache_creation.ephemeral_1h_input_tokens == 13999
+    assert usage.model_dump()["cache_creation"] == {
+        "ephemeral_5m_input_tokens": 56,
+        "ephemeral_1h_input_tokens": 13999,
+    }
+
+
 def test_container_in_provider_specific_fields_non_streaming():
     """
     Test that container is captured in provider_specific_fields for non-streaming responses.


### PR DESCRIPTION
## Relevant issues

["Feature #29998"](https://github.com/BerriAI/litellm/issues/29998)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review


## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Before this change, Anthropic prompt cache creation usage was flattened to `cache_creation_input_tokens` in Chat Completions responses. Clients could see the total number of cache write tokens, but could not tell how many were written with the 5 minute TTL versus the 1 hour TTL.

After this change, Chat Completions usage preserves the Anthropic TTL breakdown:

```json
{
  "usage": {
    "cache_creation_input_tokens": 6179,
    "cache_read_input_tokens": 0,
    "cache_creation": {
      "ephemeral_5m_input_tokens": 0,
      "ephemeral_1h_input_tokens": 6179
    }
  }
}
```
<img width="685" height="455" alt="1" src="https://github.com/user-attachments/assets/1d243deb-a7da-4025-90b4-b503b245e620" />

Validated locally with:

```bash
uv run pytest tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_handler.py -k cache_creation_details
uv run pytest tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
```

Both test runs passed.

## Type

🐛 Bug Fix
✅ Test

## Changes

Anthropic prompt caching exposes cache write usage by TTL through `usage.cache_creation`. This matters for billing because 5 minute and 1 hour cache writes can have different prices.

This PR preserves that field in LiteLLM's OpenAI-compatible Chat Completions responses. The change adds `cache_creation` to the LiteLLM `Usage` object, passes the Anthropic cache creation details through the Anthropic chat transformation, and keeps the field when streaming chunks are aggregated into the final usage response.

This keeps the existing aggregate fields, including `cache_creation_input_tokens`, `cache_read_input_tokens`, and `prompt_tokens_details.cache_creation_tokens`, while adding the missing TTL-level breakdown needed for downstream cost calculation.