### PR TITLE
fix(health): treat all-proxy-models keys as unrestricted in /health

### DIFF
--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -1056,12 +1056,23 @@ async def health_endpoint(
         # Keys granted SpecialModelNames.all_proxy_models carry the literal
         # "all-proxy-models" entry, which matches no real model_name; treat
         # them as unrestricted instead of filtering the list down to nothing.
+        # Keys granted SpecialModelNames.all_team_models inherit the parent
+        # team's allowlist (same semantics as get_key_models in
+        # model_checks.py). Without a team_id the sentinel cannot resolve and
+        # stays in the list, matching nothing; denied rather than
+        # unrestricted, mirroring _resolve_key_models_for_auth_check.
+        accessible_models = list(user_api_key_dict.models)
+        if (
+            SpecialModelNames.all_team_models.value in accessible_models
+            and user_api_key_dict.team_id is not None
+        ):
+            accessible_models = list(user_api_key_dict.team_models)
         restrict_to_allowed_models = (
-            len(user_api_key_dict.models) > 0
-            and SpecialModelNames.all_proxy_models.value not in user_api_key_dict.models
+            len(accessible_models) > 0
+            and SpecialModelNames.all_proxy_models.value not in accessible_models
         )
         if restrict_to_allowed_models:
-            allowed_models = set(user_api_key_dict.models)
+            allowed_models = set(accessible_models)
             _llm_model_list = [
                 m for m in _llm_model_list if m.get("model_name") in allowed_models
             ]

--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -24,6 +24,7 @@ from litellm.proxy._types import (
     LitellmUserRoles,
     ProxyErrorTypes,
     ProxyException,
+    SpecialModelNames,
     UserAPIKeyAuth,
     WebhookEvent,
 )
@@ -1052,7 +1053,14 @@ async def health_endpoint(
         # response but NOT in the background-cache /health response. This is
         # surfaced via the "warnings" field below so operators can fix the
         # missing model_info.id rather than guess at the discrepancy.
-        if len(user_api_key_dict.models) > 0:
+        # Keys granted SpecialModelNames.all_proxy_models carry the literal
+        # "all-proxy-models" entry, which matches no real model_name; treat
+        # them as unrestricted instead of filtering the list down to nothing.
+        restrict_to_allowed_models = (
+            len(user_api_key_dict.models) > 0
+            and SpecialModelNames.all_proxy_models.value not in user_api_key_dict.models
+        )
+        if restrict_to_allowed_models:
             allowed_models = set(user_api_key_dict.models)
             _llm_model_list = [
                 m for m in _llm_model_list if m.get("model_name") in allowed_models
@@ -1065,7 +1073,7 @@ async def health_endpoint(
             # other healthy model would still report healthy_count > 0 and
             # the targeted-503 path would never fire.
             targeted_ids = _resolve_targeted_model_ids(_llm_model_list, model, model_id)
-            if len(user_api_key_dict.models) > 0:
+            if restrict_to_allowed_models:
                 allowed_model_ids = {
                     (m.get("model_info") or {}).get("id")
                     for m in _llm_model_list

--- a/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
+++ b/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
@@ -1208,6 +1208,73 @@ async def test_health_endpoint_keeps_full_model_list_for_all_proxy_models():
 
 
 @pytest.mark.asyncio
+async def test_health_endpoint_resolves_all_team_models_to_team_allowlist():
+    """
+    A key granted "all-team-models" carries the literal sentinel in
+    user_api_key_dict.models, which matches no real model_name. With a
+    team_id the sentinel must resolve to the team's allowlist (same
+    semantics as get_key_models); otherwise the filter would zero out the
+    model list just like the all-proxy-models case.
+    """
+    from litellm.proxy._types import SpecialModelNames, UserAPIKeyAuth
+    from litellm.proxy.health_endpoints._health_endpoints import health_endpoint
+
+    full_model_list = [
+        {
+            "model_name": "model-a",
+            "litellm_params": {"model": "openai/gpt-4o"},
+            "model_info": {"id": "id-a"},
+        },
+        {
+            "model_name": "model-b",
+            "litellm_params": {"model": "openai/gpt-4o"},
+            "model_info": {"id": "id-b"},
+        },
+    ]
+
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key="hashed-test-key",
+        models=[SpecialModelNames.all_team_models.value],
+        team_id="team-1",
+        team_models=["model-b"],
+    )
+
+    captured: dict = {}
+
+    async def fake_perform(**kwargs):
+        captured["model_list"] = kwargs["model_list"]
+        return {
+            "healthy_endpoints": [],
+            "unhealthy_endpoints": [],
+            "healthy_count": 0,
+            "unhealthy_count": 0,
+        }
+
+    with (
+        patch("litellm.proxy.proxy_server.llm_model_list", full_model_list),
+        patch("litellm.proxy.proxy_server.llm_router", None),
+        patch("litellm.proxy.proxy_server.prisma_client", None),
+        patch("litellm.proxy.proxy_server.use_background_health_checks", False),
+        patch("litellm.proxy.proxy_server.user_model", None),
+        patch("litellm.proxy.proxy_server.health_check_results", {}),
+        patch("litellm.proxy.proxy_server.health_check_details", True),
+        patch("litellm.proxy.proxy_server.health_check_concurrency", 1),
+        patch(
+            "litellm.proxy.health_endpoints._health_endpoints._perform_health_check_and_save",
+            side_effect=fake_perform,
+        ),
+    ):
+        from fastapi import Response
+
+        await health_endpoint(response=Response(), user_api_key_dict=user_api_key_dict)
+
+    returned_names = {m["model_name"] for m in captured["model_list"]}
+    assert returned_names == {
+        "model-b"
+    }, f"all-team-models key should health-check the team's models: {returned_names}"
+
+
+@pytest.mark.asyncio
 async def test_health_endpoint_filters_background_cache_by_user_access():
     """
     When background_health_checks is enabled, health_endpoint() should also

--- a/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
+++ b/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
@@ -1143,6 +1143,71 @@ async def test_health_endpoint_filters_model_list_by_user_access():
 
 
 @pytest.mark.asyncio
+async def test_health_endpoint_keeps_full_model_list_for_all_proxy_models():
+    """
+    A key granted all model permissions carries the literal
+    "all-proxy-models" entry in user_api_key_dict.models. It matches no real
+    model_name, so the access filter must be skipped entirely; otherwise the
+    model list filters down to nothing and /health reports 0/0 counts.
+    """
+    from litellm.proxy._types import SpecialModelNames, UserAPIKeyAuth
+    from litellm.proxy.health_endpoints._health_endpoints import health_endpoint
+
+    full_model_list = [
+        {
+            "model_name": "model-a",
+            "litellm_params": {"model": "openai/gpt-4o"},
+            "model_info": {"id": "id-a"},
+        },
+        {
+            "model_name": "model-b",
+            "litellm_params": {"model": "openai/gpt-4o"},
+            "model_info": {"id": "id-b"},
+        },
+    ]
+
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key="hashed-test-key",
+        models=[SpecialModelNames.all_proxy_models.value],
+    )
+
+    captured: dict = {}
+
+    async def fake_perform(**kwargs):
+        captured["model_list"] = kwargs["model_list"]
+        return {
+            "healthy_endpoints": [],
+            "unhealthy_endpoints": [],
+            "healthy_count": 0,
+            "unhealthy_count": 0,
+        }
+
+    with (
+        patch("litellm.proxy.proxy_server.llm_model_list", full_model_list),
+        patch("litellm.proxy.proxy_server.llm_router", None),
+        patch("litellm.proxy.proxy_server.prisma_client", None),
+        patch("litellm.proxy.proxy_server.use_background_health_checks", False),
+        patch("litellm.proxy.proxy_server.user_model", None),
+        patch("litellm.proxy.proxy_server.health_check_results", {}),
+        patch("litellm.proxy.proxy_server.health_check_details", True),
+        patch("litellm.proxy.proxy_server.health_check_concurrency", 1),
+        patch(
+            "litellm.proxy.health_endpoints._health_endpoints._perform_health_check_and_save",
+            side_effect=fake_perform,
+        ),
+    ):
+        from fastapi import Response
+
+        await health_endpoint(response=Response(), user_api_key_dict=user_api_key_dict)
+
+    returned_names = {m["model_name"] for m in captured["model_list"]}
+    assert returned_names == {
+        "model-a",
+        "model-b",
+    }, f"all-proxy-models key should health-check every model: {returned_names}"
+
+
+@pytest.mark.asyncio
 async def test_health_endpoint_filters_background_cache_by_user_access():
     """
     When background_health_checks is enabled, health_endpoint() should also


### PR DESCRIPTION
## Relevant issues

Fixes #29744

## Linear ticket

N/A (external contribution)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Repro against a live proxy (matches the issue report):

1. Fresh database, log in to the UI as admin
2. Create a user, grant it the proxy_admin role and all model permissions (the user record ends up with `models=["all-proxy-models"]`)
3. Log in as that user, add a model, open Models -> Health Status and run the health check

Before this change the UI shows healthy_count=0, unhealthy_count=0 and the request returns 503. Same thing via curl with that user's key:

```
curl -s -w "\n%{http_code}\n" "http://localhost:4000/health" -H "Authorization: Bearer sk-<key-with-all-proxy-models>"
```

returns `{"healthy_endpoints":[],"unhealthy_endpoints":[],"healthy_count":0,"unhealthy_count":0}` with 503 on the per-model variant. After this change the same curl health-checks every configured deployment and returns the real counts. Happy to have a maintainer run the UI steps above for screenshots; I don't have a staging deployment to capture them from

## Type

🐛 Bug Fix

## Changes

`health_endpoint()` scopes the deployment list to the caller's allowed models before running checks (`litellm/proxy/health_endpoints/_health_endpoints.py:1055`). The filter compares `user_api_key_dict.models` entries against real `model_name`s, but a key granted all model permissions carries the literal marker `"all-proxy-models"` (`SpecialModelNames.all_proxy_models`), which matches no deployment. The list filters down to empty, the health check runs over nothing, and the endpoint reports 0/0 counts with a 503. The rest of the proxy already special-cases this marker (for example `_can_object_call_model` in `litellm/proxy/auth/auth_checks.py`); this filter did not.

The fix computes a single `restrict_to_allowed_models` flag that is false when the marker is present and uses it for both the live filter and the background-cache model_id scoping a few lines below, which had the same flaw. Behavior for keys scoped to explicit model names is unchanged.

Added `test_health_endpoint_keeps_full_model_list_for_all_proxy_models` to `tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py`, mirroring the existing access-scoping test. It fails on the base branch (model list filtered to empty) and passes with this change. Full mapped test file passes 47/47; `tests/test_litellm/proxy/` health and auth suites pass except `test_post_custom_auth_expired_key_returns_unauthorized`, which also fails on the base branch without this change