### PR TITLE
fix: add week unit support to get_next_standardized_reset_time

### DIFF
--- a/litellm/litellm_core_utils/duration_parser.py
+++ b/litellm/litellm_core_utils/duration_parser.py
@@ -131,6 +131,8 @@ def get_next_standardized_reset_time(
     # Handle different time units
     if unit == "d":
         return _handle_day_reset(current_time, base_midnight, value, tz)
+    elif unit == "w":
+        return _handle_day_reset(current_time, base_midnight, value * 7, tz)
     elif unit == "h":
         return _handle_hour_reset(current_time, base_midnight, value)
     elif unit == "m":

--- a/tests/test_litellm/litellm_core_utils/test_duration_parser.py
+++ b/tests/test_litellm/litellm_core_utils/test_duration_parser.py
@@ -35,13 +35,19 @@ class TestStandardizedResetTime(unittest.TestCase):
         self.assertEqual(custom_day_result, custom_day_expected)
 
     def test_week_based_resets(self):
+        """Test week-based reset durations (1w, 2w).
+        1w snaps to the next Monday at midnight (same as 7d).
+        2w advances exactly 14 days from the current date at midnight.
+        """
+        # 1w from a Wednesday -> next Monday (5 days away, not 7)
         wednesday = datetime(2023, 5, 17, 15, 45, 0, tzinfo=timezone.utc)
         weekly_expected = datetime(2023, 5, 22, 0, 0, 0, tzinfo=timezone.utc)
         weekly_result = get_next_standardized_reset_time("1w", wednesday, "UTC")
         self.assertEqual(weekly_result, weekly_expected)
 
-        base_time = datetime(2023, 5, 15, 10, 30, 0, tzinfo=timezone.utc)
-        two_week_expected = datetime(2023, 5, 29, 0, 0, 0, tzinfo=timezone.utc)
+        # 2w from a Wednesday -> exactly 14 days out (lands on a Wednesday, not Monday)
+        base_time = datetime(2023, 5, 17, 10, 30, 0, tzinfo=timezone.utc)
+        two_week_expected = datetime(2023, 5, 31, 0, 0, 0, tzinfo=timezone.utc)
         two_week_result = get_next_standardized_reset_time("2w", base_time, "UTC")
         self.assertEqual(two_week_result, two_week_expected)
 

--- a/tests/test_litellm/litellm_core_utils/test_duration_parser.py
+++ b/tests/test_litellm/litellm_core_utils/test_duration_parser.py
@@ -34,6 +34,17 @@ class TestStandardizedResetTime(unittest.TestCase):
         custom_day_result = get_next_standardized_reset_time("3d", base_time, "UTC")
         self.assertEqual(custom_day_result, custom_day_expected)
 
+    def test_week_based_resets(self):
+        wednesday = datetime(2023, 5, 17, 15, 45, 0, tzinfo=timezone.utc)
+        weekly_expected = datetime(2023, 5, 22, 0, 0, 0, tzinfo=timezone.utc)
+        weekly_result = get_next_standardized_reset_time("1w", wednesday, "UTC")
+        self.assertEqual(weekly_result, weekly_expected)
+
+        base_time = datetime(2023, 5, 15, 10, 30, 0, tzinfo=timezone.utc)
+        two_week_expected = datetime(2023, 5, 29, 0, 0, 0, tzinfo=timezone.utc)
+        two_week_result = get_next_standardized_reset_time("2w", base_time, "UTC")
+        self.assertEqual(two_week_result, two_week_expected)
+
     def test_hour_minute_second_resets(self):
         """Test hour, minute, and second based reset durations"""
         # Base time: 2023-05-15 15:20:30 UTC (3:20:30 PM)


### PR DESCRIPTION
## What

Add week (`w`) unit handling to `get_next_standardized_reset_time`.

## Why

`get_next_standardized_reset_time` dispatches on `d` / `h` / `m` / `s` / `mo`, but not `w` — even though the duration layer already fully supports weeks:

- `_extract_from_regex` tokenizes `"1w"` to `(1, "w")` via the `(\d+)(mo|[smhdw]?)` pattern (the `w` is in the `[smhdw]` class), and
- `duration_in_seconds` maps `w` to `value * 604800`.

Because the reset-time function has no `w` branch, a `budget_duration` such as `"1w"` falls through to the `else` path and silently returns next-midnight instead of the correct week-aligned reset. That's an inconsistency between the parser and the reset calculator.

This adds the missing `w` branch, mirroring the existing day branch by delegating to `_handle_day_reset` with `value * 7` days. With the existing `_handle_day_reset` logic, `"1w"` from a Wednesday returns the next Monday at 00:00 UTC, and `"2w"` returns midnight 14 days out. A `test_week_based_resets` regression test covers both.
