### PR TITLE
fix(release): stop backport releases from overwriting the latest badge

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -52,6 +52,22 @@ jobs:
             // are stable maintenance releases, not pre-releases.
             const isPrerelease = /(?:rc|nightly|alpha|beta|[-.]dev)/i.test(tag);
 
+            // A stable release should only claim the repo "latest" badge when its
+            // version is >= the current latest. Otherwise a backport (e.g. 1.84.6)
+            // would steal "latest" from a newer line (e.g. 1.88.1).
+            const versionKey = (rawTag) => {
+              const m = String(rawTag).match(/^v?(\d+)\.(\d+)\.(\d+)/);
+              if (!m) return null;
+              const maintenance = String(rawTag).match(/(?:\.post|\.patch\.)(\d+)/i);
+              return [Number(m[1]), Number(m[2]), Number(m[3]), maintenance ? Number(maintenance[1]) : 0];
+            };
+            const isAtLeast = (a, b) => {
+              for (let i = 0; i < a.length; i++) {
+                if (a[i] !== b[i]) return a[i] > b[i];
+              }
+              return true;
+            };
+
             const cosignSection = [
               `## Verify Docker Image Signature`,
               ``,
@@ -90,6 +106,22 @@ jobs:
             ].join('\n');
 
             try {
+              let makeLatest = "false";
+              const newVersion = versionKey(tag);
+              if (!isPrerelease && newVersion) {
+                let latestVersion = null;
+                try {
+                  const latest = await github.rest.repos.getLatestRelease({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                  });
+                  latestVersion = versionKey(latest.data.tag_name);
+                } catch (error) {
+                  if (error.status !== 404) throw error;
+                }
+                makeLatest = (!latestVersion || isAtLeast(newVersion, latestVersion)) ? "true" : "false";
+              }
+
               const response = await github.rest.repos.createRelease({
                 draft: true,
                 generate_release_notes: true,
@@ -108,6 +140,7 @@ jobs:
                 release_id: response.data.id,
                 body: updatedBody,
                 draft: false,
+                make_latest: makeLatest,
               });
 
             } catch (error) {


### PR DESCRIPTION
## Relevant issues

Reported internally: cutting a patch release for an older line (1.84.6) overwrote a newer release (1.88.1) as the repo "Latest" release. The create-release workflow defaults `make_latest` to GitHub's default of `true`, so every newly published stable release claimed the Latest badge regardless of version

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

Note on tests: the decision logic is a few lines of inline `github-script` JS in the workflow, and this repo has no JS test runner in CI, so there is nothing committed for `make test-unit` to exercise. I verified the logic locally instead (see Proof of Fix). If you'd prefer a committed, CI-run guard I can extract the decision into a small module with a `node --test` job, at the cost of a new checkout step and a new workflow

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

This changes a release workflow that creates real tags, releases, and branches on the public repo, so it can't be dispatch-run for a screenshot without polluting the release history. Proof here is the decision logic and the documented `make_latest` contract

GitHub's create/update release API marks a published release as Latest based on `make_latest`, which defaults to `true`. The fix sets it explicitly. Given the current Latest is v1.88.1, the decision table is:

| tag being released | type | make_latest | Latest badge after |
| --- | --- | --- | --- |
| 1.84.6 | backport to older line | `false` | stays on 1.88.1 |
| 1.88.2 | patch on current line | `true` | moves to 1.88.2 |
| 1.89.0 | new minor | `true` | moves to 1.89.0 |
| 1.89.0-rc.1 | prerelease | `false` | unchanged |
| (no releases yet) | first release | `true` | set to it |

I unit-tested the pure decision function locally with `node --test` (10 cases including the exact 1.84.6-vs-1.88.1 scenario, prereleases in both PEP 440 and SemVer forms, `.postN`, legacy `-stable.patch.N`, and the first-ever-release case); all pass. To confirm the tests actually bite I ran two mutations: flipping the version comparison operator failed 7 of 10, and removing the prerelease guard failed 1 of 10

## Type

🐛 Bug Fix

## Changes

`create-release.yml` now computes `make_latest` instead of relying on the API default. A stable release claims Latest only when its version is greater than or equal to the current Latest (read via `getLatestRelease`); a backport to an older line publishes with `make_latest: false`; prereleases always publish with `false`. Version keys parse `X.Y.Z` plus the maintenance suffix (`.postN` and legacy `-stable.patch.N`) so ordering within a line is also correct. When there is no current Latest (first release, or a 404 from `getLatestRelease`) the release is marked Latest