### PR TITLE
fix(proxy): skip double-wrapping unified batch output file ids on retrieve

### DIFF
--- a/enterprise/litellm_enterprise/proxy/hooks/managed_files.py
+++ b/enterprise/litellm_enterprise/proxy/hooks/managed_files.py
@@ -1104,20 +1104,20 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
                 for file_attr in ["output_file_id", "error_file_id"]:
                     file_id_value = getattr(response, file_attr, None)
                     if file_id_value and model_id:
-                        decoded_unified_file_id = _is_base64_encoded_unified_file_id(
+                        decoded_output_file_id = _is_base64_encoded_unified_file_id(
                             file_id_value
                         )
                         if (
-                            decoded_unified_file_id
-                            and "llm_output_file_id," in decoded_unified_file_id
+                            decoded_output_file_id
+                            and "llm_output_file_id," in decoded_output_file_id
                         ):
                             provider_file_id = (
                                 self.get_output_file_id_from_unified_file_id(
-                                    decoded_unified_file_id
+                                    decoded_output_file_id
                                 )
                             )
                             unified_file_id = file_id_value
-                        elif decoded_unified_file_id:
+                        elif decoded_output_file_id:
                             verbose_logger.warning(
                                 f"Skipping {file_attr}={file_id_value!r}: "
                                 "unified id is not a managed file output id"

--- a/enterprise/litellm_enterprise/proxy/hooks/managed_files.py
+++ b/enterprise/litellm_enterprise/proxy/hooks/managed_files.py
@@ -504,7 +504,7 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
                 if retrieve_file_id
                 else False
             )
-            if potential_file_id:
+            if potential_file_id and "llm_output_file_id," in potential_file_id:
                 model_id = self.get_model_id_from_unified_file_id(potential_file_id)
                 if model_id:
                     data["model"] = model_id
@@ -1058,7 +1058,12 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
         return file_id.split("llm_output_file_model_id,")[1].split(";")[0]
 
     def get_output_file_id_from_unified_file_id(self, file_id: str) -> str:
-        return file_id.split("llm_output_file_id,")[1].split(";")[0]
+        marker = "llm_output_file_id,"
+        if marker not in file_id:
+            raise ValueError(
+                f"Unified id does not contain {marker!r}: {file_id[:80]!r}"
+            )
+        return file_id.split(marker, 1)[1].split(";")[0]
 
     async def async_post_call_success_hook(
         self, data: Dict, user_api_key_dict: UserAPIKeyAuth, response: LLMResponseTypes
@@ -1102,13 +1107,22 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
                         decoded_unified_file_id = _is_base64_encoded_unified_file_id(
                             file_id_value
                         )
-                        if decoded_unified_file_id:
+                        if (
+                            decoded_unified_file_id
+                            and "llm_output_file_id," in decoded_unified_file_id
+                        ):
                             provider_file_id = (
                                 self.get_output_file_id_from_unified_file_id(
                                     decoded_unified_file_id
                                 )
                             )
                             unified_file_id = file_id_value
+                        elif decoded_unified_file_id:
+                            verbose_logger.warning(
+                                f"Skipping {file_attr}={file_id_value!r}: "
+                                "unified id is not a managed file output id"
+                            )
+                            continue
                         else:
                             provider_file_id = file_id_value
                             unified_file_id = self.get_unified_output_file_id(

--- a/enterprise/litellm_enterprise/proxy/hooks/managed_files.py
+++ b/enterprise/litellm_enterprise/proxy/hooks/managed_files.py
@@ -1099,13 +1099,24 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
                 for file_attr in ["output_file_id", "error_file_id"]:
                     file_id_value = getattr(response, file_attr, None)
                     if file_id_value and model_id:
-                        original_file_id = file_id_value
-                        unified_file_id = self.get_unified_output_file_id(
-                            output_file_id=original_file_id,
-                            model_id=model_id,
-                            model_name=resolved_model_name,
+                        decoded_unified_file_id = _is_base64_encoded_unified_file_id(
+                            file_id_value
                         )
-                        setattr(response, file_attr, unified_file_id)
+                        if decoded_unified_file_id:
+                            provider_file_id = (
+                                self.get_output_file_id_from_unified_file_id(
+                                    decoded_unified_file_id
+                                )
+                            )
+                            unified_file_id = file_id_value
+                        else:
+                            provider_file_id = file_id_value
+                            unified_file_id = self.get_unified_output_file_id(
+                                output_file_id=provider_file_id,
+                                model_id=model_id,
+                                model_name=resolved_model_name,
+                            )
+                            setattr(response, file_attr, unified_file_id)
 
                         # Use llm_router credentials when available. Without credentials,
                         # Azure and other auth-required providers return 500/401.
@@ -1125,27 +1136,27 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
                                     or {}
                                 )
                                 file_object = await litellm.afile_retrieve(
-                                    file_id=original_file_id,
+                                    file_id=provider_file_id,
                                     **_creds,
                                 )
                             else:
                                 file_object = await litellm.afile_retrieve(
                                     custom_llm_provider=model_name.split("/")[0] if model_name and "/" in model_name else "openai",  # type: ignore[arg-type]
-                                    file_id=original_file_id,
+                                    file_id=provider_file_id,
                                 )
                             verbose_logger.debug(
-                                f"Successfully retrieved file object for {file_attr}={original_file_id}"
+                                f"Successfully retrieved file object for {file_attr}={provider_file_id}"
                             )
                         except Exception as e:
                             verbose_logger.warning(
-                                f"Failed to retrieve file object for {file_attr}={original_file_id}: {str(e)}. Storing with None and will fetch on-demand."
+                                f"Failed to retrieve file object for {file_attr}={provider_file_id}: {str(e)}. Storing with None and will fetch on-demand."
                             )
 
                         await self.store_unified_file_id(
                             file_id=unified_file_id,
                             file_object=file_object,
                             litellm_parent_otel_span=user_api_key_dict.parent_otel_span,
-                            model_mappings={model_id: original_file_id},
+                            model_mappings={model_id: provider_file_id},
                             user_api_key_dict=user_api_key_dict,
                         )
             await self.store_unified_object_id(

--- a/tests/test_litellm/enterprise/proxy/test_managed_files_hook.py
+++ b/tests/test_litellm/enterprise/proxy/test_managed_files_hook.py
@@ -110,10 +110,9 @@ async def test_should_pass_credentials_to_afile_retrieve():
 
     mock_afile_retrieve = AsyncMock(return_value=_make_file_object("file-output-abc"))
 
-    with patch(
-        "litellm.afile_retrieve", mock_afile_retrieve
-    ), patch(
-        "litellm.proxy.proxy_server.llm_router", mock_router
+    with (
+        patch("litellm.afile_retrieve", mock_afile_retrieve),
+        patch("litellm.proxy.proxy_server.llm_router", mock_router),
     ):
         await managed_files.async_post_call_success_hook(
             data={},
@@ -128,7 +127,9 @@ async def test_should_pass_credentials_to_afile_retrieve():
             f"afile_retrieve must receive api_key from router credentials. "
             f"Got kwargs: {call_kwargs.kwargs}"
         )
-        assert call_kwargs.kwargs.get("api_base") == "https://my-azure.openai.azure.com/", (
+        assert (
+            call_kwargs.kwargs.get("api_base") == "https://my-azure.openai.azure.com/"
+        ), (
             f"afile_retrieve must receive api_base from router credentials. "
             f"Got kwargs: {call_kwargs.kwargs}"
         )
@@ -150,10 +151,9 @@ async def test_should_fallback_when_no_router():
 
     mock_afile_retrieve = AsyncMock(return_value=_make_file_object("file-output-abc"))
 
-    with patch(
-        "litellm.afile_retrieve", mock_afile_retrieve
-    ), patch(
-        "litellm.proxy.proxy_server.llm_router", None
+    with (
+        patch("litellm.afile_retrieve", mock_afile_retrieve),
+        patch("litellm.proxy.proxy_server.llm_router", None),
     ):
         await managed_files.async_post_call_success_hook(
             data={},
@@ -165,3 +165,60 @@ async def test_should_fallback_when_no_router():
         call_kwargs = mock_afile_retrieve.call_args
         assert call_kwargs.kwargs.get("custom_llm_provider") == "azure"
         assert call_kwargs.kwargs.get("file_id") == "file-output-abc"
+
+
+@pytest.mark.asyncio
+async def test_should_not_double_wrap_already_unified_output_file_id():
+    """After ensure_batch_response_managed_file_ids, retrieve must not re-wrap
+    output_file_id or store a nested unified id as the provider mapping."""
+    import base64
+
+    managed_files = _make_managed_files_instance()
+    provider_file_id = "file-WXWt9R4LzmU5WpeKzjCfLR"
+    model_id = "openai/openai/gpt-5.5-batch"
+    already_unified = managed_files.get_unified_output_file_id(
+        output_file_id=provider_file_id,
+        model_id=model_id,
+        model_name="openai/openai/gpt-5.5-batch",
+    )
+
+    batch_response = _make_batch_response(
+        model_id=model_id,
+        model_name="openai/openai/gpt-5.5-batch",
+        output_file_id=already_unified,
+    )
+    user_api_key_dict = _make_user_api_key_dict()
+
+    mock_credentials = {
+        "api_key": "test-key",
+        "api_base": "https://api.openai.com/v1",
+        "custom_llm_provider": "openai",
+    }
+    mock_router = MagicMock()
+    mock_router.get_deployment_credentials_with_provider = MagicMock(
+        return_value=mock_credentials
+    )
+    mock_afile_retrieve = AsyncMock(return_value=_make_file_object(provider_file_id))
+
+    with (
+        patch("litellm.afile_retrieve", mock_afile_retrieve),
+        patch("litellm.proxy.proxy_server.llm_router", mock_router),
+    ):
+        await managed_files.async_post_call_success_hook(
+            data={},
+            user_api_key_dict=user_api_key_dict,
+            response=batch_response,
+        )
+
+    assert batch_response.output_file_id == already_unified
+    mock_afile_retrieve.assert_called_once()
+    assert mock_afile_retrieve.call_args.kwargs["file_id"] == provider_file_id
+    managed_files.store_unified_file_id.assert_awaited_once()
+    assert managed_files.store_unified_file_id.await_args.kwargs["model_mappings"] == {
+        model_id: provider_file_id
+    }
+
+    decoded = base64.urlsafe_b64decode(
+        already_unified + "=" * (-len(already_unified) % 4)
+    ).decode()
+    assert decoded.count(f"llm_output_file_id,{provider_file_id}") == 1

--- a/tests/test_litellm/enterprise/proxy/test_managed_files_hook.py
+++ b/tests/test_litellm/enterprise/proxy/test_managed_files_hook.py
@@ -222,3 +222,36 @@ async def test_should_not_double_wrap_already_unified_output_file_id():
         already_unified + "=" * (-len(already_unified) % 4)
     ).decode()
     assert decoded.count(f"llm_output_file_id,{provider_file_id}") == 1
+
+
+@pytest.mark.asyncio
+async def test_should_skip_non_file_unified_id_on_output_file_id():
+    """Batch-style unified ids lack llm_output_file_id; must not IndexError or re-wrap."""
+    import base64
+
+    managed_files = _make_managed_files_instance()
+    batch_unified = (
+        base64.urlsafe_b64encode(
+            b"litellm_proxy;model_id:openai/openai/gpt-5.5-batch;llm_batch_id:batch_abc"
+        )
+        .decode()
+        .rstrip("=")
+    )
+
+    batch_response = _make_batch_response(
+        model_id="openai/openai/gpt-5.5-batch",
+        model_name="openai/openai/gpt-5.5-batch",
+        output_file_id=batch_unified,
+    )
+    user_api_key_dict = _make_user_api_key_dict()
+
+    with patch("litellm.afile_retrieve", AsyncMock()) as mock_afile_retrieve:
+        await managed_files.async_post_call_success_hook(
+            data={},
+            user_api_key_dict=user_api_key_dict,
+            response=batch_response,
+        )
+
+    assert batch_response.output_file_id == batch_unified
+    mock_afile_retrieve.assert_not_called()
+    managed_files.store_unified_file_id.assert_not_awaited()


### PR DESCRIPTION
## Summary
- On batch retrieve, `ensure_batch_response_managed_file_ids` already converts raw `output_file_id` to a unified managed id before `post_call_success_hook` runs.
- The managed files hook was wrapping that id again and storing the nested unified id in `model_mappings`, so `GET /files/{id}/content` passed the wrong id to OpenAI (404).
- If `output_file_id` is already unified, extract `llm_output_file_id` and skip re-encoding.

## Test plan
- [x] `pytest tests/test_litellm/enterprise/proxy/test_managed_files_hook.py::test_should_not_double_wrap_already_unified_output_file_id -v`
- [x] `pytest tests/test_litellm/enterprise/proxy/test_managed_files_hook.py tests/test_litellm/enterprise/proxy/test_batch_update_db_managed_output_file_id.py -v`


<img width="1158" height="199" alt="image" src="https://github.com/user-attachments/assets/16f7a349-d334-42e7-94c9-b680677692d0" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes managed-file ID parsing and batch post-success storage paths used by file content retrieval; incorrect behavior would cause 404s or wrong mappings, but scope is limited to unified batch output/error file handling with new regression tests.
> 
> **Overview**
> Fixes **double-wrapping** of batch `output_file_id` / `error_file_id` when those fields are already LiteLLM unified managed file IDs (e.g. after `ensure_batch_response_managed_file_ids` on batch retrieve).
> 
> In **`async_post_call_success_hook`**, the hook now decodes base64 IDs and branches: if the payload contains **`llm_output_file_id,`**, it reuses the existing unified id, retrieves with the **provider** file id, and stores **`model_mappings`** with the raw provider id; if it is unified but **not** a managed output file id (e.g. a batch unified id wrongly on `output_file_id`), it **logs and skips** retrieve/store; otherwise it still **wraps** raw provider ids as before.
> 
> **`afile_content`** pre-call mapping only runs when the decoded id includes **`llm_output_file_id,`**, so batch-style unified ids are not mis-parsed as output files. **`get_output_file_id_from_unified_file_id`** now **raises** when that marker is missing instead of failing opaquely.
> 
> New enterprise proxy tests cover no double-wrap and skipping non-file unified ids on `output_file_id`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6b0dc1d4351fab9f256720b7417f355d1cef343. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->