### PR TITLE
bump: version 1.85.5 on stable/1.85.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "litellm"
-version = "1.85.4"
+version = "1.85.5"
 description = "Library to easily interface with LLM API providers"
 readme = "README.md"
 requires-python = ">=3.10, <3.14"
@@ -250,7 +250,7 @@ source-exclude = [
 profile = "black"
 
 [tool.commitizen]
-version = "1.85.4"
+version = "1.85.5"
 version_files = [
     "pyproject.toml:^version",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-30T01:59:13.763795Z"
+exclude-newer = "2026-06-08T01:27:07.799499Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -3189,7 +3189,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.85.4"
+version = "1.85.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Relevant issues

Cuts 1.85.5 on `stable/1.85.x`. The backport PR #30149 merged without a version bump while v1.85.4 had already been released (both `release/v1.85.4` and the `v1.85.4` tag exist), so the line cannot be released as-is. This PR carries only the version bump and the matching `uv.lock` refresh; 1.85.5 will ship the #30149 content (#30064 Fable 5, CrowdStrike AIDR identity capture + #29991, #30009).

## Pre-Submission checklist

- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Type

🚄 Infrastructure

## Changes

`pyproject.toml` version fields 1.85.4 -> 1.85.5 and the corresponding `uv.lock` entry. No code changes
