### PR TITLE
fix(chatgpt): route responses with streaming transport

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
@@ -46,7 +46,7 @@ from .utils import AnthropicMessagesRequestUtils, mock_response
 
 # Providers that are routed directly to the OpenAI Responses API instead of
 # going through chat/completions.
-_RESPONSES_API_PROVIDERS = frozenset({"openai"})
+_RESPONSES_API_PROVIDERS = frozenset({"openai", "chatgpt"})
 
 
 def _should_route_to_responses_api(custom_llm_provider: Optional[str]) -> bool:

--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/handler.py
@@ -70,7 +70,11 @@ def _build_responses_kwargs(
         request_data["output_format"] = output_format
 
     anthropic_request = AnthropicMessagesRequest(**request_data)  # type: ignore[typeddict-item]
-    responses_kwargs = _ADAPTER.translate_request(anthropic_request)
+    custom_llm_provider = (extra_kwargs or {}).get("custom_llm_provider")
+    responses_kwargs = _ADAPTER.translate_request(
+        anthropic_request,
+        use_developer_role_for_system=custom_llm_provider == "chatgpt",
+    )
 
     # Normalize reasoning effort based on model capabilities
     # (e.g. "max" → "xhigh"/"high", "minimal" → "low" if unsupported)
@@ -84,7 +88,7 @@ def _build_responses_kwargs(
         normalized = normalize_reasoning_effort_value(
             effort,
             model=model,
-            custom_llm_provider=(extra_kwargs or {}).get("custom_llm_provider"),
+            custom_llm_provider=custom_llm_provider,
         )
         if normalized != effort:
             responses_kwargs["reasoning"] = {**reasoning, "effort": normalized}

--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
@@ -6,7 +6,7 @@ path used for OpenAI and Azure models.
 """
 
 import json
-from typing import Any, Dict, List, Optional, Union, cast
+from typing import Any, Dict, List, Optional, Sequence, Union, cast
 
 from litellm.llms.anthropic.experimental_pass_through.utils import (
     is_reasoning_auto_summary_enabled,
@@ -53,10 +53,11 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
 
     def translate_messages_to_responses_input(  # noqa: PLR0915
         self,
-        messages: List[
+        messages: Sequence[
             Union[
                 AnthropicMessagesUserMessageParam,
                 AnthopicMessagesAssistantMessageParam,
+                Dict[str, Any],
             ]
         ],
     ) -> List[Dict[str, Any]]:
@@ -76,7 +77,31 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
             role = m["role"]
             content = m.get("content")
 
-            if role == "user":
+            if role in ("system", "developer"):
+                if isinstance(content, str):
+                    input_items.append(
+                        {
+                            "type": "message",
+                            "role": "developer",
+                            "content": [{"type": "input_text", "text": content}],
+                        }
+                    )
+                elif isinstance(content, list):
+                    developer_parts = [
+                        {"type": "input_text", "text": block.get("text", "")}
+                        for block in content
+                        if isinstance(block, dict) and block.get("type") == "text"
+                    ]
+                    if developer_parts:
+                        input_items.append(
+                            {
+                                "type": "message",
+                                "role": "developer",
+                                "content": developer_parts,
+                            }
+                        )
+
+            elif role == "user":
                 if isinstance(content, str):
                     input_items.append(
                         {
@@ -295,9 +320,37 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
             result["summary"] = "detailed"
         return result
 
+    def _apply_system_to_responses_kwargs(
+        self,
+        responses_kwargs: Dict[str, Any],
+        system: Any,
+        use_developer_role_for_system: bool,
+    ) -> None:
+        if not system:
+            return
+
+        if use_developer_role_for_system:
+            developer_messages: List[Dict[str, Any]] = []
+            if isinstance(system, (str, list)):
+                developer_messages.append({"role": "developer", "content": system})
+            responses_kwargs["input"] = (
+                self.translate_messages_to_responses_input(developer_messages)
+                + responses_kwargs["input"]
+            )
+        elif isinstance(system, str):
+            responses_kwargs["instructions"] = system
+        elif isinstance(system, list):
+            text_parts = [
+                b.get("text", "")
+                for b in system
+                if isinstance(b, dict) and b.get("type") == "text"
+            ]
+            responses_kwargs["instructions"] = "\n".join(filter(None, text_parts))
+
     def translate_request(
         self,
         anthropic_request: AnthropicMessagesRequest,
+        use_developer_role_for_system: bool = False,
     ) -> Dict[str, Any]:
         """
         Translate a full Anthropic /v1/messages request dict to
@@ -319,18 +372,14 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
             "input": self.translate_messages_to_responses_input(messages_list),
         }
 
-        # system -> instructions
-        system = anthropic_request.get("system")
-        if system:
-            if isinstance(system, str):
-                responses_kwargs["instructions"] = system
-            elif isinstance(system, list):
-                text_parts = [
-                    b.get("text", "")
-                    for b in system
-                    if isinstance(b, dict) and b.get("type") == "text"
-                ]
-                responses_kwargs["instructions"] = "\n".join(filter(None, text_parts))
+        # system -> instructions by default. ChatGPT's Responses transport expects
+        # system/developer directives as input messages, so that path opts into
+        # developer-role conversion.
+        self._apply_system_to_responses_kwargs(
+            responses_kwargs=responses_kwargs,
+            system=anthropic_request.get("system"),
+            use_developer_role_for_system=use_developer_role_for_system,
+        )
 
         # max_tokens -> max_output_tokens
         max_tokens = anthropic_request.get("max_tokens")

--- a/litellm/llms/base_llm/responses/transformation.py
+++ b/litellm/llms/base_llm/responses/transformation.py
@@ -246,6 +246,11 @@ class BaseResponsesAPIConfig(ABC):
         """Returns True if litellm should fake a stream for the given model and stream value"""
         return False
 
+    @property
+    def requires_streaming_response_api_transport(self) -> bool:
+        """Return True when the provider requires SSE transport for Responses API calls."""
+        return False
+
     def supports_native_websocket(self) -> bool:
         """
         Returns True if the provider has a native WebSocket endpoint for Responses API.

--- a/litellm/llms/chatgpt/chat/transformation.py
+++ b/litellm/llms/chatgpt/chat/transformation.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional, Tuple
+from typing import Any, List, Optional, Tuple, cast
 
 from litellm.exceptions import AuthenticationError
 from litellm.llms.openai.openai import OpenAIConfig
@@ -40,6 +40,24 @@ class ChatGPTConfig(OpenAIConfig):
                 message=str(e),
             )
         return dynamic_api_base, dynamic_api_key, custom_llm_provider
+
+    def _transform_messages(
+        self, messages: List[AllMessageValues], model: str
+    ) -> List[AllMessageValues]:
+        transformed_messages: List[AllMessageValues] = []
+        for message in messages:
+            if message.get("role") == "system":
+                transformed_messages.append(
+                    cast(AllMessageValues, {**message, "role": "developer"})
+                )
+            else:
+                transformed_messages.append(message)
+        return transformed_messages
+
+    def translate_developer_role_to_system_role(
+        self, messages: List[AllMessageValues]
+    ) -> List[AllMessageValues]:
+        return messages
 
     def validate_environment(
         self,

--- a/litellm/llms/chatgpt/responses/transformation.py
+++ b/litellm/llms/chatgpt/responses/transformation.py
@@ -38,6 +38,10 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
     def custom_llm_provider(self) -> LlmProviders:
         return LlmProviders.CHATGPT
 
+    @property
+    def requires_streaming_response_api_transport(self) -> bool:
+        return True
+
     def validate_environment(
         self,
         headers: dict,
@@ -60,6 +64,19 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
         )
         return {**default_headers, **headers}
 
+    @staticmethod
+    def _transform_system_roles_to_developer(input: Any) -> Any:
+        if not isinstance(input, list):
+            return input
+
+        transformed_input = []
+        for item in input:
+            if isinstance(item, dict) and item.get("role") == "system":
+                transformed_input.append({**item, "role": "developer"})
+            else:
+                transformed_input.append(item)
+        return transformed_input
+
     def transform_responses_api_request(
         self,
         model: str,
@@ -68,6 +85,7 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
         litellm_params: GenericLiteLLMParams,
         headers: dict,
     ) -> dict:
+        input = self._transform_system_roles_to_developer(input)
         request = super().transform_responses_api_request(
             model,
             input,

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -2397,6 +2397,7 @@ class BaseLLMHTTPHandler:
                     custom_llm_provider=custom_llm_provider,
                     request_data=request_context,
                     call_type=CallTypes.responses.value,
+                    log_completed_response=is_stream_request,
                 )
                 if is_stream_request:
                     return response_iterator
@@ -2578,6 +2579,7 @@ class BaseLLMHTTPHandler:
                     custom_llm_provider=custom_llm_provider,
                     request_data=request_context,
                     call_type=CallTypes.responses.value,
+                    log_completed_response=is_stream_request,
                 )
                 if is_stream_request:
                     return response_iterator

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -2288,6 +2288,15 @@ class BaseLLMHTTPHandler:
 
         # Check if streaming is requested
         stream = response_api_optional_request_params.get("stream", False)
+        force_provider_stream = (
+            getattr(
+                responses_api_provider_config,
+                "requires_streaming_response_api_transport",
+                False,
+            )
+            is True
+        )
+        transport_stream = stream or force_provider_stream
 
         api_base = responses_api_provider_config.get_complete_url(
             api_base=litellm_params.api_base,
@@ -2302,6 +2311,8 @@ class BaseLLMHTTPHandler:
             headers=headers,
         )
         data = BaseResponsesAPIConfig.normalize_responses_api_request_dict(data)
+        if force_provider_stream:
+            data["stream"] = True
 
         if extra_body:
             data.update(extra_body)
@@ -2319,12 +2330,13 @@ class BaseLLMHTTPHandler:
         request_context["litellm_params"] = dict(litellm_params)
 
         is_stream_request = bool(stream)
-        if is_stream_request and fake_stream is True:
+        if is_stream_request and fake_stream is True and not force_provider_stream:
             stream, data = self._prepare_fake_stream_request(
                 stream=stream,
                 data=data,
                 fake_stream=fake_stream,
             )
+            transport_stream = stream
 
         # Sign after the body is final (post-transform/normalize/extra_body and post
         # fake-stream prep) so signed bytes match what we send. No-op for providers
@@ -2336,7 +2348,7 @@ class BaseLLMHTTPHandler:
             api_base=api_base,
             api_key=litellm_params.api_key,
             model=model,
-            stream=stream,
+            stream=transport_stream,
             fake_stream=fake_stream,
         )
         body_kwargs: Dict[str, Any] = (
@@ -2355,16 +2367,16 @@ class BaseLLMHTTPHandler:
         )
 
         try:
-            if is_stream_request:
+            if is_stream_request or force_provider_stream:
                 response = sync_httpx_client.post(
                     url=api_base,
                     headers=headers,
                     timeout=timeout
                     or float(response_api_optional_request_params.get("timeout", 0)),
-                    stream=stream,
+                    stream=transport_stream,
                     **body_kwargs,
                 )
-                if fake_stream is True:
+                if fake_stream is True and not force_provider_stream:
                     return MockResponsesAPIStreamingIterator(
                         response=response,
                         model=model,
@@ -2376,7 +2388,7 @@ class BaseLLMHTTPHandler:
                         call_type=CallTypes.responses.value,
                     )
 
-                return SyncResponsesAPIStreamingIterator(
+                response_iterator = SyncResponsesAPIStreamingIterator(
                     response=response,
                     model=model,
                     logging_obj=logging_obj,
@@ -2386,6 +2398,15 @@ class BaseLLMHTTPHandler:
                     request_data=request_context,
                     call_type=CallTypes.responses.value,
                 )
+                if is_stream_request:
+                    return response_iterator
+
+                for _ in response_iterator:
+                    pass
+                completed_response = response_iterator._get_completed_response_object()
+                if completed_response is None:
+                    raise ValueError("Stream ended without a completed response")
+                return completed_response
             else:
                 response = sync_httpx_client.post(
                     url=api_base,
@@ -2450,6 +2471,15 @@ class BaseLLMHTTPHandler:
 
         # Check if streaming is requested
         stream = response_api_optional_request_params.get("stream", False)
+        force_provider_stream = (
+            getattr(
+                responses_api_provider_config,
+                "requires_streaming_response_api_transport",
+                False,
+            )
+            is True
+        )
+        transport_stream = stream or force_provider_stream
 
         api_base = responses_api_provider_config.get_complete_url(
             api_base=litellm_params.api_base,
@@ -2464,6 +2494,8 @@ class BaseLLMHTTPHandler:
             headers=headers,
         )
         data = BaseResponsesAPIConfig.normalize_responses_api_request_dict(data)
+        if force_provider_stream:
+            data["stream"] = True
 
         if extra_body:
             data.update(extra_body)
@@ -2481,12 +2513,13 @@ class BaseLLMHTTPHandler:
         request_context["litellm_params"] = dict(litellm_params)
 
         is_stream_request = bool(stream)
-        if is_stream_request and fake_stream is True:
+        if is_stream_request and fake_stream is True and not force_provider_stream:
             stream, data = self._prepare_fake_stream_request(
                 stream=stream,
                 data=data,
                 fake_stream=fake_stream,
             )
+            transport_stream = stream
 
         headers, signed_body = responses_api_provider_config.sign_request(
             headers=headers,
@@ -2495,7 +2528,7 @@ class BaseLLMHTTPHandler:
             api_base=api_base,
             api_key=litellm_params.api_key,
             model=model,
-            stream=stream,
+            stream=transport_stream,
             fake_stream=fake_stream,
         )
         body_kwargs: Dict[str, Any] = (
@@ -2514,17 +2547,17 @@ class BaseLLMHTTPHandler:
         )
 
         try:
-            if is_stream_request:
+            if is_stream_request or force_provider_stream:
                 response = await async_httpx_client.post(
                     url=api_base,
                     headers=headers,
                     timeout=timeout
                     or float(response_api_optional_request_params.get("timeout", 0)),
-                    stream=stream,
+                    stream=transport_stream,
                     **body_kwargs,
                 )
 
-                if fake_stream is True:
+                if fake_stream is True and not force_provider_stream:
                     return MockResponsesAPIStreamingIterator(
                         response=response,
                         model=model,
@@ -2536,8 +2569,7 @@ class BaseLLMHTTPHandler:
                         call_type=CallTypes.responses.value,
                     )
 
-                # Return the streaming iterator
-                return ResponsesAPIStreamingIterator(
+                response_iterator = ResponsesAPIStreamingIterator(
                     response=response,
                     model=model,
                     logging_obj=logging_obj,
@@ -2547,6 +2579,15 @@ class BaseLLMHTTPHandler:
                     request_data=request_context,
                     call_type=CallTypes.responses.value,
                 )
+                if is_stream_request:
+                    return response_iterator
+
+                async for _ in response_iterator:
+                    pass
+                completed_response = response_iterator._get_completed_response_object()
+                if completed_response is None:
+                    raise ValueError("Stream ended without a completed response")
+                return completed_response
             else:
                 response = await async_httpx_client.post(
                     url=api_base,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -18799,6 +18799,36 @@
         "supports_response_schema": true,
         "supports_vision": true
     },
+    "chatgpt/gpt-5.4-mini": {
+        "litellm_provider": "chatgpt",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true
+    },
+    "chatgpt/gpt-5.5": {
+        "litellm_provider": "chatgpt",
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true
+    },
     "chatgpt/gpt-5.4-pro": {
         "litellm_provider": "chatgpt",
         "max_input_tokens": 1050000,

--- a/litellm/responses/streaming_iterator.py
+++ b/litellm/responses/streaming_iterator.py
@@ -25,6 +25,10 @@ from litellm.litellm_core_utils.llm_response_utils.response_metadata import (
 )
 from litellm.litellm_core_utils.thread_pool_executor import executor
 from litellm.llms.base_llm.responses.transformation import BaseResponsesAPIConfig
+from litellm.responses.sse_output_recovery import (
+    record_output_item_chunk,
+    record_output_text_chunk,
+)
 from litellm.responses.utils import ResponsesAPIRequestUtils
 from litellm.types.llms.openai import ResponsesAPIStreamEvents
 from litellm.types.utils import CallTypes
@@ -77,6 +81,8 @@ class BaseResponsesAPIStreamingIterator:
         self._completed_response_cache_hit: Optional[bool] = None
         self._persist_completed_response_before_logging = True
         self._stream_created_time: float = time.time()
+        self._streamed_output_items: Dict[int, Dict[str, Any]] = {}
+        self._text_only_output_items: Dict[int, Dict[str, Any]] = {}
 
         # track request context for hooks
         self.litellm_metadata = litellm_metadata
@@ -237,6 +243,8 @@ class BaseResponsesAPIStreamingIterator:
                                     )
                                     setattr(item, "encrypted_content", wrapped_content)
 
+                self._record_output_chunk(parsed_chunk=parsed_chunk)
+
                 # Store the completed response (also for incomplete/failed so logging still fires)
                 _chunk_type = getattr(openai_responses_api_chunk, "type", None)
                 openai_types = _get_openai_response_types()
@@ -246,6 +254,7 @@ class BaseResponsesAPIStreamingIterator:
                     openai_types.ResponsesAPIStreamEvents.RESPONSE_FAILED,
                 ):
                     self.completed_response = openai_responses_api_chunk
+                    self._recover_completed_response_output()
                     # Add cost to usage object if include_cost_in_streaming_usage is True
                     if (
                         litellm.include_cost_in_streaming_usage
@@ -304,13 +313,13 @@ class BaseResponsesAPIStreamingIterator:
         # to chat completion format (prompt_tokens/completion_tokens) for internal logging
         # Use model_dump + model_validate instead of deepcopy to avoid pickle errors with
         # Pydantic ValidatorIterator when response contains tool_choice with allowed_tools (fixes #17192)
-        logging_response = self.completed_response
-        if self.completed_response is not None and hasattr(
-            self.completed_response, "model_dump"
-        ):
+        logging_response = (
+            self._get_completed_response_object() or self.completed_response
+        )
+        if logging_response is not None and hasattr(logging_response, "model_dump"):
             try:
-                logging_response = type(self.completed_response).model_validate(
-                    self.completed_response.model_dump()
+                logging_response = type(logging_response).model_validate(
+                    logging_response.model_dump()
                 )
             except Exception:
                 # Fallback to original if serialization fails
@@ -347,6 +356,32 @@ class BaseResponsesAPIStreamingIterator:
     def _handle_logging_completed_response(self):
         """Base implementation - should be overridden by subclasses"""
         pass
+
+    def _record_output_chunk(self, parsed_chunk: Dict[str, Any]) -> None:
+        event_type = parsed_chunk.get("type")
+        if event_type == ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE:
+            record_output_item_chunk(
+                parsed_chunk=parsed_chunk,
+                output_items=self._streamed_output_items,
+            )
+        elif event_type == ResponsesAPIStreamEvents.OUTPUT_TEXT_DONE:
+            record_output_text_chunk(
+                parsed_chunk=parsed_chunk,
+                output_items=self._streamed_output_items,
+                text_only_items=self._text_only_output_items,
+            )
+
+    def _recover_completed_response_output(self) -> None:
+        response_obj = self._get_completed_response_object()
+        if response_obj is None or getattr(response_obj, "output", None):
+            return
+
+        merged_items: Dict[int, Dict[str, Any]] = {**self._text_only_output_items}
+        merged_items.update(self._streamed_output_items)
+        if not merged_items:
+            return
+
+        response_obj.output = [item for _, item in sorted(merged_items.items())]
 
     def _handle_logging_failed_response(self):
         """

--- a/litellm/responses/streaming_iterator.py
+++ b/litellm/responses/streaming_iterator.py
@@ -67,10 +67,12 @@ class BaseResponsesAPIStreamingIterator:
         custom_llm_provider: Optional[str] = None,
         request_data: Optional[Dict[str, Any]] = None,
         call_type: Optional[str] = None,
+        log_completed_response: bool = True,
     ):
         self.response = response
         self.model = model
         self.logging_obj = logging_obj
+        self.log_completed_response = log_completed_response
         self.finished = False
         self.responses_api_provider_config = responses_api_provider_config
         self.completed_response: Optional[Any] = None
@@ -301,7 +303,7 @@ class BaseResponsesAPIStreamingIterator:
             raise
 
     def _log_completed_response(self, *, is_async: bool) -> None:
-        if self._completed_response_logged:
+        if not self.log_completed_response or self._completed_response_logged:
             return
         self._completed_response_logged = True
 
@@ -659,6 +661,7 @@ class ResponsesAPIStreamingIterator(BaseResponsesAPIStreamingIterator):
         custom_llm_provider: Optional[str] = None,
         request_data: Optional[Dict[str, Any]] = None,
         call_type: Optional[str] = None,
+        log_completed_response: bool = True,
     ):
         super().__init__(
             response,
@@ -669,6 +672,7 @@ class ResponsesAPIStreamingIterator(BaseResponsesAPIStreamingIterator):
             custom_llm_provider,
             request_data,
             call_type,
+            log_completed_response,
         )
         self.stream_iterator = SSEDecoder().aiter_bytes(response.aiter_bytes())
 
@@ -733,6 +737,7 @@ class SyncResponsesAPIStreamingIterator(BaseResponsesAPIStreamingIterator):
         custom_llm_provider: Optional[str] = None,
         request_data: Optional[Dict[str, Any]] = None,
         call_type: Optional[str] = None,
+        log_completed_response: bool = True,
     ):
         super().__init__(
             response,
@@ -743,6 +748,7 @@ class SyncResponsesAPIStreamingIterator(BaseResponsesAPIStreamingIterator):
             custom_llm_provider,
             request_data,
             call_type,
+            log_completed_response,
         )
         self.stream_iterator = SSEDecoder().iter_bytes(response.iter_bytes())
 

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -3039,7 +3039,8 @@ class Router:
         - litellm_trace_id
         - metadata
         """
-        kwargs["num_retries"] = kwargs.get("num_retries", self.num_retries)
+        if kwargs.get("num_retries") is None:
+            kwargs["num_retries"] = self.num_retries
         kwargs.setdefault("litellm_trace_id", str(uuid.uuid4()))
         model_group_alias: Optional[str] = None
         if self._get_model_from_alias(model=model):

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -18799,6 +18799,36 @@
         "supports_response_schema": true,
         "supports_vision": true
     },
+    "chatgpt/gpt-5.4-mini": {
+        "litellm_provider": "chatgpt",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true
+    },
+    "chatgpt/gpt-5.5": {
+        "litellm_provider": "chatgpt",
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true
+    },
     "chatgpt/gpt-5.4-pro": {
         "litellm_provider": "chatgpt",
         "max_input_tokens": 1050000,

--- a/tests/llm_responses_api_testing/test_base_responses_api_streaming_iterator.py
+++ b/tests/llm_responses_api_testing/test_base_responses_api_streaming_iterator.py
@@ -35,6 +35,7 @@ from litellm.types.llms.openai import (
     ResponsesAPIResponse,
     ResponsesAPIStreamEvents,
     OutputTextDeltaEvent,
+    OutputTextDoneEvent,
 )
 
 
@@ -96,6 +97,164 @@ class TestBaseResponsesAPIStreamingIterator:
         assert len(chunks) == 1
         assert chunks[0].type == ResponsesAPIStreamEvents.RESPONSE_COMPLETED
         assert iterator.completed_response is not None
+
+    def test_recovers_empty_completed_response_output_from_text_done(self):
+        mock_response = Mock()
+        mock_response.headers = {}
+        mock_logging_obj = Mock(spec=LiteLLMLoggingObj)
+        mock_logging_obj.model_call_details = {"litellm_params": {}}
+        mock_config = Mock(spec=BaseResponsesAPIConfig)
+
+        completed_response = ResponsesAPIResponse.model_construct(
+            id="resp-1",
+            created_at=0,
+            output=[],
+            object="response",
+            model="gpt-5.4-mini",
+        )
+
+        text_done_event = OutputTextDoneEvent.model_construct(
+            type=ResponsesAPIStreamEvents.OUTPUT_TEXT_DONE,
+            item_id="msg_1",
+            output_index=0,
+            content_index=0,
+            text="hello from streamed text",
+        )
+        completed_event = ResponseCompletedEvent.model_construct(
+            type=ResponsesAPIStreamEvents.RESPONSE_COMPLETED,
+            response=completed_response,
+        )
+        mock_config.transform_streaming_response.side_effect = [
+            text_done_event,
+            completed_event,
+        ]
+
+        iterator = BaseResponsesAPIStreamingIterator(
+            response=mock_response,
+            model="gpt-5.4-mini",
+            responses_api_provider_config=mock_config,
+            logging_obj=mock_logging_obj,
+            litellm_metadata={},
+            custom_llm_provider="chatgpt",
+        )
+        with patch.object(iterator, "_handle_logging_completed_response"):
+            iterator._process_chunk(
+                json.dumps(
+                    {
+                        "type": "response.output_text.done",
+                        "output_index": 0,
+                        "content_index": 0,
+                        "item_id": "msg_1",
+                        "text": "hello from streamed text",
+                    }
+                )
+            )
+            iterator._process_chunk(
+                json.dumps(
+                    {
+                        "type": "response.completed",
+                        "response": {
+                            "id": "resp-1",
+                            "created_at": 0,
+                            "output": [],
+                            "object": "response",
+                            "model": "gpt-5.4-mini",
+                        },
+                    }
+                )
+            )
+
+        assert completed_response.output[0]["content"][0]["text"] == (
+            "hello from streamed text"
+        )
+
+
+    def test_recover_completed_response_output_from_output_item_done(self):
+        mock_response = Mock()
+        mock_response.headers = {}
+        mock_logging_obj = Mock(spec=LiteLLMLoggingObj)
+        mock_logging_obj.model_call_details = {"litellm_params": {}}
+
+        response = ResponsesAPIResponse.model_construct(
+            id="resp-1",
+            created_at=0,
+            output=[],
+            object="response",
+            model="gpt-5.4-mini",
+        )
+        iterator = BaseResponsesAPIStreamingIterator(
+            response=mock_response,
+            model="gpt-5.4-mini",
+            responses_api_provider_config=Mock(spec=BaseResponsesAPIConfig),
+            logging_obj=mock_logging_obj,
+            litellm_metadata={},
+            custom_llm_provider="chatgpt",
+        )
+        iterator.completed_response = ResponseCompletedEvent.model_construct(
+            type=ResponsesAPIStreamEvents.RESPONSE_COMPLETED,
+            response=response,
+        )
+
+        iterator._record_output_chunk(
+            {
+                "type": "response.output_item.done",
+                "output_index": 0,
+                "item": {
+                    "type": "message",
+                    "id": "msg_1",
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "hello from output item",
+                        }
+                    ],
+                },
+            }
+        )
+        iterator._recover_completed_response_output()
+
+        assert response.output[0]["content"][0]["text"] == "hello from output item"
+
+    def test_recover_completed_response_output_is_noop_when_unneeded(self):
+        mock_response = Mock()
+        mock_response.headers = {}
+        mock_logging_obj = Mock(spec=LiteLLMLoggingObj)
+        mock_logging_obj.model_call_details = {"litellm_params": {}}
+        iterator = BaseResponsesAPIStreamingIterator(
+            response=mock_response,
+            model="gpt-5.4-mini",
+            responses_api_provider_config=Mock(spec=BaseResponsesAPIConfig),
+            logging_obj=mock_logging_obj,
+            litellm_metadata={},
+            custom_llm_provider="chatgpt",
+        )
+
+        iterator._recover_completed_response_output()
+
+        response = ResponsesAPIResponse.model_construct(
+            id="resp-1",
+            created_at=0,
+            output=[{"type": "message"}],
+            object="response",
+            model="gpt-5.4-mini",
+        )
+        iterator.completed_response = ResponseCompletedEvent.model_construct(
+            type=ResponsesAPIStreamEvents.RESPONSE_COMPLETED,
+            response=response,
+        )
+        iterator._record_output_chunk(
+            {
+                "type": "response.output_text.done",
+                "output_index": 0,
+                "content_index": 0,
+                "item_id": "msg_1",
+                "text": "ignored",
+            }
+        )
+        iterator._recover_completed_response_output()
+
+        assert response.output == [{"type": "message"}]
 
     def test_process_chunk_with_response_completed_event(self):
         """

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_transformation.py
@@ -191,6 +191,40 @@ class TestTranslateMessagesToResponsesInput:
             }
         ]
 
+    def test_system_message_becomes_developer_input(self):
+        """ChatGPT Responses accepts developer input messages, not system roles."""
+        messages = [{"role": "system", "content": "Follow the policy."}]
+        result = _translate_messages(messages)
+        assert result == [
+            {
+                "type": "message",
+                "role": "developer",
+                "content": [{"type": "input_text", "text": "Follow the policy."}],
+            }
+        ]
+
+    def test_developer_message_with_text_blocks_is_preserved(self):
+        messages = [
+            {
+                "role": "developer",
+                "content": [
+                    {"type": "text", "text": "Be brief."},
+                    {"type": "text", "text": "Use tools."},
+                ],
+            }
+        ]
+        result = _translate_messages(messages)
+        assert result == [
+            {
+                "type": "message",
+                "role": "developer",
+                "content": [
+                    {"type": "input_text", "text": "Be brief."},
+                    {"type": "input_text", "text": "Use tools."},
+                ],
+            }
+        ]
+
     def test_user_list_text_block(self):
         """User message with text content block maps to input_text."""
         messages = [
@@ -744,6 +778,36 @@ class TestTranslateRequestBroaderCoverage:
         )
         kwargs = _ADAPTER.translate_request(req)
         assert kwargs["instructions"] == "Only text matters."
+
+    def test_system_string_becomes_developer_input_when_requested(self):
+        req = _make_request(system="You are a helpful assistant.")
+        kwargs = _ADAPTER.translate_request(req, use_developer_role_for_system=True)
+        assert "instructions" not in kwargs
+        assert kwargs["input"][0] == {
+            "type": "message",
+            "role": "developer",
+            "content": [
+                {"type": "input_text", "text": "You are a helpful assistant."}
+            ],
+        }
+
+    def test_system_list_becomes_developer_input_when_requested(self):
+        req = _make_request(
+            system=[
+                {"type": "text", "text": "Be concise."},
+                {"type": "text", "text": "Be helpful."},
+            ]
+        )
+        kwargs = _ADAPTER.translate_request(req, use_developer_role_for_system=True)
+        assert "instructions" not in kwargs
+        assert kwargs["input"][0] == {
+            "type": "message",
+            "role": "developer",
+            "content": [
+                {"type": "input_text", "text": "Be concise."},
+                {"type": "input_text", "text": "Be helpful."},
+            ],
+        }
 
     def test_max_tokens_mapped_to_max_output_tokens(self):
         req = _make_request(max_tokens=512)

--- a/tests/test_litellm/llms/chatgpt/chat/test_chatgpt_transformation.py
+++ b/tests/test_litellm/llms/chatgpt/chat/test_chatgpt_transformation.py
@@ -1,0 +1,31 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("../../../../../.."))
+
+from litellm.llms.chatgpt.chat.transformation import ChatGPTConfig
+
+
+def test_chatgpt_transforms_system_messages_to_developer_role():
+    config = ChatGPTConfig()
+    messages = [
+        {"role": "system", "content": "Follow the policy."},
+        {"role": "user", "content": "Hello"},
+    ]
+
+    transformed = config._transform_messages(messages, model="gpt-5.5")
+
+    assert transformed == [
+        {"role": "developer", "content": "Follow the policy."},
+        {"role": "user", "content": "Hello"},
+    ]
+
+
+def test_chatgpt_preserves_developer_messages_in_main_role_translation():
+    config = ChatGPTConfig()
+    messages = [
+        {"role": "developer", "content": "Follow the policy."},
+        {"role": "user", "content": "Hello"},
+    ]
+
+    assert config.translate_developer_role_to_system_role(messages) == messages

--- a/tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py
+++ b/tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py
@@ -27,6 +27,8 @@ class TestChatGPTResponsesAPITransformation:
         [
             "chatgpt/gpt-5.4",
             "chatgpt/gpt-5.4-pro",
+            "chatgpt/gpt-5.4-mini",
+            "chatgpt/gpt-5.5",
             "chatgpt/gpt-5.3-chat-latest",
             "chatgpt/gpt-5.3-instant",
             "chatgpt/gpt-5.3-codex",
@@ -42,6 +44,11 @@ class TestChatGPTResponsesAPITransformation:
         assert config is not None
         assert isinstance(config, ChatGPTResponsesAPIConfig)
         assert config.custom_llm_provider == LlmProviders.CHATGPT
+
+    def test_chatgpt_requires_streaming_response_api_transport(self):
+        config = ChatGPTResponsesAPIConfig()
+
+        assert config.requires_streaming_response_api_transport is True
 
     @patch("litellm.llms.chatgpt.responses.transformation.Authenticator")
     def test_chatgpt_responses_endpoint_url(self, mock_authenticator_class):
@@ -106,6 +113,31 @@ class TestChatGPTResponsesAPITransformation:
         assert request["stream"] is True
         assert "reasoning.encrypted_content" in request["include"]
         assert request["instructions"].startswith("You are Codex, based on GPT-5.")
+
+    def test_chatgpt_responses_transforms_system_input_to_developer(self):
+        config = ChatGPTResponsesAPIConfig()
+
+        request = config.transform_responses_api_request(
+            model="chatgpt/gpt-5.5",
+            input=[
+                {
+                    "type": "message",
+                    "role": "system",
+                    "content": [{"type": "input_text", "text": "Follow policy."}],
+                },
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "Hello"}],
+                },
+            ],
+            response_api_optional_request_params={},
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+
+        assert request["input"][0]["role"] == "developer"
+        assert request["input"][1]["role"] == "user"
 
     @pytest.mark.parametrize(
         "model_name",

--- a/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
@@ -777,6 +777,7 @@ def _make_responses_handler_call(signed_body):
     from litellm.types.router import GenericLiteLLMParams
 
     provider_config = MagicMock()
+    provider_config.requires_streaming_response_api_transport = False
     provider_config.validate_environment.return_value = {}
     provider_config.get_complete_url.return_value = (
         "https://bedrock-mantle.us-east-2.api.aws/openai/v1/responses"
@@ -884,6 +885,196 @@ def test_responses_handler_signs_after_fake_stream_prep_strips_stream():
     assert post_kwargs.get("data") == b'{"input": "hi"}'
     assert "json" not in post_kwargs
     assert "stream" in post_kwargs
+
+
+def test_responses_handler_forces_provider_stream_transport():
+    from unittest.mock import MagicMock, patch
+
+    from litellm.llms.custom_httpx.http_handler import HTTPHandler
+    from litellm.llms.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
+    from litellm.types.router import GenericLiteLLMParams
+
+    provider_config = MagicMock()
+    provider_config.requires_streaming_response_api_transport = True
+    provider_config.validate_environment.return_value = {}
+    provider_config.get_complete_url.return_value = "https://chatgpt.test/responses"
+    provider_config.transform_responses_api_request.return_value = {"input": "hi"}
+    provider_config.sign_request.return_value = ({}, None)
+
+    completed_response = MagicMock()
+    completed_response.output = [{"type": "message"}]
+    mock_stream = MagicMock()
+    mock_stream.__iter__.return_value = iter([])
+    mock_stream._get_completed_response_object.return_value = completed_response
+
+    mock_client = MagicMock(spec=HTTPHandler)
+    mock_client.post.return_value = MagicMock()
+
+    handler = BaseLLMHTTPHandler()
+    with patch(
+        "litellm.llms.custom_httpx.llm_http_handler.SyncResponsesAPIStreamingIterator",
+        return_value=mock_stream,
+    ):
+        handler.response_api_handler(
+            model="gpt-5.4-mini",
+            input="hi",
+            responses_api_provider_config=provider_config,
+            response_api_optional_request_params={},
+            custom_llm_provider="chatgpt",
+            litellm_params=GenericLiteLLMParams(),
+            logging_obj=MagicMock(),
+            client=mock_client,
+            _is_async=False,
+        )
+
+    provider_config.sign_request.assert_called_once()
+    signed_request = provider_config.sign_request.call_args.kwargs["request_data"]
+    assert signed_request["stream"] is True
+    assert provider_config.sign_request.call_args.kwargs["stream"] is True
+
+    post_kwargs = mock_client.post.call_args.kwargs
+    assert post_kwargs["stream"] is True
+    assert post_kwargs["json"]["stream"] is True
+
+
+
+
+@pytest.mark.asyncio
+async def test_async_responses_handler_forces_provider_stream_transport():
+    from unittest.mock import MagicMock, patch
+
+    from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
+    from litellm.llms.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
+    from litellm.types.router import GenericLiteLLMParams
+
+    provider_config = MagicMock()
+    provider_config.requires_streaming_response_api_transport = True
+    provider_config.validate_environment.return_value = {}
+    provider_config.get_complete_url.return_value = "https://chatgpt.test/responses"
+    provider_config.transform_responses_api_request.return_value = {"input": "hi"}
+    provider_config.sign_request.return_value = ({}, None)
+
+    completed_response = MagicMock()
+    completed_response.output = [{"type": "message"}]
+    mock_stream = MagicMock()
+    mock_stream.__aiter__.return_value = iter([])
+    mock_stream._get_completed_response_object.return_value = completed_response
+
+    mock_client = MagicMock(spec=AsyncHTTPHandler)
+    mock_client.post = AsyncMock(return_value=MagicMock())
+
+    handler = BaseLLMHTTPHandler()
+    with patch(
+        "litellm.llms.custom_httpx.llm_http_handler.ResponsesAPIStreamingIterator",
+        return_value=mock_stream,
+    ):
+        result = await handler.async_response_api_handler(
+            model="gpt-5.4-mini",
+            input="hi",
+            responses_api_provider_config=provider_config,
+            response_api_optional_request_params={},
+            custom_llm_provider="chatgpt",
+            litellm_params=GenericLiteLLMParams(),
+            logging_obj=MagicMock(),
+            client=mock_client,
+        )
+
+    assert result is completed_response
+    signed_request = provider_config.sign_request.call_args.kwargs["request_data"]
+    assert signed_request["stream"] is True
+    assert provider_config.sign_request.call_args.kwargs["stream"] is True
+
+    post_kwargs = mock_client.post.await_args.kwargs
+    assert post_kwargs["stream"] is True
+    assert post_kwargs["json"]["stream"] is True
+
+
+def test_responses_handler_returns_iterator_for_user_stream_when_forced_transport():
+    from unittest.mock import MagicMock, patch
+
+    from litellm.llms.custom_httpx.http_handler import HTTPHandler
+    from litellm.llms.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
+    from litellm.types.router import GenericLiteLLMParams
+
+    provider_config = MagicMock()
+    provider_config.requires_streaming_response_api_transport = True
+    provider_config.validate_environment.return_value = {}
+    provider_config.get_complete_url.return_value = "https://chatgpt.test/responses"
+    provider_config.transform_responses_api_request.return_value = {"input": "hi"}
+    provider_config.sign_request.return_value = ({}, None)
+
+    mock_stream = MagicMock()
+    mock_client = MagicMock(spec=HTTPHandler)
+    mock_client.post.return_value = MagicMock()
+
+    handler = BaseLLMHTTPHandler()
+    with patch(
+        "litellm.llms.custom_httpx.llm_http_handler.SyncResponsesAPIStreamingIterator",
+        return_value=mock_stream,
+    ):
+        result = handler.response_api_handler(
+            model="gpt-5.4-mini",
+            input="hi",
+            responses_api_provider_config=provider_config,
+            response_api_optional_request_params={"stream": True},
+            custom_llm_provider="chatgpt",
+            litellm_params=GenericLiteLLMParams(),
+            logging_obj=MagicMock(),
+            client=mock_client,
+            fake_stream=True,
+        )
+
+    assert result is mock_stream
+    mock_stream.__iter__.assert_not_called()
+    signed_request = provider_config.sign_request.call_args.kwargs["request_data"]
+    assert signed_request["stream"] is True
+    assert provider_config.sign_request.call_args.kwargs["stream"] is True
+    assert mock_client.post.call_args.kwargs["stream"] is True
+
+
+
+@pytest.mark.asyncio
+async def test_async_responses_handler_returns_iterator_for_user_stream_when_forced_transport():
+    from unittest.mock import MagicMock, patch
+
+    from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
+    from litellm.llms.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
+    from litellm.types.router import GenericLiteLLMParams
+
+    provider_config = MagicMock()
+    provider_config.requires_streaming_response_api_transport = True
+    provider_config.validate_environment.return_value = {}
+    provider_config.get_complete_url.return_value = "https://chatgpt.test/responses"
+    provider_config.transform_responses_api_request.return_value = {"input": "hi"}
+    provider_config.sign_request.return_value = ({}, None)
+
+    mock_stream = MagicMock()
+    mock_client = MagicMock(spec=AsyncHTTPHandler)
+    mock_client.post = AsyncMock(return_value=MagicMock())
+
+    handler = BaseLLMHTTPHandler()
+    with patch(
+        "litellm.llms.custom_httpx.llm_http_handler.ResponsesAPIStreamingIterator",
+        return_value=mock_stream,
+    ):
+        result = await handler.async_response_api_handler(
+            model="gpt-5.4-mini",
+            input="hi",
+            responses_api_provider_config=provider_config,
+            response_api_optional_request_params={"stream": True},
+            custom_llm_provider="chatgpt",
+            litellm_params=GenericLiteLLMParams(),
+            logging_obj=MagicMock(),
+            client=mock_client,
+            fake_stream=True,
+        )
+
+    assert result is mock_stream
+    mock_stream.__aiter__.assert_not_called()
+    signed_request = provider_config.sign_request.call_args.kwargs["request_data"]
+    assert signed_request["stream"] is True
+    assert provider_config.sign_request.call_args.kwargs["stream"] is True
+    assert mock_client.post.await_args.kwargs["stream"] is True
 
 
 def _make_compact_handler_call(signed_body, is_async):

--- a/tests/test_litellm/test_responses_api_bridge_non_stream.py
+++ b/tests/test_litellm/test_responses_api_bridge_non_stream.py
@@ -297,6 +297,7 @@ def test_response_handler_forced_stream_requires_completed_response():
     mock_stream = MagicMock()
     mock_stream.__iter__.return_value = iter([])
     mock_stream._get_completed_response_object.return_value = None
+    mock_stream_factory = Mock(return_value=mock_stream)
     mock_client = Mock(spec=HTTPHandler)
     mock_client.post.return_value = Mock()
 
@@ -305,7 +306,7 @@ def test_response_handler_forced_stream_requires_completed_response():
             monkeypatch.setattr(
                 "litellm.llms.custom_httpx.llm_http_handler"
                 ".SyncResponsesAPIStreamingIterator",
-                Mock(return_value=mock_stream),
+                mock_stream_factory,
             )
             BaseLLMHTTPHandler().response_api_handler(
                 model="gpt-5.5",
@@ -321,6 +322,7 @@ def test_response_handler_forced_stream_requires_completed_response():
 
     assert provider_config.sign_request.call_args.kwargs["stream"] is True
     assert mock_client.post.call_args.kwargs["stream"] is True
+    assert mock_stream_factory.call_args.kwargs["log_completed_response"] is False
 
 
 @pytest.mark.asyncio
@@ -334,6 +336,7 @@ async def test_async_response_handler_forced_stream_requires_completed_response(
     mock_stream = MagicMock()
     mock_stream.__aiter__.return_value = []
     mock_stream._get_completed_response_object.return_value = None
+    mock_stream_factory = Mock(return_value=mock_stream)
     mock_client = Mock(spec=AsyncHTTPHandler)
     mock_client.post = AsyncMock(return_value=Mock())
 
@@ -342,7 +345,7 @@ async def test_async_response_handler_forced_stream_requires_completed_response(
             monkeypatch.setattr(
                 "litellm.llms.custom_httpx.llm_http_handler"
                 ".ResponsesAPIStreamingIterator",
-                Mock(return_value=mock_stream),
+                mock_stream_factory,
             )
             await BaseLLMHTTPHandler().async_response_api_handler(
                 model="gpt-5.5",
@@ -358,6 +361,7 @@ async def test_async_response_handler_forced_stream_requires_completed_response(
 
     assert provider_config.sign_request.call_args.kwargs["stream"] is True
     assert mock_client.post.await_args.kwargs["stream"] is True
+    assert mock_stream_factory.call_args.kwargs["log_completed_response"] is False
 
 
 def test_streaming_iterator_logs_inner_completed_response_object():

--- a/tests/test_litellm/test_responses_api_bridge_non_stream.py
+++ b/tests/test_litellm/test_responses_api_bridge_non_stream.py
@@ -1,7 +1,7 @@
 import os
 import sys
 from typing import Optional
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock
 
 import pytest
 
@@ -10,14 +10,25 @@ sys.path.insert(0, os.path.abspath("../.."))
 from litellm.completion_extras.litellm_responses_transformation.handler import (
     ResponsesToCompletionBridgeHandler,
 )
+from litellm.llms.anthropic.experimental_pass_through.responses_adapters.handler import (
+    _build_responses_kwargs,
+)
+from litellm.llms.anthropic.experimental_pass_through.responses_adapters.transformation import (
+    LiteLLMAnthropicToResponsesAPIAdapter,
+)
+from litellm.llms.base_llm.responses.transformation import BaseResponsesAPIConfig
 from litellm.responses.litellm_completion_transformation.transformation import (
     LiteLLMCompletionResponsesConfig,
 )
+from litellm.responses.streaming_iterator import BaseResponsesAPIStreamingIterator
 from litellm.types.llms.openai import (
     InputTokensDetails,
     OutputTokensDetails,
+    ResponseCompletedEvent,
     ResponsesAPIResponse,
+    ResponsesAPIStreamEvents,
 )
+from litellm.types.router import GenericLiteLLMParams
 from litellm.types.utils import Choices, Message, ModelResponse, Usage
 
 """
@@ -67,6 +78,333 @@ def test_should_collect_response_from_stream():
 
     assert collected.id == "resp-1"
     assert collected._hidden_params.get("headers") == {"x-test": "1"}
+
+
+def test_streaming_iterator_recovers_output_item_and_text_chunks():
+    mock_response = Mock()
+    mock_response.headers = {}
+    mock_logging_obj = Mock()
+    mock_logging_obj.model_call_details = {"litellm_params": {}}
+    iterator = BaseResponsesAPIStreamingIterator(
+        response=mock_response,
+        model="gpt-5.4-mini",
+        responses_api_provider_config=Mock(spec=BaseResponsesAPIConfig),
+        logging_obj=mock_logging_obj,
+        litellm_metadata={},
+        custom_llm_provider="chatgpt",
+    )
+
+    # No completed response and no recovered chunks are both no-ops.
+    iterator._recover_completed_response_output()
+    empty_response = ResponsesAPIResponse.model_construct(
+        id="resp-empty",
+        created_at=0,
+        output=[],
+        object="response",
+        model="gpt-5.4-mini",
+    )
+    iterator.completed_response = ResponseCompletedEvent.model_construct(
+        type=ResponsesAPIStreamEvents.RESPONSE_COMPLETED,
+        response=empty_response,
+    )
+    iterator._recover_completed_response_output()
+    assert empty_response.output == []
+
+    iterator._record_output_chunk(
+        {
+            "type": "response.output_text.done",
+            "output_index": 1,
+            "content_index": 0,
+            "item_id": "msg_text_only",
+            "text": "hello from text done",
+        }
+    )
+    iterator._record_output_chunk(
+        {
+            "type": "response.output_item.done",
+            "output_index": 0,
+            "item": {
+                "type": "message",
+                "id": "msg_item",
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "output_text",
+                        "text": "hello from output item",
+                    }
+                ],
+            },
+        }
+    )
+    iterator._recover_completed_response_output()
+
+    assert empty_response.output[0]["content"][0]["text"] == ("hello from output item")
+    assert empty_response.output[1]["content"][0]["text"] == "hello from text done"
+
+
+def test_streaming_iterator_recovery_preserves_existing_output():
+    mock_response = Mock()
+    mock_response.headers = {}
+    mock_logging_obj = Mock()
+    mock_logging_obj.model_call_details = {"litellm_params": {}}
+    iterator = BaseResponsesAPIStreamingIterator(
+        response=mock_response,
+        model="gpt-5.4-mini",
+        responses_api_provider_config=Mock(spec=BaseResponsesAPIConfig),
+        logging_obj=mock_logging_obj,
+        litellm_metadata={},
+        custom_llm_provider="chatgpt",
+    )
+    response = ResponsesAPIResponse.model_construct(
+        id="resp-existing",
+        created_at=0,
+        output=[{"type": "message", "content": []}],
+        object="response",
+        model="gpt-5.4-mini",
+    )
+    iterator.completed_response = ResponseCompletedEvent.model_construct(
+        type=ResponsesAPIStreamEvents.RESPONSE_COMPLETED,
+        response=response,
+    )
+    iterator._record_output_chunk(
+        {
+            "type": "response.output_text.done",
+            "output_index": 0,
+            "content_index": 0,
+            "item_id": "msg_ignored",
+            "text": "ignored",
+        }
+    )
+    iterator._recover_completed_response_output()
+
+    assert response.output == [{"type": "message", "content": []}]
+
+
+def test_adapter_direct_system_and_developer_messages_to_developer_input():
+    adapter = LiteLLMAnthropicToResponsesAPIAdapter()
+
+    system_result = adapter.translate_messages_to_responses_input(
+        [{"role": "system", "content": "Follow policy."}]
+    )
+    assert system_result == [
+        {
+            "type": "message",
+            "role": "developer",
+            "content": [{"type": "input_text", "text": "Follow policy."}],
+        }
+    ]
+
+    developer_result = adapter.translate_messages_to_responses_input(
+        [
+            {
+                "role": "developer",
+                "content": [
+                    {"type": "text", "text": "Be brief."},
+                    {"type": "image", "source": {}},
+                ],
+            }
+        ]
+    )
+    assert developer_result == [
+        {
+            "type": "message",
+            "role": "developer",
+            "content": [{"type": "input_text", "text": "Be brief."}],
+        }
+    ]
+
+
+def test_adapter_build_kwargs_uses_developer_input_for_chatgpt_system():
+    kwargs = _build_responses_kwargs(
+        max_tokens=128,
+        messages=[{"role": "user", "content": "Hello"}],
+        model="gpt-5.5",
+        system=[{"type": "text", "text": "Follow policy."}],
+        extra_kwargs={"custom_llm_provider": "chatgpt"},
+    )
+
+    assert "instructions" not in kwargs
+    assert kwargs["input"][0] == {
+        "type": "message",
+        "role": "developer",
+        "content": [{"type": "input_text", "text": "Follow policy."}],
+    }
+    assert kwargs["input"][1]["role"] == "user"
+
+
+def test_adapter_build_kwargs_keeps_openai_system_as_instructions():
+    kwargs = _build_responses_kwargs(
+        max_tokens=128,
+        messages=[{"role": "user", "content": "Hello"}],
+        model="gpt-5.5",
+        system="Follow policy.",
+        extra_kwargs={"custom_llm_provider": "openai"},
+    )
+
+    assert kwargs["instructions"] == "Follow policy."
+    assert kwargs["input"][0]["role"] == "user"
+
+
+def test_chatgpt_responses_transforms_system_roles_only_for_list_input():
+    from litellm.llms.chatgpt.responses.transformation import ChatGPTResponsesAPIConfig
+
+    config = ChatGPTResponsesAPIConfig()
+    assert config._transform_system_roles_to_developer("plain input") == "plain input"
+
+    request = config.transform_responses_api_request(
+        model="chatgpt/gpt-5.5",
+        input=[
+            {
+                "type": "message",
+                "role": "system",
+                "content": [{"type": "input_text", "text": "Follow policy."}],
+            },
+            {
+                "type": "message",
+                "role": "developer",
+                "content": [{"type": "input_text", "text": "Already developer."}],
+            },
+            "raw item",
+        ],
+        response_api_optional_request_params={},
+        litellm_params=GenericLiteLLMParams(),
+        headers={},
+    )
+
+    assert request["input"][0]["role"] == "developer"
+    assert request["input"][1]["role"] == "developer"
+    assert request["input"][2] == "raw item"
+
+
+def _forced_stream_provider_config():
+    provider_config = Mock()
+    provider_config.requires_streaming_response_api_transport = True
+    provider_config.validate_environment.return_value = {}
+    provider_config.get_complete_url.return_value = "https://chatgpt.test/responses"
+    provider_config.transform_responses_api_request.return_value = {"input": "hi"}
+    provider_config.sign_request.return_value = ({}, None)
+    provider_config.get_error_class.side_effect = (
+        lambda error_message, status_code, headers: RuntimeError(error_message)
+    )
+    return provider_config
+
+
+def test_response_handler_forced_stream_requires_completed_response():
+    from litellm.llms.custom_httpx.http_handler import HTTPHandler
+    from litellm.llms.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
+
+    provider_config = _forced_stream_provider_config()
+    mock_stream = MagicMock()
+    mock_stream.__iter__.return_value = iter([])
+    mock_stream._get_completed_response_object.return_value = None
+    mock_client = Mock(spec=HTTPHandler)
+    mock_client.post.return_value = Mock()
+
+    with pytest.raises(RuntimeError, match="Stream ended without a completed response"):
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            monkeypatch.setattr(
+                "litellm.llms.custom_httpx.llm_http_handler"
+                ".SyncResponsesAPIStreamingIterator",
+                Mock(return_value=mock_stream),
+            )
+            BaseLLMHTTPHandler().response_api_handler(
+                model="gpt-5.5",
+                input="hi",
+                responses_api_provider_config=provider_config,
+                response_api_optional_request_params={},
+                custom_llm_provider="chatgpt",
+                litellm_params=GenericLiteLLMParams(),
+                logging_obj=Mock(),
+                client=mock_client,
+                fake_stream=True,
+            )
+
+    assert provider_config.sign_request.call_args.kwargs["stream"] is True
+    assert mock_client.post.call_args.kwargs["stream"] is True
+
+
+@pytest.mark.asyncio
+async def test_async_response_handler_forced_stream_requires_completed_response():
+    from unittest.mock import AsyncMock
+
+    from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
+    from litellm.llms.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
+
+    provider_config = _forced_stream_provider_config()
+    mock_stream = MagicMock()
+    mock_stream.__aiter__.return_value = []
+    mock_stream._get_completed_response_object.return_value = None
+    mock_client = Mock(spec=AsyncHTTPHandler)
+    mock_client.post = AsyncMock(return_value=Mock())
+
+    with pytest.raises(RuntimeError, match="Stream ended without a completed response"):
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            monkeypatch.setattr(
+                "litellm.llms.custom_httpx.llm_http_handler"
+                ".ResponsesAPIStreamingIterator",
+                Mock(return_value=mock_stream),
+            )
+            await BaseLLMHTTPHandler().async_response_api_handler(
+                model="gpt-5.5",
+                input="hi",
+                responses_api_provider_config=provider_config,
+                response_api_optional_request_params={},
+                custom_llm_provider="chatgpt",
+                litellm_params=GenericLiteLLMParams(),
+                logging_obj=Mock(),
+                client=mock_client,
+                fake_stream=True,
+            )
+
+    assert provider_config.sign_request.call_args.kwargs["stream"] is True
+    assert mock_client.post.await_args.kwargs["stream"] is True
+
+
+def test_streaming_iterator_logs_inner_completed_response_object():
+    logging_obj = Mock()
+    logging_obj.model_call_details = {"litellm_params": {}}
+    logging_obj.success_handler = Mock()
+    logging_obj.async_success_handler = Mock()
+    iterator = BaseResponsesAPIStreamingIterator(
+        response=Mock(headers={}),
+        model="gpt-5.5",
+        responses_api_provider_config=Mock(spec=BaseResponsesAPIConfig),
+        logging_obj=logging_obj,
+        litellm_metadata={},
+        custom_llm_provider="chatgpt",
+    )
+    iterator._persist_completed_response_before_logging = False
+    response = ResponsesAPIResponse.model_construct(
+        id="resp-log",
+        created_at=0,
+        output=[{"type": "message", "content": []}],
+        object="response",
+        model="gpt-5.5",
+    )
+    iterator.completed_response = ResponseCompletedEvent.model_construct(
+        type=ResponsesAPIStreamEvents.RESPONSE_COMPLETED,
+        response=response,
+    )
+
+    import importlib
+
+    streaming_iterator_module = importlib.import_module(
+        "litellm.responses.streaming_iterator"
+    )
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        run_async = Mock()
+        executor = Mock()
+        monkeypatch.setattr(streaming_iterator_module, "run_async_function", run_async)
+        monkeypatch.setattr(streaming_iterator_module, "executor", executor)
+        iterator._log_completed_response(is_async=False)
+
+    success_call = next(
+        call
+        for call in run_async.call_args_list
+        if call.kwargs.get("async_function") is logging_obj.async_success_handler
+    )
+    assert success_call.kwargs["result"].id == "resp-log"
+    assert executor.submit.call_args.kwargs["result"].id == "resp-log"
 
 
 def create_mock_completion_response(

--- a/tests/test_litellm/test_router_per_deployment_num_retries.py
+++ b/tests/test_litellm/test_router_per_deployment_num_retries.py
@@ -156,6 +156,27 @@ class TestPerDeploymentNumRetries:
         router._update_kwargs_before_fallbacks(model="test-model", kwargs=kwargs)
         assert kwargs["num_retries"] == 7  # Uses global
 
+    def test_null_request_num_retries_uses_global_default(self):
+        """
+        Test that explicit num_retries=None does not leak into retry arithmetic.
+        """
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "test-model",
+                    "litellm_params": {
+                        "model": "openai/gpt-4",
+                        "api_key": "test-key",
+                    },
+                },
+            ],
+            num_retries=2,
+        )
+
+        kwargs = {"num_retries": None}
+        router._update_kwargs_before_fallbacks(model="test-model", kwargs=kwargs)
+        assert kwargs["num_retries"] == 2
+
     def test_set_deployment_num_retries_with_string_value(self):
         """
         Test that _set_deployment_num_retries_on_exception handles string values


### PR DESCRIPTION
## Relevant issues

Fixes routed ChatGPT Responses regressions observed on `chatgpt/gpt-5.4-mini` / `chatgpt/gpt-5.5` and Anthropic Messages passthrough aliases.

## Linear ticket

NA

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Validated in a live LiteLLM proxy using a local carry patch equivalent to this change:

- Direct ChatGPT Responses models `chatgpt/gpt-5.4-mini` and `chatgpt/gpt-5.5` no longer fail with `Stream must be set to true`.
- Anthropic Messages passthrough aliases routed to ChatGPT Responses models no longer fall back to chat completions or fail with `Stream must be set to true`.
- Non-stream callers that are forced over provider SSE now get recovered text output instead of empty `output` / empty LangChain result.
- Recent proxy logs after validation show no `Stream must be set to true`, no `standard_logging_object` cost tracking errors, and no `Attempted to access streaming response content` errors.

Refs:
- https://github.com/anthony-spruyt/spruyt-labs/issues/1961
- https://github.com/anthony-spruyt/spruyt-labs/issues/1960
- https://github.com/anthony-spruyt/spruyt-labs/tree/main/cluster/apps/litellm/litellm/app/plugins/chatgpt

## Type

🐛 Bug Fix
✅ Test

## Changes

- Add `chatgpt` to the Anthropic Messages providers that route through the Responses API adapter.
- Add `BaseResponsesAPIConfig.requires_streaming_response_api_transport`, defaulting to `False`.
- Mark `ChatGPTResponsesAPIConfig` as requiring streaming transport because ChatGPT's backend requires both request-body `stream: true` and HTTP streaming transport for Responses calls.
- Update Responses HTTP handling so providers that require streaming transport:
  - send JSON `stream: true`
  - use HTTP `stream=True`
  - bypass fake-stream mode
  - collect the SSE stream back into a completed `ResponsesAPIResponse` for non-stream callers
- Recover final response output from streamed `response.output_text.done` / `response.output_item.done` chunks when `response.completed.response.output` is empty.
- Log the completed `ResponsesAPIResponse` rather than the wrapper event, so standard logging/cost tracking receives the normal response shape.
- Register `chatgpt/gpt-5.4-mini` and `chatgpt/gpt-5.5` as ChatGPT Responses models.
- Add regression coverage for provider registration, forced transport, and streamed-output recovery.