### PR TITLE
fix(mcp): inject per-user BYOK credential into the REST and protocol tools-list paths

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
@@ -80,6 +80,7 @@ if MCP_AVAILABLE:
     from litellm.proxy._experimental.mcp_server.server import (
         ListMCPToolsRestAPIResponseObject,
         MCPServer,
+        _get_byok_credential,
         _tool_name_matches,
         execute_mcp_tool,
         filter_tools_by_allowed_tools,
@@ -180,34 +181,20 @@ if MCP_AVAILABLE:
         server,
         user_api_key_dict: UserAPIKeyAuth,
     ) -> Optional[str]:
-        """
-        For BYOK servers, return the user's stored per-user key as the raw
-        credential string so the REST tools-list path injects it the same way
-        the MCP protocol tool-call path does in ``execute_mcp_tool``. The
-        auth_type formatting (Bearer / x-api-key / ...) is applied downstream by
-        the MCP client. Returns None for non-BYOK servers or when no credential
-        is stored.
-        """
-        if not getattr(server, "is_byok", False):
-            return None
-        user_id = getattr(user_api_key_dict, "user_id", None)
-        server_id = getattr(server, "server_id", None)
-        if not user_id or not server_id:
-            return None
+        """Resolve the caller's stored per-user BYOK key via the shared cached
+        ``_get_byok_credential`` so all three BYOK paths (REST tools-list,
+        protocol tools-list, tool-call) use one resolver. Swallows lookup errors
+        so a credential failure degrades to listing without the key instead of
+        aborting the request. Returns None for non-BYOK servers or when no
+        credential is stored."""
         try:
-            from litellm.proxy._experimental.mcp_server.db import get_user_credential
-            from litellm.proxy.utils import get_prisma_client_or_throw
-
-            prisma_client = get_prisma_client_or_throw(
-                "Database not connected. Connect a database to use BYOK MCP tools."
-            )
-            return await get_user_credential(prisma_client, user_id, server_id)
+            return await _get_byok_credential(server, user_api_key_dict)
         except Exception as e:
             verbose_logger.warning(
-                f"_get_user_byok_auth_header: failed to retrieve credential for "
-                f"user={user_id} server={server_id}: {e}"
+                f"_get_user_byok_auth_header: BYOK credential lookup failed for "
+                f"server={getattr(server, 'server_id', None)}: {e}"
             )
-        return None
+            return None
 
     async def _prefetch_user_oauth_creds(
         user_api_key_dict: UserAPIKeyAuth,

--- a/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
@@ -176,6 +176,39 @@ if MCP_AVAILABLE:
             )
         return None
 
+    async def _get_user_byok_auth_header(
+        server,
+        user_api_key_dict: UserAPIKeyAuth,
+    ) -> Optional[str]:
+        """
+        For BYOK servers, return the user's stored per-user key as the raw
+        credential string so the REST tools-list path injects it the same way
+        the MCP protocol tool-call path does in ``execute_mcp_tool``. The
+        auth_type formatting (Bearer / x-api-key / ...) is applied downstream by
+        the MCP client. Returns None for non-BYOK servers or when no credential
+        is stored.
+        """
+        if not getattr(server, "is_byok", False):
+            return None
+        user_id = getattr(user_api_key_dict, "user_id", None)
+        server_id = getattr(server, "server_id", None)
+        if not user_id or not server_id:
+            return None
+        try:
+            from litellm.proxy._experimental.mcp_server.db import get_user_credential
+            from litellm.proxy.utils import get_prisma_client_or_throw
+
+            prisma_client = get_prisma_client_or_throw(
+                "Database not connected. Connect a database to use BYOK MCP tools."
+            )
+            return await get_user_credential(prisma_client, user_id, server_id)
+        except Exception as e:
+            verbose_logger.warning(
+                f"_get_user_byok_auth_header: failed to retrieve credential for "
+                f"user={user_id} server={server_id}: {e}"
+            )
+        return None
+
     async def _prefetch_user_oauth_creds(
         user_api_key_dict: UserAPIKeyAuth,
     ) -> Dict[str, Dict[str, Any]]:
@@ -527,6 +560,10 @@ if MCP_AVAILABLE:
         server_auth_header = _get_server_auth_header(
             server, mcp_server_auth_headers, mcp_auth_header
         )
+        if not server_auth_header:
+            server_auth_header = await _get_user_byok_auth_header(
+                server, user_api_key_dict
+            )
         user_oauth_extra_headers = await _get_user_oauth_extra_headers(
             server, user_api_key_dict
         )
@@ -692,6 +729,10 @@ if MCP_AVAILABLE:
                     server_auth_header = _get_server_auth_header(
                         server, mcp_server_auth_headers, mcp_auth_header
                     )
+                    if not server_auth_header:
+                        server_auth_header = await _get_user_byok_auth_header(
+                            server, user_api_key_dict
+                        )
                     user_oauth_extra_headers = await _get_user_oauth_extra_headers(
                         server,
                         user_api_key_dict,

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -3493,6 +3493,8 @@ if MCP_AVAILABLE:
         excludes a passthrough server is not pushed into an OAuth flow for
         a server it will be 403'd on immediately after authentication.
         """
+        _req_path = scope.get("_original_path") or scope.get("path", "") or ""
+        is_single_server_scoped = len(_get_mcp_servers_in_path(_req_path) or []) == 1
         for server_name in mcp_servers or []:
             server = global_mcp_server_manager.get_mcp_server_by_name(
                 server_name, client_ip=client_ip
@@ -3560,6 +3562,41 @@ if MCP_AVAILABLE:
                     status_code=401,
                     detail="Unauthorized",
                     headers={"www-authenticate": www_authenticate},
+                )
+
+            # BYOK: on a single-server-scoped route, when the caller supplied no
+            # key inline and has none stored, fail fast with 401 + challenge so
+            # OAuth-capable MCP clients run the key-entry flow instead of seeing
+            # a silently empty tool list. Gated to single-server routes so one
+            # credential-less BYOK server cannot abort a multi-server aggregated
+            # listing, which keeps degrading per-server.
+            if (
+                server
+                and server.is_byok
+                and is_single_server_scoped
+                and not _client_has_passthrough_authorization(
+                    server, oauth2_headers, mcp_server_auth_headers
+                )
+                and await _get_byok_credential(server, user_api_key_auth) is None
+            ):
+                base_url = get_request_base_url(StarletteRequest(scope))
+                raise HTTPException(
+                    status_code=401,
+                    detail={
+                        "error": "byok_auth_required",
+                        "server_id": server.server_id,
+                        "server_name": server.server_name or server.name,
+                        "message": (
+                            "No stored credential found for this BYOK server. "
+                            "Complete the OAuth authorization flow to provide your API key."
+                        ),
+                    },
+                    headers={
+                        "www-authenticate": (
+                            "Bearer resource_metadata="
+                            f'"{base_url}/.well-known/oauth-protected-resource"'
+                        )
+                    },
                 )
 
     def _get_forwarded_auth_from_scope(scope: Scope) -> Optional[str]:

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -1766,6 +1766,15 @@ if MCP_AVAILABLE:
                     user_api_key_auth=user_api_key_auth,
                 )
 
+                # BYOK: inject the caller's stored per-user key so the protocol
+                # tools-list path authenticates the same way execute_mcp_tool
+                # does. Without this a BYOK server lists with the shared token,
+                # which is None, so the upstream rejects the listing.
+                if server.is_byok and not server_auth_header:
+                    server_auth_header = await _get_byok_credential(
+                        server, user_api_key_auth
+                    )
+
                 # Prefer server-stored per-user OAuth when configured, so a stale
                 # Authorization header from the MCP client cannot override Redis/DB
                 # (same issue as call_tool in mcp_server_manager: VS Code caches tokens).

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -1771,9 +1771,18 @@ if MCP_AVAILABLE:
                 # does. Without this a BYOK server lists with the shared token,
                 # which is None, so the upstream rejects the listing.
                 if server.is_byok and not server_auth_header:
-                    server_auth_header = await _get_byok_credential(
-                        server, user_api_key_auth
-                    )
+                    # Don't let a credential-lookup error abort the whole
+                    # multi-server listing; degrade to listing without the key,
+                    # matching the REST path's behavior.
+                    try:
+                        server_auth_header = await _get_byok_credential(
+                            server, user_api_key_auth
+                        )
+                    except Exception as e:
+                        verbose_logger.warning(
+                            f"BYOK credential lookup failed for {server.server_id}; "
+                            f"listing without it: {e}"
+                        )
 
                 # Prefer server-stored per-user OAuth when configured, so a stale
                 # Authorization header from the MCP client cannot override Redis/DB

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -1024,6 +1024,84 @@ async def test_get_tools_from_mcp_servers_injects_byok_credential():
 
 
 @pytest.mark.asyncio
+async def test_get_tools_from_mcp_servers_byok_lookup_error_does_not_abort_listing():
+    """A DB error during the BYOK credential lookup must degrade to listing
+    without the key, not propagate out of the gather and abort the whole list."""
+    try:
+        from litellm.proxy._experimental.mcp_server import server as mcp_server_module
+        from litellm.proxy._experimental.mcp_server.server import (
+            _get_tools_from_mcp_servers,
+            set_auth_context,
+        )
+    except ImportError:
+        pytest.skip("MCP server not available")
+
+    user_api_key_auth = UserAPIKeyAuth(api_key="test_key", user_id="byok_user")
+    set_auth_context(user_api_key_auth)
+
+    byok_server = MagicMock()
+    byok_server.name = "byok_server"
+    byok_server.alias = "byok"
+    byok_server.allowed_tools = None
+    byok_server.disallowed_tools = None
+    byok_server.server_id = "byok_server"
+    byok_server.server_name = "byok_server"
+    byok_server.auth_type = "authorization"
+    byok_server.extra_headers = None
+    byok_server.is_byok = True
+
+    mock_manager = MagicMock()
+    mock_manager.get_allowed_mcp_servers = AsyncMock(return_value=["byok_server"])
+    mock_manager.get_mcp_server_by_id = lambda server_id: byok_server
+    mock_manager.filter_server_ids_by_ip_with_info = lambda server_ids, client_ip: (
+        server_ids,
+        0,
+    )
+
+    captured = {}
+
+    async def mock_get_tools_from_server(
+        server,
+        mcp_auth_header=None,
+        extra_headers=None,
+        add_prefix=True,
+        raw_headers=None,
+        **kwargs,
+    ):
+        captured["mcp_auth_header"] = mcp_auth_header
+        tool = MagicMock()
+        tool.name = "byok_tool"
+        tool.description = "BYOK tool"
+        tool.inputSchema = {}
+        return [tool]
+
+    mock_manager._get_tools_from_server = mock_get_tools_from_server
+
+    with (
+        patch.object(
+            mcp_server_module,
+            "_get_byok_credential",
+            AsyncMock(side_effect=Exception("transient DB error")),
+        ),
+        patch(
+            "litellm.proxy._experimental.mcp_server.server.global_mcp_server_manager",
+            mock_manager,
+        ),
+    ):
+        # Must not raise even though the credential lookup blew up.
+        result = await _get_tools_from_mcp_servers(
+            user_api_key_auth=user_api_key_auth,
+            mcp_auth_header=None,
+            mcp_servers=["byok_server"],
+        )
+
+    # The listing still completed; the server was listed without the BYOK key.
+    assert len(result) == 1
+    assert result[0].name == "byok_tool"
+    assert captured["mcp_auth_header"] is None
+
+
+@pytest.mark.asyncio
 async def test_get_tools_from_mcp_servers_handles_all_servers_failing():
     """Test that _get_tools_from_mcp_servers handles all servers failing gracefully"""
     try:

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -1101,6 +1101,153 @@ async def test_get_tools_from_mcp_servers_byok_lookup_error_does_not_abort_listi
     assert captured["mcp_auth_header"] is None
 
 
+def _byok_preemptive_scope(path: str) -> dict:
+    return {
+        "type": "http",
+        "method": "POST",
+        "scheme": "http",
+        "server": ("testserver", 80),
+        "path": path,
+        "headers": [(b"host", b"testserver")],
+        "client": ("1.2.3.4", 12345),
+    }
+
+
+def _byok_preemptive_server() -> MagicMock:
+    server = MagicMock()
+    server.name = "byok_server"
+    server.alias = "byok"
+    server.server_id = "byok_server_id"
+    server.server_name = "byok_server"
+    server.auth_type = MCPAuth.none
+    server.is_byok = True
+    server.is_oauth_passthrough = False
+    server.needs_user_oauth_token = False
+    return server
+
+
+@pytest.mark.asyncio
+async def test_preemptive_401_byok_single_server_no_credential_raises():
+    """On a single-server-scoped route, a BYOK server with no stored credential
+    and no inline key must fail fast with 401 + WWW-Authenticate so OAuth-capable
+    MCP clients run the key-entry flow instead of seeing an empty tool list."""
+    from litellm.proxy._experimental.mcp_server import server as mcp_server_module
+
+    server = _byok_preemptive_server()
+    manager = MagicMock()
+    manager.get_mcp_server_by_name = MagicMock(return_value=server)
+
+    with (
+        patch.object(mcp_server_module, "global_mcp_server_manager", manager),
+        patch.object(
+            mcp_server_module, "_get_byok_credential", AsyncMock(return_value=None)
+        ) as mock_cred,
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await mcp_server_module._raise_preemptive_401_for_unauthenticated_servers(
+                scope=_byok_preemptive_scope("/mcp/byok_server"),
+                mcp_servers=["byok_server"],
+                oauth2_headers=None,
+                mcp_server_auth_headers=None,
+                user_api_key_auth=UserAPIKeyAuth(api_key="k", user_id="u"),
+                client_ip=None,
+            )
+
+    assert exc_info.value.status_code == 401
+    challenge = exc_info.value.headers["www-authenticate"]
+    assert challenge.startswith("Bearer ")
+    # Absolute RFC 9728 resource_metadata URI (not the relative form strict
+    # clients reject), pointing at the gateway's BYOK protected-resource doc.
+    assert 'resource_metadata="http' in challenge
+    assert "/.well-known/oauth-protected-resource" in challenge
+    mock_cred.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_preemptive_401_byok_single_server_with_credential_no_raise():
+    """A stored credential satisfies BYOK auth, so the preemptive challenge must
+    not fire (otherwise an already-authenticated user is blocked from listing)."""
+    from litellm.proxy._experimental.mcp_server import server as mcp_server_module
+
+    server = _byok_preemptive_server()
+    manager = MagicMock()
+    manager.get_mcp_server_by_name = MagicMock(return_value=server)
+
+    with (
+        patch.object(mcp_server_module, "global_mcp_server_manager", manager),
+        patch.object(
+            mcp_server_module,
+            "_get_byok_credential",
+            AsyncMock(return_value="stored-key"),
+        ),
+    ):
+        await mcp_server_module._raise_preemptive_401_for_unauthenticated_servers(
+            scope=_byok_preemptive_scope("/mcp/byok_server"),
+            mcp_servers=["byok_server"],
+            oauth2_headers=None,
+            mcp_server_auth_headers=None,
+            user_api_key_auth=UserAPIKeyAuth(api_key="k", user_id="u"),
+            client_ip=None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_preemptive_401_byok_multi_server_route_does_not_raise():
+    """A credential-less BYOK server reached through a multi-server (aggregated)
+    route must not abort the listing; the challenge is single-server only, so the
+    aggregator keeps degrading per-server."""
+    from litellm.proxy._experimental.mcp_server import server as mcp_server_module
+
+    server = _byok_preemptive_server()
+    manager = MagicMock()
+    manager.get_mcp_server_by_name = MagicMock(return_value=server)
+
+    with (
+        patch.object(mcp_server_module, "global_mcp_server_manager", manager),
+        patch.object(
+            mcp_server_module, "_get_byok_credential", AsyncMock(return_value=None)
+        ) as mock_cred,
+    ):
+        await mcp_server_module._raise_preemptive_401_for_unauthenticated_servers(
+            scope=_byok_preemptive_scope("/mcp/byok_server,other_server"),
+            mcp_servers=["byok_server"],
+            oauth2_headers=None,
+            mcp_server_auth_headers=None,
+            user_api_key_auth=UserAPIKeyAuth(api_key="k", user_id="u"),
+            client_ip=None,
+        )
+
+    mock_cred.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_preemptive_401_byok_inline_credential_does_not_raise():
+    """When the caller supplies the BYOK key inline via a per-server auth header,
+    the preemptive challenge must be skipped."""
+    from litellm.proxy._experimental.mcp_server import server as mcp_server_module
+
+    server = _byok_preemptive_server()
+    manager = MagicMock()
+    manager.get_mcp_server_by_name = MagicMock(return_value=server)
+
+    with (
+        patch.object(mcp_server_module, "global_mcp_server_manager", manager),
+        patch.object(
+            mcp_server_module, "_get_byok_credential", AsyncMock(return_value=None)
+        ) as mock_cred,
+    ):
+        await mcp_server_module._raise_preemptive_401_for_unauthenticated_servers(
+            scope=_byok_preemptive_scope("/mcp/byok_server"),
+            mcp_servers=["byok_server"],
+            oauth2_headers=None,
+            mcp_server_auth_headers={"byok": "user-supplied-key"},
+            user_api_key_auth=UserAPIKeyAuth(api_key="k", user_id="u"),
+            client_ip=None,
+        )
+
+    mock_cred.assert_not_awaited()
+
+
 @pytest.mark.asyncio
 async def test_get_tools_from_mcp_servers_handles_all_servers_failing():
     """Test that _get_tools_from_mcp_servers handles all servers failing gracefully"""

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -944,6 +944,86 @@ async def test_get_tools_from_mcp_servers_continues_when_one_server_fails():
 
 
 @pytest.mark.asyncio
+async def test_get_tools_from_mcp_servers_injects_byok_credential():
+    """The protocol tools-list path must inject the caller's stored per-user
+    BYOK credential as the upstream auth header, mirroring execute_mcp_tool.
+    Without the injection the BYOK server lists with the shared token (None)."""
+    try:
+        from litellm.proxy._experimental.mcp_server import server as mcp_server_module
+        from litellm.proxy._experimental.mcp_server.server import (
+            _get_tools_from_mcp_servers,
+            set_auth_context,
+        )
+    except ImportError:
+        pytest.skip("MCP server not available")
+
+    user_api_key_auth = UserAPIKeyAuth(api_key="test_key", user_id="byok_user")
+    set_auth_context(user_api_key_auth)
+
+    byok_server = MagicMock()
+    byok_server.name = "byok_server"
+    byok_server.alias = "byok"
+    byok_server.allowed_tools = None
+    byok_server.disallowed_tools = None
+    byok_server.server_id = "byok_server"
+    byok_server.server_name = "byok_server"
+    byok_server.auth_type = "authorization"
+    byok_server.extra_headers = None
+    byok_server.is_byok = True
+
+    mock_manager = MagicMock()
+    mock_manager.get_allowed_mcp_servers = AsyncMock(return_value=["byok_server"])
+    mock_manager.get_mcp_server_by_id = lambda server_id: byok_server
+    mock_manager.filter_server_ids_by_ip_with_info = lambda server_ids, client_ip: (
+        server_ids,
+        0,
+    )
+
+    captured = {}
+
+    async def mock_get_tools_from_server(
+        server,
+        mcp_auth_header=None,
+        extra_headers=None,
+        add_prefix=True,
+        raw_headers=None,
+        **kwargs,
+    ):
+        captured["mcp_auth_header"] = mcp_auth_header
+        tool = MagicMock()
+        tool.name = "byok_tool"
+        tool.description = "BYOK tool"
+        tool.inputSchema = {}
+        return [tool]
+
+    mock_manager._get_tools_from_server = mock_get_tools_from_server
+
+    with (
+        patch.object(
+            mcp_server_module,
+            "_get_byok_credential",
+            AsyncMock(return_value="user-stored-byok-key"),
+        ) as mock_byok,
+        patch(
+            "litellm.proxy._experimental.mcp_server.server.global_mcp_server_manager",
+            mock_manager,
+        ),
+    ):
+        result = await _get_tools_from_mcp_servers(
+            user_api_key_auth=user_api_key_auth,
+            mcp_auth_header=None,
+            mcp_servers=["byok_server"],
+        )
+
+    assert len(result) == 1
+    assert result[0].name == "byok_tool"
+    # The per-user BYOK key was looked up for this user+server...
+    mock_byok.assert_awaited_once_with(byok_server, user_api_key_auth)
+    # ...and injected as the upstream auth header for the listing call.
+    assert captured["mcp_auth_header"] == "user-stored-byok-key"
+
+
+@pytest.mark.asyncio
 async def test_get_tools_from_mcp_servers_handles_all_servers_failing():
     """Test that _get_tools_from_mcp_servers handles all servers failing gracefully"""
     try:

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
@@ -546,6 +546,174 @@ class TestListToolsRestAPI:
         assert result["error"] is None
         assert result["message"] == "Successfully retrieved tools"
 
+    async def test_injects_stored_byok_credential_for_byok_server(self, monkeypatch):
+        """A BYOK server with no incoming auth header must have the user's stored
+        per-user key resolved and forwarded as the server auth header, so the UI
+        tools playground lists tools the same way the protocol tool-call path works."""
+        import litellm.proxy._experimental.mcp_server.db as mcp_db
+        import litellm.proxy.utils as proxy_utils
+
+        async def fake_contexts(user_api_key_auth):
+            return [user_api_key_auth]
+
+        async def fake_get_allowed_mcp_servers(*args, **kwargs):
+            return ["server-1"]
+
+        class StubServer:
+            server_id = "server-1"
+            alias = "server-1"
+            server_name = "server-1"
+            name = "stub"
+            auth_type = MCPAuth.bearer_token
+            is_byok = True
+            allowed_tools = None
+            mcp_info = {"server_name": "stub"}
+            available_on_public_internet = True
+
+        stub_server = StubServer()
+        captured = {}
+
+        async def fake_get_tools(
+            server,
+            server_auth_header,
+            raw_headers=None,
+            user_api_key_auth=None,
+            extra_headers=None,
+            apply_tool_filters=True,
+        ):
+            captured["auth_header"] = server_auth_header
+            return ["tool-1"]
+
+        cred_calls = {}
+
+        async def fake_get_user_credential(prisma_client, user_id, server_id):
+            cred_calls["args"] = (user_id, server_id)
+            return "user-byok-key"
+
+        monkeypatch.setattr(
+            rest_endpoints,
+            "build_effective_auth_contexts",
+            fake_contexts,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            rest_endpoints.global_mcp_server_manager,
+            "get_allowed_mcp_servers",
+            fake_get_allowed_mcp_servers,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            rest_endpoints.global_mcp_server_manager,
+            "get_mcp_server_by_id",
+            lambda server_id: stub_server if server_id == "server-1" else None,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            rest_endpoints,
+            "_get_tools_for_single_server",
+            fake_get_tools,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            proxy_utils,
+            "get_prisma_client_or_throw",
+            lambda msg: object(),
+            raising=False,
+        )
+        monkeypatch.setattr(
+            mcp_db, "get_user_credential", fake_get_user_credential, raising=False
+        )
+
+        request = _build_request(path="/mcp-rest/tools/list", method="GET")
+        result = await rest_endpoints.list_tool_rest_api(
+            request,
+            server_id="server-1",
+            user_api_key_dict=UserAPIKeyAuth(user_id="user-1"),
+        )
+
+        assert captured["auth_header"] == "user-byok-key"
+        assert cred_calls["args"] == ("user-1", "server-1")
+        assert result["tools"] == ["tool-1"]
+
+    async def test_does_not_resolve_byok_for_non_byok_server(self, monkeypatch):
+        """A non-BYOK server must not trigger a per-user credential lookup."""
+        import litellm.proxy._experimental.mcp_server.db as mcp_db
+
+        async def fake_contexts(user_api_key_auth):
+            return [user_api_key_auth]
+
+        async def fake_get_allowed_mcp_servers(*args, **kwargs):
+            return ["server-1"]
+
+        class StubServer:
+            server_id = "server-1"
+            alias = "server-1"
+            server_name = "server-1"
+            name = "stub"
+            auth_type = MCPAuth.bearer_token
+            is_byok = False
+            allowed_tools = None
+            mcp_info = {"server_name": "stub"}
+            available_on_public_internet = True
+
+        stub_server = StubServer()
+        captured = {}
+
+        async def fake_get_tools(
+            server,
+            server_auth_header,
+            raw_headers=None,
+            user_api_key_auth=None,
+            extra_headers=None,
+            apply_tool_filters=True,
+        ):
+            captured["auth_header"] = server_auth_header
+            return []
+
+        cred_calls = {"count": 0}
+
+        async def fake_get_user_credential(prisma_client, user_id, server_id):
+            cred_calls["count"] += 1
+            return "should-not-be-used"
+
+        monkeypatch.setattr(
+            rest_endpoints,
+            "build_effective_auth_contexts",
+            fake_contexts,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            rest_endpoints.global_mcp_server_manager,
+            "get_allowed_mcp_servers",
+            fake_get_allowed_mcp_servers,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            rest_endpoints.global_mcp_server_manager,
+            "get_mcp_server_by_id",
+            lambda server_id: stub_server if server_id == "server-1" else None,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            rest_endpoints,
+            "_get_tools_for_single_server",
+            fake_get_tools,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            mcp_db, "get_user_credential", fake_get_user_credential, raising=False
+        )
+
+        request = _build_request(path="/mcp-rest/tools/list", method="GET")
+        await rest_endpoints.list_tool_rest_api(
+            request,
+            server_id="server-1",
+            user_api_key_dict=UserAPIKeyAuth(user_id="user-1"),
+        )
+
+        assert cred_calls["count"] == 0
+        assert captured["auth_header"] is None
+
     async def test_include_disabled_tools_is_admin_only(self, monkeypatch):
         """include_disabled_tools skips the allowlist filter only for PROXY_ADMIN;
         a non-admin passing it stays filtered so the REST endpoint can't be used

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
@@ -444,6 +444,17 @@ class TestTestToolsList:
 class TestListToolsRestAPI:
     pytestmark = pytest.mark.asyncio
 
+    @pytest.fixture(autouse=True)
+    def _clear_byok_cache(self):
+        """The REST BYOK helper now delegates to the shared, cached
+        ``_get_byok_credential``; clear that cache around each test so a stored
+        entry from one test cannot leak into another."""
+        from litellm.proxy._experimental.mcp_server.server import _byok_cred_cache
+
+        _byok_cred_cache.clear()
+        yield
+        _byok_cred_cache.clear()
+
     async def test_rejects_disallowed_server(self, monkeypatch):
         async def fake_contexts(user_api_key_auth):
             return [user_api_key_auth]
@@ -622,6 +633,9 @@ class TestListToolsRestAPI:
         )
         monkeypatch.setattr(
             mcp_db, "get_user_credential", fake_get_user_credential, raising=False
+        )
+        monkeypatch.setattr(
+            "litellm.proxy.proxy_server.prisma_client", object(), raising=False
         )
 
         request = _build_request(path="/mcp-rest/tools/list", method="GET")
@@ -867,6 +881,9 @@ class TestListToolsRestAPI:
         monkeypatch.setattr(
             mcp_db, "get_user_credential", fake_get_user_credential, raising=False
         )
+        monkeypatch.setattr(
+            "litellm.proxy.proxy_server.prisma_client", object(), raising=False
+        )
 
         request = _build_request(path="/mcp-rest/tools/list", method="GET")
         result = await rest_endpoints.list_tool_rest_api(
@@ -951,6 +968,9 @@ class TestListToolsRestAPI:
         )
         monkeypatch.setattr(
             mcp_db, "get_user_credential", fake_get_user_credential, raising=False
+        )
+        monkeypatch.setattr(
+            "litellm.proxy.proxy_server.prisma_client", object(), raising=False
         )
 
         request = _build_request(path="/mcp-rest/tools/list", method="GET")

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
@@ -714,6 +714,255 @@ class TestListToolsRestAPI:
         assert cred_calls["count"] == 0
         assert captured["auth_header"] is None
 
+    async def test_byok_skips_lookup_when_user_id_missing(self, monkeypatch):
+        """A BYOK server still must not query a credential when the caller has no
+        resolvable user_id; the helper short-circuits before touching the DB."""
+        import litellm.proxy._experimental.mcp_server.db as mcp_db
+
+        async def fake_contexts(user_api_key_auth):
+            return [user_api_key_auth]
+
+        async def fake_get_allowed_mcp_servers(*args, **kwargs):
+            return ["server-1"]
+
+        class StubServer:
+            server_id = "server-1"
+            alias = "server-1"
+            server_name = "server-1"
+            name = "stub"
+            auth_type = MCPAuth.bearer_token
+            is_byok = True
+            allowed_tools = None
+            mcp_info = {"server_name": "stub"}
+            available_on_public_internet = True
+
+        stub_server = StubServer()
+        captured = {}
+
+        async def fake_get_tools(
+            server,
+            server_auth_header,
+            raw_headers=None,
+            user_api_key_auth=None,
+            extra_headers=None,
+            apply_tool_filters=True,
+        ):
+            captured["auth_header"] = server_auth_header
+            return []
+
+        cred_calls = {"count": 0}
+
+        async def fake_get_user_credential(prisma_client, user_id, server_id):
+            cred_calls["count"] += 1
+            return "should-not-be-used"
+
+        monkeypatch.setattr(
+            rest_endpoints,
+            "build_effective_auth_contexts",
+            fake_contexts,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            rest_endpoints.global_mcp_server_manager,
+            "get_allowed_mcp_servers",
+            fake_get_allowed_mcp_servers,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            rest_endpoints.global_mcp_server_manager,
+            "get_mcp_server_by_id",
+            lambda server_id: stub_server if server_id == "server-1" else None,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            rest_endpoints,
+            "_get_tools_for_single_server",
+            fake_get_tools,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            mcp_db, "get_user_credential", fake_get_user_credential, raising=False
+        )
+
+        request = _build_request(path="/mcp-rest/tools/list", method="GET")
+        await rest_endpoints.list_tool_rest_api(
+            request,
+            server_id="server-1",
+            user_api_key_dict=UserAPIKeyAuth(user_id=None),
+        )
+
+        assert cred_calls["count"] == 0
+        assert captured["auth_header"] is None
+
+    async def test_byok_credential_lookup_failure_is_swallowed(self, monkeypatch):
+        """If the per-user credential lookup raises, the helper logs and returns
+        None rather than failing the whole tools-list request."""
+        import litellm.proxy._experimental.mcp_server.db as mcp_db
+        import litellm.proxy.utils as proxy_utils
+
+        async def fake_contexts(user_api_key_auth):
+            return [user_api_key_auth]
+
+        async def fake_get_allowed_mcp_servers(*args, **kwargs):
+            return ["server-1"]
+
+        class StubServer:
+            server_id = "server-1"
+            alias = "server-1"
+            server_name = "server-1"
+            name = "stub"
+            auth_type = MCPAuth.bearer_token
+            is_byok = True
+            allowed_tools = None
+            mcp_info = {"server_name": "stub"}
+            available_on_public_internet = True
+
+        stub_server = StubServer()
+        captured = {}
+
+        async def fake_get_tools(
+            server,
+            server_auth_header,
+            raw_headers=None,
+            user_api_key_auth=None,
+            extra_headers=None,
+            apply_tool_filters=True,
+        ):
+            captured["auth_header"] = server_auth_header
+            return ["tool-1"]
+
+        async def fake_get_user_credential(prisma_client, user_id, server_id):
+            raise RuntimeError("db unavailable")
+
+        monkeypatch.setattr(
+            rest_endpoints,
+            "build_effective_auth_contexts",
+            fake_contexts,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            rest_endpoints.global_mcp_server_manager,
+            "get_allowed_mcp_servers",
+            fake_get_allowed_mcp_servers,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            rest_endpoints.global_mcp_server_manager,
+            "get_mcp_server_by_id",
+            lambda server_id: stub_server if server_id == "server-1" else None,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            rest_endpoints,
+            "_get_tools_for_single_server",
+            fake_get_tools,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            proxy_utils,
+            "get_prisma_client_or_throw",
+            lambda msg: object(),
+            raising=False,
+        )
+        monkeypatch.setattr(
+            mcp_db, "get_user_credential", fake_get_user_credential, raising=False
+        )
+
+        request = _build_request(path="/mcp-rest/tools/list", method="GET")
+        result = await rest_endpoints.list_tool_rest_api(
+            request,
+            server_id="server-1",
+            user_api_key_dict=UserAPIKeyAuth(user_id="user-1"),
+        )
+
+        # Lookup failure must not inject a header nor break the request.
+        assert captured["auth_header"] is None
+        assert result["tools"] == ["tool-1"]
+
+    async def test_injects_stored_byok_credential_in_aggregator_path(self, monkeypatch):
+        """The multi-server aggregator path (no server_id) injects the stored
+        per-user BYOK credential the same way the single-server path does."""
+        import litellm.proxy._experimental.mcp_server.db as mcp_db
+        import litellm.proxy.utils as proxy_utils
+
+        async def fake_contexts(user_api_key_auth):
+            return [user_api_key_auth]
+
+        async def fake_get_allowed_mcp_servers(*args, **kwargs):
+            return ["server-1"]
+
+        class StubServer:
+            server_id = "server-1"
+            alias = "server-1"
+            server_name = "server-1"
+            name = "stub"
+            auth_type = MCPAuth.bearer_token
+            is_byok = True
+            allowed_tools = None
+            mcp_info = {"server_name": "stub"}
+            available_on_public_internet = True
+
+        stub_server = StubServer()
+        captured = {}
+
+        async def fake_get_tools(
+            server,
+            server_auth_header,
+            raw_headers=None,
+            user_api_key_auth=None,
+            extra_headers=None,
+            apply_tool_filters=True,
+        ):
+            captured["auth_header"] = server_auth_header
+            return ["tool-1"]
+
+        async def fake_get_user_credential(prisma_client, user_id, server_id):
+            return "user-byok-key"
+
+        monkeypatch.setattr(
+            rest_endpoints,
+            "build_effective_auth_contexts",
+            fake_contexts,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            rest_endpoints.global_mcp_server_manager,
+            "get_allowed_mcp_servers",
+            fake_get_allowed_mcp_servers,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            rest_endpoints.global_mcp_server_manager,
+            "get_mcp_server_by_id",
+            lambda server_id: stub_server if server_id == "server-1" else None,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            rest_endpoints,
+            "_get_tools_for_single_server",
+            fake_get_tools,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            proxy_utils,
+            "get_prisma_client_or_throw",
+            lambda msg: object(),
+            raising=False,
+        )
+        monkeypatch.setattr(
+            mcp_db, "get_user_credential", fake_get_user_credential, raising=False
+        )
+
+        request = _build_request(path="/mcp-rest/tools/list", method="GET")
+        result = await rest_endpoints.list_tool_rest_api(
+            request,
+            server_id=None,
+            user_api_key_dict=UserAPIKeyAuth(user_id="user-1"),
+        )
+
+        assert captured["auth_header"] == "user-byok-key"
+        assert result["tools"] == ["tool-1"]
+
     async def test_include_disabled_tools_is_admin_only(self, monkeypatch):
         """include_disabled_tools skips the allowlist filter only for PROXY_ADMIN;
         a non-admin passing it stays filtered so the REST endpoint can't be used


### PR DESCRIPTION
## Relevant issues

Follow-up to #30170. After surfacing the BYOK toggle in the UI, a BYOK MCP server still showed "No tools available" in the dashboard MCP Tools playground, and MCP clients connecting through the gateway saw no tools, because the tools-list paths never injected the caller's stored per-user key.

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

The tool-call path already injects the per-user BYOK key (in `execute_mcp_tool` via `_get_byok_credential`), so actual tool calls worked; the two tools-list paths did not, so a BYOK server listed with no token, the upstream returned 401, and that surfaced as an empty tool list.

There are two distinct tools-list paths and both are fixed here. The REST tools-list endpoint (`GET /mcp-rest/tools/list`, used by the UI MCP Tools playground) resolved upstream auth from only `_get_server_auth_header` (static value or passthrough header) and `_get_user_oauth_extra_headers` (OAuth2/OBO only); it never resolved the per-user BYOK credential. The MCP protocol `/tools/list` path (`_fetch_and_filter_server_tools` in server.py, used by MCP clients connecting through the gateway) had the same gap; it handled OAuth2 per-user credentials but not BYOK.

Both now resolve the stored key through the same `_get_byok_credential` helper that the tool-call path uses, so the three BYOK paths share one resolver and its 60-second credential cache rather than each rolling its own lookup. The REST path keeps a thin wrapper around that helper so a credential-lookup error still degrades to listing without the key instead of aborting the request, and the protocol path guards the call the same way; a missing credential already returns None on both. The raw credential is passed as the server auth header and is formatted per the server's auth_type downstream by the MCP client (Bearer / token / Basic / x-api-key / raw Authorization), so all five static auth types, including `authorization`, work uniformly. Non-BYOK servers and requests that already carry a header are untouched, so there is no behavior change outside BYOK.

On a missing credential the multi-server tools-list paths still degrade per-server so one credential-less BYOK server cannot abort an aggregated listing. A single-server-scoped route (`/mcp/{server}` or `/{server}/mcp`) now fails fast at connect time with a 401 and a `WWW-Authenticate` challenge so an OAuth-capable MCP client runs the BYOK key-entry flow instead of seeing an empty tool list; this reuses the existing preemptive-401 path that already challenges oauth2 and pass-through servers, gated to single-server routes so the aggregator stays fail-open. The challenge carries an absolute RFC 9728 `resource_metadata` URI pointing at the gateway's BYOK protected-resource document. The `byok_auth_required` 401 on the tool-call path is unchanged

## Screenshots / Proof of Fix

Verified on the tin-veks vcluster against the deployed image (steps and gateway logs to follow once the PR image is deployed): with a GitHub PAT stored on a BYOK server, the MCP Tools tab lists tools instead of showing "No tools available".

For the connect-time challenge, against a running proxy with a BYOK server configured (`server_name: github_byok`), as a user with no stored credential:

```
curl -i http://localhost:4000/mcp/github_byok \
  -H "Authorization: Bearer $LITELLM_KEY" \
  -H "Accept: text/event-stream" \
  -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
```

Expected: `HTTP/1.1 401 Unauthorized` with `www-authenticate: Bearer resource_metadata="http://localhost:4000/.well-known/oauth-protected-resource"` rather than a 200 carrying an empty tool list. After storing a key for that user (the dashboard Connect modal or the BYOK authorize flow), the same request returns the tools. Hitting the aggregated `/mcp` endpoint with the same keyless BYOK server in the set still returns the other servers' tools, confirming the aggregator stays fail-open.

Tests assert that, on both the REST and the protocol tools-list paths, a BYOK server with no incoming header resolves and forwards the stored key as the server auth header, that a non-BYOK server triggers no per-user credential lookup, and that a lookup error degrades to listing without the key rather than propagating. The protocol-path tests are mutation checks: each fails if the injection or the error guard is removed. For the connect-time challenge, four tests cover the single-server keyless 401 (asserting an absolute `resource_metadata` URI), the stored-credential and inline-key skips, and the multi-server route staying fail-open; dropping the single-server gate fails the multi-server test.

