### PR TITLE
fix(proxy): stop cached-plan retry from pegging Postgres; 503 (not 401) on DB outage

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2168,6 +2168,16 @@ class ConfigGeneralSettings(LiteLLMPydanticObjectBase):
             "This is the main knob for capping idle DB connections from LiteLLM."
         ),
     )
+    database_disable_prepared_statements: Optional[bool] = Field(
+        None,
+        description=(
+            "Disable server-side prepared statements by setting `pgbouncer=true` on "
+            "the Prisma DATABASE_URL / DIRECT_URL. Set this when running behind a "
+            "transaction-mode pooler (PgBouncer, RDS Proxy) or to avoid the "
+            "'cached plan must not change result type' failures that pooled prepared "
+            "statements hit when a schema changes during a rolling deploy."
+        ),
+    )
     database_extra_connection_params: Optional[Dict[str, Any]] = Field(
         None,
         description=(

--- a/litellm/proxy/auth/auth_exception_handler.py
+++ b/litellm/proxy/auth/auth_exception_handler.py
@@ -168,6 +168,14 @@ class UserAPIKeyAuthExceptionHandler:
                 )
             elif isinstance(e, ProxyException):
                 raise e
+            if PrismaDBExceptionHandler.is_database_connection_error(e):
+                raise ProxyException(
+                    message="Database connection error, unable to validate key. "
+                    + str(e),
+                    type=ProxyErrorTypes.no_db_connection,
+                    param=getattr(e, "param", "None"),
+                    code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                )
             raise ProxyException(
                 message="Authentication Error, " + str(e),
                 type=ProxyErrorTypes.auth_error,

--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -44,15 +44,19 @@ def _build_db_connection_url_params(
     pool_timeout: Optional[Union[int, float]],
     connect_timeout: Optional[Union[int, float]] = None,
     socket_timeout: Optional[Union[int, float]] = None,
+    disable_prepared_statements: bool = False,
     extra_params: Optional[dict] = None,
 ) -> dict:
     """Build the Prisma DATABASE_URL query params controlling connection pool behavior.
 
     `connect_timeout` / `socket_timeout` map to the Prisma URL params of the same
     name (https://www.prisma.io/docs/orm/overview/databases/postgresql) and are
-    omitted when None so Prisma's defaults apply. `extra_params` is an
-    untyped passthrough — keys it provides win over the named arguments above,
-    so it can be used to override any default we set here.
+    omitted when None so Prisma's defaults apply. `disable_prepared_statements`
+    sets `pgbouncer=true`, Prisma's switch for turning off server-side prepared
+    statements; use it behind a transaction-mode pooler or to sidestep the
+    cached-plan failures that pooled prepared statements suffer across schema
+    changes. `extra_params` is an untyped passthrough — keys it provides win over
+    the named arguments above, so it can be used to override any default we set here.
     """
     params: dict = {
         "connection_limit": connection_limit,
@@ -63,6 +67,8 @@ def _build_db_connection_url_params(
         params["connect_timeout"] = connect_timeout
     if socket_timeout is not None:
         params["socket_timeout"] = socket_timeout
+    if disable_prepared_statements:
+        params["pgbouncer"] = "true"
     if extra_params:
         params.update(extra_params)
     return params
@@ -947,6 +953,7 @@ def run_server(  # noqa: PLR0915
         db_connection_timeout: Optional[Union[int, float]] = 60
         db_connect_timeout: Optional[Union[int, float]] = None
         db_socket_timeout: Optional[Union[int, float]] = None
+        db_disable_prepared_statements: bool = False
         db_extra_connection_params: Optional[dict] = None
         general_settings = {}
         ### GET DB TOKEN FOR IAM AUTH ###
@@ -1067,6 +1074,9 @@ def run_server(  # noqa: PLR0915
                 )
             db_connect_timeout = general_settings.get("database_connect_timeout")
             db_socket_timeout = general_settings.get("database_socket_timeout")
+            db_disable_prepared_statements = bool(
+                general_settings.get("database_disable_prepared_statements", False)
+            )
             db_extra_connection_params = general_settings.get(
                 "database_extra_connection_params"
             )
@@ -1114,6 +1124,7 @@ def run_server(  # noqa: PLR0915
                     pool_timeout=db_connection_timeout,
                     connect_timeout=db_connect_timeout,
                     socket_timeout=db_socket_timeout,
+                    disable_prepared_statements=db_disable_prepared_statements,
                     extra_params=db_extra_connection_params,
                 )
                 if os.getenv("DATABASE_URL", None) is not None:

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -3252,40 +3252,37 @@ class PrismaClient:
         self, sql_query: str, *args
     ) -> Optional[dict]:
         """
-        Execute a query with automatic fallback for PostgreSQL cached plan errors.
+        Execute a query, recovering once from PostgreSQL's "cached plan must not
+        change result type" error.
 
-        This handles the "cached plan must not change result type" error that occurs
-        during rolling deployments when schema changes are applied while old pods
-        still have cached query plans expecting the old schema.
+        That error surfaces during rolling deployments when a schema change
+        invalidates the prepared-statement plans that pooled connections still
+        hold. We clear stale prepared statements with DEALLOCATE ALL, then retry
+        the identical query exactly once.
 
-        Args:
-            sql_query: SQL query string to execute
-
-        Returns:
-            Query result or None
-
-        Raises:
-            Original exception if not a cached plan error
+        The retry must reuse the original query byte-for-byte. Mutating the SQL
+        (e.g. injecting a unique comment) defeats PostgreSQL's plan cache, forcing
+        a fresh plan on every request and pegging the database CPU.
         """
         try:
             return await self.db.query_first(sql_query, *args)
         except Exception as e:
-            error_str = str(e)
-            if "cached plan must not change result type" in error_str:
-                # Force PostgreSQL to re-plan by invalidating the cache
-                # Add a unique comment to make the query different
-                sql_query_retry = sql_query.replace(
-                    "SELECT",
-                    f"SELECT /* cache_invalidated_{int(time.time() * 1000)} */",
-                )
-                verbose_proxy_logger.warning(
-                    "PostgreSQL cached plan error detected for token lookup, "
-                    "retrying with fresh plan. This may occur during rolling deployments "
-                    "when schema changes are applied."
-                )
-                return await self.db.query_first(sql_query_retry, *args)
-            else:
+            if "cached plan must not change result type" not in str(e):
                 raise
+            verbose_proxy_logger.warning(
+                "PostgreSQL cached plan error detected for token lookup; "
+                "clearing prepared statements and retrying with the same query. "
+                "This may occur during rolling deployments when schema changes "
+                "are applied."
+            )
+            try:
+                await self.db.execute_raw("DEALLOCATE ALL")
+            except Exception as dealloc_error:
+                verbose_proxy_logger.debug(
+                    "DEALLOCATE ALL after cached plan error failed: %s",
+                    dealloc_error,
+                )
+            return await self.db.query_first(sql_query, *args)
 
     @backoff.on_exception(
         backoff.expo,

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -3263,6 +3263,12 @@ class PrismaClient:
         The retry must reuse the original query byte-for-byte. Mutating the SQL
         (e.g. injecting a unique comment) defeats PostgreSQL's plan cache, forcing
         a fresh plan on every request and pegging the database CPU.
+
+        DEALLOCATE ALL is best-effort: Prisma may dispatch it and the retry onto
+        different pooled connections, so the stale plan is not guaranteed to be
+        cleared on the connection that serves the retry. The retry can then still
+        fail; the get_data backoff decorator re-runs the whole lookup and every
+        attempt terminates cleanly, so there is no re-plan loop.
         """
         try:
             return await self.db.query_first(sql_query, *args)

--- a/tests/test_litellm/proxy/auth/test_auth_exception_handler.py
+++ b/tests/test_litellm/proxy/auth/test_auth_exception_handler.py
@@ -113,6 +113,91 @@ async def test_handle_authentication_error_data_layer_errors_do_not_fall_back(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "db_error",
+    [
+        HTTPClientClosedError(),
+        ClientNotConnectedError(),
+        PrismaError(),
+    ],
+)
+async def test_handle_authentication_error_db_error_raises_503_not_401(db_error):
+    """A DB infra failure must surface as 503 (no_db_connection), not 401.
+
+    When ``allow_requests_on_db_unavailable`` is False the handler still falls
+    through to render the error. Before the fix every non-HTTP/Proxy/Budget
+    exception became a 401, so a Postgres outage looked like a bad key and
+    clients got auth errors across all models. Connectivity failures must map
+    to a 5xx so callers retry instead of treating the key as invalid.
+    """
+    handler = UserAPIKeyAuthExceptionHandler()
+
+    with (
+        patch(
+            "litellm.proxy.auth.auth_exception_handler.seed_request_identity",
+        ),
+        patch(
+            "litellm.proxy.proxy_server.proxy_logging_obj.post_call_failure_hook",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "litellm.proxy.proxy_server.general_settings",
+            {"allow_requests_on_db_unavailable": False},
+        ),
+    ):
+        with pytest.raises(ProxyException) as exc_info:
+            await handler._handle_authentication_error(
+                db_error,
+                MagicMock(),
+                {},
+                "/v1/chat/completions",
+                None,
+                "sk-key",
+            )
+
+    assert exc_info.value.type == ProxyErrorTypes.no_db_connection
+    assert int(exc_info.value.code) == status.HTTP_503_SERVICE_UNAVAILABLE
+
+
+@pytest.mark.asyncio
+async def test_handle_authentication_error_genuine_auth_error_still_401():
+    """A real auth failure (DB reachable, key not found) must still be a 401.
+
+    Guards the ask-#3 fix from over-reaching: only connectivity errors get the
+    503 treatment; a plain non-DB exception remains an authentication error.
+    """
+    handler = UserAPIKeyAuthExceptionHandler()
+
+    with (
+        patch(
+            "litellm.proxy.auth.auth_exception_handler.seed_request_identity",
+        ),
+        patch(
+            "litellm.proxy.proxy_server.proxy_logging_obj.post_call_failure_hook",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "litellm.proxy.proxy_server.general_settings",
+            {"allow_requests_on_db_unavailable": False},
+        ),
+    ):
+        with pytest.raises(ProxyException) as exc_info:
+            await handler._handle_authentication_error(
+                ValueError("invalid user key"),
+                MagicMock(),
+                {},
+                "/v1/chat/completions",
+                None,
+                "sk-key",
+            )
+
+    assert exc_info.value.type == ProxyErrorTypes.auth_error
+    assert int(exc_info.value.code) == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.asyncio
 async def test_handle_authentication_error_budget_exceeded():
     handler = UserAPIKeyAuthExceptionHandler()
 

--- a/tests/test_litellm/proxy/test_proxy_cli.py
+++ b/tests/test_litellm/proxy/test_proxy_cli.py
@@ -822,6 +822,82 @@ class TestProxyInitializationHelpers:
             assert appended_params["pgbouncer"] == "true"
             assert appended_params["statement_cache_size"] == 0
 
+    @patch("subprocess.run")
+    @patch("atexit.register")
+    @patch("litellm.proxy.db.prisma_client.PrismaManager.setup_database")
+    @patch(
+        "litellm.proxy.db.prisma_client.should_update_prisma_schema", return_value=False
+    )
+    def test_db_disable_prepared_statements_sets_pgbouncer_on_url(
+        self,
+        mock_should_update,
+        mock_setup_db,
+        mock_atexit_register,
+        mock_subprocess_run,
+    ):
+        from click.testing import CliRunner
+
+        from litellm.proxy.proxy_cli import run_server
+
+        runner = CliRunner()
+        mock_subprocess_run.return_value = MagicMock(returncode=0)
+
+        mock_proxy_module = MagicMock(
+            app=MagicMock(),
+            ProxyConfig=MagicMock(),
+            KeyManagementSettings=MagicMock(),
+            save_worker_config=MagicMock(),
+        )
+        mock_proxy_module.ProxyConfig.return_value.get_config = AsyncMock(
+            return_value={
+                "general_settings": {
+                    "database_url": "postgresql://test:test@localhost:5432/test",
+                    "database_disable_prepared_statements": True,
+                }
+            }
+        )
+
+        clean_env = {
+            k: v
+            for k, v in os.environ.items()
+            if k not in ("DATABASE_URL", "DIRECT_URL")
+        }
+
+        with (
+            patch.dict(os.environ, clean_env, clear=True),
+            patch.dict(
+                "sys.modules",
+                {
+                    "proxy_server": mock_proxy_module,
+                    "litellm.proxy.proxy_server": mock_proxy_module,
+                },
+            ),
+            patch(
+                "litellm.proxy.proxy_cli.ProxyInitializationHelpers._get_default_unvicorn_init_args"
+            ) as mock_get_args,
+            patch(
+                "litellm.proxy.proxy_cli.append_query_params",
+                side_effect=lambda url, params: str(url),
+            ) as mock_append_query_params,
+        ):
+            mock_get_args.return_value = {
+                "app": "litellm.proxy.proxy_server:app",
+                "host": "localhost",
+                "port": 8000,
+            }
+
+            result = runner.invoke(
+                run_server,
+                ["--local", "--config", "test-config.yaml", "--skip_server_startup"],
+            )
+
+            assert (
+                result.exit_code == 0
+            ), f"exit_code={result.exit_code}, output={result.output}"
+            mock_append_query_params.assert_called()
+            appended_params = mock_append_query_params.call_args.args[1]
+            assert appended_params["pgbouncer"] == "true"
+
     @patch("uvicorn.run")
     @patch("atexit.register")
     @patch("litellm.proxy.db.prisma_client.PrismaManager.setup_database")

--- a/tests/test_litellm/proxy/test_proxy_cli.py
+++ b/tests/test_litellm/proxy/test_proxy_cli.py
@@ -695,6 +695,33 @@ class TestProxyInitializationHelpers:
         assert params["connect_timeout"] == 15
         assert params["socket_timeout"] == 120
 
+    def test_build_db_connection_url_params_disable_prepared_statements(self):
+        from litellm.proxy.proxy_cli import _build_db_connection_url_params
+
+        params = _build_db_connection_url_params(
+            connection_limit=10,
+            pool_timeout=60,
+            disable_prepared_statements=True,
+        )
+        assert params["pgbouncer"] == "true"
+
+    def test_build_db_connection_url_params_prepared_statements_on_by_default(self):
+        from litellm.proxy.proxy_cli import _build_db_connection_url_params
+
+        params = _build_db_connection_url_params(connection_limit=10, pool_timeout=60)
+        assert "pgbouncer" not in params
+
+    def test_build_db_connection_url_params_extras_override_disable(self):
+        from litellm.proxy.proxy_cli import _build_db_connection_url_params
+
+        params = _build_db_connection_url_params(
+            connection_limit=10,
+            pool_timeout=60,
+            disable_prepared_statements=True,
+            extra_params={"pgbouncer": "false"},
+        )
+        assert params["pgbouncer"] == "false"
+
     def test_build_db_connection_url_params_extras_override_defaults(self):
         from litellm.proxy.proxy_cli import _build_db_connection_url_params
 

--- a/tests/test_litellm/proxy/utils/prisma_and_spend/test_prisma_client_get_data.py
+++ b/tests/test_litellm/proxy/utils/prisma_and_spend/test_prisma_client_get_data.py
@@ -450,6 +450,40 @@ async def test_get_data_user_find_unique_returns_user_row(
 
 
 @pytest.mark.asyncio
+async def test_get_data_combined_view_binds_token_as_parameter(
+    prisma_client: PrismaClient,
+) -> None:
+    """The combined_view token lookup must pass the token as a bind parameter
+    ($1), never interpolate it into the SQL text. String interpolation
+    (``WHERE v.token = '{token}'``) is a SQL-injection vector and also breaks
+    plan caching. Asserts the hashed token is the second positional arg and
+    never appears inside the query string.
+    """
+    token = "sk-key-xyz"
+    hashed = hashlib.sha256(token.encode()).hexdigest()
+    prisma_client.db.query_first = AsyncMock(return_value=None)
+    prisma_client.db.execute_raw = AsyncMock(return_value=0)
+
+    result = await prisma_client.get_data(
+        token=token, table_name="combined_view", check_deprecated=False
+    )
+
+    sql_arg, *bind_args = prisma_client.db.query_first.await_args.args
+    actual = {
+        "result": result,
+        "uses_placeholder": "WHERE v.token = $1" in sql_arg,
+        "bind_args": tuple(bind_args),
+        "token_not_interpolated": hashed not in sql_arg and token not in sql_arg,
+    }
+    assert actual == {
+        "result": None,
+        "uses_placeholder": True,
+        "bind_args": (hashed,),
+        "token_not_interpolated": True,
+    }
+
+
+@pytest.mark.asyncio
 async def test_get_data_logs_and_raises_on_db_error(
     prisma_client: PrismaClient,
 ) -> None:

--- a/tests/test_litellm/proxy/utils/prisma_and_spend/test_prisma_client_get_data.py
+++ b/tests/test_litellm/proxy/utils/prisma_and_spend/test_prisma_client_get_data.py
@@ -193,6 +193,7 @@ async def test_query_first_with_cached_plan_fallback_happy_returns_row(
 ) -> None:
     expected = {"token": "abc", "team_spend": 1.0, "team_max_budget": 5.0}
     prisma_client.db.query_first = AsyncMock(return_value=expected)
+    prisma_client.db.execute_raw = AsyncMock(return_value=0)
     result = await prisma_client._query_first_with_cached_plan_fallback(
         "SELECT * FROM x WHERE token = $1", "abc"
     )
@@ -208,35 +209,92 @@ async def test_query_first_with_cached_plan_fallback_happy_returns_row(
         "args": ("SELECT * FROM x WHERE token = $1", "abc"),
         "matches": True,
     }
+    prisma_client.db.execute_raw.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_query_first_with_cached_plan_fallback_retries_on_cached_plan_error(
+async def test_query_first_with_cached_plan_fallback_retries_identical_query_after_deallocate(
     prisma_client: PrismaClient,
 ) -> None:
+    original_query = 'SELECT * FROM "LiteLLM_VerificationToken" WHERE v.token = $1'
     expected = {"token": "abc", "team_spend": 1.0, "team_max_budget": 5.0}
+    manager = MagicMock()
+    query_first = AsyncMock(
+        side_effect=[
+            RuntimeError("cached plan must not change result type"),
+            expected,
+        ]
+    )
+    execute_raw = AsyncMock(return_value=0)
+    manager.attach_mock(query_first, "query_first")
+    manager.attach_mock(execute_raw, "execute_raw")
+    prisma_client.db.query_first = query_first
+    prisma_client.db.execute_raw = execute_raw
+
+    result = await prisma_client._query_first_with_cached_plan_fallback(
+        original_query, "abc"
+    )
+
+    assert result == expected
+    assert query_first.await_count == 2
+    first_call, retry_call = query_first.await_args_list
+    assert retry_call.args == first_call.args == (original_query, "abc")
+    execute_raw.assert_awaited_once_with("DEALLOCATE ALL")
+    assert [name for name, *_ in manager.mock_calls] == [
+        "query_first",
+        "execute_raw",
+        "query_first",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_query_first_with_cached_plan_fallback_propagates_when_retry_also_fails(
+    prisma_client: PrismaClient,
+) -> None:
+    plan_error = RuntimeError("cached plan must not change result type")
+    prisma_client.db.query_first = AsyncMock(side_effect=[plan_error, plan_error])
+    prisma_client.db.execute_raw = AsyncMock(return_value=0)
+
+    with pytest.raises(RuntimeError, match="cached plan must not change result type"):
+        await prisma_client._query_first_with_cached_plan_fallback("SELECT 1")
+
+    assert prisma_client.db.query_first.await_count == 2
+    prisma_client.db.execute_raw.assert_awaited_once_with("DEALLOCATE ALL")
+
+
+@pytest.mark.asyncio
+async def test_query_first_with_cached_plan_fallback_retries_when_deallocate_fails(
+    prisma_client: PrismaClient,
+) -> None:
+    expected = {"token": "abc"}
     prisma_client.db.query_first = AsyncMock(
         side_effect=[
             RuntimeError("cached plan must not change result type"),
             expected,
         ]
     )
-    result = await prisma_client._query_first_with_cached_plan_fallback(
-        "SELECT * FROM x WHERE token = $1", "abc"
+    prisma_client.db.execute_raw = AsyncMock(
+        side_effect=RuntimeError("deallocate boom")
     )
+
+    result = await prisma_client._query_first_with_cached_plan_fallback("SELECT 1")
+
     assert result == expected
     assert prisma_client.db.query_first.await_count == 2
-    second_call_sql = prisma_client.db.query_first.await_args_list[1].args[0]
-    assert "cache_invalidated_" in second_call_sql
 
 
 @pytest.mark.asyncio
 async def test_query_first_with_cached_plan_fallback_reraises_non_plan_errors(
     prisma_client: PrismaClient,
 ) -> None:
-    prisma_client.db.query_first = AsyncMock(side_effect=RuntimeError("totally unrelated"))
+    prisma_client.db.query_first = AsyncMock(
+        side_effect=RuntimeError("totally unrelated")
+    )
+    prisma_client.db.execute_raw = AsyncMock(return_value=0)
     with pytest.raises(RuntimeError, match="totally unrelated"):
         await prisma_client._query_first_with_cached_plan_fallback("SELECT 1")
+    assert prisma_client.db.query_first.await_count == 1
+    prisma_client.db.execute_raw.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -351,7 +409,9 @@ async def test_get_data_token_find_unique_returns_record(
 async def test_get_data_token_find_unique_missing_token_raises_401(
     prisma_client: PrismaClient,
 ) -> None:
-    prisma_client.db.litellm_verificationtoken.find_unique = AsyncMock(return_value=None)
+    prisma_client.db.litellm_verificationtoken.find_unique = AsyncMock(
+        return_value=None
+    )
     with pytest.raises(HTTPException) as excinfo:
         await prisma_client.get_data(token="sk-missing", table_name="key")
     err = excinfo.value

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -22013,6 +22013,11 @@ export interface components {
              */
             database_connection_timeout: number | null;
             /**
+             * Database Disable Prepared Statements
+             * @description Disable server-side prepared statements by setting `pgbouncer=true` on the Prisma DATABASE_URL / DIRECT_URL. Set this when running behind a transaction-mode pooler (PgBouncer, RDS Proxy) or to avoid the 'cached plan must not change result type' failures that pooled prepared statements hit when a schema changes during a rolling deploy.
+             */
+            database_disable_prepared_statements?: boolean | null;
+            /**
              * Database Extra Connection Params
              * @description Escape hatch: extra key/value pairs appended verbatim to the Prisma DATABASE_URL / DIRECT_URL query string (e.g. `sslmode`, `pgbouncer`, `statement_cache_size`). Keys here override any default LiteLLM sets.
              */


### PR DESCRIPTION
## Relevant issues

Cached-plan retry on the token/auth lookup can peg the Postgres writer at 100% CPU (regression from PR #19424). A schema change on live connections during a rolling deploy triggers "cached plan must not change result type"; the old recovery rewrote the retry SQL with a unique millisecond comment, so Postgres could never reuse a plan and every request re-planned until connections recycled. The writer sat at ~99.7% CPU for hours and clients saw fleet-wide 401/503 until a manual failover reset the pool.

This branch addresses all four asks from that report.

Ask 1, don't mutate the query on retry. The fallback now issues a best-effort `DEALLOCATE ALL` to drop stale prepared statements and retries the byte-identical query exactly once; a second failure propagates rather than looping. This landed in earlier commits on the branch (`_query_first_with_cached_plan_fallback` in `litellm/proxy/utils.py`).

Ask 2, add an option to disable server-side prepared statements. New `database_disable_prepared_statements` general setting sets `pgbouncer=true` on the Prisma DATABASE_URL / DIRECT_URL. Use it behind a transaction-mode pooler (PgBouncer, RDS Proxy) or to sidestep cached-plan failures entirely.

Ask 3, don't return 401 on DB errors. `UserAPIKeyAuthExceptionHandler` previously converted every non-HTTP/Proxy/Budget exception into a 401, so a Postgres outage looked like a bad key. Connectivity failures (detected via `PrismaDBExceptionHandler.is_database_connection_error`) now surface as 503 with `no_db_connection`, so callers retry instead of treating the key as invalid; genuine auth failures stay 401.

Ask 4, bind the token parameter. The combined_view lookup already passes the hashed token as a bind parameter (`WHERE v.token = $1`) rather than interpolating it, so there's no SQL-injection surface. Added a regression test to keep it that way.

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

Asks 2 and 4 are config / SQL-shape behavior; asks 1 and 3 are recovery paths that need an induced DB fault. A live-proxy runbook to reproduce against a real Postgres:

1. Start the proxy against a real Aurora/Postgres with `database_disable_prepared_statements: false` so server-side prepared statements are on
2. `curl -s -H "Authorization: Bearer $LITELLM_KEY" http://localhost:4000/v1/chat/completions -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"ping"}]}'` to confirm a normal 200 and prime the plan cache
3. Apply a benign schema change to a table in the token view (for example `ALTER TABLE "LiteLLM_VerificationToken" ADD COLUMN _canary text; ALTER TABLE "LiteLLM_VerificationToken" DROP COLUMN _canary;`) to invalidate cached plans on the live connections
4. Re-run the curl from step 2 in a short loop and watch the writer CPU on the DB; before this change it pins near 100% and the first attempt keeps failing, after it the request recovers on the single retry and CPU stays flat
5. To exercise ask 3, point the proxy at a Postgres you can stop, stop it, then curl any model; the response is now a 503 `no_db_connection` rather than a 401, and restarting Postgres restores 200s
6. To exercise ask 2, set `database_disable_prepared_statements: true`, restart, and confirm `pgbouncer=true` is present on the resolved DATABASE_URL and that token lookups still succeed

## Type

🐛 Bug Fix

## Changes

`litellm/proxy/auth/auth_exception_handler.py`: connectivity failures map to 503 `no_db_connection` instead of the catch-all 401.

`litellm/proxy/proxy_cli.py` and `litellm/proxy/_types.py`: new `database_disable_prepared_statements` general setting that appends `pgbouncer=true` to the Prisma connection URL.

Tests: regression coverage for the 503-vs-401 split, the `pgbouncer=true` toggle (including extra-params override precedence), and the combined_view token bind-parameter contract.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VgQSXJtmYM9BcDCTuYVNTN)_