### PR TITLE
fix(router): route aspeech through async_function_with_fallbacks

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -4042,47 +4042,13 @@ class Router:
         ```
         """
         try:
+            kwargs["model"] = model
             kwargs["input"] = input
             kwargs["voice"] = voice
-
-            deployment = await self.async_get_available_deployment(
-                model=model,
-                messages=[{"role": "user", "content": "prompt"}],
-                specific_deployment=kwargs.pop("specific_deployment", None),
-                request_kwargs=kwargs,
-            )
+            kwargs["original_function"] = self._aspeech
             self._update_kwargs_before_fallbacks(model=model, kwargs=kwargs)
-            data = deployment["litellm_params"].copy()
-            data["model"]
-            for k, v in self.default_litellm_params.items():
-                if (
-                    k not in kwargs
-                ):  # prioritize model-specific params > default router params
-                    kwargs[k] = v
-                elif k == "metadata":
-                    kwargs[k].update(v)
+            response = await self.async_function_with_fallbacks(**kwargs)
 
-            potential_model_client = self._get_client(
-                deployment=deployment, kwargs=kwargs, client_type="async"
-            )
-            # check if provided keys == client keys #
-            dynamic_api_key = kwargs.get("api_key", None)
-            if (
-                dynamic_api_key is not None
-                and potential_model_client is not None
-                and dynamic_api_key != potential_model_client.api_key
-            ):
-                model_client = None
-            else:
-                model_client = potential_model_client
-
-            response = await litellm.aspeech(
-                **{
-                    **data,
-                    "client": model_client,
-                    **kwargs,
-                }
-            )
             return response
         except Exception as e:
             asyncio.create_task(
@@ -4093,6 +4059,56 @@ class Router:
                     original_exception=e,
                 )
             )
+            raise e
+
+    async def _aspeech(self, model: str, input: str, voice: str, **kwargs):
+        model_name = model
+        try:
+            verbose_router_logger.debug(
+                f"Inside _aspeech()- model: {model}; kwargs: {kwargs}"
+            )
+            deployment = await self.async_get_available_deployment(
+                model=model,
+                messages=[{"role": "user", "content": "prompt"}],
+                specific_deployment=kwargs.pop("specific_deployment", None),
+                request_kwargs=kwargs,
+            )
+            data = deployment["litellm_params"].copy()
+            for k, v in self.default_litellm_params.items():
+                if (
+                    k not in kwargs
+                ):  # prioritize model-specific params > default router params
+                    kwargs[k] = v
+                elif k == "metadata":
+                    kwargs[k].update(v)
+
+            model_client = self._get_async_openai_model_client(
+                deployment=deployment,
+                kwargs=kwargs,
+            )
+
+            self.total_calls[model_name] += 1
+            response = await litellm.aspeech(
+                **{
+                    **data,
+                    "input": input,
+                    "voice": voice,
+                    "client": model_client,
+                    **kwargs,
+                }
+            )
+
+            self.success_calls[model_name] += 1
+            verbose_router_logger.info(
+                f"litellm.aspeech(model={model_name})\033[32m 200 OK\033[0m"
+            )
+            return response
+        except Exception as e:
+            verbose_router_logger.info(
+                f"litellm.aspeech(model={model_name})\033[31m Exception {str(e)}\033[0m"
+            )
+            if model_name is not None:
+                self.fail_calls[model_name] += 1
             raise e
 
     async def arerank(self, model: str, **kwargs):

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -4067,28 +4067,23 @@ class Router:
             verbose_router_logger.debug(
                 f"Inside _aspeech()- model: {model}; kwargs: {kwargs}"
             )
+            parent_otel_span = _get_parent_otel_span_from_kwargs(kwargs)
             deployment = await self.async_get_available_deployment(
                 model=model,
                 messages=[{"role": "user", "content": "prompt"}],
                 specific_deployment=kwargs.pop("specific_deployment", None),
                 request_kwargs=kwargs,
             )
-            data = deployment["litellm_params"].copy()
-            for k, v in self.default_litellm_params.items():
-                if (
-                    k not in kwargs
-                ):  # prioritize model-specific params > default router params
-                    kwargs[k] = v
-                elif k == "metadata":
-                    kwargs[k].update(v)
 
+            self._update_kwargs_with_deployment(deployment=deployment, kwargs=kwargs)
+            data = deployment["litellm_params"].copy()
             model_client = self._get_async_openai_model_client(
                 deployment=deployment,
                 kwargs=kwargs,
             )
 
             self.total_calls[model_name] += 1
-            response = await litellm.aspeech(
+            response = litellm.aspeech(
                 **{
                     **data,
                     "input": input,
@@ -4097,6 +4092,31 @@ class Router:
                     **kwargs,
                 }
             )
+
+            ### CONCURRENCY-SAFE RPM CHECKS ###
+            rpm_semaphore = self._get_client(
+                deployment=deployment,
+                kwargs=kwargs,
+                client_type="max_parallel_requests",
+            )
+
+            if rpm_semaphore is not None and isinstance(
+                rpm_semaphore, asyncio.Semaphore
+            ):
+                async with rpm_semaphore:
+                    """
+                    - Check rpm limits before making the call
+                    - If allowed, increment the rpm limit (allows global value to be updated, concurrency-safe)
+                    """
+                    await self.async_routing_strategy_pre_call_checks(
+                        deployment=deployment, parent_otel_span=parent_otel_span
+                    )
+                    response = await response
+            else:
+                await self.async_routing_strategy_pre_call_checks(
+                    deployment=deployment, parent_otel_span=parent_otel_span
+                )
+                response = await response
 
             self.success_calls[model_name] += 1
             verbose_router_logger.info(

--- a/tests/router_unit_tests/test_router_endpoints.py
+++ b/tests/router_unit_tests/test_router_endpoints.py
@@ -198,6 +198,70 @@ async def test_audio_speech_router(mode):
     assert test_logger.standard_logging_object["model_group"] == "tts"
 
 
+@pytest.mark.asyncio
+async def test_aspeech_fallbacks_on_deployment_failure():
+    router = Router(
+        model_list=[
+            {
+                "model_name": "tts-main",
+                "litellm_params": {"model": "openai/tts-1", "api_key": "fake-key"},
+            },
+            {
+                "model_name": "tts-backup",
+                "litellm_params": {"model": "openai/tts-1-hd", "api_key": "fake-key"},
+            },
+        ],
+        fallbacks=[{"tts-main": ["tts-backup"]}],
+        num_retries=0,
+    )
+
+    called_models = []
+
+    async def mock_aspeech(*args, **kwargs):
+        called_models.append(kwargs["model"])
+        if kwargs["model"] == "openai/tts-1":
+            raise litellm.InternalServerError(
+                message="deployment down",
+                llm_provider="openai",
+                model="tts-1",
+            )
+        return MagicMock()
+
+    with patch("litellm.aspeech", side_effect=mock_aspeech):
+        response = await router.aspeech(
+            model="tts-main",
+            input="the quick brown fox jumped over the lazy dogs",
+            voice="alloy",
+        )
+
+    assert response is not None
+    assert called_models == ["openai/tts-1", "openai/tts-1-hd"]
+
+
+@pytest.mark.asyncio
+async def test_aspeech_success_returns_response():
+    router = Router(
+        model_list=[
+            {
+                "model_name": "tts",
+                "litellm_params": {"model": "openai/tts-1", "api_key": "fake-key"},
+            },
+        ]
+    )
+
+    mock_response = MagicMock()
+    with patch("litellm.aspeech", return_value=mock_response) as mock_aspeech:
+        response = await router.aspeech(
+            model="tts",
+            input="the quick brown fox jumped over the lazy dogs",
+            voice="alloy",
+        )
+
+    assert response is mock_response
+    mock_aspeech.assert_called_once()
+    assert mock_aspeech.call_args.kwargs["model"] == "openai/tts-1"
+
+
 @pytest.mark.asyncio()
 async def test_rerank_endpoint(model_list):
     from litellm.types.utils import RerankResponse

--- a/tests/router_unit_tests/test_router_endpoints.py
+++ b/tests/router_unit_tests/test_router_endpoints.py
@@ -262,6 +262,32 @@ async def test_aspeech_success_returns_response():
     assert mock_aspeech.call_args.kwargs["model"] == "openai/tts-1"
 
 
+@pytest.mark.asyncio
+async def test_aspeech_sets_deployment_metadata():
+    router = Router(
+        model_list=[
+            {
+                "model_name": "tts",
+                "litellm_params": {"model": "openai/tts-1", "api_key": "fake-key"},
+            },
+        ]
+    )
+
+    mock_response = MagicMock()
+    with patch("litellm.aspeech", return_value=mock_response) as mock_aspeech:
+        response = await router._aspeech(
+            model="tts",
+            input="the quick brown fox jumped over the lazy dogs",
+            voice="alloy",
+        )
+
+    assert response is mock_response
+    metadata = mock_aspeech.call_args.kwargs["metadata"]
+    assert metadata["deployment"] == "openai/tts-1"
+    assert metadata["deployment_model_name"] == "tts"
+    assert metadata["model_info"]["id"] is not None
+
+
 @pytest.mark.asyncio()
 async def test_rerank_endpoint(model_list):
     from litellm.types.utils import RerankResponse


### PR DESCRIPTION
## Relevant issues

Fixes #27778

## Linear ticket

None

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

I don't have provider keys on this machine, so instead of a live proxy curl this PR ships a regression test that pins the failover behavior. `test_aspeech_fallbacks_on_deployment_failure` builds a router with a `tts-main` group, a `tts-backup` group and `fallbacks=[{"tts-main": ["tts-backup"]}]`, then makes the first deployment raise an InternalServerError

On the base branch the error surfaces straight to the caller because `aspeech` never enters the fallback loop:

```
$ pytest tests/router_unit_tests/test_router_endpoints.py -k aspeech
FAILED tests/router_unit_tests/test_router_endpoints.py::test_aspeech_fallbacks_on_deployment_failure
E   litellm.exceptions.InternalServerError: litellm.InternalServerError: deployment down
```

With this change the request fails over to `tts-backup` and both tests pass:

```
$ pytest tests/router_unit_tests/test_router_endpoints.py -k aspeech
tests/router_unit_tests/test_router_endpoints.py::test_aspeech_fallbacks_on_deployment_failure PASSED
tests/router_unit_tests/test_router_endpoints.py::test_aspeech_success_returns_response PASSED
```

To verify against a live proxy: configure two deployments, `tts-main` pointing at a dead key and `tts-backup` pointing at a valid one, set `fallbacks: [{"tts-main": ["tts-backup"]}]` in router_settings, then `curl http://localhost:4000/v1/audio/speech -H "Authorization: Bearer sk-1234" -d '{"model": "tts-main", "input": "hello", "voice": "alloy"}' --output speech.mp3`. Before this change the request 500s; after it returns audio from the backup deployment

## Type

🐛 Bug Fix

## Changes

`Router.aspeech` (litellm/router.py, previously around line 4012) selected a deployment with `async_get_available_deployment` and awaited `litellm.aspeech` directly. The except block only fired an exception alert and re-raised, so TTS requests got no retry and no failover even when backup deployments were configured. Every other router endpoint (`acompletion`, `aembedding`, `atranscription`, `arerank`) delegates to `async_function_with_fallbacks`

This change mirrors the `atranscription`/`_atranscription` pattern. The deployment selection and `litellm.aspeech` call move into a new private `_aspeech` method, and the public `aspeech` now sets `kwargs["original_function"] = self._aspeech`, runs `_update_kwargs_before_fallbacks` and awaits `self.async_function_with_fallbacks(**kwargs)`. While moving the body, `_aspeech` switches the inline client lookup to the shared `_get_async_openai_model_client` helper (identical logic) and adds the same `total_calls`/`success_calls`/`fail_calls` accounting and verbose logging the sibling endpoints have. A stray no-op `data["model"]` expression in the old body was dropped

Tests added in `tests/router_unit_tests/test_router_endpoints.py`: `test_aspeech_fallbacks_on_deployment_failure` (fails on the base branch, passes with this fix) and `test_aspeech_success_returns_response` (pins the plain success path and that the deployment model, not the group alias, reaches `litellm.aspeech`)