### PR TITLE
fix(bedrock): route Anthropic-shape count_tokens to InvokeModel and base64-encode the body

### DIFF
--- a/litellm/llms/bedrock/count_tokens/transformation.py
+++ b/litellm/llms/bedrock/count_tokens/transformation.py
@@ -11,6 +11,11 @@ from typing import Any, Dict, List, Optional
 from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
 from litellm.llms.bedrock.common_utils import get_bedrock_base_model
 
+# Placeholder satisfying the Anthropic InvokeModel schema's required
+# max_tokens field; CountTokens only counts input, so it has no effect
+# on any generation.
+DEFAULT_ANTHROPIC_INVOKE_MODEL_MAX_TOKENS = 1024
+
 
 class BedrockCountTokensConfig(BaseAWSLLM):
     """
@@ -191,7 +196,9 @@ class BedrockCountTokensConfig(BaseAWSLLM):
             # Bedrock validates the body against the model's InvokeModel schema;
             # Anthropic Messages bodies require these fields.
             body_data.setdefault("anthropic_version", "bedrock-2023-05-31")
-            body_data.setdefault("max_tokens", 1024)
+            body_data.setdefault(
+                "max_tokens", DEFAULT_ANTHROPIC_INVOKE_MODEL_MAX_TOKENS
+            )
 
         # The CountTokens API expects invokeModel.body as a base64-encoded blob
         encoded_body = base64.b64encode(json.dumps(body_data).encode()).decode()

--- a/litellm/llms/bedrock/count_tokens/transformation.py
+++ b/litellm/llms/bedrock/count_tokens/transformation.py
@@ -32,8 +32,20 @@ class BedrockCountTokensConfig(BaseAWSLLM):
         Returns:
             'converse' or 'invokeModel'
         """
-        # If the request has messages in the expected Anthropic format, use converse
-        if "messages" in request_data and isinstance(request_data["messages"], list):
+        messages = request_data.get("messages")
+        if isinstance(messages, list):
+            # Anthropic content blocks carry a "type" key ({"type": "text", ...});
+            # Converse blocks don't ({"text": ...}, {"toolUse": ...}). Converse
+            # rejects Anthropic-shape blocks, so route those to invokeModel,
+            # which forwards the body verbatim.
+            for message in messages:
+                if not isinstance(message, dict):
+                    continue
+                content = message.get("content")
+                if isinstance(content, list) and any(
+                    isinstance(block, dict) and "type" in block for block in content
+                ):
+                    return "invokeModel"
             return "converse"
 
         # For raw text or other formats, use invokeModel
@@ -68,7 +80,7 @@ class BedrockCountTokensConfig(BaseAWSLLM):
         {
             "input": {
                 "invokeModel": {
-                    "body": "{...raw model input...}"
+                    "body": "<base64-encoded raw model input>"
                 }
             }
         }
@@ -168,13 +180,22 @@ class BedrockCountTokensConfig(BaseAWSLLM):
         self, request_data: Dict[str, Any]
     ) -> Dict[str, Any]:
         """Transform to InvokeModel input format."""
+        import base64
         import json
 
         # For InvokeModel, we need to provide the raw body that would be sent to the model
         # Remove the 'model' field from the body as it's not part of the model input
         body_data = {k: v for k, v in request_data.items() if k != "model"}
 
-        return {"input": {"invokeModel": {"body": json.dumps(body_data)}}}
+        if "messages" in body_data:
+            # Bedrock validates the body against the model's InvokeModel schema;
+            # Anthropic Messages bodies require these fields.
+            body_data.setdefault("anthropic_version", "bedrock-2023-05-31")
+            body_data.setdefault("max_tokens", 1024)
+
+        # The CountTokens API expects invokeModel.body as a base64-encoded blob
+        encoded_body = base64.b64encode(json.dumps(body_data).encode()).decode()
+        return {"input": {"invokeModel": {"body": encoded_body}}}
 
     def get_bedrock_count_tokens_endpoint(
         self,

--- a/tests/test_litellm/llms/bedrock/count_tokens/test_bedrock_count_tokens_transformation.py
+++ b/tests/test_litellm/llms/bedrock/count_tokens/test_bedrock_count_tokens_transformation.py
@@ -6,7 +6,10 @@ import sys
 sys.path.insert(
     0, os.path.abspath("../../../../..")
 )  # Adds the parent directory to the system path
-from litellm.llms.bedrock.count_tokens.transformation import BedrockCountTokensConfig
+from litellm.llms.bedrock.count_tokens.transformation import (
+    DEFAULT_ANTHROPIC_INVOKE_MODEL_MAX_TOKENS,
+    BedrockCountTokensConfig,
+)
 
 
 def test_detect_input_type():
@@ -72,7 +75,7 @@ def test_transform_to_invoke_model_format_base64_encodes_body():
     assert body["messages"] == request["messages"]
     assert "model" not in body
     assert body["anthropic_version"] == "bedrock-2023-05-31"
-    assert body["max_tokens"] == 1024
+    assert body["max_tokens"] == DEFAULT_ANTHROPIC_INVOKE_MODEL_MAX_TOKENS
 
 
 def test_transform_to_invoke_model_format_raw_body_unchanged():

--- a/tests/test_litellm/llms/bedrock/count_tokens/test_bedrock_count_tokens_transformation.py
+++ b/tests/test_litellm/llms/bedrock/count_tokens/test_bedrock_count_tokens_transformation.py
@@ -1,3 +1,5 @@
+import base64
+import json
 import os
 import sys
 
@@ -18,6 +20,71 @@ def test_detect_input_type():
     # Test text format -> invokeModel
     request_with_text = {"inputText": "hello"}
     assert config._detect_input_type(request_with_text) == "invokeModel"
+
+
+def test_detect_input_type_anthropic_blocks_route_to_invoke_model():
+    """Anthropic-shape content blocks must not go through the Converse path,
+    which Bedrock rejects with a 400 (and the caller then silently falls back
+    to the local tokenizer)."""
+    config = BedrockCountTokensConfig()
+
+    request = {
+        "messages": [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "Reading the file."},
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_01",
+                        "name": "read_file",
+                        "input": {"path": "main.py"},
+                    },
+                ],
+            },
+        ],
+    }
+    assert config._detect_input_type(request) == "invokeModel"
+
+
+def test_detect_input_type_converse_blocks_route_to_converse():
+    """Converse-shape blocks (no "type" key) keep using the converse input."""
+    config = BedrockCountTokensConfig()
+
+    request = {"messages": [{"role": "user", "content": [{"text": "hi"}]}]}
+    assert config._detect_input_type(request) == "converse"
+
+
+def test_transform_to_invoke_model_format_base64_encodes_body():
+    """The CountTokens API expects invokeModel.body as a base64-encoded blob;
+    Anthropic Messages bodies additionally need anthropic_version/max_tokens
+    to pass Bedrock's InvokeModel schema validation."""
+    config = BedrockCountTokensConfig()
+
+    request = {
+        "model": "anthropic.claude-3-sonnet-20240229-v1:0",
+        "messages": [{"role": "user", "content": [{"type": "text", "text": "Hello"}]}],
+    }
+
+    result = config.transform_anthropic_to_bedrock_count_tokens(request)
+
+    body = json.loads(base64.b64decode(result["input"]["invokeModel"]["body"]))
+    assert body["messages"] == request["messages"]
+    assert "model" not in body
+    assert body["anthropic_version"] == "bedrock-2023-05-31"
+    assert body["max_tokens"] == 1024
+
+
+def test_transform_to_invoke_model_format_raw_body_unchanged():
+    """Non-messages bodies (e.g. Titan inputText) must not get Anthropic fields."""
+    config = BedrockCountTokensConfig()
+
+    result = config.transform_anthropic_to_bedrock_count_tokens(
+        {"model": "amazon.titan-text-express-v1", "inputText": "hello"}
+    )
+
+    body = json.loads(base64.b64decode(result["input"]["invokeModel"]["body"]))
+    assert body == {"inputText": "hello"}
 
 
 def test_transform_anthropic_to_bedrock_request():


### PR DESCRIPTION
## Relevant issues

Fixes #27632

`POST /v1/messages/count_tokens` on a Bedrock-backed Anthropic model silently returns local tiktoken counts instead of Bedrock's whenever the request carries Anthropic-shape content blocks (`{"type": "text"|"tool_use"|"tool_result"}`). Root cause is in `litellm/llms/bedrock/count_tokens/transformation.py`: `_detect_input_type` returned `"converse"` for any messages list, and `_transform_to_converse_format` copies list content through verbatim, so Anthropic blocks land untranslated in a Converse body. Bedrock rejects that with 400 `messages.N.content: Field required`, the caller catches it and falls back to the local tokenizer, and the user gets a count that can be off by ~50% on tool-heavy payloads (the issue measured 39,326 locally vs 85,780 from `bedrock-runtime:CountTokens` on the same body).

A second bug in the same file: `_transform_to_invoke_model_format` sent `invokeModel.body` as a raw JSON string. Per the AWS API reference, [InvokeModelTokensRequest.body](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InvokeModelTokensRequest.html) is "Base64-encoded binary data object", so even requests that did select InvokeModel failed with 400 and fell back the same way.

The fix routes messages whose content blocks carry a `"type"` key to the `invokeModel` input (InvokeModel forwards the body verbatim, so Bedrock scores exactly what the client sent), base64-encodes the InvokeModel body, and fills in the `anthropic_version`/`max_tokens` defaults that Bedrock's Anthropic InvokeModel schema requires when the caller omits them. String content and Converse-shape blocks (`{"text": ...}`, no `"type"` key) keep using the `converse` input, so existing callers are unaffected. AWS docs for the endpoint: [CountTokens](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_CountTokens.html).

## Linear ticket

N/A (external contribution)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code); `tests/test_litellm/llms/bedrock/count_tokens/test_bedrock_count_tokens_transformation.py` passes (13 tests), and the 3 new regression tests fail on the base branch without the fix
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Repro against a proxy with a Bedrock Anthropic model in `model_list` (the task role needs `bedrock:CountTokens`):

```bash
curl -sS http://localhost:4000/v1/messages/count_tokens \
  -H "Authorization: Bearer $KEY" \
  -H 'Content-Type: application/json' \
  -d '{
    "model": "claude-sonnet",
    "messages": [
      {"role": "user", "content": [{"type": "text", "text": "Hello"}]}
    ]
  }'
```

Before this change the proxy sends Bedrock a Converse body with the Anthropic block untranslated, Bedrock answers 400, and with `LITELLM_LOG=DEBUG` the logs show `Provider token counting failed (400): {"message":"messages.1.content: Field required"}. Falling back to local tokenizer.` The endpoint still answers 200, but `input_tokens` is the local tiktoken count.

After this change the same request produces a CountTokens payload Bedrock accepts:

```json
{"input": {"invokeModel": {"body": "<base64 of {\"messages\": [...], \"anthropic_version\": \"bedrock-2023-05-31\", \"max_tokens\": 1024}>"}}}
```

and `input_tokens` comes from `bedrock-runtime:CountTokens` (`tokenizer_used` in the response is `bedrock_api` instead of the local tokenizer). I don't have an AWS account with `bedrock:CountTokens` to capture live output; the transformation is covered by the new unit tests, and the base64 contract is straight from the AWS API reference linked above.

## Type

🐛 Bug Fix

## Changes

In `litellm/llms/bedrock/count_tokens/transformation.py`, `_detect_input_type` now scans message content blocks and returns `"invokeModel"` when any block is a dict with a `"type"` key (Anthropic shape); string content and Converse-shape blocks still return `"converse"`. `_transform_to_invoke_model_format` now base64-encodes the JSON body and, for Messages-shape bodies only, defaults `anthropic_version` and `max_tokens` so the body passes Bedrock's InvokeModel schema validation. Raw bodies such as Titan `inputText` are encoded unchanged.

New regression tests in `tests/test_litellm/llms/bedrock/count_tokens/test_bedrock_count_tokens_transformation.py`: `test_detect_input_type_anthropic_blocks_route_to_invoke_model`, `test_detect_input_type_converse_blocks_route_to_converse`, `test_transform_to_invoke_model_format_base64_encodes_body`, and `test_transform_to_invoke_model_format_raw_body_unchanged`. All three behavior changes fail on the base branch without the fix.