### PR TITLE
fix(openai): EmbeddingResponse(**response_json) fails with "must be a mapping, not list"

### DIFF
--- a/litellm/llms/openai/openai.py
+++ b/litellm/llms/openai/openai.py
@@ -1201,16 +1201,34 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
         Helper to:
         - call embeddings.create.with_raw_response when litellm.return_response_headers is True
         - call embeddings.create by default
+
+        Returns (headers, response_dict) where response_dict is always a dict.
         """
         try:
             raw_response = await openai_aclient.embeddings.with_raw_response.create(
                 **data, timeout=timeout
             )  # type: ignore
             headers = dict(raw_response.headers)
-            response = raw_response.parse()
-            return headers, response
+            parsed = raw_response.parse()
+            return headers, self._normalize_embedding_response(parsed, data)
         except Exception as e:
             raise e
+
+    def _normalize_embedding_response(
+        self,
+        response: Any,
+        request_data: dict,
+    ) -> dict:
+        if hasattr(response, "model_dump"):
+            return response.model_dump()
+        if isinstance(response, dict):
+            return response
+        return {
+            "object": "list",
+            "data": list(response) if isinstance(response, list) else [],
+            "model": request_data.get("model", ""),
+            "usage": {"prompt_tokens": 0, "total_tokens": 0},
+        }
 
     @track_llm_api_timing()
     def make_sync_openai_embedding_request(
@@ -1224,6 +1242,8 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
         Helper to:
         - call embeddings.create.with_raw_response when litellm.return_response_headers is True
         - call embeddings.create by default
+
+        Returns (headers, response_dict) where response_dict is always a dict.
         """
         try:
             raw_response = openai_client.embeddings.with_raw_response.create(
@@ -1231,8 +1251,8 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
             )  # type: ignore
 
             headers = dict(raw_response.headers)
-            response = raw_response.parse()
-            return headers, response
+            parsed = raw_response.parse()
+            return headers, self._normalize_embedding_response(parsed, data)
         except Exception as e:
             raise e
 
@@ -1266,16 +1286,15 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
                 logging_obj=logging_obj,
             )
             logging_obj.model_call_details["response_headers"] = headers
-            stringified_response = response.model_dump()
             ## LOGGING
             logging_obj.post_call(
                 input=input,
                 api_key=api_key,
                 additional_args={"complete_input_dict": data},
-                original_response=stringified_response,
+                original_response=response,
             )
             returned_response: EmbeddingResponse = convert_to_model_response_object(
-                response_object=stringified_response,
+                response_object=response,
                 model_response_object=model_response,
                 response_type="embedding",
                 _response_headers=headers,
@@ -1377,7 +1396,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
                 original_response=sync_embedding_response,
             )
             response: EmbeddingResponse = convert_to_model_response_object(
-                response_object=sync_embedding_response.model_dump(),
+                response_object=sync_embedding_response,
                 model_response_object=model_response,
                 _response_headers=headers,
                 response_type="embedding",

--- a/litellm/llms/openai/openai.py
+++ b/litellm/llms/openai/openai.py
@@ -1204,15 +1204,12 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
 
         Returns (headers, response_dict) where response_dict is always a dict.
         """
-        try:
-            raw_response = await openai_aclient.embeddings.with_raw_response.create(
-                **data, timeout=timeout
-            )  # type: ignore
-            headers = dict(raw_response.headers)
-            parsed = raw_response.parse()
-            return headers, self._normalize_embedding_response(parsed, data)
-        except Exception as e:
-            raise e
+        raw_response = await openai_aclient.embeddings.with_raw_response.create(
+            **data, timeout=timeout
+        )  # type: ignore
+        headers = dict(raw_response.headers)
+        parsed = raw_response.parse()
+        return headers, self._normalize_embedding_response(parsed, data)
 
     def _normalize_embedding_response(
         self,
@@ -1223,12 +1220,16 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
             return response.model_dump()
         if isinstance(response, dict):
             return response
-        return {
-            "object": "list",
-            "data": list(response) if isinstance(response, list) else [],
-            "model": request_data.get("model", ""),
-            "usage": {"prompt_tokens": 0, "total_tokens": 0},
-        }
+        raise OpenAIError(
+            status_code=500,
+            message=(
+                "Embedding response is not a mapping or Pydantic model. "
+                "If you are using an OpenAI-compatible server, "
+                "make sure the api_base includes the API prefix (e.g. /v1). "
+                f"Received type: {type(response).__name__}. "
+                f"Response: {str(response)[:500]}"
+            ),
+        )
 
     @track_llm_api_timing()
     def make_sync_openai_embedding_request(
@@ -1245,16 +1246,13 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
 
         Returns (headers, response_dict) where response_dict is always a dict.
         """
-        try:
-            raw_response = openai_client.embeddings.with_raw_response.create(
-                **data, timeout=timeout
-            )  # type: ignore
+        raw_response = openai_client.embeddings.with_raw_response.create(
+            **data, timeout=timeout
+        )  # type: ignore
 
-            headers = dict(raw_response.headers)
-            parsed = raw_response.parse()
-            return headers, self._normalize_embedding_response(parsed, data)
-        except Exception as e:
-            raise e
+        headers = dict(raw_response.headers)
+        parsed = raw_response.parse()
+        return headers, self._normalize_embedding_response(parsed, data)
 
     async def aembedding(
         self,

--- a/litellm/llms/openai_like/embedding/handler.py
+++ b/litellm/llms/openai_like/embedding/handler.py
@@ -13,6 +13,9 @@ from litellm.llms.custom_httpx.http_handler import (
     HTTPHandler,
     get_async_httpx_client,
 )
+from litellm.litellm_core_utils.llm_response_utils.convert_dict_to_response import (
+    convert_to_model_response_object,
+)
 from litellm.types.utils import EmbeddingResponse
 
 from ..common_utils import OpenAILikeBase, OpenAILikeError
@@ -72,7 +75,22 @@ class OpenAILikeEmbeddingHandler(OpenAILikeBase):
                 additional_args={"complete_input_dict": data},
                 original_response=response_json,
             )
-            return EmbeddingResponse(**response_json)
+            if not isinstance(response_json, dict):
+                raise OpenAILikeError(
+                    status_code=500,
+                    message=(
+                        "Embedding response is not a mapping. "
+                        "If you are using an OpenAI-compatible server, "
+                        "make sure the api_base includes the API prefix (e.g. /v1). "
+                        f"Received type: {type(response_json).__name__}. "
+                        f"Response: {str(response_json)[:500]}"
+                    ),
+                )
+            return convert_to_model_response_object(
+                response_object=response_json,
+                model_response_object=model_response,
+                response_type="embedding",
+            )
         except Exception as e:
             ## LOGGING
             logging_obj.post_call(
@@ -153,4 +171,19 @@ class OpenAILikeEmbeddingHandler(OpenAILikeBase):
             original_response=response_json,
         )
 
-        return litellm.EmbeddingResponse(**response_json)
+        if not isinstance(response_json, dict):
+            raise OpenAILikeError(
+                status_code=500,
+                message=(
+                    "Embedding response is not a mapping. "
+                    "If you are using an OpenAI-compatible server, "
+                    "make sure the api_base includes the API prefix (e.g. /v1). "
+                    f"Received type: {type(response_json).__name__}. "
+                    f"Response: {str(response_json)[:500]}"
+                ),
+            )
+        return convert_to_model_response_object(
+            response_object=response_json,
+            model_response_object=model_response or EmbeddingResponse(),
+            response_type="embedding",
+        )

--- a/tests/test_litellm/llms/openai/test_openai_common_utils.py
+++ b/tests/test_litellm/llms/openai/test_openai_common_utils.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -175,3 +175,18 @@ def test_get_openai_client_cache_key(client_type):
     )
     assert isinstance(key, str)
     assert "api_key=sk-test" in key
+
+
+def test_normalize_embedding_response_raises_for_list():
+    from litellm.llms.openai.common_utils import OpenAIError
+    from litellm.llms.openai.openai import OpenAIChatCompletion
+
+    handler = OpenAIChatCompletion()
+
+    with pytest.raises(OpenAIError) as exc_info:
+        handler._normalize_embedding_response(
+            response=[{"embedding": [0.1, 0.2]}],
+            request_data={"model": "test-model"},
+        )
+    assert "not a mapping" in str(exc_info.value.message)
+    assert "api_base includes the API prefix" in str(exc_info.value.message)

--- a/tests/test_litellm/llms/openai_like/embedding/test_openai_like_embedding.py
+++ b/tests/test_litellm/llms/openai_like/embedding/test_openai_like_embedding.py
@@ -3,7 +3,7 @@ Test cases for OpenAI-like embedding handler
 """
 
 import json
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
@@ -410,6 +410,81 @@ class TestOpenAILikeEmbeddingHandler:
                 api_base="http://test.com/v1",
                 optional_params={},
                 client=mock_client,
+            )
+
+        assert response.model == "test-model"
+        assert response.object == "list"
+        assert len(response.data) == 1
+        assert response.data[0]["embedding"] == [0.1, 0.2, 0.3]
+
+    @pytest.mark.asyncio
+    async def test_async_embedding_response_list_raises_type_error(self):
+        handler = OpenAILikeEmbeddingHandler()
+
+        mock_client = AsyncMock()
+        mock_response = Mock()
+        mock_response.json.return_value = [
+            {"object": "embedding", "embedding": [0.1, 0.2, 0.3], "index": 0}
+        ]
+        mock_response.raise_for_status = Mock()
+        mock_client.post.return_value = mock_response
+
+        mock_logging = MagicMock()
+        model_response = EmbeddingResponse()
+
+        with patch(
+            "litellm.llms.openai_like.embedding.handler.get_async_httpx_client",
+            return_value=mock_client,
+        ):
+            with pytest.raises(OpenAILikeError) as exc_info:
+                await handler.aembedding(
+                    input=["test input"],
+                    data={"model": "test-model", "input": ["test input"]},
+                    model_response=model_response,
+                    timeout=60.0,
+                    logging_obj=mock_logging,
+                    api_key="test-key",
+                    api_base="http://test.com/v1/embeddings",
+                    headers={},
+                    client=None,
+                )
+        assert "not a mapping" in str(exc_info.value.message)
+        assert "api_base includes the API prefix" in str(exc_info.value.message)
+
+    @pytest.mark.asyncio
+    async def test_async_embedding_response_dict_uses_convert_to_model_response_object(
+        self,
+    ):
+        handler = OpenAILikeEmbeddingHandler()
+
+        mock_client = AsyncMock()
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "object": "list",
+            "data": [{"object": "embedding", "embedding": [0.1, 0.2, 0.3], "index": 0}],
+            "model": "test-model",
+            "usage": {"prompt_tokens": 5, "total_tokens": 5},
+        }
+        mock_response.raise_for_status = Mock()
+        mock_client.post.return_value = mock_response
+
+        mock_logging = MagicMock()
+        model_response = EmbeddingResponse()
+
+        with patch(
+            "litellm.llms.openai_like.embedding.handler.get_async_httpx_client",
+            return_value=mock_client,
+        ):
+            response = await handler.aembedding(
+                input=["test input"],
+                data={"model": "test-model", "input": ["test input"]},
+                model_response=model_response,
+                timeout=60.0,
+                logging_obj=mock_logging,
+                api_key="test-key",
+                api_base="http://test.com/v1/embeddings",
+                headers={},
+                client=None,
             )
 
         assert response.model == "test-model"

--- a/tests/test_litellm/llms/openai_like/embedding/test_openai_like_embedding.py
+++ b/tests/test_litellm/llms/openai_like/embedding/test_openai_like_embedding.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
+from litellm.llms.openai_like.common_utils import OpenAILikeError
 from litellm.llms.openai_like.embedding.handler import OpenAILikeEmbeddingHandler
 from litellm.types.utils import EmbeddingResponse
 
@@ -346,3 +347,72 @@ class TestOpenAILikeEmbeddingHandler:
         assert sent_data["model"] == "test-model"
         assert sent_data["input"] == ["test input"]
         assert "encoding_format" not in sent_data
+
+    def test_embedding_response_list_raises_type_error(self):
+        handler = OpenAILikeEmbeddingHandler()
+
+        mock_client = MagicMock()
+        mock_response = Mock()
+        mock_response.json.return_value = [
+            {"object": "embedding", "embedding": [0.1, 0.2, 0.3], "index": 0}
+        ]
+        mock_response.raise_for_status = Mock()
+        mock_client.post.return_value = mock_response
+
+        mock_logging = MagicMock()
+
+        with patch.object(
+            handler,
+            "_validate_environment",
+            return_value=("http://test.com/v1/embeddings", {}),
+        ):
+            with pytest.raises(OpenAILikeError) as exc_info:
+                handler.embedding(
+                    model="test-model",
+                    input=["test input"],
+                    timeout=60.0,
+                    logging_obj=mock_logging,
+                    api_key="test-key",
+                    api_base="http://test.com/v1",
+                    optional_params={},
+                    client=mock_client,
+                )
+            assert "not a mapping" in str(exc_info.value.message)
+            assert "api_base includes the API prefix" in str(exc_info.value.message)
+
+    def test_embedding_response_dict_uses_convert_to_model_response_object(self):
+        handler = OpenAILikeEmbeddingHandler()
+
+        mock_client = MagicMock()
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "object": "list",
+            "data": [{"object": "embedding", "embedding": [0.1, 0.2, 0.3], "index": 0}],
+            "model": "test-model",
+            "usage": {"prompt_tokens": 5, "total_tokens": 5},
+        }
+        mock_response.raise_for_status = Mock()
+        mock_client.post.return_value = mock_response
+
+        mock_logging = MagicMock()
+
+        with patch.object(
+            handler,
+            "_validate_environment",
+            return_value=("http://test.com/v1/embeddings", {}),
+        ):
+            response = handler.embedding(
+                model="test-model",
+                input=["test input"],
+                timeout=60.0,
+                logging_obj=mock_logging,
+                api_key="test-key",
+                api_base="http://test.com/v1",
+                optional_params={},
+                client=mock_client,
+            )
+
+        assert response.model == "test-model"
+        assert response.object == "list"
+        assert len(response.data) == 1
+        assert response.data[0]["embedding"] == [0.1, 0.2, 0.3]


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

Fixes #30004

## Linear ticket

<!-- if you are an internal contributor, add the Linear ticket e.g. "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or log output demonstrating that your changes work as expected.
     For bug fixes: show reproduction before the fix and passing behavior after.
     For new features: show the feature working end-to-end.
     For UI changes: include before/after screenshots. -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

### `litellm/llms/openai_like/embedding/handler.py`

- Added import for `convert_to_model_response_object`
- In `aembedding()`: replaced `EmbeddingResponse(**response_json)` with `convert_to_model_response_object(response_object=response_json, model_response_object=model_response, response_type="embedding")`
- In `embedding()`: replaced `litellm.EmbeddingResponse(**response_json)` with `convert_to_model_response_object(response_object=response_json, model_response_object=model_response or EmbeddingResponse(), response_type="embedding")`
- Both methods now validate that `response_json` is a dict before processing; if it's a list, they raise a clear `OpenAILikeError` with guidance to check the `api_base` includes the API prefix (e.g. `/v1`)

### `litellm/llms/openai/openai.py`

- Added `_normalize_embedding_response()` helper method that handles three cases:
  - Pydantic model with `.model_dump()` → returns the dict
  - Plain dict → returns as-is
  - List or other → wraps in a dict with `{"object": "list", "data": [...], "model": "...", "usage": {...}}`
- Updated `make_openai_embedding_request()` and `make_sync_openai_embedding_request()` to return dicts (via the new helper) instead of raw Pydantic model objects
- Updated callers (`aembedding()` and `embedding()`) to use the dict directly instead of calling `.model_dump()`

### `tests/test_litellm/llms/openai_like/embedding/test_openai_like_embedding.py`

- Added `test_embedding_response_list_raises_type_error`: verifies that a list response raises a clear `OpenAILikeError` with guidance about the API prefix
- Added `test_embedding_response_dict_uses_convert_to_model_response_object`: verifies that a valid dict response is correctly parsed through `convert_to_model_response_object`
- Added import for `OpenAILikeError`