### PR TITLE
feat(together_ai): add moonshotai/Kimi-K2.6 to model cost map

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -31879,6 +31879,21 @@
         "supports_vision": true,
         "supports_reasoning": true
     },
+    "together_ai/moonshotai/Kimi-K2.6": {
+        "cache_read_input_token_cost": 2e-07,
+        "input_cost_per_token": 1.2e-06,
+        "litellm_provider": "together_ai",
+        "max_input_tokens": 256000,
+        "max_output_tokens": 256000,
+        "max_tokens": 256000,
+        "mode": "chat",
+        "output_cost_per_token": 4.5e-06,
+        "source": "https://www.together.ai/models/kimi-k26",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_reasoning": true
+    },
     "together_ai/moonshotai/Kimi-K2-Instruct-0905": {
         "input_cost_per_token": 1e-06,
         "litellm_provider": "together_ai",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -31919,6 +31919,21 @@
         "supports_vision": true,
         "supports_reasoning": true
     },
+    "together_ai/moonshotai/Kimi-K2.6": {
+        "cache_read_input_token_cost": 2e-07,
+        "input_cost_per_token": 1.2e-06,
+        "litellm_provider": "together_ai",
+        "max_input_tokens": 256000,
+        "max_output_tokens": 256000,
+        "max_tokens": 256000,
+        "mode": "chat",
+        "output_cost_per_token": 4.5e-06,
+        "source": "https://www.together.ai/models/kimi-k26",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_reasoning": true
+    },
     "together_ai/moonshotai/Kimi-K2-Instruct-0905": {
         "input_cost_per_token": 1e-06,
         "litellm_provider": "together_ai",


### PR DESCRIPTION
## Relevant issues

Fixes #27450

## Pre-Submission checklist

- [ ] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Started a live proxy with the new model and queried model info as an end user would:

```bash
$ cat config.yaml
model_list:
  - model_name: kimi-k2.6
    litellm_params:
      model: together_ai/moonshotai/Kimi-K2.6
      api_key: "placeholder-no-calls-made"
general_settings:
  master_key: sk-1234

$ LITELLM_LOCAL_MODEL_COST_MAP=True litellm --config config.yaml --port 4000
$ curl -s http://localhost:4000/model/info -H "Authorization: Bearer sk-1234"
```

Response (filtered to the relevant fields):

```json
{
  "model_name": "kimi-k2.6",
  "model_info": {
    "key": "together_ai/moonshotai/Kimi-K2.6",
    "max_input_tokens": 256000,
    "max_output_tokens": 256000,
    "input_cost_per_token": 1.2e-06,
    "cache_read_input_token_cost": 2e-07,
    "output_cost_per_token": 4.5e-06,
    "supports_function_calling": true,
    "supports_tool_choice": true,
    "supports_vision": true,
    "supports_reasoning": true,
    "mode": "chat"
  }
}
```

Cost calculation sanity check through `litellm.cost_per_token` with 1M prompt tokens and 1M completion tokens returns $1.20 and $4.50 respectively, matching the Together AI pricing page

## Type

🆕 New Feature

## Changes

Adds the `together_ai/moonshotai/Kimi-K2.6` entry to `model_prices_and_context_window.json` and its mirrored copy `litellm/model_prices_and_context_window_backup.json`. Values are from the Together AI model page (https://www.together.ai/models/kimi-k26): 256K context window, $1.20 per 1M input tokens, $0.20 per 1M cached input tokens, $4.50 per 1M output tokens, with function calling, tool choice, vision and reasoning support. The entry mirrors the existing `Kimi-K2.5` entry directly above it

This is a data-only change so no new test was added; the existing cost map schema validation (`tests/test_litellm/test_utils.py::test_aaamodel_prices_and_context_window_json_is_valid`) passes locally against the updated files
