### PR TITLE
fix(langfuse_otel): mark LLM spans as generations

### DIFF
--- a/litellm/integrations/langfuse/langfuse_otel.py
+++ b/litellm/integrations/langfuse/langfuse_otel.py
@@ -43,6 +43,7 @@ class LangfuseOtelLogger(OpenTelemetry):
         """
 
         _utils.set_attributes(span, kwargs, response_obj, LangfuseLLMObsOTELAttributes)
+        span.set_attribute("langfuse.observation.type", "generation")
 
         #########################################################
         # Set Langfuse specific attributes

--- a/tests/test_litellm/integrations/test_langfuse_otel.py
+++ b/tests/test_litellm/integrations/test_langfuse_otel.py
@@ -114,6 +114,9 @@ class TestLangfuseOtelIntegration:
             mock_set_attributes.assert_called_once_with(
                 mock_span, mock_kwargs, mock_response, LangfuseLLMObsOTELAttributes
             )
+            mock_span.set_attribute.assert_any_call(
+                "langfuse.observation.type", "generation"
+            )
 
     def test_set_langfuse_environment_attribute(self):
         """Test that Langfuse environment is set correctly when environment variable is present."""


### PR DESCRIPTION
## Relevant issues

Fixes #30249

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Before this change, `langfuse_otel` can export an LLM call span without `langfuse.observation.type`, so Langfuse classifies it as `SPAN`

After this change, the callback sets `langfuse.observation.type = "generation"`

```bash
.venv/bin/ruff check litellm/integrations/langfuse/langfuse_otel.py tests/test_litellm/integrations/test_langfuse_otel.py
.venv/bin/python -m pytest tests/test_litellm/integrations/test_langfuse_otel.py::TestLangfuseOtelIntegration::test_set_langfuse_otel_attributes
```

```text
All checks passed!
1 passed, 2 warnings in 0.46s
```

## Type

Bug Fix
Test

## Changes

Set the missing Langfuse OTEL observation type in the legacy `langfuse_otel` callback path and assert it in the existing unit test
