### PR TITLE
fix(voyage): route multimodal embeddings to correct endpoint

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -1728,6 +1728,9 @@ if TYPE_CHECKING:
     from .llms.voyage.embedding.transformation_contextual import (
         VoyageContextualEmbeddingConfig as VoyageContextualEmbeddingConfig,
     )
+    from .llms.voyage.embedding.transformation_multimodal import (
+        VoyageMultimodalEmbeddingConfig as VoyageMultimodalEmbeddingConfig,
+    )
     from .llms.infinity.embedding.transformation import (
         InfinityEmbeddingConfig as InfinityEmbeddingConfig,
     )

--- a/litellm/_lazy_imports_registry.py
+++ b/litellm/_lazy_imports_registry.py
@@ -223,6 +223,7 @@ LLM_CONFIG_NAMES = (
     "GenAIHubOrchestrationConfig",
     "VoyageEmbeddingConfig",
     "VoyageContextualEmbeddingConfig",
+    "VoyageMultimodalEmbeddingConfig",
     "InfinityEmbeddingConfig",
     "PerplexityEmbeddingConfig",
     "AzureAIStudioConfig",
@@ -902,6 +903,10 @@ _LLM_CONFIGS_IMPORT_MAP = {
     "VoyageContextualEmbeddingConfig": (
         ".llms.voyage.embedding.transformation_contextual",
         "VoyageContextualEmbeddingConfig",
+    ),
+    "VoyageMultimodalEmbeddingConfig": (
+        ".llms.voyage.embedding.transformation_multimodal",
+        "VoyageMultimodalEmbeddingConfig",
     ),
     "InfinityEmbeddingConfig": (
         ".llms.infinity.embedding.transformation",

--- a/litellm/litellm_core_utils/get_supported_openai_params.py
+++ b/litellm/litellm_core_utils/get_supported_openai_params.py
@@ -299,8 +299,10 @@ def get_supported_openai_params(  # noqa: PLR0915
             request_type == "embeddings"
             and litellm.VoyageMultimodalEmbeddingConfig.is_multimodal_embeddings(model)
         ):
-            return litellm.VoyageMultimodalEmbeddingConfig().get_supported_openai_params(
-                model=model
+            return (
+                litellm.VoyageMultimodalEmbeddingConfig().get_supported_openai_params(
+                    model=model
+                )
             )
         return litellm.VoyageEmbeddingConfig().get_supported_openai_params(model=model)
     elif custom_llm_provider == "infinity":

--- a/litellm/litellm_core_utils/get_supported_openai_params.py
+++ b/litellm/litellm_core_utils/get_supported_openai_params.py
@@ -295,6 +295,13 @@ def get_supported_openai_params(  # noqa: PLR0915
     elif custom_llm_provider == "predibase":
         return litellm.PredibaseConfig().get_supported_openai_params(model=model)
     elif custom_llm_provider == "voyage":
+        if (
+            request_type == "embeddings"
+            and litellm.VoyageMultimodalEmbeddingConfig.is_multimodal_embeddings(model)
+        ):
+            return litellm.VoyageMultimodalEmbeddingConfig().get_supported_openai_params(
+                model=model
+            )
         return litellm.VoyageEmbeddingConfig().get_supported_openai_params(model=model)
     elif custom_llm_provider == "infinity":
         return litellm.InfinityEmbeddingConfig().get_supported_openai_params(

--- a/litellm/llms/voyage/embedding/transformation_multimodal.py
+++ b/litellm/llms/voyage/embedding/transformation_multimodal.py
@@ -92,6 +92,12 @@ class VoyageMultimodalEmbeddingConfig(BaseEmbeddingConfig):
                 or get_secret_str("VOYAGE_AI_API_KEY")
                 or get_secret_str("VOYAGE_AI_TOKEN")
             )
+        if not api_key:
+            raise ValueError(
+                "Voyage API key is required for multimodal embeddings. "
+                "Set VOYAGE_API_KEY / VOYAGE_AI_API_KEY / VOYAGE_AI_TOKEN "
+                "or pass `api_key` explicitly."
+            )
         return {"Authorization": f"Bearer {api_key}"}
 
     def _normalize_content_item(self, item: Dict[str, Any]) -> Dict[str, Any]:
@@ -100,6 +106,11 @@ class VoyageMultimodalEmbeddingConfig(BaseEmbeddingConfig):
             image_url = item.get("image_url")
             if isinstance(image_url, dict):
                 image_url = image_url.get("url")
+            if image_url is None:
+                raise ValueError(
+                    "Voyage multimodal embeddings require a non-empty `image_url`. "
+                    "Got an image content block without a `url`."
+                )
             if isinstance(image_url, str) and image_url.startswith("data:image/"):
                 _, _, encoded = image_url.partition(",")
                 return {"type": "image_base64", "image_base64": encoded}

--- a/litellm/llms/voyage/embedding/transformation_multimodal.py
+++ b/litellm/llms/voyage/embedding/transformation_multimodal.py
@@ -1,0 +1,172 @@
+"""
+Transform request/response for Voyage multimodal embeddings.
+
+Voyage multimodal models use /v1/multimodalembeddings and accept `inputs`
+containing content blocks, unlike standard Voyage embeddings which use
+/v1/embeddings and a string/list `input` field.
+"""
+
+from typing import Any, Dict, List, Optional, Union
+
+import httpx
+
+from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+from litellm.llms.base_llm.chat.transformation import BaseLLMException
+from litellm.llms.base_llm.embedding.transformation import BaseEmbeddingConfig
+from litellm.secret_managers.main import get_secret_str
+from litellm.types.llms.openai import AllEmbeddingInputValues, AllMessageValues
+from litellm.types.utils import EmbeddingResponse, Usage
+
+
+class VoyageMultimodalEmbeddingError(BaseLLMException):
+    def __init__(
+        self,
+        status_code: int,
+        message: str,
+        headers: Union[dict, httpx.Headers] = {},
+    ):
+        self.status_code = status_code
+        self.message = message
+        self.request = httpx.Request(
+            method="POST", url="https://api.voyageai.com/v1/multimodalembeddings"
+        )
+        self.response = httpx.Response(status_code=status_code, request=self.request)
+        super().__init__(
+            status_code=status_code,
+            message=message,
+            headers=headers,
+        )
+
+
+class VoyageMultimodalEmbeddingConfig(BaseEmbeddingConfig):
+    """
+    Reference: https://docs.voyageai.com/reference/multimodal-embeddings-api
+    """
+
+    @staticmethod
+    def is_multimodal_embeddings(model: str) -> bool:
+        return "multimodal" in model.lower()
+
+    def get_complete_url(
+        self,
+        api_base: Optional[str],
+        api_key: Optional[str],
+        model: str,
+        optional_params: dict,
+        litellm_params: dict,
+        stream: Optional[bool] = None,
+    ) -> str:
+        if api_base:
+            if not api_base.endswith("/multimodalembeddings"):
+                api_base = f"{api_base}/multimodalembeddings"
+            return api_base
+        return "https://api.voyageai.com/v1/multimodalembeddings"
+
+    def get_supported_openai_params(self, model: str) -> list:
+        return ["dimensions"]
+
+    def map_openai_params(
+        self,
+        non_default_params: dict,
+        optional_params: dict,
+        model: str,
+        drop_params: bool,
+    ) -> dict:
+        if "dimensions" in non_default_params:
+            optional_params["output_dimension"] = non_default_params["dimensions"]
+        return optional_params
+
+    def validate_environment(
+        self,
+        headers: dict,
+        model: str,
+        messages: List[AllMessageValues],
+        optional_params: dict,
+        litellm_params: dict,
+        api_key: Optional[str] = None,
+        api_base: Optional[str] = None,
+    ) -> dict:
+        if api_key is None:
+            api_key = (
+                get_secret_str("VOYAGE_API_KEY")
+                or get_secret_str("VOYAGE_AI_API_KEY")
+                or get_secret_str("VOYAGE_AI_TOKEN")
+            )
+        return {"Authorization": f"Bearer {api_key}"}
+
+    def _normalize_content_item(self, item: Dict[str, Any]) -> Dict[str, Any]:
+        item_type = item.get("type")
+        if item_type == "image_url":
+            image_url = item.get("image_url")
+            if isinstance(image_url, dict):
+                image_url = image_url.get("url")
+            if isinstance(image_url, str) and image_url.startswith("data:image/"):
+                _, _, encoded = image_url.partition(",")
+                return {"type": "image_base64", "image_base64": encoded}
+            return {"type": "image_url", "image_url": image_url}
+        return item
+
+    def _normalize_input_item(self, item: Any) -> Dict[str, Any]:
+        if isinstance(item, str):
+            return {"content": [{"type": "text", "text": item}]}
+        if isinstance(item, dict) and "content" in item:
+            content = item.get("content") or []
+            return {
+                **item,
+                "content": [
+                    self._normalize_content_item(content_item)
+                    for content_item in content
+                ],
+            }
+        return item
+
+    def transform_embedding_request(
+        self,
+        model: str,
+        input: AllEmbeddingInputValues,
+        optional_params: dict,
+        headers: dict,
+    ) -> dict:
+        inputs = input if isinstance(input, list) else [input]
+        return {
+            "inputs": [self._normalize_input_item(item) for item in inputs],
+            "model": model,
+            **optional_params,
+        }
+
+    def transform_embedding_response(
+        self,
+        model: str,
+        raw_response: httpx.Response,
+        model_response: EmbeddingResponse,
+        logging_obj: LiteLLMLoggingObj,
+        api_key: Optional[str] = None,
+        request_data: dict = {},
+        optional_params: dict = {},
+        litellm_params: dict = {},
+    ) -> EmbeddingResponse:
+        try:
+            raw_response_json = raw_response.json()
+        except Exception:
+            raise VoyageMultimodalEmbeddingError(
+                message=raw_response.text, status_code=raw_response.status_code
+            )
+
+        model_response.model = raw_response_json.get("model")
+        model_response.data = raw_response_json.get("data")
+        model_response.object = raw_response_json.get("object")
+
+        usage_payload = raw_response_json.get("usage", {})
+        total_tokens = usage_payload.get("total_tokens", 0)
+        model_response.usage = Usage(
+            prompt_tokens=total_tokens,
+            total_tokens=total_tokens,
+        )
+        return model_response
+
+    def get_error_class(
+        self, error_message: str, status_code: int, headers: Union[dict, httpx.Headers]
+    ) -> BaseLLMException:
+        return VoyageMultimodalEmbeddingError(
+            message=error_message, status_code=status_code, headers=headers
+        )

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -35852,7 +35852,17 @@
         "max_input_tokens": 32000,
         "max_tokens": 32000,
         "mode": "embedding",
-        "output_cost_per_token": 0.0
+        "output_cost_per_token": 0.0,
+        "supports_vision": true
+    },
+    "voyage/voyage-multimodal-3.5": {
+        "input_cost_per_token": 1.2e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0,
+        "supports_vision": true
     },
     "wandb/openai/gpt-oss-120b": {
         "max_tokens": 131072,

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -3581,6 +3581,15 @@ def get_optional_params_embeddings(  # noqa: PLR0915
                     drop_params=drop_params if drop_params is not None else False,
                 )
             )
+        elif litellm.VoyageMultimodalEmbeddingConfig.is_multimodal_embeddings(model):
+            optional_params = (
+                litellm.VoyageMultimodalEmbeddingConfig().map_openai_params(
+                    non_default_params=non_default_params,
+                    optional_params={},
+                    model=model,
+                    drop_params=drop_params if drop_params is not None else False,
+                )
+            )
         else:
             optional_params = litellm.VoyageEmbeddingConfig().map_openai_params(
                 non_default_params=non_default_params,
@@ -8664,6 +8673,11 @@ class ProviderConfigManager:
             )
         ):
             return litellm.VoyageContextualEmbeddingConfig()
+        elif (
+            litellm.LlmProviders.VOYAGE == provider
+            and litellm.VoyageMultimodalEmbeddingConfig.is_multimodal_embeddings(model)
+        ):
+            return litellm.VoyageMultimodalEmbeddingConfig()
         elif litellm.LlmProviders.VOYAGE == provider:
             return litellm.VoyageEmbeddingConfig()
         elif litellm.LlmProviders.TRITON == provider:

--- a/tests/test_litellm/llms/voyage/test_voyage_multimodal_embedding.py
+++ b/tests/test_litellm/llms/voyage/test_voyage_multimodal_embedding.py
@@ -187,6 +187,30 @@ class TestVoyageMultimodalEmbeddings:
         )
         assert headers == {"Authorization": "Bearer secret-key"}
 
+    def test_validate_environment_raises_without_api_key(self, monkeypatch):
+        import litellm.llms.voyage.embedding.transformation_multimodal as module
+        from litellm.llms.voyage.embedding.transformation_multimodal import (
+            VoyageMultimodalEmbeddingConfig,
+        )
+
+        monkeypatch.setattr(module, "get_secret_str", lambda name: None)
+        config = VoyageMultimodalEmbeddingConfig()
+        with pytest.raises(ValueError) as exc_info:
+            config.validate_environment(
+                {}, "voyage-multimodal-3.5", [], {}, {}, api_key=None
+            )
+        assert "VOYAGE_API_KEY" in str(exc_info.value)
+
+    def test_normalize_image_url_dict_missing_url_raises(self):
+        from litellm.llms.voyage.embedding.transformation_multimodal import (
+            VoyageMultimodalEmbeddingConfig,
+        )
+
+        config = VoyageMultimodalEmbeddingConfig()
+        with pytest.raises(ValueError) as exc_info:
+            config._normalize_content_item({"type": "image_url", "image_url": {}})
+        assert "image_url" in str(exc_info.value)
+
     def test_passthrough_non_content_input(self):
         from litellm.llms.voyage.embedding.transformation_multimodal import (
             VoyageMultimodalEmbeddingConfig,

--- a/tests/test_litellm/llms/voyage/test_voyage_multimodal_embedding.py
+++ b/tests/test_litellm/llms/voyage/test_voyage_multimodal_embedding.py
@@ -249,6 +249,26 @@ class TestVoyageMultimodalEmbeddings:
         )
         assert optional_params.get("output_dimension") == 1024
 
+    def test_get_supported_openai_params_voyage_routes_multimodal(self):
+        from litellm.litellm_core_utils.get_supported_openai_params import (
+            get_supported_openai_params,
+        )
+
+        multimodal_params = get_supported_openai_params(
+            model="voyage-multimodal-3.5",
+            custom_llm_provider="voyage",
+            request_type="embeddings",
+        )
+        assert multimodal_params == ["dimensions"]
+
+        standard_params = get_supported_openai_params(
+            model="voyage-3.5",
+            custom_llm_provider="voyage",
+            request_type="embeddings",
+        )
+        assert "dimensions" in standard_params
+        assert "encoding_format" in standard_params
+
     def test_passthrough_non_content_input(self):
         from litellm.llms.voyage.embedding.transformation_multimodal import (
             VoyageMultimodalEmbeddingConfig,

--- a/tests/test_litellm/llms/voyage/test_voyage_multimodal_embedding.py
+++ b/tests/test_litellm/llms/voyage/test_voyage_multimodal_embedding.py
@@ -1,0 +1,139 @@
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+
+class TestVoyageMultimodalEmbeddings:
+    def test_multimodal_model_detection(self):
+        from litellm.llms.voyage.embedding.transformation_multimodal import (
+            VoyageMultimodalEmbeddingConfig,
+        )
+
+        assert VoyageMultimodalEmbeddingConfig.is_multimodal_embeddings(
+            "voyage-multimodal-3.5"
+        )
+        assert VoyageMultimodalEmbeddingConfig.is_multimodal_embeddings(
+            "voyage-multimodal-3"
+        )
+        assert not VoyageMultimodalEmbeddingConfig.is_multimodal_embeddings("voyage-4")
+
+    def test_multimodal_embedding_url_generation(self):
+        from litellm.llms.voyage.embedding.transformation_multimodal import (
+            VoyageMultimodalEmbeddingConfig,
+        )
+
+        config = VoyageMultimodalEmbeddingConfig()
+        assert (
+            config.get_complete_url(None, None, "voyage-multimodal-3.5", {}, {})
+            == "https://api.voyageai.com/v1/multimodalembeddings"
+        )
+        assert (
+            config.get_complete_url(
+                "https://custom.api.com", None, "voyage-multimodal-3.5", {}, {}
+            )
+            == "https://custom.api.com/multimodalembeddings"
+        )
+        assert (
+            config.get_complete_url(
+                "https://custom.api.com/multimodalembeddings",
+                None,
+                "voyage-multimodal-3.5",
+                {},
+                {},
+            )
+            == "https://custom.api.com/multimodalembeddings"
+        )
+
+    def test_multimodal_embedding_request_transformation(self):
+        from litellm.llms.voyage.embedding.transformation_multimodal import (
+            VoyageMultimodalEmbeddingConfig,
+        )
+
+        config = VoyageMultimodalEmbeddingConfig()
+        data_uri = "data:image/png;base64,AAAA"
+        request = config.transform_embedding_request(
+            "voyage-multimodal-3.5",
+            [
+                {
+                    "content": [
+                        {"type": "text", "text": "Describe this"},
+                        {"type": "image_url", "image_url": {"url": data_uri}},
+                    ]
+                }
+            ],
+            {"input_type": "document", "output_dimension": 512},
+            {},
+        )
+
+        assert request["model"] == "voyage-multimodal-3.5"
+        assert "inputs" in request
+        assert "input" not in request
+        assert request["input_type"] == "document"
+        assert request["output_dimension"] == 512
+        assert request["inputs"][0]["content"][1] == {
+            "type": "image_base64",
+            "image_base64": "AAAA",
+        }
+
+    def test_multimodal_embedding_string_input_transformation(self):
+        from litellm.llms.voyage.embedding.transformation_multimodal import (
+            VoyageMultimodalEmbeddingConfig,
+        )
+
+        config = VoyageMultimodalEmbeddingConfig()
+        request = config.transform_embedding_request(
+            "voyage-multimodal-3.5", "hello", {}, {}
+        )
+        assert request["inputs"] == [
+            {"content": [{"type": "text", "text": "hello"}]}
+        ]
+
+    def test_multimodal_embedding_response_transformation(self):
+        from litellm.llms.voyage.embedding.transformation_multimodal import (
+            VoyageMultimodalEmbeddingConfig,
+        )
+        from litellm.types.utils import EmbeddingResponse
+
+        config = VoyageMultimodalEmbeddingConfig()
+        response_payload = {
+            "object": "list",
+            "data": [
+                {"object": "embedding", "embedding": [0.1, 0.2], "index": 0}
+            ],
+            "model": "voyage-multimodal-3.5",
+            "usage": {
+                "text_tokens": 2,
+                "image_pixels": 0,
+                "video_pixels": 0,
+                "total_tokens": 2,
+            },
+        }
+        raw_response = MagicMock()
+        raw_response.json.return_value = response_payload
+        raw_response.status_code = 200
+        raw_response.text = json.dumps(response_payload)
+
+        model_response = EmbeddingResponse()
+        transformed = config.transform_embedding_response(
+            "voyage-multimodal-3.5", raw_response, model_response, MagicMock()
+        )
+
+        assert transformed.model == "voyage-multimodal-3.5"
+        assert transformed.object == "list"
+        assert transformed.data == response_payload["data"]
+        assert transformed.usage.prompt_tokens == 2
+        assert transformed.usage.total_tokens == 2
+
+    def test_provider_config_manager_routes_multimodal_models(self):
+        import litellm
+        from litellm.llms.voyage.embedding.transformation_multimodal import (
+            VoyageMultimodalEmbeddingConfig,
+        )
+        from litellm.utils import ProviderConfigManager
+
+        config = ProviderConfigManager.get_provider_embedding_config(
+            model="voyage-multimodal-3.5", provider=litellm.LlmProviders.VOYAGE
+        )
+
+        assert isinstance(config, VoyageMultimodalEmbeddingConfig)

--- a/tests/test_litellm/llms/voyage/test_voyage_multimodal_embedding.py
+++ b/tests/test_litellm/llms/voyage/test_voyage_multimodal_embedding.py
@@ -171,6 +171,22 @@ class TestVoyageMultimodalEmbeddings:
         )
         assert headers == {"Authorization": "Bearer test-key"}
 
+    def test_validate_environment_uses_secret_fallback(self, monkeypatch):
+        import litellm.llms.voyage.embedding.transformation_multimodal as module
+        from litellm.llms.voyage.embedding.transformation_multimodal import (
+            VoyageMultimodalEmbeddingConfig,
+        )
+
+        def fake_get_secret(name):
+            return "secret-key" if name == "VOYAGE_AI_API_KEY" else None
+
+        monkeypatch.setattr(module, "get_secret_str", fake_get_secret)
+        config = VoyageMultimodalEmbeddingConfig()
+        headers = config.validate_environment(
+            {}, "voyage-multimodal-3.5", [], {}, {}, api_key=None
+        )
+        assert headers == {"Authorization": "Bearer secret-key"}
+
     def test_passthrough_non_content_input(self):
         from litellm.llms.voyage.embedding.transformation_multimodal import (
             VoyageMultimodalEmbeddingConfig,

--- a/tests/test_litellm/llms/voyage/test_voyage_multimodal_embedding.py
+++ b/tests/test_litellm/llms/voyage/test_voyage_multimodal_embedding.py
@@ -59,6 +59,7 @@ class TestVoyageMultimodalEmbeddings:
                     "content": [
                         {"type": "text", "text": "Describe this"},
                         {"type": "image_url", "image_url": {"url": data_uri}},
+                        {"type": "image_url", "image_url": "https://example.com/a.png"},
                     ]
                 }
             ],
@@ -74,6 +75,10 @@ class TestVoyageMultimodalEmbeddings:
         assert request["inputs"][0]["content"][1] == {
             "type": "image_base64",
             "image_base64": "AAAA",
+        }
+        assert request["inputs"][0]["content"][2] == {
+            "type": "image_url",
+            "image_url": "https://example.com/a.png",
         }
 
     def test_multimodal_embedding_string_input_transformation(self):
@@ -137,3 +142,67 @@ class TestVoyageMultimodalEmbeddings:
         )
 
         assert isinstance(config, VoyageMultimodalEmbeddingConfig)
+
+    def test_map_openai_params_dimensions(self):
+        from litellm.llms.voyage.embedding.transformation_multimodal import (
+            VoyageMultimodalEmbeddingConfig,
+        )
+
+        config = VoyageMultimodalEmbeddingConfig()
+        assert config.get_supported_openai_params("voyage-multimodal-3.5") == [
+            "dimensions"
+        ]
+        optional_params = config.map_openai_params(
+            {"dimensions": 512}, {}, "voyage-multimodal-3.5", False
+        )
+        assert optional_params == {"output_dimension": 512}
+        assert (
+            config.map_openai_params({}, {}, "voyage-multimodal-3.5", False) == {}
+        )
+
+    def test_validate_environment_uses_api_key(self):
+        from litellm.llms.voyage.embedding.transformation_multimodal import (
+            VoyageMultimodalEmbeddingConfig,
+        )
+
+        config = VoyageMultimodalEmbeddingConfig()
+        headers = config.validate_environment(
+            {}, "voyage-multimodal-3.5", [], {}, {}, api_key="test-key"
+        )
+        assert headers == {"Authorization": "Bearer test-key"}
+
+    def test_passthrough_non_content_input(self):
+        from litellm.llms.voyage.embedding.transformation_multimodal import (
+            VoyageMultimodalEmbeddingConfig,
+        )
+
+        config = VoyageMultimodalEmbeddingConfig()
+        request = config.transform_embedding_request(
+            "voyage-multimodal-3.5", [{"foo": "bar"}], {}, {}
+        )
+        assert request["inputs"] == [{"foo": "bar"}]
+
+    def test_error_response_transformation_and_error_class(self):
+        from litellm.llms.voyage.embedding.transformation_multimodal import (
+            VoyageMultimodalEmbeddingConfig,
+            VoyageMultimodalEmbeddingError,
+        )
+        from litellm.types.utils import EmbeddingResponse
+
+        config = VoyageMultimodalEmbeddingConfig()
+        raw_response = MagicMock()
+        raw_response.json.side_effect = ValueError("not json")
+        raw_response.status_code = 400
+        raw_response.text = "bad request"
+
+        with pytest.raises(VoyageMultimodalEmbeddingError) as exc_info:
+            config.transform_embedding_response(
+                "voyage-multimodal-3.5", raw_response, EmbeddingResponse(), MagicMock()
+            )
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.message == "bad request"
+
+        error = config.get_error_class("rate limited", 429, {"x-test": "1"})
+        assert isinstance(error, VoyageMultimodalEmbeddingError)
+        assert error.status_code == 429
+        assert error.message == "rate limited"

--- a/tests/test_litellm/llms/voyage/test_voyage_multimodal_embedding.py
+++ b/tests/test_litellm/llms/voyage/test_voyage_multimodal_embedding.py
@@ -211,6 +211,44 @@ class TestVoyageMultimodalEmbeddings:
             config._normalize_content_item({"type": "image_url", "image_url": {}})
         assert "image_url" in str(exc_info.value)
 
+    def test_is_multimodal_embeddings_helper(self):
+        from litellm.llms.voyage.embedding.transformation_multimodal import (
+            VoyageMultimodalEmbeddingConfig,
+        )
+
+        assert VoyageMultimodalEmbeddingConfig.is_multimodal_embeddings(
+            "voyage-multimodal-3"
+        )
+        assert VoyageMultimodalEmbeddingConfig.is_multimodal_embeddings(
+            "VOYAGE-MULTIMODAL-3.5"
+        )
+        assert not VoyageMultimodalEmbeddingConfig.is_multimodal_embeddings(
+            "voyage-3.5"
+        )
+
+    def test_utils_routing_via_provider_config_and_dimensions(self):
+        import litellm
+        from litellm.llms.voyage.embedding.transformation_multimodal import (
+            VoyageMultimodalEmbeddingConfig,
+        )
+        from litellm.utils import (
+            ProviderConfigManager,
+            get_optional_params_embeddings,
+        )
+
+        config = ProviderConfigManager.get_provider_embedding_config(
+            model="voyage-multimodal-3.5", provider=litellm.LlmProviders.VOYAGE
+        )
+        assert isinstance(config, VoyageMultimodalEmbeddingConfig)
+
+        optional_params = get_optional_params_embeddings(
+            model="voyage-multimodal-3.5",
+            dimensions=1024,
+            custom_llm_provider="voyage",
+            drop_params=True,
+        )
+        assert optional_params.get("output_dimension") == 1024
+
     def test_passthrough_non_content_input(self):
         from litellm.llms.voyage.embedding.transformation_multimodal import (
             VoyageMultimodalEmbeddingConfig,


### PR DESCRIPTION
## What this fixes

Voyage multimodal embedding models (`voyage-multimodal-3`, `voyage-multimodal-3.5`) currently fall through to the standard Voyage embeddings config and are sent to `/v1/embeddings`. Voyage's multimodal models require `/v1/multimodalembeddings` and an `inputs` payload with content blocks.

This causes OpenAI-style multimodal embedding inputs to fail with upstream validation errors like `argument 'input' is not a valid string`.

## Changes

- Add `VoyageMultimodalEmbeddingConfig`
  - routes to `https://api.voyageai.com/v1/multimodalembeddings`
  - emits `inputs` instead of `input`
  - supports text strings and content blocks
  - normalizes OpenAI-style nested `image_url: { url: ... }`
  - converts `data:image/...;base64,...` URLs to Voyage `image_base64`
- Route Voyage models containing `multimodal` through the new config
- Export/register the config in LiteLLM lazy imports
- Add `voyage/voyage-multimodal-3.5` model metadata and mark multimodal models as vision-capable
- Add unit tests for routing, URL generation, request transform, response transform, error handling, and data URI normalization

## Verification

```bash
python -m pytest tests/test_litellm/llms/voyage/test_voyage_multimodal_embedding.py -q -o addopts=
# 10 passed, 2 warnings

python -m compileall -q \
  litellm/llms/voyage/embedding/transformation_multimodal.py \
  litellm/utils.py \
  litellm/__init__.py \
  litellm/_lazy_imports_registry.py
```

## Notes

I verified against Voyage's public API that `voyage-multimodal-3.5` is accepted at `/v1/multimodalembeddings` and returns 1024-d embeddings for a minimal text-only multimodal payload. This PR only changes LiteLLM routing/transformation; it does not change standard or contextual Voyage embedding behavior.

Fixes #24957
