### PR TITLE
fix(anthropic): use provider output_tokens_details.thinking_tokens for redacted adaptive thinking blocks

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -2225,12 +2225,24 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             text_tokens=raw_input_tokens,
         )
         # Always populate completion_token_details, not just when there's reasoning_content
-        estimated_reasoning_tokens = (
-            token_counter(text=reasoning_content, count_response_tokens=True)
-            if reasoning_content
-            else 0
-        )
-        reasoning_tokens = min(estimated_reasoning_tokens, completion_tokens)
+        # Prefer the provider-reported thinking_tokens when present. Redacted thinking blocks
+        # (Vertex AI Opus 4.7/4.8 with adaptive thinking) return empty thinking text but
+        # carry the real count in output_tokens_details.thinking_tokens (fixes #30099).
+        _output_tokens_details = _usage.get("output_tokens_details")
+        _provider_thinking_tokens: Optional[int] = None
+        if isinstance(_output_tokens_details, dict):
+            _tt = _output_tokens_details.get("thinking_tokens")
+            if isinstance(_tt, (int, float)) and _tt > 0:
+                _provider_thinking_tokens = int(_tt)
+        if _provider_thinking_tokens is not None:
+            reasoning_tokens = min(_provider_thinking_tokens, completion_tokens)
+        else:
+            estimated_reasoning_tokens = (
+                token_counter(text=reasoning_content, count_response_tokens=True)
+                if reasoning_content
+                else 0
+            )
+            reasoning_tokens = min(estimated_reasoning_tokens, completion_tokens)
         completion_token_details = CompletionTokensDetailsWrapper(
             reasoning_tokens=reasoning_tokens if reasoning_tokens > 0 else 0,
             text_tokens=(

--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -2150,6 +2150,28 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             ephemeral_1h_input_tokens=cache_creation.get("ephemeral_1h_input_tokens"),
         )
 
+    @staticmethod
+    def _resolve_provider_thinking_tokens(usage: Mapping[str, Any]) -> int | None:
+        """Return Anthropic's own thinking token count, or None when it is absent.
+
+        Anthropic reports adaptive-thinking usage in
+        ``output_tokens_details.thinking_tokens``. When the thinking blocks come back
+        redacted there is no thinking text to estimate from, so the text estimator
+        returns 0 and reasoning_tokens is reported as 0 even though those tokens were
+        billed. Preferring the provider count fixes that, and the estimator stays as
+        the fallback for responses that carry no details block.
+        """
+        details: Final = usage.get("output_tokens_details")
+        if not isinstance(details, Mapping):
+            return None
+        thinking_tokens: Final = details.get("thinking_tokens")
+        # bool is a subclass of int, so exclude it explicitly
+        if isinstance(thinking_tokens, bool) or not isinstance(thinking_tokens, (int, float)):
+            return None
+        if thinking_tokens <= 0:
+            return None
+        return int(thinking_tokens)
+
     def calculate_usage(
         self,
         usage_object: dict,
@@ -2223,10 +2245,18 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             text_tokens=raw_input_tokens,
         )
         # Always populate completion_token_details, not just when there's reasoning_content
+        # Prefer Anthropic's own thinking token count when the response carries one.
+        # Redacted thinking blocks (Vertex AI Opus 4.7/4.8 on adaptive thinking) return no
+        # thinking text, so the estimator below sees an empty string and yields 0 while the
+        # real count is reported in output_tokens_details.thinking_tokens. Fixes #30099.
+        provider_thinking_tokens: Final = self._resolve_provider_thinking_tokens(_usage)
         estimated_reasoning_tokens: Final = (
             token_counter(text=reasoning_content, count_response_tokens=True) if reasoning_content else 0
         )
-        reasoning_tokens: Final = min(estimated_reasoning_tokens, completion_tokens)
+        reasoning_tokens: Final = min(
+            estimated_reasoning_tokens if provider_thinking_tokens is None else provider_thinking_tokens,
+            completion_tokens,
+        )
         completion_token_details: Final = CompletionTokensDetailsWrapper(
             reasoning_tokens=max(0, reasoning_tokens),
             text_tokens=(completion_tokens - reasoning_tokens if reasoning_tokens > 0 else completion_tokens),

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -5985,3 +5985,64 @@ def test_is_anthropic_usage_object_rejects_responses_api_usage():
             "output_tokens_details": {"reasoning_tokens": 0},
         }
     )
+
+
+def test_calculate_usage_prefers_provider_thinking_tokens():
+    """Redacted thinking blocks carry no text, so reasoning_tokens must come from
+    output_tokens_details.thinking_tokens rather than the text estimator.
+
+    Regression for https://github.com/BerriAI/litellm/issues/30099 - Vertex AI
+    Opus 4.7/4.8 on adaptive thinking bills thinking tokens but returns the blocks
+    redacted, which made the estimator report reasoning_tokens=0.
+    """
+    config = AnthropicConfig()
+
+    usage_object = {
+        "input_tokens": 100,
+        "output_tokens": 1220,
+        "output_tokens_details": {"thinking_tokens": 1152},
+    }
+    usage = config.calculate_usage(usage_object=usage_object, reasoning_content=None)
+
+    assert usage.completion_tokens == 1220
+    assert usage.completion_tokens_details.reasoning_tokens == 1152
+    assert usage.completion_tokens_details.text_tokens == 1220 - 1152
+
+
+def test_calculate_usage_falls_back_to_estimator_without_provider_thinking_tokens():
+    """With no output_tokens_details the estimator path must still be used."""
+    config = AnthropicConfig()
+
+    usage_object = {"input_tokens": 10, "output_tokens": 500}
+    usage = config.calculate_usage(usage_object=usage_object, reasoning_content="some thinking text")
+
+    assert usage.completion_tokens_details.reasoning_tokens > 0
+
+
+def test_calculate_usage_ignores_non_positive_provider_thinking_tokens():
+    """A zero or missing thinking_tokens must not suppress the estimator fallback."""
+    config = AnthropicConfig()
+
+    usage_object = {
+        "input_tokens": 10,
+        "output_tokens": 500,
+        "output_tokens_details": {"thinking_tokens": 0},
+    }
+    usage = config.calculate_usage(usage_object=usage_object, reasoning_content="some thinking text")
+
+    assert usage.completion_tokens_details.reasoning_tokens > 0
+
+
+def test_calculate_usage_caps_provider_thinking_tokens_at_completion_tokens():
+    """A provider count larger than output_tokens must not produce negative text_tokens."""
+    config = AnthropicConfig()
+
+    usage_object = {
+        "input_tokens": 10,
+        "output_tokens": 100,
+        "output_tokens_details": {"thinking_tokens": 999},
+    }
+    usage = config.calculate_usage(usage_object=usage_object, reasoning_content=None)
+
+    assert usage.completion_tokens_details.reasoning_tokens == 100
+    assert usage.completion_tokens_details.text_tokens == 0


### PR DESCRIPTION
## Problem

When Claude Opus 4.7 / 4.8 is used with adaptive thinking on Vertex AI, the model returns **redacted thinking blocks** — the `thinking` field is an empty string and the block carries a `signature` instead.

`AnthropicConfig.calculate_usage` estimates `reasoning_tokens` by counting tokens in `reasoning_content`. Because redacted blocks have no visible text, `reasoning_content` is `""` and the estimate is `0`. The field `usage.reasoning_tokens` (or the equivalent `CompletionTokensDetails.reasoning_tokens`) is therefore always `0` for these responses, even though the model did substantial reasoning.

Vertex AI (and Anthropic direct API) already reports the authoritative count in the `usage` object under `output_tokens_details.thinking_tokens`.

Fixes #30099.

## Root cause

`transformation.py` `calculate_usage` (line ~2228 before this PR):

```python
estimated_reasoning_tokens = (
    token_counter(text=reasoning_content, count_response_tokens=True)
    if reasoning_content
    else 0
)
reasoning_tokens = min(estimated_reasoning_tokens, completion_tokens)
```

For a redacted thinking block `reasoning_content == ""`, so `estimated_reasoning_tokens == 0`.

## Fix

Read `output_tokens_details.thinking_tokens` from the usage object first. If it is present and positive, use it as-is (capped by `completion_tokens`). Fall back to the text-based estimate only when the field is absent, preserving backward compatibility with providers that do not emit `output_tokens_details`.

```python
_output_tokens_details = _usage.get("output_tokens_details")
_provider_thinking_tokens: Optional[int] = None
if isinstance(_output_tokens_details, dict):
    _tt = _output_tokens_details.get("thinking_tokens")
    if isinstance(_tt, (int, float)) and _tt > 0:
        _provider_thinking_tokens = int(_tt)
if _provider_thinking_tokens is not None:
    reasoning_tokens = min(_provider_thinking_tokens, completion_tokens)
else:
    estimated_reasoning_tokens = (
        token_counter(text=reasoning_content, count_response_tokens=True)
        if reasoning_content
        else 0
    )
    reasoning_tokens = min(estimated_reasoning_tokens, completion_tokens)
```

## Files changed

- `litellm/llms/anthropic/chat/transformation.py` — `AnthropicConfig.calculate_usage`

## Testing

Verified against the usage payload from the issue:

```json
{
  "input_tokens": 10,
  "output_tokens": 1220,
  "output_tokens_details": { "thinking_tokens": 1152 }
}
```

Before fix: `reasoning_tokens = 0` (redacted thinking text is empty).
After fix: `reasoning_tokens = 1152` (read directly from provider-reported field).

For providers that do not return `output_tokens_details` the fallback path is unchanged.
