### PR TITLE
test(proxy/client): isolate client tests from the developer's real CLI token

### DIFF
--- a/tests/test_litellm/proxy/client/conftest.py
+++ b/tests/test_litellm/proxy/client/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def isolate_from_real_cli_token(monkeypatch):
+    """Never let tests read the developer's real ~/.litellm/token.json from `lite login`."""
+    monkeypatch.setattr(
+        "litellm.litellm_core_utils.cli_token_utils.load_cli_token", lambda: None
+    )

--- a/tests/test_litellm/proxy/client/test_client.py
+++ b/tests/test_litellm/proxy/client/test_client.py
@@ -74,18 +74,40 @@ def test_client_without_api_key(base_url):
     assert client.http._api_key is None
 
 
-def test_client_initialization():
-    """Test that the client is initialized correctly."""
+def test_client_falls_back_to_stored_cli_token(base_url, monkeypatch):
+    """Test that the client uses the `lite login` token issued for this server"""
+    monkeypatch.setattr(
+        "litellm.litellm_core_utils.cli_token_utils.load_cli_token",
+        lambda: {"key": "sk-cli-token", "base_url": base_url},
+    )
+
+    client = Client(base_url=base_url)
+
+    assert client._api_key == "sk-cli-token"
+    assert client.http._api_key == "sk-cli-token"
+
+
+def test_client_ignores_cli_token_issued_for_other_server(base_url, monkeypatch):
+    """Test that the client never sends a stored CLI token to a different server"""
+    monkeypatch.setattr(
+        "litellm.litellm_core_utils.cli_token_utils.load_cli_token",
+        lambda: {"key": "sk-cli-token", "base_url": "https://other-proxy.example"},
+    )
+
+    client = Client(base_url=base_url)
+
+    assert client._api_key is None
+    assert client.http._api_key is None
+
+
+def test_client_custom_timeout():
+    """Test that the client passes a custom timeout to the http client."""
     client = Client(
         base_url="http://localhost:4000",
         api_key="test-key",
         timeout=60,
     )
 
-    # Check that http client is initialized correctly
-    assert isinstance(client.http, HTTPClient)
-    assert client.http._base_url == "http://localhost:4000"
-    assert client.http._api_key == "test-key"
     assert client.http._timeout == 60
 
 
@@ -97,10 +119,3 @@ def test_client_default_timeout():
     )
 
     assert client.http._timeout == 30
-
-
-def test_client_without_api_key():
-    """Test that the client works without an API key."""
-    client = Client(base_url="http://localhost:4000")
-
-    assert client.http._api_key is None


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

Note on the `make test-unit` box: the command currently aborts on `litellm_internal_staging` itself, before this PR. #29686 added `tests/test_litellm/models/test_models.py`, which collides with the long-existing `tests/test_litellm/proxy/client/test_models.py`; neither directory has an `__init__.py`, so pytest assigns both the module name `test_models` and collection dies with "import file mismatch". That needs a separate fix (add `__init__.py` files or unique basenames). Running the suite on this branch without `-x` gives 21915 passed, 113 skipped, that one pre-existing collection error, and 18 failures that are parallel-run flakes: all 18 pass when run in isolation on both this branch and a clean checkout of `litellm_internal_staging`

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

Simulate a developer who ran `lite login` against the URL the test uses, without touching the real `~/.litellm/token.json`:

```bash
mkdir -p /tmp/fakehome/.litellm
printf '{"key": "sk-fake-cli-key", "base_url": "http://localhost:4000"}' > /tmp/fakehome/.litellm/token.json
```

On `litellm_internal_staging`:

```
$ HOME=/tmp/fakehome python -m pytest tests/test_litellm/proxy/client/test_client.py -q
E       AssertionError: assert 'sk-fake-cli-key' is None
E        +  where 'sk-fake-cli-key' = <litellm.proxy.client.http_client.HTTPClient object at 0x12049d5b0>._api_key
FAILED tests/test_litellm/proxy/client/test_client.py::test_client_without_api_key
1 failed, 3 passed in 3.34s
```

On this branch:

```
$ HOME=/tmp/fakehome python -m pytest tests/test_litellm/proxy/client/ -q
269 passed in 53.02s
```

## Type

✅ Test

## Changes

`Client` falls back to `get_litellm_gateway_api_key()` when constructed without an `api_key`, which reads the token that `lite login` stores in `~/.litellm/token.json`. `test_client_without_api_key` asserts the resolved key is `None`, so it fails on any developer machine where the stored token was issued for the same base URL the test uses. The test suite's outcome should not depend on whether the developer has logged into a local proxy

This adds a `conftest.py` for `tests/test_litellm/proxy/client/` with an autouse fixture that stubs `load_cli_token` to return `None`, so every test in the directory is hermetic with respect to the developer's home directory. The same latent leak existed in `test_models.py` and `test_model_groups.py`, which also construct `Client` without a key and assert it is `None`; the directory-wide fixture covers those too. The CLI tests under `cli/` are unaffected: `auth.py` has its own `load_token`, and the tests that patch `cli_token_utils.load_cli_token` do so per test, which composes fine with the autouse fixture

While auditing the file I found that `test_client.py` defined `test_client_initialization` and `test_client_without_api_key` twice each; Python silently shadows the earlier definitions, so pytest only ever ran the second of each. The duplicates are now merged into single tests, with the custom timeout assertion split out as `test_client_custom_timeout`

The CLI token fallback had no coverage at the `Client` level, so this also adds two tests: one asserting the client picks up a stored token issued for the target server, one asserting it ignores a token issued for a different server. Besides covering the fallback and its origin check, the first one pins `load_cli_token` as the live seam, so if `client.py` ever stops resolving the key through it, the test fails and flags that the conftest isolation needs updating
