### PR TITLE
fix(mcp): coerce mcp_server_cost_info values to float at ingest

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -380,7 +380,7 @@ def _normalize_mcp_server_cost_info(mcp_info: MCPInfo) -> None:
                 server_name,
                 default_cost,
             )
-            normalized["default_cost_per_query"] = None
+            del normalized["default_cost_per_query"]
 
     tool_costs = normalized.get("tool_name_to_cost_per_query")
     if isinstance(tool_costs, dict):

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -354,6 +354,52 @@ def _deserialize_json_list(data: Any) -> Optional[List[Dict[str, Any]]]:
     ]
 
 
+def _normalize_mcp_server_cost_info(mcp_info: MCPInfo) -> None:
+    """Coerce ``mcp_server_cost_info`` numeric fields to ``float`` at ingest.
+
+    YAML 1.1 parses scientific notation without a decimal point (e.g.
+    ``7e-05``) as a string, and ``MCPServerCostInfo`` is a TypedDict with no
+    runtime validation, so string-typed costs flow through to the UI and
+    crash its ``.toFixed`` formatting. Values that cannot be coerced are
+    dropped with a warning instead of failing the server load.
+    """
+    cost_info = mcp_info.get("mcp_server_cost_info")
+    if not isinstance(cost_info, dict):
+        return
+
+    server_name = mcp_info.get("server_name")
+    normalized = dict(cost_info)
+
+    default_cost = normalized.get("default_cost_per_query")
+    if default_cost is not None:
+        try:
+            normalized["default_cost_per_query"] = float(default_cost)
+        except (TypeError, ValueError):
+            verbose_logger.warning(
+                "MCP server '%s' has non-numeric default_cost_per_query %r; ignoring it",
+                server_name,
+                default_cost,
+            )
+            normalized["default_cost_per_query"] = None
+
+    tool_costs = normalized.get("tool_name_to_cost_per_query")
+    if isinstance(tool_costs, dict):
+        normalized_tool_costs = {}
+        for tool_name, cost in tool_costs.items():
+            try:
+                normalized_tool_costs[tool_name] = float(cost)
+            except (TypeError, ValueError):
+                verbose_logger.warning(
+                    "MCP server '%s' has non-numeric cost %r for tool '%s'; ignoring it",
+                    server_name,
+                    cost,
+                    tool_name,
+                )
+        normalized["tool_name_to_cost_per_query"] = normalized_tool_costs
+
+    mcp_info["mcp_server_cost_info"] = normalized
+
+
 def _create_sampling_callback(user_api_key_auth: Optional[Any] = None):
     """
     Create a sampling callback for MCP ClientSession.
@@ -621,6 +667,7 @@ class MCPServerManager:
                 mcp_info["server_name"] = server_name
             if "description" not in mcp_info and server_config.get("description"):
                 mcp_info["description"] = server_config.get("description")
+            _normalize_mcp_server_cost_info(mcp_info)
 
             # Use alias for name if present, else server_name
             alias = server_config.get("alias", None)
@@ -1091,6 +1138,7 @@ class MCPServerManager:
             mcp_info["server_name"] = mcp_server.server_name or mcp_server.server_id
         if "description" not in mcp_info and mcp_server.description:
             mcp_info["description"] = mcp_server.description
+        _normalize_mcp_server_cost_info(mcp_info)
 
         auth_type = cast(MCPAuthType, mcp_server.auth_type)
         server_url = mcp_server.url

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -311,7 +311,7 @@ class TestMCPServerManager:
         _normalize_mcp_server_cost_info(mcp_info)
 
         cost_info = mcp_info["mcp_server_cost_info"]
-        assert cost_info["default_cost_per_query"] is None
+        assert "default_cost_per_query" not in cost_info
         assert cost_info["tool_name_to_cost_per_query"] == {"geocode": 2e-4}
 
     def test_normalize_mcp_server_cost_info_leaves_missing_cost_info_alone(self):

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -30,6 +30,7 @@ from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
     MCPServerManager,
     _deserialize_json_dict,
     _deserialize_json_list,
+    _normalize_mcp_server_cost_info,
 )
 from litellm.proxy._types import (
     LiteLLM_MCPServerTable,
@@ -256,6 +257,69 @@ class TestMCPServerManager:
         server = next(iter(manager.config_mcp_servers.values()))
         assert server.alias == "friendly_alias"
         assert server.server_name == "validserver"
+
+    @pytest.mark.asyncio
+    async def test_load_servers_from_config_coerces_cost_string_to_float(self):
+        """YAML 1.1 parses `7e-05` as a string; ingest must coerce it to float."""
+        manager = MCPServerManager()
+        config = {
+            "google_maps": {
+                "url": "https://example.com/mcp",
+                "transport": MCPTransport.http,
+                "mcp_info": {
+                    "mcp_server_cost_info": {
+                        "default_cost_per_query": "7e-05",
+                        "tool_name_to_cost_per_query": {"geocode": "1e-3"},
+                    }
+                },
+            }
+        }
+
+        await manager.load_servers_from_config(config)
+
+        server = next(iter(manager.config_mcp_servers.values()))
+        cost_info = server.mcp_info["mcp_server_cost_info"]
+        assert cost_info["default_cost_per_query"] == 7e-05
+        assert isinstance(cost_info["default_cost_per_query"], float)
+        assert cost_info["tool_name_to_cost_per_query"]["geocode"] == 1e-3
+        assert isinstance(cost_info["tool_name_to_cost_per_query"]["geocode"], float)
+
+    def test_normalize_mcp_server_cost_info_preserves_float_values(self):
+        mcp_info = {
+            "server_name": "maps",
+            "mcp_server_cost_info": {
+                "default_cost_per_query": 0.01,
+                "tool_name_to_cost_per_query": {"search": 0.05},
+            },
+        }
+
+        _normalize_mcp_server_cost_info(mcp_info)
+
+        cost_info = mcp_info["mcp_server_cost_info"]
+        assert cost_info["default_cost_per_query"] == 0.01
+        assert cost_info["tool_name_to_cost_per_query"] == {"search": 0.05}
+
+    def test_normalize_mcp_server_cost_info_drops_non_numeric_values(self):
+        mcp_info = {
+            "server_name": "maps",
+            "mcp_server_cost_info": {
+                "default_cost_per_query": "not-a-number",
+                "tool_name_to_cost_per_query": {"search": "free", "geocode": "2e-4"},
+            },
+        }
+
+        _normalize_mcp_server_cost_info(mcp_info)
+
+        cost_info = mcp_info["mcp_server_cost_info"]
+        assert cost_info["default_cost_per_query"] is None
+        assert cost_info["tool_name_to_cost_per_query"] == {"geocode": 2e-4}
+
+    def test_normalize_mcp_server_cost_info_leaves_missing_cost_info_alone(self):
+        mcp_info = {"server_name": "maps"}
+
+        _normalize_mcp_server_cost_info(mcp_info)
+
+        assert "mcp_server_cost_info" not in mcp_info
 
     def test_warns_when_custom_separator_invalid(self, monkeypatch, caplog):
         """Invalid MCP_TOOL_PREFIX_SEPARATOR values should log a warning."""


### PR DESCRIPTION
## Relevant issues

Fixes #27097

The sibling issue #27095 covers the UI side of the same crash; the `.toFixed` hardening in the dashboard components is in open PR #27096. This PR is the backend half: it normalizes the values at ingest so the proxy never hands a string-typed cost to the UI in the first place. No `.tsx` files are touched here

## Linear ticket

N/A (external contribution)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

This one is UI-visible, so here is the runbook to see it end to end:

1. Put this in `config.yaml` (note the scientific notation without a decimal point; PyYAML is a YAML 1.1 parser, so `7e-05` resolves to the string `"7e-05"`, not a float):

```yaml
mcp_servers:
  google_maps:
    url: 'https://mapstools.googleapis.com/mcp'
    transport: 'http'
    mcp_info:
      mcp_server_cost_info:
        default_cost_per_query: 7e-05
```

2. Start the proxy and open the UI, MCP Servers, click the `google_maps` server

3. On the base branch the settings page fails to render and the browser console shows `Uncaught TypeError: e.default_cost_per_query.toFixed is not a function`. With this change the page renders and the cost shows as `0.0001` (`(7e-05).toFixed(4)`), because the value arriving at the UI is now a float

For a genuinely non-numeric value (for example `default_cost_per_query: free`) the server still loads; the value is dropped and the proxy logs `MCP server 'google_maps' has non-numeric default_cost_per_query 'free'; ignoring it`

## Type

🐛 Bug Fix

## Changes

`MCPServerCostInfo` is a TypedDict (`litellm/types/mcp.py:139`), so its `Optional[float]` annotations carry no runtime validation, and both `mcp_info` ingest paths in `litellm/proxy/_experimental/mcp_server/mcp_server_manager.py` (config load in `load_servers_from_config` and the DB load path) copied `mcp_server_cost_info` through verbatim. A string-typed cost from YAML therefore survived all the way to the dashboard and crashed it

This PR adds a `_normalize_mcp_server_cost_info` helper in `mcp_server_manager.py` and applies it at both ingest points. It coerces `default_cost_per_query` and each entry of `tool_name_to_cost_per_query` to `float`, and drops values that cannot be coerced with a `verbose_logger.warning` naming the server and field instead of failing the server load (matching how the surrounding load code treats bad optional fields)

Tests added in `tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py`: an end-to-end `load_servers_from_config` test asserting the scientific-notation strings come out as floats (fails on the base branch), plus unit tests covering float passthrough, non-numeric drops with the tool-map entry removed, and the no-cost-info case