### PR TITLE
fix(project): use shared object permission helper in /project/update

### DIFF
--- a/enterprise/litellm_enterprise/proxy/management_endpoints/project_endpoints.py
+++ b/enterprise/litellm_enterprise/proxy/management_endpoints/project_endpoints.py
@@ -20,6 +20,9 @@ from litellm._uuid import uuid
 from litellm.proxy._types import *
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 from litellm.proxy.management_endpoints.common_utils import _set_object_metadata_field
+from litellm.proxy.management_helpers.object_permission_utils import (
+    handle_update_object_permission_common,
+)
 from litellm.proxy.management_helpers.utils import (
     management_endpoint_wrapper,
 )
@@ -665,27 +668,13 @@ async def update_project(  # noqa: PLR0915
                 update_data.pop(field, None)
 
         # Handle object permissions
-        if "object_permission" in update_data:
-            object_permission_data = update_data.pop("object_permission")
-            if object_permission_data:
-                if existing_project.object_permission_id:
-                    # Update existing permission
-                    await prisma_client.db.litellm_objectpermissiontable.update(
-                        where={
-                            "object_permission_id": existing_project.object_permission_id
-                        },
-                        data=object_permission_data,
-                    )
-                else:
-                    # Create new permission
-                    created_permission = (
-                        await prisma_client.db.litellm_objectpermissiontable.create(
-                            data=object_permission_data,
-                        )
-                    )
-                    update_data["object_permission_id"] = (
-                        created_permission.object_permission_id
-                    )
+        object_permission_id = await handle_update_object_permission_common(
+            data_json=update_data,
+            existing_object_permission_id=existing_project.object_permission_id,
+            prisma_client=prisma_client,
+        )
+        if object_permission_id is not None:
+            update_data["object_permission_id"] = object_permission_id
 
         # Handle metadata fields
         for field in LiteLLM_ManagementEndpoint_MetadataFields:

--- a/tests/test_litellm/proxy/management_endpoints/test_project_org_authz.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_project_org_authz.py
@@ -7,7 +7,7 @@ Unit tests for the VERIA-55 fixes:
   member of.
 """
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
@@ -193,3 +193,53 @@ async def test_assign_key_org_blocks_caller_with_no_memberships():
             prisma_client=prisma,
         )
     assert exc_info.value.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# /project/update — object_permission upsert
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_project_upserts_object_permission_as_dict():
+    """jsonify_object serializes the nested object_permission dict into a JSON
+    string; passing that string straight to the Prisma table raised
+    FieldNotFoundError. The shared helper must receive it and upsert a dict."""
+    from litellm.proxy._types import (
+        LiteLLM_ObjectPermissionBase,
+        UpdateProjectRequest,
+    )
+    from litellm.proxy.utils import PrismaClient
+    from litellm_enterprise.proxy.management_endpoints.project_endpoints import (
+        update_project,
+    )
+
+    prisma = MagicMock()
+    prisma.jsonify_object = lambda data: PrismaClient.jsonify_object(prisma, data)
+    prisma.db.litellm_projecttable.find_unique = AsyncMock(
+        return_value=MagicMock(team_id=None, budget_id=None, object_permission_id=None)
+    )
+    prisma.db.litellm_projecttable.update = AsyncMock(return_value=MagicMock())
+    perm_table = prisma.db.litellm_objectpermissiontable
+    perm_table.find_unique = AsyncMock(return_value=None)
+    perm_table.upsert = AsyncMock(return_value=MagicMock(object_permission_id="op-1"))
+
+    admin = UserAPIKeyAuth(user_id="root", user_role=LitellmUserRoles.PROXY_ADMIN.value)
+    data = UpdateProjectRequest(
+        project_id="proj-1",
+        object_permission=LiteLLM_ObjectPermissionBase(mcp_servers=["server-1"]),
+    )
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", prisma),
+        patch("litellm.proxy.proxy_server.premium_user", True),
+    ):
+        await update_project(
+            data=data, http_request=MagicMock(), user_api_key_dict=admin
+        )
+
+    perm_table.upsert.assert_awaited_once()
+    upsert_data = perm_table.upsert.await_args.kwargs["data"]
+    assert upsert_data["create"] == {"mcp_servers": ["server-1"]}
+    project_update = prisma.db.litellm_projecttable.update.await_args.kwargs["data"]
+    assert project_update["object_permission_id"] == "op-1"
+    assert "object_permission" not in project_update


### PR DESCRIPTION
## Relevant issues

Fixes #28983

## Linear ticket

N/A (external contribution)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Repro from the issue, against any proxy with a project and an MCP server:

```bash
curl -X POST http://localhost:4000/project/update \
  -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d '{"project_id": "<project-id>", "object_permission": {"mcp_servers": ["<mcp-server-id>"]}}'
```

On the base branch this returns `{"error":{"message":"Could not find field at \`createOneLiteLLM_ObjectPermissionTable.data\`",...,"code":"500"}}`. With this change the same request returns 200 and the project row carries the new `object_permission_id`. I don't have a licensed proxy plus DB handy in this environment, so the pinned proof is the regression test `test_update_project_upserts_object_permission_as_dict` in `tests/test_litellm/proxy/management_endpoints/test_project_org_authz.py`; it drives `update_project` end to end with a mocked Prisma client and fails on the base branch (the string payload reaches the object permission table write) while passing with the fix (the upsert receives a dict)

## Type

🐛 Bug Fix

## Changes

`update_project` in `enterprise/litellm_enterprise/proxy/management_endpoints/project_endpoints.py` runs `prisma_client.jsonify_object(update_data)`, which serializes every nested dict value to a JSON string, including `object_permission`. The old inline block then passed that string straight to `litellm_objectpermissiontable.create/update`, so Prisma raised `FieldNotFoundError: Could not find field at createOneLiteLLM_ObjectPermissionTable.data` and the endpoint returned 500 (lines 668-688 before this change)

The fix replaces the inline block with `handle_update_object_permission_common` from `litellm/proxy/management_helpers/object_permission_utils.py`, the same helper `/team/update`, `/key/update`, `/organization/update` and `/customer/update` already use. It parses string JSON payloads, merges with any existing permission row, serializes `mcp_tool_permissions` for the Json column, and upserts into `LiteLLM_ObjectPermissionTable`. As a side benefit `/project/update` now merges into an existing permission row instead of blindly overwriting it, matching the other entity endpoints

Tests: ran the regression test against the base branch (fails with the string payload reaching the table write) and with the fix (passes); the full `tests/test_litellm/proxy/management_endpoints/` and `tests/test_litellm/proxy/management_helpers/` suites pass (1480 tests)