### PR TITLE
fix(proxy): explain missing Anthropic credentials on passthrough 401

### DIFF
--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -646,13 +646,22 @@ async def anthropic_proxy_route(
         _forward_headers=True,
         is_streaming_request=is_streaming_request,
     )  # dynamically construct pass-through endpoint based on incoming path
-    received_value = await endpoint_func(
-        request,
-        fastapi_response,
-        user_api_key_dict,
-    )
-
-    return received_value
+    try:
+        return await endpoint_func(
+            request,
+            fastapi_response,
+            user_api_key_dict,
+        )
+    except ProxyException as e:
+        if auth_header is None and e.code == "401":
+            e.message = (
+                "No Anthropic credentials found on the proxy. Set the ANTHROPIC_API_KEY "
+                "environment variable (or ANTHROPIC_AUTH_TOKEN for OAuth) on the proxy, "
+                "or configure Anthropic pass-through credentials. The incoming request "
+                "headers were forwarded to Anthropic as-is and the request failed with "
+                f"error: {e.message}"
+            )
+        raise e
 
 
 # Bedrock endpoint actions - consolidated list used for model extraction and streaming detection

--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -655,11 +655,12 @@ async def anthropic_proxy_route(
     except ProxyException as e:
         if auth_header is None and e.code == "401":
             e.message = (
-                "No Anthropic credentials found on the proxy. Set the ANTHROPIC_API_KEY "
-                "environment variable (or ANTHROPIC_AUTH_TOKEN for OAuth) on the proxy, "
-                "or configure Anthropic pass-through credentials. The incoming request "
-                "headers were forwarded to Anthropic as-is and the request failed with "
-                f"error: {e.message}"
+                "No Anthropic credentials found on the proxy, so the incoming "
+                "request headers were forwarded to Anthropic as-is and were "
+                "rejected. Either set the ANTHROPIC_API_KEY environment variable "
+                "(or ANTHROPIC_AUTH_TOKEN for OAuth) on the proxy, configure "
+                "Anthropic pass-through credentials, or send a valid Anthropic "
+                f"credential in the request headers. Original error: {e.message}"
             )
         raise e
 

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
@@ -18,6 +18,7 @@ import litellm
 from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
     BaseOpenAIPassThroughHandler,
     RouteChecks,
+    anthropic_proxy_route,
     bedrock_llm_proxy_route,
     create_pass_through_route,
     cursor_proxy_route,
@@ -30,7 +31,7 @@ from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
     vertex_proxy_route,
     vllm_proxy_route,
 )
-from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy._types import ProxyException, UserAPIKeyAuth
 from litellm.types.passthrough_endpoints.vertex_ai import VertexPassThroughCredentials
 
 
@@ -2970,3 +2971,105 @@ class TestCursorProxyRoute:
             assert call_args["target"] == "https://api.cursor.com/v0/agents"
             assert result["id"] == "bc_abc123"
             assert result["status"] == "CREATING"
+
+
+class TestAnthropicProxyRoute:
+    ANTHROPIC_401_BODY = '{"type":"error","error":{"type":"authentication_error","message":"Invalid bearer token"}}'
+
+    def _setup_mocks(self, monkeypatch, api_key, upstream_error):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("ANTHROPIC_AUTH_TOKEN", raising=False)
+
+        mock_router = MagicMock()
+        mock_router.get_credentials.return_value = api_key
+        monkeypatch.setattr(
+            "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.passthrough_endpoint_router",
+            mock_router,
+        )
+        monkeypatch.setattr(
+            "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.is_streaming_request_fn",
+            AsyncMock(return_value=False),
+        )
+
+        mock_create_route = MagicMock(
+            return_value=AsyncMock(side_effect=upstream_error)
+        )
+        monkeypatch.setattr(
+            "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.create_pass_through_route",
+            mock_create_route,
+        )
+        return mock_create_route
+
+    async def _call_route(self):
+        return await anthropic_proxy_route(
+            endpoint="v1/messages",
+            request=MagicMock(spec=Request),
+            fastapi_response=MagicMock(spec=Response),
+            user_api_key_dict=MagicMock(spec=UserAPIKeyAuth),
+        )
+
+    @pytest.mark.asyncio
+    async def test_upstream_401_without_proxy_credentials_explains_missing_key(
+        self, monkeypatch
+    ):
+        upstream_error = ProxyException(
+            message=self.ANTHROPIC_401_BODY, type="None", param="None", code=401
+        )
+        self._setup_mocks(monkeypatch, api_key=None, upstream_error=upstream_error)
+
+        with pytest.raises(ProxyException) as exc_info:
+            await self._call_route()
+
+        assert exc_info.value.code == "401"
+        assert "No Anthropic credentials found on the proxy" in exc_info.value.message
+        assert "ANTHROPIC_API_KEY" in exc_info.value.message
+        assert self.ANTHROPIC_401_BODY in exc_info.value.message
+
+    @pytest.mark.asyncio
+    async def test_upstream_401_with_proxy_credentials_is_not_rewritten(
+        self, monkeypatch
+    ):
+        upstream_error = ProxyException(
+            message=self.ANTHROPIC_401_BODY, type="None", param="None", code=401
+        )
+        mock_create_route = self._setup_mocks(
+            monkeypatch, api_key="sk-ant-proxy-key", upstream_error=upstream_error
+        )
+
+        with pytest.raises(ProxyException) as exc_info:
+            await self._call_route()
+
+        assert exc_info.value.message == self.ANTHROPIC_401_BODY
+        assert mock_create_route.call_args.kwargs["custom_headers"] == {
+            "x-api-key": "sk-ant-proxy-key"
+        }
+
+    @pytest.mark.asyncio
+    async def test_upstream_non_401_without_proxy_credentials_is_not_rewritten(
+        self, monkeypatch
+    ):
+        upstream_error = ProxyException(
+            message="invalid request", type="None", param="None", code=400
+        )
+        self._setup_mocks(monkeypatch, api_key=None, upstream_error=upstream_error)
+
+        with pytest.raises(ProxyException) as exc_info:
+            await self._call_route()
+
+        assert exc_info.value.message == "invalid request"
+
+    @pytest.mark.asyncio
+    async def test_successful_response_is_returned_unchanged(self, monkeypatch):
+        self._setup_mocks(monkeypatch, api_key=None, upstream_error=None)
+        mock_create_route = MagicMock(
+            return_value=AsyncMock(return_value={"id": "msg_123"})
+        )
+        monkeypatch.setattr(
+            "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.create_pass_through_route",
+            mock_create_route,
+        )
+
+        result = await self._call_route()
+
+        assert result == {"id": "msg_123"}
+        assert mock_create_route.call_args.kwargs["custom_headers"] == {}


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Calling the `/anthropic/v1/messages` passthrough on a proxy that has no Anthropic credential configured forwards the caller's LiteLLM virtual key to Anthropic, which rejects it with an opaque error that gives the operator no hint that the real problem is a missing `ANTHROPIC_API_KEY` on the proxy:

```
$ curl -s -w '\nHTTP %{http_code}\n' http://localhost:4000/anthropic/v1/messages \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"model": "claude-sonnet-4-5", "max_tokens": 64000,
         "messages": [{"role": "user", "content": "What is the capital of France?"}]}'

{"error":{"message":"{\"type\":\"error\",\"error\":{\"type\":\"authentication_error\",\"message\":\"Invalid bearer token\"},\"request_id\":\"req_011CbwvBFznqLVvJopd5TdBF\"}","type":"None","param":"None","code":"401"}}
HTTP 401
```

After this change, the same request against a live proxy (no Anthropic credential configured) returns an error that says what is wrong and how to fix it, from both the operator's and the caller's side, while preserving the original Anthropic response:

```
$ curl -s -w '\nHTTP %{http_code}\n' http://localhost:4000/anthropic/v1/messages \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"model": "claude-sonnet-4-5", "max_tokens": 64000,
         "messages": [{"role": "user", "content": "What is the capital of France?"}]}'

{"error":{"message":"No Anthropic credentials found on the proxy, so the incoming request headers were forwarded to Anthropic as-is and were rejected. Either set the ANTHROPIC_API_KEY environment variable (or ANTHROPIC_AUTH_TOKEN for OAuth) on the proxy, configure Anthropic pass-through credentials, or send a valid Anthropic credential in the request headers. Original error: {\"type\":\"error\",\"error\":{\"type\":\"authentication_error\",\"message\":\"Invalid bearer token\"},\"request_id\":\"req_011CbxuSrk9BQ3vojUGPihj1\"}","type":"None","param":"None","code":"401"}}
HTTP 401
```

The happy path is unchanged. Same proxy build restarted with `ANTHROPIC_API_KEY` set, identical request, real Anthropic API:

```
{"model":"claude-sonnet-4-5-20250929","id":"msg_01PxqUjyLNcbnXcX9dM7sXFz","type":"message","role":"assistant","content":[{"type":"text","text":"The capital of France is Paris."}],"stop_reason":"end_turn",...}
HTTP 200
```

## Type

🐛 Bug Fix

## Changes

`anthropic_proxy_route` passes `_forward_headers=True`, so when the proxy has no Anthropic credential the caller's own `Authorization: Bearer <litellm virtual key>` header is the only auth that reaches `api.anthropic.com`. Anthropic treats it as an OAuth bearer token and returns `authentication_error: Invalid bearer token`, which the proxy surfaces verbatim. Operators hitting this had no way to tell the failure was a proxy misconfiguration rather than a bad client key.

The route now catches the upstream `ProxyException` and, only when no proxy-side credential was resolved and the upstream status is 401, prepends an explanation of the missing configuration before re-raising. This mirrors how `vertex_proxy_route` enriches its "No credentials found on proxy" failures. A preflight rejection was deliberately avoided since callers that bring their own valid Anthropic credentials through the passthrough must keep working; for the same reason the message is not added when the proxy does have a credential or when the upstream failure is not a 401. Following review feedback, the message also lists sending a valid Anthropic credential in the request headers as a remediation, covering deployments where the operator intentionally configures no proxy-side credentials and callers supply their own keys.

Regression tests cover the enriched 401, the unmodified 401 when proxy credentials exist, the unmodified non-401 error, and the untouched success path. The enrichment test fails on the previous code