### PR TITLE
refactor(ui): single auth engine; useAuthorized becomes a policy layer over AuthContext

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/agents/useAgents.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/agents/useAgents.test.ts
@@ -81,7 +81,6 @@ describe("useAgents", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
   });
 
@@ -144,7 +143,6 @@ describe("useAgents", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useAgents(), { wrapper });
@@ -168,7 +166,6 @@ describe("useAgents", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useAgents(), { wrapper });
@@ -192,7 +189,6 @@ describe("useAgents", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useAgents(), { wrapper });
@@ -216,7 +212,6 @@ describe("useAgents", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useAgents(), { wrapper });
@@ -240,7 +235,6 @@ describe("useAgents", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useAgents(), { wrapper });
@@ -283,7 +277,6 @@ describe("useAgents", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useAgents(), { wrapper });

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/credentials/useCredentials.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/credentials/useCredentials.test.ts
@@ -66,7 +66,6 @@ describe("useCredentials", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
   });
 
@@ -129,7 +128,6 @@ describe("useCredentials", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useCredentials(), { wrapper });

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/customers/useCustomers.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/customers/useCustomers.test.ts
@@ -83,7 +83,6 @@ describe("useCustomers", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
   });
 
@@ -146,7 +145,6 @@ describe("useCustomers", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useCustomers(), { wrapper });
@@ -170,7 +168,6 @@ describe("useCustomers", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useCustomers(), { wrapper });
@@ -194,7 +191,6 @@ describe("useCustomers", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useCustomers(), { wrapper });
@@ -218,7 +214,6 @@ describe("useCustomers", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useCustomers(), { wrapper });
@@ -242,7 +237,6 @@ describe("useCustomers", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useCustomers(), { wrapper });
@@ -285,7 +279,6 @@ describe("useCustomers", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useCustomers(), { wrapper });

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/guardrails/useGuardrails.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/guardrails/useGuardrails.test.ts
@@ -51,7 +51,6 @@ describe("useGuardrails", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
   });
 
@@ -114,7 +113,6 @@ describe("useGuardrails", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useGuardrails(), { wrapper });
@@ -138,7 +136,6 @@ describe("useGuardrails", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useGuardrails(), { wrapper });
@@ -162,7 +159,6 @@ describe("useGuardrails", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useGuardrails(), { wrapper });
@@ -186,7 +182,6 @@ describe("useGuardrails", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useGuardrails(), { wrapper });

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/keys/useKeys.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/keys/useKeys.test.ts
@@ -182,7 +182,6 @@ describe("useKeys", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     // Reset fetch mock
@@ -273,7 +272,6 @@ describe("useKeys", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useKeys(1, 10), { wrapper });
@@ -485,7 +483,6 @@ describe("useDeletedKeys", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     // Reset fetch mock
@@ -596,7 +593,6 @@ describe("useDeletedKeys", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useDeletedKeys(1, 10), { wrapper });

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/models/useModels.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/models/useModels.test.ts
@@ -67,7 +67,6 @@ describe("useModelsInfo", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
   });
 
@@ -164,7 +163,6 @@ describe("useModelsInfo", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useModelsInfo(), { wrapper });
@@ -184,7 +182,6 @@ describe("useModelsInfo", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useModelsInfo(), { wrapper });
@@ -204,7 +201,6 @@ describe("useModelsInfo", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useModelsInfo(), { wrapper });
@@ -224,7 +220,6 @@ describe("useModelsInfo", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useModelsInfo(), { wrapper });
@@ -258,7 +253,6 @@ describe("useModelHub", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
   });
 
@@ -322,7 +316,6 @@ describe("useModelHub", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useModelHub(), { wrapper });
@@ -356,7 +349,6 @@ describe("useAllProxyModels", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
   });
 
@@ -428,7 +420,6 @@ describe("useAllProxyModels", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useAllProxyModels(), { wrapper });
@@ -448,7 +439,6 @@ describe("useAllProxyModels", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useAllProxyModels(), { wrapper });
@@ -468,7 +458,6 @@ describe("useAllProxyModels", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useAllProxyModels(), { wrapper });
@@ -502,7 +491,6 @@ describe("useSelectedTeamModels", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
   });
 
@@ -574,7 +562,6 @@ describe("useSelectedTeamModels", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useSelectedTeamModels("team-1"), { wrapper });
@@ -594,7 +581,6 @@ describe("useSelectedTeamModels", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useSelectedTeamModels("team-1"), { wrapper });
@@ -614,7 +600,6 @@ describe("useSelectedTeamModels", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useSelectedTeamModels("team-1"), { wrapper });
@@ -673,7 +658,6 @@ describe("useInfiniteModelInfo", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
   });
 
@@ -802,7 +786,6 @@ describe("useInfiniteModelInfo", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useInfiniteModelInfo(), { wrapper });
@@ -822,7 +805,6 @@ describe("useInfiniteModelInfo", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useInfiniteModelInfo(), { wrapper });
@@ -842,7 +824,6 @@ describe("useInfiniteModelInfo", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useInfiniteModelInfo(), { wrapper });

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/organizations/useOrganizations.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/organizations/useOrganizations.test.ts
@@ -82,7 +82,6 @@ describe("useOrganizations", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
   });
 
@@ -145,7 +144,6 @@ describe("useOrganizations", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useOrganizations(), { wrapper });
@@ -169,7 +167,6 @@ describe("useOrganizations", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useOrganizations(), { wrapper });
@@ -193,7 +190,6 @@ describe("useOrganizations", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useOrganizations(), { wrapper });
@@ -217,7 +213,6 @@ describe("useOrganizations", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useOrganizations(), { wrapper });

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/proxyConfig/useProxyConfig.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/proxyConfig/useProxyConfig.test.ts
@@ -130,7 +130,6 @@ describe("useProxyConfig", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     fetchSpy = vi.fn();
@@ -218,7 +217,6 @@ describe("useProxyConfig", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useProxyConfig(ConfigType.GENERAL_SETTINGS), { wrapper });
@@ -301,7 +299,6 @@ describe("useDeleteProxyConfigField", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     fetchSpy = vi.fn();
@@ -388,7 +385,6 @@ describe("useDeleteProxyConfigField", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useDeleteProxyConfigField(), { wrapper });

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/router/useRouterFields.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/router/useRouterFields.test.ts
@@ -77,7 +77,6 @@ describe("useRouterFields", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
   });
 
@@ -159,7 +158,6 @@ describe("useRouterFields", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useRouterFields(), { wrapper });
@@ -182,7 +180,6 @@ describe("useRouterFields", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useRouterFields(), { wrapper });
@@ -205,7 +202,6 @@ describe("useRouterFields", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useRouterFields(), { wrapper });

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/sso/useEditSSOSettings.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/sso/useEditSSOSettings.test.ts
@@ -44,7 +44,6 @@ describe("useEditSSOSettings", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
   });
 
@@ -113,7 +112,6 @@ describe("useEditSSOSettings", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useEditSSOSettings(), { wrapper });

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/sso/useSSOSettings.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/sso/useSSOSettings.test.ts
@@ -79,7 +79,6 @@ describe("useSSOSettings", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
   });
 
@@ -143,7 +142,6 @@ describe("useSSOSettings", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useSSOSettings(), { wrapper });
@@ -164,7 +162,6 @@ describe("useSSOSettings", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useSSOSettings(), { wrapper });
@@ -185,7 +182,6 @@ describe("useSSOSettings", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useSSOSettings(), { wrapper });
@@ -206,7 +202,6 @@ describe("useSSOSettings", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useSSOSettings(), { wrapper });

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/storeModelInDB/useStoreModelInDB.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/storeModelInDB/useStoreModelInDB.test.ts
@@ -93,7 +93,6 @@ describe("useStoreModelInDB", () => {
       userEmail: null,
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     } as any);
 
     const { result } = renderHook(() => useStoreModelInDB(), { wrapper });

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/tags/useTags.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/tags/useTags.test.ts
@@ -83,7 +83,6 @@ describe("useTags", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
   });
 
@@ -146,7 +145,6 @@ describe("useTags", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useTags(), { wrapper });
@@ -170,7 +168,6 @@ describe("useTags", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useTags(), { wrapper });
@@ -194,7 +191,6 @@ describe("useTags", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useTags(), { wrapper });
@@ -218,7 +214,6 @@ describe("useTags", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useTags(), { wrapper });

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/teams/useTeams.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/teams/useTeams.test.ts
@@ -79,7 +79,6 @@ describe("useTeams", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
   });
 
@@ -150,7 +149,6 @@ describe("useTeams", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useTeams(), { wrapper });
@@ -174,7 +172,6 @@ describe("useTeams", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useTeams(), { wrapper });
@@ -250,7 +247,6 @@ describe("useTeams", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useTeams(), { wrapper });
@@ -276,7 +272,6 @@ describe("useTeams", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useTeams(), { wrapper });
@@ -312,7 +307,6 @@ describe("useTeam", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
   });
 
@@ -376,7 +370,6 @@ describe("useTeam", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useTeam("team-1"), { wrapper });
@@ -433,7 +426,6 @@ describe("useTeam", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     // Import useQueryClient to get access to query client
@@ -465,7 +457,6 @@ describe("useTeam", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const testQueryFnMissingTeamId = async () => {
@@ -651,7 +642,6 @@ describe("useDeletedTeams", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     global.fetch = vi.fn();
@@ -719,7 +709,6 @@ describe("useDeletedTeams", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useDeletedTeams(1, 10, {}), { wrapper });

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/useAuthorized.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/useAuthorized.test.ts
@@ -126,7 +126,6 @@ describe("useAuthorized", () => {
     expect(result.current.userRole).toBe("Admin");
     expect(result.current.premiumUser).toBe(true);
     expect(result.current.disabledPersonalKeyCreation).toBe(false);
-    expect(result.current.showSSOBanner).toBe(true);
     expect(replaceMock).not.toHaveBeenCalled();
     expect(clearTokenCookiesMock).not.toHaveBeenCalled();
   });
@@ -163,9 +162,15 @@ describe("useAuthorized", () => {
     expect(clearTokenCookiesMock).toHaveBeenCalled();
     expect(result.current.isAuthorized).toBe(false);
     expect(result.current.token).toBeNull();
-    expect(result.current.accessToken).toBe("api-key-123");
-    expect(result.current.userId).toBe("user-1");
-    expect(result.current.userEmail).toBe("user@example.com");
+
+    // clearAuth must reset the context, not just the cookie, so no consumer
+    // can keep acting on the revoked session until a hard reload.
+    await waitFor(() => {
+      expect(result.current.accessToken).toBeNull();
+    });
+    expect(result.current.userId).toBeNull();
+    expect(result.current.userEmail).toBeNull();
+    expect(result.current.userRole).toBe("Undefined Role");
   });
 
   it("should redirect when token is missing", async () => {

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/useAuthorized.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/useAuthorized.test.ts
@@ -3,28 +3,20 @@ import React from "react";
 import { renderHook, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { AuthProvider } from "@/contexts/AuthContext";
 import useAuthorized from "./useAuthorized";
 
 // Unmock useAuthorized to test the actual implementation
 vi.unmock("@/app/(dashboard)/hooks/useAuthorized");
 
-const {
-  replaceMock,
-  clearTokenCookiesMock,
-  getProxyBaseUrlMock,
-  getUiConfigMock,
-  decodeTokenMock,
-  checkTokenValidityMock,
-  buildLoginUrlWithReturnMock,
-} = vi.hoisted(() => ({
-  replaceMock: vi.fn(),
-  clearTokenCookiesMock: vi.fn(),
-  getProxyBaseUrlMock: vi.fn(() => "http://proxy.example"),
-  getUiConfigMock: vi.fn(),
-  decodeTokenMock: vi.fn(),
-  checkTokenValidityMock: vi.fn(),
-  buildLoginUrlWithReturnMock: vi.fn((baseUrl: string) => baseUrl),
-}));
+const { replaceMock, clearTokenCookiesMock, getProxyBaseUrlMock, getUiConfigMock, buildLoginUrlWithReturnMock } =
+  vi.hoisted(() => ({
+    replaceMock: vi.fn(),
+    clearTokenCookiesMock: vi.fn(),
+    getProxyBaseUrlMock: vi.fn(() => "http://proxy.example"),
+    getUiConfigMock: vi.fn(),
+    buildLoginUrlWithReturnMock: vi.fn((baseUrl: string) => baseUrl),
+  }));
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({
@@ -49,15 +41,6 @@ vi.mock("@/utils/cookieUtils", async (importOriginal) => {
   };
 });
 
-vi.mock("@/utils/jwtUtils", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/utils/jwtUtils")>();
-  return {
-    ...actual,
-    decodeToken: decodeTokenMock,
-    checkTokenValidity: checkTokenValidityMock,
-  };
-});
-
 vi.mock("@/utils/returnUrlUtils", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/utils/returnUrlUtils")>();
   return {
@@ -66,6 +49,7 @@ vi.mock("@/utils/returnUrlUtils", async (importOriginal) => {
     storeReturnUrl: vi.fn(),
   };
 });
+
 const createQueryClient = () =>
   new QueryClient({
     defaultOptions: {
@@ -78,7 +62,11 @@ const createQueryClient = () =>
 
 const wrapper = ({ children }: { children: React.ReactNode }) => {
   const queryClient = createQueryClient();
-  return React.createElement(QueryClientProvider, { client: queryClient }, children);
+  return React.createElement(
+    QueryClientProvider,
+    { client: queryClient },
+    React.createElement(AuthProvider, null, children),
+  );
 };
 
 const createJwt = (payload: Record<string, unknown>) => {
@@ -90,39 +78,37 @@ const clearCookie = () => {
   document.cookie = "token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;";
 };
 
+const uiConfig = (overrides: Record<string, unknown> = {}) => ({
+  server_root_path: "/",
+  proxy_base_url: null,
+  auto_redirect_to_sso: false,
+  admin_ui_disabled: false,
+  sso_configured: false,
+  ...overrides,
+});
+
+const decodedPayload = {
+  key: "api-key-123",
+  user_id: "user-1",
+  user_email: "user@example.com",
+  user_role: "app_admin",
+  premium_user: true,
+  disabled_non_admin_personal_key_creation: false,
+  login_method: "username_password",
+};
+
 describe("useAuthorized", () => {
   afterEach(() => {
     replaceMock.mockReset();
     clearTokenCookiesMock.mockReset();
     getProxyBaseUrlMock.mockClear();
     getUiConfigMock.mockReset();
-    decodeTokenMock.mockReset();
-    checkTokenValidityMock.mockReset();
     buildLoginUrlWithReturnMock.mockClear();
     clearCookie();
   });
 
   it("should decode the token and expose user details", async () => {
-    getUiConfigMock.mockResolvedValue({
-      server_root_path: "/",
-      proxy_base_url: null,
-      auto_redirect_to_sso: false,
-      admin_ui_disabled: false,
-      sso_configured: false,
-    });
-
-    const decodedPayload = {
-      key: "api-key-123",
-      user_id: "user-1",
-      user_email: "user@example.com",
-      user_role: "app_admin",
-      premium_user: true,
-      disabled_non_admin_personal_key_creation: false,
-      login_method: "username_password",
-    };
-
-    decodeTokenMock.mockReturnValue(decodedPayload);
-    checkTokenValidityMock.mockReturnValue(true);
+    getUiConfigMock.mockResolvedValue(uiConfig());
 
     const token = createJwt(decodedPayload);
     document.cookie = `token=${token}; path=/;`;
@@ -133,6 +119,7 @@ describe("useAuthorized", () => {
       expect(result.current.token).toBe(token);
     });
 
+    expect(result.current.isAuthorized).toBe(true);
     expect(result.current.accessToken).toBe("api-key-123");
     expect(result.current.userId).toBe("user-1");
     expect(result.current.userEmail).toBe("user@example.com");
@@ -144,52 +131,25 @@ describe("useAuthorized", () => {
     expect(clearTokenCookiesMock).not.toHaveBeenCalled();
   });
 
-  it("should clear cookies and redirect on an invalid token", async () => {
-    getUiConfigMock.mockResolvedValue({
-      server_root_path: "/",
-      proxy_base_url: null,
-      auto_redirect_to_sso: false,
-      admin_ui_disabled: false,
-      sso_configured: false,
-    });
-
-    decodeTokenMock.mockReturnValue(null);
-    checkTokenValidityMock.mockReturnValue(false);
+  it("should clear cookies and redirect on an undecodable token", async () => {
+    getUiConfigMock.mockResolvedValue(uiConfig());
 
     document.cookie = "token=invalid-token; path=/;";
 
     const { result } = renderHook(() => useAuthorized(), { wrapper });
 
     await waitFor(() => {
-      expect(clearTokenCookiesMock).toHaveBeenCalled();
+      expect(replaceMock).toHaveBeenCalledWith("http://proxy.example/ui/login");
     });
 
-    expect(replaceMock).toHaveBeenCalledWith("http://proxy.example/ui/login");
+    expect(clearTokenCookiesMock).toHaveBeenCalled();
+    expect(result.current.token).toBeNull();
     expect(result.current.accessToken).toBeNull();
     expect(result.current.userRole).toBe("Undefined Role");
   });
 
   it("should redirect even with valid token if admin_ui_disabled is true", async () => {
-    getUiConfigMock.mockResolvedValue({
-      server_root_path: "/",
-      proxy_base_url: null,
-      auto_redirect_to_sso: false,
-      admin_ui_disabled: true,
-      sso_configured: false,
-    });
-
-    const decodedPayload = {
-      key: "api-key-123",
-      user_id: "user-1",
-      user_email: "user@example.com",
-      user_role: "app_admin",
-      premium_user: true,
-      disabled_non_admin_personal_key_creation: false,
-      login_method: "username_password",
-    };
-
-    decodeTokenMock.mockReturnValue(decodedPayload);
-    checkTokenValidityMock.mockReturnValue(true);
+    getUiConfigMock.mockResolvedValue(uiConfig({ admin_ui_disabled: true }));
 
     const token = createJwt(decodedPayload);
     document.cookie = `token=${token}; path=/;`;
@@ -200,22 +160,16 @@ describe("useAuthorized", () => {
       expect(replaceMock).toHaveBeenCalledWith("http://proxy.example/ui/login");
     });
 
+    expect(clearTokenCookiesMock).toHaveBeenCalled();
+    expect(result.current.isAuthorized).toBe(false);
+    expect(result.current.token).toBeNull();
     expect(result.current.accessToken).toBe("api-key-123");
     expect(result.current.userId).toBe("user-1");
     expect(result.current.userEmail).toBe("user@example.com");
   });
 
   it("should redirect when token is missing", async () => {
-    getUiConfigMock.mockResolvedValue({
-      server_root_path: "/",
-      proxy_base_url: null,
-      auto_redirect_to_sso: false,
-      admin_ui_disabled: false,
-      sso_configured: false,
-    });
-
-    decodeTokenMock.mockReturnValue(null);
-    checkTokenValidityMock.mockReturnValue(false);
+    getUiConfigMock.mockResolvedValue(uiConfig());
 
     // No token cookie set
     const { result } = renderHook(() => useAuthorized(), { wrapper });
@@ -229,25 +183,9 @@ describe("useAuthorized", () => {
   });
 
   it("should clear cookies and redirect when token is expired", async () => {
-    getUiConfigMock.mockResolvedValue({
-      server_root_path: "/",
-      proxy_base_url: null,
-      auto_redirect_to_sso: false,
-      admin_ui_disabled: false,
-      sso_configured: false,
-    });
+    getUiConfigMock.mockResolvedValue(uiConfig());
 
-    const decodedPayload = {
-      key: "api-key-123",
-      user_id: "user-1",
-      user_email: "user@example.com",
-      user_role: "app_admin",
-    };
-
-    decodeTokenMock.mockReturnValue(decodedPayload);
-    checkTokenValidityMock.mockReturnValue(false);
-
-    const token = createJwt(decodedPayload);
+    const token = createJwt({ ...decodedPayload, exp: Math.floor(Date.now() / 1000) - 60 });
     document.cookie = `token=${token}; path=/;`;
 
     const { result } = renderHook(() => useAuthorized(), { wrapper });
@@ -257,6 +195,7 @@ describe("useAuthorized", () => {
     });
 
     expect(replaceMock).toHaveBeenCalledWith("http://proxy.example/ui/login");
-    expect(checkTokenValidityMock).toHaveBeenCalledWith(token);
+    expect(result.current.token).toBeNull();
+    expect(result.current.accessToken).toBeNull();
   });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/useAuthorized.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/useAuthorized.ts
@@ -1,7 +1,6 @@
 "use client";
 
 import { getProxyBaseUrl } from "@/components/networking";
-import { clearTokenCookies } from "@/utils/cookieUtils";
 import { buildLoginUrlWithReturn, storeReturnUrl } from "@/utils/returnUrlUtils";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect } from "react";
@@ -30,7 +29,7 @@ const useAuthorized = () => {
     accessToken,
     premiumUser,
     disabledPersonalKeyCreation,
-    showSSOBanner,
+    clearAuth,
   } = useAuth();
 
   const isLoading = authLoading || isUIConfigLoading;
@@ -47,11 +46,11 @@ const useAuthorized = () => {
 
     if (!isAuthorized) {
       if (token) {
-        clearTokenCookies();
+        clearAuth();
       }
       redirectToLogin();
     }
-  }, [isLoading, isAuthorized, token, redirectToLogin]);
+  }, [isLoading, isAuthorized, token, clearAuth, redirectToLogin]);
 
   return {
     isLoading,
@@ -63,7 +62,6 @@ const useAuthorized = () => {
     userRole,
     premiumUser: premiumUser as LegacyDecodedField,
     disabledPersonalKeyCreation: disabledPersonalKeyCreation as LegacyDecodedField,
-    showSSOBanner,
   };
 };
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/useAuthorized.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/useAuthorized.ts
@@ -7,16 +7,10 @@ import { useCallback, useEffect } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import { useUIConfig } from "./uiConfig/useUIConfig";
 
-// Decoded-JWT fields keep the pre-consolidation `any` typing: the old hook returned
-// `any` here and ~25 call sites pass these where `string` is expected. Tightening to
-// the context's `string | null` is a follow-up that has to fix those call sites.
+// Decoded-JWT fields keep their legacy `any` typing; call sites still pass them
+// where `string` is expected, so tightening to `string | null` is a follow-up.
 type LegacyDecodedField = any;
 
-/**
- * Policy hook for pages that require an authenticated user. Auth state itself
- * lives in AuthContext (single decode at the root); this hook layers on the
- * admin_ui_disabled check and the redirect-to-login side effect.
- */
 const useAuthorized = () => {
   const router = useRouter();
   const { data: uiConfig, isLoading: isUIConfigLoading } = useUIConfig();

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/useAuthorized.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/useAuthorized.ts
@@ -1,34 +1,47 @@
 "use client";
 
 import { getProxyBaseUrl } from "@/components/networking";
-import { clearTokenCookies, getCookie } from "@/utils/cookieUtils";
-import { checkTokenValidity, decodeToken } from "@/utils/jwtUtils";
+import { clearTokenCookies } from "@/utils/cookieUtils";
 import { buildLoginUrlWithReturn, storeReturnUrl } from "@/utils/returnUrlUtils";
 import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useMemo } from "react";
-import { formatUserRole } from "@/utils/roles";
+import { useCallback, useEffect } from "react";
+import { useAuth } from "@/contexts/AuthContext";
 import { useUIConfig } from "./uiConfig/useUIConfig";
 
+// Decoded-JWT fields keep the pre-consolidation `any` typing: the old hook returned
+// `any` here and ~25 call sites pass these where `string` is expected. Tightening to
+// the context's `string | null` is a follow-up that has to fix those call sites.
+type LegacyDecodedField = any;
+
+/**
+ * Policy hook for pages that require an authenticated user. Auth state itself
+ * lives in AuthContext (single decode at the root); this hook layers on the
+ * admin_ui_disabled check and the redirect-to-login side effect.
+ */
 const useAuthorized = () => {
   const router = useRouter();
   const { data: uiConfig, isLoading: isUIConfigLoading } = useUIConfig();
+  const {
+    authLoading,
+    token,
+    userID,
+    userRole,
+    userEmail,
+    accessToken,
+    premiumUser,
+    disabledPersonalKeyCreation,
+    showSSOBanner,
+  } = useAuth();
 
-  const token = typeof document !== "undefined" ? getCookie("token") : null;
+  const isLoading = authLoading || isUIConfigLoading;
+  const isAuthorized = token !== null && !uiConfig?.admin_ui_disabled;
 
-  const decoded = useMemo(() => decodeToken(token), [token]);
-  const isTokenValid = useMemo(() => checkTokenValidity(token), [token]);
-  const isLoading = isUIConfigLoading;
-  const isAuthorized = isTokenValid && !uiConfig?.admin_ui_disabled;
-
-  // Helper function to redirect to login while preserving the current URL
   const redirectToLogin = useCallback(() => {
     storeReturnUrl();
     const baseLoginUrl = `${getProxyBaseUrl()}/ui/login`;
-    const loginUrlWithReturn = buildLoginUrlWithReturn(baseLoginUrl);
-    router.replace(loginUrlWithReturn);
+    router.replace(buildLoginUrlWithReturn(baseLoginUrl));
   }, [router]);
 
-  // Single useEffect for all redirect logic
   useEffect(() => {
     if (isLoading) return;
 
@@ -44,13 +57,13 @@ const useAuthorized = () => {
     isLoading,
     isAuthorized,
     token: isAuthorized ? token : null,
-    accessToken: decoded?.key ?? null,
-    userId: decoded?.user_id ?? null,
-    userEmail: decoded?.user_email ?? null,
-    userRole: formatUserRole(decoded?.user_role),
-    premiumUser: decoded?.premium_user ?? null,
-    disabledPersonalKeyCreation: decoded?.disabled_non_admin_personal_key_creation ?? null,
-    showSSOBanner: decoded?.login_method === "username_password",
+    accessToken: accessToken as LegacyDecodedField,
+    userId: userID as LegacyDecodedField,
+    userEmail: userEmail as LegacyDecodedField,
+    userRole,
+    premiumUser: premiumUser as LegacyDecodedField,
+    disabledPersonalKeyCreation: disabledPersonalKeyCreation as LegacyDecodedField,
+    showSSOBanner,
   };
 };
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/users/useCurrentUser.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/users/useCurrentUser.test.ts
@@ -70,7 +70,6 @@ describe("useCurrentUser", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
   });
 
@@ -134,7 +133,6 @@ describe("useCurrentUser", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useCurrentUser(), { wrapper });
@@ -158,7 +156,6 @@ describe("useCurrentUser", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useCurrentUser(), { wrapper });
@@ -182,7 +179,6 @@ describe("useCurrentUser", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
 
     const { result } = renderHook(() => useCurrentUser(), { wrapper });

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/users/useUsers.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/users/useUsers.test.ts
@@ -33,7 +33,6 @@ const DEFAULT_AUTH = {
   userEmail: "test@example.com",
   premiumUser: false,
   disabledPersonalKeyCreation: null,
-  showSSOBanner: false,
 };
 
 const buildUserListResponse = (page: number, totalPages: number, userCount = 2): UserListResponse => ({

--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AllModelsTab.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AllModelsTab.test.tsx
@@ -119,7 +119,6 @@ describe("AllModelsTab", () => {
     userRole: "Admin",
     premiumUser: true,
     disabledPersonalKeyCreation: false,
-    showSSOBanner: false,
   };
 
   beforeEach(() => {

--- a/ui/litellm-dashboard/src/components/UsagePage/components/EntityUsage/TopKeyView.test.tsx
+++ b/ui/litellm-dashboard/src/components/UsagePage/components/EntityUsage/TopKeyView.test.tsx
@@ -42,7 +42,6 @@ describe("TopKeyView", () => {
     userRole: "admin",
     premiumUser: true,
     disabledPersonalKeyCreation: false,
-    showSSOBanner: false,
   };
 
   const mockSetTopKeysLimit = vi.fn();

--- a/ui/litellm-dashboard/src/components/UsagePage/components/UsagePageView.test.tsx
+++ b/ui/litellm-dashboard/src/components/UsagePage/components/UsagePageView.test.tsx
@@ -517,7 +517,6 @@ describe("UsagePage", () => {
       userRole: "Admin",
       premiumUser: true,
       disabledPersonalKeyCreation: false,
-      showSSOBanner: false,
     });
     mockUseCurrentUser.mockReturnValue({
       data: {
@@ -651,7 +650,6 @@ describe("UsagePage", () => {
       userRole: "internal_user",
       premiumUser: true,
       disabledPersonalKeyCreation: false,
-      showSSOBanner: false,
     });
 
     renderWithProviders(<UsagePage {...defaultProps} />);
@@ -839,7 +837,6 @@ describe("UsagePage", () => {
         userRole: "Internal User",
         premiumUser: false,
         disabledPersonalKeyCreation: false,
-        showSSOBanner: false,
       });
 
       renderWithProviders(<UsagePage {...defaultProps} />);
@@ -865,7 +862,6 @@ describe("UsagePage", () => {
         userRole: "Internal User",
         premiumUser: false,
         disabledPersonalKeyCreation: false,
-        showSSOBanner: false,
       });
 
       renderWithProviders(<UsagePage {...defaultProps} />);

--- a/ui/litellm-dashboard/src/components/add_model/AddModelForm.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/AddModelForm.test.tsx
@@ -113,7 +113,6 @@ const mockAuthorizedUser = (userRole: string, userId: string, premiumUser: boole
   userRole,
   premiumUser,
   disabledPersonalKeyCreation: false,
-  showSSOBanner: false,
 });
 
 const testTeam: Team = {

--- a/ui/litellm-dashboard/src/components/cache_settings/CacheFieldGroup.test.tsx
+++ b/ui/litellm-dashboard/src/components/cache_settings/CacheFieldGroup.test.tsx
@@ -12,7 +12,6 @@ describe("CacheFieldGroup", () => {
       userRole: "Admin",
       premiumUser: false,
       disabledPersonalKeyCreation: false,
-      showSSOBanner: false,
     }),
   }));
 

--- a/ui/litellm-dashboard/src/components/cache_settings/CacheFieldRenderer.test.tsx
+++ b/ui/litellm-dashboard/src/components/cache_settings/CacheFieldRenderer.test.tsx
@@ -12,7 +12,6 @@ vi.mock("@/app/(dashboard)/hooks/useAuthorized", () => ({
     userRole: "Admin",
     premiumUser: false,
     disabledPersonalKeyCreation: false,
-    showSSOBanner: false,
   }),
 }));
 

--- a/ui/litellm-dashboard/src/components/leftnav.test.tsx
+++ b/ui/litellm-dashboard/src/components/leftnav.test.tsx
@@ -23,7 +23,6 @@ const { mockUseAuthorized, mockUseOrganizations } = vi.hoisted(() => {
     userEmail: "test@example.com",
     premiumUser: false,
     disabledPersonalKeyCreation: false,
-    showSSOBanner: false,
   }));
 
   const mockUseOrganizations = vi.fn(() => ({
@@ -148,7 +147,6 @@ describe("Sidebar (leftnav)", () => {
       userEmail: "viewer@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: false,
-      showSSOBanner: false,
     };
 
     it("hides Playground from Admin Viewer (cost-incurring action)", () => {
@@ -192,7 +190,6 @@ describe("Sidebar (leftnav)", () => {
       userEmail: "orgadmin@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: false,
-      showSSOBanner: false,
     });
 
     mockUseOrganizations.mockReturnValueOnce({

--- a/ui/litellm-dashboard/src/components/team/TeamMemberTab.test.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamMemberTab.test.tsx
@@ -107,7 +107,6 @@ describe("TeamMembersComponent", () => {
       userEmail: "test@example.com",
       premiumUser: false,
       disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
     });
   });
 

--- a/ui/litellm-dashboard/src/components/templates/KeyInfoView.handleKeyUpdate.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/KeyInfoView.handleKeyUpdate.test.tsx
@@ -322,7 +322,6 @@ const renderView = (premiumUser: boolean) => {
     token: "token_123",
     userEmail: "test@example.com",
     disabledPersonalKeyCreation: false,
-    showSSOBanner: false,
   });
 
   return render(
@@ -353,7 +352,6 @@ describe("KeyInfoView handleKeyUpdate guardrails guard", () => {
       token: "token_123",
       userEmail: "test@example.com",
       disabledPersonalKeyCreation: false,
-      showSSOBanner: false,
     });
 
     render(

--- a/ui/litellm-dashboard/src/components/templates/key_info_view.budget_display.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.budget_display.test.tsx
@@ -102,7 +102,6 @@ const baseAuthorized = {
   token: "test-token",
   userEmail: null,
   disabledPersonalKeyCreation: null,
-  showSSOBanner: false,
 };
 
 describe("KeyInfoView overview budget display (LIT-2845)", () => {

--- a/ui/litellm-dashboard/src/components/templates/key_info_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.test.tsx
@@ -143,7 +143,6 @@ describe("KeyInfoView", () => {
     token: "test-token",
     userEmail: null,
     disabledPersonalKeyCreation: null,
-    showSSOBanner: false,
   };
 
   it("should render tags", async () => {

--- a/ui/litellm-dashboard/src/contexts/AuthContext.tsx
+++ b/ui/litellm-dashboard/src/contexts/AuthContext.tsx
@@ -25,13 +25,8 @@ type AuthContextValue = {
   disabledPersonalKeyCreation: boolean;
   showSSOBanner: boolean;
 
-  setToken: React.Dispatch<React.SetStateAction<string | null>>;
-  setUserID: React.Dispatch<React.SetStateAction<string | null>>;
   setUserRole: React.Dispatch<React.SetStateAction<string>>;
   setUserEmail: React.Dispatch<React.SetStateAction<string | null>>;
-  setAccessToken: React.Dispatch<React.SetStateAction<string | null>>;
-  setPremiumUser: React.Dispatch<React.SetStateAction<boolean>>;
-  setShowSSOBanner: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 const AuthContext = createContext<AuthContextValue | null>(null);
@@ -40,12 +35,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [authLoading, setAuthLoading] = useState(true);
   const [token, setToken] = useState<string | null>(null);
   const [userID, setUserID] = useState<string | null>(null);
-  const [userRole, setUserRole] = useState("");
+  const [userRole, setUserRole] = useState(formatUserRole(""));
   const [userEmail, setUserEmail] = useState<string | null>(null);
   const [accessToken, setAccessToken] = useState<string | null>(null);
   const [premiumUser, setPremiumUser] = useState(false);
   const [disabledPersonalKeyCreation, setDisabledPersonalKeyCreation] = useState(false);
-  const [showSSOBanner, setShowSSOBanner] = useState(true);
+  const [showSSOBanner, setShowSSOBanner] = useState(false);
 
   // Load runtime UI config (populates proxyBaseUrl etc.) before clearing
   // authLoading, so any consumer that builds proxy-rooted URLs from authLoading=false
@@ -105,15 +100,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
     setAccessToken(decoded.key);
     setDisabledPersonalKeyCreation(decoded.disabled_non_admin_personal_key_creation);
+    setShowSSOBanner(decoded.login_method === "username_password");
 
     if (decoded.user_role) {
       setUserRole(formatUserRole(decoded.user_role));
     }
     if (decoded.user_email) {
       setUserEmail(decoded.user_email);
-    }
-    if (decoded.login_method) {
-      setShowSSOBanner(decoded.login_method === "username_password");
     }
     if (decoded.premium_user) {
       setPremiumUser(decoded.premium_user);
@@ -136,13 +129,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     premiumUser,
     disabledPersonalKeyCreation,
     showSSOBanner,
-    setToken,
-    setUserID,
     setUserRole,
     setUserEmail,
-    setAccessToken,
-    setPremiumUser,
-    setShowSSOBanner,
   };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/ui/litellm-dashboard/src/contexts/AuthContext.tsx
+++ b/ui/litellm-dashboard/src/contexts/AuthContext.tsx
@@ -1,18 +1,11 @@
 "use client";
 
-import React, { createContext, useContext, useEffect, useState } from "react";
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { jwtDecode } from "jwt-decode";
 import { clearTokenCookies, getCookie } from "@/utils/cookieUtils";
 import { isJwtExpired } from "@/utils/jwtUtils";
 import { formatUserRole } from "@/utils/roles";
 import { getUiConfig, setGlobalLitellmHeaderName } from "@/components/networking";
-
-function deleteCookie(name: string, path = "/") {
-  document.cookie = `${name}=; Max-Age=0; Path=${path}`;
-  if (name === "token") {
-    clearTokenCookies();
-  }
-}
 
 type AuthContextValue = {
   authLoading: boolean;
@@ -23,8 +16,8 @@ type AuthContextValue = {
   accessToken: string | null;
   premiumUser: boolean;
   disabledPersonalKeyCreation: boolean;
-  showSSOBanner: boolean;
 
+  clearAuth: () => void;
   setUserRole: React.Dispatch<React.SetStateAction<string>>;
   setUserEmail: React.Dispatch<React.SetStateAction<string | null>>;
 };
@@ -34,13 +27,22 @@ const AuthContext = createContext<AuthContextValue | null>(null);
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [authLoading, setAuthLoading] = useState(true);
   const [token, setToken] = useState<string | null>(null);
-  const [userID, setUserID] = useState<string | null>(null);
   const [userRole, setUserRole] = useState(formatUserRole(""));
   const [userEmail, setUserEmail] = useState<string | null>(null);
-  const [accessToken, setAccessToken] = useState<string | null>(null);
-  const [premiumUser, setPremiumUser] = useState(false);
-  const [disabledPersonalKeyCreation, setDisabledPersonalKeyCreation] = useState(false);
-  const [showSSOBanner, setShowSSOBanner] = useState(false);
+
+  const decoded = useMemo<{ [k: string]: any } | null>(() => {
+    if (!token || isJwtExpired(token)) return null;
+    try {
+      return jwtDecode(token);
+    } catch {
+      return null;
+    }
+  }, [token]);
+
+  const clearAuth = useCallback(() => {
+    clearTokenCookies();
+    setToken(null);
+  }, []);
 
   // Load runtime UI config (populates proxyBaseUrl etc.) before clearing
   // authLoading, so any consumer that builds proxy-rooted URLs from authLoading=false
@@ -63,7 +65,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
       // Clear expired/invalid token so downstream code doesn't keep trying to use it.
       if (raw && !valid) {
-        deleteCookie("token", "/");
+        clearTokenCookies();
       }
 
       setToken(valid);
@@ -75,32 +77,20 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     };
   }, []);
 
-  // Decode JWT and populate derived auth state whenever the token changes.
+  // Side effects of a token change: drop tokens that fail to decode, sync the
+  // mutable user fields, and apply any custom auth header. The reset branch runs
+  // after any commit that nulls the token, so user fields cannot survive clearAuth
+  // even if a stale sync was queued in the same commit.
   useEffect(() => {
-    if (!token) {
+    if (token && !decoded) {
+      clearAuth();
       return;
     }
-
-    if (isJwtExpired(token)) {
-      deleteCookie("token", "/");
-      setToken(null);
+    if (!decoded) {
+      setUserRole(formatUserRole(""));
+      setUserEmail(null);
       return;
     }
-
-    let decoded: { [k: string]: any } | null = null;
-    try {
-      decoded = jwtDecode(token);
-    } catch {
-      deleteCookie("token", "/");
-      setToken(null);
-      return;
-    }
-
-    if (!decoded) return;
-
-    setAccessToken(decoded.key);
-    setDisabledPersonalKeyCreation(decoded.disabled_non_admin_personal_key_creation);
-    setShowSSOBanner(decoded.login_method === "username_password");
 
     if (decoded.user_role) {
       setUserRole(formatUserRole(decoded.user_role));
@@ -108,27 +98,21 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     if (decoded.user_email) {
       setUserEmail(decoded.user_email);
     }
-    if (decoded.premium_user) {
-      setPremiumUser(decoded.premium_user);
-    }
     if (decoded.auth_header_name) {
       setGlobalLitellmHeaderName(decoded.auth_header_name);
     }
-    if (decoded.user_id) {
-      setUserID(decoded.user_id);
-    }
-  }, [token]);
+  }, [token, decoded, clearAuth]);
 
   const value: AuthContextValue = {
     authLoading,
     token,
-    userID,
+    userID: decoded?.user_id ?? null,
     userRole,
     userEmail,
-    accessToken,
-    premiumUser,
-    disabledPersonalKeyCreation,
-    showSSOBanner,
+    accessToken: decoded?.key ?? null,
+    premiumUser: !!decoded?.premium_user,
+    disabledPersonalKeyCreation: !!decoded?.disabled_non_admin_personal_key_creation,
+    clearAuth,
     setUserRole,
     setUserEmail,
   };

--- a/ui/litellm-dashboard/src/contexts/AuthContext.tsx
+++ b/ui/litellm-dashboard/src/contexts/AuthContext.tsx
@@ -77,10 +77,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     };
   }, []);
 
-  // Side effects of a token change: drop tokens that fail to decode, sync the
-  // mutable user fields, and apply any custom auth header. The reset branch runs
-  // after any commit that nulls the token, so user fields cannot survive clearAuth
-  // even if a stale sync was queued in the same commit.
+  // Sync the mutable user fields and the custom auth header to the decoded token;
+  // a token that fails to decode is cleared.
   useEffect(() => {
     if (token && !decoded) {
       clearAuth();

--- a/ui/litellm-dashboard/tests/CreateKeyPage.expiredToken.test.tsx
+++ b/ui/litellm-dashboard/tests/CreateKeyPage.expiredToken.test.tsx
@@ -215,7 +215,7 @@ describe("CreateKeyPage auth behavior", () => {
       return { exp: Math.floor(Date.now() / 1000) - 60 }; // expired 60s ago
     });
 
-    // Spy on cookie writes to ensure we clear with Max-Age=0
+    // Spy on cookie writes to ensure we write a deletion for the token
     const cookieSetSpy = vi.spyOn(document, "cookie", "set");
 
     // Act
@@ -228,9 +228,13 @@ describe("CreateKeyPage auth behavior", () => {
       );
     });
 
-    // And we attempted to clear the cookie (defensive deletion)
+    // And we attempted to clear the cookie (defensive deletion, via either
+    // Max-Age=0 or an already-past expires date)
     const wroteDeletion = cookieSetSpy.mock.calls.some(
-      (args) => typeof args[0] === "string" && args[0].includes("Max-Age=0") && args[0].startsWith("token="),
+      (args) =>
+        typeof args[0] === "string" &&
+        args[0].startsWith("token=;") &&
+        (args[0].includes("Max-Age=0") || args[0].includes("expires=Thu, 01 Jan 1970")),
     );
     expect(wroteDeletion).toBe(true);
   });

--- a/ui/litellm-dashboard/tests/setupTests.ts
+++ b/ui/litellm-dashboard/tests/setupTests.ts
@@ -138,6 +138,8 @@ vi.mock("@tremor/react", async (importOriginal) => {
 // Global mock for useAuthorized hook to avoid repeating the same mock in every test file
 vi.mock("@/app/(dashboard)/hooks/useAuthorized", () => ({
   default: () => ({
+    isLoading: false,
+    isAuthorized: true,
     token: "123",
     accessToken: "123",
     userId: "user-1",

--- a/ui/litellm-dashboard/tests/setupTests.ts
+++ b/ui/litellm-dashboard/tests/setupTests.ts
@@ -147,7 +147,6 @@ vi.mock("@/app/(dashboard)/hooks/useAuthorized", () => ({
     userRole: "Admin",
     premiumUser: false,
     disabledPersonalKeyCreation: null,
-    showSSOBanner: false,
   }),
 }));
 

--- a/ui/litellm-dashboard/tests/top_key_view.test.tsx
+++ b/ui/litellm-dashboard/tests/top_key_view.test.tsx
@@ -72,7 +72,6 @@ describe("TopKeyView", () => {
       userRole: mockProps.userRole,
       premiumUser: mockProps.premiumUser,
       disabledPersonalKeyCreation: false,
-      showSSOBanner: false,
     });
   });
 


### PR DESCRIPTION
## Relevant issues

Phase 0 of the App Router migration cleanup: one auth engine for both the legacy `?page=` shell and the migrated `(dashboard)/` tree. Follow-on to #30045.

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review and received a Confidence Score of at least 4/5

## Screenshots / Proof of Fix

Manual verification on a live proxy (`python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver`), exercising both shells end to end:

1. Go to http://localhost:4000/ui and log in. The legacy shell (api-keys page) should load normally; user dropdown shows your email and role
2. Navigate to http://localhost:4000/ui/api-reference (the one migrated path route). It should render with the sidebar and navbar, no redirect loop
3. From api-reference, click a legacy sidebar item (e.g. Teams) and confirm it lands on `/ui/?page=teams` logged in, no extra login round-trip
4. Clear the `token` cookie in devtools while on `/ui/api-reference` and reload; you should be redirected to `/ui/login` with a `return_url` that brings you back to api-reference after logging in
5. Log in as a user whose JWT carries a custom `auth_header_name` (or set one) and confirm API calls from the migrated api-reference page send the custom header; before this change only the legacy shell applied it

Unit: the rewritten `useAuthorized.test.ts` now mounts the real `AuthProvider` plus the real hook with real JWTs (valid, undecodable, expired, missing, and admin_ui_disabled paths) instead of mocking the decode away.

## Type

🧹 Refactoring

## Changes

The dashboard had two parallel auth systems: `AuthContext` (root provider) and `useAuthorized` (used by ~85 files in the migrated tree), each reading the cookie, decoding the JWT, and running its own redirects. Only `AuthContext` applied the decoded `auth_header_name`, so the two shells could disagree on custom headers, and the migrated tree paid a per-consumer decode plus a duplicate uiConfig query.

This makes `AuthContext` the single engine and turns `useAuthorized` into a thin policy layer that adds only the `admin_ui_disabled` check and the redirect-to-login effect; its return shape is unchanged so none of the ~85 consumers change. Decoded JWT fields are now derived with `useMemo` and cleared through a new `clearAuth()`, the dead context setters and the never-rendered `showSSOBanner` are dropped, and migrated pages wait for `authLoading` instead of reading the cookie synchronously before uiConfig resolves the proxy base path. The decoded-JWT `any` typing stays for now since tightening it has to fix ~25 call sites
