### PR TITLE
fix(ui): dev server 404s on migrated-page links because uiBase hardcodes /ui

### DIFF
--- a/ui/litellm-dashboard/src/utils/migratedPages.test.ts
+++ b/ui/litellm-dashboard/src/utils/migratedPages.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 describe("migratedHref / legacyPageHref", () => {
   beforeEach(() => {
@@ -34,6 +34,40 @@ describe("migratedHref / legacyPageHref", () => {
 
     expect(MIGRATED_PAGES.api_ref).toBe("api-reference");
     expect(MIGRATED_PAGES["api-reference"]).toBe("api-reference");
+  });
+});
+
+describe("dev server (NODE_ENV=development)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv("NODE_ENV", "development");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("builds root-relative hrefs because next dev serves the app at /, not /ui", async () => {
+    vi.doMock("@/components/networking", () => ({ serverRootPath: "/" }));
+    const { migratedHref, legacyPageHref } = await import("./migratedPages");
+
+    expect(migratedHref("api-reference")).toBe("/api-reference");
+    expect(legacyPageHref("models")).toBe("/?page=models");
+  });
+
+  it("ignores serverRootPath, which only applies to proxy-mounted deployments", async () => {
+    vi.doMock("@/components/networking", () => ({ serverRootPath: "/team-x/" }));
+    const { migratedHref } = await import("./migratedPages");
+
+    expect(migratedHref("api-reference")).toBe("/api-reference");
+  });
+
+  it("maps a bare migrated path back to its legacy sidebar key", async () => {
+    vi.doMock("@/components/networking", () => ({ serverRootPath: "/" }));
+    const { legacyKeyForPathname } = await import("./migratedPages");
+
+    expect(legacyKeyForPathname("/api-reference/")).toBe("api_ref");
+    expect(legacyKeyForPathname("/")).toBeNull();
   });
 });
 

--- a/ui/litellm-dashboard/src/utils/migratedPages.test.ts
+++ b/ui/litellm-dashboard/src/utils/migratedPages.test.ts
@@ -3,6 +3,11 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 describe("migratedHref / legacyPageHref", () => {
   beforeEach(() => {
     vi.resetModules();
+    vi.stubEnv("NODE_ENV", "test");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it("builds a /ui-rooted path when serverRootPath is /", async () => {
@@ -74,6 +79,11 @@ describe("dev server (NODE_ENV=development)", () => {
 describe("legacyKeyForPathname", () => {
   beforeEach(() => {
     vi.resetModules();
+    vi.stubEnv("NODE_ENV", "test");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it("maps a migrated path back to its legacy sidebar key (including trailing slash)", async () => {

--- a/ui/litellm-dashboard/src/utils/migratedPages.ts
+++ b/ui/litellm-dashboard/src/utils/migratedPages.ts
@@ -15,6 +15,11 @@ export const MIGRATED_PAGES: Record<string, string> = {
 };
 
 function uiBase(): string {
+  // next dev serves the app at the root; only the proxy mounts the static export under /ui
+  // (and optionally under server_root_path). Inlined at build time, so production is unaffected.
+  if (process.env.NODE_ENV === "development") {
+    return "";
+  }
   const root = serverRootPath && serverRootPath !== "/" ? `/${serverRootPath.replace(/^\/+|\/+$/g, "")}` : "";
   return `${root}/ui`;
 }


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Refs LIT-3687

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

Reproduction before the fix, with the dashboard dev server running on localhost:3000 (`npm run dev` in `ui/litellm-dashboard`) and the proxy on 4000:

```
$ curl -s -o /dev/null -w "dev /ui/api-reference: %{http_code}\n" http://localhost:3000/ui/api-reference/
dev /ui/api-reference: 404
$ curl -s -o /dev/null -w "dev /api-reference: %{http_code}\n" http://localhost:3000/api-reference/
dev /api-reference: 200
$ curl -s -o /dev/null -w "proxy /ui/api-reference: %{http_code}\n" http://localhost:4000/ui/api-reference/
proxy /ui/api-reference: 200
```

The sidebar built every migrated-page href as `/ui/api-reference` (the first URL), so clicking API Reference on the dev server hit the 404 even though the page itself worked at the bare path (the second URL). The proxy mount (third URL) was always fine.

To verify after the fix: log in, open http://localhost:3000/?page=api-keys, and click API Reference in the sidebar. Expect the URL to change to http://localhost:3000/api-reference and the page to render instead of a 404. On the proxy at http://localhost:4000/ui/ the same click should keep producing /ui/api-reference exactly as before

## Type

🐛 Bug Fix

## Changes

`migratedHref` and `legacyPageHref` in `src/utils/migratedPages.ts` always prepend `/ui` because that is where the proxy mounts the static export. The dev server has no such mount: `basePath` is empty in `next.config.mjs` and `next dev` serves the app at the root. So on localhost:3000, every sidebar link to a migrated page and every legacy `?page=` bookmark redirect pointed at `/ui/<segment>`, which 404s. Today that bites only api-reference, but it would bite every page cut over during the App Router migration, making the dev server effectively unusable as the migration proceeds.

The fix is a guard in `uiBase()`: under `NODE_ENV=development` it returns the bare root. The check is inlined at build time by Next, so the production bundle is byte-for-byte equivalent for both deployment shapes (default `/ui` mount and `server_root_path` deployments); only `next dev` behavior changes. `legacyKeyForPathname` needed no change since it already falls back to bare-segment matching, which is why direct navigation to localhost:3000/api-reference worked all along.

Tests cover the new mode: dev hrefs are root-relative, `serverRootPath` is ignored in dev (it only applies to proxy mounts), and the reverse pathname mapping works on bare paths. The existing production-mode tests pass unchanged

