### PR TITLE
fix(ui): infer Azure API version from API base

### DIFF
--- a/ui/litellm-dashboard/src/components/add_model/provider_specific_fields.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/provider_specific_fields.test.tsx
@@ -240,4 +240,109 @@ describe("ProviderSpecificFields", () => {
       expect(apiVersionInput).toHaveValue("2024-10-21");
     });
   });
+
+  it("sets Azure API version from the hyphenated API base query parameter", async () => {
+    const queryClient = createQueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Form>
+          <ProviderSpecificFields selectedProvider={Providers.Azure} />
+        </Form>
+      </QueryClientProvider>,
+    );
+
+    const apiBaseInput = await screen.findByPlaceholderText("https://...");
+    const apiVersionInput = await screen.findByPlaceholderText("2023-07-01-preview");
+
+    fireEvent.change(apiBaseInput, {
+      target: {
+        value:
+          "https://test-resource.openai.azure.com/openai/deployments/gpt-4/chat/completions?api-version=2024-10-21",
+      },
+    });
+
+    await waitFor(() => {
+      expect(apiVersionInput).toHaveValue("2024-10-21");
+    });
+  });
+
+  it("clears an inferred Azure API version when the API base has no version parameter", async () => {
+    const queryClient = createQueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Form>
+          <ProviderSpecificFields selectedProvider={Providers.Azure} />
+        </Form>
+      </QueryClientProvider>,
+    );
+
+    const apiBaseInput = await screen.findByPlaceholderText("https://...");
+    const apiVersionInput = await screen.findByPlaceholderText("2023-07-01-preview");
+
+    fireEvent.change(apiBaseInput, {
+      target: {
+        value:
+          "https://test-resource.openai.azure.com/openai/deployments/gpt-4/chat/completions?api-version=2024-10-21",
+      },
+    });
+
+    await waitFor(() => {
+      expect(apiVersionInput).toHaveValue("2024-10-21");
+    });
+
+    fireEvent.change(apiBaseInput, {
+      target: {
+        value: "https://test-resource.openai.azure.com/openai/deployments/gpt-4/chat/completions",
+      },
+    });
+
+    await waitFor(() => {
+      expect(apiVersionInput).toHaveValue("");
+    });
+  });
+
+  it("preserves a manually edited Azure API version when the API base has no version parameter", async () => {
+    const queryClient = createQueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Form>
+          <ProviderSpecificFields selectedProvider={Providers.Azure} />
+        </Form>
+      </QueryClientProvider>,
+    );
+
+    const apiBaseInput = await screen.findByPlaceholderText("https://...");
+    const apiVersionInput = await screen.findByPlaceholderText("2023-07-01-preview");
+
+    fireEvent.change(apiBaseInput, {
+      target: {
+        value:
+          "https://test-resource.openai.azure.com/openai/deployments/gpt-4/chat/completions?api-version=2024-10-21",
+      },
+    });
+
+    await waitFor(() => {
+      expect(apiVersionInput).toHaveValue("2024-10-21");
+    });
+
+    fireEvent.change(apiVersionInput, {
+      target: {
+        value: "2025-01-01-preview",
+      },
+    });
+
+    await waitFor(() => {
+      expect(apiVersionInput).toHaveValue("2025-01-01-preview");
+    });
+
+    fireEvent.change(apiBaseInput, {
+      target: {
+        value: "https://test-resource.openai.azure.com/openai/deployments/gpt-4/chat/completions",
+      },
+    });
+
+    await waitFor(() => {
+      expect(apiVersionInput).toHaveValue("2025-01-01-preview");
+    });
+  });
 });

--- a/ui/litellm-dashboard/src/components/add_model/provider_specific_fields.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/provider_specific_fields.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { Form } from "antd";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import { Providers } from "../provider_info_helpers";
@@ -213,6 +213,31 @@ describe("ProviderSpecificFields", () => {
 
       const baseModelInput = screen.getByPlaceholderText("azure/gpt-3.5-turbo");
       expect(baseModelInput).toBeInTheDocument();
+    });
+  });
+
+  it("sets Azure API version from the API base query parameter", async () => {
+    const queryClient = createQueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Form>
+          <ProviderSpecificFields selectedProvider={Providers.Azure} />
+        </Form>
+      </QueryClientProvider>,
+    );
+
+    const apiBaseInput = await screen.findByPlaceholderText("https://...");
+    const apiVersionInput = await screen.findByPlaceholderText("2023-07-01-preview");
+
+    fireEvent.change(apiBaseInput, {
+      target: {
+        value:
+          "https://test-resource.openai.azure.com/openai/deployments/gpt-4/chat/completions?api_version=2024-10-21",
+      },
+    });
+
+    await waitFor(() => {
+      expect(apiVersionInput).toHaveValue("2024-10-21");
     });
   });
 });

--- a/ui/litellm-dashboard/src/components/add_model/provider_specific_fields.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/provider_specific_fields.tsx
@@ -180,6 +180,7 @@ const ProviderSpecificFields: React.FC<ProviderSpecificFieldsProps> = ({ selecte
   }, [selectedProviderEnum, selectedProvider, providerMetadata]);
 
   const hasApiVersionField = React.useMemo(() => allFields.some((field) => field.key === "api_version"), [allFields]);
+  const lastInferredApiVersionRef = React.useRef<string | null>(null);
 
   const handleApiBaseChange = React.useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -189,8 +190,15 @@ const ProviderSpecificFields: React.FC<ProviderSpecificFieldsProps> = ({ selecte
 
       const apiVersion = getApiVersionFromApiBase(event.target.value);
       if (apiVersion) {
+        lastInferredApiVersionRef.current = apiVersion;
         form.setFieldsValue({ api_version: apiVersion });
+        return;
       }
+
+      if (form.getFieldValue("api_version") === lastInferredApiVersionRef.current) {
+        form.setFieldsValue({ api_version: "" });
+      }
+      lastInferredApiVersionRef.current = null;
     },
     [form, hasApiVersionField],
   );

--- a/ui/litellm-dashboard/src/components/add_model/provider_specific_fields.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/provider_specific_fields.tsx
@@ -28,6 +28,18 @@ export interface CredentialValues {
   value: string;
 }
 
+const getApiVersionFromApiBase = (apiBase: string): string | null => {
+  const queryStartIndex = apiBase.indexOf("?");
+  if (queryStartIndex === -1) {
+    return null;
+  }
+
+  const queryString = apiBase.slice(queryStartIndex + 1).split("#")[0];
+  const searchParams = new URLSearchParams(queryString);
+
+  return searchParams.get("api_version") || searchParams.get("api-version");
+};
+
 const mapFieldMetadataToUiField = (field: ProviderCredentialFieldMetadata): ProviderCredentialField => {
   const type: ProviderCredentialField["type"] =
     field.field_type === "password"
@@ -167,6 +179,22 @@ const ProviderSpecificFields: React.FC<ProviderSpecificFieldsProps> = ({ selecte
     return mapped;
   }, [selectedProviderEnum, selectedProvider, providerMetadata]);
 
+  const hasApiVersionField = React.useMemo(() => allFields.some((field) => field.key === "api_version"), [allFields]);
+
+  const handleApiBaseChange = React.useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      if (!hasApiVersionField) {
+        return;
+      }
+
+      const apiVersion = getApiVersionFromApiBase(event.target.value);
+      if (apiVersion) {
+        form.setFieldsValue({ api_version: apiVersion });
+      }
+    },
+    [form, hasApiVersionField],
+  );
+
   const handleUpload = {
     name: "file",
     accept: ".json",
@@ -261,6 +289,7 @@ const ProviderSpecificFields: React.FC<ProviderSpecificFieldsProps> = ({ selecte
                 placeholder={field.placeholder}
                 type={field.type === "password" ? "password" : "text"}
                 defaultValue={field.defaultValue}
+                onChange={field.key === "api_base" ? handleApiBaseChange : undefined}
               />
             )}
           </Form.Item>


### PR DESCRIPTION
Fixes #30127

This updates the add-model provider credential fields so Azure URLs copied from Azure AI Foundry can populate the `api_version` field automatically. When the `api_base` field contains either `api_version` or `api-version`, the UI copies that value into the existing API Version form field. Providers without an `api_version` field are left unchanged.

The root cause was that the dashboard rendered both `api_base` and `api_version`, but did not connect the query parameter from the pasted Azure URL to the version field that LiteLLM saves for the model.

Validation run locally:

- `npm ci --no-audit --no-fund`
- `node ./node_modules/vitest/vitest.mjs run src/components/add_model/provider_specific_fields.test.tsx --config ./vitest.config.ts --maxWorkers 1 --minWorkers 1 --no-file-parallelism --reporter verbose`
- `node ./node_modules/prettier/bin/prettier.cjs --check src/components/add_model/provider_specific_fields.tsx src/components/add_model/provider_specific_fields.test.tsx`
- `node ./node_modules/eslint/bin/eslint.js src/components/add_model/provider_specific_fields.tsx src/components/add_model/provider_specific_fields.test.tsx`
- `npm run lint`
- `npm run build`
- `git diff --check`

Notes: the focused component test emits existing Ant Design/Tremor form warnings, but all tests and the production build pass.