### PR TITLE
chore(ui): make knip recognize .mjs scripts and openapi-typescript

### DIFF
--- a/ui/litellm-dashboard/knip.json
+++ b/ui/litellm-dashboard/knip.json
@@ -1,8 +1,9 @@
 {
   "$schema": "https://unpkg.com/knip@5/schema.json",
-  "entry": ["scripts/**/*.ts"],
-  "project": ["src/**/*.{ts,tsx}", "tests/**/*.{ts,tsx}", "scripts/**/*.ts", "e2e_tests/**/*.ts"],
+  "entry": ["scripts/**/*.{ts,mjs}"],
+  "project": ["src/**/*.{ts,tsx}", "tests/**/*.{ts,tsx}", "scripts/**/*.{ts,mjs}", "e2e_tests/**/*.ts"],
   "ignore": ["src/lib/http/schema.d.ts"],
+  "ignoreDependencies": ["openapi-typescript"],
   "playwright": {
     "config": "e2e_tests/playwright.config.ts",
     "entry": ["e2e_tests/**/*.spec.ts", "e2e_tests/**/*.setup.ts", "e2e_tests/globalSetup.ts"]


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Summary

Two small fixes to the dashboard's `knip.json` so the report is clean and trustworthy. The `entry` and `project` globs matched only `scripts/**/*.ts`, but the two scripts in that directory (`gen-api-types.mjs`, `check-lint-budgets.mjs`) are `.mjs`, so knip emitted "Refine entry pattern (no matches)" / "Refine project pattern (no matches)" hints and never analyzed those files. Widening the glob to `scripts/**/*.{ts,mjs}` clears both hints.

Separately, knip reported `openapi-typescript` as an unused devDependency. It is not unused; `gen-api-types.mjs` (the `gen:api` script) runs it to regenerate `src/lib/http/schema.d.ts`, but it does so through a dynamic `execFileSync(".../node_modules/.bin/openapi-typescript")` path that knip cannot trace statically. Widening the glob alone does not fix this, so `ignoreDependencies: ["openapi-typescript"]` records that the dependency is genuinely used.

This is a follow-up to the dead-code removal in #30047; with both merged, `knip` reports no unused files, no unused dependencies, and no configuration hints for the dashboard.

## Pre-Submission checklist

- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Test plan

- [x] `SERVER_ROOT_PATH=/litellm npm run knip` no longer reports `openapi-typescript` under "Unused devDependencies" and no longer emits the two "Refine ... pattern (no matches)" configuration hints
- [x] The `gen:api` script still resolves the openapi-typescript binary the same way (no runtime code changed)

## Type

🧹 Refactoring