### PR TITLE
fix(proxy): add realtime WebRTC HTTP sub-routes to openai_routes to unblock non-admin keys

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -358,6 +358,13 @@ class LiteLLMRoutes(enum.Enum):
         "/realtime?{model}",
         "/v1/realtime?{model}",
         "/openai/v1/realtime?{model}",
+        # realtime WebRTC HTTP sub-routes (client_secrets, calls) - fixes #29923
+        "/realtime/client_secrets",
+        "/v1/realtime/client_secrets",
+        "/openai/v1/realtime/client_secrets",
+        "/realtime/calls",
+        "/v1/realtime/calls",
+        "/openai/v1/realtime/calls",
         # responses API
         "/responses",
         "/v1/responses",


### PR DESCRIPTION
## Description

Fixes #29923

The realtime WebRTC HTTP routes `/realtime/client_secrets` and `/realtime/calls` (and their `/v1/` and `/openai/v1/` prefixed variants) are registered in `realtime_endpoints/endpoints.py` but were absent from `LiteLLMRoutes.openai_routes` in `_types.py`.

As a result, `is_llm_api_route()` returned `False` for these paths, and any non-admin virtual key (e.g. `role=internal_user_viewer`) was blocked with 401 instead of being treated as a standard LLM API call:

```
401 Only proxy admin can be used to generate, delete, update info for new keys/users/teams.
Route=/v1/realtime/client_secrets. Your role=internal_user_viewer
```

## Fix

Add the six missing paths to `LiteLLMRoutes.openai_routes`, mirroring how the WebSocket `/realtime` paths were added via PR #27323:

```python
"/realtime/client_secrets",
"/v1/realtime/client_secrets",
"/openai/v1/realtime/client_secrets",
"/realtime/calls",
"/v1/realtime/calls",
"/openai/v1/realtime/calls",
```

## File changed

- `litellm/proxy/_types.py` — 6 routes added to `LiteLLMRoutes.openai_routes`

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] All three URL prefix variants added for each route (`/`, `/v1/`, `/openai/v1/`)
- [x] Routes match exactly what is registered in `realtime_endpoints/endpoints.py`
