### PR TITLE
feat(ui/mcp): surface BYOK toggle for static auth types in create/edit forms

### DIFF
--- a/ui/litellm-dashboard/src/components/mcp_tools/ByokFields.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/ByokFields.tsx
@@ -78,6 +78,7 @@ const ByokFields: React.FC<ByokFieldsProps> = ({ form }) => {
               </span>
             }
             name="byok_api_key_help_url"
+            rules={[{ type: "url", message: "Enter a valid URL (including https://)" }]}
           >
             <Input placeholder="https://docs.example.com/api-keys" />
           </Form.Item>

--- a/ui/litellm-dashboard/src/components/mcp_tools/ByokFields.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/ByokFields.tsx
@@ -20,6 +20,7 @@ const ByokFields: React.FC<ByokFieldsProps> = ({ form }) => {
   const isByok = Form.useWatch("is_byok", form);
   const authType = Form.useWatch("auth_type", form) as string | undefined;
   const formatHint = authType ? BYOK_AUTH_FORMAT_HINT[authType] : undefined;
+  const isBasicAuth = authType === AUTH_TYPE.BASIC;
 
   return (
     <>
@@ -45,6 +46,14 @@ const ByokFields: React.FC<ByokFieldsProps> = ({ form }) => {
               <InfoCircleOutlined className="mt-0.5 flex-shrink-0" />
               <span>
                 User keys will be sent as: <code className="font-mono bg-blue-100 px-1 rounded">{formatHint}</code>
+                {isBasicAuth && (
+                  <>
+                    {" "}
+                    Each user&apos;s key must be a base64-encoded{" "}
+                    <code className="font-mono bg-blue-100 px-1 rounded">user:password</code> string, or a raw token if
+                    the server accepts one.
+                  </>
+                )}
               </span>
             </div>
           )}

--- a/ui/litellm-dashboard/src/components/mcp_tools/ByokFields.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/ByokFields.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+import { Form, Select, Input, Switch, Tooltip } from "antd";
+import type { FormInstance } from "antd";
+import { InfoCircleOutlined } from "@ant-design/icons";
+import { AUTH_TYPE } from "./types";
+
+export const BYOK_AUTH_FORMAT_HINT: Record<string, string> = {
+  [AUTH_TYPE.BEARER_TOKEN]: "Authorization: Bearer {key}",
+  [AUTH_TYPE.TOKEN]: "Authorization: token {key}",
+  [AUTH_TYPE.API_KEY]: "x-api-key: {key}",
+  [AUTH_TYPE.BASIC]: "Authorization: Basic {key}",
+};
+
+interface ByokFieldsProps {
+  form: FormInstance;
+}
+
+const ByokFields: React.FC<ByokFieldsProps> = ({ form }) => {
+  const isByok = Form.useWatch("is_byok", form);
+  const authType = Form.useWatch("auth_type", form) as string | undefined;
+  const formatHint = authType ? BYOK_AUTH_FORMAT_HINT[authType] : undefined;
+
+  return (
+    <>
+      <Form.Item
+        label={
+          <span className="text-sm font-medium text-gray-700 flex items-center gap-2">
+            BYOK (Bring Your Own Key)
+            <Tooltip title="When enabled, each user supplies their own API key for this server instead of a single shared key. Keys are stored per-user and never shared.">
+              <InfoCircleOutlined className="text-blue-400 hover:text-blue-600 cursor-help" />
+            </Tooltip>
+          </span>
+        }
+        name="is_byok"
+        valuePropName="checked"
+      >
+        <Switch />
+      </Form.Item>
+
+      {isByok && (
+        <>
+          {formatHint && (
+            <div className="mb-4 p-3 bg-blue-50 rounded-lg text-sm text-blue-700 flex items-start gap-2">
+              <InfoCircleOutlined className="mt-0.5 flex-shrink-0" />
+              <span>
+                User keys will be sent as: <code className="font-mono bg-blue-100 px-1 rounded">{formatHint}</code>
+              </span>
+            </div>
+          )}
+
+          <Form.Item
+            label={
+              <span className="text-sm font-medium text-gray-700">
+                Access Description
+                <Tooltip title="List of permissions shown to users in the connection modal (e.g. 'Create and manage Jira issues')">
+                  <InfoCircleOutlined className="ml-2 text-blue-400 hover:text-blue-600 cursor-help" />
+                </Tooltip>
+              </span>
+            }
+            name="byok_description"
+          >
+            <Select
+              mode="tags"
+              placeholder="Add access description items (press Enter after each)"
+              className="w-full"
+              tokenSeparators={[","]}
+            />
+          </Form.Item>
+
+          <Form.Item
+            label={
+              <span className="text-sm font-medium text-gray-700">
+                API Key Help URL
+                <Tooltip title="Optional link shown to users to help them find their API key">
+                  <InfoCircleOutlined className="ml-2 text-blue-400 hover:text-blue-600 cursor-help" />
+                </Tooltip>
+              </span>
+            }
+            name="byok_api_key_help_url"
+          >
+            <Input placeholder="https://docs.example.com/api-keys" />
+          </Form.Item>
+        </>
+      )}
+    </>
+  );
+};
+
+export default ByokFields;

--- a/ui/litellm-dashboard/src/components/mcp_tools/ByokFields.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/ByokFields.tsx
@@ -9,6 +9,7 @@ export const BYOK_AUTH_FORMAT_HINT: Record<string, string> = {
   [AUTH_TYPE.TOKEN]: "Authorization: token {key}",
   [AUTH_TYPE.API_KEY]: "x-api-key: {key}",
   [AUTH_TYPE.BASIC]: "Authorization: Basic {key}",
+  [AUTH_TYPE.AUTHORIZATION]: "Authorization: {key}",
 };
 
 interface ByokFieldsProps {

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
@@ -868,6 +868,62 @@ describe("CreateMCPServer BYOK toggle", () => {
     expect(payload.credentials).toBeUndefined();
   });
 
+  it("blocks submit when the API Key Help URL is not a valid URL", async () => {
+    await selectHttpTransport();
+
+    const user = userEvent.setup({ delay: null });
+    await user.type(getServerNameInput(), "Byok_Server");
+    await user.type(screen.getByPlaceholderText("https://your-mcp-server.com"), "https://example.com/mcp");
+
+    await selectAntOption("Authentication", "Bearer Token");
+    await waitFor(() => expect(screen.getByText(BYOK_LABEL)).toBeInTheDocument());
+    await act(async () => {
+      fireEvent.click(getByokSwitch()!);
+    });
+
+    const helpUrlInput = await screen.findByPlaceholderText("https://docs.example.com/api-keys");
+    await user.type(helpUrlInput, "not a url");
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Add MCP Server" }));
+    });
+
+    await waitFor(() => {
+      const inlineError = screen.queryByText("Enter a valid URL (including https://)");
+      const notCalled = !vi.mocked(networking.createMCPServer).mock.calls.length;
+      expect(inlineError !== null || notCalled).toBe(true);
+    });
+  });
+
+  it("accepts a valid API Key Help URL and submits with is_byok=true", async () => {
+    await selectHttpTransport();
+
+    const user = userEvent.setup({ delay: null });
+    await user.type(getServerNameInput(), "Byok_Server");
+    await user.type(screen.getByPlaceholderText("https://your-mcp-server.com"), "https://example.com/mcp");
+
+    await selectAntOption("Authentication", "Bearer Token");
+    await waitFor(() => expect(screen.getByText(BYOK_LABEL)).toBeInTheDocument());
+    await act(async () => {
+      fireEvent.click(getByokSwitch()!);
+    });
+
+    const helpUrlInput = await screen.findByPlaceholderText("https://docs.example.com/api-keys");
+    await user.type(helpUrlInput, "https://docs.example.com/keys");
+
+    vi.mocked(networking.createMCPServer).mockResolvedValue({ server_id: "byok-url-1" });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Add MCP Server" }));
+    });
+
+    await waitFor(() => expect(networking.createMCPServer).toHaveBeenCalledTimes(1));
+
+    const [, payload] = vi.mocked(networking.createMCPServer).mock.calls[0];
+    expect(payload.is_byok).toBe(true);
+    expect(payload.byok_api_key_help_url).toBe("https://docs.example.com/keys");
+  });
+
   it("forces is_byok=false when auth_type is switched away from a static type after enabling it", async () => {
     await selectHttpTransport();
 

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as networking from "../networking";
@@ -771,5 +771,129 @@ describe("CreateMCPServer", () => {
 
       expect(onBackToDiscovery).toHaveBeenCalledTimes(1);
     });
+  });
+});
+
+const BYOK_LABEL = "BYOK (Bring Your Own Key)";
+
+function getByokSwitch(): HTMLButtonElement | null {
+  const label = screen.queryByText(BYOK_LABEL);
+  const formItem = label?.closest(".ant-form-item");
+  return (formItem?.querySelector('button[role="switch"]') as HTMLButtonElement) ?? null;
+}
+
+describe("CreateMCPServer BYOK toggle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    oauthHook.tokenResponse = null;
+    oauthHook.onTokenReceived = null;
+  });
+
+  async function selectHttpTransport() {
+    render(<CreateMCPServer {...defaultProps} />);
+    await selectAntOption("Transport Type", "Streamable HTTP");
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("https://your-mcp-server.com")).toBeInTheDocument();
+    });
+  }
+
+  it("shows the BYOK toggle for each static-credential auth type", async () => {
+    for (const authLabel of ["API Key", "Bearer Token", "Token", "Basic Auth"]) {
+      await selectHttpTransport();
+      await selectAntOption("Authentication", authLabel);
+      await waitFor(() => {
+        expect(screen.getByText(BYOK_LABEL)).toBeInTheDocument();
+      });
+      cleanup();
+    }
+  });
+
+  it("hides the BYOK toggle for non-static auth types (none, oauth, sigv4)", async () => {
+    for (const authLabel of ["None", "OAuth", "AWS SigV4 (Bedrock AgentCore MCPs)"]) {
+      await selectHttpTransport();
+      await selectAntOption("Authentication", authLabel);
+      await waitFor(() => {
+        expect(screen.queryByText(BYOK_LABEL)).not.toBeInTheDocument();
+      });
+      cleanup();
+    }
+  });
+
+  it("swaps the shared Authentication Value field for per-user fields when BYOK is on", async () => {
+    await selectHttpTransport();
+    await selectAntOption("Authentication", "Bearer Token");
+
+    await waitFor(() => {
+      expect(screen.getByText("Authentication Value")).toBeInTheDocument();
+    });
+
+    const byokSwitch = getByokSwitch();
+    expect(byokSwitch).toBeTruthy();
+    await act(async () => {
+      fireEvent.click(byokSwitch!);
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText("Authentication Value")).not.toBeInTheDocument();
+      expect(screen.getByText("Access Description")).toBeInTheDocument();
+    });
+  });
+
+  it("sends is_byok=true and omits the shared credential when BYOK is enabled", async () => {
+    await selectHttpTransport();
+
+    const user = userEvent.setup({ delay: null });
+    await user.type(getServerNameInput(), "Byok_Server");
+    await user.type(screen.getByPlaceholderText("https://your-mcp-server.com"), "https://example.com/mcp");
+
+    await selectAntOption("Authentication", "Bearer Token");
+    await waitFor(() => expect(screen.getByText(BYOK_LABEL)).toBeInTheDocument());
+
+    await act(async () => {
+      fireEvent.click(getByokSwitch()!);
+    });
+    await waitFor(() => expect(screen.queryByText("Authentication Value")).not.toBeInTheDocument());
+
+    vi.mocked(networking.createMCPServer).mockResolvedValue({ server_id: "byok-1" } as any);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Add MCP Server" }));
+    });
+
+    await waitFor(() => expect(networking.createMCPServer).toHaveBeenCalledTimes(1));
+
+    const [, payload] = vi.mocked(networking.createMCPServer).mock.calls[0];
+    expect(payload.is_byok).toBe(true);
+    expect(payload.auth_type).toBe("bearer_token");
+    expect(payload.credentials).toBeUndefined();
+  });
+
+  it("forces is_byok=false when auth_type is switched away from a static type after enabling it", async () => {
+    await selectHttpTransport();
+
+    const user = userEvent.setup({ delay: null });
+    await user.type(getServerNameInput(), "Switched_Server");
+    await user.type(screen.getByPlaceholderText("https://your-mcp-server.com"), "https://example.com/mcp");
+
+    await selectAntOption("Authentication", "Bearer Token");
+    await waitFor(() => expect(screen.getByText(BYOK_LABEL)).toBeInTheDocument());
+    await act(async () => {
+      fireEvent.click(getByokSwitch()!);
+    });
+
+    // Switching to OAuth removes BYOK eligibility; a stale is_byok=true must not persist.
+    await selectAntOption("Authentication", "None");
+    await waitFor(() => expect(screen.queryByText(BYOK_LABEL)).not.toBeInTheDocument());
+
+    vi.mocked(networking.createMCPServer).mockResolvedValue({ server_id: "switched-1" } as any);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Add MCP Server" }));
+    });
+
+    await waitFor(() => expect(networking.createMCPServer).toHaveBeenCalledTimes(1));
+
+    const [, payload] = vi.mocked(networking.createMCPServer).mock.calls[0];
+    expect(payload.is_byok).toBe(false);
   });
 });

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
@@ -798,7 +798,7 @@ describe("CreateMCPServer BYOK toggle", () => {
   }
 
   it("shows the BYOK toggle for each static-credential auth type", async () => {
-    for (const authLabel of ["API Key", "Bearer Token", "Token", "Basic Auth"]) {
+    for (const authLabel of ["API Key", "Bearer Token", "Token", "Basic Auth", "Authorization Header"]) {
       await selectHttpTransport();
       await selectAntOption("Authentication", authLabel);
       await waitFor(() => {

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
@@ -854,7 +854,7 @@ describe("CreateMCPServer BYOK toggle", () => {
     });
     await waitFor(() => expect(screen.queryByText("Authentication Value")).not.toBeInTheDocument());
 
-    vi.mocked(networking.createMCPServer).mockResolvedValue({ server_id: "byok-1" } as any);
+    vi.mocked(networking.createMCPServer).mockResolvedValue({ server_id: "byok-1" });
 
     await act(async () => {
       fireEvent.click(screen.getByRole("button", { name: "Add MCP Server" }));
@@ -885,7 +885,7 @@ describe("CreateMCPServer BYOK toggle", () => {
     await selectAntOption("Authentication", "None");
     await waitFor(() => expect(screen.queryByText(BYOK_LABEL)).not.toBeInTheDocument());
 
-    vi.mocked(networking.createMCPServer).mockResolvedValue({ server_id: "switched-1" } as any);
+    vi.mocked(networking.createMCPServer).mockResolvedValue({ server_id: "switched-1" });
 
     await act(async () => {
       fireEvent.click(screen.getByRole("button", { name: "Add MCP Server" }));

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
@@ -868,6 +868,27 @@ describe("CreateMCPServer BYOK toggle", () => {
     expect(payload.credentials).toBeUndefined();
   });
 
+  it("shows a base64 clarification in the BYOK hint for Basic auth only", async () => {
+    await selectHttpTransport();
+    await selectAntOption("Authentication", "Basic Auth");
+    await waitFor(() => expect(screen.getByText(BYOK_LABEL)).toBeInTheDocument());
+    await act(async () => {
+      fireEvent.click(getByokSwitch()!);
+    });
+    await waitFor(() => expect(screen.getByText(/base64-encoded/)).toBeInTheDocument());
+
+    cleanup();
+
+    await selectHttpTransport();
+    await selectAntOption("Authentication", "Bearer Token");
+    await waitFor(() => expect(screen.getByText(BYOK_LABEL)).toBeInTheDocument());
+    await act(async () => {
+      fireEvent.click(getByokSwitch()!);
+    });
+    await waitFor(() => expect(screen.getByText("Access Description")).toBeInTheDocument());
+    expect(screen.queryByText(/base64-encoded/)).not.toBeInTheDocument();
+  });
+
   it("blocks submit when the API Key Help URL is not a valid URL", async () => {
     await selectHttpTransport();
 

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
@@ -46,7 +46,13 @@ interface CreateMCPServerProps {
   onBackToDiscovery?: () => void;
 }
 
-const AUTH_TYPES_REQUIRING_AUTH_VALUE = [AUTH_TYPE.API_KEY, AUTH_TYPE.BEARER_TOKEN, AUTH_TYPE.TOKEN, AUTH_TYPE.BASIC];
+const AUTH_TYPES_REQUIRING_AUTH_VALUE = [
+  AUTH_TYPE.API_KEY,
+  AUTH_TYPE.BEARER_TOKEN,
+  AUTH_TYPE.TOKEN,
+  AUTH_TYPE.BASIC,
+  AUTH_TYPE.AUTHORIZATION,
+];
 const AUTH_TYPES_REQUIRING_CREDENTIALS = [...AUTH_TYPES_REQUIRING_AUTH_VALUE, AUTH_TYPE.OAUTH2, AUTH_TYPE.AWS_SIGV4];
 const CREATE_OAUTH_UI_STATE_KEY = "litellm-mcp-oauth-create-state";
 
@@ -770,6 +776,7 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
                             <Select.Option value="bearer_token">Bearer Token</Select.Option>
                             <Select.Option value="token">Token</Select.Option>
                             <Select.Option value="basic">Basic Auth</Select.Option>
+                            <Select.Option value="authorization">Authorization Header</Select.Option>
                             <Select.Option value="oauth2">OAuth</Select.Option>
                             <Select.Option value="aws_sigv4">AWS SigV4 (Bedrock AgentCore MCPs)</Select.Option>
                           </Select>

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Modal, Tooltip, Form, Select, Input, Switch, Collapse } from "antd";
+import { Modal, Tooltip, Form, Select, Input, Collapse } from "antd";
 import { InfoCircleOutlined } from "@ant-design/icons";
 import { Button, TextInput } from "@tremor/react";
 import { createMCPServer, registerMCPServer, storeMCPOAuthUserCredential } from "../networking";
@@ -15,6 +15,7 @@ import {
   MCP_OAUTH2_FLOW_M2M,
 } from "./types";
 import OAuthFormFields from "./OAuthFormFields";
+import ByokFields from "./ByokFields";
 import MCPServerCostConfig from "./mcp_server_cost_config";
 import MCPConnectionStatus from "./mcp_connection_status";
 import MCPToolConfiguration from "./mcp_tool_configuration";
@@ -100,6 +101,7 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
 
   const authType = formValues.auth_type as string | undefined;
   const shouldShowAuthValueField = authType ? AUTH_TYPES_REQUIRING_AUTH_VALUE.includes(authType) : false;
+  const isByok = shouldShowAuthValueField && Boolean(formValues.is_byok);
   const isOAuthAuthType = authType === AUTH_TYPE.OAUTH2;
   const isAwsSigV4AuthType = authType === AUTH_TYPE.AWS_SIGV4;
   const isM2MFlow = isOAuthAuthType && formValues.oauth_flow_type === OAUTH_FLOW.M2M;
@@ -382,6 +384,14 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
         restValues.transport = "http";
       }
 
+      // BYOK is only valid for static-credential auth types; drop a stale ``true``
+      // (and its metadata) left behind by switching auth_type after toggling it on.
+      const isByokEnabled =
+        AUTH_TYPES_REQUIRING_AUTH_VALUE.includes(restValues.auth_type) && Boolean(restValues.is_byok);
+      restValues.is_byok = isByokEnabled;
+      restValues.byok_description = isByokEnabled ? restValues.byok_description || [] : [];
+      restValues.byok_api_key_help_url = isByokEnabled ? restValues.byok_api_key_help_url || null : null;
+
       // Parse token_validation JSON if provided
       let tokenValidation: Record<string, any> | null = null;
       if (rawTokenValidationJson && rawTokenValidationJson.trim() !== "") {
@@ -422,7 +432,7 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
       };
 
       const includeCredentials =
-        restValues.auth_type && AUTH_TYPES_REQUIRING_CREDENTIALS.includes(restValues.auth_type);
+        !isByokEnabled && restValues.auth_type && AUTH_TYPES_REQUIRING_CREDENTIALS.includes(restValues.auth_type);
 
       if (includeCredentials && credentialsPayload && Object.keys(credentialsPayload).length > 0) {
         payload.credentials = credentialsPayload;
@@ -742,96 +752,6 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
               />
             )}
 
-            {/* BYOK toggle - only for OpenAPI */}
-            {transportType === TRANSPORT.OPENAPI && (
-              <>
-                <Form.Item
-                  label={
-                    <span className="text-sm font-medium text-gray-700 flex items-center gap-2">
-                      BYOK (Bring Your Own Key)
-                      <Tooltip title="When enabled, each user provides their own API key for this service. Keys are stored per-user and never shared.">
-                        <InfoCircleOutlined className="text-blue-400 hover:text-blue-600 cursor-help" />
-                      </Tooltip>
-                    </span>
-                  }
-                  name="is_byok"
-                  valuePropName="checked"
-                >
-                  <Switch />
-                </Form.Item>
-
-                <Form.Item
-                  noStyle
-                  shouldUpdate={(prev, cur) => prev.is_byok !== cur.is_byok || prev.auth_type !== cur.auth_type}
-                >
-                  {({ getFieldValue }) =>
-                    getFieldValue("is_byok") ? (
-                      <>
-                        {/* Auth format hint */}
-                        {getFieldValue("auth_type") && getFieldValue("auth_type") !== "none" && (
-                          <div className="mb-4 p-3 bg-blue-50 rounded-lg text-sm text-blue-700 flex items-start gap-2">
-                            <InfoCircleOutlined className="mt-0.5 flex-shrink-0" />
-                            <span>
-                              User keys will be sent as:{" "}
-                              <code className="font-mono bg-blue-100 px-1 rounded">
-                                {getFieldValue("auth_type") === "bearer_token" && "Authorization: Bearer {key}"}
-                                {getFieldValue("auth_type") === "token" && "Authorization: token {key}"}
-                                {getFieldValue("auth_type") === "api_key" && "x-api-key: {key}"}
-                                {getFieldValue("auth_type") === "basic" && "Authorization: Basic {key}"}
-                                {getFieldValue("auth_type") === "authorization" && "Authorization: {key}"}
-                              </code>
-                              {!getFieldValue("auth_type") && "Set Authentication Type below to specify the format."}
-                            </span>
-                          </div>
-                        )}
-                        {!getFieldValue("auth_type") && (
-                          <div className="mb-4 p-3 bg-yellow-50 rounded-lg text-sm text-yellow-700 flex items-start gap-2">
-                            <InfoCircleOutlined className="mt-0.5 flex-shrink-0" />
-                            <span>
-                              Set the <strong>Authentication Type</strong> below to specify how user keys are sent
-                              (e.g., Bearer Token, API Key header).
-                            </span>
-                          </div>
-                        )}
-                        <Form.Item
-                          label={
-                            <span className="text-sm font-medium text-gray-700">
-                              Access Description
-                              <Tooltip title="List of permissions shown to users in the connection modal (e.g. 'Create and manage Jira issues')">
-                                <InfoCircleOutlined className="ml-2 text-blue-400 hover:text-blue-600 cursor-help" />
-                              </Tooltip>
-                            </span>
-                          }
-                          name="byok_description"
-                        >
-                          <Select
-                            mode="tags"
-                            placeholder="Add access description items (press Enter after each)"
-                            className="w-full"
-                            tokenSeparators={[","]}
-                          />
-                        </Form.Item>
-
-                        <Form.Item
-                          label={
-                            <span className="text-sm font-medium text-gray-700">
-                              API Key Help URL
-                              <Tooltip title="Optional link shown to users to help them find their API key">
-                                <InfoCircleOutlined className="ml-2 text-blue-400 hover:text-blue-600 cursor-help" />
-                              </Tooltip>
-                            </span>
-                          }
-                          name="byok_api_key_help_url"
-                        >
-                          <Input placeholder="https://docs.example.com/api-keys" />
-                        </Form.Item>
-                      </>
-                    ) : null
-                  }
-                </Form.Item>
-              </>
-            )}
-
             {/* Authentication - show for HTTP, SSE, and OpenAPI */}
             {transportType !== "stdio" && transportType !== "" && (
               <Collapse
@@ -855,7 +775,9 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
                           </Select>
                         </Form.Item>
 
-                        {shouldShowAuthValueField && (
+                        {shouldShowAuthValueField && <ByokFields form={form} />}
+
+                        {shouldShowAuthValueField && !isByok && (
                           <Form.Item
                             label={
                               <span className="text-sm font-medium text-gray-700 flex items-center">

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.test.tsx
@@ -940,3 +940,101 @@ describe("MCPServerEdit (OAuth token persistence on save)", () => {
     expect(mockSetToken).not.toHaveBeenCalled();
   });
 });
+
+describe("MCPServerEdit (BYOK)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const byokServer = {
+    server_id: "byok_server_1",
+    server_name: "ByokServer",
+    alias: "byok_server",
+    description: "BYOK MCP server",
+    transport: "http",
+    url: "https://example.com/mcp",
+    auth_type: "bearer_token",
+    is_byok: true,
+    byok_description: ["Create and manage issues"],
+    byok_api_key_help_url: "https://docs.example.com/keys",
+    created_at: "2024-01-01T00:00:00Z",
+    created_by: "user-1",
+    updated_at: "2024-01-01T00:00:00Z",
+    updated_by: "user-1",
+    mcp_access_groups: [],
+  };
+
+  const getByokSwitch = () => {
+    const formItem = screen.queryByText("BYOK (Bring Your Own Key)")?.closest(".ant-form-item");
+    return (formItem?.querySelector('button[role="switch"]') as HTMLButtonElement) ?? null;
+  };
+
+  const save = async () => {
+    const saveButtons = screen.getAllByRole("button", { name: "Save Changes" });
+    await act(async () => {
+      fireEvent.click(saveButtons[0]);
+    });
+    await waitFor(() => expect(networking.updateMCPServer).toHaveBeenCalledTimes(1));
+    return vi.mocked(networking.updateMCPServer).mock.calls[0][1];
+  };
+
+  it("renders the BYOK toggle on for an existing BYOK server and hides the shared auth value field", async () => {
+    render(
+      <MCPServerEdit
+        mcpServer={byokServer}
+        accessToken={null}
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+        availableAccessGroups={[]}
+      />,
+    );
+
+    await waitFor(() => expect(getByokSwitch()).toBeTruthy());
+    expect(getByokSwitch()).toHaveAttribute("aria-checked", "true");
+    expect(screen.queryByText("Authentication Value")).not.toBeInTheDocument();
+  });
+
+  it("persists is_byok=true when saving an existing BYOK server", async () => {
+    vi.mocked(networking.updateMCPServer).mockResolvedValue(byokServer as any);
+
+    render(
+      <MCPServerEdit
+        mcpServer={byokServer}
+        accessToken="access-token"
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+        availableAccessGroups={[]}
+      />,
+    );
+
+    await waitFor(() => expect(getByokSwitch()).toBeTruthy());
+
+    const payload = await save();
+    expect(payload.is_byok).toBe(true);
+    expect(payload.credentials).toBeUndefined();
+  });
+
+  it("persists is_byok=false and restores the shared auth value field when BYOK is toggled off", async () => {
+    vi.mocked(networking.updateMCPServer).mockResolvedValue({ ...byokServer, is_byok: false } as any);
+
+    render(
+      <MCPServerEdit
+        mcpServer={byokServer}
+        accessToken="access-token"
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+        availableAccessGroups={[]}
+      />,
+    );
+
+    await waitFor(() => expect(getByokSwitch()).toBeTruthy());
+    await act(async () => {
+      fireEvent.click(getByokSwitch()!);
+    });
+
+    await waitFor(() => expect(screen.getByText("Authentication Value")).toBeInTheDocument());
+
+    const payload = await save();
+    expect(payload.is_byok).toBe(false);
+  });
+});

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.test.tsx
@@ -994,6 +994,22 @@ describe("MCPServerEdit (BYOK)", () => {
     expect(screen.queryByText("Authentication Value")).not.toBeInTheDocument();
   });
 
+  it("renders the BYOK toggle for a server using the authorization auth type", async () => {
+    render(
+      <MCPServerEdit
+        mcpServer={{ ...byokServer, auth_type: "authorization" }}
+        accessToken={null}
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+        availableAccessGroups={[]}
+      />,
+    );
+
+    await waitFor(() => expect(getByokSwitch()).toBeTruthy());
+    expect(getByokSwitch()).toHaveAttribute("aria-checked", "true");
+    expect(screen.queryByText("Authentication Value")).not.toBeInTheDocument();
+  });
+
   it("persists is_byok=true when saving an existing BYOK server", async () => {
     vi.mocked(networking.updateMCPServer).mockResolvedValue(byokServer);
 

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.test.tsx
@@ -995,7 +995,7 @@ describe("MCPServerEdit (BYOK)", () => {
   });
 
   it("persists is_byok=true when saving an existing BYOK server", async () => {
-    vi.mocked(networking.updateMCPServer).mockResolvedValue(byokServer as any);
+    vi.mocked(networking.updateMCPServer).mockResolvedValue(byokServer);
 
     render(
       <MCPServerEdit
@@ -1015,7 +1015,7 @@ describe("MCPServerEdit (BYOK)", () => {
   });
 
   it("persists is_byok=false and restores the shared auth value field when BYOK is toggled off", async () => {
-    vi.mocked(networking.updateMCPServer).mockResolvedValue({ ...byokServer, is_byok: false } as any);
+    vi.mocked(networking.updateMCPServer).mockResolvedValue({ ...byokServer, is_byok: false });
 
     render(
       <MCPServerEdit

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
@@ -18,6 +18,7 @@ import MCPServerCostConfig from "./mcp_server_cost_config";
 import MCPPermissionManagement from "./MCPPermissionManagement";
 import MCPToolConfiguration from "./mcp_tool_configuration";
 import StdioConfiguration from "./StdioConfiguration";
+import ByokFields from "./ByokFields";
 import MCPLogoSelector from "./MCPLogoSelector";
 import EnvVarsSection from "./EnvVarsSection";
 import { validateMCPServerUrl, validateMCPServerName, normalizeEnvVars } from "./utils";
@@ -65,6 +66,8 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
   const isOpenAPITransport = transportType === TRANSPORT.OPENAPI;
   const isMCPTransport = !isStdioTransport && !isOpenAPITransport;
   const shouldShowAuthValueField = authType ? AUTH_TYPES_REQUIRING_AUTH_VALUE.includes(authType) : false;
+  const isByokRaw = Form.useWatch("is_byok", form);
+  const isByok = shouldShowAuthValueField && Boolean(isByokRaw);
   const isOAuthAuthType = authType === AUTH_TYPE.OAUTH2;
   const isAwsSigV4AuthType = authType === AUTH_TYPE.AWS_SIGV4;
   const oauthFlowTypeValue = Form.useWatch("oauth_flow_type", form) as string | undefined;
@@ -587,6 +590,14 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
         restValues.transport = "http";
       }
 
+      // BYOK is only valid for static-credential auth types; drop a stale ``true``
+      // (and its metadata) left behind by switching auth_type after toggling it on.
+      const isByokEnabled =
+        AUTH_TYPES_REQUIRING_AUTH_VALUE.includes(restValues.auth_type) && Boolean(restValues.is_byok);
+      restValues.is_byok = isByokEnabled;
+      restValues.byok_description = isByokEnabled ? restValues.byok_description || [] : [];
+      restValues.byok_api_key_help_url = isByokEnabled ? restValues.byok_api_key_help_url || null : null;
+
       // Parse token_validation JSON if provided
       let tokenValidation: Record<string, any> | null = null;
       if (rawTokenValidationJson && rawTokenValidationJson.trim() !== "") {
@@ -670,7 +681,7 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
       };
 
       const includeCredentials =
-        restValues.auth_type && AUTH_TYPES_REQUIRING_CREDENTIALS.includes(restValues.auth_type);
+        !isByokEnabled && restValues.auth_type && AUTH_TYPES_REQUIRING_CREDENTIALS.includes(restValues.auth_type);
 
       if (includeCredentials && credentialsPayload && Object.keys(credentialsPayload).length > 0) {
         payload.credentials = credentialsPayload;
@@ -824,6 +835,8 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
               </Form.Item>
             )}
 
+            {!isStdioTransport && shouldShowAuthValueField && <ByokFields form={form} />}
+
             {isStdioTransport && (
               <div className="rounded-lg border border-gray-200 p-4 space-y-4">
                 <p className="text-sm text-gray-600">
@@ -884,7 +897,7 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
               </div>
             )}
 
-            {!isStdioTransport && shouldShowAuthValueField && (
+            {!isStdioTransport && shouldShowAuthValueField && !isByok && (
               <Form.Item
                 label={
                   <span className="text-sm font-medium text-gray-700 flex items-center">

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
@@ -35,7 +35,13 @@ interface MCPServerEditProps {
   availableAccessGroups: string[];
 }
 
-const AUTH_TYPES_REQUIRING_AUTH_VALUE = [AUTH_TYPE.API_KEY, AUTH_TYPE.BEARER_TOKEN, AUTH_TYPE.TOKEN, AUTH_TYPE.BASIC];
+const AUTH_TYPES_REQUIRING_AUTH_VALUE = [
+  AUTH_TYPE.API_KEY,
+  AUTH_TYPE.BEARER_TOKEN,
+  AUTH_TYPE.TOKEN,
+  AUTH_TYPE.BASIC,
+  AUTH_TYPE.AUTHORIZATION,
+];
 const AUTH_TYPES_REQUIRING_CREDENTIALS = [...AUTH_TYPES_REQUIRING_AUTH_VALUE, AUTH_TYPE.OAUTH2, AUTH_TYPE.AWS_SIGV4];
 export const EDIT_OAUTH_UI_STATE_KEY = "litellm-mcp-oauth-edit-state";
 
@@ -829,6 +835,7 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
                   <Select.Option value="bearer_token">Bearer Token</Select.Option>
                   <Select.Option value="token">Token</Select.Option>
                   <Select.Option value="basic">Basic Auth</Select.Option>
+                  <Select.Option value="authorization">Authorization Header</Select.Option>
                   <Select.Option value="oauth2">OAuth</Select.Option>
                   <Select.Option value="aws_sigv4">AWS SigV4 (Bedrock AgentCore MCPs)</Select.Option>
                 </Select>

--- a/ui/litellm-dashboard/src/components/mcp_tools/types.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/types.tsx
@@ -38,6 +38,7 @@ export const AUTH_TYPE = {
   BEARER_TOKEN: "bearer_token",
   TOKEN: "token",
   BASIC: "basic",
+  AUTHORIZATION: "authorization",
   OAUTH2: "oauth2",
   AWS_SIGV4: "aws_sigv4",
 };


### PR DESCRIPTION
## Relevant issues

A POC needed to set `is_byok = true` on an MCP server but could not find that option anywhere in the admin UI and had to set it directly in the database. The scoping question was whether BYOK should be available in the UI, stay API/config-only, or be documented more clearly so setup does not require direct DB changes.

## Linear ticket
Resolves LIT-3618

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Type

🆕 New Feature

## Changes

`is_byok` was already fully supported by the backend (request/response models, per-user credential storage, the Connect modal, and upstream injection are all in place and transport-agnostic), but the only first-class way to turn a server into a BYOK server from the UI was when its transport happened to be OpenAPI. For a normal Streamable HTTP or SSE MCP server the toggle never rendered, so enabling BYOK meant editing the database by hand. That is exactly what the POC ran into.

The fix reframes BYOK as what it actually is. It is not a transport concern; it is a sub-mode of the credential format. For the static-credential auth types it switches the upstream key from a single shared admin value to a per-user value, the same way `delegate_auth_to_upstream` switches `oauth2` between passthrough and OBO. So the toggle is now gated on the static auth types instead of on transport, in both the create and edit forms. The edit form had no BYOK control at all before this, so there was previously no way to flip the flag on an existing server from the UI.

The static set is every auth type that resolves to a header the proxy builds from a single value: api_key, bearer_token, token, basic, and authorization. The first four were already selectable in the create/edit dropdowns; authorization (which sends the user-supplied value verbatim as the `Authorization` header, so the hint is `Authorization: {key}`) was a backend `MCPAuth` member that the UI never exposed as a dropdown option, and its format hint was lost when the inline hint block moved into the shared `ByokFields` component. This adds authorization as a selectable static auth type and restores its hint, so BYOK flares up for every static mode rather than only the four that happened to be in the menu.

When BYOK is on, the shared "Authentication Value" field is hidden, since a shared key and per-user keys are mutually exclusive. On submit, `is_byok` is normalized so a stale `true` cannot survive switching `auth_type` away from a static type, and the shared credential is dropped from the payload when BYOK is enabled. The per-user key entry flow (the Connect modal and the user-credential endpoint) and the upstream injection were already there; this only adds the admin-side switch that turns a server into a BYOK server.

The shared toggle and its per-user metadata fields (access description, API key help URL) are extracted into a small `ByokFields` component reused by both forms. The help URL is validated as a real URL, since it renders as a clickable link in the Connect modal and a malformed value would otherwise save as a broken link. For Basic auth the hint adds a note that each user's key must be a base64-encoded `user:password` string, so a raw token is not pasted by mistake. No backend changes.

Tests assert behavior rather than coverage: the toggle shows for all five static auth types and is absent for none/oauth/sigv4/stdio; turning it on swaps the shared value field for the per-user fields; the create payload sends `is_byok: true` with no shared credential; switching auth type away from a static type after enabling forces `is_byok: false` (the stale-value regression); and the edit form renders the toggle checked for an existing BYOK server (including one using the authorization auth type), persists `is_byok: true` on save, and persists `false` while restoring the shared field when toggled off.

## Screenshots / Proof of Fix

This is a UI-only change; suggested manual verification against a proxy at http://localhost:4000/ui/?page=mcp-servers:

1. Click "Add New MCP Server". Pick transport "Streamable HTTP", enter a URL, then under Authentication choose "Bearer Token". The "BYOK (Bring Your Own Key)" switch now appears (previously it only showed for the OpenAPI transport)
2. Flip it on: the "Authentication Value" field disappears and "Access Description" plus "API Key Help URL" appear, with the hint "User keys will be sent as: Authorization: Bearer {key}". Save the server
3. Change Authentication to "Authorization Header" (the newly added static type) and confirm the BYOK switch still appears, now with the hint "User keys will be sent as: Authorization: {key}"
4. Open the server's edit view: the BYOK switch is on and the shared value field is hidden. Switch auth type to "OAuth" and confirm the BYOK toggle disappears
5. On the server card, the existing "Connect" button lets each user paste their own key, which is stored per user
