### PR TITLE
fix(streaming): preserve 5m/1h cache creation split in combined usage

### DIFF
--- a/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
+++ b/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
@@ -7,6 +7,7 @@ from litellm.types.llms.openai import (
     ChatCompletionAudioDelta,
 )
 from litellm.types.utils import (
+    CacheCreationTokenDetails,
     ChatCompletionAudioResponse,
     ChatCompletionMessageToolCall,
     Choices,
@@ -587,6 +588,7 @@ class ChunkProcessor:
         completion_tokens = 0
         ## anthropic prompt caching information ##
         cache_creation_input_tokens: Optional[int] = None
+        cache_creation_token_details: Optional[CacheCreationTokenDetails] = None
         cache_read_input_tokens: Optional[int] = None
 
         server_tool_use: Optional[ServerToolUse] = None
@@ -651,6 +653,19 @@ class ChunkProcessor:
                         usage_chunk_dict["prompt_tokens_details"],
                         "web_search_requests",
                     )
+                if (
+                    usage_chunk_dict["prompt_tokens_details"] is not None
+                    and getattr(
+                        usage_chunk_dict["prompt_tokens_details"],
+                        "cache_creation_token_details",
+                        None,
+                    )
+                    is not None
+                ):
+                    cache_creation_token_details = getattr(
+                        usage_chunk_dict["prompt_tokens_details"],
+                        "cache_creation_token_details",
+                    )
 
                 prompt_tokens_details = usage_chunk_dict["prompt_tokens_details"]
 
@@ -658,6 +673,7 @@ class ChunkProcessor:
             prompt_tokens=prompt_tokens,
             completion_tokens=completion_tokens,
             cache_creation_input_tokens=cache_creation_input_tokens,
+            cache_creation_token_details=cache_creation_token_details,
             cache_read_input_tokens=cache_read_input_tokens,
             server_tool_use=server_tool_use,
             web_search_requests=web_search_requests,
@@ -686,6 +702,9 @@ class ChunkProcessor:
         cache_creation_input_tokens: Optional[int] = calculated_usage_per_chunk[
             "cache_creation_input_tokens"
         ]
+        cache_creation_token_details: Optional[CacheCreationTokenDetails] = (
+            calculated_usage_per_chunk["cache_creation_token_details"]
+        )
         cache_read_input_tokens: Optional[int] = calculated_usage_per_chunk[
             "cache_read_input_tokens"
         ]
@@ -757,6 +776,15 @@ class ChunkProcessor:
                 )
         if prompt_tokens_details is not None:
             returned_usage.prompt_tokens_details = prompt_tokens_details
+        if cache_creation_token_details is not None:
+            if returned_usage.prompt_tokens_details is None:
+                returned_usage.prompt_tokens_details = PromptTokensDetailsWrapper(
+                    cache_creation_token_details=cache_creation_token_details
+                )
+            else:
+                returned_usage.prompt_tokens_details.cache_creation_token_details = (
+                    cache_creation_token_details
+                )
 
         if server_tool_use is not None:
             returned_usage.server_tool_use = server_tool_use

--- a/litellm/types/litellm_core_utils/streaming_chunk_builder_utils.py
+++ b/litellm/types/litellm_core_utils/streaming_chunk_builder_utils.py
@@ -2,13 +2,19 @@ from typing import TYPE_CHECKING, Optional
 
 from typing_extensions import TypedDict
 
-from ..utils import CompletionTokensDetails, PromptTokensDetailsWrapper, ServerToolUse
+from ..utils import (
+    CacheCreationTokenDetails,
+    CompletionTokensDetails,
+    PromptTokensDetailsWrapper,
+    ServerToolUse,
+)
 
 
 class UsagePerChunk(TypedDict):
     prompt_tokens: int
     completion_tokens: int
     cache_creation_input_tokens: Optional[int]
+    cache_creation_token_details: Optional[CacheCreationTokenDetails]
     cache_read_input_tokens: Optional[int]
     server_tool_use: Optional[ServerToolUse]
     web_search_requests: Optional[int]

--- a/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
@@ -11,12 +11,14 @@ sys.path.insert(
 from litellm import stream_chunk_builder
 from litellm.litellm_core_utils.streaming_chunk_builder_utils import ChunkProcessor
 from litellm.types.utils import (
+    CacheCreationTokenDetails,
     ChatCompletionDeltaToolCall,
     ChatCompletionMessageToolCall,
     Delta,
     Function,
     ModelResponseStream,
     PromptTokensDetails,
+    PromptTokensDetailsWrapper,
     ServerToolUse,
     StreamingChoices,
     Usage,
@@ -323,6 +325,84 @@ def test_cache_read_input_tokens_retained():
     assert usage.cache_creation_input_tokens == 4
     assert usage.cache_read_input_tokens == 11775
     assert usage.prompt_tokens_details.cached_tokens == 11775
+
+
+def test_calculate_usage_retains_cache_creation_token_details():
+    """
+    The 5m/1h cache creation split only arrives in the message_start usage
+    chunk; the final message_delta usage chunk must not clobber it, or 1h
+    cache writes get billed at the 5m rate.
+    """
+    chunk1 = ModelResponseStream(
+        id="chatcmpl-c8889184-careful-fox-12345",
+        created=1745513206,
+        model="claude-opus-4-8",
+        object="chat.completion.chunk",
+        choices=[
+            StreamingChoices(
+                finish_reason=None,
+                index=0,
+                delta=Delta(content=""),
+                logprobs=None,
+            )
+        ],
+        usage=Usage(
+            completion_tokens=1,
+            prompt_tokens=76,
+            total_tokens=77,
+            prompt_tokens_details=PromptTokensDetailsWrapper(
+                cached_tokens=31034,
+                cache_creation_tokens=362,
+                cache_creation_token_details=CacheCreationTokenDetails(
+                    ephemeral_5m_input_tokens=288,
+                    ephemeral_1h_input_tokens=74,
+                ),
+            ),
+            cache_creation_input_tokens=362,
+            cache_read_input_tokens=31034,
+        ),
+    )
+
+    chunk2 = ModelResponseStream(
+        id="chatcmpl-c8889184-careful-fox-12345",
+        created=1745513207,
+        model="claude-opus-4-8",
+        object="chat.completion.chunk",
+        choices=[
+            StreamingChoices(
+                finish_reason="stop",
+                index=0,
+                delta=Delta(content=None),
+                logprobs=None,
+            )
+        ],
+        usage=Usage(
+            completion_tokens=259,
+            prompt_tokens=0,
+            total_tokens=259,
+            prompt_tokens_details=PromptTokensDetailsWrapper(cached_tokens=0),
+            cache_creation_input_tokens=0,
+            cache_read_input_tokens=0,
+        ),
+    )
+
+    chunks = [chunk1, chunk2]
+    processor = ChunkProcessor(chunks=chunks)
+
+    usage = processor.calculate_usage(
+        chunks=chunks,
+        model="claude-opus-4-8",
+        completion_output="",
+    )
+
+    assert usage.cache_creation_input_tokens == 362
+    assert usage.cache_read_input_tokens == 31034
+    cache_creation_token_details = (
+        usage.prompt_tokens_details.cache_creation_token_details
+    )
+    assert cache_creation_token_details is not None
+    assert cache_creation_token_details.ephemeral_5m_input_tokens == 288
+    assert cache_creation_token_details.ephemeral_1h_input_tokens == 74
 
 
 def test_stream_chunk_builder_litellm_usage_chunks():


### PR DESCRIPTION
## Relevant issues

Fixes #29432

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

The combine step is deterministic, so the regression is visible by replaying the exact usage chunks from the issue's Bedrock invocation log through `stream_chunk_builder`: a message_start usage carrying `cache_creation_token_details` (`ephemeral_5m_input_tokens=288`, `ephemeral_1h_input_tokens=74`) followed by a message_delta usage carrying only totals, priced against `bedrock/global.anthropic.claude-opus-4-8` (`cache_creation_input_token_cost=6.25e-6`, `cache_creation_input_token_cost_above_1hr=1.0e-5`)

```
# before (litellm_internal_staging @ e15b37a18e)
"prompt_tokens_details": {
  "cached_tokens": 31034,
  "cache_creation_tokens": 362
}
completion_cost: 0.0242545

# after (this branch)
"prompt_tokens_details": {
  "cached_tokens": 31034,
  "cache_creation_tokens": 362,
  "cache_creation_token_details": {
    "ephemeral_5m_input_tokens": 288,
    "ephemeral_1h_input_tokens": 74
  }
}
completion_cost: 0.024532
```

The 0.0002775 difference is exactly 74 tokens x (10.00 - 6.25) per million, the undercount computed in the issue. To see it end to end, run the proxy as a Bedrock passthrough and POST `/bedrock/model/<inference-profile>/invoke-with-response-stream` with `cache_control: {"type": "ephemeral", "ttl": "1h"}` on a cacheable block; SpendLog `cost_breakdown.cache_creation_cost` now bills the 1h portion at `cache_creation_input_token_cost_above_1hr` instead of the 5m rate

## Type

🐛 Bug Fix

## Changes

`ChunkProcessor._calculate_usage_per_chunk` in `litellm/litellm_core_utils/streaming_chunk_builder_utils.py` overwrote `prompt_tokens_details` with every successive usage chunk. Anthropic-style streams only send the 5m/1h cache creation split in the message_start usage; the closing message_delta repeats the totals without it, so the split was clobbered by the last chunk while the aggregate `cache_creation_input_tokens` survived through its own keep-the-meaningful-chunk tracking. Downstream, `calculate_cache_writing_cost` in `litellm/litellm_core_utils/llm_cost_calc/utils.py` then had no `usage.prompt_tokens_details.cache_creation_token_details` to read and billed the whole cache write at the 5m rate

The fix tracks `cache_creation_token_details` across usage chunks the same way the aggregate already is (keep the chunk that has it), adds the field to the `UsagePerChunk` TypedDict in `litellm/types/litellm_core_utils/streaming_chunk_builder_utils.py`, and reattaches it to the final usage's `prompt_tokens_details` in `calculate_usage`

Regression test `test_calculate_usage_retains_cache_creation_token_details` in `tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py` fails on the base branch and passes with the fix. `tests/test_litellm/litellm_core_utils/` is green apart from `test_bedrock_converse_messages_pt_document_various_formats`, which also fails on the base branch; `tests/test_litellm/test_bedrock_anthropic_1hr_cache_pricing.py`, `test_cost_calculator.py`, `test_stream_chunk_builder_annotations.py` and the anthropic passthrough logging handler tests all pass