### PR TITLE
fix(proxy): populate access_via_team_ids on /v1/model/info

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -11091,10 +11091,11 @@ async def _populate_team_access_on_models(
                         model_id, []
                     )
 
+    direct_access_model_ids = set(direct_access_models)
     for _model in all_models:
         model_id = _model.get("model_info", {}).get("id", None)
-        if model_id is not None and model_id in direct_access_models:
-            _model["model_info"]["direct_access"] = True
+        if model_id is not None:
+            _model["model_info"]["direct_access"] = model_id in direct_access_model_ids
 
     return all_models
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -12742,6 +12742,14 @@ async def model_info_v1(  # noqa: PLR0915
             },
         )
 
+    if prisma_client is None and (
+        include_team_models or (teamId is not None and teamId.strip())
+    ):
+        raise HTTPException(
+            status_code=500,
+            detail={"error": CommonProxyErrors.db_not_connected_error.value},
+        )
+
     if litellm_model_id is not None:
         # user is trying to get specific model from litellm router
         deployment_info = llm_router.get_deployment(model_id=litellm_model_id)
@@ -12765,14 +12773,6 @@ async def model_info_v1(  # noqa: PLR0915
                 )
             )[0]
         return {"data": [_deployment_info_dict]}
-
-    if prisma_client is None and (
-        include_team_models or (teamId is not None and teamId.strip())
-    ):
-        raise HTTPException(
-            status_code=500,
-            detail={"error": CommonProxyErrors.db_not_connected_error.value},
-        )
 
     # Return router deployments (same source as /v2/model/info), not wildcard-
     # expanded model names from get_complete_model_list(). Team-scoped rows

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -11031,16 +11031,26 @@ def get_direct_access_models(
     return direct_access_models
 
 
-async def get_all_team_and_direct_access_models(
+def _filter_models_to_user_accessible(all_models: List[Dict]) -> List[Dict]:
+    """Keep only deployments the caller can use via direct access or team membership."""
+    return [
+        _model
+        for _model in all_models
+        if _model.get("model_info", {}).get("direct_access", False)
+        or _model.get("model_info", {}).get("access_via_team_ids", [])
+    ]
+
+
+async def _populate_team_access_on_models(
     user_api_key_dict: UserAPIKeyAuth,
     prisma_client: PrismaClient,
     llm_router: Router,
     all_models: List[Dict],
 ) -> List[Dict]:
     """
-    Get all models across all teams user is in.
+    Populate `model_info.access_via_team_ids` and `model_info.direct_access`
+    without filtering the model list.
     """
-
     user_teams: Optional[Union[List[str], Literal["*"]]] = None
     direct_access_models: List[str] = []
     if user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN:
@@ -11059,7 +11069,6 @@ async def get_all_team_and_direct_access_models(
                 user_db_object=user_object,
                 llm_router=llm_router,
             )
-    ## ADD ACCESS_VIA_TEAM_IDS TO ALL MODELS
     if user_teams is not None:
         team_models = await get_all_team_models(
             user_teams=user_teams,
@@ -11082,21 +11091,30 @@ async def get_all_team_and_direct_access_models(
                         model_id, []
                     )
 
-    ## ADD DIRECT_ACCESS TO RELEVANT MODELS
-
     for _model in all_models:
         model_id = _model.get("model_info", {}).get("id", None)
         if model_id is not None and model_id in direct_access_models:
             _model["model_info"]["direct_access"] = True
 
-    ## FILTER OUT MODELS THAT ARE NOT IN DIRECT_ACCESS_MODELS OR ACCESS_VIA_TEAM_IDS - only show user models they can call
-    all_models = [
-        _model
-        for _model in all_models
-        if _model.get("model_info", {}).get("direct_access", False)
-        or _model.get("model_info", {}).get("access_via_team_ids", [])
-    ]
     return all_models
+
+
+async def get_all_team_and_direct_access_models(
+    user_api_key_dict: UserAPIKeyAuth,
+    prisma_client: PrismaClient,
+    llm_router: Router,
+    all_models: List[Dict],
+) -> List[Dict]:
+    """
+    Get all models across all teams user is in.
+    """
+    all_models = await _populate_team_access_on_models(
+        user_api_key_dict=user_api_key_dict,
+        prisma_client=prisma_client,
+        llm_router=llm_router,
+        all_models=all_models,
+    )
+    return _filter_models_to_user_accessible(all_models)
 
 
 def _enrich_model_info_with_litellm_data(
@@ -12633,6 +12651,14 @@ def _get_proxy_model_info(model: dict) -> dict:
 async def model_info_v1(  # noqa: PLR0915
     user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
     litellm_model_id: Optional[str] = None,
+    include_team_models: Optional[bool] = fastapi.Query(
+        False,
+        description="When true, filter to deployments the caller can use via direct access or team membership.",
+    ),
+    teamId: Optional[str] = fastapi.Query(
+        None,
+        description="Filter models by team ID. Returns models with direct_access=True or teamId in access_via_team_ids",
+    ),
 ):
     """
     Provides more info about each model in /models, including config.yaml descriptions (except api key and api base)
@@ -12642,6 +12668,11 @@ async def model_info_v1(  # noqa: PLR0915
 
         - When litellm_model_id is passed, it will return the info for that specific model
         - When litellm_model_id is not passed, it will return the info for all models
+        - include_team_models: When true, filter to deployments the caller can use (same as /v2/model/info).
+        - teamId: Filter to models accessible by the given team.
+
+    Each model in the list response includes `model_info.access_via_team_ids` and
+    `model_info.direct_access` when the proxy database is connected.
 
     Returns:
         Returns a dictionary containing information about each model.
@@ -12667,6 +12698,12 @@ async def model_info_v1(  # noqa: PLR0915
     ```
     """
     global llm_model_list, general_settings, user_config_file_path, proxy_config, llm_router, user_model
+
+    # Unit tests call this handler directly; FastAPI normally resolves Query defaults.
+    if not isinstance(include_team_models, bool):
+        include_team_models = False
+    if not isinstance(teamId, str):
+        teamId = None
 
     if user_model is not None:
         # user is trying to get specific model from litellm router
@@ -12749,12 +12786,37 @@ async def model_info_v1(  # noqa: PLR0915
         )
     ]
 
+    if prisma_client is not None:
+        all_models = await _populate_team_access_on_models(
+            user_api_key_dict=user_api_key_dict,
+            prisma_client=prisma_client,
+            llm_router=llm_router,
+            all_models=all_models,
+        )
+
+    if include_team_models:
+        all_models = _filter_models_to_user_accessible(all_models)
+
     all_models = [
         _translate_model_name_for_response(
             _enrich_model_info_with_litellm_data(model=model, llm_router=llm_router)
         )
         for model in all_models
     ]
+
+    if teamId is not None and teamId.strip():
+        if prisma_client is None:
+            raise HTTPException(
+                status_code=500,
+                detail={"error": CommonProxyErrors.db_not_connected_error.value},
+            )
+        all_models = await _filter_models_by_team_id(
+            all_models=all_models,
+            team_id=teamId.strip(),
+            prisma_client=prisma_client,
+            llm_router=llm_router,
+            user_api_key_dict=user_api_key_dict,
+        )
 
     verbose_proxy_logger.debug("all_models: %s", all_models)
     return {"data": all_models}

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -12763,16 +12763,25 @@ async def model_info_v1(  # noqa: PLR0915
         _deployment_info_dict = _get_proxy_model_info(
             model=deployment_info.model_dump(exclude_none=True)
         )
+        single_model_list: List[dict] = [_deployment_info_dict]
         if prisma_client is not None:
-            _deployment_info_dict = (
-                await _populate_team_access_on_models(
-                    user_api_key_dict=user_api_key_dict,
+            single_model_list = await _populate_team_access_on_models(
+                user_api_key_dict=user_api_key_dict,
+                prisma_client=prisma_client,
+                llm_router=llm_router,
+                all_models=single_model_list,
+            )
+            if include_team_models:
+                single_model_list = _filter_models_to_user_accessible(single_model_list)
+            if teamId is not None and teamId.strip():
+                single_model_list = await _filter_models_by_team_id(
+                    all_models=single_model_list,
+                    team_id=teamId.strip(),
                     prisma_client=prisma_client,
                     llm_router=llm_router,
-                    all_models=[_deployment_info_dict],
+                    user_api_key_dict=user_api_key_dict,
                 )
-            )[0]
-        return {"data": [_deployment_info_dict]}
+        return {"data": single_model_list}
 
     # Return router deployments (same source as /v2/model/info), not wildcard-
     # expanded model names from get_complete_model_list(). Team-scoped rows

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -12757,7 +12757,9 @@ async def model_info_v1(  # noqa: PLR0915
         )
         return {"data": [_deployment_info_dict]}
 
-    if teamId is not None and teamId.strip() and prisma_client is None:
+    if prisma_client is None and (
+        include_team_models or (teamId is not None and teamId.strip())
+    ):
         raise HTTPException(
             status_code=500,
             detail={"error": CommonProxyErrors.db_not_connected_error.value},

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -12755,6 +12755,15 @@ async def model_info_v1(  # noqa: PLR0915
         _deployment_info_dict = _get_proxy_model_info(
             model=deployment_info.model_dump(exclude_none=True)
         )
+        if prisma_client is not None:
+            _deployment_info_dict = (
+                await _populate_team_access_on_models(
+                    user_api_key_dict=user_api_key_dict,
+                    prisma_client=prisma_client,
+                    llm_router=llm_router,
+                    all_models=[_deployment_info_dict],
+                )
+            )[0]
         return {"data": [_deployment_info_dict]}
 
     if prisma_client is None and (

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -12757,6 +12757,12 @@ async def model_info_v1(  # noqa: PLR0915
         )
         return {"data": [_deployment_info_dict]}
 
+    if teamId is not None and teamId.strip() and prisma_client is None:
+        raise HTTPException(
+            status_code=500,
+            detail={"error": CommonProxyErrors.db_not_connected_error.value},
+        )
+
     # Return router deployments (same source as /v2/model/info), not wildcard-
     # expanded model names from get_complete_model_list(). Team-scoped rows
     # use internal routing keys (model_name_{team_id}_{uuid}) and were omitted
@@ -12806,15 +12812,10 @@ async def model_info_v1(  # noqa: PLR0915
     ]
 
     if teamId is not None and teamId.strip():
-        if prisma_client is None:
-            raise HTTPException(
-                status_code=500,
-                detail={"error": CommonProxyErrors.db_not_connected_error.value},
-            )
         all_models = await _filter_models_by_team_id(
             all_models=all_models,
             team_id=teamId.strip(),
-            prisma_client=prisma_client,
+            prisma_client=cast(PrismaClient, prisma_client),
             llm_router=llm_router,
             user_api_key_dict=user_api_key_dict,
         )

--- a/tests/test_litellm/proxy/proxy_server/test_team_model_name_translation.py
+++ b/tests/test_litellm/proxy/proxy_server/test_team_model_name_translation.py
@@ -486,3 +486,33 @@ async def test_model_info_v1_include_team_models_without_db_fails_fast(monkeypat
     assert exc_info.value.status_code == 500
     assert "DB not connected" in exc_info.value.detail["error"]
     enrich_spy.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_model_info_v1_litellm_model_id_team_id_without_db_fails_fast(
+    monkeypatch,
+):
+    """`litellm_model_id` + `teamId` without a connected DB must raise 500 too, not
+    return 200 with a model dict missing direct_access/access_via_team_ids."""
+    router = MagicMock()
+    router.model_list = [_team_row()]
+
+    monkeypatch.setattr(ps, "user_model", None)
+    monkeypatch.setattr(ps, "llm_model_list", router.model_list)
+    monkeypatch.setattr(ps, "llm_router", router)
+    monkeypatch.setattr(ps, "prisma_client", None)
+
+    admin = UserAPIKeyAuth(
+        user_id="u", user_role=LitellmUserRoles.PROXY_ADMIN, team_models=[]
+    )
+
+    with pytest.raises(ps.HTTPException) as exc_info:
+        await ps.model_info_v1(
+            user_api_key_dict=admin,
+            litellm_model_id="byok-id-1",
+            teamId="team-abc-123",
+        )
+
+    assert exc_info.value.status_code == 500
+    assert "DB not connected" in exc_info.value.detail["error"]
+    router.get_deployment.assert_not_called()

--- a/tests/test_litellm/proxy/proxy_server/test_team_model_name_translation.py
+++ b/tests/test_litellm/proxy/proxy_server/test_team_model_name_translation.py
@@ -374,6 +374,7 @@ async def test_model_info_v1_populates_access_via_team_ids(monkeypatch):
             model_id = model["model_info"]["id"]
             if model_id == "byok-id-1":
                 model["model_info"]["access_via_team_ids"] = [team_id]
+                model["model_info"]["direct_access"] = False
             elif model_id == "global-id-1":
                 model["model_info"]["direct_access"] = True
         return kwargs["all_models"]
@@ -394,4 +395,37 @@ async def test_model_info_v1_populates_access_via_team_ids(monkeypatch):
 
     by_id = {m["model_info"]["id"]: m for m in resp["data"]}
     assert by_id["byok-id-1"]["model_info"]["access_via_team_ids"] == [team_id]
-    assert by_id["global-id-1"]["model_info"].get("direct_access") is True
+    assert by_id["byok-id-1"]["model_info"]["direct_access"] is False
+    assert by_id["global-id-1"]["model_info"]["direct_access"] is True
+
+
+@pytest.mark.asyncio
+async def test_populate_team_access_sets_direct_access_false_by_default(monkeypatch):
+    """Team-accessible models without direct access must return direct_access=false."""
+    team_row = _team_row()
+    global_row = {
+        "model_name": "gpt-4o",
+        "litellm_params": {"model": "gpt-4o"},
+        "model_info": {"id": "global-id-1", "db_model": False},
+    }
+    router = MagicMock()
+    router.get_model_ids.return_value = ["global-id-1"]
+    monkeypatch.setattr(
+        ps,
+        "get_all_team_models",
+        AsyncMock(return_value={"byok-id-1": ["team-abc-123"]}),
+    )
+
+    admin = UserAPIKeyAuth(
+        user_id="u", user_role=LitellmUserRoles.PROXY_ADMIN, team_models=[]
+    )
+    result = await ps._populate_team_access_on_models(
+        user_api_key_dict=admin,
+        prisma_client=MagicMock(),
+        llm_router=router,
+        all_models=[team_row, global_row],
+    )
+
+    by_id = {m["model_info"]["id"]: m for m in result}
+    assert by_id["byok-id-1"]["model_info"]["direct_access"] is False
+    assert by_id["global-id-1"]["model_info"]["direct_access"] is True

--- a/tests/test_litellm/proxy/proxy_server/test_team_model_name_translation.py
+++ b/tests/test_litellm/proxy/proxy_server/test_team_model_name_translation.py
@@ -279,6 +279,11 @@ async def test_model_info_v1_unrestricted_key_hides_other_team_byok(monkeypatch)
     prisma_client = MagicMock()
     caller_user_row = MagicMock()
     caller_user_row.teams = ["team-abc-123"]
+    caller_user_row.model_dump.return_value = {
+        "user_id": "user-1",
+        "teams": ["team-abc-123"],
+        "models": [],
+    }
     prisma_client.db.litellm_usertable.find_unique = AsyncMock(
         return_value=caller_user_row
     )
@@ -287,6 +292,7 @@ async def test_model_info_v1_unrestricted_key_hides_other_team_byok(monkeypatch)
     monkeypatch.setattr(ps, "llm_model_list", router.model_list)
     monkeypatch.setattr(ps, "llm_router", router)
     monkeypatch.setattr(ps, "prisma_client", prisma_client)
+    monkeypatch.setattr(ps, "get_all_team_models", AsyncMock(return_value={}))
     monkeypatch.setattr(
         ps, "_enrich_model_info_with_litellm_data", lambda model, **kw: model
     )
@@ -343,3 +349,49 @@ async def test_model_info_v1_service_key_hides_all_team_byok(monkeypatch):
     resp = await ps.model_info_v1(user_api_key_dict=caller, litellm_model_id=None)
 
     assert [m["model_info"]["id"] for m in resp["data"]] == ["global-id-1"]
+
+
+@pytest.mark.asyncio
+async def test_model_info_v1_populates_access_via_team_ids(monkeypatch):
+    """`/v1/model/info` must populate access_via_team_ids when the DB is connected."""
+    team_id = "team-abc-123"
+    team_row = _team_row()
+    global_row = {
+        "model_name": "gpt-4o",
+        "litellm_params": {"model": "gpt-4o"},
+        "model_info": {"id": "global-id-1", "db_model": False},
+    }
+    router = MagicMock()
+    router.model_list = [team_row, global_row]
+    router.get_model_names.return_value = ["gpt-4o", "team-claude-sonnet"]
+    router.get_model_access_groups.return_value = {}
+    router.get_model_ids.return_value = ["global-id-1"]
+
+    prisma_client = MagicMock()
+
+    async def _fake_populate(**kwargs):
+        for model in kwargs["all_models"]:
+            model_id = model["model_info"]["id"]
+            if model_id == "byok-id-1":
+                model["model_info"]["access_via_team_ids"] = [team_id]
+            elif model_id == "global-id-1":
+                model["model_info"]["direct_access"] = True
+        return kwargs["all_models"]
+
+    monkeypatch.setattr(ps, "user_model", None)
+    monkeypatch.setattr(ps, "llm_model_list", router.model_list)
+    monkeypatch.setattr(ps, "llm_router", router)
+    monkeypatch.setattr(ps, "prisma_client", prisma_client)
+    monkeypatch.setattr(ps, "_populate_team_access_on_models", _fake_populate)
+    monkeypatch.setattr(
+        ps, "_enrich_model_info_with_litellm_data", lambda model, **kw: model
+    )
+
+    admin = UserAPIKeyAuth(
+        user_id="u", user_role=LitellmUserRoles.PROXY_ADMIN, team_models=[]
+    )
+    resp = await ps.model_info_v1(user_api_key_dict=admin, litellm_model_id=None)
+
+    by_id = {m["model_info"]["id"]: m for m in resp["data"]}
+    assert by_id["byok-id-1"]["model_info"]["access_via_team_ids"] == [team_id]
+    assert by_id["global-id-1"]["model_info"].get("direct_access") is True

--- a/tests/test_litellm/proxy/proxy_server/test_team_model_name_translation.py
+++ b/tests/test_litellm/proxy/proxy_server/test_team_model_name_translation.py
@@ -429,3 +429,31 @@ async def test_populate_team_access_sets_direct_access_false_by_default(monkeypa
     by_id = {m["model_info"]["id"]: m for m in result}
     assert by_id["byok-id-1"]["model_info"]["direct_access"] is False
     assert by_id["global-id-1"]["model_info"]["direct_access"] is True
+
+
+@pytest.mark.asyncio
+async def test_model_info_v1_team_id_without_db_fails_fast(monkeypatch):
+    """`teamId` without a connected DB raises 500 before any enrichment work runs."""
+    router = MagicMock()
+    router.model_list = [_team_row()]
+
+    enrich_spy = MagicMock(side_effect=lambda model, **kw: model)
+
+    monkeypatch.setattr(ps, "user_model", None)
+    monkeypatch.setattr(ps, "llm_model_list", router.model_list)
+    monkeypatch.setattr(ps, "llm_router", router)
+    monkeypatch.setattr(ps, "prisma_client", None)
+    monkeypatch.setattr(ps, "_enrich_model_info_with_litellm_data", enrich_spy)
+
+    admin = UserAPIKeyAuth(
+        user_id="u", user_role=LitellmUserRoles.PROXY_ADMIN, team_models=[]
+    )
+
+    with pytest.raises(ps.HTTPException) as exc_info:
+        await ps.model_info_v1(
+            user_api_key_dict=admin, litellm_model_id=None, teamId="team-abc-123"
+        )
+
+    assert exc_info.value.status_code == 500
+    assert "DB not connected" in exc_info.value.detail["error"]
+    enrich_spy.assert_not_called()

--- a/tests/test_litellm/proxy/proxy_server/test_team_model_name_translation.py
+++ b/tests/test_litellm/proxy/proxy_server/test_team_model_name_translation.py
@@ -516,3 +516,80 @@ async def test_model_info_v1_litellm_model_id_team_id_without_db_fails_fast(
     assert exc_info.value.status_code == 500
     assert "DB not connected" in exc_info.value.detail["error"]
     router.get_deployment.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_model_info_v1_litellm_model_id_include_team_models_filters_inaccessible(
+    monkeypatch,
+):
+    """`litellm_model_id` + `include_team_models` must drop a model the caller cannot
+    use instead of returning it unconditionally from the single-model lookup."""
+    team_row = _team_row()
+
+    router = MagicMock()
+    deployment = MagicMock()
+    deployment.model_dump.return_value = team_row
+    router.get_deployment.return_value = deployment
+
+    async def _fake_populate(**kwargs):
+        for model in kwargs["all_models"]:
+            model["model_info"]["direct_access"] = False
+            model["model_info"]["access_via_team_ids"] = []
+        return kwargs["all_models"]
+
+    monkeypatch.setattr(ps, "user_model", None)
+    monkeypatch.setattr(ps, "llm_model_list", [team_row])
+    monkeypatch.setattr(ps, "llm_router", router)
+    monkeypatch.setattr(ps, "prisma_client", MagicMock())
+    monkeypatch.setattr(ps, "_get_proxy_model_info", lambda model: team_row)
+    monkeypatch.setattr(ps, "_populate_team_access_on_models", _fake_populate)
+
+    caller = UserAPIKeyAuth(
+        user_id="u", user_role=LitellmUserRoles.INTERNAL_USER, team_models=[]
+    )
+    resp = await ps.model_info_v1(
+        user_api_key_dict=caller,
+        litellm_model_id="byok-id-1",
+        include_team_models=True,
+    )
+
+    assert resp["data"] == []
+
+
+@pytest.mark.asyncio
+async def test_model_info_v1_litellm_model_id_team_id_applies_team_filter(monkeypatch):
+    """`litellm_model_id` + `teamId` must run the teamId filter on the single model
+    rather than returning it regardless of the team's access."""
+    team_row = _team_row()
+
+    router = MagicMock()
+    deployment = MagicMock()
+    deployment.model_dump.return_value = team_row
+    router.get_deployment.return_value = deployment
+
+    async def _fake_populate(**kwargs):
+        return kwargs["all_models"]
+
+    team_filter = AsyncMock(return_value=[])
+
+    monkeypatch.setattr(ps, "user_model", None)
+    monkeypatch.setattr(ps, "llm_model_list", [team_row])
+    monkeypatch.setattr(ps, "llm_router", router)
+    monkeypatch.setattr(ps, "prisma_client", MagicMock())
+    monkeypatch.setattr(ps, "_get_proxy_model_info", lambda model: team_row)
+    monkeypatch.setattr(ps, "_populate_team_access_on_models", _fake_populate)
+    monkeypatch.setattr(ps, "_filter_models_by_team_id", team_filter)
+
+    admin = UserAPIKeyAuth(
+        user_id="u", user_role=LitellmUserRoles.PROXY_ADMIN, team_models=[]
+    )
+    resp = await ps.model_info_v1(
+        user_api_key_dict=admin,
+        litellm_model_id="byok-id-1",
+        teamId="other-team",
+    )
+
+    assert resp["data"] == []
+    team_filter.assert_awaited_once()
+    assert team_filter.await_args.kwargs["team_id"] == "other-team"
+    assert team_filter.await_args.kwargs["all_models"] == [team_row]

--- a/tests/test_litellm/proxy/proxy_server/test_team_model_name_translation.py
+++ b/tests/test_litellm/proxy/proxy_server/test_team_model_name_translation.py
@@ -457,3 +457,32 @@ async def test_model_info_v1_team_id_without_db_fails_fast(monkeypatch):
     assert exc_info.value.status_code == 500
     assert "DB not connected" in exc_info.value.detail["error"]
     enrich_spy.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_model_info_v1_include_team_models_without_db_fails_fast(monkeypatch):
+    """`include_team_models` without a connected DB raises 500 instead of silently
+    returning an empty list (the access fields can only be populated from the DB)."""
+    router = MagicMock()
+    router.model_list = [_team_row()]
+
+    enrich_spy = MagicMock(side_effect=lambda model, **kw: model)
+
+    monkeypatch.setattr(ps, "user_model", None)
+    monkeypatch.setattr(ps, "llm_model_list", router.model_list)
+    monkeypatch.setattr(ps, "llm_router", router)
+    monkeypatch.setattr(ps, "prisma_client", None)
+    monkeypatch.setattr(ps, "_enrich_model_info_with_litellm_data", enrich_spy)
+
+    admin = UserAPIKeyAuth(
+        user_id="u", user_role=LitellmUserRoles.PROXY_ADMIN, team_models=[]
+    )
+
+    with pytest.raises(ps.HTTPException) as exc_info:
+        await ps.model_info_v1(
+            user_api_key_dict=admin, litellm_model_id=None, include_team_models=True
+        )
+
+    assert exc_info.value.status_code == 500
+    assert "DB not connected" in exc_info.value.detail["error"]
+    enrich_spy.assert_not_called()

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -7338,6 +7338,11 @@ export interface paths {
          *
          *         - When litellm_model_id is passed, it will return the info for that specific model
          *         - When litellm_model_id is not passed, it will return the info for all models
+         *         - include_team_models: When true, filter to deployments the caller can use (same as /v2/model/info).
+         *         - teamId: Filter to models accessible by the given team.
+         *
+         *     Each model in the list response includes `model_info.access_via_team_ids` and
+         *     `model_info.direct_access` when the proxy database is connected.
          *
          *     Returns:
          *         Returns a dictionary containing information about each model.
@@ -16565,6 +16570,11 @@ export interface paths {
          *
          *         - When litellm_model_id is passed, it will return the info for that specific model
          *         - When litellm_model_id is not passed, it will return the info for all models
+         *         - include_team_models: When true, filter to deployments the caller can use (same as /v2/model/info).
+         *         - teamId: Filter to models accessible by the given team.
+         *
+         *     Each model in the list response includes `model_info.access_via_team_ids` and
+         *     `model_info.direct_access` when the proxy database is connected.
          *
          *     Returns:
          *         Returns a dictionary containing information about each model.
@@ -42430,6 +42440,10 @@ export interface operations {
         parameters: {
             query?: {
                 litellm_model_id?: string | null;
+                /** @description When true, filter to deployments the caller can use via direct access or team membership. */
+                include_team_models?: boolean | null;
+                /** @description Filter models by team ID. Returns models with direct_access=True or teamId in access_via_team_ids */
+                teamId?: string | null;
             };
             header?: never;
             path?: never;
@@ -53695,6 +53709,10 @@ export interface operations {
         parameters: {
             query?: {
                 litellm_model_id?: string | null;
+                /** @description When true, filter to deployments the caller can use via direct access or team membership. */
+                include_team_models?: boolean | null;
+                /** @description Filter models by team ID. Returns models with direct_access=True or teamId in access_via_team_ids */
+                teamId?: string | null;
             };
             header?: never;
             path?: never;


### PR DESCRIPTION
## Summary
- Populate `model_info.access_via_team_ids` and `model_info.direct_access` on `GET /v1/model/info` when the proxy database is connected
- Add optional `include_team_models` and `teamId` query params to `/v1/model/info` for parity with `/v2/model/info`
- Extract shared team-access enrichment into `_populate_team_access_on_models`

## Test plan
- [x] `poetry run pytest tests/test_litellm/proxy/proxy_server/test_team_model_name_translation.py -q`
- [x] `poetry run pytest tests/test_litellm/proxy/proxy_server/test_team_model_name_translation.py::test_model_info_v1_populates_access_via_team_ids -v`
- [ ] Verify locally: `curl /v1/model/info` returns `access_via_team_ids` per model

<img width="1171" height="694" alt="image" src="https://github.com/user-attachments/assets/797ded6f-1a14-4d92-9adc-fa4fdda61ed5" />
