### PR TITLE
feat(bedrock): add bedrock mantle gemma 4 models

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -41680,6 +41680,48 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
+    "bedrock_mantle/google.gemma-4-31b": {
+        "input_cost_per_token": 1.4e-07,
+        "output_cost_per_token": 4e-07,
+        "litellm_provider": "bedrock_mantle",
+        "max_input_tokens": 256000,
+        "max_output_tokens": 256000,
+        "max_tokens": 256000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": false,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "bedrock_mantle/google.gemma-4-26b-a4b": {
+        "input_cost_per_token": 1.3e-07,
+        "output_cost_per_token": 4e-07,
+        "litellm_provider": "bedrock_mantle",
+        "max_input_tokens": 256000,
+        "max_output_tokens": 256000,
+        "max_tokens": 256000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": false,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "bedrock_mantle/google.gemma-4-e2b": {
+        "input_cost_per_token": 4e-08,
+        "output_cost_per_token": 8e-08,
+        "litellm_provider": "bedrock_mantle",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": false,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "volcengine/doubao-seed-2-0-pro-260215": {
         "litellm_provider": "volcengine",
         "max_input_tokens": 256000,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -41720,6 +41720,48 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
+    "bedrock_mantle/google.gemma-4-31b": {
+        "input_cost_per_token": 1.4e-07,
+        "output_cost_per_token": 4e-07,
+        "litellm_provider": "bedrock_mantle",
+        "max_input_tokens": 256000,
+        "max_output_tokens": 256000,
+        "max_tokens": 256000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": false,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "bedrock_mantle/google.gemma-4-26b-a4b": {
+        "input_cost_per_token": 1.3e-07,
+        "output_cost_per_token": 4e-07,
+        "litellm_provider": "bedrock_mantle",
+        "max_input_tokens": 256000,
+        "max_output_tokens": 256000,
+        "max_tokens": 256000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": false,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "bedrock_mantle/google.gemma-4-e2b": {
+        "input_cost_per_token": 4e-08,
+        "output_cost_per_token": 8e-08,
+        "litellm_provider": "bedrock_mantle",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": false,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "volcengine/doubao-seed-2-0-pro-260215": {
         "litellm_provider": "volcengine",
         "max_input_tokens": 256000,

--- a/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py
+++ b/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py
@@ -24,11 +24,11 @@ from litellm.types.utils import LlmProviders
 def local_cost_map(monkeypatch):
     original_model_cost = litellm.model_cost
     original_bedrock_mantle_models = set(litellm.bedrock_mantle_models)
-    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "true")
-    litellm.model_cost = litellm.get_model_cost_map(url="")
-    litellm.get_model_info.cache_clear()
-    litellm.add_known_models()
     try:
+        monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "true")
+        litellm.model_cost = litellm.get_model_cost_map(url="")
+        litellm.get_model_info.cache_clear()
+        litellm.add_known_models()
         yield
     finally:
         litellm.model_cost = original_model_cost

--- a/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py
+++ b/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py
@@ -20,6 +20,23 @@ from litellm.llms.bedrock_mantle.chat.transformation import BedrockMantleChatCon
 from litellm.types.utils import LlmProviders
 
 
+@pytest.fixture
+def local_cost_map(monkeypatch):
+    original_model_cost = litellm.model_cost
+    original_bedrock_mantle_models = set(litellm.bedrock_mantle_models)
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "true")
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+    litellm.get_model_info.cache_clear()
+    litellm.add_known_models()
+    try:
+        yield
+    finally:
+        litellm.model_cost = original_model_cost
+        litellm.bedrock_mantle_models.clear()
+        litellm.bedrock_mantle_models.update(original_bedrock_mantle_models)
+        litellm.get_model_info.cache_clear()
+
+
 class TestBedrockMantleProviderRegistration:
     def test_provider_enum_exists(self):
         assert LlmProviders.BEDROCK_MANTLE == "bedrock_mantle"
@@ -245,3 +262,52 @@ class TestBedrockMantlePricing:
         litellm.add_known_models()
         info = litellm.get_model_info("bedrock_mantle/openai.gpt-oss-120b")
         assert info["max_input_tokens"] == 131072
+
+
+@pytest.mark.parametrize(
+    "model_id,input_cost,output_cost,max_tokens",
+    [
+        ("google.gemma-4-31b", 1.4e-07, 4e-07, 256000),
+        ("google.gemma-4-26b-a4b", 1.3e-07, 4e-07, 256000),
+        ("google.gemma-4-e2b", 4e-08, 8e-08, 128000),
+    ],
+)
+def test_gemma_4_bedrock_mantle_model_metadata(
+    local_cost_map, model_id, input_cost, output_cost, max_tokens
+):
+    full_model_name = f"bedrock_mantle/{model_id}"
+    info = litellm.get_model_info(full_model_name)
+
+    assert info["mode"] == "chat"
+    assert info["input_cost_per_token"] == pytest.approx(input_cost)
+    assert info["output_cost_per_token"] == pytest.approx(output_cost)
+    assert info["max_input_tokens"] == max_tokens
+    assert info["max_output_tokens"] == max_tokens
+    assert info["supports_function_calling"] is True
+    assert info["supports_reasoning"] is True
+    assert info["supports_tool_choice"] is True
+    assert info["supports_vision"] is True
+    assert (
+        litellm.supports_parallel_function_calling(
+            model=full_model_name, custom_llm_provider="bedrock_mantle"
+        )
+        is False
+    )
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "google.gemma-4-31b",
+        "google.gemma-4-26b-a4b",
+        "google.gemma-4-e2b",
+    ],
+)
+def test_gemma_4_models_register_under_bedrock_mantle(local_cost_map, model_id):
+    full_model_name = f"bedrock_mantle/{model_id}"
+
+    assert full_model_name in litellm.bedrock_mantle_models
+
+    resolved_model, provider, _, _ = litellm.get_llm_provider(full_model_name)
+    assert provider == "bedrock_mantle"
+    assert resolved_model == model_id


### PR DESCRIPTION
## Relevant issues


## Linear ticket


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Need AWS Bedrock Mantle credentials for a live proof. Suggested QA runbook:

1. Export `BEDROCK_MANTLE_API_KEY` and `BEDROCK_MANTLE_REGION` for a region where Gemma 4 is enabled
2. Start the proxy with `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log`
3. Send a chat completion through the proxy for each of `bedrock_mantle/google.gemma-4-31b`, `bedrock_mantle/google.gemma-4-26b-a4b`, and `bedrock_mantle/google.gemma-4-e2b`; confirm each request resolves and the reported spend matches the Bedrock pricing page

## Type

New Feature

## Changes

Amazon Bedrock exposes the Gemma 4 family only on the Bedrock Mantle endpoint. This PR adds `google.gemma-4-31b`, `google.gemma-4-26b-a4b`, and `google.gemma-4-e2b` to LiteLLM's Bedrock Mantle model map with the official AWS model IDs, token pricing, and context windows. It also records the published reasoning, vision, and tool-calling capabilities and extends the Bedrock Mantle tests so registration, provider resolution, and pricing metadata are locked against the bundled local backup map
