### PR TITLE
fix(openai/gpt-5): detect gpt-5.4+ in prefixed custom deployment names

### DIFF
--- a/litellm/llms/openai/chat/gpt_5_transformation.py
+++ b/litellm/llms/openai/chat/gpt_5_transformation.py
@@ -103,10 +103,16 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
 
     @classmethod
     def is_model_gpt_5_4_plus_model(cls, model: str) -> bool:
-        """Check if the model is gpt-5.4 or newer (5.4, 5.5, 5.6, etc., including pro)."""
+        """Check if the model is gpt-5.4 or newer (5.4, 5.5, 5.6, etc., including pro).
+
+        Handles custom deployment names with prefixes (e.g. Azure deployments
+        like ``my-prefix-gpt-5.5``) by locating ``gpt-5.`` inside the name.
+        """
         model_name = model.split("/")[-1]
-        if not model_name.startswith("gpt-5."):
+        idx = model_name.find("gpt-5.")
+        if idx == -1:
             return False
+        model_name = model_name[idx:]
         try:
             version_str = model_name.replace("gpt-5.", "").split("-")[0]
             major = version_str.split(".")[0]

--- a/tests/test_litellm/llms/openai/test_gpt5_transformation.py
+++ b/tests/test_litellm/llms/openai/test_gpt5_transformation.py
@@ -342,6 +342,27 @@ def test_gpt5_4_pro_allows_reasoning_effort_xhigh(config: OpenAIConfig):
     assert params["reasoning_effort"] == "xhigh"
 
 
+def test_is_model_gpt_5_4_plus_model_prefixed_deployment_names(
+    gpt5_config: OpenAIGPT5Config,
+):
+    """Custom deployment names with prefixes (e.g. Azure) are recognized as gpt-5.4+."""
+    assert gpt5_config.is_model_gpt_5_4_plus_model("my-prefix-gpt-5.5")
+    assert gpt5_config.is_model_gpt_5_4_plus_model("azure/something-something-gpt-5.5")
+    assert gpt5_config.is_model_gpt_5_4_plus_model("my-prefix-gpt-5.4-pro")
+    assert gpt5_config.is_model_gpt_5_4_plus_model("gpt-5.4")
+    assert gpt5_config.is_model_gpt_5_4_plus_model("openai/gpt-5.6")
+
+
+def test_is_model_gpt_5_4_plus_model_rejects_non_5_4_plus_names(
+    gpt5_config: OpenAIGPT5Config,
+):
+    """Names below 5.4 or merely containing gpt-5 without a version must not match."""
+    assert not gpt5_config.is_model_gpt_5_4_plus_model("my-prefix-gpt-5.2")
+    assert not gpt5_config.is_model_gpt_5_4_plus_model("my-gpt-5-deployment")
+    assert not gpt5_config.is_model_gpt_5_4_plus_model("gpt-5")
+    assert not gpt5_config.is_model_gpt_5_4_plus_model("azure/prefix-gpt-5.x")
+
+
 def test_gpt5_4_mini_allows_reasoning_effort_xhigh(config: OpenAIConfig):
     """gpt-5.4-mini supports reasoning_effort='xhigh'."""
     params = config.map_openai_params(


### PR DESCRIPTION
## Relevant issues

Fixes #28782

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

`is_model_gpt_5_4_plus_model` now recognizes prefixed deployment names, which makes the Responses bridge gate in `litellm/main.py` fire for them:

```
$ python -c "
from litellm.llms.openai.chat.gpt_5_transformation import OpenAIGPT5Config
for m in ['my-prefix-gpt-5.5', 'azure/something-something-gpt-5.5', 'my-gpt-5-deployment', 'my-prefix-gpt-5.2']:
    print(m, OpenAIGPT5Config.is_model_gpt_5_4_plus_model(m))
"
my-prefix-gpt-5.5 True
azure/something-something-gpt-5.5 True
my-gpt-5-deployment False
my-prefix-gpt-5.2 False
```

Before this change the first two printed False, so chat completion calls with tools plus reasoning_effort against prefixed Azure gpt-5.5 deployments stayed on /v1/chat/completions and got back "Function tools with reasoning_effort are not supported for something-something-gpt-5.5". I don't have an Azure gpt-5.5 deployment with a prefixed name to curl against; if a maintainer has one handy the repro from the issue is a tools call with reasoning_effort=high

## Type

🐛 Bug Fix

## Changes

Custom Azure/OpenAI deployment names commonly carry a prefix (e.g. `my-prefix-gpt-5.5`). `is_model_gpt_5_4_plus_model` in `litellm/llms/openai/chat/gpt_5_transformation.py` (line 105) checked `model.split("/")[-1].startswith("gpt-5.")`, so any prefixed name returned False. That meant the Responses API bridge condition at `litellm/main.py:1012` never fired for those deployments, and tools plus reasoning_effort requests failed with a 400 from the completions endpoint.

The fix locates `gpt-5.` inside the last path segment, slices from there, and runs the existing version parse unchanged. This mirrors the substring matching `is_model_gpt_5_model` already uses in the same class. Names that merely contain `gpt-5` without a minor version (e.g. `my-gpt-5-deployment`) still return False, as do prefixed sub-5.4 versions like `my-prefix-gpt-5.2`.

Tests: added `test_is_model_gpt_5_4_plus_model_prefixed_deployment_names` and `test_is_model_gpt_5_4_plus_model_rejects_non_5_4_plus_names` to `tests/test_litellm/llms/openai/test_gpt5_transformation.py`. The positive-case test fails on the base branch and passes with the fix; the full file (91 tests) passes