### PR TITLE
fix(sdk): stop mirroring reasoning_content into provider_specific_fields on cache replay

### DIFF
--- a/litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py
+++ b/litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py
@@ -633,11 +633,6 @@ def convert_to_model_response_object(  # noqa: PLR0915
                         thinking_blocks = choice["message"]["thinking_blocks"]
                         provider_specific_fields["thinking_blocks"] = thinking_blocks
 
-                    if reasoning_content:
-                        provider_specific_fields["reasoning_content"] = (
-                            reasoning_content
-                        )
-
                     message = Message(
                         content=content,
                         role=choice["message"]["role"] or "assistant",

--- a/tests/llm_translation/test_llm_response_utils/test_convert_dict_to_chat_completion.py
+++ b/tests/llm_translation/test_llm_response_utils/test_convert_dict_to_chat_completion.py
@@ -2425,6 +2425,42 @@ class TestConvertToModelResponseObjectCompletion:
         assert result.choices[0].message.content == "The answer is 4."
         assert result.choices[0].message.reasoning_content == "2+2=4"
 
+    def test_reasoning_content_not_mirrored_into_provider_specific_fields(self):
+        """Mirroring reasoning_content into provider_specific_fields made
+        cache-replayed messages diverge from live Anthropic messages, which
+        only set it top-level, breaking cache key stability (issue #27337)."""
+        response_object = {
+            "id": "chatcmpl-5",
+            "model": "claude-sonnet-4-5",
+            "choices": [
+                {
+                    "finish_reason": "stop",
+                    "index": 0,
+                    "message": {
+                        "content": "The answer is 4.",
+                        "role": "assistant",
+                        "reasoning_content": "2+2=4",
+                        "thinking_blocks": [
+                            {
+                                "type": "thinking",
+                                "thinking": "2+2=4",
+                                "signature": "sig",
+                            }
+                        ],
+                    },
+                }
+            ],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 10, "total_tokens": 15},
+        }
+
+        result = convert_to_model_response_object(
+            response_object=response_object,
+            model_response_object=ModelResponse(),
+        )
+        message = result.choices[0].message
+        assert message.reasoning_content == "2+2=4"
+        assert "reasoning_content" not in (message.provider_specific_fields or {})
+
     def test_response_none_raises(self):
         with pytest.raises(Exception):
             convert_to_model_response_object(


### PR DESCRIPTION
## Relevant issues

Fixes #27337

## Linear ticket

N/A (external contribution)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link: N/A (external contribution)

- [ ] **CI run for the last commit**  
       Link: N/A (external contribution)

- [ ] **Merge / cherry-pick CI run**  
       Links: N/A (external contribution)

## Screenshots / Proof of Fix

The bug is reproducible offline because the cache replay path is the deterministic dict-to-Message conversion. Feed it a message shaped exactly like a live Anthropic thinking response and compare the provider_specific_fields it produces:

```bash
python - <<'PY'
import json
from litellm import ModelResponse
from litellm.litellm_core_utils.llm_response_utils.convert_dict_to_response import convert_to_model_response_object

live_msg = {
    "content": "4",
    "role": "assistant",
    "reasoning_content": "2+2=4",
    "thinking_blocks": [{"type": "thinking", "thinking": "2+2=4", "signature": "sig"}],
    "provider_specific_fields": {
        "citations": None,
        "thinking_blocks": [{"type": "thinking", "thinking": "2+2=4", "signature": "sig"}],
    },
}
cached = {
    "id": "chatcmpl-1", "model": "claude-sonnet-4-5",
    "choices": [{"finish_reason": "stop", "index": 0, "message": dict(live_msg)}],
    "usage": {"prompt_tokens": 5, "completion_tokens": 1, "total_tokens": 6},
}
r = convert_to_model_response_object(response_object=cached, model_response_object=ModelResponse())
replayed = r.choices[0].message.model_dump()["provider_specific_fields"]
print("replayed provider_specific_fields keys:", sorted(replayed.keys()))
print("matches live:", sorted(replayed.keys()) == sorted(live_msg["provider_specific_fields"].keys()))
PY
```

On `litellm_internal_staging` before this change:

```
replayed provider_specific_fields keys: ['citations', 'reasoning_content', 'thinking_blocks']
matches live: False
```

With this change:

```
replayed provider_specific_fields keys: ['citations', 'thinking_blocks']
matches live: True
```

The injected `reasoning_content` key is exactly the asymmetry from the issue's diff. Since the disk cache key is built from `str(messages)`, a multi-turn loop that appends a cache-hit assistant message back into `messages` produced a different key than the same loop running live, so turn 2 onwards always cache-missed

## Type

🐛 Bug Fix

## Changes

`convert_to_model_response_object` mirrored `reasoning_content` into `provider_specific_fields` when rebuilding a `Message` from a dict (`litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py:636-639`). The live Anthropic path (`_build_provider_specific_fields` in `litellm/llms/anthropic/chat/transformation.py`) only sets `citations` and `thinking_blocks` there and puts `reasoning_content` top-level on the `Message`. The cached and live copies of the same response therefore serialized differently, which broke disk cache key stability for thinking responses (see #27337 for the full root cause analysis)

This PR removes the mirroring. The converter still sets top-level `Message.reasoning_content`, so DeepSeek's request-side promotion in `_fill_reasoning_content` (`litellm/llms/deepseek/chat/transformation.py`) keeps working; it only falls back to `provider_specific_fields` when the top-level field is missing. Same for Moonshot

One behavior note: for OpenAI-compatible reasoning providers (DeepSeek, Moonshot, etc.) the converted response no longer duplicates `reasoning_content` inside `provider_specific_fields`. The field is still present top-level on the `Message`, and removing the duplicate is what makes live and replayed responses symmetric. The mirror dates from #8288, before `Message.reasoning_content` existed as a top-level attribute

Regression test: `test_reasoning_content_not_mirrored_into_provider_specific_fields` in `tests/llm_translation/test_llm_response_utils/test_convert_dict_to_chat_completion.py`. It fails on the base branch and passes with the fix; the full file (73 tests) plus the DeepSeek and Moonshot transformation tests pass with the change