### PR TITLE
fix(proxy): persist guardrail info in spend logs for /v1/responses

### DIFF
--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -2486,6 +2486,7 @@ class LoggedLiteLLMParams(TypedDict, total=False):
     litellm_call_id: Optional[str]
     model_alias_map: Optional[dict]
     metadata: Optional[dict]
+    litellm_metadata: Optional[dict]
     model_info: Optional[dict]
     proxy_server_request: Optional[dict]
     acompletion: Optional[bool]

--- a/tests/test_litellm/proxy/test_proxy_utils.py
+++ b/tests/test_litellm/proxy/test_proxy_utils.py
@@ -118,6 +118,63 @@ async def test_proxy_only_error_log_marks_no_upstream_llm_call():
     assert captured.get("flag") is True
 
 
+@pytest.mark.asyncio
+async def test_proxy_only_error_log_keeps_litellm_metadata_in_litellm_params():
+    """Responses API requests carry guardrail info under ``litellm_metadata``
+    (not ``metadata``). It must land in litellm_params so
+    ``merge_litellm_metadata`` can surface ``guardrail_information`` in the
+    spend-log failure row, matching the chat completions path."""
+    from litellm.proxy._types import UserAPIKeyAuth
+
+    proxy_logging_obj = ProxyLogging(user_api_key_cache=DualCache())
+    captured = {}
+    guardrail_info = [{"guardrail_name": "test-guard", "guardrail_status": "blocked"}]
+
+    def fake_update_environment_variables(self, *args, **kwargs):
+        captured["litellm_params"] = kwargs.get("litellm_params")
+        captured["optional_params"] = kwargs.get("optional_params")
+
+    from litellm.litellm_core_utils.litellm_logging import Logging
+
+    orig_update_env = Logging.update_environment_variables
+    orig_pre_call = Logging.pre_call
+    orig_async_failure = Logging.async_failure_handler
+
+    async def _noop_async_failure(self, *args, **kwargs):
+        return None
+
+    Logging.update_environment_variables = fake_update_environment_variables
+    Logging.pre_call = lambda self, *args, **kwargs: None
+    Logging.async_failure_handler = _noop_async_failure
+    try:
+        await proxy_logging_obj._handle_logging_proxy_only_error(
+            request_data={
+                "model": "gpt-4o",
+                "input": "blocked prompt",
+                "litellm_metadata": {
+                    "standard_logging_guardrail_information": guardrail_info
+                },
+            },
+            user_api_key_dict=UserAPIKeyAuth(
+                api_key="sk-1234", request_route="/v1/responses"
+            ),
+            route="/v1/responses",
+            original_exception=HTTPException(status_code=400, detail="blocked"),
+        )
+    finally:
+        Logging.update_environment_variables = orig_update_env
+        Logging.pre_call = orig_pre_call
+        Logging.async_failure_handler = orig_async_failure
+
+    assert (
+        captured["litellm_params"]["litellm_metadata"][
+            "standard_logging_guardrail_information"
+        ]
+        == guardrail_info
+    )
+    assert "litellm_metadata" not in captured["optional_params"]
+
+
 def test_get_model_group_info_order():
     from litellm import Router
     from litellm.proxy.proxy_server import _get_model_group_info


### PR DESCRIPTION
## Relevant issues

Fixes #28971

## Linear ticket

N/A (external contribution)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

When a pre_call guardrail blocks a /v1/responses request, the block is enforced but `metadata.guardrail_information` lands as null in `LiteLLM_SpendLogs`, so the Guardrails Monitor undercounts blocks for Responses API clients. The same guardrail and prompt on /v1/chat/completions persists the full object.

Root cause: on a proxy-only error, `_handle_logging_proxy_only_error` (litellm/proxy/utils.py:2249) splits `request_data` by `LoggedLiteLLMParams.__annotations__.keys()` (litellm/types/utils.py:2482). The Responses API stores request metadata under `litellm_metadata` (litellm/proxy/litellm_pre_call_utils.py:108), and guardrails attach `standard_logging_guardrail_information` there (litellm/integrations/custom_guardrail.py:789). `metadata` is in the TypedDict so the chat path survives the split, but `litellm_metadata` is not, so it falls into `optional_params` and `merge_litellm_metadata` (litellm/litellm_core_utils/litellm_logging.py:4862) never sees it; `guardrail_information` ends up null in the standard logging payload and SpendLogs.

The regression test `test_proxy_only_error_log_keeps_litellm_metadata_in_litellm_params` fails on `litellm_internal_staging` (litellm_metadata routed to optional_params) and passes with this change; the full `tests/test_litellm/proxy/test_proxy_utils.py` file passes (26 tests).

To verify on a live proxy: configure any pre_call guardrail that blocks on a phrase, send the same blocked prompt to /v1/chat/completions and /v1/responses, then run

```sql
SELECT request_id, call_type, status,
       metadata ? 'guardrail_information' AS has_gi
FROM "LiteLLM_SpendLogs"
WHERE request_id IN ('<chat-call-id>', '<responses-call-id>');
```

Before this change the responses row has `has_gi = false`; after, both rows carry the full guardrail_information array, the `LiteLLM_SpendLogGuardrailIndex` row is written, and the block shows up in the Guardrails Monitor

## Type

🐛 Bug Fix

## Changes

Adds `litellm_metadata: Optional[dict]` to the `LoggedLiteLLMParams` TypedDict (litellm/types/utils.py). That TypedDict's only consumer is the request_data split in `_handle_logging_proxy_only_error`, so the change routes `litellm_metadata` into `litellm_params` the same way `metadata` already is, letting `merge_litellm_metadata` surface the guardrail info in the failure spend log. Also adds a regression test in tests/test_litellm/proxy/test_proxy_utils.py asserting that `litellm_metadata` (carrying `standard_logging_guardrail_information`) reaches `litellm_params` and not `optional_params` for a blocked /v1/responses request