### PR TITLE
fix(callbacks): guard compression/websearch interceptors against non-dict callback_settings

### DIFF
--- a/litellm/integrations/compression_interception/handler.py
+++ b/litellm/integrations/compression_interception/handler.py
@@ -72,8 +72,13 @@ class CompressionInterceptionLogger(CustomLogger):
         compression_params: CompressionInterceptionConfig = {}
         if "compression_interception_params" in litellm_settings:
             compression_params = litellm_settings["compression_interception_params"]
-        elif "compression_interception" in callback_specific_params:
-            compression_params = callback_specific_params["compression_interception"]
+        elif "compression_interception" in callback_specific_params and isinstance(
+            callback_specific_params["compression_interception"], dict
+        ):
+            compression_params = cast(
+                CompressionInterceptionConfig,
+                callback_specific_params["compression_interception"],
+            )
         return CompressionInterceptionLogger.from_config_yaml(compression_params)
 
     async def async_pre_call_deployment_hook(

--- a/litellm/integrations/websearch_interception/handler.py
+++ b/litellm/integrations/websearch_interception/handler.py
@@ -1339,8 +1339,13 @@ class WebSearchInterceptionLogger(CustomLogger):
         websearch_params: WebSearchInterceptionConfig = {}
         if "websearch_interception_params" in litellm_settings:
             websearch_params = litellm_settings["websearch_interception_params"]
-        elif "websearch_interception" in callback_specific_params:
-            websearch_params = callback_specific_params["websearch_interception"]
+        elif "websearch_interception" in callback_specific_params and isinstance(
+            callback_specific_params["websearch_interception"], dict
+        ):
+            websearch_params = cast(
+                WebSearchInterceptionConfig,
+                callback_specific_params["websearch_interception"],
+            )
 
         # Use classmethod to initialize from config
         return WebSearchInterceptionLogger.from_config_yaml(websearch_params)

--- a/tests/test_litellm/integrations/compression_interception/test_compression_interception_handler.py
+++ b/tests/test_litellm/integrations/compression_interception/test_compression_interception_handler.py
@@ -32,6 +32,40 @@ def test_initialize_from_proxy_config():
     assert logger.compression_target == 789
 
 
+def test_initialize_from_proxy_config_ignores_non_dict_callback_specific_params():
+    """Regression (#29590): a non-dict value under
+    callback_settings.compression_interception must not crash initialization.
+
+    Forwarding callback_settings as callback_specific_params activates this
+    branch; without the isinstance(dict) guard a non-dict value reached
+    from_config_yaml(...).get(...) and raised AttributeError at proxy startup.
+    The value is ignored and the logger falls back to defaults.
+    """
+    logger = CompressionInterceptionLogger.initialize_from_proxy_config(
+        litellm_settings={},
+        callback_specific_params={"compression_interception": True},
+    )
+
+    assert logger.enabled is True
+    assert logger.compression_trigger == 200_000
+
+
+def test_initialize_from_proxy_config_honors_dict_callback_specific_params():
+    """A valid dict under callback_settings.compression_interception is applied."""
+    logger = CompressionInterceptionLogger.initialize_from_proxy_config(
+        litellm_settings={},
+        callback_specific_params={
+            "compression_interception": {
+                "enabled": False,
+                "compression_trigger": 12345,
+            }
+        },
+    )
+
+    assert logger.enabled is False
+    assert logger.compression_trigger == 12345
+
+
 @pytest.mark.asyncio
 async def test_pre_call_hook_compresses_messages_and_injects_tool(monkeypatch):
     """Test pre-call hook compresses and stores per-call cache."""

--- a/tests/test_litellm/integrations/websearch_interception/test_websearch_interception_handler.py
+++ b/tests/test_litellm/integrations/websearch_interception/test_websearch_interception_handler.py
@@ -34,6 +34,35 @@ def test_initialize_from_proxy_config():
     assert logger.search_tool_name == "my-search"
 
 
+def test_initialize_from_proxy_config_ignores_non_dict_callback_specific_params():
+    """Regression (#29590): a non-dict value under
+    callback_settings.websearch_interception must not crash initialization.
+
+    Forwarding callback_settings as callback_specific_params activates this
+    branch; without the isinstance(dict) guard a non-dict value reached
+    from_config_yaml(...).get(...) and raised AttributeError at proxy startup.
+    The value is ignored and the logger falls back to defaults.
+    """
+    logger = WebSearchInterceptionLogger.initialize_from_proxy_config(
+        litellm_settings={},
+        callback_specific_params={"websearch_interception": True},
+    )
+
+    assert logger.search_tool_name is None
+
+
+def test_initialize_from_proxy_config_honors_dict_callback_specific_params():
+    """A valid dict under callback_settings.websearch_interception is applied."""
+    logger = WebSearchInterceptionLogger.initialize_from_proxy_config(
+        litellm_settings={},
+        callback_specific_params={
+            "websearch_interception": {"search_tool_name": "ws-tool"}
+        },
+    )
+
+    assert logger.search_tool_name == "ws-tool"
+
+
 @pytest.mark.asyncio
 async def test_async_should_run_agentic_loop():
     """Test that agentic loop is NOT triggered for wrong provider or missing WebSearch tool"""


### PR DESCRIPTION
## Relevant issues

Completes the regression guard started in #29590. That PR forwards `callback_settings` into `initialize_callbacks_on_proxy` and added an `isinstance(dict)` guard for `lakera_prompt_injection`, but the same forwarding also activates the `compression_interception` and `websearch_interception` consumers, which had no such guard

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Type

Bug Fix

## Changes

Since #29590 forwards the full `callback_settings` dict into `initialize_callbacks_on_proxy`, every callback that reads its init params from `callback_specific_params` now sees real config where it previously saw an empty dict. The `compression_interception` and `websearch_interception` consumers read their `callback_settings` subkey in `initialize_from_proxy_config` without checking that it is a dict, then pass it to `from_config_yaml`, which calls `.get(...)` on it. A non-dict value such as `callback_settings: {compression_interception: true}` therefore aborts proxy startup with `AttributeError: 'bool' object has no attribute 'get'`. #29590 guarded `lakera_prompt_injection` against the same failure but not these two

This adds the `isinstance(dict)` guard already used by the lakera, presidio, and datadog branches to both interceptors, so a non-dict value is ignored and the callback initializes with its defaults while a valid dict is still honored. A parametrized test in `test_callback_utils.py` drives every `callback_settings` consumer through `initialize_callbacks_on_proxy` with a non-dict value, so a future consumer that forgets the guard fails the suite

## Screenshots / Proof of Fix

The failure is at config load, so booting the proxy is the whole reproduction; no LLM call is involved.

```bash
cat > /tmp/crash.yaml <<'YAML'
model_list: []
litellm_settings:
  callbacks: ["compression_interception"]
callback_settings:
  compression_interception: true
YAML

python litellm/proxy/proxy_cli.py --config /tmp/crash.yaml --detailed_debug
```

On `litellm_yj_june10` (before this change) the proxy aborts at startup:

```
File ".../litellm/integrations/compression_interception/handler.py", line 60, in from_config_yaml
    enabled=bool(config.get("enabled", True)),
AttributeError: 'bool' object has no attribute 'get'
```

With this change the proxy reaches `Application startup complete` and `curl http://localhost:4000/health/liveliness` returns `{"status":"healthy"}`. Swapping the config to `callbacks: ["websearch_interception"]` with `callback_settings: {websearch_interception: true}` shows the same before/after
