### PR TITLE
fix(anthropic_passthrough): honor base_model in passthrough cost calculation

### DIFF
--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
@@ -18,7 +18,6 @@ from litellm.types.passthrough_endpoints.pass_through_endpoints import (
     PassthroughStandardLoggingPayload,
 )
 from litellm.types.utils import LiteLLMBatch, ModelResponse, TextCompletionResponse
-from litellm.utils import _get_base_model_from_metadata
 
 if TYPE_CHECKING:
     from litellm.types.passthrough_endpoints.pass_through_endpoints import EndpointType
@@ -142,8 +141,11 @@ class AnthropicPassthroughLoggingHandler:
                 )
             )
 
-            base_model = _get_base_model_from_metadata(
-                model_call_details=logging_obj.model_call_details
+            # Resolve base_model from the router deployment config (server-side
+            # source of truth) instead of request metadata, which is
+            # client-controllable on pass-through endpoints.
+            base_model = AnthropicPassthroughLoggingHandler._get_base_model_from_router(
+                router_model_id=router_model_id
             )
 
             response_cost = litellm.completion_cost(
@@ -190,6 +192,20 @@ class AnthropicPassthroughLoggingHandler:
                 "Error creating Anthropic response logging payload: %s", e
             )
             return kwargs
+
+    @staticmethod
+    def _get_base_model_from_router(router_model_id: Optional[str]) -> Optional[str]:
+        """Read model_info.base_model from the router deployment config."""
+        if router_model_id is None:
+            return None
+        from litellm.proxy.proxy_server import llm_router
+
+        if llm_router is None:
+            return None
+        deployment = llm_router.get_deployment(model_id=router_model_id)
+        if deployment is None or deployment.model_info is None:
+            return None
+        return deployment.model_info.base_model
 
     @staticmethod
     def _handle_logging_anthropic_collected_chunks(

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
@@ -18,6 +18,7 @@ from litellm.types.passthrough_endpoints.pass_through_endpoints import (
     PassthroughStandardLoggingPayload,
 )
 from litellm.types.utils import LiteLLMBatch, ModelResponse, TextCompletionResponse
+from litellm.utils import _get_base_model_from_metadata
 
 if TYPE_CHECKING:
     from litellm.types.passthrough_endpoints.pass_through_endpoints import EndpointType
@@ -141,12 +142,17 @@ class AnthropicPassthroughLoggingHandler:
                 )
             )
 
+            base_model = _get_base_model_from_metadata(
+                model_call_details=logging_obj.model_call_details
+            )
+
             response_cost = litellm.completion_cost(
                 completion_response=litellm_model_response,
                 model=model_for_cost,
                 custom_llm_provider=custom_llm_provider,
                 custom_pricing=custom_pricing,
                 router_model_id=router_model_id,
+                base_model=base_model,
             )
 
             kwargs["response_cost"] = response_cost

--- a/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_anthropic_passthrough_logging_handler.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_anthropic_passthrough_logging_handler.py
@@ -360,6 +360,129 @@ class TestAzureAnthropicCostCalculation:
         assert kwargs["response_cost"] > 0
 
 
+class TestBaseModelCostCalculation:
+    """Test that the deployment's model_info.base_model is used for cost calculation."""
+
+    def _create_mock_logging_obj(
+        self,
+        model: str,
+        base_model: str = None,
+        custom_llm_provider: str = None,
+    ) -> LiteLLMLoggingObj:
+        mock_logging_obj = MagicMock()
+        model_call_details = {"model": model}
+        if custom_llm_provider:
+            model_call_details["custom_llm_provider"] = custom_llm_provider
+        if base_model:
+            model_call_details["litellm_params"] = {
+                "metadata": {"model_info": {"base_model": base_model}}
+            }
+        mock_logging_obj.model_call_details = model_call_details
+        mock_logging_obj.litellm_call_id = "test-call-id"
+        mock_logging_obj.get_router_model_id.return_value = None
+        mock_logging_obj.litellm_params = {}
+        return mock_logging_obj
+
+    @patch("litellm.completion_cost")
+    def test_base_model_passed_to_completion_cost(self, mock_completion_cost):
+        """base_model from litellm_params metadata must be forwarded to completion_cost"""
+        from litellm.types.utils import ModelResponse
+
+        mock_completion_cost.return_value = 0.001
+
+        logging_obj = self._create_mock_logging_obj(
+            model="us/aws/anthropic/eccn-claude-sonnet-4-6",
+            base_model="claude-sonnet-4-6",
+            custom_llm_provider="anthropic",
+        )
+
+        mock_response = MagicMock(spec=ModelResponse)
+        mock_response.id = "test-id"
+        mock_response.model = "us/aws/anthropic/eccn-claude-sonnet-4-6"
+
+        AnthropicPassthroughLoggingHandler._create_anthropic_response_logging_payload(
+            litellm_model_response=mock_response,
+            model="us/aws/anthropic/eccn-claude-sonnet-4-6",
+            kwargs={},
+            start_time=datetime.now(),
+            end_time=datetime.now(),
+            logging_obj=logging_obj,
+        )
+
+        mock_completion_cost.assert_called_once()
+        call_kwargs = mock_completion_cost.call_args[1]
+        assert call_kwargs["base_model"] == "claude-sonnet-4-6"
+
+    @patch("litellm.completion_cost")
+    def test_base_model_none_when_not_configured(self, mock_completion_cost):
+        """base_model should be None when the deployment doesn't set it"""
+        from litellm.types.utils import ModelResponse
+
+        mock_completion_cost.return_value = 0.001
+
+        logging_obj = self._create_mock_logging_obj(model="claude-3-sonnet-20240229")
+
+        mock_response = MagicMock(spec=ModelResponse)
+        mock_response.id = "test-id"
+        mock_response.model = "claude-3-sonnet-20240229"
+
+        AnthropicPassthroughLoggingHandler._create_anthropic_response_logging_payload(
+            litellm_model_response=mock_response,
+            model="claude-3-sonnet-20240229",
+            kwargs={},
+            start_time=datetime.now(),
+            end_time=datetime.now(),
+            logging_obj=logging_obj,
+        )
+
+        mock_completion_cost.assert_called_once()
+        call_kwargs = mock_completion_cost.call_args[1]
+        assert call_kwargs["base_model"] is None
+
+    def test_unmapped_alias_with_base_model_computes_cost(self):
+        """
+        Unmapped model alias (e.g. proxy-to-proxy setup) with base_model set must
+        compute a real cost instead of failing with 'This model isn't mapped yet'.
+        """
+        from litellm.types.utils import Choices, Message, ModelResponse
+
+        logging_obj = self._create_mock_logging_obj(
+            model="us/aws/anthropic/eccn-claude-sonnet-4-6",
+            base_model="claude-sonnet-4-6",
+            custom_llm_provider="anthropic",
+        )
+
+        response = ModelResponse(
+            id="test-id",
+            choices=[
+                Choices(
+                    finish_reason="stop",
+                    index=0,
+                    message=Message(content="test", role="assistant"),
+                )
+            ],
+            created=1234567890,
+            model="us/aws/anthropic/eccn-claude-sonnet-4-6",
+            usage={
+                "prompt_tokens": 25,
+                "completion_tokens": 10,
+                "total_tokens": 35,
+            },
+        )
+
+        kwargs = AnthropicPassthroughLoggingHandler._create_anthropic_response_logging_payload(
+            litellm_model_response=response,
+            model="us/aws/anthropic/eccn-claude-sonnet-4-6",
+            kwargs={},
+            start_time=datetime.now(),
+            end_time=datetime.now(),
+            logging_obj=logging_obj,
+        )
+
+        assert "response_cost" in kwargs
+        assert kwargs["response_cost"] > 0
+
+
 class TestAnthropicBatchPassthroughCostTracking:
     """Test cases for Anthropic batch passthrough cost tracking functionality"""
 

--- a/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_anthropic_passthrough_logging_handler.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_anthropic_passthrough_logging_handler.py
@@ -361,54 +361,67 @@ class TestAzureAnthropicCostCalculation:
 
 
 class TestBaseModelCostCalculation:
-    """Test that the deployment's model_info.base_model is used for cost calculation."""
+    """base_model must come from the router deployment config, not request metadata."""
 
     def _create_mock_logging_obj(
         self,
         model: str,
-        base_model: str = None,
         custom_llm_provider: str = None,
+        router_model_id: str = None,
+        metadata_base_model: str = None,
     ) -> LiteLLMLoggingObj:
         mock_logging_obj = MagicMock()
         model_call_details = {"model": model}
         if custom_llm_provider:
             model_call_details["custom_llm_provider"] = custom_llm_provider
-        if base_model:
+        if metadata_base_model:
             model_call_details["litellm_params"] = {
-                "metadata": {"model_info": {"base_model": base_model}}
+                "metadata": {"model_info": {"base_model": metadata_base_model}}
             }
         mock_logging_obj.model_call_details = model_call_details
         mock_logging_obj.litellm_call_id = "test-call-id"
-        mock_logging_obj.get_router_model_id.return_value = None
+        mock_logging_obj.get_router_model_id.return_value = router_model_id
         mock_logging_obj.litellm_params = {}
         return mock_logging_obj
 
+    def _create_mock_router(self, base_model: str = None) -> MagicMock:
+        mock_router = MagicMock()
+        deployment = MagicMock()
+        deployment.model_info.base_model = base_model
+        mock_router.get_deployment.return_value = deployment
+        return mock_router
+
     @patch("litellm.completion_cost")
-    def test_base_model_passed_to_completion_cost(self, mock_completion_cost):
-        """base_model from litellm_params metadata must be forwarded to completion_cost"""
+    def test_base_model_from_router_passed_to_completion_cost(
+        self, mock_completion_cost
+    ):
+        """base_model from the router deployment must be forwarded to completion_cost"""
         from litellm.types.utils import ModelResponse
 
         mock_completion_cost.return_value = 0.001
 
         logging_obj = self._create_mock_logging_obj(
             model="us/aws/anthropic/eccn-claude-sonnet-4-6",
-            base_model="claude-sonnet-4-6",
             custom_llm_provider="anthropic",
+            router_model_id="test-model-id",
         )
 
         mock_response = MagicMock(spec=ModelResponse)
         mock_response.id = "test-id"
         mock_response.model = "us/aws/anthropic/eccn-claude-sonnet-4-6"
 
-        AnthropicPassthroughLoggingHandler._create_anthropic_response_logging_payload(
-            litellm_model_response=mock_response,
-            model="us/aws/anthropic/eccn-claude-sonnet-4-6",
-            kwargs={},
-            start_time=datetime.now(),
-            end_time=datetime.now(),
-            logging_obj=logging_obj,
-        )
+        mock_router = self._create_mock_router(base_model="claude-sonnet-4-6")
+        with patch("litellm.proxy.proxy_server.llm_router", mock_router):
+            AnthropicPassthroughLoggingHandler._create_anthropic_response_logging_payload(
+                litellm_model_response=mock_response,
+                model="us/aws/anthropic/eccn-claude-sonnet-4-6",
+                kwargs={},
+                start_time=datetime.now(),
+                end_time=datetime.now(),
+                logging_obj=logging_obj,
+            )
 
+        mock_router.get_deployment.assert_called_once_with(model_id="test-model-id")
         mock_completion_cost.assert_called_once()
         call_kwargs = mock_completion_cost.call_args[1]
         assert call_kwargs["base_model"] == "claude-sonnet-4-6"
@@ -420,20 +433,60 @@ class TestBaseModelCostCalculation:
 
         mock_completion_cost.return_value = 0.001
 
-        logging_obj = self._create_mock_logging_obj(model="claude-3-sonnet-20240229")
+        logging_obj = self._create_mock_logging_obj(
+            model="claude-3-sonnet-20240229",
+            router_model_id="test-model-id",
+        )
 
         mock_response = MagicMock(spec=ModelResponse)
         mock_response.id = "test-id"
         mock_response.model = "claude-3-sonnet-20240229"
 
-        AnthropicPassthroughLoggingHandler._create_anthropic_response_logging_payload(
-            litellm_model_response=mock_response,
-            model="claude-3-sonnet-20240229",
-            kwargs={},
-            start_time=datetime.now(),
-            end_time=datetime.now(),
-            logging_obj=logging_obj,
+        mock_router = self._create_mock_router(base_model=None)
+        with patch("litellm.proxy.proxy_server.llm_router", mock_router):
+            AnthropicPassthroughLoggingHandler._create_anthropic_response_logging_payload(
+                litellm_model_response=mock_response,
+                model="claude-3-sonnet-20240229",
+                kwargs={},
+                start_time=datetime.now(),
+                end_time=datetime.now(),
+                logging_obj=logging_obj,
+            )
+
+        mock_completion_cost.assert_called_once()
+        call_kwargs = mock_completion_cost.call_args[1]
+        assert call_kwargs["base_model"] is None
+
+    @patch("litellm.completion_cost")
+    def test_client_supplied_metadata_base_model_is_ignored(self, mock_completion_cost):
+        """
+        Security: base_model planted in request metadata (client-controllable on
+        pass-through endpoints) must NOT be used for cost calculation.
+        """
+        from litellm.types.utils import ModelResponse
+
+        mock_completion_cost.return_value = 0.001
+
+        logging_obj = self._create_mock_logging_obj(
+            model="claude-opus-4-6",
+            custom_llm_provider="anthropic",
+            router_model_id=None,
+            metadata_base_model="claude-haiku-4-5",
         )
+
+        mock_response = MagicMock(spec=ModelResponse)
+        mock_response.id = "test-id"
+        mock_response.model = "claude-opus-4-6"
+
+        with patch("litellm.proxy.proxy_server.llm_router", None):
+            AnthropicPassthroughLoggingHandler._create_anthropic_response_logging_payload(
+                litellm_model_response=mock_response,
+                model="claude-opus-4-6",
+                kwargs={},
+                start_time=datetime.now(),
+                end_time=datetime.now(),
+                logging_obj=logging_obj,
+            )
 
         mock_completion_cost.assert_called_once()
         call_kwargs = mock_completion_cost.call_args[1]
@@ -441,15 +494,16 @@ class TestBaseModelCostCalculation:
 
     def test_unmapped_alias_with_base_model_computes_cost(self):
         """
-        Unmapped model alias (e.g. proxy-to-proxy setup) with base_model set must
-        compute a real cost instead of failing with 'This model isn't mapped yet'.
+        Unmapped model alias (e.g. proxy-to-proxy setup) with base_model set on
+        the deployment must compute a real cost instead of failing with
+        'This model isn't mapped yet'.
         """
         from litellm.types.utils import Choices, Message, ModelResponse
 
         logging_obj = self._create_mock_logging_obj(
             model="us/aws/anthropic/eccn-claude-sonnet-4-6",
-            base_model="claude-sonnet-4-6",
             custom_llm_provider="anthropic",
+            router_model_id="test-model-id",
         )
 
         response = ModelResponse(
@@ -470,14 +524,16 @@ class TestBaseModelCostCalculation:
             },
         )
 
-        kwargs = AnthropicPassthroughLoggingHandler._create_anthropic_response_logging_payload(
-            litellm_model_response=response,
-            model="us/aws/anthropic/eccn-claude-sonnet-4-6",
-            kwargs={},
-            start_time=datetime.now(),
-            end_time=datetime.now(),
-            logging_obj=logging_obj,
-        )
+        mock_router = self._create_mock_router(base_model="claude-sonnet-4-6")
+        with patch("litellm.proxy.proxy_server.llm_router", mock_router):
+            kwargs = AnthropicPassthroughLoggingHandler._create_anthropic_response_logging_payload(
+                litellm_model_response=response,
+                model="us/aws/anthropic/eccn-claude-sonnet-4-6",
+                kwargs={},
+                start_time=datetime.now(),
+                end_time=datetime.now(),
+                logging_obj=logging_obj,
+            )
 
         assert "response_cost" in kwargs
         assert kwargs["response_cost"] > 0


### PR DESCRIPTION
<!-- Title: fix(anthropic_passthrough): honor base_model in passthrough cost calculation -->

## Relevant issues

No exact public issue; surfaced via a customer proxy-to-proxy deployment (Anthropic-SDK clients → LiteLLM → second LiteLLM hosting aliased models). Related "model isn't mapped" log-noise reports: #4818, #13935

## Linear ticket

Resolves LIT-3714

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

### Problem

When a deployment uses a model alias that isn't in `model_prices_and_context_window.json` (common in proxy-to-proxy setups, e.g. `model: anthropic/us/aws/anthropic/eccn-claude-sonnet-*` pointing at another LiteLLM), every **streaming** `/v1/messages` request logs an ERROR with a full traceback:

```
LiteLLM Proxy:ERROR: anthropic_passthrough_logging_handler.py:183 - Error creating Anthropic
response logging payload: This model isn't mapped yet. model=anthropic/us/aws/anthropic/eccn-claude-sonnet-4-6,
custom_llm_provider=anthropic. Add it here - https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json.
```

Setting `model_info.base_model` — the documented fix for exactly this error — does not silence it.

### Root cause

`AnthropicPassthroughLoggingHandler._create_anthropic_response_logging_payload` calls `litellm.completion_cost()` without the deployment's `base_model`:

```python
response_cost = litellm.completion_cost(
    completion_response=litellm_model_response,
    model=model_for_cost,
    custom_llm_provider=custom_llm_provider,
    custom_pricing=custom_pricing,
    router_model_id=router_model_id,
)
```

The standard cost-tracking path resolves `base_model` from the call metadata (`_get_base_model_from_metadata`) and passes it through, so the **final** spend is actually computed correctly — the passthrough handler's earlier attempt just fails loudly first. The result is pure log pollution on every streaming request.

### Fix

Resolve `base_model` from the router deployment config (server-side source of truth) and forward it to `completion_cost`:

```python
base_model = AnthropicPassthroughLoggingHandler._get_base_model_from_router(
    router_model_id=router_model_id
)

response_cost = litellm.completion_cost(
    ...,
    base_model=base_model,
)
```

The helper reads `model_info.base_model` from `llm_router.get_deployment(model_id=router_model_id)`. Request metadata is deliberately **not** consulted — on pass-through endpoints, body-supplied litellm params/metadata are client-controllable, and trusting them here would let an authenticated caller bill an expensive model at a cheaper model's rate (flagged by Veria on the first revision of this PR).

Precedence is unchanged: explicit custom pricing still wins over `base_model` inside `completion_cost` (`_select_model_name_for_cost_calc`). When `base_model` isn't configured (or the call didn't go through the router), behavior is identical to before.

### Tests

Added `TestBaseModelCostCalculation` (4 tests) to `tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_anthropic_passthrough_logging_handler.py`:

- `base_model` from the router deployment is forwarded to `completion_cost`
- `base_model` is `None` when the deployment doesn't set it (no behavior change)
- Security regression: `base_model` planted in request metadata (client-controllable on pass-through endpoints) is ignored
- Regression: unmapped alias (`us/aws/anthropic/eccn-claude-sonnet-4-6`) with deployment `base_model: claude-sonnet-4-6` computes a real cost via the un-mocked `completion_cost` instead of raising "This model isn't mapped yet"

Full handler test file: 37/37 pass.

## Screenshots / Proof of Fix

Reproduced against a live proxy with a wildcard deployment `anthropic/us/aws/anthropic/eccn-claude-sonnet-*` + `model_info.base_model: claude-sonnet-4-6`, backed by a mock upstream that returns the unmapped alias in the response body. Re-verified live on the final revision (router-lookup) — the wildcard deployment's `base_model` resolves correctly via `llm_router.get_deployment()`.

**Before** (`litellm_internal_staging`) — every streaming `/v1/messages` request logs the full traceback:

<img width="924" height="594" alt="image" src="https://github.com/user-attachments/assets/b12321ba-5d44-477c-b965-4cfa111981d2" />

**After** (this branch) — identical requests: no error, cost resolved via `base_model` ($0.000225 = exact `claude-sonnet-4-6` pricing for 25 in / 10 out tokens), unit tests pass:

<img width="900" height="306" alt="image" src="https://github.com/user-attachments/assets/ef2e7fab-a5a2-436c-9067-dc85f9d5c25f" />
