### PR TITLE
feat(provider): Add Hanzo provider as OpenAI Compatible

### DIFF
--- a/docs/my-website/docs/providers/hanzo.md
+++ b/docs/my-website/docs/providers/hanzo.md
@@ -1,0 +1,176 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Hanzo
+
+## Overview
+
+| Property | Details |
+|-------|-------|
+| Description | Hanzo Cloud is an OpenAI-compatible AI gateway that serves Hanzo's native Zen model family alongside 444 models across 56 underlying providers through a unified `/v1/chat/completions` surface. |
+| Provider Route on LiteLLM | `hanzo/` |
+| Link to Provider Doc | [Hanzo API Documentation ↗](https://api.hanzo.ai) |
+| Base URL | `https://api.hanzo.ai/v1` |
+| Supported Operations | [`/chat/completions`](#sample-usage) |
+
+<br />
+<br />
+
+**This entry covers Hanzo's native Zen family. Other upstream models reachable through the Hanzo gateway can be invoked by passing the upstream model id under the `hanzo/` prefix.**
+
+## Available Models
+
+| Model | Description | Context Window |
+|-------|-------------|----------------|
+| `hanzo/zen4` | Hanzo Zen4 chat model | 200,000 tokens |
+| `hanzo/zen4-max` | Hanzo Zen4 Max — extended-reasoning long-context | 1,000,000 tokens |
+
+## Required Variables
+
+```python showLineNumbers title="Environment Variables"
+os.environ["HANZO_API_KEY"] = ""  # your Hanzo API key
+```
+
+## Usage - LiteLLM Python SDK
+
+### Non-streaming
+
+```python showLineNumbers title="Hanzo Non-streaming Completion"
+import os
+import litellm
+from litellm import completion
+
+os.environ["HANZO_API_KEY"] = ""  # your Hanzo API key
+
+messages = [{"content": "Hello, how are you?", "role": "user"}]
+
+# Hanzo call
+response = completion(
+    model="hanzo/zen4",
+    messages=messages
+)
+
+print(response)
+```
+
+### Streaming
+
+```python showLineNumbers title="Hanzo Streaming Completion"
+import os
+import litellm
+from litellm import completion
+
+os.environ["HANZO_API_KEY"] = ""  # your Hanzo API key
+
+messages = [{"content": "Write a short story about AI", "role": "user"}]
+
+# Hanzo call with streaming
+response = completion(
+    model="hanzo/zen4-max",
+    messages=messages,
+    stream=True
+)
+
+for chunk in response:
+    print(chunk)
+```
+
+### Function Calling
+
+```python showLineNumbers title="Hanzo Function Calling"
+import os
+import litellm
+from litellm import completion
+
+os.environ["HANZO_API_KEY"] = ""  # your Hanzo API key
+
+tools = [{
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get the current weather in a location",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "location": {
+                    "type": "string",
+                    "description": "The city and state, e.g. San Francisco, CA"
+                }
+            },
+            "required": ["location"]
+        }
+    }
+}]
+
+messages = [{"role": "user", "content": "What's the weather in Boston?"}]
+
+response = completion(
+    model="hanzo/zen4",
+    messages=messages,
+    tools=tools,
+    tool_choice="auto"
+)
+
+print(response)
+```
+
+## Usage - LiteLLM Proxy Server
+
+```yaml showLineNumbers title="config.yaml"
+model_list:
+  - model_name: zen4
+    litellm_params:
+      model: hanzo/zen4
+      api_key: os.environ/HANZO_API_KEY
+  - model_name: zen4-max
+    litellm_params:
+      model: hanzo/zen4-max
+      api_key: os.environ/HANZO_API_KEY
+```
+
+## Custom API Base
+
+**Option 1: Environment variable**
+
+```python showLineNumbers title="Custom API Base via env var"
+import os
+from litellm import completion
+
+os.environ["HANZO_API_BASE"] = "https://custom.hanzo.example/v1"
+os.environ["HANZO_API_KEY"] = ""  # your API key
+
+response = completion(
+    model="hanzo/zen4",
+    messages=[{"content": "Hello!", "role": "user"}],
+)
+```
+
+**Option 2: Pass directly**
+
+```python showLineNumbers title="Custom API Base via parameter"
+from litellm import completion
+
+response = completion(
+    model="hanzo/zen4",
+    messages=[{"content": "Hello!", "role": "user"}],
+    api_base="https://custom.hanzo.example/v1",
+    api_key="your-api-key",
+)
+```
+
+## Supported OpenAI Parameters
+
+- `temperature`
+- `max_tokens`
+- `max_completion_tokens`
+- `top_p`
+- `frequency_penalty`
+- `presence_penalty`
+- `stop`
+- `n`
+- `stream`
+- `tools`
+- `tool_choice`
+- `response_format`
+- `seed`
+- `user`

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -1373,6 +1373,7 @@ from .search.main import *
 from .realtime_api.main import (
     _arealtime,
     acreate_realtime_client_secret,
+    acreate_realtime_transcription_session,
     arealtime_calls,
 )
 from .responses.main import _aresponses_websocket

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -154,6 +154,7 @@ _custom_logger_compatible_callbacks_literal = Literal[
     "gitlab",
     "cloudzero",
     "focus",
+    "mavvrik",
     "vantage",
     "posthog",
     "levo",

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -776,6 +776,7 @@ openai_compatible_endpoints: List = [
     "https://api.publicai.co/v1",
     "https://api.synthetic.new/openai/v1",
     "https://serverless.tensormesh.ai/v1",
+    "https://api.hanzo.ai/v1",
     "https://api.stima.tech/v1",
     "https://nano-gpt.com/api/v1",
     "https://api.poe.com/v1",
@@ -832,6 +833,7 @@ openai_compatible_providers: List = [
     "poe",  # Poe - JSON-configured provider
     "chutes",  # Chutes - JSON-configured provider
     "parasail",  # Parasail - JSON-configured provider
+    "hanzo",  # Hanzo - JSON-configured provider
     "featherless_ai",
     "nscale",
     "nebius",

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -1480,6 +1480,7 @@ DB_SPEND_UPDATE_JOB_NAME = "db_spend_update_job"
 DB_DAILY_TAG_SPEND_UPDATE_JOB_NAME = "db_daily_tag_spend_update_job"
 PROMETHEUS_EMIT_BUDGET_METRICS_JOB_NAME = "prometheus_emit_budget_metrics"
 CLOUDZERO_EXPORT_USAGE_DATA_JOB_NAME = "cloudzero_export_usage_data"
+MAVVRIK_FOCUS_EXPORT_JOB_NAME = "mavvrik_focus_export_usage_data"
 CLOUDZERO_MAX_FETCHED_DATA_RECORDS = int(
     os.getenv("CLOUDZERO_MAX_FETCHED_DATA_RECORDS", 50000)
 )

--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -2533,4 +2533,102 @@ def handle_realtime_stream_cost_calculation(
         break  # exit if we find a valid model
     total_cost = input_cost_per_token + output_cost_per_token
 
+    if any(r.get("type") == _TRANSCRIPTION_COMPLETED_EVENT_TYPE for r in results):
+        total_cost += handle_realtime_transcription_cost_calculation(
+            results=results,
+            custom_llm_provider=custom_llm_provider,
+            litellm_model_name=litellm_model_name,
+        )
+
     return total_cost
+
+
+_TRANSCRIPTION_COMPLETED_EVENT_TYPE = (
+    "conversation.item.input_audio_transcription.completed"
+)
+
+
+def handle_realtime_transcription_cost_calculation(
+    results: OpenAIRealtimeStreamList,
+    custom_llm_provider: str,
+    litellm_model_name: str,
+) -> float:
+    """
+    Cost for realtime transcription sessions (e.g. gpt-realtime-whisper).
+
+    Transcription sessions emit no `response.done` events; instead each
+    `conversation.item.input_audio_transcription.completed` event carries a
+    `usage` object billed by the ASR model. The usage is one of:
+      - {"type": "duration", "seconds": <float>}  → priced via input_cost_per_second
+      - {"type": "tokens", "input_tokens": ...}    → priced via input/audio token cost
+    """
+    completed_events = [
+        cast(dict, result)
+        for result in results
+        if result.get("type") == _TRANSCRIPTION_COMPLETED_EVENT_TYPE
+    ]
+    if not completed_events:
+        return 0.0
+
+    model_name = (
+        _get_transcription_model_name_from_results(results) or litellm_model_name
+    )
+    try:
+        model_info = litellm.get_model_info(
+            model=model_name, custom_llm_provider=custom_llm_provider
+        )
+    except Exception:
+        model_info = {}
+
+    total_cost = 0.0
+    for event in completed_events:
+        usage = event.get("usage") or {}
+        total_cost += _transcription_usage_cost(usage, model_info)
+    return total_cost
+
+
+def _get_transcription_model_name_from_results(
+    results: OpenAIRealtimeStreamList,
+) -> Optional[str]:
+    """Resolve the ASR model from a transcription_session.* / session.* event."""
+    for result in results:
+        if result.get("type") in (
+            "transcription_session.created",
+            "transcription_session.updated",
+            "session.created",
+            "session.updated",
+        ):
+            session = cast(dict, result).get("session", {}) or {}
+            transcription = (
+                (session.get("audio", {}) or {}).get("input", {}) or {}
+            ).get("transcription", {}) or session.get("input_audio_transcription", {})
+            model = (transcription or {}).get("model") or session.get("model")
+            if model:
+                return model
+    return None
+
+
+def _transcription_usage_cost(usage: dict, model_info: dict) -> float:
+    usage_type = usage.get("type")
+    if usage_type == "duration":
+        seconds = usage.get("seconds") or 0.0
+        per_second = model_info.get("input_cost_per_second") or 0.0
+        return float(seconds) * float(per_second)
+    if usage_type == "tokens":
+        input_token_details = usage.get("input_token_details") or {}
+        audio_tokens = input_token_details.get("audio_tokens") or 0
+        text_tokens = input_token_details.get("text_tokens") or 0
+        output_tokens = usage.get("output_tokens") or 0
+        audio_cost = float(audio_tokens) * float(
+            model_info.get("input_cost_per_audio_token")
+            or model_info.get("input_cost_per_token")
+            or 0.0
+        )
+        text_cost = float(text_tokens) * float(
+            model_info.get("input_cost_per_token") or 0.0
+        )
+        output_cost = float(output_tokens) * float(
+            model_info.get("output_cost_per_token") or 0.0
+        )
+        return audio_cost + text_cost + output_cost
+    return 0.0

--- a/litellm/integrations/focus/destinations/__init__.py
+++ b/litellm/integrations/focus/destinations/__init__.py
@@ -4,6 +4,7 @@ from .base import FocusDestination, FocusTimeWindow
 from .factory import FocusDestinationFactory
 from .gcs_destination import FocusGCSDestination
 from .s3_destination import FocusS3Destination
+from .mavvrik_destination import FocusMavvrikDestination
 from .vantage_destination import FocusVantageDestination
 
 __all__ = [
@@ -12,5 +13,6 @@ __all__ = [
     "FocusGCSDestination",
     "FocusTimeWindow",
     "FocusS3Destination",
+    "FocusMavvrikDestination",
     "FocusVantageDestination",
 ]

--- a/litellm/integrations/focus/destinations/factory.py
+++ b/litellm/integrations/focus/destinations/factory.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, Optional
 from .base import FocusDestination
 from .gcs_destination import FocusGCSDestination
 from .s3_destination import FocusS3Destination
+from .mavvrik_destination import FocusMavvrikDestination
 from .vantage_destination import FocusVantageDestination
 
 
@@ -32,6 +33,8 @@ class FocusDestinationFactory:
             return FocusVantageDestination(prefix=prefix, config=normalized_config)
         if provider_lower == "gcs":
             return FocusGCSDestination(prefix=prefix, config=normalized_config)
+        if provider_lower == "mavvrik":
+            return FocusMavvrikDestination(prefix=prefix, config=normalized_config)
         raise NotImplementedError(
             f"Provider '{provider}' not supported for Focus export"
         )
@@ -86,6 +89,15 @@ class FocusDestinationFactory:
                 raise ValueError(
                     "FOCUS_GCS_BUCKET_NAME must be provided for GCS exports"
                 )
+            return {k: v for k, v in resolved.items() if v is not None}
+        if provider == "mavvrik":
+            resolved = {
+                "api_key": overrides.get("api_key") or os.getenv("MAVVRIK_API_KEY"),
+                "api_endpoint": overrides.get("api_endpoint")
+                or os.getenv("MAVVRIK_API_ENDPOINT"),
+                "connection_id": overrides.get("connection_id")
+                or os.getenv("MAVVRIK_CONNECTION_ID"),
+            }
             return {k: v for k, v in resolved.items() if v is not None}
         raise NotImplementedError(
             f"Provider '{provider}' not supported for Focus export configuration"

--- a/litellm/integrations/focus/destinations/mavvrik_destination.py
+++ b/litellm/integrations/focus/destinations/mavvrik_destination.py
@@ -1,0 +1,345 @@
+"""Mavvrik GCS destination for FOCUS export.
+
+Flow:
+  1. GET /metrics/agent/ai/{connection_id}/upload-url → GCS signed URL
+  2. PUT <signed_url> with CSV content
+"""
+
+from __future__ import annotations
+
+import gzip
+from typing import Any, Optional
+from urllib.parse import urlparse
+
+from litellm._logging import verbose_logger
+from litellm.llms.custom_httpx.http_handler import (
+    AsyncHTTPHandler,
+    get_async_httpx_client,
+    httpxSpecialProvider,
+)
+
+from .base import FocusDestination, FocusTimeWindow
+
+_MAVVRIK_ALLOWED_SUFFIXES = (".mavvrik.dev", ".mavvrik.ai", ".mavvrik.app")
+
+# GCS requires intermediate chunks to be a multiple of 256 KB.
+# 8 MB gives a good balance between round-trips and memory pressure.
+_GCS_CHUNK_SIZE = 8 * 1024 * 1024  # 8 MB
+
+
+def _validate_api_endpoint(api_endpoint: str) -> None:
+    if not api_endpoint.startswith("https://"):
+        raise ValueError("MAVVRIK_API_ENDPOINT must be an HTTPS URL")
+    hostname = (urlparse(api_endpoint).hostname or "").lower()
+    if not any(hostname.endswith(suffix) for suffix in _MAVVRIK_ALLOWED_SUFFIXES):
+        raise ValueError(
+            "MAVVRIK_API_ENDPOINT host must be a Mavvrik domain "
+            "(e.g. https://api.mavvrik.dev/<tenant_id>)"
+        )
+
+
+def _validate_gcs_url(url: str, label: str) -> None:
+    parsed = urlparse(url)
+    if parsed.scheme != "https":
+        raise ValueError(
+            f"Mavvrik FOCUS destination: {label} must be HTTPS, got scheme '{parsed.scheme}'"
+        )
+    hostname = (parsed.hostname or "").lower()
+    if not (
+        hostname == "storage.googleapis.com"
+        or hostname.endswith(".storage.googleapis.com")
+    ):
+        raise ValueError(
+            f"Mavvrik FOCUS destination: {label} must be a GCS endpoint "
+            f"(storage.googleapis.com), got '{hostname}'"
+        )
+
+
+class FocusMavvrikDestination(FocusDestination):
+    """Upload FOCUS CSV exports to Mavvrik via GCS signed URL."""
+
+    def __init__(
+        self,
+        *,
+        prefix: str,
+        config: Optional[dict[str, Any]] = None,
+    ) -> None:
+        config = config or {}
+        api_key = config.get("api_key")
+        api_endpoint = config.get("api_endpoint")
+        connection_id = config.get("connection_id")
+
+        if not api_key:
+            raise ValueError(
+                "MAVVRIK_API_KEY must be provided for Mavvrik FOCUS destination "
+                "(set MAVVRIK_API_KEY env var or pass in destination_config)"
+            )
+        if not api_endpoint:
+            raise ValueError(
+                "MAVVRIK_API_ENDPOINT must be provided for Mavvrik FOCUS destination "
+                "(set MAVVRIK_API_ENDPOINT env var or pass in destination_config)"
+            )
+        if not connection_id:
+            raise ValueError(
+                "MAVVRIK_CONNECTION_ID must be provided for Mavvrik FOCUS destination "
+                "(set MAVVRIK_CONNECTION_ID env var or pass in destination_config)"
+            )
+
+        _validate_api_endpoint(api_endpoint)
+
+        self.api_key = api_key
+        self.api_endpoint = api_endpoint.rstrip("/")
+        self.connection_id = connection_id
+        self.prefix = prefix
+        self._http: AsyncHTTPHandler = get_async_httpx_client(
+            llm_provider=httpxSpecialProvider.LoggingCallback
+        )
+        self._registered = False
+
+    @property
+    def _agent_url(self) -> str:
+        return f"{self.api_endpoint}/metrics/agent/ai/{self.connection_id}"
+
+    @property
+    def _upload_url_endpoint(self) -> str:
+        return f"{self.api_endpoint}/metrics/agent/ai/{self.connection_id}/upload-url"
+
+    @property
+    def _auth_headers(self) -> dict[str, str]:
+        return {"Content-Type": "application/json", "x-api-key": self.api_key}
+
+    async def _ensure_registered(self) -> Optional[int]:
+        """POST agent endpoint to register/initialize the connector (once per instance).
+
+        Returns metricsMarker from the Mavvrik response — the last date index
+        Mavvrik has successfully processed. Used by the logger to catch up any
+        dates that were missed due to previous export failures.
+
+        Returns None if the connector was already registered (cached).
+        """
+        if self._registered:
+            return None
+        resp = await self._http.client.request(
+            method="POST",
+            url=self._agent_url,
+            headers=self._auth_headers,
+            json={"name": self.connection_id},
+            timeout=30.0,
+        )
+        if resp.status_code == 410:
+            # Connector has been disconnected in Mavvrik — reset flag so next
+            # delivery attempt re-registers after it becomes active again.
+            self._registered = False
+            raise RuntimeError(
+                "Mavvrik FOCUS destination: connector is disconnected (410). "
+                "Re-enable the connection in the Mavvrik dashboard."
+            )
+        if resp.status_code >= 400:
+            raise RuntimeError(
+                f"Mavvrik FOCUS destination: register failed "
+                f"({resp.status_code}): {resp.text[:200]}"
+            )
+        self._registered = True
+        metrics_marker = resp.json().get("metricsMarker", 0)
+        verbose_logger.debug(
+            "Mavvrik FOCUS destination: connector registered (metricsMarker=%s)",
+            metrics_marker,
+        )
+        return metrics_marker
+
+    async def _get_signed_url(self, date_str: str) -> str:
+        """GET upload-url endpoint → GCS signed URL for the given date."""
+        params = {"name": date_str, "type": "metrics", "datetime": date_str}
+        resp = await self._http.client.request(
+            method="GET",
+            url=self._upload_url_endpoint,
+            headers=self._auth_headers,
+            params=params,
+            timeout=30.0,
+        )
+        if resp.status_code >= 400:
+            raise RuntimeError(
+                f"Mavvrik FOCUS destination: failed to get signed URL "
+                f"({resp.status_code}): {resp.text[:200]}"
+            )
+        signed_url = resp.json().get("url")
+        if not signed_url:
+            raise RuntimeError(
+                f"Mavvrik FOCUS destination: response missing 'url' field: {resp.json()}"
+            )
+        _validate_gcs_url(signed_url, "signed URL")
+        verbose_logger.debug(
+            "Mavvrik FOCUS destination: got signed URL for date %s", date_str
+        )
+        return signed_url
+
+    async def _upload_to_gcs(self, signed_url: str, content: bytes) -> None:
+        """Upload gzip-compressed CSV to GCS via chunked resumable upload.
+
+        The full CSV is gzip-compressed first, then uploaded in _GCS_CHUNK_SIZE
+        chunks using the GCS resumable upload protocol. GCS assembles the chunks
+        server-side into a single complete object — the bucket receives one file
+        regardless of how many chunks were sent.
+
+        Intermediate chunks: Content-Range: bytes X-Y/*   → expect 308
+        Final chunk:         Content-Range: bytes X-Y/T   → expect 200/201
+
+        This handles exports larger than available memory for a single PUT while
+        keeping the destination code self-contained (no changes to the FOCUS
+        pipeline upstream).
+        """
+        gzip_bytes = gzip.compress(content)
+        total = len(gzip_bytes)
+
+        # Step 1: initiate resumable upload session
+        metadata = b'{"contentEncoding":"gzip","contentDisposition":"attachment"}'
+        init_resp = await self._http.client.request(
+            method="POST",
+            url=signed_url,
+            headers={
+                "Content-Type": "application/gzip",
+                "x-goog-resumable": "start",
+            },
+            content=metadata,
+            timeout=30.0,
+        )
+        if init_resp.status_code not in (200, 201):
+            raise RuntimeError(
+                f"Mavvrik FOCUS destination: GCS session init failed "
+                f"({init_resp.status_code}): {init_resp.text[:400]}"
+            )
+
+        session_uri = init_resp.headers.get("Location")
+        if not session_uri:
+            raise RuntimeError(
+                "Mavvrik FOCUS destination: GCS session init missing Location header"
+            )
+        _validate_gcs_url(session_uri, "session URI")
+
+        verbose_logger.debug(
+            "Mavvrik FOCUS destination: GCS session started, uploading %d gzip bytes "
+            "in %d chunk(s)",
+            total,
+            max(1, -(-total // _GCS_CHUNK_SIZE)),  # ceiling division
+        )
+
+        # Step 2: upload in chunks; cancel session on any failure to avoid
+        # lingering GCS sessions (they stay open for ~1 week otherwise).
+        offset = 0
+        try:
+            while offset < total:
+                chunk = gzip_bytes[offset : offset + _GCS_CHUNK_SIZE]
+                chunk_end = offset + len(chunk) - 1
+                is_final = (offset + len(chunk)) >= total
+                content_range = (
+                    f"bytes {offset}-{chunk_end}/{total}"
+                    if is_final
+                    else f"bytes {offset}-{chunk_end}/*"
+                )
+                expected_statuses = {200, 201} if is_final else {308}
+
+                resp = await self._http.client.request(
+                    method="PUT",
+                    url=session_uri,
+                    headers={
+                        "Content-Type": "application/gzip",
+                        "Content-Range": content_range,
+                    },
+                    content=chunk,
+                    timeout=120.0,
+                )
+                if resp.status_code not in expected_statuses:
+                    raise RuntimeError(
+                        f"Mavvrik FOCUS destination: GCS chunk upload failed "
+                        f"(chunk offset={offset}, expected={expected_statuses}, "
+                        f"got={resp.status_code}): {resp.text[:400]}"
+                    )
+                offset += len(chunk)
+                verbose_logger.debug(
+                    "Mavvrik FOCUS destination: uploaded chunk offset=%d/%d",
+                    offset,
+                    total,
+                )
+        except Exception:
+            # Cancel the open GCS session so it doesn't linger for up to 1 week.
+            try:
+                await self._http.client.request(
+                    method="DELETE", url=session_uri, timeout=10.0
+                )
+                verbose_logger.debug(
+                    "Mavvrik FOCUS destination: cancelled GCS session after error"
+                )
+            except Exception:
+                pass
+            raise
+
+    async def get_metrics_marker(self) -> Optional[int]:
+        """Register with Mavvrik and return the current metricsMarker.
+
+        The metricsMarker is a Unix timestamp (seconds) representing the last
+        date Mavvrik has successfully ingested. Called on every scheduled run
+        so the logger can detect and catch up any dates missed due to previous
+        export failures.
+
+        Always calls the Mavvrik register API — unlike deliver() which skips
+        registration once _registered is True, catch-up requires a fresh
+        marker value on every run.
+        """
+        resp = await self._http.client.request(
+            method="POST",
+            url=self._agent_url,
+            headers=self._auth_headers,
+            json={"name": self.connection_id},
+            timeout=30.0,
+        )
+        if resp.status_code == 410:
+            self._registered = False
+            raise RuntimeError(
+                "Mavvrik FOCUS destination: connector is disconnected (410). "
+                "Re-enable the connection in the Mavvrik dashboard."
+            )
+        if resp.status_code >= 400:
+            raise RuntimeError(
+                f"Mavvrik FOCUS destination: register failed "
+                f"({resp.status_code}): {resp.text[:200]}"
+            )
+        self._registered = True
+        metrics_marker = resp.json().get("metricsMarker", 0)
+        verbose_logger.debug(
+            "Mavvrik FOCUS destination: got metricsMarker=%s", metrics_marker
+        )
+        return metrics_marker
+
+    async def deliver(
+        self,
+        *,
+        content: bytes,
+        time_window: FocusTimeWindow,
+        filename: str,
+    ) -> None:
+        """Upload FOCUS CSV to Mavvrik via GCS signed URL.
+
+        Uses the start date of the time window as the object date key.
+        """
+        if not content:
+            verbose_logger.debug(
+                "Mavvrik FOCUS destination: empty content, skipping upload"
+            )
+            return
+
+        date_str = time_window.start_time.strftime("%Y-%m-%d")
+
+        verbose_logger.debug(
+            "Mavvrik FOCUS destination: uploading %d bytes for date=%s (%s)",
+            len(content),
+            date_str,
+            filename,
+        )
+
+        await self._ensure_registered()
+        signed_url = await self._get_signed_url(date_str)
+        await self._upload_to_gcs(signed_url, content)
+
+        verbose_logger.debug(
+            "Mavvrik FOCUS destination: upload complete for date=%s", date_str
+        )

--- a/litellm/integrations/mavvrik_focus/mavvrik_focus_logger.py
+++ b/litellm/integrations/mavvrik_focus/mavvrik_focus_logger.py
@@ -1,0 +1,272 @@
+"""MavvrikFocusLogger — FOCUS-based Mavvrik export logger.
+
+Usage in config.yaml:
+    litellm_settings:
+      callbacks: ["mavvrik"]
+
+Required env vars:
+    MAVVRIK_API_KEY
+    MAVVRIK_API_ENDPOINT
+    MAVVRIK_CONNECTION_ID
+
+Optional env vars:
+    MAVVRIK_FOCUS_MAX_ROWS  — row cap per export window (default: 500000)
+
+Only daily frequency is supported. The Mavvrik ingestion protocol stores one
+file per calendar date (metrics/YYYY-MM-DD). Hourly or interval exports would
+overwrite each other within the same day, producing incomplete data.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING, Any, List, Optional
+
+import litellm
+from litellm._logging import verbose_proxy_logger
+from litellm.constants import MAVVRIK_FOCUS_EXPORT_JOB_NAME
+from litellm.integrations.focus.destinations.base import FocusTimeWindow
+from litellm.integrations.focus.focus_logger import FocusLogger
+
+if TYPE_CHECKING:
+    from apscheduler.schedulers.asyncio import AsyncIOScheduler
+else:
+    AsyncIOScheduler = Any
+
+
+def _parse_metrics_marker(
+    marker: Optional[object],
+) -> Optional[datetime]:
+    """Parse metricsMarker from Mavvrik register response into a UTC datetime.
+
+    Handles both formats Mavvrik may return:
+    - Unix timestamp (int/float): e.g. 1749340800
+    - ISO date string: e.g. "2026-06-09" or "2026-06-09T00:00:00Z"
+
+    Returns None for falsy values (0, None, empty string) which indicate
+    no data has been ingested yet.
+    """
+    if not marker:
+        return None
+    try:
+        if isinstance(marker, (int, float)):
+            return datetime.fromtimestamp(float(marker), tz=timezone.utc).replace(
+                hour=0, minute=0, second=0, microsecond=0
+            )
+        if isinstance(marker, str):
+            marker = marker.strip()
+            if not marker:
+                return None
+            # Try ISO date first (YYYY-MM-DD), then full ISO datetime
+            for fmt in ("%Y-%m-%d", "%Y-%m-%dT%H:%M:%SZ", "%Y-%m-%dT%H:%M:%S"):
+                try:
+                    return datetime.strptime(marker, fmt).replace(tzinfo=timezone.utc)
+                except ValueError:
+                    continue
+    except Exception:
+        pass
+    verbose_proxy_logger.warning(
+        "Mavvrik FOCUS: could not parse metricsMarker %r — skipping catch-up", marker
+    )
+    return None
+
+
+class MavvrikFocusLogger(FocusLogger):
+    """FOCUS-based export logger that routes to the Mavvrik destination."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        frequency = os.getenv("MAVVRIK_FOCUS_FREQUENCY", "daily").lower()
+        if frequency != "daily":
+            raise ValueError(
+                f"MAVVRIK_FOCUS_FREQUENCY='{frequency}' is not supported. "
+                "Only 'daily' is allowed — the Mavvrik ingestion protocol stores one "
+                "file per calendar date (metrics/YYYY-MM-DD). Hourly or interval "
+                "exports would overwrite each other within the same day."
+            )
+        super().__init__(
+            provider="mavvrik",
+            export_format="csv",
+            frequency="daily",
+            prefix="mavvrik_focus_exports",
+            destination_config={
+                "api_key": os.getenv("MAVVRIK_API_KEY"),
+                "api_endpoint": os.getenv("MAVVRIK_API_ENDPOINT"),
+                "connection_id": os.getenv("MAVVRIK_CONNECTION_ID"),
+            },
+            **kwargs,
+        )
+        raw = os.getenv("MAVVRIK_FOCUS_MAX_ROWS")
+        self._max_rows: Optional[int] = int(raw) if raw else 500_000
+
+    async def _export_window(
+        self,
+        *,
+        window: FocusTimeWindow,
+        limit: Optional[int],
+    ) -> None:
+        """Export with Mavvrik row cap applied when no explicit limit is passed."""
+        effective_limit = limit if limit is not None else self._max_rows
+        engine = self._ensure_engine()
+        data = await engine._database.get_usage_data(
+            limit=effective_limit,
+            start_time_utc=window.start_time,
+            end_time_utc=window.end_time,
+        )
+        if effective_limit is not None and len(data) >= effective_limit:
+            verbose_proxy_logger.warning(
+                "Mavvrik FOCUS export: row cap reached (%d rows). "
+                "Some data for window %s→%s may be excluded. "
+                "Increase MAVVRIK_FOCUS_MAX_ROWS to export all rows.",
+                effective_limit,
+                window.start_time.date(),
+                window.end_time.date(),
+            )
+        if data.is_empty():
+            verbose_proxy_logger.debug(
+                "Mavvrik FOCUS export: no usage data for window %s", window
+            )
+            return
+        normalized = engine._transformer.transform(data)
+        if normalized.is_empty():
+            return
+        payload = engine._serializer.serialize(normalized)
+        if not payload:
+            return
+        await engine._destination.deliver(
+            content=payload,
+            time_window=window,
+            filename=engine._build_filename(window),
+        )
+
+    # Maximum number of days to catch up in a single run. Prevents runaway
+    # loops if the connector was disabled for a long time, and avoids querying
+    # data that has likely been cleaned up from LiteLLM_DailyUserSpend.
+    _MAX_CATCHUP_DAYS = 7
+
+    async def _run_scheduled_export(self) -> None:
+        """Export today's window, catching up any dates Mavvrik has not yet received.
+
+        On each run:
+        1. Register with Mavvrik → get metricsMarker (last successfully ingested date)
+        2. If metricsMarker is behind yesterday, catch up missed dates (capped at
+           _MAX_CATCHUP_DAYS to avoid runaway loops on long outages)
+        3. Export yesterday (today's daily window)
+
+        This ensures a failed export on day N is automatically retried on day N+1
+        without any manual intervention.
+        """
+        engine = self._ensure_engine()
+        from litellm.integrations.focus.destinations.mavvrik_destination import (  # noqa: PLC0415
+            FocusMavvrikDestination,
+        )
+
+        destination = engine._destination
+        if not isinstance(destination, FocusMavvrikDestination):
+            await super()._run_scheduled_export()
+            return
+
+        # Register and get the last date Mavvrik has processed.
+        # metricsMarker may be a Unix timestamp (int/float) or an ISO date string.
+        marker = await destination.get_metrics_marker()
+
+        now = datetime.now(timezone.utc)
+        yesterday = now.replace(hour=0, minute=0, second=0, microsecond=0) - timedelta(
+            days=1
+        )
+
+        last_ingested = _parse_metrics_marker(marker)
+
+        # Catch up missed dates, capped at _MAX_CATCHUP_DAYS
+        if last_ingested and last_ingested < yesterday:
+            # Never go further back than _MAX_CATCHUP_DAYS from yesterday
+            earliest_catchup = yesterday - timedelta(days=self._MAX_CATCHUP_DAYS - 1)
+            catch_up_date = max(last_ingested + timedelta(days=1), earliest_catchup)
+
+            if last_ingested + timedelta(days=1) < earliest_catchup:
+                verbose_proxy_logger.warning(
+                    "Mavvrik FOCUS export: metricsMarker is more than %d days behind "
+                    "(%s). Catching up from %s only; earlier data will not be re-exported.",
+                    self._MAX_CATCHUP_DAYS,
+                    last_ingested.date(),
+                    catch_up_date.date(),
+                )
+
+            while catch_up_date < yesterday:
+                verbose_proxy_logger.info(
+                    "Mavvrik FOCUS export: catching up missed date %s",
+                    catch_up_date.date(),
+                )
+                window = FocusTimeWindow(
+                    start_time=catch_up_date,
+                    end_time=catch_up_date + timedelta(days=1),
+                    frequency="daily",
+                )
+                await self._export_window(window=window, limit=None)
+                catch_up_date += timedelta(days=1)
+
+        # Export yesterday's window (the normal daily run)
+        window = FocusTimeWindow(
+            start_time=yesterday,
+            end_time=yesterday + timedelta(days=1),
+            frequency="daily",
+        )
+        await self._export_window(window=window, limit=None)
+
+    async def initialize_mavvrik_focus_export_job(self) -> None:
+        """Scheduler entry point — uses Mavvrik-specific pod-lock key."""
+        from litellm.proxy.proxy_server import proxy_logging_obj  # noqa: PLC0415
+
+        pod_lock_manager = None
+        if proxy_logging_obj is not None:
+            writer = getattr(proxy_logging_obj, "db_spend_update_writer", None)
+            if writer is not None:
+                pod_lock_manager = getattr(writer, "pod_lock_manager", None)
+
+        if pod_lock_manager and pod_lock_manager.redis_cache:
+            acquired = await pod_lock_manager.acquire_lock(
+                cronjob_id=MAVVRIK_FOCUS_EXPORT_JOB_NAME
+            )
+            if not acquired:
+                verbose_proxy_logger.debug(
+                    "Mavvrik FOCUS export: unable to acquire pod lock"
+                )
+                return
+            try:
+                await self._run_scheduled_export()
+            finally:
+                await pod_lock_manager.release_lock(
+                    cronjob_id=MAVVRIK_FOCUS_EXPORT_JOB_NAME
+                )
+        else:
+            await self._run_scheduled_export()
+
+    @staticmethod
+    async def init_mavvrik_focus_background_job(
+        scheduler: AsyncIOScheduler,
+    ) -> None:
+        """Register the Mavvrik FOCUS export job on the provided scheduler."""
+        loggers: List[MavvrikFocusLogger] = [
+            cb
+            for cb in litellm.logging_callback_manager.get_custom_loggers_for_type(
+                callback_type=MavvrikFocusLogger
+            )
+            if type(cb) is MavvrikFocusLogger
+        ]
+        if not loggers:
+            verbose_proxy_logger.debug(
+                "No MavvrikFocusLogger registered; skipping scheduler"
+            )
+            return
+
+        logger = loggers[0]
+        trigger_kwargs = logger._build_scheduler_trigger()
+        scheduler.add_job(  # type: ignore[attr-defined]
+            logger.initialize_mavvrik_focus_export_job,
+            id=MAVVRIK_FOCUS_EXPORT_JOB_NAME,
+            replace_existing=True,
+            **trigger_kwargs,
+        )
+        verbose_proxy_logger.info(
+            "mavvrik_focus: background export job scheduled (%s)", trigger_kwargs
+        )

--- a/litellm/litellm_core_utils/custom_logger_registry.py
+++ b/litellm/litellm_core_utils/custom_logger_registry.py
@@ -25,6 +25,7 @@ from litellm.integrations.datadog.datadog_metrics import DatadogMetricsLogger
 from litellm.integrations.deepeval import DeepEvalLogger
 from litellm.integrations.dotprompt import DotpromptManager
 from litellm.integrations.focus.focus_logger import FocusLogger
+from litellm.integrations.mavvrik_focus.mavvrik_focus_logger import MavvrikFocusLogger
 from litellm.integrations.vantage.vantage_logger import VantageLogger
 from litellm.integrations.galileo import GalileoObserve
 from litellm.integrations.gcs_bucket.gcs_bucket import GCSBucketLogger
@@ -102,6 +103,7 @@ class CustomLoggerRegistry:
         "gitlab": GitLabPromptManager,
         "cloudzero": CloudZeroLogger,
         "focus": FocusLogger,
+        "mavvrik": MavvrikFocusLogger,
         "vantage": VantageLogger,
         "posthog": PostHogLogger,
     }

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -4124,6 +4124,17 @@ def _init_custom_logger_compatible_class(  # noqa: PLR0915
             focus_logger = FocusLogger()
             _in_memory_loggers.append(focus_logger)
             return focus_logger  # type: ignore
+        elif logging_integration == "mavvrik":
+            from litellm.integrations.mavvrik_focus.mavvrik_focus_logger import (
+                MavvrikFocusLogger,
+            )
+
+            for callback in _in_memory_loggers:
+                if type(callback) is MavvrikFocusLogger:
+                    return callback  # type: ignore
+            mavvrik_focus_logger = MavvrikFocusLogger()
+            _in_memory_loggers.append(mavvrik_focus_logger)
+            return mavvrik_focus_logger  # type: ignore
         elif logging_integration == "vantage":
             from litellm.integrations.vantage.vantage_logger import VantageLogger
 

--- a/litellm/litellm_core_utils/realtime_streaming.py
+++ b/litellm/litellm_core_utils/realtime_streaming.py
@@ -47,6 +47,7 @@ class RealTimeStreaming:
         user_api_key_dict: Optional[Any] = None,
         request_data: Optional[Dict] = None,
         backend_uses_beta_protocol: Optional[bool] = None,
+        force_transcription_model: Optional[str] = None,
     ):
         self.websocket = websocket
         self.backend_ws = backend_ws
@@ -100,6 +101,11 @@ class RealTimeStreaming:
         self._flushing_pending_messages_until_setup: bool = False
         self._pending_messages_until_setup: List[str] = []
         self._pending_messages_byte_total: int = 0
+        # Whether this is a transcription-only session (session.type == "transcription",
+        # e.g. gpt-realtime-whisper). Such sessions must not be sent response.create and
+        # their input_audio_transcription.completed usage drives duration-based cost.
+        self._force_transcription_model = force_transcription_model
+        self._is_transcription_session: bool = force_transcription_model is not None
 
     # Per-connection caps for pre-setup audio frames (message count + total bytes).
     _MAX_BUFFERED_MESSAGES: int = 200
@@ -209,6 +215,8 @@ class RealTimeStreaming:
                     self.session_tools = tools
                 # GA: session.type is required; log it for traceability but no action needed
                 verbose_logger.debug(f"Realtime session.type: {session.get('type')}")
+                if session.get("type") == "transcription":
+                    self._is_transcription_session = True
         except (json.JSONDecodeError, AttributeError, TypeError):
             pass
 
@@ -222,6 +230,55 @@ class RealTimeStreaming:
                 transcript = cast(str, event_obj.get("transcript", ""))
                 if transcript:
                     self.input_messages.append({"role": "user", "content": transcript})
+        except (AttributeError, TypeError):
+            pass
+
+    def _detect_transcription_session_from_backend(
+        self, event_obj: Union[dict, OpenAIRealtimeEvents]
+    ) -> None:
+        """Flag transcription-only sessions from backend session events."""
+        try:
+            event_type = event_obj.get("type", "")
+            if event_type in (
+                "transcription_session.created",
+                "transcription_session.updated",
+            ):
+                self._is_transcription_session = True
+            elif event_type in ("session.created", "session.updated"):
+                session = cast(dict, event_obj).get("session", {}) or {}
+                if session.get("type") == "transcription":
+                    self._is_transcription_session = True
+        except (AttributeError, TypeError):
+            pass
+
+    def _capture_transcription_usage(
+        self, event_obj: Union[dict, OpenAIRealtimeEvents]
+    ) -> None:
+        """
+        Append a usage-only transcription completed event to the logged results so
+        the cost calculator can bill it by audio duration. The default logged event
+        types exclude this event, so it is captured here directly for transcription
+        sessions rather than widening logging for every realtime session. Only the
+        type and usage are kept — the transcript is already captured separately in
+        input_messages, so it is not duplicated into the response log here.
+        """
+        try:
+            usage = event_obj.get("usage")
+            if usage is None:
+                return
+            # If this event type is already captured by store_message (e.g. the user
+            # logs all realtime events), don't append a second copy.
+            if self._should_store_message(event_obj):
+                return
+            self.messages.append(
+                cast(
+                    OpenAIRealtimeEvents,
+                    {
+                        "type": "conversation.item.input_audio_transcription.completed",
+                        "usage": usage,
+                    },
+                )
+            )
         except (AttributeError, TypeError):
             pass
 
@@ -285,6 +342,7 @@ class RealTimeStreaming:
         backend, False if the provider transformation produced no output and
         the message was effectively dropped.
         """
+        message = self._enforce_transcription_session_model(message)
         if self.provider_config:
             transformed = self.provider_config.transform_realtime_request(
                 message, self.model, self.session_configuration_request
@@ -303,6 +361,80 @@ class RealTimeStreaming:
             return sent
         await self.backend_ws.send(message)  # type: ignore[union-attr, attr-defined]
         return True
+
+    def _enforce_transcription_session_model(self, message: str) -> str:
+        """Force client transcription session updates to the authorized model.
+
+        `/v1/realtime?intent=transcription` may intentionally omit `model` from
+        the upstream URL for Azure compatibility, but the proxy still authorizes
+        a resolved LiteLLM model before opening the backend websocket. If a
+        client later sends a transcription `session.update`, any model embedded
+        in that update must be rewritten to the same authorized model instead of
+        allowing a post-auth model/deployment switch.
+
+        Normal realtime sessions keep their independent nested transcription
+        model behavior because `_force_transcription_model` is only set for
+        transcription-intent websocket routes.
+        """
+        if self._force_transcription_model is None:
+            return message
+
+        try:
+            message_obj = json.loads(message)
+        except (json.JSONDecodeError, TypeError):
+            return message
+
+        if message_obj.get("type") not in (
+            "session.update",
+            "transcription_session.update",
+        ):
+            return message
+
+        session = message_obj.get("session")
+        if not isinstance(session, dict):
+            return message
+
+        if session.get("type") == "transcription":
+            self._is_transcription_session = True
+
+        authorized_model = self._force_transcription_model
+        changed = False
+
+        transcription = session.get("input_audio_transcription")
+        if (
+            isinstance(transcription, dict)
+            and transcription.get("model") != authorized_model
+        ):
+            session["input_audio_transcription"] = {
+                **transcription,
+                "model": authorized_model,
+            }
+            changed = True
+
+        audio = session.get("audio")
+        if isinstance(audio, dict):
+            audio_input = audio.get("input")
+            if isinstance(audio_input, dict):
+                nested_transcription = audio_input.get("transcription")
+                if (
+                    isinstance(nested_transcription, dict)
+                    and nested_transcription.get("model") != authorized_model
+                ):
+                    session["audio"] = {
+                        **audio,
+                        "input": {
+                            **audio_input,
+                            "transcription": {
+                                **nested_transcription,
+                                "model": authorized_model,
+                            },
+                        },
+                    }
+                    changed = True
+
+        if not changed:
+            return message
+        return json.dumps(message_obj)
 
     def _uses_deferred_backend_setup(self) -> bool:
         """True when setup is deferred until the client's first session.update."""
@@ -713,6 +845,8 @@ class RealTimeStreaming:
         try:
             event_obj = json.loads(raw_response)
 
+            self._detect_transcription_session_from_backend(event_obj)
+
             # For audio/VAD guardrail path: once the session is ready, tell the backend
             # not to auto-respond after VAD detects end-of-speech.  We send the
             # session.created to the client FIRST so the client is always in sync, then
@@ -731,12 +865,20 @@ class RealTimeStreaming:
                 event_obj.get("type")
                 == "conversation.item.input_audio_transcription.completed"
             ):
-                transcript = event_obj.get("transcript", "")
                 self._collect_user_input_from_backend_event(event_obj)
                 ## LOGGING — must happen before continue below
                 self.store_message(raw_response)
                 # Forward transcript to client so user sees what they said
                 await self.websocket.send_text(raw_response)
+
+                # Transcription-only sessions (e.g. gpt-realtime-whisper) have no
+                # assistant turn: capture audio-duration usage for cost and never
+                # trigger response.create.
+                if self._is_transcription_session:
+                    self._capture_transcription_usage(event_obj)
+                    return True
+
+                transcript = event_obj.get("transcript", "")
                 blocked = await self.run_realtime_guardrails(
                     transcript,
                     item_id=event_obj.get("item_id"),

--- a/litellm/llms/azure/realtime/handler.py
+++ b/litellm/llms/azure/realtime/handler.py
@@ -35,6 +35,7 @@ class AzureOpenAIRealtime(AzureChatCompletion):
         model: str,
         api_version: Optional[str],
         realtime_protocol: Optional[str] = None,
+        query_params: Optional[dict] = None,
     ) -> str:
         """
         Construct Azure realtime WebSocket URL.
@@ -46,6 +47,7 @@ class AzureOpenAIRealtime(AzureChatCompletion):
             realtime_protocol: Protocol version to use:
                 - "GA" or "v1": Uses /openai/v1/realtime (GA path)
                 - "beta" or None: Uses /openai/realtime (beta path, default)
+            query_params: Extra query params to forward (e.g. intent=transcription).
 
         Returns:
             WebSocket URL string
@@ -54,6 +56,8 @@ class AzureOpenAIRealtime(AzureChatCompletion):
             beta/default: "wss://.../openai/realtime?api-version=2024-10-01-preview&deployment=gpt-4o-realtime-preview"
             GA/v1:        "wss://.../openai/v1/realtime?model=gpt-realtime-deployment"
         """
+        from urllib.parse import urlencode
+
         api_base = api_base.replace("https://", "wss://")
 
         # Determine path based on realtime_protocol (case-insensitive)
@@ -61,13 +65,25 @@ class AzureOpenAIRealtime(AzureChatCompletion):
             "GA",
             "V1",
         )
+        intent = (query_params or {}).get("intent")
+
         if _is_ga:
             path = "/openai/v1/realtime"
-            return f"{api_base}{path}?model={model}"
+            query_parts = []
+            if intent != "transcription" and (
+                query_params is None or "model" in query_params
+            ):
+                query_parts.append(urlencode({"model": model}))
         else:
             # Default to beta path for backwards compatibility
             path = "/openai/realtime"
-            return f"{api_base}{path}?api-version={api_version}&deployment={model}"
+            query_parts = [urlencode({"api-version": api_version, "deployment": model})]
+
+        if intent:
+            query_parts.append(urlencode({"intent": intent}))
+
+        qs = "&".join(query_parts)
+        return f"{api_base}{path}?{qs}" if qs else f"{api_base}{path}"
 
     async def async_realtime(
         self,
@@ -81,6 +97,7 @@ class AzureOpenAIRealtime(AzureChatCompletion):
         client: Optional[Any] = None,
         timeout: Optional[float] = None,
         realtime_protocol: Optional[str] = None,
+        query_params: Optional[dict] = None,
         user_api_key_dict: Optional[Any] = None,
         litellm_metadata: Optional[dict] = None,
     ):
@@ -96,7 +113,11 @@ class AzureOpenAIRealtime(AzureChatCompletion):
             raise ValueError("api_version is required for Azure OpenAI calls")
 
         url = self._construct_url(
-            api_base, model, api_version, realtime_protocol=realtime_protocol
+            api_base,
+            model,
+            api_version,
+            realtime_protocol=realtime_protocol,
+            query_params=query_params,
         )
 
         try:
@@ -113,9 +134,15 @@ class AzureOpenAIRealtime(AzureChatCompletion):
                     websocket,
                     cast(ClientConnection, backend_ws),
                     logging_obj,
+                    model=model,
                     user_api_key_dict=user_api_key_dict,
                     request_data={"litellm_metadata": litellm_metadata or {}},
                     backend_uses_beta_protocol=backend_uses_beta_protocol,
+                    force_transcription_model=(
+                        model
+                        if (query_params or {}).get("intent") == "transcription"
+                        else None
+                    ),
                 )
                 await realtime_streaming.bidirectional_forward()
 

--- a/litellm/llms/azure/realtime/http_transformation.py
+++ b/litellm/llms/azure/realtime/http_transformation.py
@@ -40,6 +40,13 @@ class AzureRealtimeHTTPConfig(BaseRealtimeHTTPConfig):
         version = api_version or get_secret_str("AZURE_API_VERSION") or "2024-12-17"
         return f"{base}/openai/realtime/calls?api-version={version}"
 
+    def get_transcription_session_url(
+        self, api_base: Optional[str], model: str, api_version: Optional[str] = None
+    ) -> str:
+        base = self.get_api_base(api_base).rstrip("/")
+        version = api_version or get_secret_str("AZURE_API_VERSION") or "2024-12-17"
+        return f"{base}/openai/realtime/transcription_sessions?api-version={version}"
+
     def get_realtime_calls_headers(self, ephemeral_key: str) -> dict:
         return {
             "api-key": ephemeral_key,

--- a/litellm/llms/base_llm/realtime/http_transformation.py
+++ b/litellm/llms/base_llm/realtime/http_transformation.py
@@ -59,6 +59,15 @@ class BaseRealtimeHTTPConfig(ABC):
     ) -> str:
         """Return the full URL for POST /realtime/client_secrets."""
 
+    def get_transcription_session_url(
+        self, api_base: Optional[str], model: str, api_version: Optional[str] = None
+    ) -> str:
+        """Return the full URL for POST /realtime/transcription_sessions."""
+        base = (api_base or "").rstrip("/")
+        if base.endswith("/v1"):
+            base = base[:-3]
+        return f"{base}/v1/realtime/transcription_sessions"
+
     @abstractmethod
     def validate_environment(
         self,

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -5315,6 +5315,21 @@ class BaseLLMHTTPHandler:
             headers=error_headers,
         )
 
+    @staticmethod
+    def _append_query_params(url: str, query_params: Optional[Dict[str, Any]]) -> str:
+        """Append query_params to url, skipping keys already present in the URL."""
+        if not query_params:
+            return url
+        from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
+
+        parsed = urlparse(url)
+        existing = dict(parse_qsl(parsed.query))
+        extras = {k: v for k, v in query_params.items() if k not in existing}
+        if not extras:
+            return url
+        new_query = parsed.query + ("&" if parsed.query else "") + urlencode(extras)
+        return urlunparse(parsed._replace(query=new_query))
+
     async def async_realtime(
         self,
         model: str,
@@ -5328,11 +5343,14 @@ class BaseLLMHTTPHandler:
         timeout: Optional[float] = None,
         user_api_key_dict: Optional[Any] = None,
         litellm_metadata: Optional[Dict[str, Any]] = None,
+        query_params: Optional[Dict[str, Any]] = None,
     ):
         import websockets
         from websockets.asyncio.client import ClientConnection
 
-        url = provider_config.get_complete_url(api_base, model, api_key)
+        url = self._append_query_params(
+            provider_config.get_complete_url(api_base, model, api_key), query_params
+        )
         headers = provider_config.validate_environment(
             headers=headers,
             model=model,
@@ -5373,6 +5391,11 @@ class BaseLLMHTTPHandler:
                     model,
                     user_api_key_dict=user_api_key_dict,
                     request_data=_request_data,
+                    force_transcription_model=(
+                        model
+                        if (query_params or {}).get("intent") == "transcription"
+                        else None
+                    ),
                 )
                 if _session_config:
                     realtime_streaming.session_configuration_request = _session_config
@@ -5440,6 +5463,69 @@ class BaseLLMHTTPHandler:
         Uses provider_config (BaseRealtimeHTTPConfig) for URL construction and
         header auth when available; falls back to the legacy OpenAI-style defaults.
         """
+        return await self._async_realtime_session_post(
+            endpoint="client_secrets",
+            api_base=api_base,
+            api_key=api_key,
+            request_data=request_data,
+            logging_obj=logging_obj,
+            timeout=timeout,
+            provider_config=provider_config,
+            model=model,
+            extra_headers=extra_headers,
+            client=client,
+            api_version=api_version,
+        )
+
+    async def async_realtime_transcription_session_handler(
+        self,
+        api_base: str,
+        api_key: str,
+        request_data: Dict[str, Any],
+        logging_obj: LiteLLMLoggingObj,
+        timeout: Union[float, httpx.Timeout],
+        provider_config: Optional[Any] = None,
+        model: Optional[str] = None,
+        extra_headers: Optional[Dict[str, Any]] = None,
+        client: Optional[Union[HTTPHandler, AsyncHTTPHandler]] = None,
+        api_version: Optional[str] = None,
+    ) -> httpx.Response:
+        """Forward POST /v1/realtime/transcription_sessions to upstream provider."""
+        return await self._async_realtime_session_post(
+            endpoint="transcription_sessions",
+            api_base=api_base,
+            api_key=api_key,
+            request_data=request_data,
+            logging_obj=logging_obj,
+            timeout=timeout,
+            provider_config=provider_config,
+            model=model,
+            extra_headers=extra_headers,
+            client=client,
+            api_version=api_version,
+        )
+
+    async def _async_realtime_session_post(
+        self,
+        endpoint: Literal["client_secrets", "transcription_sessions"],
+        api_base: str,
+        api_key: str,
+        request_data: Dict[str, Any],
+        logging_obj: LiteLLMLoggingObj,
+        timeout: Union[float, httpx.Timeout],
+        provider_config: Optional[Any] = None,
+        model: Optional[str] = None,
+        extra_headers: Optional[Dict[str, Any]] = None,
+        client: Optional[Union[HTTPHandler, AsyncHTTPHandler]] = None,
+        api_version: Optional[str] = None,
+    ) -> httpx.Response:
+        """
+        Shared POST flow for the realtime HTTP session endpoints
+        (client_secrets and transcription_sessions).
+
+        Uses provider_config (BaseRealtimeHTTPConfig) for URL construction and
+        header auth when available; falls back to the legacy OpenAI-style defaults.
+        """
         if client is None or not isinstance(client, AsyncHTTPHandler):
             async_httpx_client = get_async_httpx_client(
                 llm_provider=litellm.LlmProviders.OPENAI,
@@ -5448,14 +5534,19 @@ class BaseLLMHTTPHandler:
             async_httpx_client = client
 
         if provider_config is not None:
-            url = provider_config.get_complete_url(
-                api_base=api_base, model=model or "", api_version=api_version
-            )
+            if endpoint == "transcription_sessions":
+                url = provider_config.get_transcription_session_url(
+                    api_base=api_base, model=model or "", api_version=api_version
+                )
+            else:
+                url = provider_config.get_complete_url(
+                    api_base=api_base, model=model or "", api_version=api_version
+                )
             headers: Dict[str, Any] = provider_config.validate_environment(
                 headers={}, model=model or "", api_key=api_key
             )
         else:
-            url = f"{api_base.rstrip('/')}/v1/realtime/client_secrets"
+            url = f"{api_base.rstrip('/')}/v1/realtime/{endpoint}"
             headers = {
                 "Authorization": f"Bearer {api_key}",
                 "Content-Type": "application/json",

--- a/litellm/llms/openai/realtime/handler.py
+++ b/litellm/llms/openai/realtime/handler.py
@@ -157,8 +157,14 @@ class OpenAIRealtime(OpenAIChatCompletion):
                     websocket,
                     cast(ClientConnection, backend_ws),
                     logging_obj,
+                    model=model,
                     user_api_key_dict=user_api_key_dict,
                     request_data={"litellm_metadata": litellm_metadata or {}},
+                    force_transcription_model=(
+                        model
+                        if (query_params or {}).get("intent") == "transcription"
+                        else None
+                    ),
                 )
                 await realtime_streaming.bidirectional_forward()
 

--- a/litellm/llms/openai/realtime/http_transformation.py
+++ b/litellm/llms/openai/realtime/http_transformation.py
@@ -41,6 +41,14 @@ class OpenAIRealtimeHTTPConfig(BaseRealtimeHTTPConfig):
             base = base[:-3]
         return f"{base}/v1/realtime/calls"
 
+    def get_transcription_session_url(
+        self, api_base: Optional[str], model: str, api_version: Optional[str] = None
+    ) -> str:
+        base = self.get_api_base(api_base).rstrip("/")
+        if base.endswith("/v1"):
+            base = base[:-3]
+        return f"{base}/v1/realtime/transcription_sessions"
+
     def validate_environment(
         self,
         headers: dict,

--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -141,5 +141,14 @@
     "special_handling": {
       "force_store_false": true
     }
+  },
+  "hanzo": {
+    "base_url": "https://api.hanzo.ai/v1",
+    "api_key_env": "HANZO_API_KEY",
+    "api_base_env": "HANZO_API_BASE",
+    "param_mappings": {
+      "max_completion_tokens": "max_tokens"
+    },
+    "supported_endpoints": ["/v1/chat/completions"]
   }
 }

--- a/litellm/llms/parallel_ai/search/transformation.py
+++ b/litellm/llms/parallel_ai/search/transformation.py
@@ -1,7 +1,7 @@
 """
-Calls Parallel AI's /search endpoint to search the web.
+Calls Parallel AI's /v1/search endpoint to search the web.
 
-Parallel AI API Reference: https://docs.parallel.ai/api-reference/search-and-extract-api-beta/search
+Parallel AI API Reference: https://docs.parallel.ai/api-reference/search/search
 """
 
 from typing import Dict, List, Optional, TypedDict, Union
@@ -18,36 +18,43 @@ from litellm.secret_managers.main import get_secret_str
 
 
 class _ParallelAISourcePolicy(TypedDict, total=False):
-    """Source policy for Parallel AI search results."""
-
-    allowed_domains: List[str]  # Optional - list of allowed domains
-    disallowed_domains: List[str]  # Optional - list of disallowed domains
-
-
-class _ParallelAISearchRequestRequired(TypedDict):
-    """Required fields for Parallel AI Search API request."""
-
-    # Note: At least one of objective or search_queries must be provided
-    pass
+    include_domains: List[str]
+    exclude_domains: List[str]
+    after_date: str
 
 
-class ParallelAISearchRequest(_ParallelAISearchRequestRequired, total=False):
+class _ParallelAIExcerptSettings(TypedDict, total=False):
+    max_chars_per_result: int
+
+
+class _ParallelAIAdvancedSettings(TypedDict, total=False):
+    source_policy: _ParallelAISourcePolicy
+    excerpt_settings: _ParallelAIExcerptSettings
+    fetch_policy: Dict
+    location: str
+    max_results: int
+
+
+class ParallelAISearchRequest(TypedDict, total=False):
     """
-    Parallel AI Search API request format.
-    Based on: https://docs.parallel.ai/api-reference/search-and-extract-api-beta/search
+    Parallel AI v1 Search API request format.
+    Based on: https://docs.parallel.ai/api-reference/search/search
     """
 
+    search_queries: List[str]  # Required - at least one keyword search query
     objective: str  # Optional - natural-language description of search goal
-    search_queries: List[str]  # Optional - list of keyword search queries
-    processor: str  # Optional - search processor ('base', 'pro'), default 'base'
-    max_results: int  # Optional - maximum number of results, default 10
-    max_chars_per_result: int  # Optional - max characters per result excerpt
-    source_policy: _ParallelAISourcePolicy  # Optional - source policy for allowed/disallowed domains
+    mode: str  # Optional - 'turbo', 'basic', or 'advanced' (default 'advanced')
+    max_chars_total: int  # Optional - upper bound on total excerpt characters
+    session_id: str  # Optional - tracks calls across search/extract requests
+    client_model: str  # Optional - model consuming the results
+    advanced_settings: _ParallelAIAdvancedSettings
+
+
+LEGACY_PROCESSOR_TO_MODE = {"base": "basic", "pro": "advanced"}
 
 
 class ParallelAISearchConfig(BaseSearchConfig):
     PARALLEL_AI_API_BASE = "https://api.parallel.ai"
-    PARALLEL_HEADER_SEARCH_EXTRACT_VALUE = "search-extract-2025-10-10"
 
     @staticmethod
     def ui_friendly_name() -> str:
@@ -60,9 +67,6 @@ class ParallelAISearchConfig(BaseSearchConfig):
         api_base: Optional[str] = None,
         **kwargs,
     ) -> Dict:
-        """
-        Validate environment and return headers.
-        """
         api_key = (
             api_key
             or get_secret_str("PARALLEL_AI_API_KEY")
@@ -74,7 +78,6 @@ class ParallelAISearchConfig(BaseSearchConfig):
             )
         headers["x-api-key"] = api_key
         headers["Content-Type"] = "application/json"
-        headers["parallel-beta"] = self.PARALLEL_HEADER_SEARCH_EXTRACT_VALUE
         return headers
 
     def get_complete_url(
@@ -84,31 +87,17 @@ class ParallelAISearchConfig(BaseSearchConfig):
         data: Optional[Union[Dict, List[Dict]]] = None,
         **kwargs,
     ) -> str:
-        """
-        Get complete URL for Search endpoint.
-        """
         api_base = (
             api_base
             or get_secret_str("PARALLEL_AI_API_BASE")
             or self.PARALLEL_AI_API_BASE
         )
 
-        # Parallel AI search endpoint is at /v1beta/search
-        if not api_base.endswith("/v1beta/search"):
-            if api_base.endswith("/"):
-                api_base = f"{api_base}v1beta/search"
-            else:
-                api_base = f"{api_base}/v1beta/search"
+        api_base = api_base.rstrip("/")
+        if not api_base.endswith("/v1/search"):
+            api_base = f"{api_base.removesuffix('/v1')}/v1/search"
 
         return api_base
-
-    def _transform_query_to_objective(self, query: Union[str, List[str]]) -> str:
-        """
-        Transform query to objective.
-        """
-        if isinstance(query, list):
-            return " ".join(query)
-        return query
 
     def transform_search_request(
         self,
@@ -117,57 +106,78 @@ class ParallelAISearchConfig(BaseSearchConfig):
         **kwargs,
     ) -> Dict:
         """
-        Transform Search request to Parallel AI API format.
+        Transform Search request to Parallel AI v1 API format.
 
         Args:
             query: Search query (string or list of strings)
-                - If string: maps to `objective` (natural language)
+                - If string: maps to `search_queries` (single item) and `objective`
                 - If list: maps to `search_queries` (keyword queries)
             optional_params: Optional parameters for the request
-                - max_results: Maximum number of search results (default 10)
-                - search_domain_filter: List of domains to include -> maps to `source_policy.allowed_domains`
-                - exclude_domains: List of domains to exclude -> maps to `source_policy.disallowed_domains`
-                - processor: Search processor ('base', 'pro')
-                - max_chars_per_result: Max characters per result excerpt
+                - mode: Search mode ('turbo', 'basic', 'advanced'); defaults to 'basic'
+                - processor: Legacy v1beta param; 'base' maps to mode 'basic', 'pro' to 'advanced'
+                - max_results: Maximum number of search results -> `advanced_settings.max_results`
+                - search_domain_filter: Domains to include -> `advanced_settings.source_policy.include_domains`
+                - exclude_domains: Domains to exclude -> `advanced_settings.source_policy.exclude_domains`
+                - country: ISO 3166-1 alpha-2 code -> `advanced_settings.location`
+                - max_chars_per_result: -> `advanced_settings.excerpt_settings.max_chars_per_result`
+                - Any other params are passed through to the request body as-is
 
         Returns:
-            Dict with typed request data following ParallelAISearchRequest spec
+            Dict with request data following the v1 search request spec
         """
+        params = dict(optional_params)
+
         request_data: ParallelAISearchRequest = {}
 
-        # Map query to objective (string or list both become objective)
         if isinstance(query, list):
-            request_data["objective"] = self._transform_query_to_objective(query)
+            request_data["search_queries"] = query
         else:
+            request_data["search_queries"] = [query]
             request_data["objective"] = query
 
-        # Transform Perplexity unified spec parameters to Parallel AI format
-        if "max_results" in optional_params:
-            request_data["max_results"] = optional_params["max_results"]
+        mode = params.pop("mode", None)
+        processor = params.pop("processor", None)
+        if mode is None and processor is not None:
+            mode = LEGACY_PROCESSOR_TO_MODE.get(processor, processor)
+        # the v1 API defaults to 'advanced' when mode is omitted; default to 'basic'
+        # instead to keep v1beta's default tier (processor 'base') and litellm's
+        # $0.004/query cost map entry for `parallel_ai/search` accurate
+        request_data["mode"] = mode or "basic"
 
-        # Map domain filters to source_policy
+        advanced_settings: _ParallelAIAdvancedSettings = {}
+
+        if "max_results" in params:
+            advanced_settings["max_results"] = params.pop("max_results")
+
+        if "country" in params:
+            advanced_settings["location"] = params.pop("country")
+
+        if "max_chars_per_result" in params:
+            advanced_settings["excerpt_settings"] = {
+                "max_chars_per_result": params.pop("max_chars_per_result")
+            }
+
         source_policy: _ParallelAISourcePolicy = {}
 
-        if "search_domain_filter" in optional_params:
-            source_policy["allowed_domains"] = optional_params["search_domain_filter"]
+        if "search_domain_filter" in params:
+            source_policy["include_domains"] = params.pop("search_domain_filter")
 
-        if "exclude_domains" in optional_params:
-            source_policy["disallowed_domains"] = optional_params["exclude_domains"]
+        if "exclude_domains" in params:
+            source_policy["exclude_domains"] = params.pop("exclude_domains")
 
         if source_policy:
-            request_data["source_policy"] = source_policy
+            advanced_settings["source_policy"] = source_policy
 
-        # Convert to dict before dynamic key assignments
-        result_data = dict(request_data)
+        advanced_settings.update(params.pop("advanced_settings", {}))
 
-        # pass through all other parameters as-is
-        for param, value in optional_params.items():
-            if (
-                param not in self.get_supported_perplexity_optional_params()
-                and param not in result_data
-            ):
-                result_data[param] = value
+        if advanced_settings:
+            request_data["advanced_settings"] = advanced_settings
 
+        # unified-spec param with no v1 equivalent
+        params.pop("max_tokens_per_page", None)
+
+        result_data: Dict = dict(request_data)
+        result_data.update(params)
         return result_data
 
     def transform_search_response(
@@ -177,36 +187,27 @@ class ParallelAISearchConfig(BaseSearchConfig):
         **kwargs,
     ) -> SearchResponse:
         """
-        Transform Parallel AI API response to LiteLLM unified SearchResponse format.
+        Transform Parallel AI v1 API response to LiteLLM unified SearchResponse format.
 
-        Parallel AI → LiteLLM mappings:
-        - results[].title → SearchResult.title
-        - results[].url → SearchResult.url
-        - results[].excerpts (array) → SearchResult.snippet (joined string)
-        - No date/last_updated fields in Parallel AI response (set to None)
-
-        Args:
-            raw_response: Raw httpx response from Parallel AI API
-            logging_obj: Logging object for tracking
-
-        Returns:
-            SearchResponse with standardized format
+        Parallel AI -> LiteLLM mappings:
+        - results[].title -> SearchResult.title
+        - results[].url -> SearchResult.url
+        - results[].excerpts (array) -> SearchResult.snippet (joined string)
+        - results[].publish_date -> SearchResult.date
         """
         response_json = raw_response.json()
 
-        # Transform results to SearchResult objects
         results = []
         for result in response_json.get("results", []):
-            # Join excerpts array into a single snippet string
-            excerpts = result.get("excerpts", [])
+            excerpts = result.get("excerpts") or []
             snippet = " ... ".join(excerpts) if excerpts else ""
 
             search_result = SearchResult(
-                title=result.get("title", ""),
-                url=result.get("url", ""),
+                title=result.get("title") or "",
+                url=result.get("url") or "",
                 snippet=snippet,
-                date=None,  # Parallel AI doesn't provide date in response
-                last_updated=None,  # Parallel AI doesn't provide last_updated in response
+                date=result.get("publish_date"),
+                last_updated=None,
             )
             results.append(search_result)
 

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -4409,6 +4409,23 @@
             "/v1/audio/transcriptions"
         ]
     },
+    "azure/gpt-realtime-whisper": {
+        "input_cost_per_second": 0.0002833333333333333,
+        "litellm_provider": "azure",
+        "mode": "audio_transcription",
+        "source": "https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/gpt-realtime-whisper",
+        "supported_endpoints": [
+            "/v1/realtime",
+            "/v1/realtime/transcription_sessions"
+        ],
+        "supported_modalities": [
+            "audio"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_audio_input": true
+    },
     "azure/gpt-5.1-2025-11-13": {
         "cache_read_input_token_cost": 1.25e-07,
         "cache_read_input_token_cost_priority": 2.5e-07,
@@ -40915,6 +40932,23 @@
         "supports_parallel_function_calling": true,
         "supports_system_messages": true,
         "supports_tool_choice": true
+    },
+    "gpt-realtime-whisper": {
+        "input_cost_per_second": 0.0002833333333333333,
+        "litellm_provider": "openai",
+        "mode": "audio_transcription",
+        "source": "https://platform.openai.com/docs/models/gpt-realtime-whisper",
+        "supported_endpoints": [
+            "/v1/realtime",
+            "/v1/realtime/transcription_sessions"
+        ],
+        "supported_modalities": [
+            "audio"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_audio_input": true
     },
     "sora-2": {
         "litellm_provider": "openai",

--- a/litellm/provider_endpoints_support_backup.json
+++ b/litellm/provider_endpoints_support_backup.json
@@ -1129,6 +1129,23 @@
         "interactions": true
       }
     },
+    "hanzo": {
+      "display_name": "Hanzo (`hanzo`)",
+      "url": "https://docs.litellm.ai/docs/providers/hanzo",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": false,
+        "responses": false,
+        "embeddings": false,
+        "image_generations": false,
+        "audio_transcriptions": false,
+        "audio_speech": false,
+        "moderations": false,
+        "batches": false,
+        "rerank": false,
+        "a2a": false
+      }
+    },
     "heroku": {
       "display_name": "Heroku (`heroku`)",
       "url": "https://docs.litellm.ai/docs/providers/heroku",

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -3155,6 +3155,98 @@ async def can_key_call_model(
         raise
 
 
+async def can_key_call_resolved_model(
+    model: str,
+    llm_model_list: Optional[list],
+    valid_token: UserAPIKeyAuth,
+    llm_router: Optional[litellm.Router],
+) -> None:
+    from litellm.proxy.proxy_server import (
+        prisma_client,
+        proxy_logging_obj,
+        user_api_key_cache,
+    )
+
+    skip_key_model_check = valid_token.config or (
+        isinstance(valid_token.models, list)
+        and SpecialModelNames.all_team_models.value in valid_token.models
+    )
+    if not skip_key_model_check:
+        await can_key_call_model(
+            model=model,
+            llm_model_list=llm_model_list,
+            valid_token=valid_token,
+            llm_router=llm_router,
+        )
+
+    team_object: Optional[LiteLLM_TeamTableCachedObj] = None
+    team_object_from_lookup = False
+    if valid_token.team_id is not None:
+        try:
+            team_object = await get_team_object(
+                team_id=valid_token.team_id,
+                prisma_client=prisma_client,
+                user_api_key_cache=user_api_key_cache,
+                parent_otel_span=valid_token.parent_otel_span,
+                proxy_logging_obj=proxy_logging_obj,
+            )
+            team_object_from_lookup = True
+        except Exception:
+            team_object = LiteLLM_TeamTableCachedObj(
+                team_id=valid_token.team_id,
+                models=valid_token.team_models,
+                blocked=valid_token.team_blocked,
+                team_alias=valid_token.team_alias,
+                metadata=valid_token.team_metadata,
+                object_permission_id=valid_token.team_object_permission_id,
+                object_permission=valid_token.team_object_permission,
+            )
+
+    if team_object is not None:
+        try:
+            await can_team_access_model(
+                model=model,
+                team_object=team_object,
+                llm_router=llm_router,
+                team_model_aliases=valid_token.team_model_aliases,
+            )
+        except ProxyException as team_denial:
+            if team_denial.type != ProxyErrorTypes.team_model_access_denied:
+                raise
+            if not await _key_access_group_grants_model(
+                model=model,
+                valid_token=valid_token,
+                team_object=team_object,
+                llm_router=llm_router,
+            ):
+                raise
+
+        if valid_token.user_id is not None and team_object_from_lookup:
+            await _check_team_member_model_access(
+                model=model,
+                team_object=team_object,
+                valid_token=valid_token,
+                llm_router=llm_router,
+                prisma_client=prisma_client,
+                user_api_key_cache=user_api_key_cache,
+                proxy_logging_obj=proxy_logging_obj,
+            )
+
+    if valid_token.project_id is not None:
+        project_object = await get_project_object(
+            project_id=valid_token.project_id,
+            prisma_client=prisma_client,
+            user_api_key_cache=user_api_key_cache,
+            proxy_logging_obj=proxy_logging_obj,
+        )
+        if project_object is not None and len(project_object.models) > 0:
+            can_project_access_model(
+                model=model,
+                project_object=project_object,
+                llm_router=llm_router,
+            )
+
+
 def can_org_access_model(
     model: str,
     org_object: Optional[LiteLLM_OrganizationTable],

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -174,9 +174,7 @@ async def chat_completion_pass_through_endpoint(  # noqa: PLR0915
 
         data["adapter_id"] = adapter_id
 
-        verbose_proxy_logger.debug(
-            "Request received by LiteLLM:\n{}".format(json.dumps(data, indent=4)),
-        )
+        verbose_proxy_logger.debug("Request received by LiteLLM:\n%s", data)
         data["model"] = (
             general_settings.get("completion_model", None)  # server default
             or user_model  # model name passed via cli args
@@ -298,7 +296,7 @@ async def chat_completion_pass_through_endpoint(  # noqa: PLR0915
             )
         )
 
-        verbose_proxy_logger.debug("\nResponse from Litellm:\n{}".format(response))
+        verbose_proxy_logger.debug("\nResponse from Litellm:\n%s", response)
         return response
     except Exception as e:
         await proxy_logging_obj.post_call_failure_hook(
@@ -811,9 +809,10 @@ async def pass_through_request(  # noqa: PLR0915
         else:
             _parsed_body = await _read_request_body(request)
         verbose_proxy_logger.debug(
-            "Pass through endpoint sending request to \nURL {}\nheaders: {}\nbody: {}\n".format(
-                url, headers, _parsed_body
-            )
+            "Pass through endpoint sending request to \nURL %s\nheaders: %s\nbody: %s\n",
+            url,
+            headers,
+            _parsed_body,
         )
 
         ### COLLECT GUARDRAILS FOR PASSTHROUGH ENDPOINT ###

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -252,6 +252,7 @@ from litellm.proxy.analytics_endpoints.analytics_endpoints import (
 )
 from litellm.proxy.auth.auth_checks import (
     ExperimentalUIJWTToken,
+    can_key_call_resolved_model,
     get_team_object,
     log_db_metrics,
 )
@@ -9458,13 +9459,15 @@ async def vertex_ai_live_passthrough_endpoint(
 
 @lru_cache(maxsize=_REALTIME_BODY_CACHE_SIZE)
 def _realtime_query_params_template(
-    model: str, intent: Optional[str]
+    model: Optional[str], intent: Optional[str]
 ) -> Tuple[Tuple[str, str], ...]:
     """
     Build a hashable representation of the realtime query params so we can cache
     the repetitive model/intent combinations.
     """
-    params: List[Tuple[str, str]] = [("model", model)]
+    params: List[Tuple[str, str]] = []
+    if model is not None:
+        params.append(("model", model))
     if intent is not None:
         params.append(("intent", intent))
     return tuple(params)
@@ -9475,8 +9478,10 @@ def _realtime_query_params_template(
 @app.websocket("/realtime")
 async def realtime_websocket_endpoint(
     websocket: WebSocket,
-    model: str,
-    intent: str = fastapi.Query(
+    model: Optional[str] = fastapi.Query(
+        None, description="The model to use for the websocket connection."
+    ),
+    intent: Optional[str] = fastapi.Query(
         None, description="The intent of the websocket connection."
     ),
     guardrails: Optional[str] = fastapi.Query(
@@ -9493,6 +9498,27 @@ async def realtime_websocket_endpoint(
     accept_kwargs: dict = {}
     if requested_protocols:
         accept_kwargs["subprotocol"] = requested_protocols[0]
+
+    route_model = model
+    if route_model is None:
+        if intent == "transcription":
+            route_model = "gpt-realtime-whisper"
+        else:
+            await websocket.close(
+                code=1008, reason="model query parameter is required"
+            )
+            return
+    assert route_model is not None
+    try:
+        await can_key_call_resolved_model(
+            model=route_model,
+            llm_model_list=llm_model_list,
+            valid_token=user_api_key_dict,
+            llm_router=llm_router,
+        )
+    except ProxyException as e:
+        await websocket.close(code=1008, reason=e.message[:120])
+        return
     await websocket.accept(**accept_kwargs)
 
     # Only use explicit parameters, not all query params
@@ -9501,7 +9527,7 @@ async def realtime_websocket_endpoint(
     )
 
     data: Dict[str, Any] = {
-        "model": model,
+        "model": route_model,
         "websocket": websocket,
         "query_params": query_params,  # Only explicit params
     }
@@ -9521,7 +9547,7 @@ async def realtime_websocket_endpoint(
     request._url = websocket.url
 
     async def return_body():
-        return _realtime_request_body(model)
+        return _realtime_request_body(route_model)
 
     request.body = return_body  # type: ignore
 
@@ -9547,7 +9573,7 @@ async def realtime_websocket_endpoint(
             user_request_timeout=user_request_timeout,
             user_max_tokens=user_max_tokens,
             user_api_base=user_api_base,
-            model=model,
+            model=route_model,
             route_type="_arealtime",
         )
     except Exception as e:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7841,6 +7841,15 @@ class ProxyStartupEvent:
             await VantageLogger.init_vantage_background_job(scheduler=scheduler)
 
         ########################################################
+        # Mavvrik FOCUS Background Job
+        ########################################################
+        from litellm.integrations.mavvrik_focus.mavvrik_focus_logger import (  # noqa: PLC0415
+            MavvrikFocusLogger,
+        )
+
+        await MavvrikFocusLogger.init_mavvrik_focus_background_job(scheduler=scheduler)
+
+        ########################################################
         # Prometheus Background Job
         ########################################################
         if litellm.prometheus_initialize_budget_metrics is True:
@@ -9504,9 +9513,7 @@ async def realtime_websocket_endpoint(
         if intent == "transcription":
             route_model = "gpt-realtime-whisper"
         else:
-            await websocket.close(
-                code=1008, reason="model query parameter is required"
-            )
+            await websocket.close(code=1008, reason="model query parameter is required")
             return
     assert route_model is not None
     try:

--- a/litellm/proxy/realtime_endpoints/endpoints.py
+++ b/litellm/proxy/realtime_endpoints/endpoints.py
@@ -10,6 +10,7 @@ from fastapi import status as http_status
 
 from litellm._logging import verbose_proxy_logger
 from litellm.proxy._types import ProxyException, UserAPIKeyAuth
+from litellm.proxy.auth.auth_checks import can_key_call_resolved_model
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 from litellm.proxy.common_utils.encrypt_decrypt_utils import (
     decrypt_value_helper,
@@ -19,11 +20,143 @@ from litellm.proxy.common_utils.http_parsing_utils import _read_request_body
 from litellm.types.realtime import (
     RealtimeClientSecretRequest,
     RealtimeClientSecretResponse,
+    RealtimeTranscriptionSessionRequest,
+    RealtimeTranscriptionSessionResponse,
 )
 
 router = APIRouter()
 
 _REALTIME_TOKEN_VERSION = "realtime_v1"
+_DEFAULT_REALTIME_MODEL = "gpt-4o-realtime-preview"
+_DEFAULT_TRANSCRIPTION_MODEL = "gpt-realtime-whisper"
+_ALLOWED_SESSION_TYPES = ("realtime", "transcription")
+
+
+def _coerce_realtime_session_type(session_type: Optional[str]) -> str:
+    if session_type in _ALLOWED_SESSION_TYPES:
+        return session_type
+    return "realtime"
+
+
+def _append_model_candidate(candidates: list[str], model: Any) -> None:
+    if isinstance(model, str) and model and model not in candidates:
+        candidates.append(model)
+
+
+def _transcription_model_candidates_from_session(session: dict) -> list[str]:
+    candidates: list[str] = []
+
+    audio = session.get("audio")
+    if isinstance(audio, dict):
+        audio_input = audio.get("input")
+        if isinstance(audio_input, dict):
+            nested_transcription = audio_input.get("transcription")
+            if isinstance(nested_transcription, dict):
+                _append_model_candidate(
+                    candidates,
+                    nested_transcription.get("model"),
+                )
+
+    flat_transcription = session.get("input_audio_transcription")
+    if isinstance(flat_transcription, dict):
+        _append_model_candidate(candidates, flat_transcription.get("model"))
+
+    return candidates
+
+
+def _set_transcription_model_on_session(
+    session: dict,
+    model: str,
+    create_if_missing: bool = False,
+) -> None:
+    updated_existing_config = False
+
+    flat_transcription = session.get("input_audio_transcription")
+    if isinstance(flat_transcription, dict):
+        session["input_audio_transcription"] = {
+            **flat_transcription,
+            "model": model,
+        }
+        updated_existing_config = True
+
+    audio = session.get("audio")
+    if isinstance(audio, dict):
+        audio_input = audio.get("input")
+        if isinstance(audio_input, dict):
+            nested_transcription = audio_input.get("transcription")
+            if isinstance(nested_transcription, dict):
+                session["audio"] = {
+                    **audio,
+                    "input": {
+                        **audio_input,
+                        "transcription": {
+                            **nested_transcription,
+                            "model": model,
+                        },
+                    },
+                }
+                updated_existing_config = True
+
+    if updated_existing_config or not create_if_missing:
+        return
+
+    audio = audio if isinstance(audio, dict) else {}
+    audio_input = audio.get("input")
+    audio_input = audio_input if isinstance(audio_input, dict) else {}
+    session["audio"] = {
+        **audio,
+        "input": {
+            **audio_input,
+            "transcription": {"model": model},
+        },
+    }
+
+
+async def _prepare_client_secret_session(
+    req: RealtimeClientSecretRequest,
+    user_api_key_dict: UserAPIKeyAuth,
+    llm_model_list: Optional[list],
+    llm_router: Any,
+) -> tuple[str, Optional[dict], str]:
+    session_type = _coerce_realtime_session_type(
+        req.session.type if req.session else None
+    )
+    session_data: Optional[dict] = (
+        req.session.model_dump(exclude_none=True) if req.session else None
+    )
+    if session_data is not None:
+        session_data["type"] = session_type
+
+    session_model = req.session.model if req.session else None
+    model: str = session_model or req.model or _DEFAULT_REALTIME_MODEL
+    if session_type != "transcription":
+        return model, session_data, session_type
+
+    transcription_model_candidates = _transcription_model_candidates_from_session(
+        session_data or {}
+    )
+    if not transcription_model_candidates:
+        _append_model_candidate(transcription_model_candidates, session_model)
+        _append_model_candidate(transcription_model_candidates, req.model)
+    if not transcription_model_candidates:
+        transcription_model_candidates.append(_DEFAULT_TRANSCRIPTION_MODEL)
+
+    model = transcription_model_candidates[0]
+    for transcription_model in transcription_model_candidates:
+        await can_key_call_resolved_model(
+            model=transcription_model,
+            valid_token=user_api_key_dict,
+            llm_model_list=llm_model_list,
+            llm_router=llm_router,
+        )
+    if session_data is not None:
+        _set_transcription_model_on_session(
+            session=session_data,
+            model=model,
+            create_if_missing=True,
+        )
+        session_data.pop("model", None)
+    return model, session_data, session_type
 
 
 def _encode_realtime_token_payload(
@@ -32,6 +165,7 @@ def _encode_realtime_token_payload(
     user_id: Optional[str],
     team_id: Optional[str],
     expires_at: Optional[int],
+    session_type: str = "realtime",
 ) -> str:
     """
     Encode metadata with the upstream ephemeral key so /realtime/calls can
@@ -44,6 +178,7 @@ def _encode_realtime_token_payload(
         "user_id": user_id or "",
         "team_id": team_id or "",
         "expires_at": expires_at,
+        "session_type": session_type,
     }
     return json.dumps(payload, separators=(",", ":"))
 
@@ -94,6 +229,7 @@ async def create_realtime_client_secret(
         add_litellm_data_to_request,
         general_settings,
         llm_router,
+        llm_model_list,
         proxy_config,
         proxy_logging_obj,
         route_request,
@@ -106,17 +242,18 @@ async def create_realtime_client_secret(
         body = await _read_request_body(request=request)
         req = RealtimeClientSecretRequest(**body)
 
-        model: str = (
-            (req.session.model if req.session else None)
-            or req.model
-            or "gpt-4o-realtime-preview"
+        model, session_data, session_type = await _prepare_client_secret_session(
+            req=req,
+            user_api_key_dict=user_api_key_dict,
+            llm_model_list=llm_model_list,
+            llm_router=llm_router,
         )
 
         data = {"model": model}
 
         # If session is provided, use it; otherwise create one from model
-        if req.session:
-            data["session"] = req.session.model_dump(exclude_none=True)
+        if session_data is not None:
+            data["session"] = session_data
         elif req.model:
             # User provided model at root level, convert to session format
             data["session"] = {"type": "realtime", "model": model}
@@ -161,6 +298,8 @@ async def create_realtime_client_secret(
             "litellm.proxy.realtime_endpoints.webrtc.create_realtime_client_secret(): Exception - %s",
             str(e),
         )
+        if isinstance(e, ProxyException):
+            raise e
         if isinstance(e, HTTPException):
             raise ProxyException(
                 message=getattr(e, "message", str(e)),
@@ -199,6 +338,7 @@ async def create_realtime_client_secret(
         user_id=getattr(user_api_key_dict, "user_id", None),
         team_id=getattr(user_api_key_dict, "team_id", None),
         expires_at=expires_at if isinstance(expires_at, int) else None,
+        session_type=session_type,
     )
     encrypted_token: str = encrypt_value_helper(token_payload)
     upstream_json["value"] = encrypted_token
@@ -279,16 +419,20 @@ async def proxy_realtime_calls(
         model = (
             decoded_payload.get("model_id")
             or request.query_params.get("model")
-            or "gpt-4o-realtime-preview"
+            or _DEFAULT_REALTIME_MODEL
         )
         user_id = decoded_payload.get("user_id") or None
         team_id = decoded_payload.get("team_id") or None
+        session_type = _coerce_realtime_session_type(
+            decoded_payload.get("session_type")
+        )
     else:
         # Backward compatibility: older tokens contained only encrypted upstream key.
         openai_ephemeral_key = decrypted_token_value
-        model = request.query_params.get("model", "gpt-4o-realtime-preview")
+        model = request.query_params.get("model", _DEFAULT_REALTIME_MODEL)
         user_id = None
         team_id = None
+        session_type = "realtime"
 
     # Build a minimal UserAPIKeyAuth with user/team IDs from the token
     # so spend tracking and budget enforcement work correctly.
@@ -299,11 +443,17 @@ async def proxy_realtime_calls(
 
     data: dict = {}
     try:
-        # Build session config for the multipart form data
         session_config = {
-            "type": "realtime",
-            "model": model,
+            "type": session_type,
         }
+        if session_type == "transcription":
+            _set_transcription_model_on_session(
+                session=session_config,
+                model=model,
+                create_if_missing=True,
+            )
+        else:
+            session_config["model"] = model
 
         data = {
             "model": model,
@@ -366,3 +516,145 @@ async def proxy_realtime_calls(
         status_code=upstream_resp.status_code,
         media_type=upstream_resp.headers.get("content-type", "application/sdp"),
     )
+
+
+@router.post(
+    "/v1/realtime/transcription_sessions",
+    dependencies=[Depends(user_api_key_auth)],
+    tags=["realtime"],
+)
+@router.post(
+    "/realtime/transcription_sessions",
+    dependencies=[Depends(user_api_key_auth)],
+    tags=["realtime"],
+)
+@router.post(
+    "/openai/v1/realtime/transcription_sessions",
+    dependencies=[Depends(user_api_key_auth)],
+    tags=["realtime"],
+)
+async def create_realtime_transcription_session(
+    request: Request,
+    fastapi_response: Response,
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+) -> RealtimeTranscriptionSessionResponse:
+    """
+    Create an ephemeral Realtime transcription session
+    (POST /v1/realtime/transcription_sessions) for the WebRTC/WebSocket flow.
+
+    Mirrors the client_secrets route but targets the transcription_sessions
+    endpoint and encrypts the ephemeral key returned under `client_secret.value`.
+    """
+    from litellm.proxy.proxy_server import (
+        add_litellm_data_to_request,
+        general_settings,
+        llm_router,
+        llm_model_list,
+        proxy_config,
+        proxy_logging_obj,
+        route_request,
+        user_model,
+        version,
+    )
+
+    data: dict = {}
+    try:
+        body = await _read_request_body(request=request)
+        req = RealtimeTranscriptionSessionRequest(**body)
+
+        model: str = req.resolved_model() or "gpt-realtime-whisper"
+        await can_key_call_resolved_model(
+            model=model,
+            valid_token=user_api_key_dict,
+            llm_model_list=llm_model_list,
+            llm_router=llm_router,
+        )
+
+        transcription_session = {k: v for k, v in body.items() if k != "model"}
+        data = {"model": model, "transcription_session": transcription_session}
+
+        data = await add_litellm_data_to_request(
+            data=data,
+            request=request,
+            general_settings=general_settings,
+            user_api_key_dict=user_api_key_dict,
+            version=version,
+            proxy_config=proxy_config,
+        )
+
+        data = await proxy_logging_obj.pre_call_hook(
+            user_api_key_dict=user_api_key_dict,
+            data=data,
+            call_type="acreate_realtime_transcription_session",
+        )
+
+        verbose_proxy_logger.debug(
+            "Realtime: /v1/realtime/transcription_sessions (model=%s)", model
+        )
+
+        llm_call = await route_request(
+            data=data,
+            route_type="acreate_realtime_transcription_session",
+            llm_router=llm_router,
+            user_model=user_model,
+        )
+        upstream_resp: httpx.Response = await llm_call  # type: ignore
+
+    except Exception as e:
+        await proxy_logging_obj.post_call_failure_hook(
+            user_api_key_dict=user_api_key_dict,
+            original_exception=e,
+            request_data=data,
+        )
+        verbose_proxy_logger.error(
+            "litellm.proxy.realtime_endpoints.create_realtime_transcription_session(): Exception - %s",
+            str(e),
+        )
+        if isinstance(e, ProxyException):
+            raise e
+        if isinstance(e, HTTPException):
+            raise ProxyException(
+                message=getattr(e, "detail", getattr(e, "message", str(e))),
+                type=getattr(e, "type", "None"),
+                param=getattr(e, "param", "None"),
+                code=getattr(e, "status_code", http_status.HTTP_400_BAD_REQUEST),
+            )
+        raise ProxyException(
+            message=getattr(e, "message", str(e)),
+            type=getattr(e, "type", "None"),
+            param=getattr(e, "param", "None"),
+            code=getattr(e, "status_code", 500),
+        )
+
+    if upstream_resp.status_code != 200:
+        verbose_proxy_logger.error(
+            "Realtime transcription_sessions upstream error %s: %s",
+            upstream_resp.status_code,
+            upstream_resp.text,
+        )
+        return Response(  # type: ignore[return-value]
+            content=upstream_resp.content,
+            status_code=upstream_resp.status_code,
+            media_type="application/json",
+        )
+
+    upstream_json: dict = upstream_resp.json()
+
+    # Encrypt the ephemeral key (returned under client_secret.value) with routing
+    # metadata so the follow-up /realtime/calls request can recover the model.
+    client_secret = upstream_json.get("client_secret")
+    if isinstance(client_secret, dict) and "value" in client_secret:
+        raw_value: str = client_secret.get("value", "")
+        expires_at = client_secret.get("expires_at")
+        token_payload = _encode_realtime_token_payload(
+            ephemeral_key=raw_value,
+            model_id=model,
+            user_id=getattr(user_api_key_dict, "user_id", None),
+            team_id=getattr(user_api_key_dict, "team_id", None),
+            expires_at=expires_at if isinstance(expires_at, int) else None,
+            session_type="transcription",
+        )
+        client_secret["value"] = encrypt_value_helper(token_payload)
+        upstream_json["client_secret"] = client_secret
+
+    return RealtimeTranscriptionSessionResponse(**upstream_json)

--- a/litellm/proxy/route_llm_request.py
+++ b/litellm/proxy/route_llm_request.py
@@ -74,6 +74,7 @@ ROUTE_ENDPOINT_MAPPING = {
     "avideo_extension": "/videos/extensions",
     "acreate_realtime_client_secret": "/realtime/client_secrets",
     "arealtime_calls": "/realtime/calls",
+    "acreate_realtime_transcription_session": "/realtime/transcription_sessions",
     "acreate_container": "/containers",
     "alist_containers": "/containers",
     "aretrieve_container": "/containers/{container_id}",
@@ -261,6 +262,7 @@ async def route_request(  # noqa: PLR0915 - Complex routing function, refactorin
         "_arealtime",  # private function for realtime API
         "acreate_realtime_client_secret",
         "arealtime_calls",
+        "acreate_realtime_transcription_session",
         "_aresponses_websocket",  # private function for responses WebSocket mode
         "aimage_edit",
         "agenerate_content",
@@ -427,6 +429,7 @@ async def route_request(  # noqa: PLR0915 - Complex routing function, refactorin
             "adelete_run",
             "acreate_realtime_client_secret",
             "arealtime_calls",
+            "acreate_realtime_transcription_session",
         ]:
             # If a model is provided, get its credentials from the router
             model = data.get("model")

--- a/litellm/realtime_api/README.md
+++ b/litellm/realtime_api/README.md
@@ -1,1 +1,9 @@
-Abstraction / Routing logic for OpenAI's `/v1/realtime` endpoint.
+Abstraction / Routing logic for OpenAI's `/v1/realtime` endpoints.
+
+Supported endpoints:
+- WebSocket: `/v1/realtime` (with `intent=transcription` for transcription-only sessions)
+- HTTP: `/v1/realtime/client_secrets`, `/v1/realtime/transcription_sessions`
+
+Supported providers: OpenAI, Azure OpenAI, Bedrock, Vertex AI, xAI.
+
+For user-facing documentation and usage examples, see the litellm-docs repo.

--- a/litellm/realtime_api/main.py
+++ b/litellm/realtime_api/main.py
@@ -15,6 +15,7 @@ from litellm.types.realtime import (
     RealtimeExpiresAfter,
     RealtimeQueryParams,
     RealtimeSessionConfig,
+    RealtimeTranscriptionSessionRequest,
 )
 from litellm.types.router import GenericLiteLLMParams
 from litellm.types.utils import LlmProviders
@@ -160,6 +161,78 @@ async def acreate_realtime_client_secret(
 
 
 @wrapper_client
+async def acreate_realtime_transcription_session(
+    model: Optional[str] = None,
+    transcription_session: Optional[Dict[str, Any]] = None,
+    timeout: Optional[float] = None,
+    **kwargs,
+):
+    """
+    Create an ephemeral transcription session via POST
+    /v1/realtime/transcription_sessions.
+
+    ``transcription_session`` is the upstream request body (input_audio_format,
+    input_audio_transcription, turn_detection, …). ``model`` is a LiteLLM-only
+    routing hint; the provider model lives in
+    ``transcription_session.input_audio_transcription.model``.
+    """
+    req = RealtimeTranscriptionSessionRequest(
+        model=model,
+        **(transcription_session or {}),
+    )
+    model_name = req.resolved_model() or "gpt-realtime-whisper"
+    litellm_logging_obj: LiteLLMLogging = kwargs.get("litellm_logging_obj")  # type: ignore
+    litellm_params = GenericLiteLLMParams(**kwargs)
+
+    (
+        model_name,
+        custom_llm_provider,
+        dynamic_api_key,
+        dynamic_api_base,
+    ) = get_llm_provider(
+        model=model_name,
+        api_base=litellm_params.api_base,
+        api_key=litellm_params.api_key,
+    )
+    (
+        provider_config,
+        resolved_api_base,
+        resolved_api_key,
+    ) = _get_realtime_http_provider_config(
+        custom_llm_provider=custom_llm_provider,
+        dynamic_api_base=dynamic_api_base,
+        dynamic_api_key=dynamic_api_key,
+        litellm_params=litellm_params,
+    )
+    litellm_logging_obj.update_from_kwargs(
+        kwargs=kwargs,
+        model=model_name,
+        optional_params={"transcription_session": transcription_session},
+        litellm_params={"api_base": resolved_api_base},
+        custom_llm_provider=custom_llm_provider,
+    )
+    request_data = req.model_dump(exclude_none=True, exclude={"model"})
+    # Ensure the upstream body's input_audio_transcription.model matches the
+    # authorized routing model. This prevents a caller from supplying an allowed
+    # top-level model for auth while sneaking a different model into the nested
+    # transcription config that gets forwarded to the provider.
+    if isinstance(request_data.get("input_audio_transcription"), dict):
+        request_data["input_audio_transcription"]["model"] = model_name
+    return await base_llm_http_handler.async_realtime_transcription_session_handler(
+        api_base=resolved_api_base,
+        api_key=resolved_api_key,
+        request_data=request_data,
+        logging_obj=litellm_logging_obj,
+        timeout=timeout or request_timeout,
+        provider_config=provider_config,
+        model=model_name,
+        extra_headers=kwargs.get("extra_headers"),
+        client=kwargs.get("client"),
+        api_version=litellm_params.api_version,
+    )
+
+
+@wrapper_client
 async def arealtime_calls(
     openai_ephemeral_key: str,
     sdp_body: bytes,
@@ -246,9 +319,13 @@ async def _arealtime(  # noqa: PLR0915
         api_key=api_key,
     )
 
-    # Ensure query params use the normalized provider model (no proxy aliases).
+    # If the client supplied `model` in the URL, ensure it uses the normalized
+    # provider model (no proxy aliases). If they omitted it, preserve that shape
+    # for transcription-only sessions like OpenAI's `?intent=transcription`.
     if query_params is not None:
-        query_params = {**query_params, "model": model}
+        query_params = {**query_params}
+        if "model" in query_params:
+            query_params["model"] = model
 
     litellm_logging_obj.update_from_kwargs(
         kwargs=kwargs,
@@ -278,6 +355,7 @@ async def _arealtime(  # noqa: PLR0915
             headers=headers,
             user_api_key_dict=kwargs.get("user_api_key_dict"),
             litellm_metadata=_build_litellm_metadata(kwargs),
+            query_params=query_params,
         )
     elif _custom_llm_provider == "azure":
         api_base = (
@@ -300,8 +378,13 @@ async def _arealtime(  # noqa: PLR0915
             kwargs.get("realtime_protocol")
             or litellm_params.get("realtime_protocol")
             or os.environ.get("LITELLM_AZURE_REALTIME_PROTOCOL")
-            or "beta"
         )
+        if (
+            realtime_protocol is None
+            and (query_params or {}).get("intent") == "transcription"
+        ):
+            realtime_protocol = "GA"
+        realtime_protocol = realtime_protocol or "beta"
         await azure_realtime.async_realtime(
             model=model,
             websocket=websocket,
@@ -313,6 +396,7 @@ async def _arealtime(  # noqa: PLR0915
             timeout=timeout,
             logging_obj=litellm_logging_obj,
             realtime_protocol=realtime_protocol,
+            query_params=query_params,
             user_api_key_dict=kwargs.get("user_api_key_dict"),
             litellm_metadata=_build_litellm_metadata(kwargs),
         )
@@ -450,6 +534,7 @@ async def _arealtime(  # noqa: PLR0915
             headers=headers,
             user_api_key_dict=kwargs.get("user_api_key_dict"),
             litellm_metadata=_build_litellm_metadata(kwargs),
+            query_params=query_params,
         )
     else:
         raise ValueError(f"Unsupported model: {model}")

--- a/litellm/types/realtime.py
+++ b/litellm/types/realtime.py
@@ -115,3 +115,40 @@ class RealtimeClientSecretResponse(BaseModel):
     expires_at: Optional[int] = None
     value: str
     session: Optional[Dict[str, Any]] = None
+
+
+class RealtimeTranscriptionSessionRequest(BaseModel):
+    """
+    Request body for POST /v1/realtime/transcription_sessions.
+
+    Mirrors OpenAI's RealtimeTranscriptionSessionCreateRequest. The model used
+    for routing is taken from the LiteLLM-only top-level `model` hint, falling
+    back to `input_audio_transcription.model`. All other fields pass through
+    unchanged to the provider.
+    """
+
+    model_config = {"extra": "allow"}
+
+    # LiteLLM-only routing hint — stripped before forwarding upstream.
+    model: Optional[str] = None
+    input_audio_transcription: Optional[Dict[str, Any]] = None
+
+    def resolved_model(self) -> Optional[str]:
+        if self.model:
+            return self.model
+        if self.input_audio_transcription:
+            return self.input_audio_transcription.get("model")
+        return None
+
+
+class RealtimeTranscriptionSessionResponse(BaseModel):
+    """
+    Response from POST /v1/realtime/transcription_sessions.
+
+    `client_secret.value` contains the encrypted token instead of the raw
+    ephemeral key. Unknown fields pass through unchanged.
+    """
+
+    model_config = {"extra": "allow"}
+
+    client_secret: Optional[Dict[str, Any]] = None

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3412,6 +3412,7 @@ class LlmProviders(str, Enum):
     PARASAIL = "parasail"
     XIAOMI_MIMO = "xiaomi_mimo"
     TENSORMESH = "tensormesh"
+    HANZO = "hanzo"
     LITELLM_AGENT = "litellm_agent"
     CURSOR = "cursor"
     BEDROCK_MANTLE = "bedrock_mantle"

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -533,6 +533,7 @@ CallTypesLiteral = Literal[
     "acreate_skill",
     "acreate_realtime_client_secret",
     "arealtime_calls",
+    "acreate_realtime_transcription_session",
 ]
 
 # Mapping of API routes to their corresponding call types

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -42218,6 +42218,33 @@
     "supported_endpoints": ["/v1/audio/transcriptions"],
     "supports_audio_input": true
   },
+  "hanzo/zen4": {
+    "litellm_provider": "hanzo",
+    "mode": "chat",
+    "input_cost_per_token": 1.5e-06,
+    "output_cost_per_token": 4.5e-06,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 8192,
+    "supports_function_calling": true,
+    "supports_tool_choice": true,
+    "supports_response_schema": true,
+    "supports_system_messages": true,
+    "source": "https://api.hanzo.ai/v1/models"
+  },
+  "hanzo/zen4-max": {
+    "litellm_provider": "hanzo",
+    "mode": "chat",
+    "input_cost_per_token": 3e-06,
+    "output_cost_per_token": 1.2e-05,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 16384,
+    "supports_function_calling": true,
+    "supports_tool_choice": true,
+    "supports_response_schema": true,
+    "supports_system_messages": true,
+    "supports_reasoning": true,
+    "source": "https://api.hanzo.ai/v1/models"
+  },
   "tensormesh/Qwen/Qwen3.5-397B-A17B-FP8": {
     "litellm_provider": "tensormesh",
     "mode": "chat",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -4409,6 +4409,23 @@
             "/v1/audio/transcriptions"
         ]
     },
+    "azure/gpt-realtime-whisper": {
+        "input_cost_per_second": 0.0002833333333333333,
+        "litellm_provider": "azure",
+        "mode": "audio_transcription",
+        "source": "https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/gpt-realtime-whisper",
+        "supported_endpoints": [
+            "/v1/realtime",
+            "/v1/realtime/transcription_sessions"
+        ],
+        "supported_modalities": [
+            "audio"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_audio_input": true
+    },
     "azure/gpt-5.1-2025-11-13": {
         "cache_read_input_token_cost": 1.25e-07,
         "cache_read_input_token_cost_priority": 2.5e-07,
@@ -40955,6 +40972,23 @@
         "supports_parallel_function_calling": true,
         "supports_system_messages": true,
         "supports_tool_choice": true
+    },
+    "gpt-realtime-whisper": {
+        "input_cost_per_second": 0.0002833333333333333,
+        "litellm_provider": "openai",
+        "mode": "audio_transcription",
+        "source": "https://platform.openai.com/docs/models/gpt-realtime-whisper",
+        "supported_endpoints": [
+            "/v1/realtime",
+            "/v1/realtime/transcription_sessions"
+        ],
+        "supported_modalities": [
+            "audio"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_audio_input": true
     },
     "sora-2": {
         "litellm_provider": "openai",

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -1182,6 +1182,23 @@
         "interactions": true
       }
     },
+    "hanzo": {
+      "display_name": "Hanzo (`hanzo`)",
+      "url": "https://docs.litellm.ai/docs/providers/hanzo",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": false,
+        "responses": false,
+        "embeddings": false,
+        "image_generations": false,
+        "audio_transcriptions": false,
+        "audio_speech": false,
+        "moderations": false,
+        "batches": false,
+        "rerank": false,
+        "a2a": false
+      }
+    },
     "heroku": {
       "display_name": "Heroku (`heroku`)",
       "url": "https://docs.litellm.ai/docs/providers/heroku",

--- a/tests/llm_translation/realtime/test_openai_realtime.py
+++ b/tests/llm_translation/realtime/test_openai_realtime.py
@@ -393,3 +393,38 @@ async def test_realtime_query_params_use_normalized_model_name(monkeypatch):
     called_kwargs = mock_async_realtime.call_args.kwargs
     assert called_kwargs["query_params"]["model"] == "gpt-4o-realtime-preview"
     assert called_kwargs["query_params"]["intent"] == "chat"
+
+
+@pytest.mark.asyncio
+async def test_realtime_query_params_preserve_missing_model(monkeypatch):
+    """
+    OpenAI-compatible transcription clients can connect with only
+    ?intent=transcription and send the model in session.update. Do not add
+    model= back into the upstream query params when the client omitted it.
+    """
+    from litellm.realtime_api import main as realtime_main
+
+    mock_async_realtime = AsyncMock()
+    monkeypatch.setattr(
+        realtime_main,
+        "openai_realtime",
+        MagicMock(async_realtime=mock_async_realtime),
+    )
+
+    def fake_get_llm_provider(model, api_base=None, api_key=None):
+        return ("gpt-realtime-whisper", "openai", None, None)
+
+    monkeypatch.setattr(realtime_main, "get_llm_provider", fake_get_llm_provider)
+
+    query_params: RealtimeQueryParams = {"intent": "transcription"}
+
+    await realtime_main._arealtime(
+        model="gpt-realtime-whisper",
+        websocket=MagicMock(),
+        api_key="sk-test",
+        query_params=query_params,
+        litellm_logging_obj=MagicMock(),
+    )
+
+    called_kwargs = mock_async_realtime.call_args.kwargs
+    assert called_kwargs["query_params"] == {"intent": "transcription"}

--- a/tests/proxy_unit_tests/test_realtime_cache.py
+++ b/tests/proxy_unit_tests/test_realtime_cache.py
@@ -44,10 +44,14 @@ def test_realtime_query_params_template_caches_each_pair_separately():
     params_with_intent_first = _realtime_query_params_template("gpt-4o", "intent-a")
     params_with_intent_second = _realtime_query_params_template("gpt-4o", "intent-a")
     params_without_intent = _realtime_query_params_template("gpt-4o", None)
+    params_transcription_without_model = _realtime_query_params_template(
+        None, "transcription"
+    )
 
     assert params_with_intent_first is params_with_intent_second
     assert params_with_intent_first == (("model", "gpt-4o"), ("intent", "intent-a"))
     assert params_without_intent == (("model", "gpt-4o"),)
+    assert params_transcription_without_model == (("intent", "transcription"),)
     assert params_with_intent_first is not params_without_intent
 
 

--- a/tests/test_litellm/integrations/focus/test_mavvrik_destination.py
+++ b/tests/test_litellm/integrations/focus/test_mavvrik_destination.py
@@ -1,0 +1,751 @@
+"""Tests for FocusMavvrikDestination."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from litellm.integrations.focus.destinations.base import FocusTimeWindow
+from litellm.integrations.focus.destinations.mavvrik_destination import (
+    FocusMavvrikDestination,
+    _validate_api_endpoint,
+)
+
+VALID_ENDPOINT = "https://api.mavvrik.ai/tenant123"
+
+
+def _make_window() -> FocusTimeWindow:
+    return FocusTimeWindow(
+        start_time=datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+        end_time=datetime(2026, 1, 2, 0, 0, 0, tzinfo=timezone.utc),
+        frequency="daily",
+    )
+
+
+def _dest(**overrides) -> FocusMavvrikDestination:
+    config = {
+        "api_key": "test-key",
+        "api_endpoint": VALID_ENDPOINT,
+        "connection_id": "conn-123",
+    }
+    config.update(overrides)
+    return FocusMavvrikDestination(prefix="mavvrik_focus_exports", config=config)
+
+
+def test_missing_api_key_raises():
+    with pytest.raises(ValueError, match="MAVVRIK_API_KEY"):
+        FocusMavvrikDestination(
+            prefix="p",
+            config={"api_endpoint": VALID_ENDPOINT, "connection_id": "c"},
+        )
+
+
+def test_missing_api_endpoint_raises():
+    with pytest.raises(ValueError, match="MAVVRIK_API_ENDPOINT"):
+        FocusMavvrikDestination(
+            prefix="p",
+            config={"api_key": "k", "connection_id": "c"},
+        )
+
+
+def test_missing_connection_id_raises():
+    with pytest.raises(ValueError, match="MAVVRIK_CONNECTION_ID"):
+        FocusMavvrikDestination(
+            prefix="p",
+            config={"api_key": "k", "api_endpoint": VALID_ENDPOINT},
+        )
+
+
+def test_non_https_endpoint_raises():
+    with pytest.raises(ValueError, match="HTTPS"):
+        _validate_api_endpoint("http://api.mavvrik.ai/tenant")
+
+
+def test_non_mavvrik_domain_raises():
+    with pytest.raises(ValueError, match="Mavvrik domain"):
+        _validate_api_endpoint("https://evil.com/tenant")
+
+
+def test_valid_mavvrik_domains_accepted():
+    for domain in (
+        "https://api.mavvrik.ai/tenant",
+        "https://api.mavvrik.dev/tenant",
+        "https://api.mavvrik.app/tenant",
+    ):
+        _validate_api_endpoint(domain)  # must not raise
+
+
+def test_initializes_with_not_registered():
+    dest = _dest()
+    assert dest._registered is False
+
+
+@pytest.mark.asyncio
+async def test_deliver_skips_empty_content():
+    dest = _dest()
+    await dest.deliver(content=b"", time_window=_make_window(), filename="usage.csv")
+    # _registered still False — _ensure_registered was never called
+    assert dest._registered is False
+
+
+@pytest.mark.asyncio
+async def test_large_content_uploads_in_multiple_chunks():
+    """Content larger than _GCS_CHUNK_SIZE must be uploaded in multiple chunks.
+
+    GCS assembles intermediate chunks (308) + final chunk (200) into one object.
+    The destination must send Content-Range headers for each chunk correctly.
+    """
+    from litellm.integrations.focus.destinations.mavvrik_destination import (
+        FocusMavvrikDestination,
+        _GCS_CHUNK_SIZE,
+    )
+
+    dest = FocusMavvrikDestination(
+        prefix="p",
+        config={"api_key": "k", "api_endpoint": VALID_ENDPOINT, "connection_id": "c"},
+    )
+
+    register_resp = MagicMock()
+    register_resp.status_code = 200
+
+    signed_url_resp = MagicMock()
+    signed_url_resp.status_code = 200
+    signed_url_resp.json.return_value = {
+        "url": "https://storage.googleapis.com/upload?sig=x"
+    }
+
+    init_resp = MagicMock()
+    init_resp.status_code = 200
+    init_resp.headers = {"Location": "https://storage.googleapis.com/session"}
+
+    # First chunk → 308, second (final) chunk → 200
+    chunk1_resp = MagicMock()
+    chunk1_resp.status_code = 308
+
+    chunk2_resp = MagicMock()
+    chunk2_resp.status_code = 200
+
+    mock_http = MagicMock()
+    mock_http.client = MagicMock()
+    mock_http.client.request = AsyncMock(
+        side_effect=[
+            register_resp,
+            signed_url_resp,
+            init_resp,
+            chunk1_resp,
+            chunk2_resp,
+        ]
+    )
+    dest._http = mock_http
+
+    # Build content that when gzipped exceeds one chunk.
+    # Use incompressible random-ish bytes to ensure gzip doesn't shrink it below the chunk size.
+    import os as _os
+
+    raw = b"col1,col2\n" + _os.urandom(_GCS_CHUNK_SIZE + 1024)
+
+    await dest.deliver(
+        content=raw,
+        time_window=_make_window(),
+        filename="usage.csv",
+    )
+
+    # register + get_signed_url + init + 2 chunk PUTs = 5 calls
+    assert mock_http.client.request.call_count == 5
+
+    # Check Content-Range headers
+    put_calls = mock_http.client.request.call_args_list[3:]
+    assert "bytes" in put_calls[0].kwargs["headers"]["Content-Range"]
+    assert "/*" in put_calls[0].kwargs["headers"]["Content-Range"]  # intermediate
+    assert "/*" not in put_calls[1].kwargs["headers"]["Content-Range"]  # final
+
+
+@pytest.mark.asyncio
+async def test_deliver_calls_register_get_url_and_upload():
+    dest = _dest()
+
+    register_resp = MagicMock()
+    register_resp.status_code = 200
+
+    signed_url_resp = MagicMock()
+    signed_url_resp.status_code = 200
+    signed_url_resp.json.return_value = {"url": "https://storage.googleapis.com/signed"}
+
+    init_resp = MagicMock()
+    init_resp.status_code = 200
+    init_resp.headers = {"Location": "https://storage.googleapis.com/session-uri"}
+
+    upload_resp = MagicMock()
+    upload_resp.status_code = 200
+
+    mock_http = MagicMock()
+    mock_http.client = MagicMock()
+    # All 4 calls go through self._http.client.request:
+    # 1. register, 2. get_signed_url, 3. GCS session init POST, 4. GCS PUT
+    mock_http.client.request = AsyncMock(
+        side_effect=[register_resp, signed_url_resp, init_resp, upload_resp]
+    )
+    dest._http = mock_http
+
+    await dest.deliver(
+        content=b"header\nrow1\n",
+        time_window=_make_window(),
+        filename="usage.csv",
+    )
+
+    assert dest._registered is True
+    assert mock_http.client.request.call_count == 4
+    # Verify Content-Range header was set on the PUT
+    put_call = mock_http.client.request.call_args_list[3]
+    assert "Content-Range" in put_call.kwargs["headers"]
+
+
+@pytest.mark.asyncio
+async def test_register_called_only_once_across_multiple_deliveries():
+    dest = _dest()
+
+    register_resp = MagicMock()
+    register_resp.status_code = 200
+
+    def _signed_url_resp():
+        r = MagicMock()
+        r.status_code = 200
+        r.json.return_value = {"url": "https://storage.googleapis.com/signed"}
+        return r
+
+    init_resp = MagicMock()
+    init_resp.status_code = 200
+    init_resp.headers = {"Location": "https://storage.googleapis.com/session-uri"}
+
+    upload_resp = MagicMock()
+    upload_resp.status_code = 200
+
+    mock_http = MagicMock()
+    mock_http.client = MagicMock()
+    # First delivery:  register, get_signed_url, GCS init, GCS PUT
+    # Second delivery: get_signed_url, GCS init, GCS PUT  (register skipped)
+    mock_http.client.request = AsyncMock(
+        side_effect=[
+            register_resp,
+            _signed_url_resp(),
+            init_resp,
+            upload_resp,
+            _signed_url_resp(),
+            init_resp,
+            upload_resp,
+        ]
+    )
+    dest._http = mock_http
+
+    window = _make_window()
+    await dest.deliver(content=b"header\nrow1\n", time_window=window, filename="1.csv")
+    await dest.deliver(content=b"header\nrow2\n", time_window=window, filename="2.csv")
+
+    # 7 total: register(1) + [get_url+init+put](2) × 2 deliveries
+    assert mock_http.client.request.call_count == 7
+    # First call was register
+    first_call = mock_http.client.request.call_args_list[0]
+    assert first_call.kwargs["method"] == "POST"
+    assert "/upload-url" not in first_call.kwargs["url"]
+
+
+@pytest.mark.asyncio
+async def test_deliver_raises_on_register_failure():
+    dest = _dest()
+
+    fail_resp = MagicMock()
+    fail_resp.status_code = 403
+    fail_resp.text = "Forbidden"
+
+    mock_http = MagicMock()
+    mock_http.client = MagicMock()
+    mock_http.client.request = AsyncMock(return_value=fail_resp)
+    dest._http = mock_http
+
+    with pytest.raises(RuntimeError, match="register failed"):
+        await dest.deliver(
+            content=b"data",
+            time_window=_make_window(),
+            filename="usage.csv",
+        )
+
+
+@pytest.mark.asyncio
+async def test_deliver_raises_on_signed_url_api_error():
+    """_get_signed_url must raise RuntimeError when the API returns a 4xx."""
+    dest = _dest()
+
+    register_resp = MagicMock()
+    register_resp.status_code = 200
+
+    fail_resp = MagicMock()
+    fail_resp.status_code = 500
+    fail_resp.text = "Internal Server Error"
+
+    mock_http = MagicMock()
+    mock_http.client = MagicMock()
+    mock_http.client.request = AsyncMock(side_effect=[register_resp, fail_resp])
+    dest._http = mock_http
+
+    with pytest.raises(RuntimeError, match="failed to get signed URL"):
+        await dest.deliver(
+            content=b"data",
+            time_window=_make_window(),
+            filename="usage.csv",
+        )
+
+
+@pytest.mark.asyncio
+async def test_deliver_raises_on_missing_signed_url():
+    dest = _dest()
+
+    register_resp = MagicMock()
+    register_resp.status_code = 200
+
+    bad_url_resp = MagicMock()
+    bad_url_resp.status_code = 200
+    bad_url_resp.json.return_value = {}  # no 'url' field
+
+    mock_http = MagicMock()
+    mock_http.client = MagicMock()
+    mock_http.client.request = AsyncMock(side_effect=[register_resp, bad_url_resp])
+    dest._http = mock_http
+
+    with pytest.raises(RuntimeError, match="missing 'url' field"):
+        await dest.deliver(
+            content=b"data",
+            time_window=_make_window(),
+            filename="usage.csv",
+        )
+
+
+@pytest.mark.asyncio
+async def test_deliver_raises_on_non_gcs_signed_url():
+    """Signed URL pointing to a non-GCS host must be rejected before any upload."""
+    from litellm.integrations.focus.destinations.mavvrik_destination import (
+        _validate_gcs_url,
+    )
+
+    with pytest.raises(ValueError, match="GCS endpoint"):
+        _validate_gcs_url("https://evil.com/upload?token=abc", "signed URL")
+
+
+@pytest.mark.asyncio
+async def test_deliver_raises_on_non_gcs_session_uri():
+    """Session URI from Location header pointing to a non-GCS host must be rejected."""
+    dest = _dest()
+
+    register_resp = MagicMock()
+    register_resp.status_code = 200
+
+    signed_url_resp = MagicMock()
+    signed_url_resp.status_code = 200
+    # signed URL is valid GCS
+    signed_url_resp.json.return_value = {
+        "url": "https://storage.googleapis.com/upload?sig=abc"
+    }
+
+    # Location header points to a non-GCS host
+    init_resp = MagicMock()
+    init_resp.status_code = 200
+    init_resp.headers = {"Location": "https://evil.com/session-uri"}
+
+    mock_http = MagicMock()
+    mock_http.client = MagicMock()
+    # register, get_signed_url, GCS session init (returns bad Location)
+    mock_http.client.request = AsyncMock(
+        side_effect=[register_resp, signed_url_resp, init_resp]
+    )
+    dest._http = mock_http
+
+    with pytest.raises(ValueError, match="GCS endpoint"):
+        await dest.deliver(
+            content=b"data",
+            time_window=_make_window(),
+            filename="usage.csv",
+        )
+
+
+def test_factory_creates_mavvrik_destination(monkeypatch):
+    monkeypatch.setenv("MAVVRIK_API_KEY", "k")
+    monkeypatch.setenv("MAVVRIK_API_ENDPOINT", VALID_ENDPOINT)
+    monkeypatch.setenv("MAVVRIK_CONNECTION_ID", "c")
+
+    from litellm.integrations.focus.destinations.factory import FocusDestinationFactory
+
+    dest = FocusDestinationFactory.create(provider="mavvrik", prefix="p")
+
+    assert isinstance(dest, FocusMavvrikDestination)
+    assert dest.api_key == "k"
+    assert dest.connection_id == "c"
+
+
+def test_only_daily_frequency_is_supported():
+    """MavvrikFocusLogger must raise ValueError for non-daily frequencies."""
+    import importlib
+
+    for freq in ("hourly", "interval"):
+
+        def _make(f=freq, monkeypatch=None):
+            import os
+
+            old = os.environ.get("MAVVRIK_FOCUS_FREQUENCY")
+            os.environ["MAVVRIK_FOCUS_FREQUENCY"] = f
+            try:
+                from litellm.integrations.mavvrik_focus import mavvrik_focus_logger
+
+                importlib.reload(mavvrik_focus_logger)
+                with pytest.raises(ValueError, match="Only 'daily' is allowed"):
+                    mavvrik_focus_logger.MavvrikFocusLogger()
+            finally:
+                if old is None:
+                    os.environ.pop("MAVVRIK_FOCUS_FREQUENCY", None)
+                else:
+                    os.environ["MAVVRIK_FOCUS_FREQUENCY"] = old
+
+        _make()
+
+
+def test_max_rows_defaults_to_500k():
+    """MAVVRIK_FOCUS_MAX_ROWS defaults to 500_000 when not set."""
+    from litellm.integrations.mavvrik_focus.mavvrik_focus_logger import (
+        MavvrikFocusLogger,
+    )
+
+    logger = MavvrikFocusLogger()
+    assert logger._max_rows == 500_000
+
+
+def test_max_rows_reads_from_env(monkeypatch):
+    """MAVVRIK_FOCUS_MAX_ROWS env var is respected."""
+    monkeypatch.setenv("MAVVRIK_FOCUS_MAX_ROWS", "100000")
+
+    from litellm.integrations.mavvrik_focus.mavvrik_focus_logger import (
+        MavvrikFocusLogger,
+    )
+
+    logger = MavvrikFocusLogger()
+    assert logger._max_rows == 100_000
+
+
+@pytest.mark.asyncio
+async def test_export_window_passes_max_rows_as_limit(monkeypatch):
+    """_export_window must pass _max_rows as limit to get_usage_data."""
+    monkeypatch.setenv("MAVVRIK_FOCUS_MAX_ROWS", "1000")
+
+    import polars as pl
+    from litellm.integrations.mavvrik_focus.mavvrik_focus_logger import (
+        MavvrikFocusLogger,
+    )
+    from litellm.integrations.focus.destinations.base import FocusTimeWindow
+    from datetime import datetime, timezone
+
+    logger = MavvrikFocusLogger()
+    assert logger._max_rows == 1000
+
+    # Mock the engine internals so _export_window runs through our new code path
+    db_mock = MagicMock()
+    db_mock.get_usage_data = AsyncMock(return_value=pl.DataFrame())  # empty → no upload
+
+    engine_mock = MagicMock()
+    engine_mock._database = db_mock
+    logger._engine = engine_mock
+
+    window = FocusTimeWindow(
+        start_time=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        end_time=datetime(2026, 1, 2, tzinfo=timezone.utc),
+        frequency="daily",
+    )
+    await logger._export_window(window=window, limit=None)
+
+    db_mock.get_usage_data.assert_called_once_with(
+        limit=1000,
+        start_time_utc=window.start_time,
+        end_time_utc=window.end_time,
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_scheduled_export_catches_up_missed_dates():
+    """If metricsMarker is 2 days behind, _run_scheduled_export exports missed dates first."""
+    import polars as pl
+    from datetime import datetime, timedelta, timezone
+    from litellm.integrations.mavvrik_focus.mavvrik_focus_logger import (
+        MavvrikFocusLogger,
+    )
+    from litellm.integrations.focus.destinations.mavvrik_destination import (
+        FocusMavvrikDestination,
+    )
+
+    logger = MavvrikFocusLogger()
+
+    # metricsMarker = 3 days ago → 2 missed dates (day-2 and day-1) + today's run
+    now = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+    yesterday = now - timedelta(days=1)
+    two_days_ago = now - timedelta(days=2)
+    three_days_ago = now - timedelta(days=3)
+
+    marker_ts = int(three_days_ago.timestamp())
+
+    # Mock destination
+    dest_mock = MagicMock(spec=FocusMavvrikDestination)
+    dest_mock.get_metrics_marker = AsyncMock(return_value=marker_ts)
+
+    # Mock engine
+    db_mock = MagicMock()
+    db_mock.get_usage_data = AsyncMock(return_value=pl.DataFrame())
+    engine_mock = MagicMock()
+    engine_mock._database = db_mock
+    engine_mock._destination = dest_mock
+    logger._engine = engine_mock
+
+    await logger._run_scheduled_export()
+
+    # Should have queried DB 3 times: day-2, day-1 (yesterday), and the normal yesterday window
+    # Actually: catch-up covers [three_days_ago+1 .. yesterday) = [two_days_ago, yesterday)
+    # = two_days_ago only (1 missed), then normal yesterday = 2 total calls
+    calls = db_mock.get_usage_data.call_args_list
+    assert len(calls) == 2
+    # First call is the catch-up (two_days_ago)
+    assert calls[0].kwargs["start_time_utc"].date() == two_days_ago.date()
+    # Second call is yesterday's normal daily run
+    assert calls[1].kwargs["start_time_utc"].date() == yesterday.date()
+
+
+@pytest.mark.asyncio
+async def test_run_scheduled_export_no_catchup_when_marker_is_current():
+    """If metricsMarker = yesterday, no catch-up needed — just export yesterday."""
+    import polars as pl
+    from datetime import datetime, timedelta, timezone
+    from litellm.integrations.mavvrik_focus.mavvrik_focus_logger import (
+        MavvrikFocusLogger,
+    )
+    from litellm.integrations.focus.destinations.mavvrik_destination import (
+        FocusMavvrikDestination,
+    )
+
+    logger = MavvrikFocusLogger()
+
+    now = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+    yesterday = now - timedelta(days=1)
+    marker_ts = int(yesterday.timestamp())
+
+    dest_mock = MagicMock(spec=FocusMavvrikDestination)
+    dest_mock.get_metrics_marker = AsyncMock(return_value=marker_ts)
+
+    db_mock = MagicMock()
+    db_mock.get_usage_data = AsyncMock(return_value=pl.DataFrame())
+    engine_mock = MagicMock()
+    engine_mock._database = db_mock
+    engine_mock._destination = dest_mock
+    logger._engine = engine_mock
+
+    await logger._run_scheduled_export()
+
+    # Only one call — yesterday's normal run, no catch-up
+    assert db_mock.get_usage_data.call_count == 1
+    assert (
+        db_mock.get_usage_data.call_args.kwargs["start_time_utc"].date()
+        == yesterday.date()
+    )
+
+
+@pytest.mark.asyncio
+async def test_metrics_marker_always_calls_api():
+    """get_metrics_marker must call the register API every time to get a fresh marker.
+
+    This is the key difference from deliver() — catch-up requires the current
+    metricsMarker on every scheduled run, not just the first one.
+    """
+    dest = _dest()
+
+    register_resp = MagicMock()
+    register_resp.status_code = 200
+    register_resp.json.return_value = {
+        "id": "litellm-conn-123",
+        "metricsMarker": 1749340800,
+    }
+
+    mock_http = MagicMock()
+    mock_http.client = MagicMock()
+    mock_http.client.request = AsyncMock(return_value=register_resp)
+    dest._http = mock_http
+
+    # First call
+    marker = await dest.get_metrics_marker()
+    assert marker == 1749340800
+    assert dest._registered is True
+
+    # Second call — must call API again to get fresh marker (not return None)
+    marker2 = await dest.get_metrics_marker()
+    assert marker2 == 1749340800
+    assert mock_http.client.request.call_count == 2  # API called both times
+
+
+def test_parse_metrics_marker_handles_unix_timestamp():
+    from litellm.integrations.mavvrik_focus.mavvrik_focus_logger import (
+        _parse_metrics_marker,
+    )
+    from datetime import datetime, timezone
+
+    # Use a known date and compute its timestamp to avoid hardcoding
+    known_date = datetime(2026, 6, 9, 0, 0, 0, tzinfo=timezone.utc)
+    ts = int(known_date.timestamp())
+
+    result = _parse_metrics_marker(ts)
+    assert result is not None
+    assert result.date().isoformat() == "2026-06-09"
+    assert result.tzinfo == timezone.utc
+
+
+def test_parse_metrics_marker_handles_iso_date_string():
+    from litellm.integrations.mavvrik_focus.mavvrik_focus_logger import (
+        _parse_metrics_marker,
+    )
+
+    result = _parse_metrics_marker("2026-06-09")
+    assert result is not None
+    assert result.date().isoformat() == "2026-06-09"
+
+
+def test_parse_metrics_marker_handles_iso_datetime_string():
+    from litellm.integrations.mavvrik_focus.mavvrik_focus_logger import (
+        _parse_metrics_marker,
+    )
+
+    result = _parse_metrics_marker("2026-06-09T00:00:00Z")
+    assert result is not None
+    assert result.date().isoformat() == "2026-06-09"
+
+
+def test_parse_metrics_marker_returns_none_for_zero():
+    from litellm.integrations.mavvrik_focus.mavvrik_focus_logger import (
+        _parse_metrics_marker,
+    )
+
+    assert _parse_metrics_marker(0) is None
+    assert _parse_metrics_marker(None) is None
+    assert _parse_metrics_marker("") is None
+
+
+def test_parse_metrics_marker_returns_none_for_garbage():
+    from litellm.integrations.mavvrik_focus.mavvrik_focus_logger import (
+        _parse_metrics_marker,
+    )
+
+    # Should not raise — logs warning and returns None
+    assert _parse_metrics_marker("not-a-date") is None
+
+
+@pytest.mark.asyncio
+async def test_catchup_capped_at_max_catchup_days():
+    """Catch-up must not go further back than _MAX_CATCHUP_DAYS."""
+    import polars as pl
+    from datetime import datetime, timedelta, timezone
+    from litellm.integrations.mavvrik_focus.mavvrik_focus_logger import (
+        MavvrikFocusLogger,
+    )
+    from litellm.integrations.focus.destinations.mavvrik_destination import (
+        FocusMavvrikDestination,
+    )
+
+    logger = MavvrikFocusLogger()
+    max_days = MavvrikFocusLogger._MAX_CATCHUP_DAYS
+
+    now = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+    yesterday = now - timedelta(days=1)
+    # Marker is 30 days ago — well beyond the cap
+    thirty_days_ago = now - timedelta(days=30)
+    marker_ts = int(thirty_days_ago.timestamp())
+
+    dest_mock = MagicMock(spec=FocusMavvrikDestination)
+    dest_mock.get_metrics_marker = AsyncMock(return_value=marker_ts)
+
+    db_mock = MagicMock()
+    db_mock.get_usage_data = AsyncMock(return_value=pl.DataFrame())
+    engine_mock = MagicMock()
+    engine_mock._database = db_mock
+    engine_mock._destination = dest_mock
+    logger._engine = engine_mock
+
+    await logger._run_scheduled_export()
+
+    # Should have queried at most _MAX_CATCHUP_DAYS times
+    # (max_days - 1 catch-up dates + 1 yesterday = max_days total)
+    assert db_mock.get_usage_data.call_count <= max_days
+
+    # First catch-up date must not be earlier than (yesterday - max_days + 1)
+    earliest_allowed = yesterday - timedelta(days=max_days - 1)
+    first_call_start = db_mock.get_usage_data.call_args_list[0].kwargs["start_time_utc"]
+    assert first_call_start.date() >= earliest_allowed.date()
+
+
+@pytest.mark.asyncio
+async def test_register_resets_on_410():
+    """_registered flag must be False after a 410 so next run re-registers."""
+    dest = _dest()
+
+    resp_410 = MagicMock()
+    resp_410.status_code = 410
+    resp_410.text = "Gone"
+
+    mock_http = MagicMock()
+    mock_http.client = MagicMock()
+    mock_http.client.request = AsyncMock(return_value=resp_410)
+    dest._http = mock_http
+    dest._registered = False  # not yet registered — trigger the call
+
+    with pytest.raises(RuntimeError, match="disconnected"):
+        await dest._ensure_registered()
+
+    assert dest._registered is False
+
+
+@pytest.mark.asyncio
+async def test_gcs_session_cancelled_on_chunk_failure():
+    """GCS session must be cancelled (DELETE) when a chunk PUT fails."""
+    dest = _dest()
+
+    register_resp = MagicMock()
+    register_resp.status_code = 200
+
+    signed_url_resp = MagicMock()
+    signed_url_resp.status_code = 200
+    signed_url_resp.json.return_value = {
+        "url": "https://storage.googleapis.com/upload?sig=x"
+    }
+
+    init_resp = MagicMock()
+    init_resp.status_code = 200
+    init_resp.headers = {"Location": "https://storage.googleapis.com/session"}
+
+    # Chunk PUT fails with 500
+    fail_resp = MagicMock()
+    fail_resp.status_code = 500
+    fail_resp.text = "Internal Server Error"
+
+    # DELETE (session cancel)
+    delete_resp = MagicMock()
+    delete_resp.status_code = 200
+
+    mock_http = MagicMock()
+    mock_http.client = MagicMock()
+    mock_http.client.request = AsyncMock(
+        side_effect=[register_resp, signed_url_resp, init_resp, fail_resp, delete_resp]
+    )
+    dest._http = mock_http
+
+    with pytest.raises(RuntimeError, match="GCS chunk upload failed"):
+        await dest.deliver(
+            content=b"header\nrow1\n",
+            time_window=_make_window(),
+            filename="usage.csv",
+        )
+
+    # Verify DELETE was called to cancel the session
+    calls = mock_http.client.request.call_args_list
+    delete_call = calls[4]
+    assert delete_call.kwargs["method"] == "DELETE"
+    assert "storage.googleapis.com/session" in delete_call.kwargs["url"]

--- a/tests/test_litellm/litellm_core_utils/test_realtime_streaming.py
+++ b/tests/test_litellm/litellm_core_utils/test_realtime_streaming.py
@@ -522,6 +522,290 @@ async def test_transcription_captured_in_backend_to_client():
 
 
 @pytest.mark.asyncio
+async def test_transcription_session_captures_usage_and_skips_response_create():
+    """
+    For a transcription-only session (session.type == "transcription", e.g.
+    gpt-realtime-whisper), the completed event's audio-duration usage must be
+    captured for cost and response.create must NOT be sent to the backend.
+    """
+    client_ws = MagicMock()
+    client_ws.send_text = AsyncMock()
+
+    session_created = json.dumps(
+        {
+            "type": "session.created",
+            "session": {
+                "type": "transcription",
+                "audio": {
+                    "input": {"transcription": {"model": "gpt-realtime-whisper"}}
+                },
+            },
+        }
+    ).encode()
+    completed = json.dumps(
+        {
+            "type": "conversation.item.input_audio_transcription.completed",
+            "transcript": "hello world",
+            "item_id": "item_1",
+            "usage": {"type": "duration", "seconds": 12.0},
+        }
+    ).encode()
+
+    backend_ws = MagicMock()
+    backend_ws.recv = AsyncMock(
+        side_effect=[session_created, completed, ConnectionClosed(None, None)]
+    )
+    backend_ws.send = AsyncMock()
+
+    logging_obj = MagicMock()
+    logging_obj.model_call_details = {}
+    logging_obj.async_success_handler = AsyncMock()
+    logging_obj.success_handler = MagicMock()
+
+    streaming = RealTimeStreaming(client_ws, backend_ws, logging_obj)
+    await streaming.backend_to_client_send_messages()
+
+    assert streaming._is_transcription_session is True
+
+    captured = [
+        m
+        for m in streaming.messages
+        if m.get("type") == "conversation.item.input_audio_transcription.completed"
+    ]
+    assert len(captured) == 1, "completed usage event must be captured for cost"
+    assert captured[0]["usage"]["seconds"] == 12.0
+
+    # Transcript still forwarded to the client.
+    client_ws.send_text.assert_any_call(completed.decode())
+
+    # No response.create — transcription sessions have no assistant turn.
+    sent_to_backend = [
+        json.loads(c.args[0]) for c in backend_ws.send.call_args_list if c.args
+    ]
+    assert all(
+        e.get("type") != "response.create" for e in sent_to_backend
+    ), f"transcription session must not trigger response.create, got: {sent_to_backend}"
+
+
+@pytest.mark.asyncio
+async def test_non_transcription_completed_event_still_triggers_response_create():
+    """
+    Regression guard: a normal (non-transcription) session with no guardrails must
+    keep triggering response.create on a completed transcription event.
+    """
+    client_ws = MagicMock()
+    client_ws.send_text = AsyncMock()
+
+    completed = json.dumps(
+        {
+            "type": "conversation.item.input_audio_transcription.completed",
+            "transcript": "hi",
+            "item_id": "item_1",
+        }
+    ).encode()
+
+    backend_ws = MagicMock()
+    backend_ws.recv = AsyncMock(side_effect=[completed, ConnectionClosed(None, None)])
+    backend_ws.send = AsyncMock()
+
+    logging_obj = MagicMock()
+    logging_obj.async_success_handler = AsyncMock()
+    logging_obj.success_handler = MagicMock()
+
+    streaming = RealTimeStreaming(client_ws, backend_ws, logging_obj)
+    await streaming.backend_to_client_send_messages()
+
+    assert streaming._is_transcription_session is False
+    sent_to_backend = [
+        json.loads(c.args[0]) for c in backend_ws.send.call_args_list if c.args
+    ]
+    assert any(e.get("type") == "response.create" for e in sent_to_backend)
+
+
+def test_client_session_update_marks_transcription_session():
+    """A client session.update with type=transcription flags the session."""
+    streaming = RealTimeStreaming(MagicMock(), MagicMock(), MagicMock())
+    assert streaming._is_transcription_session is False
+    streaming._collect_user_input_from_client_event(
+        json.dumps({"type": "session.update", "session": {"type": "transcription"}})
+    )
+    assert streaming._is_transcription_session is True
+
+
+@pytest.mark.asyncio
+async def test_transcription_session_update_enforces_authorized_flat_model():
+    backend_ws = MagicMock()
+    backend_ws.send = AsyncMock()
+    streaming = RealTimeStreaming(
+        MagicMock(),
+        backend_ws,
+        MagicMock(),
+        model="gpt-realtime-whisper",
+        force_transcription_model="gpt-realtime-whisper",
+    )
+
+    await streaming._send_to_backend(
+        json.dumps(
+            {
+                "type": "session.update",
+                "session": {
+                    "type": "transcription",
+                    "input_audio_transcription": {
+                        "model": "restricted-transcription-model",
+                        "language": "en",
+                    },
+                },
+            }
+        )
+    )
+
+    sent = json.loads(backend_ws.send.await_args.args[0])
+    assert sent["session"]["input_audio_transcription"] == {
+        "model": "gpt-realtime-whisper",
+        "language": "en",
+    }
+    assert streaming._is_transcription_session is True
+
+
+@pytest.mark.asyncio
+async def test_transcription_session_update_enforces_authorized_nested_model():
+    backend_ws = MagicMock()
+    backend_ws.send = AsyncMock()
+    streaming = RealTimeStreaming(
+        MagicMock(),
+        backend_ws,
+        MagicMock(),
+        model="gpt-realtime-whisper",
+        force_transcription_model="gpt-realtime-whisper",
+    )
+
+    await streaming._send_to_backend(
+        json.dumps(
+            {
+                "type": "session.update",
+                "session": {
+                    "type": "transcription",
+                    "audio": {
+                        "input": {
+                            "transcription": {
+                                "model": "restricted-transcription-model",
+                                "prompt": "domain words",
+                            },
+                            "format": {"type": "audio/pcm", "rate": 24000},
+                        }
+                    },
+                },
+            }
+        )
+    )
+
+    sent = json.loads(backend_ws.send.await_args.args[0])
+    assert sent["session"]["audio"]["input"]["transcription"] == {
+        "model": "gpt-realtime-whisper",
+        "prompt": "domain words",
+    }
+    assert sent["session"]["audio"]["input"]["format"] == {
+        "type": "audio/pcm",
+        "rate": 24000,
+    }
+    assert streaming._is_transcription_session is True
+
+
+@pytest.mark.asyncio
+async def test_normal_realtime_session_keeps_nested_transcription_model():
+    backend_ws = MagicMock()
+    backend_ws.send = AsyncMock()
+    streaming = RealTimeStreaming(
+        MagicMock(),
+        backend_ws,
+        MagicMock(),
+        model="gpt-4o-realtime-preview",
+    )
+
+    await streaming._send_to_backend(
+        json.dumps(
+            {
+                "type": "session.update",
+                "session": {
+                    "type": "realtime",
+                    "audio": {
+                        "input": {
+                            "transcription": {
+                                "model": "whisper-1",
+                                "language": "en",
+                            }
+                        }
+                    },
+                },
+            }
+        )
+    )
+
+    sent = json.loads(backend_ws.send.await_args.args[0])
+    assert sent["session"]["audio"]["input"]["transcription"] == {
+        "model": "whisper-1",
+        "language": "en",
+    }
+    assert streaming._is_transcription_session is False
+
+
+def test_detect_transcription_session_from_backend_transcription_session_events():
+    """Backend transcription_session.created/updated events flag the session."""
+    streaming = RealTimeStreaming(MagicMock(), MagicMock(), MagicMock())
+    assert streaming._is_transcription_session is False
+    streaming._detect_transcription_session_from_backend(
+        {"type": "transcription_session.created"}
+    )
+    assert streaming._is_transcription_session is True
+
+    streaming2 = RealTimeStreaming(MagicMock(), MagicMock(), MagicMock())
+    streaming2._detect_transcription_session_from_backend(
+        {"type": "transcription_session.updated"}
+    )
+    assert streaming2._is_transcription_session is True
+
+
+def test_detect_transcription_session_from_backend_session_created_with_type():
+    """Backend session.created with type=transcription flags the session."""
+    streaming = RealTimeStreaming(MagicMock(), MagicMock(), MagicMock())
+    streaming._detect_transcription_session_from_backend(
+        {"type": "session.created", "session": {"type": "transcription"}}
+    )
+    assert streaming._is_transcription_session is True
+
+
+def test_detect_transcription_session_from_backend_ignores_non_transcription():
+    """Backend session.created without type=transcription does not flag the session."""
+    streaming = RealTimeStreaming(MagicMock(), MagicMock(), MagicMock())
+    streaming._detect_transcription_session_from_backend(
+        {"type": "session.created", "session": {"model": "gpt-4o-realtime-preview"}}
+    )
+    assert streaming._is_transcription_session is False
+
+
+def test_capture_transcription_usage_deduplicates_when_already_stored():
+    """
+    When the event is already in messages (logged via store_message), it must not
+    be appended a second time by _capture_transcription_usage.
+    """
+    import litellm
+
+    streaming = RealTimeStreaming(MagicMock(), MagicMock(), MagicMock())
+    # Add the event type to the default logged list so _should_store_message returns True.
+    streaming.logged_real_time_event_types = [
+        "conversation.item.input_audio_transcription.completed"
+    ]
+    event = {
+        "type": "conversation.item.input_audio_transcription.completed",
+        "usage": {"type": "duration", "seconds": 5.0},
+    }
+    streaming.store_message(json.dumps(event))
+    initial_count = len(streaming.messages)
+    streaming._capture_transcription_usage(event)
+    assert len(streaming.messages) == initial_count  # no duplicate
+
+
+@pytest.mark.asyncio
 async def test_client_ack_caches_setup_to_prevent_duplicate_session_update_setup():
     websocket = MagicMock()
     backend_ws = MagicMock()

--- a/tests/test_litellm/llms/azure/realtime/test_azure_realtime_handler.py
+++ b/tests/test_litellm/llms/azure/realtime/test_azure_realtime_handler.py
@@ -148,6 +148,103 @@ async def test_construct_url_ga_protocol():
 
 
 @pytest.mark.asyncio
+async def test_construct_url_forwards_transcription_intent_ga():
+    """
+    Transcription sessions connect with intent=transcription. The Azure handler
+    must forward that query param so gpt-realtime-whisper opens a transcription
+    session instead of a normal realtime session.
+    """
+    from litellm.llms.azure.realtime.handler import AzureOpenAIRealtime
+
+    handler = AzureOpenAIRealtime()
+    url = handler._construct_url(
+        api_base="https://my-endpoint.openai.azure.com",
+        model="gpt-realtime-whisper",
+        api_version="2025-04-01-preview",
+        realtime_protocol="GA",
+        query_params={"model": "gpt-realtime-whisper", "intent": "transcription"},
+    )
+
+    assert "/openai/v1/realtime?" in url
+    assert "intent=transcription" in url
+    assert "model=" not in url
+
+
+@pytest.mark.asyncio
+async def test_construct_url_forwards_transcription_intent_ga_without_model_query():
+    """
+    OpenAI-compatible transcription clients may connect with only
+    intent=transcription and send the transcription model in session.update.
+    Preserve that query shape instead of forcing model= into the upstream URL.
+    """
+    from litellm.llms.azure.realtime.handler import AzureOpenAIRealtime
+
+    handler = AzureOpenAIRealtime()
+    url = handler._construct_url(
+        api_base="https://my-endpoint.openai.azure.com",
+        model="gpt-realtime-whisper",
+        api_version="2025-04-01-preview",
+        realtime_protocol="GA",
+        query_params={"intent": "transcription"},
+    )
+
+    assert url == (
+        "wss://my-endpoint.openai.azure.com/openai/v1/realtime"
+        "?intent=transcription"
+    )
+
+
+@pytest.mark.asyncio
+async def test_construct_url_forwards_transcription_intent_beta():
+    from litellm.llms.azure.realtime.handler import AzureOpenAIRealtime
+
+    handler = AzureOpenAIRealtime()
+    url = handler._construct_url(
+        api_base="https://my-endpoint.openai.azure.com",
+        model="whisper-deploy",
+        api_version="2024-10-01-preview",
+        query_params={"intent": "transcription"},
+    )
+
+    assert "/openai/realtime?" in url
+    assert "deployment=whisper-deploy" in url
+    assert "intent=transcription" in url
+
+
+@pytest.mark.asyncio
+async def test_construct_url_encodes_intent_value():
+    """A crafted intent value must be URL-encoded, not injected as raw query params."""
+    from litellm.llms.azure.realtime.handler import AzureOpenAIRealtime
+
+    handler = AzureOpenAIRealtime()
+    url = handler._construct_url(
+        api_base="https://my-endpoint.openai.azure.com",
+        model="gpt-realtime-whisper",
+        api_version="2025-04-01-preview",
+        realtime_protocol="GA",
+        query_params={"intent": "transcription&foo=bar"},
+    )
+    assert "intent=transcription%26foo%3Dbar" in url
+    assert "&foo=bar" not in url
+
+
+@pytest.mark.asyncio
+async def test_construct_url_no_intent_when_absent():
+    """No intent param leaks into the URL when not provided."""
+    from litellm.llms.azure.realtime.handler import AzureOpenAIRealtime
+
+    handler = AzureOpenAIRealtime()
+    url = handler._construct_url(
+        api_base="https://my-endpoint.openai.azure.com",
+        model="gpt-4o-realtime-preview",
+        api_version="2024-10-01-preview",
+        realtime_protocol="GA",
+        query_params={"model": "gpt-4o-realtime-preview"},
+    )
+    assert "intent=" not in url
+
+
+@pytest.mark.asyncio
 async def test_construct_url_v1_protocol():
     """
     Test that realtime_protocol='v1' also uses /openai/v1/realtime.
@@ -366,6 +463,45 @@ async def test_realtime_protocol_from_litellm_params():
     # Simulate config.yaml with realtime_protocol as an extra field
     litellm_params = GenericLiteLLMParams(realtime_protocol="GA")
     assert litellm_params.get("realtime_protocol") == "GA"
+
+
+@pytest.mark.asyncio
+async def test_arealtime_transcription_intent_defaults_to_ga(monkeypatch):
+    """
+    Azure gpt-realtime-whisper transcription connects on the GA /openai/v1/realtime
+    path. If the DB model lacks realtime_protocol, infer GA from intent=transcription.
+    """
+    from litellm.realtime_api import main as realtime_main
+
+    mock_async_realtime = AsyncMock()
+    monkeypatch.setattr(
+        realtime_main,
+        "azure_realtime",
+        MagicMock(async_realtime=mock_async_realtime),
+    )
+
+    def fake_get_llm_provider(model, api_base=None, api_key=None):
+        return (
+            "gpt-realtime-whisper",
+            "azure",
+            "test-key",
+            "https://my-endpoint.openai.azure.com",
+        )
+
+    monkeypatch.setattr(realtime_main, "get_llm_provider", fake_get_llm_provider)
+
+    await realtime_main._arealtime(
+        model="azure/gpt-realtime-whisper",
+        websocket=MagicMock(),
+        api_key="test-key",
+        api_version="2025-04-01-preview",
+        query_params={"intent": "transcription"},
+        litellm_logging_obj=MagicMock(),
+    )
+
+    called_kwargs = mock_async_realtime.call_args.kwargs
+    assert called_kwargs["realtime_protocol"] == "GA"
+    assert called_kwargs["query_params"] == {"intent": "transcription"}
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/llms/openai/realtime/test_transcription_sessions.py
+++ b/tests/test_litellm/llms/openai/realtime/test_transcription_sessions.py
@@ -1,0 +1,226 @@
+"""
+Tests for the Realtime transcription_sessions surface used by gpt-realtime-whisper:
+  - OpenAI / Azure URL construction (POST /v1/realtime/transcription_sessions)
+  - RealtimeTranscriptionSessionRequest model-resolution + passthrough
+  - BaseLLMHTTPHandler.async_realtime_transcription_session_handler targeting
+"""
+
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../../../.."))
+
+from litellm.llms.azure.realtime.http_transformation import AzureRealtimeHTTPConfig
+from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
+from litellm.llms.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
+from litellm.llms.openai.realtime.http_transformation import OpenAIRealtimeHTTPConfig
+from litellm.types.realtime import RealtimeTranscriptionSessionRequest
+
+
+def test_openai_transcription_session_url():
+    cfg = OpenAIRealtimeHTTPConfig()
+    assert (
+        cfg.get_transcription_session_url(
+            api_base="https://api.openai.com", model="gpt-realtime-whisper"
+        )
+        == "https://api.openai.com/v1/realtime/transcription_sessions"
+    )
+
+
+def test_openai_transcription_session_url_strips_trailing_v1():
+    """A /v1 suffix must not be duplicated in the path."""
+    cfg = OpenAIRealtimeHTTPConfig()
+    assert (
+        cfg.get_transcription_session_url(
+            api_base="https://api.openai.com/v1", model="gpt-realtime-whisper"
+        )
+        == "https://api.openai.com/v1/realtime/transcription_sessions"
+    )
+
+
+def test_azure_transcription_session_url_uses_deployment_and_api_version():
+    cfg = AzureRealtimeHTTPConfig()
+    url = cfg.get_transcription_session_url(
+        api_base="https://my.openai.azure.com",
+        model="whisper-deploy",
+        api_version="2025-04-01-preview",
+    )
+    assert (
+        url
+        == "https://my.openai.azure.com/openai/realtime/transcription_sessions?api-version=2025-04-01-preview"
+    )
+
+
+def test_request_resolves_model_returns_none_when_both_absent():
+    req = RealtimeTranscriptionSessionRequest(input_audio_format="pcm16")
+    assert req.resolved_model() is None
+
+    req = RealtimeTranscriptionSessionRequest(
+        model="openai/gpt-realtime-whisper",
+        input_audio_transcription={"model": "gpt-realtime-whisper"},
+    )
+    assert req.resolved_model() == "openai/gpt-realtime-whisper"
+
+
+def test_request_resolves_model_from_input_audio_transcription():
+    req = RealtimeTranscriptionSessionRequest(
+        input_audio_transcription={"model": "gpt-realtime-whisper", "language": "en"},
+    )
+    assert req.resolved_model() == "gpt-realtime-whisper"
+
+
+def test_request_passthrough_excludes_routing_hint():
+    """Unknown fields pass through; the litellm-only `model` hint is not forwarded."""
+    req = RealtimeTranscriptionSessionRequest(
+        model="openai/gpt-realtime-whisper",
+        input_audio_format="pcm16",
+        input_audio_transcription={"model": "gpt-realtime-whisper"},
+        turn_detection=None,
+    )
+    forwarded = req.model_dump(exclude_none=True, exclude={"model"})
+    assert "model" not in forwarded
+    assert forwarded["input_audio_format"] == "pcm16"
+    assert forwarded["input_audio_transcription"] == {"model": "gpt-realtime-whisper"}
+
+
+@pytest.mark.asyncio
+async def test_handler_posts_to_transcription_sessions_url():
+    handler = BaseLLMHTTPHandler()
+
+    mock_response = MagicMock(spec=httpx.Response)
+    mock_client = MagicMock(spec=AsyncHTTPHandler)
+    mock_client.post = AsyncMock(return_value=mock_response)
+
+    logging_obj = MagicMock()
+    logging_obj.pre_call = MagicMock()
+
+    request_body = {"input_audio_transcription": {"model": "gpt-realtime-whisper"}}
+    result = await handler.async_realtime_transcription_session_handler(
+        api_base="https://api.openai.com",
+        api_key="sk-test",
+        request_data=request_body,
+        logging_obj=logging_obj,
+        timeout=10.0,
+        provider_config=OpenAIRealtimeHTTPConfig(),
+        model="gpt-realtime-whisper",
+        client=mock_client,
+    )
+
+    assert result is mock_response
+    _, kwargs = mock_client.post.call_args
+    assert kwargs["url"] == "https://api.openai.com/v1/realtime/transcription_sessions"
+    assert kwargs["json"] == request_body
+    assert kwargs["headers"]["Authorization"] == "Bearer sk-test"
+
+
+@pytest.mark.asyncio
+async def test_client_secret_handler_still_targets_client_secrets_url():
+    """Refactor regression: the client_secrets handler must keep its own URL."""
+    handler = BaseLLMHTTPHandler()
+
+    mock_response = MagicMock(spec=httpx.Response)
+    mock_client = MagicMock(spec=AsyncHTTPHandler)
+    mock_client.post = AsyncMock(return_value=mock_response)
+
+    logging_obj = MagicMock()
+    logging_obj.pre_call = MagicMock()
+
+    await handler.async_realtime_client_secret_handler(
+        api_base="https://api.openai.com",
+        api_key="sk-test",
+        request_data={"session": {"type": "realtime"}},
+        logging_obj=logging_obj,
+        timeout=10.0,
+        provider_config=OpenAIRealtimeHTTPConfig(),
+        model="gpt-4o-realtime-preview",
+        client=mock_client,
+    )
+
+    _, kwargs = mock_client.post.call_args
+    assert kwargs["url"] == "https://api.openai.com/v1/realtime/client_secrets"
+
+
+@pytest.mark.asyncio
+async def test_sdk_fn_routes_openai_transcription_session(monkeypatch):
+    """
+    litellm.acreate_realtime_transcription_session resolves the OpenAI provider
+    from the transcription model and POSTs to the OpenAI transcription_sessions URL.
+    """
+    import litellm
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-unit-test")
+
+    mock_response = MagicMock(spec=httpx.Response)
+    mock_client = MagicMock(spec=AsyncHTTPHandler)
+    mock_client.post = AsyncMock(return_value=mock_response)
+
+    result = await litellm.acreate_realtime_transcription_session(
+        model="openai/gpt-realtime-whisper",
+        transcription_session={
+            "input_audio_format": "pcm16",
+            "input_audio_transcription": {"model": "gpt-realtime-whisper"},
+        },
+        client=mock_client,
+    )
+
+    assert result is mock_response
+    _, kwargs = mock_client.post.call_args
+    assert kwargs["url"].endswith("/v1/realtime/transcription_sessions")
+    # The litellm-only routing hint must not be forwarded upstream.
+    assert "model" not in kwargs["json"]
+    assert kwargs["json"]["input_audio_transcription"] == {
+        "model": "gpt-realtime-whisper"
+    }
+
+
+def test_append_query_params_skips_existing_keys():
+    from litellm.llms.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
+
+    url = "wss://example.com/v1/realtime?model=gpt-4o"
+    result = BaseLLMHTTPHandler._append_query_params(
+        url, {"model": "ignored", "intent": "transcription"}
+    )
+    assert "model=ignored" not in result
+    assert "intent=transcription" in result
+
+
+def test_append_query_params_no_params_returns_unchanged():
+    from litellm.llms.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
+
+    url = "wss://example.com/v1/realtime?model=gpt-4o"
+    assert BaseLLMHTTPHandler._append_query_params(url, None) == url
+    assert BaseLLMHTTPHandler._append_query_params(url, {}) == url
+
+
+def test_append_query_params_encodes_special_chars():
+    from litellm.llms.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
+
+    url = "wss://example.com/v1/realtime"
+    result = BaseLLMHTTPHandler._append_query_params(url, {"intent": "a&b=c"})
+    assert "intent=a%26b%3Dc" in result
+    assert "&b=c" not in result
+
+
+def test_azure_construct_url_encodes_model_and_api_version():
+    """model and api-version must be URL-encoded to prevent query-string injection."""
+    from litellm.llms.azure.realtime.handler import AzureOpenAIRealtime
+
+    h = AzureOpenAIRealtime()
+    url = h._construct_url(
+        "https://x.openai.azure.com",
+        "deploy&evil=1",
+        "2024-10-01-preview",
+    )
+    assert "evil=1" not in url.split("?", 1)[1]
+
+    url_ga = h._construct_url(
+        "https://x.openai.azure.com",
+        "deploy&evil=1",
+        None,
+        realtime_protocol="GA",
+    )
+    assert "evil=1" not in url_ga.split("?", 1)[1]

--- a/tests/test_litellm/llms/openai_like/test_hanzo_provider.py
+++ b/tests/test_litellm/llms/openai_like/test_hanzo_provider.py
@@ -1,0 +1,134 @@
+"""
+Tests for Hanzo provider configuration and integration.
+"""
+
+import pytest
+
+import litellm
+
+HANZO_MODELS = [
+    "hanzo/zen4",
+    "hanzo/zen4-max",
+]
+
+
+class TestHanzoProviderConfig:
+    """Test Hanzo provider configuration"""
+
+    def test_hanzo_in_provider_list(self):
+        """Test that hanzo is in the provider list"""
+        from litellm import LlmProviders
+
+        assert hasattr(LlmProviders, "HANZO")
+        assert LlmProviders.HANZO.value == "hanzo"
+        assert "hanzo" in litellm.provider_list
+
+    def test_hanzo_json_config_exists(self):
+        """Test that hanzo is configured in providers.json"""
+        from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+
+        assert JSONProviderRegistry.exists("hanzo")
+
+        hanzo = JSONProviderRegistry.get("hanzo")
+        assert hanzo is not None
+        assert hanzo.base_url == "https://api.hanzo.ai/v1"
+        assert hanzo.api_key_env == "HANZO_API_KEY"
+        assert hanzo.api_base_env == "HANZO_API_BASE"
+        assert hanzo.param_mappings.get("max_completion_tokens") == "max_tokens"
+
+    def test_hanzo_provider_resolution(self):
+        """Test that provider resolution finds hanzo and the default base URL"""
+        from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+
+        model, provider, api_key, api_base = get_llm_provider(
+            model="hanzo/zen4",
+            custom_llm_provider=None,
+            api_base=None,
+            api_key=None,
+        )
+
+        assert model == "zen4"
+        assert provider == "hanzo"
+        assert api_base == "https://api.hanzo.ai/v1"
+
+    def test_hanzo_api_base_override(self):
+        """Test that an explicit api_base / api_key overrides the default"""
+        from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+
+        model, provider, api_key, api_base = get_llm_provider(
+            model="hanzo/zen4",
+            custom_llm_provider=None,
+            api_base="https://custom.example.com/v1",
+            api_key="sk-test",
+        )
+
+        assert provider == "hanzo"
+        assert api_base == "https://custom.example.com/v1"
+        assert api_key == "sk-test"
+
+    def test_hanzo_router_config(self):
+        """Test that hanzo can be used in Router configuration"""
+        from litellm import Router
+
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "hanzo-chat",
+                    "litellm_params": {
+                        "model": "hanzo/zen4",
+                        "api_key": "test-key",
+                    },
+                }
+            ]
+        )
+
+        assert len(router.model_list) == 1
+        assert router.model_list[0]["model_name"] == "hanzo-chat"
+
+
+class TestHanzoCostMap:
+    """Hanzo Zen models are registered in the cost map so LiteLLM can
+    price requests and unblock tool-calling params on the JSON provider path."""
+
+    @pytest.fixture(autouse=True)
+    def _use_local_model_cost_map(self, monkeypatch):
+        original_model_cost = litellm.model_cost
+        monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+        litellm.model_cost = litellm.get_model_cost_map(url="")
+        litellm.get_model_info.cache_clear()
+        try:
+            yield
+        finally:
+            litellm.model_cost = original_model_cost
+            litellm.get_model_info.cache_clear()
+
+    def test_models_registered_with_capabilities(self):
+        for model in HANZO_MODELS:
+            info = litellm.get_model_info(model)
+            assert info["litellm_provider"] == "hanzo"
+            assert info["mode"] == "chat"
+            assert litellm.supports_function_calling(model) is True, model
+            assert litellm.supports_response_schema(model) is True, model
+            assert litellm.model_cost[model]["supports_tool_choice"] is True, model
+
+    def test_zen4_cost_is_wired(self):
+        prompt_cost, completion_cost = litellm.cost_per_token(
+            model="hanzo/zen4",
+            prompt_tokens=1_000_000,
+            completion_tokens=1_000_000,
+        )
+        assert prompt_cost == pytest.approx(1.5)
+        assert completion_cost == pytest.approx(4.5)
+
+    def test_zen4_max_cost_is_wired(self):
+        prompt_cost, completion_cost = litellm.cost_per_token(
+            model="hanzo/zen4-max",
+            prompt_tokens=1_000_000,
+            completion_tokens=1_000_000,
+        )
+        assert prompt_cost == pytest.approx(3.0)
+        assert completion_cost == pytest.approx(12.0)
+
+    def test_zen4_max_long_context_window(self):
+        info = litellm.get_model_info("hanzo/zen4-max")
+        assert info["max_input_tokens"] == 1_000_000

--- a/tests/test_litellm/llms/parallel_ai/test_parallel_ai_search.py
+++ b/tests/test_litellm/llms/parallel_ai/test_parallel_ai_search.py
@@ -1,0 +1,324 @@
+"""
+Tests for Parallel AI Search API integration (v1 endpoint).
+"""
+
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../../.."))
+
+import litellm
+
+MOCK_V1_RESPONSE = {
+    "search_id": "search_abc123",
+    "session_id": "session_xyz",
+    "results": [
+        {
+            "url": "https://example.com/1",
+            "title": "Test Result 1",
+            "publish_date": "2026-01-15",
+            "excerpts": ["First excerpt.", "Second excerpt."],
+        },
+        {
+            "url": "https://example.com/2",
+            "title": None,
+            "publish_date": None,
+            "excerpts": ["Only excerpt."],
+        },
+    ],
+    "usage": [{"name": "search_advanced", "count": 1}],
+}
+
+
+def _mock_response():
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = MOCK_V1_RESPONSE
+    return mock_response
+
+
+class TestParallelAISearch:
+    @pytest.fixture(autouse=True)
+    def _set_api_key(self, monkeypatch):
+        monkeypatch.setenv("PARALLEL_API_KEY", "test-api-key")
+        monkeypatch.delenv("PARALLEL_AI_API_BASE", raising=False)
+
+    @pytest.mark.asyncio
+    async def test_v1_endpoint_and_headers(self):
+        with patch(
+            "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+            new_callable=AsyncMock,
+        ) as mock_post:
+            mock_post.return_value = _mock_response()
+
+            await litellm.asearch(
+                query="latest developments in AI",
+                search_provider="parallel_ai",
+            )
+
+            call_args = mock_post.call_args
+            assert call_args.kwargs["url"] == "https://api.parallel.ai/v1/search"
+
+            headers = call_args.kwargs.get("headers", {})
+            assert headers["x-api-key"] == "test-api-key"
+            assert headers["Content-Type"] == "application/json"
+            assert "parallel-beta" not in headers
+
+    @pytest.mark.asyncio
+    async def test_string_query_maps_to_search_queries_and_objective(self):
+        with patch(
+            "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+            new_callable=AsyncMock,
+        ) as mock_post:
+            mock_post.return_value = _mock_response()
+
+            await litellm.asearch(
+                query="latest developments in AI",
+                search_provider="parallel_ai",
+            )
+
+            json_data = mock_post.call_args.kwargs.get("json")
+            assert json_data["search_queries"] == ["latest developments in AI"]
+            assert json_data["objective"] == "latest developments in AI"
+
+    @pytest.mark.asyncio
+    async def test_list_query_maps_to_search_queries(self):
+        with patch(
+            "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+            new_callable=AsyncMock,
+        ) as mock_post:
+            mock_post.return_value = _mock_response()
+
+            await litellm.asearch(
+                query=["AI developments", "machine learning trends"],
+                search_provider="parallel_ai",
+            )
+
+            json_data = mock_post.call_args.kwargs.get("json")
+            assert json_data["search_queries"] == [
+                "AI developments",
+                "machine learning trends",
+            ]
+            assert "objective" not in json_data
+
+    @pytest.mark.asyncio
+    async def test_mode_param_passthrough(self):
+        with patch(
+            "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+            new_callable=AsyncMock,
+        ) as mock_post:
+            mock_post.return_value = _mock_response()
+
+            await litellm.asearch(
+                query="AI developments",
+                search_provider="parallel_ai",
+                mode="turbo",
+            )
+
+            json_data = mock_post.call_args.kwargs.get("json")
+            assert json_data["mode"] == "turbo"
+
+    @pytest.mark.asyncio
+    async def test_default_mode_is_basic(self):
+        """v1 defaults to 'advanced' server-side; litellm must send 'basic' to keep v1beta's default tier and cost tracking accurate."""
+        with patch(
+            "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+            new_callable=AsyncMock,
+        ) as mock_post:
+            mock_post.return_value = _mock_response()
+
+            await litellm.asearch(
+                query="AI developments",
+                search_provider="parallel_ai",
+            )
+
+            json_data = mock_post.call_args.kwargs.get("json")
+            assert json_data["mode"] == "basic"
+
+    @pytest.mark.parametrize(
+        "processor,expected_mode", [("base", "basic"), ("pro", "advanced")]
+    )
+    @pytest.mark.asyncio
+    async def test_legacy_processor_maps_to_mode(self, processor, expected_mode):
+        with patch(
+            "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+            new_callable=AsyncMock,
+        ) as mock_post:
+            mock_post.return_value = _mock_response()
+
+            await litellm.asearch(
+                query="AI developments",
+                search_provider="parallel_ai",
+                processor=processor,
+            )
+
+            json_data = mock_post.call_args.kwargs.get("json")
+            assert json_data["mode"] == expected_mode
+            assert "processor" not in json_data
+
+    @pytest.mark.asyncio
+    async def test_explicit_mode_wins_over_processor(self):
+        with patch(
+            "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+            new_callable=AsyncMock,
+        ) as mock_post:
+            mock_post.return_value = _mock_response()
+
+            await litellm.asearch(
+                query="AI developments",
+                search_provider="parallel_ai",
+                mode="turbo",
+                processor="pro",
+            )
+
+            json_data = mock_post.call_args.kwargs.get("json")
+            assert json_data["mode"] == "turbo"
+            assert "processor" not in json_data
+
+    @pytest.mark.asyncio
+    async def test_top_level_v1_params_pass_through(self):
+        with patch(
+            "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+            new_callable=AsyncMock,
+        ) as mock_post:
+            mock_post.return_value = _mock_response()
+
+            await litellm.asearch(
+                query="AI developments",
+                search_provider="parallel_ai",
+                session_id="session_123",
+                max_chars_total=4000,
+                max_tokens_per_page=1024,
+            )
+
+            json_data = mock_post.call_args.kwargs.get("json")
+            assert json_data["session_id"] == "session_123"
+            assert json_data["max_chars_total"] == 4000
+            assert "max_tokens_per_page" not in json_data
+
+    @pytest.mark.asyncio
+    async def test_optional_params_nest_under_advanced_settings(self):
+        with patch(
+            "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+            new_callable=AsyncMock,
+        ) as mock_post:
+            mock_post.return_value = _mock_response()
+
+            await litellm.asearch(
+                query="AI developments",
+                search_provider="parallel_ai",
+                max_results=5,
+                country="US",
+                search_domain_filter=["arxiv.org", "nature.com"],
+                exclude_domains=["reddit.com"],
+                max_chars_per_result=1500,
+            )
+
+            json_data = mock_post.call_args.kwargs.get("json")
+            advanced_settings = json_data["advanced_settings"]
+            assert advanced_settings["max_results"] == 5
+            assert advanced_settings["location"] == "US"
+            assert advanced_settings["source_policy"]["include_domains"] == [
+                "arxiv.org",
+                "nature.com",
+            ]
+            assert advanced_settings["source_policy"]["exclude_domains"] == [
+                "reddit.com"
+            ]
+            assert advanced_settings["excerpt_settings"]["max_chars_per_result"] == 1500
+
+            assert "max_results" not in json_data
+            assert "source_policy" not in json_data
+            assert "search_domain_filter" not in json_data
+            assert "exclude_domains" not in json_data
+            assert "max_chars_per_result" not in json_data
+            assert "country" not in json_data
+
+    @pytest.mark.asyncio
+    async def test_explicit_advanced_settings_take_precedence(self):
+        with patch(
+            "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+            new_callable=AsyncMock,
+        ) as mock_post:
+            mock_post.return_value = _mock_response()
+
+            await litellm.asearch(
+                query="AI developments",
+                search_provider="parallel_ai",
+                max_results=5,
+                advanced_settings={"max_results": 7},
+            )
+
+            json_data = mock_post.call_args.kwargs.get("json")
+            assert json_data["advanced_settings"]["max_results"] == 7
+
+    @pytest.mark.asyncio
+    async def test_response_transformation(self):
+        with patch(
+            "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+            new_callable=AsyncMock,
+        ) as mock_post:
+            mock_post.return_value = _mock_response()
+
+            response = await litellm.asearch(
+                query="AI developments",
+                search_provider="parallel_ai",
+            )
+
+            assert response.object == "search"
+            assert len(response.results) == 2
+
+            first = response.results[0]
+            assert first.title == "Test Result 1"
+            assert first.url == "https://example.com/1"
+            assert first.snippet == "First excerpt. ... Second excerpt."
+            assert first.date == "2026-01-15"
+
+            second = response.results[1]
+            assert second.title == ""
+            assert second.snippet == "Only excerpt."
+            assert second.date is None
+
+    @pytest.mark.parametrize(
+        "api_base",
+        [
+            "https://proxy.internal.example.com",
+            "https://proxy.internal.example.com/",
+            "https://proxy.internal.example.com/v1",
+            "https://proxy.internal.example.com/v1/",
+            "https://proxy.internal.example.com/v1/search",
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_custom_api_base_appends_v1_search(self, api_base):
+        with patch(
+            "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+            new_callable=AsyncMock,
+        ) as mock_post:
+            mock_post.return_value = _mock_response()
+
+            await litellm.asearch(
+                query="AI developments",
+                search_provider="parallel_ai",
+                api_base=api_base,
+            )
+
+            call_args = mock_post.call_args
+            assert (
+                call_args.kwargs["url"]
+                == "https://proxy.internal.example.com/v1/search"
+            )
+
+    @pytest.mark.asyncio
+    async def test_missing_api_key_raises(self, monkeypatch):
+        monkeypatch.delenv("PARALLEL_API_KEY", raising=False)
+        monkeypatch.delenv("PARALLEL_AI_API_KEY", raising=False)
+
+        with pytest.raises(Exception, match="PARALLEL_API_KEY"):
+            await litellm.asearch(
+                query="AI developments",
+                search_provider="parallel_ai",
+            )

--- a/tests/test_litellm/proxy/realtime_endpoints/test_realtime_webrtc_endpoints.py
+++ b/tests/test_litellm/proxy/realtime_endpoints/test_realtime_webrtc_endpoints.py
@@ -241,6 +241,142 @@ async def test_client_secrets_success_with_mock(
         proxy_app.dependency_overrides.pop(user_api_key_auth, None)
 
 
+@pytest.mark.asyncio
+async def test_client_secrets_transcription_rejects_disallowed_nested_model(
+    proxy_app,
+):
+    proxy_app.dependency_overrides[user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_id="test-user",
+        models=["gpt-4o-realtime-preview"],
+    )
+    try:
+        client = TestClient(proxy_app, raise_server_exceptions=False)
+        with (
+            patch("litellm.proxy.proxy_server.route_request") as mock_route_request,
+            patch("litellm.proxy.proxy_server.proxy_logging_obj") as mock_logging,
+        ):
+            mock_logging.post_call_failure_hook = AsyncMock()
+
+            response = client.post(
+                "/v1/realtime/client_secrets",
+                headers={"Authorization": "Bearer sk-test-master-key"},
+                json={
+                    "model": "gpt-4o-realtime-preview",
+                    "session": {
+                        "type": "transcription",
+                        "model": "gpt-4o-realtime-preview",
+                        "audio": {
+                            "input": {
+                                "transcription": {
+                                    "model": "gpt-realtime-whisper"
+                                }
+                            }
+                        },
+                    },
+                },
+            )
+
+        assert response.status_code == 403
+        assert "Tried to access gpt-realtime-whisper" in response.text
+        mock_route_request.assert_not_called()
+    finally:
+        proxy_app.dependency_overrides.pop(user_api_key_auth, None)
+
+
+@pytest.mark.asyncio
+async def test_client_secrets_transcription_routes_on_nested_model(
+    proxy_app,
+    mock_add_litellm_data,
+    mock_pre_call_hook,
+):
+    proxy_app.dependency_overrides[user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_id="test-user",
+        models=["gpt-4o-realtime-preview", "gpt-realtime-whisper"],
+    )
+    captured = {}
+    future_expires_at = int(time.time()) + 3600
+
+    async def _capturing_route(*args, **kwargs):
+        captured["data"] = kwargs.get("data")
+
+        async def _inner():
+            resp = MagicMock(spec=httpx.Response)
+            resp.status_code = 200
+            resp.text = (
+                f'{{"value":"upstream_ephemeral_key","expires_at":{future_expires_at}}}'
+            )
+            resp.content = (
+                f'{{"value":"upstream_ephemeral_key","expires_at":{future_expires_at}}}'
+            ).encode()
+            resp.headers = {}
+            resp.json.return_value = {
+                "value": "upstream_ephemeral_key",
+                "expires_at": future_expires_at,
+            }
+            return resp
+
+        return _inner()
+
+    try:
+        client = TestClient(proxy_app)
+        with (
+            patch(
+                "litellm.proxy.proxy_server.route_request",
+                side_effect=_capturing_route,
+            ),
+            patch(
+                "litellm.proxy.proxy_server.add_litellm_data_to_request",
+                side_effect=mock_add_litellm_data,
+            ),
+            patch("litellm.proxy.proxy_server.proxy_logging_obj") as mock_logging,
+        ):
+            mock_logging.pre_call_hook = AsyncMock(side_effect=mock_pre_call_hook)
+            mock_logging.post_call_failure_hook = AsyncMock()
+
+            response = client.post(
+                "/v1/realtime/client_secrets",
+                headers={"Authorization": "Bearer sk-test-master-key"},
+                json={
+                    "model": "gpt-4o-realtime-preview",
+                    "session": {
+                        "type": "transcription",
+                        "model": "gpt-4o-realtime-preview",
+                        "audio": {
+                            "input": {
+                                "transcription": {
+                                    "model": "gpt-realtime-whisper"
+                                }
+                            }
+                        },
+                    },
+                },
+            )
+
+        assert response.status_code == 200
+        assert captured["data"]["model"] == "gpt-realtime-whisper"
+        session = captured["data"]["session"]
+        assert session["type"] == "transcription"
+        assert "model" not in session
+        assert (
+            session["audio"]["input"]["transcription"]["model"]
+            == "gpt-realtime-whisper"
+        )
+        encrypted_value = response.json()["value"]
+        decoded = _decode_realtime_token_payload(
+            decrypt_value_helper(
+                encrypted_value,
+                key="client_secret.value",
+                exception_type="debug",
+            )
+            or ""
+        )
+        assert decoded is not None
+        assert decoded["model_id"] == "gpt-realtime-whisper"
+        assert decoded["session_type"] == "transcription"
+    finally:
+        proxy_app.dependency_overrides.pop(user_api_key_auth, None)
+
+
 def test_realtime_calls_requires_auth(proxy_app):
     """POST /v1/realtime/calls returns 401 without Authorization.
 
@@ -311,3 +447,547 @@ async def test_realtime_calls_success_with_valid_encrypted_token(
     assert response.status_code == 201
     assert response.content.startswith(b"v=0")
     assert b"application/sdp" in response.headers.get("content-type", "").encode()
+
+
+def test_token_payload_carries_session_type():
+    """The encrypted token records the session kind so /realtime/calls can replay it."""
+    payload = _encode_realtime_token_payload(
+        ephemeral_key="epk",
+        model_id="gpt-realtime-whisper",
+        user_id=None,
+        team_id=None,
+        expires_at=None,
+        session_type="transcription",
+    )
+    decoded = _decode_realtime_token_payload(payload)
+    assert decoded is not None
+    assert decoded["session_type"] == "transcription"
+
+
+@pytest.mark.asyncio
+async def test_realtime_calls_replays_transcription_session_type(
+    proxy_app,
+    mock_add_litellm_data,
+    mock_pre_call_hook,
+):
+    """
+    A token minted for a transcription session must drive /realtime/calls to send
+    session.type == "transcription" upstream, not the default "realtime".
+    """
+    captured = {}
+
+    async def _capturing_route(*args, **kwargs):
+        captured["session"] = kwargs.get("data", {}).get("session")
+
+        async def _inner():
+            resp = MagicMock(spec=httpx.Response)
+            resp.status_code = 201
+            resp.content = b"v=0\r\n"
+            resp.headers = {"content-type": "application/sdp"}
+            return resp
+
+        return _inner()
+
+    token_payload = _encode_realtime_token_payload(
+        ephemeral_key="epk",
+        model_id="gpt-realtime-whisper",
+        user_id=None,
+        team_id=None,
+        expires_at=int(time.time()) + 3600,
+        session_type="transcription",
+    )
+    encrypted_token = encrypt_value_helper(token_payload)
+
+    client = TestClient(proxy_app)
+    with (
+        patch(
+            "litellm.proxy.proxy_server.route_request",
+            side_effect=_capturing_route,
+        ),
+        patch(
+            "litellm.proxy.proxy_server.add_litellm_data_to_request",
+            side_effect=mock_add_litellm_data,
+        ),
+        patch("litellm.proxy.proxy_server.proxy_logging_obj") as mock_logging,
+    ):
+        mock_logging.pre_call_hook = AsyncMock(side_effect=mock_pre_call_hook)
+        mock_logging.post_call_failure_hook = AsyncMock()
+
+        client.post(
+            "/v1/realtime/calls",
+            headers={"Authorization": f"Bearer {encrypted_token}"},
+            content=b"v=0\r\n",
+        )
+
+    assert captured["session"]["type"] == "transcription"
+    assert (
+        captured["session"]["audio"]["input"]["transcription"]["model"]
+        == "gpt-realtime-whisper"
+    )
+
+
+# --- transcription_sessions endpoint ---
+
+
+@pytest.fixture
+def mock_route_request_transcription_sessions():
+    """Mock route_request to return a fake transcription_sessions upstream response."""
+    future_expires_at = int(time.time()) + 3600
+    body = {
+        "id": "sess_abc",
+        "object": "realtime.transcription_session",
+        "client_secret": {
+            "value": "upstream_ephemeral_key",
+            "expires_at": future_expires_at,
+        },
+    }
+    mock_resp = MagicMock(spec=httpx.Response)
+    mock_resp.status_code = 200
+    mock_resp.text = json.dumps(body)
+    mock_resp.content = json.dumps(body).encode()
+    mock_resp.headers = {}
+    mock_resp.json.return_value = body
+
+    async def _mock_route(*args, **kwargs):
+        async def _inner():
+            return mock_resp
+
+        return _inner()
+
+    return _mock_route
+
+
+def test_transcription_sessions_requires_auth(proxy_app):
+    """POST /v1/realtime/transcription_sessions returns 401 without Authorization."""
+    from fastapi import HTTPException
+
+    def _raise_401():
+        raise HTTPException(status_code=401, detail="Unauthorized")
+
+    proxy_app.dependency_overrides[user_api_key_auth] = _raise_401
+    try:
+        client = TestClient(proxy_app, raise_server_exceptions=False)
+        response = client.post(
+            "/v1/realtime/transcription_sessions",
+            json={"input_audio_transcription": {"model": "gpt-realtime-whisper"}},
+        )
+        assert response.status_code == 401
+    finally:
+        proxy_app.dependency_overrides.pop(user_api_key_auth, None)
+
+
+@pytest.mark.asyncio
+async def test_transcription_sessions_rejects_disallowed_resolved_model(
+    proxy_app,
+):
+    proxy_app.dependency_overrides[user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_id="test-user",
+        models=["gpt-4o-realtime-preview"],
+    )
+    try:
+        client = TestClient(proxy_app, raise_server_exceptions=False)
+        with (
+            patch("litellm.proxy.proxy_server.route_request") as mock_route_request,
+            patch("litellm.proxy.proxy_server.proxy_logging_obj") as mock_logging,
+        ):
+            mock_logging.post_call_failure_hook = AsyncMock()
+
+            response = client.post(
+                "/v1/realtime/transcription_sessions",
+                headers={"Authorization": "Bearer sk-test-master-key"},
+                json={
+                    "input_audio_transcription": {"model": "gpt-realtime-whisper"}
+                },
+            )
+
+        assert response.status_code == 403
+        assert "Tried to access gpt-realtime-whisper" in response.text
+        mock_route_request.assert_not_called()
+    finally:
+        proxy_app.dependency_overrides.pop(user_api_key_auth, None)
+
+
+@pytest.mark.asyncio
+async def test_transcription_sessions_rejects_disallowed_team_model_scope(
+    proxy_app,
+):
+    from litellm.proxy._types import LiteLLM_TeamTableCachedObj
+
+    team = LiteLLM_TeamTableCachedObj(
+        team_id="team-a",
+        models=["gpt-4o-realtime-preview"],
+    )
+    proxy_app.dependency_overrides[user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_id="test-user",
+        team_id="team-a",
+        models=["*"],
+    )
+    try:
+        client = TestClient(proxy_app, raise_server_exceptions=False)
+        with (
+            patch("litellm.proxy.proxy_server.route_request") as mock_route_request,
+            patch("litellm.proxy.proxy_server.proxy_logging_obj") as mock_logging,
+            patch(
+                "litellm.proxy.auth.auth_checks.get_team_object",
+                new=AsyncMock(return_value=team),
+            ),
+            patch(
+                "litellm.proxy.auth.auth_checks.get_team_membership",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            mock_logging.post_call_failure_hook = AsyncMock()
+
+            response = client.post(
+                "/v1/realtime/transcription_sessions",
+                headers={"Authorization": "Bearer sk-test-master-key"},
+                json={
+                    "input_audio_transcription": {"model": "gpt-realtime-whisper"}
+                },
+            )
+
+        assert response.status_code == 403
+        assert "team" in response.text.lower()
+        assert "Tried to access gpt-realtime-whisper" in response.text
+        mock_route_request.assert_not_called()
+    finally:
+        proxy_app.dependency_overrides.pop(user_api_key_auth, None)
+
+
+@pytest.mark.asyncio
+async def test_transcription_sessions_rejects_disallowed_project_model_scope(
+    proxy_app,
+):
+    from litellm.proxy._types import LiteLLM_ProjectTableCachedObj
+
+    project = LiteLLM_ProjectTableCachedObj(
+        project_id="project-a",
+        models=["gpt-4o-realtime-preview"],
+        created_by="test-user",
+        updated_by="test-user",
+    )
+    proxy_app.dependency_overrides[user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_id="test-user",
+        project_id="project-a",
+        models=["*"],
+    )
+    try:
+        client = TestClient(proxy_app, raise_server_exceptions=False)
+        with (
+            patch("litellm.proxy.proxy_server.route_request") as mock_route_request,
+            patch("litellm.proxy.proxy_server.proxy_logging_obj") as mock_logging,
+            patch(
+                "litellm.proxy.auth.auth_checks.get_project_object",
+                new=AsyncMock(return_value=project),
+            ),
+        ):
+            mock_logging.post_call_failure_hook = AsyncMock()
+
+            response = client.post(
+                "/v1/realtime/transcription_sessions",
+                headers={"Authorization": "Bearer sk-test-master-key"},
+                json={
+                    "input_audio_transcription": {"model": "gpt-realtime-whisper"}
+                },
+            )
+
+        assert response.status_code == 403
+        assert "project" in response.text.lower()
+        assert "Tried to access gpt-realtime-whisper" in response.text
+        mock_route_request.assert_not_called()
+    finally:
+        proxy_app.dependency_overrides.pop(user_api_key_auth, None)
+
+
+@pytest.mark.asyncio
+async def test_transcription_sessions_rejects_disallowed_team_member_model_scope(
+    proxy_app,
+):
+    from litellm.proxy._types import (
+        LiteLLM_BudgetTable,
+        LiteLLM_TeamMembership,
+        LiteLLM_TeamTableCachedObj,
+    )
+
+    team = LiteLLM_TeamTableCachedObj(team_id="team-a", models=["*"])
+    membership = LiteLLM_TeamMembership(
+        user_id="test-user",
+        team_id="team-a",
+        litellm_budget_table=LiteLLM_BudgetTable(
+            allowed_models=["gpt-4o-realtime-preview"],
+        ),
+    )
+    proxy_app.dependency_overrides[user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_id="test-user",
+        team_id="team-a",
+        models=["*"],
+    )
+    try:
+        client = TestClient(proxy_app, raise_server_exceptions=False)
+        with (
+            patch("litellm.proxy.proxy_server.route_request") as mock_route_request,
+            patch("litellm.proxy.proxy_server.proxy_logging_obj") as mock_logging,
+            patch(
+                "litellm.proxy.auth.auth_checks.get_team_object",
+                new=AsyncMock(return_value=team),
+            ),
+            patch(
+                "litellm.proxy.auth.auth_checks.get_team_membership",
+                new=AsyncMock(return_value=membership),
+            ),
+        ):
+            mock_logging.post_call_failure_hook = AsyncMock()
+
+            response = client.post(
+                "/v1/realtime/transcription_sessions",
+                headers={"Authorization": "Bearer sk-test-master-key"},
+                json={
+                    "input_audio_transcription": {"model": "gpt-realtime-whisper"}
+                },
+            )
+
+        assert response.status_code == 403
+        assert "Team member not allowed to access model" in response.text
+        mock_route_request.assert_not_called()
+    finally:
+        proxy_app.dependency_overrides.pop(user_api_key_auth, None)
+
+
+@pytest.mark.asyncio
+async def test_realtime_transcription_websocket_default_model_checks_key_scope():
+    from litellm.proxy import proxy_server
+
+    websocket = MagicMock()
+    websocket.headers = {}
+    websocket.close = AsyncMock()
+    websocket.accept = AsyncMock()
+
+    await proxy_server.realtime_websocket_endpoint(
+        websocket=websocket,
+        model=None,
+        intent="transcription",
+        user_api_key_dict=UserAPIKeyAuth(models=["gpt-4o-realtime-preview"]),
+    )
+
+    websocket.accept.assert_not_awaited()
+    websocket.close.assert_awaited_once()
+    _, close_kwargs = websocket.close.call_args
+    assert close_kwargs["code"] == 1008
+    assert "not allowed to access model" in close_kwargs["reason"]
+
+
+@pytest.mark.asyncio
+async def test_realtime_transcription_websocket_default_model_checks_team_scope():
+    from litellm.proxy import proxy_server
+    from litellm.proxy._types import LiteLLM_TeamTableCachedObj
+
+    team = LiteLLM_TeamTableCachedObj(
+        team_id="team-a",
+        models=["gpt-4o-realtime-preview"],
+    )
+    websocket = MagicMock()
+    websocket.headers = {}
+    websocket.close = AsyncMock()
+    websocket.accept = AsyncMock()
+
+    with (
+        patch(
+            "litellm.proxy.auth.auth_checks.get_team_object",
+            new=AsyncMock(return_value=team),
+        ),
+        patch(
+            "litellm.proxy.auth.auth_checks.get_team_membership",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        await proxy_server.realtime_websocket_endpoint(
+            websocket=websocket,
+            model=None,
+            intent="transcription",
+            user_api_key_dict=UserAPIKeyAuth(
+                user_id="test-user",
+                team_id="team-a",
+                models=["*"],
+            ),
+        )
+
+    websocket.accept.assert_not_awaited()
+    websocket.close.assert_awaited_once()
+    _, close_kwargs = websocket.close.call_args
+    assert close_kwargs["code"] == 1008
+    assert "not allowed to access model" in close_kwargs["reason"]
+
+
+@pytest.mark.asyncio
+async def test_transcription_sessions_encrypts_client_secret(
+    proxy_app,
+    mock_route_request_transcription_sessions,
+    mock_add_litellm_data,
+    mock_pre_call_hook,
+):
+    """
+    POST /v1/realtime/transcription_sessions returns 200 and the ephemeral key
+    under client_secret.value must be encrypted (never the raw upstream key).
+    """
+    proxy_app.dependency_overrides[user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_id="test-user", team_id="test-team"
+    )
+    captured_route_type = {}
+
+    async def _capturing_route(*args, **kwargs):
+        captured_route_type["route_type"] = kwargs.get("route_type")
+        return await mock_route_request_transcription_sessions(*args, **kwargs)
+
+    try:
+        client = TestClient(proxy_app)
+        with (
+            patch(
+                "litellm.proxy.proxy_server.route_request",
+                side_effect=_capturing_route,
+            ),
+            patch(
+                "litellm.proxy.proxy_server.add_litellm_data_to_request",
+                side_effect=mock_add_litellm_data,
+            ),
+            patch("litellm.proxy.proxy_server.proxy_logging_obj") as mock_logging,
+        ):
+            mock_logging.pre_call_hook = AsyncMock(side_effect=mock_pre_call_hook)
+            mock_logging.post_call_failure_hook = AsyncMock()
+
+            response = client.post(
+                "/v1/realtime/transcription_sessions",
+                headers={"Authorization": "Bearer sk-test-master-key"},
+                json={
+                    "input_audio_format": "pcm16",
+                    "input_audio_transcription": {"model": "gpt-realtime-whisper"},
+                },
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["client_secret"]["value"] != "upstream_ephemeral_key"
+        # The encrypted value must decrypt back to a payload carrying the raw key.
+        decrypted = decrypt_value_helper(
+            data["client_secret"]["value"],
+            key="client_secret.value",
+            exception_type="debug",
+        )
+        assert decrypted is not None
+        assert "upstream_ephemeral_key" in decrypted
+        # Routed through the dedicated transcription_sessions route type.
+        assert (
+            captured_route_type["route_type"]
+            == "acreate_realtime_transcription_session"
+        )
+    finally:
+        proxy_app.dependency_overrides.pop(user_api_key_auth, None)
+
+
+def test_session_type_coerced_for_unknown_value():
+    """An unrecognized session_type in the token falls back to 'realtime'."""
+    payload = _encode_realtime_token_payload(
+        ephemeral_key="epk",
+        model_id="gpt-4o",
+        user_id=None,
+        team_id=None,
+        expires_at=None,
+        session_type="INJECTED_TYPE",
+    )
+    # Force-deserialize and check the coercion that happens in proxy_realtime_calls.
+    decoded = json.loads(payload)
+    session_type = decoded.get("session_type") or "realtime"
+    if session_type not in ("realtime", "transcription"):
+        session_type = "realtime"
+    assert session_type == "realtime"
+
+
+@pytest.mark.asyncio
+async def test_transcription_sessions_returns_upstream_error_verbatim(
+    proxy_app,
+    mock_add_litellm_data,
+    mock_pre_call_hook,
+):
+    """Non-200 upstream response is forwarded unchanged (no encryption attempted)."""
+    mock_resp = MagicMock(spec=httpx.Response)
+    mock_resp.status_code = 400
+    mock_resp.content = b'{"error":"bad_request"}'
+    mock_resp.headers = {}
+    mock_resp.json.return_value = {"error": "bad_request"}
+    mock_resp.text = '{"error":"bad_request"}'
+
+    async def _mock_route(*args, **kwargs):
+        async def _inner():
+            return mock_resp
+
+        return _inner()
+
+    proxy_app.dependency_overrides[user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_id="test-user", team_id="test-team"
+    )
+    try:
+        client = TestClient(proxy_app)
+        with (
+            patch(
+                "litellm.proxy.proxy_server.route_request",
+                side_effect=_mock_route,
+            ),
+            patch(
+                "litellm.proxy.proxy_server.add_litellm_data_to_request",
+                side_effect=mock_add_litellm_data,
+            ),
+            patch("litellm.proxy.proxy_server.proxy_logging_obj") as mock_logging,
+        ):
+            mock_logging.pre_call_hook = AsyncMock(side_effect=mock_pre_call_hook)
+            mock_logging.post_call_failure_hook = AsyncMock()
+
+            response = client.post(
+                "/v1/realtime/transcription_sessions",
+                headers={"Authorization": "Bearer sk-test-master-key"},
+                json={"input_audio_transcription": {"model": "gpt-realtime-whisper"}},
+            )
+        assert response.status_code == 400
+        assert response.content == b'{"error":"bad_request"}'
+    finally:
+        proxy_app.dependency_overrides.pop(user_api_key_auth, None)
+
+
+@pytest.mark.asyncio
+async def test_transcription_sessions_wraps_route_exception(
+    proxy_app,
+    mock_add_litellm_data,
+    mock_pre_call_hook,
+):
+    """A route exception is wrapped in a ProxyException with a human-readable message."""
+    from fastapi import HTTPException
+
+    async def _raise_http(*args, **kwargs):
+        raise HTTPException(status_code=403, detail="Model not allowed")
+
+    proxy_app.dependency_overrides[user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_id="test-user"
+    )
+    try:
+        client = TestClient(proxy_app, raise_server_exceptions=False)
+        with (
+            patch(
+                "litellm.proxy.proxy_server.route_request",
+                side_effect=_raise_http,
+            ),
+            patch(
+                "litellm.proxy.proxy_server.add_litellm_data_to_request",
+                side_effect=mock_add_litellm_data,
+            ),
+            patch("litellm.proxy.proxy_server.proxy_logging_obj") as mock_logging,
+        ):
+            mock_logging.pre_call_hook = AsyncMock(side_effect=mock_pre_call_hook)
+            mock_logging.post_call_failure_hook = AsyncMock()
+
+            response = client.post(
+                "/v1/realtime/transcription_sessions",
+                headers={"Authorization": "Bearer sk-test-master-key"},
+                json={"input_audio_transcription": {"model": "gpt-realtime-whisper"}},
+            )
+        assert response.status_code == 403
+        assert "Model not allowed" in response.text
+    finally:
+        proxy_app.dependency_overrides.pop(user_api_key_auth, None)

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -463,12 +463,154 @@ def test_realtime_logging_object_allows_null_transcript_in_conversation_item_add
         usage=usage,
         results=results,
     )
-
     assert logging_result.usage.total_tokens == 18
+    assert logging_result.results[0]["item"]["content"][0]["transcript"] is None
     assert logging_result.results[0]["item"]["content"][0]["transcript"] is None
 
 
-def test_custom_pricing_with_router_model_id():
+def test_realtime_transcription_duration_cost(monkeypatch):
+    """
+    gpt-realtime-whisper transcription sessions are billed by input audio duration
+    ($0.017/min). The .completed events carry usage {type: duration, seconds: N};
+    cost must equal total_seconds * input_cost_per_second.
+    """
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    monkeypatch.setattr(litellm, "model_cost", litellm.get_model_cost_map(url=""))
+
+    from litellm.cost_calculator import RealtimeAPITokenUsageProcessor
+
+    results: OpenAIRealtimeStreamList = [
+        {
+            "type": "session.created",
+            "session": {
+                "type": "transcription",
+                "audio": {
+                    "input": {"transcription": {"model": "gpt-realtime-whisper"}}
+                },
+            },
+        },
+        {
+            "type": "conversation.item.input_audio_transcription.completed",
+            "transcript": "hello",
+            "usage": {"type": "duration", "seconds": 60.0},
+        },
+        {
+            "type": "conversation.item.input_audio_transcription.completed",
+            "transcript": "world",
+            "usage": {"type": "duration", "seconds": 30.0},
+        },
+    ]
+
+    combined = RealtimeAPITokenUsageProcessor.collect_and_combine_usage_from_realtime_stream_results(
+        results=results
+    )
+    cost = handle_realtime_stream_cost_calculation(
+        results=results,
+        combined_usage_object=combined,
+        custom_llm_provider="openai",
+        litellm_model_name="gpt-realtime-whisper",
+    )
+
+    # 90 seconds at $0.017/minute.
+    expected = 90.0 * (0.017 / 60)
+    assert abs(cost - expected) < 1e-9
+    assert cost > 0  # guards against the duration branch being dropped
+
+
+def test_realtime_transcription_duration_cost_resolves_model_from_litellm_name(
+    monkeypatch,
+):
+    """When no session event carries the ASR model, the litellm_model_name is used."""
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    monkeypatch.setattr(litellm, "model_cost", litellm.get_model_cost_map(url=""))
+
+    results: OpenAIRealtimeStreamList = [
+        {
+            "type": "conversation.item.input_audio_transcription.completed",
+            "usage": {"type": "duration", "seconds": 120.0},
+        },
+    ]
+    cost = handle_realtime_stream_cost_calculation(
+        results=results,
+        combined_usage_object=Usage(),
+        custom_llm_provider="azure",
+        litellm_model_name="azure/gpt-realtime-whisper",
+    )
+    assert abs(cost - 120.0 * (0.017 / 60)) < 1e-9
+
+
+def test_realtime_transcription_no_completed_events_is_zero(monkeypatch):
+    """A realtime stream without transcription completed events adds no extra cost."""
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    monkeypatch.setattr(litellm, "model_cost", litellm.get_model_cost_map(url=""))
+
+    from litellm.cost_calculator import handle_realtime_transcription_cost_calculation
+
+    results: OpenAIRealtimeStreamList = [
+        {"type": "session.created", "session": {"model": "gpt-realtime-whisper"}},
+        {"type": "response.done", "response": {"usage": {}}},
+    ]
+    assert (
+        handle_realtime_transcription_cost_calculation(
+            results=results,
+            custom_llm_provider="openai",
+            litellm_model_name="gpt-realtime-whisper",
+        )
+        == 0.0
+    )
+
+
+def test_realtime_transcription_token_billed_fallback(monkeypatch):
+    """
+    Token-billed transcription models price by audio/text tokens. Verify the
+    fallback path multiplies audio tokens by the model's audio token cost.
+    """
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    monkeypatch.setattr(litellm, "model_cost", litellm.get_model_cost_map(url=""))
+
+    from litellm.cost_calculator import _transcription_usage_cost
+
+    # gpt-4o-transcribe: input_cost_per_audio_token = 2.5e-06, input_cost_per_token = 2.5e-06,
+    # output_cost_per_token = 1e-05
+    model_info = litellm.get_model_info(
+        model="gpt-4o-transcribe", custom_llm_provider="openai"
+    )
+    usage = {
+        "type": "tokens",
+        "input_tokens": 40,
+        "output_tokens": 10,
+        "total_tokens": 50,
+        "input_token_details": {"audio_tokens": 30, "text_tokens": 10},
+    }
+    cost = _transcription_usage_cost(usage, model_info)
+    expected = (
+        30 * 2.5e-06  # audio tokens
+        + 10 * 2.5e-06  # text tokens
+        + 10 * 1e-05  # output tokens
+    )
+    assert abs(cost - expected) < 1e-12
+
+
+def test_transcription_usage_cost_returns_zero_for_unknown_type():
+    """An unrecognized usage type yields 0 (safe fallback, no exception)."""
+    from litellm.cost_calculator import _transcription_usage_cost
+
+    assert _transcription_usage_cost({"type": "future_billing_type"}, {}) == 0.0
+    assert _transcription_usage_cost({}, {}) == 0.0
+
+
+def test_get_transcription_model_falls_back_to_session_model(monkeypatch):
+    """session.model is used when transcription-specific model fields are absent."""
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    monkeypatch.setattr(litellm, "model_cost", litellm.get_model_cost_map(url=""))
+
+    from litellm.cost_calculator import _get_transcription_model_name_from_results
+
+    results: OpenAIRealtimeStreamList = [
+        {"type": "session.created", "session": {"model": "gpt-realtime-whisper"}},
+    ]
+    assert _get_transcription_model_name_from_results(results) == "gpt-realtime-whisper"
+
     from litellm import Router
 
     router = Router(


### PR DESCRIPTION
## What

Adds Hanzo (`hanzo/`) as a JSON-configured OpenAI-compatible provider. Mirrors the same shape as the recently-merged Neosantara (#29646) and Tensormesh (#29063) entries.

- Provider route: `hanzo/`
- Base URL: `https://api.hanzo.ai/v1`
- Auth: `HANZO_API_KEY` (Bearer token, OpenAI-style). `HANZO_API_BASE` overrides the default base URL.
- Endpoint: `/v1/chat/completions`
- `max_completion_tokens` -> `max_tokens` param mapping.

Hanzo Cloud (hanzo.ai) is an OpenAI-compatible AI gateway. This PR covers Hanzo's native Zen model family; other upstream models routed through Hanzo's gateway can be reached by passing the upstream id under the `hanzo/` prefix.

## Files

- `litellm/llms/openai_like/providers.json` — `hanzo` entry
- `litellm/types/utils.py` — `LlmProviders.HANZO`
- `litellm/constants.py` — base URL, `provider_list` entry
- `provider_endpoints_support.json` + `litellm/provider_endpoints_support_backup.json` — `hanzo` capability entry
- `model_prices_and_context_window.json` — `hanzo/zen4` ($1.50 / $4.50 per MTok), `hanzo/zen4-max` ($3 / $12 per MTok, 1M context)
- `docs/my-website/docs/providers/hanzo.md` — provider docs page
- `tests/test_litellm/llms/openai_like/test_hanzo_provider.py` — provider config + cost map unit tests

## Test plan

- [x] JSON files parse
- [x] `LlmProviders.HANZO` resolves and is in `litellm.provider_list`
- [x] `JSONProviderRegistry.exists("hanzo")` and config fields match
- [x] `get_llm_provider("hanzo/zen4")` returns base URL `https://api.hanzo.ai/v1`
- [x] `litellm.cost_per_token` for `hanzo/zen4` and `hanzo/zen4-max` returns the expected values
- [x] Custom `api_base` / `api_key` overrides the default