### PR TITLE
fix(cerebras): include max_retries in supported OpenAI params allowlist

### DIFF
--- a/litellm/llms/cerebras/chat.py
+++ b/litellm/llms/cerebras/chat.py
@@ -68,6 +68,7 @@ class CerebrasConfig(OpenAIGPTConfig):
             "tool_choice",
             "tools",
             "user",
+            "max_retries",
         ]
 
         # Only add reasoning_effort for models that support it

--- a/tests/test_litellm/llms/cerebras/test_cerebras_chat_transformation.py
+++ b/tests/test_litellm/llms/cerebras/test_cerebras_chat_transformation.py
@@ -1,0 +1,53 @@
+"""
+Unit tests for Cerebras chat configuration.
+"""
+
+import os
+import sys
+
+sys.path.insert(
+    0, os.path.abspath("../../../../..")
+)  # project root for ``litellm`` import
+
+from litellm.llms.cerebras.chat import CerebrasConfig
+
+
+class TestCerebrasGetSupportedOpenAIParams:
+    """Validates the OpenAI-param allowlist exposed by ``CerebrasConfig``."""
+
+    def test_max_retries_in_supported_params(self):
+        """``max_retries`` is a standard OpenAI client parameter that Cerebras
+        accepts. It must appear in the supported-param allowlist so callers
+        can override the default retry count per request without LiteLLM
+        stripping the value silently.
+        """
+        config = CerebrasConfig()
+        params = config.get_supported_openai_params(model="llama3.1-8b")
+        assert "max_retries" in params, (
+            f"max_retries should be in the Cerebras supported_params allowlist; "
+            f"got: {params!r}"
+        )
+
+    def test_core_openai_params_still_supported(self):
+        """Regression guard: the standard OpenAI params Cerebras has always
+        accepted must remain in the allowlist after the ``max_retries``
+        addition (no accidental removals)."""
+        config = CerebrasConfig()
+        params = config.get_supported_openai_params(model="llama3.1-8b")
+        for expected in (
+            "max_tokens",
+            "max_completion_tokens",
+            "response_format",
+            "seed",
+            "stop",
+            "stream",
+            "temperature",
+            "top_p",
+            "tool_choice",
+            "tools",
+            "user",
+        ):
+            assert expected in params, (
+                f"{expected!r} unexpectedly missing from Cerebras supported_params: "
+                f"{params!r}"
+            )


### PR DESCRIPTION
## Relevant issues

`max_retries` is a standard parameter exposed by both the OpenAI Python client and `litellm.completion()`. The Cerebras inference endpoint accepts it, but `CerebrasConfig.get_supported_openai_params` was omitting it from the allowlist, so LiteLLM was silently stripping the value before forwarding the call.

Callers passing `max_retries=N` on Cerebras requests therefore had no way to override the default retry behaviour â the request flowed through unchanged but the per-call override was dropped without warning.

## Linear ticket

(external contributor)

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit` (targeted: 2/2 pass)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

Before this change:
```python
import litellm
# Caller intends 5 retries
litellm.completion(
    model="cerebras/llama3.1-8b",
    messages=[{"role": "user", "content": "hi"}],
    max_retries=5,   # â silently stripped by CerebrasConfig; default still applies
)

After this change, max_retries=5 reaches the underlying HTTP client as expected.

Type

ð Bug Fix

Changes

litellm/llms/cerebras/chat.py:  adds "max_retries" to the supported_params list returned by CerebrasConfig.get_supported_openai_params: One-line allowlist addition; no behavioural change beyond letting the param through.

tests/test_litellm/llms/cerebras/test_cerebras_chat_transformation.py 2 new tests (no existing Cerebras test file in tests/test_litellm/llms/cerebras/):
- test_max_retries_in_supported_params - asserts "max_retries" is present in the allowlist.
- test_core_openai_params_still_supported - regression guard ensuring no existing allowlist entries are accidentally dropped by the change.