### PR TITLE
fix(mcp): propagate model into model_call_details for passthrough tool calls

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -2535,6 +2535,7 @@ if MCP_AVAILABLE:
                 standard_logging_mcp_tool_call
             )
             litellm_logging_obj.model = f"MCP: {name}"
+            litellm_logging_obj.model_call_details["model"] = f"MCP: {name}"
         # Resolve the MCP server early so BYOK checks and credential injection
         # apply to ALL dispatch paths (local tool registry AND managed MCP server).
         if mcp_server is None:

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -5363,3 +5363,88 @@ async def test_create_mcp_client_sampling_enabled():
 
     client = await manager._create_mcp_client(server=server)
     assert client._sampling_callback is not None
+
+
+@pytest.mark.asyncio
+async def test_execute_mcp_tool_sets_model_in_model_call_details():
+    """Regression test: MCP passthrough tools/call spend logs had model="".
+
+    The @client decorator on call_mcp_tool creates the logging object via
+    function_setup without a "model" kwarg, so model_call_details["model"]
+    starts as None. execute_mcp_tool set logging_obj.model as an instance
+    attribute only, which the spend-log writer never reads (it reads
+    kwargs["model"] from model_call_details). The tools/call rows therefore
+    persisted with an empty model while list_tools rows showed
+    "MCP: list_tools".
+    """
+    import uuid
+    from datetime import timezone
+
+    from litellm.proxy._experimental.mcp_server import server as mcp_module
+    from litellm.proxy._types import LitellmUserRoles
+    from litellm.utils import Rules, function_setup
+
+    user = UserAPIKeyAuth(
+        api_key="sk-user",
+        user_id="alice",
+        user_role=LitellmUserRoles.INTERNAL_USER.value,
+    )
+
+    fake_server = MagicMock()
+    fake_server.name = "openapi-petstore"
+    fake_server.is_byok = False
+    fake_server.auth_type = None
+    fake_server.mcp_info = None
+    fake_server.server_id = "srv-1"
+    fake_server.server_name = "openapi-petstore"
+
+    fake_tool = MagicMock()
+    fake_tool.name = "list_pets"
+
+    start_time = datetime.now(timezone.utc)
+    litellm_logging_obj, _ = function_setup(
+        original_function="call_mcp_tool",
+        rules_obj=Rules(),
+        start_time=start_time,
+        litellm_call_id=str(uuid.uuid4()),
+        name="list_pets",
+        arguments={"limit": 10},
+    )
+    assert litellm_logging_obj.model_call_details.get("model") is None
+
+    with (
+        patch.object(
+            mcp_module.global_mcp_server_manager,
+            "_get_mcp_server_from_tool_name",
+            return_value=fake_server,
+        ),
+        patch.object(
+            mcp_module.global_mcp_server_manager,
+            "pre_call_tool_check",
+            new=AsyncMock(return_value={}),
+        ),
+        patch.object(
+            mcp_module.global_mcp_tool_registry,
+            "get_tool",
+            return_value=fake_tool,
+        ),
+        patch(
+            "litellm.proxy._experimental.mcp_server.server._handle_local_mcp_tool",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch(
+            "litellm.proxy._experimental.mcp_server.server.MCPRequestHandler.is_tool_allowed",
+            return_value=True,
+        ),
+    ):
+        await mcp_module.execute_mcp_tool(
+            name="list_pets",
+            arguments={"limit": 10},
+            allowed_mcp_servers=[fake_server],
+            start_time=start_time,
+            user_api_key_auth=user,
+            litellm_logging_obj=litellm_logging_obj,
+        )
+
+    assert litellm_logging_obj.model_call_details["model"] == "MCP: list_pets"
+    assert litellm_logging_obj.model == "MCP: list_pets"

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -5367,15 +5367,11 @@ async def test_create_mcp_client_sampling_enabled():
 
 @pytest.mark.asyncio
 async def test_execute_mcp_tool_sets_model_in_model_call_details():
-    """Regression test: MCP passthrough tools/call spend logs had model="".
+    """Regression test: MCP tools/call spend logs persisted with model="".
 
-    The @client decorator on call_mcp_tool creates the logging object via
-    function_setup without a "model" kwarg, so model_call_details["model"]
-    starts as None. execute_mcp_tool set logging_obj.model as an instance
-    attribute only, which the spend-log writer never reads (it reads
-    kwargs["model"] from model_call_details). The tools/call rows therefore
-    persisted with an empty model while list_tools rows showed
-    "MCP: list_tools".
+    execute_mcp_tool set logging_obj.model only; the spend-log writer reads
+    model_call_details["model"], which stays None when function_setup builds
+    the logging object without a "model" kwarg.
     """
     import uuid
     from datetime import timezone


### PR DESCRIPTION
## Relevant issues

Addresses the blank model name in #23878; MCP tools/call spend log rows now persist `MCP: <tool_name>` instead of an empty model, so they can be filtered by model in the Logs UI. The `call_type` filter requested in that issue is out of scope here.

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

Before this fix the tools/call row persisted with `"model": ""` (only list_tools rows showed `MCP: list_tools`). After the fix the row shows `"MCP: <tool_name>"`, the Logs UI now show entries for mcp tool calls 

<img width="995" height="582" alt="image" src="https://github.com/user-attachments/assets/16b7a2de-ca06-48da-a870-dd9e5dd6ea38" />

## Type

🐛 Bug Fix

## Changes

The `@client` decorator on `call_mcp_tool` creates the logging object via `function_setup` without a `model` kwarg, so `model_call_details["model"]` starts as `None`. `execute_mcp_tool` only set `logging_obj.model` as an instance attribute, which the spend-log writer never reads; it reads `kwargs["model"]` from `model_call_details`. MCP passthrough tools/call rows therefore persisted with `model=""` while list_tools rows showed `MCP: list_tools`, degrading the Logs UI display and bucketing all MCP tool spend under an empty model in DailyUserSpend.

This PR propagates the model into `model_call_details` alongside the existing attribute assignment in `litellm/proxy/_experimental/mcp_server/server.py` (one line), so the `StandardLoggingPayload` and SpendLogs writer pick it up. Covers the /mcp passthrough, REST /mcp-rest/tools/call, and orchestrated paths; the orchestrated path already passed `model` into `function_setup`, so this is a no-op there.

Includes a regression test (`test_execute_mcp_tool_sets_model_in_model_call_details`) that builds the logging object through the real `function_setup` path, mirroring how the `@client` decorator constructs it in production, and asserts `model_call_details["model"]` is set after `execute_mcp_tool`. The test fails without the one-line fix.