### PR TITLE
fix(main): clarify backend route handling for Swagger static assets

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -20,7 +20,11 @@ DatabaseURLSettings.from_env().apply_to_env()
 
 from litellm.proxy.proxy_server import app
 
-from backend.routes.allowlist import BACKEND_EXACT_PATHS, BACKEND_PATH_PREFIXES
+from backend.routes.allowlist import (
+    BACKEND_EXACT_PATHS,
+    BACKEND_MOUNT_PATHS,
+    BACKEND_PATH_PREFIXES,
+)
 
 
 def _is_backend_route(route) -> bool:
@@ -30,8 +34,8 @@ def _is_backend_route(route) -> bool:
         return False
     if isinstance(route, Mount):
         # The dashboard UI static mounts are served by the dedicated UI container.
-        # Swagger static assets belong to the backend API docs and must remain available.
-        return path == "/swagger"
+        # Only Mounts in the backend allowlist (e.g. swagger docs) remain on backend.
+        return path in BACKEND_MOUNT_PATHS
     if path in BACKEND_EXACT_PATHS:
         return True
     return any(path.startswith(prefix) for prefix in BACKEND_PATH_PREFIXES)

--- a/backend/main.py
+++ b/backend/main.py
@@ -29,8 +29,9 @@ def _is_backend_route(route) -> bool:
     if path is None:
         return False
     if isinstance(route, Mount):
-        # Static UI mounts are served by the dedicated UI container, not here.
-        return False
+        # The dashboard UI static mounts are served by the dedicated UI container.
+        # Swagger static assets belong to the backend API docs and must remain available.
+        return path == "/swagger"
     if path in BACKEND_EXACT_PATHS:
         return True
     return any(path.startswith(prefix) for prefix in BACKEND_PATH_PREFIXES)

--- a/backend/routes/allowlist.py
+++ b/backend/routes/allowlist.py
@@ -133,3 +133,9 @@ BACKEND_EXACT_PATHS: frozenset[str] = frozenset(
         "/fallback/login",
     }
 )
+
+BACKEND_MOUNT_PATHS: frozenset[str] = frozenset(
+    {
+        "/swagger",  # API documentation static assets belong to the backend
+    }
+)

--- a/tests/test_litellm/proxy/test_component_allowlists.py
+++ b/tests/test_litellm/proxy/test_component_allowlists.py
@@ -42,7 +42,11 @@ _REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..",
 if _REPO_ROOT not in sys.path:
     sys.path.insert(0, _REPO_ROOT)
 
-from backend.routes.allowlist import BACKEND_EXACT_PATHS, BACKEND_PATH_PREFIXES
+from backend.routes.allowlist import (
+    BACKEND_EXACT_PATHS,
+    BACKEND_MOUNT_PATHS,
+    BACKEND_PATH_PREFIXES,
+)
 from gateway.routes.allowlist import GATEWAY_EXACT_PATHS, GATEWAY_PATH_PREFIXES
 from litellm.proxy.proxy_server import app
 
@@ -88,3 +92,44 @@ def test_gateway_plus_backend_covers_full_app():
         f"Update gateway/routes/allowlist.py or backend/routes/allowlist.py to cover:\n  "
         + "\n  ".join(sorted(uncovered))
     )
+
+
+def test_backend_mount_paths_defined():
+    """BACKEND_MOUNT_PATHS constant must exist and be a frozenset."""
+    assert isinstance(BACKEND_MOUNT_PATHS, frozenset), \
+        f"BACKEND_MOUNT_PATHS must be a frozenset, got {type(BACKEND_MOUNT_PATHS)}"
+    assert len(BACKEND_MOUNT_PATHS) > 0, \
+        "BACKEND_MOUNT_PATHS must contain at least one Mount path"
+
+
+def test_swagger_mount_in_backend_allowlist():
+    """The /swagger Mount must be in BACKEND_MOUNT_PATHS."""
+    assert "/swagger" in BACKEND_MOUNT_PATHS, \
+        "/swagger Mount path must be in BACKEND_MOUNT_PATHS"
+
+
+def test_backend_keeps_swagger_mount():
+    """Verify that Mounts in BACKEND_MOUNT_PATHS are kept on the backend."""
+    backend_mounts = {
+        getattr(r, "path")
+        for r in app.router.routes
+        if isinstance(r, Mount) and getattr(r, "path", None) in BACKEND_MOUNT_PATHS
+    }
+    assert "/swagger" in backend_mounts, \
+        "/swagger Mount is expected on the proxy app and should be in BACKEND_MOUNT_PATHS"
+
+
+def test_backend_drops_non_allowlisted_mounts():
+    """Verify that Mounts NOT in BACKEND_MOUNT_PATHS would be dropped from backend."""
+    all_mounts = {
+        getattr(r, "path")
+        for r in app.router.routes
+        if isinstance(r, Mount) and getattr(r, "path", None) is not None
+    }
+    non_backend_mounts = all_mounts - BACKEND_MOUNT_PATHS
+
+    assert len(non_backend_mounts) > 0, \
+        "Expected at least one non-backend Mount (e.g., /ui, /_next) to verify filtering logic"
+    for mount_path in non_backend_mounts:
+        assert mount_path not in BACKEND_MOUNT_PATHS, \
+            f"Mount {mount_path} should not be in BACKEND_MOUNT_PATHS"


### PR DESCRIPTION
## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Before this change, Swagger was reachable at `/swagger`, but its static assets were incorrectly classified as non-backend routes. This caused the Swagger UI assets to return `404 Not Found`.

Reproduction before fix:
<img width="930" height="431" alt="fix" src="https://github.com/user-attachments/assets/d8de5af7-5c97-4e9c-bc0c-d65085a554d7" />

```text
GET / HTTP/1.1                                  200 OK
GET /openapi.json HTTP/1.1                      200 OK
GET /swagger/swagger-ui.css HTTP/1.1            404 Not Found
GET /swagger/swagger-ui-bundle.js HTTP/1.1      404 Not Found
GET /swagger/favicon.png HTTP/1.1               404 Not Found
````

After this change, `/swagger` mounted routes are kept on the backend so the Swagger static assets remain available.

Validation after fix:

```text
GET / HTTP/1.1                                  200 OK
GET /swagger/swagger-ui.css HTTP/1.1            200 OK
GET /swagger/swagger-ui-bundle.js HTTP/1.1      200 OK
GET /openapi.json HTTP/1.1                      200 OK
```

Manual verification command:

```bash
uvicorn backend.main:app --host 0.0.0.0 --port 4001
```

## Type

🐛 Bug Fix

## Changes

This PR fixes backend route classification for Swagger static assets.

Previously, all mounted routes were excluded from backend handling because static UI mounts are served by the dedicated UI container. That also excluded the `/swagger` mount, causing Swagger UI static files such as `swagger-ui.css`, `swagger-ui-bundle.js`, and `favicon.png` to return 404.

The route handling now keeps `/swagger` on the backend while continuing to exclude dashboard UI static mounts. This preserves the split between the backend API/docs and the dedicated UI container.

Changed behavior:

* `/swagger` mounted static assets are served by the backend.
* Dashboard UI static mounts remain delegated to the UI container.
* `/openapi.json` remains available.
* The change is isolated to `backend/main.py`.


