### PR TITLE
Translation v2: Grok (xAI)

### DIFF
--- a/litellm/translation/CLAUDE.md
+++ b/litellm/translation/CLAUDE.md
@@ -83,7 +83,9 @@ translation/
 │   │   │                #   normalizer; transform_response is dead on the SDK
 │   │   │                #   path); rides the outbound body on ChatResponse.wire
 │   │   └── stream.py    # SSE chunk -> wire_chunk events normalized to the
-│   │                    #   SDK-dump shape; the openai chunk dialect folds them
+│   │                    #   SDK-dump shape; the openai chunk dialect folds
+│   │                    #   them; make_parse_line is the ONE data:-line
+│   │                    #   decode every same-family provider composes
 │   ├── google_genai/    # ONE generateContent family for BOTH google routes:
 │   │   │                #   providers "vertex_ai" and "gemini" are the same
 │   │   │                #   serializer parameterized by the drift list
@@ -166,11 +168,14 @@ translation/
 │       │                #   web_search_requests); the finish_reason "" chain
 │       │                #   needs no arm: v1's own fix is dead, both sides
 │       │                #   map "" -> "stop" in the live Choices constructor
-│       └── stream.py    # SSE dict-path parser: per-chunk usage fold, no
+│       └── stream.py    # SSE dict-path parser: per-chunk usage fold with
+│                        #   the folded usage attached ONLY to the choices:[]
+│                        #   tail (v1's wrapper strips it elsewhere), no
 │                        #   extras/system_fingerprint passthrough (the
 │                        #   chunk_parser rebuild drops them), reasoning
-│                        #   rename, tool_call type "function" default;
-│                        #   the "xai" chunk dialect folds it
+│                        #   rename, refusal forwarded when it rides a
+│                        #   role/content delta, tool_call type "function"
+│                        #   default; the "xai" chunk dialect folds it
 └── engine/
     ├── pipeline.py # prepare (pure, drives the fallback decision) -> send;
     │               #   per-provider serializer/parser/dialect tables; the
@@ -385,11 +390,19 @@ depth), the openai guard's raw shapes, and the parse-level unknowns v1
 passes through for grok (presence/frequency penalties on supported
 families, seed, logprobs, top_logprobs, logit_bias, n, stream_options,
 web_search_options). The xai completion() fork is NOT wired (integrator
-scope, like openai/azure); when it lands it must fall back on
-`use_xai_oauth`/web_search_options BEFORE building deps, route through
-`dispatch.route` with provider "xai", keep the bare wire model (the B1
-re-prefix arm must never fire: xai presets no model), and synthesize the
-final stream usage chunk from the passthrough `choices: []` tail.
+scope, like openai/azure); when it lands these are HARD OBLIGATIONS, not
+notes: the in-package `use_xai_oauth` guard arm is defense-in-depth ONLY
+and unreachable through `_raw_openai_body` (use_xai_oauth is a litellm
+param, never in non_default_params — the canary
+`test_use_xai_oauth_guard_reachability_facts` pins the classification), so
+the fork MUST either include the kwarg in the raw body it routes (making
+the guard live) or fall back on it BEFORE building deps, and MUST pin that
+with a completion()-level `use_xai_oauth=True` fallback test before the
+xai flag can turn on; route through `dispatch.route` with provider "xai";
+keep the bare wire model (the B1 re-prefix arm must never fire: xai
+presets no model); synthesize the final stream usage chunk from the
+passthrough `choices: []` tail (non-tail usage is withheld exactly like
+v1's wrapper, so the synthesis covers the tail-chunk shape only).
 Not yet here, each its own follow-up: streaming seams live; the other
 inbound schemas (`anthropic_messages`, `google_genai`, `responses`,
 `completions`); the same-family fast path (waits on the opaque-body

--- a/litellm/translation/CLAUDE.md
+++ b/litellm/translation/CLAUDE.md
@@ -137,15 +137,40 @@ translation/
 │   │   │                #   normalizer; json_mode requests fail closed)
 │   │   └── stream.py    # openai parser + per-chunk model re-attach and the
 │   │                    #   SDK service_tier default; "azure" chunk dialect
-│   └── azure_ai/        # the Foundry override set + the Claude route:
-│       ├── guard.py     # azure guard + the text-only content-list flatten
-│       ├── serialize.py # azure_ai gates (grok, model-map tool_choice) then
-│       │                #   the openai_compat body
-│       ├── response.py  # openai parser + the azure_ai/{model} rename
-│       ├── stream.py    # re-export of the azure parser ("azure" dialect)
-│       └── claude.py    # anthropic serializer/parsers re-exported; NO
-│                        #   response-format model spoof (v1 maps with the
-│                        #   real model); billing-header blocks fail closed
+│   ├── azure_ai/        # the Foundry override set + the Claude route:
+│   │   ├── guard.py     # azure guard + the text-only content-list flatten
+│   │   ├── serialize.py # azure_ai gates (grok, model-map tool_choice) then
+│   │   │                #   the openai_compat body
+│   │   ├── response.py  # openai parser + the azure_ai/{model} rename
+│   │   ├── stream.py    # re-export of the azure parser ("azure" dialect)
+│   │   └── claude.py    # anthropic serializer/parsers re-exported; NO
+│   │                    #   response-format model spoof (v1 maps with the
+│   │                    #   real model); billing-header blocks fail closed
+│   └── xai/             # Grok over openai_compat (httpx path: NO model
+│       │                #   prefix anywhere, transform_response is LIVE):
+│       ├── guard.py     # web_search_options (v1's Responses-bridge reroute
+│       │                #   sits ABOVE the seam) + use_xai_oauth (PKCE I/O
+│       │                #   in validate_environment) + explicit stream:false
+│       │                #   + nested tool `strict` keys; then the openai
+│       │                #   guard with the user-only message-name fallback
+│       │                #   (v1 strips non-user names, so the IR drop IS v1)
+│       ├── params.py    # v1's RAISE-unless-drop_params supported-list truth
+│       │                #   as typed fallbacks (max_completion_tokens always;
+│       │                #   stop/frequency_penalty/reasoning_effort per model
+│       │                #   family; reasoning via deps over xai/{model})
+│       ├── serialize.py # xai gates -> openai_compat assemble_body ->
+│       │                #   function-level strict strip + user/
+│       │                #   reasoning_effort emission
+│       ├── response.py  # openai parser + the xai usage post-steps (reasoning
+│       │                #   fold, total normalize, num_sources_used ->
+│       │                #   web_search_requests); the finish_reason "" chain
+│       │                #   needs no arm: v1's own fix is dead, both sides
+│       │                #   map "" -> "stop" in the live Choices constructor
+│       └── stream.py    # SSE dict-path parser: per-chunk usage fold, no
+│                        #   extras/system_fingerprint passthrough (the
+│                        #   chunk_parser rebuild drops them), reasoning
+│                        #   rename, tool_call type "function" default;
+│                        #   the "xai" chunk dialect folds it
 └── engine/
     ├── pipeline.py # prepare (pure, drives the fallback decision) -> send;
     │               #   per-provider serializer/parser/dialect tables; the
@@ -270,17 +295,21 @@ A behavior change ships as its own snapshot-diffed PR, never inside a port.
 
 ## Current scope
 
-OpenAI-chat-in to ten providers out — `anthropic`, `bedrock_converse`,
+OpenAI-chat-in to eleven providers out — `anthropic`, `bedrock_converse`,
 `bedrock_invoke`, `openai_compat`, `vertex_ai` (gemini route), `gemini`
 (AI Studio), `vertex_anthropic`, `azure`, `azure_ai`,
-`azure_ai_anthropic` — request, response, and stream translation,
+`azure_ai_anthropic`, `xai` — request, response, and stream translation,
 differential-green (anthropic: 46-shape corpus + responses + stream
 replays; bedrock and google: the characterization corpus per route + quirk
 corpora; openai: 17-shape request corpus + 17 typed-fallback rows +
 response and SDK-chunk stream replays; azure: 19-shape request corpus + the
 vendored characterization corpus second gate + content-filter
 response/stream rows with the azure dialect's per-chunk model re-read;
-azure_ai: the Foundry override-set and no-spoof Claude-route corpora),
+azure_ai: the Foundry override-set and no-spoof Claude-route corpora;
+xai: a 21-shape generated characterization corpus — provenance v1
+in-process at HEAD, zero recorded vendor fixtures exist — two-sided over
+`tests/test_litellm/translation/characterization_xai/` plus 7 rows pinning
+v1's UnsupportedParamsError raises and the line-seam stream replays),
 fail-closed everywhere else, with non-streaming flag-gated seams live in
 `completion()` for the anthropic, bedrock, and google routes (the
 openai/azure seam forks are integrator scope and NOT wired; the google
@@ -342,6 +371,25 @@ tool_choice, grok models, and `x-anthropic-billing-header` system blocks on
 the Claude route. None of the azure family fast-paths; the api-version
 URL/query, deployment SDK client, api-key-vs-AD-token auth and the
 `.../anthropic/v1/messages` rewrite are envelope (seam scope, unwired here).
+Deliberate xai fallback surfaces (each names the v1 path): every param v1's
+supported-list gate RAISES on (max_completion_tokens on every grok model —
+the rename arm is dead code; stop on grok-3-mini/grok-4/grok-code-fast;
+frequency_penalty on grok-4/grok-code-fast; reasoning_effort on
+non-reasoning models per the model map), `web_search_options` (v1 reroutes
+to the Responses-API bridge above the chat seam), `use_xai_oauth` (browser
+PKCE flow inside validate_environment), explicit `stream: false` (the httpx
+path keeps the key on the wire), user-message `name` (v1 forwards it; non-
+user names are STRIPPED by v1, so those serve through the IR drop), tool
+definitions with `strict` keys below the function level (v1 deletes every
+depth), the openai guard's raw shapes, and the parse-level unknowns v1
+passes through for grok (presence/frequency penalties on supported
+families, seed, logprobs, top_logprobs, logit_bias, n, stream_options,
+web_search_options). The xai completion() fork is NOT wired (integrator
+scope, like openai/azure); when it lands it must fall back on
+`use_xai_oauth`/web_search_options BEFORE building deps, route through
+`dispatch.route` with provider "xai", keep the bare wire model (the B1
+re-prefix arm must never fire: xai presets no model), and synthesize the
+final stream usage chunk from the passthrough `choices: []` tail.
 Not yet here, each its own follow-up: streaming seams live; the other
 inbound schemas (`anthropic_messages`, `google_genai`, `responses`,
 `completions`); the same-family fast path (waits on the opaque-body

--- a/litellm/translation/dispatch.py
+++ b/litellm/translation/dispatch.py
@@ -31,6 +31,7 @@ Provider = Literal[
     "openai_compat",
     "gemini",
     "vertex_anthropic",
+    "xai",
 ]
 
 _SAME_FAMILY: frozenset[tuple[InboundSchema, Provider]] = frozenset(
@@ -40,6 +41,9 @@ _SAME_FAMILY: frozenset[tuple[InboundSchema, Provider]] = frozenset(
         ("anthropic_messages", "vertex_ai"),
         ("anthropic_messages", "vertex_anthropic"),
         ("openai_chat", "openai_compat"),
+        # xai is NOT same-family despite speaking openai-chat: v1's transform
+        # touches the body (tools strict strip, non-user message name strip),
+        # so a verbatim fast-path forward would diverge from v1.
     }
 )
 

--- a/litellm/translation/engine/pipeline.py
+++ b/litellm/translation/engine/pipeline.py
@@ -76,6 +76,11 @@ from ..providers.vertex_anthropic import (
 from ..providers.vertex_anthropic import (
     serialize_request as vertex_anthropic_serialize_request,
 )
+from ..providers.xai import parse_response as xai_parse_response
+from ..providers.xai import serialize_request as xai_serialize_request
+from ..providers.xai import (
+    unsupported_request_shapes as xai_unsupported_request_shapes,
+)
 from .http import Endpoint, ExecuteError, HttpPort, ProviderHttpError
 
 _Serializer = Callable[[ChatRequest, TranslationDeps], Result[Body, TranslationError]]
@@ -95,6 +100,7 @@ _SERIALIZERS: Mapping[Provider, _Serializer] = MappingProxyType(
         "azure": azure_serialize_request,
         "azure_ai": azure_ai_serialize_request,
         "azure_ai_anthropic": azure_ai_claude_serialize_request,
+        "xai": xai_serialize_request,
     }
 )
 
@@ -110,6 +116,7 @@ _RESPONSE_PARSERS: Mapping[Provider, _ResponseParser] = MappingProxyType(
         "azure": azure_parse_response,
         "azure_ai": azure_ai_parse_response,
         "azure_ai_anthropic": azure_ai_claude_parse_response,
+        "xai": xai_parse_response,
     }
 )
 
@@ -125,6 +132,7 @@ _RESPONSE_DIALECTS: Mapping[Provider, ResponseDialect] = MappingProxyType(
         "azure": "openai",  # same normalizer (convert_to_model_response_object)
         "azure_ai": "openai",
         "azure_ai_anthropic": "anthropic",  # genuine anthropic wire format
+        "xai": "openai",  # httpx path, same normalized wire-body ride
     }
 )
 
@@ -142,6 +150,7 @@ _RAW_GUARDS: Mapping[Provider, _RawGuard] = MappingProxyType(
         "azure_ai": azure_ai_unsupported_request_shapes,
         "vertex_ai": google_unsupported_request_shapes,
         "gemini": google_unsupported_request_shapes,
+        "xai": xai_unsupported_request_shapes,
     }
 )
 

--- a/litellm/translation/inbound/openai_chat/stream.py
+++ b/litellm/translation/inbound/openai_chat/stream.py
@@ -31,7 +31,10 @@ chunk that carries one, choice-level ``content_filter_results`` survives on
 content chunks (the ``StreamingChoices(**choice_json)`` rebuild) but not on
 the finish flush (default-choice ``Delta(content=None)``), and the
 empty-choices ``prompt_filter_results`` chunk is swallowed exactly like
-v1's empty-delta handling.
+v1's empty-delta handling. The ``xai`` dialect is the openai fold with two
+deltas: ``reasoning_content``-only deltas count as non-empty (v1 emits Grok
+reasoning chunks) and the model is never re-read from chunks (the httpx
+wrapper stamps the request model).
 """
 
 from __future__ import annotations
@@ -47,8 +50,8 @@ from ...ir import Body, CompositeChunk, PlainJson, StreamEvent
 
 BlockDialect = Literal["anthropic", "bedrock_converse"]
 """Dialects whose provider parsers emit per-block delta events
-(text/thinking/signature/tool deltas). The wire dialects (openai, azure)
-fold ``wire_chunk`` events and gemini folds composite ``chunk`` events;
+(text/thinking/signature/tool deltas). The wire dialects (openai, azure,
+xai) fold ``wire_chunk`` events and gemini folds composite ``chunk`` events;
 their parsers can never produce a per-block delta, and the step surfaces a
 loud error (never a fabricated placeholder body) if one ever arrives."""
 

--- a/litellm/translation/inbound/openai_chat/stream.py
+++ b/litellm/translation/inbound/openai_chat/stream.py
@@ -52,7 +52,7 @@ fold ``wire_chunk`` events and gemini folds composite ``chunk`` events;
 their parsers can never produce a per-block delta, and the step surfaces a
 loud error (never a fabricated placeholder body) if one ever arrives."""
 
-ChunkDialect = Literal[BlockDialect, "openai", "azure", "gemini"]
+ChunkDialect = Literal[BlockDialect, "openai", "azure", "gemini", "xai"]
 
 
 @dataclass(frozen=True)
@@ -131,7 +131,7 @@ def _as_block_dialect(
     match dialect:
         case "anthropic" | "bedrock_converse":
             return dialect
-        case "openai" | "azure" | "gemini":
+        case "openai" | "azure" | "gemini" | "xai":
             # wire/composite dialects fold whole chunks; a per-block delta
             # here is a wiring bug and must be loud, never a fabricated
             # anthropic-shaped placeholder (critic-google M5 / critic-azure M3).
@@ -197,7 +197,7 @@ _OPENAI_WIRE_KEYS = frozenset({"id", "model", "system_fingerprint", "choices", "
 
 
 def _step_openai(state: StreamState, chunk: PlainJson) -> _StepResult:
-    if state.dialect not in ("openai", "azure"):
+    if state.dialect not in ("openai", "azure", "xai"):
         return _dialect_mismatch(state.dialect, "wire_chunk")
     if not isinstance(chunk, dict):
         return state, ()  # the parser only emits dict wire chunks
@@ -307,6 +307,12 @@ def _openai_chunk_non_empty(state: StreamState, delta: dict[str, PlainJson]) -> 
     tool_calls = delta.get("tool_calls")
     if isinstance(tool_calls, list) and len(tool_calls) > 0:
         return True
+    if state.dialect == "xai":
+        # Grok reasoning deltas carry only reasoning_content; v1's wrapper
+        # emits them (is_delta_empty consults reasoning_content too).
+        reasoning = delta.get("reasoning_content")
+        if isinstance(reasoning, str) and len(reasoning) > 0:
+            return True
     return not state.sent_role and delta.get("role") is not None
 
 

--- a/litellm/translation/providers/azure/stream.py
+++ b/litellm/translation/providers/azure/stream.py
@@ -14,36 +14,14 @@ empty-choices chunk entirely, which the fold reproduces.
 
 from __future__ import annotations
 
-import json
+from expression import Ok, Result
 
-from expression import Error, Ok, Result
-from expression.collections import Block
-
-from ...errors import BoundaryError, TranslationError
+from ...errors import TranslationError
 from ...ir import JsonBlob, PlainJson, StreamEvent
+from ..openai_compat.stream import make_parse_line
 from ..openai_compat.stream import parse_event as openai_parse_event
 
 _EventResult = Result[StreamEvent | None, TranslationError]
-
-
-def parse_line(line: str) -> _EventResult:
-    stripped = line.strip()
-    if not stripped.startswith("data:"):
-        return Ok(None)
-    payload = stripped[len("data:") :].strip()
-    if payload == "[DONE]":
-        return Ok(StreamEvent.of_stop())
-    try:
-        event: PlainJson = json.loads(payload)
-    except ValueError:
-        return Error(
-            TranslationError.of_boundary(
-                BoundaryError.of(
-                    Block.of_seq([f"stream payload is not JSON: {payload[:120]!r}"])
-                )
-            )
-        )
-    return parse_event(event)
 
 
 def parse_event(event: PlainJson) -> _EventResult:
@@ -68,3 +46,6 @@ def parse_event(event: PlainJson) -> _EventResult:
             JsonBlob(value={"service_tier": None, **chunk, "model": model})
         )
     )
+
+
+parse_line = make_parse_line(parse_event)

--- a/litellm/translation/providers/openai_compat/guard.py
+++ b/litellm/translation/providers/openai_compat/guard.py
@@ -21,8 +21,18 @@ from ...errors import TranslationError
 _Raw = Mapping[str, object]
 
 
-def unsupported_request_shapes(raw: _Raw) -> TranslationError | None:
-    reason = _params_reason(raw) or _tools_reason(raw) or _messages_reason(raw)
+def unsupported_request_shapes(
+    raw: _Raw, *, name_fallback_user_only: bool = False
+) -> TranslationError | None:
+    """``name_fallback_user_only``: providers whose v1 transform STRIPS the
+    message ``name`` from non-user roles (xai ``strip_name_from_messages``)
+    only need the fallback for user messages, where v1 forwards it verbatim;
+    the IR's name-drop IS v1's behavior on the other roles."""
+    reason = (
+        _params_reason(raw)
+        or _tools_reason(raw)
+        or _messages_reason(raw, name_fallback_user_only)
+    )
     if reason is None:
         return None
     return TranslationError.of_unsupported(f"{reason}; v1 forwards the original shape")
@@ -71,7 +81,7 @@ def _tools_reason(raw: _Raw) -> str | None:
     return None
 
 
-def _messages_reason(raw: _Raw) -> str | None:
+def _messages_reason(raw: _Raw, name_fallback_user_only: bool = False) -> str | None:
     messages = _as_seq(raw.get("messages"))
     if messages is None:
         return None
@@ -84,7 +94,9 @@ def _messages_reason(raw: _Raw) -> str | None:
             # keep scanning so the guard stays locally conservative too
             continue
         role = entry.get("role")
-        if entry.get("name") is not None:
+        if entry.get("name") is not None and (
+            not name_fallback_user_only or role == "user"
+        ):
             return "message name field (not carried by the IR)"
         reason = _message_reason(entry, role, seen_non_system)
         if reason is not None:

--- a/litellm/translation/providers/openai_compat/response.py
+++ b/litellm/translation/providers/openai_compat/response.py
@@ -98,7 +98,7 @@ def parse_response(raw: PlainJson, request: ChatRequest) -> _ParseResult:
             model=model if isinstance(model, str) else request.model,
             content=Block.of_seq(blocks),
             finish=semantic_finish,
-            usage=_semantic_usage(raw.get("usage")),
+            usage=semantic_usage(raw.get("usage")),
             synthesized_json_content=False,
             wire=Some(JsonBlob(value=body)),
         )
@@ -327,7 +327,7 @@ def _tool_use_block(call: PlainJson) -> ContentBlock | TranslationError:
     )
 
 
-def _semantic_usage(raw: PlainJson) -> ResponseUsage:
+def semantic_usage(raw: PlainJson) -> ResponseUsage:
     if not isinstance(raw, dict):
         return ResponseUsage(
             input_tokens=0,

--- a/litellm/translation/providers/openai_compat/serialize.py
+++ b/litellm/translation/providers/openai_compat/serialize.py
@@ -37,6 +37,13 @@ def serialize_request(request: ChatRequest, deps: TranslationDeps) -> _Serialize
     )
     if reason is not None:
         return Error(TranslationError.of_unsupported(reason))
+    return assemble_body(request)
+
+
+def assemble_body(request: ChatRequest) -> _SerializeResult:
+    """The gate-free five-touch body assembly, for consumers (xai) whose v1
+    config inherits OpenAIGPTConfig's transform_request but replaces the
+    openai param gates with their own."""
     messages = serialize_messages(request)
     if isinstance(messages, TranslationError):
         return Error(messages)

--- a/litellm/translation/providers/openai_compat/stream.py
+++ b/litellm/translation/providers/openai_compat/stream.py
@@ -16,6 +16,7 @@ values.
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 
 from expression import Error, Ok, Result
 from expression.collections import Block
@@ -24,6 +25,8 @@ from ...errors import BoundaryError, TranslationError
 from ...ir import JsonBlob, PlainJson, StreamEvent
 
 _EventResult = Result[StreamEvent | None, TranslationError]
+_ParseEvent = Callable[[PlainJson], _EventResult]
+_ParseLine = Callable[[str], _EventResult]
 
 _DELTA_KEYS = ("content", "function_call", "refusal", "role", "tool_calls")
 
@@ -44,18 +47,27 @@ _ENVELOPE_KEYS = frozenset(
 )
 
 
-def parse_line(line: str) -> _EventResult:
-    stripped = line.strip()
-    if not stripped.startswith("data:"):
-        return Ok(None)
-    payload = stripped[len("data:") :].strip()
-    if payload == "[DONE]":
-        return Ok(StreamEvent.of_stop())
-    try:
-        event: PlainJson = json.loads(payload)
-    except ValueError:
-        return Error(_boundary(f"stream payload is not JSON: {payload[:120]!r}"))
-    return parse_event(event)
+def make_parse_line(parse_event: _ParseEvent) -> _ParseLine:
+    """The ONE SSE ``data:``-line decode over any chunk parser (a single-line
+    subset; the v2 HttpPort streaming seam owns real SSE framing when it
+    lands). Same-family providers compose their parser through this factory
+    instead of pasting the decode (critic-openai N3 / critic-azure N1 /
+    critic-grok M3)."""
+
+    def parse_line(line: str) -> _EventResult:
+        stripped = line.strip()
+        if not stripped.startswith("data:"):
+            return Ok(None)
+        payload = stripped[len("data:") :].strip()
+        if payload == "[DONE]":
+            return Ok(StreamEvent.of_stop())
+        try:
+            event: PlainJson = json.loads(payload)
+        except ValueError:
+            return Error(_boundary(f"stream payload is not JSON: {payload[:120]!r}"))
+        return parse_event(event)
+
+    return parse_line
 
 
 def parse_event(event: PlainJson) -> _EventResult:
@@ -218,3 +230,6 @@ def _delta_bears_content(delta: dict[str, PlainJson]) -> bool:
     return (isinstance(content, str) and len(content) > 0) or delta.get(
         "tool_calls"
     ) is not None
+
+
+parse_line = make_parse_line(parse_event)

--- a/litellm/translation/providers/xai/__init__.py
+++ b/litellm/translation/providers/xai/__init__.py
@@ -1,0 +1,12 @@
+from .guard import unsupported_request_shapes
+from .response import parse_response
+from .serialize import serialize_request
+from .stream import parse_event, parse_line
+
+__all__ = (
+    "parse_event",
+    "parse_line",
+    "parse_response",
+    "serialize_request",
+    "unsupported_request_shapes",
+)

--- a/litellm/translation/providers/xai/guard.py
+++ b/litellm/translation/providers/xai/guard.py
@@ -42,6 +42,16 @@ def unsupported_request_shapes(raw: _Raw) -> TranslationError | None:
             "(responses_api_bridge_check); v1 owns it"
         )
     if raw.get("use_xai_oauth"):
+        # DEFENSE-IN-DEPTH ONLY, unreachable through translation_seam's
+        # _raw_openai_body today: use_xai_oauth is a litellm param
+        # (all_litellm_params), not an OpenAI param, so completion() never
+        # places it in non_default_params/optional_param_args. The REAL
+        # protection is the seam obligation (CLAUDE.md): the xai fork must
+        # either include the kwarg in the raw body it routes (making this
+        # arm live) or fall back on it BEFORE building deps, and must pin
+        # that with a completion()-level test before the flag turns on.
+        # test_use_xai_oauth_guard_reachability pins the classification facts
+        # this analysis rests on.
         return TranslationError.of_unsupported(
             "use_xai_oauth: v1 runs an interactive browser PKCE flow inside "
             "validate_environment (llms/xai/oauth.py); v1 owns it"
@@ -82,7 +92,9 @@ def _nested_tool_strict_reason(raw: _Raw) -> str | None:
 
 def _contains_strict_key(value: object, depth: int) -> bool:
     if depth > DEFAULT_MAX_RECURSE_DEPTH:
-        return False
+        # exhaustion never admits: fall back (the polarity integration
+        # db99d00be5 set for cap exhaustion; strictly widens the fallback)
+        return True
     if isinstance(value, Mapping):
         mapping = cast(_Raw, value)
         return any(

--- a/litellm/translation/providers/xai/guard.py
+++ b/litellm/translation/providers/xai/guard.py
@@ -1,0 +1,97 @@
+"""Raw-shape fidelity guard for the xai (Grok) serializer.
+
+Three xai-only checks run before the shared openai guard:
+
+- ``web_search_options``: v1 reroutes xai chat to the Responses-API bridge
+  BEFORE any chat seam (``responses_api_bridge_check``, main.py:982-984), so
+  a chat-route v2 must never serve it.
+- ``use_xai_oauth``: v1's ``validate_environment`` runs an interactive
+  browser PKCE flow with a localhost callback server (llms/xai/oauth.py);
+  envelope I/O the v2 surface cannot reproduce.
+- tool definitions carrying a ``strict`` key anywhere BELOW the function
+  level: v1's ``filter_value_from_dict(tool, "strict")`` deletes EVERY key
+  named ``strict`` at any depth (including JSON-schema properties literally
+  named ``strict``); v2 reproduces only the standard function-level strip.
+
+The shared openai guard then runs with ``name_fallback_user_only``: v1's xai
+transform strips message ``name`` from every non-user role
+(``strip_name_from_messages``), so the IR's name-drop IS v1's behavior there
+and only a user-message ``name`` (forwarded verbatim by v1) falls back.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import cast
+
+from litellm.constants import DEFAULT_MAX_RECURSE_DEPTH
+
+from ...errors import TranslationError
+from ..openai_compat.guard import (
+    unsupported_request_shapes as openai_unsupported_request_shapes,
+)
+
+_Raw = Mapping[str, object]
+
+
+def unsupported_request_shapes(raw: _Raw) -> TranslationError | None:
+    if raw.get("web_search_options") is not None:
+        return TranslationError.of_unsupported(
+            "web_search_options on xai: v1 reroutes the request to the "
+            "Responses-API bridge above the chat seam "
+            "(responses_api_bridge_check); v1 owns it"
+        )
+    if raw.get("use_xai_oauth"):
+        return TranslationError.of_unsupported(
+            "use_xai_oauth: v1 runs an interactive browser PKCE flow inside "
+            "validate_environment (llms/xai/oauth.py); v1 owns it"
+        )
+    if "stream" in raw and raw.get("stream") is False:
+        return TranslationError.of_unsupported(
+            "explicit stream: false (the xai httpx path keeps the key on the "
+            "wire; absent-vs-false is lost in the IR)"
+        )
+    reason = _nested_tool_strict_reason(raw)
+    if reason is not None:
+        return TranslationError.of_unsupported(reason)
+    return openai_unsupported_request_shapes(raw, name_fallback_user_only=True)
+
+
+def _nested_tool_strict_reason(raw: _Raw) -> str | None:
+    raw_tools = raw.get("tools")
+    if not isinstance(raw_tools, Sequence) or isinstance(raw_tools, str):
+        return None
+    for tool in cast(Sequence[object], raw_tools):
+        if not isinstance(tool, Mapping):
+            continue
+        entry = cast(_Raw, tool)
+        function = entry.get("function")
+        if not isinstance(function, Mapping):
+            continue
+        for key, value in cast(_Raw, function).items():
+            if key == "strict":
+                continue  # the standard slot; the serializer strips it like v1
+            if _contains_strict_key(value, 0):
+                return (
+                    "tool definition carries a nested 'strict' key below the "
+                    "function level; v1's filter_value_from_dict deletes it "
+                    "at every depth"
+                )
+    return None
+
+
+def _contains_strict_key(value: object, depth: int) -> bool:
+    if depth > DEFAULT_MAX_RECURSE_DEPTH:
+        return False
+    if isinstance(value, Mapping):
+        mapping = cast(_Raw, value)
+        return any(
+            key == "strict" or _contains_strict_key(item, depth + 1)
+            for key, item in mapping.items()
+        )
+    if isinstance(value, Sequence) and not isinstance(value, str):
+        return any(
+            _contains_strict_key(item, depth + 1)
+            for item in cast(Sequence[object], value)
+        )
+    return False

--- a/litellm/translation/providers/xai/params.py
+++ b/litellm/translation/providers/xai/params.py
@@ -1,0 +1,57 @@
+"""Parameter gates for the xai (Grok) serializer.
+
+v1's gate is ``_check_valid_arg`` over ``XAIChatConfig.
+get_supported_openai_params`` (utils.py:4162-4203): an unsupported param
+RAISES ``UnsupportedParamsError`` unless ``drop_params``, in which case it is
+popped BEFORE ``map_openai_params`` runs — so the ``max_completion_tokens ->
+max_tokens`` rename arm (x_t:185-186) is dead code on the standard path.
+v2 mirrors the SUPPORTED-LIST truth, never the raise-vs-drop interplay:
+every shape v1 raises or drops on falls back typed so v1 serves its own
+error (the v2-openai response_format precedent).
+
+Per-model gates mirror x_t:155-174 (substring checks) and the
+``litellm.supports_reasoning(model, "xai")`` model-map read, reproduced
+through ``deps.supports_capability`` over the ``xai/{model}`` map key (the
+bare wire model has no model-map row; verified in-process at HEAD).
+"""
+
+from __future__ import annotations
+
+from ...deps import TranslationDeps
+from ...ir import ChatRequest
+
+_NO_STOP_FAMILIES = ("grok-3-mini", "grok-4", "grok-code-fast")
+
+
+def supports_stop(model: str) -> bool:
+    return not any(family in model for family in _NO_STOP_FAMILIES)
+
+
+def supports_reasoning(model: str, deps: TranslationDeps) -> bool:
+    return deps.supports_capability(f"xai/{model}", "supports_reasoning")
+
+
+def unsupported_params(request: ChatRequest, deps: TranslationDeps) -> str | None:
+    if request.params.max_completion_tokens.is_some():
+        return (
+            "max_completion_tokens is outside xai's supported list; v1's "
+            "get_optional_params raises UnsupportedParamsError (or drops it "
+            "under drop_params) before the rename arm can run"
+        )
+    if request.params.top_k.is_some():
+        return "top_k is not an xai chat param; v1's get_optional_params raises or drops it"
+    if request.thinking.is_some():
+        return "thinking is not an xai chat param; v1's get_optional_params raises or drops it"
+    if len(request.params.stop) > 0 and not supports_stop(request.model):
+        return (
+            f"stop on {request.model}: outside xai's supported list "
+            "(grok-3-mini/grok-4/grok-code-fast); v1 raises or drops it"
+        )
+    if request.reasoning_effort.is_some() and not supports_reasoning(
+        request.model, deps
+    ):
+        return (
+            f"reasoning_effort on non-reasoning xai model {request.model}; "
+            "v1 raises or drops it"
+        )
+    return None

--- a/litellm/translation/providers/xai/response.py
+++ b/litellm/translation/providers/xai/response.py
@@ -1,0 +1,113 @@
+"""xai (Grok) chat-completion response JSON -> IR ``ChatResponse``.
+
+The live v1 normalizer is ``XAIChatConfig.transform_response`` (xai is on
+the dedicated httpx branch, main.py:2289, so transform_response RUNS —
+the inverse of the openai SDK path): the shared
+``convert_to_model_response_object`` conversion, then the xai post-steps.
+v2 mirrors that chain over the openai_compat parser's normalized wire body:
+
+- finish_reason ``""`` (Grok's tool-call quirk) needs NO xai arm: v1's own
+  ``_fix_choice_finish_reason_for_tool_calls`` is empirically dead
+  (``Choices.__init__`` maps ``""`` -> ``"stop"`` before the check ever
+  runs), so v1-as-executed emits ``"stop"`` WITH tool_calls. The openai
+  parser already rides the native ``""`` on the wire body and the seam's
+  ``Choices`` runs the same live ``map_finish_reason`` — identical chain.
+- ``_enhance_usage_with_xai_web_search_fields``: ``usage.num_sources_used``
+  > 0 copies into ``prompt_tokens_details.web_search_requests`` (the
+  live-search billing hook).
+- ``_fold_reasoning_tokens_into_completion``: fold reasoning into
+  completion_tokens when ``total == prompt + completion + reasoning``.
+- ``_normalize_openai_compatible_usage_totals``: bump total_tokens up to
+  ``prompt + completion``.
+
+``citations`` and any future live-search top-level keys ride the parser's
+unknown-key mirror exactly like v1's cdr:727-729 setattr.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+from expression import Result, Some
+
+from ...errors import TranslationError
+from ...ir import ChatRequest, ChatResponse, JsonBlob, PlainJson
+from ..openai_compat.response import parse_response as openai_parse_response
+from ..openai_compat.response import semantic_usage as openai_semantic_usage
+
+_ParseResult = Result[ChatResponse, TranslationError]
+
+
+def parse_response(raw: PlainJson, request: ChatRequest) -> _ParseResult:
+    return openai_parse_response(raw, request).map(_with_xai_usage_post_steps)
+
+
+def _with_xai_usage_post_steps(response: ChatResponse) -> ChatResponse:
+    wire = response.wire.default_value(None)
+    if wire is None or not isinstance(wire.value, dict):
+        return response
+    usage = wire.value.get("usage")
+    if not isinstance(usage, dict):
+        return response
+    transformed = normalize_usage_totals(
+        fold_reasoning_tokens(_websearch_fields(usage))
+    )
+    if transformed == usage:
+        return response
+    body: dict[str, PlainJson] = {**wire.value, "usage": transformed}
+    return dataclasses.replace(
+        response,
+        usage=openai_semantic_usage(transformed),
+        wire=Some(JsonBlob(value=body)),
+    )
+
+
+def _websearch_fields(usage: dict[str, PlainJson]) -> dict[str, PlainJson]:
+    sources = usage.get("num_sources_used")
+    if not isinstance(sources, (int, float)) or isinstance(sources, bool):
+        return usage
+    if sources <= 0:
+        return usage
+    details = usage.get("prompt_tokens_details")
+    seeded: dict[str, PlainJson] = dict(details) if isinstance(details, dict) else {}
+    return {
+        **usage,
+        "num_sources_used": int(sources),
+        "prompt_tokens_details": {**seeded, "web_search_requests": int(sources)},
+    }
+
+
+def fold_reasoning_tokens(usage: dict[str, PlainJson]) -> dict[str, PlainJson]:
+    """Pure dict mirror of ``_fold_reasoning_tokens_into_completion`` (the
+    same arithmetic the stream chunk variant runs)."""
+    details = usage.get("completion_tokens_details")
+    reasoning = details.get("reasoning_tokens") if isinstance(details, dict) else 0
+    reasoning_tokens = _int_of(reasoning)
+    if reasoning_tokens <= 0:
+        return usage
+    prompt_tokens = _int_of(usage.get("prompt_tokens"))
+    completion_tokens = _int_of(usage.get("completion_tokens"))
+    total_tokens = _int_of(usage.get("total_tokens"))
+    if total_tokens == prompt_tokens + completion_tokens:
+        return usage
+    if total_tokens != prompt_tokens + completion_tokens + reasoning_tokens:
+        return usage  # v1's double-count guard
+    return {**usage, "completion_tokens": completion_tokens + reasoning_tokens}
+
+
+def normalize_usage_totals(usage: dict[str, PlainJson]) -> dict[str, PlainJson]:
+    """Pure dict mirror of ``_normalize_openai_compatible_usage_totals``."""
+    expected = _int_of(usage.get("prompt_tokens")) + _int_of(
+        usage.get("completion_tokens")
+    )
+    if _int_of(usage.get("total_tokens")) >= expected:
+        return usage
+    return {**usage, "total_tokens": expected}
+
+
+def _int_of(value: PlainJson) -> int:
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, (int, float)):
+        return int(value)
+    return 0

--- a/litellm/translation/providers/xai/response.py
+++ b/litellm/translation/providers/xai/response.py
@@ -14,11 +14,19 @@ v2 mirrors that chain over the openai_compat parser's normalized wire body:
   ``Choices`` runs the same live ``map_finish_reason`` — identical chain.
 - ``_enhance_usage_with_xai_web_search_fields``: ``usage.num_sources_used``
   > 0 copies into ``prompt_tokens_details.web_search_requests`` (the
-  live-search billing hook).
+  live-search billing hook). v1 swallows non-numeric values (the whole
+  post-step sits in a try/except-debug), so non-numerics skip silently.
 - ``_fold_reasoning_tokens_into_completion``: fold reasoning into
   completion_tokens when ``total == prompt + completion + reasoning``.
 - ``_normalize_openai_compatible_usage_totals``: bump total_tokens up to
   ``prompt + completion``.
+
+Token coercion mirrors v1's ``int(x or 0)`` exactly: numeric strings fold
+(``int("7") == 7``, matching the pydantic-lax ``Usage(**raw)`` on v1's
+response path), bools coerce (``int(True or 0) == 1``), and an uncoercible
+value is a typed boundary error — LOUD where v1 raises (``int("abc")``
+inside the chunk_parser / the ``Usage`` validation inside cdr), never a
+silent zero.
 
 ``citations`` and any future live-search top-level keys ride the parser's
 unknown-key mirror exactly like v1's cdr:727-729 setattr.
@@ -28,44 +36,51 @@ from __future__ import annotations
 
 import dataclasses
 
-from expression import Result, Some
+from expression import Error, Ok, Result, Some
+from expression.collections import Block
 
-from ...errors import TranslationError
+from ...errors import BoundaryError, TranslationError
 from ...ir import ChatRequest, ChatResponse, JsonBlob, PlainJson
 from ..openai_compat.response import parse_response as openai_parse_response
 from ..openai_compat.response import semantic_usage as openai_semantic_usage
 
 _ParseResult = Result[ChatResponse, TranslationError]
+_Usage = dict[str, PlainJson]
 
 
 def parse_response(raw: PlainJson, request: ChatRequest) -> _ParseResult:
-    return openai_parse_response(raw, request).map(_with_xai_usage_post_steps)
+    return openai_parse_response(raw, request).bind(_with_xai_usage_post_steps)
 
 
-def _with_xai_usage_post_steps(response: ChatResponse) -> ChatResponse:
+def _with_xai_usage_post_steps(response: ChatResponse) -> _ParseResult:
     wire = response.wire.default_value(None)
     if wire is None or not isinstance(wire.value, dict):
-        return response
+        return Ok(response)
     usage = wire.value.get("usage")
     if not isinstance(usage, dict):
-        return response
-    transformed = normalize_usage_totals(
-        fold_reasoning_tokens(_websearch_fields(usage))
-    )
+        return Ok(response)
+    folded = fold_reasoning_tokens(_websearch_fields(usage))
+    if isinstance(folded, TranslationError):
+        return Error(folded)
+    transformed = normalize_usage_totals(folded)
+    if isinstance(transformed, TranslationError):
+        return Error(transformed)
     if transformed == usage:
-        return response
+        return Ok(response)
     body: dict[str, PlainJson] = {**wire.value, "usage": transformed}
-    return dataclasses.replace(
-        response,
-        usage=openai_semantic_usage(transformed),
-        wire=Some(JsonBlob(value=body)),
+    return Ok(
+        dataclasses.replace(
+            response,
+            usage=openai_semantic_usage(transformed),
+            wire=Some(JsonBlob(value=body)),
+        )
     )
 
 
-def _websearch_fields(usage: dict[str, PlainJson]) -> dict[str, PlainJson]:
+def _websearch_fields(usage: _Usage) -> _Usage:
     sources = usage.get("num_sources_used")
-    if not isinstance(sources, (int, float)) or isinstance(sources, bool):
-        return usage
+    if not isinstance(sources, (bool, int, float)):
+        return usage  # v1's `n > 0` raises on non-numerics and is swallowed
     if sources <= 0:
         return usage
     details = usage.get("prompt_tokens_details")
@@ -77,37 +92,72 @@ def _websearch_fields(usage: dict[str, PlainJson]) -> dict[str, PlainJson]:
     }
 
 
-def fold_reasoning_tokens(usage: dict[str, PlainJson]) -> dict[str, PlainJson]:
-    """Pure dict mirror of ``_fold_reasoning_tokens_into_completion`` (the
-    same arithmetic the stream chunk variant runs)."""
+def fold_reasoning_tokens(usage: _Usage) -> _Usage | TranslationError:
+    """Mirror ``_fold_reasoning_tokens_into_completion``'s dict variant in
+    v1's read order: reasoning first (early return at <= 0), then
+    prompt/completion/total."""
     details = usage.get("completion_tokens_details")
-    reasoning = details.get("reasoning_tokens") if isinstance(details, dict) else 0
-    reasoning_tokens = _int_of(reasoning)
-    if reasoning_tokens <= 0:
+    reasoning = _coerce_int(
+        details.get("reasoning_tokens") if isinstance(details, dict) else None,
+        "completion_tokens_details.reasoning_tokens",
+    )
+    if isinstance(reasoning, TranslationError):
+        return reasoning
+    if reasoning <= 0:
         return usage
-    prompt_tokens = _int_of(usage.get("prompt_tokens"))
-    completion_tokens = _int_of(usage.get("completion_tokens"))
-    total_tokens = _int_of(usage.get("total_tokens"))
+    tokens = _coerced_token_triple(usage)
+    if isinstance(tokens, TranslationError):
+        return tokens
+    prompt_tokens, completion_tokens, total_tokens = tokens
     if total_tokens == prompt_tokens + completion_tokens:
         return usage
-    if total_tokens != prompt_tokens + completion_tokens + reasoning_tokens:
+    if total_tokens != prompt_tokens + completion_tokens + reasoning:
         return usage  # v1's double-count guard
-    return {**usage, "completion_tokens": completion_tokens + reasoning_tokens}
+    return {**usage, "completion_tokens": completion_tokens + reasoning}
 
 
-def normalize_usage_totals(usage: dict[str, PlainJson]) -> dict[str, PlainJson]:
-    """Pure dict mirror of ``_normalize_openai_compatible_usage_totals``."""
-    expected = _int_of(usage.get("prompt_tokens")) + _int_of(
-        usage.get("completion_tokens")
-    )
-    if _int_of(usage.get("total_tokens")) >= expected:
+def normalize_usage_totals(usage: _Usage) -> _Usage | TranslationError:
+    """Mirror ``_normalize_openai_compatible_usage_totals``'s dict variant."""
+    tokens = _coerced_token_triple(usage)
+    if isinstance(tokens, TranslationError):
+        return tokens
+    prompt_tokens, completion_tokens, total_tokens = tokens
+    expected = prompt_tokens + completion_tokens
+    if total_tokens >= expected:
         return usage
     return {**usage, "total_tokens": expected}
 
 
-def _int_of(value: PlainJson) -> int:
-    if isinstance(value, bool):
+def _coerced_token_triple(
+    usage: _Usage,
+) -> tuple[int, int, int] | TranslationError:
+    prompt = _coerce_int(usage.get("prompt_tokens"), "prompt_tokens")
+    if isinstance(prompt, TranslationError):
+        return prompt
+    completion = _coerce_int(usage.get("completion_tokens"), "completion_tokens")
+    if isinstance(completion, TranslationError):
+        return completion
+    total = _coerce_int(usage.get("total_tokens"), "total_tokens")
+    if isinstance(total, TranslationError):
+        return total
+    return prompt, completion, total
+
+
+def _coerce_int(value: PlainJson, field: str) -> int | TranslationError:
+    """v1's ``int(x or 0)``: None/""/0 -> 0, bools and numeric strings
+    coerce, anything ``int()`` rejects is loud (v1 raises out of the
+    post-step or the Usage validation; v2 returns the boundary error)."""
+    if value is None:
         return 0
-    if isinstance(value, (int, float)):
+    if isinstance(value, (bool, int, float)):
         return int(value)
-    return 0
+    if isinstance(value, str):
+        try:
+            return int(value) if value else 0
+        except ValueError:
+            pass
+    return TranslationError.of_boundary(
+        BoundaryError.of(
+            Block.of_seq([f"usage {field} is not int-coercible: {value!r} (v1 raises)"])
+        )
+    )

--- a/litellm/translation/providers/xai/serialize.py
+++ b/litellm/translation/providers/xai/serialize.py
@@ -1,0 +1,58 @@
+"""Serialize the IR into an xai (Grok) ``/v1/chat/completions`` request body.
+
+v1's chain is ``XAIChatConfig.map_openai_params`` (own supported list, tools
+``strict`` strip) then ``transform_request`` = ``strip_name_from_messages``
++ the inherited OpenAIGPTConfig five-touch assembly. The body is therefore
+the openai_compat assembly with three deltas: the function-level ``strict``
+key is stripped from every tool (v1 ``filter_value_from_dict(tool,
+"strict")``; deeper ``strict`` keys fall back in the raw guard), and ``user``
+/ ``reasoning_effort`` — typed fallbacks on plain GPT — are emitted verbatim
+because xai supports them (reasoning_effort gated per model in params.py).
+The non-user message ``name`` strip needs no code: the IR never carries
+``name`` and the xai raw guard only falls back on user-message names.
+"""
+
+from __future__ import annotations
+
+from expression import Error, Result
+
+from ...deps import TranslationDeps
+from ...errors import TranslationError
+from ...ir import Body, ChatRequest, PlainJson
+from ..openai_compat.serialize import assemble_body
+from . import params as p
+
+_SerializeResult = Result[Body, TranslationError]
+
+
+def serialize_request(request: ChatRequest, deps: TranslationDeps) -> _SerializeResult:
+    reason = p.unsupported_params(request, deps)
+    if reason is not None:
+        return Error(TranslationError.of_unsupported(reason))
+    return assemble_body(request).map(lambda body: _with_xai_deltas(body, request))
+
+
+def _with_xai_deltas(body: Body, request: ChatRequest) -> Body:
+    extras: dict[str, PlainJson] = {}
+    user = request.user.default_value(None)
+    if user is not None:
+        extras = {**extras, "user": user}
+    effort = request.reasoning_effort.default_value(None)
+    if effort is not None:
+        extras = {**extras, "reasoning_effort": effort}
+    tools = body.get("tools")
+    if not isinstance(tools, list):
+        return {**body, **extras}
+    return {**body, "tools": [_without_strict(tool) for tool in tools], **extras}
+
+
+def _without_strict(tool: PlainJson) -> PlainJson:
+    if not isinstance(tool, dict):
+        return tool
+    function = tool.get("function")
+    if not isinstance(function, dict):
+        return tool
+    return {
+        **tool,
+        "function": {key: value for key, value in function.items() if key != "strict"},
+    }

--- a/litellm/translation/providers/xai/stream.py
+++ b/litellm/translation/providers/xai/stream.py
@@ -1,0 +1,224 @@
+"""xai (Grok) SSE ``chat.completion.chunk`` payloads -> IR stream events.
+
+The v1 decode is the httpx dict path: ``BaseModelResponseIterator`` strips
+``data:`` lines, ``XAIChatCompletionStreamingHandler.chunk_parser`` applies
+the xai rewrites, and the rebuilt ``ModelResponseStream`` flows through
+``CustomStreamWrapper``'s default openai branch. The xai deltas vs the
+openai parser (all verified in-process at HEAD):
+
+- the chunk_parser rebuild keeps ONLY id/created/model/choices/usage:
+  ``system_fingerprint`` and every top-level extra (``citations``) are
+  DROPPED — the opposite of the SDK path's verbatim extras passthrough.
+- a ``choices: []`` chunk carrying ``usage`` gets a dummy choice injected in
+  v1 purely so the wrapper machinery swallows it and re-synthesizes the
+  final usage chunk; v2 keeps the openai passthrough shape (``choices: []``
+  + the FOLDED usage) so the seam's synthesized-final-usage contract from
+  the openai port applies unchanged.
+- every usage-bearing chunk gets the reasoning fold + total normalize
+  (the dict variants of the response post-steps).
+- ``delta.reasoning`` is renamed to ``reasoning_content`` (the base
+  handler's rename) and native ``reasoning_content`` deltas are admitted —
+  real Grok reasoning traffic, not an unreachable shape.
+- a tool_call entry WITHOUT a ``type`` key gains ``type: "function"``
+  (litellm's ``ChatCompletionDeltaToolCall`` default fires on the dict
+  path; the SDK path yields None there, so the openai parser must not).
+"""
+
+from __future__ import annotations
+
+import json
+
+from expression import Error, Ok, Result
+
+from ...errors import BoundaryError, TranslationError
+from ...ir import JsonBlob, PlainJson, StreamEvent
+from .response import fold_reasoning_tokens, normalize_usage_totals
+
+_EventResult = Result[StreamEvent | None, TranslationError]
+
+_DELTA_KEYS = (
+    "content",
+    "function_call",
+    "refusal",
+    "role",
+    "tool_calls",
+    "reasoning",
+    "reasoning_content",
+)
+
+
+def parse_line(line: str) -> _EventResult:
+    stripped = line.strip()
+    if not stripped.startswith("data:"):
+        return Ok(None)
+    payload = stripped[len("data:") :].strip()
+    if payload == "[DONE]":
+        return Ok(StreamEvent.of_stop())
+    try:
+        event: PlainJson = json.loads(payload)
+    except ValueError:
+        return Error(_boundary(f"stream payload is not JSON: {payload[:120]!r}"))
+    return parse_event(event)
+
+
+def parse_event(event: PlainJson) -> _EventResult:
+    if not isinstance(event, dict):
+        return Error(_boundary("stream chunk is not an object"))
+    if event.get("error") is not None:
+        return Error(_boundary(f"provider stream error: {event.get('error')!r}"))
+    choices = event.get("choices")
+    if not isinstance(choices, list):
+        return Error(_boundary("stream chunk 'choices' is missing"))
+    if len(choices) > 1:
+        return Error(
+            TranslationError.of_unsupported(
+                "multiple stream choices (n > 1); unreachable for v2-sent requests"
+            )
+        )
+    raw_usage = event.get("usage")
+    usage: PlainJson = (
+        normalize_usage_totals(fold_reasoning_tokens(raw_usage))
+        if isinstance(raw_usage, dict)
+        else None
+    )
+    normalized_choices: list[PlainJson] = []
+    if len(choices) == 1:
+        normalized = _normalize_choice(choices[0])
+        if isinstance(normalized, TranslationError):
+            return Error(normalized)
+        normalized_choices = [normalized]
+    identifier = event.get("id")
+    chunk: dict[str, PlainJson] = {
+        # No extras passthrough and no system_fingerprint: the v1 chunk_parser
+        # rebuild keeps only id/created/model/choices/usage.
+        "id": identifier if isinstance(identifier, str) else None,
+        "system_fingerprint": None,
+        "choices": normalized_choices,
+        "usage": usage,
+    }
+    return Ok(StreamEvent.of_wire_chunk(JsonBlob(value=chunk)))
+
+
+def _boundary(reason: str) -> TranslationError:
+    from expression.collections import Block
+
+    return TranslationError.of_boundary(BoundaryError.of(Block.of_seq([reason])))
+
+
+def _string_or_none(value: PlainJson) -> PlainJson:
+    return value if isinstance(value, str) else None
+
+
+def _normalize_choice(choice: PlainJson) -> PlainJson | TranslationError:
+    if not isinstance(choice, dict):
+        return _boundary("stream choice is not an object")
+    extra_keys = set(choice.keys()) - {"index", "delta", "logprobs", "finish_reason"}
+    if extra_keys:
+        return TranslationError.of_unsupported(
+            f"stream choice keys {sorted(extra_keys)!r}; unreachable for v2-sent requests"
+        )
+    if choice.get("logprobs") is not None:
+        return TranslationError.of_unsupported(
+            "stream logprobs; unreachable for v2-sent requests"
+        )
+    finish = choice.get("finish_reason")
+    if finish is not None and not isinstance(finish, str):
+        return _boundary("stream finish_reason is not a string")
+    if finish == "function_call":
+        return TranslationError.of_unsupported(
+            "legacy function_call stream finish; the v2 surface cannot send 'functions'"
+        )
+    raw_delta = choice.get("delta")
+    delta = raw_delta if isinstance(raw_delta, dict) else {}
+    normalized_delta = _normalize_delta(delta)
+    if isinstance(normalized_delta, TranslationError):
+        return normalized_delta
+    if finish is not None and _delta_bears_content(normalized_delta):
+        return TranslationError.of_unsupported(
+            "finish chunk with a non-empty delta; v1's wrapper interleaves it"
+        )
+    index = choice.get("index")
+    return {
+        "index": index if isinstance(index, int) else 0,
+        "delta": normalized_delta,
+        "logprobs": None,
+        "finish_reason": finish,
+    }
+
+
+def _normalize_delta(
+    delta: dict[str, PlainJson],
+) -> dict[str, PlainJson] | TranslationError:
+    extra_keys = set(delta.keys()) - set(_DELTA_KEYS)
+    if extra_keys:
+        return TranslationError.of_unsupported(
+            f"stream delta keys {sorted(extra_keys)!r}; unreachable for v2-sent requests"
+        )
+    if delta.get("function_call") is not None:
+        return TranslationError.of_unsupported(
+            "legacy function_call stream delta; the v2 surface cannot send 'functions'"
+        )
+    tool_calls = delta.get("tool_calls")
+    normalized_calls: PlainJson = None
+    if tool_calls is not None:
+        if not isinstance(tool_calls, list):
+            return _boundary("stream delta 'tool_calls' is not an array")
+        gathered: list[PlainJson] = []
+        for call in tool_calls:
+            normalized = _normalize_tool_call(call)
+            if isinstance(normalized, TranslationError):
+                return normalized
+            gathered = [*gathered, normalized]
+        normalized_calls = gathered
+    # No "refusal" key and an explicit provider_specific_fields: None — the
+    # dict-path wrapper rebuild drops refusal and always stamps the null
+    # provider field on content-bearing deltas (verified in-process replay).
+    base: dict[str, PlainJson] = {
+        "content": _string_or_none(delta.get("content")),
+        "function_call": None,
+        "provider_specific_fields": None,
+        "role": _string_or_none(delta.get("role")),
+        "tool_calls": normalized_calls,
+    }
+    # the base handler renames delta.reasoning unconditionally
+    # (_map_reasoning_to_reasoning_content); the key is only present when the
+    # wire carried one, mirroring Delta's set-only serialization.
+    reasoning = (
+        delta.get("reasoning")
+        if "reasoning" in delta
+        else (delta.get("reasoning_content") if "reasoning_content" in delta else None)
+    )
+    if "reasoning" in delta or "reasoning_content" in delta:
+        return {**base, "reasoning_content": _string_or_none(reasoning)}
+    return base
+
+
+def _normalize_tool_call(call: PlainJson) -> PlainJson | TranslationError:
+    if not isinstance(call, dict):
+        return _boundary("stream tool_call is not an object")
+    extra_keys = set(call.keys()) - {"index", "id", "function", "type"}
+    if extra_keys:
+        return TranslationError.of_unsupported(
+            f"stream tool_call keys {sorted(extra_keys)!r}; unreachable for v2-sent requests"
+        )
+    raw_function = call.get("function")
+    function = raw_function if isinstance(raw_function, dict) else {}
+    index = call.get("index")
+    return {
+        "index": index if isinstance(index, int) else 0,
+        "id": _string_or_none(call.get("id")),
+        "function": {
+            "arguments": _string_or_none(function.get("arguments")),
+            "name": _string_or_none(function.get("name")),
+        },
+        # dict-path default: ChatCompletionDeltaToolCall fills "function" when
+        # the wire omits the key (the SDK path keeps None there)
+        "type": _string_or_none(call.get("type")) if "type" in call else "function",
+    }
+
+
+def _delta_bears_content(delta: dict[str, PlainJson]) -> bool:
+    content = delta.get("content")
+    return (isinstance(content, str) and len(content) > 0) or delta.get(
+        "tool_calls"
+    ) is not None

--- a/litellm/translation/providers/xai/stream.py
+++ b/litellm/translation/providers/xai/stream.py
@@ -15,7 +15,10 @@ openai parser (all verified in-process at HEAD):
   + the FOLDED usage) so the seam's synthesized-final-usage contract from
   the openai port applies unchanged.
 - every usage-bearing chunk gets the reasoning fold + total normalize
-  (the dict variants of the response post-steps).
+  (the dict variants of the response post-steps), but the folded usage is
+  ATTACHED only to the ``choices: []`` tail: v1's wrapper strips usage from
+  every emitted content/finish chunk and only the synthesized final chunk
+  carries it (verifier-grok F2).
 - ``delta.reasoning`` is renamed to ``reasoning_content`` (the base
   handler's rename) and native ``reasoning_content`` deltas are admitted —
   real Grok reasoning traffic, not an unreachable shape.
@@ -26,12 +29,12 @@ openai parser (all verified in-process at HEAD):
 
 from __future__ import annotations
 
-import json
-
 from expression import Error, Ok, Result
+from expression.collections import Block
 
 from ...errors import BoundaryError, TranslationError
 from ...ir import JsonBlob, PlainJson, StreamEvent
+from ..openai_compat.stream import make_parse_line
 from .response import fold_reasoning_tokens, normalize_usage_totals
 
 _EventResult = Result[StreamEvent | None, TranslationError]
@@ -45,20 +48,6 @@ _DELTA_KEYS = (
     "reasoning",
     "reasoning_content",
 )
-
-
-def parse_line(line: str) -> _EventResult:
-    stripped = line.strip()
-    if not stripped.startswith("data:"):
-        return Ok(None)
-    payload = stripped[len("data:") :].strip()
-    if payload == "[DONE]":
-        return Ok(StreamEvent.of_stop())
-    try:
-        event: PlainJson = json.loads(payload)
-    except ValueError:
-        return Error(_boundary(f"stream payload is not JSON: {payload[:120]!r}"))
-    return parse_event(event)
 
 
 def parse_event(event: PlainJson) -> _EventResult:
@@ -75,12 +64,9 @@ def parse_event(event: PlainJson) -> _EventResult:
                 "multiple stream choices (n > 1); unreachable for v2-sent requests"
             )
         )
-    raw_usage = event.get("usage")
-    usage: PlainJson = (
-        normalize_usage_totals(fold_reasoning_tokens(raw_usage))
-        if isinstance(raw_usage, dict)
-        else None
-    )
+    folded = _folded_usage(event.get("usage"))
+    if isinstance(folded, TranslationError):
+        return Error(folded)
     normalized_choices: list[PlainJson] = []
     if len(choices) == 1:
         normalized = _normalize_choice(choices[0])
@@ -90,18 +76,32 @@ def parse_event(event: PlainJson) -> _EventResult:
     identifier = event.get("id")
     chunk: dict[str, PlainJson] = {
         # No extras passthrough and no system_fingerprint: the v1 chunk_parser
-        # rebuild keeps only id/created/model/choices/usage.
+        # rebuild keeps only id/created/model/choices/usage. Usage rides ONLY
+        # the choices:[] tail: v1's wrapper strips usage from every emitted
+        # content/finish chunk and re-synthesizes the final usage chunk
+        # (verifier-grok F2; the fold above still runs so uncoercible values
+        # stay as loud as v1's chunk_parser).
         "id": identifier if isinstance(identifier, str) else None,
         "system_fingerprint": None,
         "choices": normalized_choices,
-        "usage": usage,
+        "usage": folded if len(normalized_choices) == 0 else None,
     }
     return Ok(StreamEvent.of_wire_chunk(JsonBlob(value=chunk)))
 
 
-def _boundary(reason: str) -> TranslationError:
-    from expression.collections import Block
+def _folded_usage(raw_usage: PlainJson) -> PlainJson | TranslationError:
+    """v1 folds + normalizes every usage-bearing chunk inside chunk_parser;
+    an uncoercible token value raises out of the iterator there, so the
+    coercion errors from the shared arithmetic stay loud here too."""
+    if not isinstance(raw_usage, dict):
+        return None
+    folded = fold_reasoning_tokens(raw_usage)
+    if isinstance(folded, TranslationError):
+        return folded
+    return normalize_usage_totals(folded)
 
+
+def _boundary(reason: str) -> TranslationError:
     return TranslationError.of_boundary(BoundaryError.of(Block.of_seq([reason])))
 
 
@@ -170,9 +170,12 @@ def _normalize_delta(
                 return normalized
             gathered = [*gathered, normalized]
         normalized_calls = gathered
-    # No "refusal" key and an explicit provider_specific_fields: None — the
-    # dict-path wrapper rebuild drops refusal and always stamps the null
-    # provider field on content-bearing deltas (verified in-process replay).
+    # provider_specific_fields: None always (the dict-path wrapper stamps the
+    # null provider field on content-bearing deltas); refusal and
+    # reasoning_content ride VERBATIM but only when the wire carried the key,
+    # mirroring Delta's set-only serialization — v1 FORWARDS a refusal that
+    # rides a role/content delta and swallows refusal-only deltas
+    # (verifier-grok F1 corrected the earlier drop claim; replay-verified).
     base: dict[str, PlainJson] = {
         "content": _string_or_none(delta.get("content")),
         "function_call": None,
@@ -180,9 +183,10 @@ def _normalize_delta(
         "role": _string_or_none(delta.get("role")),
         "tool_calls": normalized_calls,
     }
+    if "refusal" in delta:
+        base = {**base, "refusal": _string_or_none(delta.get("refusal"))}
     # the base handler renames delta.reasoning unconditionally
-    # (_map_reasoning_to_reasoning_content); the key is only present when the
-    # wire carried one, mirroring Delta's set-only serialization.
+    # (_map_reasoning_to_reasoning_content)
     reasoning = (
         delta.get("reasoning")
         if "reasoning" in delta
@@ -222,3 +226,6 @@ def _delta_bears_content(delta: dict[str, PlainJson]) -> bool:
     return (isinstance(content, str) and len(content) > 0) or delta.get(
         "tool_calls"
     ) is not None
+
+
+parse_line = make_parse_line(parse_event)

--- a/tests/test_litellm/translation/DIFFERENTIAL_REPORT.md
+++ b/tests/test_litellm/translation/DIFFERENTIAL_REPORT.md
@@ -1,4 +1,4 @@
-# Translation v2 differential report (anthropic + bedrock + openai + google + azure)
+# Translation v2 differential report (anthropic + bedrock + openai + google + azure + xai)
 
 v1 and v2 run over the same corpus; every row must be IDENTICAL (or an
 explained FALLBACK that v1 serves) for a provider's flag to turn on.
@@ -6,7 +6,7 @@ Bedrock and google rows additionally pin the characterization-corpus
 snapshot, so each row proves snapshot == v1-at-HEAD == v2. Regenerate with:
 `python -m tests.test_litellm.translation.generate_differential_report`
 
-- commit: ff5c320127
+- commit: 3fe015ef6c
 
 ## anthropic: request bodies (v1 map_openai_params + transform_request vs v2)
 
@@ -133,6 +133,75 @@ snapshot, so each row proves snapshot == v1-at-HEAD == v2. Regenerate with:
 - IDENTICAL: text_no_leading_role
 - IDENTICAL: tools
 - SEAM CONTRACT: usage tail (v2 passes the wire choices=[] usage chunk through; v1's wrapper synthesizes its final usage chunk from it, which is the streaming seam's envelope to reproduce)
+
+## xai: request bodies (characterization snapshot == v1-at-HEAD == v2, canonical JSON; v1 = get_optional_params('xai') + transform_request)
+
+- IDENTICAL: cache_control_stripped_grok4
+- IDENTICAL: image_base64_grok4
+- IDENTICAL: image_url_string_grok4
+- IDENTICAL: max_tokens_grok3mini
+- IDENTICAL: multiturn_stop_list_stream_grok3
+- IDENTICAL: nonuser_name_stripped_grok4
+- IDENTICAL: parallel_tool_calls_false_grok4
+- IDENTICAL: reasoning_effort_grok3mini
+- IDENTICAL: reasoning_effort_grok_code_fast
+- IDENTICAL: response_format_json_object_grok4
+- IDENTICAL: response_format_json_schema_strict_kept_grok4
+- IDENTICAL: stop_list_grok2
+- IDENTICAL: system_and_sampling_grok4
+- IDENTICAL: temperature_int_stays_int_grok4
+- IDENTICAL: text_grok4
+- IDENTICAL: tool_call_roundtrip_compact_grok4
+- IDENTICAL: tool_choice_required_grok4
+- IDENTICAL: tool_choice_specific_grok4
+- IDENTICAL: tools_auto_grok4
+- IDENTICAL: tools_strict_stripped_grok4
+- IDENTICAL: user_param_grok4
+- FALLBACK (v1 raises UnsupportedParamsError): frequency_penalty_on_grok4 (frequency_penalty)
+- FALLBACK (v1 raises UnsupportedParamsError): max_completion_tokens_any_grok (max_completion_tokens)
+- FALLBACK (v1 raises UnsupportedParamsError): max_completion_tokens_grok3mini (max_completion_tokens)
+- FALLBACK (v1 raises UnsupportedParamsError): reasoning_effort_on_non_reasoning_grok4 (reasoning_effort on non-reasoning xai model)
+- FALLBACK (v1 raises UnsupportedParamsError): stop_on_grok3mini (stop on grok-3-mini)
+- FALLBACK (v1 raises UnsupportedParamsError): stop_on_grok4 (stop on grok-4-0709)
+- FALLBACK (v1 raises UnsupportedParamsError): stop_on_grok_code_fast (stop on grok-code-fast-1)
+- FALLBACK (v1 serves it): both_max_tokens_keys (both max_tokens and max_completion_tokens)
+- FALLBACK (v1 serves it): consecutive_user_messages (consecutive user messages)
+- FALLBACK (v1 serves it): empty_tools_list (empty tools list)
+- FALLBACK (v1 serves it): explicit_stream_false_reaches_wire (explicit stream: false)
+- FALLBACK (v1 serves it): frequency_penalty_supported_family_outside_ir (frequency_penalty)
+- FALLBACK (v1 serves it): image_detail_key (image_url detail/format)
+- FALLBACK (v1 serves it): logprobs_outside_ir (logprobs)
+- FALLBACK (v1 serves it): nested_tool_strict_below_function (nested 'strict' key)
+- FALLBACK (v1 serves it): presence_penalty_outside_ir (presence_penalty)
+- FALLBACK (v1 serves it): seed_outside_ir (seed)
+- FALLBACK (v1 serves it): stream_options_outside_ir (stream_options)
+- FALLBACK (v1 serves it): string_form_stop_supported_family (string-form stop)
+- FALLBACK (v1 serves it): top_k_not_an_xai_param (top_k)
+- FALLBACK (v1 serves it): use_xai_oauth_pkce_flow (PKCE)
+- FALLBACK (v1 serves it): user_message_name_forwarded_by_v1 (message name field)
+- FALLBACK (v1 serves it): web_search_options_responses_bridge (Responses-API bridge)
+
+## xai: responses (snapshot == v1 XAIChatConfig.transform_response == v2; the LIVE httpx-path normalizer incl. the usage post-steps)
+
+- IDENTICAL: cached_tokens_usage_passthrough
+- IDENTICAL: finish_empty_string_with_tool_calls
+- IDENTICAL: finish_stop_with_tool_calls_rewrites
+- IDENTICAL: reasoning_tokens_already_folded_idempotent
+- IDENTICAL: reasoning_tokens_folded
+- IDENTICAL: text_basic
+- IDENTICAL: total_tokens_normalized_up
+- IDENTICAL: websearch_sources_and_citations
+
+## xai: streams (snapshot == v1 line-seam replay through XAIChatCompletionStreamingHandler + CustomStreamWrapper('xai') == v2 xai dialect)
+
+- IDENTICAL: citations_dropped_by_the_dict_path
+- IDENTICAL: empty_keepalive_swallowed
+- IDENTICAL: reasoning_content
+- IDENTICAL: reasoning_renamed
+- IDENTICAL: text
+- IDENTICAL: text_no_leading_role
+- IDENTICAL: tools_typeless_continuation
+- SEAM CONTRACT: usage_tail_include_usage (v1's chunk_parser injects a dummy choice so the wrapper swallows the tail and synthesizes the final usage chunk; v2 passes the wire choices=[] chunk through with the FOLDED usage for the streaming seam to synthesize from)
 
 ## azure: request bodies (v1 api-version-aware map_openai_params + transform_request vs v2)
 

--- a/tests/test_litellm/translation/DIFFERENTIAL_REPORT.md
+++ b/tests/test_litellm/translation/DIFFERENTIAL_REPORT.md
@@ -6,7 +6,7 @@ Bedrock and google rows additionally pin the characterization-corpus
 snapshot, so each row proves snapshot == v1-at-HEAD == v2. Regenerate with:
 `python -m tests.test_litellm.translation.generate_differential_report`
 
-- commit: 3fe015ef6c
+- commit: ae4643ba8a
 
 ## anthropic: request bodies (v1 map_openai_params + transform_request vs v2)
 
@@ -186,6 +186,7 @@ snapshot, so each row proves snapshot == v1-at-HEAD == v2. Regenerate with:
 - IDENTICAL: cached_tokens_usage_passthrough
 - IDENTICAL: finish_empty_string_with_tool_calls
 - IDENTICAL: finish_stop_with_tool_calls_rewrites
+- IDENTICAL: numeric_string_usage_coerced
 - IDENTICAL: reasoning_tokens_already_folded_idempotent
 - IDENTICAL: reasoning_tokens_folded
 - IDENTICAL: text_basic
@@ -198,10 +199,12 @@ snapshot, so each row proves snapshot == v1-at-HEAD == v2. Regenerate with:
 - IDENTICAL: empty_keepalive_swallowed
 - IDENTICAL: reasoning_content
 - IDENTICAL: reasoning_renamed
+- IDENTICAL: refusal_rides_content_deltas
 - IDENTICAL: text
 - IDENTICAL: text_no_leading_role
 - IDENTICAL: tools_typeless_continuation
 - SEAM CONTRACT: usage_tail_include_usage (v1's chunk_parser injects a dummy choice so the wrapper swallows the tail and synthesizes the final usage chunk; v2 passes the wire choices=[] chunk through with the FOLDED usage for the streaming seam to synthesize from)
+- IDENTICAL: usage_withheld_on_content_chunks
 
 ## azure: request bodies (v1 api-version-aware map_openai_params + transform_request vs v2)
 

--- a/tests/test_litellm/translation/_xai_corpus.py
+++ b/tests/test_litellm/translation/_xai_corpus.py
@@ -1,0 +1,180 @@
+"""Shared plumbing for the xai (Grok) differential gates.
+
+The reference corpus under ``characterization_xai/`` is GENERATED, not
+vendored: the characterization branch
+(mateo/translation-characterization-providers) carries zero xai fixtures, so
+every snapshot here pins v1 IN-PROCESS AT HEAD (the primary reference per
+the differential rule) invoked exactly the way the xai httpx handler runs
+(provenance documented in characterization_xai/README.md; regenerate with
+``python -m tests.test_litellm.translation.generate_xai_snapshots``).
+
+The v1 invokers mirror main.py's dedicated xai elif (main.py:2289 ->
+``base_llm_http_handler.completion``):
+
+- requests: ``get_optional_params(custom_llm_provider="xai")`` (the
+  RAISE-unless-drop_params gate over XAIChatConfig's supported list) with
+  completion()'s ``stream=None`` default, then the handler's ``extra_body``
+  pop (hh:398-399; the injected ``{}`` merges nothing onto the wire), then
+  ``XAIChatConfig.transform_request``.
+- responses: ``XAIChatConfig.transform_response`` over an ``httpx.Response``
+  — LIVE on the httpx path (the inverse of the openai SDK route), including
+  the websearch/fold/normalize usage post-steps.
+- streams: SSE ``data:`` lines through ``XAIChatCompletionStreamingHandler``
+  + ``CustomStreamWrapper(custom_llm_provider="xai")`` (the line seam the
+  dossier prescribes: the chunk_parser rewrites are xai BEHAVIOR and sit
+  below the parsed-chunk seam).
+"""
+
+import copy
+import json
+import pathlib
+import time
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+import litellm
+from litellm.litellm_core_utils.litellm_logging import Logging
+from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
+from litellm.llms.xai.chat.transformation import (
+    XAIChatCompletionStreamingHandler,
+    XAIChatConfig,
+)
+from litellm.types.utils import ModelResponse
+from litellm.utils import get_optional_params
+
+CORPUS_DIR = pathlib.Path(__file__).parent / "characterization_xai"
+CASES_DIR = CORPUS_DIR / "cases"
+FIXTURES_DIR = CORPUS_DIR / "fixtures"
+SNAPSHOTS_DIR = CORPUS_DIR / "snapshots"
+
+STREAM_MODEL = "grok-3-mini"
+
+FROZEN_TIME = 1718064000.0  # matches the translation conftest frozen_ambient
+
+
+def load_json(path: pathlib.Path) -> Any:
+    with open(path) as f:
+        return json.load(f)
+
+
+def corpus(kind: str) -> Dict[str, Any]:
+    directory = CASES_DIR if kind == "cases" else FIXTURES_DIR / kind
+    return {path.stem: load_json(path) for path in sorted(directory.glob("*.json"))}
+
+
+def jsonable(obj: Any) -> Any:
+    if hasattr(obj, "model_dump"):
+        return jsonable(obj.model_dump())
+    if isinstance(obj, dict):
+        return {str(k): jsonable(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [jsonable(v) for v in obj]
+    if isinstance(obj, (str, int, float, bool)) or obj is None:
+        return obj
+    return repr(obj)
+
+
+def canonical_json(obj: Any) -> str:
+    return json.dumps(jsonable(obj), indent=2, sort_keys=True) + "\n"
+
+
+def run_v1_request_transform(case: Dict[str, Any]) -> Dict[str, Any]:
+    """May RAISE UnsupportedParamsError: that IS the pinned v1 behavior for
+    the R2 gate rows (the differential asserts the raise, never a remap)."""
+    request = copy.deepcopy(case)
+    model = request.pop("model")
+    messages = request.pop("messages")
+    optional_params = get_optional_params(
+        model=model,
+        custom_llm_provider="xai",
+        messages=copy.deepcopy(messages),
+        stream=request.pop("stream", None),
+        **request,
+    )
+    optional_params.pop("extra_body", None)
+    return XAIChatConfig().transform_request(
+        model=model,
+        messages=messages,
+        optional_params=optional_params,
+        litellm_params={},
+        headers={},
+    )
+
+
+def make_logging(model: str, messages: List[dict], stream: bool = False) -> Logging:
+    logging_obj = Logging(
+        model=model,
+        messages=messages,
+        stream=stream,
+        call_type="completion",
+        start_time=time.time(),
+        litellm_call_id="diff-xai-call-id",
+        function_id="diff-xai-function-id",
+    )
+    logging_obj.update_environment_variables(
+        model=model, user=None, optional_params={}, litellm_params={}
+    )
+    return logging_obj
+
+
+def run_v1_response_transform(
+    provider_response: Dict[str, Any], model: str
+) -> ModelResponse:
+    messages = [{"role": "user", "content": "hi"}]
+    raw_response = httpx.Response(
+        status_code=200,
+        json=copy.deepcopy(provider_response),
+        request=httpx.Request("POST", "https://api.x.ai/v1/chat/completions"),
+    )
+    return XAIChatConfig().transform_response(
+        model=model,
+        raw_response=raw_response,
+        model_response=ModelResponse(),
+        logging_obj=make_logging(model, messages),
+        request_data={},
+        messages=messages,
+        optional_params={},
+        litellm_params={},
+        encoding=litellm.encoding,
+        api_key=None,
+        json_mode=None,
+    )
+
+
+def replay_xai_sse_lines(
+    events: List[dict], stream_options: Optional[dict] = None
+) -> List[dict]:
+    lines = [f"data: {json.dumps(event)}" for event in copy.deepcopy(events)]
+    lines.append("data: [DONE]")
+    handler = XAIChatCompletionStreamingHandler(
+        streaming_response=iter(lines), sync_stream=True
+    )
+    wrapper = CustomStreamWrapper(
+        completion_stream=handler,
+        model=STREAM_MODEL,
+        custom_llm_provider="xai",
+        logging_obj=make_logging(
+            STREAM_MODEL, [{"role": "user", "content": "stream"}], stream=True
+        ),
+        stream_options=stream_options,
+    )
+    return [chunk.model_dump() for chunk in wrapper]
+
+
+__all__ = (
+    "CASES_DIR",
+    "CORPUS_DIR",
+    "FIXTURES_DIR",
+    "FROZEN_TIME",
+    "SNAPSHOTS_DIR",
+    "STREAM_MODEL",
+    "canonical_json",
+    "corpus",
+    "jsonable",
+    "load_json",
+    "make_logging",
+    "replay_xai_sse_lines",
+    "run_v1_request_transform",
+    "run_v1_response_transform",
+)

--- a/tests/test_litellm/translation/characterization_xai/README.md
+++ b/tests/test_litellm/translation/characterization_xai/README.md
@@ -1,0 +1,28 @@
+# characterization_xai — Grok (xai) corpus
+
+Provenance: GENERATED from v1 in-process at HEAD, not vendored. The
+characterization branch (mateo/translation-characterization-providers) has
+zero xai fixtures and no recorded xai vendor traffic exists in the repo, so
+every snapshot pins v1-as-executed (the primary reference under the
+differential rule in 05-provider-expansion.md). The wire shapes in
+`fixtures/` are hand-authored to the documented xAI API shapes plus the
+quirks researcher-3 verified in-process (finish_reason "", reasoning token
+accounting, num_sources_used, the `choices: []` usage tail).
+
+- `cases/` — OpenAI-format chat requests (request seam input). Models cover
+  grok-2-1212 / grok-3 / grok-3-mini / grok-4-0709 / grok-code-fast-1, the
+  serve side of all three per-model gates (stop, frequency_penalty,
+  reasoning_effort).
+- `fixtures/responses/` — provider response bodies `{model, body}`.
+- `fixtures/streams/` — SSE chunk payload lists `{stream_options, events}`.
+- `snapshots/` — v1 output at the pinned seams (canonical JSON: sorted keys,
+  2-space indent, trailing newline):
+  - `requests/`: `get_optional_params("xai")` -> extra_body pop ->
+    `XAIChatConfig.transform_request` (the httpx-handler call order)
+  - `responses/`: `XAIChatConfig.transform_response().model_dump()` (LIVE on
+    the httpx path; includes the xai usage post-steps)
+  - `streams/`: SSE data-lines -> `XAIChatCompletionStreamingHandler` ->
+    `CustomStreamWrapper("xai")` chunk dumps, ambient frozen at 1718064000
+
+Regenerate (a reviewed snapshot diff, never silent):
+`LITELLM_LOCAL_MODEL_COST_MAP=True python -m tests.test_litellm.translation.generate_xai_snapshots`

--- a/tests/test_litellm/translation/characterization_xai/cases/cache_control_stripped_grok4.json
+++ b/tests/test_litellm/translation/characterization_xai/cases/cache_control_stripped_grok4.json
@@ -1,0 +1,36 @@
+{
+  "messages": [
+    {
+      "content": [
+        {
+          "cache_control": {
+            "type": "ephemeral"
+          },
+          "text": "cached context",
+          "type": "text"
+        },
+        {
+          "text": "question",
+          "type": "text"
+        }
+      ],
+      "role": "user"
+    }
+  ],
+  "model": "grok-4-0709",
+  "tools": [
+    {
+      "function": {
+        "cache_control": {
+          "type": "ephemeral"
+        },
+        "name": "lookup",
+        "parameters": {
+          "properties": {},
+          "type": "object"
+        }
+      },
+      "type": "function"
+    }
+  ]
+}

--- a/tests/test_litellm/translation/characterization_xai/cases/image_base64_grok4.json
+++ b/tests/test_litellm/translation/characterization_xai/cases/image_base64_grok4.json
@@ -1,0 +1,20 @@
+{
+  "messages": [
+    {
+      "content": [
+        {
+          "text": "and this",
+          "type": "text"
+        },
+        {
+          "image_url": {
+            "url": "data:image/png;base64,iVBORw0KGgo="
+          },
+          "type": "image_url"
+        }
+      ],
+      "role": "user"
+    }
+  ],
+  "model": "grok-4-0709"
+}

--- a/tests/test_litellm/translation/characterization_xai/cases/image_url_string_grok4.json
+++ b/tests/test_litellm/translation/characterization_xai/cases/image_url_string_grok4.json
@@ -1,0 +1,18 @@
+{
+  "messages": [
+    {
+      "content": [
+        {
+          "text": "what is this",
+          "type": "text"
+        },
+        {
+          "image_url": "https://e.test/a.png",
+          "type": "image_url"
+        }
+      ],
+      "role": "user"
+    }
+  ],
+  "model": "grok-4-0709"
+}

--- a/tests/test_litellm/translation/characterization_xai/cases/max_tokens_grok3mini.json
+++ b/tests/test_litellm/translation/characterization_xai/cases/max_tokens_grok3mini.json
@@ -1,0 +1,10 @@
+{
+  "max_tokens": 64,
+  "messages": [
+    {
+      "content": "hi",
+      "role": "user"
+    }
+  ],
+  "model": "grok-3-mini"
+}

--- a/tests/test_litellm/translation/characterization_xai/cases/multiturn_stop_list_stream_grok3.json
+++ b/tests/test_litellm/translation/characterization_xai/cases/multiturn_stop_list_stream_grok3.json
@@ -1,0 +1,23 @@
+{
+  "max_tokens": 64,
+  "messages": [
+    {
+      "content": "Hello",
+      "role": "user"
+    },
+    {
+      "content": "Hi there",
+      "role": "assistant"
+    },
+    {
+      "content": "How are you?",
+      "role": "user"
+    }
+  ],
+  "model": "grok-3",
+  "stop": [
+    "END",
+    "STOP"
+  ],
+  "stream": true
+}

--- a/tests/test_litellm/translation/characterization_xai/cases/nonuser_name_stripped_grok4.json
+++ b/tests/test_litellm/translation/characterization_xai/cases/nonuser_name_stripped_grok4.json
@@ -1,0 +1,23 @@
+{
+  "messages": [
+    {
+      "content": "s",
+      "name": "sys",
+      "role": "system"
+    },
+    {
+      "content": "q",
+      "role": "user"
+    },
+    {
+      "content": "a",
+      "name": "bot",
+      "role": "assistant"
+    },
+    {
+      "content": "q2",
+      "role": "user"
+    }
+  ],
+  "model": "grok-4-0709"
+}

--- a/tests/test_litellm/translation/characterization_xai/cases/parallel_tool_calls_false_grok4.json
+++ b/tests/test_litellm/translation/characterization_xai/cases/parallel_tool_calls_false_grok4.json
@@ -1,0 +1,30 @@
+{
+  "messages": [
+    {
+      "content": "Weather in Paris and Rome?",
+      "role": "user"
+    }
+  ],
+  "model": "grok-4-0709",
+  "parallel_tool_calls": false,
+  "tools": [
+    {
+      "function": {
+        "description": "Get weather",
+        "name": "get_weather",
+        "parameters": {
+          "properties": {
+            "city": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "city"
+          ],
+          "type": "object"
+        }
+      },
+      "type": "function"
+    }
+  ]
+}

--- a/tests/test_litellm/translation/characterization_xai/cases/reasoning_effort_grok3mini.json
+++ b/tests/test_litellm/translation/characterization_xai/cases/reasoning_effort_grok3mini.json
@@ -1,0 +1,10 @@
+{
+  "messages": [
+    {
+      "content": "think",
+      "role": "user"
+    }
+  ],
+  "model": "grok-3-mini",
+  "reasoning_effort": "high"
+}

--- a/tests/test_litellm/translation/characterization_xai/cases/reasoning_effort_grok_code_fast.json
+++ b/tests/test_litellm/translation/characterization_xai/cases/reasoning_effort_grok_code_fast.json
@@ -1,0 +1,10 @@
+{
+  "messages": [
+    {
+      "content": "code",
+      "role": "user"
+    }
+  ],
+  "model": "grok-code-fast-1",
+  "reasoning_effort": "low"
+}

--- a/tests/test_litellm/translation/characterization_xai/cases/response_format_json_object_grok4.json
+++ b/tests/test_litellm/translation/characterization_xai/cases/response_format_json_object_grok4.json
@@ -1,0 +1,12 @@
+{
+  "messages": [
+    {
+      "content": "json please",
+      "role": "user"
+    }
+  ],
+  "model": "grok-4-0709",
+  "response_format": {
+    "type": "json_object"
+  }
+}

--- a/tests/test_litellm/translation/characterization_xai/cases/response_format_json_schema_strict_kept_grok4.json
+++ b/tests/test_litellm/translation/characterization_xai/cases/response_format_json_schema_strict_kept_grok4.json
@@ -1,0 +1,28 @@
+{
+  "messages": [
+    {
+      "content": "capital of France?",
+      "role": "user"
+    }
+  ],
+  "model": "grok-4-0709",
+  "response_format": {
+    "json_schema": {
+      "name": "answer",
+      "schema": {
+        "additionalProperties": false,
+        "properties": {
+          "capital": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "capital"
+        ],
+        "type": "object"
+      },
+      "strict": true
+    },
+    "type": "json_schema"
+  }
+}

--- a/tests/test_litellm/translation/characterization_xai/cases/stop_list_grok2.json
+++ b/tests/test_litellm/translation/characterization_xai/cases/stop_list_grok2.json
@@ -1,0 +1,12 @@
+{
+  "messages": [
+    {
+      "content": "x",
+      "role": "user"
+    }
+  ],
+  "model": "grok-2-1212",
+  "stop": [
+    "END"
+  ]
+}

--- a/tests/test_litellm/translation/characterization_xai/cases/system_and_sampling_grok4.json
+++ b/tests/test_litellm/translation/characterization_xai/cases/system_and_sampling_grok4.json
@@ -1,0 +1,16 @@
+{
+  "max_tokens": 50,
+  "messages": [
+    {
+      "content": "You are helpful",
+      "role": "system"
+    },
+    {
+      "content": "Hi",
+      "role": "user"
+    }
+  ],
+  "model": "grok-4-0709",
+  "temperature": 0.5,
+  "top_p": 0.9
+}

--- a/tests/test_litellm/translation/characterization_xai/cases/temperature_int_stays_int_grok4.json
+++ b/tests/test_litellm/translation/characterization_xai/cases/temperature_int_stays_int_grok4.json
@@ -1,0 +1,10 @@
+{
+  "messages": [
+    {
+      "content": "hi",
+      "role": "user"
+    }
+  ],
+  "model": "grok-4-0709",
+  "temperature": 1
+}

--- a/tests/test_litellm/translation/characterization_xai/cases/text_grok4.json
+++ b/tests/test_litellm/translation/characterization_xai/cases/text_grok4.json
@@ -1,0 +1,9 @@
+{
+  "messages": [
+    {
+      "content": "Hello, world",
+      "role": "user"
+    }
+  ],
+  "model": "grok-4-0709"
+}

--- a/tests/test_litellm/translation/characterization_xai/cases/tool_call_roundtrip_compact_grok4.json
+++ b/tests/test_litellm/translation/characterization_xai/cases/tool_call_roundtrip_compact_grok4.json
@@ -1,0 +1,48 @@
+{
+  "messages": [
+    {
+      "content": "w?",
+      "role": "user"
+    },
+    {
+      "content": null,
+      "role": "assistant",
+      "tool_calls": [
+        {
+          "function": {
+            "arguments": "{\"city\":\"Paris\"}",
+            "name": "get_weather"
+          },
+          "id": "call_1",
+          "type": "function"
+        }
+      ]
+    },
+    {
+      "content": "Sunny, 20C",
+      "role": "tool",
+      "tool_call_id": "call_1"
+    }
+  ],
+  "model": "grok-4-0709",
+  "tools": [
+    {
+      "function": {
+        "description": "Get weather",
+        "name": "get_weather",
+        "parameters": {
+          "properties": {
+            "city": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "city"
+          ],
+          "type": "object"
+        }
+      },
+      "type": "function"
+    }
+  ]
+}

--- a/tests/test_litellm/translation/characterization_xai/cases/tool_choice_required_grok4.json
+++ b/tests/test_litellm/translation/characterization_xai/cases/tool_choice_required_grok4.json
@@ -1,0 +1,30 @@
+{
+  "messages": [
+    {
+      "content": "Weather in Paris?",
+      "role": "user"
+    }
+  ],
+  "model": "grok-4-0709",
+  "tool_choice": "required",
+  "tools": [
+    {
+      "function": {
+        "description": "Get weather",
+        "name": "get_weather",
+        "parameters": {
+          "properties": {
+            "city": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "city"
+          ],
+          "type": "object"
+        }
+      },
+      "type": "function"
+    }
+  ]
+}

--- a/tests/test_litellm/translation/characterization_xai/cases/tool_choice_specific_grok4.json
+++ b/tests/test_litellm/translation/characterization_xai/cases/tool_choice_specific_grok4.json
@@ -1,0 +1,35 @@
+{
+  "messages": [
+    {
+      "content": "Weather in Paris?",
+      "role": "user"
+    }
+  ],
+  "model": "grok-4-0709",
+  "tool_choice": {
+    "function": {
+      "name": "get_weather"
+    },
+    "type": "function"
+  },
+  "tools": [
+    {
+      "function": {
+        "description": "Get weather",
+        "name": "get_weather",
+        "parameters": {
+          "properties": {
+            "city": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "city"
+          ],
+          "type": "object"
+        }
+      },
+      "type": "function"
+    }
+  ]
+}

--- a/tests/test_litellm/translation/characterization_xai/cases/tools_auto_grok4.json
+++ b/tests/test_litellm/translation/characterization_xai/cases/tools_auto_grok4.json
@@ -1,0 +1,30 @@
+{
+  "messages": [
+    {
+      "content": "Weather in Paris?",
+      "role": "user"
+    }
+  ],
+  "model": "grok-4-0709",
+  "tool_choice": "auto",
+  "tools": [
+    {
+      "function": {
+        "description": "Get weather",
+        "name": "get_weather",
+        "parameters": {
+          "properties": {
+            "city": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "city"
+          ],
+          "type": "object"
+        }
+      },
+      "type": "function"
+    }
+  ]
+}

--- a/tests/test_litellm/translation/characterization_xai/cases/tools_strict_stripped_grok4.json
+++ b/tests/test_litellm/translation/characterization_xai/cases/tools_strict_stripped_grok4.json
@@ -1,0 +1,30 @@
+{
+  "messages": [
+    {
+      "content": "report this",
+      "role": "user"
+    }
+  ],
+  "model": "grok-4-0709",
+  "tools": [
+    {
+      "function": {
+        "name": "report",
+        "parameters": {
+          "additionalProperties": false,
+          "properties": {
+            "body": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "body"
+          ],
+          "type": "object"
+        },
+        "strict": true
+      },
+      "type": "function"
+    }
+  ]
+}

--- a/tests/test_litellm/translation/characterization_xai/cases/user_param_grok4.json
+++ b/tests/test_litellm/translation/characterization_xai/cases/user_param_grok4.json
@@ -1,0 +1,10 @@
+{
+  "messages": [
+    {
+      "content": "x",
+      "role": "user"
+    }
+  ],
+  "model": "grok-4-0709",
+  "user": "u-1"
+}

--- a/tests/test_litellm/translation/characterization_xai/fixtures/responses/cached_tokens_usage_passthrough.json
+++ b/tests/test_litellm/translation/characterization_xai/fixtures/responses/cached_tokens_usage_passthrough.json
@@ -1,0 +1,29 @@
+{
+  "body": {
+    "choices": [
+      {
+        "finish_reason": "length",
+        "index": 0,
+        "logprobs": null,
+        "message": {
+          "content": "partial",
+          "role": "assistant"
+        }
+      }
+    ],
+    "created": 1718000007,
+    "id": "resp-c1",
+    "model": "grok-4-0709",
+    "object": "chat.completion",
+    "usage": {
+      "completion_tokens": 100,
+      "prompt_tokens": 1000,
+      "prompt_tokens_details": {
+        "audio_tokens": 0,
+        "cached_tokens": 512
+      },
+      "total_tokens": 1100
+    }
+  },
+  "model": "grok-4-0709"
+}

--- a/tests/test_litellm/translation/characterization_xai/fixtures/responses/finish_empty_string_with_tool_calls.json
+++ b/tests/test_litellm/translation/characterization_xai/fixtures/responses/finish_empty_string_with_tool_calls.json
@@ -1,0 +1,35 @@
+{
+  "body": {
+    "choices": [
+      {
+        "finish_reason": "",
+        "index": 0,
+        "logprobs": null,
+        "message": {
+          "content": null,
+          "role": "assistant",
+          "tool_calls": [
+            {
+              "function": {
+                "arguments": "{\"city\":\"Paris\"}",
+                "name": "get_weather"
+              },
+              "id": "call_1",
+              "type": "function"
+            }
+          ]
+        }
+      }
+    ],
+    "created": 1718000001,
+    "id": "resp-r1",
+    "model": "grok-4-0709",
+    "object": "chat.completion",
+    "usage": {
+      "completion_tokens": 6,
+      "prompt_tokens": 12,
+      "total_tokens": 18
+    }
+  },
+  "model": "grok-4-0709"
+}

--- a/tests/test_litellm/translation/characterization_xai/fixtures/responses/finish_stop_with_tool_calls_rewrites.json
+++ b/tests/test_litellm/translation/characterization_xai/fixtures/responses/finish_stop_with_tool_calls_rewrites.json
@@ -1,0 +1,35 @@
+{
+  "body": {
+    "choices": [
+      {
+        "finish_reason": "stop",
+        "index": 0,
+        "logprobs": null,
+        "message": {
+          "content": null,
+          "role": "assistant",
+          "tool_calls": [
+            {
+              "function": {
+                "arguments": "{\"city\":\"Rome\"}",
+                "name": "get_weather"
+              },
+              "id": "call_2",
+              "type": "function"
+            }
+          ]
+        }
+      }
+    ],
+    "created": 1718000002,
+    "id": "resp-r2",
+    "model": "grok-4-0709",
+    "object": "chat.completion",
+    "usage": {
+      "completion_tokens": 6,
+      "prompt_tokens": 12,
+      "total_tokens": 18
+    }
+  },
+  "model": "grok-4-0709"
+}

--- a/tests/test_litellm/translation/characterization_xai/fixtures/responses/numeric_string_usage_coerced.json
+++ b/tests/test_litellm/translation/characterization_xai/fixtures/responses/numeric_string_usage_coerced.json
@@ -1,0 +1,28 @@
+{
+  "body": {
+    "choices": [
+      {
+        "finish_reason": "stop",
+        "index": 0,
+        "logprobs": null,
+        "message": {
+          "content": "a",
+          "role": "assistant"
+        }
+      }
+    ],
+    "created": 1718000010,
+    "id": "resp-s1",
+    "model": "grok-3-mini",
+    "object": "chat.completion",
+    "usage": {
+      "completion_tokens": "5",
+      "completion_tokens_details": {
+        "reasoning_tokens": "7"
+      },
+      "prompt_tokens": "10",
+      "total_tokens": "22"
+    }
+  },
+  "model": "grok-3-mini"
+}

--- a/tests/test_litellm/translation/characterization_xai/fixtures/responses/reasoning_tokens_already_folded_idempotent.json
+++ b/tests/test_litellm/translation/characterization_xai/fixtures/responses/reasoning_tokens_already_folded_idempotent.json
@@ -1,0 +1,28 @@
+{
+  "body": {
+    "choices": [
+      {
+        "finish_reason": "stop",
+        "index": 0,
+        "logprobs": null,
+        "message": {
+          "content": "a",
+          "role": "assistant"
+        }
+      }
+    ],
+    "created": 1718000004,
+    "id": "resp-f2",
+    "model": "grok-3-mini",
+    "object": "chat.completion",
+    "usage": {
+      "completion_tokens": 12,
+      "completion_tokens_details": {
+        "reasoning_tokens": 7
+      },
+      "prompt_tokens": 10,
+      "total_tokens": 22
+    }
+  },
+  "model": "grok-3-mini"
+}

--- a/tests/test_litellm/translation/characterization_xai/fixtures/responses/reasoning_tokens_folded.json
+++ b/tests/test_litellm/translation/characterization_xai/fixtures/responses/reasoning_tokens_folded.json
@@ -1,0 +1,29 @@
+{
+  "body": {
+    "choices": [
+      {
+        "finish_reason": "stop",
+        "index": 0,
+        "logprobs": null,
+        "message": {
+          "content": "answer",
+          "reasoning_content": "thought hard",
+          "role": "assistant"
+        }
+      }
+    ],
+    "created": 1718000003,
+    "id": "resp-f1",
+    "model": "grok-3-mini",
+    "object": "chat.completion",
+    "usage": {
+      "completion_tokens": 5,
+      "completion_tokens_details": {
+        "reasoning_tokens": 7
+      },
+      "prompt_tokens": 10,
+      "total_tokens": 22
+    }
+  },
+  "model": "grok-3-mini"
+}

--- a/tests/test_litellm/translation/characterization_xai/fixtures/responses/text_basic.json
+++ b/tests/test_litellm/translation/characterization_xai/fixtures/responses/text_basic.json
@@ -1,0 +1,26 @@
+{
+  "body": {
+    "choices": [
+      {
+        "finish_reason": "stop",
+        "index": 0,
+        "logprobs": null,
+        "message": {
+          "content": "Hello there.",
+          "role": "assistant"
+        }
+      }
+    ],
+    "created": 1718000000,
+    "id": "resp-t1",
+    "model": "grok-4-0709",
+    "object": "chat.completion",
+    "system_fingerprint": "fp_xai_1",
+    "usage": {
+      "completion_tokens": 6,
+      "prompt_tokens": 12,
+      "total_tokens": 18
+    }
+  },
+  "model": "grok-4-0709"
+}

--- a/tests/test_litellm/translation/characterization_xai/fixtures/responses/total_tokens_normalized_up.json
+++ b/tests/test_litellm/translation/characterization_xai/fixtures/responses/total_tokens_normalized_up.json
@@ -1,0 +1,25 @@
+{
+  "body": {
+    "choices": [
+      {
+        "finish_reason": "stop",
+        "index": 0,
+        "logprobs": null,
+        "message": {
+          "content": "a",
+          "role": "assistant"
+        }
+      }
+    ],
+    "created": 1718000006,
+    "id": "resp-n1",
+    "model": "grok-4-0709",
+    "object": "chat.completion",
+    "usage": {
+      "completion_tokens": 9,
+      "prompt_tokens": 30,
+      "total_tokens": 5
+    }
+  },
+  "model": "grok-4-0709"
+}

--- a/tests/test_litellm/translation/characterization_xai/fixtures/responses/websearch_sources_and_citations.json
+++ b/tests/test_litellm/translation/characterization_xai/fixtures/responses/websearch_sources_and_citations.json
@@ -1,0 +1,30 @@
+{
+  "body": {
+    "choices": [
+      {
+        "finish_reason": "stop",
+        "index": 0,
+        "logprobs": null,
+        "message": {
+          "content": "cited answer",
+          "role": "assistant"
+        }
+      }
+    ],
+    "citations": [
+      "https://a.test",
+      "https://b.test"
+    ],
+    "created": 1718000005,
+    "id": "resp-w1",
+    "model": "grok-4-0709",
+    "object": "chat.completion",
+    "usage": {
+      "completion_tokens": 9,
+      "num_sources_used": 3,
+      "prompt_tokens": 30,
+      "total_tokens": 39
+    }
+  },
+  "model": "grok-4-0709"
+}

--- a/tests/test_litellm/translation/characterization_xai/fixtures/streams/citations_dropped_by_the_dict_path.json
+++ b/tests/test_litellm/translation/characterization_xai/fixtures/streams/citations_dropped_by_the_dict_path.json
@@ -1,0 +1,61 @@
+{
+  "events": [
+    {
+      "choices": [
+        {
+          "delta": {
+            "content": "c",
+            "role": "assistant"
+          },
+          "finish_reason": null,
+          "index": 0,
+          "logprobs": null
+        }
+      ],
+      "created": 1718000000,
+      "id": "cmpl-xs1",
+      "model": "grok-3-mini",
+      "object": "chat.completion.chunk",
+      "system_fingerprint": "fp_xai_s",
+      "usage": null
+    },
+    {
+      "choices": [
+        {
+          "delta": {
+            "content": "ited"
+          },
+          "finish_reason": null,
+          "index": 0,
+          "logprobs": null
+        }
+      ],
+      "citations": [
+        "https://a.test"
+      ],
+      "created": 1718000000,
+      "id": "cmpl-xs1",
+      "model": "grok-3-mini",
+      "object": "chat.completion.chunk",
+      "system_fingerprint": "fp_xai_s",
+      "usage": null
+    },
+    {
+      "choices": [
+        {
+          "delta": {},
+          "finish_reason": "stop",
+          "index": 0,
+          "logprobs": null
+        }
+      ],
+      "created": 1718000000,
+      "id": "cmpl-xs1",
+      "model": "grok-3-mini",
+      "object": "chat.completion.chunk",
+      "system_fingerprint": "fp_xai_s",
+      "usage": null
+    }
+  ],
+  "stream_options": null
+}

--- a/tests/test_litellm/translation/characterization_xai/fixtures/streams/empty_keepalive_swallowed.json
+++ b/tests/test_litellm/translation/characterization_xai/fixtures/streams/empty_keepalive_swallowed.json
@@ -1,0 +1,74 @@
+{
+  "events": [
+    {
+      "choices": [
+        {
+          "delta": {
+            "content": "",
+            "role": "assistant"
+          },
+          "finish_reason": null,
+          "index": 0,
+          "logprobs": null
+        }
+      ],
+      "created": 1718000000,
+      "id": "cmpl-xs1",
+      "model": "grok-3-mini",
+      "object": "chat.completion.chunk",
+      "system_fingerprint": "fp_xai_s",
+      "usage": null
+    },
+    {
+      "choices": [
+        {
+          "delta": {},
+          "finish_reason": null,
+          "index": 0,
+          "logprobs": null
+        }
+      ],
+      "created": 1718000000,
+      "id": "cmpl-xs1",
+      "model": "grok-3-mini",
+      "object": "chat.completion.chunk",
+      "system_fingerprint": "fp_xai_s",
+      "usage": null
+    },
+    {
+      "choices": [
+        {
+          "delta": {
+            "content": "ok"
+          },
+          "finish_reason": null,
+          "index": 0,
+          "logprobs": null
+        }
+      ],
+      "created": 1718000000,
+      "id": "cmpl-xs1",
+      "model": "grok-3-mini",
+      "object": "chat.completion.chunk",
+      "system_fingerprint": "fp_xai_s",
+      "usage": null
+    },
+    {
+      "choices": [
+        {
+          "delta": {},
+          "finish_reason": "stop",
+          "index": 0,
+          "logprobs": null
+        }
+      ],
+      "created": 1718000000,
+      "id": "cmpl-xs1",
+      "model": "grok-3-mini",
+      "object": "chat.completion.chunk",
+      "system_fingerprint": "fp_xai_s",
+      "usage": null
+    }
+  ],
+  "stream_options": null
+}

--- a/tests/test_litellm/translation/characterization_xai/fixtures/streams/reasoning_content.json
+++ b/tests/test_litellm/translation/characterization_xai/fixtures/streams/reasoning_content.json
@@ -1,0 +1,76 @@
+{
+  "events": [
+    {
+      "choices": [
+        {
+          "delta": {
+            "reasoning_content": "Let me think",
+            "role": "assistant"
+          },
+          "finish_reason": null,
+          "index": 0,
+          "logprobs": null
+        }
+      ],
+      "created": 1718000000,
+      "id": "cmpl-xs1",
+      "model": "grok-3-mini",
+      "object": "chat.completion.chunk",
+      "system_fingerprint": "fp_xai_s",
+      "usage": null
+    },
+    {
+      "choices": [
+        {
+          "delta": {
+            "reasoning_content": " more"
+          },
+          "finish_reason": null,
+          "index": 0,
+          "logprobs": null
+        }
+      ],
+      "created": 1718000000,
+      "id": "cmpl-xs1",
+      "model": "grok-3-mini",
+      "object": "chat.completion.chunk",
+      "system_fingerprint": "fp_xai_s",
+      "usage": null
+    },
+    {
+      "choices": [
+        {
+          "delta": {
+            "content": "Answer"
+          },
+          "finish_reason": null,
+          "index": 0,
+          "logprobs": null
+        }
+      ],
+      "created": 1718000000,
+      "id": "cmpl-xs1",
+      "model": "grok-3-mini",
+      "object": "chat.completion.chunk",
+      "system_fingerprint": "fp_xai_s",
+      "usage": null
+    },
+    {
+      "choices": [
+        {
+          "delta": {},
+          "finish_reason": "stop",
+          "index": 0,
+          "logprobs": null
+        }
+      ],
+      "created": 1718000000,
+      "id": "cmpl-xs1",
+      "model": "grok-3-mini",
+      "object": "chat.completion.chunk",
+      "system_fingerprint": "fp_xai_s",
+      "usage": null
+    }
+  ],
+  "stream_options": null
+}

--- a/tests/test_litellm/translation/characterization_xai/fixtures/streams/reasoning_renamed.json
+++ b/tests/test_litellm/translation/characterization_xai/fixtures/streams/reasoning_renamed.json
@@ -1,0 +1,58 @@
+{
+  "events": [
+    {
+      "choices": [
+        {
+          "delta": {
+            "reasoning": "hmm",
+            "role": "assistant"
+          },
+          "finish_reason": null,
+          "index": 0,
+          "logprobs": null
+        }
+      ],
+      "created": 1718000000,
+      "id": "cmpl-xs1",
+      "model": "grok-3-mini",
+      "object": "chat.completion.chunk",
+      "system_fingerprint": "fp_xai_s",
+      "usage": null
+    },
+    {
+      "choices": [
+        {
+          "delta": {
+            "content": "A"
+          },
+          "finish_reason": null,
+          "index": 0,
+          "logprobs": null
+        }
+      ],
+      "created": 1718000000,
+      "id": "cmpl-xs1",
+      "model": "grok-3-mini",
+      "object": "chat.completion.chunk",
+      "system_fingerprint": "fp_xai_s",
+      "usage": null
+    },
+    {
+      "choices": [
+        {
+          "delta": {},
+          "finish_reason": "stop",
+          "index": 0,
+          "logprobs": null
+        }
+      ],
+      "created": 1718000000,
+      "id": "cmpl-xs1",
+      "model": "grok-3-mini",
+      "object": "chat.completion.chunk",
+      "system_fingerprint": "fp_xai_s",
+      "usage": null
+    }
+  ],
+  "stream_options": null
+}

--- a/tests/test_litellm/translation/characterization_xai/fixtures/streams/refusal_rides_content_deltas.json
+++ b/tests/test_litellm/translation/characterization_xai/fixtures/streams/refusal_rides_content_deltas.json
@@ -1,0 +1,77 @@
+{
+  "events": [
+    {
+      "choices": [
+        {
+          "delta": {
+            "refusal": "NO",
+            "role": "assistant"
+          },
+          "finish_reason": null,
+          "index": 0,
+          "logprobs": null
+        }
+      ],
+      "created": 1718000000,
+      "id": "cmpl-xs1",
+      "model": "grok-3-mini",
+      "object": "chat.completion.chunk",
+      "system_fingerprint": "fp_xai_s",
+      "usage": null
+    },
+    {
+      "choices": [
+        {
+          "delta": {
+            "refusal": " WAY"
+          },
+          "finish_reason": null,
+          "index": 0,
+          "logprobs": null
+        }
+      ],
+      "created": 1718000000,
+      "id": "cmpl-xs1",
+      "model": "grok-3-mini",
+      "object": "chat.completion.chunk",
+      "system_fingerprint": "fp_xai_s",
+      "usage": null
+    },
+    {
+      "choices": [
+        {
+          "delta": {
+            "content": "ok",
+            "refusal": "!"
+          },
+          "finish_reason": null,
+          "index": 0,
+          "logprobs": null
+        }
+      ],
+      "created": 1718000000,
+      "id": "cmpl-xs1",
+      "model": "grok-3-mini",
+      "object": "chat.completion.chunk",
+      "system_fingerprint": "fp_xai_s",
+      "usage": null
+    },
+    {
+      "choices": [
+        {
+          "delta": {},
+          "finish_reason": "stop",
+          "index": 0,
+          "logprobs": null
+        }
+      ],
+      "created": 1718000000,
+      "id": "cmpl-xs1",
+      "model": "grok-3-mini",
+      "object": "chat.completion.chunk",
+      "system_fingerprint": "fp_xai_s",
+      "usage": null
+    }
+  ],
+  "stream_options": null
+}

--- a/tests/test_litellm/translation/characterization_xai/fixtures/streams/text.json
+++ b/tests/test_litellm/translation/characterization_xai/fixtures/streams/text.json
@@ -1,0 +1,76 @@
+{
+  "events": [
+    {
+      "choices": [
+        {
+          "delta": {
+            "content": "",
+            "role": "assistant"
+          },
+          "finish_reason": null,
+          "index": 0,
+          "logprobs": null
+        }
+      ],
+      "created": 1718000000,
+      "id": "cmpl-xs1",
+      "model": "grok-3-mini",
+      "object": "chat.completion.chunk",
+      "system_fingerprint": "fp_xai_s",
+      "usage": null
+    },
+    {
+      "choices": [
+        {
+          "delta": {
+            "content": "Paris is"
+          },
+          "finish_reason": null,
+          "index": 0,
+          "logprobs": null
+        }
+      ],
+      "created": 1718000000,
+      "id": "cmpl-xs1",
+      "model": "grok-3-mini",
+      "object": "chat.completion.chunk",
+      "system_fingerprint": "fp_xai_s",
+      "usage": null
+    },
+    {
+      "choices": [
+        {
+          "delta": {
+            "content": " the capital."
+          },
+          "finish_reason": null,
+          "index": 0,
+          "logprobs": null
+        }
+      ],
+      "created": 1718000000,
+      "id": "cmpl-xs1",
+      "model": "grok-3-mini",
+      "object": "chat.completion.chunk",
+      "system_fingerprint": "fp_xai_s",
+      "usage": null
+    },
+    {
+      "choices": [
+        {
+          "delta": {},
+          "finish_reason": "stop",
+          "index": 0,
+          "logprobs": null
+        }
+      ],
+      "created": 1718000000,
+      "id": "cmpl-xs1",
+      "model": "grok-3-mini",
+      "object": "chat.completion.chunk",
+      "system_fingerprint": "fp_xai_s",
+      "usage": null
+    }
+  ],
+  "stream_options": null
+}

--- a/tests/test_litellm/translation/characterization_xai/fixtures/streams/text_no_leading_role.json
+++ b/tests/test_litellm/translation/characterization_xai/fixtures/streams/text_no_leading_role.json
@@ -1,0 +1,57 @@
+{
+  "events": [
+    {
+      "choices": [
+        {
+          "delta": {
+            "content": "Hi"
+          },
+          "finish_reason": null,
+          "index": 0,
+          "logprobs": null
+        }
+      ],
+      "created": 1718000000,
+      "id": "cmpl-xs1",
+      "model": "grok-3-mini",
+      "object": "chat.completion.chunk",
+      "system_fingerprint": "fp_xai_s",
+      "usage": null
+    },
+    {
+      "choices": [
+        {
+          "delta": {
+            "content": " there"
+          },
+          "finish_reason": null,
+          "index": 0,
+          "logprobs": null
+        }
+      ],
+      "created": 1718000000,
+      "id": "cmpl-xs1",
+      "model": "grok-3-mini",
+      "object": "chat.completion.chunk",
+      "system_fingerprint": "fp_xai_s",
+      "usage": null
+    },
+    {
+      "choices": [
+        {
+          "delta": {},
+          "finish_reason": "stop",
+          "index": 0,
+          "logprobs": null
+        }
+      ],
+      "created": 1718000000,
+      "id": "cmpl-xs1",
+      "model": "grok-3-mini",
+      "object": "chat.completion.chunk",
+      "system_fingerprint": "fp_xai_s",
+      "usage": null
+    }
+  ],
+  "stream_options": null
+}

--- a/tests/test_litellm/translation/characterization_xai/fixtures/streams/tools_typeless_continuation.json
+++ b/tests/test_litellm/translation/characterization_xai/fixtures/streams/tools_typeless_continuation.json
@@ -1,0 +1,75 @@
+{
+  "events": [
+    {
+      "choices": [
+        {
+          "delta": {
+            "role": "assistant",
+            "tool_calls": [
+              {
+                "function": {
+                  "arguments": "",
+                  "name": "get_weather"
+                },
+                "id": "call_1",
+                "index": 0,
+                "type": "function"
+              }
+            ]
+          },
+          "finish_reason": null,
+          "index": 0,
+          "logprobs": null
+        }
+      ],
+      "created": 1718000000,
+      "id": "cmpl-xs1",
+      "model": "grok-3-mini",
+      "object": "chat.completion.chunk",
+      "system_fingerprint": "fp_xai_s",
+      "usage": null
+    },
+    {
+      "choices": [
+        {
+          "delta": {
+            "tool_calls": [
+              {
+                "function": {
+                  "arguments": "{\"city\": \"Paris\"}"
+                },
+                "index": 0
+              }
+            ]
+          },
+          "finish_reason": null,
+          "index": 0,
+          "logprobs": null
+        }
+      ],
+      "created": 1718000000,
+      "id": "cmpl-xs1",
+      "model": "grok-3-mini",
+      "object": "chat.completion.chunk",
+      "system_fingerprint": "fp_xai_s",
+      "usage": null
+    },
+    {
+      "choices": [
+        {
+          "delta": {},
+          "finish_reason": "tool_calls",
+          "index": 0,
+          "logprobs": null
+        }
+      ],
+      "created": 1718000000,
+      "id": "cmpl-xs1",
+      "model": "grok-3-mini",
+      "object": "chat.completion.chunk",
+      "system_fingerprint": "fp_xai_s",
+      "usage": null
+    }
+  ],
+  "stream_options": null
+}

--- a/tests/test_litellm/translation/characterization_xai/fixtures/streams/usage_tail_include_usage.json
+++ b/tests/test_litellm/translation/characterization_xai/fixtures/streams/usage_tail_include_usage.json
@@ -1,0 +1,79 @@
+{
+  "events": [
+    {
+      "choices": [
+        {
+          "delta": {
+            "content": "",
+            "role": "assistant"
+          },
+          "finish_reason": null,
+          "index": 0,
+          "logprobs": null
+        }
+      ],
+      "created": 1718000000,
+      "id": "cmpl-xs1",
+      "model": "grok-3-mini",
+      "object": "chat.completion.chunk",
+      "system_fingerprint": "fp_xai_s",
+      "usage": null
+    },
+    {
+      "choices": [
+        {
+          "delta": {
+            "content": "Hello"
+          },
+          "finish_reason": null,
+          "index": 0,
+          "logprobs": null
+        }
+      ],
+      "created": 1718000000,
+      "id": "cmpl-xs1",
+      "model": "grok-3-mini",
+      "object": "chat.completion.chunk",
+      "system_fingerprint": "fp_xai_s",
+      "usage": null
+    },
+    {
+      "choices": [
+        {
+          "delta": {},
+          "finish_reason": "stop",
+          "index": 0,
+          "logprobs": null
+        }
+      ],
+      "created": 1718000000,
+      "id": "cmpl-xs1",
+      "model": "grok-3-mini",
+      "object": "chat.completion.chunk",
+      "system_fingerprint": "fp_xai_s",
+      "usage": null
+    },
+    {
+      "choices": [],
+      "created": 1718000000,
+      "id": "cmpl-xs1",
+      "model": "grok-3-mini",
+      "object": "chat.completion.chunk",
+      "system_fingerprint": "fp_xai_s",
+      "usage": {
+        "completion_tokens": 2,
+        "completion_tokens_details": {
+          "reasoning_tokens": 7
+        },
+        "prompt_tokens": 171,
+        "prompt_tokens_details": {
+          "cached_tokens": 0
+        },
+        "total_tokens": 180
+      }
+    }
+  ],
+  "stream_options": {
+    "include_usage": true
+  }
+}

--- a/tests/test_litellm/translation/characterization_xai/fixtures/streams/usage_withheld_on_content_chunks.json
+++ b/tests/test_litellm/translation/characterization_xai/fixtures/streams/usage_withheld_on_content_chunks.json
@@ -1,0 +1,48 @@
+{
+  "events": [
+    {
+      "choices": [
+        {
+          "delta": {
+            "content": "hi",
+            "role": "assistant"
+          },
+          "finish_reason": null,
+          "index": 0,
+          "logprobs": null
+        }
+      ],
+      "created": 1718000000,
+      "id": "cmpl-xs1",
+      "model": "grok-3-mini",
+      "object": "chat.completion.chunk",
+      "system_fingerprint": "fp_xai_s",
+      "usage": {
+        "completion_tokens": 1,
+        "prompt_tokens": 1,
+        "total_tokens": 2
+      }
+    },
+    {
+      "choices": [
+        {
+          "delta": {},
+          "finish_reason": "stop",
+          "index": 0,
+          "logprobs": null
+        }
+      ],
+      "created": 1718000000,
+      "id": "cmpl-xs1",
+      "model": "grok-3-mini",
+      "object": "chat.completion.chunk",
+      "system_fingerprint": "fp_xai_s",
+      "usage": {
+        "completion_tokens": 2,
+        "prompt_tokens": 1,
+        "total_tokens": 3
+      }
+    }
+  ],
+  "stream_options": null
+}

--- a/tests/test_litellm/translation/characterization_xai/snapshots/requests/cache_control_stripped_grok4.json
+++ b/tests/test_litellm/translation/characterization_xai/snapshots/requests/cache_control_stripped_grok4.json
@@ -1,0 +1,30 @@
+{
+  "messages": [
+    {
+      "content": [
+        {
+          "text": "cached context",
+          "type": "text"
+        },
+        {
+          "text": "question",
+          "type": "text"
+        }
+      ],
+      "role": "user"
+    }
+  ],
+  "model": "grok-4-0709",
+  "tools": [
+    {
+      "function": {
+        "name": "lookup",
+        "parameters": {
+          "properties": {},
+          "type": "object"
+        }
+      },
+      "type": "function"
+    }
+  ]
+}

--- a/tests/test_litellm/translation/characterization_xai/snapshots/requests/image_base64_grok4.json
+++ b/tests/test_litellm/translation/characterization_xai/snapshots/requests/image_base64_grok4.json
@@ -1,0 +1,20 @@
+{
+  "messages": [
+    {
+      "content": [
+        {
+          "text": "and this",
+          "type": "text"
+        },
+        {
+          "image_url": {
+            "url": "data:image/png;base64,iVBORw0KGgo="
+          },
+          "type": "image_url"
+        }
+      ],
+      "role": "user"
+    }
+  ],
+  "model": "grok-4-0709"
+}

--- a/tests/test_litellm/translation/characterization_xai/snapshots/requests/image_url_string_grok4.json
+++ b/tests/test_litellm/translation/characterization_xai/snapshots/requests/image_url_string_grok4.json
@@ -1,0 +1,20 @@
+{
+  "messages": [
+    {
+      "content": [
+        {
+          "text": "what is this",
+          "type": "text"
+        },
+        {
+          "image_url": {
+            "url": "https://e.test/a.png"
+          },
+          "type": "image_url"
+        }
+      ],
+      "role": "user"
+    }
+  ],
+  "model": "grok-4-0709"
+}

--- a/tests/test_litellm/translation/characterization_xai/snapshots/requests/max_tokens_grok3mini.json
+++ b/tests/test_litellm/translation/characterization_xai/snapshots/requests/max_tokens_grok3mini.json
@@ -1,0 +1,10 @@
+{
+  "max_tokens": 64,
+  "messages": [
+    {
+      "content": "hi",
+      "role": "user"
+    }
+  ],
+  "model": "grok-3-mini"
+}

--- a/tests/test_litellm/translation/characterization_xai/snapshots/requests/multiturn_stop_list_stream_grok3.json
+++ b/tests/test_litellm/translation/characterization_xai/snapshots/requests/multiturn_stop_list_stream_grok3.json
@@ -1,0 +1,23 @@
+{
+  "max_tokens": 64,
+  "messages": [
+    {
+      "content": "Hello",
+      "role": "user"
+    },
+    {
+      "content": "Hi there",
+      "role": "assistant"
+    },
+    {
+      "content": "How are you?",
+      "role": "user"
+    }
+  ],
+  "model": "grok-3",
+  "stop": [
+    "END",
+    "STOP"
+  ],
+  "stream": true
+}

--- a/tests/test_litellm/translation/characterization_xai/snapshots/requests/nonuser_name_stripped_grok4.json
+++ b/tests/test_litellm/translation/characterization_xai/snapshots/requests/nonuser_name_stripped_grok4.json
@@ -1,0 +1,21 @@
+{
+  "messages": [
+    {
+      "content": "s",
+      "role": "system"
+    },
+    {
+      "content": "q",
+      "role": "user"
+    },
+    {
+      "content": "a",
+      "role": "assistant"
+    },
+    {
+      "content": "q2",
+      "role": "user"
+    }
+  ],
+  "model": "grok-4-0709"
+}

--- a/tests/test_litellm/translation/characterization_xai/snapshots/requests/parallel_tool_calls_false_grok4.json
+++ b/tests/test_litellm/translation/characterization_xai/snapshots/requests/parallel_tool_calls_false_grok4.json
@@ -1,0 +1,30 @@
+{
+  "messages": [
+    {
+      "content": "Weather in Paris and Rome?",
+      "role": "user"
+    }
+  ],
+  "model": "grok-4-0709",
+  "parallel_tool_calls": false,
+  "tools": [
+    {
+      "function": {
+        "description": "Get weather",
+        "name": "get_weather",
+        "parameters": {
+          "properties": {
+            "city": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "city"
+          ],
+          "type": "object"
+        }
+      },
+      "type": "function"
+    }
+  ]
+}

--- a/tests/test_litellm/translation/characterization_xai/snapshots/requests/reasoning_effort_grok3mini.json
+++ b/tests/test_litellm/translation/characterization_xai/snapshots/requests/reasoning_effort_grok3mini.json
@@ -1,0 +1,10 @@
+{
+  "messages": [
+    {
+      "content": "think",
+      "role": "user"
+    }
+  ],
+  "model": "grok-3-mini",
+  "reasoning_effort": "high"
+}

--- a/tests/test_litellm/translation/characterization_xai/snapshots/requests/reasoning_effort_grok_code_fast.json
+++ b/tests/test_litellm/translation/characterization_xai/snapshots/requests/reasoning_effort_grok_code_fast.json
@@ -1,0 +1,10 @@
+{
+  "messages": [
+    {
+      "content": "code",
+      "role": "user"
+    }
+  ],
+  "model": "grok-code-fast-1",
+  "reasoning_effort": "low"
+}

--- a/tests/test_litellm/translation/characterization_xai/snapshots/requests/response_format_json_object_grok4.json
+++ b/tests/test_litellm/translation/characterization_xai/snapshots/requests/response_format_json_object_grok4.json
@@ -1,0 +1,12 @@
+{
+  "messages": [
+    {
+      "content": "json please",
+      "role": "user"
+    }
+  ],
+  "model": "grok-4-0709",
+  "response_format": {
+    "type": "json_object"
+  }
+}

--- a/tests/test_litellm/translation/characterization_xai/snapshots/requests/response_format_json_schema_strict_kept_grok4.json
+++ b/tests/test_litellm/translation/characterization_xai/snapshots/requests/response_format_json_schema_strict_kept_grok4.json
@@ -1,0 +1,28 @@
+{
+  "messages": [
+    {
+      "content": "capital of France?",
+      "role": "user"
+    }
+  ],
+  "model": "grok-4-0709",
+  "response_format": {
+    "json_schema": {
+      "name": "answer",
+      "schema": {
+        "additionalProperties": false,
+        "properties": {
+          "capital": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "capital"
+        ],
+        "type": "object"
+      },
+      "strict": true
+    },
+    "type": "json_schema"
+  }
+}

--- a/tests/test_litellm/translation/characterization_xai/snapshots/requests/stop_list_grok2.json
+++ b/tests/test_litellm/translation/characterization_xai/snapshots/requests/stop_list_grok2.json
@@ -1,0 +1,12 @@
+{
+  "messages": [
+    {
+      "content": "x",
+      "role": "user"
+    }
+  ],
+  "model": "grok-2-1212",
+  "stop": [
+    "END"
+  ]
+}

--- a/tests/test_litellm/translation/characterization_xai/snapshots/requests/system_and_sampling_grok4.json
+++ b/tests/test_litellm/translation/characterization_xai/snapshots/requests/system_and_sampling_grok4.json
@@ -1,0 +1,16 @@
+{
+  "max_tokens": 50,
+  "messages": [
+    {
+      "content": "You are helpful",
+      "role": "system"
+    },
+    {
+      "content": "Hi",
+      "role": "user"
+    }
+  ],
+  "model": "grok-4-0709",
+  "temperature": 0.5,
+  "top_p": 0.9
+}

--- a/tests/test_litellm/translation/characterization_xai/snapshots/requests/temperature_int_stays_int_grok4.json
+++ b/tests/test_litellm/translation/characterization_xai/snapshots/requests/temperature_int_stays_int_grok4.json
@@ -1,0 +1,10 @@
+{
+  "messages": [
+    {
+      "content": "hi",
+      "role": "user"
+    }
+  ],
+  "model": "grok-4-0709",
+  "temperature": 1
+}

--- a/tests/test_litellm/translation/characterization_xai/snapshots/requests/text_grok4.json
+++ b/tests/test_litellm/translation/characterization_xai/snapshots/requests/text_grok4.json
@@ -1,0 +1,9 @@
+{
+  "messages": [
+    {
+      "content": "Hello, world",
+      "role": "user"
+    }
+  ],
+  "model": "grok-4-0709"
+}

--- a/tests/test_litellm/translation/characterization_xai/snapshots/requests/tool_call_roundtrip_compact_grok4.json
+++ b/tests/test_litellm/translation/characterization_xai/snapshots/requests/tool_call_roundtrip_compact_grok4.json
@@ -1,0 +1,48 @@
+{
+  "messages": [
+    {
+      "content": "w?",
+      "role": "user"
+    },
+    {
+      "content": null,
+      "role": "assistant",
+      "tool_calls": [
+        {
+          "function": {
+            "arguments": "{\"city\":\"Paris\"}",
+            "name": "get_weather"
+          },
+          "id": "call_1",
+          "type": "function"
+        }
+      ]
+    },
+    {
+      "content": "Sunny, 20C",
+      "role": "tool",
+      "tool_call_id": "call_1"
+    }
+  ],
+  "model": "grok-4-0709",
+  "tools": [
+    {
+      "function": {
+        "description": "Get weather",
+        "name": "get_weather",
+        "parameters": {
+          "properties": {
+            "city": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "city"
+          ],
+          "type": "object"
+        }
+      },
+      "type": "function"
+    }
+  ]
+}

--- a/tests/test_litellm/translation/characterization_xai/snapshots/requests/tool_choice_required_grok4.json
+++ b/tests/test_litellm/translation/characterization_xai/snapshots/requests/tool_choice_required_grok4.json
@@ -1,0 +1,30 @@
+{
+  "messages": [
+    {
+      "content": "Weather in Paris?",
+      "role": "user"
+    }
+  ],
+  "model": "grok-4-0709",
+  "tool_choice": "required",
+  "tools": [
+    {
+      "function": {
+        "description": "Get weather",
+        "name": "get_weather",
+        "parameters": {
+          "properties": {
+            "city": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "city"
+          ],
+          "type": "object"
+        }
+      },
+      "type": "function"
+    }
+  ]
+}

--- a/tests/test_litellm/translation/characterization_xai/snapshots/requests/tool_choice_specific_grok4.json
+++ b/tests/test_litellm/translation/characterization_xai/snapshots/requests/tool_choice_specific_grok4.json
@@ -1,0 +1,35 @@
+{
+  "messages": [
+    {
+      "content": "Weather in Paris?",
+      "role": "user"
+    }
+  ],
+  "model": "grok-4-0709",
+  "tool_choice": {
+    "function": {
+      "name": "get_weather"
+    },
+    "type": "function"
+  },
+  "tools": [
+    {
+      "function": {
+        "description": "Get weather",
+        "name": "get_weather",
+        "parameters": {
+          "properties": {
+            "city": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "city"
+          ],
+          "type": "object"
+        }
+      },
+      "type": "function"
+    }
+  ]
+}

--- a/tests/test_litellm/translation/characterization_xai/snapshots/requests/tools_auto_grok4.json
+++ b/tests/test_litellm/translation/characterization_xai/snapshots/requests/tools_auto_grok4.json
@@ -1,0 +1,30 @@
+{
+  "messages": [
+    {
+      "content": "Weather in Paris?",
+      "role": "user"
+    }
+  ],
+  "model": "grok-4-0709",
+  "tool_choice": "auto",
+  "tools": [
+    {
+      "function": {
+        "description": "Get weather",
+        "name": "get_weather",
+        "parameters": {
+          "properties": {
+            "city": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "city"
+          ],
+          "type": "object"
+        }
+      },
+      "type": "function"
+    }
+  ]
+}

--- a/tests/test_litellm/translation/characterization_xai/snapshots/requests/tools_strict_stripped_grok4.json
+++ b/tests/test_litellm/translation/characterization_xai/snapshots/requests/tools_strict_stripped_grok4.json
@@ -1,0 +1,29 @@
+{
+  "messages": [
+    {
+      "content": "report this",
+      "role": "user"
+    }
+  ],
+  "model": "grok-4-0709",
+  "tools": [
+    {
+      "function": {
+        "name": "report",
+        "parameters": {
+          "additionalProperties": false,
+          "properties": {
+            "body": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "body"
+          ],
+          "type": "object"
+        }
+      },
+      "type": "function"
+    }
+  ]
+}

--- a/tests/test_litellm/translation/characterization_xai/snapshots/requests/user_param_grok4.json
+++ b/tests/test_litellm/translation/characterization_xai/snapshots/requests/user_param_grok4.json
@@ -1,0 +1,10 @@
+{
+  "messages": [
+    {
+      "content": "x",
+      "role": "user"
+    }
+  ],
+  "model": "grok-4-0709",
+  "user": "u-1"
+}

--- a/tests/test_litellm/translation/characterization_xai/snapshots/responses/cached_tokens_usage_passthrough.json
+++ b/tests/test_litellm/translation/characterization_xai/snapshots/responses/cached_tokens_usage_passthrough.json
@@ -1,0 +1,30 @@
+{
+  "choices": [
+    {
+      "finish_reason": "length",
+      "index": 0,
+      "message": {
+        "content": "partial",
+        "function_call": null,
+        "role": "assistant",
+        "tool_calls": null
+      },
+      "provider_specific_fields": {}
+    }
+  ],
+  "created": 1718000007,
+  "id": "resp-c1",
+  "model": "grok-4-0709",
+  "object": "chat.completion",
+  "system_fingerprint": null,
+  "usage": {
+    "completion_tokens": 100,
+    "completion_tokens_details": null,
+    "prompt_tokens": 1000,
+    "prompt_tokens_details": {
+      "audio_tokens": 0,
+      "cached_tokens": 512
+    },
+    "total_tokens": 1100
+  }
+}

--- a/tests/test_litellm/translation/characterization_xai/snapshots/responses/finish_empty_string_with_tool_calls.json
+++ b/tests/test_litellm/translation/characterization_xai/snapshots/responses/finish_empty_string_with_tool_calls.json
@@ -1,0 +1,38 @@
+{
+  "choices": [
+    {
+      "finish_reason": "stop",
+      "index": 0,
+      "message": {
+        "content": null,
+        "function_call": null,
+        "role": "assistant",
+        "tool_calls": [
+          {
+            "function": {
+              "arguments": "{\"city\":\"Paris\"}",
+              "name": "get_weather"
+            },
+            "id": "call_1",
+            "type": "function"
+          }
+        ]
+      },
+      "provider_specific_fields": {
+        "native_finish_reason": ""
+      }
+    }
+  ],
+  "created": 1718000001,
+  "id": "resp-r1",
+  "model": "grok-4-0709",
+  "object": "chat.completion",
+  "system_fingerprint": null,
+  "usage": {
+    "completion_tokens": 6,
+    "completion_tokens_details": null,
+    "prompt_tokens": 12,
+    "prompt_tokens_details": null,
+    "total_tokens": 18
+  }
+}

--- a/tests/test_litellm/translation/characterization_xai/snapshots/responses/finish_stop_with_tool_calls_rewrites.json
+++ b/tests/test_litellm/translation/characterization_xai/snapshots/responses/finish_stop_with_tool_calls_rewrites.json
@@ -1,0 +1,36 @@
+{
+  "choices": [
+    {
+      "finish_reason": "tool_calls",
+      "index": 0,
+      "message": {
+        "content": null,
+        "function_call": null,
+        "role": "assistant",
+        "tool_calls": [
+          {
+            "function": {
+              "arguments": "{\"city\":\"Rome\"}",
+              "name": "get_weather"
+            },
+            "id": "call_2",
+            "type": "function"
+          }
+        ]
+      },
+      "provider_specific_fields": {}
+    }
+  ],
+  "created": 1718000002,
+  "id": "resp-r2",
+  "model": "grok-4-0709",
+  "object": "chat.completion",
+  "system_fingerprint": null,
+  "usage": {
+    "completion_tokens": 6,
+    "completion_tokens_details": null,
+    "prompt_tokens": 12,
+    "prompt_tokens_details": null,
+    "total_tokens": 18
+  }
+}

--- a/tests/test_litellm/translation/characterization_xai/snapshots/responses/numeric_string_usage_coerced.json
+++ b/tests/test_litellm/translation/characterization_xai/snapshots/responses/numeric_string_usage_coerced.json
@@ -1,0 +1,29 @@
+{
+  "choices": [
+    {
+      "finish_reason": "stop",
+      "index": 0,
+      "message": {
+        "content": "a",
+        "function_call": null,
+        "role": "assistant",
+        "tool_calls": null
+      },
+      "provider_specific_fields": {}
+    }
+  ],
+  "created": 1718000010,
+  "id": "resp-s1",
+  "model": "grok-3-mini",
+  "object": "chat.completion",
+  "system_fingerprint": null,
+  "usage": {
+    "completion_tokens": 12,
+    "completion_tokens_details": {
+      "reasoning_tokens": 7
+    },
+    "prompt_tokens": 10,
+    "prompt_tokens_details": null,
+    "total_tokens": 22
+  }
+}

--- a/tests/test_litellm/translation/characterization_xai/snapshots/responses/reasoning_tokens_already_folded_idempotent.json
+++ b/tests/test_litellm/translation/characterization_xai/snapshots/responses/reasoning_tokens_already_folded_idempotent.json
@@ -1,0 +1,29 @@
+{
+  "choices": [
+    {
+      "finish_reason": "stop",
+      "index": 0,
+      "message": {
+        "content": "a",
+        "function_call": null,
+        "role": "assistant",
+        "tool_calls": null
+      },
+      "provider_specific_fields": {}
+    }
+  ],
+  "created": 1718000004,
+  "id": "resp-f2",
+  "model": "grok-3-mini",
+  "object": "chat.completion",
+  "system_fingerprint": null,
+  "usage": {
+    "completion_tokens": 12,
+    "completion_tokens_details": {
+      "reasoning_tokens": 7
+    },
+    "prompt_tokens": 10,
+    "prompt_tokens_details": null,
+    "total_tokens": 22
+  }
+}

--- a/tests/test_litellm/translation/characterization_xai/snapshots/responses/reasoning_tokens_folded.json
+++ b/tests/test_litellm/translation/characterization_xai/snapshots/responses/reasoning_tokens_folded.json
@@ -1,0 +1,30 @@
+{
+  "choices": [
+    {
+      "finish_reason": "stop",
+      "index": 0,
+      "message": {
+        "content": "answer",
+        "function_call": null,
+        "reasoning_content": "thought hard",
+        "role": "assistant",
+        "tool_calls": null
+      },
+      "provider_specific_fields": {}
+    }
+  ],
+  "created": 1718000003,
+  "id": "resp-f1",
+  "model": "grok-3-mini",
+  "object": "chat.completion",
+  "system_fingerprint": null,
+  "usage": {
+    "completion_tokens": 12,
+    "completion_tokens_details": {
+      "reasoning_tokens": 7
+    },
+    "prompt_tokens": 10,
+    "prompt_tokens_details": null,
+    "total_tokens": 22
+  }
+}

--- a/tests/test_litellm/translation/characterization_xai/snapshots/responses/text_basic.json
+++ b/tests/test_litellm/translation/characterization_xai/snapshots/responses/text_basic.json
@@ -1,0 +1,27 @@
+{
+  "choices": [
+    {
+      "finish_reason": "stop",
+      "index": 0,
+      "message": {
+        "content": "Hello there.",
+        "function_call": null,
+        "role": "assistant",
+        "tool_calls": null
+      },
+      "provider_specific_fields": {}
+    }
+  ],
+  "created": 1718000000,
+  "id": "resp-t1",
+  "model": "grok-4-0709",
+  "object": "chat.completion",
+  "system_fingerprint": "fp_xai_1",
+  "usage": {
+    "completion_tokens": 6,
+    "completion_tokens_details": null,
+    "prompt_tokens": 12,
+    "prompt_tokens_details": null,
+    "total_tokens": 18
+  }
+}

--- a/tests/test_litellm/translation/characterization_xai/snapshots/responses/total_tokens_normalized_up.json
+++ b/tests/test_litellm/translation/characterization_xai/snapshots/responses/total_tokens_normalized_up.json
@@ -1,0 +1,27 @@
+{
+  "choices": [
+    {
+      "finish_reason": "stop",
+      "index": 0,
+      "message": {
+        "content": "a",
+        "function_call": null,
+        "role": "assistant",
+        "tool_calls": null
+      },
+      "provider_specific_fields": {}
+    }
+  ],
+  "created": 1718000006,
+  "id": "resp-n1",
+  "model": "grok-4-0709",
+  "object": "chat.completion",
+  "system_fingerprint": null,
+  "usage": {
+    "completion_tokens": 9,
+    "completion_tokens_details": null,
+    "prompt_tokens": 30,
+    "prompt_tokens_details": null,
+    "total_tokens": 39
+  }
+}

--- a/tests/test_litellm/translation/characterization_xai/snapshots/responses/websearch_sources_and_citations.json
+++ b/tests/test_litellm/translation/characterization_xai/snapshots/responses/websearch_sources_and_citations.json
@@ -1,0 +1,34 @@
+{
+  "choices": [
+    {
+      "finish_reason": "stop",
+      "index": 0,
+      "message": {
+        "content": "cited answer",
+        "function_call": null,
+        "role": "assistant",
+        "tool_calls": null
+      },
+      "provider_specific_fields": {}
+    }
+  ],
+  "citations": [
+    "https://a.test",
+    "https://b.test"
+  ],
+  "created": 1718000005,
+  "id": "resp-w1",
+  "model": "grok-4-0709",
+  "object": "chat.completion",
+  "system_fingerprint": null,
+  "usage": {
+    "completion_tokens": 9,
+    "completion_tokens_details": null,
+    "num_sources_used": 3,
+    "prompt_tokens": 30,
+    "prompt_tokens_details": {
+      "web_search_requests": 3
+    },
+    "total_tokens": 39
+  }
+}

--- a/tests/test_litellm/translation/characterization_xai/snapshots/streams/citations_dropped_by_the_dict_path.json
+++ b/tests/test_litellm/translation/characterization_xai/snapshots/streams/citations_dropped_by_the_dict_path.json
@@ -1,0 +1,72 @@
+[
+  {
+    "choices": [
+      {
+        "delta": {
+          "audio": null,
+          "content": "c",
+          "function_call": null,
+          "provider_specific_fields": null,
+          "role": "assistant",
+          "tool_calls": null
+        },
+        "finish_reason": null,
+        "index": 0,
+        "logprobs": null
+      }
+    ],
+    "citations": null,
+    "created": 1718064000,
+    "id": "cmpl-xs1",
+    "model": "grok-3-mini",
+    "object": "chat.completion.chunk",
+    "provider_specific_fields": null,
+    "system_fingerprint": null
+  },
+  {
+    "choices": [
+      {
+        "delta": {
+          "audio": null,
+          "content": "ited",
+          "function_call": null,
+          "provider_specific_fields": null,
+          "role": null,
+          "tool_calls": null
+        },
+        "finish_reason": null,
+        "index": 0,
+        "logprobs": null
+      }
+    ],
+    "citations": null,
+    "created": 1718064000,
+    "id": "cmpl-xs1",
+    "model": "grok-3-mini",
+    "object": "chat.completion.chunk",
+    "provider_specific_fields": null,
+    "system_fingerprint": null
+  },
+  {
+    "choices": [
+      {
+        "delta": {
+          "audio": null,
+          "content": null,
+          "function_call": null,
+          "role": null,
+          "tool_calls": null
+        },
+        "finish_reason": "stop",
+        "index": 0,
+        "logprobs": null
+      }
+    ],
+    "created": 1718064000,
+    "id": "cmpl-xs1",
+    "model": "grok-3-mini",
+    "object": "chat.completion.chunk",
+    "provider_specific_fields": null,
+    "system_fingerprint": null
+  }
+]

--- a/tests/test_litellm/translation/characterization_xai/snapshots/streams/empty_keepalive_swallowed.json
+++ b/tests/test_litellm/translation/characterization_xai/snapshots/streams/empty_keepalive_swallowed.json
@@ -1,0 +1,72 @@
+[
+  {
+    "choices": [
+      {
+        "delta": {
+          "audio": null,
+          "content": "",
+          "function_call": null,
+          "provider_specific_fields": null,
+          "role": "assistant",
+          "tool_calls": null
+        },
+        "finish_reason": null,
+        "index": 0,
+        "logprobs": null
+      }
+    ],
+    "citations": null,
+    "created": 1718064000,
+    "id": "cmpl-xs1",
+    "model": "grok-3-mini",
+    "object": "chat.completion.chunk",
+    "provider_specific_fields": null,
+    "system_fingerprint": null
+  },
+  {
+    "choices": [
+      {
+        "delta": {
+          "audio": null,
+          "content": "ok",
+          "function_call": null,
+          "provider_specific_fields": null,
+          "role": null,
+          "tool_calls": null
+        },
+        "finish_reason": null,
+        "index": 0,
+        "logprobs": null
+      }
+    ],
+    "citations": null,
+    "created": 1718064000,
+    "id": "cmpl-xs1",
+    "model": "grok-3-mini",
+    "object": "chat.completion.chunk",
+    "provider_specific_fields": null,
+    "system_fingerprint": null
+  },
+  {
+    "choices": [
+      {
+        "delta": {
+          "audio": null,
+          "content": null,
+          "function_call": null,
+          "role": null,
+          "tool_calls": null
+        },
+        "finish_reason": "stop",
+        "index": 0,
+        "logprobs": null
+      }
+    ],
+    "created": 1718064000,
+    "id": "cmpl-xs1",
+    "model": "grok-3-mini",
+    "object": "chat.completion.chunk",
+    "provider_specific_fields": null,
+    "system_fingerprint": null
+  }
+]

--- a/tests/test_litellm/translation/characterization_xai/snapshots/streams/reasoning_content.json
+++ b/tests/test_litellm/translation/characterization_xai/snapshots/streams/reasoning_content.json
@@ -1,0 +1,98 @@
+[
+  {
+    "choices": [
+      {
+        "delta": {
+          "audio": null,
+          "content": null,
+          "function_call": null,
+          "provider_specific_fields": null,
+          "reasoning_content": "Let me think",
+          "role": "assistant",
+          "tool_calls": null
+        },
+        "finish_reason": null,
+        "index": 0,
+        "logprobs": null
+      }
+    ],
+    "citations": null,
+    "created": 1718064000,
+    "id": "cmpl-xs1",
+    "model": "grok-3-mini",
+    "object": "chat.completion.chunk",
+    "provider_specific_fields": null,
+    "system_fingerprint": null
+  },
+  {
+    "choices": [
+      {
+        "delta": {
+          "audio": null,
+          "content": null,
+          "function_call": null,
+          "provider_specific_fields": null,
+          "reasoning_content": " more",
+          "role": null,
+          "tool_calls": null
+        },
+        "finish_reason": null,
+        "index": 0,
+        "logprobs": null
+      }
+    ],
+    "citations": null,
+    "created": 1718064000,
+    "id": "cmpl-xs1",
+    "model": "grok-3-mini",
+    "object": "chat.completion.chunk",
+    "provider_specific_fields": null,
+    "system_fingerprint": null
+  },
+  {
+    "choices": [
+      {
+        "delta": {
+          "audio": null,
+          "content": "Answer",
+          "function_call": null,
+          "provider_specific_fields": null,
+          "role": null,
+          "tool_calls": null
+        },
+        "finish_reason": null,
+        "index": 0,
+        "logprobs": null
+      }
+    ],
+    "citations": null,
+    "created": 1718064000,
+    "id": "cmpl-xs1",
+    "model": "grok-3-mini",
+    "object": "chat.completion.chunk",
+    "provider_specific_fields": null,
+    "system_fingerprint": null
+  },
+  {
+    "choices": [
+      {
+        "delta": {
+          "audio": null,
+          "content": null,
+          "function_call": null,
+          "role": null,
+          "tool_calls": null
+        },
+        "finish_reason": "stop",
+        "index": 0,
+        "logprobs": null
+      }
+    ],
+    "created": 1718064000,
+    "id": "cmpl-xs1",
+    "model": "grok-3-mini",
+    "object": "chat.completion.chunk",
+    "provider_specific_fields": null,
+    "system_fingerprint": null
+  }
+]

--- a/tests/test_litellm/translation/characterization_xai/snapshots/streams/reasoning_renamed.json
+++ b/tests/test_litellm/translation/characterization_xai/snapshots/streams/reasoning_renamed.json
@@ -1,0 +1,73 @@
+[
+  {
+    "choices": [
+      {
+        "delta": {
+          "audio": null,
+          "content": null,
+          "function_call": null,
+          "provider_specific_fields": null,
+          "reasoning_content": "hmm",
+          "role": "assistant",
+          "tool_calls": null
+        },
+        "finish_reason": null,
+        "index": 0,
+        "logprobs": null
+      }
+    ],
+    "citations": null,
+    "created": 1718064000,
+    "id": "cmpl-xs1",
+    "model": "grok-3-mini",
+    "object": "chat.completion.chunk",
+    "provider_specific_fields": null,
+    "system_fingerprint": null
+  },
+  {
+    "choices": [
+      {
+        "delta": {
+          "audio": null,
+          "content": "A",
+          "function_call": null,
+          "provider_specific_fields": null,
+          "role": null,
+          "tool_calls": null
+        },
+        "finish_reason": null,
+        "index": 0,
+        "logprobs": null
+      }
+    ],
+    "citations": null,
+    "created": 1718064000,
+    "id": "cmpl-xs1",
+    "model": "grok-3-mini",
+    "object": "chat.completion.chunk",
+    "provider_specific_fields": null,
+    "system_fingerprint": null
+  },
+  {
+    "choices": [
+      {
+        "delta": {
+          "audio": null,
+          "content": null,
+          "function_call": null,
+          "role": null,
+          "tool_calls": null
+        },
+        "finish_reason": "stop",
+        "index": 0,
+        "logprobs": null
+      }
+    ],
+    "created": 1718064000,
+    "id": "cmpl-xs1",
+    "model": "grok-3-mini",
+    "object": "chat.completion.chunk",
+    "provider_specific_fields": null,
+    "system_fingerprint": null
+  }
+]

--- a/tests/test_litellm/translation/characterization_xai/snapshots/streams/refusal_rides_content_deltas.json
+++ b/tests/test_litellm/translation/characterization_xai/snapshots/streams/refusal_rides_content_deltas.json
@@ -1,0 +1,74 @@
+[
+  {
+    "choices": [
+      {
+        "delta": {
+          "audio": null,
+          "content": null,
+          "function_call": null,
+          "provider_specific_fields": null,
+          "refusal": "NO",
+          "role": "assistant",
+          "tool_calls": null
+        },
+        "finish_reason": null,
+        "index": 0,
+        "logprobs": null
+      }
+    ],
+    "citations": null,
+    "created": 1718064000,
+    "id": "cmpl-xs1",
+    "model": "grok-3-mini",
+    "object": "chat.completion.chunk",
+    "provider_specific_fields": null,
+    "system_fingerprint": null
+  },
+  {
+    "choices": [
+      {
+        "delta": {
+          "audio": null,
+          "content": "ok",
+          "function_call": null,
+          "provider_specific_fields": null,
+          "refusal": "!",
+          "role": null,
+          "tool_calls": null
+        },
+        "finish_reason": null,
+        "index": 0,
+        "logprobs": null
+      }
+    ],
+    "citations": null,
+    "created": 1718064000,
+    "id": "cmpl-xs1",
+    "model": "grok-3-mini",
+    "object": "chat.completion.chunk",
+    "provider_specific_fields": null,
+    "system_fingerprint": null
+  },
+  {
+    "choices": [
+      {
+        "delta": {
+          "audio": null,
+          "content": null,
+          "function_call": null,
+          "role": null,
+          "tool_calls": null
+        },
+        "finish_reason": "stop",
+        "index": 0,
+        "logprobs": null
+      }
+    ],
+    "created": 1718064000,
+    "id": "cmpl-xs1",
+    "model": "grok-3-mini",
+    "object": "chat.completion.chunk",
+    "provider_specific_fields": null,
+    "system_fingerprint": null
+  }
+]

--- a/tests/test_litellm/translation/characterization_xai/snapshots/streams/text.json
+++ b/tests/test_litellm/translation/characterization_xai/snapshots/streams/text.json
@@ -1,0 +1,96 @@
+[
+  {
+    "choices": [
+      {
+        "delta": {
+          "audio": null,
+          "content": "",
+          "function_call": null,
+          "provider_specific_fields": null,
+          "role": "assistant",
+          "tool_calls": null
+        },
+        "finish_reason": null,
+        "index": 0,
+        "logprobs": null
+      }
+    ],
+    "citations": null,
+    "created": 1718064000,
+    "id": "cmpl-xs1",
+    "model": "grok-3-mini",
+    "object": "chat.completion.chunk",
+    "provider_specific_fields": null,
+    "system_fingerprint": null
+  },
+  {
+    "choices": [
+      {
+        "delta": {
+          "audio": null,
+          "content": "Paris is",
+          "function_call": null,
+          "provider_specific_fields": null,
+          "role": null,
+          "tool_calls": null
+        },
+        "finish_reason": null,
+        "index": 0,
+        "logprobs": null
+      }
+    ],
+    "citations": null,
+    "created": 1718064000,
+    "id": "cmpl-xs1",
+    "model": "grok-3-mini",
+    "object": "chat.completion.chunk",
+    "provider_specific_fields": null,
+    "system_fingerprint": null
+  },
+  {
+    "choices": [
+      {
+        "delta": {
+          "audio": null,
+          "content": " the capital.",
+          "function_call": null,
+          "provider_specific_fields": null,
+          "role": null,
+          "tool_calls": null
+        },
+        "finish_reason": null,
+        "index": 0,
+        "logprobs": null
+      }
+    ],
+    "citations": null,
+    "created": 1718064000,
+    "id": "cmpl-xs1",
+    "model": "grok-3-mini",
+    "object": "chat.completion.chunk",
+    "provider_specific_fields": null,
+    "system_fingerprint": null
+  },
+  {
+    "choices": [
+      {
+        "delta": {
+          "audio": null,
+          "content": null,
+          "function_call": null,
+          "role": null,
+          "tool_calls": null
+        },
+        "finish_reason": "stop",
+        "index": 0,
+        "logprobs": null
+      }
+    ],
+    "created": 1718064000,
+    "id": "cmpl-xs1",
+    "model": "grok-3-mini",
+    "object": "chat.completion.chunk",
+    "provider_specific_fields": null,
+    "system_fingerprint": null
+  }
+]

--- a/tests/test_litellm/translation/characterization_xai/snapshots/streams/text_no_leading_role.json
+++ b/tests/test_litellm/translation/characterization_xai/snapshots/streams/text_no_leading_role.json
@@ -1,0 +1,72 @@
+[
+  {
+    "choices": [
+      {
+        "delta": {
+          "audio": null,
+          "content": "Hi",
+          "function_call": null,
+          "provider_specific_fields": null,
+          "role": "assistant",
+          "tool_calls": null
+        },
+        "finish_reason": null,
+        "index": 0,
+        "logprobs": null
+      }
+    ],
+    "citations": null,
+    "created": 1718064000,
+    "id": "cmpl-xs1",
+    "model": "grok-3-mini",
+    "object": "chat.completion.chunk",
+    "provider_specific_fields": null,
+    "system_fingerprint": null
+  },
+  {
+    "choices": [
+      {
+        "delta": {
+          "audio": null,
+          "content": " there",
+          "function_call": null,
+          "provider_specific_fields": null,
+          "role": null,
+          "tool_calls": null
+        },
+        "finish_reason": null,
+        "index": 0,
+        "logprobs": null
+      }
+    ],
+    "citations": null,
+    "created": 1718064000,
+    "id": "cmpl-xs1",
+    "model": "grok-3-mini",
+    "object": "chat.completion.chunk",
+    "provider_specific_fields": null,
+    "system_fingerprint": null
+  },
+  {
+    "choices": [
+      {
+        "delta": {
+          "audio": null,
+          "content": null,
+          "function_call": null,
+          "role": null,
+          "tool_calls": null
+        },
+        "finish_reason": "stop",
+        "index": 0,
+        "logprobs": null
+      }
+    ],
+    "created": 1718064000,
+    "id": "cmpl-xs1",
+    "model": "grok-3-mini",
+    "object": "chat.completion.chunk",
+    "provider_specific_fields": null,
+    "system_fingerprint": null
+  }
+]

--- a/tests/test_litellm/translation/characterization_xai/snapshots/streams/tools_typeless_continuation.json
+++ b/tests/test_litellm/translation/characterization_xai/snapshots/streams/tools_typeless_continuation.json
@@ -1,0 +1,92 @@
+[
+  {
+    "choices": [
+      {
+        "delta": {
+          "audio": null,
+          "content": null,
+          "function_call": null,
+          "provider_specific_fields": null,
+          "role": "assistant",
+          "tool_calls": [
+            {
+              "function": {
+                "arguments": "",
+                "name": "get_weather"
+              },
+              "id": "call_1",
+              "index": 0,
+              "type": "function"
+            }
+          ]
+        },
+        "finish_reason": null,
+        "index": 0,
+        "logprobs": null
+      }
+    ],
+    "citations": null,
+    "created": 1718064000,
+    "id": "cmpl-xs1",
+    "model": "grok-3-mini",
+    "object": "chat.completion.chunk",
+    "provider_specific_fields": null,
+    "system_fingerprint": null
+  },
+  {
+    "choices": [
+      {
+        "delta": {
+          "audio": null,
+          "content": null,
+          "function_call": null,
+          "provider_specific_fields": null,
+          "role": null,
+          "tool_calls": [
+            {
+              "function": {
+                "arguments": "{\"city\": \"Paris\"}",
+                "name": null
+              },
+              "id": null,
+              "index": 0,
+              "type": "function"
+            }
+          ]
+        },
+        "finish_reason": null,
+        "index": 0,
+        "logprobs": null
+      }
+    ],
+    "citations": null,
+    "created": 1718064000,
+    "id": "cmpl-xs1",
+    "model": "grok-3-mini",
+    "object": "chat.completion.chunk",
+    "provider_specific_fields": null,
+    "system_fingerprint": null
+  },
+  {
+    "choices": [
+      {
+        "delta": {
+          "audio": null,
+          "content": null,
+          "function_call": null,
+          "role": null,
+          "tool_calls": null
+        },
+        "finish_reason": "tool_calls",
+        "index": 0,
+        "logprobs": null
+      }
+    ],
+    "created": 1718064000,
+    "id": "cmpl-xs1",
+    "model": "grok-3-mini",
+    "object": "chat.completion.chunk",
+    "provider_specific_fields": null,
+    "system_fingerprint": null
+  }
+]

--- a/tests/test_litellm/translation/characterization_xai/snapshots/streams/usage_tail_include_usage.json
+++ b/tests/test_litellm/translation/characterization_xai/snapshots/streams/usage_tail_include_usage.json
@@ -1,0 +1,114 @@
+[
+  {
+    "choices": [
+      {
+        "delta": {
+          "audio": null,
+          "content": "",
+          "function_call": null,
+          "provider_specific_fields": null,
+          "role": "assistant",
+          "tool_calls": null
+        },
+        "finish_reason": null,
+        "index": 0,
+        "logprobs": null
+      }
+    ],
+    "citations": null,
+    "created": 1718064000,
+    "id": "cmpl-xs1",
+    "model": "grok-3-mini",
+    "object": "chat.completion.chunk",
+    "provider_specific_fields": null,
+    "system_fingerprint": null
+  },
+  {
+    "choices": [
+      {
+        "delta": {
+          "audio": null,
+          "content": "Hello",
+          "function_call": null,
+          "provider_specific_fields": null,
+          "role": null,
+          "tool_calls": null
+        },
+        "finish_reason": null,
+        "index": 0,
+        "logprobs": null
+      }
+    ],
+    "citations": null,
+    "created": 1718064000,
+    "id": "cmpl-xs1",
+    "model": "grok-3-mini",
+    "object": "chat.completion.chunk",
+    "provider_specific_fields": null,
+    "system_fingerprint": null
+  },
+  {
+    "choices": [
+      {
+        "delta": {
+          "audio": null,
+          "content": null,
+          "function_call": null,
+          "role": null,
+          "tool_calls": null
+        },
+        "finish_reason": "stop",
+        "index": 0,
+        "logprobs": null
+      }
+    ],
+    "created": 1718064000,
+    "id": "cmpl-xs1",
+    "model": "grok-3-mini",
+    "object": "chat.completion.chunk",
+    "provider_specific_fields": null,
+    "system_fingerprint": null
+  },
+  {
+    "choices": [
+      {
+        "delta": {
+          "audio": null,
+          "content": null,
+          "function_call": null,
+          "role": null,
+          "tool_calls": null
+        },
+        "finish_reason": null,
+        "index": 0,
+        "logprobs": null
+      }
+    ],
+    "created": 1718064000,
+    "id": "cmpl-xs1",
+    "model": "grok-3-mini",
+    "object": "chat.completion.chunk",
+    "provider_specific_fields": null,
+    "usage": {
+      "completion_tokens": 9,
+      "completion_tokens_details": {
+        "accepted_prediction_tokens": null,
+        "audio_tokens": null,
+        "image_tokens": null,
+        "reasoning_tokens": 7,
+        "rejected_prediction_tokens": null,
+        "text_tokens": null,
+        "video_tokens": null
+      },
+      "prompt_tokens": 171,
+      "prompt_tokens_details": {
+        "audio_tokens": null,
+        "cached_tokens": 0,
+        "image_tokens": null,
+        "text_tokens": null,
+        "video_tokens": null
+      },
+      "total_tokens": 180
+    }
+  }
+]

--- a/tests/test_litellm/translation/characterization_xai/snapshots/streams/usage_withheld_on_content_chunks.json
+++ b/tests/test_litellm/translation/characterization_xai/snapshots/streams/usage_withheld_on_content_chunks.json
@@ -1,0 +1,48 @@
+[
+  {
+    "choices": [
+      {
+        "delta": {
+          "audio": null,
+          "content": "hi",
+          "function_call": null,
+          "provider_specific_fields": null,
+          "role": "assistant",
+          "tool_calls": null
+        },
+        "finish_reason": null,
+        "index": 0,
+        "logprobs": null
+      }
+    ],
+    "citations": null,
+    "created": 1718064000,
+    "id": "cmpl-xs1",
+    "model": "grok-3-mini",
+    "object": "chat.completion.chunk",
+    "provider_specific_fields": null,
+    "system_fingerprint": null
+  },
+  {
+    "choices": [
+      {
+        "delta": {
+          "audio": null,
+          "content": null,
+          "function_call": null,
+          "role": null,
+          "tool_calls": null
+        },
+        "finish_reason": "stop",
+        "index": 0,
+        "logprobs": null
+      }
+    ],
+    "created": 1718064000,
+    "id": "cmpl-xs1",
+    "model": "grok-3-mini",
+    "object": "chat.completion.chunk",
+    "provider_specific_fields": null,
+    "system_fingerprint": null
+  }
+]

--- a/tests/test_litellm/translation/generate_differential_report.py
+++ b/tests/test_litellm/translation/generate_differential_report.py
@@ -146,6 +146,121 @@ def _openai_rows(lines: list) -> int:
     return failures
 
 
+def _xai_rows(lines: list) -> int:
+    from litellm.exceptions import UnsupportedParamsError
+
+    from . import _xai_corpus as corpus
+    from . import test_differential_xai_request as req
+    from . import test_differential_xai_response as resp
+    from . import test_differential_xai_stream as stream
+
+    failures = 0
+    lines += [
+        "",
+        "## xai: request bodies (characterization snapshot == v1-at-HEAD == v2, canonical JSON; v1 = get_optional_params('xai') + transform_request)",
+        "",
+    ]
+    for name in sorted(req.CASES):
+        case = req.CASES[name]
+        snapshot = (corpus.SNAPSHOTS_DIR / "requests" / f"{name}.json").read_text()
+        v1_same = corpus.canonical_json(corpus.run_v1_request_transform(case)) == (
+            snapshot
+        )
+        result = req._v2(case)
+        v2_same = result.is_ok() and req._norm(result.ok) == req._norm(
+            corpus.load_json(corpus.SNAPSHOTS_DIR / "requests" / f"{name}.json")
+        )
+        same = v1_same and v2_same
+        failures += 0 if same else 1
+        lines.append(f"- {'IDENTICAL' if same else 'DIVERGENT'}: {name}")
+    for name in sorted(req.V1_RAISES):
+        case, reason = req.V1_RAISES[name]
+        result = req._v2(case)
+        try:
+            corpus.run_v1_request_transform(case)
+            raised = False
+        except UnsupportedParamsError:
+            raised = True
+        ok = result.is_error() and reason in result.error.summary and raised
+        failures += 0 if ok else 1
+        label = "FALLBACK (v1 raises UnsupportedParamsError)" if ok else "DIVERGENT"
+        lines.append(f"- {label}: {name} ({reason})")
+    for name in sorted(req.EXPECTED_FALLBACKS):
+        case, reason = req.EXPECTED_FALLBACKS[name]
+        result = req._v2(case)
+        ok = result.is_error() and reason in result.error.summary
+        failures += 0 if ok else 1
+        label = "FALLBACK (v1 serves it)" if ok else "DIVERGENT"
+        lines.append(f"- {label}: {name} ({reason})")
+    lines += [
+        "",
+        "## xai: responses (snapshot == v1 XAIChatConfig.transform_response == v2; the LIVE httpx-path normalizer incl. the usage post-steps)",
+        "",
+    ]
+    responses = corpus.corpus("responses")
+    for name in sorted(responses):
+        row = responses[name]
+        snapshot = (corpus.SNAPSHOTS_DIR / "responses" / f"{name}.json").read_text()
+        same = (
+            corpus.canonical_json(
+                corpus.run_v1_response_transform(row["body"], row["model"])
+            )
+            == snapshot
+            and corpus.canonical_json(
+                resp._v2_model_response(row["body"], row["model"])
+            )
+            == snapshot
+        )
+        failures += 0 if same else 1
+        lines.append(f"- {'IDENTICAL' if same else 'DIVERGENT'}: {name}")
+    lines += [
+        "",
+        "## xai: streams (snapshot == v1 line-seam replay through XAIChatCompletionStreamingHandler + CustomStreamWrapper('xai') == v2 xai dialect)",
+        "",
+    ]
+    streams = corpus.corpus("streams")
+    for name in sorted(streams):
+        row = streams[name]
+        snapshot_text = (corpus.SNAPSHOTS_DIR / "streams" / f"{name}.json").read_text()
+        v1_same = (
+            corpus.canonical_json(
+                corpus.replay_xai_sse_lines(row["events"], row["stream_options"])
+            )
+            == snapshot_text
+        )
+        if name == stream._TAIL_ROW:
+            snapshot = corpus.load_json(
+                corpus.SNAPSHOTS_DIR / "streams" / f"{name}.json"
+            )
+            v2 = stream._v2_chunks(row["events"])
+            tail_ok = (
+                v1_same
+                and len(v2) == len(snapshot)
+                and stream._norm(v2[:-1]) == stream._norm(snapshot[: len(v2) - 1])
+                and v2[-1]["choices"] == []
+                and all(
+                    snapshot[-1]["usage"][k] == v2[-1]["usage"][k]
+                    for k in ("prompt_tokens", "completion_tokens", "total_tokens")
+                )
+            )
+            failures += 0 if tail_ok else 1
+            lines.append(
+                ("- SEAM CONTRACT: " if tail_ok else "- DIVERGENT: ")
+                + f"{name} (v1's chunk_parser injects a dummy choice so the"
+                " wrapper swallows the tail and synthesizes the final usage"
+                " chunk; v2 passes the wire choices=[] chunk through with the"
+                " FOLDED usage for the streaming seam to synthesize from)"
+            )
+            continue
+        v2_same = stream._norm(stream._v2_chunks(row["events"])) == stream._norm(
+            corpus.load_json(corpus.SNAPSHOTS_DIR / "streams" / f"{name}.json")
+        )
+        same = v1_same and v2_same
+        failures += 0 if same else 1
+        lines.append(f"- {'IDENTICAL' if same else 'DIVERGENT'}: {name}")
+    return failures
+
+
 def _azure_rows(lines: list) -> int:
     import os
 
@@ -617,7 +732,7 @@ def main() -> None:
     _stub_vertex_token()
 
     lines = [
-        "# Translation v2 differential report (anthropic + bedrock + openai + google + azure)",
+        "# Translation v2 differential report (anthropic + bedrock + openai + google + azure + xai)",
         "",
         "v1 and v2 run over the same corpus; every row must be IDENTICAL (or an",
         "explained FALLBACK that v1 serves) for a provider's flag to turn on.",
@@ -630,6 +745,7 @@ def main() -> None:
     ]
     failures = _anthropic_rows(lines)
     failures += _openai_rows(lines)
+    failures += _xai_rows(lines)
     failures += _azure_rows(lines)
     failures += _azure_ai_rows(lines)
     failures += _bedrock_request_rows(lines)

--- a/tests/test_litellm/translation/generate_xai_snapshots.py
+++ b/tests/test_litellm/translation/generate_xai_snapshots.py
@@ -1,0 +1,73 @@
+"""Regenerate the characterization_xai snapshots from v1 IN-PROCESS at HEAD.
+
+Run: LITELLM_LOCAL_MODEL_COST_MAP=True \
+    python -m tests.test_litellm.translation.generate_xai_snapshots
+
+Provenance: there are no recorded xai vendor fixtures anywhere (the
+characterization branch has zero), so the snapshots pin v1-as-executed —
+the primary differential reference. The drift gate in the xai differential
+tests re-runs the same invokers and fails if v1 at HEAD ever stops matching
+the committed snapshots; regenerating is a reviewed snapshot-diff, never a
+silent step.
+
+Ambient freeze mirrors tests' ``frozen_ambient``: stream chunks stamp
+``created`` from ``time.time`` and the wrapper mints fastuuid ids.
+"""
+
+import itertools
+import pathlib
+import sys
+import time
+import uuid
+
+
+def _freeze_ambient() -> None:
+    import fastuuid
+
+    import litellm._uuid
+
+    counter = itertools.count(1)
+
+    def fake_uuid4():
+        return uuid.UUID(int=next(counter))
+
+    uuid.uuid4 = fake_uuid4  # type: ignore[assignment]
+    fastuuid.uuid4 = fake_uuid4
+    litellm._uuid.uuid4 = fake_uuid4
+    time.time = lambda: FROZEN_TIME  # type: ignore[assignment]
+
+
+def _write(path: pathlib.Path, payload: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(payload)
+    print(f"wrote {path}")
+
+
+if __name__ == "__main__":
+    sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[3]))
+    from tests.test_litellm.translation._xai_corpus import (
+        FROZEN_TIME,
+        SNAPSHOTS_DIR,
+        canonical_json,
+        corpus,
+        run_v1_request_transform,
+        run_v1_response_transform,
+        replay_xai_sse_lines,
+    )
+
+    _freeze_ambient()
+    for name, case in corpus("cases").items():
+        _write(
+            SNAPSHOTS_DIR / "requests" / f"{name}.json",
+            canonical_json(run_v1_request_transform(case)),
+        )
+    for name, row in corpus("responses").items():
+        _write(
+            SNAPSHOTS_DIR / "responses" / f"{name}.json",
+            canonical_json(run_v1_response_transform(row["body"], row["model"])),
+        )
+    for name, row in corpus("streams").items():
+        _write(
+            SNAPSHOTS_DIR / "streams" / f"{name}.json",
+            canonical_json(replay_xai_sse_lines(row["events"], row["stream_options"])),
+        )

--- a/tests/test_litellm/translation/test_differential_xai_request.py
+++ b/tests/test_litellm/translation/test_differential_xai_request.py
@@ -251,7 +251,10 @@ def test_unsupported_shape_is_a_typed_fallback(name: str) -> None:
 def test_reasoning_gate_matches_v1_capability_read() -> None:
     """The v2 gate reads deps.supports_capability over the ``xai/{model}``
     map key; it must agree with v1's litellm.supports_reasoning on the
-    models the corpus serves and falls back."""
+    models the corpus serves and falls back. The ``xai/`` prefix is
+    LOAD-BEARING: the model map has no bare-model rows, so an unprefixed
+    lookup is False even for reasoning models — asserted below so the next
+    consumer of this template cannot miss it."""
     import litellm
 
     from litellm.translation.providers.xai.params import supports_reasoning
@@ -267,3 +270,68 @@ def test_reasoning_gate_matches_v1_capability_read() -> None:
         assert supports_reasoning(model, deps) == litellm.supports_reasoning(
             model=model, custom_llm_provider="xai"
         ), model
+    assert deps.supports_capability("grok-3-mini", "supports_reasoning") is False
+    assert deps.supports_capability("xai/grok-3-mini", "supports_reasoning") is True
+
+
+def test_supported_list_mirrors_track_v1_at_head() -> None:
+    """Drift gate for the hand-copied supported-list mirrors (critic-grok
+    M4): for EVERY xai chat model in the map at HEAD, the v2 gates must
+    agree with ``XAIChatConfig.get_supported_openai_params``, and every
+    param the v2 serializer emits unconditionally must still be in v1's
+    supported list (otherwise v2 would serve what v1 raises on)."""
+    import litellm
+
+    from litellm.llms.xai.chat.transformation import XAIChatConfig
+
+    from litellm.translation.providers.xai.params import (
+        supports_reasoning,
+        supports_stop,
+    )
+
+    deps = build_real_deps()
+    config = XAIChatConfig()
+    models = sorted(
+        key.split("/", 1)[1]
+        for key, info in litellm.model_cost.items()
+        if key.startswith("xai/") and info.get("mode") == "chat"
+    )
+    assert len(models) >= 5, "model map lost its xai chat entries"
+    always_served = (
+        "max_tokens",
+        "parallel_tool_calls",
+        "response_format",
+        "stream",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "top_p",
+        "user",
+    )
+    for model in models:
+        supported = config.get_supported_openai_params(model)
+        assert supports_stop(model) == ("stop" in supported), model
+        assert supports_reasoning(model, deps) == (
+            "reasoning_effort" in supported
+        ), model
+        for param in always_served:
+            assert param in supported, (model, param)
+
+
+def test_use_xai_oauth_guard_reachability_facts() -> None:
+    """The use_xai_oauth guard arm is DEFENSE-IN-DEPTH, not the protection
+    (critic-grok M1): use_xai_oauth is a litellm param, so completion()
+    never places it in the OpenAI body and the seam's _raw_openai_body
+    cannot carry the key today. The protection is the seam obligation in
+    CLAUDE.md (route the kwarg into the raw body, or fall back on it before
+    building deps, pinned at completion() level before the flag turns on).
+    This canary pins the classification facts that analysis rests on; if
+    either flips, re-derive the guard's reachability."""
+    from litellm.constants import OPENAI_CHAT_COMPLETION_PARAMS
+    from litellm.types.utils import all_litellm_params
+
+    assert "use_xai_oauth" in all_litellm_params
+    assert "use_xai_oauth" not in OPENAI_CHAT_COMPLETION_PARAMS
+    # web_search_options IS an OpenAI param: that guard arm is genuinely
+    # reachable through _raw_openai_body
+    assert "web_search_options" in OPENAI_CHAT_COMPLETION_PARAMS

--- a/tests/test_litellm/translation/test_differential_xai_request.py
+++ b/tests/test_litellm/translation/test_differential_xai_request.py
@@ -1,0 +1,269 @@
+"""Differential parity: v2 xai translation vs the v1 XAIChatConfig chain.
+
+Two-sided over the generated characterization corpus (provenance:
+characterization_xai/README.md): v1 AT HEAD must still equal the committed
+snapshot (drift guard) AND v2 must equal the snapshot byte-for-byte. The v1
+invoker is ``get_optional_params(custom_llm_provider="xai")`` -> extra_body
+pop -> ``transform_request`` — v1 AS EXECUTED on the httpx path, never bare
+``map_openai_params`` (whose max_completion_tokens rename arm is dead code:
+``_check_valid_arg`` raises first; researcher-3 R2).
+
+The R2 gate rows therefore pin the RAISE: v1 must raise
+UnsupportedParamsError in-process AND v2 must return a typed fallback, so
+flag-on traffic gets v1's own error, never a remap.
+"""
+
+import copy
+import json
+
+import pytest
+
+from litellm.exceptions import UnsupportedParamsError
+
+from litellm.translation import translate_chat_request
+
+from ._xai_corpus import (
+    SNAPSHOTS_DIR,
+    canonical_json,
+    corpus,
+    load_json,
+    run_v1_request_transform,
+)
+from .conftest import build_real_deps
+
+CASES = corpus("cases")
+
+_WEATHER_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "parameters": {"type": "object", "properties": {"city": {"type": "string"}}},
+    },
+}
+
+_USER = [{"role": "user", "content": "x"}]
+
+# Rows where v1 RAISES UnsupportedParamsError (the R2 supported-list gate);
+# v2 must be a typed fallback so v1 serves its own raise. The reason fragment
+# is asserted on the v2 error; the raise is asserted on v1 in-process.
+V1_RAISES = {
+    "max_completion_tokens_any_grok": (
+        {"model": "grok-4-0709", "max_completion_tokens": 128, "messages": _USER},
+        "max_completion_tokens",
+    ),
+    "max_completion_tokens_grok3mini": (
+        {"model": "grok-3-mini", "max_completion_tokens": 128, "messages": _USER},
+        "max_completion_tokens",
+    ),
+    "stop_on_grok4": (
+        {"model": "grok-4-0709", "stop": ["END"], "messages": _USER},
+        "stop on grok-4-0709",
+    ),
+    "stop_on_grok3mini": (
+        {"model": "grok-3-mini", "stop": ["END"], "messages": _USER},
+        "stop on grok-3-mini",
+    ),
+    "stop_on_grok_code_fast": (
+        {"model": "grok-code-fast-1", "stop": ["END"], "messages": _USER},
+        "stop on grok-code-fast-1",
+    ),
+    "reasoning_effort_on_non_reasoning_grok4": (
+        {"model": "grok-4-0709", "reasoning_effort": "high", "messages": _USER},
+        "reasoning_effort on non-reasoning xai model",
+    ),
+    "frequency_penalty_on_grok4": (
+        # parse-level fallback (penalties are outside the IR); v1's gate
+        # raises for this family, so the fallback serves v1's own error
+        {"model": "grok-4-0709", "frequency_penalty": 0.5, "messages": _USER},
+        "frequency_penalty",
+    ),
+}
+
+# Typed fallbacks where v1 SERVES the request (v1 is not invoked: the seam
+# routes these to v1 untouched, so v1's behavior is by-construction v1's).
+EXPECTED_FALLBACKS = {
+    "web_search_options_responses_bridge": (
+        {
+            "model": "grok-4-0709",
+            "web_search_options": {"search_context_size": "high"},
+            "messages": _USER,
+        },
+        "Responses-API bridge",
+    ),
+    "use_xai_oauth_pkce_flow": (
+        {"model": "grok-4-0709", "use_xai_oauth": True, "messages": _USER},
+        "PKCE",
+    ),
+    "explicit_stream_false_reaches_wire": (
+        {"model": "grok-4-0709", "stream": False, "messages": _USER},
+        "explicit stream: false",
+    ),
+    "user_message_name_forwarded_by_v1": (
+        {
+            "model": "grok-4-0709",
+            "messages": [{"role": "user", "content": "x", "name": "alice"}],
+        },
+        "message name field",
+    ),
+    "nested_tool_strict_below_function": (
+        {
+            "model": "grok-4-0709",
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "f",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"strict": {"type": "boolean"}},
+                        },
+                    },
+                }
+            ],
+            "messages": _USER,
+        },
+        "nested 'strict' key",
+    ),
+    "presence_penalty_outside_ir": (
+        # v1 passes presence_penalty through for every grok model; the hub
+        # keeps penalties parse-level fallbacks (integrator's unified
+        # _raw_openai_body semantics), so v1 serves it
+        {"model": "grok-4-0709", "presence_penalty": 0.5, "messages": _USER},
+        "presence_penalty",
+    ),
+    "frequency_penalty_supported_family_outside_ir": (
+        # supported on grok-3-mini in v1; still a parse-level fallback
+        {"model": "grok-3-mini", "frequency_penalty": 0.5, "messages": _USER},
+        "frequency_penalty",
+    ),
+    "seed_outside_ir": (
+        {"model": "grok-4-0709", "seed": 42, "messages": _USER},
+        "seed",
+    ),
+    "logprobs_outside_ir": (
+        {"model": "grok-4-0709", "logprobs": True, "messages": _USER},
+        "logprobs",
+    ),
+    "stream_options_outside_ir": (
+        {
+            "model": "grok-4-0709",
+            "stream": True,
+            "stream_options": {"include_usage": True},
+            "messages": _USER,
+        },
+        "stream_options",
+    ),
+    "string_form_stop_supported_family": (
+        {"model": "grok-3", "stop": "END", "messages": _USER},
+        "string-form stop",
+    ),
+    "both_max_tokens_keys": (
+        {
+            "model": "grok-4-0709",
+            "max_tokens": 5,
+            "max_completion_tokens": 6,
+            "messages": _USER,
+        },
+        "both max_tokens and max_completion_tokens",
+    ),
+    "top_k_not_an_xai_param": (
+        {"model": "grok-4-0709", "top_k": 40, "messages": _USER},
+        "top_k",
+    ),
+    "image_detail_key": (
+        {
+            "model": "grok-4-0709",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "see"},
+                        {
+                            "type": "image_url",
+                            "image_url": {
+                                "url": "https://e.test/a.png",
+                                "detail": "low",
+                            },
+                        },
+                    ],
+                }
+            ],
+        },
+        "image_url detail/format",
+    ),
+    "consecutive_user_messages": (
+        {
+            "model": "grok-4-0709",
+            "messages": [
+                {"role": "user", "content": "a"},
+                {"role": "user", "content": "b"},
+            ],
+        },
+        "consecutive user messages",
+    ),
+    "empty_tools_list": (
+        {"model": "grok-4-0709", "tools": [], "messages": _USER},
+        "empty tools list",
+    ),
+}
+
+
+def _v2(case: dict):
+    return translate_chat_request(copy.deepcopy(case), "xai", build_real_deps())
+
+
+def _norm(body: dict) -> str:
+    return json.dumps(body, sort_keys=True, default=str)
+
+
+@pytest.mark.parametrize("name", sorted(CASES))
+def test_v1_at_head_still_matches_the_snapshot(name: str) -> None:
+    snapshot = (SNAPSHOTS_DIR / "requests" / f"{name}.json").read_text()
+    assert canonical_json(run_v1_request_transform(CASES[name])) == snapshot
+
+
+@pytest.mark.parametrize("name", sorted(CASES))
+def test_v2_request_matches_the_snapshot(name: str) -> None:
+    result = _v2(CASES[name])
+    assert result.is_ok(), result.error.summary
+    snapshot = load_json(SNAPSHOTS_DIR / "requests" / f"{name}.json")
+    assert _norm(result.ok) == _norm(snapshot)
+
+
+@pytest.mark.parametrize("name", sorted(V1_RAISES))
+def test_v1_raise_rows_fall_back_typed(name: str) -> None:
+    case, reason_fragment = V1_RAISES[name]
+    result = _v2(case)
+    assert result.is_error(), f"{name} unexpectedly translated: {result.ok!r}"
+    assert reason_fragment in result.error.summary, result.error.summary
+    with pytest.raises(UnsupportedParamsError):
+        run_v1_request_transform(case)
+
+
+@pytest.mark.parametrize("name", sorted(EXPECTED_FALLBACKS))
+def test_unsupported_shape_is_a_typed_fallback(name: str) -> None:
+    case, reason_fragment = EXPECTED_FALLBACKS[name]
+    result = _v2(case)
+    assert result.is_error(), f"{name} unexpectedly translated: {result.ok!r}"
+    assert reason_fragment in result.error.summary, result.error.summary
+
+
+def test_reasoning_gate_matches_v1_capability_read() -> None:
+    """The v2 gate reads deps.supports_capability over the ``xai/{model}``
+    map key; it must agree with v1's litellm.supports_reasoning on the
+    models the corpus serves and falls back."""
+    import litellm
+
+    from litellm.translation.providers.xai.params import supports_reasoning
+
+    deps = build_real_deps()
+    for model in (
+        "grok-3",
+        "grok-3-mini",
+        "grok-4-0709",
+        "grok-code-fast-1",
+        "grok-2-1212",
+    ):
+        assert supports_reasoning(model, deps) == litellm.supports_reasoning(
+            model=model, custom_llm_provider="xai"
+        ), model

--- a/tests/test_litellm/translation/test_differential_xai_response.py
+++ b/tests/test_litellm/translation/test_differential_xai_response.py
@@ -157,3 +157,39 @@ def test_unreachable_response_shape_is_a_typed_error(name: str) -> None:
     result = parse_response(copy.deepcopy(raw), parsed.ok)
     assert result.is_error(), f"{name} unexpectedly parsed"
     assert reason_fragment in result.error.summary, result.error.summary
+
+
+def test_uncoercible_usage_is_loud_on_both_sides() -> None:
+    """v1 raises out of cdr's Usage validation for an uncoercible token
+    value; v2 must return a boundary error, never silently treat it as 0
+    (critic-grok M2). The numeric-string direction is the two-sided corpus
+    row numeric_string_usage_coerced."""
+    raw = {
+        "id": "resp-bad",
+        "object": "chat.completion",
+        "created": 1718000011,
+        "model": "grok-3-mini",
+        "choices": [
+            {
+                "index": 0,
+                "finish_reason": "stop",
+                "logprobs": None,
+                "message": {"role": "assistant", "content": "a"},
+            }
+        ],
+        "usage": {
+            "prompt_tokens": "abc",
+            "completion_tokens": 2,
+            "total_tokens": 9,
+            "completion_tokens_details": {"reasoning_tokens": 7},
+        },
+    }
+    from ._xai_corpus import run_v1_response_transform
+
+    with pytest.raises(Exception):
+        run_v1_response_transform(raw, "grok-3-mini")
+    parsed = parse_request(copy.deepcopy(_REQUEST))
+    assert parsed.is_ok()
+    result = parse_response(copy.deepcopy(raw), parsed.ok)
+    assert result.is_error(), "uncoercible usage must be loud, not a silent 0"
+    assert "not int-coercible" in result.error.summary, result.error.summary

--- a/tests/test_litellm/translation/test_differential_xai_response.py
+++ b/tests/test_litellm/translation/test_differential_xai_response.py
@@ -1,0 +1,159 @@
+"""Differential parity for the xai response path.
+
+The v1 reference is ``XAIChatConfig.transform_response`` — LIVE on the
+httpx path (main.py:2289), the inverse of the openai SDK route — over a
+real ``httpx.Response``. Two-sided: v1 at HEAD must equal the committed
+snapshot (drift guard) AND v2 (``parse_response`` ->
+``serialize_response("openai")`` -> ``to_model_response("openai")``) must
+equal it byte-for-byte.
+
+The corpus pins the five xai response behaviors: the R1 finish_reason ""
+chain (v1's own ``_fix_choice_finish_reason_for_tool_calls`` is dead;
+v1-as-executed emits "stop" WITH tool_calls — both sides run the same live
+``map_finish_reason`` via ``Choices``), the reasoning-token fold (+ its
+idempotency guard), num_sources_used -> web_search_requests (live-search
+billing), total_tokens normalization, and the citations top-level
+passthrough. The R4 row proves the bare wire model: NO ``xai/`` prefix ever
+appears (fresh ModelResponse, the cdr ``model is None`` arm).
+"""
+
+import copy
+import json
+
+import pytest
+
+from litellm.types.utils import ModelResponse
+
+from litellm.translation.inbound.openai_chat import parse_request
+from litellm.translation.inbound.openai_chat.response import serialize_response
+from litellm.translation.providers.xai.response import parse_response
+from litellm.translation_seam import build_translation_deps, to_model_response
+
+from ._xai_corpus import (
+    SNAPSHOTS_DIR,
+    canonical_json,
+    corpus,
+    jsonable,
+    run_v1_response_transform,
+)
+
+RESPONSES = corpus("responses")
+
+_REQUEST = {
+    "model": "grok-4-0709",
+    "messages": [{"role": "user", "content": "hi"}],
+    "tools": [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ],
+}
+
+
+def _v2_model_response(raw: dict, request_model: str) -> dict:
+    request = {**copy.deepcopy(_REQUEST), "model": request_model}
+    parsed = parse_request(request)
+    assert parsed.is_ok(), parsed.error.summary
+    response = parse_response(copy.deepcopy(raw), parsed.ok)
+    assert response.is_ok(), response.error.summary
+    body = serialize_response(response.ok, build_translation_deps(), "openai")
+    return to_model_response(body, ModelResponse(), usage_style="openai").model_dump()
+
+
+def _norm(payload: object) -> str:
+    return json.dumps(jsonable(payload), sort_keys=True)
+
+
+@pytest.mark.parametrize("name", sorted(RESPONSES))
+def test_v1_at_head_still_matches_the_snapshot(name: str) -> None:
+    row = RESPONSES[name]
+    snapshot = (SNAPSHOTS_DIR / "responses" / f"{name}.json").read_text()
+    assert canonical_json(run_v1_response_transform(row["body"], row["model"])) == (
+        snapshot
+    )
+
+
+@pytest.mark.parametrize("name", sorted(RESPONSES))
+def test_v2_response_matches_the_snapshot(name: str) -> None:
+    row = RESPONSES[name]
+    snapshot = (SNAPSHOTS_DIR / "responses" / f"{name}.json").read_text()
+    assert canonical_json(_v2_model_response(row["body"], row["model"])) == snapshot
+
+
+def test_finish_empty_string_yields_stop_with_tool_calls() -> None:
+    """R1 pinned semantically, not just byte-wise: the served finish is
+    "stop" AND the tool calls survive (the violated stop->tool_calls
+    invariant v1-as-executed exhibits)."""
+    row = RESPONSES["finish_empty_string_with_tool_calls"]
+    dumped = _v2_model_response(row["body"], row["model"])
+    choice = dumped["choices"][0]
+    assert choice["finish_reason"] == "stop"
+    assert choice["message"]["tool_calls"], "tool_calls must survive the '' finish"
+
+
+def test_no_xai_prefix_on_the_response_model() -> None:
+    """R4: the xai httpx path starts from a FRESH ModelResponse (model=None,
+    main.py:1401) and adopts the bare wire model; no seam may prefix it."""
+    row = RESPONSES["text_basic"]
+    v1 = run_v1_response_transform(row["body"], row["model"]).model_dump()
+    v2 = _v2_model_response(row["body"], row["model"])
+    assert v1["model"] == v2["model"] == "grok-4-0709"
+    assert "/" not in v2["model"]
+
+
+def test_websearch_billing_fields_reach_usage() -> None:
+    """The live-search billing hook: cost_per_web_search_request reads
+    usage.prompt_tokens_details.web_search_requests."""
+    row = RESPONSES["websearch_sources_and_citations"]
+    dumped = _v2_model_response(row["body"], row["model"])
+    assert dumped["usage"]["prompt_tokens_details"]["web_search_requests"] == 3
+    assert dumped["citations"] == ["https://a.test", "https://b.test"]
+
+
+_UNSUPPORTED = {
+    "multiple_choices": (
+        {
+            "id": "r",
+            "created": 1,
+            "model": "grok-4-0709",
+            "choices": [
+                {"index": 0, "finish_reason": "stop", "message": {"content": "a"}},
+                {"index": 1, "finish_reason": "stop", "message": {"content": "b"}},
+            ],
+        },
+        "multiple response choices",
+    ),
+    "legacy_function_call_output": (
+        {
+            "id": "r",
+            "created": 1,
+            "model": "grok-4-0709",
+            "choices": [
+                {
+                    "index": 0,
+                    "finish_reason": "function_call",
+                    "message": {
+                        "content": None,
+                        "role": "assistant",
+                        "function_call": {"name": "f", "arguments": "{}"},
+                    },
+                }
+            ],
+        },
+        "function_call",
+    ),
+}
+
+
+@pytest.mark.parametrize("name", sorted(_UNSUPPORTED))
+def test_unreachable_response_shape_is_a_typed_error(name: str) -> None:
+    raw, reason_fragment = _UNSUPPORTED[name]
+    parsed = parse_request(copy.deepcopy(_REQUEST))
+    assert parsed.is_ok()
+    result = parse_response(copy.deepcopy(raw), parsed.ok)
+    assert result.is_error(), f"{name} unexpectedly parsed"
+    assert reason_fragment in result.error.summary, result.error.summary

--- a/tests/test_litellm/translation/test_differential_xai_stream.py
+++ b/tests/test_litellm/translation/test_differential_xai_stream.py
@@ -1,0 +1,173 @@
+"""Differential parity for xai streaming, pinned at the SSE data-line seam.
+
+v1 side: raw ``data:`` lines through ``XAIChatCompletionStreamingHandler``
+(the chunk_parser owns the xai BEHAVIOR: dummy-choice injection into
+``choices: []`` usage tails, per-chunk usage fold/normalize, the base
+handler's reasoning rename) into ``CustomStreamWrapper("xai")`` — NOT the
+parsed-chunk seam the openai gate uses, because those rewrites sit below
+the line seam (researcher-3 R3). v2 side: ``fold_lines`` with the xai
+parser and the ``xai`` chunk dialect. Two-sided over the generated corpus:
+v1 at HEAD must equal the committed snapshot AND v2 must equal it
+byte-for-byte for content/reasoning/tool/finish chunks.
+
+The usage tail is the one pinned envelope difference (the openai-port seam
+contract, inherited unchanged): v1's wrapper swallows the dummy-choice tail
+mid-stream and SYNTHESIZES a final usage chunk at StopIteration (only under
+``include_usage``); the v2 fold passes the wire ``choices: []`` chunk
+through with the FOLDED usage, and the future streaming seam owns the
+synthesis. The contract row pins byte-identical prefixes and equal usage
+numbers (reasoning folded into completion on both sides).
+"""
+
+import copy
+import json
+
+import pytest
+
+from litellm.translation.engine.stream import fold_events, fold_lines
+from litellm.translation.inbound.openai_chat.stream import initial_state
+from litellm.translation.providers.xai.stream import parse_event, parse_line
+from litellm.translation_seam import to_model_response_stream
+
+from ._xai_corpus import (
+    SNAPSHOTS_DIR,
+    STREAM_MODEL,
+    canonical_json,
+    corpus,
+    load_json,
+    replay_xai_sse_lines,
+)
+
+STREAMS = corpus("streams")
+_TAIL_ROW = "usage_tail_include_usage"
+_PREFIX_ROWS = sorted(name for name in STREAMS if name != _TAIL_ROW)
+
+
+def _v2_chunks(events: list) -> list:
+    lines = [f"data: {json.dumps(event)}" for event in copy.deepcopy(events)]
+    lines.append("data: [DONE]")
+    folded = fold_lines(lines, parse_line, initial_state(STREAM_MODEL, dialect="xai"))
+    assert folded.is_ok(), folded.error.summary
+    return [
+        to_model_response_stream(chunk, "chatcmpl-AMBIENT").model_dump()
+        for chunk in folded.ok
+    ]
+
+
+def _norm(chunks: list) -> str:
+    return json.dumps(chunks, sort_keys=True, default=str)
+
+
+@pytest.mark.parametrize("name", sorted(STREAMS))
+def test_v1_at_head_still_matches_the_snapshot(name: str, frozen_ambient) -> None:
+    row = STREAMS[name]
+    snapshot = (SNAPSHOTS_DIR / "streams" / f"{name}.json").read_text()
+    assert (
+        canonical_json(replay_xai_sse_lines(row["events"], row["stream_options"]))
+        == snapshot
+    )
+
+
+@pytest.mark.parametrize("name", _PREFIX_ROWS)
+def test_v2_stream_matches_the_snapshot(name: str, frozen_ambient) -> None:
+    snapshot = load_json(SNAPSHOTS_DIR / "streams" / f"{name}.json")
+    assert _norm(_v2_chunks(STREAMS[name]["events"])) == _norm(snapshot)
+
+
+def test_usage_tail_pins_the_seam_contract(frozen_ambient) -> None:
+    """v1's tail is the wrapper-synthesized usage chunk (envelope); v2's
+    tail is the wire ``choices: []`` chunk with the folded usage. Prefix
+    byte-identical, usage numbers equal — including the reasoning fold
+    (2 + 7 -> 9) and the normalized total."""
+    snapshot = load_json(SNAPSHOTS_DIR / "streams" / f"{_TAIL_ROW}.json")
+    v2 = _v2_chunks(STREAMS[_TAIL_ROW]["events"])
+    assert len(v2) == len(snapshot)
+    assert _norm(v2[:-1]) == _norm(snapshot[: len(v2) - 1])
+    v1_tail, v2_tail = snapshot[-1], v2[-1]
+    assert v2_tail["choices"] == []
+    for key in ("prompt_tokens", "completion_tokens", "total_tokens"):
+        assert v1_tail["usage"][key] == v2_tail["usage"][key], key
+    assert v2_tail["usage"]["completion_tokens"] == 9  # 2 + 7 folded
+    assert (
+        v1_tail["usage"]["completion_tokens_details"]["reasoning_tokens"]
+        == v2_tail["usage"]["completion_tokens_details"]["reasoning_tokens"]
+        == 7
+    )
+
+
+def test_usage_tail_swallowed_without_stream_options(frozen_ambient) -> None:
+    """Without include_usage v1 swallows the tail entirely (usage goes to
+    hidden params); the v2 passthrough keeps the prefix identical and the
+    seam owns withholding the tail — pinned so the streaming seam knows."""
+    events = STREAMS[_TAIL_ROW]["events"]
+    v1 = replay_xai_sse_lines(events, None)
+    v2 = _v2_chunks(events)
+    assert len(v1) == len(v2) - 1
+    assert _norm([c for c in map(dict, v1)]) == _norm(v2[:-1])
+
+
+def test_v2_line_and_event_folds_agree(frozen_ambient) -> None:
+    events = STREAMS["text"]["events"]
+    folded = fold_events(
+        copy.deepcopy(events), parse_event, initial_state(STREAM_MODEL, dialect="xai")
+    )
+    assert folded.is_ok(), folded.error.summary
+    via_events = [
+        to_model_response_stream(chunk, "chatcmpl-AMBIENT").model_dump()
+        for chunk in folded.ok
+    ]
+    assert _norm(via_events) == _norm(_v2_chunks(events))
+
+
+def _chunk(delta=None, finish=None, usage=None, choices=None):
+    payload = {
+        "id": "cmpl-u1",
+        "object": "chat.completion.chunk",
+        "created": 1718000000,
+        "model": STREAM_MODEL,
+        "choices": [
+            {
+                "index": 0,
+                "delta": delta or {},
+                "logprobs": None,
+                "finish_reason": finish,
+            }
+        ],
+        "usage": usage,
+    }
+    if choices is not None:
+        payload["choices"] = choices
+    return payload
+
+
+_UNSUPPORTED_CHUNKS = {
+    "function_call_delta": (
+        _chunk({"function_call": {"name": "f", "arguments": ""}}),
+        "function_call",
+    ),
+    "multiple_choices": (
+        _chunk(
+            choices=[
+                {"index": 0, "delta": {"content": "a"}, "finish_reason": None},
+                {"index": 1, "delta": {"content": "b"}, "finish_reason": None},
+            ]
+        ),
+        "multiple stream choices",
+    ),
+    "unknown_delta_key": (
+        _chunk({"content": "x", "thinking_blocks": []}),
+        "stream delta keys",
+    ),
+    "error_payload": (
+        {"error": {"message": "boom"}, "choices": []},
+        "provider stream error",
+    ),
+}
+
+
+@pytest.mark.parametrize("name", sorted(_UNSUPPORTED_CHUNKS))
+def test_unreachable_chunk_shape_is_a_typed_error(name: str) -> None:
+    event, reason_fragment = _UNSUPPORTED_CHUNKS[name]
+    result = parse_event(event)
+    assert result.is_error(), f"{name} unexpectedly parsed"
+    assert reason_fragment in result.error.summary, result.error.summary

--- a/tests/test_litellm/translation/test_differential_xai_stream.py
+++ b/tests/test_litellm/translation/test_differential_xai_stream.py
@@ -171,3 +171,49 @@ def test_unreachable_chunk_shape_is_a_typed_error(name: str) -> None:
     result = parse_event(event)
     assert result.is_error(), f"{name} unexpectedly parsed"
     assert reason_fragment in result.error.summary, result.error.summary
+
+
+def test_numeric_string_usage_folds_like_v1s_own_arithmetic() -> None:
+    """v1's dict-path fold is int(x or 0): numeric strings fold
+    (completion 2+7 -> 9, untouched keys keep their original values).
+    Pinned against v1's OWN static methods (critic-grok M2)."""
+    from litellm.llms.xai.chat.transformation import XAIChatConfig
+
+    from litellm.translation.providers.xai.response import (
+        fold_reasoning_tokens,
+        normalize_usage_totals,
+    )
+
+    usage = {
+        "prompt_tokens": "171",
+        "completion_tokens": "2",
+        "total_tokens": "180",
+        "completion_tokens_details": {"reasoning_tokens": "7"},
+    }
+    v1_usage = copy.deepcopy(usage)
+    XAIChatConfig._fold_reasoning_tokens_into_completion(v1_usage)
+    XAIChatConfig._normalize_openai_compatible_usage_totals(v1_usage)
+    folded = fold_reasoning_tokens(copy.deepcopy(usage))
+    assert not isinstance(folded, Exception)
+    v2_usage = normalize_usage_totals(folded)
+    assert v2_usage == v1_usage
+    assert v2_usage["completion_tokens"] == 9
+
+
+def test_uncoercible_usage_chunk_is_loud_on_both_sides() -> None:
+    """v1's chunk_parser raises ValueError out of the stream iterator on an
+    uncoercible token value; v2's parse_event must error, never serve the
+    chunk with the field read as 0 (critic-grok M2)."""
+    from litellm.llms.xai.chat.transformation import XAIChatConfig
+
+    usage = {
+        "prompt_tokens": "abc",
+        "completion_tokens": 2,
+        "total_tokens": 180,
+        "completion_tokens_details": {"reasoning_tokens": 7},
+    }
+    with pytest.raises(ValueError):
+        XAIChatConfig._fold_reasoning_tokens_into_completion(copy.deepcopy(usage))
+    result = parse_event(_chunk(choices=[], usage=copy.deepcopy(usage)))
+    assert result.is_error(), "uncoercible usage must be loud, not a silent 0"
+    assert "not int-coercible" in result.error.summary, result.error.summary


### PR DESCRIPTION
Stacked on #30275. Ports xAI/Grok as an openai_compat consumer with its own param gates, response handling, and stream dialect.

## What's here
- `providers/xai`: param-map mirroring v1's raise-style gates as typed fallbacks (max_completion_tokens, per-model stop/frequency_penalty/reasoning_effort — pinned against v1's real `get_optional_params("xai")` raises, never remapped); response path reproducing v1-as-executed for Grok's `finish_reason: ""` + tool_calls quirk (v1's own fix function is dead code — documented + tested as an explicit decision); a dedicated `xai` stream dialect pinned at the SSE line seam (per-chunk usage fold, refusal-delta forwarding, usage attached only to the `choices: []` tail, exactly like `CustomStreamWrapper("xai")`).
- Raw guards forcing v1 fallback for the above-seam reroutes: `web_search_options` (Responses-bridge) and `use_xai_oauth` (PKCE flow).
- Generated `characterization_xai/` corpus (zero recorded fixtures exist upstream): deterministic, drift-gated, provenance documented.
- Shared improvement: one `make_parse_line` SSE factory composed by the openai/azure/xai dialects (three copies deleted).

## Verification
- Differential regenerated: **336 IDENTICAL / 78 typed-FALLBACK / 0 divergent** (xai: 39 identical, 7 raise-rows, 16 v1-serves rows, 1 seam-contract).
- Gates: full `make lint-translation` exit 0 (pyright strict 0 errors, semgrep/effects-boundary clean, file-size + CLAUDE.md gates); translation pytest 685 passed / 8 skipped.
- Flag-off: `tests/test_litellm/llms/xai` 104 = 104 vs base.
- Adversarially reviewed (hostile tenet critic + antagonist verifier, both verdicts publishable; all MAJOR findings fixed in-history, including two builder claims the verifier refuted with in-process evidence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)