### PR TITLE
fix(proxy): iam refresh engine watcher race

### DIFF
--- a/litellm/proxy/db/prisma_client.py
+++ b/litellm/proxy/db/prisma_client.py
@@ -12,7 +12,7 @@ import urllib
 import urllib.parse
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Any, Dict, Optional, Union
+from typing import Any, Callable, Dict, Optional, Set, Union
 
 from litellm._logging import verbose_proxy_logger
 from litellm.secret_managers.main import str_to_bool
@@ -119,6 +119,22 @@ class PrismaWrapper:
         self._token_refresh_task: Optional[asyncio.Task] = None
         self._reconnection_lock = asyncio.Lock()
         self._last_refresh_time: Optional[datetime] = None
+
+        # Coordination for planned engine restarts (issue #29176). Every
+        # `recreate_prisma_client` SIGTERMs the running query-engine on
+        # purpose. The engine-death watcher (in `PrismaClient`) must be able
+        # to tell that planned kill apart from a real crash, otherwise it
+        # triggers its own reconnect and kills the freshly-spawned engine.
+        #   - `_expected_engine_deaths`: PIDs we intentionally killed; the
+        #     watcher consumes these instead of reconnecting.
+        #   - `_engine_generation`: monotonic counter bumped on every
+        #     successful recreate, used by callers as an optimistic-lock token
+        #     so racing/cascading recreates collapse into a single restart.
+        #   - `on_engine_replaced`: optional callback fired after a recreate so
+        #     the owner (PrismaClient) can re-arm its watcher on the new PID.
+        self._expected_engine_deaths: Set[int] = set()
+        self._engine_generation: int = 0
+        self.on_engine_replaced: Optional[Callable[[], None]] = None
 
     def _get_engine_pid(self) -> int:
         """Get the PID of the current Prisma engine subprocess, or 0 if unavailable."""
@@ -313,8 +329,12 @@ class PrismaWrapper:
         return _db_url
 
     async def recreate_prisma_client(
-        self, new_db_url: str, http_client: Optional[Any] = None
-    ):
+        self,
+        new_db_url: str,
+        http_client: Optional[Any] = None,
+        *,
+        expected_generation: Optional[int] = None,
+    ) -> bool:
         """Disconnect and reconnect the Prisma client with a new database URL.
 
         Kills the old engine subprocess directly (SIGTERM → SIGKILL) rather than
@@ -327,11 +347,67 @@ class PrismaWrapper:
         the reader wrapper opts into `recreate_uses_datasource=True` so the
         new URL is passed explicitly via `datasource={"url": ...}` (Prisma
         does not auto-read alternate env vars like DATABASE_URL_READ_REPLICA).
+
+        Serializes all recreations through `self._reconnection_lock` so the
+        IAM-refresh path and the engine-death/transport-error reconnect paths
+        cannot recreate concurrently (issue #29176). `expected_generation`, if
+        given, is an optimistic-lock token: when it no longer matches
+        `self._engine_generation` once the lock is held, another path already
+        replaced the engine, so this call is a no-op and returns ``False``.
+
+        Returns:
+            bool: ``True`` if the client was actually recreated, ``False`` if
+            the recreate was skipped because the engine generation moved on.
+        """
+        async with self._reconnection_lock:
+            return await self._recreate_prisma_client_locked(
+                new_db_url,
+                http_client=http_client,
+                expected_generation=expected_generation,
+            )
+
+    async def _recreate_prisma_client_locked(
+        self,
+        new_db_url: str,
+        http_client: Optional[Any] = None,
+        *,
+        expected_generation: Optional[int] = None,
+    ) -> bool:
+        """Core recreate logic. Caller MUST hold `self._reconnection_lock`.
+
+        Split out so callers that already hold the lock (e.g.
+        `_safe_refresh_token`, which double-checks token freshness under the
+        lock) don't re-acquire it — `asyncio.Lock` is not reentrant.
         """
         from prisma import Prisma  # type: ignore
 
+        if (
+            expected_generation is not None
+            and expected_generation != self._engine_generation
+        ):
+            verbose_proxy_logger.info(
+                "%sSkipping Prisma client recreate: engine already replaced "
+                "(generation %s != expected %s).",
+                self._log_prefix,
+                self._engine_generation,
+                expected_generation,
+            )
+            return False
+
         old_engine_pid = self._get_engine_pid()
         if old_engine_pid > 0:
+            # Record BEFORE the kill so the engine-death watcher, which may
+            # fire the instant the process dies, recognizes this as a planned
+            # restart and does not launch its own reconnect.
+            #
+            # A stale entry can linger when the watcher re-arms on the new PID
+            # before the old PID's death callback runs (the callback then
+            # early-returns on PID mismatch without consuming it). Such entries
+            # are harmless but would accumulate on a long-running proxy (~one
+            # per IAM refresh), so cap the set — those old PIDs are long dead.
+            if len(self._expected_engine_deaths) >= 64:
+                self._expected_engine_deaths.clear()
+            self._expected_engine_deaths.add(old_engine_pid)
             await self._kill_engine_process(old_engine_pid)
 
         kwargs: Dict[str, Any] = {}
@@ -342,6 +418,15 @@ class PrismaWrapper:
         self._original_prisma = Prisma(**kwargs)
 
         await self._original_prisma.connect()
+        self._engine_generation += 1
+
+        # Let the owner (PrismaClient) re-arm its engine-death watcher on the
+        # newly-spawned engine PID. Scheduled, never awaited, so a slow watcher
+        # can't stall the refresh while we hold the reconnection lock.
+        if self.on_engine_replaced is not None:
+            self.on_engine_replaced()
+
+        return True
 
     async def start_token_refresh_task(self) -> None:
         """
@@ -441,9 +526,23 @@ class PrismaWrapper:
         preventing multiple concurrent reconnection attempts.
         """
         async with self._reconnection_lock:
+            # Double-checked under the lock: another trigger (e.g. the
+            # proactive loop racing a __getattr__ fallback) may have already
+            # refreshed while we waited. Recreating again would needlessly kill
+            # the engine that refresh just spawned (issue #29176), so coalesce
+            # by skipping when the current token still has comfortable runway.
+            if self._token_refresh_not_needed(os.getenv(self._db_url_env_var)):
+                verbose_proxy_logger.debug(
+                    "%sRDS IAM token still fresh; skipping redundant refresh.",
+                    self._log_prefix,
+                )
+                return
+
             new_db_url = self.get_rds_iam_token()
             if new_db_url:
-                await self.recreate_prisma_client(new_db_url)
+                # We already hold `_reconnection_lock`; call the locked core
+                # directly (the public method would re-acquire and deadlock).
+                await self._recreate_prisma_client_locked(new_db_url)
                 self._last_refresh_time = datetime.utcnow()
                 verbose_proxy_logger.info(
                     "%sRDS IAM token refreshed successfully. New token valid for ~15 minutes.",
@@ -454,6 +553,23 @@ class PrismaWrapper:
                     "%sFailed to generate new RDS IAM token during proactive refresh",
                     self._log_prefix,
                 )
+
+    def _token_refresh_not_needed(self, token_url: Optional[str]) -> bool:
+        """True iff the token in ``token_url`` has more than the refresh buffer
+        of runway left, so a refresh would be redundant.
+
+        Used to coalesce stacked refresh triggers. Deliberately mirrors the
+        proactive loop's schedule (refresh at ``expiration - buffer``): a token
+        with exactly ``buffer`` seconds left is NOT considered fresh, so the
+        legitimate proactive refresh still fires. Unparseable tokens return
+        ``False`` (refresh) — skipping them would mean never refreshing.
+        """
+        token = self._extract_token_from_db_url(token_url)
+        expiration_time = self._parse_token_expiration(token)
+        if expiration_time is None:
+            return False
+        seconds_left = (expiration_time - datetime.utcnow()).total_seconds()
+        return seconds_left > self.TOKEN_REFRESH_BUFFER_SECONDS
 
     def __getattr__(self, name: str):
         """

--- a/litellm/proxy/db/routing_prisma_wrapper.py
+++ b/litellm/proxy/db/routing_prisma_wrapper.py
@@ -144,8 +144,12 @@ class RoutingPrismaWrapper:
         await self._reader.stop_token_refresh_task()
 
     async def recreate_prisma_client(
-        self, new_db_url: str, http_client: Optional[Any] = None
-    ) -> None:
+        self,
+        new_db_url: str,
+        http_client: Optional[Any] = None,
+        *,
+        expected_generation: Optional[int] = None,
+    ) -> bool:
         """Recreate both writer and reader Prisma clients.
 
         The writer reconnect path in PrismaClient calls
@@ -155,8 +159,19 @@ class RoutingPrismaWrapper:
         the writer first (its URL is the one passed in), then best-effort
         recreate the reader. A reader failure flips `_reader_unavailable=True`
         so reads transparently fall through to the writer.
+
+        `expected_generation` is forwarded to the writer's optimistic-lock
+        guard. If the writer recreate is skipped (another path already replaced
+        the engine — issue #29176), we skip the reader too rather than churning
+        it needlessly, and return ``False``.
         """
-        await self._writer.recreate_prisma_client(new_db_url, http_client=http_client)
+        writer_recreated = await self._writer.recreate_prisma_client(
+            new_db_url,
+            http_client=http_client,
+            expected_generation=expected_generation,
+        )
+        if not writer_recreated:
+            return False
         try:
             await self._recreate_reader(http_client=http_client)
             self._reader_unavailable = False
@@ -167,6 +182,7 @@ class RoutingPrismaWrapper:
                 "Reads will fall back to the writer until the reader recovers.",
                 e,
             )
+        return True
 
     async def _recreate_reader(self, http_client: Optional[Any] = None) -> None:
         """Resolve the reader URL and recreate its Prisma client.

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -4404,6 +4404,14 @@ class PrismaClient:
                 "prisma-query-engine PID %s already dead at watch start.",
                 pid,
             )
+            if self._consume_expected_death(pid):
+                verbose_proxy_logger.info(
+                    "PID %s death was planned (engine already replaced); "
+                    "not reconnecting.",
+                    pid,
+                )
+                self._cleanup_engine_watcher()
+                return True
             self._engine_confirmed_dead = True
             self._reap_all_zombies()
             self._cleanup_engine_watcher()
@@ -4448,11 +4456,38 @@ class PrismaClient:
         except RuntimeError:
             pass
 
+    def _consume_expected_death(self, pid: int) -> bool:
+        """True iff ``pid`` was killed on purpose by a planned recreate.
+
+        `PrismaWrapper.recreate_prisma_client` records the old engine PID in
+        `_expected_engine_deaths` before SIGTERM-ing it (IAM token refresh,
+        guarded reconnect). When the watcher then sees that PID die, this lets
+        it recognize the death as planned and skip its own reconnect, which
+        would otherwise kill the engine the recreate just spawned (#29176).
+
+        Consumes (removes) the PID so a later real crash of a reused PID is
+        still handled. Tolerant of `self.db` stand-ins (tests / older clients)
+        that don't expose a real set.
+        """
+        expected = getattr(self.db, "_expected_engine_deaths", None)
+        if isinstance(expected, set) and pid in expected:
+            expected.discard(pid)
+            return True
+        return False
+
     def _on_engine_death_from_thread(self, dead_pid: int) -> None:
         """Called on the event loop thread when the waitpid thread detects engine death."""
         if self._engine_confirmed_dead:
             return
         if dead_pid != self._engine_pid:
+            return
+        if self._consume_expected_death(dead_pid):
+            verbose_proxy_logger.info(
+                "prisma-query-engine PID %s exited as part of a planned restart; "
+                "not reconnecting (engine already replaced).",
+                dead_pid,
+            )
+            self._cleanup_engine_watcher()
             return
         verbose_proxy_logger.error(
             "prisma-query-engine PID %s exited (waitpid thread); triggering reconnect.",
@@ -4508,6 +4543,14 @@ class PrismaClient:
                 self._engine_pidfd = -1
             return
         dead_pid = self._engine_pid
+        if self._consume_expected_death(dead_pid):
+            verbose_proxy_logger.info(
+                "prisma-query-engine PID %s exited (pidfd event) as part of a "
+                "planned restart; not reconnecting (engine already replaced).",
+                dead_pid,
+            )
+            self._cleanup_engine_watcher()
+            return
         verbose_proxy_logger.error(
             "prisma-query-engine PID %s exited (pidfd event); triggering reconnect.",
             dead_pid,
@@ -4531,9 +4574,18 @@ class PrismaClient:
             try:
                 os.kill(self._engine_pid, 0)
             except ProcessLookupError:
+                dead_pid = self._engine_pid
+                if self._consume_expected_death(dead_pid):
+                    verbose_proxy_logger.info(
+                        "prisma-query-engine PID %s gone as part of a planned "
+                        "restart; not reconnecting (engine already replaced).",
+                        dead_pid,
+                    )
+                    self._cleanup_engine_watcher()
+                    return
                 verbose_proxy_logger.error(
                     "prisma-query-engine PID %s gone; triggering reconnect.",
-                    self._engine_pid,
+                    dead_pid,
                 )
                 self._engine_confirmed_dead = True
                 self._reap_all_zombies()
@@ -4620,6 +4672,22 @@ class PrismaClient:
         self._engine_confirmed_dead = False
         verbose_proxy_logger.debug("Stopped engine process watcher.")
 
+    def _handle_writer_engine_replaced(self) -> None:
+        """Re-arm the engine watcher after a planned writer-engine restart.
+
+        Wired as `PrismaWrapper.on_engine_replaced` and invoked from inside
+        `recreate_prisma_client` once the new engine is connected (IAM token
+        refresh, guarded reconnect). The old watcher was tracking the engine
+        we just intentionally killed, so we tear it down and re-arm on the new
+        PID. Scheduling `_start_engine_watcher` as a task (rather than awaiting)
+        keeps us from blocking the recreate while it still holds the wrapper's
+        reconnection lock. Without this re-arm, a planned restart would leave
+        the proxy with no engine-death detection until the next reconnect.
+        """
+        self._engine_confirmed_dead = False
+        self._cleanup_engine_watcher()
+        asyncio.create_task(self._start_engine_watcher())
+
     async def _run_reconnect_cycle(
         self, timeout_seconds: Optional[float] = None
     ) -> None:
@@ -4639,6 +4707,17 @@ class PrismaClient:
             if timeout_seconds is not None
             else self._db_watchdog_reconnect_timeout_seconds
         )
+
+        # Snapshot the writer's engine generation BEFORE any await. Both
+        # reconnect branches forward it to recreate_prisma_client as an
+        # optimistic-lock token: if a concurrent IAM token refresh replaces the
+        # engine after this point, the generation moves and the recreate becomes
+        # a no-op instead of killing the engine the refresh just spawned
+        # (#29176). Captured here — atomically with the dead-engine decision
+        # below — rather than inside the reconnect closures, because those run
+        # after an `asyncio.wait_for(...)` yield during which a refresh could
+        # otherwise slip in and bump the very generation the closure then reads.
+        expected_generation = getattr(self.writer_db, "_engine_generation", None)
 
         engine_is_dead = self._engine_confirmed_dead or (
             self._engine_pid > 0 and not self._is_engine_alive()
@@ -4660,7 +4739,16 @@ class PrismaClient:
                         "DATABASE_URL not set; cannot recreate Prisma client."
                     )
                     raise RuntimeError("DATABASE_URL not set")
-                await self.db.recreate_prisma_client(db_url)
+                # Forward the entry-snapshot generation. The engine was
+                # confirmed dead, but a concurrent IAM refresh may have already
+                # respawned it; the guard makes this recreate a no-op in that
+                # case rather than killing the fresh engine (#29176). Unlike the
+                # direct path there is no SELECT 1 probe here, so the generation
+                # guard is the only thing standing between a crash-reconnect and
+                # a refresh that raced it.
+                await self.db.recreate_prisma_client(
+                    db_url, expected_generation=expected_generation
+                )
                 await self._start_engine_watcher()
 
             await asyncio.wait_for(_do_heavy_reconnect(), timeout=effective_timeout)
@@ -4682,13 +4770,36 @@ class PrismaClient:
                         "DATABASE_URL not set; cannot reconnect Prisma client."
                     )
                     raise RuntimeError("DATABASE_URL not set")
+                # Probe the writer BEFORE recreating. A concurrent IAM token
+                # refresh may have just replaced the engine (issue #29176); if
+                # the writer answers SELECT 1 the connection is already healthy
+                # and recreating would needlessly kill that fresh engine. If we
+                # do recreate, the entry-snapshot generation lets the wrapper
+                # detect a refresh that landed since cycle entry and skip the
+                # redundant restart.
+                writer = self.writer_db
+                try:
+                    await writer.query_raw("SELECT 1")
+                    verbose_proxy_logger.info(
+                        "Writer healthy on probe; skipping recreate (engine "
+                        "likely already replaced by a token refresh)."
+                    )
+                    await self._start_engine_watcher()
+                    return
+                except Exception as probe_err:
+                    verbose_proxy_logger.warning(
+                        "Writer probe failed (%s); recreating Prisma client.",
+                        probe_err,
+                    )
                 # Fresh Prisma client + new engine subprocess. The previous
                 # "lightweight" path called `disconnect()` which blocks the
                 # event loop on `subprocess.Popen.wait()`; since that call
                 # ends up killing the engine anyway, we do it non-blockingly
                 # via `_kill_engine_process` inside `recreate_prisma_client`.
                 self._cleanup_engine_watcher()
-                await self.db.recreate_prisma_client(db_url)
+                await self.db.recreate_prisma_client(
+                    db_url, expected_generation=expected_generation
+                )
                 await self._start_engine_watcher()
                 # Smoke-test the writer specifically; query_raw on the routing
                 # wrapper sends to the reader, which would not validate the
@@ -4849,6 +4960,11 @@ class PrismaClient:
             return
         if self._db_health_watchdog_task is not None:
             return
+        # Let planned writer-engine restarts (IAM token refresh, guarded
+        # reconnect) re-arm the watcher on the new PID instead of being
+        # mistaken for a crash (issue #29176). Set on the writer wrapper since
+        # the watcher tracks the writer engine.
+        self.writer_db.on_engine_replaced = self._handle_writer_engine_replaced
         self._db_health_watchdog_task = asyncio.create_task(
             self._db_health_watchdog_loop()
         )

--- a/tests/litellm/proxy/test_prisma_engine_watchdog.py
+++ b/tests/litellm/proxy/test_prisma_engine_watchdog.py
@@ -18,7 +18,7 @@ import asyncio
 import os
 import threading
 import time
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -219,7 +219,7 @@ async def test_run_reconnect_cycle_uses_heavy_path_when_engine_dead(
         await engine_client._run_reconnect_cycle(timeout_seconds=5.0)
 
     engine_client.db.recreate_prisma_client.assert_awaited_once_with(
-        "postgresql://test"
+        "postgresql://test", expected_generation=ANY
     )
     engine_client._start_engine_watcher.assert_awaited_once()
     engine_client.db.connect.assert_not_awaited()
@@ -246,7 +246,7 @@ async def test_run_reconnect_cycle_uses_heavy_path_when_confirmed_dead(
         await engine_client._run_reconnect_cycle(timeout_seconds=5.0)
 
     engine_client.db.recreate_prisma_client.assert_awaited_once_with(
-        "postgresql://test"
+        "postgresql://test", expected_generation=ANY
     )
     engine_client._start_engine_watcher.assert_awaited_once()
     engine_client.db.connect.assert_not_awaited()
@@ -257,12 +257,16 @@ async def test_run_reconnect_cycle_uses_heavy_path_when_confirmed_dead(
 async def test_run_reconnect_cycle_uses_direct_path_when_engine_alive(
     engine_client,
 ) -> None:
-    """Direct reconnect (engine alive) calls recreate_prisma_client + SELECT 1.
+    """Direct reconnect (engine alive) probes the writer first and skips the
+    recreate when the probe is healthy.
 
-    The old "lightweight" path called `disconnect()` + `connect()`, which
-    blocks the event loop on the sync `process.wait()` inside aclose().
-    The fix routes both engine-alive and engine-dead paths through
-    `recreate_prisma_client`, which non-blockingly kills the old engine.
+    The engine-alive path now runs a SELECT 1 probe before recreating. A
+    healthy probe means the connection is fine — e.g. an IAM token refresh
+    already replaced the engine (issue #29176) — so recreating would kill a
+    working engine. Recreate happens only when the probe fails (covered in
+    test_prisma_client_reconnect.py::
+    test_run_reconnect_cycle_direct_path_recreates_when_probe_fails). Either
+    way the blocking `disconnect()` is never called.
     """
     engine_client._engine_pid = 1234
     engine_client._start_engine_watcher = AsyncMock()
@@ -273,29 +277,28 @@ async def test_run_reconnect_cycle_uses_direct_path_when_engine_alive(
     ):
         await engine_client._run_reconnect_cycle(timeout_seconds=5.0)
 
-    engine_client.db.recreate_prisma_client.assert_awaited_once_with(
-        "postgresql://test"
-    )
+    engine_client.db.recreate_prisma_client.assert_not_awaited()
     engine_client.db.query_raw.assert_awaited_once_with("SELECT 1")
     engine_client.db.disconnect.assert_not_awaited()
+    engine_client._start_engine_watcher.assert_awaited_once()
 
 
 @pytest.mark.asyncio
 async def test_run_reconnect_cycle_uses_direct_path_when_pid_unknown(
     engine_client,
 ) -> None:
-    """When the engine PID is not tracked, direct reconnect still runs."""
+    """When the engine PID is not tracked, direct reconnect still runs and a
+    healthy probe likewise skips the recreate."""
     engine_client._engine_pid = 0
     engine_client._start_engine_watcher = AsyncMock()
 
     with patch.dict(os.environ, {"DATABASE_URL": "postgresql://test"}):
         await engine_client._run_reconnect_cycle(timeout_seconds=5.0)
 
-    engine_client.db.recreate_prisma_client.assert_awaited_once_with(
-        "postgresql://test"
-    )
+    engine_client.db.recreate_prisma_client.assert_not_awaited()
     engine_client.db.query_raw.assert_awaited_once_with("SELECT 1")
     engine_client.db.disconnect.assert_not_awaited()
+    engine_client._start_engine_watcher.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -497,7 +500,10 @@ async def test_escalation_after_consecutive_direct_reconnect_failures(engine_cli
     engine_client._db_reconnect_cooldown_seconds = 0  # disable cooldown for test
     engine_client._start_engine_watcher = AsyncMock(return_value=None)
 
-    # Make direct reconnect fail every time
+    # Make the direct path's writer probe fail so it proceeds to recreate
+    # (a healthy probe would correctly skip recreate), then make recreate
+    # fail every time.
+    engine_client.db.query_raw = AsyncMock(side_effect=Exception("probe failed"))
     engine_client.db.recreate_prisma_client = AsyncMock(
         side_effect=Exception("recreate failed")
     )

--- a/tests/test_litellm/proxy/db/test_prisma_planned_engine_restart.py
+++ b/tests/test_litellm/proxy/db/test_prisma_planned_engine_restart.py
@@ -1,0 +1,341 @@
+"""Coordination between planned Prisma engine restarts and reconnect paths.
+
+Covers the fix for https://github.com/BerriAI/litellm/issues/29176 — an RDS
+IAM token refresh recreates the Prisma client (killing the query-engine
+subprocess), and the engine-death watcher / in-flight transport-error
+retries must not treat that planned restart as a crash and recreate the
+client a second time.
+
+Symbols pinned here:
+  - ``PrismaWrapper._expected_engine_deaths``
+  - ``PrismaWrapper._engine_generation``
+  - ``PrismaWrapper.on_engine_replaced``
+  - ``PrismaWrapper.recreate_prisma_client`` (expected_generation guard)
+  - ``PrismaWrapper._safe_refresh_token`` (refresh coalescing)
+  - ``RoutingPrismaWrapper.recreate_prisma_client`` (guard forwarding)
+"""
+
+import asyncio
+import os
+import sys
+import urllib.parse
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.path.insert(
+    0, os.path.abspath("../../../..")
+)  # Adds the parent directory to the system path
+
+from litellm.proxy.db.prisma_client import PrismaWrapper
+
+
+@pytest.fixture(autouse=True)
+def mock_prisma_binary():
+    """Mock prisma.Prisma to avoid requiring generated Prisma binaries for unit tests."""
+    mock_module = MagicMock()
+    with patch.dict(sys.modules, {"prisma": mock_module}):
+        yield mock_module
+
+
+def _make_wrapper(engine_pid: int = 111, iam: bool = False) -> PrismaWrapper:
+    mock_prisma = MagicMock()
+    mock_prisma.connect = AsyncMock()
+    mock_prisma._engine = MagicMock()
+    mock_prisma._engine.process.pid = engine_pid
+    return PrismaWrapper(original_prisma=mock_prisma, iam_token_db_auth=iam)
+
+
+def _token_db_url(created: datetime, expires_in: int = 900) -> str:
+    """Build a DATABASE_URL whose password is a parseable RDS IAM token."""
+    token = (
+        f"host/?X-Amz-Date={created.strftime('%Y%m%dT%H%M%SZ')}"
+        f"&X-Amz-Expires={expires_in}&X-Amz-Signature=abc"
+    )
+    quoted = urllib.parse.quote(token, safe="")
+    return f"postgresql://user:{quoted}@host:5432/db"
+
+
+@pytest.mark.asyncio
+async def test_recreate_marks_old_engine_pid_as_expected_death(mock_prisma_binary):
+    """The watcher must be able to tell a planned kill from a crash."""
+    wrapper = _make_wrapper(engine_pid=111)
+    mock_prisma_binary.Prisma.return_value = MagicMock(connect=AsyncMock())
+
+    with (
+        patch("os.kill"),
+        patch("asyncio.sleep", new_callable=AsyncMock),
+    ):
+        await wrapper.recreate_prisma_client("postgresql://new")
+
+    assert 111 in wrapper._expected_engine_deaths
+
+
+@pytest.mark.asyncio
+async def test_recreate_increments_engine_generation(mock_prisma_binary):
+    wrapper = _make_wrapper(engine_pid=111)
+    mock_prisma_binary.Prisma.return_value = MagicMock(connect=AsyncMock())
+
+    assert wrapper._engine_generation == 0
+    with (
+        patch("os.kill"),
+        patch("asyncio.sleep", new_callable=AsyncMock),
+    ):
+        await wrapper.recreate_prisma_client("postgresql://new")
+
+    assert wrapper._engine_generation == 1
+
+
+@pytest.mark.asyncio
+async def test_recreate_skips_when_expected_generation_is_stale(mock_prisma_binary):
+    """A reconnect that observed a failure before another path already
+    recreated the client must not recreate (and kill the fresh engine) again."""
+    wrapper = _make_wrapper(engine_pid=111)
+    old_prisma = wrapper._original_prisma
+    wrapper._engine_generation = 3
+
+    with (
+        patch("os.kill") as mock_kill,
+        patch("asyncio.sleep", new_callable=AsyncMock),
+    ):
+        recreated = await wrapper.recreate_prisma_client(
+            "postgresql://new", expected_generation=2
+        )
+
+    pinned = {
+        "recreated": recreated,
+        "prisma_constructed": mock_prisma_binary.Prisma.call_count,
+        "killed": mock_kill.call_count,
+        "client_unchanged": wrapper._original_prisma is old_prisma,
+        "generation": wrapper._engine_generation,
+    }
+    assert pinned == {
+        "recreated": False,
+        "prisma_constructed": 0,
+        "killed": 0,
+        "client_unchanged": True,
+        "generation": 3,
+    }
+
+
+@pytest.mark.asyncio
+async def test_recreate_proceeds_when_expected_generation_matches(mock_prisma_binary):
+    wrapper = _make_wrapper(engine_pid=111)
+    wrapper._engine_generation = 3
+    mock_prisma_binary.Prisma.return_value = MagicMock(connect=AsyncMock())
+
+    with (
+        patch("os.kill"),
+        patch("asyncio.sleep", new_callable=AsyncMock),
+    ):
+        recreated = await wrapper.recreate_prisma_client(
+            "postgresql://new", expected_generation=3
+        )
+
+    assert recreated is True
+    assert wrapper._engine_generation == 4
+
+
+@pytest.mark.asyncio
+async def test_concurrent_guarded_recreates_only_recreate_once(mock_prisma_binary):
+    """Two racing reconnect paths that both observed generation 0 must result
+    in exactly one engine recreate (the loser sees the bumped generation)."""
+    wrapper = _make_wrapper(engine_pid=111)
+    mock_prisma_binary.Prisma.return_value = MagicMock(connect=AsyncMock())
+
+    with (
+        patch("os.kill"),
+        patch("asyncio.sleep", new_callable=AsyncMock),
+    ):
+        results = await asyncio.gather(
+            wrapper.recreate_prisma_client("postgresql://new", expected_generation=0),
+            wrapper.recreate_prisma_client("postgresql://new", expected_generation=0),
+        )
+
+    pinned = {
+        "results": sorted(results),
+        "prisma_constructed": mock_prisma_binary.Prisma.call_count,
+        "generation": wrapper._engine_generation,
+    }
+    assert pinned == {
+        "results": [False, True],
+        "prisma_constructed": 1,
+        "generation": 1,
+    }
+
+
+@pytest.mark.asyncio
+async def test_on_engine_replaced_invoked_after_successful_recreate(
+    mock_prisma_binary,
+):
+    """PrismaClient hooks this to re-arm the engine watcher on the new PID."""
+    wrapper = _make_wrapper(engine_pid=111)
+    mock_prisma_binary.Prisma.return_value = MagicMock(connect=AsyncMock())
+    hook = MagicMock()
+    wrapper.on_engine_replaced = hook
+
+    with (
+        patch("os.kill"),
+        patch("asyncio.sleep", new_callable=AsyncMock),
+    ):
+        await wrapper.recreate_prisma_client("postgresql://new")
+
+    assert hook.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_on_engine_replaced_not_invoked_when_recreate_skipped(
+    mock_prisma_binary,
+):
+    wrapper = _make_wrapper(engine_pid=111)
+    wrapper._engine_generation = 5
+    hook = MagicMock()
+    wrapper.on_engine_replaced = hook
+
+    await wrapper.recreate_prisma_client("postgresql://new", expected_generation=1)
+
+    assert hook.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_safe_refresh_token_skips_when_token_still_fresh(
+    mock_prisma_binary, monkeypatch
+):
+    """Stacked refresh triggers (e.g. __getattr__ scheduling a refresh task
+    that runs after the proactive loop already refreshed) must coalesce
+    instead of killing the freshly-spawned engine again."""
+    wrapper = _make_wrapper(engine_pid=111, iam=True)
+    monkeypatch.setenv(
+        "DATABASE_URL", _token_db_url(created=datetime.utcnow(), expires_in=900)
+    )
+    wrapper.get_rds_iam_token = MagicMock(return_value="postgresql://fresh")
+
+    await wrapper._safe_refresh_token()
+
+    pinned = {
+        "token_minted": wrapper.get_rds_iam_token.call_count,
+        "prisma_constructed": mock_prisma_binary.Prisma.call_count,
+    }
+    assert pinned == {"token_minted": 0, "prisma_constructed": 0}
+
+
+@pytest.mark.asyncio
+async def test_safe_refresh_token_refreshes_when_token_expired(
+    mock_prisma_binary, monkeypatch
+):
+    wrapper = _make_wrapper(engine_pid=111, iam=True)
+    expired = datetime.utcnow() - timedelta(seconds=1200)
+    monkeypatch.setenv("DATABASE_URL", _token_db_url(created=expired, expires_in=900))
+    wrapper.get_rds_iam_token = MagicMock(return_value="postgresql://fresh")
+    mock_prisma_binary.Prisma.return_value = MagicMock(connect=AsyncMock())
+
+    with (
+        patch("os.kill"),
+        patch("asyncio.sleep", new_callable=AsyncMock),
+    ):
+        await wrapper._safe_refresh_token()
+
+    pinned = {
+        "token_minted": wrapper.get_rds_iam_token.call_count,
+        "prisma_constructed": mock_prisma_binary.Prisma.call_count,
+    }
+    assert pinned == {"token_minted": 1, "prisma_constructed": 1}
+
+
+@pytest.mark.asyncio
+async def test_safe_refresh_token_refreshes_when_token_unparseable(
+    mock_prisma_binary, monkeypatch
+):
+    """Unparseable tokens follow the fallback-interval path and must always
+    refresh — skipping here would mean never refreshing at all."""
+    wrapper = _make_wrapper(engine_pid=111, iam=True)
+    monkeypatch.setenv("DATABASE_URL", "postgresql://user:plainpass@host:5432/db")
+    wrapper.get_rds_iam_token = MagicMock(return_value="postgresql://fresh")
+    mock_prisma_binary.Prisma.return_value = MagicMock(connect=AsyncMock())
+
+    with (
+        patch("os.kill"),
+        patch("asyncio.sleep", new_callable=AsyncMock),
+    ):
+        await wrapper._safe_refresh_token()
+
+    assert wrapper.get_rds_iam_token.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_routing_recreate_skips_reader_when_writer_generation_stale(
+    mock_prisma_binary, monkeypatch
+):
+    from litellm.proxy.db.routing_prisma_wrapper import RoutingPrismaWrapper
+
+    monkeypatch.setenv("DATABASE_URL_READ_REPLICA", "postgresql://reader")
+    writer = _make_wrapper(engine_pid=111)
+    reader = _make_wrapper(engine_pid=222)
+    writer._engine_generation = 2
+    reader.recreate_prisma_client = AsyncMock()
+    routing = RoutingPrismaWrapper(writer=writer, reader=reader)
+
+    recreated = await routing.recreate_prisma_client(
+        "postgresql://new", expected_generation=1
+    )
+
+    pinned = {
+        "recreated": recreated,
+        "reader_recreated": reader.recreate_prisma_client.await_count,
+        "writer_prisma_constructed": mock_prisma_binary.Prisma.call_count,
+    }
+    assert pinned == {
+        "recreated": False,
+        "reader_recreated": 0,
+        "writer_prisma_constructed": 0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_routing_recreate_recreates_both_when_generation_matches(
+    mock_prisma_binary, monkeypatch
+):
+    from litellm.proxy.db.routing_prisma_wrapper import RoutingPrismaWrapper
+
+    monkeypatch.setenv("DATABASE_URL_READ_REPLICA", "postgresql://reader")
+    writer = _make_wrapper(engine_pid=111)
+    reader = _make_wrapper(engine_pid=222)
+    reader.recreate_prisma_client = AsyncMock()
+    routing = RoutingPrismaWrapper(writer=writer, reader=reader)
+    mock_prisma_binary.Prisma.return_value = MagicMock(connect=AsyncMock())
+
+    with (
+        patch("os.kill"),
+        patch("asyncio.sleep", new_callable=AsyncMock),
+    ):
+        recreated = await routing.recreate_prisma_client(
+            "postgresql://new", expected_generation=0
+        )
+
+    pinned = {
+        "recreated": recreated,
+        "reader_recreated": reader.recreate_prisma_client.await_count,
+    }
+    assert pinned == {"recreated": True, "reader_recreated": 1}
+
+
+@pytest.mark.asyncio
+async def test_recreate_caps_expected_engine_deaths_set(mock_prisma_binary):
+    """The planned-death set is bounded. Stale PIDs accrue when a death
+    callback early-returns on PID mismatch (watcher already re-armed on the new
+    engine), so a recreate clears the set once it grows past the cap, then
+    records only the current old PID."""
+    wrapper = _make_wrapper(engine_pid=111)
+    mock_prisma_binary.Prisma.return_value = MagicMock(connect=AsyncMock())
+    # Seed with stale PIDs at the cap so the next recreate triggers the clear.
+    wrapper._expected_engine_deaths = set(range(1000, 1064))
+    assert len(wrapper._expected_engine_deaths) >= 64
+
+    with (
+        patch("os.kill"),
+        patch("asyncio.sleep", new_callable=AsyncMock),
+    ):
+        await wrapper.recreate_prisma_client("postgresql://new")
+
+    assert wrapper._expected_engine_deaths == {111}

--- a/tests/test_litellm/proxy/db/test_prisma_self_heal.py
+++ b/tests/test_litellm/proxy/db/test_prisma_self_heal.py
@@ -35,8 +35,13 @@ async def test_attempt_db_reconnect_should_succeed(mock_proxy_logging):
     client = PrismaClient(
         database_url="mock://test", proxy_logging_obj=mock_proxy_logging
     )
-    client.db.recreate_prisma_client = AsyncMock(return_value=None)
-    client.db.query_raw = AsyncMock(return_value=[{"result": 1}])
+    client.db.recreate_prisma_client = AsyncMock(return_value=True)
+    # Probe fails (connection genuinely broken) so the direct path proceeds to
+    # recreate; the post-recreate smoke test then succeeds. A healthy probe
+    # would instead skip the recreate (covered in test_prisma_client_reconnect).
+    client.db.query_raw = AsyncMock(
+        side_effect=[ConnectionError("probe failed"), [{"result": 1}]]
+    )
     client._start_engine_watcher = AsyncMock()
 
     with patch.dict(os.environ, {"DATABASE_URL": "postgresql://test"}):
@@ -46,8 +51,10 @@ async def test_attempt_db_reconnect_should_succeed(mock_proxy_logging):
         )
 
     assert result is True
-    client.db.recreate_prisma_client.assert_awaited_once_with("postgresql://test")
-    client.db.query_raw.assert_awaited_once_with("SELECT 1")
+    client.db.recreate_prisma_client.assert_awaited_once_with(
+        "postgresql://test", expected_generation=0
+    )
+    assert client.db.query_raw.await_count == 2
 
 
 @pytest.mark.asyncio
@@ -179,15 +186,21 @@ async def test_run_reconnect_cycle_watchdog_should_use_recreate_prisma_client(
     client.db.disconnect = AsyncMock(
         side_effect=AssertionError("disconnect must not be called")
     )
-    client.db.recreate_prisma_client = AsyncMock(return_value=None)
-    client.db.query_raw = AsyncMock(return_value=[{"result": 1}])
+    client.db.recreate_prisma_client = AsyncMock(return_value=True)
+    # Probe fails so we proceed to recreate (and verify disconnect is never
+    # used — issue #26191); the post-recreate smoke test then succeeds.
+    client.db.query_raw = AsyncMock(
+        side_effect=[ConnectionError("probe failed"), [{"result": 1}]]
+    )
     client._start_engine_watcher = AsyncMock()
 
     with patch.dict(os.environ, {"DATABASE_URL": "postgresql://test"}):
         await client._run_reconnect_cycle(timeout_seconds=None)
 
-    client.db.recreate_prisma_client.assert_awaited_once_with("postgresql://test")
-    client.db.query_raw.assert_awaited_once_with("SELECT 1")
+    client.db.recreate_prisma_client.assert_awaited_once_with(
+        "postgresql://test", expected_generation=0
+    )
+    assert client.db.query_raw.await_count == 2
     client.db.disconnect.assert_not_awaited()
 
 
@@ -201,15 +214,22 @@ async def test_run_reconnect_cycle_watchdog_should_use_default_timeout_budget(
     client._db_watchdog_reconnect_timeout_seconds = 0.1
     client._start_engine_watcher = AsyncMock()
 
-    async def _slow_recreate(_db_url):
+    async def _slow_recreate(_db_url, **_kwargs):
         await asyncio.sleep(0.08)
 
-    async def _slow_query(_query: str):
+    probe_calls = {"n": 0}
+
+    async def _probe_fails_then_slow_smoke(_query: str):
+        probe_calls["n"] += 1
+        if probe_calls["n"] == 1:
+            # Probe fails fast so the cycle proceeds to the slow recreate +
+            # smoke test, whose combined time must exceed the overall budget.
+            raise ConnectionError("probe failed")
         await asyncio.sleep(0.08)
         return [{"result": 1}]
 
     client.db.recreate_prisma_client = AsyncMock(side_effect=_slow_recreate)
-    client.db.query_raw = AsyncMock(side_effect=_slow_query)
+    client.db.query_raw = AsyncMock(side_effect=_probe_fails_then_slow_smoke)
 
     with (
         pytest.raises(asyncio.TimeoutError),
@@ -227,15 +247,22 @@ async def test_run_reconnect_cycle_timeout_should_use_single_overall_budget(
     )
     client._start_engine_watcher = AsyncMock()
 
-    async def _slow_recreate(_db_url):
+    async def _slow_recreate(_db_url, **_kwargs):
         await asyncio.sleep(0.08)
 
-    async def _slow_query(_query: str):
+    probe_calls = {"n": 0}
+
+    async def _probe_fails_then_slow_smoke(_query: str):
+        probe_calls["n"] += 1
+        if probe_calls["n"] == 1:
+            # Probe fails fast so the cycle proceeds to the slow recreate +
+            # smoke test, whose combined time must exceed the overall budget.
+            raise ConnectionError("probe failed")
         await asyncio.sleep(0.08)
         return [{"result": 1}]
 
     client.db.recreate_prisma_client = AsyncMock(side_effect=_slow_recreate)
-    client.db.query_raw = AsyncMock(side_effect=_slow_query)
+    client.db.query_raw = AsyncMock(side_effect=_probe_fails_then_slow_smoke)
 
     with (
         pytest.raises(asyncio.TimeoutError),

--- a/tests/test_litellm/proxy/db/test_routing_prisma_wrapper.py
+++ b/tests/test_litellm/proxy/db/test_routing_prisma_wrapper.py
@@ -296,7 +296,7 @@ async def test_recreate_prisma_client_recreates_both_writer_and_reader():
         await routing.recreate_prisma_client("writer-url", http_client=None)
 
     writer.recreate_prisma_client.assert_awaited_once_with(
-        "writer-url", http_client=None
+        "writer-url", http_client=None, expected_generation=None
     )
     reader.recreate_prisma_client.assert_awaited_once_with(
         "reader-url", http_client=None

--- a/tests/test_litellm/proxy/utils/prisma_and_spend/test_prisma_client_engine_watcher.py
+++ b/tests/test_litellm/proxy/utils/prisma_and_spend/test_prisma_client_engine_watcher.py
@@ -519,3 +519,186 @@ def test_stop_engine_watcher_error_in_cleanup_propagates(
     prisma_client._cleanup_engine_watcher = MagicMock(side_effect=RuntimeError("cleanup boom"))
     with pytest.raises(RuntimeError, match="cleanup boom"):
         prisma_client._stop_engine_watcher()
+
+
+# ---------------------------------------------------------------------------
+# Planned engine restarts (https://github.com/BerriAI/litellm/issues/29176)
+#
+# An RDS IAM token refresh kills + respawns the engine on purpose. The death
+# handlers must not treat that as a crash and trigger a forced reconnect that
+# would kill the freshly-spawned engine; the wrapper's on_engine_replaced
+# hook re-arms the watcher on the new PID instead.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_on_engine_death_from_thread_planned_death_skips_reconnect(
+    prisma_client: PrismaClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    prisma_client._engine_pid = 7777
+    prisma_client._engine_confirmed_dead = False
+    prisma_client.db._expected_engine_deaths = {7777}
+    prisma_client.attempt_db_reconnect = AsyncMock(return_value=True)
+    monkeypatch.setattr(PrismaClient, "_reap_all_zombies", staticmethod(lambda: set()))
+    monkeypatch.setattr(prisma_client, "_cleanup_engine_watcher", MagicMock())
+
+    prisma_client._on_engine_death_from_thread(7777)
+    await asyncio.sleep(0)
+    pinned = {
+        "confirmed_dead": prisma_client._engine_confirmed_dead,
+        "reconnect_called": prisma_client.attempt_db_reconnect.await_count,
+        "cleanup_called": prisma_client._cleanup_engine_watcher.call_count,
+        "planned_pid_consumed": 7777 not in prisma_client.db._expected_engine_deaths,
+    }
+    assert pinned == {
+        "confirmed_dead": False,
+        "reconnect_called": 0,
+        "cleanup_called": 1,
+        "planned_pid_consumed": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_on_engine_death_from_thread_planned_death_after_rearm_keeps_watcher(
+    prisma_client: PrismaClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A stale death event for the old PID arriving after the watcher already
+    re-armed on the new PID must not tear down the new watcher."""
+    prisma_client._engine_pid = 8888  # watcher already re-armed on the new engine
+    prisma_client._engine_confirmed_dead = False
+    prisma_client.db._expected_engine_deaths = {7777}
+    prisma_client.attempt_db_reconnect = AsyncMock(return_value=True)
+    monkeypatch.setattr(PrismaClient, "_reap_all_zombies", staticmethod(lambda: set()))
+    monkeypatch.setattr(prisma_client, "_cleanup_engine_watcher", MagicMock())
+
+    prisma_client._on_engine_death_from_thread(7777)
+    await asyncio.sleep(0)
+    pinned = {
+        "reconnect_called": prisma_client.attempt_db_reconnect.await_count,
+        "cleanup_called": prisma_client._cleanup_engine_watcher.call_count,
+        "watched_pid": prisma_client._engine_pid,
+    }
+    assert pinned == {
+        "reconnect_called": 0,
+        "cleanup_called": 0,
+        "watched_pid": 8888,
+    }
+
+
+@pytest.mark.asyncio
+async def test_on_pidfd_readable_planned_death_cleans_up_without_reconnect(
+    prisma_client: PrismaClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    prisma_client._engine_pid = 4321
+    prisma_client._engine_confirmed_dead = False
+    prisma_client.db._expected_engine_deaths = {4321}
+    prisma_client.attempt_db_reconnect = AsyncMock(return_value=True)
+    monkeypatch.setattr(PrismaClient, "_reap_all_zombies", staticmethod(lambda: set()))
+    cleanup = MagicMock()
+    prisma_client._cleanup_engine_watcher = cleanup
+
+    prisma_client._on_pidfd_readable()
+    await asyncio.sleep(0)
+    pinned = {
+        "confirmed_dead": prisma_client._engine_confirmed_dead,
+        "reconnect_called": prisma_client.attempt_db_reconnect.await_count,
+        "cleanup_called": cleanup.call_count,
+    }
+    assert pinned == {
+        "confirmed_dead": False,
+        "reconnect_called": 0,
+        "cleanup_called": 1,
+    }
+
+
+@pytest.mark.asyncio
+async def test_try_waitpid_watch_already_dead_planned_skips_reconnect(
+    prisma_client: PrismaClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Arming the watcher while a planned kill is mid-flight must not trigger
+    a reconnect for the already-dead PID."""
+    prisma_client.db._expected_engine_deaths = {123}
+    prisma_client.attempt_db_reconnect = AsyncMock(return_value=True)
+    monkeypatch.setattr("os.waitpid", MagicMock(return_value=(123, 0)))
+    monkeypatch.setattr(PrismaClient, "_reap_all_zombies", staticmethod(lambda: set()))
+    monkeypatch.setattr(prisma_client, "_cleanup_engine_watcher", MagicMock())
+
+    result = prisma_client._try_waitpid_watch(123)
+    await asyncio.sleep(0)
+    pinned = {
+        "handled": result,
+        "reconnect_called": prisma_client.attempt_db_reconnect.await_count,
+        "confirmed_dead": prisma_client._engine_confirmed_dead,
+    }
+    assert pinned == {
+        "handled": True,
+        "reconnect_called": 0,
+        "confirmed_dead": False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_handle_writer_engine_replaced_rearms_watcher(
+    prisma_client: PrismaClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    prisma_client._engine_confirmed_dead = True
+    monkeypatch.setattr(prisma_client, "_cleanup_engine_watcher", MagicMock())
+    monkeypatch.setattr(prisma_client, "_start_engine_watcher", AsyncMock())
+
+    prisma_client._handle_writer_engine_replaced()
+    await asyncio.sleep(0)
+    pinned = {
+        "confirmed_dead": prisma_client._engine_confirmed_dead,
+        "cleanup_called": prisma_client._cleanup_engine_watcher.call_count,
+        "watcher_rearmed": prisma_client._start_engine_watcher.await_count,
+    }
+    assert pinned == {
+        "confirmed_dead": False,
+        "cleanup_called": 1,
+        "watcher_rearmed": 1,
+    }
+
+
+@pytest.mark.asyncio
+async def test_start_db_health_watchdog_task_wires_engine_replaced_hook(
+    prisma_client: PrismaClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    prisma_client._db_health_watchdog_enabled = True
+    prisma_client._db_health_watchdog_task = None
+    monkeypatch.setattr(prisma_client, "_start_engine_watcher", AsyncMock())
+
+    await prisma_client.start_db_health_watchdog_task()
+    try:
+        assert (
+            prisma_client.db.on_engine_replaced
+            == prisma_client._handle_writer_engine_replaced
+        )
+    finally:
+        await prisma_client.stop_db_health_watchdog_task()
+
+
+@pytest.mark.asyncio
+async def test_poll_engine_proc_planned_death_skips_reconnect(
+    prisma_client: PrismaClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The os.kill polling fallback must also honor planned deaths."""
+    prisma_client._engine_pid = 555
+    prisma_client._watching_engine = True
+    prisma_client._engine_confirmed_dead = False
+    prisma_client.db._expected_engine_deaths = {555}
+    prisma_client.attempt_db_reconnect = AsyncMock(return_value=True)
+    monkeypatch.setattr(PrismaClient, "_reap_all_zombies", staticmethod(lambda: set()))
+    monkeypatch.setattr(prisma_client, "_cleanup_engine_watcher", MagicMock())
+    monkeypatch.setattr("os.kill", MagicMock(side_effect=ProcessLookupError()))
+
+    await prisma_client._poll_engine_proc()
+    pinned = {
+        "reconnect_called": prisma_client.attempt_db_reconnect.await_count,
+        "cleanup_called": prisma_client._cleanup_engine_watcher.call_count,
+        "confirmed_dead": prisma_client._engine_confirmed_dead,
+    }
+    assert pinned == {
+        "reconnect_called": 0,
+        "cleanup_called": 1,
+        "confirmed_dead": False,
+    }

--- a/tests/test_litellm/proxy/utils/prisma_and_spend/test_prisma_client_reconnect.py
+++ b/tests/test_litellm/proxy/utils/prisma_and_spend/test_prisma_client_reconnect.py
@@ -21,9 +21,13 @@ from litellm.proxy.utils import PrismaClient
 
 
 @pytest.mark.asyncio
-async def test_run_reconnect_cycle_direct_path_when_engine_alive(
+async def test_run_reconnect_cycle_direct_path_skips_recreate_when_probe_healthy(
     prisma_client: PrismaClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """Direct path probes the writer first: if SELECT 1 succeeds the
+    connection is healthy (e.g. an IAM token refresh just replaced the
+    engine) and recreating — killing the fresh engine — must be skipped.
+    Part of the fix for https://github.com/BerriAI/litellm/issues/29176."""
     monkeypatch.setenv("DATABASE_URL", "postgres://x:y@h:5432/db")
     prisma_client._engine_confirmed_dead = False
     prisma_client._engine_pid = 0
@@ -43,15 +47,83 @@ async def test_run_reconnect_cycle_direct_path_when_engine_alive(
     pinned = {
         "recreate_called": prisma_client.db.recreate_prisma_client.await_count,
         "start_watcher_called": prisma_client._start_engine_watcher.await_count,
-        "writer_smoke_test_called": writer.query_raw.await_count,
+        "writer_probe_called": writer.query_raw.await_count,
         "engine_confirmed_dead": prisma_client._engine_confirmed_dead,
+    }
+    assert pinned == {
+        "recreate_called": 0,
+        "start_watcher_called": 1,
+        "writer_probe_called": 1,
+        "engine_confirmed_dead": False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_run_reconnect_cycle_direct_path_recreates_when_probe_fails(
+    prisma_client: PrismaClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Genuine network blip: probe fails, so the client is recreated and the
+    final SELECT 1 smoke test validates the new writer engine."""
+    monkeypatch.setenv("DATABASE_URL", "postgres://x:y@h:5432/db")
+    prisma_client._engine_confirmed_dead = False
+    prisma_client._engine_pid = 0
+    prisma_client.db.recreate_prisma_client = AsyncMock()
+    prisma_client._start_engine_watcher = AsyncMock()
+    prisma_client._cleanup_engine_watcher = MagicMock()
+
+    writer = MagicMock()
+    writer.query_raw = AsyncMock(
+        side_effect=[ConnectionError("probe failed"), [{"?column?": 1}]]
+    )
+    monkeypatch.setattr(
+        PrismaClient,
+        "writer_db",
+        property(lambda self: writer),
+    )
+
+    await prisma_client._run_reconnect_cycle(timeout_seconds=5)
+    pinned = {
+        "recreate_called": prisma_client.db.recreate_prisma_client.await_count,
+        "start_watcher_called": prisma_client._start_engine_watcher.await_count,
+        "writer_query_raw_calls": writer.query_raw.await_count,
+        "cleanup_called": prisma_client._cleanup_engine_watcher.call_count,
     }
     assert pinned == {
         "recreate_called": 1,
         "start_watcher_called": 1,
-        "writer_smoke_test_called": 1,
-        "engine_confirmed_dead": False,
+        "writer_query_raw_calls": 2,
+        "cleanup_called": 1,
     }
+
+
+@pytest.mark.asyncio
+async def test_run_reconnect_cycle_passes_writer_generation_to_recreate(
+    prisma_client: PrismaClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The cycle snapshots the writer's engine generation at entry and passes
+    it to recreate_prisma_client so a recreate that lost the race against a
+    planned restart (IAM refresh) is skipped inside the wrapper."""
+    monkeypatch.setenv("DATABASE_URL", "postgres://x:y@h:5432/db")
+    prisma_client._engine_confirmed_dead = False
+    prisma_client._engine_pid = 0
+    prisma_client.db.recreate_prisma_client = AsyncMock()
+    prisma_client._start_engine_watcher = AsyncMock()
+    prisma_client._cleanup_engine_watcher = MagicMock()
+
+    writer = MagicMock()
+    writer._engine_generation = 7
+    writer.query_raw = AsyncMock(
+        side_effect=[ConnectionError("probe failed"), [{"?column?": 1}]]
+    )
+    monkeypatch.setattr(
+        PrismaClient,
+        "writer_db",
+        property(lambda self: writer),
+    )
+
+    await prisma_client._run_reconnect_cycle(timeout_seconds=5)
+    recreate_kwargs = prisma_client.db.recreate_prisma_client.await_args.kwargs
+    assert recreate_kwargs.get("expected_generation") == 7
 
 
 @pytest.mark.asyncio
@@ -369,3 +441,146 @@ async def test_db_health_watchdog_loop_swallows_non_db_errors(
     monkeypatch.setattr("asyncio.wait_for", _raise_then_cancel)
     await prisma_client._db_health_watchdog_loop()
     assert prisma_client.attempt_db_reconnect.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_iam_refresh_racing_reconnect_recreates_engine_only_once(
+    prisma_client: PrismaClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Integration repro for https://github.com/BerriAI/litellm/issues/29176.
+
+    An IAM token refresh (PrismaWrapper._safe_refresh_token) is mid-recreate
+    when an in-flight transport error triggers attempt_db_reconnect. The
+    reconnect must NOT recreate the Prisma client a second time (which would
+    SIGTERM the engine the refresh just spawned).
+    """
+    import os
+    import urllib.parse
+    from datetime import datetime, timedelta
+
+    import prisma as prisma_pkg
+
+    from litellm.proxy.db.prisma_client import PrismaWrapper
+
+    def token_db_url(created: datetime) -> str:
+        token = (
+            f"host/?X-Amz-Date={created.strftime('%Y%m%dT%H%M%SZ')}"
+            f"&X-Amz-Expires=900&X-Amz-Signature=abc"
+        )
+        return f"postgresql://user:{urllib.parse.quote(token, safe='')}@host:5432/db"
+
+    # Old engine (PID 111) carries an expired token; in-flight queries on it
+    # fail with a transport error.
+    expired_url = token_db_url(datetime.utcnow() - timedelta(seconds=1200))
+    fresh_url = token_db_url(datetime.utcnow())
+    monkeypatch.setenv("DATABASE_URL", expired_url)
+
+    old_prisma = MagicMock(name="OldPrisma")
+    old_prisma._engine = MagicMock()
+    old_prisma._engine.process.pid = 111
+    old_prisma.query_raw = AsyncMock(side_effect=ConnectionError("engine restarting"))
+
+    wrapper = PrismaWrapper(original_prisma=old_prisma, iam_token_db_auth=True)
+    prisma_client.db = wrapper
+    prisma_client._engine_pid = 0
+    prisma_client._engine_confirmed_dead = False
+    prisma_client._start_engine_watcher = AsyncMock()
+
+    # The refresh's recreate is held open at connect() so the reconnect path
+    # races it deterministically.
+    connect_started = asyncio.Event()
+    release_connect = asyncio.Event()
+
+    async def slow_connect(*args: Any, **kwargs: Any) -> None:
+        connect_started.set()
+        await release_connect.wait()
+
+    new_prisma = MagicMock(name="NewPrisma")
+    new_prisma.connect = AsyncMock(side_effect=slow_connect)
+    new_prisma._engine = MagicMock()
+    new_prisma._engine.process.pid = 222
+    new_prisma.query_raw = AsyncMock(return_value=[{"?column?": 1}])
+
+    prisma_factory = MagicMock(name="PrismaFactory", return_value=new_prisma)
+    monkeypatch.setattr(prisma_pkg, "Prisma", prisma_factory, raising=False)
+
+    def fake_get_token() -> str:
+        os.environ["DATABASE_URL"] = fresh_url
+        return fresh_url
+
+    monkeypatch.setattr(wrapper, "get_rds_iam_token", fake_get_token)
+    kill_mock = MagicMock()
+    monkeypatch.setattr("os.kill", kill_mock)
+
+    refresh_task = asyncio.create_task(wrapper._safe_refresh_token())
+    await asyncio.wait_for(connect_started.wait(), timeout=5)
+
+    # In-flight transport-error path fires while the refresh holds the
+    # wrapper's reconnection lock mid-recreate.
+    reconnect_task = asyncio.create_task(
+        prisma_client.attempt_db_reconnect(
+            reason="in_flight_transport_error", force=True
+        )
+    )
+    await asyncio.sleep(0.05)
+    release_connect.set()
+
+    await asyncio.wait_for(refresh_task, timeout=5)
+    reconnect_ok = await asyncio.wait_for(reconnect_task, timeout=5)
+
+    # Drain any refresh task scheduled by PrismaWrapper.__getattr__ during
+    # the probe (expired-token path) so it coalesces before we assert.
+    for _ in range(3):
+        await asyncio.sleep(0)
+
+    killed_pids = [c.args[0] for c in kill_mock.call_args_list]
+    pinned = {
+        "prisma_constructed": prisma_factory.call_count,
+        "fresh_engine_killed": 222 in killed_pids,
+        "reconnect_ok": reconnect_ok,
+        "wrapper_client_is_new": wrapper._original_prisma is new_prisma,
+    }
+    assert pinned == {
+        "prisma_constructed": 1,
+        "fresh_engine_killed": False,
+        "reconnect_ok": True,
+        "wrapper_client_is_new": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_run_reconnect_cycle_heavy_path_forwards_entry_generation_to_recreate(
+    prisma_client: PrismaClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The heavy (engine-dead) path must also forward an engine-generation
+    snapshot to recreate_prisma_client, captured atomically at cycle entry.
+
+    A concurrent IAM refresh that replaces the engine mid-cycle bumps the
+    generation, so the guarded recreate becomes a no-op instead of killing the
+    freshly-spawned engine (#29176). The snapshot must be taken before any
+    await — `asyncio.wait_for(_do_heavy_reconnect())` yields, during which a
+    refresh can slip in. A side effect that bumps the generation AFTER entry
+    must NOT change the forwarded value (proves entry-snapshot, not in-closure).
+    """
+    monkeypatch.setenv("DATABASE_URL", "postgres://x:y@h:5432/db")
+    prisma_client._engine_confirmed_dead = True
+    prisma_client._engine_pid = 1234
+    prisma_client.db.recreate_prisma_client = AsyncMock()
+    prisma_client._start_engine_watcher = AsyncMock()
+    monkeypatch.setattr(PrismaClient, "_reap_all_zombies", staticmethod(lambda: set()))
+
+    writer = MagicMock()
+    writer._engine_generation = 4
+    monkeypatch.setattr(PrismaClient, "writer_db", property(lambda self: writer))
+
+    # Simulate a concurrent refresh bumping the generation after cycle entry:
+    # _cleanup_engine_watcher runs between the entry snapshot and the recreate.
+    def _bump_then_cleanup() -> None:
+        writer._engine_generation = 5
+
+    monkeypatch.setattr(prisma_client, "_cleanup_engine_watcher", _bump_then_cleanup)
+
+    await prisma_client._run_reconnect_cycle(timeout_seconds=5)
+
+    kwargs = prisma_client.db.recreate_prisma_client.await_args.kwargs
+    assert kwargs.get("expected_generation") == 4


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->
Fixes https://github.com/BerriAI/litellm/issues/29176
## Linear ticket

<!-- if you are an internal contributor, add the Linear ticket e.g. "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

This is a concurrency race in the IAM-refresh path (no UI, no steady-state log line to screenshot), so the proof is the before/after of the end-to-end repro test, test_iam_refresh_racing_reconnect_recreates_engine_only_once.

It reproduces the exact reported scenario: an RDS IAM token refresh is mid-recreate — it has already spawned a fresh query-engine (PID 222) and is holding _reconnection_lock — when an in-flight transport-error reconnect (attempt_db_reconnect(force=True)) fires. The test asserts the engine is recreated exactly once (prisma_constructed == 1) and that the refresh's freshly-spawned engine (PID 222) is never killed (fresh_engine_killed == False).

❌ Before the fix — source reverted to the base branch, the repro test kept. The racing reconnect undoes the refresh, reproducing the kill/respawn storm from the issue:

$ pytest test_iam_refresh_racing_reconnect_recreates_engine_only_once
FAILED
{'prisma_constructed': 2} != {'prisma_constructed': 1} # engine spawned twice
{'fresh_engine_killed': True} != {'fresh_engine_killed': False} # refresh's new engine (PID 222) killed by the reconnect
1 failed
✅ After the fix — the racing reconnect probes the writer / checks the engine generation, recognizes the planned restart, and no-ops. The engine is spawned once and the fresh engine is never killed:

$ pytest test_iam_refresh_racing_reconnect_recreates_engine_only_once
tests/test_litellm/proxy/utils/prisma_and_spend/test_prisma_client_reconnect.py::test_iam_refresh_racing_reconnect_recreates_engine_only_once PASSED [100%]
1 passed
Full affected-suite run (engine watcher, reconnect cycle, IAM token expiry, routing wrapper, planned-restart, self-heal, backoff-retry): 311 passed, mypy clean, and codecov reports all modified lines covered.

## Type

🐛 Bug Fix
✅ Test

## Changes

Problem
When IAM_TOKEN_DB_AUTH is enabled, the proxy refreshes its RDS IAM token on a ~12-minute cadence. Each refresh recreates the Prisma client, which SIGKILLs the running query-engine and spawns a new one. The problem: this planned engine restart was indistinguishable from an engine crash, and three independent reconnect paths guarded by two uncoordinated locks all reacted to it — recreating the client again and again, each time killing the engine a prior path had just spawned.

The three colliding paths:

IAM refresh — PrismaWrapper._safe_refresh_token (holds _reconnection_lock) → recreate_prisma_client kills the old engine and spawns a new one.
Engine-death watcher — sees that kill and assumes a crash, calling attempt_db_reconnect(reason="engine_process_death", force=True), which takes a different lock (PrismaClient._db_reconnect_lock) and recreates the client again, killing the engine the refresh just spawned.
In-flight queries — requests hitting the brief restart window fail with httpx.ConnectError/ReadError, get classified as transport errors, and trigger their own attempt_db_reconnect via call_with_db_reconnect_retry → yet another recreate.
The net effect is a storm of engine kill/respawn cycles and a burst of DB exception errors on every token refresh.

Fix
Make planned restarts first-class and idempotent, and close the two-lock gap:

Planned-death tracking — recreate_prisma_client records the old engine PID in _expected_engine_deaths before killing it. All four watcher death detectors (waitpid thread, pidfd, already-dead probe, os.kill poll) consume that PID and skip the reconnect instead of treating it as a crash.
Engine-generation guard — every successful recreate increments a monotonic _engine_generation. Callers pass expected_generation as an optimistic-lock token; if it no longer matches once the lock is held, another path already replaced the engine and the recreate becomes a no-op. recreate_prisma_client now serializes all recreations through _reconnection_lock, so the refresh path and the reconnect paths can no longer recreate concurrently.
Probe-first reconnect — the direct (engine-alive) reconnect path runs SELECT 1 before recreating. A healthy connection — e.g. the engine was already replaced by a refresh — skips the recreate entirely instead of needlessly killing a working engine.
Refresh coalescing + watcher re-arm — _safe_refresh_token skips when the current token still has more than the refresh buffer of runway, so stacked triggers (proactive loop racing the __getattr__ fallback) don't each restart the engine. A new on_engine_replaced hook lets the owning PrismaClient re-arm its watcher on the new PID after a planned restart.
RoutingPrismaWrapper forwards expected_generation to the writer and skips recreating the reader when the writer recreate was skipped.

Testing
New tests/test_litellm/proxy/db/test_prisma_planned_engine_restart.py, including an end-to-end repro of the race: an IAM refresh held mid-recreate while an in-flight transport-error reconnect fires — asserts the engine is recreated exactly once and the freshly-spawned engine is never killed.
New planned-death coverage across all four watcher death detectors, plus probe-first and generation-guard cases for the reconnect cycle.
Red-green verified: with the source fix reverted, the key regression tests fail (prisma_constructed: 2, fresh engine killed); restored, they pass.
336 passing across the 7 affected test files plus the exception-handler reconnect paths. Existing tests that pinned the old "always recreate" behavior were updated to the probe-first contract; the #26191 guarantee (never call the blocking disconnect()) is preserved.