### PR TITLE
fix(proxy): cancel in-flight upstream LLM request on client disconnect (opt-in)

### DIFF
--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -556,6 +556,51 @@ def _has_attribute_error_in_chain(exc: Exception) -> bool:
     return False
 
 
+def _log_llm_api_exception(e: Exception) -> None:
+    if getattr(e, "status_code", None) == 499:
+        verbose_proxy_logger.info(
+            "litellm.proxy.proxy_server._handle_llm_api_exception(): client disconnected, upstream LLM request cancelled"
+        )
+        return
+    verbose_proxy_logger.exception(
+        f"litellm.proxy.proxy_server._handle_llm_api_exception(): Exception occured - {str(e)}"
+    )
+
+
+async def _cancel_llm_call_on_client_disconnect(
+    request: Request,
+    llm_api_call: "asyncio.Future[Any]",
+    disconnect_event: asyncio.Event,
+) -> None:
+    while True:
+        message = await request.receive()
+        if message["type"] == "http.disconnect":
+            disconnect_event.set()
+            llm_api_call.cancel()
+            return
+
+
+async def _await_llm_call_cancelling_on_disconnect(
+    request: Request,
+    llm_api_call: "asyncio.Future[Any]",
+) -> Any:
+    disconnect_event = asyncio.Event()
+    monitor = asyncio.create_task(
+        _cancel_llm_call_on_client_disconnect(request, llm_api_call, disconnect_event)
+    )
+    try:
+        return await llm_api_call
+    except asyncio.CancelledError:
+        if disconnect_event.is_set():
+            raise HTTPException(
+                status_code=499,
+                detail="Client disconnected the request",
+            )
+        raise
+    finally:
+        monitor.cancel()
+
+
 class ProxyBaseLLMRequestProcessing:
     def __init__(self, data: dict):
         self.data = data
@@ -1222,7 +1267,12 @@ class ProxyBaseLLMRequestProcessing:
             *tasks
         )  # run the moderation check in parallel to the actual llm api call
 
-        responses = await llm_responses
+        if general_settings.get("cancel_on_disconnect", False):
+            responses = await _await_llm_call_cancelling_on_disconnect(
+                request, llm_responses
+            )
+        else:
+            responses = await llm_responses
 
         response = responses[1]
 
@@ -1834,9 +1884,7 @@ class ProxyBaseLLMRequestProcessing:
         version: Optional[str] = None,
     ):
         """Raises ProxyException (OpenAI API compatible) if an exception is raised"""
-        verbose_proxy_logger.exception(
-            f"litellm.proxy.proxy_server._handle_llm_api_exception(): Exception occured - {str(e)}"
-        )
+        _log_llm_api_exception(e)
         # Allow callbacks to transform the error response
         transformed_exception = await proxy_logging_obj.post_call_failure_hook(
             user_api_key_dict=user_api_key_dict,

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -556,8 +556,14 @@ def _has_attribute_error_in_chain(exc: Exception) -> bool:
     return False
 
 
+_CLIENT_DISCONNECT_DETAIL = "Client disconnected the request"
+
+
 def _log_llm_api_exception(e: Exception) -> None:
-    if getattr(e, "status_code", None) == 499:
+    if (
+        getattr(e, "status_code", None) == 499
+        and getattr(e, "detail", None) == _CLIENT_DISCONNECT_DETAIL
+    ):
         verbose_proxy_logger.info(
             "litellm.proxy.proxy_server._handle_llm_api_exception(): client disconnected, upstream LLM request cancelled"
         )
@@ -572,12 +578,19 @@ async def _cancel_llm_call_on_client_disconnect(
     llm_api_call: "asyncio.Future[Any]",
     disconnect_event: asyncio.Event,
 ) -> None:
-    while True:
-        message = await request.receive()
-        if message["type"] == "http.disconnect":
-            disconnect_event.set()
-            llm_api_call.cancel()
-            return
+    try:
+        while True:
+            message = await request.receive()
+            if message["type"] == "http.disconnect":
+                disconnect_event.set()
+                llm_api_call.cancel()
+                return
+    except Exception as exc:
+        verbose_proxy_logger.warning(
+            "cancel_on_disconnect: request.receive() raised %s; "
+            "upstream LLM call will not be cancelled on disconnect",
+            exc,
+        )
 
 
 async def _await_llm_call_cancelling_on_disconnect(
@@ -594,7 +607,7 @@ async def _await_llm_call_cancelling_on_disconnect(
         if disconnect_event.is_set():
             raise HTTPException(
                 status_code=499,
-                detail="Client disconnected the request",
+                detail=_CLIENT_DISCONNECT_DETAIL,
             )
         raise
     finally:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1941,34 +1941,6 @@ db_writer_client: Optional[AsyncHTTPHandler] = None
 ### logger ###
 
 
-async def check_request_disconnection(request: Request, llm_api_call_task):
-    """
-    Asynchronously checks if the request is disconnected at regular intervals.
-    If the request is disconnected
-    - cancel the litellm.router task
-    - raises an HTTPException with status code 499 and detail "Client disconnected the request".
-
-    Parameters:
-    - request: Request: The request object to check for disconnection.
-    Returns:
-    - None
-    """
-
-    # only run this function for 10 mins -> if these don't get cancelled -> we don't want the server to have many while loops
-    start_time = time.time()
-    while time.time() - start_time < 600:
-        await asyncio.sleep(1)
-        if await request.is_disconnected():
-            # cancel the LLM API Call task if any passed - this is passed from individual providers
-            # Example OpenAI, Azure, VertexAI etc
-            llm_api_call_task.cancel()
-
-            raise HTTPException(
-                status_code=499,
-                detail="Client disconnected the request",
-            )
-
-
 def _resolve_typed_dict_type(typ):
     """Resolve the actual TypedDict class from a potentially wrapped type."""
     from typing_extensions import _TypedDictMeta  # type: ignore

--- a/proxy_server_config.yaml
+++ b/proxy_server_config.yaml
@@ -230,6 +230,7 @@ general_settings:
   # background_health_checks: true
   # use_shared_health_check: true
   # health_check_interval: 30
+  # cancel_on_disconnect: true # cancel the in-flight upstream LLM request (non-streaming) when the client disconnects, freeing backend capacity (e.g. a vLLM GPU slot)
   # database_url: "postgresql://<user>:<password>@<host>:<port>/<dbname>" # [OPTIONAL] use for token-based auth to proxy
 
   pass_through_endpoints:

--- a/tests/test_litellm/proxy/proxy_server/test_lifecycle.py
+++ b/tests/test_litellm/proxy/proxy_server/test_lifecycle.py
@@ -9,7 +9,6 @@ Pins covered:
 - ``initialize``
 - ``load_from_azure_key_vault``
 - ``cost_tracking``
-- ``check_request_disconnection``
 - ``_resolve_typed_dict_type``
 - ``_resolve_pydantic_type``
 - ``get_litellm_model_info``
@@ -26,7 +25,7 @@ from typing import List, Optional, Union
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI
 from pydantic import BaseModel
 from typing_extensions import TypedDict
 
@@ -35,7 +34,6 @@ from litellm.proxy.proxy_server import (
     _initialize_shared_aiohttp_session,
     _resolve_pydantic_type,
     _resolve_typed_dict_type,
-    check_request_disconnection,
     cleanup_router_config_variables,
     cost_tracking,
     get_litellm_model_info,
@@ -322,62 +320,6 @@ def test_cost_tracking_no_op_when_prisma_missing(monkeypatch):
 
     assert litellm.callbacks == []
     assert litellm._async_success_callback == []
-
-
-# ---------------------------------------------------------------------------
-# check_request_disconnection
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_check_request_disconnection_cancels_task_and_raises_499(monkeypatch):
-    monkeypatch.setattr(ps.asyncio, "sleep", AsyncMock(return_value=None))
-
-    request = MagicMock()
-    request.is_disconnected = AsyncMock(return_value=True)
-    task = MagicMock()
-
-    raised_status = None
-    try:
-        await check_request_disconnection(request=request, llm_api_call_task=task)
-    except HTTPException as exc:
-        raised_status = exc.status_code
-
-    observed = {
-        "raised_status": raised_status,
-        "cancel_called": task.cancel.called,
-        "is_async": inspect.iscoroutinefunction(check_request_disconnection),
-    }
-    assert normalize(observed) == {
-        "raised_status": 499,
-        "cancel_called": True,
-        "is_async": True,
-    }
-
-
-@pytest.mark.asyncio
-async def test_check_request_disconnection_invalid_when_connected_times_out(monkeypatch):
-    """With a connected request the function loops for up to 10 minutes —
-    wrap in wait_for and assert it times out. Patch ``asyncio.sleep`` so the
-    loop spins without real wall-clock waits."""
-    import litellm.proxy.proxy_server as ps
-
-    request = MagicMock()
-    request.is_disconnected = AsyncMock(return_value=False)
-    task = MagicMock()
-
-    _real_sleep = asyncio.sleep
-
-    async def _instant_sleep(_seconds):
-        await _real_sleep(0)
-
-    monkeypatch.setattr(ps.asyncio, "sleep", _instant_sleep)
-
-    with pytest.raises(asyncio.TimeoutError):
-        await asyncio.wait_for(
-            check_request_disconnection(request=request, llm_api_call_task=task),
-            timeout=0.05,
-        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -2427,6 +2427,24 @@ class TestCancelOnDisconnect:
         assert not disconnect_event.is_set()
         monitor.cancel()
 
+    async def test_monitor_survives_receive_failure_without_cancelling(self):
+        """If request.receive() fails (e.g. transport reset) the watcher must
+        degrade to a no-op instead of crashing or cancelling the LLM call."""
+
+        async def receive():
+            raise RuntimeError("transport reset")
+
+        request = Request(scope={"type": "http", "headers": []}, receive=receive)
+        llm_call = asyncio.get_running_loop().create_future()
+        disconnect_event = asyncio.Event()
+
+        await _cancel_llm_call_on_client_disconnect(
+            request, llm_call, disconnect_event
+        )
+
+        assert not llm_call.cancelled()
+        assert not disconnect_event.is_set()
+
     async def test_cancellation_without_disconnect_reraises_cancelled_error(self):
         """A CancelledError that is NOT client-initiated (e.g. server shutdown)
         must propagate as-is instead of being masked as a 499."""

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -1,3 +1,4 @@
+import asyncio
 import copy
 import datetime
 from typing import AsyncGenerator
@@ -15,6 +16,8 @@ from litellm.integrations.opentelemetry import UserAPIKeyAuth
 from litellm.proxy.common_request_processing import (
     ProxyBaseLLMRequestProcessing,
     ProxyConfig,
+    _await_llm_call_cancelling_on_disconnect,
+    _cancel_llm_call_on_client_disconnect,
     _extract_error_from_sse_chunk,
     _get_cost_breakdown_from_logging_obj,
     _has_attribute_error_in_chain,
@@ -2372,3 +2375,176 @@ class TestAsyncStreamingDataGeneratorFastPath:
         hook_spy.assert_awaited_once()
 
         ProxyLogging._callback_capabilities_cache.clear()
+
+
+class TestCancelOnDisconnect:
+    """
+    Coverage for the opt-in `general_settings.cancel_on_disconnect` flag:
+    cancelling the in-flight upstream LLM call when the HTTP client disconnects
+    (issue #13774), without changing the default code path and without skipping
+    failure accounting (post_call_failure_hook) on the resulting 499.
+    """
+
+    def _request(self, messages: list) -> Request:
+        async def receive():
+            if messages:
+                return messages.pop(0)
+            await asyncio.Event().wait()
+
+        return Request(scope={"type": "http", "headers": []}, receive=receive)
+
+    async def test_monitor_cancels_llm_call_and_sets_event_on_disconnect(self):
+        request = self._request(
+            [
+                {"type": "http.request", "body": b"", "more_body": False},
+                {"type": "http.disconnect"},
+            ]
+        )
+        llm_call = asyncio.get_running_loop().create_future()
+        disconnect_event = asyncio.Event()
+
+        await _cancel_llm_call_on_client_disconnect(
+            request, llm_call, disconnect_event
+        )
+
+        assert llm_call.cancelled()
+        assert disconnect_event.is_set()
+
+    async def test_monitor_is_noop_while_client_stays_connected(self):
+        request = self._request(
+            [{"type": "http.request", "body": b"", "more_body": False}]
+        )
+        llm_call = asyncio.get_running_loop().create_future()
+        disconnect_event = asyncio.Event()
+
+        monitor = asyncio.create_task(
+            _cancel_llm_call_on_client_disconnect(request, llm_call, disconnect_event)
+        )
+        await asyncio.sleep(0.01)
+
+        assert not monitor.done()
+        assert not llm_call.cancelled()
+        assert not disconnect_event.is_set()
+        monitor.cancel()
+
+    async def test_cancellation_without_disconnect_reraises_cancelled_error(self):
+        """A CancelledError that is NOT client-initiated (e.g. server shutdown)
+        must propagate as-is instead of being masked as a 499."""
+        request = self._request([])
+        llm_call = asyncio.get_running_loop().create_future()
+        llm_call.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await _await_llm_call_cancelling_on_disconnect(request, llm_call)
+
+    async def _drive_base_process_llm_request(
+        self, monkeypatch, general_settings: dict, llm_call, request: Request
+    ):
+        from litellm.proxy._types import UserAPIKeyAuth
+
+        logging_obj = MagicMock()
+        logging_obj.litellm_call_id = "test-cancel-on-disconnect"
+        logging_obj._defer_async_logging = False
+        logging_obj._on_deferred_stream_complete = None
+        logging_obj.cost_breakdown = None
+
+        processor = ProxyBaseLLMRequestProcessing(
+            data={"model": "fake-model", "litellm_logging_obj": logging_obj}
+        )
+
+        proxy_logging_obj = MagicMock(spec=ProxyLogging)
+        proxy_logging_obj.during_call_hook = AsyncMock(return_value=None)
+        proxy_logging_obj.update_request_status = AsyncMock(return_value=None)
+        proxy_logging_obj.post_call_success_hook = AsyncMock(
+            side_effect=lambda data, user_api_key_dict, response: response
+        )
+        proxy_logging_obj.post_call_response_headers_hook = AsyncMock(
+            return_value=None
+        )
+
+        async def fake_route_request(**kwargs):
+            return llm_call()
+
+        monkeypatch.setattr(
+            litellm.proxy.common_request_processing,
+            "route_request",
+            fake_route_request,
+        )
+
+        return await processor.base_process_llm_request(
+            request=request,
+            fastapi_response=Response(),
+            user_api_key_dict=UserAPIKeyAuth(api_key="sk-test"),
+            route_type="acompletion",
+            proxy_logging_obj=proxy_logging_obj,
+            general_settings=general_settings,
+            proxy_config=MagicMock(spec=ProxyConfig),
+            skip_pre_call_logic=True,
+        )
+
+    async def test_disconnect_ignored_when_flag_disabled(self, monkeypatch):
+        upstream_cancelled = asyncio.Event()
+        model_response = litellm.ModelResponse()
+
+        async def llm_call():
+            try:
+                await asyncio.sleep(0.05)
+                return model_response
+            except asyncio.CancelledError:
+                upstream_cancelled.set()
+                raise
+
+        result = await self._drive_base_process_llm_request(
+            monkeypatch,
+            general_settings={},
+            llm_call=llm_call,
+            request=self._request([{"type": "http.disconnect"}]),
+        )
+
+        assert result is model_response
+        assert not upstream_cancelled.is_set()
+
+    async def test_disconnect_cancels_upstream_when_flag_enabled(self, monkeypatch):
+        upstream_cancelled = asyncio.Event()
+
+        async def llm_call():
+            try:
+                await asyncio.sleep(5)
+                return litellm.ModelResponse()
+            except asyncio.CancelledError:
+                upstream_cancelled.set()
+                raise
+
+        with pytest.raises(HTTPException) as exc_info:
+            await self._drive_base_process_llm_request(
+                monkeypatch,
+                general_settings={"cancel_on_disconnect": True},
+                llm_call=llm_call,
+                request=self._request([{"type": "http.disconnect"}]),
+            )
+
+        assert exc_info.value.status_code == 499
+        assert upstream_cancelled.is_set()
+
+    async def test_499_still_fires_post_call_failure_hook(self):
+        """Regression guard: the 499 path must NOT bypass post_call_failure_hook,
+        which releases max_parallel_requests slots and fires spend/alerting
+        callbacks (cf. #14457; P1 review finding on #25776/#27146)."""
+        from litellm.proxy._types import ProxyException, UserAPIKeyAuth
+
+        processor = ProxyBaseLLMRequestProcessing(data={})
+        proxy_logging_obj = MagicMock()
+        proxy_logging_obj.post_call_failure_hook = AsyncMock(return_value=None)
+        proxy_logging_obj.post_call_response_headers_hook = AsyncMock(return_value={})
+
+        with pytest.raises(ProxyException) as exc_info:
+            await processor._handle_llm_api_exception(
+                e=HTTPException(
+                    status_code=499, detail="Client disconnected the request"
+                ),
+                user_api_key_dict=UserAPIKeyAuth(api_key="sk-test"),
+                proxy_logging_obj=proxy_logging_obj,
+            )
+
+        assert exc_info.value.code == "499"
+        proxy_logging_obj.post_call_failure_hook.assert_awaited_once()


### PR DESCRIPTION
## Relevant issues

Addresses #13774. Re-fixes #22805, which regressed when #14295 was reverted in #14304. Builds on the receive-based design from #25776 (credited via Co-authored-by) and the maintainer port in #27146, and resolves the two P1 findings Greptile raised on both: the watcher is now opt-in instead of always-on, and the 499 path no longer skips `post_call_failure_hook`. Related accounting context: #14457, #30020

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Setup: a slow OpenAI-compatible mock backend on :9090 that takes 20s per completion and logs whether it observed the client (the proxy) abort; this stands in for vLLM, whose request slot stays occupied exactly as long as the proxy holds the connection open. Proxy config:

```yaml
model_list:
  - model_name: mock-model
    litellm_params:
      model: openai/mock-model
      api_base: http://localhost:9090/v1
      api_key: fake-key

general_settings:
  master_key: sk-1234
  cancel_on_disconnect: true
```

Run the proxy and kill the client 2 seconds into the request:

```
$ python litellm/proxy/proxy_cli.py --config /tmp/cancel_on_disconnect_config.yaml --port 4000 --detailed_debug
$ curl --max-time 2 -sS http://localhost:4000/v1/chat/completions \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"model": "mock-model", "messages": [{"role": "user", "content": "hi"}]}'
curl: (28) Operation timed out after 2010 milliseconds with 0 bytes received
```

Backend log with `cancel_on_disconnect: true`; the upstream request is aborted the moment the client drops instead of running the full 20s:

```
[backend] request started at 20:34:34
[backend] request ABORTED by client after 1.4s (GPU slot freed)
```

Proxy log shows the 499 flowing through the normal failure path (so `post_call_failure_hook` fires: parallel-request slot release, spend logging, alerting):

```
20:34:35 - LiteLLM Proxy:INFO: common_request_processing.py:561 - litellm.proxy.proxy_server._handle_llm_api_exception(): client disconnected, upstream LLM request cancelled
20:34:35 - LiteLLM Proxy:DEBUG: common_request_processing.py:1898 - An error occurred: 499: Client disconnected the request
```

Control run with the flag omitted (default), same curl kill at 2s; behavior is unchanged from today, the backend keeps generating to completion:

```
[backend] request started at 20:35:13
[backend] request COMPLETED after 20.4s
```

## Type

🐛 Bug Fix

## Changes

On the non-streaming path, `base_process_llm_request` awaited the upstream LLM call with no disconnect monitoring. When the HTTP client went away, the upstream request kept running until completion or `request_timeout` (6000s default), holding a backend slot (for example a vLLM GPU slot) for output nobody would read. vLLM aborts correctly when its own client disconnects, so propagating the disconnect from LiteLLM is enough to free the backend

This adds an opt-in `general_settings.cancel_on_disconnect` flag (default off). When enabled, a watcher task awaits `request.receive()` and on `http.disconnect` cancels the `asyncio.gather` driving the upstream call. Receive-based monitoring is used instead of `is_disconnected()` polling because Starlette's `BaseHTTPMiddleware` breaks `is_disconnected()` (cf. vllm-project/vllm#10087, #11190), and it costs nothing while the client stays connected

Design notes. The resulting `CancelledError` is converted to `HTTPException(499)` only when the watcher set its disconnect event, so server-initiated cancellations (shutdown) still propagate as-is; the conversion also matters because `CancelledError` subclasses `BaseException` and would bypass the route handlers' `except Exception` accounting path entirely. The 499 then flows through `_handle_llm_api_exception` like any other failure, so `post_call_failure_hook` still releases `max_parallel_requests` slots and fires spend and alerting callbacks; the disconnect-specific 499 (matched on the shared detail message, so other 499s keep their tracebacks) is logged at info level instead of a full traceback since a client hangup is not a server error. If `request.receive()` itself fails (e.g. a transport reset) the watcher logs a warning and degrades to a no-op rather than crashing or cancelling the call. With the flag off (default) the awaited path is byte-identical to before, which is what killed #14295 (always-on watcher changed behavior for every request) and what blocks #25776/#27146. Scope is non-streaming only; the streaming path already releases slots on disconnect since #30020. Retries and fallbacks inside the cancelled gather are cancelled too, which is the desired outcome since the client is gone

Also removes the dead `check_request_disconnection` helper in `proxy_server.py` (zero call sites since at least the #14304 revert) together with its behavior-pin tests, and documents the flag in `proxy_server_config.yaml`

Tests in `tests/test_litellm/proxy/test_common_request_processing.py` (`TestCancelOnDisconnect`): the watcher cancels the call and sets the event on `http.disconnect` and is a no-op while the client stays connected; a `CancelledError` without a disconnect re-raises instead of masking as 499; driving `base_process_llm_request` end to end shows the default path ignores a disconnect and returns normally while the enabled path cancels the upstream task and raises 499; and a regression guard proves the 499 path still awaits `post_call_failure_hook` exactly once
