### PR TITLE
fix(ui): wrap selected models in model picker instead of single respo…

### DIFF
--- a/ui/litellm-dashboard/src/app/globals.css
+++ b/ui/litellm-dashboard/src/app/globals.css
@@ -38,6 +38,9 @@ body {
   border: 1px solid var(--neutral-border);
 }
 
+/* Caps the multi-select tag area so selected models wrap and scroll instead of
+   collapsing onto one row. Targets antd-internal .ant-select-selector (validated
+   on antd 5.29.3); re-verify if antd is upgraded. */
 .model-select-multi .ant-select-selector {
   max-height: 132px;
   overflow-y: auto;

--- a/ui/litellm-dashboard/src/app/globals.css
+++ b/ui/litellm-dashboard/src/app/globals.css
@@ -37,3 +37,8 @@ body {
 .custom-border {
   border: 1px solid var(--neutral-border);
 }
+
+.model-select-multi .ant-select-selector {
+  max-height: 132px;
+  overflow-y: auto;
+}

--- a/ui/litellm-dashboard/src/components/ModelSelect/ModelSelect.test.tsx
+++ b/ui/litellm-dashboard/src/components/ModelSelect/ModelSelect.test.tsx
@@ -33,21 +33,20 @@ vi.mock("antd", async (importOriginal) => {
       "data-testid": dataTestId,
       allowClear,
       maxTagCount,
-      maxTagPlaceholder,
       mode,
+      className,
       ...props
     }: any) => {
-      // Simulate maxTagCount responsive behavior - if value length > 5, call maxTagPlaceholder
-      const shouldShowPlaceholder = maxTagCount === "responsive" && Array.isArray(value) && value.length > 5;
-      const visibleValues = shouldShowPlaceholder ? value.slice(0, 5) : value;
-      const omittedValues = shouldShowPlaceholder ? value.slice(5).map((v: string) => ({ value: v, label: v })) : [];
-
       return (
-        <div data-testid={dataTestId || "model-select"}>
+        <div
+          data-testid={dataTestId || "model-select"}
+          data-classname={className}
+          data-max-tag-count={maxTagCount ?? ""}
+        >
           <select
             multiple={mode === "multiple"}
             role="listbox"
-            value={visibleValues}
+            value={value}
             onChange={(e) => {
               const selectedValues = Array.from(e.target.selectedOptions, (option) => option.value);
               onChange(mode === "multiple" ? selectedValues : selectedValues[0]);
@@ -67,16 +66,12 @@ vi.mock("antd", async (importOriginal) => {
               </optgroup>
             ))}
           </select>
-          {shouldShowPlaceholder && maxTagPlaceholder && (
-            <div data-testid="max-tag-placeholder">{maxTagPlaceholder(omittedValues)}</div>
-          )}
         </div>
       );
     },
     Skeleton: {
       Input: ({ active, block }: any) => <div data-testid="skeleton-input" data-active={active} data-block={block} />,
     },
-    Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   };
 });
 
@@ -546,36 +541,13 @@ describe("ModelSelect", () => {
     });
   });
 
-  it("should render maxTagPlaceholder when many items are selected", async () => {
-    // Create many models to trigger maxTagCount responsive behavior
-    const manyModels: ProxyModel[] = Array.from({ length: 20 }, (_, i) => ({
-      id: `model-${i}`,
-      object: "model",
-      created: 1234567890,
-      owned_by: "test",
-    }));
-
-    mockUseAllProxyModels.mockReturnValue({
-      data: { data: manyModels },
-      isLoading: false,
-    } as any);
-
-    const selectedValues = manyModels.slice(0, 10).map((m) => m.id);
-
+  it("wraps selected tags instead of collapsing them onto a single responsive row", async () => {
     renderWithProviders(
-      <ModelSelect
-        onChange={mockOnChange}
-        value={selectedValues}
-        context="user"
-        options={{ showAllProxyModelsOverride: true }}
-      />,
+      <ModelSelect onChange={mockOnChange} context="user" options={{ showAllProxyModelsOverride: true }} />,
     );
 
-    await waitFor(() => {
-      expect(screen.getByTestId("model-select")).toBeInTheDocument();
-      // Verify maxTagPlaceholder is rendered with omitted values
-      expect(screen.getByTestId("max-tag-placeholder")).toBeInTheDocument();
-      expect(screen.getByText(/\+5 more/)).toBeInTheDocument();
-    });
+    const select = await screen.findByTestId("model-select");
+    expect(select).toHaveAttribute("data-classname", "model-select-multi");
+    expect(select.getAttribute("data-max-tag-count")).toBe("");
   });
 });

--- a/ui/litellm-dashboard/src/components/ModelSelect/ModelSelect.tsx
+++ b/ui/litellm-dashboard/src/components/ModelSelect/ModelSelect.tsx
@@ -2,7 +2,7 @@ import { ProxyModel, useAllProxyModels } from "@/app/(dashboard)/hooks/models/us
 import { useOrganization } from "@/app/(dashboard)/hooks/organizations/useOrganizations";
 import { useTeam } from "@/app/(dashboard)/hooks/teams/useTeams";
 import { useCurrentUser } from "@/app/(dashboard)/hooks/users/useCurrentUser";
-import { Select, Skeleton, Tooltip, type SelectProps } from "antd";
+import { Select, Skeleton, type SelectProps } from "antd";
 import { Organization, Team } from "../networking";
 import { splitWildcardModels } from "./modelUtils";
 
@@ -208,15 +208,7 @@ export const ModelSelect = (props: ModelSelectProps) => {
       mode="multiple"
       placeholder="Select Models"
       allowClear
-      maxTagCount="responsive"
-      maxTagPlaceholder={(omittedValues) => (
-        <Tooltip
-          styles={{ root: { pointerEvents: "none" } }}
-          title={omittedValues.map(({ value }) => value).join(", ")}
-        >
-          <span>+{omittedValues.length} more</span>
-        </Tooltip>
-      )}
+      className="model-select-multi"
     />
   );
 };


### PR DESCRIPTION
# PR: fix(ui): wrap selected models in the multi-select picker instead of collapsing onto one row

> **Branch**: `Bytechoreographer:litellm_team_model_select_wrap`
> **Target**: `BerriAI:litellm_internal_staging`
> **PR link**: https://github.com/Bytechoreographer/litellm/pull/new/litellm_team_model_select_wrap

---

## Relevant issues

<!-- No upstream issue; reported internally on the Teams page edit form -->

## Pre-Submission checklist

- [x] `npx vitest run src/components/ModelSelect/ModelSelect.test.tsx` passes (13/13, including a new regression test that fails when the fix is reverted)
- [x] Consumer tests still green: `TeamInfo.test.tsx` + `key_edit_view.test.tsx` (53/53)
- [x] `npx tsc --noEmit` introduces zero new type errors (455 pre-existing, unchanged with this diff)
- [x] Scope isolated: 3 files, no new dependencies, no API/backend change
- [x] Comment `@greptileai` and get Confidence Score >= 4/5 before requesting maintainer review

## Type

🐛 Bug Fix

## Changes

### Problem

On the team edit form (Teams -> a team -> Settings -> Models), the model picker only ever shows a single row of selected models; anything past the first row collapses into a `+N more` chip. A team with many models is effectively unreadable. The virtual-key edit form does not have this problem; its picker wraps every selected model across as many rows as needed, which is the behavior users expect.

### Root cause

Both forms render an antd multi-select, but the team form goes through the shared `ModelSelect` component, which sets `maxTagCount="responsive"`. That prop forces all selected tags onto one row and folds the overflow into the `+N more` placeholder. The key edit form (`key_edit_view.tsx`) uses a plain `Select mode="multiple"` with no `maxTagCount`, so antd's default wrapping applies and every tag is visible.

`ModelSelect` is shared by the team, organization, access-group and user model pickers, so they all inherited the single-row behavior.

### Fix

Drop `maxTagCount="responsive"` (and the now-unused `maxTagPlaceholder` / `Tooltip`) from `ModelSelect` so selected tags wrap, matching the key edit form. To keep the picker from growing without bound when a team has a large model list, add a scoped class `model-select-multi` whose `.ant-select-selector` is capped at `132px` (about four to five rows) with `overflow-y: auto`, so the selection area scrolls past that height.

This applies to every `ModelSelect` consumer (team, organization, access group, user), which all had the same one-row limitation; the behavior now converges with the virtual-key picker.

### Tests

Replaced the obsolete `maxTagPlaceholder` test with a regression test asserting `ModelSelect` passes `className="model-select-multi"` and does not set `maxTagCount`. Verified by mutation: re-adding `maxTagCount="responsive"` or removing the class makes the test fail.

### Files changed

| File | Change |
|------|--------|
| `ui/litellm-dashboard/src/components/ModelSelect/ModelSelect.tsx` | Remove `maxTagCount="responsive"` + `maxTagPlaceholder` + unused `Tooltip` import; add `className="model-select-multi"` so tags wrap |
| `ui/litellm-dashboard/src/app/globals.css` | Add `.model-select-multi .ant-select-selector` rule capping height at 132px with vertical scroll |
| `ui/litellm-dashboard/src/components/ModelSelect/ModelSelect.test.tsx` | Update antd mock to expose `className` / `maxTagCount`; replace the placeholder test with a wrap-behavior regression test |

## Screenshots / Proof of Fix

UI change. To verify on a running proxy:

1. Open `http://localhost:4000/ui/?page=teams`
2. Click a team that has several models, go to the Settings tab and click Edit
3. Open the Models field: selected models now wrap across multiple rows; once they exceed ~4-5 rows the box scrolls instead of staying on one line
4. Cross-check `http://localhost:4000/ui/?page=api-keys` -> edit a key -> Models, which already wrapped; both pickers now behave the same
