### PR TITLE
fix: buffer native gemini sse frames

### DIFF
--- a/litellm/proxy/google_endpoints/endpoints.py
+++ b/litellm/proxy/google_endpoints/endpoints.py
@@ -107,6 +107,7 @@ async def google_stream_generate_content(
     data["stream"] = True
     # google-genai SDK (?alt=sse) must not receive OpenAI's data: [DONE] terminator.
     data["_litellm_skip_openai_stream_done"] = True
+    data["_litellm_raw_sse_stream"] = True
 
     processor = ProxyBaseLLMRequestProcessing(data=data)
     try:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7106,15 +7106,15 @@ async def async_data_generator(  # noqa: PLR0915
                 chunk = chunk.decode("utf-8", errors="replace")
                 if is_raw_sse_stream:
                     raw_sse_buffer += chunk
-                    if len(raw_sse_buffer) > _MAX_RAW_SSE_BUFFER_CHARS:
-                        raise ValueError(
-                            "Raw SSE stream exceeded maximum buffered size without a frame delimiter"
-                        )
                     while True:
                         frame, raw_sse_buffer = _pop_complete_sse_frame(raw_sse_buffer)
                         if frame is None:
                             break
                         yield frame
+                    if len(raw_sse_buffer) > _MAX_RAW_SSE_BUFFER_CHARS:
+                        raise ValueError(
+                            "Raw SSE stream exceeded maximum buffered size without a frame delimiter"
+                        )
                     continue
                 if chunk.startswith(("data:", "event:", ":")):
                     yield (
@@ -7125,15 +7125,15 @@ async def async_data_generator(  # noqa: PLR0915
                     continue
             elif isinstance(chunk, str) and is_raw_sse_stream:
                 raw_sse_buffer += chunk
-                if len(raw_sse_buffer) > _MAX_RAW_SSE_BUFFER_CHARS:
-                    raise ValueError(
-                        "Raw SSE stream exceeded maximum buffered size without a frame delimiter"
-                    )
                 while True:
                     frame, raw_sse_buffer = _pop_complete_sse_frame(raw_sse_buffer)
                     if frame is None:
                         break
                     yield frame
+                if len(raw_sse_buffer) > _MAX_RAW_SSE_BUFFER_CHARS:
+                    raise ValueError(
+                        "Raw SSE stream exceeded maximum buffered size without a frame delimiter"
+                    )
                 continue
             elif isinstance(chunk, str) and chunk.startswith("data: "):
                 error_message = chunk

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7028,6 +7028,23 @@ def _format_streaming_sse_chunk(chunk: Union[str, bytes]) -> Union[str, bytes]:
     return f"data: {chunk}\n\n"
 
 
+_SSE_FRAME_DELIMITERS = ("\r\n\r\n", "\n\n", "\r\r")
+
+
+def _pop_complete_sse_frame(buffer: str) -> Tuple[Optional[str], str]:
+    delimiter_positions = [
+        (position, delimiter)
+        for delimiter in _SSE_FRAME_DELIMITERS
+        if (position := buffer.find(delimiter)) != -1
+    ]
+    if not delimiter_positions:
+        return None, buffer
+
+    position, delimiter = min(delimiter_positions, key=lambda item: item[0])
+    frame_end = position + len(delimiter)
+    return buffer[:frame_end], buffer[frame_end:]
+
+
 async def async_data_generator(  # noqa: PLR0915
     response, user_api_key_dict: UserAPIKeyAuth, request_data: dict
 ):
@@ -7053,6 +7070,8 @@ async def async_data_generator(  # noqa: PLR0915
         # happened to ship a streaming-iterator override (the default).
         needs_iterator_wrap = proxy_logging_obj.needs_iterator_wrap()
         needs_per_chunk_hook = proxy_logging_obj.needs_per_chunk_streaming_hook()
+        is_raw_sse_stream = bool(request_data.get("_litellm_skip_openai_stream_done"))
+        raw_sse_buffer = ""
 
         if needs_iterator_wrap:
             stream_iterator = proxy_logging_obj.async_post_call_streaming_iterator_hook(
@@ -7083,13 +7102,18 @@ async def async_data_generator(  # noqa: PLR0915
             if isinstance(chunk, BaseModel):
                 chunk = _serialize_streaming_chunk(chunk)
             elif isinstance(chunk, bytes):
-                # Some upstream streaming iterators (e.g. AsyncGoogleGenAIGenerateContentStreamingIterator
-                # for /v1beta/.../streamGenerateContent) yield raw SSE bytes from Gemini.
-                # Decode to str so the f-string below does not emit a Python b'...' literal,
-                # and pass already-formatted SSE through unchanged to avoid double "data:" prefix.
                 chunk = chunk.decode("utf-8", errors="replace")
-                if chunk.startswith(("data:", "event:", ":")):
-                    yield chunk if chunk.endswith("\n\n") else chunk + "\n\n"
+                if (
+                    is_raw_sse_stream
+                    or raw_sse_buffer
+                    or chunk.startswith(("data:", "event:", ":"))
+                ):
+                    raw_sse_buffer += chunk
+                    while True:
+                        frame, raw_sse_buffer = _pop_complete_sse_frame(raw_sse_buffer)
+                        if frame is None:
+                            break
+                        yield frame
                     continue
             elif isinstance(chunk, str) and chunk.startswith("data: "):
                 error_message = chunk

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7029,6 +7029,7 @@ def _format_streaming_sse_chunk(chunk: Union[str, bytes]) -> Union[str, bytes]:
 
 
 _SSE_FRAME_DELIMITERS = ("\r\n\r\n", "\n\n", "\r\r")
+_MAX_RAW_SSE_BUFFER_CHARS = 8 * 1024 * 1024
 
 
 def _pop_complete_sse_frame(buffer: str) -> Tuple[Optional[str], str]:
@@ -7070,7 +7071,7 @@ async def async_data_generator(  # noqa: PLR0915
         # happened to ship a streaming-iterator override (the default).
         needs_iterator_wrap = proxy_logging_obj.needs_iterator_wrap()
         needs_per_chunk_hook = proxy_logging_obj.needs_per_chunk_streaming_hook()
-        is_raw_sse_stream = bool(request_data.get("_litellm_skip_openai_stream_done"))
+        is_raw_sse_stream = bool(request_data.get("_litellm_raw_sse_stream"))
         raw_sse_buffer = ""
 
         if needs_iterator_wrap:
@@ -7103,18 +7104,37 @@ async def async_data_generator(  # noqa: PLR0915
                 chunk = _serialize_streaming_chunk(chunk)
             elif isinstance(chunk, bytes):
                 chunk = chunk.decode("utf-8", errors="replace")
-                if (
-                    is_raw_sse_stream
-                    or raw_sse_buffer
-                    or chunk.startswith(("data:", "event:", ":"))
-                ):
+                if is_raw_sse_stream:
                     raw_sse_buffer += chunk
+                    if len(raw_sse_buffer) > _MAX_RAW_SSE_BUFFER_CHARS:
+                        raise ValueError(
+                            "Raw SSE stream exceeded maximum buffered size without a frame delimiter"
+                        )
                     while True:
                         frame, raw_sse_buffer = _pop_complete_sse_frame(raw_sse_buffer)
                         if frame is None:
                             break
                         yield frame
                     continue
+                if chunk.startswith(("data:", "event:", ":")):
+                    yield (
+                        chunk
+                        if chunk.endswith(_SSE_FRAME_DELIMITERS)
+                        else chunk + "\n\n"
+                    )
+                    continue
+            elif isinstance(chunk, str) and is_raw_sse_stream:
+                raw_sse_buffer += chunk
+                if len(raw_sse_buffer) > _MAX_RAW_SSE_BUFFER_CHARS:
+                    raise ValueError(
+                        "Raw SSE stream exceeded maximum buffered size without a frame delimiter"
+                    )
+                while True:
+                    frame, raw_sse_buffer = _pop_complete_sse_frame(raw_sse_buffer)
+                    if frame is None:
+                        break
+                    yield frame
+                continue
             elif isinstance(chunk, str) and chunk.startswith("data: "):
                 error_message = chunk
                 break
@@ -7123,6 +7143,11 @@ async def async_data_generator(  # noqa: PLR0915
                 yield _format_streaming_sse_chunk(chunk=chunk)
             except Exception as e:
                 yield f"data: {str(e)}\n\n"
+
+        if raw_sse_buffer:
+            raise ValueError(
+                "Raw SSE stream ended before a complete frame delimiter was received"
+            )
 
         if not needs_iterator_wrap:
             # The iterator-wrap path fires deferred logging itself; fire it

--- a/tests/test_litellm/proxy/google_endpoints/test_google_api_endpoints.py
+++ b/tests/test_litellm/proxy/google_endpoints/test_google_api_endpoints.py
@@ -2,6 +2,7 @@
 """
 Test to verify the Google GenAI proxy API endpoints
 """
+
 import os
 import sys
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -88,6 +89,8 @@ def test_google_stream_generate_content_endpoint():
         # stream=True must be forced into the data the processor receives.
         init_kwargs = mock_init.call_args.kwargs
         assert init_kwargs["data"]["stream"] is True
+        assert init_kwargs["data"]["_litellm_raw_sse_stream"] is True
+        assert init_kwargs["data"]["_litellm_skip_openai_stream_done"] is True
         assert init_kwargs["data"]["model"] == "test-model"
         assert init_kwargs["data"]["contents"] == [
             {"role": "user", "parts": [{"text": "Hello"}]}

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -5244,8 +5244,8 @@ async def test_async_data_generator_uses_direct_stream_fast_path_without_callbac
 @pytest.mark.asyncio
 async def test_async_data_generator_passes_through_google_native_sse_bytes():
     """
-    Google-native streamGenerateContent yields raw SSE bytes; they must not be
-    re-wrapped as data: b'data: {...}'.
+    Google-native streamGenerateContent yields raw SSE bytes. The proxy must
+    preserve complete SSE frames without re-wrapping them.
     """
     from litellm.proxy._types import UserAPIKeyAuth
     from litellm.proxy.proxy_server import async_data_generator
@@ -5257,7 +5257,6 @@ async def test_async_data_generator_passes_through_google_native_sse_bytes():
         "messages": [{"role": "user", "content": "test"}],
     }
     gemini_event = b'data: {"candidates": [{"content": "hi"}]}\n\n'
-    gemini_event_without_terminator = b'data: {"candidates": [{"content": "there"}]}'
     raw_payload = b'{"partial": true}'
 
     class MockStream:
@@ -5266,7 +5265,6 @@ async def test_async_data_generator_passes_through_google_native_sse_bytes():
 
         async def _stream(self):
             yield gemini_event
-            yield gemini_event_without_terminator
             yield raw_payload
 
         async def aclose(self):
@@ -5295,10 +5293,74 @@ async def test_async_data_generator_passes_through_google_native_sse_bytes():
         for chunk in yielded_data
     ]
     assert yielded_text[0] == gemini_event.decode("utf-8")
-    assert yielded_text[1] == gemini_event_without_terminator.decode("utf-8") + "\n\n"
-    assert yielded_text[2] == f'data: {raw_payload.decode("utf-8")}\n\n'
+    assert yielded_text[1] == f'data: {raw_payload.decode("utf-8")}\n\n'
     assert "b'data:" not in "".join(yielded_text)
     assert yielded_text[-1] == "data: [DONE]\n\n"
+
+
+@pytest.mark.asyncio
+async def test_async_data_generator_buffers_split_google_native_sse_json_frame():
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.proxy.proxy_server import async_data_generator
+    from litellm.proxy.utils import ProxyLogging
+
+    mock_user_api_key_dict = MagicMock(spec=UserAPIKeyAuth)
+    mock_request_data = {
+        "model": "gemini-3.5-flash",
+        "_litellm_skip_openai_stream_done": True,
+    }
+    payload = (
+        'data: {"candidates": [{"content": {"role": "model", "parts": '
+        '[{"text": "", "thoughtSignature": "abc123def456"}]}}]}\n\n'
+    )
+    raw_chunks = [
+        payload[:2].encode("utf-8"),
+        payload[
+            2 : payload.index("thoughtSignature") + len('thoughtSignature": "abc')
+        ].encode("utf-8"),
+        payload[
+            payload.index("thoughtSignature") + len('thoughtSignature": "abc') :
+        ].encode("utf-8"),
+    ]
+
+    class MockStream:
+        def __aiter__(self):
+            return self._stream()
+
+        async def _stream(self):
+            for chunk in raw_chunks:
+                yield chunk
+
+        async def aclose(self):
+            pass
+
+    mock_response = MockStream()
+    mock_response.aclose = AsyncMock()
+    mock_proxy_logging_obj = MagicMock(spec=ProxyLogging)
+    mock_proxy_logging_obj.has_streaming_callbacks.return_value = False
+    mock_proxy_logging_obj.needs_iterator_wrap.return_value = False
+    mock_proxy_logging_obj.needs_per_chunk_streaming_hook.return_value = False
+    mock_proxy_logging_obj.async_post_call_streaming_iterator_hook = MagicMock()
+    mock_proxy_logging_obj.async_post_call_streaming_hook = AsyncMock()
+    mock_proxy_logging_obj.post_call_failure_hook = AsyncMock()
+
+    with patch("litellm.proxy.proxy_server.proxy_logging_obj", mock_proxy_logging_obj):
+        with patch.object(ProxyLogging, "_fire_deferred_stream_logging"):
+            yielded_data = []
+            async for data in async_data_generator(
+                mock_response, mock_user_api_key_dict, mock_request_data
+            ):
+                yielded_data.append(data)
+
+    yielded_text = [
+        chunk.decode("utf-8") if isinstance(chunk, bytes) else chunk
+        for chunk in yielded_data
+    ]
+
+    assert yielded_text == [payload]
+    for chunk in yielded_text:
+        assert chunk.endswith("\n\n")
+        assert json.loads(chunk.removeprefix("data: ").strip())
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -5242,10 +5242,10 @@ async def test_async_data_generator_uses_direct_stream_fast_path_without_callbac
 
 
 @pytest.mark.asyncio
-async def test_async_data_generator_passes_through_google_native_sse_bytes():
+async def test_async_data_generator_preserves_non_raw_sse_like_bytes():
     """
-    Google-native streamGenerateContent yields raw SSE bytes. The proxy must
-    preserve complete SSE frames without re-wrapping them.
+    Already formatted SSE bytes from non-raw streams keep the legacy passthrough
+    behavior, including appending a missing event terminator.
     """
     from litellm.proxy._types import UserAPIKeyAuth
     from litellm.proxy.proxy_server import async_data_generator
@@ -5257,6 +5257,7 @@ async def test_async_data_generator_passes_through_google_native_sse_bytes():
         "messages": [{"role": "user", "content": "test"}],
     }
     gemini_event = b'data: {"candidates": [{"content": "hi"}]}\n\n'
+    gemini_event_without_terminator = b'data: {"candidates": [{"content": "there"}]}'
     raw_payload = b'{"partial": true}'
 
     class MockStream:
@@ -5265,6 +5266,7 @@ async def test_async_data_generator_passes_through_google_native_sse_bytes():
 
         async def _stream(self):
             yield gemini_event
+            yield gemini_event_without_terminator
             yield raw_payload
 
         async def aclose(self):
@@ -5293,7 +5295,8 @@ async def test_async_data_generator_passes_through_google_native_sse_bytes():
         for chunk in yielded_data
     ]
     assert yielded_text[0] == gemini_event.decode("utf-8")
-    assert yielded_text[1] == f'data: {raw_payload.decode("utf-8")}\n\n'
+    assert yielded_text[1] == gemini_event_without_terminator.decode("utf-8") + "\n\n"
+    assert yielded_text[2] == f'data: {raw_payload.decode("utf-8")}\n\n'
     assert "b'data:" not in "".join(yielded_text)
     assert yielded_text[-1] == "data: [DONE]\n\n"
 
@@ -5308,6 +5311,7 @@ async def test_async_data_generator_buffers_split_google_native_sse_json_frame()
     mock_request_data = {
         "model": "gemini-3.5-flash",
         "_litellm_skip_openai_stream_done": True,
+        "_litellm_raw_sse_stream": True,
     }
     payload = (
         'data: {"candidates": [{"content": {"role": "model", "parts": '
@@ -5361,6 +5365,114 @@ async def test_async_data_generator_buffers_split_google_native_sse_json_frame()
     for chunk in yielded_text:
         assert chunk.endswith("\n\n")
         assert json.loads(chunk.removeprefix("data: ").strip())
+
+
+@pytest.mark.asyncio
+async def test_async_data_generator_errors_when_raw_sse_stream_ends_mid_frame():
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.proxy.proxy_server import async_data_generator
+    from litellm.proxy.utils import ProxyLogging
+
+    mock_user_api_key_dict = MagicMock(spec=UserAPIKeyAuth)
+    mock_request_data = {
+        "model": "gemini-3.5-flash",
+        "_litellm_skip_openai_stream_done": True,
+        "_litellm_raw_sse_stream": True,
+    }
+
+    class MockStream:
+        def __aiter__(self):
+            return self._stream()
+
+        async def _stream(self):
+            yield b'data: {"candidates": [{"content": "unterminated"}]'
+
+        async def aclose(self):
+            pass
+
+    mock_response = MockStream()
+    mock_response.aclose = AsyncMock()
+    mock_proxy_logging_obj = MagicMock(spec=ProxyLogging)
+    mock_proxy_logging_obj.has_streaming_callbacks.return_value = False
+    mock_proxy_logging_obj.needs_iterator_wrap.return_value = False
+    mock_proxy_logging_obj.needs_per_chunk_streaming_hook.return_value = False
+    mock_proxy_logging_obj.async_post_call_streaming_iterator_hook = MagicMock()
+    mock_proxy_logging_obj.async_post_call_streaming_hook = AsyncMock()
+    mock_proxy_logging_obj.post_call_failure_hook = AsyncMock()
+
+    with (
+        patch("litellm.proxy.proxy_server.proxy_logging_obj", mock_proxy_logging_obj),
+        patch.object(ProxyLogging, "_fire_deferred_stream_logging"),
+    ):
+        yielded_data = []
+        async for data in async_data_generator(
+            mock_response, mock_user_api_key_dict, mock_request_data
+        ):
+            yielded_data.append(data)
+
+    yielded_text = [
+        chunk.decode("utf-8") if isinstance(chunk, bytes) else chunk
+        for chunk in yielded_data
+    ]
+    assert len(yielded_text) == 1
+    assert "ended before a complete frame delimiter" in yielded_text[0]
+    assert "[DONE]" not in yielded_text[0]
+    mock_proxy_logging_obj.post_call_failure_hook.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_async_data_generator_errors_when_raw_sse_frame_exceeds_buffer_limit():
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.proxy.proxy_server import async_data_generator
+    from litellm.proxy.utils import ProxyLogging
+
+    mock_user_api_key_dict = MagicMock(spec=UserAPIKeyAuth)
+    mock_request_data = {
+        "model": "gemini-3.5-flash",
+        "_litellm_skip_openai_stream_done": True,
+        "_litellm_raw_sse_stream": True,
+    }
+
+    class MockStream:
+        def __aiter__(self):
+            return self._stream()
+
+        async def _stream(self):
+            yield b"data: "
+            yield b'{"candidates": [{"content": "unterminated"}]'
+
+        async def aclose(self):
+            pass
+
+    mock_response = MockStream()
+    mock_response.aclose = AsyncMock()
+    mock_proxy_logging_obj = MagicMock(spec=ProxyLogging)
+    mock_proxy_logging_obj.has_streaming_callbacks.return_value = False
+    mock_proxy_logging_obj.needs_iterator_wrap.return_value = False
+    mock_proxy_logging_obj.needs_per_chunk_streaming_hook.return_value = False
+    mock_proxy_logging_obj.async_post_call_streaming_iterator_hook = MagicMock()
+    mock_proxy_logging_obj.async_post_call_streaming_hook = AsyncMock()
+    mock_proxy_logging_obj.post_call_failure_hook = AsyncMock()
+
+    with (
+        patch("litellm.proxy.proxy_server.proxy_logging_obj", mock_proxy_logging_obj),
+        patch("litellm.proxy.proxy_server._MAX_RAW_SSE_BUFFER_CHARS", 8),
+        patch.object(ProxyLogging, "_fire_deferred_stream_logging"),
+    ):
+        yielded_data = []
+        async for data in async_data_generator(
+            mock_response, mock_user_api_key_dict, mock_request_data
+        ):
+            yielded_data.append(data)
+
+    yielded_text = [
+        chunk.decode("utf-8") if isinstance(chunk, bytes) else chunk
+        for chunk in yielded_data
+    ]
+    assert len(yielded_text) == 1
+    assert "maximum buffered size" in yielded_text[0]
+    assert "[DONE]" not in yielded_text[0]
+    mock_proxy_logging_obj.post_call_failure_hook.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -5476,6 +5476,67 @@ async def test_async_data_generator_errors_when_raw_sse_frame_exceeds_buffer_lim
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("as_bytes", [True, False])
+async def test_async_data_generator_checks_raw_sse_buffer_limit_after_complete_frames(
+    as_bytes,
+):
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.proxy.proxy_server import async_data_generator
+    from litellm.proxy.utils import ProxyLogging
+
+    complete_frame = 'data: {"candidates": [{"content": "ok"}]}\n\n'
+    partial_frame = "data: "
+    raw_chunk = complete_frame + partial_frame
+
+    mock_user_api_key_dict = MagicMock(spec=UserAPIKeyAuth)
+    mock_request_data = {
+        "model": "gemini-3.5-flash",
+        "_litellm_skip_openai_stream_done": True,
+        "_litellm_raw_sse_stream": True,
+    }
+
+    class MockStream:
+        def __aiter__(self):
+            return self._stream()
+
+        async def _stream(self):
+            yield raw_chunk.encode("utf-8") if as_bytes else raw_chunk
+
+        async def aclose(self):
+            pass
+
+    mock_response = MockStream()
+    mock_response.aclose = AsyncMock()
+    mock_proxy_logging_obj = MagicMock(spec=ProxyLogging)
+    mock_proxy_logging_obj.has_streaming_callbacks.return_value = False
+    mock_proxy_logging_obj.needs_iterator_wrap.return_value = False
+    mock_proxy_logging_obj.needs_per_chunk_streaming_hook.return_value = False
+    mock_proxy_logging_obj.async_post_call_streaming_iterator_hook = MagicMock()
+    mock_proxy_logging_obj.async_post_call_streaming_hook = AsyncMock()
+    mock_proxy_logging_obj.post_call_failure_hook = AsyncMock()
+
+    with (
+        patch("litellm.proxy.proxy_server.proxy_logging_obj", mock_proxy_logging_obj),
+        patch("litellm.proxy.proxy_server._MAX_RAW_SSE_BUFFER_CHARS", 8),
+        patch.object(ProxyLogging, "_fire_deferred_stream_logging"),
+    ):
+        yielded_data = []
+        async for data in async_data_generator(
+            mock_response, mock_user_api_key_dict, mock_request_data
+        ):
+            yielded_data.append(data)
+
+    yielded_text = [
+        chunk.decode("utf-8") if isinstance(chunk, bytes) else chunk
+        for chunk in yielded_data
+    ]
+    assert yielded_text[0] == complete_frame
+    assert "ended before a complete frame delimiter" in yielded_text[1]
+    assert "[DONE]" not in "".join(yielded_text)
+    mock_proxy_logging_obj.post_call_failure_hook.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_async_data_generator_google_genai_stream_omits_openai_done():
     """
     google-genai SDK streamGenerateContent?alt=sse must not receive data: [DONE].


### PR DESCRIPTION
## Relevant issues

Fixes #30224

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Delays in PR merge?

N/A

## CI (LiteLLM team)

- [ ] Branch creation CI run
       Link:

- [ ] CI run for the last commit
       Link:

- [ ] Merge / cherry-pick CI run
       Links:

## Screenshots / Proof of Fix

Backend stream-framing change; no screenshot attached. The regression covers a Gemini native SSE event split before the `data:` prefix completes and again inside a `thoughtSignature` JSON string, and verifies the proxy emits one parseable SSE frame

## Type

Bug Fix
Test

## Changes

The Google native `streamGenerateContent` proxy path can receive raw SSE bytes from `response.aiter_bytes()`. That iterator can split one upstream SSE event across multiple transport chunks, but the proxy previously appended `\n\n` to any raw bytes chunk that started with `data:` and did not already include a delimiter. When the split happened inside a JSON string, downstream clients received a complete-looking SSE frame with invalid JSON

This PR buffers raw SSE bytes until a real SSE delimiter is present, then forwards the complete frame unchanged. It keeps non-SSE byte chunks on the existing OpenAI-style wrapping path and preserves the Google native behavior that skips OpenAI's `[DONE]` sentinel

Validation run locally:

```bash
uv run --extra proxy python -m pytest tests/test_litellm/proxy/test_proxy_server.py::test_async_data_generator_passes_through_google_native_sse_bytes tests/test_litellm/proxy/test_proxy_server.py::test_async_data_generator_buffers_split_google_native_sse_json_frame tests/test_litellm/proxy/test_proxy_server.py::test_async_data_generator_google_genai_stream_omits_openai_done tests/test_litellm/proxy/test_proxy_server.py::test_async_data_generator_google_genai_stream_forwards_error_without_done tests/test_litellm/proxy/google_endpoints/test_google_api_endpoints.py -q
```

```text
9 passed in 5.25s
```

```bash
uv run --extra proxy black --check litellm/proxy/proxy_server.py tests/test_litellm/proxy/test_proxy_server.py
```

```text
2 files would be left unchanged
```