### PR TITLE
fix(alerting): dedupe team soft budget alerts by team_id instead of token

### DIFF
--- a/litellm/integrations/SlackAlerting/budget_alert_types.py
+++ b/litellm/integrations/SlackAlerting/budget_alert_types.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Literal
 
-from litellm.proxy._types import CallInfo
+from litellm.proxy._types import CallInfo, Litellm_EntityType
 
 
 class BaseBudgetAlertType(ABC):
@@ -31,6 +31,8 @@ class SoftBudgetAlert(BaseBudgetAlertType):
         return "Soft Budget Crossed: "
 
     def get_id(self, user_info: CallInfo) -> str:
+        if user_info.event_group == Litellm_EntityType.TEAM:
+            return user_info.team_id or "default_id"
         return user_info.token or "default_id"
 
 

--- a/tests/test_litellm/integrations/SlackAlerting/test_budget_alert_types.py
+++ b/tests/test_litellm/integrations/SlackAlerting/test_budget_alert_types.py
@@ -28,6 +28,31 @@ class TestSoftBudgetAlert:
         result = alert.get_id(user_info)
         assert result == "default_id"
 
+    def test_get_id_returns_team_id_for_team_event_group(self):
+        """Team soft budget alerts dedupe by team, not by the calling key's token"""
+        alert = SoftBudgetAlert()
+        user_info = CallInfo(
+            spend=120.0,
+            token="test_token_123",
+            team_id="team_456",
+            event_group=Litellm_EntityType.TEAM,
+        )
+
+        result = alert.get_id(user_info)
+        assert result == "team_456"
+
+    def test_get_id_returns_default_id_for_team_event_group_without_team_id(self):
+        alert = SoftBudgetAlert()
+        user_info = CallInfo(
+            spend=120.0,
+            token="test_token_123",
+            team_id=None,
+            event_group=Litellm_EntityType.TEAM,
+        )
+
+        result = alert.get_id(user_info)
+        assert result == "default_id"
+
     def test_get_id_with_empty_token(self):
         """Test that get_id returns 'default_id' when token is empty string"""
         alert = SoftBudgetAlert()


### PR DESCRIPTION
## Relevant issues

Fixes #27398

## Linear ticket

N/A (external contribution)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

`_team_soft_budget_check` (`litellm/proxy/auth/auth_checks.py`) sends team soft budget alerts as `type="soft_budget"` with `event_group=TEAM` and `token=valid_token.token`. `SoftBudgetAlert.get_id` (`litellm/integrations/SlackAlerting/budget_alert_types.py:33-34`) returned `user_info.token` unconditionally, so `SlackAlerting.budget_alerts` built a per-key cache key (`budget_alerts:soft_budget_crossed:<token>`). Every active key in a team over its soft budget fired its own alert within `budget_alert_ttl`, flooding the channel

To observe the behavior on a live proxy: configure `alerting: ["slack"]` with `alert_types: ["budget_alerts"]`, create a team with `soft_budget` and `metadata.soft_budget_alerting_emails`, create two keys in that team, push team spend past the soft budget, then send one chat completion through each key within the TTL. Before this change you get one `soft_budget_crossed` alert per key; after it you get one per team per TTL

The two new regression tests fail on `litellm_internal_staging` (get_id returns the token for a TEAM event_group) and pass with this change

## Type

🐛 Bug Fix

## Changes

`SoftBudgetAlert.get_id` now returns `user_info.team_id` when `user_info.event_group == Litellm_EntityType.TEAM`, matching how `TeamBudgetAlert` dedupes hard team budget alerts. All other event groups keep the existing per-token dedupe; key level soft budget alerts (which also carry a `team_id` when the key belongs to a team) intentionally branch on `event_group` rather than `team_id` presence so each key keeps its own alert window for its own `soft_budget`

Added `test_get_id_returns_team_id_for_team_event_group` and `test_get_id_returns_default_id_for_team_event_group_without_team_id` to the existing `tests/test_litellm/integrations/SlackAlerting/test_budget_alert_types.py`