### PR TITLE
fix(openai): forward client headers on the text completion path

### DIFF
--- a/litellm/llms/openai/completion/handler.py
+++ b/litellm/llms/openai/completion/handler.py
@@ -49,6 +49,8 @@ class OpenAITextCompletion(BaseLLM):
         headers: Optional[dict] = None,
     ):
         try:
+            if headers:
+                optional_params = {**optional_params, "extra_headers": headers}
             if headers is None:
                 headers = self.validate_environment(api_key=api_key)
             if model is None or messages is None:

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -2162,6 +2162,7 @@ def completion(  # type: ignore # noqa: PLR0915
             _response = openai_text_completions.completion(
                 model=model,
                 messages=messages,
+                headers=headers,
                 model_response=model_response,
                 print_verbose=print_verbose,
                 api_key=api_key,

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -2134,9 +2134,6 @@ def completion(  # type: ignore # noqa: PLR0915
 
             headers = headers or litellm.headers
 
-            if extra_headers is not None:
-                optional_params["extra_headers"] = extra_headers
-
             ## LOAD CONFIG - if set
             config = litellm.OpenAITextCompletionConfig.get_config()
             for k, v in config.items():

--- a/tests/test_litellm/llms/openai/completion/test_completion_handler.py
+++ b/tests/test_litellm/llms/openai/completion/test_completion_handler.py
@@ -65,6 +65,19 @@ def test_completion_forwards_client_headers_to_provider(mock_completions_endpoin
 
 
 @respx.mock
+def test_completion_forwards_extra_headers_to_provider(mock_completions_endpoint):
+    text_completion(
+        model="gpt-3.5-turbo-instruct",
+        prompt="hello",
+        max_tokens=5,
+        extra_headers={"x-mycorp-llmcall-id": "abc-123"},
+    )
+
+    request_headers = mock_completions_endpoint.calls.last.request.headers
+    assert request_headers["x-mycorp-llmcall-id"] == "abc-123"
+
+
+@respx.mock
 async def test_acompletion_forwards_client_headers_to_provider(
     mock_completions_endpoint, monkeypatch
 ):

--- a/tests/test_litellm/llms/openai/completion/test_handler.py
+++ b/tests/test_litellm/llms/openai/completion/test_handler.py
@@ -1,0 +1,80 @@
+"""
+Tests that client headers are forwarded to the provider on the OpenAI
+text completion path.
+
+Regression tests for https://github.com/BerriAI/litellm/issues/27410
+"""
+
+import os
+import sys
+
+import pytest
+import respx
+from httpx import Response
+
+sys.path.insert(0, os.path.abspath("../../../../.."))
+
+import litellm
+from litellm import atext_completion, text_completion
+
+
+@pytest.fixture(autouse=True)
+def setup_env(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-fake-key")
+
+
+@pytest.fixture
+def mock_completions_endpoint():
+    return respx.post("https://api.openai.com/v1/completions").mock(
+        return_value=Response(
+            200,
+            json={
+                "id": "cmpl-test123",
+                "object": "text_completion",
+                "created": 1677652288,
+                "model": "gpt-3.5-turbo-instruct",
+                "choices": [
+                    {
+                        "text": "hi",
+                        "index": 0,
+                        "logprobs": None,
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 1,
+                    "completion_tokens": 1,
+                    "total_tokens": 2,
+                },
+            },
+        )
+    )
+
+
+@respx.mock
+def test_completion_forwards_client_headers_to_provider(mock_completions_endpoint):
+    text_completion(
+        model="gpt-3.5-turbo-instruct",
+        prompt="hello",
+        max_tokens=5,
+        headers={"x-mycorp-llmcall-id": "abc-123"},
+    )
+
+    request_headers = mock_completions_endpoint.calls.last.request.headers
+    assert request_headers["x-mycorp-llmcall-id"] == "abc-123"
+
+
+@respx.mock
+async def test_acompletion_forwards_client_headers_to_provider(
+    mock_completions_endpoint, monkeypatch
+):
+    monkeypatch.setattr(litellm, "disable_aiohttp_transport", True)
+    await atext_completion(
+        model="gpt-3.5-turbo-instruct",
+        prompt="hello",
+        max_tokens=5,
+        headers={"x-mycorp-llmcall-id": "abc-123"},
+    )
+
+    request_headers = mock_completions_endpoint.calls.last.request.headers
+    assert request_headers["x-mycorp-llmcall-id"] == "abc-123"


### PR DESCRIPTION
## Relevant issues

Fixes #27410

## Linear ticket

N/A (external contribution)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

I don't have a billable OpenAI key on this machine, so here are the exact steps to confirm against a live proxy, mirroring the repro from #27410. With `forward_client_headers_to_llm_api: true` in `general_settings` and a `text-completion-openai/gpt-3.5-turbo-instruct` model in the config, start the proxy with `--detailed_debug` and run

```bash
curl -X POST http://localhost:4000/v1/completions \
  -H "Authorization: Bearer sk-1234" \
  -H "x-mycorp-llmcall-id: abc-123" \
  -d '{"model": "gpt-3.5-turbo-instruct", "prompt": "hi", "max_tokens": 5}'
```

Before this change the debug pre-call log for the outbound OpenAI request shows no trace of `x-mycorp-llmcall-id`. With this change the request data carries `extra_headers={'x-mycorp-llmcall-id': 'abc-123', ...}` and the header reaches the provider, matching what `/v1/chat/completions` and `/v1/embeddings` already do

The new regression tests in `tests/test_litellm/llms/openai/completion/test_handler.py` pin this end to end through `litellm.text_completion` and `litellm.atext_completion`: they mock only the HTTP layer with respx and assert the `x-*` header is present on the captured outbound request. Both fail on the current base branch and pass with this change

## Type

🐛 Bug Fix

## Changes

`litellm.completion()` merges caller headers with `extra_headers` early on (`litellm/main.py:1280-1294`), and the proxy puts forwardable `x-*` client headers into that same `headers` kwarg. The chat completion dispatch passes the merged dict down (`openai_chat_completions.completion(..., headers=headers)`) but the `text-completion-openai` branch never did, so the merged headers were dropped at the call site in `litellm/main.py`. On top of that, `OpenAITextCompletion.completion()` in `litellm/llms/openai/completion/handler.py` accepted a `headers` argument but only used it for `validate_environment` fallback and pre-call logging; it never attached it to the request sent to the SDK

Two small changes, mirroring the chat handler idiom (`litellm/llms/openai/openai.py:663`, `if headers: inference_params["extra_headers"] = headers`):

1. `litellm/main.py`: pass `headers=headers` to `openai_text_completions.completion(...)` in the text completion branch
2. `litellm/llms/openai/completion/handler.py`: when caller-supplied headers exist, set them as `extra_headers` on the request params so they flow through `transform_text_completion_request` into `completions.create(**data)`. The merged `headers` dict already contains anything the caller passed via `extra_headers` (merged at `litellm/main.py:1293-1294`), so nothing is lost when it takes precedence

The guard happens before the `validate_environment` fallback, so the default `content-type`/`Authorization` logging headers are never injected as `extra_headers` when no caller headers were supplied