### PR TITLE
fix(github_copilot): normalize per-event item_id in /responses streaming so AI SDK clients don't drop reasoning/text parts

### DIFF
--- a/litellm/llms/github_copilot/responses/transformation.py
+++ b/litellm/llms/github_copilot/responses/transformation.py
@@ -101,6 +101,7 @@ class GithubCopilotResponsesAPIConfig(OpenAIResponsesAPIConfig):
     def __init__(self) -> None:
         super().__init__()
         self.authenticator = Authenticator()
+        self._stream_item_ids_by_output_index: Dict[int, str] = {}
 
     @property
     def custom_llm_provider(self) -> LlmProviders:
@@ -128,6 +129,61 @@ class GithubCopilotResponsesAPIConfig(OpenAIResponsesAPIConfig):
         so no transformation is needed.
         """
         return dict(response_api_optional_params)
+
+    def transform_streaming_response(
+        self,
+        model: str,
+        parsed_chunk: dict,
+        logging_obj: LiteLLMLoggingObj,
+    ) -> Any:
+        parsed_chunk = self._normalize_stream_item_id(parsed_chunk)
+        return super().transform_streaming_response(
+            model=model,
+            parsed_chunk=parsed_chunk,
+            logging_obj=logging_obj,
+        )
+
+    def _normalize_stream_item_id(self, parsed_chunk: dict) -> dict:
+        """Rewrite streamed item ids to one stable id per output_index.
+
+        GitHub Copilot tags each event of a single output item with a different
+        item id, so clients that key streaming state by item id (e.g. the Vercel
+        AI SDK) crash with "reasoning part <id> not found" / "text part <id> not
+        found". Every sub-event carries a top-level ``item_id`` (whatever the
+        item type), so its presence is the rewrite signal; output_item.added /
+        .done instead nest the id under ``item``. The anchor is keyed by
+        output_index and taken from output_item.added, which the protocol always
+        emits first, so it is written before any sub-event reads it. Copilot
+        accepts that id paired with the final encrypted_content next turn, so
+        multi-turn replay is unaffected.
+
+        State is keyed by output_index on this config, which
+        ProviderConfigManager builds fresh per request, so it is stream-scoped.
+        """
+        output_index = parsed_chunk.get("output_index")
+        if not isinstance(output_index, int):
+            return parsed_chunk
+
+        if parsed_chunk.get("type") == "response.output_item.added":
+            item = parsed_chunk.get("item")
+            if isinstance(item, dict) and isinstance(item.get("id"), str):
+                self._stream_item_ids_by_output_index[output_index] = item["id"]
+            return parsed_chunk
+
+        stable_id = self._stream_item_ids_by_output_index.get(output_index)
+        if stable_id is None:
+            return parsed_chunk
+
+        if isinstance(parsed_chunk.get("item_id"), str):
+            parsed_chunk = dict(parsed_chunk)
+            parsed_chunk["item_id"] = stable_id
+        elif parsed_chunk.get("type") == "response.output_item.done":
+            item = parsed_chunk.get("item")
+            if isinstance(item, dict):
+                parsed_chunk = dict(parsed_chunk)
+                parsed_chunk["item"] = {**item, "id": stable_id}
+
+        return parsed_chunk
 
     def validate_environment(
         self,

--- a/tests/test_litellm/llms/github_copilot/responses/test_github_copilot_responses_transformation.py
+++ b/tests/test_litellm/llms/github_copilot/responses/test_github_copilot_responses_transformation.py
@@ -585,3 +585,221 @@ class TestGithubCopilotResponsesAPIRouting:
             provider=LlmProviders.GITHUB_COPILOT,
         )
         assert isinstance(config, GithubCopilotResponsesAPIConfig)
+
+
+class TestGithubCopilotReasoningStreamItemIdNormalization:
+    """GitHub Copilot's native /responses stream tags every reasoning-summary
+    event with a different item_id (and the reasoning output_item.added /
+    output_item.done ids also differ). Strict clients (Vercel ai-sdk) key
+    reasoning state by item_id and crash when a summary delta references an
+    unregistered id. The config normalizes every reasoning event in an
+    output_index group to the id from its output_item.added."""
+
+    def _config(self):
+        with patch(
+            "litellm.llms.github_copilot.responses.transformation.Authenticator"
+        ):
+            return GithubCopilotResponsesAPIConfig()
+
+    def _transform(self, config, chunk):
+        return config.transform_streaming_response(
+            model="github_copilot/gpt-5.5",
+            parsed_chunk=chunk,
+            logging_obj=MagicMock(),
+        )
+
+    def test_summary_events_normalized_to_output_item_added_id(self):
+        config = self._config()
+
+        self._transform(
+            config,
+            {
+                "type": "response.output_item.added",
+                "output_index": 0,
+                "item": {"id": "stable_rs_id", "type": "reasoning"},
+            },
+        )
+
+        summary_chunks = [
+            {
+                "type": "response.reasoning_summary_part.added",
+                "output_index": 0,
+                "summary_index": 0,
+                "item_id": "bad_part_added",
+                "part": {"type": "summary_text", "text": ""},
+            },
+            {
+                "type": "response.reasoning_summary_text.delta",
+                "output_index": 0,
+                "summary_index": 0,
+                "item_id": "bad_delta_1",
+                "delta": "Hello",
+            },
+            {
+                "type": "response.reasoning_summary_text.delta",
+                "output_index": 0,
+                "summary_index": 0,
+                "item_id": "bad_delta_2",
+                "delta": " world",
+            },
+            {
+                "type": "response.reasoning_summary_text.done",
+                "output_index": 0,
+                "summary_index": 0,
+                "item_id": "bad_text_done",
+                "text": "Hello world",
+            },
+            {
+                "type": "response.reasoning_summary_part.done",
+                "output_index": 0,
+                "summary_index": 0,
+                "item_id": "bad_part_done",
+                "part": {"type": "summary_text", "text": "Hello world"},
+            },
+        ]
+        for chunk in summary_chunks:
+            event = self._transform(config, chunk)
+            assert event.item_id == "stable_rs_id"
+
+    def test_reasoning_output_item_done_normalized_to_added_id(self):
+        config = self._config()
+        self._transform(
+            config,
+            {
+                "type": "response.output_item.added",
+                "output_index": 0,
+                "item": {"id": "stable_rs_id", "type": "reasoning"},
+            },
+        )
+        event = self._transform(
+            config,
+            {
+                "type": "response.output_item.done",
+                "output_index": 0,
+                "item": {
+                    "id": "different_done_id",
+                    "type": "reasoning",
+                    "encrypted_content": "ENC",
+                },
+            },
+        )
+        assert event.item.id == "stable_rs_id"
+
+    def test_interleaved_message_item_does_not_corrupt_mapping(self):
+        config = self._config()
+        self._transform(
+            config,
+            {
+                "type": "response.output_item.added",
+                "output_index": 0,
+                "item": {"id": "stable_rs_id", "type": "reasoning"},
+            },
+        )
+        self._transform(
+            config,
+            {
+                "type": "response.output_item.added",
+                "output_index": 1,
+                "item": {"id": "msg_id", "type": "message"},
+            },
+        )
+        event = self._transform(
+            config,
+            {
+                "type": "response.reasoning_summary_text.delta",
+                "output_index": 0,
+                "summary_index": 0,
+                "item_id": "bad_delta",
+                "delta": "x",
+            },
+        )
+        assert event.item_id == "stable_rs_id"
+
+    def test_event_without_registered_item_passes_through_unchanged(self):
+        config = self._config()
+        event = self._transform(
+            config,
+            {
+                "type": "response.output_text.delta",
+                "output_index": 0,
+                "item_id": "msg_native_id",
+                "delta": "hi",
+            },
+        )
+        assert event.item_id == "msg_native_id"
+
+    def test_message_text_events_normalized_to_output_item_added_id(self):
+        config = self._config()
+        self._transform(
+            config,
+            {
+                "type": "response.output_item.added",
+                "output_index": 0,
+                "item": {"id": "stable_msg_id", "type": "message"},
+            },
+        )
+        for chunk in [
+            {
+                "type": "response.content_part.added",
+                "output_index": 0,
+                "content_index": 0,
+                "item_id": "bad_cp_added",
+                "part": {"type": "output_text", "text": ""},
+            },
+            {
+                "type": "response.output_text.delta",
+                "output_index": 0,
+                "content_index": 0,
+                "item_id": "bad_text_delta",
+                "delta": "Paris",
+            },
+            {
+                "type": "response.output_text.done",
+                "output_index": 0,
+                "content_index": 0,
+                "item_id": "bad_text_done",
+                "text": "Paris",
+            },
+        ]:
+            event = self._transform(config, chunk)
+            assert event.item_id == "stable_msg_id"
+
+    def test_event_without_output_index_passes_through_unchanged(self):
+        config = self._config()
+        event = self._transform(
+            config,
+            {
+                "type": "response.completed",
+                "response": {"id": "resp_1", "status": "completed", "output": []},
+            },
+        )
+        assert event.type == "response.completed"
+
+    def test_normalization_continues_after_a_terminal_event(self):
+        config = self._config()
+        self._transform(
+            config,
+            {
+                "type": "response.output_item.added",
+                "output_index": 0,
+                "item": {"id": "stable_rs_id", "type": "reasoning"},
+            },
+        )
+        self._transform(
+            config,
+            {
+                "type": "response.completed",
+                "response": {"id": "resp_1", "status": "completed", "output": []},
+            },
+        )
+        event = self._transform(
+            config,
+            {
+                "type": "response.reasoning_summary_text.delta",
+                "output_index": 0,
+                "summary_index": 0,
+                "item_id": "bad_delta",
+                "delta": "x",
+            },
+        )
+        assert event.item_id == "stable_rs_id"


### PR DESCRIPTION
## Relevant issues

Fixes #30071

## Root cause

GitHub Copilot's native `/v1/responses` stream tags **every event that belongs to a single output item with a different `item_id`**. For one reasoning item, the ids on `response.output_item.added`, `response.reasoning_summary_part.added`, every `response.reasoning_summary_text.delta`, and `response.output_item.done` are all distinct (each is a fresh ~400-char encrypted blob). The same is true for assistant message items (`content_part.added` / `output_text.delta` differ from the message's `output_item.added` id). LiteLLM passes these through unchanged.

The OpenAI Responses spec emits the **same** `item_id` for all events of one output item. Spec-strict clients such as the Vercel AI SDK (used by the OpenCode SDK and other agent frameworks) register a streaming part on `*.part.added` keyed by `item_id`, then look that key up on each delta. Because Copilot's delta `item_id` was never registered, the lookup misses and the SDK aborts the stream with `reasoning part <id> not found` / `text part <id> not found` (and, on `@ai-sdk/openai` v2, a `TypeError: ... 'summaryParts'`). A raw `curl` stream "succeeds" because it does not enforce the part-registration lifecycle — the breakage only surfaces with spec-strict clients.

## Fix

Override `transform_streaming_response` in `GithubCopilotResponsesAPIConfig` to normalize the per-event `item_id`. For each `output_index`, the id from `response.output_item.added` is remembered and re-applied to that item's subsequent streaming events (`*.part.added`, the summary/text deltas and dones, and `output_item.done`). The corrected id then flows into the untouched base-class event construction, so the emitted stream stays byte-faithful to the OpenAI Responses spec and LiteLLM remains a transparent passthrough.

State is keyed by `output_index` on the config instance, which `ProviderConfigManager` builds **fresh per request**, so it is inherently stream-scoped — there is no cross-request leakage and no terminal-reset bookkeeping to get wrong. Anchoring to the `output_item.added` id (rather than minting a synthetic one) is deliberate and is what keeps multi-turn replay working (see below). The change is scoped to `github_copilot`; providers with already-stable ids (OpenAI/Azure) are untouched.

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

**Reproduction (bug exists before the fix).** Real Vercel AI SDK (`ai` + `@ai-sdk/openai`) against a proxy serving `github_copilot/gpt-5.5` (`mode: responses`). Repro client (`repro.ts`):

```ts
import { createOpenAI } from '@ai-sdk/openai';
import { streamText } from 'ai';

const litellm = createOpenAI({
  baseURL: `${process.env.LITELLM_BASE_URL ?? 'http://localhost:4000'}/v1`,
  apiKey: process.env.LITELLM_API_KEY ?? 'sk-1234',
});

const result = streamText({
  model: litellm.responses(process.env.LITELLM_MODEL ?? 'github_copilot/gpt-5.5'),
  providerOptions: { openai: { reasoningSummary: 'detailed', store: false } },
  prompt: 'Reason step by step about why the sky is blue, then answer in one sentence.',
});

for await (const part of result.fullStream) {
  if (part.type === 'error') { console.error('REPRODUCED:', part.error); process.exit(1); }
}
console.log('OK: stream completed with no error parts.');
```

**Before the fix:**

```
REPRODUCED: reasoning part <copilot-encrypted-id>:0 not found
```

**After the fix:**

```
OK: stream completed with no error parts.
```

**Multi-turn replay — verified live against GitHub Copilot** (`github_copilot/gpt-5.3-codex`, `mode: responses`, `store: false`, `include: ["reasoning.encrypted_content"]`, direct `litellm.aresponses`). The fix replaces Copilot's per-event id with the `output_item.added` id; I confirmed Copilot accepts that substituted id on the next turn:

| Turn-2 replay input | Result |
|---|---|
| Normalized `output_item.added` id + matching `encrypted_content` (**what the fix sends**) | **200 OK** |
| Raw `output_item.done` id + matching `encrypted_content` (pre-fix value) | **200 OK** |
| A *different* valid reasoning id (from another response) + `encrypted_content` | **400** |
| Correct id + *mismatched* `encrypted_content` | **400** |

Copilot cross-validates `(id, encrypted_content)` as a pair, and both the `output_item.added` and `output_item.done` ids are valid handles for the **same** logical item — so substituting one for the other is safe and multi-turn replay (`store: false` + encrypted-content include) is unaffected.

**Prior art / FYI for reviewers.** OpenCode's GitHub Copilot integration independently arrived at the **same core invariant** — anchoring streamed events to the `output_item.added` id keyed by `output_index` ([`github-copilot.ts`](https://github.com/anomalyco/opencode/blob/97e713e8aac75a0254c34d134f0608af5cb4935c/packages/llm/src/providers/github-copilot.ts)). Note OpenCode is a **terminal consumer** that re-parses into its own event model (emitting synthetic `${id}:${summary_index}` part ids), whereas LiteLLM is a **passthrough proxy** — so here the anchor is applied as a minimal id-normalization pass over OpenAI-spec events rather than a parser rewrite (which would emit non-spec ids and break multi-turn replay through the gateway).

**Unit tests:**

```
$ pytest tests/test_litellm/llms/github_copilot/responses/ -q
....................................                                     [100%]
36 passed in 1.14s
```

## Type

🐛 Bug Fix

## Changes

- `litellm/llms/github_copilot/responses/transformation.py`: add `transform_streaming_response` override + `_normalize_stream_item_id` helper on `GithubCopilotResponsesAPIConfig`. It tracks the `output_item.added` id per `output_index` and rewrites the `item_id` of that item's subsequent streaming events to the stable id, then delegates to the base-class transform. State is held per-request on the config instance (`ProviderConfigManager` constructs it fresh per request), so it is stream-scoped. Other behavior (headers, URL, param mapping, non-stream transforms) is unchanged.
- `tests/test_litellm/llms/github_copilot/responses/test_github_copilot_responses_transformation.py`: add `TestGithubCopilotReasoningStreamItemIdNormalization` with mocked-chunk tests covering reasoning-summary events, message/text events, `output_item.done`, interleaved items across `output_index`, pass-through of unregistered / `output_index`-less events, and continued normalization after a terminal event.

**Scope:** `github_copilot` `/v1/responses` streaming only. Native OpenAI/Azure Responses streams use a stable per-item id and are untouched. The similar-looking `item_id` reports for Gemini (#25336) and the chat-completions `text part <id> not found` for Claude (#26529) are different paths / root causes and out of scope.
