### PR TITLE
fix(proxy): restore spend logging for /cursor/chat/completions (#30126)

### DIFF
--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -110,6 +110,7 @@ LITELLM_METADATA_ROUTES = (
     "/v1/messages",
     "responses",
     "files",
+    "/cursor/chat/completions",
 )
 
 _UNTRUSTED_ROOT_CONTROL_FIELDS = (

--- a/tests/test_litellm/proxy/response_api_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/response_api_endpoints/test_endpoints.py
@@ -198,6 +198,74 @@ class TestResponsesAPIEndpoints(unittest.TestCase):
         assert response_cost_value == pytest.approx(0.0005, abs=1e-10)
 
 
+class TestCursorChatCompletionsSpendTracking:
+    @patch("litellm.proxy.proxy_server.llm_router")
+    def test_proxy_auth_metadata_forwarded_as_litellm_metadata(self, mock_router):
+        """
+        /cursor/chat/completions runs through the Responses API pipeline, so
+        proxy auth metadata (user_api_key etc.) must be sent as
+        `litellm_metadata`. If it lands in the user-facing `metadata` param
+        instead, the spend tracking callback sees user_api_key=None and
+        silently skips the SpendLogs write. Regression test for #30126.
+        """
+        from openai.types.responses import ResponseOutputMessage, ResponseOutputText
+
+        from litellm.proxy._types import UserAPIKeyAuth
+        from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+        from litellm.types.llms.openai import ResponsesAPIResponse
+
+        mock_router.aresponses = AsyncMock(
+            return_value=ResponsesAPIResponse(
+                id="resp_cursor123",
+                created_at=1234567890,
+                model="gpt-4o",
+                object="response",
+                output=[
+                    ResponseOutputMessage(
+                        id="msg_cursor123",
+                        type="message",
+                        role="assistant",
+                        status="completed",
+                        content=[
+                            ResponseOutputText(
+                                type="output_text",
+                                text="Hello from Cursor!",
+                                annotations=[],
+                            )
+                        ],
+                    )
+                ],
+            )
+        )
+
+        app.dependency_overrides[user_api_key_auth] = lambda: UserAPIKeyAuth(
+            api_key="hashed-test-key",
+            user_id="test-user",
+            request_route="/cursor/chat/completions",
+        )
+        try:
+            client = TestClient(app)
+            response = client.post(
+                "/cursor/chat/completions",
+                json={
+                    "model": "gpt-4o",
+                    "input": [{"role": "user", "content": "Hello"}],
+                },
+                headers={"Authorization": "Bearer sk-1234"},
+            )
+        finally:
+            app.dependency_overrides.pop(user_api_key_auth, None)
+
+        assert response.status_code == 200
+        mock_router.aresponses.assert_called_once()
+        request_kwargs = mock_router.aresponses.call_args.kwargs
+        litellm_metadata = request_kwargs.get("litellm_metadata") or {}
+        assert litellm_metadata.get("user_api_key") == "hashed-test-key"
+        assert litellm_metadata.get("user_api_key_user_id") == "test-user"
+        # proxy internals must not leak into the user-facing metadata param
+        assert "user_api_key" not in (request_kwargs.get("metadata") or {})
+
+
 import json
 
 

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -84,6 +84,10 @@ class TestGetMetadataVariableName:
         request = self._make_request("/v1/files")
         assert _get_metadata_variable_name(request) == "litellm_metadata"
 
+    def test_returns_litellm_metadata_for_cursor_chat_completions(self):
+        request = self._make_request("/cursor/chat/completions")
+        assert _get_metadata_variable_name(request) == "litellm_metadata"
+
     def test_returns_metadata_for_chat_completions(self):
         request = self._make_request("/chat/completions")
         assert _get_metadata_variable_name(request) == "metadata"


### PR DESCRIPTION
## Relevant issues

Fixes #30126

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Re-ran the A/B against a live proxy with a real provider and a Postgres-backed SpendLogs table, so the row actually lands instead of hitting a mock. The OpenAI key I had was rate-limited, so the model here is `claude-haiku-4-5`; the fix is proxy-side metadata routing so it is provider-agnostic, and the cursor response-format conversion is OpenAI-specific and separate from spend tracking, so the check is the SpendLogs write itself (which is what #30126 reports missing)

Config is one model `claude-haiku-4-5 -> anthropic/claude-haiku-4-5-20251001`, `master_key: sk-1234`, `DATABASE_URL` set. Generate a key, hit the cursor route, and read SpendLogs (truncating it before each run so the diff is clean):

```
KEY=$(curl -s -X POST localhost:4000/key/generate -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" -d '{"models":["claude-haiku-4-5"],"key_alias":"cursor-demo"}' | jq -r .key)

curl -s -X POST localhost:4000/cursor/chat/completions -H "Authorization: Bearer $KEY" \
  -H "Content-Type: application/json" \
  -d '{"model":"claude-haiku-4-5","input":[{"role":"user","content":"ping"}]}' > /dev/null

# after the spend-log batch flush:
psql "$DATABASE_URL" -c 'select call_type, model, spend from "LiteLLM_SpendLogs" order by "startTime" desc'
```

Without the fix (current `litellm_internal_staging`) the cursor call's cost is never recorded; only the proxy-level row lands, at spend 0:

```
 call_type | model            | spend
-----------+------------------+-------
           | claude-haiku-4-5 |     0
```

With the fix the same call writes the LLM spend row with the real cost:

```
 call_type  | model                               | spend
------------+-------------------------------------+---------
            | claude-haiku-4-5                    |       0
 aresponses | anthropic/claude-haiku-4-5-20251001 | 3.3e-05
```

So proxy auth metadata now reaches the spend callback and the SpendLogs write for `/cursor/chat/completions` fires the same way it does for `/v1/chat/completions`

## Type

🐛 Bug Fix

## Changes

`/cursor/chat/completions` is served through the Responses API pipeline, which keeps proxy-internal metadata under `litellm_metadata` because `metadata` is the user-facing Responses API param. The route was missing from `LITELLM_METADATA_ROUTES`, so `add_litellm_data_to_request` wrote `user_api_key` and friends into the user-facing `metadata` param, the spend tracking callback saw `user_api_key=None`, and the SpendLogs write was silently skipped; hence 200 + provider billed + nothing in the Logs UI

The fix adds the route to `LITELLM_METADATA_ROUTES`, matching `/v1/responses` which this endpoint bridges to. Two regression tests cover it (the `_get_metadata_variable_name` mapping and an endpoint test asserting the kwargs reaching `llm_router.aresponses` carry `litellm_metadata.user_api_key`); both fail without the one line change

