### PR TITLE
fix(spend-tracking): fall back to direct increment when reservation reconcile fails

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -2263,7 +2263,7 @@ async def _reconcile_budget_reservation_for_counter_update(
         )
     except Exception:
         verbose_proxy_logger.warning(
-            "Failed to reconcile budget reservation after persisted spend; invalidating reserved counters and continuing",
+            "Failed to reconcile budget reservation after persisted spend; invalidating reserved counters and falling back to direct increment",
             exc_info=True,
         )
         try:
@@ -2274,6 +2274,7 @@ async def _reconcile_budget_reservation_for_counter_update(
             verbose_proxy_logger.exception(
                 "Failed to invalidate reserved counters after reservation reconciliation failed"
             )
+        return set()
     return reserved_counter_keys
 
 

--- a/tests/test_litellm/proxy/proxy_server/test_spend_counters.py
+++ b/tests/test_litellm/proxy/proxy_server/test_spend_counters.py
@@ -192,8 +192,9 @@ async def test_reconcile_budget_reservation_for_counter_update_returns_empty_set
 async def test_reconcile_budget_reservation_for_counter_update_failure_invalidates(
     monkeypatch,
 ):
-    """Reservation reconcile raising must invalidate reserved counters but
-    not propagate the exception."""
+    """Reservation reconcile raising must invalidate reserved counters, swallow
+    the exception, and return an empty set so the caller falls back to the
+    direct spend-counter increment instead of skipping it."""
     import litellm.proxy.spend_tracking.budget_reservation as br
 
     monkeypatch.setattr(
@@ -213,7 +214,7 @@ async def test_reconcile_budget_reservation_for_counter_update_failure_invalidat
         budget_reservation={"foo": "bar"}, response_cost=1.0
     )
 
-    assert result == {"spend:key:abc"}
+    assert result == set()
     assert fake_invalidate.called is True
 
 

--- a/tests/test_litellm/proxy/spend_tracking/test_budget_reservation_redis_failure.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_budget_reservation_redis_failure.py
@@ -1,0 +1,87 @@
+"""
+Regression test for enforced-spend underreporting when Redis fails during the
+budget-reservation reconcile step of ``increment_spend_counters``.
+
+Production failure mode: a managed Redis returns an intermittent timeout on the
+reconcile increment. Reconcile deletes (invalidates) the shared counter and
+gives up, but ``increment_spend_counters`` still treats the counter as
+"already reconciled" and skips the direct increment. The actual call cost never
+lands in the enforced counter, so budgets stop gating until the next cold
+reseed pulls a lagging value from the DB.
+
+The fix makes the reconcile path fall back to the direct increment when it
+fails, so the actual cost is always written to the shared counter.
+"""
+
+import pytest
+
+from litellm.caching import DualCache
+from litellm.proxy import proxy_server
+
+
+class _FlakyRedisCache:
+    def __init__(self) -> None:
+        self._store: dict = {}
+        self._increment_calls = 0
+
+    async def async_increment(self, key, value, **kwargs):
+        self._increment_calls += 1
+        if self._increment_calls == 1:
+            raise Exception("Redis timeout")
+        self._store[key] = float(self._store.get(key, 0.0)) + float(value)
+        return self._store[key]
+
+    async def async_get_cache(self, key, *args, **kwargs):
+        return self._store.get(key)
+
+    async def async_delete_cache(self, key, *args, **kwargs):
+        self._store.pop(key, None)
+
+    async def async_set_cache(self, key, value, *args, **kwargs):
+        self._store[key] = float(value)
+        return True
+
+
+@pytest.mark.asyncio
+async def test_direct_increment_runs_when_reservation_reconcile_hits_redis_failure(
+    monkeypatch,
+):
+    hashed_token = "hashed_test_token"
+    counter_key = f"spend:key:{hashed_token}"
+    reserved_cost = 0.5
+    response_cost = 1.0
+
+    flaky_redis = _FlakyRedisCache()
+    flaky_redis._store[counter_key] = reserved_cost
+
+    monkeypatch.setattr(proxy_server, "prisma_client", None)
+    monkeypatch.setattr(proxy_server, "user_api_key_cache", DualCache())
+    monkeypatch.setattr(proxy_server.spend_counter_cache, "redis_cache", flaky_redis)
+    proxy_server.spend_counter_cache.in_memory_cache.set_cache(
+        key=counter_key, value=reserved_cost
+    )
+
+    budget_reservation = {
+        "reserved_cost": reserved_cost,
+        "finalized": False,
+        "entries": [
+            {
+                "counter_key": counter_key,
+                "entity_type": "Key",
+                "entity_id": hashed_token,
+                "reserved_cost": reserved_cost,
+                "applied_adjustment": 0.0,
+            }
+        ],
+    }
+
+    await proxy_server.increment_spend_counters(
+        token=hashed_token,
+        team_id=None,
+        user_id=None,
+        response_cost=response_cost,
+        budget_reservation=budget_reservation,
+    )
+
+    enforced_spend = await flaky_redis.async_get_cache(key=counter_key)
+    assert enforced_spend == response_cost


### PR DESCRIPTION
## Relevant issues

Multi-pod deployments backed by a managed Redis intermittently saw enforced spend collapse to a stale value, so per-key, per-team, and per-user budgets stopped gating on the affected counters. Reported by an enterprise customer running v1.87.0 with many pods sharing a single managed Redis instance.

## Linear ticket

TBD

## What was broken

`increment_spend_counters` reconciles each reserved counter (pushing `actual_cost - reserved_cost` into Redis) and then skips the regular direct increment for every key the reservation pre-counted. When the reconcile path hit a Redis error, `_increment_spend_counter_cache` deleted the counter and re-raised; the wrapper `_reconcile_budget_reservation_for_counter_update` swallowed that error, invalidated the reserved counters, then still returned the reserved counter keys. The caller therefore skipped the direct increment as well, so the actual call cost was never written to the enforced shared counter. The next request reseeded the just-deleted counter from `LiteLLM_VerificationToken.spend`; that DB column is only updated by the batched flusher every few seconds, so the enforced counter was reseeded to a value that lagged the last several seconds of traffic. Under Redis-timeout spikes this fired on most calls and the enforced cross-pod spend kept collapsing toward the stale snapshot, while raw `SpendLogs` rows continued to be written correctly through the independent `update_database` path.

## The fix

When `_reconcile_budget_reservation_for_counter_update` cannot complete the reconcile, return an empty set so the caller falls back to the normal direct-increment path. Net effect: a transient Redis failure during reconcile no longer drops the actual cost; the direct-increment path retries and the enforced counter ends up holding the real spend.

The change is one line plus a logging-message tweak, scoped to the exception branch of the existing function.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit` for the touched modules
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI

- [ ] **Branch creation CI run**
       Link:
- [ ] **CI run for the last commit**
       Link:
- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

Repro is a controlled Redis-timeout injection against a live proxy. Steps:

1. Start a local proxy with a key that has `max_budget=0.10`. Point it at a real Redis. Run with `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log`.
2. Use `redis-cli DEBUG SLEEP 1` (or `CLIENT PAUSE 1000`) to inject a one-shot Redis stall during the next response's reconcile.
3. Send three sequential real chat completions against a real provider (e.g. Anthropic Sonnet 4.6 or OpenAI gpt-5-mini) with the same key, where each response costs about \$0.04. Curl each one:

```bash
for i in 1 2 3; do
  curl -s -X POST http://localhost:4000/v1/chat/completions \
    -H "Authorization: Bearer sk-budget-test" \
    -H "Content-Type: application/json" \
    -d '{"model": "claude-sonnet-4-6", "messages": [{"role": "user", "content": "Write 50 words about durable spend tracking."}]}' | jq '.usage,.choices[0].message.content[0:60]'
  redis-cli DEBUG SLEEP 1 &
done
```

4. Read the enforced counter and the persisted `LiteLLM_VerificationToken.spend`:

```bash
redis-cli GET "spend:key:$(python -c 'import litellm.proxy.utils as u; print(u.hash_token(token="sk-budget-test"))')"
PGPASSWORD=... psql -h ... -c "select spend from \"LiteLLM_VerificationToken\" where token = '<hashed>';"
```

Before the fix: the Redis counter is missing or stale at the lagging DB value, and a fourth request still succeeds even though cumulative spend has exceeded `max_budget`.

After the fix: the Redis counter holds the full cumulative spend across the three calls, and the fourth request is rejected with the expected budget-exceeded error.

## Type

Bug Fix

## Changes

`litellm/proxy/proxy_server.py`: in `_reconcile_budget_reservation_for_counter_update`, return an empty set after a reconcile failure so the caller falls back to the direct increment.

`tests/test_litellm/proxy/spend_tracking/test_budget_reservation_redis_failure.py`: new regression test that drives `increment_spend_counters` with a flaky Redis backend and asserts the actual cost lands in the shared counter. Fails on the prior behavior; passes with the fix.

`tests/test_litellm/proxy/proxy_server/test_spend_counters.py`: update an existing unit test that was pinning the old, incorrect return value to reflect the corrected contract.