### PR TITLE
fix(anthropic): preserve text delta when opening stream block

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
@@ -291,7 +291,10 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
             "thinking_delta": "thinking",
             "signature_delta": "signature",
         }
-        payload_key = delta_payload_keys.get(delta.get("type"))
+        delta_type = delta.get("type")
+        if not isinstance(delta_type, str):
+            return False
+        payload_key = delta_payload_keys.get(delta_type)
         return bool(payload_key and delta.get(payload_key))
 
     def __next__(self):  # noqa: PLR0915

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
@@ -276,6 +276,24 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
             cache_read_input_tokens=0,
         )
 
+    def _should_queue_block_transition_delta(
+        self, processed_chunk: Dict[str, Any]
+    ) -> bool:
+        if processed_chunk.get("type") != "content_block_delta":
+            return False
+        delta = processed_chunk.get("delta")
+        if not isinstance(delta, dict):
+            return False
+
+        delta_payload_keys = {
+            "input_json_delta": "partial_json",
+            "text_delta": "text",
+            "thinking_delta": "thinking",
+            "signature_delta": "signature",
+        }
+        payload_key = delta_payload_keys.get(delta.get("type"))
+        return bool(payload_key and delta.get(payload_key))
+
     def __next__(self):  # noqa: PLR0915
         from .transformation import LiteLLMAnthropicMessagesAdapter
 
@@ -373,12 +391,8 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
 
                 if should_start_new_block and not self.sent_content_block_finish:
                     # Queue the sequence: content_block_stop -> content_block_start
-                    # For text blocks the trigger chunk is not emitted as a separate
-                    # delta because content_block_start carries the information.
-                    # For tool_use blocks we must also emit the trigger chunk's delta
-                    # when it carries input_json_delta data, because some providers
-                    # (e.g. xAI, Gemini) include tool arguments in the same streaming
-                    # chunk as the function name/id.
+                    # If the trigger chunk also carries content, queue that delta too
+                    # so text, thinking, signatures, and tool args are preserved.
 
                     # 1. Stop current content block
                     self.chunk_queue.append(
@@ -397,14 +411,8 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
                         }
                     )
 
-                    # 3. If the trigger chunk carries tool argument data, queue it
-                    # so the input_json_delta is not silently dropped.
-                    if (
-                        processed_chunk.get("type") == "content_block_delta"
-                        and isinstance(processed_chunk.get("delta"), dict)
-                        and processed_chunk["delta"].get("type") == "input_json_delta"
-                        and processed_chunk["delta"].get("partial_json")
-                    ):
+                    # 3. If the trigger chunk carries delta data, queue it.
+                    if self._should_queue_block_transition_delta(processed_chunk):
                         self.chunk_queue.append(processed_chunk)
 
                     self.sent_content_block_finish = False
@@ -615,12 +623,9 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
                 if not self.queued_usage_chunk:
                     if should_start_new_block and not self.sent_content_block_finish:
                         # Queue the sequence: content_block_stop -> content_block_start
-                        # For text blocks the trigger chunk is not emitted as a separate
-                        # delta because content_block_start carries the information.
-                        # For tool_use blocks we must also emit the trigger chunk's delta
-                        # when it carries input_json_delta data, because some providers
-                        # (e.g. xAI, Gemini) include tool arguments in the same streaming
-                        # chunk as the function name/id.
+                        # If the trigger chunk also carries content, queue that delta
+                        # too so text, thinking, signatures, and tool args are
+                        # preserved.
 
                         # 1. Stop current content block
                         self.chunk_queue.append(
@@ -637,15 +642,8 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
                             }
                         )
 
-                        # 3. If the trigger chunk carries tool argument data, queue it
-                        # so the input_json_delta is not silently dropped.
-                        if (
-                            processed_chunk.get("type") == "content_block_delta"
-                            and isinstance(processed_chunk.get("delta"), dict)
-                            and processed_chunk["delta"].get("type")
-                            == "input_json_delta"
-                            and processed_chunk["delta"].get("partial_json")
-                        ):
+                        # 3. If the trigger chunk carries delta data, queue it.
+                        if self._should_queue_block_transition_delta(processed_chunk):
                             self.chunk_queue.append(processed_chunk)
 
                         # Reset state for new block

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -2502,7 +2502,7 @@ class TestAnthropicStreamWrapperToolArgs:
 class TestAnthropicStreamWrapperTextDeltas:
     """Regression test for Anthropic streams that switch back to text output."""
 
-    def _build_chunks(self):
+    def _build_thinking_to_text_chunks(self):
         thinking_chunk = ModelResponseStream(
             id="chatcmpl-456",
             created=1700000000,
@@ -2559,6 +2559,63 @@ class TestAnthropicStreamWrapperTextDeltas:
 
         return [thinking_chunk, text_chunk, finish_chunk]
 
+    def _build_text_to_thinking_chunks(self):
+        text_chunk = ModelResponseStream(
+            id="chatcmpl-789",
+            created=1700000000,
+            model="claude-code-proxy",
+            object="chat.completion.chunk",
+            choices=[
+                StreamingChoices(
+                    index=0,
+                    delta=Delta(content="I will check that", role="assistant"),
+                    finish_reason=None,
+                )
+            ],
+        )
+
+        thinking_chunk = ModelResponseStream(
+            id="chatcmpl-789",
+            created=1700000000,
+            model="claude-code-proxy",
+            object="chat.completion.chunk",
+            choices=[
+                StreamingChoices(
+                    index=0,
+                    delta=Delta(
+                        reasoning_content="Reading the inputs",
+                        thinking_blocks=[
+                            {
+                                "type": "thinking",
+                                "thinking": "Reading the inputs",
+                                "signature": None,
+                            }
+                        ],
+                        content="",
+                        role="assistant",
+                    ),
+                    finish_reason=None,
+                )
+            ],
+        )
+
+        finish_chunk = ModelResponseStream(
+            id="chatcmpl-789",
+            created=1700000000,
+            model="claude-code-proxy",
+            object="chat.completion.chunk",
+            choices=[
+                StreamingChoices(
+                    index=0,
+                    delta=Delta(),
+                    finish_reason="stop",
+                )
+            ],
+            usage=Usage(prompt_tokens=12, completion_tokens=4, total_tokens=16),
+        )
+
+        return [text_chunk, thinking_chunk, finish_chunk]
+
     def _make_stream_wrapper(self, chunks):
         from litellm.llms.anthropic.experimental_pass_through.adapters.streaming_iterator import (
             AnthropicStreamWrapper,
@@ -2599,8 +2656,19 @@ class TestAnthropicStreamWrapperTextDeltas:
             and e["delta"].get("text")
         ]
 
+    def _find_thinking_deltas(self, events):
+        return [
+            e
+            for e in events
+            if isinstance(e, dict)
+            and e.get("type") == "content_block_delta"
+            and isinstance(e.get("delta"), dict)
+            and e["delta"].get("type") == "thinking_delta"
+            and e["delta"].get("thinking")
+        ]
+
     def test_sync_text_delta_not_dropped_when_text_block_starts(self):
-        chunks = self._build_chunks()
+        chunks = self._build_thinking_to_text_chunks()
         wrapper = self._make_stream_wrapper(chunks)
 
         events = list(wrapper)
@@ -2612,7 +2680,7 @@ class TestAnthropicStreamWrapperTextDeltas:
 
     @pytest.mark.asyncio
     async def test_async_text_delta_not_dropped_when_text_block_starts(self):
-        chunks = self._build_chunks()
+        chunks = self._build_thinking_to_text_chunks()
         wrapper = self._make_stream_wrapper(chunks)
 
         events = []
@@ -2623,6 +2691,32 @@ class TestAnthropicStreamWrapperTextDeltas:
 
         assert [delta["delta"]["text"] for delta in text_deltas] == [
             "Here is the answer"
+        ]
+
+    def test_sync_thinking_delta_not_dropped_when_thinking_block_starts(self):
+        chunks = self._build_text_to_thinking_chunks()
+        wrapper = self._make_stream_wrapper(chunks)
+
+        events = list(wrapper)
+        thinking_deltas = self._find_thinking_deltas(events)
+
+        assert [delta["delta"]["thinking"] for delta in thinking_deltas] == [
+            "Reading the inputs"
+        ]
+
+    @pytest.mark.asyncio
+    async def test_async_thinking_delta_not_dropped_when_thinking_block_starts(self):
+        chunks = self._build_text_to_thinking_chunks()
+        wrapper = self._make_stream_wrapper(chunks)
+
+        events = []
+        async for event in wrapper:
+            events.append(event)
+
+        thinking_deltas = self._find_thinking_deltas(events)
+
+        assert [delta["delta"]["thinking"] for delta in thinking_deltas] == [
+            "Reading the inputs"
         ]
 
 

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -2499,6 +2499,133 @@ class TestAnthropicStreamWrapperToolArgs:
         assert parsed == {"city": "Tokyo"}
 
 
+class TestAnthropicStreamWrapperTextDeltas:
+    """Regression test for Anthropic streams that switch back to text output."""
+
+    def _build_chunks(self):
+        thinking_chunk = ModelResponseStream(
+            id="chatcmpl-456",
+            created=1700000000,
+            model="claude-code-proxy",
+            object="chat.completion.chunk",
+            choices=[
+                StreamingChoices(
+                    index=0,
+                    delta=Delta(
+                        reasoning_content="Checking the request",
+                        thinking_blocks=[
+                            {
+                                "type": "thinking",
+                                "thinking": "Checking the request",
+                                "signature": None,
+                            }
+                        ],
+                        content="",
+                        role="assistant",
+                    ),
+                    finish_reason=None,
+                )
+            ],
+        )
+
+        text_chunk = ModelResponseStream(
+            id="chatcmpl-456",
+            created=1700000000,
+            model="claude-code-proxy",
+            object="chat.completion.chunk",
+            choices=[
+                StreamingChoices(
+                    index=0,
+                    delta=Delta(content="Here is the answer", role="assistant"),
+                    finish_reason=None,
+                )
+            ],
+        )
+
+        finish_chunk = ModelResponseStream(
+            id="chatcmpl-456",
+            created=1700000000,
+            model="claude-code-proxy",
+            object="chat.completion.chunk",
+            choices=[
+                StreamingChoices(
+                    index=0,
+                    delta=Delta(),
+                    finish_reason="stop",
+                )
+            ],
+            usage=Usage(prompt_tokens=12, completion_tokens=4, total_tokens=16),
+        )
+
+        return [thinking_chunk, text_chunk, finish_chunk]
+
+    def _make_stream_wrapper(self, chunks):
+        from litellm.llms.anthropic.experimental_pass_through.adapters.streaming_iterator import (
+            AnthropicStreamWrapper,
+        )
+
+        class SimpleIterator:
+            def __init__(self, items):
+                self._items = iter(items)
+
+            def __iter__(self):
+                return self
+
+            def __next__(self):
+                return next(self._items)
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                try:
+                    return next(self._items)
+                except StopIteration:
+                    raise StopAsyncIteration
+
+        return AnthropicStreamWrapper(
+            completion_stream=SimpleIterator(chunks),
+            model="claude-code-proxy",
+        )
+
+    def _find_text_deltas(self, events):
+        return [
+            e
+            for e in events
+            if isinstance(e, dict)
+            and e.get("type") == "content_block_delta"
+            and isinstance(e.get("delta"), dict)
+            and e["delta"].get("type") == "text_delta"
+            and e["delta"].get("text")
+        ]
+
+    def test_sync_text_delta_not_dropped_when_text_block_starts(self):
+        chunks = self._build_chunks()
+        wrapper = self._make_stream_wrapper(chunks)
+
+        events = list(wrapper)
+        text_deltas = self._find_text_deltas(events)
+
+        assert [delta["delta"]["text"] for delta in text_deltas] == [
+            "Here is the answer"
+        ]
+
+    @pytest.mark.asyncio
+    async def test_async_text_delta_not_dropped_when_text_block_starts(self):
+        chunks = self._build_chunks()
+        wrapper = self._make_stream_wrapper(chunks)
+
+        events = []
+        async for event in wrapper:
+            events.append(event)
+
+        text_deltas = self._find_text_deltas(events)
+
+        assert [delta["delta"]["text"] for delta in text_deltas] == [
+            "Here is the answer"
+        ]
+
+
 def test_translate_anthropic_tool_choice_none():
     """
     Regression test for issue #24443.

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -2645,6 +2645,63 @@ class TestAnthropicStreamWrapperTextDeltas:
             model="claude-code-proxy",
         )
 
+    def test_should_queue_block_transition_delta_ignores_non_payload_chunks(self):
+        wrapper = self._make_stream_wrapper([])
+
+        assert (
+            wrapper._should_queue_block_transition_delta({"type": "message_delta"})
+            is False
+        )
+        assert (
+            wrapper._should_queue_block_transition_delta(
+                {"type": "content_block_delta", "delta": None}
+            )
+            is False
+        )
+        assert (
+            wrapper._should_queue_block_transition_delta(
+                {
+                    "type": "content_block_delta",
+                    "delta": {"type": None, "text": "hello"},
+                }
+            )
+            is False
+        )
+        assert (
+            wrapper._should_queue_block_transition_delta(
+                {
+                    "type": "content_block_delta",
+                    "delta": {"type": "text_delta", "text": ""},
+                }
+            )
+            is False
+        )
+        assert (
+            wrapper._should_queue_block_transition_delta(
+                {
+                    "type": "content_block_delta",
+                    "delta": {"type": "unknown_delta", "text": "hello"},
+                }
+            )
+            is False
+        )
+
+    def test_should_queue_block_transition_delta_accepts_signature_payload(self):
+        wrapper = self._make_stream_wrapper([])
+
+        assert (
+            wrapper._should_queue_block_transition_delta(
+                {
+                    "type": "content_block_delta",
+                    "delta": {
+                        "type": "signature_delta",
+                        "signature": "signature-value",
+                    },
+                }
+            )
+            is True
+        )
+
     def _find_text_deltas(self, events):
         return [
             e

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_parallel_tool_calls.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_parallel_tool_calls.py
@@ -2,7 +2,6 @@ import os
 import sys
 from typing import List
 
-
 sys.path.insert(0, os.path.abspath("../../../../.."))
 
 from litellm.llms.anthropic.experimental_pass_through.adapters.streaming_iterator import (
@@ -279,6 +278,7 @@ def test_anthropic_stream_wrapper_interleaved_tool_calls_and_text():
         "content_block_delta",  # "NY"}
         "content_block_stop",  # End of first tool_use content block
         "content_block_start",  # "The weather is nice today"
+        "content_block_delta",  # "The weather is nice today."
         "content_block_stop",
         "content_block_start",  # Start of second tool_use content block
         "content_block_delta",  # {"city":
@@ -289,12 +289,24 @@ def test_anthropic_stream_wrapper_interleaved_tool_calls_and_text():
         "content_block_delta",  # " CHI"}
         "content_block_stop",  # End of third tool_use content block
         "content_block_start",  # "The weather is not so nice today"
+        "content_block_delta",  # "The weather is not so nice today."
         "content_block_stop",
         "message_delta",  # Stop reason with merged usage
         "message_stop",  # Final message stop
     ]
 
     assert expected_types == chunk_types
+    text_delta_values = [
+        chunk["delta"]["text"]
+        for chunk in chunks
+        if chunk.get("type") == "content_block_delta"
+        and chunk.get("delta", {}).get("type") == "text_delta"
+        and chunk["delta"].get("text")
+    ]
+    assert text_delta_values == [
+        "The weather is nice today.",
+        "The weather is not so nice today.",
+    ]
 
     get_weather_calls = 0
 


### PR DESCRIPTION
## Relevant issues
Fixes #30014

## Summary
Anthropic stream wrapping was dropping the first non empty delta that opened a new content block unless that delta was a tool argument. In the `/v1/messages` to `/v1/chat/completions` path, that can make the first text chunk after a block transition disappear from the client stream.

This keeps the existing tool argument behavior and also queues non empty text, thinking, signature, and tool argument deltas when they trigger a content block transition. I added sync and async regression coverage for switching from thinking output back to text output.

## Checklist
* [x] I have added meaningful tests
* [x] My PR passes all unit tests on make test-unit
* [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
* [ ] I have requested a Greptile review and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Tests
* `uv run pytest tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py::TestAnthropicStreamWrapperTextDeltas -q`
* `uv run pytest tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py::TestAnthropicStreamWrapperToolArgs tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py::TestAnthropicStreamWrapperTextDeltas -q`
* `uv run pytest tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py -q`
* `uv run ruff check litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py`
* `git diff --cached --check`