### PR TITLE
fix: preserve responses streaming flag

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/handler.py
+++ b/litellm/completion_extras/litellm_responses_transformation/handler.py
@@ -171,6 +171,8 @@ class ResponsesToCompletionBridgeHandler:
         model_response = validated_kwargs["model_response"]
         logging_obj = validated_kwargs["logging_obj"]
         custom_llm_provider = validated_kwargs["custom_llm_provider"]
+        if kwargs.get("stream") is True and optional_params.get("stream") is not True:
+            optional_params = {**optional_params, "stream": True}
 
         request_data = self.transformation_handler.transform_request(
             model=model,
@@ -263,6 +265,8 @@ class ResponsesToCompletionBridgeHandler:
         model_response = validated_kwargs["model_response"]
         logging_obj = validated_kwargs["logging_obj"]
         custom_llm_provider = validated_kwargs["custom_llm_provider"]
+        if kwargs.get("stream") is True and optional_params.get("stream") is not True:
+            optional_params = {**optional_params, "stream": True}
 
         try:
             request_data = self.transformation_handler.transform_request(

--- a/litellm/completion_extras/litellm_responses_transformation/handler.py
+++ b/litellm/completion_extras/litellm_responses_transformation/handler.py
@@ -171,7 +171,7 @@ class ResponsesToCompletionBridgeHandler:
         model_response = validated_kwargs["model_response"]
         logging_obj = validated_kwargs["logging_obj"]
         custom_llm_provider = validated_kwargs["custom_llm_provider"]
-        if kwargs.get("stream") is True and optional_params.get("stream") is not True:
+        if kwargs.get("stream") is True and "stream" not in optional_params:
             optional_params = {**optional_params, "stream": True}
 
         request_data = self.transformation_handler.transform_request(
@@ -265,7 +265,7 @@ class ResponsesToCompletionBridgeHandler:
         model_response = validated_kwargs["model_response"]
         logging_obj = validated_kwargs["logging_obj"]
         custom_llm_provider = validated_kwargs["custom_llm_provider"]
-        if kwargs.get("stream") is True and optional_params.get("stream") is not True:
+        if kwargs.get("stream") is True and "stream" not in optional_params:
             optional_params = {**optional_params, "stream": True}
 
         try:

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -2305,6 +2305,7 @@ class BaseLLMHTTPHandler:
 
         if extra_body:
             data.update(extra_body)
+        stream = bool(stream or data.get("stream"))
 
         # Preserve the OpenAI-style request context (not sent to the provider) for streaming
         # hooks/metadata; the streaming iterator now consumes this to run deployment hooks
@@ -2467,6 +2468,7 @@ class BaseLLMHTTPHandler:
 
         if extra_body:
             data.update(extra_body)
+        stream = bool(stream or data.get("stream"))
 
         # Preserve the OpenAI-style request context (not sent to the provider) for streaming
         # hooks/metadata; the streaming iterator now consumes this to run deployment hooks

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_handler.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_handler.py
@@ -131,6 +131,7 @@ def test_completion_preserves_top_level_stream_flag_in_responses_request():
     bridge = ResponsesToCompletionBridgeHandler()
     kwargs = _bridge_kwargs(stream=False)
     kwargs["stream"] = True
+    kwargs["optional_params"].pop("stream")
 
     with (
         patch.object(
@@ -183,6 +184,7 @@ async def test_acompletion_preserves_top_level_stream_flag_in_responses_request(
     bridge = ResponsesToCompletionBridgeHandler()
     kwargs = _bridge_kwargs(stream=False)
     kwargs["stream"] = True
+    kwargs["optional_params"].pop("stream")
 
     with (
         patch.object(

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_handler.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_handler.py
@@ -125,6 +125,32 @@ def test_completion_skips_rewrapping_preformatted_cached_chat_stream():
     assert result is stream
 
 
+def test_completion_preserves_top_level_stream_flag_in_responses_request():
+    stream = MagicMock(spec=CustomStreamWrapper)
+    stream.custom_llm_provider = "cached_response"
+    bridge = ResponsesToCompletionBridgeHandler()
+    kwargs = _bridge_kwargs(stream=False)
+    kwargs["stream"] = True
+
+    with (
+        patch.object(
+            bridge.transformation_handler,
+            "transform_request",
+            return_value={"model": "gpt-5.4", "input": "hi"},
+        ) as transform_request,
+        patch("litellm.responses", return_value=stream),
+        patch.object(
+            bridge,
+            "_apply_post_stream_processing",
+            side_effect=lambda s, *a, **kw: s,
+        ),
+    ):
+        result = bridge.completion(**kwargs)
+
+    assert result is stream
+    assert transform_request.call_args.kwargs["optional_params"]["stream"] is True
+
+
 @pytest.mark.asyncio
 async def test_acompletion_skips_rewrapping_preformatted_cached_chat_stream():
     stream = MagicMock(spec=CustomStreamWrapper)
@@ -148,3 +174,30 @@ async def test_acompletion_skips_rewrapping_preformatted_cached_chat_stream():
 
     post.assert_called_once()
     assert result is stream
+
+
+@pytest.mark.asyncio
+async def test_acompletion_preserves_top_level_stream_flag_in_responses_request():
+    stream = MagicMock(spec=CustomStreamWrapper)
+    stream.custom_llm_provider = "cached_response"
+    bridge = ResponsesToCompletionBridgeHandler()
+    kwargs = _bridge_kwargs(stream=False)
+    kwargs["stream"] = True
+
+    with (
+        patch.object(
+            bridge.transformation_handler,
+            "transform_request",
+            return_value={"model": "gpt-5.4", "input": "hi"},
+        ) as transform_request,
+        patch("litellm.aresponses", new=AsyncMock(return_value=stream)),
+        patch.object(
+            bridge,
+            "_apply_post_stream_processing",
+            side_effect=lambda s, *a, **kw: s,
+        ),
+    ):
+        result = await bridge.acompletion(**kwargs)
+
+    assert result is stream
+    assert transform_request.call_args.kwargs["optional_params"]["stream"] is True

--- a/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
@@ -81,6 +81,41 @@ def test_prepare_fake_stream_request():
     assert result_data["messages"] == [{"role": "user", "content": "Hello"}]
 
 
+def test_response_api_handler_streams_when_provider_transform_adds_stream():
+    handler = BaseLLMHTTPHandler()
+    config = Mock()
+    config.validate_environment.return_value = {}
+    config.get_complete_url.return_value = "https://chatgpt.example.com/responses"
+    config.transform_responses_api_request.return_value = {
+        "model": "gpt-5.3-codex",
+        "input": "hi",
+        "stream": True,
+    }
+    config.sign_request.return_value = ({}, None)
+    client = HTTPHandler(client=httpx.Client())
+    client.post = Mock(
+        return_value=httpx.Response(
+            200,
+            request=httpx.Request("POST", "https://chatgpt.example.com/responses"),
+        )
+    )
+    logging_obj = Mock()
+
+    handler.response_api_handler(
+        model="gpt-5.3-codex",
+        input="hi",
+        responses_api_provider_config=config,
+        response_api_optional_request_params={},
+        custom_llm_provider="chatgpt",
+        litellm_params=GenericLiteLLMParams(),
+        logging_obj=logging_obj,
+        client=client,
+    )
+
+    assert client.post.call_args.kwargs["stream"] is True
+    assert client.post.call_args.kwargs["json"]["stream"] is True
+
+
 def test_get_agentic_loop_settings_defaults_and_overrides():
     handler = BaseLLMHTTPHandler()
 

--- a/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
@@ -116,6 +116,42 @@ def test_response_api_handler_streams_when_provider_transform_adds_stream():
     assert client.post.call_args.kwargs["json"]["stream"] is True
 
 
+@pytest.mark.asyncio
+async def test_async_response_api_handler_streams_when_provider_transform_adds_stream():
+    handler = BaseLLMHTTPHandler()
+    config = Mock()
+    config.validate_environment.return_value = {}
+    config.get_complete_url.return_value = "https://chatgpt.example.com/responses"
+    config.transform_responses_api_request.return_value = {
+        "model": "gpt-5.3-codex",
+        "input": "hi",
+        "stream": True,
+    }
+    config.sign_request.return_value = ({}, None)
+    client = AsyncHTTPHandler()
+    client.post = AsyncMock(
+        return_value=httpx.Response(
+            200,
+            request=httpx.Request("POST", "https://chatgpt.example.com/responses"),
+        )
+    )
+    logging_obj = Mock()
+
+    await handler.async_response_api_handler(
+        model="gpt-5.3-codex",
+        input="hi",
+        responses_api_provider_config=config,
+        response_api_optional_request_params={},
+        custom_llm_provider="chatgpt",
+        litellm_params=GenericLiteLLMParams(),
+        logging_obj=logging_obj,
+        client=client,
+    )
+
+    assert client.post.call_args.kwargs["stream"] is True
+    assert client.post.call_args.kwargs["json"]["stream"] is True
+
+
 def test_get_agentic_loop_settings_defaults_and_overrides():
     handler = BaseLLMHTTPHandler()
 


### PR DESCRIPTION
## Relevant issues

Fixes streaming requests for ChatGPT subscription Responses API routes when the provider transform or the chat-to-responses bridge is the component that resolves `stream=true`

## Linear ticket


## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on Slack (#pr-review)

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

Manual proxy proof still needs to be run against a live ChatGPT subscription model. The expected customer-facing check is a streaming chat completion request through a local proxy route backed by a `chatgpt/*-codex*` model, then confirming the upstream call is made as a streaming Responses API request instead of a non-streaming POST

Local validation run for this branch:

```bash
uv run pytest tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_handler.py tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py -q
```

Result: `35 passed, 1 warning in 2.14s`

`make lint` was also attempted, but it fails on existing formatting drift in 13 enterprise files outside this PR's diff

## Type

Bug Fix
Test

## Changes

This keeps the stream flag consistent across both places that can resolve it for Responses API traffic. The chat-to-responses bridge now preserves a top-level `stream=True` value in the optional params it passes into the Responses request transform. The Responses HTTP handler also re-checks the transformed provider request body before choosing the HTTP streaming path, so provider transforms that force `stream: true`, including ChatGPT Codex subscription models, do not accidentally get sent through the non-streaming branch
