### PR TITLE
feat(rate-limiter): allow opting out of v3 TPM reservation and Redis circuit breaker

### DIFF
--- a/litellm/caching/redis_cache.py
+++ b/litellm/caching/redis_cache.py
@@ -22,6 +22,7 @@ import litellm
 from litellm._logging import print_verbose, verbose_logger
 from litellm.constants import (
     DEFAULT_REDIS_MAJOR_VERSION,
+    REDIS_CIRCUIT_BREAKER_ENABLED,
     REDIS_CIRCUIT_BREAKER_FAILURE_THRESHOLD,
     REDIS_CIRCUIT_BREAKER_RECOVERY_TIMEOUT,
 )
@@ -114,15 +115,23 @@ class RedisCircuitBreaker:
     OPEN = "open"
     HALF_OPEN = "half_open"
 
-    def __init__(self, failure_threshold: int, recovery_timeout: int) -> None:
+    def __init__(
+        self,
+        failure_threshold: int,
+        recovery_timeout: int,
+        enabled: bool = True,
+    ) -> None:
         self.failure_threshold = failure_threshold
         self.recovery_timeout = recovery_timeout
+        self.enabled = enabled
         self._failure_count = 0
         self._opened_at: Optional[float] = None
         self._state = self.CLOSED
 
     def is_open(self) -> bool:
         """Returns True if Redis calls should be skipped."""
+        if not self.enabled:
+            return False
         if self._state == self.HALF_OPEN:
             # Probe already in flight — fast-fail all concurrent requests.
             # Only the one call that caused the OPEN→HALF_OPEN transition
@@ -136,6 +145,8 @@ class RedisCircuitBreaker:
         return False
 
     def record_failure(self) -> None:
+        if not self.enabled:
+            return
         self._failure_count += 1
         self._opened_at = time.time()
         if self._failure_count >= self.failure_threshold:
@@ -149,6 +160,8 @@ class RedisCircuitBreaker:
             self._state = self.OPEN
 
     def record_success(self) -> None:
+        if not self.enabled:
+            return
         if self._state == self.HALF_OPEN:
             verbose_logger.info("Redis circuit breaker CLOSED — Redis recovered")
         self._failure_count = 0
@@ -243,6 +256,7 @@ class RedisCache(BaseCache):
         self._circuit_breaker = RedisCircuitBreaker(
             failure_threshold=REDIS_CIRCUIT_BREAKER_FAILURE_THRESHOLD,
             recovery_timeout=REDIS_CIRCUIT_BREAKER_RECOVERY_TIMEOUT,
+            enabled=REDIS_CIRCUIT_BREAKER_ENABLED,
         )
 
         self._setup_health_pings()

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -398,6 +398,9 @@ REDIS_CIRCUIT_BREAKER_FAILURE_THRESHOLD = int(
 REDIS_CIRCUIT_BREAKER_RECOVERY_TIMEOUT = int(
     os.getenv("REDIS_CIRCUIT_BREAKER_RECOVERY_TIMEOUT", 60)
 )
+REDIS_CIRCUIT_BREAKER_ENABLED = (
+    os.getenv("REDIS_CIRCUIT_BREAKER_ENABLED", "true").lower() == "true"
+)
 # Default Redis major version to assume when version cannot be determined
 # Using 7 as it's the modern version that supports LPOP with count parameter
 DEFAULT_REDIS_MAJOR_VERSION = int(os.getenv("DEFAULT_REDIS_MAJOR_VERSION", 7))

--- a/litellm/proxy/hooks/parallel_request_limiter_v3.py
+++ b/litellm/proxy/hooks/parallel_request_limiter_v3.py
@@ -313,6 +313,14 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
 
         self.window_size = int(os.getenv("LITELLM_RATE_LIMIT_WINDOW_SIZE", 60))
 
+        # When disabled, TPM is enforced post-call from actual usage (pre-v1.82
+        # behavior) instead of reserving an estimated budget upfront, shedding
+        # the extra per-request Redis Lua round-trip and the global-lock
+        # in-memory fallback that the reservation path incurs.
+        self.tpm_reservation_enabled = (
+            os.getenv("LITELLM_TPM_TOKEN_RESERVATION_ENABLED", "true").lower() == "true"
+        )
+
         # Batch rate limiter (lazy loaded)
         self._batch_rate_limiter: Optional[Any] = None
 
@@ -2113,17 +2121,19 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
         # Only check rate limits if we have descriptors with actual limits
         if descriptors:
             # First pass: RPM and max_parallel_requests sliding-window check.
-            # `skip_tpm_check=True` tells should_rate_limit to ignore each
-            # descriptor's tokens_per_unit so its +1-per-key Lua / in-memory
-            # increment never touches the :tokens counters — those are owned
-            # exclusively by the atomic reserve_tpm_tokens path below. Without
-            # this, every concurrent in-flight request would pre-inflate the
-            # :tokens counter by 1, shrinking the effective TPM budget by N
-            # and causing false-positive 429s under bursts.
+            # When reservation is enabled, `skip_tpm_check=True` tells
+            # should_rate_limit to ignore each descriptor's tokens_per_unit so
+            # its +1-per-key Lua / in-memory increment never touches the
+            # :tokens counters — those are owned exclusively by the atomic
+            # reserve_tpm_tokens path below. Without this, every concurrent
+            # in-flight request would pre-inflate the :tokens counter by 1,
+            # shrinking the effective TPM budget by N and causing
+            # false-positive 429s under bursts. When reservation is disabled,
+            # this pass enforces TPM directly from the post-call counters.
             response = await self.should_rate_limit(
                 descriptors=descriptors,
                 parent_otel_span=user_api_key_dict.parent_otel_span,
-                skip_tpm_check=True,
+                skip_tpm_check=self.tpm_reservation_enabled,
             )
 
             if response["overall_code"] == "OVER_LIMIT":
@@ -2153,7 +2163,7 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
             ]
             has_tpm_limits = bool(configured_tpm_limits)
 
-            if has_tpm_limits:
+            if has_tpm_limits and self.tpm_reservation_enabled:
                 min_configured_tpm_limit = min(configured_tpm_limits)
 
                 # When the configured TPM cap is small enough to constrain the

--- a/scripts/health_check/health_check_client.py
+++ b/scripts/health_check/health_check_client.py
@@ -54,7 +54,7 @@ class LiteLLMHealthCheckClient:
             timeout: Request timeout in seconds (default: 120, matching Go implementation)
             completion_prompt: Test prompt for chat/completion models
             embedding_text: Test text for embedding models
-            custom_auth_header: Optional custom header name for authentication (e.g., "x-ifood-requester-service").
+            custom_auth_header: Optional custom header name for authentication (e.g., "x-requester-service").
                 If provided, uses this header instead of standard "Authorization" header.
         """
         self.base_url = base_url.rstrip("/")
@@ -404,7 +404,7 @@ async def main():
     yaml_path = os.environ.get("LITELLM_MODELS_YAML")
     custom_auth_header = os.environ.get(
         "LITELLM_CUSTOM_AUTH_HEADER"
-    )  # e.g., "x-ifood-requester-service"
+    )  # e.g., "x-requester-service"
 
     # Debug: Print custom auth header value if set
     if custom_auth_header:

--- a/tests/test_litellm/caching/test_dual_cache.py
+++ b/tests/test_litellm/caching/test_dual_cache.py
@@ -243,6 +243,67 @@ def test_circuit_breaker_half_open_concurrent_calls_are_fast_failed():
         ), "concurrent callers should be fast-failed in HALF_OPEN"
 
 
+def test_circuit_breaker_disabled_never_opens():
+    """When disabled, failures never open the circuit and is_open() stays False."""
+    from litellm.caching.redis_cache import RedisCircuitBreaker
+
+    cb = RedisCircuitBreaker(failure_threshold=3, recovery_timeout=60, enabled=False)
+
+    for _ in range(100):
+        cb.record_failure()
+
+    assert cb._state == "closed"
+    assert cb.is_open() is False
+
+
+def test_circuit_breaker_disabled_record_success_leaves_state_untouched():
+    """
+    A disabled breaker must not mutate state in any state-machine method. Force
+    a non-default (OPEN) state and assert record_success() returns without
+    resetting it — the same enabled-guard contract as is_open/record_failure.
+    """
+    from litellm.caching.redis_cache import RedisCircuitBreaker
+
+    cb = RedisCircuitBreaker(failure_threshold=3, recovery_timeout=60, enabled=False)
+    cb._state = "open"
+    cb._failure_count = 3
+
+    cb.record_success()
+
+    assert cb._state == "open"
+    assert cb._failure_count == 3
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_disabled_guard_always_calls_method():
+    """A disabled breaker lets every guarded call through, even after failures."""
+    from litellm.caching.redis_cache import (
+        RedisCircuitBreaker,
+        _redis_circuit_breaker_guard,
+    )
+
+    class FakeRedis:
+        def __init__(self):
+            self._circuit_breaker = RedisCircuitBreaker(
+                failure_threshold=1, recovery_timeout=60, enabled=False
+            )
+            self.call_count = 0
+
+        @_redis_circuit_breaker_guard
+        async def boom(self):
+            self.call_count += 1
+            raise RuntimeError("redis down")
+
+    fr = FakeRedis()
+    for _ in range(5):
+        with pytest.raises(RuntimeError, match="redis down"):
+            await fr.boom()
+
+    # Every call reached the method body; the breaker never short-circuited.
+    assert fr.call_count == 5
+    assert fr._circuit_breaker.is_open() is False
+
+
 @pytest.mark.asyncio
 async def test_async_increment_cache_returns_none_when_no_in_memory_cache_and_redis_fails():
     """

--- a/tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py
+++ b/tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py
@@ -3187,3 +3187,111 @@ def test_get_key_mcp_rpm_limit_precedence():
     none_set = UserAPIKeyAuth(api_key=hash_token("sk-mcp-key"))
     assert get_key_mcp_rpm_limit(none_set) is None
     assert get_team_mcp_rpm_limit(none_set) is None
+
+
+def test_tpm_reservation_enabled_by_default(monkeypatch):
+    """Upfront TPM reservation is on unless explicitly disabled via env."""
+    monkeypatch.delenv("LITELLM_TPM_TOKEN_RESERVATION_ENABLED", raising=False)
+    handler = _PROXY_MaxParallelRequestsHandler(
+        internal_usage_cache=InternalUsageCache(DualCache())
+    )
+    assert handler.tpm_reservation_enabled is True
+
+
+@pytest.mark.parametrize("value", ["false", "False", "FALSE"])
+def test_tpm_reservation_disabled_via_env(monkeypatch, value):
+    monkeypatch.setenv("LITELLM_TPM_TOKEN_RESERVATION_ENABLED", value)
+    handler = _PROXY_MaxParallelRequestsHandler(
+        internal_usage_cache=InternalUsageCache(DualCache())
+    )
+    assert handler.tpm_reservation_enabled is False
+
+
+@pytest.mark.asyncio
+async def test_pre_call_hook_reserves_tpm_when_enabled(monkeypatch):
+    """
+    With reservation enabled, the pre-call hook reserves the estimated token
+    budget upfront and tells should_rate_limit to skip the :tokens counter so
+    only the reservation path owns it.
+    """
+    monkeypatch.delenv("LITELLM_TPM_TOKEN_RESERVATION_ENABLED", raising=False)
+    handler = _PROXY_MaxParallelRequestsHandler(
+        internal_usage_cache=InternalUsageCache(DualCache())
+    )
+
+    user_api_key_dict = UserAPIKeyAuth(api_key=hash_token("sk-tpm"), tpm_limit=10_000)
+
+    should_rate_limit_calls: List[Dict[str, Any]] = []
+    original_should_rate_limit = handler.should_rate_limit
+
+    async def spy_should_rate_limit(*args, **kwargs):
+        should_rate_limit_calls.append(kwargs)
+        return await original_should_rate_limit(*args, **kwargs)
+
+    reserve_calls: List[int] = []
+    original_reserve = handler.reserve_tpm_tokens
+
+    async def spy_reserve(*args, **kwargs):
+        reserve_calls.append(kwargs.get("estimated_tokens"))
+        return await original_reserve(*args, **kwargs)
+
+    monkeypatch.setattr(handler, "should_rate_limit", spy_should_rate_limit)
+    monkeypatch.setattr(handler, "reserve_tpm_tokens", spy_reserve)
+
+    await handler.async_pre_call_hook(
+        user_api_key_dict=user_api_key_dict,
+        cache=handler.internal_usage_cache.dual_cache,
+        data={"model": "gpt-4", "messages": [{"role": "user", "content": "hi"}]},
+        call_type="completion",
+    )
+
+    assert len(reserve_calls) == 1, "reservation must run when enabled"
+    assert should_rate_limit_calls[0]["skip_tpm_check"] is True
+
+
+@pytest.mark.asyncio
+async def test_pre_call_hook_skips_reservation_when_disabled(monkeypatch):
+    """
+    With reservation disabled, the pre-call hook never calls reserve_tpm_tokens
+    and enforces TPM directly in should_rate_limit (skip_tpm_check=False), the
+    pre-v1.82 post-call accounting behavior.
+    """
+    monkeypatch.setenv("LITELLM_TPM_TOKEN_RESERVATION_ENABLED", "false")
+    handler = _PROXY_MaxParallelRequestsHandler(
+        internal_usage_cache=InternalUsageCache(DualCache())
+    )
+
+    user_api_key_dict = UserAPIKeyAuth(api_key=hash_token("sk-tpm"), tpm_limit=10_000)
+
+    should_rate_limit_calls: List[Dict[str, Any]] = []
+    original_should_rate_limit = handler.should_rate_limit
+
+    async def spy_should_rate_limit(*args, **kwargs):
+        should_rate_limit_calls.append(kwargs)
+        return await original_should_rate_limit(*args, **kwargs)
+
+    reserve_calls: List[Any] = []
+
+    async def spy_reserve(*args, **kwargs):
+        reserve_calls.append(kwargs)
+        raise AssertionError("reserve_tpm_tokens must not run when disabled")
+
+    monkeypatch.setattr(handler, "should_rate_limit", spy_should_rate_limit)
+    monkeypatch.setattr(handler, "reserve_tpm_tokens", spy_reserve)
+
+    data = {"model": "gpt-4", "messages": [{"role": "user", "content": "hi"}]}
+    await handler.async_pre_call_hook(
+        user_api_key_dict=user_api_key_dict,
+        cache=handler.internal_usage_cache.dual_cache,
+        data=data,
+        call_type="completion",
+    )
+
+    assert reserve_calls == [], "reservation must be skipped when disabled"
+    assert should_rate_limit_calls[0]["skip_tpm_check"] is False
+    # No reservation stash leaks into the request metadata.
+    from litellm.proxy.hooks.parallel_request_limiter_v3 import (
+        TPM_RESERVED_TOKENS_KEY,
+    )
+
+    assert TPM_RESERVED_TOKENS_KEY not in (data.get("metadata") or {})


### PR DESCRIPTION
## Relevant issues

A user reported Redis timeouts and latency regressions after deploying v1.82.0 or greater of the v3 rate limiter.

## Linear ticket

Resolves LIT-3612

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

This was run against a live proxy talking to the real OpenAI API (gpt-4o-mini), with a real Redis backing the v3 rate limiter and a real Postgres for key storage. The two new toggles default to the current behavior, so an existing deployment is unaffected unless it opts out.

### Setup

```bash
docker run -d --name pr30211-redis -p 6379:6379 redis:7-alpine
docker run -d --name pr30211-pg -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=litellm -p 5432:5432 postgres:16-alpine
```

Config (`/tmp/pr30211_config.yaml`):

```yaml
model_list:
  - model_name: gpt-4o-mini
    litellm_params:
      model: openai/gpt-4o-mini
      api_key: os.environ/OPENAI_API_KEY

litellm_settings:
  cache: true
  cache_params:
    type: redis
    host: localhost
    port: 6379

general_settings:
  master_key: sk-1234
```

A virtual key with a deliberately small TPM cap so the reservation behavior is easy to see:

```bash
curl -s -X POST http://localhost:4000/key/generate \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"models":["gpt-4o-mini"],"tpm_limit":200,"max_budget":5}'
# -> {"key":"sk-...", "tpm_limit":200, ...}
```

### Scenario A: default behavior, upfront TPM reservation ON

Started the proxy with neither toggle set, so reservation is on (the v1.82+ behavior). A single request with `max_tokens=120` reserves the full estimated budget up front even though the model only returns a handful of tokens.

```
single request, max_tokens=120 -> http=200
actual total_tokens = 15
proxy log: TPM reservation estimate: input=4, max_tokens=120 (explicit=True), total=124
proxy log: limit_remaining': 76, 'rate_limit_type': 'tokens'
```

So 124 of the 200 token budget is consumed at admission time against an actual usage of 15. Under a concurrent burst the reservations stack and the limiter sheds requests that would otherwise fit:

```bash
for i in 1 2 3 4; do
  curl -s -o /dev/null -w "req$i http=%{http_code}\n" -X POST http://localhost:4000/v1/chat/completions \
    -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
    -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Say hi in one word."}],"max_tokens":120}' &
done; wait
```

```
req4 http=200
req2 http=429
req1 http=429
req3 http=200
```

```json
{"error":{"message":"Rate limit exceeded for api_key: <hash>. Limit type: tokens. Current limit: 200, Remaining: 76. Limit resets at: 2026-06-11 10:12:27 UTC","type":"throttling_error","param":null,"code":"429"}}
```

Two of four concurrent requests are rejected with a token limit error even though their combined actual usage is well under 200, because each in-flight request reserves about 124 tokens up front.

### Scenario B: opt out, reservation OFF and circuit breaker OFF

Restarted the proxy with both toggles disabled:

```bash
LITELLM_TPM_TOKEN_RESERVATION_ENABLED=false REDIS_CIRCUIT_BREAKER_ENABLED=false \
  python litellm/proxy/proxy_cli.py --config /tmp/pr30211_config.yaml --port 4000 --detailed_debug
```

The exact same concurrent burst now all succeeds, no reservation runs, and the Redis `:tokens` counter reflects only actual post-call usage:

```
req3 http=200
req1 http=200
req2 http=200
req4 http=200

reservation-estimate log lines: 0
{api_key:<hash>}:tokens = 64
{model_per_key:<hash>:gpt-4o-mini}:tokens = 60
```

TPM enforcement still holds, it is just charged from real usage after the call rather than reserved up front. Firing sequential requests against the same key shows the counter climbing by actual tokens until it crosses the cap, at which point a 429 is returned:

```
req1  http=200  :tokens_after=16
req2  http=200  :tokens_after=32
...
req12 http=200  :tokens_after=192
req13 http=200  :tokens_after=208
req14 http=429  :tokens_after=209
```

```json
{"error":{"message":"Rate limit exceeded for api_key: <hash>. Limit type: tokens. Current limit: 200, Remaining: 0. Limit resets at: 2026-06-11 10:13:13 UTC","type":"throttling_error","param":null,"code":"429"}}
```

### Redis circuit breaker toggle

The circuit breaker only fires when Redis calls fail, so its effect is shown directly against the constant the proxy resolves at startup. With the toggle off the breaker never opens regardless of failures, so the limiter keeps using Redis instead of fast-failing to the in-memory fallback.

```
REDIS_CIRCUIT_BREAKER_ENABLED=false -> const=False, is_open() after 5 failures = False
default (enabled)                    -> const=True,  breaker OPENS after 2 failures, is_open() = True
```

### Cleanup

```bash
docker rm -f pr30211-redis pr30211-pg
```

## Type

🐛 Bug Fix

## Changes

The v3 rate limiter's upfront TPM token reservation (PR #27001) atomically debits each request's estimated token budget before the upstream call. That costs an extra Redis Lua round-trip per request and, when Redis fails, serializes the in-memory fallback through a process-global `asyncio.Lock`. Against a shared limit pool with thousands of concurrent users all hitting the same `{api_key:pool}:tokens` key, this compounds into occasional Lua timeouts, which trip the Redis circuit breaker open, which then fans every async Redis call out to the locked in-memory fallback and serializes the event loop.

Rather than fork a `_v4` handler, this gates the two pieces behind environment variables so the deployment can shed the overhead while everyone else is unaffected. Both default to the current behavior.

`LITELLM_TPM_TOKEN_RESERVATION_ENABLED=false` skips the reservation path entirely. The first sliding-window pass then enforces TPM directly (it no longer sets `skip_tpm_check`), and TPM is reconciled post-call from actual usage; this is the pre-v1.82 accounting model, which the post-call reconciliation already supports unchanged (no reservation stashed means every scope is charged the full actual usage). No extra Lua call, and the global-lock in-memory fallback is no longer on the per-request TPM path.

`REDIS_CIRCUIT_BREAKER_ENABLED=false` keeps the breaker permanently closed: `is_open()` always returns False, and `record_failure()` / `record_success()` are no-ops, so a burst of Lua timeouts can't open it and force every Redis call through the locked fallback. The existing `REDIS_CIRCUIT_BREAKER_FAILURE_THRESHOLD` / `_RECOVERY_TIMEOUT` knobs are unchanged.

Tests cover the breaker staying closed under sustained failures (and the guard always invoking the wrapped method), and the pre-call hook reserving vs. skipping based on the flag, including that no reservation stash leaks into request metadata when disabled.

Companion docs PR documenting the two env vars (unblocks the documentation and code-quality CI checks): BerriAI/litellm-docs#334
