### PR TITLE
fix(ui/mcp): reset OAuth state on create-server modal close so a prior server's token no longer leaks into the next add-server session

### DIFF
--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
@@ -67,7 +67,9 @@ vi.mock("./mcp_tool_configuration", () => ({
 }));
 
 vi.mock("./mcp_connection_status", () => ({
-  default: () => <div data-testid="mcp-connection-status" />,
+  default: ({ tools }: { tools?: any[] }) => (
+    <div data-testid="mcp-connection-status" data-tool-count={tools?.length ?? 0} />
+  ),
 }));
 
 vi.mock("./StdioConfiguration", () => ({
@@ -671,6 +673,51 @@ describe("CreateMCPServer", () => {
 
       // The previous server's token must never be replayed for the new session.
       expect(usedToken("stale-token-A")).toBe(false);
+    });
+
+    it("clears the tool list and form fields when a parent dismisses the modal", async () => {
+      vi.mocked(networking.testMCPToolsListRequest).mockResolvedValue({
+        tools: [{ name: "tool_a" }],
+        error: null,
+      });
+      const toolCount = () => screen.getByTestId("mcp-connection-status").getAttribute("data-tool-count");
+
+      const { rerender } = render(<CreateMCPServer {...defaultProps} />);
+
+      await selectAntOption("Transport Type", "Streamable HTTP");
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText("https://your-mcp-server.com")).toBeInTheDocument();
+      });
+      await selectAntOption("Authentication", "OAuth");
+      await waitFor(() => {
+        expect(screen.getByText("OAuth Flow Type")).toBeInTheDocument();
+      });
+
+      const urlInput = screen.getByPlaceholderText("https://your-mcp-server.com");
+      await act(async () => {
+        fireEvent.change(urlInput, { target: { value: "https://server-a.example.com/mcp" } });
+      });
+      await act(async () => {
+        oauthHook.onTokenReceived?.({ access_token: "stale-token-A", expires_in: 3600 });
+      });
+
+      // Precondition: a tool list is shown for server A.
+      await waitFor(() => {
+        expect(toolCount()).toBe("1");
+      });
+
+      // Parent dismisses the modal without routing through Cancel or create.
+      rerender(<CreateMCPServer {...defaultProps} isModalVisible={false} />);
+
+      // Stale tools are cleared even though neither handler ran.
+      await waitFor(() => {
+        expect(toolCount()).toBe("0");
+      });
+
+      // Reopening starts clean: the URL the prior server left in the Ant form store is gone.
+      rerender(<CreateMCPServer {...defaultProps} isModalVisible={true} />);
+      const reopenedUrlInput = screen.getByPlaceholderText("https://your-mcp-server.com") as HTMLInputElement;
+      expect(reopenedUrlInput.value).toBe("");
     });
   });
 

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
@@ -17,15 +17,23 @@ vi.mock("@/utils/mcpTokenStore", () => ({
 }));
 
 // Mutable holder so individual tests can simulate "Authorize & Fetch" having
-// produced a token before submit.
-const oauthHook = vi.hoisted(() => ({ tokenResponse: null as Record<string, unknown> | null }));
+// produced a token before submit, and inspect the reset wiring.
+const oauthHook = vi.hoisted(() => ({
+  tokenResponse: null as Record<string, unknown> | null,
+  reset: vi.fn(),
+  onTokenReceived: null as ((token: Record<string, unknown> | null) => void) | null,
+}));
 vi.mock("@/hooks/useMcpOAuthFlow", () => ({
-  useMcpOAuthFlow: () => ({
-    startOAuthFlow: vi.fn(),
-    status: "idle",
-    error: null,
-    tokenResponse: oauthHook.tokenResponse,
-  }),
+  useMcpOAuthFlow: (opts: { onTokenReceived: (token: Record<string, unknown> | null) => void }) => {
+    oauthHook.onTokenReceived = opts.onTokenReceived;
+    return {
+      startOAuthFlow: vi.fn(),
+      status: "idle",
+      error: null,
+      tokenResponse: oauthHook.tokenResponse,
+      reset: oauthHook.reset,
+    };
+  },
 }));
 
 vi.mock("./mcp_server_cost_config", () => ({
@@ -121,6 +129,7 @@ describe("CreateMCPServer", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     oauthHook.tokenResponse = null;
+    oauthHook.onTokenReceived = null;
   });
 
   it("should render the modal with title when visible", () => {
@@ -613,6 +622,55 @@ describe("CreateMCPServer", () => {
       });
 
       expect(defaultProps.setModalVisible).toHaveBeenCalledWith(false);
+    });
+
+    it("does not leak a previous server's OAuth token into the next add-server session", async () => {
+      const usedToken = (token: string) =>
+        vi.mocked(networking.testMCPToolsListRequest).mock.calls.some((call) => call[2] === token);
+
+      const { rerender } = render(<CreateMCPServer {...defaultProps} />);
+
+      await selectAntOption("Transport Type", "Streamable HTTP");
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText("https://your-mcp-server.com")).toBeInTheDocument();
+      });
+      await selectAntOption("Authentication", "OAuth");
+      await waitFor(() => {
+        expect(screen.getByText("OAuth Flow Type")).toBeInTheDocument();
+      });
+
+      const urlInput = screen.getByPlaceholderText("https://your-mcp-server.com");
+      await act(async () => {
+        fireEvent.change(urlInput, { target: { value: "https://server-a.example.com/mcp" } });
+      });
+
+      // Simulate "Authorize & Fetch Token" completing for server A.
+      await act(async () => {
+        oauthHook.onTokenReceived?.({ access_token: "stale-token-A", expires_in: 3600 });
+      });
+
+      // Precondition: the freshly fetched token drives the tool preview for server A.
+      await waitFor(() => {
+        expect(usedToken("stale-token-A")).toBe(true);
+      });
+
+      // Parent hides the modal (Cancel / successful create both flip this prop).
+      rerender(<CreateMCPServer {...defaultProps} isModalVisible={false} />);
+
+      // The OAuth flow state (source of the "Token fetched" badge) is reset on close.
+      expect(oauthHook.reset).toHaveBeenCalled();
+
+      vi.mocked(networking.testMCPToolsListRequest).mockClear();
+
+      // Reopen for a brand-new server and enter a different URL without re-authorizing.
+      rerender(<CreateMCPServer {...defaultProps} isModalVisible={true} />);
+      const reopenedUrlInput = screen.getByPlaceholderText("https://your-mcp-server.com");
+      await act(async () => {
+        fireEvent.change(reopenedUrlInput, { target: { value: "https://server-b.example.com/mcp" } });
+      });
+
+      // The previous server's token must never be replayed for the new session.
+      expect(usedToken("stale-token-A")).toBe(false);
     });
   });
 

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
@@ -555,15 +555,19 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
     }
   }, [formValues.server_name]);
 
-  // Clear form and OAuth state when the modal closes so a previous server's
-  // authorization never bleeds into the next "Add New MCP Server" session.
+  // Clear form, tools, and OAuth state when the modal closes so a previous server's
+  // authorization, credentials, or tool list never bleed into the next "Add New MCP
+  // Server" session, including when a parent dismisses the modal without routing
+  // through handleCancel or handleCreate.
   React.useEffect(() => {
     if (!isModalVisible) {
+      form.resetFields();
       setFormValues({});
       setOauthAccessToken(null);
+      clearTools();
       resetOAuthFlow();
     }
-  }, [isModalVisible, resetOAuthFlow]);
+  }, [isModalVisible, form, clearTools, resetOAuthFlow]);
 
   const isAdmin = isAdminRole(userRole);
 

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
@@ -134,6 +134,7 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
     status: oauthStatus,
     error: oauthError,
     tokenResponse: oauthTokenResponse,
+    reset: resetOAuthFlow,
   } = useMcpOAuthFlow({
     accessToken,
     getCredentials: () => form.getFieldValue("credentials"),
@@ -554,12 +555,15 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
     }
   }, [formValues.server_name]);
 
-  // Clear formValues when modal closes to reset child components
+  // Clear form and OAuth state when the modal closes so a previous server's
+  // authorization never bleeds into the next "Add New MCP Server" session.
   React.useEffect(() => {
     if (!isModalVisible) {
       setFormValues({});
+      setOauthAccessToken(null);
+      resetOAuthFlow();
     }
-  }, [isModalVisible]);
+  }, [isModalVisible, resetOAuthFlow]);
 
   const isAdmin = isAdminRole(userRole);
 

--- a/ui/litellm-dashboard/src/hooks/useMcpOAuthFlow.test.tsx
+++ b/ui/litellm-dashboard/src/hooks/useMcpOAuthFlow.test.tsx
@@ -20,9 +20,13 @@ vi.mock("@/components/molecules/notifications_manager", () => ({
 const FLOW_STATE_KEY = "litellm-mcp-oauth-flow-state";
 const RESULT_KEY = "litellm-mcp-oauth-result";
 
-/** Seed storage so the hook's on-mount resume flow exchanges a code for a token. */
-function seedCompletedRedirect() {
-  setSecureItem(RESULT_KEY, JSON.stringify({ state: "state-1", code: "code-1" }));
+/** Seed the redirect result (the code returned by the IdP callback). */
+function seedResult(code: string) {
+  setSecureItem(RESULT_KEY, JSON.stringify({ state: "state-1", code }));
+}
+
+/** Seed the flow state stored before the redirect. */
+function seedFlowState() {
   setSecureItem(
     FLOW_STATE_KEY,
     JSON.stringify({
@@ -36,15 +40,23 @@ function seedCompletedRedirect() {
   );
 }
 
+/** Seed storage so the hook's on-mount resume flow exchanges a code for a token. */
+function seedCompletedRedirect() {
+  seedResult("code-1");
+  seedFlowState();
+}
+
 function renderFlow(onTokenReceived = vi.fn()) {
-  return renderHook(() =>
-    useMcpOAuthFlow({
-      accessToken: "admin-token",
-      getCredentials: () => ({}),
-      getTemporaryPayload: () => ({ url: "https://server-1.example.com/mcp", transport: "http" }),
-      onTokenReceived,
-      flowSource: "create",
-    }),
+  return renderHook(
+    ({ onTokenReceived: cb }: { onTokenReceived: (t: any) => void }) =>
+      useMcpOAuthFlow({
+        accessToken: "admin-token",
+        getCredentials: () => ({}),
+        getTemporaryPayload: () => ({ url: "https://server-1.example.com/mcp", transport: "http" }),
+        onTokenReceived: cb,
+        flowSource: "create",
+      }),
+    { initialProps: { onTokenReceived } },
   );
 }
 
@@ -74,5 +86,32 @@ describe("useMcpOAuthFlow reset", () => {
     expect(result.current.status).toBe("idle");
     expect(result.current.tokenResponse).toBeNull();
     expect(result.current.error).toBeNull();
+  });
+
+  it("clears the in-flight guard so a callback after a mid-exchange close is not swallowed", async () => {
+    // First exchange hangs, mimicking the modal being closed while the token
+    // endpoint is still in flight. processingRef is left true at that point.
+    vi.mocked(networking.exchangeMcpOAuthToken).mockReturnValueOnce(new Promise<any>(() => {}));
+    seedFlowState();
+    seedResult("code-1");
+
+    const onTokenReceived1 = vi.fn();
+    const { result, rerender } = renderFlow(onTokenReceived1);
+
+    await waitFor(() => expect(result.current.status).toBe("exchanging"));
+
+    act(() => {
+      result.current.reset();
+    });
+
+    // The reopened modal receives a fresh callback; it must be processed, not
+    // dropped by a stale in-flight guard.
+    const token = { access_token: "tok-2" };
+    vi.mocked(networking.exchangeMcpOAuthToken).mockResolvedValueOnce(token);
+    seedResult("code-2");
+    const onTokenReceived2 = vi.fn();
+    rerender({ onTokenReceived: onTokenReceived2 });
+
+    await waitFor(() => expect(onTokenReceived2).toHaveBeenCalledWith(token));
   });
 });

--- a/ui/litellm-dashboard/src/hooks/useMcpOAuthFlow.test.tsx
+++ b/ui/litellm-dashboard/src/hooks/useMcpOAuthFlow.test.tsx
@@ -1,0 +1,78 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as networking from "@/components/networking";
+import { setSecureItem } from "@/utils/secureStorage";
+import { useMcpOAuthFlow } from "./useMcpOAuthFlow";
+
+vi.mock("@/components/networking", () => ({
+  exchangeMcpOAuthToken: vi.fn(),
+  cacheTemporaryMcpServer: vi.fn(),
+  registerMcpOAuthClient: vi.fn(),
+  buildMcpOAuthAuthorizeUrl: vi.fn(),
+  getProxyBaseUrl: vi.fn(() => ""),
+  serverRootPath: "",
+}));
+
+vi.mock("@/components/molecules/notifications_manager", () => ({
+  default: { success: vi.fn(), error: vi.fn() },
+}));
+
+const FLOW_STATE_KEY = "litellm-mcp-oauth-flow-state";
+const RESULT_KEY = "litellm-mcp-oauth-result";
+
+/** Seed storage so the hook's on-mount resume flow exchanges a code for a token. */
+function seedCompletedRedirect() {
+  setSecureItem(RESULT_KEY, JSON.stringify({ state: "state-1", code: "code-1" }));
+  setSecureItem(
+    FLOW_STATE_KEY,
+    JSON.stringify({
+      state: "state-1",
+      codeVerifier: "verifier-1",
+      serverId: "server-1",
+      clientId: "client-1",
+      redirectUri: "https://app.example.com/ui/mcp/oauth/callback",
+      flowSource: "create",
+    }),
+  );
+}
+
+function renderFlow(onTokenReceived = vi.fn()) {
+  return renderHook(() =>
+    useMcpOAuthFlow({
+      accessToken: "admin-token",
+      getCredentials: () => ({}),
+      getTemporaryPayload: () => ({ url: "https://server-1.example.com/mcp", transport: "http" }),
+      onTokenReceived,
+      flowSource: "create",
+    }),
+  );
+}
+
+describe("useMcpOAuthFlow reset", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.sessionStorage.clear();
+    window.localStorage.clear();
+  });
+
+  it("clears a successfully fetched token so it cannot leak into the next session", async () => {
+    const token = { access_token: "tok-123", expires_in: 3600 };
+    vi.mocked(networking.exchangeMcpOAuthToken).mockResolvedValue(token);
+    seedCompletedRedirect();
+
+    const onTokenReceived = vi.fn();
+    const { result } = renderFlow(onTokenReceived);
+
+    await waitFor(() => expect(result.current.status).toBe("success"));
+    expect(result.current.tokenResponse).toEqual(token);
+    expect(onTokenReceived).toHaveBeenCalledWith(token);
+
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.status).toBe("idle");
+    expect(result.current.tokenResponse).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/ui/litellm-dashboard/src/hooks/useMcpOAuthFlow.tsx
+++ b/ui/litellm-dashboard/src/hooks/useMcpOAuthFlow.tsx
@@ -341,6 +341,7 @@ export const useMcpOAuthFlow = ({
     setStatus("idle");
     setError(null);
     setTokenResponse(null);
+    processingRef.current = false;
   }, []);
 
   return {

--- a/ui/litellm-dashboard/src/hooks/useMcpOAuthFlow.tsx
+++ b/ui/litellm-dashboard/src/hooks/useMcpOAuthFlow.tsx
@@ -40,6 +40,7 @@ interface UseMcpOAuthFlowResult {
   status: McpOAuthStatus;
   error: string | null;
   tokenResponse: Record<string, any> | null;
+  reset: () => void;
 }
 
 export const useMcpOAuthFlow = ({
@@ -336,10 +337,17 @@ export const useMcpOAuthFlow = ({
     resumeOAuthFlow();
   }, [resumeOAuthFlow]);
 
+  const reset = useCallback(() => {
+    setStatus("idle");
+    setError(null);
+    setTokenResponse(null);
+  }, []);
+
   return {
     startOAuthFlow,
     status,
     error,
     tokenResponse,
+    reset,
   };
 };

--- a/ui/litellm-dashboard/src/hooks/useTestMCPConnection.tsx
+++ b/ui/litellm-dashboard/src/hooks/useTestMCPConnection.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { testMCPToolsListRequest } from "../components/networking";
 import { AUTH_TYPE, OAUTH_FLOW, TRANSPORT } from "@/components/mcp_tools/types";
 
@@ -177,12 +177,12 @@ export const useTestMCPConnection = ({
     }
   };
 
-  const clearTools = () => {
+  const clearTools = useCallback(() => {
     setTools([]);
     setToolsError(null);
     setToolsErrorStackTrace(null);
     setHasShownSuccessMessage(false);
-  };
+  }, []);
 
   // Auto-fetch tools when form values change and required fields are available
   useEffect(() => {


### PR DESCRIPTION
## Relevant issues

Reported MCP server isolation problem in the admin UI:

- After authorizing one OAuth-PKCE MCP server, opening the add-server form again (no page refresh) shows a "Token fetched. Expires in ? seconds." badge that was never authorized
- The new server's tool preview lists tools that belong to the previously authorized server
- The reporter read this as LiteLLM treating `https://mcp.atlassian.com/v1/mcp` and `https://mcp.atlassian.com/v1/mcp/authv2` as the same server

The fix adds a reset in two places:

- a new `reset()` on the `useMcpOAuthFlow` hook that clears its in-memory `status`/`error`/`tokenResponse` (the source of the "Token fetched" badge), while leaving the sessionStorage flow keys alone so the OAuth redirect round-trip still works
- the modal-close effect in `create_mcp_server.tsx`, which now also clears `oauthAccessToken` and calls that `reset()`, so both the cancel and successful-create paths drop the prior server's OAuth state

## Linear ticket
Resolves LIT-3616

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

The root cause is frontend state, not backend server identity. The backend already derives `server_id` from the full URL including path (`_generate_stable_server_id` hashes `server_name|url|transport|auth_type|alias`), so `/v1/mcp` and `/v1/mcp/authv2` are distinct servers with distinct credential rows. The leak is in the "Add New MCP Server" modal, which is permanently mounted (`Modal forceRender`, no `destroyOnClose`), so its OAuth state survived across separate add-server sessions.

Two pieces of state leaked into the next add-server attempt once one interactive OAuth flow completed:

- `oauthAccessToken` held in `create_mcp_server.tsx`, which drives the tool-list preview (`useTestMCPConnection` replays it against whatever URL is now in the form). When both servers point at the same upstream the leftover token authenticates, so the new server's preview fills with the old server's tools; that is the apparent `/mcp` vs `/mcp/authv2` cross-talk
- the `useMcpOAuthFlow` hook's own `status`/`tokenResponse`, which render the "Token fetched. Expires in ? seconds." badge in `OAuthFormFields`

The fix adds a reset in two places:

- a new `reset()` on the `useMcpOAuthFlow` hook that clears its in-memory `status`/`error`/`tokenResponse`; it deliberately leaves the sessionStorage flow keys alone so the OAuth redirect round-trip (which reads `RESULT_KEY`/`FLOW_STATE_KEY` on return) still works
- the modal-close effect in `create_mcp_server.tsx`, which now also clears `oauthAccessToken` and calls that `reset()`, so both the cancel and successful-create paths drop the prior server's OAuth state instead of each path needing to remember to clear it

Tests:

- `useMcpOAuthFlow.test.tsx` drives the hook through its on-mount resume flow to a fetched-token "success" state, then asserts `reset()` clears `status`/`tokenResponse`/`error`
- `create_mcp_server.test.tsx` authorizes server A, closes the modal, reopens for server B with a different URL, and asserts the stale token is neither replayed in the `POST /mcp-rest/test/tools/list` preview nor left in the hook

Verified the tests are real regressions by mutation: removing `setOauthAccessToken(null)` fails the stale-token-reuse assertion, removing `resetOAuthFlow()` fails the reset-called assertion, and making `reset()` skip `setTokenResponse(null)` fails the hook test. 136 tests pass across the hook test plus the full `mcp_tools` suite.

## Screenshots / Proof of Fix
https://berriaillm.slack.com/files/U0B1TDTHL4Q/F0B9ELF08L9/screen_recording_2026-06-09_at_9.30.31___am.mov
Manual UI runbook (admin UI, no page refresh between steps):

1. Go to the MCP page, click Add New MCP Server. Pick Streamable HTTP transport, OAuth auth (interactive). Enter an OAuth-PKCE server URL, click "Authorize & Fetch Token" and complete the dance. The tool list populates and the OAuth box shows "Token fetched".
2. Click Cancel (do not save).
3. Click Add New MCP Server again. Select OAuth auth and enter a different server URL, without clicking Authorize.

Before this change the second form shows a green "Token fetched. Expires in ? seconds." badge and the tool preview fires `POST /mcp-rest/test/tools/list` carrying the previous server's `Authorization: Bearer` token. After this change the second form starts clean: no "Token fetched" badge, and no preview request is sent until you authorize the new server. Open devtools Network and confirm there is no `/mcp-rest/test/tools/list` call carrying the prior token.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UI state cleanup in the admin MCP create flow with targeted tests; no backend or credential-storage changes beyond clearing client-side preview state.
> 
> **Overview**
> Fixes **stale OAuth and tool-preview state** when the “Add New MCP Server” modal stays mounted (`forceRender`) across sessions.
> 
> On **`isModalVisible === false`**, the create modal now **`form.resetFields()`**, clears **`oauthAccessToken`**, **`clearTools()`**, and calls new **`resetOAuthFlow()`** so a prior server’s token, “Token fetched” badge, and tool list do not carry into the next add attempt—even if the parent hides the modal without Cancel/Create.
> 
> **`useMcpOAuthFlow`** exposes **`reset()`** to clear in-memory `status` / `error` / `tokenResponse` and the in-flight **`processingRef`** guard (sessionStorage OAuth redirect keys are unchanged). **`useTestMCPConnection`** memoizes **`clearTools`** for stable effect dependencies.
> 
> Regression tests cover token reuse across close/reopen, form/tool clearing on parent dismiss, and hook **`reset()`** behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e523f5c67e17060cb2cf9cdbfe831cfe2cd780d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Closing and reopening the modal now reliably starts fresh, clearing previous connection details and input values.
  * Tool lists and connection status no longer carry over from a prior session after dismissing the modal.
  * OAuth sign-in flow now resets correctly, helping prevent stale login state from affecting a new connection attempt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->