### PR TITLE
feat(proxy): auto-enable drop_params for Claude Code requests

### DIFF
--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -397,6 +397,11 @@ def get_chain_id_from_headers(headers: Optional[Dict[str, str]]) -> Optional[str
     )
 
 
+def is_claude_code_user_agent(user_agent: str) -> bool:
+    """Claude Code (CLI, IDE extensions, Agent SDK) identifies itself as ``claude-cli/<version> ...``."""
+    return user_agent.startswith("claude-cli/")
+
+
 def safe_add_api_version_from_query_params(data: dict, request: Request):
     try:
         if hasattr(request, "query_params"):
@@ -1741,6 +1746,12 @@ async def add_litellm_data_to_request(  # noqa: PLR0915
     ):
         user_agent = request.headers["user-agent"]
     data[_metadata_variable_name]["user_agent"] = user_agent
+
+    # Claude Code sends Anthropic-specific params (e.g. top_k, thinking) that
+    # break requests routed to non-Anthropic providers; drop them instead of
+    # failing, unless the caller set drop_params explicitly.
+    if is_claude_code_user_agent(user_agent) and "drop_params" not in data:
+        data["drop_params"] = True
 
     # Merge caller-supplied tags (x-litellm-tags header, data["tags"] root-level)
     # into request metadata for tag-based routing and spend attribution.

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -398,8 +398,29 @@ def get_chain_id_from_headers(headers: Optional[Dict[str, str]]) -> Optional[str
 
 
 def is_claude_code_user_agent(user_agent: str) -> bool:
-    """Claude Code (CLI, IDE extensions, Agent SDK) identifies itself as ``claude-cli/<version> ...``."""
+    """Claude Code identifies itself as ``claude-cli/<version> ...``; the IDE
+    extensions and the Agent SDK run through the same CLI and share that prefix."""
     return user_agent.startswith("claude-cli/")
+
+
+def should_auto_drop_params_for_claude_code(
+    user_agent: str, data: dict, proxy_config: ProxyConfig
+) -> bool:
+    """drop_params defaults to on for Claude Code so its Anthropic-specific
+    params (e.g. thinking) don't fail requests routed to non-Anthropic
+    providers. An explicit drop_params from the caller or in the operator's
+    ``litellm_settings`` always wins over this default."""
+    if not is_claude_code_user_agent(user_agent):
+        return False
+    if "drop_params" in data:
+        return False
+    config = getattr(proxy_config, "config", None)
+    litellm_settings = (
+        config.get("litellm_settings") if isinstance(config, dict) else None
+    )
+    return not (
+        isinstance(litellm_settings, dict) and "drop_params" in litellm_settings
+    )
 
 
 def safe_add_api_version_from_query_params(data: dict, request: Request):
@@ -1747,10 +1768,7 @@ async def add_litellm_data_to_request(  # noqa: PLR0915
         user_agent = request.headers["user-agent"]
     data[_metadata_variable_name]["user_agent"] = user_agent
 
-    # Claude Code sends Anthropic-specific params (e.g. top_k, thinking) that
-    # break requests routed to non-Anthropic providers; drop them instead of
-    # failing, unless the caller set drop_params explicitly.
-    if is_claude_code_user_agent(user_agent) and "drop_params" not in data:
+    if should_auto_drop_params_for_claude_code(user_agent, data, proxy_config):
         data["drop_params"] = True
 
     # Merge caller-supplied tags (x-litellm-tags header, data["tags"] root-level)

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -4603,3 +4603,55 @@ def test_apply_overrides_provider_prefix_in_model_skips_router_lookup(
     assert data["api_base"] == "https://hotel-eastus.openai.azure.com/"
     assert data["api_key"] == "key-hotel-eastus"
     router.get_deployment_by_model_group_name.assert_not_called()
+
+
+def _make_request_mock(path: str, headers: dict) -> MagicMock:
+    request_mock = MagicMock(spec=Request)
+    request_mock.url = MagicMock()
+    request_mock.url.path = path
+    request_mock.url.__str__.return_value = f"http://localhost{path}"
+    request_mock.method = "POST"
+    request_mock.query_params = {}
+    request_mock.headers = headers
+    request_mock.client = MagicMock()
+    request_mock.client.host = "127.0.0.1"
+    return request_mock
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "user_agent, request_drop_params, expected_drop_params",
+    [
+        ("claude-cli/2.0.69 (external, cli)", None, True),
+        ("claude-cli/1.0.44 (external, sdk-py)", None, True),
+        ("claude-cli/2.0.69 (external, cli)", False, False),
+        ("PostmanRuntime/7.53.0", None, None),
+        (None, None, None),
+    ],
+)
+async def test_add_litellm_data_to_request_claude_code_drop_params(
+    user_agent, request_drop_params, expected_drop_params
+):
+    """Claude Code sends Anthropic-specific params that fail on non-Anthropic
+    providers, so its user agent must turn on drop_params automatically,
+    without overriding an explicit caller value or affecting other clients.
+    """
+    headers = {"Content-Type": "application/json"}
+    if user_agent is not None:
+        headers["user-agent"] = user_agent
+    request_mock = _make_request_mock("/v1/messages", headers)
+
+    data = {"model": "gpt-4o", "messages": [{"role": "user", "content": "hi"}]}
+    if request_drop_params is not None:
+        data["drop_params"] = request_drop_params
+
+    updated = await add_litellm_data_to_request(
+        data=data,
+        request=request_mock,
+        user_api_key_dict=UserAPIKeyAuth(api_key="hashed-key"),
+        proxy_config=MagicMock(),
+        general_settings={},
+        version="test-version",
+    )
+
+    assert updated.get("drop_params") == expected_drop_params

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -4620,21 +4620,24 @@ def _make_request_mock(path: str, headers: dict) -> MagicMock:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "user_agent, request_drop_params, expected_drop_params",
+    "user_agent, request_drop_params, operator_drop_params, expected_drop_params",
     [
-        ("claude-cli/2.0.69 (external, cli)", None, True),
-        ("claude-cli/1.0.44 (external, sdk-py)", None, True),
-        ("claude-cli/2.0.69 (external, cli)", False, False),
-        ("PostmanRuntime/7.53.0", None, None),
-        (None, None, None),
+        ("claude-cli/2.0.69 (external, cli)", None, None, True),
+        ("claude-cli/1.0.44 (external, sdk-py)", None, None, True),
+        ("claude-cli/2.0.69 (external, cli)", False, None, False),
+        ("claude-cli/2.0.69 (external, cli)", None, False, None),
+        ("claude-cli/2.0.69 (external, cli)", None, True, None),
+        ("PostmanRuntime/7.53.0", None, None, None),
+        (None, None, None, None),
     ],
 )
 async def test_add_litellm_data_to_request_claude_code_drop_params(
-    user_agent, request_drop_params, expected_drop_params
+    user_agent, request_drop_params, operator_drop_params, expected_drop_params
 ):
     """Claude Code sends Anthropic-specific params that fail on non-Anthropic
     providers, so its user agent must turn on drop_params automatically,
-    without overriding an explicit caller value or affecting other clients.
+    without overriding an explicit caller value, an explicit operator-level
+    litellm_settings value, or affecting other clients.
     """
     headers = {"Content-Type": "application/json"}
     if user_agent is not None:
@@ -4645,11 +4648,18 @@ async def test_add_litellm_data_to_request_claude_code_drop_params(
     if request_drop_params is not None:
         data["drop_params"] = request_drop_params
 
+    proxy_config = MagicMock()
+    proxy_config.config = (
+        {"litellm_settings": {"drop_params": operator_drop_params}}
+        if operator_drop_params is not None
+        else {"litellm_settings": {}}
+    )
+
     updated = await add_litellm_data_to_request(
         data=data,
         request=request_mock,
         user_api_key_dict=UserAPIKeyAuth(api_key="hashed-key"),
-        proxy_config=MagicMock(),
+        proxy_config=proxy_config,
         general_settings={},
         version="test-version",
     )


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Ran a live proxy with an OpenAI and a Gemini model (real provider APIs, no mocks):

```
python litellm/proxy/proxy_cli.py --config /tmp/cc_config.yaml --port 4000
```

config:

```yaml
model_list:
  - model_name: gpt-4o-mini
    litellm_params:
      model: openai/gpt-4o-mini
  - model_name: gemma-4-31b-it
    litellm_params:
      model: gemini/gemma-4-31b-it

general_settings:
  master_key: sk-1234
```

The repro is Claude Code's extended thinking param sent to a non-reasoning, non-Anthropic model. Without the Claude Code user agent the request fails:

```
$ curl -s http://localhost:4000/v1/messages \
  -H "x-api-key: sk-1234" \
  -H "anthropic-version: 2023-06-01" \
  -H "content-type: application/json" \
  -H "user-agent: PostmanRuntime/7.53.0" \
  -d '{"model": "gemma-4-31b-it", "max_tokens": 2048, "thinking": {"type": "enabled", "budget_tokens": 1024}, "messages": [{"role": "user", "content": "Say hi in 3 words"}]}'

{"error":{"message":"litellm.UnsupportedParamsError: gemini does not support parameters: ['reasoning_effort'], for model=gemma-4-31b-it. To drop these, set `litellm.drop_params=True` ...","type":"None","param":null,"code":"400"}}
```

The identical request with Claude Code's user agent now succeeds because drop_params is turned on automatically:

```
$ curl -s http://localhost:4000/v1/messages \
  -H "x-api-key: sk-1234" \
  -H "anthropic-version: 2023-06-01" \
  -H "content-type: application/json" \
  -H "user-agent: claude-cli/2.0.69 (external, cli)" \
  -d '{"model": "gemma-4-31b-it", "max_tokens": 2048, "thinking": {"type": "enabled", "budget_tokens": 1024}, "messages": [{"role": "user", "content": "Say hi in 3 words"}]}'

{"id":"i_IqasOxFZqQjrEP9670yA8","type":"message","role":"assistant","model":"gemma-4-31b-it","stop_sequence":null,"usage":{"input_tokens":7,"output_tokens":358},"content":[{"type":"thinking","thinking":"*   Task: Say \"hi\". ..."},{"type":"text","text":"Hi there, friend!"}],"stop_reason":"end_turn"}
```

An explicit caller value still wins; the same Claude Code request with `"drop_params": false` in the body fails with the UnsupportedParamsError as before

## Type

🆕 New Feature

## Changes

Claude Code identifies itself with a `claude-cli/<version>` user agent and sends Anthropic-specific params (thinking, top_k, etc.) on every request. When a LiteLLM proxy routes those requests to a non-Anthropic provider, the unsupported params fail the call with UnsupportedParamsError unless the operator remembered to configure `litellm_settings: drop_params: true`.

`add_litellm_data_to_request` now detects the Claude Code user agent and defaults `drop_params` to true for that request. The check runs for every endpoint that goes through pre-call setup, so both `/v1/messages` and `/v1/chat/completions` are covered.

The default never overrides an explicit value: a `drop_params` sent by the caller in the request body wins, and so does a `drop_params` the operator explicitly configured in `litellm_settings` (true or false). The auto-default only fills the gap when neither is set. Covered by a parametrized regression test in `tests/test_litellm/proxy/test_litellm_pre_call_utils.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow, User-Agent-gated default on the existing drop_params path; explicit request and config values still win.
> 
> **Overview**
> The proxy **defaults `drop_params` to true** for requests whose `User-Agent` starts with `claude-cli/`, so Anthropic-specific body fields (e.g. `thinking`) are stripped when routing to non-Anthropic models instead of failing with `UnsupportedParamsError`.
> 
> Pre-call setup in `add_litellm_data_to_request` calls new helpers `is_claude_code_user_agent` and `should_auto_drop_params_for_claude_code`. **Explicit `drop_params` in the request body or in operator `litellm_settings` is left unchanged**; other clients are unaffected. Parametrized tests cover Claude Code vs other agents and override precedence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b69b66f049f661d3051344543804df322b853271. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->