### PR TITLE
fix(router): release aiohttp connection when stream iteration ends abnormally

### DIFF
--- a/litellm/llms/custom_httpx/aiohttp_transport.py
+++ b/litellm/llms/custom_httpx/aiohttp_transport.py
@@ -116,6 +116,16 @@ class AiohttpResponseStream(httpx.AsyncByteStream):
             # For other exceptions, use the normal mapping
             with map_aiohttp_exceptions():
                 raise
+        finally:
+            # Release the aiohttp connection when iteration ends for any
+            # reason (read timeout, cancellation from a client disconnect,
+            # GeneratorExit). Without this, abnormally terminated streams
+            # permanently hold a slot in the TCPConnector pool; once the
+            # pool is exhausted every request to that host times out (408)
+            # until the proxy is restarted, even after the backend recovers.
+            # On a fully-read response the connection was already released
+            # at EOF and close() is a no-op.
+            self._aiohttp_response.close()
 
     async def aclose(self) -> None:
         with map_aiohttp_exceptions():

--- a/tests/test_litellm/llms/custom_httpx/test_aiohttp_transport.py
+++ b/tests/test_litellm/llms/custom_httpx/test_aiohttp_transport.py
@@ -63,9 +63,13 @@ class MockAiohttpResponse:
     ):
         self.status = status
         self.headers = headers or {}
+        self.closed = False
         self.content = MockContent(
             content_chunks, exception_to_raise, exception_at_chunk
         )
+
+    def close(self):
+        self.closed = True
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         pass
@@ -613,3 +617,97 @@ async def test_handle_session_closed_during_request():
     assert counts["requests"] == 2  # First request failed, second succeeded
     assert counts["sessions"] == 2  # Created 2 sessions for retry
     assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_response_stream_closes_response_on_error():
+    """
+    Regression test for #30192: when body iteration ends with an error, the
+    underlying aiohttp response must be closed so its connector slot is
+    released. Leaked slots exhaust the pool and every later request times
+    out (408) until the proxy restarts, even after the backend recovers.
+    """
+    mock_response = MockAiohttpResponse(
+        content_chunks=[b"chunk1", b"chunk2"],
+        exception_to_raise=aiohttp.ServerTimeoutError("read timeout"),
+        exception_at_chunk=1,
+    )
+
+    stream = AiohttpResponseStream(mock_response)  # type: ignore
+    with pytest.raises(httpx.TimeoutException):
+        async for _ in stream:
+            pass
+
+    assert mock_response.closed is True
+
+
+@pytest.mark.asyncio
+async def test_response_stream_closes_response_on_cancellation():
+    """
+    Regression test for #30192: a task cancelled mid-stream (e.g. the caller
+    disconnects during a traffic spike) must not leak its aiohttp connection.
+    """
+    mock_response = MockAiohttpResponse(
+        content_chunks=[b"chunk1", b"chunk2", b"chunk3"],
+        exception_to_raise=asyncio.CancelledError(),
+        exception_at_chunk=1,
+    )
+
+    stream = AiohttpResponseStream(mock_response)  # type: ignore
+    with pytest.raises(asyncio.CancelledError):
+        async for _ in stream:
+            pass
+
+    assert mock_response.closed is True
+
+
+@pytest.mark.asyncio
+async def test_stream_read_timeout_releases_connection_slot():
+    """
+    Regression test for #30192 with a real single-connection pool: a request
+    that times out mid-stream must release its connector slot so a follow-up
+    request to the recovered backend succeeds instead of waiting on the pool.
+    """
+    from aiohttp import TCPConnector, web
+
+    async def trickle_handler(request):
+        response = web.StreamResponse()
+        await response.prepare(request)
+        await response.write(b"chunk0\n")
+        await asyncio.sleep(5)
+        await response.write(b"chunk1\n")
+        return response
+
+    async def fast_handler(request):
+        return web.Response(text="ok")
+
+    app = web.Application()
+    app.router.add_get("/trickle", trickle_handler)
+    app.router.add_get("/fast", fast_handler)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    port = site._server.sockets[0].getsockname()[1]
+
+    transport = LiteLLMAiohttpTransport(
+        client=lambda: aiohttp.ClientSession(connector=TCPConnector(limit=1))
+    )
+
+    try:
+        slow_request = httpx.Request("GET", f"http://127.0.0.1:{port}/trickle")
+        slow_request.extensions["timeout"] = {"connect": 5.0, "read": 0.1, "pool": 1.0}
+        response = await transport.handle_async_request(slow_request)
+        with pytest.raises(httpx.TimeoutException):
+            async for _ in response.aiter_bytes():
+                pass
+
+        fast_request = httpx.Request("GET", f"http://127.0.0.1:{port}/fast")
+        fast_request.extensions["timeout"] = {"connect": 5.0, "read": 1.0, "pool": 1.0}
+        fast_response = await transport.handle_async_request(fast_request)
+        assert fast_response.status_code == 200
+        await fast_response.aread()
+        await fast_response.aclose()
+    finally:
+        await transport.aclose()
+        await runner.cleanup()

--- a/tests/test_litellm/llms/custom_httpx/test_aiohttp_transport.py
+++ b/tests/test_litellm/llms/custom_httpx/test_aiohttp_transport.py
@@ -662,52 +662,19 @@ async def test_response_stream_closes_response_on_cancellation():
 
 
 @pytest.mark.asyncio
-async def test_stream_read_timeout_releases_connection_slot():
+async def test_response_stream_closes_response_on_generator_exit():
     """
-    Regression test for #30192 with a real single-connection pool: a request
-    that times out mid-stream must release its connector slot so a follow-up
-    request to the recovered backend succeeds instead of waiting on the pool.
+    Regression test for #30192: when the consumer stops iterating early and the
+    stream generator is closed (GeneratorExit), the underlying aiohttp response
+    must still be closed so its connector slot is released.
     """
-    from aiohttp import TCPConnector, web
-
-    async def trickle_handler(request):
-        response = web.StreamResponse()
-        await response.prepare(request)
-        await response.write(b"chunk0\n")
-        await asyncio.sleep(5)
-        await response.write(b"chunk1\n")
-        return response
-
-    async def fast_handler(request):
-        return web.Response(text="ok")
-
-    app = web.Application()
-    app.router.add_get("/trickle", trickle_handler)
-    app.router.add_get("/fast", fast_handler)
-    runner = web.AppRunner(app)
-    await runner.setup()
-    site = web.TCPSite(runner, "127.0.0.1", 0)
-    await site.start()
-    port = site._server.sockets[0].getsockname()[1]
-
-    transport = LiteLLMAiohttpTransport(
-        client=lambda: aiohttp.ClientSession(connector=TCPConnector(limit=1))
+    mock_response = MockAiohttpResponse(
+        content_chunks=[b"chunk1", b"chunk2", b"chunk3"],
     )
 
-    try:
-        slow_request = httpx.Request("GET", f"http://127.0.0.1:{port}/trickle")
-        slow_request.extensions["timeout"] = {"connect": 5.0, "read": 0.1, "pool": 1.0}
-        response = await transport.handle_async_request(slow_request)
-        with pytest.raises(httpx.TimeoutException):
-            async for _ in response.aiter_bytes():
-                pass
+    stream = AiohttpResponseStream(mock_response)  # type: ignore
+    iterator = stream.__aiter__()
+    assert await iterator.__anext__() == b"chunk1"
+    await iterator.aclose()
 
-        fast_request = httpx.Request("GET", f"http://127.0.0.1:{port}/fast")
-        fast_request.extensions["timeout"] = {"connect": 5.0, "read": 1.0, "pool": 1.0}
-        fast_response = await transport.handle_async_request(fast_request)
-        assert fast_response.status_code == 200
-        await fast_response.aread()
-        await fast_response.aclose()
-    finally:
-        await transport.aclose()
-        await runner.cleanup()
+    assert mock_response.closed is True


### PR DESCRIPTION
## Relevant issues

Fixes #30192

## Root cause

When a streaming response's body iteration ends abnormally (mid-stream `sock_read` timeout, cancellation from a client disconnect, `GeneratorExit`), `AiohttpResponseStream.__aiter__` never closes the underlying `aiohttp.ClientResponse`. aiohttp only auto-releases a connector slot at body EOF, so each such stream permanently leaks one slot from the shared `TCPConnector`. A traffic spike drains the pool; afterwards every request waits on a slot and raises `litellm.Timeout` (408) **indefinitely — even though the backend is healthy** — until the proxy is restarted (the sessions are in-memory).

The router cooldown caches were ruled out: all cooldown/health state is TTL-bound and self-heals.

## Fix

Add a `finally` block in `AiohttpResponseStream.__aiter__` that closes the aiohttp response when iteration ends for any reason. On a fully-read response the connection was already released at EOF and `close()` is a no-op; keep-alive reuse for sequential requests is unaffected (verified).

## Live proxy evidence (vLLM backend on CPU, pool=10, stream_timeout=1)

**Before** — after a traffic spike ended and the backend was idle and healthy:

```
$ curl http://localhost:8011/v1/chat/completions ...   # direct to vLLM
HTTP 200 in 0.096s
$ curl http://localhost:4010/v1/chat/completions ...   # via litellm proxy
{"error":{"message":"litellm.Timeout: ... Timeout passed=3.0 ...","code":"408"}}
HTTP 408 in 3.04s        # still 408 at +95s and +4min — never recovers
```

**After (this fix)** — identical spike, same 10 mid-stream read timeouts logged during overload:

```
$ curl http://localhost:8011/v1/chat/completions ...   # direct
HTTP 200 in 0.093s
$ curl http://localhost:4010/v1/chat/completions ...   # via proxy
HTTP 200 in 0.077s       # immediate recovery; 408s occurred only during the overload window
```

Leak verified via connector introspection: cancellation leaked 10/10 slots and read-timeout 3/3 without the fix; 0 with it.

## Tests

3 new regression tests in `tests/test_litellm/llms/custom_httpx/test_aiohttp_transport.py` (read-timeout, cancellation, GeneratorExit paths) — all fail without the fix and pass with it. Full file: 19 passed; `tests/test_litellm/llms/custom_httpx/`: 157 passed; router cooldown tests: 9 passed.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit` (relevant subset above; no other areas touched)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review
