### PR TITLE
fix(proxy): store the actual selected model in spend logs for Azure Model Router

### DIFF
--- a/litellm/proxy/spend_tracking/spend_tracking_utils.py
+++ b/litellm/proxy/spend_tracking/spend_tracking_utils.py
@@ -411,7 +411,13 @@ def get_logging_payload(  # noqa: PLR0915
     agent_id: Optional[str] = kwargs.get("agent_id") or metadata.get("agent_id")
     custom_llm_provider = kwargs.get("custom_llm_provider")
     raw_model = cast(str, kwargs.get("model") or "")
-    model_name = reconstruct_model_name(raw_model, custom_llm_provider, metadata or {})
+    # prefer the standard logging payload's model; it carries response-level
+    # overrides (e.g. the model Azure Model Router actually selected)
+    model_name = (
+        standard_logging_payload.get("model")
+        if standard_logging_payload is not None
+        else None
+    ) or reconstruct_model_name(raw_model, custom_llm_provider, metadata or {})
 
     try:
         payload: SpendLogsPayload = SpendLogsPayload(

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
@@ -2073,3 +2073,52 @@ def test_sanitize_error_information_redacts_pydantic_assignment_form(
     assert sanitized is not None
     assert "leaked-via-pydantic-msg" not in sanitized["error_message"]
     assert REDACTED_BY_LITELM_STRING in sanitized["error_message"]
+
+
+def _model_router_spend_log_kwargs(slp_model) -> dict:
+    standard_logging_payload = cast(
+        StandardLoggingPayload,
+        {
+            "model": slp_model,
+            "metadata": {},
+            "model_map_information": StandardLoggingModelInformation(
+                model_map_key="azure_ai/model_router", model_map_value=None
+            ),
+        },
+    )
+    return {
+        "model": "azure_ai/model_router/model-router",
+        "litellm_params": {"metadata": {"user_api_key": "sk-test-key"}},
+        "standard_logging_object": standard_logging_payload,
+    }
+
+
+@patch("litellm.proxy.proxy_server.master_key", None)
+@patch("litellm.proxy.proxy_server.general_settings", {})
+def test_get_logging_payload_uses_standard_logging_payload_model():
+    """
+    Azure Model Router regression: the standard logging payload model (the
+    model Azure actually selected) must win over the router model
+    reconstructed from request kwargs.
+    """
+    payload = get_logging_payload(
+        kwargs=_model_router_spend_log_kwargs(slp_model="azure_ai/gpt-5-mini"),
+        response_obj={},
+        start_time=datetime.datetime.now(timezone.utc),
+        end_time=datetime.datetime.now(timezone.utc),
+    )
+
+    assert payload["model"] == "azure_ai/gpt-5-mini"
+
+
+@patch("litellm.proxy.proxy_server.master_key", None)
+@patch("litellm.proxy.proxy_server.general_settings", {})
+def test_get_logging_payload_falls_back_to_kwargs_model_when_slp_model_missing():
+    payload = get_logging_payload(
+        kwargs=_model_router_spend_log_kwargs(slp_model=None),
+        response_obj={},
+        start_time=datetime.datetime.now(timezone.utc),
+        end_time=datetime.datetime.now(timezone.utc),
+    )
+
+    assert payload["model"] == "azure_ai/model_router/model-router"


### PR DESCRIPTION
## Relevant issues

Fixes #27942

## Linear ticket

N/A (external contribution)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

To reproduce against a live proxy, configure a model group whose `litellm_params.model` is `azure_ai/model_router/model-router`, send a chat completion to it, and compare the response model with the spend log row:

```bash
curl -s http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer $LITELLM_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"model": "model-router", "messages": [{"role": "user", "content": "hi"}]}' | jq .model

curl -s "http://localhost:4000/spend/logs?request_id=<id from the response>" \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" | jq '.[0].model'
```

Before this change the first command returns the actual selected model (for example `azure_ai/gpt-5.4-mini-2026-03-17`) while the second returns `azure_ai/model_router/model-router`. With this change both return the actual selected model. Regression coverage lives in `tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py`; `test_get_logging_payload_uses_standard_logging_payload_model` fails on the base branch and passes with the fix

## Type

🐛 Bug Fix

## Changes

`get_logging_payload` in `litellm/proxy/spend_tracking/spend_tracking_utils.py` re-derived the spend log model from request kwargs via `reconstruct_model_name`, discarding `standard_logging_payload["model"]`. The standard logging payload already carries the Azure Model Router override (set in `litellm/litellm_core_utils/litellm_logging.py`, which replaces the router model with the model name from the provider response), so the spend log stored the configured router path instead of the model Azure actually selected.

The fix prefers `standard_logging_payload["model"]` when it is set and falls back to the existing kwargs reconstruction otherwise (failure paths have no standard logging payload). For non-router calls the standard logging payload model is built by the same `reconstruct_model_name` call from the same inputs, so behavior is unchanged there.

Tests added: `test_get_logging_payload_uses_standard_logging_payload_model` and `test_get_logging_payload_falls_back_to_kwargs_model_when_slp_model_missing` in `tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py`. All 78 tests in the file pass