### PR TITLE
fix(anthropic_passthrough): resolve costing model from message_start chunk, litellm_params and model_group instead of 'unknown'

### DIFF
--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
@@ -101,6 +101,42 @@ class AnthropicPassthroughLoggingHandler:
         return None
 
     @staticmethod
+    def _resolve_costing_model(model: str, logging_obj: LiteLLMLoggingObj) -> str:
+        if model and model != "unknown":
+            return model
+        litellm_params = (getattr(logging_obj, "model_call_details", {}) or {}).get(
+            "litellm_params", {}
+        ) or {}
+        deployment_model = litellm_params.get("model")
+        if deployment_model and deployment_model != "unknown":
+            return deployment_model
+        model_group = (litellm_params.get("metadata", {}) or {}).get("model_group")
+        if model_group:
+            return model_group.removeprefix("passthrough/")
+        return model
+
+    @staticmethod
+    def _extract_model_from_anthropic_chunks(
+        all_chunks: Sequence[Union[str, bytes]],
+    ) -> Optional[str]:
+        for raw in all_chunks:
+            text = raw.decode("utf-8") if isinstance(raw, bytes) else raw
+            for line in text.splitlines():
+                if not line.startswith("data:"):
+                    continue
+                try:
+                    data = json.loads(line[len("data:") :].strip())
+                except (json.JSONDecodeError, ValueError):
+                    continue
+                if not isinstance(data, dict):
+                    continue
+                if data.get("type") == "message_start":
+                    model = (data.get("message") or {}).get("model")
+                    if model:
+                        return model
+        return None
+
+    @staticmethod
     def _create_anthropic_response_logging_payload(
         litellm_model_response: Union[ModelResponse, TextCompletionResponse],
         model: str,
@@ -125,6 +161,10 @@ class AnthropicPassthroughLoggingHandler:
             # Get custom_llm_provider from logging object if available (e.g., azure_ai for Azure Anthropic)
             custom_llm_provider = logging_obj.model_call_details.get(
                 "custom_llm_provider"
+            )
+
+            model = AnthropicPassthroughLoggingHandler._resolve_costing_model(
+                model, logging_obj
             )
 
             # Prepend custom_llm_provider to model if not already present
@@ -212,6 +252,15 @@ class AnthropicPassthroughLoggingHandler:
             and litellm_logging_obj.model_call_details.get("model")
         ):
             model = cast(str, litellm_logging_obj.model_call_details.get("model"))
+
+        if not model or model == "unknown":
+            chunk_model = (
+                AnthropicPassthroughLoggingHandler._extract_model_from_anthropic_chunks(
+                    all_chunks
+                )
+            )
+            if chunk_model:
+                model = chunk_model
 
         complete_streaming_response = (
             AnthropicPassthroughLoggingHandler._build_complete_streaming_response(

--- a/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_anthropic_passthrough_logging_handler.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_anthropic_passthrough_logging_handler.py
@@ -321,6 +321,269 @@ class TestAzureAnthropicCostCalculation:
         assert call_kwargs["model"] == "azure_ai/claude-sonnet-4-5_gb_20250929"
         assert call_kwargs["custom_llm_provider"] == "azure_ai"
 
+    @patch("litellm.completion_cost")
+    def test_cost_calculation_resolves_unknown_model_from_litellm_params(
+        self, mock_completion_cost
+    ):
+        """When the body model is the "unknown" sentinel, the deployment model
+        from litellm_params must be used for costing, not "unknown" (which makes
+        completion_cost raise and the cost silently fall back to $0)."""
+        from datetime import datetime
+
+        from litellm.types.utils import ModelResponse
+
+        mock_completion_cost.return_value = 0.001
+
+        logging_obj = self._create_mock_logging_obj(model="unknown")
+        logging_obj.model_call_details["litellm_params"] = {
+            "model": "anthropic/claude-3-5-haiku-20241022",
+            "metadata": {
+                "model_group": "passthrough/anthropic/claude-3-5-haiku-20241022"
+            },
+        }
+        logging_obj.litellm_params = logging_obj.model_call_details["litellm_params"]
+
+        mock_response = MagicMock(spec=ModelResponse)
+        mock_response.id = "test-id"
+        mock_response.model = "unknown"
+
+        kwargs = AnthropicPassthroughLoggingHandler._create_anthropic_response_logging_payload(
+            litellm_model_response=mock_response,
+            model="unknown",
+            kwargs={},
+            start_time=datetime.now(),
+            end_time=datetime.now(),
+            logging_obj=logging_obj,
+        )
+
+        mock_completion_cost.assert_called_once()
+        assert (
+            mock_completion_cost.call_args[1]["model"]
+            == "anthropic/claude-3-5-haiku-20241022"
+        )
+        assert kwargs["response_cost"] == 0.001
+        assert kwargs["model"] == "anthropic/claude-3-5-haiku-20241022"
+
+    @patch("litellm.completion_cost")
+    def test_cost_calculation_resolves_unknown_model_from_model_group(
+        self, mock_completion_cost
+    ):
+        """With only model_group available (no deployment litellm_params.model),
+        the leading passthrough/ prefix must be stripped so the cost map can
+        resolve the model."""
+        from datetime import datetime
+
+        from litellm.types.utils import ModelResponse
+
+        mock_completion_cost.return_value = 0.002
+
+        logging_obj = self._create_mock_logging_obj(model="unknown")
+        logging_obj.model_call_details["litellm_params"] = {
+            "metadata": {
+                "model_group": "passthrough/anthropic/claude-3-5-haiku-20241022"
+            }
+        }
+        logging_obj.litellm_params = logging_obj.model_call_details["litellm_params"]
+
+        mock_response = MagicMock(spec=ModelResponse)
+        mock_response.id = "test-id"
+        mock_response.model = "unknown"
+
+        kwargs = AnthropicPassthroughLoggingHandler._create_anthropic_response_logging_payload(
+            litellm_model_response=mock_response,
+            model="unknown",
+            kwargs={},
+            start_time=datetime.now(),
+            end_time=datetime.now(),
+            logging_obj=logging_obj,
+        )
+
+        mock_completion_cost.assert_called_once()
+        assert (
+            mock_completion_cost.call_args[1]["model"]
+            == "anthropic/claude-3-5-haiku-20241022"
+        )
+        assert kwargs["response_cost"] == 0.002
+
+    @patch("litellm.completion_cost")
+    def test_cost_calculation_skips_unknown_litellm_params_model_for_model_group(
+        self, mock_completion_cost
+    ):
+        """When litellm_params.model is itself the "unknown" sentinel, the
+        deployment-model branch must not short-circuit; resolution falls through
+        to model_group so costing still prices the real model instead of "unknown"."""
+        from datetime import datetime
+
+        from litellm.types.utils import ModelResponse
+
+        mock_completion_cost.return_value = 0.003
+
+        logging_obj = self._create_mock_logging_obj(model="unknown")
+        logging_obj.model_call_details["litellm_params"] = {
+            "model": "unknown",
+            "metadata": {
+                "model_group": "passthrough/anthropic/claude-3-5-haiku-20241022"
+            },
+        }
+        logging_obj.litellm_params = logging_obj.model_call_details["litellm_params"]
+
+        mock_response = MagicMock(spec=ModelResponse)
+        mock_response.id = "test-id"
+        mock_response.model = "unknown"
+
+        kwargs = AnthropicPassthroughLoggingHandler._create_anthropic_response_logging_payload(
+            litellm_model_response=mock_response,
+            model="unknown",
+            kwargs={},
+            start_time=datetime.now(),
+            end_time=datetime.now(),
+            logging_obj=logging_obj,
+        )
+
+        mock_completion_cost.assert_called_once()
+        assert (
+            mock_completion_cost.call_args[1]["model"]
+            == "anthropic/claude-3-5-haiku-20241022"
+        )
+        assert kwargs["response_cost"] == 0.003
+        assert kwargs["model"] == "anthropic/claude-3-5-haiku-20241022"
+
+    @patch("litellm.completion_cost")
+    def test_streaming_cost_calculation_resolves_model_from_message_start_chunk(
+        self, mock_completion_cost
+    ):
+        """On the bare /anthropic passthrough path litellm_params carries no model
+        or model_group and the body model is the "unknown" sentinel; the model
+        must be recovered from the message_start SSE event so completion_cost
+        prices the real model instead of failing on "unknown" and logging $0."""
+        from datetime import datetime
+
+        from litellm.litellm_core_utils.litellm_logging import (
+            Logging as RealLoggingObj,
+        )
+        from litellm.proxy.pass_through_endpoints.streaming_handler import (
+            PassThroughStreamingHandler,
+        )
+
+        mock_completion_cost.return_value = 0.001
+
+        def _sse(event, data):
+            return f"event: {event}\ndata: {json.dumps(data)}\n\n".encode()
+
+        frames = [
+            _sse(
+                "message_start",
+                {
+                    "type": "message_start",
+                    "message": {
+                        "id": "msg_1",
+                        "type": "message",
+                        "role": "assistant",
+                        "model": "claude-3-5-haiku-20241022",
+                        "content": [],
+                        "stop_reason": None,
+                        "stop_sequence": None,
+                        "usage": {"input_tokens": 10, "output_tokens": 0},
+                    },
+                },
+            ),
+            _sse(
+                "content_block_start",
+                {
+                    "type": "content_block_start",
+                    "index": 0,
+                    "content_block": {"type": "text", "text": ""},
+                },
+            ),
+            _sse(
+                "content_block_delta",
+                {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "text_delta", "text": "hi"},
+                },
+            ),
+            _sse("content_block_stop", {"type": "content_block_stop", "index": 0}),
+            _sse(
+                "message_delta",
+                {
+                    "type": "message_delta",
+                    "delta": {"stop_reason": "end_turn", "stop_sequence": None},
+                    "usage": {"output_tokens": 1},
+                },
+            ),
+            _sse("message_stop", {"type": "message_stop"}),
+        ]
+        all_chunks = list(
+            PassThroughStreamingHandler._convert_raw_bytes_to_str_lines(frames)
+        )
+
+        logging_obj = RealLoggingObj(
+            model="unknown",
+            messages=[{"role": "user", "content": "hi"}],
+            stream=True,
+            call_type="pass_through_endpoint",
+            start_time=datetime.now(),
+            litellm_call_id="test-call-id",
+            function_id="1",
+        )
+        logging_obj.model_call_details["model"] = "unknown"
+        logging_obj.model_call_details["stream"] = True
+        logging_obj.model_call_details["litellm_params"] = {}
+        logging_obj.litellm_params = {}
+
+        result = AnthropicPassthroughLoggingHandler._handle_logging_anthropic_collected_chunks(
+            litellm_logging_obj=logging_obj,
+            passthrough_success_handler_obj=MagicMock(),
+            url_route="/anthropic/v1/messages",
+            request_body={"stream": True},
+            endpoint_type="messages",
+            start_time=datetime.now(),
+            all_chunks=all_chunks,
+            end_time=datetime.now(),
+        )
+
+        assert result["result"] is not None
+        mock_completion_cost.assert_called_once()
+        assert mock_completion_cost.call_args[1]["model"] == "claude-3-5-haiku-20241022"
+        assert result["kwargs"]["response_cost"] == 0.001
+        assert result["kwargs"]["model"] == "claude-3-5-haiku-20241022"
+
+    def test_extract_model_skips_non_dict_data_payload(self):
+        """A scalar data: payload (e.g. `data: null`) must be skipped, not crash
+        the streaming log handler with AttributeError, which would propagate out
+        and break spend logging for the whole request."""
+        chunks = [
+            "event: ping\ndata: null\n\n",
+            'event: message_start\ndata: {"type": "message_start", "message": '
+            '{"model": "claude-3-5-haiku-20241022"}}\n\n',
+        ]
+
+        assert (
+            AnthropicPassthroughLoggingHandler._extract_model_from_anthropic_chunks(
+                chunks
+            )
+            == "claude-3-5-haiku-20241022"
+        )
+
+    def test_extract_model_parses_per_line_not_first_data_substring(self):
+        """A raw multi-line SSE event whose non-data line contains the substring
+        "data:" must not derail parsing: matching only lines that start with
+        "data:" recovers the message_start model, whereas a first-substring slice
+        would consume the wrong offset, fail to parse JSON, and return None."""
+        raw_event = (
+            "event: ping data: not-json\n"
+            'data: {"type": "message_start", "message": '
+            '{"model": "claude-3-5-haiku-20241022"}}\n\n'
+        )
+
+        assert (
+            AnthropicPassthroughLoggingHandler._extract_model_from_anthropic_chunks(
+                [raw_event]
+            )
+            == "claude-3-5-haiku-20241022"
+        )
+
     def test_passthrough_logging_sets_response_cost_with_server_tool_use_dict(self):
         from litellm.types.utils import Choices, Message, ModelResponse
 


### PR DESCRIPTION
## Relevant issues

Related: #12933 (same `anthropic_passthrough_logging_handler` cost path raising "LLM Provider NOT provided" so spend logs $0)

## Linear ticket

LIT-3716

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review (5/5 on HEAD 2c68c3b)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link: https://github.com/BerriAI/litellm/pull/30160/checks

- [ ] **CI run for the last commit**  
       Link: https://github.com/BerriAI/litellm/pull/30160/checks

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

A faithful live-curl `$0` reproduction is not achievable on the current branch: the pass-through layer re-serializes the parsed request body before forwarding upstream, so a request that succeeds always carries a parsed model into costing. The reporter saw `$0` on v1.83.7-stable, which forwarded raw bodies; there a request whose body the proxy could not parse still succeeded upstream while the logging path fell back to the `model="unknown"` sentinel. The window where "upstream succeeded but costing got unknown" closed on main as a side effect of the re-serialization change, but the affected stable line still runs the raw-byte forwarding, and the buggy handler code is identical there. The before/after proof below therefore drives `_create_anthropic_response_logging_payload` directly with `model="unknown"` against the real cost map (not mocked), exercising the exact method the proxy runs to populate the spend log, and the live streaming curl serves as the no-regression check on the happy path

### Before / after of the exact spend-log computation (real cost map)

The driver builds a real `ModelResponse` (usage 14 in / 8 out) whose model is `"unknown"`, a logging object whose `litellm_params` carry `model="anthropic/claude-haiku-4-5-20251001"` and `metadata.model_group="passthrough/anthropic/claude-haiku-4-5-20251001"`, then calls `AnthropicPassthroughLoggingHandler._create_anthropic_response_logging_payload(model="unknown", ...)`

Before (unfixed, `litellm_internal_staging`):

```
handler has _resolve_costing_model: False
ERROR anthropic_passthrough_logging_handler.py:183 - Error creating Anthropic response
  logging payload: litellm.BadRequestError: LLM Provider NOT provided.
  Pass in the LLM provider you are trying to call. You passed model=unknown
logged model      : None
response_cost     : None        <-- spend log records $0
```

After (this branch):

```
handler has _resolve_costing_model: True
logged model      : anthropic/claude-haiku-4-5-20251001
response_cost     : 5.4e-05     <-- real cost resolved from model_group
```

### Live streaming pass-through, real Anthropic, real spend (no happy-path regression)

Proxy launched from this branch against `api.anthropic.com` with a mapped model:

```bash
curl -s http://localhost:4000/anthropic/v1/messages \
  -H "Authorization: Bearer sk-1234" \
  -H "anthropic-version: 2023-06-01" \
  -H "content-type: application/json" \
  -d '{"model":"claude-haiku-4-5-20251001","max_tokens":20,"stream":true,"messages":[{"role":"user","content":"Say hi in 3 words"}]}'
```

Output:

```
HTTP/1.1 200 OK
x-litellm-call-id: d18878b8-7396-4f70-8d59-f398383af406
event: message_delta
data: {"type":"message_delta","delta":{"stop_reason":"end_turn",...},"usage":{"input_tokens":14,...,"output_tokens":9}}
event: message_stop
```

litellm.log for that call logged `response_cost: 5.9e-05` (non-zero, correct), with zero "You passed model=unknown" occurrences

## Type

🐛 Bug Fix

## Changes

Anthropic `/v1/messages` pass-through logging recorded `$0` whenever the cost path received `model="unknown"` (the sentinel the generic pass-through layer assigns when the request body has no usable model). `litellm.completion_cost(model="unknown")` raised "LLM Provider NOT provided", the surrounding `except` swallowed it, `response_cost` stayed unset, and the spend log recorded zero while usage tokens were still captured; key and team budget enforcement was silently bypassed for that pass-through traffic. This is the reported state on v1.83.7-stable, where pass-through forwarded raw request bytes so an unparseable body still succeeded upstream. On current main the body re-serialization means a successful request always carries a parsed model, so the sentinel cannot reach costing through a live request; the handler itself is unchanged between the two lines though, so this patch is what gets cherry-picked to stable, and it makes the costing path correct by construction rather than dependent on the re-serialization behavior of the forwarding layer (a future return to raw-byte forwarding, plausible since re-serializing breaks signed payloads, would otherwise silently reintroduce $0 spend)

The fix adds a model-resolution step in `anthropic_passthrough_logging_handler.py` before pricing. For streaming, `_extract_model_from_anthropic_chunks` recovers the model from the `message_start` SSE event by matching lines that start with `data:` (explicit about the SSE shape and robust to raw multi-line events), guarded against malformed or non-dict payloads. `_resolve_costing_model` then prefers a real response model and otherwise falls back to `litellm_params.model`, then to `metadata.model_group` with a leading `passthrough/` prefix stripped (`get_llm_provider` rejects the prefixed form but accepts the stripped one); a `litellm_params.model` of `"unknown"` is treated as missing so the `model_group` fallback still runs. The resolved value is used both for `completion_cost` and for the logged model, so spend logs show the real model instead of `unknown`. Both streaming and non-streaming funnel through `_create_anthropic_response_logging_payload`, so the fix covers both

Six regression tests were added in `tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_anthropic_passthrough_logging_handler.py`, each verified to fail when its corresponding code is reverted
