### PR TITLE
fix(router): preserve azure_ad_token through CredentialLiteLLMParams for /v1/files + batches (#30235)

### DIFF
--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -166,6 +166,13 @@ class CredentialLiteLLMParams(BaseModel):
     api_key: Optional[str] = None
     api_base: Optional[str] = None
     api_version: Optional[str] = None
+    ## AZURE OAUTH ##
+    # Without this field, ``get_deployment_credentials_with_provider``
+    # round-trips ``litellm_params`` through a strict Pydantic dump and
+    # silently drops the OAuth token before the files/batch/passthrough
+    # callers see it, breaking Azure deployments configured with
+    # ``azure_ad_token`` instead of a static ``api_key`` (#30235).
+    azure_ad_token: Optional[str] = None
     ## VERTEX AI ##
     vertex_project: Optional[str] = None
     vertex_location: Optional[str] = None

--- a/tests/test_litellm/test_azure_ad_token_credential_resolution.py
+++ b/tests/test_litellm/test_azure_ad_token_credential_resolution.py
@@ -1,0 +1,145 @@
+"""
+Regression for #30235.
+
+``Router.get_deployment_credentials_with_provider`` (router.py:8954) is
+used by the proxy's ``/v1/files``, ``/v1/batches`` and passthrough
+routing code paths to resolve the upstream credentials for a deployment
+by model_id::
+
+    return CredentialLiteLLMParams(
+        **deployment.litellm_params.model_dump(exclude_none=True)
+    ).model_dump(exclude_none=True)
+
+That re-validation is strict. Any field NOT declared on
+``CredentialLiteLLMParams`` gets dropped on the way through, even when
+it was present on the original ``litellm_params``.
+
+Pre-fix, ``azure_ad_token`` was undeclared, so Azure deployments
+configured with OAuth/M2M (``azure_ad_token`` in place of ``api_key``)
+silently lost their token on every file upload and the proxy returned::
+
+    Missing credentials. Please pass one of api_key, azure_ad_token,
+    azure_ad_token_provider, ...
+
+Tests below pin two things:
+1. ``CredentialLiteLLMParams`` directly accepts and round-trips
+   ``azure_ad_token``.
+2. ``Router.get_deployment_credentials_with_provider`` preserves
+   ``azure_ad_token`` from a deployment's ``litellm_params``.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestCredentialLiteLLMParamsAzureAdToken:
+    def test_azure_ad_token_round_trips_through_model_dump(self):
+        from litellm.types.router import CredentialLiteLLMParams
+
+        params = CredentialLiteLLMParams(
+            api_base="https://my.openai.azure.com",
+            api_version="2024-08-01-preview",
+            azure_ad_token="oauth-bearer-token-xyz",
+        )
+        dumped = params.model_dump(exclude_none=True)
+        assert dumped["azure_ad_token"] == "oauth-bearer-token-xyz", (
+            "azure_ad_token dropped from CredentialLiteLLMParams.model_dump() — "
+            "every callsite that round-trips litellm_params through this class "
+            "will lose the token (#30235)"
+        )
+
+    def test_azure_ad_token_is_optional(self):
+        """Adding the field must not break deployments that don't use it
+        — confirm the default is None and it's excluded by
+        ``exclude_none``."""
+        from litellm.types.router import CredentialLiteLLMParams
+
+        params = CredentialLiteLLMParams(api_key="sk-static")
+        dumped = params.model_dump(exclude_none=True)
+        assert "azure_ad_token" not in dumped
+        assert dumped["api_key"] == "sk-static"
+
+    def test_round_trip_preserves_full_credential_shape(self):
+        """The Router's get_deployment_credentials_with_provider pattern:
+        construct from a dict that has azure_ad_token alongside other
+        fields, dump, expect azure_ad_token to ride through alongside
+        the other declared fields."""
+        from litellm.types.router import CredentialLiteLLMParams
+
+        source = {
+            "api_base": "https://my.openai.azure.com",
+            "api_version": "2024-08-01-preview",
+            "azure_ad_token": "tok-123",
+            "api_key": None,  # M2M deployment has no static key
+        }
+        rebuilt = CredentialLiteLLMParams(
+            **{k: v for k, v in source.items() if v is not None}
+        ).model_dump(exclude_none=True)
+        assert rebuilt.get("azure_ad_token") == "tok-123"
+        assert rebuilt.get("api_base") == "https://my.openai.azure.com"
+        assert "api_key" not in rebuilt
+
+
+class TestRouterCredentialResolution:
+    """The actual fix surface: Router.get_deployment_credentials_with_provider
+    must preserve azure_ad_token on the resolved credentials dict so the
+    files endpoint can forward it to the Azure files client."""
+
+    def test_credentials_preserve_azure_ad_token(self):
+        from litellm import Router
+
+        deployment_id = "azure-m2m-deployment-fixed-uuid"
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "gpt-4o-azure-m2m",
+                    "litellm_params": {
+                        "model": "azure/gpt-4o",
+                        "api_base": "https://my.openai.azure.com",
+                        "api_version": "2024-08-01-preview",
+                        "azure_ad_token": "tok-azure-m2m-xyz",
+                    },
+                    "model_info": {"id": deployment_id},
+                }
+            ]
+        )
+
+        credentials = router.get_deployment_credentials_with_provider(
+            model_id=deployment_id
+        )
+        assert credentials is not None
+        assert credentials.get("azure_ad_token") == "tok-azure-m2m-xyz", (
+            "Router credential resolution dropped azure_ad_token; the "
+            "files / batches / passthrough callers will not be able to "
+            "authenticate against Azure (#30235)"
+        )
+
+    def test_credentials_static_api_key_unaffected(self):
+        """Don't break the pre-fix happy path: a deployment with a
+        static api_key (no azure_ad_token) keeps its api_key and
+        azure_ad_token doesn't appear in the dump."""
+        from litellm import Router
+
+        deployment_id = "azure-static-key-deployment-fixed-uuid"
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "gpt-4o-azure-static",
+                    "litellm_params": {
+                        "model": "azure/gpt-4o",
+                        "api_base": "https://my.openai.azure.com",
+                        "api_version": "2024-08-01-preview",
+                        "api_key": "sk-static-key",
+                    },
+                    "model_info": {"id": deployment_id},
+                }
+            ]
+        )
+
+        credentials = router.get_deployment_credentials_with_provider(
+            model_id=deployment_id
+        )
+        assert credentials is not None
+        assert credentials.get("api_key") == "sk-static-key"
+        assert "azure_ad_token" not in credentials

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -24899,6 +24899,8 @@ export interface components {
             aws_region_name?: string | null;
             /** Aws Secret Access Key */
             aws_secret_access_key?: string | null;
+            /** Azure Ad Token */
+            azure_ad_token?: string | null;
             /** Budget Duration */
             budget_duration?: string | null;
             /** Cache Creation Input Audio Token Cost */
@@ -32505,6 +32507,8 @@ export interface components {
             aws_region_name?: string | null;
             /** Aws Secret Access Key */
             aws_secret_access_key?: string | null;
+            /** Azure Ad Token */
+            azure_ad_token?: string | null;
             /** Budget Duration */
             budget_duration?: string | null;
             /** Cache Creation Input Audio Token Cost */


### PR DESCRIPTION
## Relevant issues

Fixes #30235

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Type

🐛 Bug Fix

## Summary

\`Router.get_deployment_credentials_with_provider\` re-validates a deployment's \`litellm_params\` through \`CredentialLiteLLMParams\` before handing them to file/batch/passthrough callers:

\`\`\`python
return CredentialLiteLLMParams(
    **deployment.litellm_params.model_dump(exclude_none=True)
).model_dump(exclude_none=True)
\`\`\`

Any field NOT declared on \`CredentialLiteLLMParams\` gets dropped on the way through. \`azure_ad_token\` was undeclared, so Azure deployments using OAuth/M2M (\`azure_ad_token\` in place of a static \`api_key\`) silently lost their token at the \`/v1/files\` and \`/v1/batches\` endpoints and the proxy returned \`Missing credentials. Please pass one of api_key, azure_ad_token, azure_ad_token_provider, ...\`.

Declare \`azure_ad_token\` on \`CredentialLiteLLMParams\` alongside \`api_key\` / \`api_base\` / \`api_version\` so it rides through the round-trip. Static-key deployments stay unaffected — \`Optional\`, default \`None\`, dropped by \`exclude_none=True\`.

\`azure_ad_token_provider\` (callable) is a separate concern and out of scope here.

## Real-behavior proof

Verifiable via the captured \`Router.get_deployment_credentials_with_provider\` output:

\`\`\`python
router = Router(model_list=[{
    \"model_name\": \"gpt-4o-azure-m2m\",
    \"litellm_params\": {
        \"model\": \"azure/gpt-4o\",
        \"api_base\": \"https://my.openai.azure.com\",
        \"api_version\": \"2024-08-01-preview\",
        \"azure_ad_token\": \"tok-xyz\",
    },
    \"model_info\": {\"id\": \"deployment-id\"},
}])
print(router.get_deployment_credentials_with_provider(model_id=\"deployment-id\"))
\`\`\`

Base: \`{'api_base': 'https://my.openai.azure.com', 'api_version': '2024-08-01-preview'}\` (no azure_ad_token)
With this branch: \`{'api_base': '...', 'api_version': '...', 'azure_ad_token': 'tok-xyz'}\`

## Tests

\`tests/test_litellm/test_azure_ad_token_credential_resolution.py\` — 5 tests:
- \`azure_ad_token\` round-trips through \`CredentialLiteLLMParams.model_dump()\` (FAILS on base)
- field is Optional, default None, dropped by \`exclude_none\` (pre-fix happy path)
- full credential shape preserved alongside other fields (FAILS on base)
- \`Router.get_deployment_credentials_with_provider\` preserves \`azure_ad_token\` (FAILS on base)
- static \`api_key\` deployments unaffected (no regression)

\`\`\`
$ .venv/bin/python -m pytest tests/test_litellm/test_azure_ad_token_credential_resolution.py -q
5 passed in 0.23s
\`\`\`

3/5 fail on base as expected.

Adjacent: \`test_router_order_fallback.py\` 13/13 still green. mypy clean (2117 files).

## Out of scope

Issue also mentions \`extra_headers.Authorization\` dynamic Bearer token forwarding on upload requests — separate add_provider_specific_headers_to_request path; not addressed here to keep this PR narrow.