### PR TITLE
feat(responses): enable the responses API for the Tensormesh provider

### DIFF
--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -132,10 +132,7 @@
     "param_mappings": {
       "max_completion_tokens": "max_tokens"
     },
-    "supported_endpoints": [
-      "/v1/chat/completions",
-      "/v1/responses"
-    ]
+    "supported_endpoints": ["/v1/chat/completions", "/v1/responses"]
   },
   "parasail": {
     "base_url": "https://api.parasail.io/v1",

--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -131,7 +131,11 @@
     "base_class": "openai_gpt",
     "param_mappings": {
       "max_completion_tokens": "max_tokens"
-    }
+    },
+    "supported_endpoints": [
+      "/v1/chat/completions",
+      "/v1/responses"
+    ]
   },
   "parasail": {
     "base_url": "https://api.parasail.io/v1",

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -2153,7 +2153,7 @@
       "endpoints": {
         "chat_completions": true,
         "messages": true,
-        "responses": false,
+        "responses": true,
         "embeddings": false,
         "image_generations": false,
         "audio_transcriptions": false,

--- a/tests/test_litellm/llms/openai_like/test_tensormesh_provider.py
+++ b/tests/test_litellm/llms/openai_like/test_tensormesh_provider.py
@@ -79,6 +79,20 @@ class TestTensormeshProviderConfig:
         matching the text_completion flag in provider_endpoints_support.json."""
         assert "tensormesh" in litellm.openai_text_completion_compatible_providers
 
+    def test_tensormesh_responses_api_enabled(self):
+        """Tensormesh declares /v1/responses in supported_endpoints, so litellm
+        resolves a responses config for it."""
+        from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+        from litellm.utils import ProviderConfigManager
+
+        assert JSONProviderRegistry.supports_responses_api("tensormesh") is True
+        config = ProviderConfigManager.get_provider_responses_api_config(
+            provider="tensormesh",
+            model="tensormesh/openai/gpt-oss-120b",
+        )
+        assert config is not None
+        assert config.custom_llm_provider == "tensormesh"
+
     def test_tensormesh_router_config(self):
         """Test that tensormesh can be used in Router configuration"""
         from litellm import Router


### PR DESCRIPTION
## Relevant issues

N/A

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Notes on `make test-unit`

- `make test-unit` does not complete on a clean checkout of `litellm_internal_staging`. It stops during collection on an import file mismatch between `tests/test_litellm/models/test_models.py` and `tests/test_litellm/proxy/client/test_models.py`; the two share the `test_models` basename and neither directory has a package `__init__.py`, so pytest's default prepend import mode cannot disambiguate them. This reproduces with this branch's changes reverted, so it is pre-existing and unrelated to this PR. Running with `--import-mode=importlib` resolves the collision; the provider suite passes:

```bash
uv run pytest tests/test_litellm/llms/openai_like/test_tensormesh_provider.py --import-mode=importlib -q
```
10 passed

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on Slack (#pr-review) (https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

CI (LiteLLM team)

- [ ] Branch creation CI run
 Link:
- [ ] CI run for the last commit
 Link:
- [ ] Merge / cherry-pick CI run
 Links:

## Screenshots / Proof of Fix

- Verified against a local proxy hitting the real Tensormesh serverless `/v1/responses`. Config `tm-responses.yaml`:

```yaml
model_list:
  - model_name: tm-gpt-oss-120b
    litellm_params:
      model: tensormesh/openai/gpt-oss-120b
      api_key: os.environ/TENSORMESH_INFERENCE_API_KEY
general_settings:
  master_key: os.environ/LITELLM_MASTER_KEY
```

```bash
LITELLM_LOCAL_MODEL_COST_MAP=True uv run litellm --config tm-responses.yaml --port 4000
```

```bash
curl -sS http://localhost:4000/v1/responses \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" \
  -d '{"model":"tm-gpt-oss-120b","input":"Say hello in one sentence.","max_output_tokens":200}'
```

<img width="1479" height="182" alt="Screenshot 2026-06-11 at 22 20 13" src="https://github.com/user-attachments/assets/3c473b44-76ec-4a96-8fec-e0ae9fe9244d" />

## Type

🆕 New Feature

## Changes

- This enables the OpenAI Responses API (`/v1/responses`) for the Tensormesh provider, building on the provider and cost-map work in #29063 and #30037. Tensormesh's serverless `/v1/responses` endpoint already returns spec-conformant output and usage (input_tokens, output_tokens, total_tokens with details), so no provider-specific transformation is needed; declaring `/v1/responses` in the provider's `supported_endpoints` lets litellm resolve the generic JSON responses config and route requests, the same pattern the `neosantara` and `parasail` providers use. The change is the `supported_endpoints` addition in `litellm/llms/openai_like/providers.json`, flipping `responses` to `true` in `provider_endpoints_support.json`, and a test that the responses config resolves for the tensormesh provider