### PR TITLE
test(otel): add regression tests for None start/end times in service hooks

### DIFF
--- a/tests/test_litellm/integrations/test_otel_none_timestamp.py
+++ b/tests/test_litellm/integrations/test_otel_none_timestamp.py
@@ -1,0 +1,87 @@
+"""Regression tests for the OTEL service hooks crashing on None start/end times.
+
+When a service success/failure event is logged without timing information,
+``start_time``/``end_time`` arrive as ``None`` and were passed straight into
+``_to_ns``, which called ``.timestamp()`` on ``None`` and raised
+``AttributeError``. See https://github.com/BerriAI/litellm/issues/30061.
+"""
+
+from datetime import datetime
+from typing import Optional
+
+import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+
+from litellm.integrations.opentelemetry import OpenTelemetry
+from litellm.types.services import ServiceLoggerPayload, ServiceTypes
+
+
+def _make_otel():
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    otel = OpenTelemetry()
+    otel.tracer = provider.get_tracer(__name__)
+    return otel, exporter
+
+
+def _payload(is_error: bool = False, error: Optional[str] = None):
+    return ServiceLoggerPayload(
+        is_error=is_error,
+        error=error,
+        service=ServiceTypes.DB,
+        duration=0.0,
+        call_type="query",
+        event_metadata=None,
+    )
+
+
+def test_to_ns_handles_none():
+    """_to_ns should fall back to now() instead of crashing on None."""
+    otel, _ = _make_otel()
+    assert otel._to_ns(None) > 0
+
+    fixed = datetime(2024, 1, 1)
+    assert otel._to_ns(fixed) == int(fixed.timestamp() * 1e9)
+
+
+@pytest.mark.asyncio
+async def test_async_service_success_hook_with_none_times():
+    """Success hook must not raise when start_time/end_time are None."""
+    otel, exporter = _make_otel()
+    parent = otel.tracer.start_span("parent")
+
+    await otel.async_service_success_hook(
+        payload=_payload(),
+        parent_otel_span=parent,
+        start_time=None,
+        end_time=None,
+    )
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) >= 1
+    assert all(span.start_time > 0 for span in spans)
+
+
+@pytest.mark.asyncio
+async def test_async_service_failure_hook_with_none_times():
+    """Failure hook must not raise when start_time/end_time are None."""
+    otel, exporter = _make_otel()
+    parent = otel.tracer.start_span("parent")
+
+    await otel.async_service_failure_hook(
+        payload=_payload(is_error=True, error="boom"),
+        error="boom",
+        parent_otel_span=parent,
+        start_time=None,
+        end_time=None,
+    )
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) >= 1
+    assert all(span.start_time > 0 for span in spans)


### PR DESCRIPTION
## Description

Rebased onto `litellm_internal_staging` as requested.

`litellm_internal_staging` already handles `None` in `_to_ns` (it returns `datetime.now()`, and also handles int/float), so the original code fix from this PR is already covered there. This PR therefore lands as the **regression tests** that lock in that behavior: the OTEL `async_service_success_hook` / `async_service_failure_hook` must not crash when `start_time`/`end_time` are `None`, and `_to_ns(None)` returns a valid timestamp.

## Testing

`tests/test_litellm/integrations/test_otel_none_timestamp.py` (3 tests) passes against current `litellm_internal_staging`. Each test reproduces the original crash scenario (None start/end times) and asserts the span is produced without an `AttributeError`.


_PR title is conventional (`test(otel): ...`); the earlier `Validate PR title` red was a stale run from a push that preceded the title update._
