### PR TITLE
fix(anthropic): strip vector_store_ids from the outgoing request payload

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -1977,8 +1977,13 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                 optional_params.pop("metadata")
 
         # Remove internal LiteLLM parameters that should not be sent to Anthropic API
-        optional_params.pop("is_vertex_request", None)
-        optional_params.pop("client_metadata", None)
+        for internal_param in (
+            "is_vertex_request",
+            "client_metadata",
+            "vector_store_ids",
+            "vector_store_id",
+        ):
+            optional_params.pop(internal_param, None)
 
         # ``top_k`` is a provider-specific kwarg that bypasses
         # ``map_openai_params``; gate it here, the single boundary shared by

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -5361,6 +5361,25 @@ def test_client_metadata_stripped_from_anthropic_request():
     assert "client_metadata" not in result
 
 
+def test_transform_request_strips_vector_store_ids():
+    """vector_store_ids injected by proxy vector store hooks must not reach the Anthropic payload."""
+    config = AnthropicConfig()
+    result = config.transform_request(
+        model="claude-3-5-haiku-20241022",
+        messages=[{"role": "user", "content": "hello"}],
+        optional_params={
+            "max_tokens": 10,
+            "vector_store_ids": ["vs_abc123"],
+            "vector_store_id": "vs_abc123",
+        },
+        litellm_params={},
+        headers={},
+    )
+    assert "vector_store_ids" not in result
+    assert "vector_store_id" not in result
+    assert result["max_tokens"] == 10
+
+
 @pytest.mark.parametrize(
     "model",
     ["claude-fable-5", "claude-opus-4-7", "claude-opus-4-8-20260120"],


### PR DESCRIPTION
## Relevant issues

Fixes #23741

## Linear ticket

N/A (community contribution)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Reproduction (any proxy or SDK call that carries `vector_store_ids`, e.g. injected by the vector store pre-call hooks or saved into `litellm_params` by the Admin UI):

```bash
python -c "
import litellm
litellm.completion(
    model='anthropic/claude-3-5-haiku-20241022',
    messages=[{'role': 'user', 'content': 'hello'}],
    vector_store_ids=['vs_abc123'],
)"
```

On `litellm_internal_staging` this returns:

```
litellm.BadRequestError: AnthropicException - b'{"type":"error","error":{"type":"invalid_request_error","message":"vector_store_ids: Extra inputs are not permitted"}}'
```

because the transformed request body contains the field:

```json
{"model": "claude-3-5-haiku-20241022", "messages": [...], "vector_store_ids": ["vs_abc123"], "max_tokens": ...}
```

With this branch the same call produces a body without `vector_store_ids` / `vector_store_id` and the request succeeds. The regression test `test_transform_request_strips_vector_store_ids` fails on the base branch and passes with the fix

## Type

🐛 Bug Fix

## Changes

`AnthropicConfig.transform_request` builds the request body by spreading `**optional_params` (litellm/llms/anthropic/chat/transformation.py:1997). It already pops the internal `is_vertex_request` and `client_metadata` keys first, but not `vector_store_ids` / `vector_store_id`, so those leak into the body and Anthropic rejects the request with a 400. The proxy injects `vector_store_ids` for its vector store pre-call hooks, and the Admin UI persists `vector_store_ids: []` into `litellm_params` on every model save, so any Anthropic model touched by either path starts failing

This PR adds the two keys to the existing internal-param cleanup at litellm/llms/anthropic/chat/transformation.py:1979 (folded into a small loop to keep the function under the ruff PLR0915 statement limit). Scope is intentionally limited to the Anthropic transform per the one-problem-per-PR rule; commenters report similar leaks on Azure and Fireworks, which would be separate fixes

Test: `test_transform_request_strips_vector_store_ids` in tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py transforms a request carrying both keys and asserts neither reaches the payload while `max_tokens` still passes through. Verified it fails on the base branch and passes with the fix; the full file (267 tests) passes, and ruff plus black are clean on both touched files