### PR TITLE
Add above-512k pricing tier for MiniMax-M3 and correct its base rates

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -24392,9 +24392,12 @@
         "max_output_tokens": 8192
     },
     "minimax/MiniMax-M3": {
-        "input_cost_per_token": 6e-07,
-        "output_cost_per_token": 2.4e-06,
-        "cache_read_input_token_cost": 1.2e-07,
+        "input_cost_per_token": 3e-07,
+        "input_cost_per_token_above_512k_tokens": 6e-07,
+        "output_cost_per_token": 1.2e-06,
+        "output_cost_per_token_above_512k_tokens": 2.4e-06,
+        "cache_read_input_token_cost": 6e-08,
+        "cache_read_input_token_cost_above_512k_tokens": 1.2e-07,
         "litellm_provider": "minimax",
         "mode": "chat",
         "supports_function_calling": true,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -24406,7 +24406,7 @@
         "supports_reasoning": true,
         "supports_system_messages": true,
         "supports_vision": true,
-        "max_input_tokens": 512000,
+        "max_input_tokens": 1000000,
         "max_output_tokens": 128000
     },
     "mistral.devstral-2-123b": {

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -197,6 +197,7 @@ class ModelInfoBase(ProviderSpecificModelInfo, total=False):
     ]  # OpenAI priority service tier pricing
     cache_read_input_token_cost_above_200k_tokens: Optional[float]
     cache_read_input_token_cost_above_272k_tokens: Optional[float]
+    cache_read_input_token_cost_above_512k_tokens: Optional[float]
     input_cost_per_character: Optional[float]  # only for vertex ai models
     input_cost_per_audio_token: Optional[float]
     input_cost_per_token_above_128k_tokens: Optional[float]  # only for vertex ai models
@@ -206,6 +207,9 @@ class ModelInfoBase(ProviderSpecificModelInfo, total=False):
     input_cost_per_token_above_272k_tokens: Optional[
         float
     ]  # GPT-5.4/5.4-pro: prompts >272K priced at 2x input
+    input_cost_per_token_above_512k_tokens: Optional[
+        float
+    ]  # MiniMax-M3: prompts >512K priced at 2x input
     input_cost_per_character_above_128k_tokens: Optional[
         float
     ]  # only for vertex ai models
@@ -239,6 +243,9 @@ class ModelInfoBase(ProviderSpecificModelInfo, total=False):
     output_cost_per_token_above_272k_tokens: Optional[
         float
     ]  # GPT-5.4/5.4-pro: prompts >272K priced at 1.5x output
+    output_cost_per_token_above_512k_tokens: Optional[
+        float
+    ]  # MiniMax-M3: prompts >512K priced at 2x output
     output_cost_per_character_above_128k_tokens: Optional[
         float
     ]  # only for vertex ai models

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -5936,6 +5936,9 @@ def _get_model_info_helper(  # noqa: PLR0915
                 cache_read_input_token_cost_above_272k_tokens=_model_info.get(
                     "cache_read_input_token_cost_above_272k_tokens", None
                 ),
+                cache_read_input_token_cost_above_512k_tokens=_model_info.get(
+                    "cache_read_input_token_cost_above_512k_tokens", None
+                ),
                 cache_read_input_token_cost_flex=_model_info.get(
                     "cache_read_input_token_cost_flex", None
                 ),
@@ -5956,6 +5959,9 @@ def _get_model_info_helper(  # noqa: PLR0915
                 ),
                 input_cost_per_token_above_272k_tokens=_model_info.get(
                     "input_cost_per_token_above_272k_tokens", None
+                ),
+                input_cost_per_token_above_512k_tokens=_model_info.get(
+                    "input_cost_per_token_above_512k_tokens", None
                 ),
                 input_cost_per_query=_model_info.get("input_cost_per_query", None),
                 input_cost_per_second=_model_info.get("input_cost_per_second", None),
@@ -6011,6 +6017,9 @@ def _get_model_info_helper(  # noqa: PLR0915
                 ),
                 output_cost_per_token_above_272k_tokens=_model_info.get(
                     "output_cost_per_token_above_272k_tokens", None
+                ),
+                output_cost_per_token_above_512k_tokens=_model_info.get(
+                    "output_cost_per_token_above_512k_tokens", None
                 ),
                 output_cost_per_second=_model_info.get("output_cost_per_second", None),
                 output_cost_per_second_1080p=_model_info.get(

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -24392,9 +24392,12 @@
         "max_output_tokens": 8192
     },
     "minimax/MiniMax-M3": {
-        "input_cost_per_token": 6e-07,
-        "output_cost_per_token": 2.4e-06,
-        "cache_read_input_token_cost": 1.2e-07,
+        "input_cost_per_token": 3e-07,
+        "input_cost_per_token_above_512k_tokens": 6e-07,
+        "output_cost_per_token": 1.2e-06,
+        "output_cost_per_token_above_512k_tokens": 2.4e-06,
+        "cache_read_input_token_cost": 6e-08,
+        "cache_read_input_token_cost_above_512k_tokens": 1.2e-07,
         "litellm_provider": "minimax",
         "mode": "chat",
         "supports_function_calling": true,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -24406,7 +24406,7 @@
         "supports_reasoning": true,
         "supports_system_messages": true,
         "supports_vision": true,
-        "max_input_tokens": 512000,
+        "max_input_tokens": 1000000,
         "max_output_tokens": 128000
     },
     "mistral.devstral-2-123b": {

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
@@ -328,6 +328,41 @@ def test_generic_cost_per_token_gpt54_above_272k_tokens():
     assert round(completion_cost, 10) == round(expected_completion, 10)
 
 
+def test_generic_cost_per_token_minimax_m3_above_512k_tokens():
+    """MiniMax-M3: prompts >512K input tokens priced at 2x input, output, and cache read."""
+    model = "minimax/MiniMax-M3"
+    custom_llm_provider = "minimax"
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+
+    model_cost_map = litellm.model_cost[model]
+    prompt_tokens = 600000
+    cached_tokens = 100000
+    completion_tokens = 1000
+    usage = Usage(
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=prompt_tokens + completion_tokens,
+        prompt_tokens_details=PromptTokensDetailsWrapper(cached_tokens=cached_tokens),
+    )
+    prompt_cost, completion_cost = generic_cost_per_token(
+        model=model,
+        usage=usage,
+        custom_llm_provider=custom_llm_provider,
+    )
+    expected_prompt = (
+        model_cost_map["input_cost_per_token_above_512k_tokens"]
+        * (prompt_tokens - cached_tokens)
+        + model_cost_map["cache_read_input_token_cost_above_512k_tokens"]
+        * cached_tokens
+    )
+    expected_completion = (
+        model_cost_map["output_cost_per_token_above_512k_tokens"] * completion_tokens
+    )
+    assert round(prompt_cost, 10) == round(expected_prompt, 10)
+    assert round(completion_cost, 10) == round(expected_completion, 10)
+
+
 def test_generic_cost_per_token_gpt55():
     """gpt-5.5: base pricing — $5/1M input, $30/1M output, $0.50/1M cached input."""
     model = "gpt-5.5"

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -700,6 +700,7 @@ def test_aaamodel_prices_and_context_window_json_is_valid():
                 "cache_read_input_token_cost": {"type": "number"},
                 "cache_read_input_token_cost_above_200k_tokens": {"type": "number"},
                 "cache_read_input_token_cost_above_272k_tokens": {"type": "number"},
+                "cache_read_input_token_cost_above_512k_tokens": {"type": "number"},
                 "cache_read_input_token_cost_batches": {"type": "number"},
                 "cache_creation_input_token_cost_above_1hr_above_200k_tokens": {
                     "type": "number"
@@ -721,6 +722,7 @@ def test_aaamodel_prices_and_context_window_json_is_valid():
                 "input_cost_per_token_above_200k_tokens": {"type": "number"},
                 "input_cost_per_token_above_256k_tokens": {"type": "number"},
                 "input_cost_per_token_above_272k_tokens": {"type": "number"},
+                "input_cost_per_token_above_512k_tokens": {"type": "number"},
                 "cache_read_input_token_cost_flex": {"type": "number"},
                 "cache_read_input_token_cost_priority": {"type": "number"},
                 "cache_read_input_token_cost_above_200k_tokens_priority": {
@@ -811,6 +813,7 @@ def test_aaamodel_prices_and_context_window_json_is_valid():
                 "output_cost_per_token_above_200k_tokens": {"type": "number"},
                 "output_cost_per_token_above_256k_tokens": {"type": "number"},
                 "output_cost_per_token_above_272k_tokens": {"type": "number"},
+                "output_cost_per_token_above_512k_tokens": {"type": "number"},
                 "output_cost_per_image_above_1024_and_1024_pixels": {"type": "number"},
                 "output_cost_per_image_above_1024_and_1024_pixels_and_premium_image": {
                     "type": "number"


### PR DESCRIPTION
## Relevant issues

Fixes #29663

## Linear ticket

N/A (external contribution)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

A real above-512k MiniMax request needs a 512k+ token prompt against their paid API, so the proof drives the cost calculator directly against the updated local cost map

```
$ LITELLM_LOCAL_MODEL_COST_MAP=True python -c "
import litellm
from litellm.types.utils import Usage
from litellm.litellm_core_utils.llm_cost_calc.utils import generic_cost_per_token
litellm.model_cost = litellm.get_model_cost_map(url='')
for prompt_tokens in (1000, 600000):
    usage = Usage(prompt_tokens=prompt_tokens, completion_tokens=1000, total_tokens=prompt_tokens + 1000)
    p, c = generic_cost_per_token(model='minimax/MiniMax-M3', usage=usage, custom_llm_provider='minimax')
    print(f'prompt_tokens={prompt_tokens}: prompt_cost={p:.6f} completion_cost={c:.6f}')"
prompt_tokens=1000: prompt_cost=0.000300 completion_cost=0.001200
prompt_tokens=600000: prompt_cost=0.360000 completion_cost=0.002400
```

The 1000 token request now prices at the published base rates ($0.30/M in, $1.20/M out) instead of double, and the 600k token request picks up the above-512k rates ($0.60/M in, $2.40/M out). On the base branch both requests price at the flat 6e-7/2.4e-6 rates

## Type

🐛 Bug Fix

## Changes

MiniMax-M3 doubles its per-token rates once a prompt exceeds 512k input tokens (source: https://platform.minimax.io/docs/guides/pricing-paygo). LiteLLM could not represent that tier, and the existing flat rates for `minimax/MiniMax-M3` were wrong on top of it: 6e-7 input / 2.4e-6 output / 1.2e-7 cache read match MiniMax's above-512k tier, not the published base tier of 3e-7 / 1.2e-6 / 6e-8 (the page lists $0.30/M, $1.20/M, $0.06/M with a permanent 50% discount already applied). So every request at or below 512k tokens was billed at twice the real price

The tiered cost parser in `litellm/litellm_core_utils/llm_cost_calc/utils.py` already handles arbitrary `*_above_<N>k_tokens` thresholds dynamically. The gap is in `get_model_info` (`litellm/utils.py:5933`), which copies only keys whitelisted in `ModelInfoBase` (`litellm/types/utils.py:198`). That schema has 128k/200k/272k variants but no 512k, so `*_above_512k_tokens` keys in the cost map were silently dropped before the parser ever saw them

This PR adds `input_cost_per_token_above_512k_tokens`, `output_cost_per_token_above_512k_tokens`, and `cache_read_input_token_cost_above_512k_tokens` to `ModelInfoBase` plus the matching pass-throughs in `get_model_info`, corrects the `minimax/MiniMax-M3` base rates, and adds the above-512k rates in both `model_prices_and_context_window.json` and `litellm/model_prices_and_context_window_backup.json`

Regression test: `test_generic_cost_per_token_minimax_m3_above_512k_tokens` in `tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py` asserts a 600k token request (with 100k cached) prices input, output, and cache read at the above-512k rates. It fails on the base branch and passes with this change. `tests/test_litellm/litellm_core_utils/` passes locally (969 passed; `test_bedrock_converse_messages_pt_document_various_formats` fails on the base branch too and is unrelated)