### PR TITLE
fix(proxy): set Retry-After header on RouterRateLimitError 429 responses

### DIFF
--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import logging
+import math
 import time
 import traceback
 from datetime import datetime
@@ -49,6 +50,7 @@ from litellm.proxy.route_llm_request import route_request
 from litellm.proxy.utils import ProxyLogging
 from litellm.router import Router
 from litellm.types.guardrails import GuardrailEventHooks
+from litellm.types.router import RouterRateLimitError
 from litellm.types.utils import ServerToolUse
 
 # Type alias for streaming chunk serializer (chunk after hooks + cost injection -> wire format)
@@ -1891,6 +1893,9 @@ class ProxyBaseLLMRequestProcessing:
                 if _response_headers:
                     headers = get_response_headers(dict(_response_headers))
         headers.update(custom_headers)
+
+        if isinstance(e, RouterRateLimitError) and e.cooldown_time > 0:
+            headers["retry-after"] = str(math.ceil(e.cooldown_time))
 
         # Call response headers hook for failure
         try:

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -1828,6 +1828,10 @@ class ProxyBaseLLMRequestProcessing:
                     e,
                 )
 
+    def _apply_router_cooldown_retry_after(self, headers: dict, e: Exception) -> None:
+        if isinstance(e, RouterRateLimitError) and e.cooldown_time > 0:
+            headers["retry-after"] = str(math.ceil(e.cooldown_time))
+
     async def _handle_llm_api_exception(
         self,
         e: Exception,
@@ -1894,9 +1898,6 @@ class ProxyBaseLLMRequestProcessing:
                     headers = get_response_headers(dict(_response_headers))
         headers.update(custom_headers)
 
-        if isinstance(e, RouterRateLimitError) and e.cooldown_time > 0:
-            headers["retry-after"] = str(math.ceil(e.cooldown_time))
-
         # Call response headers hook for failure
         try:
             callback_headers = await proxy_logging_obj.post_call_response_headers_hook(
@@ -1911,6 +1912,8 @@ class ProxyBaseLLMRequestProcessing:
                 headers.update(callback_headers)
         except Exception:
             pass
+
+        self._apply_router_cooldown_retry_after(headers, e)
 
         if isinstance(e, HTTPException):
             raw_detail = getattr(e, "detail", str(e))

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -1,6 +1,6 @@
 import copy
 import datetime
-from typing import AsyncGenerator
+from typing import AsyncGenerator, Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -2303,14 +2303,16 @@ class TestHandleLLMApiExceptionDictDetail:
 class TestHandleLLMApiExceptionRetryAfter:
     """RouterRateLimitError cooldown_time must surface as a retry-after header."""
 
-    async def _invoke(self, exc: Exception):
+    async def _invoke(self, exc: Exception, callback_headers: Optional[dict] = None):
         from litellm.proxy._types import ProxyException, UserAPIKeyAuth
 
         processor = ProxyBaseLLMRequestProcessing(data={})
         user_api_key_dict = UserAPIKeyAuth(api_key="sk-test")
         proxy_logging_obj = MagicMock()
         proxy_logging_obj.post_call_failure_hook = AsyncMock(return_value=None)
-        proxy_logging_obj.post_call_response_headers_hook = AsyncMock(return_value={})
+        proxy_logging_obj.post_call_response_headers_hook = AsyncMock(
+            return_value=callback_headers or {}
+        )
 
         try:
             await processor._handle_llm_api_exception(
@@ -2352,6 +2354,21 @@ class TestHandleLLMApiExceptionRetryAfter:
     async def test_handle_llm_api_exception_no_retry_after_for_plain_exception(self):
         proxy_exc = await self._invoke(ValueError("some other failure"))
         assert "retry-after" not in proxy_exc.headers
+
+    async def test_handle_llm_api_exception_retry_after_survives_callback_headers(self):
+        from litellm.types.router import RouterRateLimitError
+
+        exc = RouterRateLimitError(
+            model="gpt-4",
+            cooldown_time=42.3,
+            enable_pre_call_checks=False,
+            cooldown_list=[],
+        )
+        proxy_exc = await self._invoke(
+            exc, callback_headers={"retry-after": "", "x-custom": "1"}
+        )
+        assert proxy_exc.headers["retry-after"] == "43"
+        assert proxy_exc.headers["x-custom"] == "1"
 
 
 class TestAsyncStreamingDataGeneratorFastPath:

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -2300,6 +2300,60 @@ class TestHandleLLMApiExceptionDictDetail:
         assert proxy_exc.code == "500"
 
 
+class TestHandleLLMApiExceptionRetryAfter:
+    """RouterRateLimitError cooldown_time must surface as a retry-after header."""
+
+    async def _invoke(self, exc: Exception):
+        from litellm.proxy._types import ProxyException, UserAPIKeyAuth
+
+        processor = ProxyBaseLLMRequestProcessing(data={})
+        user_api_key_dict = UserAPIKeyAuth(api_key="sk-test")
+        proxy_logging_obj = MagicMock()
+        proxy_logging_obj.post_call_failure_hook = AsyncMock(return_value=None)
+        proxy_logging_obj.post_call_response_headers_hook = AsyncMock(return_value={})
+
+        try:
+            await processor._handle_llm_api_exception(
+                e=exc,
+                user_api_key_dict=user_api_key_dict,
+                proxy_logging_obj=proxy_logging_obj,
+            )
+        except ProxyException as raised:
+            return raised
+        raise AssertionError("ProxyException was not raised")
+
+    async def test_handle_llm_api_exception_sets_retry_after_from_cooldown_time(self):
+        from litellm.types.router import RouterRateLimitError
+
+        exc = RouterRateLimitError(
+            model="gpt-4",
+            cooldown_time=42.3,
+            enable_pre_call_checks=False,
+            cooldown_list=[],
+        )
+        proxy_exc = await self._invoke(exc)
+        assert proxy_exc.headers["retry-after"] == "43"
+        assert proxy_exc.code == "429"
+
+    async def test_handle_llm_api_exception_skips_retry_after_when_cooldown_is_zero(
+        self,
+    ):
+        from litellm.types.router import RouterRateLimitError
+
+        exc = RouterRateLimitError(
+            model="gpt-4",
+            cooldown_time=0,
+            enable_pre_call_checks=False,
+            cooldown_list=[],
+        )
+        proxy_exc = await self._invoke(exc)
+        assert "retry-after" not in proxy_exc.headers
+
+    async def test_handle_llm_api_exception_no_retry_after_for_plain_exception(self):
+        proxy_exc = await self._invoke(ValueError("some other failure"))
+        assert "retry-after" not in proxy_exc.headers
+
+
 class TestAsyncStreamingDataGeneratorFastPath:
     """Fast/slow path branching in async_streaming_data_generator."""
 


### PR DESCRIPTION
## Relevant issues

Fixes #27823

## Linear ticket

N/A (external contribution)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

To reproduce against a live proxy, put all deployments of a model group into cooldown (for example by pointing a deployment at a key that 429s) and then send a request to it:

```bash
curl -sS -D - http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model": "gpt-4", "messages": [{"role": "user", "content": "hi"}]}' \
  -o /dev/null
```

Before this change the 429 response carries no retry-after header; the cooldown timing only exists inside the error message string ("Try again in 60.0 seconds"). After this change the same response includes:

```
HTTP/1.1 429 Too Many Requests
retry-after: 60
```

Unit test proof: `tests/test_litellm/proxy/test_common_request_processing.py::TestHandleLLMApiExceptionRetryAfter` fails on the base branch (no retry-after header present) and passes with this change; the full file (94 tests) passes

## Type

🐛 Bug Fix

## Changes

When every deployment for a model group is in cooldown, the router raises `RouterRateLimitError`, which the proxy maps to a 429 via `ProxyException`. The error object already carries `cooldown_time`, but `_handle_llm_api_exception` in `litellm/proxy/common_request_processing.py` only assembled response headers from `e.headers` / `e.response.headers`, which a `RouterRateLimitError` (a plain `ValueError`) does not have. Clients therefore had no machine-readable signal for when to retry and had to parse the message string

This PR adds a check in `_handle_llm_api_exception` after header assembly: if the exception is a `RouterRateLimitError` with a positive `cooldown_time`, it sets `headers["retry-after"]` to the cooldown rounded up to the next whole second (`math.ceil`, so clients never retry before the cooldown window actually ends). Fallback handling in the router re-raises the original exception object, so the proxy sees the raw `RouterRateLimitError` and a direct `isinstance` check covers the real request path

This is distinct from #21553 (forwarding an upstream provider's Retry-After) and #26070 (parsing retry timing out of provider messages); here LiteLLM itself is the rate limiter

Tests added in `tests/test_litellm/proxy/test_common_request_processing.py`:
- `test_handle_llm_api_exception_sets_retry_after_from_cooldown_time` asserts a fractional cooldown of 42.3 produces `retry-after: 43` on a 429
- `test_handle_llm_api_exception_skips_retry_after_when_cooldown_is_zero` asserts no header when there is no meaningful cooldown
- `test_handle_llm_api_exception_no_retry_after_for_plain_exception` asserts unrelated exceptions are untouched