### PR TITLE
fix(proxy): populate tool registry for anthropic_messages traffic

### DIFF
--- a/litellm/proxy/db/db_spend_update_writer.py
+++ b/litellm/proxy/db/db_spend_update_writer.py
@@ -321,37 +321,53 @@ class DBSpendUpdateWriter:
                 if name:
                     _enqueue(name)
 
-            # --- Response tool_calls (OpenAI format; Anthropic pass-through converts tool_use here) ---
-            if completion_response is not None and hasattr(
-                completion_response, "choices"
+            # --- Tool calls / tool_use blocks from the response ---
+            for tool_name in self._extract_tool_names_from_response(
+                completion_response
             ):
-                for choice in completion_response.choices or []:
-                    message = getattr(choice, "message", None)
-                    if message is None:
-                        continue
-                    tool_calls = getattr(message, "tool_calls", None)
-                    if not tool_calls:
-                        continue
-                    for tc in tool_calls:
-                        fn = getattr(tc, "function", None)
-                        if fn is None:
-                            continue
-                        tool_name = getattr(fn, "name", None)
-                        if tool_name:
-                            _enqueue(tool_name)
-
-            # --- Response tool_use blocks (anthropic_messages route returns
-            #     AnthropicMessagesResponse, a TypedDict / plain dict) ---
-            elif isinstance(completion_response, dict):
-                for block in completion_response.get("content") or []:
-                    if isinstance(block, dict) and block.get("type") == "tool_use":
-                        name = block.get("name")
-                        if name:
-                            _enqueue(name)
+                _enqueue(tool_name)
         except Exception as e:
             verbose_proxy_logger.debug(
                 "_enqueue_tool_registry_upsert error (non-blocking): %s", e
             )
+
+    @staticmethod
+    def _extract_tool_names_from_response(
+        completion_response: Optional[Any],
+    ) -> List[str]:
+        """
+        Collect tool names from an LLM response: OpenAI-format objects
+        (choices[].message.tool_calls[].function.name) and anthropic_messages
+        dict responses (content[].name where type == "tool_use").
+        """
+        tool_names: List[str] = []
+        if completion_response is None:
+            return tool_names
+
+        if hasattr(completion_response, "choices"):
+            for choice in completion_response.choices or []:
+                message = getattr(choice, "message", None)
+                if message is None:
+                    continue
+                tool_calls = getattr(message, "tool_calls", None)
+                if not tool_calls:
+                    continue
+                for tc in tool_calls:
+                    fn = getattr(tc, "function", None)
+                    if fn is None:
+                        continue
+                    tool_name = getattr(fn, "name", None)
+                    if tool_name:
+                        tool_names.append(tool_name)
+        # AnthropicMessagesResponse is a TypedDict, a plain dict at runtime with
+        # no .choices attribute, so this branch never overlaps with the one above
+        elif isinstance(completion_response, dict):
+            for block in completion_response.get("content") or []:
+                if isinstance(block, dict) and block.get("type") == "tool_use":
+                    name = block.get("name")
+                    if name:
+                        tool_names.append(name)
+        return tool_names
 
     async def _batch_database_updates(
         self,

--- a/litellm/proxy/db/db_spend_update_writer.py
+++ b/litellm/proxy/db/db_spend_update_writer.py
@@ -245,12 +245,15 @@ class DBSpendUpdateWriter:
         Extract tool names from the LLM request and response and enqueue them
         for upsert into LiteLLM_ToolTable via ToolDiscoveryQueue.
 
-        Handles four sources:
+        Handles five sources:
         - MCP tools: standard_logging_object.mcp_tool_call_metadata.namespaced_tool_name
         - Response tool_calls (OpenAI / Anthropic pass-through converted to OpenAI format):
             completion_response.choices[].message.tool_calls[].function.name
-        - Request tools array (OpenAI format): kwargs["tools"][].function.name
-        - Request tools array (Anthropic /messages format): kwargs["passthrough_logging_payload"]
+        - Response tool_use blocks (anthropic_messages route, dict response):
+            completion_response["content"][].name where type == "tool_use"
+        - Request tools array (OpenAI format: tools[].function.name,
+            Anthropic /messages format: tools[].name)
+        - Request tools array (Anthropic pass-through): kwargs["passthrough_logging_payload"]
             ["request_body"]["tools"][].name
         """
         try:
@@ -290,13 +293,16 @@ class DBSpendUpdateWriter:
                     if tool_name:
                         _enqueue(tool_name, origin=mcp_server_name or "user_defined")
 
-            # --- Tools from request body (OpenAI format: tools[].function.name) ---
+            # --- Tools from request body (OpenAI format: tools[].function.name,
+            #     Anthropic /messages format: tools[].name) ---
             request_tools = kwargs.get("tools") or []
             for tool_def in request_tools:
                 if not isinstance(tool_def, dict):
                     continue
                 fn = tool_def.get("function") or {}
-                name = fn.get("name") if isinstance(fn, dict) else None
+                name = (
+                    fn.get("name") if isinstance(fn, dict) else None
+                ) or tool_def.get("name")
                 if name:
                     _enqueue(name)
 
@@ -333,6 +339,15 @@ class DBSpendUpdateWriter:
                         tool_name = getattr(fn, "name", None)
                         if tool_name:
                             _enqueue(tool_name)
+
+            # --- Response tool_use blocks (anthropic_messages route returns
+            #     AnthropicMessagesResponse, a TypedDict / plain dict) ---
+            elif isinstance(completion_response, dict):
+                for block in completion_response.get("content") or []:
+                    if isinstance(block, dict) and block.get("type") == "tool_use":
+                        name = block.get("name")
+                        if name:
+                            _enqueue(name)
         except Exception as e:
             verbose_proxy_logger.debug(
                 "_enqueue_tool_registry_upsert error (non-blocking): %s", e

--- a/tests/test_litellm/proxy/db/test_db_spend_update_writer.py
+++ b/tests/test_litellm/proxy/db/test_db_spend_update_writer.py
@@ -1656,3 +1656,52 @@ async def test_commit_spend_updates_iterates_in_sorted_order(
     )
 
     assert captured_where_values == expected_order
+
+
+def test_enqueue_tool_registry_upsert_anthropic_format_request_tools():
+    writer = DBSpendUpdateWriter()
+    writer.tool_discovery_queue.add_update = MagicMock()
+
+    writer._enqueue_tool_registry_upsert(
+        kwargs={
+            "tools": [
+                {"name": "get_weather", "input_schema": {"type": "object"}},
+                {"name": "search_docs", "input_schema": {"type": "object"}},
+            ]
+        },
+        completion_response=None,
+    )
+
+    enqueued = [
+        c.args[0]["tool_name"]
+        for c in writer.tool_discovery_queue.add_update.call_args_list
+    ]
+    assert enqueued == ["get_weather", "search_docs"]
+
+
+def test_enqueue_tool_registry_upsert_dict_response_tool_use_blocks():
+    writer = DBSpendUpdateWriter()
+    writer.tool_discovery_queue.add_update = MagicMock()
+
+    writer._enqueue_tool_registry_upsert(
+        kwargs={},
+        completion_response={
+            "id": "msg_123",
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "Let me check the weather."},
+                {
+                    "type": "tool_use",
+                    "id": "toolu_01",
+                    "name": "get_weather",
+                    "input": {"city": "San Francisco"},
+                },
+            ],
+        },
+    )
+
+    enqueued = [
+        c.args[0]["tool_name"]
+        for c in writer.tool_discovery_queue.add_update.call_args_list
+    ]
+    assert enqueued == ["get_weather"]


### PR DESCRIPTION
## Relevant issues

Fixes #27840

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

With a proxy running against a database and a model served on `/v1/messages`:

```bash
curl http://localhost:4000/v1/messages \
  -H "Authorization: Bearer sk-1234" \
  -H "content-type: application/json" \
  -d '{
    "model": "claude-sonnet-4-5",
    "max_tokens": 256,
    "messages": [{"role": "user", "content": "What is the weather in San Francisco?"}],
    "tools": [{
      "name": "get_weather",
      "description": "Get the current weather for a city",
      "input_schema": {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]}
    }]
  }'
```

then

```bash
psql "$DATABASE_URL" -c 'SELECT tool_name, origin, call_count FROM "LiteLLM_ToolTable";'
psql "$DATABASE_URL" -c 'SELECT request_id, tool_name FROM "LiteLLM_SpendLogToolIndex" ORDER BY start_time DESC LIMIT 5;'
```

Before this change both queries return zero rows for `/v1/messages` traffic; with it, `get_weather` appears in both tables, matching the behavior `/chat/completions` traffic already has

## Type

🐛 Bug Fix

## Changes

`_enqueue_tool_registry_upsert` in `litellm/proxy/db/db_spend_update_writer.py` never saw tool names for traffic on the native `/v1/messages` path (`route_type="anthropic_messages"`), so `LiteLLM_ToolTable` and `LiteLLM_SpendLogToolIndex` stayed empty for those requests. Two gaps caused this. On the request side, extraction only read `tools[].function.name` (OpenAI format) plus the pass-through payload, missing Anthropic-format tool definitions where the name is top-level (`tools[].name`). On the response side, extraction was gated on `hasattr(completion_response, "choices")`, which is False for `AnthropicMessagesResponse` because it is a TypedDict, a plain dict at runtime (`litellm/types/llms/anthropic_messages/anthropic_response.py`), so `tool_use` content blocks were silently dropped

The fix extends the existing request-tools loop to fall back to the top-level `name` key (OpenAI-format tool definitions have no top-level `name`, so nothing double-enqueues) and adds a branch that walks the `content` blocks of dict-shaped responses and enqueues the name of each `tool_use` block

Two regression tests in `tests/test_litellm/proxy/db/test_db_spend_update_writer.py` cover the new extraction paths, one for Anthropic-format request tools and one for `tool_use` blocks in a dict response. Both fail on `litellm_internal_staging` without this change and pass with it