### PR TITLE
fix(bedrock): make document names unique across conversation turns

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -4290,6 +4290,35 @@ def _deduplicate_bedrock_tool_content(
     return _deduplicate_bedrock_content_blocks(tool_content, "toolResult")
 
 
+def _rename_duplicate_bedrock_document_names(
+    contents: List[BedrockMessageBlock],
+) -> List[BedrockMessageBlock]:
+    """
+    Rename duplicate document names across all messages in a Bedrock request.
+
+    Document names are derived from a content hash, so the same file appearing
+    in multiple conversation turns produces identical names and Bedrock rejects
+    the request with "Messages can not contain duplicate document names".  The
+    first occurrence keeps its original name so prompt-cache prefixes stay
+    stable; later occurrences get a deterministic positional suffix
+    (``_2``, ``_3``, ...).
+    """
+    name_counts: Dict[str, int] = {}
+    for message in contents:
+        for block in message.get("content") or []:
+            document = block.get("document")
+            if not isinstance(document, dict):
+                continue
+            name = document.get("name")
+            if not name:
+                continue
+            count = name_counts.get(name, 0) + 1
+            name_counts[name] = count
+            if count > 1:
+                document["name"] = f"{name}_{count}"
+    return contents
+
+
 def _sort_bedrock_assistant_content_blocks(
     blocks: List[BedrockContentBlock],
 ) -> List[BedrockContentBlock]:
@@ -4938,7 +4967,7 @@ class BedrockConverseMessagesProcessor:
                     llm_provider=llm_provider,
                 )
 
-        return contents
+        return _rename_duplicate_bedrock_document_names(contents)
 
     @staticmethod
     def translate_thinking_blocks_to_reasoning_content_blocks(
@@ -5360,7 +5389,7 @@ def _bedrock_converse_messages_pt(  # noqa: PLR0915
                 llm_provider=llm_provider,
             )
 
-    return contents
+    return _rename_duplicate_bedrock_document_names(contents)
 
 
 def make_valid_bedrock_tool_name(input_tool_name: str) -> str:

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -4301,8 +4301,16 @@ def _rename_duplicate_bedrock_document_names(
     the request with "Messages can not contain duplicate document names".  The
     first occurrence keeps its original name so prompt-cache prefixes stay
     stable; later occurrences get a deterministic positional suffix
-    (``_2``, ``_3``, ...).
+    (``_2``, ``_3``, ...), bumped further if the suffixed name already
+    belongs to another document (e.g. an organic name ending in ``_2``).
     """
+    used_names: Set[str] = set()
+    for message in contents:
+        for block in message.get("content") or []:
+            document = block.get("document")
+            if isinstance(document, dict) and document.get("name"):
+                used_names.add(document["name"])
+
     name_counts: Dict[str, int] = {}
     for message in contents:
         for block in message.get("content") or []:
@@ -4315,7 +4323,13 @@ def _rename_duplicate_bedrock_document_names(
             count = name_counts.get(name, 0) + 1
             name_counts[name] = count
             if count > 1:
-                document["name"] = f"{name}_{count}"
+                suffix = count
+                new_name = f"{name}_{suffix}"
+                while new_name in used_names:
+                    suffix += 1
+                    new_name = f"{name}_{suffix}"
+                used_names.add(new_name)
+                document["name"] = new_name
     return contents
 
 

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -2809,6 +2809,64 @@ def test_bedrock_converse_messages_pt_document_deterministic_name():
     assert name1 == name2
 
 
+def test_bedrock_converse_messages_pt_renames_duplicate_document_names():
+    """
+    The same document in multiple turns must not produce duplicate names;
+    Bedrock rejects requests with "Messages can not contain duplicate
+    document names". The first occurrence keeps its hash-based name and
+    later occurrences get a deterministic positional suffix.
+    """
+    document_block = {
+        "type": "document",
+        "source": {
+            "type": "base64",
+            "media_type": "application/pdf",
+            "data": "dGVzdA==",
+        },
+    }
+    messages = [
+        {
+            "role": "user",
+            "content": [document_block, {"type": "text", "text": "summarize this"}],
+        },
+        {"role": "assistant", "content": "It says test."},
+        {
+            "role": "user",
+            "content": [document_block, {"type": "text", "text": "summarize again"}],
+        },
+    ]
+
+    result1 = _bedrock_converse_messages_pt(
+        messages, "anthropic.claude-sonnet-4-6", "bedrock"
+    )
+    result2 = _bedrock_converse_messages_pt(
+        messages, "anthropic.claude-sonnet-4-6", "bedrock"
+    )
+
+    names1 = [
+        block["document"]["name"]
+        for message in result1
+        for block in message["content"]
+        if "document" in block
+    ]
+    names2 = [
+        block["document"]["name"]
+        for message in result2
+        for block in message["content"]
+        if "document" in block
+    ]
+
+    assert len(names1) == 2
+    assert len(set(names1)) == 2
+    assert names1[1] == f"{names1[0]}_2"
+    assert names1 == names2
+
+    single_turn = _bedrock_converse_messages_pt(
+        [messages[0]], "anthropic.claude-sonnet-4-6", "bedrock"
+    )
+    assert names1[0] == single_turn[0]["content"][0]["document"]["name"]
+
+
 def test_bedrock_converse_messages_pt_document_rejects_url_source():
     """Test that a URL-type document source raises a clear error instead of KeyError."""
     messages = [

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -11,6 +11,7 @@ from litellm.litellm_core_utils.prompt_templates.factory import (
     BedrockImageProcessor,
     _bedrock_converse_messages_pt,
     _bedrock_tools_pt,
+    _rename_duplicate_bedrock_document_names,
     _convert_to_bedrock_tool_call_invoke,
     _convert_to_bedrock_tool_call_result,
     anthropic_messages_pt,
@@ -2865,6 +2866,35 @@ def test_bedrock_converse_messages_pt_renames_duplicate_document_names():
         [messages[0]], "anthropic.claude-sonnet-4-6", "bedrock"
     )
     assert names1[0] == single_turn[0]["content"][0]["document"]["name"]
+
+
+def test_rename_duplicate_bedrock_document_names_skips_organic_suffixes():
+    """
+    A renamed duplicate must not collide with a document whose organic name
+    already carries the would-be suffix (e.g. an existing ``report_2``),
+    regardless of whether that document appears before or after the rename.
+    """
+
+    def _contents(names):
+        return [
+            {
+                "role": "user",
+                "content": [{"document": {"name": name}} for name in names],
+            }
+        ]
+
+    def _names(contents):
+        return [block["document"]["name"] for block in contents[0]["content"]]
+
+    organic_first = _rename_duplicate_bedrock_document_names(
+        _contents(["report", "report_2", "report"])
+    )
+    assert _names(organic_first) == ["report", "report_2", "report_3"]
+
+    organic_last = _rename_duplicate_bedrock_document_names(
+        _contents(["report", "report", "report_2"])
+    )
+    assert _names(organic_last) == ["report", "report_3", "report_2"]
 
 
 def test_bedrock_converse_messages_pt_document_rejects_url_source():


### PR DESCRIPTION
## Relevant issues

Fixes #29418

## Linear ticket

N/A (external contribution)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

PR #16275 made `_create_bedrock_block` (`litellm/litellm_core_utils/prompt_templates/factory.py:3882`) and `_process_document_message` (`factory.py:5044`) derive the Bedrock document name purely from a content hash. The same file attached in two different conversation turns therefore produces the identical name twice, and Bedrock rejects the request with "Messages can not contain duplicate document names". The existing `_deduplicate_bedrock_content_blocks` pass only covers toolUse/toolResult IDs, so document blocks were never deduplicated

To reproduce against a live proxy with a Bedrock model configured, attach the same base64 PDF in two user turns of one request:

```bash
DOC=$(base64 -i sample.pdf)
curl http://localhost:4000/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d "{
  \"model\": \"bedrock-claude\",
  \"messages\": [
    {\"role\": \"user\", \"content\": [{\"type\": \"file\", \"file\": {\"file_data\": \"data:application/pdf;base64,$DOC\"}}, {\"type\": \"text\", \"text\": \"summarize this\"}]},
    {\"role\": \"assistant\", \"content\": \"It is a sample PDF.\"},
    {\"role\": \"user\", \"content\": [{\"type\": \"file\", \"file\": {\"file_data\": \"data:application/pdf;base64,$DOC\"}}, {\"type\": \"text\", \"text\": \"summarize again\"}]}
  ]
}"
```

Before this change Bedrock returns a 400 ValidationException ("Messages can not contain duplicate document names"); with it the second occurrence is sent as `<name>_2` and the request succeeds

Regression test, run from the repo root:

```
$ pytest tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py::test_bedrock_converse_messages_pt_renames_duplicate_document_names -q
1 passed in 0.30s
```

On the base branch (fix reverted) the same test fails because both turns carry the identical document name

Note: `test_bedrock_converse_messages_pt_document_various_formats` in this file already fails on the current `litellm_internal_staging` HEAD (e15b37a18e) before this change (`text/markdown` raises "No supported extensions for MIME type"). It is unrelated to this PR and left untouched

## Type

🐛 Bug Fix

## Changes

Adds `_rename_duplicate_bedrock_document_names`, a small post-pass over the assembled `contents` that walks every message's document blocks and appends a positional suffix (`_2`, `_3`, ...) to the second and later occurrences of a duplicate name. Both `_bedrock_converse_messages_pt` and `_bedrock_converse_messages_pt_async` now return through it. The first occurrence keeps its original hash-based name and the suffixes are positional, so names stay deterministic across identical requests and prompt cache prefixes are unaffected

Adds `test_bedrock_converse_messages_pt_renames_duplicate_document_names`, which sends the same base64 PDF in two user turns and asserts that the two resulting document names are unique, that the second is the first plus `_2`, that the output is identical across two invocations, and that the first name matches what a single-turn request produces