### PR TITLE
fix(proxy): authorize batch files using upload target_model_names (LIT-3593)

### DIFF
--- a/litellm/proxy/hooks/batch_rate_limiter.py
+++ b/litellm/proxy/hooks/batch_rate_limiter.py
@@ -531,11 +531,17 @@ class _PROXY_BatchRateLimiter(CustomLogger):
             # Check if this is a managed file (base64 encoded unified file ID)
             from litellm.proxy.openai_files_endpoints.common_utils import (
                 _is_base64_encoded_unified_file_id,
+                get_models_from_unified_file_id,
             )
 
             # Managed files require bypassing the HTTP endpoint (which runs access-check hooks)
             # and calling the managed files hook directly with the user's credentials.
             is_managed_file = _is_base64_encoded_unified_file_id(file_id)
+            target_model_names = (
+                get_models_from_unified_file_id(is_managed_file)
+                if is_managed_file
+                else []
+            )
             if is_managed_file and user_api_key_dict is not None:
                 file_content = await self._fetch_managed_file_content(
                     file_id=file_id,
@@ -573,6 +579,7 @@ class _PROXY_BatchRateLimiter(CustomLogger):
                 await self._enforce_batch_file_model_access(
                     user_api_key_dict=user_api_key_dict,
                     file_content_as_dict=file_content_as_dict,
+                    target_model_names=target_model_names or None,
                 )
 
             input_file_usage = _get_batch_job_input_file_usage(
@@ -608,9 +615,13 @@ class _PROXY_BatchRateLimiter(CustomLogger):
         self,
         user_api_key_dict: UserAPIKeyAuth,
         file_content_as_dict: List[dict],
+        target_model_names: Optional[List[str]] = None,
     ) -> None:
-        """Reject the batch if the caller is not authorized for every
-        ``body.model`` named inside the JSONL.
+        """Reject the batch if the caller is not authorized for the upload target.
+
+        For managed files, ``target_model_names`` (from the unified file id) is
+        the proxy alias the file was uploaded for and is used directly for auth.
+        For legacy/non-managed files, falls back to ``body.model`` values in the JSONL.
 
         Reuses standard auth helpers so the same model access rules the proxy
         enforces on `/chat/completions` apply here.
@@ -627,9 +638,12 @@ class _PROXY_BatchRateLimiter(CustomLogger):
         from litellm.proxy.proxy_server import proxy_logging_obj
         from litellm.proxy.proxy_server import user_api_key_cache
 
-        models = _get_models_from_batch_input_file_content(file_content_as_dict)
-        if not models:
-            return
+        if target_model_names:
+            models = target_model_names
+        else:
+            models = _get_models_from_batch_input_file_content(file_content_as_dict)
+            if not models:
+                return
 
         team_object = None
         if (
@@ -660,12 +674,7 @@ class _PROXY_BatchRateLimiter(CustomLogger):
 
         llm_model_list = llm_router.model_list if llm_router is not None else None
         for model in models:
-            # body.model may be the provider id after replace_model_in_jsonl; map to proxy model_name for auth.
             model_to_check = model
-            if llm_router is not None:
-                proxy_model_name = llm_router.resolve_model_name_from_model_id(model)
-                if proxy_model_name is not None:
-                    model_to_check = proxy_model_name
             try:
                 if team_object is not None:
                     try:

--- a/litellm/proxy/hooks/batch_rate_limiter.py
+++ b/litellm/proxy/hooks/batch_rate_limiter.py
@@ -579,7 +579,7 @@ class _PROXY_BatchRateLimiter(CustomLogger):
                 await self._enforce_batch_file_model_access(
                     user_api_key_dict=user_api_key_dict,
                     file_content_as_dict=file_content_as_dict,
-                    target_model_names=target_model_names or None,
+                    target_model_names=target_model_names if target_model_names else None,
                 )
 
             input_file_usage = _get_batch_job_input_file_usage(
@@ -640,10 +640,14 @@ class _PROXY_BatchRateLimiter(CustomLogger):
 
         if target_model_names:
             models = target_model_names
+            resolve_via_router = False
         else:
             models = _get_models_from_batch_input_file_content(file_content_as_dict)
             if not models:
                 return
+            # body.model may be the provider id after replace_model_in_jsonl;
+            # map to proxy model_name for auth on the JSONL fallback path.
+            resolve_via_router = True
 
         team_object = None
         if (
@@ -675,6 +679,10 @@ class _PROXY_BatchRateLimiter(CustomLogger):
         llm_model_list = llm_router.model_list if llm_router is not None else None
         for model in models:
             model_to_check = model
+            if resolve_via_router and llm_router is not None:
+                proxy_model_name = llm_router.resolve_model_name_from_model_id(model)
+                if proxy_model_name is not None:
+                    model_to_check = proxy_model_name
             try:
                 if team_object is not None:
                     try:

--- a/litellm/proxy/hooks/batch_rate_limiter.py
+++ b/litellm/proxy/hooks/batch_rate_limiter.py
@@ -579,7 +579,7 @@ class _PROXY_BatchRateLimiter(CustomLogger):
                 await self._enforce_batch_file_model_access(
                     user_api_key_dict=user_api_key_dict,
                     file_content_as_dict=file_content_as_dict,
-                    target_model_names=target_model_names if target_model_names else None,
+                    target_model_names=target_model_names or None,
                 )
 
             input_file_usage = _get_batch_job_input_file_usage(
@@ -640,14 +640,10 @@ class _PROXY_BatchRateLimiter(CustomLogger):
 
         if target_model_names:
             models = target_model_names
-            resolve_via_router = False
         else:
             models = _get_models_from_batch_input_file_content(file_content_as_dict)
             if not models:
                 return
-            # body.model may be the provider id after replace_model_in_jsonl;
-            # map to proxy model_name for auth on the JSONL fallback path.
-            resolve_via_router = True
 
         team_object = None
         if (
@@ -679,10 +675,6 @@ class _PROXY_BatchRateLimiter(CustomLogger):
         llm_model_list = llm_router.model_list if llm_router is not None else None
         for model in models:
             model_to_check = model
-            if resolve_via_router and llm_router is not None:
-                proxy_model_name = llm_router.resolve_model_name_from_model_id(model)
-                if proxy_model_name is not None:
-                    model_to_check = proxy_model_name
             try:
                 if team_object is not None:
                     try:

--- a/tests/test_litellm/proxy/hooks/test_batch_file_validation.py
+++ b/tests/test_litellm/proxy/hooks/test_batch_file_validation.py
@@ -713,7 +713,8 @@ async def test_count_input_file_usage_decodes_model_embedded_file_id():
 @pytest.mark.asyncio
 async def test_pre_call_allows_stripped_provider_model_when_key_has_proxy_alias():
     """After replace_model_in_jsonl, body.model is the provider id (e.g. gpt-5.5).
-    Auth must check the proxy model_name the key was granted, not the stripped id."""
+    Auth must check target_model_names from the unified file id, not reverse-map
+    the stripped id."""
     from litellm.proxy.hooks.batch_rate_limiter import _PROXY_BatchRateLimiter
 
     rate_limiter = _PROXY_BatchRateLimiter(
@@ -732,7 +733,6 @@ async def test_pre_call_allows_stripped_provider_model_when_key_has_proxy_alias(
     )
     mock_router = MagicMock()
     mock_router.model_list = []
-    mock_router.resolve_model_name_from_model_id.return_value = proxy_alias
     can_key_call_model = AsyncMock(return_value=True)
 
     with (
@@ -745,10 +745,105 @@ async def test_pre_call_allows_stripped_provider_model_when_key_has_proxy_alias(
         await rate_limiter._enforce_batch_file_model_access(
             user_api_key_dict=user,
             file_content_as_dict=file_dict,
+            target_model_names=[proxy_alias],
         )
 
     can_key_call_model.assert_awaited_once()
     assert can_key_call_model.await_args.kwargs["model"] == proxy_alias
+    mock_router.resolve_model_name_from_model_id.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "model_list_order",
+    [
+        [
+            "openai/openai/gpt-5.5",
+            "openai/openai/gpt-5.5-batch",
+            "us/azure/openai/gpt-5.5",
+        ],
+        [
+            "us/azure/openai/gpt-5.5",
+            "openai/openai/gpt-5.5",
+            "openai/openai/gpt-5.5-batch",
+        ],
+        [
+            "openai/openai/gpt-5.5-batch",
+            "us/azure/openai/gpt-5.5",
+            "openai/openai/gpt-5.5",
+        ],
+    ],
+)
+async def test_pre_call_uses_target_model_names_not_stripped_reverse_lookup(
+    model_list_order,
+):
+    """LIT-3593: three deployments strip to gpt-5.5; auth must use the upload
+    target alias from target_model_names, not first-match reverse lookup."""
+    from litellm.proxy.hooks.batch_rate_limiter import _PROXY_BatchRateLimiter
+
+    rate_limiter = _PROXY_BatchRateLimiter(
+        internal_usage_cache=MagicMock(),
+        parallel_request_limiter=MagicMock(),
+    )
+    batch_alias = "openai/openai/gpt-5.5-batch"
+    deployment_templates = {
+        "openai/openai/gpt-5.5": {
+            "model_name": "openai/openai/gpt-5.5",
+            "litellm_params": {"model": "openai/gpt-5.5"},
+            "model_info": {"id": "openai/openai/gpt-5.5", "mode": "chat"},
+        },
+        "openai/openai/gpt-5.5-batch": {
+            "model_name": "openai/openai/gpt-5.5-batch",
+            "litellm_params": {"model": "openai/gpt-5.5"},
+            "model_info": {"id": "openai/openai/gpt-5.5-batch", "mode": "batch"},
+        },
+        "us/azure/openai/gpt-5.5": {
+            "model_name": "us/azure/openai/gpt-5.5",
+            "litellm_params": {"model": "azure/gpt-5.5"},
+            "model_info": {"id": "openai/openai/gpt-5.5", "mode": "chat"},
+        },
+    }
+    mock_router = MagicMock()
+    mock_router.model_list = [deployment_templates[name] for name in model_list_order]
+
+    def _resolve(model_id):
+        for deployment in mock_router.model_list:
+            actual_model = deployment.get("litellm_params", {}).get("model")
+            if actual_model == model_id or (
+                actual_model and actual_model.endswith(f"/{model_id}")
+            ):
+                return deployment.get("model_name")
+        return None
+
+    mock_router.resolve_model_name_from_model_id.side_effect = _resolve
+
+    file_dict = [
+        {"body": {"model": "gpt-5.5", "messages": [{"role": "user", "content": "x"}]}}
+    ]
+    user = UserAPIKeyAuth(
+        api_key="sk-ok",
+        user_id="alice",
+        models=[batch_alias],
+        user_role=LitellmUserRoles.INTERNAL_USER.value,
+    )
+    can_key_call_model = AsyncMock(return_value=True)
+
+    with (
+        patch(
+            "litellm.proxy.auth.auth_checks.can_key_call_model",
+            new=can_key_call_model,
+        ),
+        patch("litellm.proxy.proxy_server.llm_router", mock_router),
+    ):
+        await rate_limiter._enforce_batch_file_model_access(
+            user_api_key_dict=user,
+            file_content_as_dict=file_dict,
+            target_model_names=[batch_alias],
+        )
+
+    can_key_call_model.assert_awaited_once()
+    assert can_key_call_model.await_args.kwargs["model"] == batch_alias
+    mock_router.resolve_model_name_from_model_id.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Fixes false 403 on `batches.create` when multiple deployments strip to the same provider model id (regression from #29264).
- Batch file auth now uses `target_model_names` from the unified file id (the proxy alias the file was uploaded for) instead of reverse-mapping stripped `body.model` via `resolve_model_name_from_model_id`.
- Falls back to JSONL `body.model` values for legacy/non-managed files.

## Test plan
- [x] `pytest tests/test_litellm/proxy/hooks/test_batch_file_validation.py::test_pre_call_allows_stripped_provider_model_when_key_has_proxy_alias -v`
- [x] `pytest tests/test_litellm/proxy/hooks/test_batch_file_validation.py::test_pre_call_uses_target_model_names_not_stripped_reverse_lookup -v`
- [x] Full `test_batch_file_validation.py` suite (48 tests)


**Before**
<img width="1158" height="199" alt="image" src="https://github.com/user-attachments/assets/19050588-1504-4af8-86ee-6f499ebc88d2" />

**After**
<img width="1158" height="396" alt="image" src="https://github.com/user-attachments/assets/cd41b1f7-9acc-40e5-afdc-8ba747b8eadb" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes batch authorization logic in the proxy rate limiter; scope is narrow but incorrect auth could still allow or deny batch creation incorrectly.
> 
> **Overview**
> Fixes false **403** on `batches.create` when several proxy deployments share the same stripped provider model id (e.g. chat vs batch aliases all mapping to `gpt-5.5` in the JSONL).
> 
> For **managed/unified** batch input files, `_enforce_batch_file_model_access` now authorizes against **`target_model_names`** decoded from the unified file id (the upload proxy alias) instead of reverse-mapping JSONL `body.model` through `llm_router.resolve_model_name_from_model_id`, which could pick the wrong deployment. **Legacy** files still validate models listed in the JSONL.
> 
> Tests assert the proxy alias is checked directly and that router reverse lookup is not used when `target_model_names` is set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66805250f3a865cd435602fb9a0584ef71469e44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->