### PR TITLE
fix(key): allow /key/update to clear budget_limits with [] or null

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -1861,18 +1861,23 @@ async def prepare_key_update_data(
             non_default_values["budget_reset_at"] = key_reset_at
             non_default_values["budget_duration"] = budget_duration
 
-    if "budget_limits" in non_default_values and non_default_values["budget_limits"]:
-        from litellm.proxy.common_utils.timezone_utils import get_budget_reset_time
-
+    if "budget_limits" in non_default_values:
         raw_windows = non_default_values["budget_limits"]
-        initialized_windows = []
-        for window in raw_windows:
-            w = window if isinstance(window, dict) else window.model_dump()
-            w["reset_at"] = get_budget_reset_time(
-                budget_duration=w["budget_duration"]
-            ).isoformat()
-            initialized_windows.append(w)
-        non_default_values["budget_limits"] = json.dumps(initialized_windows)
+        if raw_windows:
+            from litellm.proxy.common_utils.timezone_utils import get_budget_reset_time
+
+            initialized_windows = []
+            for window in raw_windows:
+                w = window if isinstance(window, dict) else window.model_dump()
+                w["reset_at"] = get_budget_reset_time(
+                    budget_duration=w["budget_duration"]
+                ).isoformat()
+                initialized_windows.append(w)
+            non_default_values["budget_limits"] = json.dumps(initialized_windows)
+        else:
+            # [] / None clears the field; prisma-client-py has no DbNull
+            # sentinel for Json? columns, so store the JSON literal null
+            non_default_values["budget_limits"] = json.dumps(None)
 
     if "object_permission" in non_default_values:
         non_default_values = await _handle_update_object_permission(

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -2254,14 +2254,18 @@ async def _validate_update_key_data(
     # - Anyone else (non-PROXY_ADMIN, not the owner, not a team member
     #   on a team key): must pass _check_key_admin_access (PROXY_ADMIN
     #   / key-owner / team-admin / org-admin of the key).
-    # - max_budget / spend: always require the admin check, even for the
-    #   key owner or a team member (matches the existing admin-only
-    #   budget semantics).
+    # - max_budget / spend / budget_limits: always require the admin
+    #   check, even for the key owner or a team member (matches the
+    #   existing admin-only budget semantics).  budget_limits uses
+    #   model_fields_set because an explicit null/[] clears the field
+    #   and must gate the same as setting or changing it.
     _is_budget_change = (
-        data.max_budget is not None and data.max_budget != existing_key_row.max_budget
-    ) or (
-        data.spend is not None
-        and data.spend != getattr(existing_key_row, "spend", None)
+        (data.max_budget is not None and data.max_budget != existing_key_row.max_budget)
+        or (
+            data.spend is not None
+            and data.spend != getattr(existing_key_row, "spend", None)
+        )
+        or "budget_limits" in data.model_fields_set
     )
 
     # Personal-key bypass: the caller both created the key AND still owns it

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -1489,6 +1489,65 @@ async def test_prepare_key_update_data_duration_none_never_expires():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("cleared_value", [[], None])
+async def test_prepare_key_update_data_budget_limits_clears_field(cleared_value):
+    """budget_limits=[] / None must serialize to JSON null, never reach Prisma raw."""
+    from litellm.proxy._types import UpdateKeyRequest
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        prepare_key_update_data,
+    )
+
+    existing_key = LiteLLM_VerificationToken(
+        token="test-token",
+        key_alias="test-key",
+        models=["gpt-3.5-turbo"],
+        user_id="test-user",
+        team_id=None,
+        metadata={},
+    )
+
+    update_request = UpdateKeyRequest(key="test-token", budget_limits=cleared_value)
+
+    result = await prepare_key_update_data(
+        data=update_request, existing_key_row=existing_key
+    )
+
+    assert result["budget_limits"] == json.dumps(None)
+
+
+@pytest.mark.asyncio
+async def test_prepare_key_update_data_budget_limits_serializes_windows():
+    """Non-empty budget_limits stay JSON-encoded with reset_at initialized."""
+    from litellm.proxy._types import UpdateKeyRequest
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        prepare_key_update_data,
+    )
+
+    existing_key = LiteLLM_VerificationToken(
+        token="test-token",
+        key_alias="test-key",
+        models=["gpt-3.5-turbo"],
+        user_id="test-user",
+        team_id=None,
+        metadata={},
+    )
+
+    update_request = UpdateKeyRequest(
+        key="test-token",
+        budget_limits=[{"budget_duration": "1d", "max_budget": 10.0}],
+    )
+
+    result = await prepare_key_update_data(
+        data=update_request, existing_key_row=existing_key
+    )
+
+    windows = json.loads(result["budget_limits"])
+    assert isinstance(result["budget_limits"], str)
+    assert windows[0]["max_budget"] == 10.0
+    assert windows[0]["reset_at"] is not None
+
+
+@pytest.mark.asyncio
 async def test_validate_team_id_used_in_service_account_request_requires_team_id():
     """
     Test that validate_team_id_used_in_service_account_request raises HTTPException

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -9672,6 +9672,58 @@ class TestKeyOwnerPrivilegeEscalation:
         mock_check.assert_called_once()
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("cleared_value", [[], None])
+    async def test_creator_cannot_clear_own_budget_limits(self, cleared_value):
+        """Clearing budget_limits is a budget change and requires admin."""
+        data = UpdateKeyRequest(key="sk-test", budget_limits=cleared_value)
+        existing = self._make_existing_key(created_by="creator-123")
+        auth = self._make_auth(user_id="creator-123")
+
+        mock_check = AsyncMock(
+            side_effect=HTTPException(status_code=403, detail="Not authorized")
+        )
+        with patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints._check_key_admin_access",
+            mock_check,
+        ):
+            with pytest.raises(HTTPException):
+                await _validate_update_key_data(
+                    data=data,
+                    existing_key_row=existing,
+                    user_api_key_dict=auth,
+                    llm_router=None,
+                    premium_user=False,
+                    prisma_client=AsyncMock(),
+                    user_api_key_cache=MagicMock(),
+                )
+        mock_check.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_admin_can_clear_budget_limits(self):
+        data = UpdateKeyRequest(key="sk-test", budget_limits=[])
+        existing = self._make_existing_key(created_by="someone-else")
+        auth = UserAPIKeyAuth(
+            user_id="admin-user",
+            user_role=LitellmUserRoles.PROXY_ADMIN,
+        )
+
+        mock_check = AsyncMock()
+        with patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints._check_key_admin_access",
+            mock_check,
+        ):
+            await _validate_update_key_data(
+                data=data,
+                existing_key_row=existing,
+                user_api_key_dict=auth,
+                llm_router=None,
+                premium_user=False,
+                prisma_client=AsyncMock(),
+                user_api_key_cache=MagicMock(),
+            )
+        mock_check.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_admin_can_update_any_field(self):
         data = UpdateKeyRequest(key="sk-test", models=["gpt-4"], max_budget=999.0)
         existing = self._make_existing_key(created_by="someone-else")


### PR DESCRIPTION
## Relevant issues

Fixes #30067

## Linear ticket

N/A (external contribution)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

I don't have a Prisma-backed proxy handy in this environment, so the proof here is the regression test pair, which fails on `litellm_internal_staging` and passes with the fix:

```
$ git stash push -- litellm/proxy/management_endpoints/key_management_endpoints.py
$ pytest tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py -k budget_limits -v
FAILED ...::test_prepare_key_update_data_budget_limits_clears_field[None]
FAILED ...::test_prepare_key_update_data_budget_limits_clears_field[cleared_value0]
2 failed, 1 passed

$ git stash pop
$ pytest tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py -k budget_limits -v
3 passed
```

To verify against a live proxy with a DB, give a key some windows and then clear them; both clear shapes returned HTTP 400 before this change and return 200 after

```
curl -sS -X POST 'http://localhost:4000/key/update' -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H 'Content-Type: application/json' \
  -d '{"key": "<key>", "budget_limits": [{"budget_duration": "1d", "max_budget": 10.0}]}'
curl -sS -X POST 'http://localhost:4000/key/update' -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H 'Content-Type: application/json' \
  -d '{"key": "<key>", "budget_limits": []}'
curl -sS -X POST 'http://localhost:4000/key/update' -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H 'Content-Type: application/json' \
  -d '{"key": "<key>", "budget_limits": null}'
```

## Type

🐛 Bug Fix

## Changes

Once a key has any `budget_limits` windows there is no accepted value that removes the last one: both `budget_limits: []` and `budget_limits: null` on `/key/update` come back as HTTP 400

Root cause is the truthy guard in `prepare_key_update_data` (`litellm/proxy/management_endpoints/key_management_endpoints.py:1864`). `if "budget_limits" in non_default_values and non_default_values["budget_limits"]:` skips serialization for `[]` and `None`, so the raw Python value reaches the Prisma `Json?` column. `jsonify_object` in `litellm/proxy/utils.py` only json-dumps dicts, and prisma-client-py has no DbNull sentinel for writing `Json?` columns (RobertCraigie/prisma-client-py#714), so Prisma rejects both shapes with a 400

The guard is now membership-only. Truthy values keep the existing path (per-window `reset_at` initialization plus `json.dumps`). Falsy values (`[]` or `null`) are stored as `json.dumps(None)`, the JSON literal null, which is the same workaround `_serialize_metadata_for_prisma` in `litellm/proxy/memory/memory_endpoints.py` already uses for `metadata` on the same column type

Tests added in `tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py`: `test_prepare_key_update_data_budget_limits_clears_field` (parametrized over `[]` and `None`, asserts the value handed to Prisma is the JSON string `"null"`, never a raw list or `None`) and `test_prepare_key_update_data_budget_limits_serializes_windows` (pins the non-empty path: result is a JSON string with `reset_at` initialized)