### PR TITLE
fix(responses): emit empty incremental fields on synthetic *.added events (cached stream replay duplicates tool-call arguments)

### DIFF
--- a/litellm/responses/streaming_iterator.py
+++ b/litellm/responses/streaming_iterator.py
@@ -1056,6 +1056,32 @@ def _add_text_like_part_events(
         )
 
 
+def _initial_added_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a copy of an output-item/content-part payload with its
+    incrementally streamed fields emptied, matching what the OpenAI
+    Responses API emits on ``*.added`` events.
+
+    The full values are delivered through the subsequent delta events and
+    repeated on the corresponding ``*.done`` events. Emitting them on the
+    ``added`` event as well makes spec-following clients — which seed an
+    accumulator from ``added`` and append every delta — assemble the
+    content twice (for function calls the arguments JSON is doubled,
+    which is invalid JSON).
+    """
+    payload_type = payload.get("type")
+    if payload_type == "function_call":
+        return {**payload, "arguments": ""}
+    if payload_type == "message":
+        return {**payload, "content": []}
+    if payload_type == "reasoning":
+        return {**payload, "summary": []}
+    if payload_type == "output_text":
+        return {**payload, "text": "", "annotations": []}
+    if payload_type == "refusal":
+        return {**payload, "refusal": ""}
+    return payload
+
+
 def _build_synthetic_response_events(
     *,
     transformed: Any,
@@ -1097,7 +1123,7 @@ def _build_synthetic_response_events(
                 type=openai_types.ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED,
                 output_index=output_index,
                 item=openai_types.BaseLiteLLMOpenAIResponseObject(
-                    **output_item_payload
+                    **_initial_added_payload(output_item_payload)
                 ),
             )
         )
@@ -1114,7 +1140,7 @@ def _build_synthetic_response_events(
                         output_index=output_index,
                         content_index=content_index,
                         part=openai_types.BaseLiteLLMOpenAIResponseObject(
-                            **part_payload
+                            **_initial_added_payload(part_payload)
                         ),
                     )
                 )

--- a/tests/test_litellm/responses/test_synthetic_stream_replay_events.py
+++ b/tests/test_litellm/responses/test_synthetic_stream_replay_events.py
@@ -1,0 +1,280 @@
+"""Contract tests for synthetic Responses API replay events.
+
+``_build_synthetic_response_events`` (used by
+``CachedResponsesAPIStreamingIterator`` to replay cached streamed
+responses) must emit ``*.added`` events with their incrementally
+streamed fields empty, matching real OpenAI streams. Carrying the full
+payload on ``added`` while also re-streaming it as deltas makes
+spec-following clients (which seed from ``added`` and append deltas)
+assemble the content twice — for function calls the arguments JSON is
+doubled, which is invalid JSON.
+"""
+
+import json
+from datetime import datetime
+from unittest.mock import MagicMock
+
+from litellm.responses import streaming_iterator as streaming_module
+from litellm.types.llms.openai import ResponsesAPIResponse
+
+
+def _FakeLoggingObj():
+    logging_obj = MagicMock()
+    logging_obj.model_call_details = {"litellm_params": {}}
+    return logging_obj
+
+
+def _build_full_fixture_response() -> ResponsesAPIResponse:
+    return ResponsesAPIResponse(
+        id="resp_contract",
+        created_at=int(datetime.now().timestamp()),
+        status="completed",
+        model="gpt-4.1-mini",
+        object="response",
+        output=[
+            {
+                "type": "function_call",
+                "id": "fc_contract",
+                "call_id": "call_contract",
+                "name": "get_weather",
+                "arguments": '{"city":"Paris","unit":"celsius"}',
+            },
+            {
+                "type": "message",
+                "id": "msg_contract",
+                "status": "completed",
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "output_text",
+                        "text": "Hello, world!",
+                        "annotations": [{"type": "file_citation", "file_id": "file_abc"}],
+                    },
+                    {
+                        "type": "refusal",
+                        "refusal": "I cannot do that.",
+                    },
+                ],
+            },
+            {
+                "type": "reasoning",
+                "id": "rs_x",
+                "summary": [{"type": "summary_text", "text": "thinking..."}],
+            },
+        ],
+    )
+
+
+def test_synthetic_output_item_added_has_empty_incremental_fields():
+    transformed = _build_full_fixture_response()
+
+    events = streaming_module._build_synthetic_response_events(
+        transformed=transformed,
+        logging_obj=_FakeLoggingObj(),
+        chunk_size=5,
+    )
+
+    def event_type_str(e):
+        return e.type.value if hasattr(e.type, "value") else str(e.type)
+
+    added_events = [e for e in events if event_type_str(e) == "response.output_item.added"]
+    content_part_added_events = [
+        e for e in events if event_type_str(e) == "response.content_part.added"
+    ]
+
+    fc_added = next(
+        e for e in added_events if getattr(e.item, "type", None) == "function_call"
+    )
+    msg_added = next(
+        e for e in added_events if getattr(e.item, "type", None) == "message"
+    )
+    reasoning_added = next(
+        e for e in added_events if getattr(e.item, "type", None) == "reasoning"
+    )
+
+    assert getattr(fc_added.item, "arguments", None) == "", (
+        f"function_call output_item.added should have arguments='' but got: "
+        f"{getattr(fc_added.item, 'arguments', '<missing>')!r}"
+    )
+
+    assert getattr(msg_added.item, "content", None) == [], (
+        f"message output_item.added should have content=[] but got: "
+        f"{getattr(msg_added.item, 'content', '<missing>')!r}"
+    )
+
+    assert getattr(reasoning_added.item, "summary", None) == [], (
+        f"reasoning output_item.added should have summary=[] but got: "
+        f"{getattr(reasoning_added.item, 'summary', '<missing>')!r}"
+    )
+
+    output_text_part_added = next(
+        e
+        for e in content_part_added_events
+        if getattr(e.part, "type", None) == "output_text"
+    )
+    assert getattr(output_text_part_added.part, "text", None) == "", (
+        f"output_text content_part.added should have text='' but got: "
+        f"{getattr(output_text_part_added.part, 'text', '<missing>')!r}"
+    )
+    assert getattr(output_text_part_added.part, "annotations", None) == [], (
+        f"output_text content_part.added should have annotations=[] but got: "
+        f"{getattr(output_text_part_added.part, 'annotations', '<missing>')!r}"
+    )
+
+    refusal_part_added = next(
+        e
+        for e in content_part_added_events
+        if getattr(e.part, "type", None) == "refusal"
+    )
+    assert getattr(refusal_part_added.part, "refusal", None) == "", (
+        f"refusal content_part.added should have refusal='' but got: "
+        f"{getattr(refusal_part_added.part, 'refusal', '<missing>')!r}"
+    )
+
+
+def test_synthetic_replay_client_assembly_is_not_duplicated():
+    fc_args = '{"city":"Paris","unit":"celsius"}'
+    original_text = "Hello, world!"
+    transformed = _build_full_fixture_response()
+
+    events = streaming_module._build_synthetic_response_events(
+        transformed=transformed,
+        logging_obj=_FakeLoggingObj(),
+        chunk_size=5,
+    )
+
+    def event_type_str(e):
+        return e.type.value if hasattr(e.type, "value") else str(e.type)
+
+    fc_added_item = next(
+        e.item
+        for e in events
+        if event_type_str(e) == "response.output_item.added"
+        and getattr(e, "output_index", None) == 0
+    )
+    fc_arg_deltas = [
+        e
+        for e in events
+        if event_type_str(e) == "response.function_call_arguments.delta"
+        and getattr(e, "output_index", None) == 0
+    ]
+
+    assembled_args = getattr(fc_added_item, "arguments", "") + "".join(
+        e.delta for e in fc_arg_deltas
+    )
+    assert assembled_args == fc_args, (
+        f"Client assembly of tool arguments doubled: expected {fc_args!r}, got {assembled_args!r}"
+    )
+    assert json.loads(assembled_args) == {"city": "Paris", "unit": "celsius"}, (
+        f"Assembled arguments are not valid JSON: {assembled_args!r}"
+    )
+
+    text_part_added = next(
+        e
+        for e in events
+        if event_type_str(e) == "response.content_part.added"
+        and getattr(e, "output_index", None) == 1
+        and getattr(e.part, "type", None) == "output_text"
+    )
+    output_text_deltas = [
+        e
+        for e in events
+        if event_type_str(e) == "response.output_text.delta"
+        and getattr(e, "output_index", None) == 1
+        and getattr(e, "content_index", None) == 0
+    ]
+
+    assembled_text = getattr(text_part_added.part, "text", "") + "".join(
+        e.delta for e in output_text_deltas
+    )
+    assert assembled_text == original_text, (
+        f"Client assembly of message text doubled: expected {original_text!r}, got {assembled_text!r}"
+    )
+
+
+def test_synthetic_done_events_keep_full_payloads():
+    fc_args = '{"city":"Paris","unit":"celsius"}'
+    original_text = "Hello, world!"
+    transformed = _build_full_fixture_response()
+
+    events = streaming_module._build_synthetic_response_events(
+        transformed=transformed,
+        logging_obj=_FakeLoggingObj(),
+        chunk_size=5,
+    )
+
+    def event_type_str(e):
+        return e.type.value if hasattr(e.type, "value") else str(e.type)
+
+    fc_args_done = next(
+        e for e in events if event_type_str(e) == "response.function_call_arguments.done"
+    )
+    assert fc_args_done.arguments == fc_args, (
+        f"function_call_arguments.done should carry full args, got: {fc_args_done.arguments!r}"
+    )
+
+    output_text_done = next(
+        e for e in events if event_type_str(e) == "response.output_text.done"
+    )
+    assert output_text_done.text == original_text, (
+        f"output_text.done should carry full text, got: {output_text_done.text!r}"
+    )
+
+    fc_item_done = next(
+        e
+        for e in events
+        if event_type_str(e) == "response.output_item.done"
+        and getattr(e.item, "type", None) == "function_call"
+    )
+    assert getattr(fc_item_done.item, "arguments", None) == fc_args, (
+        f"output_item.done for function_call should have full arguments, got: "
+        f"{getattr(fc_item_done.item, 'arguments', '<missing>')!r}"
+    )
+
+    msg_item_done = next(
+        e
+        for e in events
+        if event_type_str(e) == "response.output_item.done"
+        and getattr(e.item, "type", None) == "message"
+    )
+    assert getattr(msg_item_done.item, "content", None), (
+        f"output_item.done for message should have non-empty content, got: "
+        f"{getattr(msg_item_done.item, 'content', '<missing>')!r}"
+    )
+
+
+
+
+def test_synthetic_added_passthrough_for_types_without_incremental_fields():
+    """Item types with no delta-streamed fields (e.g. web_search_call)
+    must pass through to ``output_item.added`` unchanged."""
+    transformed = ResponsesAPIResponse(
+        id="resp_passthrough",
+        created_at=int(datetime.now().timestamp()),
+        status="completed",
+        model="gpt-4.1-mini",
+        object="response",
+        output=[
+            {
+                "type": "web_search_call",
+                "id": "ws_1",
+                "status": "completed",
+            },
+        ],
+    )
+
+    events = streaming_module._build_synthetic_response_events(
+        transformed=transformed,
+        logging_obj=_FakeLoggingObj(),
+        chunk_size=5,
+    )
+
+    added = next(
+        e
+        for e in events
+        if (e.type.value if hasattr(e.type, "value") else str(e.type))
+        == "response.output_item.added"
+    )
+    assert getattr(added.item, "type", None) == "web_search_call"
+    assert getattr(added.item, "id", None) == "ws_1"
+    assert getattr(added.item, "status", None) == "completed"


### PR DESCRIPTION
## Relevant issues

None filed yet — happy to open one if maintainers prefer an issue to track this.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code) — affected matrix groups (`tests/test_litellm/caching`, `tests/test_litellm/responses`) pass fully; remaining local failures are environment-only (no Redis service, optional a2a deps) and are byte-identical between this branch and current `main`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## What this fixes

`_build_synthetic_response_events()` (introduced in #24580, used by `CachedResponsesAPIStreamingIterator` to replay cached streamed `/v1/responses` requests) emits `response.output_item.added` and `response.content_part.added` events that carry the **full final payloads**, and then re-streams the same content as delta events.

The OpenAI Responses API sends those `added` events with the incrementally-streamed fields **empty** (verified against live OpenAI streams):

| Event | Field on real OpenAI `added` |
|---|---|
| `output_item.added` (function_call) | `"arguments": ""` |
| `output_item.added` (message) | `"content": []` |
| `output_item.added` (reasoning) | `"summary": []` |
| `content_part.added` (output_text) | `"text": ""`, `"annotations": []` |
| `content_part.added` (refusal) | `"refusal": ""` |

The full values arrive only via the delta events and are repeated on the `*.done` events.

Spec-following clients — pydantic-ai is one concrete example (`openai.py` seeds its accumulator from `output_item.added` and appends every `function_call_arguments.delta`) — therefore assemble the content **twice** on every cache-hit replay. For function calls this produces `{"city":"Paris"}{"city":"Paris"}` — invalid JSON — so any agent framework that retries the identical request fails deterministically forever, because the retry is also a cache hit. Message text is silently doubled the same way.

Live passthrough streams (cache miss) are unaffected, which makes this easy to miss in testing: the **first** request always works; only repeats of an already-cached streamed request break.

## Reproduction

1. Proxy config with `cache: true` + Redis, any model
2. Send the same streamed `/v1/responses` request with a `tools` array twice
3. Call 2 returns `x-litellm-cache-key` (cache hit) and its `output_item.added` event carries the full `arguments`, followed by deltas carrying the full arguments again
4. Assemble per the OpenAI contract (seed from `added`, append deltas) → doubled JSON

## The fix

`_initial_added_payload()` empties the incrementally-streamed fields on synthetic `*.added` events, per item/part type (table above). Delta events and `*.done` events are unchanged and still carry the full payloads.

The type list is derived from what `_build_synthetic_response_events` itself replays as deltas — `message` / `function_call` / `reasoning` items and `output_text` / `refusal` parts are the only types that get synthetic delta events, so they are the only types where a full `added` payload causes client-side doubling. Every other type (e.g. `web_search_call`, `mcp_call`) intentionally passes through unchanged: the replay emits no deltas for those, so emptying their fields would lose the content rather than fix anything.

**Maintainer note — invariant to carry forward:** if a new item/part type ever gains synthetic delta replay in `_build_synthetic_response_events`, it must also be added to `_initial_added_payload()`, or the doubled-content bug reappears for that type.

## Tests

In `tests/test_litellm/responses/test_synthetic_stream_replay_events.py`:

- `test_synthetic_output_item_added_has_empty_incremental_fields` — pins the `added`-event contract for function_call / message / reasoning items and output_text / refusal parts
- `test_synthetic_replay_client_assembly_is_not_duplicated` — simulates a spec-following client (seed from `added` + append deltas); fails on current `main` with the exact doubled-JSON output
- `test_synthetic_done_events_keep_full_payloads` — guards against over-correcting: `function_call_arguments.done`, `output_text.done`, and `output_item.done` must keep full payloads (this already passes on `main` and must stay passing)
- `test_synthetic_added_passthrough_for_types_without_incremental_fields` — pins that item types with no synthetic delta replay (e.g. `web_search_call`) pass through `added` unchanged

## Proof of fix

Patched proxy from source with Redis caching, same streamed tool-call request sent twice:

```
--- call 2 (cache HIT: x-litellm-cache-key present, synthetic replay path) ---
added.arguments        = ''
deltas concatenated    = '{"city":"Paris","unit":"celsius"}'
client assembly        = '{"city":"Paris","unit":"celsius"}'
assembly valid JSON    = True
```

Before the fix, the same setup yields `'{"city":"Paris","unit":"celsius"}{"city":"Paris","unit":"celsius"}'` (invalid JSON) on every cache hit.
