### PR TITLE
fix(presidio): robust PII unmasking for Anthropic native SSE streams (follow-up to #30028)

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -62,6 +62,168 @@ from litellm.utils import (
     ModelResponseStream,
 )
 
+# Anthropic SSE delta types that carry model-generated text, mapped to
+# (payload field, needs JSON escaping). partial_json fragments need
+# replacements JSON-escaped so the assembled tool input stays valid JSON.
+_ANTHROPIC_SSE_DELTA_FIELDS: Dict[str, Tuple[str, bool]] = {
+    "text_delta": ("text", False),
+    "thinking_delta": ("thinking", False),
+    "input_json_delta": ("partial_json", True),
+}
+
+# Event types that terminate the current content block / message: any held
+# partial-token carry is literal text and must be flushed before them.
+# Deliberately excludes "ping" — keepalives interleave mid-block and a
+# placeholder may continue right after one.
+_ANTHROPIC_SSE_CARRY_FLUSH_EVENTS = {
+    "content_block_start",
+    "content_block_stop",
+    "message_delta",
+    "message_stop",
+    "error",
+}
+
+
+class _AnthropicSSEUnmasker:
+    """Incremental PII unmasker for an Anthropic native SSE byte stream.
+
+    feed() accepts arbitrarily split byte chunks and buffers to complete
+    lines, so a ``data:`` line (or a multi-byte UTF-8 character) split
+    across chunks is never parsed partially. Placeholder tokens may also be
+    split across delta *events* (``"…<PERS"`` then ``"ON_1>…"``): a trailing
+    fragment that is still a strict prefix of a known token is carried and
+    prepended to the next delta of the same content block; carries are
+    flushed as a synthetic delta event when the block ends without
+    completing one. Call flush() once the stream is exhausted.
+    """
+
+    def __init__(self, pii_tokens: Dict[str, str]) -> None:
+        self._tokens: Dict[str, str] = dict(pii_tokens)
+        self._buffer: bytes = b""
+        self._carry: str = ""
+        self._carry_ctx: Optional[Tuple[Any, str]] = None  # (index, delta_type)
+
+    def feed(self, chunk: bytes) -> bytes:
+        self._buffer += chunk
+        out: List[bytes] = []
+        while True:
+            newline_idx = self._buffer.find(b"\n")
+            if newline_idx == -1:
+                break
+            line = self._buffer[: newline_idx + 1]
+            self._buffer = self._buffer[newline_idx + 1 :]
+            out.append(self._process_line(line))
+        return b"".join(out)
+
+    def flush(self) -> bytes:
+        """Emit any held carry and unterminated trailing bytes at stream end."""
+        out = self._flush_carry() + self._buffer
+        self._buffer = b""
+        return out
+
+    def _process_line(self, line: bytes) -> bytes:
+        if line.startswith(b"event: "):
+            # Flush a held carry *before* the event line so the synthetic
+            # delta does not split the next event's `event:`/`data:` framing.
+            event_name = (
+                line[len(b"event: ") :].strip().decode("utf-8", errors="replace")
+            )
+            if event_name in _ANTHROPIC_SSE_CARRY_FLUSH_EVENTS:
+                return self._flush_carry() + line
+            return line
+        if not line.startswith(b"data: "):
+            return line
+
+        try:
+            text = line.decode("utf-8")
+        except UnicodeDecodeError:
+            return line
+        stripped = text.rstrip("\r\n")
+        line_ending = text[len(stripped) :]
+        raw_json = stripped[len("data: ") :]
+        if raw_json == "[DONE]":
+            return line
+        try:
+            event = json.loads(raw_json)
+        except json.JSONDecodeError:
+            return line
+        if not isinstance(event, dict):
+            return line
+
+        event_type = event.get("type")
+        delta = event.get("delta")
+        delta_type = delta.get("type") if isinstance(delta, dict) else None
+        field_spec = _ANTHROPIC_SSE_DELTA_FIELDS.get(delta_type) if delta_type else None
+        if (
+            event_type == "content_block_delta"
+            and delta is not None
+            and field_spec is not None
+            and isinstance(delta.get(field_spec[0]), str)
+        ):
+            field, json_escape = field_spec
+            prefix = b""
+            ctx = (event.get("index"), str(delta_type))
+            if self._carry and self._carry_ctx != ctx:
+                # Safety net: Anthropic blocks are sequential, so a context
+                # switch without an intervening block stop should not happen.
+                prefix = self._flush_carry()
+            delta_text = self._carry + delta[field]
+            self._carry = ""
+            self._carry_ctx = None
+            unmasked = self._replace(delta_text, json_escape)
+            emit_text, carry = self._split_partial_token(unmasked)
+            if carry:
+                self._carry = carry
+                self._carry_ctx = ctx
+            delta[field] = emit_text
+            new_line = "data: " + json.dumps(event, ensure_ascii=False) + line_ending
+            return prefix + new_line.encode("utf-8")
+
+        if event_type in _ANTHROPIC_SSE_CARRY_FLUSH_EVENTS:
+            # Fallback for streams without `event:` lines (already a no-op
+            # when the preceding event line flushed the carry).
+            return self._flush_carry() + line
+        return line
+
+    def _replace(self, text: str, json_escape: bool) -> str:
+        for token, original in self._tokens.items():
+            if token in text:
+                if json_escape:
+                    original = json.dumps(original, ensure_ascii=False)[1:-1]
+                text = text.replace(token, original)
+        return text
+
+    def _split_partial_token(self, text: str) -> Tuple[str, str]:
+        """Split off a trailing fragment that may still grow into a token."""
+        idx = text.rfind("<")
+        if idx == -1:
+            return text, ""
+        candidate = text[idx:]
+        if ">" not in candidate and any(
+            len(token) > len(candidate) and token.startswith(candidate)
+            for token in self._tokens
+        ):
+            return text[:idx], candidate
+        return text, ""
+
+    def _flush_carry(self) -> bytes:
+        if not self._carry:
+            return b""
+        index, delta_type = self._carry_ctx or (0, "text_delta")
+        field, _ = _ANTHROPIC_SSE_DELTA_FIELDS[delta_type]
+        event = {
+            "type": "content_block_delta",
+            "index": index,
+            "delta": {"type": delta_type, field: self._carry},
+        }
+        self._carry = ""
+        self._carry_ctx = None
+        return (
+            "event: content_block_delta\ndata: "
+            + json.dumps(event, ensure_ascii=False)
+            + "\n\n"
+        ).encode("utf-8")
+
 
 class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
     user_api_key_cache = None
@@ -1225,39 +1387,6 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
             for chunk in all_chunks:
                 yield chunk
 
-    @staticmethod
-    def _unmask_sse_bytes_chunk(chunk: bytes, pii_tokens: Dict[str, str]) -> bytes:
-        try:
-            text = chunk.decode("utf-8")
-        except UnicodeDecodeError:
-            return chunk
-
-        result_lines: List[str] = []
-        for line in text.split("\n"):
-            line = line.rstrip("\r")
-            if line.startswith("data: ") and line != "data: [DONE]":
-                raw_json = line[6:]
-                try:
-                    event = json.loads(raw_json)
-                    delta = event.get("delta") if isinstance(event, dict) else None
-                    if (
-                        isinstance(delta, dict)
-                        and event.get("type") == "content_block_delta"
-                        and delta.get("type") == "text_delta"
-                        and isinstance(delta.get("text"), str)
-                    ):
-                        unmasked = _OPTIONAL_PresidioPIIMasking._unmask_pii_text(
-                            delta["text"], pii_tokens
-                        )
-                        if unmasked != delta["text"]:
-                            event["delta"]["text"] = unmasked
-                            line = "data: " + json.dumps(event, ensure_ascii=False)
-                except (json.JSONDecodeError, KeyError, TypeError):
-                    pass
-            result_lines.append(line)
-
-        return "\n".join(result_lines).encode("utf-8")
-
     async def _stream_pii_unmasking(
         self,
         response: Any,
@@ -1273,6 +1402,7 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         metadata = (request_data.get("metadata") or {}) if request_data else {}
         pii_tokens: Dict[str, str] = metadata.get("pii_tokens", {})
 
+        sse_unmasker: Optional[_AnthropicSSEUnmasker] = None
         remaining_chunks: List[ModelResponseStream] = []
         try:
             async for chunk in response:
@@ -1280,10 +1410,19 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                     remaining_chunks.append(chunk)
                 elif isinstance(chunk, bytes):
                     if pii_tokens:
-                        yield self._unmask_sse_bytes_chunk(chunk, pii_tokens)  # type: ignore[misc]
+                        if sse_unmasker is None:
+                            sse_unmasker = _AnthropicSSEUnmasker(pii_tokens)
+                        unmasked_bytes = sse_unmasker.feed(chunk)
+                        if unmasked_bytes:
+                            yield unmasked_bytes  # type: ignore[misc]
                     else:
                         yield chunk  # type: ignore[misc]
                     continue
+
+            if sse_unmasker is not None:
+                trailing_bytes = sse_unmasker.flush()
+                if trailing_bytes:
+                    yield trailing_bytes  # type: ignore[misc]
 
             if not remaining_chunks:
                 return
@@ -1314,6 +1453,10 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
 
         except Exception as e:
             verbose_proxy_logger.error(f"Error in PII streaming processing: {str(e)}")
+            if sse_unmasker is not None:
+                trailing_bytes = sse_unmasker.flush()
+                if trailing_bytes:
+                    yield trailing_bytes  # type: ignore[misc]
             for chunk in remaining_chunks:
                 yield chunk
 

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
@@ -2495,82 +2495,121 @@ async def test_anonymize_text_uses_correct_positions_with_parse_pii():
     assert pii_tokens.get("<PHONE_NUMBER_3>") == "555-867-5309"
 
 
-def test_unmask_sse_bytes_chunk_replaces_text_delta():
+def _sse_event_bytes(event: dict, event_name: str = "") -> bytes:
     import json
 
-    pii_tokens = {"<PERSON_1>": "Bobby"}
-    event = {
-        "type": "content_block_delta",
-        "index": 0,
-        "delta": {"type": "text_delta", "text": "Hello <PERSON_1>, how are you?"},
-    }
-    chunk = ("data: " + json.dumps(event) + "\n\n").encode("utf-8")
-
-    result = _OPTIONAL_PresidioPIIMasking._unmask_sse_bytes_chunk(chunk, pii_tokens)
-
-    decoded = result.decode("utf-8")
-    parsed = json.loads(decoded.split("data: ", 1)[1].strip())
-    assert parsed["delta"]["text"] == "Hello Bobby, how are you?"
+    prefix = f"event: {event_name}\n" if event_name else ""
+    # ensure_ascii=False matches Anthropic's wire format (raw UTF-8)
+    return (prefix + "data: " + json.dumps(event, ensure_ascii=False) + "\n\n").encode(
+        "utf-8"
+    )
 
 
-def test_unmask_sse_bytes_chunk_ignores_non_text_delta():
+def _text_delta_bytes(text: str, index: int = 0) -> bytes:
+    return _sse_event_bytes(
+        {
+            "type": "content_block_delta",
+            "index": index,
+            "delta": {"type": "text_delta", "text": text},
+        }
+    )
+
+
+def _collect_delta_text(raw: bytes, field: str = "text") -> str:
+    """Concatenate every delta `field` value across all events in `raw`."""
     import json
 
+    parts = []
+    for line in raw.split(b"\n"):
+        if line.startswith(b"data: ") and line != b"data: [DONE]":
+            try:
+                event = json.loads(line[len(b"data: ") :])
+            except json.JSONDecodeError:
+                continue
+            delta = event.get("delta") or {}
+            if field in delta:
+                parts.append(delta[field])
+    return "".join(parts)
+
+
+def _run_unmasker(pii_tokens: dict, *chunks: bytes) -> bytes:
+    from litellm.proxy.guardrails.guardrail_hooks.presidio import (
+        _AnthropicSSEUnmasker,
+    )
+
+    unmasker = _AnthropicSSEUnmasker(pii_tokens)
+    return b"".join(unmasker.feed(c) for c in chunks) + unmasker.flush()
+
+
+def test_unmask_sse_bytes_replaces_text_delta():
     pii_tokens = {"<PERSON_1>": "Bobby"}
-
-    # message_start event — no delta
-    event = {"type": "message_start", "message": {"id": "msg_01", "role": "assistant"}}
-    chunk = ("data: " + json.dumps(event) + "\n\n").encode("utf-8")
-    result = _OPTIONAL_PresidioPIIMasking._unmask_sse_bytes_chunk(chunk, pii_tokens)
-    assert result == chunk
-
-    # input_json_delta — should not be touched
-    event2 = {
-        "type": "content_block_delta",
-        "index": 1,
-        "delta": {"type": "input_json_delta", "partial_json": '{"name": "<PERSON_1>"}'},
-    }
-    chunk2 = ("data: " + json.dumps(event2) + "\n\n").encode("utf-8")
-    result2 = _OPTIONAL_PresidioPIIMasking._unmask_sse_bytes_chunk(chunk2, pii_tokens)
-    assert result2 == chunk2
+    result = _run_unmasker(
+        pii_tokens, _text_delta_bytes("Hello <PERSON_1>, how are you?")
+    )
+    assert _collect_delta_text(result) == "Hello Bobby, how are you?"
 
 
-def test_unmask_sse_bytes_chunk_handles_malformed_json():
+def test_unmask_sse_bytes_ignores_events_without_delta():
+    pii_tokens = {"<PERSON_1>": "Bobby"}
+    chunk = _sse_event_bytes(
+        {"type": "message_start", "message": {"id": "msg_01", "role": "assistant"}}
+    )
+    assert _run_unmasker(pii_tokens, chunk) == chunk
+
+
+def test_unmask_sse_bytes_unmasks_input_json_delta_with_escaping():
+    import json
+
+    # Tool inputs are executed by agentic clients — placeholders must be
+    # restored there too. The original contains a double quote, which must be
+    # JSON-escaped so the assembled tool input stays valid JSON.
+    pii_tokens = {"<PERSON_1>": 'Bobby "Bob" Tables'}
+    chunk = _sse_event_bytes(
+        {
+            "type": "content_block_delta",
+            "index": 1,
+            "delta": {
+                "type": "input_json_delta",
+                "partial_json": '{"name": "<PERSON_1>"}',
+            },
+        }
+    )
+    result = _run_unmasker(pii_tokens, chunk)
+    fragment = _collect_delta_text(result, field="partial_json")
+    assert json.loads(fragment) == {"name": 'Bobby "Bob" Tables'}
+
+
+def test_unmask_sse_bytes_unmasks_thinking_delta():
+    pii_tokens = {"<PERSON_1>": "Bobby"}
+    chunk = _sse_event_bytes(
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "thinking_delta", "thinking": "user is <PERSON_1>"},
+        }
+    )
+    result = _run_unmasker(pii_tokens, chunk)
+    assert _collect_delta_text(result, field="thinking") == "user is Bobby"
+
+
+def test_unmask_sse_bytes_handles_malformed_json():
     chunk = b"data: {not valid json}\n\n"
-    result = _OPTIONAL_PresidioPIIMasking._unmask_sse_bytes_chunk(
-        chunk, {"<PERSON_1>": "Bobby"}
-    )
-    assert result == chunk
+    assert _run_unmasker({"<PERSON_1>": "Bobby"}, chunk) == chunk
 
 
-def test_unmask_sse_bytes_chunk_handles_unicode_decode_error():
-    chunk = b"\xff\xfe invalid utf-8"
-    result = _OPTIONAL_PresidioPIIMasking._unmask_sse_bytes_chunk(
-        chunk, {"<PERSON_1>": "Bobby"}
-    )
-    assert result == chunk
+def test_unmask_sse_bytes_handles_unicode_decode_error():
+    chunk = b"\xff\xfe invalid utf-8\n"
+    assert _run_unmasker({"<PERSON_1>": "Bobby"}, chunk) == chunk
 
 
-def test_unmask_sse_bytes_chunk_non_ascii_pii_not_escaped():
-    import json
-
+def test_unmask_sse_bytes_non_ascii_pii_not_escaped():
     pii_tokens = {"<PERSON_1>": "José"}
-    event = {
-        "type": "content_block_delta",
-        "index": 0,
-        "delta": {"type": "text_delta", "text": "Hello <PERSON_1>!"},
-    }
-    chunk = ("data: " + json.dumps(event) + "\n\n").encode("utf-8")
-
-    result = _OPTIONAL_PresidioPIIMasking._unmask_sse_bytes_chunk(chunk, pii_tokens)
-
-    decoded = result.decode("utf-8")
-    assert "Jos\\u" not in decoded
-    parsed = json.loads(decoded.split("data: ", 1)[1].strip())
-    assert parsed["delta"]["text"] == "Hello José!"
+    result = _run_unmasker(pii_tokens, _text_delta_bytes("Hello <PERSON_1>!"))
+    assert "Jos\\u" not in result.decode("utf-8")
+    assert _collect_delta_text(result) == "Hello José!"
 
 
-def test_unmask_sse_bytes_chunk_handles_crlf_line_endings():
+def test_unmask_sse_bytes_handles_crlf_line_endings():
     import json
 
     pii_tokens = {"<PERSON_1>": "Bobby"}
@@ -2581,14 +2620,82 @@ def test_unmask_sse_bytes_chunk_handles_crlf_line_endings():
     }
     crlf_chunk = ("data: " + json.dumps(event) + "\r\ndata: [DONE]\r\n").encode("utf-8")
 
-    result = _OPTIONAL_PresidioPIIMasking._unmask_sse_bytes_chunk(
-        crlf_chunk, pii_tokens
-    )
+    result = _run_unmasker(pii_tokens, crlf_chunk)
 
     decoded = result.decode("utf-8")
     parsed = json.loads(decoded.split("data: ", 1)[1].split("\n")[0].strip())
     assert parsed["delta"]["text"] == "Hi Bobby!"
+    assert "\r\n" in decoded  # original line endings preserved
     assert "data: [DONE]" in decoded
+
+
+def test_unmask_sse_bytes_event_split_across_chunks():
+    # Network framing splits chunks arbitrarily — a `data:` line (and even a
+    # multi-byte UTF-8 character) may arrive split across two bytes chunks.
+    pii_tokens = {"<PERSON_1>": "Bobby"}
+    raw = _text_delta_bytes("Grüße an <PERSON_1>!")
+    split_at = raw.index("ü".encode("utf-8")) + 1  # mid multi-byte character
+    result = _run_unmasker(pii_tokens, raw[:split_at], raw[split_at:])
+    assert _collect_delta_text(result) == "Grüße an Bobby!"
+
+
+def test_unmask_sse_bytes_token_split_across_delta_events():
+    # Models routinely emit a placeholder split across multiple text deltas;
+    # no single delta contains the full token.
+    pii_tokens = {"<PERSON_1>": "Bobby", "<EMAIL_ADDRESS_2>": "bob@example.com"}
+    result = _run_unmasker(
+        pii_tokens,
+        _text_delta_bytes("Mail to <PERS"),
+        _text_delta_bytes("ON_1> at <EMAIL_"),
+        _text_delta_bytes("ADDRESS_2> today"),
+        _sse_event_bytes(
+            {"type": "content_block_stop", "index": 0}, "content_block_stop"
+        ),
+    )
+    assert _collect_delta_text(result) == "Mail to Bobby at bob@example.com today"
+
+
+def test_unmask_sse_bytes_numbered_token_disambiguation():
+    # <PERSON_1> must not match inside <PERSON_12>
+    pii_tokens = {"<PERSON_1>": "Bobby", "<PERSON_12>": "Alice"}
+    result = _run_unmasker(pii_tokens, _text_delta_bytes("<PERSON_12> vs <PERSON_1>"))
+    assert _collect_delta_text(result) == "Alice vs Bobby"
+
+
+def test_unmask_sse_bytes_literal_angle_bracket_released():
+    pii_tokens = {"<PERSON_1>": "Bobby"}
+    result = _run_unmasker(pii_tokens, _text_delta_bytes("Vec<String> stays"))
+    assert _collect_delta_text(result) == "Vec<String> stays"
+
+
+def test_unmask_sse_bytes_carry_flushed_on_block_stop():
+    # A dangling partial-token prefix at block end is literal text — it must
+    # be emitted (as a synthetic delta), not swallowed.
+    pii_tokens = {"<PERSON_1>": "Bobby"}
+    result = _run_unmasker(
+        pii_tokens,
+        _text_delta_bytes("ends with <PERSON"),
+        _sse_event_bytes(
+            {"type": "content_block_stop", "index": 0}, "content_block_stop"
+        ),
+    )
+    assert _collect_delta_text(result) == "ends with <PERSON"
+
+
+def test_unmask_sse_bytes_carry_not_flushed_by_ping():
+    # ping keepalives interleave mid-block; a placeholder may continue right
+    # after one, so pings must not flush the carry.
+    pii_tokens = {"<PERSON_1>": "Bobby"}
+    result = _run_unmasker(
+        pii_tokens,
+        _text_delta_bytes("Hi <PERS"),
+        _sse_event_bytes({"type": "ping"}, "ping"),
+        _text_delta_bytes("ON_1>!"),
+        _sse_event_bytes(
+            {"type": "content_block_stop", "index": 0}, "content_block_stop"
+        ),
+    )
+    assert _collect_delta_text(result) == "Hi Bobby!"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Relevant issues

Follow-up to #30028 — closes the remaining gaps of #22821 (root cause 4).
As discussed in https://github.com/BerriAI/litellm/pull/30028#issuecomment-4670157166 — cc @Sameerlite 🙏

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests (16 unit tests covering every case below)
- [x] My PR passes all unit tests — `tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py`: **79 passed** (full module)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

We run litellm as an Anthropic gateway for Claude Code with the Presidio guardrail (`output_parse_pii: true`). The per-chunk implementation from #30028 still leaked placeholders in production traffic; this implementation (running as a sidecar hook on our gateway) restores them in all the cases below.

```
$ python -m pytest tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py -q
79 passed in 1.79s

$ mypy litellm/proxy/guardrails/guardrail_hooks/presidio.py --ignore-missing-imports
Success: no issues found in 1 source file
```

## Type

🐛 Bug Fix

## Changes

`_unmask_sse_bytes_chunk` (added in #30028) operates per-chunk / per-line with a plain replace, which misses:

| Case | #30028 | this PR |
| --- | --- | --- |
| `data:` line split across byte chunks (arbitrary network framing) | ❌ `json.loads` fails → silent passthrough | ✅ buffers to complete lines |
| Multi-byte UTF-8 character split across chunks | ❌ `UnicodeDecodeError` → whole chunk passthrough | ✅ |
| Placeholder split across delta events (`"…<PERS"` + `"ON_1>…"`) | ❌ no carry | ✅ carry buffer + synthetic flush |
| Tool inputs (`input_json_delta`) — executed by agentic clients | ❌ skipped | ✅ unmasked, JSON-escaped |
| `thinking_delta` | ❌ skipped | ✅ |

**Implementation:** replaces the static per-chunk method with a stateful per-stream `_AnthropicSSEUnmasker` (instantiated lazily in `_stream_pii_unmasking`, flushed at stream end and on the error path):

- **Line buffering** — `feed()` accepts arbitrarily split byte chunks and only parses complete lines, so split `data:` lines / UTF-8 characters are never parsed partially. Original line endings (`\n` / `\r\n`) are preserved.
- **Carry buffer** — a trailing fragment that is still a strict prefix of a known token (e.g. `"<PERS"`) is held and prepended to the next delta of the same content block. A dangling carry is flushed as a synthetic `content_block_delta` event on block end (`content_block_stop` / `content_block_start` / `message_delta` / `message_stop` / `error`). `ping` keepalives deliberately do **not** flush — they interleave mid-block and a placeholder may continue right after one. The flush is triggered from the `event:` line (when present) so the synthetic event never splits the next event's `event:`/`data:` framing.
- **Field coverage** — `text_delta.text`, `thinking_delta.thinking`, and `input_json_delta.partial_json`; for `partial_json` the replacement is JSON-escaped (`json.dumps(original)[1:-1]`) so the assembled tool input stays valid JSON.
- **Failure containment** — undecodable or unparseable lines pass through verbatim; `data: [DONE]` untouched; passthrough unchanged when `pii_tokens` is empty.

**Behavior change vs #30028:** `input_json_delta` is now unmasked (the `test_unmask_sse_bytes_chunk_ignores_non_text_delta` assertion is updated accordingly). Rationale: for agentic clients (Claude Code et al.) tool inputs become file writes and executed commands — leaving `<PERSON_1>` placeholders there is the most user-visible leak.

**Tests:** the 7 tests from #30028 are preserved with their intent (rewritten against the stateful API) plus 9 new ones: chunk-split events incl. mid-UTF-8-character, delta-split tokens, numbered-token disambiguation (`<PERSON_1>` vs `<PERSON_12>`), literal `<` release (`Vec<String>`), carry flush on block stop, ping non-flush, thinking/tool-input deltas, CRLF preservation.
