### PR TITLE
fix(prometheus): fix remaining budget metric showing +Inf on batch/files/responses routes

### DIFF
--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -1362,7 +1362,13 @@ class PrometheusLogger(CustomLogger):
         user_id: Optional[str] = None,
         user_api_key_org_id: Optional[str] = None,
     ):
-        _metadata = litellm_params.get("metadata") or {}
+        # For batch/files/responses/thread/assistant endpoints, add_litellm_data_to_request
+        # stores budget metadata under "litellm_metadata" not "metadata" (fixes #29937).
+        _metadata = (
+            litellm_params.get("metadata")
+            or litellm_params.get("litellm_metadata")
+            or {}
+        )
         _team_spend = _metadata.get("user_api_key_team_spend", None)
         _team_max_budget = _metadata.get("user_api_key_team_max_budget", None)
 


### PR DESCRIPTION
## Description

Fixes #29937

`litellm_remaining_team_budget_metric` (and the equivalent API-key and user metrics) always shows `+Inf` even when a budget is configured on the team or key.

## Root cause

`_increment_remaining_budget_metrics` in `prometheus.py` reads budget metadata from `litellm_params.get("metadata")`:

```python
_metadata = litellm_params.get("metadata") or {}
_team_max_budget = _metadata.get("user_api_key_team_max_budget", None)
```

However, `add_litellm_data_to_request` stores all per-request metadata under `litellm_params["litellm_metadata"]` (not `["metadata"]`) for these route families:

| Pattern | Examples |
|---|---|
| `batches` | `/v1/batches`, `/v1/batches/{id}` |
| `responses` | `/v1/responses` |
| `files` | `/v1/files` |
| `/v1/messages` | Anthropic pass-through |
| `thread` / `assistant` | OpenAI Assistants API |

This is controlled by `_get_metadata_variable_name` in `litellm_pre_call_utils.py`, which returns `"litellm_metadata"` for those routes and `"metadata"` for everything else.

Because the budget fields (`user_api_key_team_max_budget`, `user_api_key_team_spend`, etc.) are stored under the wrong key for those routes, `_team_max_budget` is `None`, `_safe_get_remaining_budget` returns `float("inf")`, and the Prometheus gauge is set to `+Inf`.

The symptom is asymmetric: `litellm_team_max_budget_metric` still shows the correct value (`25.0`) because that metric is only written when `team.max_budget is not None` (from the initialization path), while `litellm_remaining_team_budget_metric` is overwritten to `+Inf` by every post-request update on a litellm-metadata route.

## Fix

Fall back to `litellm_params.get("litellm_metadata")` when `"metadata"` does not contain the budget fields:

```python
# Before
_metadata = litellm_params.get("metadata") or {}

# After
_metadata = (
    litellm_params.get("metadata")
    or litellm_params.get("litellm_metadata")
    or {}
)
```

## File changed

- `litellm/integrations/prometheus.py` - one-line fix in `_increment_remaining_budget_metrics`

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] Fix is minimal - touches only the one metadata read that controls budget metric values
- [x] Regular chat completions routes are unaffected (they still use `"metadata"`)
- [x] Batch, files, responses, Anthropic messages, and assistants routes now correctly read budget from `"litellm_metadata"`
