### PR TITLE
feat(ui): gate "Default Credentials" hint on /ui/login behind env flag

### DIFF
--- a/litellm/proxy/discovery_endpoints/ui_discovery_endpoints.py
+++ b/litellm/proxy/discovery_endpoints/ui_discovery_endpoints.py
@@ -25,6 +25,10 @@ async def get_ui_config():
         or general_settings.get("auto_redirect_ui_login_to_sso", False) is True
     )
     admin_ui_disabled = os.getenv("DISABLE_ADMIN_UI", "false").lower() == "true"
+    hide_default_credentials_hint = (
+        os.getenv("LITELLM_HIDE_DEFAULT_CREDENTIALS_HINT", "false").lower() == "true"
+        or general_settings.get("hide_default_credentials_hint", False) is True
+    )
 
     sso_configured = _has_user_setup_sso()
 
@@ -38,6 +42,7 @@ async def get_ui_config():
         auto_redirect_to_sso=sso_configured and auto_redirect_ui_login_to_sso,
         admin_ui_disabled=admin_ui_disabled,
         sso_configured=sso_configured,
+        hide_default_credentials_hint=hide_default_credentials_hint,
         is_control_plane=is_control_plane,
         workers=proxy_config.worker_registry if is_control_plane else [],
     )

--- a/litellm/types/proxy/discovery_endpoints/ui_discovery_endpoints.py
+++ b/litellm/types/proxy/discovery_endpoints/ui_discovery_endpoints.py
@@ -11,5 +11,6 @@ class UiDiscoveryEndpoints(BaseModel):
     auto_redirect_to_sso: bool
     admin_ui_disabled: bool
     sso_configured: bool
+    hide_default_credentials_hint: bool = False
     is_control_plane: bool = False
     workers: List[WorkerRegistryEntry] = []

--- a/tests/test_litellm/proxy/discovery_endpoints/test_ui_discovery_endpoints.py
+++ b/tests/test_litellm/proxy/discovery_endpoints/test_ui_discovery_endpoints.py
@@ -352,6 +352,79 @@ def test_ui_discovery_endpoints_is_control_plane_true_when_workers_configured():
         assert data["workers"][0]["url"] == "https://worker-1:4001"
 
 
+def test_ui_discovery_endpoints_hide_default_credentials_hint_default_false():
+    """Default credentials hint is shown by default (flag false)."""
+    app = FastAPI()
+    app.include_router(router)
+    client = TestClient(app)
+
+    with (
+        patch("litellm.proxy.utils.get_server_root_path", return_value="/"),
+        patch("litellm.proxy.utils.get_proxy_base_url", return_value=None),
+        patch("litellm.proxy.auth.auth_utils._has_user_setup_sso", return_value=False),
+        patch.dict(os.environ, {"DISABLE_ADMIN_UI": "false"}, clear=False),
+    ):
+        os.environ.pop("LITELLM_HIDE_DEFAULT_CREDENTIALS_HINT", None)
+
+        response = client.get("/.well-known/litellm-ui-config")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["hide_default_credentials_hint"] is False
+
+
+def test_ui_discovery_endpoints_hide_default_credentials_hint_via_env_var():
+    """LITELLM_HIDE_DEFAULT_CREDENTIALS_HINT=true hides the login-page credentials card."""
+    app = FastAPI()
+    app.include_router(router)
+    client = TestClient(app)
+
+    with (
+        patch("litellm.proxy.utils.get_server_root_path", return_value="/"),
+        patch("litellm.proxy.utils.get_proxy_base_url", return_value=None),
+        patch("litellm.proxy.auth.auth_utils._has_user_setup_sso", return_value=False),
+        patch.dict(
+            os.environ,
+            {
+                "LITELLM_HIDE_DEFAULT_CREDENTIALS_HINT": "true",
+                "DISABLE_ADMIN_UI": "false",
+            },
+            clear=False,
+        ),
+    ):
+
+        response = client.get("/.well-known/litellm-ui-config")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["hide_default_credentials_hint"] is True
+
+
+def test_ui_discovery_endpoints_hide_default_credentials_hint_via_general_settings():
+    """general_settings.hide_default_credentials_hint=true also hides the card."""
+    app = FastAPI()
+    app.include_router(router)
+    client = TestClient(app)
+
+    with (
+        patch("litellm.proxy.utils.get_server_root_path", return_value="/"),
+        patch("litellm.proxy.utils.get_proxy_base_url", return_value=None),
+        patch("litellm.proxy.auth.auth_utils._has_user_setup_sso", return_value=False),
+        patch(
+            "litellm.proxy.proxy_server.general_settings",
+            {"hide_default_credentials_hint": True},
+        ),
+        patch.dict(os.environ, {"DISABLE_ADMIN_UI": "false"}, clear=False),
+    ):
+        os.environ.pop("LITELLM_HIDE_DEFAULT_CREDENTIALS_HINT", None)
+
+        response = client.get("/.well-known/litellm-ui-config")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["hide_default_credentials_hint"] is True
+
+
 def test_ui_discovery_endpoints_is_control_plane_false_when_no_workers():
     app = FastAPI()
     app.include_router(router)

--- a/ui/litellm-dashboard/src/app/login/LoginPage.tsx
+++ b/ui/litellm-dashboard/src/app/login/LoginPage.tsx
@@ -188,28 +188,30 @@ function LoginPageContent() {
             <Text type="secondary">Access your LiteLLM Admin UI.</Text>
           </div>
 
-          <Alert
-            message="Default Credentials"
-            description={
-              <>
-                <Paragraph className="text-sm">
-                  By default, Username is <code className="bg-gray-100 px-1 py-0.5 rounded text-xs">admin</code> and
-                  Password is your set LiteLLM Proxy
-                  <code className="bg-gray-100 px-1 py-0.5 rounded text-xs">MASTER_KEY</code>.
-                </Paragraph>
-                <Paragraph className="text-sm">
-                  Need to set UI credentials or SSO?{" "}
-                  <a href="https://docs.litellm.ai/docs/proxy/ui" target="_blank" rel="noopener noreferrer">
-                    Check the documentation
-                  </a>
-                  .
-                </Paragraph>
-              </>
-            }
-            type="info"
-            icon={<InfoCircleOutlined />}
-            showIcon
-          />
+          {!uiConfig?.hide_default_credentials_hint && (
+            <Alert
+              message="Default Credentials"
+              description={
+                <>
+                  <Paragraph className="text-sm">
+                    By default, Username is <code className="bg-gray-100 px-1 py-0.5 rounded text-xs">admin</code> and
+                    Password is your set LiteLLM Proxy
+                    <code className="bg-gray-100 px-1 py-0.5 rounded text-xs">MASTER_KEY</code>.
+                  </Paragraph>
+                  <Paragraph className="text-sm">
+                    Need to set UI credentials or SSO?{" "}
+                    <a href="https://docs.litellm.ai/docs/proxy/ui" target="_blank" rel="noopener noreferrer">
+                      Check the documentation
+                    </a>
+                    .
+                  </Paragraph>
+                </>
+              }
+              type="info"
+              icon={<InfoCircleOutlined />}
+              showIcon
+            />
+          )}
 
           {error && <Alert message={error} type="error" showIcon />}
 

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -285,6 +285,7 @@ export interface LiteLLMWellKnownUiConfig {
   auto_redirect_to_sso: boolean;
   admin_ui_disabled: boolean;
   sso_configured: boolean;
+  hide_default_credentials_hint?: boolean;
   is_control_plane?: boolean;
   workers?: WorkerInfo[];
 }


### PR DESCRIPTION
## Title
feat(ui): gate "Default Credentials" hint on /ui/login behind `LITELLM_HIDE_DEFAULT_CREDENTIALS_HINT`

## Relevant issues
Closes #30232

## Pre-Submission checklist
- [x] I have added a test that covers the change
- [x] Backwards compatible — default behaviour is unchanged
- [x] No breaking API/schema changes

## Type
🆕 New Feature

## What this PR does

Adds a way to suppress the **"Default Credentials"** info card on `/ui/login` (and `/fallback/login`) — the one that says *"By default, Username is `admin` and Password is your set LiteLLM Proxy `MASTER_KEY`"*.

Today that card is rendered unconditionally in [`ui/litellm-dashboard/src/app/login/LoginPage.tsx`](https://github.com/BerriAI/litellm/blob/main/ui/litellm-dashboard/src/app/login/LoginPage.tsx). In production deployments where operators set `UI_USERNAME` / `UI_PASSWORD` (or SSO), the hint is factually wrong and gets flagged by security scanners (e.g. [Tenable WAS plugin 114625](https://www.tenable.com/plugins/was/114625)) as information disclosure. There's no way to suppress it without forking the dashboard.

## How to use

Either set the env var:

```bash
LITELLM_HIDE_DEFAULT_CREDENTIALS_HINT=true
```

…or in `general_settings`:

```yaml
general_settings:
  hide_default_credentials_hint: true
```

When set, the `<Alert>` block on the login page is not rendered. All other login UI (form, SSO button, errors) is unchanged.

## Implementation

- `litellm/types/proxy/discovery_endpoints/ui_discovery_endpoints.py` — adds `hide_default_credentials_hint: bool = False` to `UiDiscoveryEndpoints` pydantic model.
- `litellm/proxy/discovery_endpoints/ui_discovery_endpoints.py` — reads env var (and `general_settings`) in `get_ui_config()`, identical pattern to existing `AUTO_REDIRECT_UI_LOGIN_TO_SSO` / `auto_redirect_ui_login_to_sso`. Default is `false`, so existing deployments are unaffected.
- `ui/litellm-dashboard/src/components/networking.tsx` — adds the optional field to the `LiteLLMWellKnownUiConfig` TS interface.
- `ui/litellm-dashboard/src/app/login/LoginPage.tsx` — wraps the existing `<Alert message="Default Credentials" ... />` block in `{!uiConfig?.hide_default_credentials_hint && (...)}`. Indentation is the only other diff.
- `tests/test_litellm/proxy/discovery_endpoints/test_ui_discovery_endpoints.py` — adds three tests: default-false, env-var-true, general_settings-true.

## Backwards compatibility

- New field has a `False` default on both the pydantic model and the TS interface.
- Field is optional on the TS side (`hide_default_credentials_hint?: boolean`), so older UI builds talking to a newer backend (or vice versa) keep working — the card stays visible in either case.

Refs: #30232