### PR TITLE
fix(proxy): coalesce NULL rollup metrics in aggregated daily-activity

### DIFF
--- a/litellm/proxy/management_endpoints/common_daily_activity.py
+++ b/litellm/proxy/management_endpoints/common_daily_activity.py
@@ -699,17 +699,23 @@ _GROUP_DATE_ENDPOINT_API_KEY = 30  # 0b0011110
 
 
 def _record_to_spend_metrics(record: Any) -> SpendMetrics:
-    """Build a SpendMetrics directly from one already-aggregated rollup row."""
+    """Build a SpendMetrics directly from one already-aggregated rollup row.
+
+    SUM() over zero rows is SQL NULL, so rollup rows (notably the grand-total
+    row, which Postgres emits even on an empty match) can carry None values.
+    """
+    prompt_tokens = record.prompt_tokens or 0
+    completion_tokens = record.completion_tokens or 0
     return SpendMetrics(
-        spend=record.spend,
-        prompt_tokens=record.prompt_tokens,
-        completion_tokens=record.completion_tokens,
-        total_tokens=record.prompt_tokens + record.completion_tokens,
-        cache_read_input_tokens=record.cache_read_input_tokens,
-        cache_creation_input_tokens=record.cache_creation_input_tokens,
-        api_requests=record.api_requests,
-        successful_requests=record.successful_requests,
-        failed_requests=record.failed_requests,
+        spend=record.spend or 0.0,
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=prompt_tokens + completion_tokens,
+        cache_read_input_tokens=record.cache_read_input_tokens or 0,
+        cache_creation_input_tokens=record.cache_creation_input_tokens or 0,
+        api_requests=record.api_requests or 0,
+        successful_requests=record.successful_requests or 0,
+        failed_requests=record.failed_requests or 0,
     )
 
 

--- a/tests/test_litellm/proxy/management_endpoints/test_common_daily_activity.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_common_daily_activity.py
@@ -585,3 +585,61 @@ async def test_aggregated_activity_preserves_metadata_for_deleted_keys():
     assert key_data.metadata.key_alias == "toto-test-2"
     assert key_data.metadata.team_id == "69cd4b77-b095-4489-8c46-4f2f31d840a2"
     assert key_data.metrics.spend == 10.0
+
+
+@pytest.mark.asyncio
+async def test_get_daily_activity_aggregated_empty_result_set():
+    """Regression test for the empty-range 500.
+
+    When the date filter matches zero rows, Postgres still emits the
+    grand-total () grouping-set row with every SUM column NULL. The
+    endpoint must return an empty result set with zeroed totals, not
+    crash on None + None.
+    """
+    mock_prisma = MagicMock()
+    mock_prisma.db = MagicMock()
+
+    mock_rows = [
+        {
+            "date": None,
+            "api_key": None,
+            "model": None,
+            "model_group": None,
+            "custom_llm_provider": None,
+            "mcp_namespaced_tool_name": None,
+            "endpoint": None,
+            "group_level": 127,
+            "spend": None,
+            "prompt_tokens": None,
+            "completion_tokens": None,
+            "cache_read_input_tokens": None,
+            "cache_creation_input_tokens": None,
+            "api_requests": None,
+            "successful_requests": None,
+            "failed_requests": None,
+        }
+    ]
+    mock_prisma.db.query_raw = AsyncMock(return_value=mock_rows)
+
+    result = await get_daily_activity_aggregated(
+        prisma_client=mock_prisma,
+        table_name="litellm_dailyuserspend",
+        entity_id_field="user_id",
+        entity_id=None,
+        entity_metadata_field=None,
+        start_date="2026-06-16",
+        end_date="2026-06-16",
+        model=None,
+        api_key=None,
+    )
+
+    assert result.results == []
+    assert result.metadata.total_spend == 0.0
+    assert result.metadata.total_prompt_tokens == 0
+    assert result.metadata.total_completion_tokens == 0
+    assert result.metadata.total_tokens == 0
+    assert result.metadata.total_api_requests == 0
+    assert result.metadata.total_successful_requests == 0
+    assert result.metadata.total_failed_requests == 0
+    assert result.metadata.total_cache_read_input_tokens == 0
+    assert result.metadata.total_cache_creation_input_tokens == 0


### PR DESCRIPTION
## Relevant issues

Fixes #28858

## Linear ticket

Resolves LIT-3674

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

`GET /user/daily/activity/aggregated` for a date range with no spend rows (e.g. a future date) returns 500 instead of an empty result set. The GROUPING SETS query still emits the grand-total `()` rollup row on a zero-row match, but with every `SUM()` column as SQL NULL; `_record_to_spend_metrics` then computes `record.prompt_tokens + record.completion_tokens` → `None + None` → `TypeError`, surfaced as the 500.

**Before:**

```
$ curl -s "http://localhost:4000/user/daily/activity/aggregated?start_date=2026-06-16&end_date=2026-06-16&timezone=0" \
    -H "Authorization: Bearer sk-..."

{"detail":{"error":"Failed to fetch analytics: unsupported operand type(s) for +: 'NoneType' and 'NoneType'"}}
```

**After:**

```
$ curl -s "http://localhost:4000/user/daily/activity/aggregated?start_date=2026-06-16&end_date=2026-06-16&timezone=0" \
    -H "Authorization: Bearer sk-..." | python3 -m json.tool
{
    "results": [],
    "metadata": {
        "total_spend": 0.0,
        "total_prompt_tokens": 0,
        "total_completion_tokens": 0,
        "total_tokens": 0,
        "total_api_requests": 0,
        "total_successful_requests": 0,
        "total_failed_requests": 0,
        "total_cache_read_input_tokens": 0,
        "total_cache_creation_input_tokens": 0,
        "page": 1,
        "total_pages": 1,
        "has_more": false
    }
}
```

## Type

🐛 Bug Fix

## Changes

- `litellm/proxy/management_endpoints/common_daily_activity.py` — coalesce each `SUM()` column to `0`/`0.0` in `_record_to_spend_metrics` before building `SpendMetrics`, computing `total_tokens` from the coalesced values. Non-NULL rows are unaffected (`x or 0` is identity for every value Postgres can emit except NULL). Applies to all `/daily/activity/aggregated` variants (user, team, org, tag, end-user, agent), which share this conversion.
- `tests/test_litellm/proxy/management_endpoints/test_common_daily_activity.py` — regression test `test_get_daily_activity_aggregated_empty_result_set`: empty date range → Postgres returns only the grand-total rollup row with all SUM columns NULL → asserts the endpoint returns `results: []` with all metadata totals zeroed. Fails with the `None + None` `TypeError` without the fix.
