### PR TITLE
feat(gemini): forward web search tools in image generation

### DIFF
--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -929,6 +929,43 @@ def calculate_image_response_cost_from_usage(
     return prompt_cost + completion_cost
 
 
+def calculate_image_response_web_search_cost(
+    image_response: ImageResponse,
+    custom_llm_provider: str,
+    model_info: ModelInfo,
+) -> float:
+    """
+    Cost of Google Search grounding performed during image generation.
+
+    The grounding request count is carried on the image usage object by the
+    provider transformers; it is billed with the same per-request accounting
+    used for chat completions.
+    """
+    usage = image_response.usage
+    if usage is None:
+        return 0.0
+
+    web_search_requests = getattr(usage, "web_search_requests", None)
+    if not web_search_requests:
+        return 0.0
+
+    from litellm.llms import get_cost_for_web_search_request
+
+    synthetic_usage = Usage(
+        prompt_tokens_details=PromptTokensDetailsWrapper(
+            web_search_requests=web_search_requests
+        )
+    )
+    return (
+        get_cost_for_web_search_request(
+            custom_llm_provider=custom_llm_provider,
+            usage=synthetic_usage,
+            model_info=model_info,
+        )
+        or 0.0
+    )
+
+
 class CostCalculatorUtils:
     @staticmethod
     def _call_type_has_image_response(call_type: str) -> bool:

--- a/litellm/llms/gemini/common_utils.py
+++ b/litellm/llms/gemini/common_utils.py
@@ -183,23 +183,58 @@ def map_openai_image_params_to_gemini(
     return mapped_params
 
 
+def _dedupe_gemini_search_tools(tools: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+        VertexGeminiConfig,
+    )
+
+    search_tool_keys = VertexGeminiConfig._search_tool_keys()
+    seen_search_keys: set[str] = set()
+    deduped_tools: List[Dict[str, Any]] = []
+
+    for tool in tools:
+        if not isinstance(tool, dict):
+            deduped_tools.append(tool)
+            continue
+
+        search_key = next((key for key in search_tool_keys if key in tool), None)
+        if search_key is None:
+            deduped_tools.append(tool)
+            continue
+
+        if search_key in seen_search_keys:
+            continue
+
+        seen_search_keys.add(search_key)
+        deduped_tools.append(tool)
+
+    return deduped_tools
+
+
+def _has_gemini_search_tool(tools: List[Any]) -> bool:
+    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+        VertexGeminiConfig,
+    )
+
+    search_tool_keys = VertexGeminiConfig._search_tool_keys()
+    return any(
+        isinstance(tool, dict) and any(key in tool for key in search_tool_keys)
+        for tool in tools
+    )
+
+
 def map_gemini_image_tools_params(
     non_default_params: Dict[str, Any],
     mapped_params: Dict[str, Any],
 ) -> Dict[str, Any]:
-    """
-    Map tools and web_search_options to Gemini googleSearch tools for image generation.
-
-    Reuses VertexGeminiConfig tool mapping so OpenAI-style web_search tools,
-    web_search_options, and native googleSearch/google_search tools are supported.
-    """
     from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
         VertexGeminiConfig,
     )
 
     gemini_config = VertexGeminiConfig()
-    working_params = dict(mapped_params)
-    working_params.pop("web_search_options", None)
+    result = dict(mapped_params)
+    result.pop("web_search_options", None)
+    working_params = dict(result)
 
     tools_value = non_default_params.get("tools")
     if isinstance(tools_value, list) and tools_value:
@@ -211,7 +246,10 @@ def map_gemini_image_tools_params(
         )
 
     web_search_options = non_default_params.get("web_search_options")
-    if isinstance(web_search_options, dict):
+    existing_tools = working_params.get("tools")
+    if isinstance(web_search_options, dict) and not (
+        isinstance(existing_tools, list) and _has_gemini_search_tool(existing_tools)
+    ):
         search_tool = gemini_config._map_web_search_options(web_search_options)
         working_params = gemini_config._add_tools_to_optional_params(
             working_params, [search_tool]
@@ -219,10 +257,10 @@ def map_gemini_image_tools_params(
 
     gemini_config._drop_search_tools_mixed_with_functions(working_params)
 
-    if "tools" in working_params:
-        mapped_params["tools"] = working_params["tools"]
-    mapped_params.pop("web_search_options", None)
-    return mapped_params
+    if isinstance(working_params.get("tools"), list):
+        result["tools"] = _dedupe_gemini_search_tools(working_params["tools"])
+
+    return result
 
 
 def get_gemini_image_generation_config(

--- a/litellm/llms/gemini/common_utils.py
+++ b/litellm/llms/gemini/common_utils.py
@@ -174,9 +174,54 @@ def map_openai_image_params_to_gemini(
         mapped_params["imageConfig"] = image_config_param
 
     for key, value in filtered_params.items():
-        if key not in ("n", "size", "imageConfig") and key not in optional_params:
+        if (
+            key not in ("n", "size", "imageConfig", "tools", "web_search_options")
+            and key not in optional_params
+        ):
             mapped_params[key] = value
 
+    return mapped_params
+
+
+def map_gemini_image_tools_params(
+    non_default_params: Dict[str, Any],
+    mapped_params: Dict[str, Any],
+) -> Dict[str, Any]:
+    """
+    Map tools and web_search_options to Gemini googleSearch tools for image generation.
+
+    Reuses VertexGeminiConfig tool mapping so OpenAI-style web_search tools,
+    web_search_options, and native googleSearch/google_search tools are supported.
+    """
+    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+        VertexGeminiConfig,
+    )
+
+    gemini_config = VertexGeminiConfig()
+    working_params = dict(mapped_params)
+    working_params.pop("web_search_options", None)
+
+    tools_value = non_default_params.get("tools")
+    if isinstance(tools_value, list) and tools_value:
+        mapped_tools = gemini_config._map_function(
+            value=tools_value, optional_params=working_params
+        )
+        working_params = gemini_config._add_tools_to_optional_params(
+            working_params, mapped_tools
+        )
+
+    web_search_options = non_default_params.get("web_search_options")
+    if isinstance(web_search_options, dict):
+        search_tool = gemini_config._map_web_search_options(web_search_options)
+        working_params = gemini_config._add_tools_to_optional_params(
+            working_params, [search_tool]
+        )
+
+    gemini_config._drop_search_tools_mixed_with_functions(working_params)
+
+    if "tools" in working_params:
+        mapped_params["tools"] = working_params["tools"]
+    mapped_params.pop("web_search_options", None)
     return mapped_params
 
 

--- a/litellm/llms/gemini/common_utils.py
+++ b/litellm/llms/gemini/common_utils.py
@@ -234,31 +234,26 @@ def map_gemini_image_tools_params(
     gemini_config = VertexGeminiConfig()
     result = dict(mapped_params)
     result.pop("web_search_options", None)
-    working_params = dict(result)
 
     tools_value = non_default_params.get("tools")
     if isinstance(tools_value, list) and tools_value:
         mapped_tools = gemini_config._map_function(
-            value=tools_value, optional_params=working_params
+            value=tools_value, optional_params=result
         )
-        working_params = gemini_config._add_tools_to_optional_params(
-            working_params, mapped_tools
-        )
+        result = gemini_config._add_tools_to_optional_params(result, mapped_tools)
 
     web_search_options = non_default_params.get("web_search_options")
-    existing_tools = working_params.get("tools")
+    existing_tools = result.get("tools")
     if isinstance(web_search_options, dict) and not (
         isinstance(existing_tools, list) and _has_gemini_search_tool(existing_tools)
     ):
         search_tool = gemini_config._map_web_search_options(web_search_options)
-        working_params = gemini_config._add_tools_to_optional_params(
-            working_params, [search_tool]
-        )
+        result = gemini_config._add_tools_to_optional_params(result, [search_tool])
 
-    gemini_config._drop_search_tools_mixed_with_functions(working_params)
+    gemini_config._drop_search_tools_mixed_with_functions(result)
 
-    if isinstance(working_params.get("tools"), list):
-        result["tools"] = _dedupe_gemini_search_tools(working_params["tools"])
+    if isinstance(result.get("tools"), list):
+        result["tools"] = _dedupe_gemini_search_tools(result["tools"])
 
     return result
 

--- a/litellm/llms/gemini/common_utils.py
+++ b/litellm/llms/gemini/common_utils.py
@@ -258,6 +258,26 @@ def map_gemini_image_tools_params(
     return result
 
 
+def get_gemini_image_web_search_requests(
+    response_data: Dict[str, Any],
+) -> Optional[int]:
+    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+        VertexGeminiConfig,
+    )
+
+    grounding_metadata: List[Dict[str, Any]] = []
+    for candidate in response_data.get("candidates", []):
+        if not isinstance(candidate, dict):
+            continue
+        candidate_grounding = candidate.get("groundingMetadata")
+        if isinstance(candidate_grounding, list):
+            grounding_metadata.extend(candidate_grounding)
+        elif isinstance(candidate_grounding, dict):
+            grounding_metadata.append(candidate_grounding)
+
+    return VertexGeminiConfig._calculate_web_search_requests(grounding_metadata)
+
+
 def get_gemini_image_generation_config(
     model: str,
     optional_params: Dict[str, Any],

--- a/litellm/llms/gemini/image_generation/cost_calculator.py
+++ b/litellm/llms/gemini/image_generation/cost_calculator.py
@@ -7,6 +7,7 @@ from typing import Any
 import litellm
 from litellm.litellm_core_utils.llm_cost_calc.utils import (
     calculate_image_response_cost_from_usage,
+    calculate_image_response_web_search_cost,
 )
 from litellm.types.utils import ImageResponse
 
@@ -23,22 +24,25 @@ def cost_calculator(
         custom_llm_provider="gemini",
     )
 
-    if isinstance(image_response, ImageResponse):
-        token_based_cost = calculate_image_response_cost_from_usage(
-            model=model,
-            image_response=image_response,
-            custom_llm_provider="gemini",
-        )
-        if token_based_cost is not None:
-            return token_based_cost
-
-    output_cost_per_image: float = _model_info.get("output_cost_per_image") or 0.0
-    num_images: int = 0
-    if isinstance(image_response, ImageResponse):
-        if image_response.data:
-            num_images = len(image_response.data)
-        return output_cost_per_image * num_images
-    else:
+    if not isinstance(image_response, ImageResponse):
         raise ValueError(
             f"image_response must be of type ImageResponse got type={type(image_response)}"
         )
+
+    web_search_cost = calculate_image_response_web_search_cost(
+        image_response=image_response,
+        custom_llm_provider="gemini",
+        model_info=_model_info,
+    )
+
+    token_based_cost = calculate_image_response_cost_from_usage(
+        model=model,
+        image_response=image_response,
+        custom_llm_provider="gemini",
+    )
+    if token_based_cost is not None:
+        return token_based_cost + web_search_cost
+
+    output_cost_per_image: float = _model_info.get("output_cost_per_image") or 0.0
+    num_images: int = len(image_response.data) if image_response.data else 0
+    return output_cost_per_image * num_images + web_search_cost

--- a/litellm/llms/gemini/image_generation/transformation.py
+++ b/litellm/llms/gemini/image_generation/transformation.py
@@ -8,6 +8,7 @@ from litellm.llms.base_llm.image_generation.transformation import (
 from litellm.llms.gemini.common_utils import (
     get_gemini_image_generation_config,
     is_gemini_image_model,
+    map_gemini_image_tools_params,
     map_openai_image_params_to_gemini,
 )
 from litellm.llms.gemini.image_usage_transformation import (
@@ -41,7 +42,7 @@ class GoogleImageGenConfig(BaseImageGenerationConfig):
         """
         supported_params = ["n", "size"]
         if is_gemini_image_model(model):
-            supported_params.append("imageConfig")
+            supported_params.extend(["imageConfig", "tools", "web_search_options"])
         return supported_params  # type: ignore[return-value]
 
     def map_openai_params(
@@ -51,12 +52,15 @@ class GoogleImageGenConfig(BaseImageGenerationConfig):
         model: str,
         drop_params: bool,
     ) -> dict:
-        return map_openai_image_params_to_gemini(
+        mapped_params = map_openai_image_params_to_gemini(
             params=non_default_params,
             model=model,
             supported_params=self.get_supported_openai_params(model),
             optional_params=optional_params,
         )
+        if is_gemini_image_model(model):
+            map_gemini_image_tools_params(non_default_params, mapped_params)
+        return mapped_params
 
     def get_complete_url(
         self,
@@ -140,6 +144,8 @@ class GoogleImageGenConfig(BaseImageGenerationConfig):
                     optional_params=optional_params,
                 ),
             }
+            if tools := optional_params.get("tools"):
+                request_body["tools"] = tools
             return request_body
         else:
             # For other Imagen models, use the original Imagen format

--- a/litellm/llms/gemini/image_generation/transformation.py
+++ b/litellm/llms/gemini/image_generation/transformation.py
@@ -59,7 +59,9 @@ class GoogleImageGenConfig(BaseImageGenerationConfig):
             optional_params=optional_params,
         )
         if is_gemini_image_model(model):
-            map_gemini_image_tools_params(non_default_params, mapped_params)
+            mapped_params = map_gemini_image_tools_params(
+                non_default_params, mapped_params
+            )
         return mapped_params
 
     def get_complete_url(

--- a/litellm/llms/gemini/image_generation/transformation.py
+++ b/litellm/llms/gemini/image_generation/transformation.py
@@ -148,6 +148,8 @@ class GoogleImageGenConfig(BaseImageGenerationConfig):
             }
             if tools := optional_params.get("tools"):
                 request_body["tools"] = tools
+            if tool_config := optional_params.get("toolConfig"):
+                request_body["toolConfig"] = tool_config
             return request_body
         else:
             # For other Imagen models, use the original Imagen format

--- a/litellm/llms/gemini/image_generation/transformation.py
+++ b/litellm/llms/gemini/image_generation/transformation.py
@@ -7,6 +7,7 @@ from litellm.llms.base_llm.image_generation.transformation import (
 )
 from litellm.llms.gemini.common_utils import (
     get_gemini_image_generation_config,
+    get_gemini_image_web_search_requests,
     is_gemini_image_model,
     map_gemini_image_tools_params,
     map_openai_image_params_to_gemini,
@@ -226,6 +227,11 @@ class GoogleImageGenConfig(BaseImageGenerationConfig):
             if "usageMetadata" in response_data:
                 model_response.usage = transform_gemini_image_usage(
                     response_data["usageMetadata"]
+                )
+            web_search_requests = get_gemini_image_web_search_requests(response_data)
+            if web_search_requests and model_response.usage is not None:
+                setattr(
+                    model_response.usage, "web_search_requests", web_search_requests
                 )
         else:
             # Original Imagen format - predictions with generated images

--- a/litellm/llms/vertex_ai/image_generation/cost_calculator.py
+++ b/litellm/llms/vertex_ai/image_generation/cost_calculator.py
@@ -5,6 +5,7 @@ Vertex AI Image Generation Cost Calculator
 import litellm
 from litellm.litellm_core_utils.llm_cost_calc.utils import (
     calculate_image_response_cost_from_usage,
+    calculate_image_response_web_search_cost,
 )
 from litellm.types.utils import ImageResponse
 
@@ -21,16 +22,20 @@ def cost_calculator(
         custom_llm_provider="vertex_ai",
     )
 
+    web_search_cost = calculate_image_response_web_search_cost(
+        image_response=image_response,
+        custom_llm_provider="vertex_ai",
+        model_info=_model_info,
+    )
+
     token_based_cost = calculate_image_response_cost_from_usage(
         model=model,
         image_response=image_response,
         custom_llm_provider="vertex_ai",
     )
     if token_based_cost is not None:
-        return token_based_cost
+        return token_based_cost + web_search_cost
 
     output_cost_per_image: float = _model_info.get("output_cost_per_image") or 0.0
-    num_images: int = 0
-    if image_response.data:
-        num_images = len(image_response.data)
-    return output_cost_per_image * num_images
+    num_images: int = len(image_response.data) if image_response.data else 0
+    return output_cost_per_image * num_images + web_search_cost

--- a/litellm/llms/vertex_ai/image_generation/vertex_gemini_transformation.py
+++ b/litellm/llms/vertex_ai/image_generation/vertex_gemini_transformation.py
@@ -7,6 +7,7 @@ import litellm
 from litellm.llms.base_llm.image_generation.transformation import (
     BaseImageGenerationConfig,
 )
+from litellm.llms.gemini.common_utils import map_gemini_image_tools_params
 from litellm.llms.vertex_ai.common_utils import get_vertex_base_url
 from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import VertexLLM
 from litellm.secret_managers.main import get_secret_str
@@ -52,6 +53,8 @@ class VertexAIGeminiImageGenerationConfig(BaseImageGenerationConfig, VertexLLM):
             "aspect_ratio",
             "imageSize",
             "image_size",
+            "tools",
+            "web_search_options",
         ]
 
     def map_openai_params(
@@ -77,9 +80,10 @@ class VertexAIGeminiImageGenerationConfig(BaseImageGenerationConfig, VertexLLM):
                         mapped_params["aspectRatio"] = v
                     elif k in ("imageSize", "image_size"):
                         mapped_params["imageSize"] = v
-                    else:
+                    elif k not in ("tools", "web_search_options"):
                         mapped_params[k] = v
 
+        map_gemini_image_tools_params(non_default_params, mapped_params)
         return mapped_params
 
     def _map_size_to_aspect_ratio(self, size: str) -> str:
@@ -246,6 +250,9 @@ class VertexAIGeminiImageGenerationConfig(BaseImageGenerationConfig, VertexLLM):
             "contents": contents,
             "generationConfig": generation_config,
         }
+
+        if tools := optional_params.get("tools"):
+            request_body["tools"] = tools
 
         return request_body
 

--- a/litellm/llms/vertex_ai/image_generation/vertex_gemini_transformation.py
+++ b/litellm/llms/vertex_ai/image_generation/vertex_gemini_transformation.py
@@ -7,7 +7,10 @@ import litellm
 from litellm.llms.base_llm.image_generation.transformation import (
     BaseImageGenerationConfig,
 )
-from litellm.llms.gemini.common_utils import map_gemini_image_tools_params
+from litellm.llms.gemini.common_utils import (
+    get_gemini_image_web_search_requests,
+    map_gemini_image_tools_params,
+)
 from litellm.llms.vertex_ai.common_utils import get_vertex_base_url
 from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import VertexLLM
 from litellm.secret_managers.main import get_secret_str
@@ -332,5 +335,9 @@ class VertexAIGeminiImageGenerationConfig(BaseImageGenerationConfig, VertexLLM):
 
         if usage_metadata := response_data.get("usageMetadata", None):
             model_response.usage = self._transform_image_usage(usage_metadata)
+
+        web_search_requests = get_gemini_image_web_search_requests(response_data)
+        if web_search_requests and model_response.usage is not None:
+            setattr(model_response.usage, "web_search_requests", web_search_requests)
 
         return model_response

--- a/litellm/llms/vertex_ai/image_generation/vertex_gemini_transformation.py
+++ b/litellm/llms/vertex_ai/image_generation/vertex_gemini_transformation.py
@@ -83,7 +83,7 @@ class VertexAIGeminiImageGenerationConfig(BaseImageGenerationConfig, VertexLLM):
                     elif k not in ("tools", "web_search_options"):
                         mapped_params[k] = v
 
-        map_gemini_image_tools_params(non_default_params, mapped_params)
+        mapped_params = map_gemini_image_tools_params(non_default_params, mapped_params)
         return mapped_params
 
     def _map_size_to_aspect_ratio(self, size: str) -> str:

--- a/litellm/llms/vertex_ai/image_generation/vertex_gemini_transformation.py
+++ b/litellm/llms/vertex_ai/image_generation/vertex_gemini_transformation.py
@@ -253,6 +253,8 @@ class VertexAIGeminiImageGenerationConfig(BaseImageGenerationConfig, VertexLLM):
 
         if tools := optional_params.get("tools"):
             request_body["tools"] = tools
+        if tool_config := optional_params.get("toolConfig"):
+            request_body["toolConfig"] = tool_config
 
         return request_body
 

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -3185,6 +3185,8 @@ def get_optional_params_image_gen(
         "style": None,
         "user": None,
         "imageConfig": None,
+        "tools": None,
+        "web_search_options": None,
     }
 
     non_default_params = _get_non_default_params(

--- a/tests/test_litellm/llms/gemini/test_cost_calculator.py
+++ b/tests/test_litellm/llms/gemini/test_cost_calculator.py
@@ -247,3 +247,57 @@ def test_gemini_image_edit_cost_falls_back_to_flat_image_pricing():
     )
 
     assert cost == len(image_response.data or []) * model_info["output_cost_per_image"]
+
+
+def _image_response_with_web_search(web_search_requests):
+    usage = ImageUsage(
+        input_tokens=20,
+        input_tokens_details=ImageUsageInputTokensDetails(
+            text_tokens=20,
+            image_tokens=0,
+        ),
+        output_tokens=1120,
+        total_tokens=1140,
+    )
+    if web_search_requests is not None:
+        usage.web_search_requests = web_search_requests
+    return ImageResponse(data=[ImageObject(b64_json="img1")], usage=usage)
+
+
+def test_gemini_image_generation_cost_adds_web_search_grounding():
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+    model = "gemini/gemini-3-pro-image-preview"
+    model_info = litellm.get_model_info(model=model, custom_llm_provider="gemini")
+
+    grounded = gemini_image_generation_cost_calculator(
+        model=model,
+        image_response=_image_response_with_web_search(2),
+    )
+    ungrounded = gemini_image_generation_cost_calculator(
+        model=model,
+        image_response=_image_response_with_web_search(None),
+    )
+
+    expected_web_search_cost = cost_per_web_search_request(
+        usage=_make_usage(2), model_info=model_info
+    )
+    assert expected_web_search_cost > 0
+    assert round(grounded - ungrounded, 10) == round(expected_web_search_cost, 10)
+
+
+def test_gemini_image_generation_cost_no_web_search_when_absent():
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+    model = "gemini/gemini-3-pro-image-preview"
+
+    cost_zero = gemini_image_generation_cost_calculator(
+        model=model,
+        image_response=_image_response_with_web_search(0),
+    )
+    cost_none = gemini_image_generation_cost_calculator(
+        model=model,
+        image_response=_image_response_with_web_search(None),
+    )
+
+    assert cost_zero == cost_none

--- a/tests/test_litellm/llms/gemini/test_gemini_image_generation_transformation.py
+++ b/tests/test_litellm/llms/gemini/test_gemini_image_generation_transformation.py
@@ -243,6 +243,22 @@ def test_gemini_image_generation_openai_web_search_tool_maps_to_google_search():
     assert request["tools"] == [{"googleSearch": {}}]
 
 
+def test_gemini_image_generation_dedupes_search_tools_from_tools_and_web_search_options():
+    config = GoogleImageGenConfig()
+
+    mapped = config.map_openai_params(
+        non_default_params={
+            "tools": [{"type": "web_search"}],
+            "web_search_options": {},
+        },
+        optional_params={},
+        model="gemini-3.1-flash-image-preview",
+        drop_params=False,
+    )
+
+    assert mapped["tools"] == [{"googleSearch": {}}]
+
+
 def test_gemini_image_generation_usage_without_output_details_treats_output_as_image():
     config = GoogleImageGenConfig()
     raw_response = httpx.Response(

--- a/tests/test_litellm/llms/gemini/test_gemini_image_generation_transformation.py
+++ b/tests/test_litellm/llms/gemini/test_gemini_image_generation_transformation.py
@@ -259,6 +259,24 @@ def test_gemini_image_generation_dedupes_search_tools_from_tools_and_web_search_
     assert mapped["tools"] == [{"googleSearch": {}}]
 
 
+def test_gemini_image_generation_preserves_tool_config_side_effect():
+    config = GoogleImageGenConfig()
+
+    mapped = config.map_openai_params(
+        non_default_params={
+            "tools": [{"googleMaps": {"latitude": 37.7, "longitude": -122.4}}]
+        },
+        optional_params={},
+        model="gemini-3.1-flash-image-preview",
+        drop_params=False,
+    )
+
+    assert mapped["tools"] == [{"googleMaps": {}}]
+    assert mapped["toolConfig"] == {
+        "retrievalConfig": {"latLng": {"latitude": 37.7, "longitude": -122.4}}
+    }
+
+
 def test_gemini_image_generation_usage_without_output_details_treats_output_as_image():
     config = GoogleImageGenConfig()
     raw_response = httpx.Response(

--- a/tests/test_litellm/llms/gemini/test_gemini_image_generation_transformation.py
+++ b/tests/test_litellm/llms/gemini/test_gemini_image_generation_transformation.py
@@ -276,6 +276,19 @@ def test_gemini_image_generation_preserves_tool_config_side_effect():
         "retrievalConfig": {"latLng": {"latitude": 37.7, "longitude": -122.4}}
     }
 
+    request = config.transform_image_generation_request(
+        model="gemini-3.1-flash-image-preview",
+        prompt="Generate an image of a coffee shop nearby",
+        optional_params=mapped,
+        litellm_params={},
+        headers={},
+    )
+
+    assert request["tools"] == [{"googleMaps": {}}]
+    assert request["toolConfig"] == {
+        "retrievalConfig": {"latLng": {"latitude": 37.7, "longitude": -122.4}}
+    }
+
 
 def test_gemini_image_generation_usage_without_output_details_treats_output_as_image():
     config = GoogleImageGenConfig()

--- a/tests/test_litellm/llms/gemini/test_gemini_image_generation_transformation.py
+++ b/tests/test_litellm/llms/gemini/test_gemini_image_generation_transformation.py
@@ -332,3 +332,90 @@ def test_gemini_image_generation_usage_without_output_details_treats_output_as_i
     usage = result.model_dump()["usage"]
     assert usage["completion_tokens_details"]["text_tokens"] == 0
     assert usage["completion_tokens_details"]["image_tokens"] == 1716
+
+
+def test_gemini_image_generation_response_tracks_web_search_requests():
+    config = GoogleImageGenConfig()
+    raw_response = httpx.Response(
+        status_code=200,
+        json={
+            "candidates": [
+                {
+                    "content": {
+                        "parts": [
+                            {
+                                "inlineData": {
+                                    "mimeType": "image/png",
+                                    "data": "fake-image",
+                                }
+                            }
+                        ]
+                    },
+                    "groundingMetadata": {
+                        "webSearchQueries": ["latest iphone", "iphone colors"]
+                    },
+                }
+            ],
+            "usageMetadata": {
+                "promptTokenCount": 35,
+                "candidatesTokenCount": 1716,
+                "totalTokenCount": 1751,
+                "promptTokensDetails": [{"modality": "TEXT", "tokenCount": 35}],
+            },
+        },
+    )
+
+    result = config.transform_image_generation_response(
+        model="gemini-3.1-flash-image-preview",
+        raw_response=raw_response,
+        model_response=ImageResponse(data=[]),
+        logging_obj=None,
+        request_data={},
+        optional_params={},
+        litellm_params={},
+        encoding=None,
+    )
+
+    assert result.usage.web_search_requests == 2
+
+
+def test_gemini_image_generation_response_without_grounding_has_no_web_search_requests():
+    config = GoogleImageGenConfig()
+    raw_response = httpx.Response(
+        status_code=200,
+        json={
+            "candidates": [
+                {
+                    "content": {
+                        "parts": [
+                            {
+                                "inlineData": {
+                                    "mimeType": "image/png",
+                                    "data": "fake-image",
+                                }
+                            }
+                        ]
+                    }
+                }
+            ],
+            "usageMetadata": {
+                "promptTokenCount": 35,
+                "candidatesTokenCount": 1716,
+                "totalTokenCount": 1751,
+                "promptTokensDetails": [{"modality": "TEXT", "tokenCount": 35}],
+            },
+        },
+    )
+
+    result = config.transform_image_generation_response(
+        model="gemini-3.1-flash-image-preview",
+        raw_response=raw_response,
+        model_response=ImageResponse(data=[]),
+        logging_obj=None,
+        request_data={},
+        optional_params={},
+        litellm_params={},
+        encoding=None,
+    )
+
+    assert getattr(result.usage, "web_search_requests", None) is None

--- a/tests/test_litellm/llms/gemini/test_gemini_image_generation_transformation.py
+++ b/tests/test_litellm/llms/gemini/test_gemini_image_generation_transformation.py
@@ -196,6 +196,53 @@ def test_gemini_image_generation_usage_includes_chat_token_details():
     assert logging_usage["completion_tokens_details"]["image_tokens"] == 1120
 
 
+def test_gemini_image_generation_web_search_options_maps_to_google_search_tool():
+    config = GoogleImageGenConfig()
+
+    mapped = config.map_openai_params(
+        non_default_params={"web_search_options": {}},
+        optional_params={},
+        model="gemini-3.1-flash-image-preview",
+        drop_params=False,
+    )
+
+    assert "tools" in mapped
+    assert mapped["tools"] == [{"googleSearch": {}}]
+
+    request = config.transform_image_generation_request(
+        model="gemini-3.1-flash-image-preview",
+        prompt="Generate an image of the latest iPhone",
+        optional_params=mapped,
+        litellm_params={},
+        headers={},
+    )
+
+    assert request["tools"] == [{"googleSearch": {}}]
+
+
+def test_gemini_image_generation_openai_web_search_tool_maps_to_google_search():
+    config = GoogleImageGenConfig()
+
+    mapped = config.map_openai_params(
+        non_default_params={"tools": [{"type": "web_search"}]},
+        optional_params={},
+        model="gemini-3.1-flash-image-preview",
+        drop_params=False,
+    )
+
+    assert mapped["tools"] == [{"googleSearch": {}}]
+
+    request = config.transform_image_generation_request(
+        model="gemini-3.1-flash-image-preview",
+        prompt="Generate an image of the latest iPhone",
+        optional_params=mapped,
+        litellm_params={},
+        headers={},
+    )
+
+    assert request["tools"] == [{"googleSearch": {}}]
+
+
 def test_gemini_image_generation_usage_without_output_details_treats_output_as_image():
     config = GoogleImageGenConfig()
     raw_response = httpx.Response(

--- a/tests/test_litellm/llms/vertex_ai/image_generation/test_vertex_ai_image_generation_cost_calculator.py
+++ b/tests/test_litellm/llms/vertex_ai/image_generation/test_vertex_ai_image_generation_cost_calculator.py
@@ -1,0 +1,72 @@
+import os
+
+import litellm
+from litellm.llms.vertex_ai.gemini.cost_calculator import cost_per_web_search_request
+from litellm.llms.vertex_ai.image_generation.cost_calculator import (
+    cost_calculator as vertex_image_generation_cost_calculator,
+)
+from litellm.types.utils import (
+    ImageObject,
+    ImageResponse,
+    ImageUsage,
+    ImageUsageInputTokensDetails,
+    PromptTokensDetailsWrapper,
+    Usage,
+)
+
+
+def _image_response_with_web_search(web_search_requests):
+    usage = ImageUsage(
+        input_tokens=20,
+        input_tokens_details=ImageUsageInputTokensDetails(
+            text_tokens=20,
+            image_tokens=0,
+        ),
+        output_tokens=1120,
+        total_tokens=1140,
+    )
+    if web_search_requests is not None:
+        usage.web_search_requests = web_search_requests
+    return ImageResponse(data=[ImageObject(b64_json="img1")], usage=usage)
+
+
+def test_vertex_image_generation_cost_adds_web_search_grounding():
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+    model = "gemini-3-pro-image-preview"
+    model_info = litellm.get_model_info(model=model, custom_llm_provider="vertex_ai")
+
+    grounded = vertex_image_generation_cost_calculator(
+        model=model,
+        image_response=_image_response_with_web_search(3),
+    )
+    ungrounded = vertex_image_generation_cost_calculator(
+        model=model,
+        image_response=_image_response_with_web_search(None),
+    )
+
+    expected_web_search_cost = cost_per_web_search_request(
+        usage=Usage(
+            prompt_tokens_details=PromptTokensDetailsWrapper(web_search_requests=3)
+        ),
+        model_info=model_info,
+    )
+    assert expected_web_search_cost > 0
+    assert round(grounded - ungrounded, 10) == round(expected_web_search_cost, 10)
+
+
+def test_vertex_image_generation_cost_no_web_search_when_absent():
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+    model = "gemini-3-pro-image-preview"
+
+    cost_zero = vertex_image_generation_cost_calculator(
+        model=model,
+        image_response=_image_response_with_web_search(0),
+    )
+    cost_none = vertex_image_generation_cost_calculator(
+        model=model,
+        image_response=_image_response_with_web_search(None),
+    )
+
+    assert cost_zero == cost_none

--- a/tests/test_litellm/llms/vertex_ai/image_generation/test_vertex_ai_image_generation_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/image_generation/test_vertex_ai_image_generation_transformation.py
@@ -349,6 +349,51 @@ class TestVertexAIGeminiImageGenerationConfig:
             == "test_signature_abc123"
         )
 
+    def test_transform_image_generation_response_tracks_web_search_requests(self):
+        """Grounding queries are carried onto usage so search spend can be billed"""
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "candidates": [
+                {
+                    "content": {
+                        "parts": [
+                            {
+                                "inlineData": {
+                                    "mimeType": "image/png",
+                                    "data": "base64_encoded_image_data",
+                                }
+                            }
+                        ]
+                    },
+                    "groundingMetadata": {
+                        "webSearchQueries": ["eiffel tower", "paris skyline"]
+                    },
+                }
+            ],
+            "usageMetadata": {
+                "promptTokenCount": 93,
+                "candidatesTokenCount": 17,
+                "totalTokenCount": 110,
+            },
+        }
+        mock_response.headers = {}
+
+        from litellm.types.utils import ImageResponse
+
+        result = self.config.transform_image_generation_response(
+            model="gemini-2.5-flash-image",
+            raw_response=mock_response,
+            model_response=ImageResponse(),
+            logging_obj=MagicMock(),
+            request_data={},
+            optional_params={},
+            litellm_params={},
+            encoding=None,
+        )
+
+        assert result.usage.web_search_requests == 2
+
 
 class TestVertexAIImagenImageGenerationConfig:
     def setup_method(self):

--- a/tests/test_litellm/llms/vertex_ai/image_generation/test_vertex_ai_image_generation_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/image_generation/test_vertex_ai_image_generation_transformation.py
@@ -139,6 +139,24 @@ class TestVertexAIGeminiImageGenerationConfig:
         )
         assert request["generationConfig"]["imageConfig"]["imageSize"] == "4K"
 
+    def test_map_openai_params_web_search_options(self):
+        """Test web_search_options maps to googleSearch tool"""
+        result = self.config.map_openai_params(
+            {"web_search_options": {}}, {}, "gemini-3.1-flash-image-preview", False
+        )
+        assert result["tools"] == [{"googleSearch": {}}]
+
+    def test_transform_image_generation_request_with_web_search_tools(self):
+        """Test request transformation includes googleSearch tools"""
+        request = self.config.transform_image_generation_request(
+            model="gemini-3.1-flash-image-preview",
+            prompt="Generate an image of the latest iPhone",
+            optional_params={"tools": [{"googleSearch": {}}]},
+            litellm_params={},
+            headers={},
+        )
+        assert request["tools"] == [{"googleSearch": {}}]
+
     def test_transform_image_generation_request_with_candidate_count(self):
         """Test request transformation with candidate_count"""
         request = self.config.transform_image_generation_request(

--- a/tests/test_litellm/llms/vertex_ai/image_generation/test_vertex_ai_image_generation_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/image_generation/test_vertex_ai_image_generation_transformation.py
@@ -157,6 +157,26 @@ class TestVertexAIGeminiImageGenerationConfig:
         )
         assert request["tools"] == [{"googleSearch": {}}]
 
+    def test_transform_image_generation_request_forwards_tool_config(self):
+        """Test request transformation forwards toolConfig side-effects from tool mapping"""
+        mapped = self.config.map_openai_params(
+            {"tools": [{"googleMaps": {"latitude": 37.7, "longitude": -122.4}}]},
+            {},
+            "gemini-3.1-flash-image-preview",
+            False,
+        )
+        request = self.config.transform_image_generation_request(
+            model="gemini-3.1-flash-image-preview",
+            prompt="Generate an image of a coffee shop nearby",
+            optional_params=mapped,
+            litellm_params={},
+            headers={},
+        )
+        assert request["tools"] == [{"googleMaps": {}}]
+        assert request["toolConfig"] == {
+            "retrievalConfig": {"latLng": {"latitude": 37.7, "longitude": -122.4}}
+        }
+
     def test_transform_image_generation_request_with_candidate_count(self):
         """Test request transformation with candidate_count"""
         request = self.config.transform_image_generation_request(


### PR DESCRIPTION
## Summary
- Map `tools` and `web_search_options` to `googleSearch` on Gemini image `:generateContent` requests
- Support Google AI Studio (`gemini/`) and Vertex AI Gemini image models (e.g. `gemini-3.1-flash-image-preview`)
- Include `tools` and `web_search_options` in `get_optional_params_image_gen` so proxy `/v1/images/generations` passes them through


FIxes LIT-3575
http://github.com/BerriAI/litellm-docs/pull/324

## Test plan
- [x] `pytest tests/test_litellm/llms/gemini/test_gemini_image_generation_transformation.py::test_gemini_image_generation_web_search_options_maps_to_google_search_tool -v`
- [x] `pytest tests/test_litellm/llms/gemini/test_gemini_image_generation_transformation.py::test_gemini_image_generation_openai_web_search_tool_maps_to_google_search -v`
- [x] `pytest tests/test_litellm/llms/vertex_ai/image_generation/test_vertex_ai_image_generation_transformation.py::TestVertexAIGeminiImageGenerationConfig::test_map_openai_params_web_search_options -v`
- [x] `pytest tests/test_litellm/llms/vertex_ai/image_generation/test_vertex_ai_image_generation_transformation.py::TestVertexAIGeminiImageGenerationConfig::test_transform_image_generation_request_with_web_search_tools -v`

<img width="1102" height="826" alt="image" src="https://github.com/user-attachments/assets/ce57e45d-05e2-4558-86fb-666e598cae01" />