### PR TITLE
fix(proxy): allow non-admin virtual keys to call GA Realtime WebRTC HTTP routes

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -368,6 +368,9 @@ class LiteLLMRoutes(enum.Enum):
         "/realtime/calls",
         "/v1/realtime/calls",
         "/openai/v1/realtime/calls",
+        "/realtime/transcription_sessions",
+        "/v1/realtime/transcription_sessions",
+        "/openai/v1/realtime/transcription_sessions",
         # responses API
         "/responses",
         "/v1/responses",

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -361,6 +361,13 @@ class LiteLLMRoutes(enum.Enum):
         "/realtime?{model}",
         "/v1/realtime?{model}",
         "/openai/v1/realtime?{model}",
+        # realtime (GA WebRTC HTTP routes)
+        "/realtime/client_secrets",
+        "/v1/realtime/client_secrets",
+        "/openai/v1/realtime/client_secrets",
+        "/realtime/calls",
+        "/v1/realtime/calls",
+        "/openai/v1/realtime/calls",
         # responses API
         "/responses",
         "/v1/responses",

--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -1227,6 +1227,14 @@ _MODEL_ROUTING_BODY_TARGET_MODEL_ROUTE_MARKERS = (
     "/vector_stores",
 )
 _MODEL_ROUTING_COMPLETION_MODEL_ROUTE_MARKERS = ("/evals",)
+# Realtime WebRTC routes carry the effective model inside the nested
+# ``session.model`` field (see realtime_endpoints.endpoints), so the model the
+# request will actually use is not present at the top level. Extract it here so
+# can_key_call_model() validates the real target model.
+_MODEL_ROUTING_SESSION_MODEL_ROUTE_MARKERS = (
+    "/realtime/client_secrets",
+    "/realtime/calls",
+)
 _MODEL_ROUTING_ID_FIELDS = (
     "file_id",
     "input_file_id",
@@ -1409,6 +1417,12 @@ def _extract_model_candidates_from_request(
     _append_model_candidates(candidates, body_model)
     if uses_body_target_model_sources or not body_model:
         _append_model_candidates(candidates, request_data.get("target_model_names"))
+    if _route_matches_any_marker(
+        route=route, markers=_MODEL_ROUTING_SESSION_MODEL_ROUTE_MARKERS
+    ):
+        session = request_data.get("session")
+        if isinstance(session, dict):
+            _append_model_candidates(candidates, session.get("model"))
     if uses_completion_model_sources and isinstance(
         request_data.get("completion"), dict
     ):

--- a/tests/test_litellm/proxy/auth/test_auth_utils.py
+++ b/tests/test_litellm/proxy/auth/test_auth_utils.py
@@ -530,6 +530,59 @@ def test_get_model_from_request_handles_managed_id_decoder_failures():
         )
 
 
+@pytest.mark.parametrize(
+    "route",
+    [
+        "/realtime/client_secrets",
+        "/v1/realtime/client_secrets",
+        "/openai/v1/realtime/client_secrets",
+        "/realtime/calls",
+        "/v1/realtime/calls",
+        "/openai/v1/realtime/calls",
+    ],
+)
+def test_get_model_from_request_extracts_realtime_session_model(route):
+    """The effective realtime model lives in ``session.model`` (not the
+    top-level ``model``). It must be surfaced so can_key_call_model() can
+    validate the model a restricted key is actually requesting.
+
+    Regression test for the model-access bypass on the GA Realtime WebRTC
+    HTTP routes (https://github.com/BerriAI/litellm/issues/29923).
+    """
+    assert (
+        get_model_from_request(
+            request_data={"session": {"type": "realtime", "model": "gpt-realtime"}},
+            route=route,
+        )
+        == "gpt-realtime"
+    )
+
+
+def test_get_model_from_request_realtime_includes_top_level_and_session_model():
+    """When both top-level and session model are present, both are returned so
+    neither path can smuggle a disallowed model past the model-access check."""
+    models = get_model_from_request(
+        request_data={
+            "model": "gpt-4o-realtime-preview",
+            "session": {"type": "realtime", "model": "gpt-realtime"},
+        },
+        route="/v1/realtime/client_secrets",
+    )
+    assert models == ["gpt-4o-realtime-preview", "gpt-realtime"]
+
+
+def test_get_model_from_request_ignores_session_model_on_non_realtime_routes():
+    """A nested ``session.model`` must not leak into model resolution for
+    unrelated routes."""
+    assert (
+        get_model_from_request(
+            request_data={"session": {"type": "realtime", "model": "gpt-realtime"}},
+            route="/v1/chat/completions",
+        )
+        is None
+    )
+
+
 def test_abbreviate_api_key():
     assert abbreviate_api_key("sk-test-1234") == "sk-...1234"
 

--- a/tests/test_litellm/proxy/auth/test_route_checks.py
+++ b/tests/test_litellm/proxy/auth/test_route_checks.py
@@ -460,6 +460,29 @@ def test_mcp_inference_routes_classified_as_llm_api(route):
     assert RouteChecks.is_management_route(route=route) is False
 
 
+@pytest.mark.parametrize(
+    "route",
+    [
+        "/realtime/client_secrets",
+        "/v1/realtime/client_secrets",
+        "/openai/v1/realtime/client_secrets",
+        "/realtime/calls",
+        "/v1/realtime/calls",
+        "/openai/v1/realtime/calls",
+    ],
+)
+def test_realtime_webrtc_http_routes_classified_as_llm_api(route):
+    """GA Realtime WebRTC HTTP routes must be classified as LLM API routes so
+    non-admin virtual keys can call them instead of hitting the admin-only
+    401 branch in non_proxy_admin_allowed_routes_check.
+
+    Regression test for https://github.com/BerriAI/litellm/issues/29923
+    """
+
+    assert RouteChecks.is_llm_api_route(route=route) is True
+    assert RouteChecks.is_management_route(route=route) is False
+
+
 def test_virtual_key_allowed_routes_with_litellm_routes_member_name_denied():
     """Test that virtual key is denied when route is not in the allowed LiteLLMRoutes group"""
 

--- a/tests/test_litellm/proxy/auth/test_route_checks.py
+++ b/tests/test_litellm/proxy/auth/test_route_checks.py
@@ -469,6 +469,9 @@ def test_mcp_inference_routes_classified_as_llm_api(route):
         "/realtime/calls",
         "/v1/realtime/calls",
         "/openai/v1/realtime/calls",
+        "/realtime/transcription_sessions",
+        "/v1/realtime/transcription_sessions",
+        "/openai/v1/realtime/transcription_sessions",
     ],
 )
 def test_realtime_webrtc_http_routes_classified_as_llm_api(route):


### PR DESCRIPTION
## Relevant issues

Fixes #29923

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code) (targeted: `tests/test_litellm/proxy/auth/test_route_checks.py` — 304 passed)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

**Before** (current `main`):

```python
>>> RouteChecks.is_llm_api_route('/v1/realtime/client_secrets')
False
>>> RouteChecks.is_llm_api_route('/v1/realtime/calls')
False
```

A non-admin virtual key calling `POST /v1/realtime/client_secrets` therefore falls through `non_proxy_admin_allowed_routes_check` to the admin-only branch:

```
401 {"error": {"message": "Only proxy admin can be used to generate, delete, update info for new keys/users/teams. Route=/v1/realtime/client_secrets. Your role=internal_user_viewer", ...}}
```

**After** (this PR):

```python
>>> RouteChecks.is_llm_api_route('/v1/realtime/client_secrets')
True
>>> RouteChecks.is_llm_api_route('/v1/realtime/calls')
True
```

Test run:

```
$ python -m pytest tests/test_litellm/proxy/auth/test_route_checks.py -q
304 passed, 1 warning in 2.09s
```

## Type

🐛 Bug Fix

## Changes

- `litellm/proxy/_types.py`: add the GA Realtime WebRTC HTTP sub-routes to `LiteLLMRoutes.openai_routes` — `/realtime/client_secrets`, `/realtime/calls` and their `/v1` + `/openai/v1` variants (6 entries). These routes are registered in `litellm/proxy/realtime_endpoints/endpoints.py` (added in #27110) but were never added to `openai_routes` (#27323 only added the WSS `/openai/v1/realtime` path), so `is_llm_api_route()` returned `False` and non-admin virtual keys were rejected with the admin-only 401.
- `tests/test_litellm/proxy/auth/test_route_checks.py`: add `test_realtime_webrtc_http_routes_classified_as_llm_api`, a parametrized regression test asserting all 6 routes are classified as LLM API routes (and not management routes), mirroring the existing MCP route classification test.

No behavior change for admin keys; this only stops the WebRTC HTTP endpoints from being incorrectly admin-gated for normal virtual keys, matching the existing treatment of the realtime WSS routes.


---

## Follow-up: model-access hardening (review feedback)

While reviewing this change, [@veria-ai](https://github.com/apps/veria-ai) flagged a pre-existing model-access gap on the realtime routes. The endpoint resolves the effective model as `session.model or model`, but the auth layer's `get_model_from_request()` only extracted the top-level `model`. A model-restricted virtual key could therefore put a disallowed model in `session.model`, omit the top-level `model`, and skip `can_key_call_model()` — obtaining an ephemeral token for a model it is not allowed to use.

Addressed in `9ce4b358`:

- `litellm/proxy/auth/auth_utils.py`: added `_MODEL_ROUTING_SESSION_MODEL_ROUTE_MARKERS` (`/realtime/client_secrets`, `/realtime/calls`) and extract `session.model` in `_extract_model_candidates_from_request()`, so the model-access check runs against the model the request will actually use. Both top-level and `session.model` are surfaced when present (neither path can smuggle a disallowed model); `session.model` is ignored on non-realtime routes.
- `tests/test_litellm/proxy/auth/test_auth_utils.py`: parametrized regression tests over all 6 realtime routes plus the combined and negative cases.

Legitimate callers are unaffected — their permitted model still validates normally.
