### PR TITLE
fix(router/proxy): propagate completed_response through FallbackResponsesStreamWrapper for streaming /v1/responses container ownership (#30210)

### DIFF
--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -1572,6 +1572,21 @@ class ProxyBaseLLMRequestProcessing:
                         response=completed_obj,
                         user_api_key_dict=user_api_key_dict,
                     )
+                else:
+                    # Silent skip caused #30210: the proxy's Router wrapper
+                    # of the responses streaming iterator wasn't propagating
+                    # ``completed_response``, so this hook recorded nothing
+                    # and follow-up /v1/containers/<id>/files calls 403'd
+                    # for non-admin keys with no proxy-side hint. Log a
+                    # warning so future regressions of the same shape
+                    # surface in operator logs.
+                    verbose_proxy_logger.warning(
+                        "Container ownership recording skipped on streaming /v1/responses: "
+                        "no completed_response on stream iterator %s. Any code_interpreter "
+                        "container created in this call will return 403 on follow-up file "
+                        "lookups for non-admin keys.",
+                        type(original_stream_response).__name__,
+                    )
             except Exception as e:
                 verbose_proxy_logger.exception(
                     "Container ownership recording failed after streaming responses call: %s",

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -1581,10 +1581,12 @@ class ProxyBaseLLMRequestProcessing:
                     # warning so future regressions of the same shape
                     # surface in operator logs.
                     verbose_proxy_logger.warning(
-                        "Container ownership recording skipped on streaming /v1/responses: "
-                        "no completed_response on stream iterator %s. Any code_interpreter "
-                        "container created in this call will return 403 on follow-up file "
-                        "lookups for non-admin keys.",
+                        "Container ownership recording skipped on streaming "
+                        "/v1/responses: no completed_response on stream "
+                        "iterator %s. If this stream created any tool "
+                        "container (e.g. code_interpreter), follow-up "
+                        "/v1/containers/<id>/files calls will 403 for "
+                        "non-admin keys.",
                         type(original_stream_response).__name__,
                     )
             except Exception as e:

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -2561,9 +2561,16 @@ class Router:
                 # is missing many of these attributes — use getattr fallbacks
                 # so wrapper construction never raises AttributeError. The
                 # bridge stores the logging object as `litellm_logging_obj`.
-                self.response = getattr(source_iterator, "response", None)
-                self.model = getattr(source_iterator, "model", None)
-                self.logging_obj = getattr(
+                # base class declares non-Optional types for these
+                # fields but the bridge path (LiteLLMCompletionStreamingIterator)
+                # can legitimately omit them at runtime — keep the None
+                # fallback. Same lines passed mypy on the pre-fix file
+                # because the surrounding function body wasn't fully
+                # type-narrowed; the new typed terminal-event tuple above
+                # is what made these surface.
+                self.response = getattr(source_iterator, "response", None)  # type: ignore[assignment]
+                self.model = getattr(source_iterator, "model", None)  # type: ignore[assignment]
+                self.logging_obj = getattr(  # type: ignore[assignment]
                     source_iterator,
                     "logging_obj",
                     getattr(source_iterator, "litellm_logging_obj", None),

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -2520,9 +2520,21 @@ class Router:
         from litellm.exceptions import MidStreamFallbackError
         from litellm.responses.streaming_iterator import (
             BaseResponsesAPIStreamingIterator,
+            _get_openai_response_types,
         )
 
         source_iterator = response
+
+        # Pre-resolve the set of terminal stream event types so the
+        # per-chunk type check inside FallbackResponsesStreamWrapper
+        # stays cheap; mirrors the source-iterator filter at
+        # responses/streaming_iterator.py:243-247.
+        _openai_types = _get_openai_response_types()
+        _RESPONSES_TERMINAL_EVENT_TYPES = (
+            _openai_types.ResponsesAPIStreamEvents.RESPONSE_COMPLETED,
+            _openai_types.ResponsesAPIStreamEvents.RESPONSE_INCOMPLETE,
+            _openai_types.ResponsesAPIStreamEvents.RESPONSE_FAILED,
+        )
 
         class FallbackResponsesStreamWrapper(BaseResponsesAPIStreamingIterator):
             """
@@ -2586,7 +2598,23 @@ class Router:
                 return self
 
             async def __anext__(self):
-                return await self._async_generator.__anext__()
+                chunk = await self._async_generator.__anext__()
+                # Sniff the terminal stream event off each forwarded chunk
+                # so ``self.completed_response`` is populated regardless of
+                # which inner iterator produced it (source_iterator,
+                # fallback_iterator, or any future wrapper). Without this
+                # the proxy's container-ownership hook (which reads
+                # ``getattr(stream_response, "completed_response", None)``
+                # via _extract_completed_responses_response) silently
+                # records nothing on streaming /v1/responses calls — every
+                # follow-up /v1/containers/<id>/files call then 403s for
+                # the very key that created the container (#30210).
+                if (
+                    self.completed_response is None
+                    and getattr(chunk, "type", None) in _RESPONSES_TERMINAL_EVENT_TYPES
+                ):
+                    self.completed_response = chunk
+                return chunk
 
             async def aclose(self):
                 # async generators always expose aclose — no defensive check needed.

--- a/tests/test_litellm/test_responses_streaming_container_ownership.py
+++ b/tests/test_litellm/test_responses_streaming_container_ownership.py
@@ -1,0 +1,261 @@
+"""
+Regression for #30210.
+
+When streaming /v1/responses goes through the proxy + Router, the
+streaming iterator is wrapped by ``Router._aresponses_streaming_iterator``
+which returns ``FallbackResponsesStreamWrapper``. That wrapper set
+``self.completed_response = None`` in __init__ and never updated it,
+so the proxy's container-ownership hook (which reads
+``getattr(stream_response, "completed_response", None)`` via
+``ProxyBaseLLMRequestProcessing._extract_completed_responses_response``)
+saw None on every streaming call and silently recorded nothing —
+follow-up ``GET /v1/containers/<id>/files`` then 403'd for the very
+key that created the container.
+
+Tests below construct the wrapper from a fake async generator that
+yields one terminal ``response.completed`` chunk and assert the
+wrapper now carries that chunk on ``completed_response`` so the
+proxy hook can walk it.
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_wrapper_class():
+    """Pull ``FallbackResponsesStreamWrapper`` out by running
+    ``Router._aresponses_streaming_iterator`` long enough to construct
+    the class then return it. Mirrors how the wrapper is actually
+    instantiated in production."""
+    from litellm.router import Router
+    from litellm.responses.streaming_iterator import (
+        BaseResponsesAPIStreamingIterator,
+    )
+
+    # Minimal source iterator stub with every attribute the wrapper
+    # copies in __init__ (see router.py:2552-2583).
+    source = SimpleNamespace(
+        response=None,
+        model="openai/gpt-5.5",
+        logging_obj=None,
+        responses_api_provider_config=None,
+        start_time=None,
+        litellm_metadata=None,
+        custom_llm_provider="openai",
+        request_data={},
+        call_type="aresponses",
+        _hidden_params={},
+    )
+
+    # The class is defined inside _aresponses_streaming_iterator; capture
+    # it by patching FallbackResponsesStreamWrapper into a sentinel on
+    # construction.
+    captured = {}
+
+    real_router_module = __import__("litellm.router", fromlist=["Router"])
+
+    async def _drive():
+        async def empty_gen():
+            if False:
+                yield  # pragma: no cover
+            return
+
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "openai/gpt-5.5",
+                    "litellm_params": {"model": "openai/gpt-5.5", "api_key": "sk-test"},
+                }
+            ]
+        )
+        wrapped = await router._aresponses_streaming_iterator(
+            response=source,  # type: ignore[arg-type]
+            initial_kwargs={},
+        )
+        captured["wrapper_cls"] = type(wrapped)
+        captured["instance"] = wrapped
+
+    asyncio.run(_drive())
+    return captured["wrapper_cls"], captured["instance"]
+
+
+def _terminal_chunk(event_type: str):
+    """A SimpleNamespace shaped like the openai responses-api terminal
+    event chunks the wrapper inspects (.type attribute)."""
+    return SimpleNamespace(
+        type=event_type,
+        response=SimpleNamespace(
+            id="resp_test",
+            output=[],
+            container={"id": "cntr_test", "type": "code_interpreter"},
+        ),
+    )
+
+
+def _non_terminal_chunk(event_type: str = "response.output_text.delta"):
+    return SimpleNamespace(type=event_type, delta="hello")
+
+
+class TestStreamWrapperCapturesTerminalEvent:
+    def test_terminal_completed_event_is_recorded_on_wrapper(self):
+        """The #30210 bug: a forwarded ``response.completed`` chunk used
+        to leave ``completed_response`` at None on the wrapper. Verify
+        it now carries the chunk."""
+        wrapper_cls, _ = _make_wrapper_class()
+
+        async def gen():
+            yield _non_terminal_chunk()
+            yield _terminal_chunk("response.completed")
+
+        wrapper = wrapper_cls(gen())
+        # Drain the wrapper.
+        out = asyncio.run(_drain(wrapper))
+        assert len(out) == 2
+        assert wrapper.completed_response is not None, (
+            "FallbackResponsesStreamWrapper.completed_response is still None "
+            "after a response.completed chunk passed through — the proxy "
+            "container-ownership hook will 403 follow-up file lookups (#30210)"
+        )
+        assert wrapper.completed_response.type == "response.completed"
+
+    def test_terminal_incomplete_event_is_recorded(self):
+        wrapper_cls, _ = _make_wrapper_class()
+
+        async def gen():
+            yield _terminal_chunk("response.incomplete")
+
+        wrapper = wrapper_cls(gen())
+        asyncio.run(_drain(wrapper))
+        assert wrapper.completed_response is not None
+        assert wrapper.completed_response.type == "response.incomplete"
+
+    def test_terminal_failed_event_is_recorded(self):
+        wrapper_cls, _ = _make_wrapper_class()
+
+        async def gen():
+            yield _terminal_chunk("response.failed")
+
+        wrapper = wrapper_cls(gen())
+        asyncio.run(_drain(wrapper))
+        assert wrapper.completed_response is not None
+        assert wrapper.completed_response.type == "response.failed"
+
+    def test_non_terminal_chunks_do_not_set_completed_response(self):
+        wrapper_cls, _ = _make_wrapper_class()
+
+        async def gen():
+            yield _non_terminal_chunk("response.output_text.delta")
+            yield _non_terminal_chunk("response.code_interpreter.in_progress")
+
+        wrapper = wrapper_cls(gen())
+        asyncio.run(_drain(wrapper))
+        assert (
+            wrapper.completed_response is None
+        ), "non-terminal chunks must not set completed_response"
+
+    def test_first_terminal_event_wins(self):
+        """Real streams only emit one terminal event, but defend against
+        future producers emitting more: keep the first one (the inner
+        source iterator behaves the same way)."""
+        wrapper_cls, _ = _make_wrapper_class()
+
+        first = _terminal_chunk("response.completed")
+        first.response.id = "resp_first"
+        second = _terminal_chunk("response.completed")
+        second.response.id = "resp_second"
+
+        async def gen():
+            yield first
+            yield second
+
+        wrapper = wrapper_cls(gen())
+        asyncio.run(_drain(wrapper))
+        assert wrapper.completed_response.response.id == "resp_first"
+
+
+class TestProxyOwnershipHookReadsCompletedResponse:
+    """End-to-end: the proxy hook reads exactly the attribute the
+    wrapper now populates. Pin that the helper still extracts the
+    response correctly so the ownership recording path doesn't break."""
+
+    def test_extract_returns_inner_response_object(self):
+        from litellm.proxy.common_request_processing import (
+            ProxyBaseLLMRequestProcessing,
+        )
+
+        wrapper_cls, _ = _make_wrapper_class()
+
+        async def gen():
+            yield _terminal_chunk("response.completed")
+
+        wrapper = wrapper_cls(gen())
+        asyncio.run(_drain(wrapper))
+
+        extracted = ProxyBaseLLMRequestProcessing._extract_completed_responses_response(
+            wrapper
+        )
+        assert extracted is not None
+        assert extracted.id == "resp_test"
+        assert extracted.container["id"] == "cntr_test"
+
+
+class TestSilentSkipNowLogged:
+    """Reporter's secondary ask: when completed_response is None, the
+    ownership hook silently dropped on the floor. Make sure the new
+    warning fires so operators see a hint instead of a mute 403."""
+
+    def test_warning_logged_when_completed_response_missing(self, caplog):
+        import logging
+        from litellm.proxy.common_request_processing import (
+            ProxyBaseLLMRequestProcessing,
+        )
+
+        # Wrap a generator that produces NO terminal event so the
+        # wrapper stays at completed_response=None — same shape as the
+        # pre-fix bug.
+        wrapper_cls, _ = _make_wrapper_class()
+
+        async def gen():
+            yield _non_terminal_chunk()
+
+        wrapper = wrapper_cls(gen())
+
+        async def driver():
+            async def inner_gen():
+                async for c in wrapper:
+                    yield c
+
+            # Patch _record_container_owners_from_responses_if_needed to
+            # a noop async so the warning branch is exercised in
+            # isolation.
+            with patch.object(
+                ProxyBaseLLMRequestProcessing,
+                "_record_container_owners_from_responses_if_needed",
+                new=MagicMock(),
+            ):
+                wrapped = ProxyBaseLLMRequestProcessing._wrap_responses_stream_for_container_ownership(
+                    original_stream_response=wrapper,
+                    wrapped_generator=inner_gen(),
+                    user_api_key_dict=MagicMock(),
+                )
+                async for _ in wrapped:
+                    pass
+
+        with caplog.at_level(logging.WARNING, logger="LiteLLM Proxy"):
+            asyncio.run(driver())
+
+        assert any(
+            "Container ownership recording skipped on streaming /v1/responses"
+            in r.message
+            for r in caplog.records
+        ), "silent-skip warning never fired despite completed_response=None"
+
+
+async def _drain(it):
+    out = []
+    async for chunk in it:
+        out.append(chunk)
+    return out


### PR DESCRIPTION
## Relevant issues

Fixes #30210

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Type

🐛 Bug Fix

## Summary

\`_wrap_responses_stream_for_container_ownership\` reads \`completed_response\` off the stream iterator to record container ownership at end-of-stream. Through the Router (every proxy deployment), the stream is wrapped by \`FallbackResponsesStreamWrapper\` (router.py:2527) which set \`completed_response = None\` in __init__ and never updated it — the inner source iterator's terminal event never bubbled up. So the hook saw None on every streaming call, silently recorded nothing, and follow-up \`GET /v1/containers/<id>/files\` 403'd for non-admin keys.

#28990's unit test bypassed the Router so it never caught this. Reporter's repro is exact (vanilla v1.88.0 + Docker postgres + virtual key → streaming returns 403, non-streaming returns 200, DB shows ownership row only for the non-streaming container).

## What changed

- **router.py**: pre-resolves the responses-API terminal event tuple (\`response.completed\` / \`.incomplete\` / \`.failed\`) once per \`_aresponses_streaming_iterator\` call, and has the wrapper's \`__anext__\` sniff each forwarded chunk's \`.type\`. First terminal event hit stores the chunk on the wrapper's \`completed_response\`. Iterator-agnostic — works for source_iterator, the post-fallback iterator, and any future wrapper between them.
- **common_request_processing.py**: when \`_extract_completed_responses_response\` returns None, log a warning instead of silently skipping. The reporter lost time to exactly this silent skip; surfacing it in operator logs makes the next regression of the same shape immediately visible.

## Real-behavior proof

Pinned by the regression test suite — wraps a fake async generator that emits one \`response.completed\` chunk, drains the wrapper, asserts \`wrapper.completed_response.type == \"response.completed\"\` and that \`_extract_completed_responses_response\` returns the inner \`.response\` body with the container id intact.

## Tests

\`tests/test_litellm/test_responses_streaming_container_ownership.py\` — 7 mock-only tests:
- terminal \`response.completed\` event recorded on wrapper (FAILS on base)
- terminal \`response.incomplete\` event recorded (FAILS on base)
- terminal \`response.failed\` event recorded (FAILS on base)
- non-terminal chunks DO NOT set completed_response (pins shape)
- first terminal event wins (defends against future producers emitting more than one)
- proxy \`_extract_completed_responses_response\` walks the wrapper end-to-end (FAILS on base)
- silent-skip warning fires when completed_response stays None (FAILS on base)

\`\`\`
$ .venv/bin/python -m pytest tests/test_litellm/test_responses_streaming_container_ownership.py -q
7 passed in 0.29s
\`\`\`

On base, 6/7 fail as expected; only the pre-bug-shape test passes.

Adjacent suites both green:
\`\`\`
$ .venv/bin/python -m pytest tests/test_litellm/test_router_order_fallback.py -q                    # 13 passed
$ .venv/bin/python -m pytest tests/test_litellm/proxy/test_common_request_processing.py -q          # 94 passed
\`\`\`

## Changes

- \`litellm/router.py\` (+19 -1): import \`_get_openai_response_types\`, pre-resolve terminal tuple in \`_aresponses_streaming_iterator\`, sniff chunk type in wrapper's \`__anext__\`.
- \`litellm/proxy/common_request_processing.py\` (+16 -0): warn instead of silently skip when \`completed_response\` is None.
- \`tests/test_litellm/test_responses_streaming_container_ownership.py\` (+270): 7 mock-only regression tests.