### PR TITLE
fix(guardrails): pass custom redaction tags to ContentFilterGuardrail initialization

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/__init__.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/__init__.py
@@ -38,6 +38,10 @@ def initialize_guardrail(
         patterns=litellm_params.patterns,
         blocked_words=litellm_params.blocked_words,
         blocked_words_file=litellm_params.blocked_words_file,
+        pattern_redaction_format=getattr(
+            litellm_params, "pattern_redaction_format", None
+        ),
+        keyword_redaction_tag=getattr(litellm_params, "keyword_redaction_tag", None),
         event_hook=litellm_params.mode,  # type: ignore
         default_on=litellm_params.default_on or False,
         categories=getattr(litellm_params, "categories", None),

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_content_filter.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_content_filter.py
@@ -4,7 +4,7 @@ Tests for the Content Filter Guardrail
 
 import os
 import sys
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -17,11 +17,15 @@ from fastapi import HTTPException
 from litellm.proxy.guardrails.guardrail_hooks.litellm_content_filter.content_filter import (
     ContentFilterGuardrail,
 )
+from litellm.proxy.guardrails.guardrail_hooks.litellm_content_filter import (
+    initialize_guardrail,
+)
 from litellm.types.guardrails import (
     BlockedWord,
     ContentFilterAction,
     ContentFilterPattern,
     GuardrailEventHooks,
+    LitellmParams,
 )
 from litellm.types.proxy.guardrails.guardrail_hooks.litellm_content_filter import (
     ContentFilterCategoryConfig,
@@ -75,6 +79,43 @@ class TestContentFilterGuardrail:
         assert len(guardrail.blocked_words) == 2
         assert "secret_project" in guardrail.blocked_words
         assert guardrail.blocked_words["secret_project"][0] == ContentFilterAction.BLOCK
+
+    @pytest.mark.asyncio
+    async def test_initializer_preserves_custom_redaction_formats(self):
+        litellm_params = LitellmParams(
+            guardrail="litellm_content_filter",
+            mode="pre_call",
+            patterns=[
+                ContentFilterPattern(
+                    pattern_type="regex",
+                    pattern=r"1[3-9]\d{9}",
+                    name="phone_number",
+                    action=ContentFilterAction.MASK,
+                )
+            ],
+            blocked_words=[
+                BlockedWord(
+                    keyword="secret_project",
+                    action=ContentFilterAction.MASK,
+                )
+            ],
+            pattern_redaction_format="<<{pattern_name}>>",
+            keyword_redaction_tag="<<KEYWORD>>",
+        )
+
+        with patch("litellm.logging_callback_manager.add_litellm_callback"):
+            guardrail = initialize_guardrail(
+                litellm_params=litellm_params,
+                guardrail={"guardrail_name": "test-content-filter"},
+            )
+
+        result = await guardrail.apply_guardrail(
+            inputs={"texts": ["Call 13912345678 about secret_project"]},
+            request_data={},
+            input_type="request",
+        )
+
+        assert result["texts"] == ["Call <<PHONE_NUMBER>> about <<KEYWORD>>"]
 
     def test_check_patterns_ssn(self):
         """


### PR DESCRIPTION
## TLDR

Problem this solves:

- Custom redaction formats persist but runtime ignores them
- Responses always use the built-in redaction placeholders

How it solves it:

- Forward both saved formats into the content filter
- Add regression coverage for both masking paths

## User Flow

Before: a proxy admin saves custom redaction formats, but guardrail output still uses the defaults

1. They send `POST https://litellm-domain/guardrails` with custom keyword and pattern formats
2. They send `POST https://litellm-domain/guardrails/apply_guardrail` with a phone number and blocked keyword
3. The response contains `[PHONE_NUMBER_REDACTED]` and `[KEYWORD_REDACTED]`

After: the same requests return the custom redaction formats the admin configured

1. They send `POST https://litellm-domain/guardrails` with custom keyword and pattern formats
2. They send `POST https://litellm-domain/guardrails/apply_guardrail` with a phone number and blocked keyword
3. The response contains `<<PHONE_NUMBER>>` and `<<KEYWORD>>`

## Relevant issues

Fixes #30008

## Affected release

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

Both runs used a local PostgreSQL-backed proxy with `STORE_MODEL_IN_DB=True`, master key `sk-1234`, and the same guardrail configuration

```yaml
general_settings:
  master_key: sk-1234

litellm_settings:
  telemetry: false
```

The JSON below was saved as `/tmp/pr30017-guardrail.json`, with the guardrail name changed between runs

```json
{
  "guardrail": {
    "guardrail_name": "pr30017-redaction-proof",
    "litellm_params": {
      "guardrail": "litellm_content_filter",
      "mode": "pre_call",
      "default_on": true,
      "keyword_redaction_tag": "<<KEYWORD>>",
      "pattern_redaction_format": "<<{pattern_name}>>",
      "blocked_words": [{"keyword": "secret_project", "action": "MASK"}],
      "patterns": [{"pattern_type": "regex", "pattern": "1[3-9]\\d{9}", "name": "phone_number", "action": "MASK"}]
    }
  }
}
```

### Before (252c71c)

1. Started the proxy from the merge base on `http://localhost:4001`

```bash
DATABASE_URL=postgresql://postgres:<password>@localhost:55432/litellm_review \
STORE_MODEL_IN_DB=True \
uv run python litellm/proxy/proxy_cli.py \
  --config /tmp/litellm-pr30017-config.yaml \
  --port 4001 \
  --use_v2_migration_resolver
```

2. Sent the configuration to `POST /guardrails`; the API persisted both custom values

```bash
curl -X POST http://localhost:4001/guardrails \
  -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d @/tmp/pr30017-guardrail.json
```

```text
{"guardrail_name":"pr30017-before-252c71c","pattern_redaction_format":"<<{pattern_name}>>","keyword_redaction_tag":"<<KEYWORD>>"}
HTTP 200
```

3. Applied the saved guardrail to `Call 13912345678 about secret_project`

```bash
curl -X POST http://localhost:4001/guardrails/apply_guardrail \
  -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d '{"guardrail_name":"pr30017-before-252c71c","text":"Call 13912345678 about secret_project"}'
```

```text
{"response_text":"Call [PHONE_NUMBER_REDACTED] about [KEYWORD_REDACTED]"}
HTTP 200
```

### After (1b3cec0)

1. Started the proxy from the PR tip on `http://localhost:4002`

```bash
DATABASE_URL=postgresql://postgres:<password>@localhost:55432/litellm_review \
STORE_MODEL_IN_DB=True \
uv run python litellm/proxy/proxy_cli.py \
  --config /tmp/litellm-pr30017-config.yaml \
  --port 4002 \
  --use_v2_migration_resolver
```

2. Sent the same configuration to `POST /guardrails`; the API persisted both custom values

```bash
curl -X POST http://localhost:4002/guardrails \
  -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d @/tmp/pr30017-guardrail.json
```

```text
{"guardrail_name":"pr30017-after-1b3cec0","pattern_redaction_format":"<<{pattern_name}>>","keyword_redaction_tag":"<<KEYWORD>>"}
HTTP 200
```

3. Applied the saved guardrail to `Call 13912345678 about secret_project`

```bash
curl -X POST http://localhost:4002/guardrails/apply_guardrail \
  -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d '{"guardrail_name":"pr30017-after-1b3cec0","text":"Call 13912345678 about secret_project"}'
```

```text
{"response_text":"Call <<PHONE_NUMBER>> about <<KEYWORD>>"}
HTTP 200
```

## Type

🐛 Bug Fix

## Caveats (if any)

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR