### PR TITLE
docs: require a reproduction video for security reports

### DIFF
--- a/security.md
+++ b/security.md
@@ -3,11 +3,19 @@
 
 ## Security Vulnerability Reporting Guidelines
 
+> [!WARNING]
+> Reports that do not include a video demonstrating the exploit will be closed without review. See [Reproduction Video Requirement](#reproduction-video-requirement) below.
+
 We value the security community's role in protecting our systems and users. To report a security vulnerability:
 
 - File a private vulnerability report on GitHub: [Report a vulnerability](https://github.com/BerriAI/litellm/security/advisories/new)
 - Include steps to reproduce the issue
+- Include a video or screen recording demonstrating the full exploit against a live LiteLLM instance, from initial access through to impact. A terminal recording (for example asciinema) is fine for CLI-only exploits.
 - Provide any relevant additional information
+
+### Reproduction Video Requirement
+
+A video demonstrating the exploit is required for every report. AI tools have made it easy to produce plausible-sounding vulnerability reports that do not reproduce in practice, and triaging them takes time away from real issues. Reports submitted without a working reproduction video will be closed without review. If you add a video to a closed report, we will reopen and triage it.
 
 ### Vulnerability Categories
 
@@ -38,7 +46,7 @@ We offer bounties for responsibly disclosed vulnerabilities based on severity:
 | **Medium** | N/A | P2 authenticated privilege escalation |
 | **Low** | N/A | Minor information disclosure, low-impact misconfigurations |
 
-To qualify for a bounty, reports must include clear reproduction steps and must not involve systems or accounts you do not own. We review all submissions promptly and will follow up within 5 business days.
+To qualify for a bounty, reports must include clear reproduction steps, a reproduction video as described above, and must not involve systems or accounts you do not own. We review all submissions promptly and will follow up within 5 business days.
 
 ### Known Non-Issues
 


### PR DESCRIPTION
Updates security.md to require a video demonstrating the exploit against a live instance, with a warning that reports lacking one will be closed without review. This is to keep triage manageable as AI-generated report volume grows.