### PR TITLE
fix(anthropic): only strip x-anthropic-billing-header on Bedrock targets

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -245,6 +245,13 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
     metadata: Optional[dict] = None
     system: Optional[str] = None
 
+    # Bedrock rejects `x-anthropic-billing-header:` text blocks in the system
+    # array as reserved-keyword (see #20951), so its subclasses set this to True
+    # to drop them on the wire. Anthropic-direct (this base class) must leave
+    # them in place: Claude Code uses them as the recognition signal for
+    # Max/Pro OAuth tokens, and stripping them causes 429s on Anthropic (#29572).
+    _strips_x_anthropic_billing_header: bool = False
+
     def __init__(
         self,
         max_tokens: Optional[int] = None,
@@ -1622,10 +1629,13 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                     # Skip empty text blocks - Anthropic API raises errors for empty text
                     if not system_message_block["content"]:
                         continue
-                    # Skip system messages containing x-anthropic-billing-header metadata
-                    if system_message_block["content"].startswith(
-                        "x-anthropic-billing-header:"
-                    ):
+                    # Skip system messages containing x-anthropic-billing-header
+                    # metadata only for targets that reject it (e.g. Bedrock).
+                    # Anthropic-direct keeps the header so Claude Code's
+                    # Max/Pro OAuth recognition signal isn't dropped (#29572).
+                    if self._strips_x_anthropic_billing_header and system_message_block[
+                        "content"
+                    ].startswith("x-anthropic-billing-header:"):
                         continue
                     anthropic_system_message_content = AnthropicSystemMessageContent(
                         type="text",
@@ -1644,9 +1654,11 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                         text_value = _content.get("text")
                         if _content.get("type") == "text" and not text_value:
                             continue
-                        # Skip system messages containing x-anthropic-billing-header metadata
+                        # Skip x-anthropic-billing-header text blocks only for
+                        # targets that reject the header (#29572).
                         if (
-                            _content.get("type") == "text"
+                            self._strips_x_anthropic_billing_header
+                            and _content.get("type") == "text"
                             and text_value
                             and text_value.startswith("x-anthropic-billing-header:")
                         ):
@@ -2429,11 +2441,13 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             tool_calls,
         )
 
-        json_mode_message, tool_calls_for_message, json_extra_content = (
-            self._resolve_json_mode_non_streaming(
-                json_mode=json_mode,
-                tool_calls=tool_calls,
-            )
+        (
+            json_mode_message,
+            tool_calls_for_message,
+            json_extra_content,
+        ) = self._resolve_json_mode_non_streaming(
+            json_mode=json_mode,
+            tool_calls=tool_calls,
         )
         merged_text = text_content or ""
         if json_extra_content:

--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -250,6 +250,13 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
     # to drop them on the wire. Anthropic-direct (this base class) must leave
     # them in place: Claude Code uses them as the recognition signal for
     # Max/Pro OAuth tokens, and stripping them causes 429s on Anthropic (#29572).
+    #
+    # Other subclasses (`VertexAIAnthropicConfig`, `AzureAnthropicConfig`,
+    # `DatabricksConfig`) inherit False and therefore forward the header.
+    # The reserved-keyword rejection in #20951 was reported only for Bedrock;
+    # those gateways pass the system array through to Anthropic models, which
+    # tolerate the block. If another gateway is found to reject it, set this
+    # flag to True on that subclass.
     _strips_x_anthropic_billing_header: bool = False
 
     def __init__(
@@ -1617,7 +1624,9 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
         Translate system message to anthropic format.
 
         Removes system message from the original list and returns a new list of anthropic system message content.
-        Filters out system messages containing x-anthropic-billing-header metadata.
+        When `_strips_x_anthropic_billing_header` is True (Bedrock subclasses),
+        also filters out system messages containing x-anthropic-billing-header
+        metadata; Anthropic-direct keeps them (#29572).
         """
         system_prompt_indices = []
         anthropic_system_message_list: List[AnthropicSystemMessageContent] = []

--- a/litellm/llms/bedrock/chat/invoke_transformations/anthropic_claude3_transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_transformations/anthropic_claude3_transformation.py
@@ -53,6 +53,10 @@ class AmazonAnthropicClaudeConfig(AmazonInvokeConfig, AnthropicConfig):
 
     anthropic_version: str = "bedrock-2023-05-31"
 
+    # Bedrock rejects `x-anthropic-billing-header:` text blocks in the system
+    # array as a reserved keyword (#20951), so strip them on the wire.
+    _strips_x_anthropic_billing_header: bool = True
+
     @property
     def custom_llm_provider(self) -> Optional[str]:
         return "bedrock"

--- a/litellm/llms/bedrock/claude_platform/transformation.py
+++ b/litellm/llms/bedrock/claude_platform/transformation.py
@@ -13,6 +13,10 @@ class BedrockClaudePlatformConfig(BedrockClaudePlatformMixin, AnthropicConfig):
     Bedrock Claude Platform uses Anthropic's Messages API with AWS gateway auth.
     """
 
+    # Bedrock rejects `x-anthropic-billing-header:` text blocks in the system
+    # array as a reserved keyword (#20951), so strip them on the wire.
+    _strips_x_anthropic_billing_header: bool = True
+
     @property
     def custom_llm_provider(self) -> Optional[str]:
         return "bedrock"

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -4864,3 +4864,86 @@ def test_sanitize_tool_names_in_request_no_tools_is_noop():
     forward, reverse = AnthropicConfig._sanitize_tool_names_in_request({"tools": []})
     assert forward == {}
     assert reverse == {}
+
+
+def test_translate_system_message_preserves_x_anthropic_billing_header_on_anthropic_direct():
+    """Regression for #29572.
+
+    Anthropic-direct must preserve `x-anthropic-billing-header:` text blocks
+    in the system array: Claude Code uses them as the recognition signal for
+    Max/Pro OAuth tokens, and stripping them causes 429s on Anthropic.
+    Only Bedrock subclasses strip the header.
+    """
+    config = AnthropicConfig()
+
+    # String content path
+    messages_str = [
+        {"role": "system", "content": "x-anthropic-billing-header: claude-code"},
+        {"role": "user", "content": "hi"},
+    ]
+    result = config.translate_system_message(messages_str)
+    assert len(result) == 1
+    assert result[0]["text"] == "x-anthropic-billing-header: claude-code"
+
+    # List content path
+    messages_list = [
+        {
+            "role": "system",
+            "content": [
+                {"type": "text", "text": "x-anthropic-billing-header: claude-code"},
+                {
+                    "type": "text",
+                    "text": "You are a security monitor for autonomous AI coding agents.",
+                },
+            ],
+        },
+        {"role": "user", "content": "hi"},
+    ]
+    result = config.translate_system_message(messages_list)
+    assert [block["text"] for block in result] == [
+        "x-anthropic-billing-header: claude-code",
+        "You are a security monitor for autonomous AI coding agents.",
+    ]
+
+
+def test_translate_system_message_strips_x_anthropic_billing_header_on_bedrock_invoke():
+    """Bedrock (AmazonAnthropicClaudeConfig) must strip `x-anthropic-billing-header:`
+    blocks because Bedrock rejects them as a reserved keyword (#20951).
+    Verifies the per-subclass `_strips_x_anthropic_billing_header` flag wired
+    up for #29572 doesn't regress that behavior.
+    """
+    from litellm.llms.bedrock.chat.invoke_transformations.anthropic_claude3_transformation import (
+        AmazonAnthropicClaudeConfig,
+    )
+
+    config = AmazonAnthropicClaudeConfig()
+
+    messages = [
+        {
+            "role": "system",
+            "content": [
+                {"type": "text", "text": "x-anthropic-billing-header: claude-code"},
+                {"type": "text", "text": "You are a helpful assistant."},
+            ],
+        },
+        {"role": "user", "content": "hi"},
+    ]
+    result = config.translate_system_message(messages)
+    assert [block["text"] for block in result] == ["You are a helpful assistant."]
+
+
+def test_translate_system_message_strips_x_anthropic_billing_header_on_bedrock_claude_platform():
+    """Same as above for BedrockClaudePlatformConfig."""
+    from litellm.llms.bedrock.claude_platform.transformation import (
+        BedrockClaudePlatformConfig,
+    )
+
+    config = BedrockClaudePlatformConfig()
+
+    messages = [
+        {"role": "system", "content": "x-anthropic-billing-header: claude-code"},
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "hi"},
+    ]
+    result = config.translate_system_message(messages)
+    assert [block["text"] for block in result] == ["You are a helpful assistant."]


### PR DESCRIPTION
## Summary

Closes #29572. Supersedes #29701 — that PR was briefly retargeted from `main` to `litellm_oss_branch` without a rebase, which ballooned the diff to ~1000 files and it was (reasonably) closed. This is the same 4-file change, properly based on `litellm_oss_branch`.

`AnthropicConfig.translate_system_message` strips any system block starting with `x-anthropic-billing-header:` for every Anthropic-derived config. That strip was added in #20951 because Bedrock rejects the header as a reserved keyword.

The strip is wrong for **Anthropic-direct**: Claude Code uses that block as the recognition signal for Max/Pro subscription OAuth tokens (`sk-ant-oat01-*`). When LiteLLM removes it, Anthropic stops recognizing the request as Claude Code and replies with a misleading `rate_limit_error` 429 — breaking the tool-safety classifier across `auto`, `plan`, and `accept-edits` modes on every Sonnet and Opus model.

## Fix shape

Gate the strip on a new class attribute `_strips_x_anthropic_billing_header`:

| Subclass | Value | Behavior |
|---|---|---|
| `AnthropicConfig` (base, Anthropic-direct) | `False` (new default) | Preserves the header → Claude Code OAuth tokens authenticate correctly |
| `AmazonAnthropicClaudeConfig` (Bedrock invoke) | `True` | Strips the header → matches #20951 (unchanged) |
| `BedrockClaudePlatformConfig` (Bedrock claude_platform) | `True` | Strips the header → matches #20951 (unchanged) |

## Test plan

- [x] `test_translate_system_message_preserves_x_anthropic_billing_header_on_anthropic_direct` — string + list content paths
- [x] `test_translate_system_message_strips_x_anthropic_billing_header_on_bedrock_invoke` — Bedrock invoke strip preserved
- [x] `test_translate_system_message_strips_x_anthropic_billing_header_on_bedrock_claude_platform` — claude_platform strip preserved
- [x] All existing `translate_system_message` tests pass (7/7 in the translate_system_message group)
- [x] `black` (pinned 26.3.1) clean on touched files