### PR TITLE
fix(mcp): allow team access-group grants in OAuth authorize/token access check

### DIFF
--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -21,7 +21,7 @@ import json
 import os
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, Iterable, List, Literal, Optional
+from typing import Any, Dict, Iterable, List, Literal, Optional, Set
 
 from fastapi import (
     APIRouter,
@@ -1722,11 +1722,13 @@ if MCP_AVAILABLE:
                     status_code=status.HTTP_403_FORBIDDEN,
                     detail={"error": f"Access denied to MCP server {server_id}"},
                 )
-            allowed_server_ids = (
-                await global_mcp_server_manager.get_allowed_mcp_servers(
-                    user_api_key_dict
+            allowed_server_ids: Set[str] = set()
+            for auth_context in await build_effective_auth_contexts(user_api_key_dict):
+                allowed_server_ids.update(
+                    await global_mcp_server_manager.get_allowed_mcp_servers(
+                        auth_context
+                    )
                 )
-            )
             if server.server_id not in allowed_server_ids:
                 raise HTTPException(
                     status_code=status.HTTP_403_FORBIDDEN,

--- a/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
@@ -1522,6 +1522,58 @@ class TestTemporaryMCPSessionEndpoints:
         assert result is registry_server
 
     @pytest.mark.asyncio
+    async def test_get_cached_temporary_mcp_server_non_admin_allowed_via_team_access_group(
+        self,
+    ):
+        """Internal user whose only grant to the server flows through a team
+        access-group must pass the authorize/token access check. The check has to
+        expand the UI session into per-team contexts (build_effective_auth_contexts),
+        the same way the server-list grid does; checking only the bare session
+        context leaves the team grant invisible and 403s the user."""
+        from litellm.constants import UI_SESSION_TOKEN_TEAM_ID
+        from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+            _get_cached_temporary_mcp_server_or_404,
+        )
+
+        registry_server = generate_mock_mcp_server_config_record(server_id="server-x")
+        ui_session_auth = generate_mock_user_api_key_auth(
+            user_role=LitellmUserRoles.INTERNAL_USER,
+            team_id=UI_SESSION_TOKEN_TEAM_ID,
+        )
+        team_context = ui_session_auth.model_copy()
+        team_context.team_id = "team-with-mcp-grant"
+
+        mock_manager = MagicMock()
+        mock_manager.get_mcp_server_by_id.return_value = registry_server
+        mock_manager.get_mcp_server_by_name.return_value = None
+
+        def allowed_for(auth):
+            return ["server-x"] if auth.team_id == "team-with-mcp-grant" else []
+
+        mock_manager.get_allowed_mcp_servers = AsyncMock(side_effect=allowed_for)
+
+        with (
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.get_cached_temporary_mcp_server",
+                return_value=None,
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.global_mcp_server_manager",
+                mock_manager,
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.build_effective_auth_contexts",
+                AsyncMock(return_value=[ui_session_auth, team_context]),
+            ),
+        ):
+            result = await _get_cached_temporary_mcp_server_or_404(
+                "server-x", ui_session_auth
+            )
+
+        assert result is registry_server
+        assert mock_manager.get_allowed_mcp_servers.await_count == 2
+
+    @pytest.mark.asyncio
     async def test_get_cached_temporary_mcp_server_temp_cache_non_admin_denied(self):
         """Servers resolved from the admin-only temp cache reject non-admins."""
         from litellm.proxy.management_endpoints.mcp_management_endpoints import (

--- a/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
@@ -1482,6 +1482,10 @@ class TestTemporaryMCPSessionEndpoints:
                 "litellm.proxy.management_endpoints.mcp_management_endpoints.global_mcp_server_manager",
                 mock_manager,
             ),
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.build_effective_auth_contexts",
+                AsyncMock(return_value=[non_admin]),
+            ),
         ):
             with pytest.raises(HTTPException) as exc_info:
                 await _get_cached_temporary_mcp_server_or_404("server-x", non_admin)
@@ -1513,6 +1517,10 @@ class TestTemporaryMCPSessionEndpoints:
             patch(
                 "litellm.proxy.management_endpoints.mcp_management_endpoints.global_mcp_server_manager",
                 mock_manager,
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.build_effective_auth_contexts",
+                AsyncMock(return_value=[non_admin]),
             ),
         ):
             result = await _get_cached_temporary_mcp_server_or_404(


### PR DESCRIPTION
## Relevant issues
Internal Users aren't able to authorize tools in the MCP server page even though added to their access group and are able to view in the MCP page

## Root cause: 
- The server is granted at the team level. 
- The MCP grid resolves access by expanding the user's UI session into one context per team they belong to (build_effective_auth_contexts), so the team's grant is honored and the server shows up. 
- The OAuth Authorize/token endpoints instead checked the bare session context, whose team id is the UI-session placeholder (UI_SESSION_TOKEN_TEAM_ID) rather than a real team, so the team grant resolved to nothing and the user was denied. Admins were unaffected because the admin-view short-circuit skips the check.

## Fix: 
Make the Authorize/token access check expand the session into the same per-team contexts the grid uses and union the allowed servers, so a server that's visible is also authorizable.

## Linear ticket
Resolves LIT-3673

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix
Tested via an Internal User's Account
<img width="2858" height="1792" alt="image" src="https://github.com/user-attachments/assets/cd3a6587-fbfc-46f2-955c-5b2d6c5512f8" />
<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/8e50a9f6-7cd4-43c9-9308-9b7bae66a42e" />


Repro against a live proxy. The grant is team-level: an MCP OAuth server is attached to a team, the team is given access to it, and an internal (non-admin) user is added to that team. The user logs into the dashboard with a UI session (SSO / username-password), sees the server under all-servers and the Authorize option under tools, but clicking Authorize hits the per-user OAuth endpoint and is rejected.

Before (the bug):

```
GET /v1/mcp/server/oauth/<server_id>/authorize?redirect_uri=...&state=...
-> 403 {"detail":{"error":"Access denied to MCP server <server_id>"}}
```

After the fix the same request resolves the team grant and redirects to the upstream IdP authorize URL (302), so the internal user completes the OAuth flow.

UI repro steps for screenshots: sign in as the internal user, go to http://localhost:4000/ui/?page=mcp, open the server's tools, click Authorize, and confirm the redirect to the provider login instead of the red "Access denied" toast.

## Type

🐛 Bug Fix

## Changes

Internal (non-admin) users granted an MCP server through their team could see the server in their all-servers grid but got `403 Access denied to MCP server <id>` when clicking Authorize.

This is specific to team-level grants reached through a UI session login. Both team fields are affected, since both resolve through `_get_allowed_mcp_servers_for_team`: the team's unified "Access Groups" (`access_group_ids`) and the team's "MCP Servers / Access Groups" (`object_permission.mcp_servers` plus legacy `mcp_access_groups`). Key-level grants were never broken; the bare session context already carries the key, so a key's own permissions resolve without any expansion.

The all-servers grid (`_resolve_accessible_mcp_servers`) resolves access by expanding the UI session token into one auth context per team membership via `build_effective_auth_contexts`. A UI session token carries `team_id = UI_SESSION_TOKEN_TEAM_ID` (a sentinel, not a real team), so that expansion into the user's actual teams is what lets `get_allowed_mcp_servers` see team grants at all. The shared authorize/token helper `_get_cached_temporary_mcp_server_or_404` instead checked a single un-expanded context: `get_team_object(UI_SESSION_TOKEN_TEAM_ID)` returns None, every team source comes back empty, and the user is denied even though the same server renders in their grid. Admins were unaffected because `_user_has_admin_view` short-circuits the whole block.

The fix expands the caller the same way the grid does and unions the allowed-server sets before the access check; this covers both `mcp_authorize` and `mcp_token` since they share the helper.

Added a regression test (`test_get_cached_temporary_mcp_server_non_admin_allowed_via_team_access_group`) for an internal user whose only grant flows through a team context. It asserts the server is returned and that every effective context is consulted. With the source change reverted the test fails with the exact `403 Access denied to MCP server server-x`, and passes with the fix.
