### PR TITLE
fix(router): strip stale Credential: tags before fallback routing to prevent spurious 401

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -2735,8 +2735,14 @@ class Router:
         if credential_name:
             credential_tag = f"Credential: {credential_name}"
             existing_tags = kwargs[metadata_variable_name].get("tags") or []
-            if credential_tag not in existing_tags:
-                existing_tags.append(credential_tag)
+            # Strip Credential: tags from any previous deployment attempt so they
+            # do not leak into fallback routing tag checks (fixes #25276).
+            existing_tags = [
+                t
+                for t in existing_tags
+                if not (isinstance(t, str) and t.startswith("Credential: "))
+            ]
+            existing_tags.append(credential_tag)
             kwargs[metadata_variable_name]["tags"] = existing_tags
 
         kwargs["model_info"] = model_info


### PR DESCRIPTION
## Description

Fixes #25276

When a request fails and triggers fallback routing, the fallback model receives a `Credential: openai` tag that was added by the router for the first (failed) deployment. Because the fallback model group does not have that tag in its allowed-tags list, the routing check rejects it:

```
Not allowed to access model due to tags configuration.
Passed model=gpt-image-1.5 and tags=['Credential: openai']
```

## Root cause

In `Router._add_model_to_request`, the router appends an observability tag `"Credential: <name>"` to `kwargs[metadata_variable_name]["tags"]` when a deployment has `litellm_credential_name` set:

```python
## CREDENTIAL NAME AS TAG
credential_name = deployment.get("litellm_params", {}).get("litellm_credential_name")
if credential_name:
    credential_tag = f"Credential: {credential_name}"
    existing_tags = kwargs[metadata_variable_name].get("tags") or []
    if credential_tag not in existing_tags:
        existing_tags.append(credential_tag)
    kwargs[metadata_variable_name]["tags"] = existing_tags
```

On fallback, the same `kwargs` dict is reused, so `Credential: openai` (from deployment A) persists in `tags` when deployment B is evaluated. If `enable_tag_filtering` is active, the tag-access check sees a request carrying `Credential: openai` and rejects deployment B because B is not allowed for that tag.

## Fix

Before appending the current deployment's `Credential:` tag, strip any `Credential:` tags that were injected by a prior deployment. This ensures fallback routing only carries the new deployment's credential tag — not stale tags from failed attempts.

```python
existing_tags = [
    t
    for t in existing_tags
    if not (isinstance(t, str) and t.startswith("Credential: "))
]
existing_tags.append(credential_tag)
```

The credential tag for the successful (or current) deployment is still appended, so observability is unchanged for the delivered request.

## File changed

- `litellm/router.py` — 4-line guard added inside the `## CREDENTIAL NAME AS TAG` block

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] Fix is targeted to the credential-tag block only
- [x] Client-provided tags and deployment-level `tags:` config are untouched
- [x] The credential tag for the current deployment is still recorded
