### PR TITLE
docs(security): require a reproduction video for vulnerability reports

### DIFF
--- a/security.md
+++ b/security.md
@@ -3,11 +3,19 @@
 
 ## Security Vulnerability Reporting Guidelines
 
+> [!WARNING]
+> Reports that do not include a video demonstrating the exploit will be closed without review. See [Reproduction Video Requirement](#reproduction-video-requirement) below.
+
 We value the security community's role in protecting our systems and users. To report a security vulnerability:
 
 - File a private vulnerability report on GitHub: [Report a vulnerability](https://github.com/BerriAI/litellm/security/advisories/new)
 - Include steps to reproduce the issue
+- Include a video or screen recording demonstrating the full exploit against a live LiteLLM instance, from initial access through to impact. A terminal recording (for example asciinema) is fine for CLI-only exploits.
 - Provide any relevant additional information
+
+### Reproduction Video Requirement
+
+A video demonstrating the exploit is required for every report. AI tools have made it easy to produce plausible-sounding vulnerability reports that do not reproduce in practice, and triaging them takes time away from real issues. Reports submitted without a working reproduction video will be closed without review. If you add a video to a closed report, we will reopen and triage it.
 
 ### Vulnerability Categories
 
@@ -38,7 +46,7 @@ We offer bounties for responsibly disclosed vulnerabilities based on severity:
 | **Medium** | N/A | P2 authenticated privilege escalation |
 | **Low** | N/A | Minor information disclosure, low-impact misconfigurations |
 
-To qualify for a bounty, reports must include clear reproduction steps and must not involve systems or accounts you do not own. We review all submissions promptly and will follow up within 5 business days.
+To qualify for a bounty, reports must include clear reproduction steps, a reproduction video as described above, and must not involve systems or accounts you do not own. We review all submissions promptly and will follow up within 5 business days.
 
 ### Known Non-Issues
 


### PR DESCRIPTION
## Relevant issues

Faithful re-issue of #30048 so the change runs against CCI before merging into `litellm_internal_staging`. No content changes from the original

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Documentation-only change to `security.md`; no proxy runtime behavior to exercise. The diff adds a warning callout at the top of the reporting guidelines, a new "Reproduction Video Requirement" section, a bullet asking for a screen recording of the exploit against a live instance, and a bounty-qualification line that now references the video. The same content was reviewed and merged as #30048

## Type

📖 Documentation

## Changes

`security.md` now requires a video demonstrating the exploit against a live LiteLLM instance for every vulnerability report. With AI tooling making it cheap to generate plausible-but-unreproducible reports, the video requirement raises the bar and keeps triage focused on real issues. Reports submitted without a working reproduction video are closed without review, and reopened if a video is added later. A terminal recording such as asciinema is acceptable for CLI-only exploits
