### PR TITLE
feat(passthrough): add configurable pass-through request timeouts

### DIFF
--- a/litellm/passthrough/main.py
+++ b/litellm/passthrough/main.py
@@ -201,12 +201,6 @@ def llm_passthrough_route(
 
     _is_async = allm_passthrough_route
 
-    if client is None:
-        if _is_async:
-            client = litellm.module_level_aclient
-        else:
-            client = litellm.module_level_client
-
     litellm_logging_obj = cast("LiteLLMLoggingObj", kwargs.get("litellm_logging_obj"))
 
     model, custom_llm_provider, api_key, api_base = get_llm_provider(
@@ -217,6 +211,28 @@ def llm_passthrough_route(
     )
 
     litellm_params_dict = get_litellm_params(**kwargs)
+
+    if client is None:
+        from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
+            resolve_llm_passthrough_timeout,
+        )
+
+        resolved_timeout = resolve_llm_passthrough_timeout(
+            kwargs=kwargs,
+            litellm_params=litellm_params_dict,
+        )
+        if _is_async:
+            from litellm.llms.custom_httpx.http_handler import get_async_httpx_client
+            from litellm.types.llms.custom_http import httpxSpecialProvider
+
+            client = get_async_httpx_client(
+                llm_provider=httpxSpecialProvider.PassThroughEndpoint,
+                params={"timeout": resolved_timeout},
+            )
+        else:
+            from litellm.llms.custom_httpx.http_handler import HTTPHandler
+
+            client = HTTPHandler(timeout=resolved_timeout)
 
     # Add model_id to litellm_params if present in kwargs (for Bedrock Application Inference Profiles)
     if "model_id" in kwargs:

--- a/litellm/passthrough/main.py
+++ b/litellm/passthrough/main.py
@@ -20,7 +20,6 @@ from typing import (
 import httpx
 from httpx._types import CookieTypes, QueryParamTypes, RequestFiles
 
-import litellm
 from litellm._logging import verbose_logger
 from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
 from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler, HTTPHandler

--- a/litellm/passthrough/main.py
+++ b/litellm/passthrough/main.py
@@ -212,26 +212,24 @@ def llm_passthrough_route(
     litellm_params_dict = get_litellm_params(**kwargs)
 
     if client is None:
-        from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
-            resolve_llm_passthrough_timeout,
+        from litellm.llms.custom_httpx.http_handler import (
+            _get_httpx_client,
+            get_async_httpx_client,
         )
+        from litellm.passthrough.timeout_utils import resolve_llm_passthrough_timeout
+        from litellm.types.llms.custom_http import httpxSpecialProvider
 
         resolved_timeout = resolve_llm_passthrough_timeout(
             kwargs=kwargs,
             litellm_params=litellm_params_dict,
         )
         if _is_async:
-            from litellm.llms.custom_httpx.http_handler import get_async_httpx_client
-            from litellm.types.llms.custom_http import httpxSpecialProvider
-
             client = get_async_httpx_client(
                 llm_provider=httpxSpecialProvider.PassThroughEndpoint,
                 params={"timeout": resolved_timeout},
             )
         else:
-            from litellm.llms.custom_httpx.http_handler import HTTPHandler
-
-            client = HTTPHandler(timeout=resolved_timeout)
+            client = _get_httpx_client(params={"timeout": resolved_timeout})
 
     # Add model_id to litellm_params if present in kwargs (for Bedrock Application Inference Profiles)
     if "model_id" in kwargs:

--- a/litellm/passthrough/timeout_utils.py
+++ b/litellm/passthrough/timeout_utils.py
@@ -1,3 +1,4 @@
+import sys
 from typing import Optional
 
 DEFAULT_PASS_THROUGH_REQUEST_TIMEOUT_SECONDS = 600.0
@@ -10,16 +11,21 @@ def resolve_pass_through_request_timeout(
     Resolve the upstream httpx timeout for pass_through_request.
 
     Precedence: per-endpoint timeout -> general_settings.pass_through_request_timeout -> 600s default.
+
+    Uses sys.modules to read general_settings only when the proxy module is already
+    loaded, avoiding a fastapi transitive import in pure SDK contexts.
     """
     if endpoint_timeout is not None:
         return float(endpoint_timeout)
 
     try:
-        from litellm.proxy.proxy_server import general_settings
-
-        global_timeout = general_settings.get("pass_through_request_timeout")
-        if global_timeout is not None:
-            return float(global_timeout)
+        proxy_server = sys.modules.get("litellm.proxy.proxy_server")
+        if proxy_server is not None:
+            global_timeout = getattr(proxy_server, "general_settings", {}).get(
+                "pass_through_request_timeout"
+            )
+            if global_timeout is not None:
+                return float(global_timeout)
     except Exception:
         pass
 

--- a/litellm/passthrough/timeout_utils.py
+++ b/litellm/passthrough/timeout_utils.py
@@ -1,0 +1,52 @@
+from typing import Optional
+
+DEFAULT_PASS_THROUGH_REQUEST_TIMEOUT_SECONDS = 600.0
+
+
+def resolve_pass_through_request_timeout(
+    endpoint_timeout: Optional[float] = None,
+) -> float:
+    """
+    Resolve the upstream httpx timeout for pass_through_request.
+
+    Precedence: per-endpoint timeout -> general_settings.pass_through_request_timeout -> 600s default.
+    """
+    if endpoint_timeout is not None:
+        return float(endpoint_timeout)
+
+    try:
+        from litellm.proxy.proxy_server import general_settings
+
+        global_timeout = general_settings.get("pass_through_request_timeout")
+        if global_timeout is not None:
+            return float(global_timeout)
+    except Exception:
+        pass
+
+    return DEFAULT_PASS_THROUGH_REQUEST_TIMEOUT_SECONDS
+
+
+def resolve_llm_passthrough_timeout(
+    kwargs: Optional[dict] = None,
+    litellm_params: Optional[dict] = None,
+    router_timeout: Optional[float] = None,
+) -> float:
+    """
+    Resolve upstream httpx timeout for SDK native passthrough (e.g. Bedrock /converse).
+
+    Precedence: kwargs timeout/request_timeout -> litellm_params timeout/request_timeout
+    -> router_timeout -> general_settings.pass_through_request_timeout -> 600s default.
+    """
+    kwargs = kwargs or {}
+    litellm_params = litellm_params or {}
+
+    for source in (kwargs, litellm_params):
+        for key in ("timeout", "request_timeout"):
+            val = source.get(key)
+            if val is not None:
+                return float(val)
+
+    if router_timeout is not None:
+        return float(router_timeout)
+
+    return resolve_pass_through_request_timeout()

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2045,6 +2045,10 @@ class PassThroughGenericEndpoint(LiteLLMPydanticObjectBase):
         default=0.0,
         description="The USD cost per request to the target endpoint. This is used to calculate the cost of the request to the target endpoint.",
     )
+    timeout: Optional[float] = Field(
+        default=None,
+        description="Upstream request timeout in seconds for this pass-through endpoint. If unset, uses general_settings.pass_through_request_timeout (default 600).",
+    )
     auth: bool = Field(
         default=True,
         description="Whether authentication is required for the pass-through endpoint. Defaults to True so a pass-through silently created without an explicit value still requires a valid LiteLLM API key — set to False only if the endpoint is meant to be a public forwarder (e.g. an unauthenticated webhook target).",
@@ -2274,6 +2278,10 @@ class ConfigGeneralSettings(LiteLLMPydanticObjectBase):
     enable_public_model_hub: bool = Field(
         default=False,
         description="Public model hub for users to see what models they have access to, supported openai params, etc.",
+    )
+    pass_through_request_timeout: Optional[float] = Field(
+        default=None,
+        description="Default upstream request timeout in seconds for native and custom pass-through endpoints that use pass_through_request. Defaults to 600 when unset.",
     )
     pass_through_endpoints: Optional[List[PassThroughGenericEndpoint]] = Field(
         default=None,

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -696,52 +696,11 @@ def _carry_guardrail_logging_info(
     metadata.setdefault("standard_logging_guardrail_information", list(entries))
 
 
-DEFAULT_PASS_THROUGH_REQUEST_TIMEOUT_SECONDS = 600.0
-
-
-def resolve_pass_through_request_timeout(
-    endpoint_timeout: Optional[float] = None,
-) -> float:
-    """
-    Resolve the upstream httpx timeout for pass_through_request.
-
-    Precedence: per-endpoint timeout -> general_settings.pass_through_request_timeout -> 600s default.
-    """
-    if endpoint_timeout is not None:
-        return float(endpoint_timeout)
-
-    try:
-        from litellm.proxy.proxy_server import general_settings
-
-        global_timeout = general_settings.get("pass_through_request_timeout")
-        if global_timeout is not None:
-            return float(global_timeout)
-    except Exception:
-        pass
-
-    return DEFAULT_PASS_THROUGH_REQUEST_TIMEOUT_SECONDS
-
-
-def resolve_llm_passthrough_timeout(
-    kwargs: Optional[dict] = None,
-    litellm_params: Optional[dict] = None,
-) -> float:
-    """
-    Resolve upstream httpx timeout for SDK native passthrough (e.g. Bedrock /converse).
-
-    Precedence: kwargs timeout/request_timeout -> litellm_params timeout/request_timeout
-    -> general_settings.pass_through_request_timeout -> 600s default.
-    """
-    kwargs = kwargs or {}
-    litellm_params = litellm_params or {}
-
-    for source in (kwargs, litellm_params):
-        for key in ("timeout", "request_timeout"):
-            val = source.get(key)
-            if val is not None:
-                return float(val)
-
-    return resolve_pass_through_request_timeout()
+from litellm.passthrough.timeout_utils import (
+    DEFAULT_PASS_THROUGH_REQUEST_TIMEOUT_SECONDS,
+    resolve_llm_passthrough_timeout,
+    resolve_pass_through_request_timeout,
+)  # re-exported for backward compat; resolve_pass_through_request_timeout also used below
 
 
 async def pass_through_request(  # noqa: PLR0915

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -697,7 +697,8 @@ def _carry_guardrail_logging_info(
 
 
 from litellm.passthrough.timeout_utils import (
-    DEFAULT_PASS_THROUGH_REQUEST_TIMEOUT_SECONDS,
+    DEFAULT_PASS_THROUGH_REQUEST_TIMEOUT_SECONDS,  # noqa: F401 - re-exported for backward compat
+    resolve_llm_passthrough_timeout,  # noqa: F401 - re-exported for backward compat
     resolve_pass_through_request_timeout,
 )
 

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -696,6 +696,54 @@ def _carry_guardrail_logging_info(
     metadata.setdefault("standard_logging_guardrail_information", list(entries))
 
 
+DEFAULT_PASS_THROUGH_REQUEST_TIMEOUT_SECONDS = 600.0
+
+
+def resolve_pass_through_request_timeout(
+    endpoint_timeout: Optional[float] = None,
+) -> float:
+    """
+    Resolve the upstream httpx timeout for pass_through_request.
+
+    Precedence: per-endpoint timeout -> general_settings.pass_through_request_timeout -> 600s default.
+    """
+    if endpoint_timeout is not None:
+        return float(endpoint_timeout)
+
+    try:
+        from litellm.proxy.proxy_server import general_settings
+
+        global_timeout = general_settings.get("pass_through_request_timeout")
+        if global_timeout is not None:
+            return float(global_timeout)
+    except Exception:
+        pass
+
+    return DEFAULT_PASS_THROUGH_REQUEST_TIMEOUT_SECONDS
+
+
+def resolve_llm_passthrough_timeout(
+    kwargs: Optional[dict] = None,
+    litellm_params: Optional[dict] = None,
+) -> float:
+    """
+    Resolve upstream httpx timeout for SDK native passthrough (e.g. Bedrock /converse).
+
+    Precedence: kwargs timeout/request_timeout -> litellm_params timeout/request_timeout
+    -> general_settings.pass_through_request_timeout -> 600s default.
+    """
+    kwargs = kwargs or {}
+    litellm_params = litellm_params or {}
+
+    for source in (kwargs, litellm_params):
+        for key in ("timeout", "request_timeout"):
+            val = source.get(key)
+            if val is not None:
+                return float(val)
+
+    return resolve_pass_through_request_timeout()
+
+
 async def pass_through_request(  # noqa: PLR0915
     request: Request,
     target: str,
@@ -710,6 +758,7 @@ async def pass_through_request(  # noqa: PLR0915
     cost_per_request: Optional[float] = None,
     custom_llm_provider: Optional[str] = None,
     guardrails_config: Optional[dict] = None,
+    timeout: Optional[float] = None,
 ):
     """
     Pass through endpoint handler, makes the httpx request for pass-through endpoints and ensures logging hooks are called
@@ -728,6 +777,8 @@ async def pass_through_request(  # noqa: PLR0915
         cost_per_request: Optional field - cost per request to the target endpoint
         custom_llm_provider: Optional field - custom LLM provider for the endpoint
         guardrails_config: Optional field - guardrails configuration for passthrough endpoint
+        timeout: Optional per-endpoint timeout in seconds. Falls back to
+            general_settings.pass_through_request_timeout, then 600s.
     """
     from litellm.exceptions import ModifyResponseException
     from litellm.litellm_core_utils.litellm_logging import Logging
@@ -866,9 +917,10 @@ async def pass_through_request(  # noqa: PLR0915
             data=_parsed_body,
             call_type="pass_through_endpoint",
         )
+        resolved_timeout = resolve_pass_through_request_timeout(timeout)
         async_client_obj = get_async_httpx_client(
             llm_provider=httpxSpecialProvider.PassThroughEndpoint,
-            params={"timeout": 600},
+            params={"timeout": resolved_timeout},
         )
         async_client = async_client_obj.client
         passthrough_logging_payload = PassthroughStandardLoggingPayload(
@@ -1545,6 +1597,7 @@ def create_pass_through_route(
     default_query_params: Optional[dict] = None,
     guardrails: Optional[Dict[str, Any]] = None,
     config_file_path: Optional[str] = None,
+    timeout: Optional[float] = None,
 ):
     # check if target is an adapter.py or a url
     from litellm._uuid import uuid
@@ -1628,6 +1681,7 @@ def create_pass_through_route(
                 "merge_query_params": _merge_query_params,
                 "cost_per_request": cost_per_request,
                 "guardrails": None,
+                "timeout": timeout,
             }
 
             if passthrough_params is not None:
@@ -1647,6 +1701,7 @@ def create_pass_through_route(
             )
             param_guardrails = target_params.get("guardrails", None)
             param_default_query_params = target_params.get("default_query_params", None)
+            param_timeout = target_params.get("timeout", timeout)
 
             # Construct the full target URL with subpath if needed
             full_target = (
@@ -1701,6 +1756,7 @@ def create_pass_through_route(
                     cost_per_request=cast(Optional[float], param_cost_per_request),
                     custom_llm_provider=custom_llm_provider,
                     guardrails_config=cast(Optional[dict], param_guardrails),
+                    timeout=cast(Optional[float], param_timeout),
                 )
             finally:
                 if hasattr(request.state, LITELLM_PASS_THROUGH_CUSTOM_BODY_STATE_KEY):
@@ -2349,6 +2405,7 @@ class InitPassThroughEndpointHelpers:
         default_query_params: Optional[dict] = None,
         config_file_path: Optional[str] = None,
         auth: bool = False,
+        timeout: Optional[float] = None,
     ):
         """Add exact path route for pass-through endpoint"""
         # Default to all methods if none specified (backward compatibility)
@@ -2389,6 +2446,7 @@ class InitPassThroughEndpointHelpers:
                 default_query_params=default_query_params,
                 guardrails=guardrails,
                 config_file_path=config_file_path,
+                timeout=timeout,
             ),
             methods=methods,
             dependencies=dependencies,
@@ -2410,6 +2468,7 @@ class InitPassThroughEndpointHelpers:
                 "dependencies": dependencies,
                 "cost_per_request": cost_per_request,
                 "guardrails": guardrails,
+                "timeout": timeout,
             },
         }
 
@@ -2429,6 +2488,7 @@ class InitPassThroughEndpointHelpers:
         default_query_params: Optional[dict] = None,
         config_file_path: Optional[str] = None,
         auth: bool = False,
+        timeout: Optional[float] = None,
     ):
         """Add wildcard route for sub-paths"""
         # Default to all methods if none specified (backward compatibility)
@@ -2470,6 +2530,7 @@ class InitPassThroughEndpointHelpers:
                 default_query_params=default_query_params,
                 guardrails=guardrails,
                 config_file_path=config_file_path,
+                timeout=timeout,
             ),
             methods=methods,
             dependencies=dependencies,
@@ -2491,6 +2552,7 @@ class InitPassThroughEndpointHelpers:
                 "dependencies": dependencies,
                 "cost_per_request": cost_per_request,
                 "guardrails": guardrails,
+                "timeout": timeout,
             },
         }
 
@@ -2684,6 +2746,7 @@ async def _register_pass_through_endpoint(
     guardrails = endpoint_data.get("guardrails")
     methods = endpoint_data.get("methods")
     cost_per_request = endpoint_data.get("cost_per_request")
+    timeout = endpoint_data.get("timeout")
 
     verbose_proxy_logger.debug(
         "Initializing pass through endpoint: %s (ID: %s)", path, endpoint_id
@@ -2703,6 +2766,7 @@ async def _register_pass_through_endpoint(
         default_query_params=default_query_params,
         config_file_path=config_file_path,
         auth=auth_enforced,
+        timeout=timeout,
     )
 
     methods_for_key = methods if methods else ["GET", "POST", "PUT", "DELETE", "PATCH"]
@@ -2729,6 +2793,7 @@ async def _register_pass_through_endpoint(
             default_query_params=default_query_params,
             config_file_path=config_file_path,
             auth=auth_enforced,
+            timeout=timeout,
         )
         visited_endpoints.add(f"{endpoint_id}:subpath:{path}:{methods_str}")
 
@@ -3112,6 +3177,7 @@ async def update_pass_through_endpoints(
             methods=updated_endpoint.methods,
             default_query_params=updated_endpoint.default_query_params,
             auth=updated_endpoint.auth,
+            timeout=updated_endpoint.timeout,
         )
     else:
         InitPassThroughEndpointHelpers.add_exact_path_route(
@@ -3128,6 +3194,7 @@ async def update_pass_through_endpoints(
             methods=updated_endpoint.methods,
             default_query_params=updated_endpoint.default_query_params,
             auth=updated_endpoint.auth,
+            timeout=updated_endpoint.timeout,
         )
 
     return PassThroughEndpointResponse(
@@ -3207,6 +3274,7 @@ async def create_pass_through_endpoints(
             methods=created_endpoint.methods,
             default_query_params=created_endpoint.default_query_params,
             auth=created_endpoint.auth,
+            timeout=created_endpoint.timeout,
         )
     else:
         InitPassThroughEndpointHelpers.add_exact_path_route(
@@ -3223,6 +3291,7 @@ async def create_pass_through_endpoints(
             methods=created_endpoint.methods,
             default_query_params=created_endpoint.default_query_params,
             auth=created_endpoint.auth,
+            timeout=created_endpoint.timeout,
         )
 
     return PassThroughEndpointResponse(endpoints=[created_endpoint])

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -696,7 +696,10 @@ def _carry_guardrail_logging_info(
     metadata.setdefault("standard_logging_guardrail_information", list(entries))
 
 
-from litellm.passthrough.timeout_utils import resolve_pass_through_request_timeout
+from litellm.passthrough.timeout_utils import (
+    DEFAULT_PASS_THROUGH_REQUEST_TIMEOUT_SECONDS,
+    resolve_pass_through_request_timeout,
+)
 
 
 async def pass_through_request(  # noqa: PLR0915

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -696,11 +696,7 @@ def _carry_guardrail_logging_info(
     metadata.setdefault("standard_logging_guardrail_information", list(entries))
 
 
-from litellm.passthrough.timeout_utils import (
-    DEFAULT_PASS_THROUGH_REQUEST_TIMEOUT_SECONDS,
-    resolve_llm_passthrough_timeout,
-    resolve_pass_through_request_timeout,
-)  # re-exported for backward compat; resolve_pass_through_request_timeout also used below
+from litellm.passthrough.timeout_utils import resolve_pass_through_request_timeout
 
 
 async def pass_through_request(  # noqa: PLR0915

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -1582,7 +1582,7 @@ async def _parse_request_data_by_content_type(
     return query_params_data, custom_body_data, file_data, stream
 
 
-def create_pass_through_route(
+def create_pass_through_route(  # noqa: PLR0915
     endpoint,
     target: str,
     custom_headers: Optional[Mapping[str, Any]] = None,

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -562,6 +562,7 @@ class Router:
         else:
             self.max_fallbacks = litellm.ROUTER_MAX_FALLBACKS
 
+        self._explicit_timeout = timeout  # None when user did not pass timeout
         self.timeout = timeout or litellm.request_timeout
         self.stream_timeout = stream_timeout
 
@@ -3226,11 +3227,13 @@ class Router:
         kwargs["model_info"] = model_info
 
         if function_name == "_ageneric_api_call_with_fallbacks":
-            from litellm.passthrough.timeout_utils import resolve_llm_passthrough_timeout
+            from litellm.passthrough.timeout_utils import (
+                resolve_llm_passthrough_timeout,
+            )
 
             _router_timeout = (
-                float(self.timeout)
-                if isinstance(self.timeout, (int, float))
+                float(self._explicit_timeout)
+                if isinstance(self._explicit_timeout, (int, float))
                 else None
             )
             kwargs["timeout"] = resolve_llm_passthrough_timeout(

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -3225,9 +3225,19 @@ class Router:
 
         kwargs["model_info"] = model_info
 
-        kwargs["timeout"] = self._get_timeout(
-            kwargs=kwargs, data=deployment["litellm_params"]
-        )
+        if function_name == "_ageneric_api_call_with_fallbacks":
+            from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
+                resolve_llm_passthrough_timeout,
+            )
+
+            kwargs["timeout"] = resolve_llm_passthrough_timeout(
+                kwargs=kwargs,
+                litellm_params=deployment["litellm_params"],
+            )
+        else:
+            kwargs["timeout"] = self._get_timeout(
+                kwargs=kwargs, data=deployment["litellm_params"]
+            )
 
         self._update_kwargs_with_default_litellm_params(
             kwargs=kwargs, metadata_variable_name=metadata_variable_name

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -3226,13 +3226,17 @@ class Router:
         kwargs["model_info"] = model_info
 
         if function_name == "_ageneric_api_call_with_fallbacks":
-            from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
-                resolve_llm_passthrough_timeout,
-            )
+            from litellm.passthrough.timeout_utils import resolve_llm_passthrough_timeout
 
+            _router_timeout = (
+                float(self.timeout)
+                if isinstance(self.timeout, (int, float))
+                else None
+            )
             kwargs["timeout"] = resolve_llm_passthrough_timeout(
                 kwargs=kwargs,
                 litellm_params=deployment["litellm_params"],
+                router_timeout=_router_timeout,
             )
         else:
             kwargs["timeout"] = self._get_timeout(

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
@@ -16,9 +16,13 @@ sys.path.insert(
 )  # Adds the parent directory to the system path
 
 from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
+    DEFAULT_PASS_THROUGH_REQUEST_TIMEOUT_SECONDS,
     HttpPassThroughEndpointHelpers,
     LITELLM_PASS_THROUGH_CUSTOM_BODY_STATE_KEY,
+    create_pass_through_route,
     pass_through_request,
+    resolve_pass_through_request_timeout,
+    resolve_llm_passthrough_timeout,
 )
 from litellm.types.passthrough_endpoints.pass_through_endpoints import (
     LITELLM_PASS_THROUGH_RAW_BODY_STATE_KEY,
@@ -869,6 +873,131 @@ async def test_create_pass_through_route_with_cost_per_request():
         mock_pass_through.assert_called_once()
         call_kwargs = mock_pass_through.call_args[1]
         assert call_kwargs["cost_per_request"] == 3.75
+
+
+def test_resolve_pass_through_request_timeout_precedence():
+    assert resolve_pass_through_request_timeout(endpoint_timeout=900) == 900.0
+
+    with patch(
+        "litellm.proxy.proxy_server.general_settings",
+        {"pass_through_request_timeout": 1200},
+    ):
+        assert resolve_pass_through_request_timeout() == 1200.0
+        assert resolve_pass_through_request_timeout(endpoint_timeout=800) == 800.0
+
+    with patch("litellm.proxy.proxy_server.general_settings", {}):
+        assert (
+            resolve_pass_through_request_timeout()
+            == DEFAULT_PASS_THROUGH_REQUEST_TIMEOUT_SECONDS
+        )
+
+
+def test_resolve_llm_passthrough_timeout_precedence():
+    assert resolve_llm_passthrough_timeout(kwargs={"timeout": 45}) == 45.0
+    assert (
+        resolve_llm_passthrough_timeout(
+            kwargs={"request_timeout": 30},
+            litellm_params={"timeout": 60},
+        )
+        == 30.0
+    )
+    assert (
+        resolve_llm_passthrough_timeout(
+            litellm_params={"timeout": 90},
+        )
+        == 90.0
+    )
+
+    with patch(
+        "litellm.proxy.proxy_server.general_settings",
+        {"pass_through_request_timeout": 6},
+    ):
+        assert resolve_llm_passthrough_timeout() == 6.0
+
+
+@pytest.mark.asyncio
+async def test_pass_through_request_uses_resolved_timeout():
+    with patch("litellm.proxy.proxy_server.proxy_logging_obj") as mock_proxy_logging:
+        with patch(
+            "litellm.proxy.pass_through_endpoints.pass_through_endpoints.get_async_httpx_client"
+        ) as mock_get_client:
+            mock_proxy_logging.pre_call_hook = AsyncMock(
+                side_effect=lambda **kwargs: kwargs["data"]
+            )
+
+            mock_client = MagicMock()
+            mock_client.client = MagicMock()
+            mock_client.client.request = AsyncMock(
+                side_effect=httpx.HTTPError("Request failed")
+            )
+            mock_get_client.return_value = mock_client
+
+            mock_request = MagicMock(spec=Request)
+            mock_request.method = "POST"
+            mock_request.body = AsyncMock(return_value=b'{"test": "data"}')
+            mock_request.headers = Headers({})
+            mock_request.query_params = QueryParams({})
+
+            mock_user_api_key_dict = MagicMock()
+
+            with pytest.raises(Exception):
+                await pass_through_request(
+                    request=mock_request,
+                    target="http://test.com",
+                    custom_headers={},
+                    user_api_key_dict=mock_user_api_key_dict,
+                    timeout=1500,
+                )
+
+            mock_get_client.assert_called_once()
+            assert mock_get_client.call_args[1]["params"]["timeout"] == 1500
+
+
+@pytest.mark.asyncio
+async def test_create_pass_through_route_forwards_timeout():
+    unique_path = "/test/path/unique/timeout"
+    endpoint_func = create_pass_through_route(
+        endpoint=unique_path,
+        target="http://example.com",
+        custom_headers={},
+        _forward_headers=True,
+        _merge_query_params=False,
+        dependencies=[],
+        timeout=1800,
+    )
+
+    with (
+        patch(
+            "litellm.proxy.pass_through_endpoints.pass_through_endpoints.pass_through_request"
+        ) as mock_pass_through,
+        patch(
+            "litellm.proxy.pass_through_endpoints.pass_through_endpoints.InitPassThroughEndpointHelpers.is_registered_pass_through_route"
+        ) as mock_is_registered,
+        patch(
+            "litellm.proxy.pass_through_endpoints.pass_through_endpoints.InitPassThroughEndpointHelpers.get_registered_pass_through_route"
+        ) as mock_get_registered,
+    ):
+        mock_pass_through.return_value = MagicMock()
+        mock_is_registered.return_value = True
+        mock_get_registered.return_value = None
+
+        mock_request = MagicMock(spec=Request)
+        mock_request.url = MagicMock()
+        mock_request.url.path = unique_path
+        mock_request.path_params = {}
+        mock_request.query_params = QueryParams({})
+
+        mock_user_api_key_dict = MagicMock()
+        mock_user_api_key_dict.api_key = "test-key"
+
+        await endpoint_func(
+            request=mock_request,
+            user_api_key_dict=mock_user_api_key_dict,
+            fastapi_response=MagicMock(),
+        )
+
+        call_kwargs = mock_pass_through.call_args[1]
+        assert call_kwargs["timeout"] == 1800
 
 
 def test_initialize_pass_through_endpoints_with_cost_per_request():

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -213,9 +213,10 @@ async def test_encrypted_content_affinity_model_group_config_is_additive():
     )
 
     assert unfiltered == healthy_deployments
-    assert "encrypted_content_affinity_enabled" not in disabled_request_kwargs[
-        "litellm_metadata"
-    ]
+    assert (
+        "encrypted_content_affinity_enabled"
+        not in disabled_request_kwargs["litellm_metadata"]
+    )
 
     global_check = EncryptedContentAffinityCheck(
         enable_global_affinity=True,
@@ -1265,10 +1266,16 @@ async def test_ageneric_api_call_deployment_model_overrides_alias():
         # calling the helper through async_function_with_fallbacks).
         kwargs["model"] = "not-gemini-2.5-flash"
 
-    with patch.object(router, "async_get_available_deployment") as mock_dep, \
-         patch.object(router, "_update_kwargs_with_deployment", side_effect=inject_alias_into_kwargs), \
-         patch.object(router, "async_routing_strategy_pre_call_checks"), \
-         patch.object(router, "_get_client", return_value=None):
+    with (
+        patch.object(router, "async_get_available_deployment") as mock_dep,
+        patch.object(
+            router,
+            "_update_kwargs_with_deployment",
+            side_effect=inject_alias_into_kwargs,
+        ),
+        patch.object(router, "async_routing_strategy_pre_call_checks"),
+        patch.object(router, "_get_client", return_value=None),
+    ):
         mock_dep.return_value = {
             "model_name": "not-gemini-2.5-flash",
             "litellm_params": {
@@ -1282,9 +1289,9 @@ async def test_ageneric_api_call_deployment_model_overrides_alias():
             original_generic_function=capture_model,
         )
 
-    assert captured["model"] == "vertex_ai/gemini-2.5-flash", (
-        f"Expected deployment model 'vertex_ai/gemini-2.5-flash', got '{captured['model']}'"
-    )
+    assert (
+        captured["model"] == "vertex_ai/gemini-2.5-flash"
+    ), f"Expected deployment model 'vertex_ai/gemini-2.5-flash', got '{captured['model']}'"
 
 
 def test_router_get_model_access_groups_team_only_models():
@@ -2918,6 +2925,33 @@ def test_add_deployment_model_to_endpoint_for_llm_passthrough_route():
     assert (
         result["endpoint"] == "/model/us.meta.llama3-8b-instruct-v1:0/invoke"
     ), f"Expected '/model/us.meta.llama3-8b-instruct-v1:0/invoke', got '{result['endpoint']}'"
+
+
+def test_update_kwargs_with_deployment_uses_pass_through_request_timeout():
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "my-bedrock-model",
+                "litellm_params": {
+                    "model": "bedrock/us.anthropic.claude-opus-4-5-20251101-v1:0",
+                },
+            }
+        ],
+    )
+    deployment = router.model_list[0]
+    kwargs: dict = {}
+
+    with patch(
+        "litellm.proxy.proxy_server.general_settings",
+        {"pass_through_request_timeout": 6},
+    ):
+        router._update_kwargs_with_deployment(
+            deployment=deployment,
+            kwargs=kwargs,
+            function_name="_ageneric_api_call_with_fallbacks",
+        )
+
+    assert kwargs["timeout"] == 6.0
 
 
 @pytest.mark.asyncio

--- a/ui/litellm-dashboard/src/components/add_pass_through.tsx
+++ b/ui/litellm-dashboard/src/components/add_pass_through.tsx
@@ -326,6 +326,31 @@ const AddPassThroughEndpoint: React.FC<AddFallbacksProps> = ({
             {/* Guardrails Section */}
             <PassThroughGuardrailsSection accessToken={accessToken} value={guardrails} onChange={setGuardrails} />
 
+            {/* Performance Section */}
+            <Card className="p-6">
+              <Title className="text-lg font-semibold text-gray-900 mb-2">Performance</Title>
+              <Subtitle className="text-gray-600 mb-6">Configure upstream request timeout for this endpoint</Subtitle>
+
+              <Form.Item
+                label={
+                  <span className="text-sm font-medium text-gray-700 flex items-center">
+                    Request Timeout (seconds)
+                    <Tooltip title="Max time to wait for the upstream API to respond. Leave empty to use general_settings.pass_through_request_timeout (default 600s).">
+                      <InfoCircleOutlined className="ml-2 text-gray-400 hover:text-gray-600" />
+                    </Tooltip>
+                  </span>
+                }
+                name="timeout"
+                extra={
+                  <div className="text-xs text-gray-500 mt-2">
+                    Use a higher value for slow upstream APIs (e.g. 1200 for long-running LLM calls)
+                  </div>
+                }
+              >
+                <NumericalInput min={1} step={1} precision={0} placeholder="600" size="large" />
+              </Form.Item>
+            </Card>
+
             {/* Billing Section */}
             <Card className="p-6">
               <Title className="text-lg font-semibold text-gray-900 mb-2">Billing</Title>

--- a/ui/litellm-dashboard/src/components/pass_through_info.tsx
+++ b/ui/litellm-dashboard/src/components/pass_through_info.tsx
@@ -40,6 +40,7 @@ interface PassThroughEndpoint {
   headers: Record<string, any>;
   include_subpath?: boolean;
   cost_per_request?: number;
+  timeout?: number;
   auth?: boolean;
   methods?: string[];
   guardrails?: Record<string, { request_fields?: string[]; response_fields?: string[] } | null>;
@@ -101,6 +102,7 @@ const PassThroughInfoView: React.FC<PassThroughInfoProps> = ({
         headers: headers,
         include_subpath: values.include_subpath,
         cost_per_request: values.cost_per_request,
+        timeout: values.timeout,
         auth: premiumUser ? values.auth : undefined,
         methods: selectedMethods && selectedMethods.length > 0 ? selectedMethods : undefined,
         guardrails: guardrails && Object.keys(guardrails).length > 0 ? guardrails : undefined,
@@ -297,6 +299,7 @@ const PassThroughInfoView: React.FC<PassThroughInfoProps> = ({
                       headers: endpointData.headers ? JSON.stringify(endpointData.headers, null, 2) : "",
                       include_subpath: endpointData.include_subpath || false,
                       cost_per_request: endpointData.cost_per_request,
+                      timeout: endpointData.timeout,
                       auth: endpointData.auth || false,
                       methods: endpointData.methods || [],
                     }}
@@ -350,6 +353,14 @@ const PassThroughInfoView: React.FC<PassThroughInfoProps> = ({
                       <InputNumber min={0} step={0.01} precision={2} placeholder="0.00" addonBefore="$" />
                     </Form.Item>
 
+                    <Form.Item
+                      label="Request Timeout (seconds)"
+                      name="timeout"
+                      extra="Max time to wait for upstream response. Leave empty to use the global pass_through_request_timeout (default 600s)."
+                    >
+                      <InputNumber min={1} step={1} precision={0} placeholder="600" style={{ width: "100%" }} />
+                    </Form.Item>
+
                     <PassThroughSecuritySection
                       premiumUser={premiumUser}
                       authEnabled={authEnabled}
@@ -392,6 +403,12 @@ const PassThroughInfoView: React.FC<PassThroughInfoProps> = ({
                       <div>
                         <Text className="font-medium">Cost per Request</Text>
                         <div>${endpointData.cost_per_request}</div>
+                      </div>
+                    )}
+                    {endpointData.timeout !== undefined && endpointData.timeout !== null && (
+                      <div>
+                        <Text className="font-medium">Request Timeout</Text>
+                        <div>{endpointData.timeout}s</div>
                       </div>
                     )}
                     <div>

--- a/ui/litellm-dashboard/src/components/pass_through_settings.tsx
+++ b/ui/litellm-dashboard/src/components/pass_through_settings.tsx
@@ -38,6 +38,7 @@ export interface passThroughItem {
   headers: object;
   include_subpath?: boolean;
   cost_per_request?: number;
+  timeout?: number;
   auth?: boolean;
   methods?: string[];
   guardrails?: Record<string, { request_fields?: string[]; response_fields?: string[] } | null>;

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -22135,6 +22135,11 @@ export interface components {
              */
             pass_through_endpoints?: components["schemas"]["PassThroughGenericEndpoint"][] | null;
             /**
+             * Pass Through Request Timeout
+             * @description Default upstream request timeout in seconds for native and custom pass-through endpoints that use pass_through_request. Defaults to 600 when unset.
+             */
+            pass_through_request_timeout?: number | null;
+            /**
              * Reject Clientside Metadata Tags
              * @description When set to True, rejects requests that contain client-side 'metadata.tags' to prevent users from influencing budgets by sending different tags. Tags can only be inherited from the API key metadata.
              */
@@ -27896,6 +27901,11 @@ export interface components {
              * @description The URL to which requests for this path should be forwarded.
              */
             target: string;
+            /**
+             * Timeout
+             * @description Upstream request timeout in seconds for this pass-through endpoint. If unset, uses general_settings.pass_through_request_timeout (default 600).
+             */
+            timeout?: number | null;
         };
         /**
          * PassThroughGuardrailSettings


### PR DESCRIPTION
## Summary
- Add `general_settings.pass_through_request_timeout` and per-endpoint `timeout` for custom pass-through routes
- Apply resolved timeouts to `pass_through_request()` and SDK native passthrough (`llm_passthrough_route`, including Bedrock `/converse` via router)
- Expose timeout fields in the pass-through endpoints admin UI

Fixes LIT-3451

## Test plan
- [x] `pytest tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py::test_resolve_pass_through_request_timeout_precedence`
- [x] `pytest tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py::test_resolve_llm_passthrough_timeout_precedence`
- [x] `pytest tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py::test_pass_through_request_uses_resolved_timeout`
- [x] `pytest tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py::test_create_pass_through_route_forwards_timeout`
- [x] `pytest tests/test_litellm/test_router.py::test_update_kwargs_with_deployment_uses_pass_through_request_timeout`

<img width="947" height="88" alt="image" src="https://github.com/user-attachments/assets/352ea600-772c-4e4f-83d4-88313b70a349" />
<img width="975" height="204" alt="image" src="https://github.com/user-attachments/assets/dfbacbbe-e258-4db5-a31d-0786911add70" />

