### PR TITLE
fix(bedrock): stop stream_chunk_size leaking into invoke request bodies

### DIFF
--- a/litellm/llms/bedrock/chat/invoke_transformations/anthropic_claude3_transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_transformations/anthropic_claude3_transformation.py
@@ -215,6 +215,7 @@ class AmazonAnthropicClaudeConfig(AmazonInvokeConfig, AnthropicConfig):
 
         anthropic_request.pop("model", None)
         anthropic_request.pop("stream", None)
+        anthropic_request.pop("stream_chunk_size", None)
         output_format = anthropic_request.pop("output_format", None)
         output_config_format = pop_bedrock_invoke_output_config_format(
             anthropic_request

--- a/litellm/llms/bedrock/chat/invoke_transformations/base_invoke_transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_transformations/base_invoke_transformation.py
@@ -150,6 +150,7 @@ class AmazonInvokeConfig(BaseConfig, BaseAWSLLM):
     ) -> dict:
         ## SETUP ##
         stream = optional_params.pop("stream", None)
+        optional_params.pop("stream_chunk_size", None)
         custom_prompt_dict: dict = litellm_params.pop("custom_prompt_dict", None) or {}
         hf_model_name = litellm_params.get("hf_model_name", None)
 

--- a/tests/test_litellm/llms/bedrock/chat/invoke_transformations/test_base_invoke_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/invoke_transformations/test_base_invoke_transformation.py
@@ -1,0 +1,41 @@
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(
+    0, os.path.abspath("../../../../../..")
+)  # Adds the parent directory to the system path
+
+from litellm.llms.bedrock.chat.invoke_transformations.anthropic_claude3_transformation import (
+    AmazonAnthropicClaudeConfig,
+)
+from litellm.llms.bedrock.chat.invoke_transformations.base_invoke_transformation import (
+    AmazonInvokeConfig,
+)
+
+
+@pytest.mark.parametrize(
+    "config,model",
+    [
+        (AmazonInvokeConfig, "anthropic.claude-3-sonnet-20240229-v1:0"),
+        (AmazonInvokeConfig, "amazon.titan-text-express-v1"),
+        (AmazonInvokeConfig, "mistral.mistral-7b-instruct-v0:2"),
+        (AmazonAnthropicClaudeConfig, "anthropic.claude-sonnet-4-6"),
+    ],
+)
+def test_transform_request_drops_stream_chunk_size(config, model):
+    """stream_chunk_size is a LiteLLM-internal knob for re-chunking the HTTP
+    response stream. Leaking it into the provider request body makes Bedrock
+    reject the whole request: ValidationException 'stream_chunk_size: Extra
+    inputs are not permitted'."""
+    request_body = config().transform_request(
+        model=model,
+        messages=[{"role": "user", "content": "hi"}],
+        optional_params={"stream": True, "stream_chunk_size": 2048, "max_tokens": 10},
+        litellm_params={},
+        headers={},
+    )
+
+    assert "stream_chunk_size" not in json.dumps(request_body)


### PR DESCRIPTION
## Relevant issues

Fixes #30239

Related context: #17357 introduced `stream_chunk_size`; #30231 changes its default for the streaming buffer fix. This bug predates both and exists on `main` independently

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Proxy started from this branch with a config routing `claude-invoke` to `bedrock/invoke/eu.anthropic.claude-sonnet-4-6` (eu-west-1, real Bedrock calls)

```bash
curl -s -X POST "http://localhost:4000/v1/chat/completions" \
  -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
  -d '{"model":"claude-invoke","stream":true,"max_tokens":20,"messages":[{"role":"user","content":"hi"}],"stream_chunk_size":2048}'
```

Before this PR (same command, unpatched `litellm_internal_staging`):

```
{"error":{"message":"litellm.BadRequestError: BedrockException - {\"message\":\"stream_chunk_size: Extra inputs are not permitted\"}","type":null,"param":null,"code":"400"}}
```

After:

```
data: {"id":"chatcmpl-042a607a-854c-4f2c-90b6-e5b025a13a0a","object":"chat.completion.chunk","created":1781212008,"model":"claude-invoke","choices":[{"index":0,"delta":{"role":"assistant","content":"Hi"}}]}
```

## Type

🐛 Bug Fix

## Changes

`stream_chunk_size` is a LiteLLM-internal parameter (it controls client-side re-chunking of the HTTP response stream), but the Bedrock invoke transformations splat `optional_params` into the provider request body without dropping it. Bedrock rejects unknown fields, so any `bedrock/invoke/...` request that sets the parameter fails outright with `ValidationException: stream_chunk_size: Extra inputs are not permitted` (verified with direct boto3 `invoke_model_with_response_stream` as well)

The fix drops the parameter in two places: the invoke dispatcher `AmazonInvokeConfig.transform_request` (covers the cohere, titan, mistral, meta/llama and ai21 branches that splat inference params) and `AmazonAnthropicClaudeConfig._build_bedrock_anthropic_request_base` (the route actually used for `bedrock/invoke` Anthropic models, shared by its sync and async transforms, next to the existing `model`/`stream` pops). Nova was checked and does not leak; its transform maps parameters strictly

A parametrized regression test asserts the serialized request body contains no `stream_chunk_size` for both transform entry points across four provider/model combinations; all four cases fail without the fix
