### PR TITLE
fix(managed_files): treat duplicate model_object_id registration as benign no-op

### DIFF
--- a/enterprise/litellm_enterprise/proxy/hooks/managed_files.py
+++ b/enterprise/litellm_enterprise/proxy/hooks/managed_files.py
@@ -169,26 +169,46 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
             litellm_parent_otel_span=litellm_parent_otel_span,
         )
 
-        await self.prisma_client.db.litellm_managedobjecttable.upsert(
-            where={"unified_object_id": unified_object_id},
-            data={
-                "create": {
-                    "unified_object_id": unified_object_id,
-                    "file_object": file_object.model_dump_json(),
-                    "model_object_id": model_object_id,
-                    "file_purpose": file_purpose,
-                    "created_by": user_api_key_dict.user_id,
-                    "team_id": user_api_key_dict.team_id,
-                    "updated_by": user_api_key_dict.user_id,
-                    "status": file_object.status,
+        try:
+            from prisma.errors import UniqueViolationError
+        except ImportError:
+            UniqueViolationError = Exception  # type: ignore
+
+        try:
+            await self.prisma_client.db.litellm_managedobjecttable.upsert(
+                where={"unified_object_id": unified_object_id},
+                data={
+                    "create": {
+                        "unified_object_id": unified_object_id,
+                        "file_object": file_object.model_dump_json(),
+                        "model_object_id": model_object_id,
+                        "file_purpose": file_purpose,
+                        "created_by": user_api_key_dict.user_id,
+                        "team_id": user_api_key_dict.team_id,
+                        "updated_by": user_api_key_dict.user_id,
+                        "status": file_object.status,
+                    },
+                    "update": {
+                        "file_object": file_object.model_dump_json(),
+                        "status": file_object.status,
+                        "updated_by": user_api_key_dict.user_id,
+                    },  # FIX: Update status and file_object on every operation to keep state in sync
                 },
-                "update": {
-                    "file_object": file_object.model_dump_json(),
-                    "status": file_object.status,
-                    "updated_by": user_api_key_dict.user_id,
-                },  # FIX: Update status and file_object on every operation to keep state in sync
-            },
-        )
+            )
+        except UniqueViolationError:
+            # The upsert is keyed on `unified_object_id`, but the table also has a
+            # separate UNIQUE constraint on `model_object_id`. When the same
+            # provider object is re-registered under a NEW unified_object_id
+            # (e.g. a chat turn re-references an already-uploaded managed file),
+            # the "create" branch violates that constraint. The existing mapping
+            # is valid — re-registering is a benign no-op, not an error.
+            verbose_logger.debug(
+                "LiteLLM Managed %s object with model_object_id=%s is already "
+                "registered under another unified_object_id — skipping duplicate "
+                "registration.",
+                file_purpose,
+                model_object_id,
+            )
 
     async def get_unified_file_id(
         self, file_id: str, litellm_parent_otel_span: Optional[Span] = None

--- a/tests/test_litellm/enterprise/proxy/test_managed_files_hook.py
+++ b/tests/test_litellm/enterprise/proxy/test_managed_files_hook.py
@@ -165,3 +165,49 @@ async def test_should_fallback_when_no_router():
         call_kwargs = mock_afile_retrieve.call_args
         assert call_kwargs.kwargs.get("custom_llm_provider") == "azure"
         assert call_kwargs.kwargs.get("file_id") == "file-output-abc"
+
+
+@pytest.mark.asyncio
+async def test_store_unified_object_id_swallows_model_object_id_unique_violation():
+    """
+    The upsert in store_unified_object_id is keyed on unified_object_id, but the
+    LiteLLM_ManagedObjectTable also has a separate UNIQUE constraint on
+    model_object_id. When the same provider object is re-registered under a NEW
+    unified_object_id (e.g. a chat turn re-references an already-uploaded managed
+    file through the Anthropic passthrough), the "create" branch of the upsert
+    raises UniqueViolationError inside a fire-and-forget task.
+
+    The existing mapping is valid, so duplicate registration must be a benign
+    no-op instead of an unhandled exception.
+    """
+    from prisma.errors import UniqueViolationError
+
+    from litellm_enterprise.proxy.hooks.managed_files import (
+        _PROXY_LiteLLMManagedFiles,
+    )
+
+    mock_cache = MagicMock()
+    mock_cache.async_set_cache = AsyncMock()
+    mock_prisma = MagicMock()
+    # Real instance without invoking prisma's __init__ (requires engine payload).
+    unique_violation = UniqueViolationError.__new__(UniqueViolationError)
+    mock_prisma.db.litellm_managedobjecttable.upsert = AsyncMock(
+        side_effect=unique_violation
+    )
+
+    instance = _PROXY_LiteLLMManagedFiles(
+        internal_usage_cache=mock_cache,
+        prisma_client=mock_prisma,
+    )
+
+    # Must NOT raise — the provider object is simply already registered.
+    await instance.store_unified_object_id(
+        unified_object_id="unified-batch-2",
+        file_object=_make_batch_response(batch_id="batch-456"),
+        litellm_parent_otel_span=None,
+        model_object_id="provider-batch-abc",
+        file_purpose="batch",
+        user_api_key_dict=_make_user_api_key_dict(),
+    )
+
+    mock_prisma.db.litellm_managedobjecttable.upsert.assert_awaited_once()


### PR DESCRIPTION
## Title

fix(managed_files): treat duplicate `model_object_id` registration as benign no-op

## Relevant issues

Fixes #30251

## Pre-Submission checklist

- [x] I have Added testing in the `tests/test_litellm/` directory
- [x] I have added a screenshot of my new test passing locally *(unit test, see below)*
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

`store_unified_object_id()` upserts into `LiteLLM_ManagedObjectTable` keyed on `unified_object_id`, but the table also has a separate **UNIQUE constraint on `model_object_id`**. When the same provider object is re-registered under a **new** `unified_object_id` (e.g. a chat turn re-references an already-uploaded managed file through the Anthropic passthrough), the `create` branch of the upsert raises `prisma.errors.UniqueViolationError` inside a fire-and-forget task (`Task exception was never retrieved`), spamming logs on every affected request.

The first registration succeeded and the mapping is valid, so this PR catches `UniqueViolationError` around the upsert and logs at debug level instead of letting the exception escape. Lazy `from prisma.errors import UniqueViolationError` with the same `ImportError` fallback pattern already used in `mcp_management_endpoints.py`.

Includes a regression test (`test_store_unified_object_id_swallows_model_object_id_unique_violation`) in `tests/test_litellm/enterprise/proxy/test_managed_files_hook.py`.