### PR TITLE
fix(register_model): drop synthesized zero costs to preserve sparse entries (#30198)

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -3022,9 +3022,11 @@ def register_model(model_cost: Union[str, dict]):  # noqa: PLR0915
         # to "cost keys = 0" (free), which makes
         # ``_is_cost_explicitly_configured`` return True and silently
         # disables budget enforcement on the next re-registration.
-        _raw_entry = (
-            litellm.model_cost.get(model_cost_key) or litellm.model_cost.get(key) or {}
-        )
+        _raw_entry = litellm.model_cost.get(model_cost_key)
+        if _raw_entry is None:
+            _raw_entry = litellm.model_cost.get(key)
+        if _raw_entry is None:
+            _raw_entry = {}
         for _cost_field in ("input_cost_per_token", "output_cost_per_token"):
             if _cost_field not in _raw_entry and _cost_field not in value:
                 existing_model.pop(_cost_field, None)

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -3015,6 +3015,19 @@ def register_model(model_cost: Union[str, dict]):  # noqa: PLR0915
         # custom pricing on subsequent cost lookups.
         if existing_model.get("litellm_provider") is None:
             existing_model.pop("litellm_provider", None)
+        # Same pattern for cost fields (#30198): ``_get_model_info_helper``
+        # synthesizes ``input_cost_per_token`` / ``output_cost_per_token``
+        # = 0 when they are absent from the raw entry. Writing those zeros
+        # back flips a sparse entry from "no cost keys" (priced via name)
+        # to "cost keys = 0" (free), which makes
+        # ``_is_cost_explicitly_configured`` return True and silently
+        # disables budget enforcement on the next re-registration.
+        _raw_entry = (
+            litellm.model_cost.get(model_cost_key) or litellm.model_cost.get(key) or {}
+        )
+        for _cost_field in ("input_cost_per_token", "output_cost_per_token"):
+            if _cost_field not in _raw_entry and _cost_field not in value:
+                existing_model.pop(_cost_field, None)
         ## override / add new keys to the existing model cost dictionary
         updated_dictionary = _update_dictionary(existing_model, value)
         litellm.model_cost.setdefault(model_cost_key, {}).update(updated_dictionary)

--- a/tests/test_litellm/test_register_model_zero_cost_persistence.py
+++ b/tests/test_litellm/test_register_model_zero_cost_persistence.py
@@ -1,0 +1,191 @@
+"""
+Regression for #30198.
+
+``register_model`` calls ``get_model_info(key)`` to fetch the existing
+entry, then ``_update_dictionary`` merges its own ``value`` over it and
+the result is written back into ``litellm.model_cost``.
+
+``_get_model_info_helper`` synthesizes ``input_cost_per_token`` and
+``output_cost_per_token`` as 0 when the cost keys are missing from the
+raw entry (the "price unknown" and "free" cases share the same
+representation). So on the SECOND ``register_model`` call against an
+already-present sparse entry (e.g. router model id with only
+``{"id": ..., "db_model": True}``), the synthesized zeros get written
+back, and the entry flips from "no cost keys" → "cost keys = 0".
+
+That defeats ``_is_cost_explicitly_configured`` (added in #24949), which
+checks whether the cost keys are present in the raw entry — after the
+write-back they are. ``_is_model_cost_zero`` then returns ``True`` and
+``common_checks`` skips every tag / key / team / user / org budget check
+for the group. Spend keeps recording (cost calc resolves by model name),
+so the symptom is silent: requests that should 429 keep returning 200.
+
+Tests below replicate the Router-built-twice scenario from the report
+and confirm the sparse entry stays sparse.
+"""
+
+import importlib
+import os
+import sys
+from typing import Any, Dict
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _restore_model_cost():
+    import litellm
+
+    original = dict(litellm.model_cost)
+    try:
+        yield
+    finally:
+        litellm.model_cost.clear()
+        litellm.model_cost.update(original)
+
+
+def _sparse_router_value(model_cost_key: str) -> Dict[str, Any]:
+    # Mirrors what Router builds for a db_model deployment with no custom
+    # pricing (litellm/router.py:_create_deployment).
+    return {
+        "model_name": "gpt-4o-mini",
+        "litellm_params": {
+            "model": "gpt-4o-mini",
+            "custom_llm_provider": "openai",
+            "api_key": "sk-test",
+        },
+        "model_info": {"id": model_cost_key, "db_model": True},
+    }
+
+
+def test_first_registration_leaves_sparse_entry_without_cost_keys():
+    """First ``register_model`` call against an unknown key must NOT add
+    cost keys to the entry — otherwise the very first registration would
+    already poison the map."""
+    import litellm
+
+    key = "fixed-uuid-30198-first"
+    litellm.model_cost.pop(key, None)
+
+    litellm.register_model({key: {"litellm_provider": "openai"}})
+
+    entry = litellm.model_cost.get(key, {})
+    assert "input_cost_per_token" not in entry, entry
+    assert "output_cost_per_token" not in entry, entry
+
+
+def test_second_registration_does_not_persist_synthesized_zero_costs():
+    """The #30198 bug: re-registering the same sparse entry made
+    ``get_model_info`` synthesize cost = 0 and write it back. Verify the
+    entry stays clean after a second pass."""
+    import litellm
+
+    key = "fixed-uuid-30198-double-register"
+    litellm.model_cost.pop(key, None)
+
+    payload = {key: {"litellm_provider": "openai"}}
+    litellm.register_model(payload)
+    litellm.register_model(payload)
+
+    entry = litellm.model_cost.get(key, {})
+    assert "input_cost_per_token" not in entry, (
+        "second register_model() persisted a synthesized zero "
+        "input_cost_per_token; this disables budget enforcement"
+    )
+    assert "output_cost_per_token" not in entry, (
+        "second register_model() persisted a synthesized zero "
+        "output_cost_per_token; this disables budget enforcement"
+    )
+
+
+def test_explicit_zero_cost_in_value_is_preserved():
+    """If the caller actually wants the model marked free, the explicit
+    zero must survive the dedup. The fix must only strip SYNTHESIZED
+    zeros, not caller-provided ones."""
+    import litellm
+
+    key = "fixed-uuid-30198-explicit-zero"
+    litellm.model_cost.pop(key, None)
+
+    litellm.register_model(
+        {
+            key: {
+                "litellm_provider": "openai",
+                "input_cost_per_token": 0,
+                "output_cost_per_token": 0,
+            }
+        }
+    )
+
+    entry = litellm.model_cost[key]
+    assert entry["input_cost_per_token"] == 0
+    assert entry["output_cost_per_token"] == 0
+
+    # Re-registering with the same explicit zeros must keep them.
+    litellm.register_model(
+        {
+            key: {
+                "litellm_provider": "openai",
+                "input_cost_per_token": 0,
+                "output_cost_per_token": 0,
+            }
+        }
+    )
+    entry = litellm.model_cost[key]
+    assert entry["input_cost_per_token"] == 0
+    assert entry["output_cost_per_token"] == 0
+
+
+def test_real_pricing_for_known_model_survives_re_registration():
+    """A model with built-in pricing (e.g. gpt-4o-mini) must keep its
+    real per-token rates across repeated registrations of an empty
+    payload that names the same key."""
+    import litellm
+
+    base_in = litellm.model_cost["gpt-4o-mini"]["input_cost_per_token"]
+    base_out = litellm.model_cost["gpt-4o-mini"]["output_cost_per_token"]
+    assert base_in > 0 and base_out > 0
+
+    litellm.register_model({"gpt-4o-mini": {"litellm_provider": "openai"}})
+    litellm.register_model({"gpt-4o-mini": {"litellm_provider": "openai"}})
+
+    assert litellm.model_cost["gpt-4o-mini"]["input_cost_per_token"] == base_in
+    assert litellm.model_cost["gpt-4o-mini"]["output_cost_per_token"] == base_out
+
+
+def test_router_double_init_keeps_db_model_entry_sparse():
+    """End-to-end repro from the issue body: building Router twice on
+    the same model_list must not flip the per-deployment entry to
+    cost=0. This is the exact production symptom (#30198)."""
+    import litellm
+    from litellm import Router
+
+    deployment_id = "fixed-uuid-30198-router-init"
+    litellm.model_cost.pop(deployment_id, None)
+
+    model_list = [_sparse_router_value(deployment_id)]
+
+    Router(model_list=model_list)
+    after_first = dict(litellm.model_cost.get(deployment_id, {}))
+
+    Router(model_list=model_list)
+    after_second = dict(litellm.model_cost.get(deployment_id, {}))
+
+    # Neither pass should write cost = 0 into the deployment entry.
+    for snapshot, label in (
+        (after_first, "first Router()"),
+        (after_second, "second Router()"),
+    ):
+        assert snapshot.get("input_cost_per_token") in (None, 0) or (
+            "input_cost_per_token" not in snapshot
+        ), f"{label} wrote unexpected cost: {snapshot}"
+        # The strong assertion: cost keys must not appear AT ALL on a
+        # sparse db_model deployment (matches the pre-bug shape).
+        assert "input_cost_per_token" not in snapshot, (
+            f"{label} persisted input_cost_per_token={snapshot.get('input_cost_per_token')!r} "
+            f"on a sparse db_model entry; this disables budget enforcement"
+        )
+        assert "output_cost_per_token" not in snapshot, (
+            f"{label} persisted output_cost_per_token={snapshot.get('output_cost_per_token')!r} "
+            f"on a sparse db_model entry; this disables budget enforcement"
+        )

--- a/tests/test_litellm/test_register_model_zero_cost_persistence.py
+++ b/tests/test_litellm/test_register_model_zero_cost_persistence.py
@@ -171,16 +171,12 @@ def test_router_double_init_keeps_db_model_entry_sparse():
     Router(model_list=model_list)
     after_second = dict(litellm.model_cost.get(deployment_id, {}))
 
-    # Neither pass should write cost = 0 into the deployment entry.
+    # Cost keys must not appear AT ALL on a sparse db_model deployment
+    # (matches the pre-bug shape) — the bug rewrites them as 0.
     for snapshot, label in (
         (after_first, "first Router()"),
         (after_second, "second Router()"),
     ):
-        assert snapshot.get("input_cost_per_token") in (None, 0) or (
-            "input_cost_per_token" not in snapshot
-        ), f"{label} wrote unexpected cost: {snapshot}"
-        # The strong assertion: cost keys must not appear AT ALL on a
-        # sparse db_model deployment (matches the pre-bug shape).
         assert "input_cost_per_token" not in snapshot, (
             f"{label} persisted input_cost_per_token={snapshot.get('input_cost_per_token')!r} "
             f"on a sparse db_model entry; this disables budget enforcement"


### PR DESCRIPTION
## Relevant issues

Fixes #30198

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Type

🐛 Bug Fix

## Summary

\`get_model_info\` synthesizes \`input_cost_per_token\` / \`output_cost_per_token\` = 0 when missing from the raw entry. \`register_model\` then writes that synthesized result back, flipping a sparse entry from "no cost keys" to "cost keys = 0". That defeats \`_is_cost_explicitly_configured\` (#24949): \`_is_model_cost_zero\` returns True, \`common_checks\` skips every budget check for the group, and over-budget tags keep returning 200 silently — cost calc still resolves by name so spend keeps recording.

Triggers on the 2nd registration of the same key (router rebuild, /model/update, config sync). Reporter saw a tag with max_budget 0.05 USD reach 138 USD spend, then a pod restart fixes it until the next re-registration.

Mirror the existing \`litellm_provider\` None-pop guard at \`litellm/utils.py:3016\` for cost fields — only strip them when they are absent from BOTH the raw entry AND the caller's value, so caller-provided zeros (genuinely free BYOK) survive.

## Real-behavior proof

Reporter's exact repro from #30198:

\`\`\`
$ .venv/bin/python -c '<repro>'
\`\`\`

On \`upstream/litellm_internal_staging\` (49ca04d8c3):
\`\`\`
2nd Router persisted: {'input_cost_per_token': 0, 'output_cost_per_token': 0}
group cost in/out: 0.0 0.0
_is_model_cost_zero: True       # budget enforcement off
\`\`\`

With this branch:
\`\`\`
2nd Router persisted: {'input_cost_per_token': None, 'output_cost_per_token': None}
group cost in/out: 1.5e-07 6e-07  # real gpt-4o-mini price
_is_model_cost_zero: False      # budget enforcement intact
\`\`\`

## Tests

\`tests/test_litellm/test_register_model_zero_cost_persistence.py\` — 5 mock-only regression tests:
- \`test_second_registration_does_not_persist_synthesized_zero_costs\` (the #30198 bug; FAILS on base)
- \`test_router_double_init_keeps_db_model_entry_sparse\` (end-to-end repro; FAILS on base)
- \`test_first_registration_leaves_sparse_entry_without_cost_keys\` (pins pre-bug behavior)
- \`test_explicit_zero_cost_in_value_is_preserved\` (caller-provided 0 must survive)
- \`test_real_pricing_for_known_model_survives_re_registration\` (gpt-4o-mini real rates preserved)

\`\`\`
$ .venv/bin/python -m pytest tests/test_litellm/test_register_model_zero_cost_persistence.py -v
5 passed in 0.26s
\`\`\`

35 adjacent register_model / model_cost / aliases tests pass:
\`\`\`
$ .venv/bin/python -m pytest tests/test_litellm/test_register_model_custom_pricing.py tests/test_litellm/test_router_model_cost_isolation.py tests/test_litellm/test_model_cost_aliases.py -q
35 passed in 2.01s
\`\`\`

## Changes

- \`litellm/utils.py\` (+13): in \`register_model\`, after the existing \`litellm_provider\` None-pop, pop cost fields synthesized by \`get_model_info\` when they are absent from both the raw entry and the caller's value.
- \`tests/test_litellm/test_register_model_zero_cost_persistence.py\` (+191): 5 new regression tests.