### PR TITLE
fix(slack_alerting): stop false-positive hanging request alerts for requests below the alerting threshold

### DIFF
--- a/litellm/integrations/SlackAlerting/hanging_request_check.py
+++ b/litellm/integrations/SlackAlerting/hanging_request_check.py
@@ -8,6 +8,7 @@ Notes:
 """
 
 import asyncio
+import time
 from typing import TYPE_CHECKING, Any, Optional
 
 import litellm
@@ -36,11 +37,15 @@ class AlertingHangingRequestCheck:
         slack_alerting_object: SlackAlerting,
     ):
         self.slack_alerting_object = slack_alerting_object
+        # checks run every alerting_threshold / 2 seconds, so entries must
+        # stay cached for at least 1.5x the threshold to guarantee a check
+        # happens after they cross it
+        self.hanging_request_cache_ttl = int(
+            self.slack_alerting_object.alerting_threshold * 1.5
+            + HANGING_ALERT_BUFFER_TIME_SECONDS
+        )
         self.hanging_request_cache = InMemoryCache(
-            default_ttl=int(
-                self.slack_alerting_object.alerting_threshold
-                + HANGING_ALERT_BUFFER_TIME_SECONDS
-            ),
+            default_ttl=self.hanging_request_cache_ttl,
         )
 
     async def add_request_to_hanging_request_check(
@@ -76,10 +81,7 @@ class AlertingHangingRequestCheck:
         await self.hanging_request_cache.async_set_cache(
             key=hanging_request_data.request_id,
             value=hanging_request_data,
-            ttl=int(
-                self.slack_alerting_object.alerting_threshold
-                + HANGING_ALERT_BUFFER_TIME_SECONDS
-            ),
+            ttl=self.hanging_request_cache_ttl,
         )
         return
 
@@ -125,6 +127,12 @@ class AlertingHangingRequestCheck:
                 self.hanging_request_cache._remove_key(
                     key=request_id,
                 )
+                continue
+
+            request_age_seconds = time.time() - hanging_request_data.created_at
+            if request_age_seconds < self.slack_alerting_object.alerting_threshold:
+                # in-flight but below the alerting threshold; keep it cached
+                # so a later check can alert if it never completes
                 continue
 
             ################

--- a/litellm/integrations/SlackAlerting/hanging_request_check.py
+++ b/litellm/integrations/SlackAlerting/hanging_request_check.py
@@ -113,6 +113,9 @@ class AlertingHangingRequestCheck:
             if hanging_request_data is None:
                 continue
 
+            if hanging_request_data.alerted:
+                continue
+
             request_status = (
                 await proxy_logging_obj.internal_usage_cache.async_get_cache(
                     key="request_status:{}".format(hanging_request_data.request_id),
@@ -141,6 +144,9 @@ class AlertingHangingRequestCheck:
             await self.send_hanging_request_alert(
                 hanging_request_data=hanging_request_data
             )
+            # flag so the entry is skipped on later ticks; one alert per hang,
+            # with the existing TTL still handling cleanup
+            hanging_request_data.alerted = True
 
         return
 

--- a/litellm/types/integrations/slack_alerting.py
+++ b/litellm/types/integrations/slack_alerting.py
@@ -1,4 +1,5 @@
 import os
+import time
 from datetime import datetime as dt
 from enum import Enum
 from typing import Any, Dict, List, Literal, Optional, Set, Union
@@ -201,6 +202,7 @@ class HangingRequestData(BaseModel):
     key_alias: Optional[str] = None
     team_alias: Optional[str] = None
     alerting_metadata: Optional[dict] = None
+    created_at: float = Field(default_factory=time.time)
 
 
 class AlertTypeConfig(LiteLLMPydanticObjectBase):

--- a/litellm/types/integrations/slack_alerting.py
+++ b/litellm/types/integrations/slack_alerting.py
@@ -203,6 +203,7 @@ class HangingRequestData(BaseModel):
     team_alias: Optional[str] = None
     alerting_metadata: Optional[dict] = None
     created_at: float = Field(default_factory=time.time)
+    alerted: bool = False
 
 
 class AlertTypeConfig(LiteLLMPydanticObjectBase):

--- a/tests/test_litellm/integrations/SlackAlerting/test_hanging_request_check.py
+++ b/tests/test_litellm/integrations/SlackAlerting/test_hanging_request_check.py
@@ -239,6 +239,43 @@ class TestAlertingHangingRequestCheck:
         hanging_request_checker.slack_alerting_object.send_alert.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_send_alerts_for_hanging_requests_alerts_once_per_hang(
+        self, hanging_request_checker
+    ):
+        """
+        A single hanging request must alert exactly once even though the
+        checker tick revisits it on every run within the cache TTL.
+        """
+        hanging_data = HangingRequestData(
+            request_id="hanging_once_555",
+            model="gpt-4",
+            api_base="https://api.openai.com/v1",
+            created_at=time.time() - 301,
+        )
+        await hanging_request_checker.hanging_request_cache.async_set_cache(
+            key="hanging_once_555", value=hanging_data, ttl=300
+        )
+
+        with patch("litellm.proxy.proxy_server.proxy_logging_obj") as mock_proxy:
+            mock_internal_cache = AsyncMock()
+            mock_internal_cache.async_get_cache.return_value = None
+            mock_proxy.internal_usage_cache = mock_internal_cache
+
+            hanging_request_checker.hanging_request_cache.async_get_oldest_n_keys = (
+                AsyncMock(return_value=["hanging_once_555"])
+            )
+
+            for _ in range(3):
+                await hanging_request_checker.send_alerts_for_hanging_requests()
+
+        assert hanging_request_checker.slack_alerting_object.send_alert.call_count == 1
+        cached = await hanging_request_checker.hanging_request_cache.async_get_cache(
+            key="hanging_once_555"
+        )
+        assert cached is not None
+        assert cached.alerted is True
+
+    @pytest.mark.asyncio
     async def test_send_alerts_for_hanging_requests_skips_request_younger_than_threshold(
         self, hanging_request_checker
     ):

--- a/tests/test_litellm/integrations/SlackAlerting/test_hanging_request_check.py
+++ b/tests/test_litellm/integrations/SlackAlerting/test_hanging_request_check.py
@@ -1,6 +1,7 @@
 import json
 import os
 import sys
+import time
 from typing import Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -35,13 +36,13 @@ class TestAlertingHangingRequestCheck:
     async def test_init_creates_cache_with_correct_ttl(self, mock_slack_alerting):
         """
         Test that initialization creates a hanging request cache with correct TTL.
-        The TTL should be alerting_threshold + buffer time.
+        The TTL should be 1.5x alerting_threshold + buffer time, so entries
+        survive long enough to be checked after crossing the threshold.
         """
         checker = AlertingHangingRequestCheck(slack_alerting_object=mock_slack_alerting)
 
-        # The cache should be created with TTL = alerting_threshold + buffer time
-        expected_ttl = (
-            mock_slack_alerting.alerting_threshold + 60
+        expected_ttl = int(
+            mock_slack_alerting.alerting_threshold * 1.5 + 60
         )  # HANGING_ALERT_BUFFER_TIME_SECONDS
         assert checker.hanging_request_cache.default_ttl == expected_ttl
 
@@ -208,13 +209,14 @@ class TestAlertingHangingRequestCheck:
         Test send_alerts_for_hanging_requests when request is actually hanging.
         Should send alert for requests that haven't completed within threshold.
         """
-        # Add a hanging request to the cache
+        # Add a hanging request that is older than the alerting threshold
         hanging_data = HangingRequestData(
             request_id="hanging_request_999",
             model="gpt-4",
             api_base="https://api.openai.com/v1",
             key_alias="test_key",
             team_alias="test_team",
+            created_at=time.time() - 301,
         )
         await hanging_request_checker.hanging_request_cache.async_set_cache(
             key="hanging_request_999", value=hanging_data, ttl=300
@@ -235,6 +237,45 @@ class TestAlertingHangingRequestCheck:
 
         # Verify alert was sent for hanging request
         hanging_request_checker.slack_alerting_object.send_alert.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_send_alerts_for_hanging_requests_skips_request_younger_than_threshold(
+        self, hanging_request_checker
+    ):
+        """
+        Test that an in-flight request younger than the alerting threshold
+        does not trigger an alert and stays in the cache for later checks.
+        """
+        hanging_data = HangingRequestData(
+            request_id="young_request_123",
+            model="gpt-4",
+            api_base="https://api.openai.com/v1",
+        )
+        await hanging_request_checker.hanging_request_cache.async_set_cache(
+            key="young_request_123", value=hanging_data, ttl=300
+        )
+
+        with patch("litellm.proxy.proxy_server.proxy_logging_obj") as mock_proxy:
+            # Mock internal usage cache to return None (request still in flight)
+            mock_internal_cache = AsyncMock()
+            mock_internal_cache.async_get_cache.return_value = None
+            mock_proxy.internal_usage_cache = mock_internal_cache
+
+            hanging_request_checker.hanging_request_cache.async_get_oldest_n_keys = (
+                AsyncMock(return_value=["young_request_123"])
+            )
+
+            await hanging_request_checker.send_alerts_for_hanging_requests()
+
+        # No alert for a request below the threshold, and it must remain
+        # cached so a later check can alert if it never completes
+        hanging_request_checker.slack_alerting_object.send_alert.assert_not_called()
+        assert (
+            await hanging_request_checker.hanging_request_cache.async_get_cache(
+                key="young_request_123"
+            )
+            is not None
+        )
 
     @pytest.mark.asyncio
     async def test_send_alerts_for_hanging_requests_with_missing_hanging_data(


### PR DESCRIPTION
## Relevant issues

Fixes #27855

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

The bug is timing dependent, so the cleanest way to see it live is with a small threshold. Steps to reproduce on the base branch and verify on this branch:

1. Config with `general_settings: {alerting: ["slack"], alerting_threshold: 30}`, `SLACK_WEBHOOK_URL` set to a test channel webhook, and one normal model entry
2. `python litellm/proxy/proxy_cli.py --config <config> --detailed_debug`
3. Send a single request that takes roughly 15-25 seconds to complete, for example `curl http://localhost:4000/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model": "gpt-5.1", "messages": [{"role": "user", "content": "write a 2000 word story"}], "max_tokens": 8000}'`
4. On the base branch, a "Requests are hanging - 30s+ request time" Slack alert fires at the next checker tick (the loop runs every threshold/2 seconds and the first tick can land seconds after startup) even though the request is mid flight and well under 30s. This is the false positive from the issue; the reporter's alerted requests had completed in 205-334s against a 600s threshold
5. On this branch, the same request produces no alert. To confirm real hangs still alert, point a model's `api_base` at an unroutable address (for example `http://10.255.255.1`) with a high `timeout`, send a request, and the alert fires once the request has been pending past the threshold

## Type

🐛 Bug Fix

## Changes

`send_alerts_for_hanging_requests` in `litellm/integrations/SlackAlerting/hanging_request_check.py` alerted on every cached request whose completion status was not yet recorded, with no check on how long the request had actually been running. Requests enter the cache the moment they start, and the background loop ticks every `alerting_threshold / 2` seconds, so any request that happened to be in flight at a tick fired a "hanging" alert even if it was seconds old

This PR adds a `created_at` timestamp to `HangingRequestData` (`litellm/types/integrations/slack_alerting.py`), stamped via `default_factory=time.time` when the entry is built right before caching, and skips entries younger than `alerting_threshold` in `send_alerts_for_hanging_requests`. Skipped entries are not evicted, so a later tick still alerts if the request never completes. Any `HangingRequestData` built without an explicit `created_at` is treated as just created, which means skip rather than alert; that is the safer default because the entry stays cached and alerts later if it is genuinely hanging, instead of reintroducing an immediate false positive

The cache TTL also moves from `threshold + 60s` to `1.5x threshold + 60s`. With the new age gate an entry only becomes alertable after `threshold` seconds, and ticks are `threshold / 2` apart, so under the old TTL a genuinely hanging request could expire before any tick saw it cross the threshold (a roughly 60 second alertable window per 300 second tick interval at the default 600s threshold)

Tests in `tests/test_litellm/integrations/SlackAlerting/test_hanging_request_check.py`: a new test asserts a young in-flight request is not alerted and stays cached, and the existing hanging-request test now constructs an entry older than the threshold and still alerts. The new test fails on the base branch (the alert fires) and passes with this change. All 33 tests in the SlackAlerting suite pass