### PR TITLE
fix(router): don't drop bedrock pass-through deployments using IAM credentials

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -8471,6 +8471,13 @@ class Router:
                     credential_values.get("api_key")
                     or deployment.litellm_params.api_key
                 )
+                if api_key is None:
+                    verbose_router_logger.debug(
+                        "Skipping pass-through credential setup for deployment model=%s, custom_llm_provider=%s; no api_key set. Providers like bedrock resolve credentials at request time.",
+                        model,
+                        custom_llm_provider,
+                    )
+                    return
                 passthrough_endpoint_router.set_pass_through_credentials(
                     custom_llm_provider=custom_llm_provider,
                     api_base=api_base,

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -4311,6 +4311,47 @@ def test_get_available_deployment_for_pass_through_raises_when_dict_blocked():
         )
 
 
+def test_initialize_deployment_for_pass_through_keeps_bedrock_iam_deployment():
+    """
+    Bedrock deployments using IAM/OIDC auth have no api_key; pass-through
+    init must not raise and drop them from routing (#27728).
+    """
+    import litellm
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "bedrock-claude",
+                "litellm_params": {
+                    "model": "bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0",
+                    "aws_role_name": "arn:aws:iam::123456789012:role/my-role",
+                    "aws_session_name": "my-session",
+                    "use_in_pass_through": True,
+                },
+                "model_info": {"id": "bedrock-iam-pt"},
+            }
+        ]
+    )
+    assert [m["model_info"]["id"] for m in router.get_model_list()] == [
+        "bedrock-iam-pt"
+    ]
+
+
+def test_initialize_deployment_for_pass_through_sets_credentials_with_api_key():
+    from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
+        passthrough_endpoint_router,
+    )
+
+    router = _router_with_two_pass_through_deployments([False, False])
+    assert len(router.get_model_list()) == 2
+    assert (
+        passthrough_endpoint_router.get_credentials(
+            custom_llm_provider="openai", region_name=None
+        )
+        == "sk-fake-for-tests"
+    )
+
+
 def test_get_deployment_credentials_returns_none_for_blocked_deployment():
     router = _router_with_two_deployments([True, False])
     assert router.get_deployment_credentials(model_id="dep-0") is None

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -4342,6 +4342,7 @@ def test_initialize_deployment_for_pass_through_sets_credentials_with_api_key():
         passthrough_endpoint_router,
     )
 
+    passthrough_endpoint_router.credentials.clear()
     router = _router_with_two_pass_through_deployments([False, False])
     assert len(router.get_model_list()) == 2
     assert (


### PR DESCRIPTION
## Relevant issues

Fixes #27728

## Linear ticket

N/A (external contribution)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link: pending

- [ ] **CI run for the last commit**  
       Link: pending

- [ ] **Merge / cherry-pick CI run**  
       Links: pending

## Screenshots / Proof of Fix

Config used (Bedrock deployment with IAM role auth, no api_key):

```yaml
model_list:
  - model_name: bedrock-claude
    litellm_params:
      model: bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0
      aws_role_name: "arn:aws:iam::123456789012:role/MyRole"
      aws_session_name: "my-session"
      use_in_pass_through: true

general_settings:
  master_key: sk-1234
```

On `litellm_internal_staging` (e15b37a18e), proxy startup logs the error from the issue and the deployment is dropped from routing entirely:

```
$ python litellm/proxy/proxy_cli.py --config config.yaml --port 4000
10:37:34 - LiteLLM Router:ERROR: router.py:7864 - Error creating deployment: api_key is required for setting pass-through credentials, ignoring and continuing with other deployments.

$ curl -s http://localhost:4000/v1/models -H "Authorization: Bearer sk-1234"
{"data":[],"object":"list"}
```

With this PR, same config and commands, no error in the startup log and the deployment is routable:

```
$ curl -s http://localhost:4000/v1/models -H "Authorization: Bearer sk-1234"
{"data":[{"id":"bedrock-claude","object":"model","created":1677610602,"owned_by":"openai"}],"object":"list"}
```

## Type

🐛 Bug Fix

## Changes

`Router._initialize_deployment_for_pass_through` has a vertex_ai branch, but every other provider falls into the generic branch that calls `set_pass_through_credentials`. That call raises `ValueError("api_key is required for setting pass-through credentials")` when `api_key` is None (`litellm/proxy/pass_through_endpoints/passthrough_endpoint_router.py:45`), which is the expected state for Bedrock deployments authenticating via IAM/OIDC (`aws_role_name`, `aws_web_identity_token`). The exception is caught in `_create_deployment`, so the whole deployment is silently dropped; this breaks not just passthrough but normal routing for that model

The fix skips the credential store write (with a debug log) when no `api_key` is resolvable. Nothing is lost by skipping: the bedrock passthrough route does not read the passthrough credential store, it resolves AWS credentials at request time via `BedrockConverseLLM.get_credentials()` in `litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py`, so registering an api_key for these deployments was never meaningful

Regression tests in `tests/test_litellm/test_router.py`: `test_initialize_deployment_for_pass_through_keeps_bedrock_iam_deployment` reproduces the issue config (fails on the base branch with the exact ValueError above, passes with this fix), and `test_initialize_deployment_for_pass_through_sets_credentials_with_api_key` pins the existing behavior that deployments with an api_key still register pass-through credentials