### PR TITLE
fix(anthropic): resolve opus 4.7/4.8 capabilities through vertex @version suffix (#30101)

### DIFF
--- a/litellm/llms/anthropic/common_utils.py
+++ b/litellm/llms/anthropic/common_utils.py
@@ -3,6 +3,7 @@ This file contains common utils for anthropic calls.
 """
 
 import copy
+import re
 from typing import Any, Dict, List, Optional, Union
 
 import httpx
@@ -272,6 +273,20 @@ class AnthropicModelInfo(BaseLLMModelInfo):
         )
 
     @staticmethod
+    def _is_claude_4_8_model(model: str) -> bool:
+        """Check if the model is a Claude 4.8 model (Opus 4.8)."""
+        model_lower = model.lower()
+        return any(
+            v in model_lower
+            for v in (
+                "opus-4-8",
+                "opus_4_8",
+                "opus-4.8",
+                "opus_4.8",
+            )
+        )
+
+    @staticmethod
     def _supports_sampling_params(model: str) -> bool:
         """Claude 4.7+ (Opus 4.7/4.8, Fable 5) removed sampling params: the API
         rejects ``top_p``, ``top_k``, and any ``temperature`` other than 1 with
@@ -335,6 +350,15 @@ class AnthropicModelInfo(BaseLLMModelInfo):
         """Model-map keys to try for ``model``, stripping bedrock/vertex
         prefixes so a provider-routed Claude still resolves to its entry."""
         candidates = [model]
+        # Vertex appends ``@<version>`` (e.g. ``@default``, ``@20251101``) to
+        # the model id; the bare name is what carries the capability flags in
+        # the model map. Without this strip, ``claude-opus-4-8@default``
+        # misses ``claude-opus-4-8`` and downstream
+        # ``supports_adaptive_thinking`` / ``supports_output_config`` checks
+        # silently fall back to the partial name-substring path (#30101).
+        suffix_stripped = re.sub(r"@[^@/]+$", "", model)
+        if suffix_stripped != model:
+            candidates.append(suffix_stripped)
         for prefix in (
             "bedrock/converse/",
             "bedrock/invoke/",
@@ -343,6 +367,8 @@ class AnthropicModelInfo(BaseLLMModelInfo):
         ):
             if model.startswith(prefix):
                 candidates.append(model[len(prefix) :])
+            if suffix_stripped != model and suffix_stripped.startswith(prefix):
+                candidates.append(suffix_stripped[len(prefix) :])
         try:
             from litellm.llms.bedrock.common_utils import BedrockModelInfo
 
@@ -399,9 +425,11 @@ class AnthropicModelInfo(BaseLLMModelInfo):
             model, "supports_adaptive_thinking"
         ):
             return True
-        return AnthropicModelInfo._is_claude_4_6_model(
-            model
-        ) or AnthropicModelInfo._is_claude_4_7_model(model)
+        return (
+            AnthropicModelInfo._is_claude_4_6_model(model)
+            or AnthropicModelInfo._is_claude_4_7_model(model)
+            or AnthropicModelInfo._is_claude_4_8_model(model)
+        )
 
     def is_effort_used(
         self, optional_params: Optional[dict], model: Optional[str] = None

--- a/litellm/llms/anthropic/common_utils.py
+++ b/litellm/llms/anthropic/common_utils.py
@@ -273,20 +273,6 @@ class AnthropicModelInfo(BaseLLMModelInfo):
         )
 
     @staticmethod
-    def _is_claude_4_8_model(model: str) -> bool:
-        """Check if the model is a Claude 4.8 model (Opus 4.8)."""
-        model_lower = model.lower()
-        return any(
-            v in model_lower
-            for v in (
-                "opus-4-8",
-                "opus_4_8",
-                "opus-4.8",
-                "opus_4.8",
-            )
-        )
-
-    @staticmethod
     def _supports_sampling_params(model: str) -> bool:
         """Claude 4.7+ (Opus 4.7/4.8, Fable 5) removed sampling params: the API
         rejects ``top_p``, ``top_k``, and any ``temperature`` other than 1 with
@@ -425,11 +411,9 @@ class AnthropicModelInfo(BaseLLMModelInfo):
             model, "supports_adaptive_thinking"
         ):
             return True
-        return (
-            AnthropicModelInfo._is_claude_4_6_model(model)
-            or AnthropicModelInfo._is_claude_4_7_model(model)
-            or AnthropicModelInfo._is_claude_4_8_model(model)
-        )
+        return AnthropicModelInfo._is_claude_4_6_model(
+            model
+        ) or AnthropicModelInfo._is_claude_4_7_model(model)
 
     def is_effort_used(
         self, optional_params: Optional[dict], model: Optional[str] = None

--- a/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
+++ b/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
@@ -1506,17 +1506,3 @@ class TestVertexVersionSuffixModelResolution:
             )
             is True
         )
-
-    def test_is_claude_4_8_model_recognizes_suffix_and_provider_prefix(self):
-        from litellm.llms.anthropic.common_utils import AnthropicModelInfo
-
-        assert AnthropicModelInfo._is_claude_4_8_model("claude-opus-4-8") is True
-        assert (
-            AnthropicModelInfo._is_claude_4_8_model("claude-opus-4-8@default") is True
-        )
-        assert (
-            AnthropicModelInfo._is_claude_4_8_model("vertex_ai/claude-opus-4-8@default")
-            is True
-        )
-        assert AnthropicModelInfo._is_claude_4_8_model("claude-opus-4-7") is False
-        assert AnthropicModelInfo._is_claude_4_8_model("claude-opus-4-5") is False

--- a/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
+++ b/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
@@ -1450,3 +1450,73 @@ class TestClaudeOpus48AdaptiveThinking:
         from litellm.llms.anthropic.common_utils import AnthropicModelInfo
 
         assert AnthropicModelInfo._is_adaptive_thinking_model(model) is False
+
+
+class TestVertexVersionSuffixModelResolution:
+    """Regression for #30101.
+
+    Vertex appends ``@<version>`` (``@default``, ``@20251101``, ...) to the
+    routed model id. ``_model_map_lookup_candidates`` stripped bedrock/vertex
+    prefixes but not the trailing suffix, so a request id like
+    ``vertex_ai/claude-opus-4-8@default`` never resolved to the bare
+    ``claude-opus-4-8`` map entry that carries the ``supports_adaptive_thinking``
+    and ``supports_output_config`` flags. Downstream adaptive-thinking +
+    effort detection fell through to the partial name-substring path.
+    """
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "claude-opus-4-7@default",
+            "claude-opus-4-8@default",
+            "claude-opus-4-8@20251101",
+            "vertex_ai/claude-opus-4-7@default",
+            "vertex_ai/claude-opus-4-8@default",
+        ],
+    )
+    def test_adaptive_thinking_detected_with_vertex_version_suffix(
+        self, local_model_cost_map, model
+    ):
+        from litellm.llms.anthropic.common_utils import AnthropicModelInfo
+
+        assert AnthropicModelInfo._is_adaptive_thinking_model(model) is True
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "claude-opus-4-7@default",
+            "claude-opus-4-8@default",
+            "vertex_ai/claude-opus-4-8@default",
+        ],
+    )
+    def test_capability_resolves_through_version_suffix(
+        self, local_model_cost_map, model
+    ):
+        from litellm.llms.anthropic.common_utils import AnthropicModelInfo
+
+        assert (
+            AnthropicModelInfo._supports_model_capability(
+                model, "supports_adaptive_thinking"
+            )
+            is True
+        )
+        assert (
+            AnthropicModelInfo._supports_model_capability(
+                model, "supports_output_config"
+            )
+            is True
+        )
+
+    def test_is_claude_4_8_model_recognizes_suffix_and_provider_prefix(self):
+        from litellm.llms.anthropic.common_utils import AnthropicModelInfo
+
+        assert AnthropicModelInfo._is_claude_4_8_model("claude-opus-4-8") is True
+        assert (
+            AnthropicModelInfo._is_claude_4_8_model("claude-opus-4-8@default") is True
+        )
+        assert (
+            AnthropicModelInfo._is_claude_4_8_model("vertex_ai/claude-opus-4-8@default")
+            is True
+        )
+        assert AnthropicModelInfo._is_claude_4_8_model("claude-opus-4-7") is False
+        assert AnthropicModelInfo._is_claude_4_8_model("claude-opus-4-5") is False


### PR DESCRIPTION
Fixes #30101.

vertex appends `@<version>` (e.g. `@default`, `@20251101`) to routed model ids. `_model_map_lookup_candidates` stripped bedrock/vertex prefixes but not the suffix, so `vertex_ai/claude-opus-4-8@default` never reached the `claude-opus-4-8` map entry that carries `supports_adaptive_thinking` + `supports_output_config`. callers fell through to the name-fallback chain — which has no 4.8 case.

three changes:
- `_model_map_lookup_candidates`: also try the suffix-stripped candidate (and the prefix-stripped form of it)
- `_is_claude_4_8_model`: new helper mirroring 4.7 substring style
- `_is_adaptive_thinking_model`: include 4.8 in the name-fallback OR chain

8 regression tests in `TestVertexVersionSuffixModelResolution` covering bare/suffixed/prefixed permutations. TDD-verified — stashed the fix, the 6 new tests fail on main, 21 pass with the patch:

```
$ .venv/bin/python -m pytest tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py -q -k 'VertexVersionSuffix or ClaudeOpus48Adaptive'
.....................                                                    [100%]
21 passed, 72 deselected in 0.58s
```