### PR TITLE
fix(mcp): drop orphaned per-user credential rows when an MCP server is deleted

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/db.py
+++ b/litellm/proxy/_experimental/mcp_server/db.py
@@ -568,10 +568,12 @@ async def delete_mcp_server(
     """
     Delete the mcp server from the db by server_id
 
-    The server-row delete is the commit point. Per-user env var rows have no FK
-    cascade, so they are cleaned up afterwards on a best-effort basis: a transient
-    failure there leaves only orphaned rows pointing at a now-missing server and
-    must not turn a successful delete into a caller-visible error.
+    The server-row delete is the commit point. Per-user credential and env var
+    rows have no FK cascade, so they are cleaned up afterwards on a best-effort
+    basis: a transient failure there leaves only orphaned rows pointing at a
+    now-missing server and must not turn a successful delete into a
+    caller-visible error. Each table is cleaned independently so a failure on one
+    still attempts the other.
 
     Returns the deleted mcp server record if it exists, otherwise None
     """
@@ -581,17 +583,20 @@ async def delete_mcp_server(
         },
     )
     if deleted_server is not None:
-        try:
-            await prisma_client.db.litellm_mcpuserenvvars.delete_many(
-                where={"server_id": server_id}
-            )
-        except Exception as e:
-            verbose_proxy_logger.warning(
-                "MCP server %s deleted but per-user env var cleanup failed; "
-                "orphaned rows can be removed on a later delete: %s",
-                server_id,
-                e,
-            )
+        for model, label in (
+            (prisma_client.db.litellm_mcpusercredentials, "credential"),
+            (prisma_client.db.litellm_mcpuserenvvars, "env var"),
+        ):
+            try:
+                await model.delete_many(where={"server_id": server_id})
+            except Exception as e:
+                verbose_proxy_logger.warning(
+                    "MCP server %s deleted but per-user %s cleanup failed; "
+                    "orphaned rows can be removed on a later delete: %s",
+                    server_id,
+                    label,
+                    e,
+                )
     return deleted_server
 
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_env_vars.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_env_vars.py
@@ -872,6 +872,7 @@ def _mock_env_vars_prisma(row=None):
     prisma.db.litellm_mcpuserenvvars.find_many = AsyncMock(return_value=[])
     prisma.db.litellm_mcpuserenvvars.upsert = AsyncMock()
     prisma.db.litellm_mcpuserenvvars.delete_many = AsyncMock()
+    prisma.db.litellm_mcpusercredentials.delete_many = AsyncMock()
     return prisma
 
 
@@ -1249,6 +1250,64 @@ async def test_delete_mcp_server_succeeds_when_orphan_cleanup_fails():
     result = await delete_mcp_server(prisma, "srv-1")
 
     assert result is deleted
+    prisma.db.litellm_mcpuserenvvars.delete_many.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_delete_mcp_server_removes_orphaned_user_credentials():
+    """Deleting a server must also drop every user's stored BYOK/OAuth credential
+    rows for it; there is no FK cascade, so skipping this leaves encrypted secrets
+    pointing at a now-missing server."""
+    from unittest.mock import AsyncMock
+
+    from litellm.proxy._experimental.mcp_server.db import delete_mcp_server
+
+    prisma = _mock_env_vars_prisma()
+    prisma.db.litellm_mcpservertable.delete = AsyncMock(return_value=object())
+
+    await delete_mcp_server(prisma, "srv-1")
+
+    prisma.db.litellm_mcpusercredentials.delete_many.assert_awaited_once()
+    call = prisma.db.litellm_mcpusercredentials.delete_many.call_args
+    assert call.kwargs["where"] == {"server_id": "srv-1"}
+
+
+@pytest.mark.asyncio
+async def test_delete_mcp_server_skips_credential_cleanup_when_server_missing():
+    """A no-op delete (server not found) must not touch the credential table."""
+    from unittest.mock import AsyncMock
+
+    from litellm.proxy._experimental.mcp_server.db import delete_mcp_server
+
+    prisma = _mock_env_vars_prisma()
+    prisma.db.litellm_mcpservertable.delete = AsyncMock(return_value=None)
+
+    result = await delete_mcp_server(prisma, "srv-1")
+
+    assert result is None
+    prisma.db.litellm_mcpusercredentials.delete_many.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_delete_mcp_server_credential_cleanup_failure_still_cleans_env_vars():
+    """Each per-user table is cleaned independently: a failure dropping credential
+    rows must not skip the env var cleanup (or vice versa), and the delete must
+    still succeed for the caller."""
+    from unittest.mock import AsyncMock
+
+    from litellm.proxy._experimental.mcp_server.db import delete_mcp_server
+
+    deleted = object()
+    prisma = _mock_env_vars_prisma()
+    prisma.db.litellm_mcpservertable.delete = AsyncMock(return_value=deleted)
+    prisma.db.litellm_mcpusercredentials.delete_many = AsyncMock(
+        side_effect=Exception("connection pool exhausted")
+    )
+
+    result = await delete_mcp_server(prisma, "srv-1")
+
+    assert result is deleted
+    prisma.db.litellm_mcpusercredentials.delete_many.assert_awaited_once()
     prisma.db.litellm_mcpuserenvvars.delete_many.assert_awaited_once()
 
 


### PR DESCRIPTION
## Relevant issues
- MCP User credentials still stored in DB after the server is removed. Could cause overflowing DB
- Doesn't affect behavior since user credentials are keyed by (user_id, server_id). And if the user adds the same server back, they would have a new server_id, so the credentials wouldn't work

Main Fix:
- Added a post-commit cleanup to clear the credential table, loops over per-user table to delete credentials if tied to that server_id

## Linear ticket
Resolves LIT-3709

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

<img width="652" height="97" alt="image" src="https://github.com/user-attachments/assets/ed4ac910-16f5-4112-8fa0-7d60b77f3129" />
<img width="428" height="89" alt="Screenshot 2026-06-10 at 12 42 50 PM" src="https://github.com/user-attachments/assets/17a34bfc-4af9-4c9c-af11-142da0e7bd2a" />

Verified end to end on a live deployment running this PR's build (gateway, backend, and UI images all on `pr-30141-<sha>`), driving the real OAuth BYOK flow from the dashboard and inspecting the database directly. The check queries `LiteLLM_MCPUserCredentials` read-only and never prints the credential value.

1. Added a Slack MCP server through the dashboard (`auth_type=oauth2`, `https://mcp.slack.com/mcp`) and completed the authorize flow, which persists the user's OAuth token to `LiteLLM_MCPUserCredentials`.

2. Confirmed the credential landed in the DB:

```
slack server_id = 27309460-8959-4eca-ade5-5c72a8b28bae   created 2026-06-10 19:38:39 UTC
credential row:  user_id=default_user_id  server_id=27309460-...  (encrypted, b64 len 1232)  updated 19:38:39 UTC
```

3. Deleted the Slack server from the dashboard.

4. Re-queried the same `server_id`:

```
server row for 27309460-8959-4eca-ade5-5c72a8b28bae:      0
credential rows for 27309460-8959-4eca-ade5-5c72a8b28bae: 0
VERDICT: cleaned up
```

The OAuth token was removed in the same operation as the server delete, instead of being left behind.

The contrast against the old behavior was visible in the same database: several Slack credential rows from earlier create/authorize/delete cycles on a pre-fix build are still present as orphans (their `server_id` no longer exists in `LiteLLM_MCPServerTable`), whereas the server deleted under this build left none. That is the leak this PR closes. The pre-existing orphans are left untouched on purpose; this change prevents new orphans, and a separate config-aware cleanup handles the historical rows.

## Type

🐛 Bug Fix

## Changes

Deleting an MCP server already dropped its per-user env var rows (`LiteLLM_MCPUserEnvVars`) but left the per-user credential rows (`LiteLLM_MCPUserCredentials`, which hold BYOK API keys and OAuth tokens) behind, so every server deletion leaked encrypted secrets that nothing referenced anymore.

A database foreign key with `ON DELETE CASCADE` is not viable here: config-defined MCP servers get a deterministic hashed `server_id` and are never persisted to `LiteLLM_MCPServerTable`, so a credential row can legitimately reference a server that has no row in that table. A real FK would reject those inserts outright.

The fix extends the existing best-effort, post-commit cleanup in `delete_mcp_server` to also clear the credential table. Each per-user table is now cleaned independently so a transient failure on one still attempts the other, and a cleanup failure never turns an already-committed server delete into a caller-visible error (which would otherwise make the retry 404).

Note this only prevents future orphans. Rows already orphaned on an existing deployment need a separate, config-aware one-off cleanup, because from the DB alone an orphan is indistinguishable from a valid config-server credential.
