### PR TITLE
Translation v2: long-tail wave 1a (13 SDK-path compat providers)

### DIFF
--- a/litellm/translation/CLAUDE.md
+++ b/litellm/translation/CLAUDE.md
@@ -83,9 +83,13 @@ translation/
 │   │   │                #   normalizer; transform_response is dead on the SDK
 │   │   │                #   path); rides the outbound body on ChatResponse.wire
 │   │   └── stream.py    # SSE chunk -> wire_chunk events normalized to the
-│   │                    #   SDK-dump shape; the openai chunk dialect folds
-│   │                    #   them; make_parse_line is the ONE data:-line
-│   │                    #   decode every same-family provider composes
+│   │                    #   SDK-dump shape (service_tier preset to None:
+│   │                    #   the validated SDK chunk materializes it even
+│   │                    #   when the wire omits the key, and v1's wrapper
+│   │                    #   copies it onto every chunk); the openai chunk
+│   │                    #   dialect folds them; make_parse_line is the ONE
+│   │                    #   data:-line decode every same-family provider
+│   │                    #   composes
 │   ├── google_genai/    # ONE generateContent family for BOTH google routes:
 │   │   │                #   providers "vertex_ai" and "gemini" are the same
 │   │   │                #   serializer parameterized by the drift list
@@ -137,8 +141,9 @@ translation/
 │   │   ├── serialize.py # azure gates then the openai_compat body verbatim
 │   │   ├── response.py  # re-export of openai parse_response (same live
 │   │   │                #   normalizer; json_mode requests fail closed)
-│   │   └── stream.py    # openai parser + per-chunk model re-attach and the
-│   │                    #   SDK service_tier default; "azure" chunk dialect
+│   │   └── stream.py    # openai parser + per-chunk model re-attach;
+│   │                    #   "azure" chunk dialect (the SDK service_tier
+│   │                    #   preset is the shared openai parser's)
 │   ├── azure_ai/        # the Foundry override set + the Claude route:
 │   │   ├── guard.py     # azure guard + the text-only content-list flatten
 │   │   ├── serialize.py # azure_ai gates (grok, model-map tool_choice) then

--- a/litellm/translation/CLAUDE.md
+++ b/litellm/translation/CLAUDE.md
@@ -171,11 +171,19 @@ translation/
 │   │   │                #   the list); capability gates read deps over the
 │   │   │                #   LOAD-BEARING {provider}/{model} map keys
 │   │   │                #   (together_ai function calling, cerebras
-│   │   │                #   reasoning); nvidia_nim's static per-model table
-│   │   ├── serialize.py # frozen CompatProfile per provider (mct rename /
-│   │   │                #   user emission / together's rf-text drop /
-│   │   │                #   cerebras reasoning_effort) -> gates ->
-│   │   │                #   openai_compat assemble_body -> deltas
+│   │   │                #   reasoning); nvidia_nim's static per-model
+│   │   │                #   table; ALLOWED — the per-provider MAXIMAL
+│   │   │                #   allowed sets, the ONE source the gates narrow
+│   │   │                #   and serialization derives emission from
+│   │   ├── serialize.py # frozen CompatProfile per provider (gate + mct
+│   │   │                #   rename / together's rf-text drop; user and
+│   │   │                #   reasoning_effort emission DERIVED from
+│   │   │                #   params.ALLOWED, never cached as booleans) ->
+│   │   │                #   gates -> openai_compat assemble_body ->
+│   │   │                #   deltas; PROFILES is the family registry and
+│   │   │                #   SERIALIZERS its derived serializer table —
+│   │   │                #   pipeline splices them whole, one line per
+│   │   │                #   TABLE
 │   │   └── guard.py     # explicit stream:false (the SDK serializes the
 │   │                    #   key; absent-vs-false is lost in the IR), then
 │   │                    #   the shared openai guard with the full
@@ -210,9 +218,12 @@ translation/
 │                        #   default; the "xai" chunk dialect folds it
 └── engine/
     ├── pipeline.py # prepare (pure, drives the fallback decision) -> send;
-    │               #   per-provider serializer/parser/dialect tables; the
-    │               #   wire_body step strips transform-seam markers
-    │               #   (json_mode; converse additionalModelRequestFields.stream)
+    │               #   per-provider serializer/parser/dialect tables —
+    │               #   family packages register as DATA (compat_sdk's
+    │               #   SERIALIZERS spliced in whole; one line per table
+    │               #   per family, never per provider); the wire_body
+    │               #   step strips transform-seam markers (json_mode;
+    │               #   converse additionalModelRequestFields.stream)
     ├── http.py     # the injected HttpPort + ExecuteError values
     └── stream.py   # the ONE accumulator: lines OR parsed events -> IR
                     #   events -> chunks (fold_lines / fold_events)
@@ -478,8 +489,17 @@ v1's wrapper, so the synthesis covers the tail-chunk shape only).
 Not yet here, each its own follow-up: streaming seams live; the other
 inbound schemas (`anthropic_messages`, `google_genai`, `responses`,
 `completions`); the same-family fast path (waits on the opaque-body
-relay). To add a provider: write
-`providers/<name>/`, register it in `engine/pipeline._SERIALIZERS` /
-`_RESPONSE_PARSERS` / `_RESPONSE_DIALECTS` (plus `_RAW_GUARDS` when the
-inbound schema is the provider's own family), add a differential corpus,
-keep the flag off until differential-green.
+relay). To add a provider that is a pure param-surface delta over an
+existing wire family, add DATA rows to that family's package instead of a
+new subpackage (the `compat_sdk/` shape, THE wave-1b/2 convention): an
+allowed frozenset + `ALLOWED` row in the family's params.py, a profile row
+in its serialize.py registry, and one dispatch `Provider` Literal line —
+pipeline already splices the family's exported `SERIALIZERS` table whole
+(one `**` line per table per FAMILY; never add per-provider rows for a
+family member), and the registration-completeness gate
+(`test_differential_compat_sdk_request.py`) fails any registered provider
+without a differential corpus row. To add a provider with its own wire
+format: write `providers/<name>/`, register it in
+`engine/pipeline._SERIALIZERS` / `_RESPONSE_PARSERS` / `_RESPONSE_DIALECTS`
+(plus `_RAW_GUARDS` when the inbound schema is the provider's own family),
+add a differential corpus, keep the flag off until differential-green.

--- a/litellm/translation/CLAUDE.md
+++ b/litellm/translation/CLAUDE.md
@@ -148,6 +148,38 @@ translation/
 │   │   └── claude.py    # anthropic serializer/parsers re-exported; NO
 │   │                    #   response-format model spoof (v1 maps with the
 │   │                    #   real model); billing-header blocks fail closed
+│   ├── compat_sdk/      # the wave-1a SDK-path openai-compat family in ONE
+│   │   │                #   subpackage (the google_genai "one family,
+│   │   │                #   parameterized" precedent): together_ai,
+│   │   │                #   cerebras, nvidia_nim, lm_studio, llamafile,
+│   │   │                #   lambda_ai, nebius, novita, wandb,
+│   │   │                #   featherless_ai, nscale, hyperbolic, volcengine.
+│   │   │                #   All ride v1's big openai elif into the SDK, so
+│   │   │                #   the body is openai_compat.assemble_body after
+│   │   │                #   per-provider gates; the response parser is
+│   │   │                #   openai_compat's verbatim (same live normalizer)
+│   │   │                #   and the {provider}/{wire_model} re-prefix is
+│   │   │                #   the SEAM's preset arm, never parser scope;
+│   │   │                #   streams are the "openai" chunk dialect (pinned
+│   │   │                #   per provider by wrapper replays). baseten is
+│   │   │                #   DELIBERATELY ABSENT: its streams ride a
+│   │   │                #   dedicated legacy wrapper branch
+│   │   │                #   (handle_baseten_chunk), so it stays a typed v1
+│   │   │                #   fallback (canary-pinned).
+│   │   ├── params.py    # per-provider supported-list truths as pure gates
+│   │   │                #   (v1 RAISES-unless-drop_params on anything off
+│   │   │                #   the list); capability gates read deps over the
+│   │   │                #   LOAD-BEARING {provider}/{model} map keys
+│   │   │                #   (together_ai function calling, cerebras
+│   │   │                #   reasoning); nvidia_nim's static per-model table
+│   │   ├── serialize.py # frozen CompatProfile per provider (mct rename /
+│   │   │                #   user emission / together's rf-text drop /
+│   │   │                #   cerebras reasoning_effort) -> gates ->
+│   │   │                #   openai_compat assemble_body -> deltas
+│   │   └── guard.py     # explicit stream:false (the SDK serializes the
+│   │                    #   key; absent-vs-false is lost in the IR), then
+│   │                    #   the shared openai guard with the full
+│   │                    #   message-name fallback (nobody here strips names)
 │   └── xai/             # Grok over openai_compat (httpx path: NO model
 │       │                #   prefix anywhere, transform_response is LIVE):
 │       ├── guard.py     # web_search_options (v1's Responses-bridge reroute
@@ -300,10 +332,13 @@ A behavior change ships as its own snapshot-diffed PR, never inside a port.
 
 ## Current scope
 
-OpenAI-chat-in to eleven providers out — `anthropic`, `bedrock_converse`,
-`bedrock_invoke`, `openai_compat`, `vertex_ai` (gemini route), `gemini`
-(AI Studio), `vertex_anthropic`, `azure`, `azure_ai`,
-`azure_ai_anthropic`, `xai` — request, response, and stream translation,
+OpenAI-chat-in to twenty-four providers out — `anthropic`,
+`bedrock_converse`, `bedrock_invoke`, `openai_compat`, `vertex_ai` (gemini
+route), `gemini` (AI Studio), `vertex_anthropic`, `azure`, `azure_ai`,
+`azure_ai_anthropic`, `xai`, and the thirteen wave-1a compat_sdk providers
+(`together_ai`, `cerebras`, `nvidia_nim`, `lm_studio`, `llamafile`,
+`lambda_ai`, `nebius`, `novita`, `wandb`, `featherless_ai`, `nscale`,
+`hyperbolic`, `volcengine`) — request, response, and stream translation,
 differential-green (anthropic: 46-shape corpus + responses + stream
 replays; bedrock and google: the characterization corpus per route + quirk
 corpora; openai: 17-shape request corpus + 17 typed-fallback rows +
@@ -314,7 +349,12 @@ azure_ai: the Foundry override-set and no-spoof Claude-route corpora;
 xai: a 21-shape generated characterization corpus — provenance v1
 in-process at HEAD, zero recorded vendor fixtures exist — two-sided over
 `tests/test_litellm/translation/characterization_xai/` plus 7 rows pinning
-v1's UnsupportedParamsError raises and the line-seam stream replays),
+v1's UnsupportedParamsError raises and the line-seam stream replays;
+compat_sdk: per-provider generated corpora vs v1 in-process at HEAD
+(`test_differential_compat_sdk_{request,response,stream}.py` over
+`_compat_sdk_corpus.py` — served rows, UnsupportedParamsError raise rows,
+preset-model re-prefix response rows, per-provider wrapper stream replays,
+and supported-list mirror drift gates over every model-map row)),
 fail-closed everywhere else, with non-streaming flag-gated seams live in
 `completion()` for the anthropic, bedrock, and google routes (the
 openai/azure seam forks are integrator scope and NOT wired; the google
@@ -389,7 +429,39 @@ definitions with `strict` keys below the function level (v1 deletes every
 depth), the openai guard's raw shapes, and the parse-level unknowns v1
 passes through for grok (presence/frequency penalties on supported
 families, seed, logprobs, top_logprobs, logit_bias, n, stream_options,
-web_search_options). The xai completion() fork is NOT wired (integrator
+web_search_options).
+Deliberate compat_sdk (wave-1a) fallback surfaces (each names the v1
+path): every IR-carried param a provider's supported list excludes — v1's
+`_check_valid_arg` raises UnsupportedParamsError or drops under
+drop_params, so the typed fallback serves v1's own behavior
+(max_completion_tokens on nscale/hyperbolic — both rename arms are dead
+code behind the list gate; tools/tool_choice/response_format on
+featherless_ai, on volcengine (response_format only), on together_ai
+models without the supports_function_calling map flag, and on
+nvidia_nim's reduced static-table models; parallel_tool_calls on
+cerebras/featherless_ai/nscale/hyperbolic/volcengine; reasoning_effort
+everywhere except capability-flagged cerebras models; response_format on
+base-list providers when the model is literally named gpt-4 /
+gpt-3.5-turbo-16k); `user` wherever a provider's own list doesn't carry
+it (v1's base list gates it on openai model-list membership and silently
+drops it otherwise — only cerebras and hyperbolic emit it);
+volcengine `thinking` (v1 packs the verbatim dict into extra_body for the
+SDK to merge top-level); lm_studio's bare-`schema` response_format wrap
+(non-canonical inbound shape, parse rejects it); explicit `stream: false`
+(the SDK serializes the key; absent-vs-false is lost in the IR); the
+openai guard's raw shapes with the FULL message-name fallback (no config
+here strips names); and the parse-level unknowns (seed, penalties,
+logprobs, n, logit_bias, stream_options, ...) regardless of whether a
+given provider's list serves or raises on them. The compat_sdk
+completion() forks are NOT wired (integrator scope, like openai/azure/
+xai); when they land, the seam must pre-set
+`ModelResponse(model=f"{provider}/{model}")` exactly like openai.py:
+676-677 so `_to_model_response_openai`'s re-prefix arm reproduces
+cdr:699-710 (pinned per provider by the preset-model differential rows),
+and baseten must NEVER be added to the family without resolving its
+dedicated legacy wrapper stream branch (handle_baseten_chunk — the
+test_baseten_drop_canary evidence).
+The xai completion() fork is NOT wired (integrator
 scope, like openai/azure); when it lands these are HARD OBLIGATIONS, not
 notes: the in-package `use_xai_oauth` guard arm is defense-in-depth ONLY
 and unreachable through `_raw_openai_body` (use_xai_oauth is a litellm

--- a/litellm/translation/dispatch.py
+++ b/litellm/translation/dispatch.py
@@ -32,6 +32,23 @@ Provider = Literal[
     "gemini",
     "vertex_anthropic",
     "xai",
+    # wave-1a: the SDK-path openai-compat family (providers/compat_sdk).
+    # baseten is deliberately ABSENT: its streams ride a dedicated legacy
+    # CustomStreamWrapper branch (handle_baseten_chunk), not the openai
+    # dialect, so it stays a typed v1 fallback (wave1a-port.md).
+    "together_ai",
+    "cerebras",
+    "nvidia_nim",
+    "lm_studio",
+    "llamafile",
+    "lambda_ai",
+    "nebius",
+    "novita",
+    "wandb",
+    "featherless_ai",
+    "nscale",
+    "hyperbolic",
+    "volcengine",
 ]
 
 _SAME_FAMILY: frozenset[tuple[InboundSchema, Provider]] = frozenset(
@@ -44,6 +61,10 @@ _SAME_FAMILY: frozenset[tuple[InboundSchema, Provider]] = frozenset(
         # xai is NOT same-family despite speaking openai-chat: v1's transform
         # touches the body (tools strict strip, non-user message name strip),
         # so a verbatim fast-path forward would diverge from v1.
+        # The compat_sdk family is NOT same-family either: their param maps
+        # touch the body (mct -> max_tokens renames, supported-list raises,
+        # together's response_format pop), so a verbatim forward would
+        # diverge from v1's gates.
     }
 )
 

--- a/litellm/translation/engine/pipeline.py
+++ b/litellm/translation/engine/pipeline.py
@@ -53,21 +53,7 @@ from ..providers.bedrock_invoke import parse_response as bedrock_invoke_parse_re
 from ..providers.bedrock_invoke import (
     serialize_request as bedrock_invoke_serialize_request,
 )
-from ..providers.compat_sdk import (
-    cerebras_serialize_request,
-    featherless_ai_serialize_request,
-    hyperbolic_serialize_request,
-    lambda_ai_serialize_request,
-    llamafile_serialize_request,
-    lm_studio_serialize_request,
-    nebius_serialize_request,
-    novita_serialize_request,
-    nscale_serialize_request,
-    nvidia_nim_serialize_request,
-    together_ai_serialize_request,
-    volcengine_serialize_request,
-    wandb_serialize_request,
-)
+from ..providers.compat_sdk import SERIALIZERS as compat_sdk_serializers
 from ..providers.compat_sdk import (
     unsupported_request_shapes as compat_sdk_unsupported_request_shapes,
 )
@@ -119,19 +105,11 @@ _SERIALIZERS: Mapping[Provider, _Serializer] = MappingProxyType(
         "azure_ai": azure_ai_serialize_request,
         "azure_ai_anthropic": azure_ai_claude_serialize_request,
         "xai": xai_serialize_request,
-        "together_ai": together_ai_serialize_request,
-        "cerebras": cerebras_serialize_request,
-        "nvidia_nim": nvidia_nim_serialize_request,
-        "lm_studio": lm_studio_serialize_request,
-        "llamafile": llamafile_serialize_request,
-        "lambda_ai": lambda_ai_serialize_request,
-        "nebius": nebius_serialize_request,
-        "novita": novita_serialize_request,
-        "wandb": wandb_serialize_request,
-        "featherless_ai": featherless_ai_serialize_request,
-        "nscale": nscale_serialize_request,
-        "hyperbolic": hyperbolic_serialize_request,
-        "volcengine": volcengine_serialize_request,
+        # compat_sdk family: the registry is the family's own frozen
+        # PROFILES-derived table, spliced in whole. This splice (one line per
+        # TABLE, never per provider) is the registration convention every
+        # wave-1b/2 family follows.
+        **compat_sdk_serializers,
     }
 )
 
@@ -152,21 +130,14 @@ _RESPONSE_PARSERS: Mapping[Provider, _ResponseParser] = MappingProxyType(
         # convert_to_model_response_object the openai parser mirrors; the
         # {provider}/{wire_model} re-prefix is the seam's preset arm
         # (_to_model_response_openai), not parser scope.
-        "together_ai": openai_compat_parse_response,
-        "cerebras": openai_compat_parse_response,
-        "nvidia_nim": openai_compat_parse_response,
-        "lm_studio": openai_compat_parse_response,
-        "llamafile": openai_compat_parse_response,
-        "lambda_ai": openai_compat_parse_response,
-        "nebius": openai_compat_parse_response,
-        "novita": openai_compat_parse_response,
-        "wandb": openai_compat_parse_response,
-        "featherless_ai": openai_compat_parse_response,
-        "nscale": openai_compat_parse_response,
-        "hyperbolic": openai_compat_parse_response,
-        "volcengine": openai_compat_parse_response,
+        **{
+            provider: openai_compat_parse_response
+            for provider in compat_sdk_serializers
+        },
     }
 )
+
+_OPENAI_DIALECT: ResponseDialect = "openai"
 
 _RESPONSE_DIALECTS: Mapping[Provider, ResponseDialect] = MappingProxyType(
     {
@@ -183,19 +154,7 @@ _RESPONSE_DIALECTS: Mapping[Provider, ResponseDialect] = MappingProxyType(
         "xai": "openai",  # httpx path, same normalized wire-body ride
         # compat_sdk family: SDK path, default openai wrapper arm (the
         # per-provider stream replays pin that no dedicated branch fires)
-        "together_ai": "openai",
-        "cerebras": "openai",
-        "nvidia_nim": "openai",
-        "lm_studio": "openai",
-        "llamafile": "openai",
-        "lambda_ai": "openai",
-        "nebius": "openai",
-        "novita": "openai",
-        "wandb": "openai",
-        "featherless_ai": "openai",
-        "nscale": "openai",
-        "hyperbolic": "openai",
-        "volcengine": "openai",
+        **{provider: _OPENAI_DIALECT for provider in compat_sdk_serializers},
     }
 )
 
@@ -214,19 +173,10 @@ _RAW_GUARDS: Mapping[Provider, _RawGuard] = MappingProxyType(
         "vertex_ai": google_unsupported_request_shapes,
         "gemini": google_unsupported_request_shapes,
         "xai": xai_unsupported_request_shapes,
-        "together_ai": compat_sdk_unsupported_request_shapes,
-        "cerebras": compat_sdk_unsupported_request_shapes,
-        "nvidia_nim": compat_sdk_unsupported_request_shapes,
-        "lm_studio": compat_sdk_unsupported_request_shapes,
-        "llamafile": compat_sdk_unsupported_request_shapes,
-        "lambda_ai": compat_sdk_unsupported_request_shapes,
-        "nebius": compat_sdk_unsupported_request_shapes,
-        "novita": compat_sdk_unsupported_request_shapes,
-        "wandb": compat_sdk_unsupported_request_shapes,
-        "featherless_ai": compat_sdk_unsupported_request_shapes,
-        "nscale": compat_sdk_unsupported_request_shapes,
-        "hyperbolic": compat_sdk_unsupported_request_shapes,
-        "volcengine": compat_sdk_unsupported_request_shapes,
+        **{
+            provider: compat_sdk_unsupported_request_shapes
+            for provider in compat_sdk_serializers
+        },
     }
 )
 

--- a/litellm/translation/engine/pipeline.py
+++ b/litellm/translation/engine/pipeline.py
@@ -53,6 +53,24 @@ from ..providers.bedrock_invoke import parse_response as bedrock_invoke_parse_re
 from ..providers.bedrock_invoke import (
     serialize_request as bedrock_invoke_serialize_request,
 )
+from ..providers.compat_sdk import (
+    cerebras_serialize_request,
+    featherless_ai_serialize_request,
+    hyperbolic_serialize_request,
+    lambda_ai_serialize_request,
+    llamafile_serialize_request,
+    lm_studio_serialize_request,
+    nebius_serialize_request,
+    novita_serialize_request,
+    nscale_serialize_request,
+    nvidia_nim_serialize_request,
+    together_ai_serialize_request,
+    volcengine_serialize_request,
+    wandb_serialize_request,
+)
+from ..providers.compat_sdk import (
+    unsupported_request_shapes as compat_sdk_unsupported_request_shapes,
+)
 from ..providers.google_genai import parse_response as google_parse_response
 from ..providers.google_genai import (
     serialize_request_studio as google_serialize_request_studio,
@@ -101,6 +119,19 @@ _SERIALIZERS: Mapping[Provider, _Serializer] = MappingProxyType(
         "azure_ai": azure_ai_serialize_request,
         "azure_ai_anthropic": azure_ai_claude_serialize_request,
         "xai": xai_serialize_request,
+        "together_ai": together_ai_serialize_request,
+        "cerebras": cerebras_serialize_request,
+        "nvidia_nim": nvidia_nim_serialize_request,
+        "lm_studio": lm_studio_serialize_request,
+        "llamafile": llamafile_serialize_request,
+        "lambda_ai": lambda_ai_serialize_request,
+        "nebius": nebius_serialize_request,
+        "novita": novita_serialize_request,
+        "wandb": wandb_serialize_request,
+        "featherless_ai": featherless_ai_serialize_request,
+        "nscale": nscale_serialize_request,
+        "hyperbolic": hyperbolic_serialize_request,
+        "volcengine": volcengine_serialize_request,
     }
 )
 
@@ -117,6 +148,23 @@ _RESPONSE_PARSERS: Mapping[Provider, _ResponseParser] = MappingProxyType(
         "azure_ai": azure_ai_parse_response,
         "azure_ai_anthropic": azure_ai_claude_parse_response,
         "xai": xai_parse_response,
+        # compat_sdk family: the live v1 normalizer is the same
+        # convert_to_model_response_object the openai parser mirrors; the
+        # {provider}/{wire_model} re-prefix is the seam's preset arm
+        # (_to_model_response_openai), not parser scope.
+        "together_ai": openai_compat_parse_response,
+        "cerebras": openai_compat_parse_response,
+        "nvidia_nim": openai_compat_parse_response,
+        "lm_studio": openai_compat_parse_response,
+        "llamafile": openai_compat_parse_response,
+        "lambda_ai": openai_compat_parse_response,
+        "nebius": openai_compat_parse_response,
+        "novita": openai_compat_parse_response,
+        "wandb": openai_compat_parse_response,
+        "featherless_ai": openai_compat_parse_response,
+        "nscale": openai_compat_parse_response,
+        "hyperbolic": openai_compat_parse_response,
+        "volcengine": openai_compat_parse_response,
     }
 )
 
@@ -133,6 +181,21 @@ _RESPONSE_DIALECTS: Mapping[Provider, ResponseDialect] = MappingProxyType(
         "azure_ai": "openai",
         "azure_ai_anthropic": "anthropic",  # genuine anthropic wire format
         "xai": "openai",  # httpx path, same normalized wire-body ride
+        # compat_sdk family: SDK path, default openai wrapper arm (the
+        # per-provider stream replays pin that no dedicated branch fires)
+        "together_ai": "openai",
+        "cerebras": "openai",
+        "nvidia_nim": "openai",
+        "lm_studio": "openai",
+        "llamafile": "openai",
+        "lambda_ai": "openai",
+        "nebius": "openai",
+        "novita": "openai",
+        "wandb": "openai",
+        "featherless_ai": "openai",
+        "nscale": "openai",
+        "hyperbolic": "openai",
+        "volcengine": "openai",
     }
 )
 
@@ -151,6 +214,19 @@ _RAW_GUARDS: Mapping[Provider, _RawGuard] = MappingProxyType(
         "vertex_ai": google_unsupported_request_shapes,
         "gemini": google_unsupported_request_shapes,
         "xai": xai_unsupported_request_shapes,
+        "together_ai": compat_sdk_unsupported_request_shapes,
+        "cerebras": compat_sdk_unsupported_request_shapes,
+        "nvidia_nim": compat_sdk_unsupported_request_shapes,
+        "lm_studio": compat_sdk_unsupported_request_shapes,
+        "llamafile": compat_sdk_unsupported_request_shapes,
+        "lambda_ai": compat_sdk_unsupported_request_shapes,
+        "nebius": compat_sdk_unsupported_request_shapes,
+        "novita": compat_sdk_unsupported_request_shapes,
+        "wandb": compat_sdk_unsupported_request_shapes,
+        "featherless_ai": compat_sdk_unsupported_request_shapes,
+        "nscale": compat_sdk_unsupported_request_shapes,
+        "hyperbolic": compat_sdk_unsupported_request_shapes,
+        "volcengine": compat_sdk_unsupported_request_shapes,
     }
 )
 

--- a/litellm/translation/providers/azure/guard.py
+++ b/litellm/translation/providers/azure/guard.py
@@ -22,6 +22,7 @@ from litellm.constants import DEFAULT_MAX_RECURSE_DEPTH
 
 from ...errors import TranslationError
 from ..openai_compat import unsupported_request_shapes as openai_unsupported_shapes
+from ..openai_compat.guard import explicit_stream_false
 
 _Raw = Mapping[str, object]
 
@@ -30,6 +31,9 @@ def unsupported_request_shapes(raw: _Raw) -> TranslationError | None:
     shared = openai_unsupported_shapes(raw)
     if shared is not None:
         return shared
+    stream_false = explicit_stream_false(raw)
+    if stream_false is not None:
+        return stream_false
     reason = _azure_reason(raw)
     if reason is None:
         return None
@@ -37,8 +41,6 @@ def unsupported_request_shapes(raw: _Raw) -> TranslationError | None:
 
 
 def _azure_reason(raw: _Raw) -> str | None:
-    if "stream" in raw and raw.get("stream") is False:
-        return "explicit stream: false (azure keeps the key on the wire; absent-vs-false is lost in the IR)"
     for field in ("messages", "tools"):
         if _carries_cache_control(raw.get(field), 0):
             return (

--- a/litellm/translation/providers/azure/stream.py
+++ b/litellm/translation/providers/azure/stream.py
@@ -37,15 +37,10 @@ def parse_event(event: PlainJson) -> _EventResult:
     chunk = parsed.wire_chunk.value
     if not isinstance(model, str) or not isinstance(chunk, dict):
         return base
-    # The azure decode seam is the VALIDATED SDK ChatCompletionChunk, which
-    # materializes service_tier=None even when the wire JSON omits it; v1's
-    # preserve_upstream_non_openai_attributes then copies it onto every
-    # emitted chunk.
-    return Ok(
-        StreamEvent.of_wire_chunk(
-            JsonBlob(value={"service_tier": None, **chunk, "model": model})
-        )
-    )
+    # The SDK service_tier materialization preset lives in the shared openai
+    # parser (the SAME validated-ChatCompletionChunk seam); only the model
+    # re-attach is azure's.
+    return Ok(StreamEvent.of_wire_chunk(JsonBlob(value={**chunk, "model": model})))
 
 
 parse_line = make_parse_line(parse_event)

--- a/litellm/translation/providers/compat_sdk/__init__.py
+++ b/litellm/translation/providers/compat_sdk/__init__.py
@@ -1,35 +1,14 @@
 from ..openai_compat.response import parse_response
 from .guard import unsupported_request_shapes
-from .serialize import (
-    cerebras_serialize_request,
-    featherless_ai_serialize_request,
-    hyperbolic_serialize_request,
-    lambda_ai_serialize_request,
-    llamafile_serialize_request,
-    lm_studio_serialize_request,
-    nebius_serialize_request,
-    novita_serialize_request,
-    nscale_serialize_request,
-    nvidia_nim_serialize_request,
-    together_ai_serialize_request,
-    volcengine_serialize_request,
-    wandb_serialize_request,
-)
+from .params import ALLOWED, CompatSdkProvider
+from .serialize import PROFILES, SERIALIZERS, CompatProfile
 
 __all__ = (
-    "cerebras_serialize_request",
-    "featherless_ai_serialize_request",
-    "hyperbolic_serialize_request",
-    "lambda_ai_serialize_request",
-    "llamafile_serialize_request",
-    "lm_studio_serialize_request",
-    "nebius_serialize_request",
-    "novita_serialize_request",
-    "nscale_serialize_request",
-    "nvidia_nim_serialize_request",
+    "ALLOWED",
+    "PROFILES",
+    "SERIALIZERS",
+    "CompatProfile",
+    "CompatSdkProvider",
     "parse_response",
-    "together_ai_serialize_request",
     "unsupported_request_shapes",
-    "volcengine_serialize_request",
-    "wandb_serialize_request",
 )

--- a/litellm/translation/providers/compat_sdk/__init__.py
+++ b/litellm/translation/providers/compat_sdk/__init__.py
@@ -1,0 +1,35 @@
+from ..openai_compat.response import parse_response
+from .guard import unsupported_request_shapes
+from .serialize import (
+    cerebras_serialize_request,
+    featherless_ai_serialize_request,
+    hyperbolic_serialize_request,
+    lambda_ai_serialize_request,
+    llamafile_serialize_request,
+    lm_studio_serialize_request,
+    nebius_serialize_request,
+    novita_serialize_request,
+    nscale_serialize_request,
+    nvidia_nim_serialize_request,
+    together_ai_serialize_request,
+    volcengine_serialize_request,
+    wandb_serialize_request,
+)
+
+__all__ = (
+    "cerebras_serialize_request",
+    "featherless_ai_serialize_request",
+    "hyperbolic_serialize_request",
+    "lambda_ai_serialize_request",
+    "llamafile_serialize_request",
+    "lm_studio_serialize_request",
+    "nebius_serialize_request",
+    "novita_serialize_request",
+    "nscale_serialize_request",
+    "nvidia_nim_serialize_request",
+    "parse_response",
+    "together_ai_serialize_request",
+    "unsupported_request_shapes",
+    "volcengine_serialize_request",
+    "wandb_serialize_request",
+)

--- a/litellm/translation/providers/compat_sdk/guard.py
+++ b/litellm/translation/providers/compat_sdk/guard.py
@@ -1,14 +1,14 @@
 """Raw-shape fidelity guard for the SDK-path openai-compat family.
 
-One family-wide arm before the shared openai guard: an explicit
-``stream: false``. On this path ``completion()`` forwards the caller's False
-into ``get_optional_params`` (non-default against the ``None`` default), it
-lands in optional_params, and the SDK serializes the key onto the wire —
-while the IR cannot represent absent-vs-false (verified in-process at HEAD;
-the same arm the azure and xai guards carry).
+The shared explicit ``stream: false`` arm runs first: on this path
+``completion()`` forwards the caller's False into ``get_optional_params``
+(non-default against the ``None`` default), it lands in optional_params,
+and the SDK serializes the key onto the wire — while the IR cannot
+represent absent-vs-false (verified in-process at HEAD; the same arm the
+azure and xai guards compose).
 
-The openai guard runs with its full message-``name`` fallback: none of the
-family configs strips names (only xai does), so v1 forwards ``name``
+The openai guard then runs with its full message-``name`` fallback: none of
+the family configs strips names (only xai does), so v1 forwards ``name``
 verbatim on every role.
 """
 
@@ -17,6 +17,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 
 from ...errors import TranslationError
+from ..openai_compat.guard import explicit_stream_false
 from ..openai_compat.guard import (
     unsupported_request_shapes as openai_unsupported_request_shapes,
 )
@@ -25,9 +26,4 @@ _Raw = Mapping[str, object]
 
 
 def unsupported_request_shapes(raw: _Raw) -> TranslationError | None:
-    if "stream" in raw and raw.get("stream") is False:
-        return TranslationError.of_unsupported(
-            "explicit stream: false (the SDK path serializes the key onto "
-            "the wire; absent-vs-false is lost in the IR)"
-        )
-    return openai_unsupported_request_shapes(raw)
+    return explicit_stream_false(raw) or openai_unsupported_request_shapes(raw)

--- a/litellm/translation/providers/compat_sdk/guard.py
+++ b/litellm/translation/providers/compat_sdk/guard.py
@@ -1,0 +1,33 @@
+"""Raw-shape fidelity guard for the SDK-path openai-compat family.
+
+One family-wide arm before the shared openai guard: an explicit
+``stream: false``. On this path ``completion()`` forwards the caller's False
+into ``get_optional_params`` (non-default against the ``None`` default), it
+lands in optional_params, and the SDK serializes the key onto the wire —
+while the IR cannot represent absent-vs-false (verified in-process at HEAD;
+the same arm the azure and xai guards carry).
+
+The openai guard runs with its full message-``name`` fallback: none of the
+family configs strips names (only xai does), so v1 forwards ``name``
+verbatim on every role.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from ...errors import TranslationError
+from ..openai_compat.guard import (
+    unsupported_request_shapes as openai_unsupported_request_shapes,
+)
+
+_Raw = Mapping[str, object]
+
+
+def unsupported_request_shapes(raw: _Raw) -> TranslationError | None:
+    if "stream" in raw and raw.get("stream") is False:
+        return TranslationError.of_unsupported(
+            "explicit stream: false (the SDK path serializes the key onto "
+            "the wire; absent-vs-false is lost in the IR)"
+        )
+    return openai_unsupported_request_shapes(raw)

--- a/litellm/translation/providers/compat_sdk/params.py
+++ b/litellm/translation/providers/compat_sdk/params.py
@@ -91,6 +91,16 @@ def unsupported_against(
         note = notes.get(key)
         if note is not None:
             return note
+        if key == "top_k":
+            # top_k is not an OpenAI param: it never enters
+            # non_default_params, so _check_valid_arg never sees it and v1
+            # drops it WITHOUT drop_params (verified in-process at HEAD;
+            # verifier-wave1a F6).
+            return (
+                f"top_k on {provider}: not an OpenAI param; v1's "
+                "get_optional_params silently drops it (no raise, even "
+                "without drop_params)"
+            )
         return (
             f"{key} on {provider}: outside v1's supported list; "
             "get_optional_params raises UnsupportedParamsError "

--- a/litellm/translation/providers/compat_sdk/params.py
+++ b/litellm/translation/providers/compat_sdk/params.py
@@ -27,7 +27,10 @@ from typing import Literal
 
 from ...deps import TranslationDeps
 from ...ir import ChatRequest
-from ..openai_compat.params import unsupported_response_format
+from ..openai_compat.params import (
+    RESPONSE_FORMAT_UNSUPPORTED_MODELS,
+    unsupported_response_format,
+)
 
 CompatSdkProvider = Literal[
     "together_ai",
@@ -147,11 +150,20 @@ def together_ai_unsupported(request: ChatRequest, deps: TranslationDeps) -> str 
     base list unless ``supports_function_calling(model, "together_ai")`` is
     True (together_ai/chat.py); parallel_tool_calls stays supported either
     way (v1 truth, not an oversight here)."""
-    allowed = (
-        _BASE_LIST
-        if supports_together_tools(request.model, deps)
-        else _BASE_LIST - _FUNCTION_CALLING_KEYS
-    )
+    supports_tools = supports_together_tools(request.model, deps)
+    if request.model in RESPONSE_FORMAT_UNSUPPORTED_MODELS and not supports_tools:
+        # The base list already dropped response_format for this model name,
+        # so the non-fc fork's list.remove("response_format") crashes inside
+        # get_supported_openai_params -- which _check_valid_arg runs on EVERY
+        # together_ai request, plain text included (verifier-wave1a F2).
+        return (
+            f"model {request.model!r} on together_ai without the model-map "
+            "supports_function_calling flag: v1's TogetherAIConfig."
+            "get_supported_openai_params raises ValueError (list.remove on "
+            "a base list that already dropped response_format for this "
+            "model name) on every request; v1 raises its own error"
+        )
+    allowed = _BASE_LIST if supports_tools else _BASE_LIST - _FUNCTION_CALLING_KEYS
     return unsupported_against(
         request,
         provider="together_ai",

--- a/litellm/translation/providers/compat_sdk/params.py
+++ b/litellm/translation/providers/compat_sdk/params.py
@@ -23,10 +23,27 @@ from __future__ import annotations
 
 from collections.abc import Callable, Mapping
 from types import MappingProxyType
+from typing import Literal
 
 from ...deps import TranslationDeps
 from ...ir import ChatRequest
 from ..openai_compat.params import unsupported_response_format
+
+CompatSdkProvider = Literal[
+    "together_ai",
+    "cerebras",
+    "nvidia_nim",
+    "lm_studio",
+    "llamafile",
+    "lambda_ai",
+    "nebius",
+    "novita",
+    "wandb",
+    "featherless_ai",
+    "nscale",
+    "hyperbolic",
+    "volcengine",
+]
 
 _Present = Callable[[ChatRequest], bool]
 
@@ -143,6 +160,9 @@ def together_ai_unsupported(request: ChatRequest, deps: TranslationDeps) -> str 
     ) or unsupported_response_format(request)
 
 
+# The MAXIMAL cerebras surface: ``reasoning_effort`` is capability-narrowed
+# per model in the gate below, so its membership here means "emittable", not
+# "always allowed" (the ALLOWED table at the bottom feeds emission).
 _CEREBRAS_LIST = frozenset(
     {
         "max_tokens",
@@ -155,6 +175,7 @@ _CEREBRAS_LIST = frozenset(
         "tool_choice",
         "response_format",
         "user",
+        "reasoning_effort",
     }
 )
 
@@ -165,9 +186,9 @@ def supports_cerebras_reasoning(model: str, deps: TranslationDeps) -> bool:
 
 def cerebras_unsupported(request: ChatRequest, deps: TranslationDeps) -> str | None:
     allowed = (
-        _CEREBRAS_LIST | {"reasoning_effort"}
+        _CEREBRAS_LIST
         if supports_cerebras_reasoning(request.model, deps)
-        else _CEREBRAS_LIST
+        else _CEREBRAS_LIST - {"reasoning_effort"}
     )
     return unsupported_against(
         request,
@@ -324,3 +345,27 @@ def volcengine_unsupported(request: ChatRequest, deps: TranslationDeps) -> str |
             )
         },
     )
+
+
+# The single source of per-provider supported-surface truth: each provider's
+# MAXIMAL allowed set (capability and per-model gates above only ever NARROW
+# it). Serialization derives user/reasoning_effort emission from membership
+# here, so the gate facts and the emission facts can never desync
+# (critic-wave1a M3).
+ALLOWED: Mapping[CompatSdkProvider, frozenset[str]] = MappingProxyType(
+    {
+        "together_ai": _BASE_LIST,
+        "cerebras": _CEREBRAS_LIST,
+        "nvidia_nim": _NVIDIA_DEFAULT_LIST,
+        "lm_studio": _BASE_LIST,
+        "llamafile": _BASE_LIST,
+        "lambda_ai": _BASE_LIST,
+        "nebius": _BASE_LIST,
+        "novita": _BASE_LIST,
+        "wandb": _BASE_LIST,
+        "featherless_ai": _FEATHERLESS_LIST,
+        "nscale": _NSCALE_LIST,
+        "hyperbolic": _HYPERBOLIC_LIST,
+        "volcengine": _VOLCENGINE_LIST,
+    }
+)

--- a/litellm/translation/providers/compat_sdk/params.py
+++ b/litellm/translation/providers/compat_sdk/params.py
@@ -1,0 +1,326 @@
+"""Per-provider parameter gates for the SDK-path openai-compat family.
+
+v1's gate for every provider here is ``_check_valid_arg`` over the provider
+config's ``get_supported_openai_params``: an unsupported param RAISES
+``UnsupportedParamsError`` unless ``drop_params``, in which case it is popped
+BEFORE ``map_openai_params`` runs. v2 mirrors the SUPPORTED-LIST truth as
+typed fallbacks (the v2-openai/xai precedent — never re-implement the
+raise-vs-drop interplay): every IR-carried param a provider's list excludes
+falls back so v1 serves its own raise or drop. Params outside the IR
+(seed, penalties, logprobs, n, stream_options, ...) already fall back at the
+inbound boundary and never reach these gates.
+
+The capability reads mirror v1's model-map lookups through
+``deps.supports_capability`` over the ``{provider}/{model}`` map key — the
+provider prefix is LOAD-BEARING (bare wire models have no model-map rows;
+see the xai drift-gate note). Verified in-process at HEAD:
+``together_ai/...`` rows answer ``supports_function_calling`` and
+``cerebras/...`` rows answer ``supports_reasoning``; the bare keys are False
+even for capable models.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from types import MappingProxyType
+
+from ...deps import TranslationDeps
+from ...ir import ChatRequest
+from ..openai_compat.params import unsupported_response_format
+
+_Present = Callable[[ChatRequest], bool]
+
+# IR-carried params, checked in a stable order so fallback reasons are
+# deterministic. ``max_tokens`` only counts as caller-sent when
+# ``max_completion_tokens`` is absent: the inbound parse collapses mct into
+# max_tokens and the raw guard rejects requests carrying both keys.
+_CHECKS: tuple[tuple[str, _Present], ...] = (
+    (
+        "max_tokens",
+        lambda r: r.params.max_tokens.is_some()
+        and r.params.max_completion_tokens.is_none(),
+    ),
+    ("max_completion_tokens", lambda r: r.params.max_completion_tokens.is_some()),
+    ("temperature", lambda r: r.params.temperature.is_some()),
+    ("top_p", lambda r: r.params.top_p.is_some()),
+    ("top_k", lambda r: r.params.top_k.is_some()),
+    ("stream", lambda r: r.stream),
+    ("stop", lambda r: len(r.params.stop) > 0),
+    ("tools", lambda r: len(r.tools) > 0),
+    ("tool_choice", lambda r: r.tool_choice.is_some()),
+    ("parallel_tool_calls", lambda r: r.parallel_tool_calls.is_some()),
+    ("response_format", lambda r: r.response_format.is_some()),
+    ("user", lambda r: r.user.is_some()),
+    ("reasoning_effort", lambda r: r.reasoning_effort.is_some()),
+    ("thinking", lambda r: r.thinking.is_some()),
+)
+
+_NO_NOTES: Mapping[str, str] = MappingProxyType({})
+
+
+def unsupported_against(
+    request: ChatRequest,
+    *,
+    provider: str,
+    allowed: frozenset[str],
+    notes: Mapping[str, str] = _NO_NOTES,
+) -> str | None:
+    for key, present in _CHECKS:
+        if not present(request) or key in allowed:
+            continue
+        note = notes.get(key)
+        if note is not None:
+            return note
+        return (
+            f"{key} on {provider}: outside v1's supported list; "
+            "get_optional_params raises UnsupportedParamsError "
+            "(or drops it under drop_params)"
+        )
+    return None
+
+
+def _user_note(provider: str) -> str:
+    return (
+        f"user on {provider}: gated on litellm.open_ai_chat_completion_models "
+        "membership in v1's base supported list; v1 handles it"
+    )
+
+
+# OpenAIGPTConfig's base list restricted to IR-carried keys. ``user`` is
+# deliberately absent (model-list gated in v1) and ``response_format`` rides
+# the base list's gpt-4/gpt-3.5-turbo-16k name gate, applied per provider
+# below for the configs that inherit the base list.
+_BASE_LIST = frozenset(
+    {
+        "max_tokens",
+        "max_completion_tokens",
+        "temperature",
+        "top_p",
+        "stream",
+        "stop",
+        "tools",
+        "tool_choice",
+        "parallel_tool_calls",
+        "response_format",
+    }
+)
+
+_FUNCTION_CALLING_KEYS = frozenset({"tools", "tool_choice", "response_format"})
+
+
+def base_list_unsupported(
+    request: ChatRequest, deps: TranslationDeps, provider: str
+) -> str | None:
+    """llamafile / novita / lm_studio (plain base config) and lambda_ai /
+    nebius / wandb (base list + mct rename, applied in serialize)."""
+    return unsupported_against(
+        request,
+        provider=provider,
+        allowed=_BASE_LIST,
+        notes={"user": _user_note(provider)},
+    ) or unsupported_response_format(request)
+
+
+def supports_together_tools(model: str, deps: TranslationDeps) -> bool:
+    return deps.supports_capability(f"together_ai/{model}", "supports_function_calling")
+
+
+def together_ai_unsupported(request: ChatRequest, deps: TranslationDeps) -> str | None:
+    """TogetherAIConfig removes tools/tool_choice/response_format from the
+    base list unless ``supports_function_calling(model, "together_ai")`` is
+    True (together_ai/chat.py); parallel_tool_calls stays supported either
+    way (v1 truth, not an oversight here)."""
+    allowed = (
+        _BASE_LIST
+        if supports_together_tools(request.model, deps)
+        else _BASE_LIST - _FUNCTION_CALLING_KEYS
+    )
+    return unsupported_against(
+        request,
+        provider="together_ai",
+        allowed=allowed,
+        notes={"user": _user_note("together_ai")},
+    ) or unsupported_response_format(request)
+
+
+_CEREBRAS_LIST = frozenset(
+    {
+        "max_tokens",
+        "max_completion_tokens",
+        "temperature",
+        "top_p",
+        "stream",
+        "stop",
+        "tools",
+        "tool_choice",
+        "response_format",
+        "user",
+    }
+)
+
+
+def supports_cerebras_reasoning(model: str, deps: TranslationDeps) -> bool:
+    return deps.supports_capability(f"cerebras/{model}", "supports_reasoning")
+
+
+def cerebras_unsupported(request: ChatRequest, deps: TranslationDeps) -> str | None:
+    allowed = (
+        _CEREBRAS_LIST | {"reasoning_effort"}
+        if supports_cerebras_reasoning(request.model, deps)
+        else _CEREBRAS_LIST
+    )
+    return unsupported_against(
+        request,
+        provider="cerebras",
+        allowed=allowed,
+        notes={
+            "reasoning_effort": (
+                f"reasoning_effort on non-reasoning cerebras model {request.model} "
+                "(model-map supports_reasoning gate); v1 raises or drops it"
+            )
+        },
+    )
+
+
+# NvidiaNimConfig's static per-model allowlists (nvidia_nim/chat/
+# transformation.py), restricted to IR-carried keys; the drift gate re-derives
+# them from the v1 config at HEAD.
+_NVIDIA_GEMMA_MODELS = frozenset(
+    {
+        "google/recurrentgemma-2b",
+        "google/gemma-2-27b-it",
+        "google/gemma-2-9b-it",
+        "gemma-2-9b-it",
+    }
+)
+_NVIDIA_GEMMA_LIST = frozenset({"stream", "temperature", "top_p", "max_tokens", "stop"})
+_NVIDIA_NEMOTRON_INSTRUCT_LIST = frozenset(
+    {"stream", "temperature", "top_p", "max_tokens", "max_completion_tokens"}
+)
+_NVIDIA_REWARD_LIST = frozenset({"stream"})
+_NVIDIA_CODEGEMMA_LIST = frozenset(
+    {"stream", "temperature", "top_p", "max_tokens", "max_completion_tokens", "stop"}
+)
+_NVIDIA_DEFAULT_LIST = frozenset(
+    {
+        "stream",
+        "temperature",
+        "top_p",
+        "max_tokens",
+        "max_completion_tokens",
+        "stop",
+        "tools",
+        "tool_choice",
+        "parallel_tool_calls",
+        "response_format",
+    }
+)
+
+
+def nvidia_nim_allowed(model: str) -> frozenset[str]:
+    if model in _NVIDIA_GEMMA_MODELS:
+        return _NVIDIA_GEMMA_LIST
+    if model == "nvidia/nemotron-4-340b-instruct":
+        return _NVIDIA_NEMOTRON_INSTRUCT_LIST
+    if model == "nvidia/nemotron-4-340b-reward":
+        return _NVIDIA_REWARD_LIST
+    if model == "google/codegemma-1.1-7b":
+        return _NVIDIA_CODEGEMMA_LIST
+    return _NVIDIA_DEFAULT_LIST
+
+
+def nvidia_nim_unsupported(request: ChatRequest, deps: TranslationDeps) -> str | None:
+    return unsupported_against(
+        request, provider="nvidia_nim", allowed=nvidia_nim_allowed(request.model)
+    )
+
+
+_FEATHERLESS_LIST = frozenset(
+    {
+        "max_tokens",
+        "max_completion_tokens",
+        "temperature",
+        "top_p",
+        "stream",
+        "stop",
+    }
+)
+
+
+def featherless_ai_unsupported(
+    request: ChatRequest, deps: TranslationDeps
+) -> str | None:
+    """tools and tool_choice are outside FeatherlessAIConfig's supported
+    list, so ``_check_valid_arg`` raises before the map's tool_choice
+    auto/none arm can run — that arm is dead code (the xai R2 pattern,
+    verified in-process at HEAD)."""
+    return unsupported_against(
+        request, provider="featherless_ai", allowed=_FEATHERLESS_LIST
+    )
+
+
+_NSCALE_LIST = frozenset(
+    {"max_tokens", "temperature", "top_p", "stream", "stop", "response_format"}
+)
+
+
+def nscale_unsupported(request: ChatRequest, deps: TranslationDeps) -> str | None:
+    """NscaleConfig inherits the BASE map (no mct rename), and mct is outside
+    its supported list, so max_completion_tokens RAISES (verified at HEAD)."""
+    return unsupported_against(request, provider="nscale", allowed=_NSCALE_LIST)
+
+
+_HYPERBOLIC_LIST = frozenset(
+    {
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stream",
+        "stop",
+        "tools",
+        "tool_choice",
+        "response_format",
+        "user",
+    }
+)
+
+
+def hyperbolic_unsupported(request: ChatRequest, deps: TranslationDeps) -> str | None:
+    """max_completion_tokens is outside HyperbolicChatConfig's own list, so
+    OpenAILikeChatConfig's rename arm is dead code — v1 raises (verified at
+    HEAD; the xai R2 trap again)."""
+    return unsupported_against(request, provider="hyperbolic", allowed=_HYPERBOLIC_LIST)
+
+
+_VOLCENGINE_LIST = frozenset(
+    {
+        "max_tokens",
+        "max_completion_tokens",
+        "temperature",
+        "top_p",
+        "stream",
+        "stop",
+        "tools",
+        "tool_choice",
+    }
+)
+
+
+def volcengine_unsupported(request: ChatRequest, deps: TranslationDeps) -> str | None:
+    """response_format is OUTSIDE VolcEngineChatConfig's supported list
+    (v1 raises, verified at HEAD). ``thinking`` IS supported in v1 but its
+    map packs the verbatim dict into ``extra_body`` for the SDK to merge
+    top-level — an unported crossing, so it falls back typed."""
+    return unsupported_against(
+        request,
+        provider="volcengine",
+        allowed=_VOLCENGINE_LIST,
+        notes={
+            "thinking": (
+                "thinking on volcengine: v1 packs the verbatim dict into "
+                "extra_body (VolcEngineChatConfig.map_openai_params) and the "
+                "SDK merges it top-level; that crossing is unported, v1 "
+                "serves it"
+            )
+        },
+    )

--- a/litellm/translation/providers/compat_sdk/serialize.py
+++ b/litellm/translation/providers/compat_sdk/serialize.py
@@ -5,19 +5,25 @@ OpenAI SDK: ``get_optional_params`` runs the provider config's param gates,
 ``provider_config.transform_request`` (openai.py:727) runs the inherited
 base five-touch assembly, and none of the family overrides it. The v2 body
 is therefore ``openai_compat.assemble_body`` after the provider's gates,
-plus at most three mechanical deltas captured per provider in a frozen
+plus at most two mechanical deltas captured per provider in a frozen
 ``CompatProfile``:
 
 - ``rename_max_completion_tokens``: the configs whose map renames mct ->
   max_tokens (cerebras/nvidia_nim/nebius/wandb/featherless_ai and the
-  OpenAILike-based lambda_ai/volcengine). The IR already collapses mct into
-  ``max_tokens``, so the rename is emitting that collapsed key.
-- ``emit_user``: providers whose own supported list carries ``user``
-  unconditionally (cerebras, hyperbolic) — a typed fallback everywhere else.
+  OpenAILike-based lambda_ai/volcengine).
 - ``drop_text_response_format``: together_ai's map pops a verbatim
   ``{"type": "text"}`` response_format.
-- ``emit_reasoning_effort``: cerebras, gated per model in params.py before
-  emission ever happens.
+
+``user`` and ``reasoning_effort`` emission is NOT profile data: it is
+derived from ``params.ALLOWED[provider]`` — the same single source the
+gates narrow — so the emission facts can never desync from the gate facts
+(critic-wave1a M3).
+
+The registration surface is data too: ``PROFILES`` is the family registry
+and ``SERIALIZERS`` its derived serializer table; ``engine/pipeline.py``
+splices both so adding a provider to this family costs a profile row here,
+an allowed set + ALLOWED row in params.py, and one dispatch Literal line
+(critic-wave1a M1).
 
 The response side needs NO per-provider code: the live v1 normalizer is the
 same ``convert_to_model_response_object`` the openai_compat parser mirrors,
@@ -30,8 +36,9 @@ one would-be member that does NOT, and is dropped from the wave for it).
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
+from types import MappingProxyType
 
 from expression import Error, Result
 
@@ -42,17 +49,16 @@ from ..openai_compat.serialize import assemble_body
 from . import params as p
 
 _SerializeResult = Result[Body, TranslationError]
+Serializer = Callable[[ChatRequest, TranslationDeps], _SerializeResult]
 _GateFn = Callable[[ChatRequest, TranslationDeps], str | None]
 
 
 @dataclass(frozen=True)
 class CompatProfile:
-    provider: str
+    provider: p.CompatSdkProvider
     unsupported: _GateFn
     rename_max_completion_tokens: bool = False
-    emit_user: bool = False
     drop_text_response_format: bool = False
-    emit_reasoning_effort: bool = False
 
 
 def serialize_with_profile(
@@ -66,22 +72,22 @@ def serialize_with_profile(
 
 def _with_deltas(body: Body, request: ChatRequest, profile: CompatProfile) -> Body:
     if profile.rename_max_completion_tokens and "max_completion_tokens" in body:
-        collapsed = request.params.max_tokens.default_value(None)
         body = {
             **{k: v for k, v in body.items() if k != "max_completion_tokens"},
-            "max_tokens": collapsed,
+            "max_tokens": body["max_completion_tokens"],
         }
     if profile.drop_text_response_format and body.get("response_format") == {
         "type": "text"
     }:
         body = {k: v for k, v in body.items() if k != "response_format"}
+    emittable = p.ALLOWED[profile.provider]
     extras: dict[str, PlainJson] = {}
-    user = request.user.default_value(None) if profile.emit_user else None
+    user = request.user.default_value(None) if "user" in emittable else None
     if user is not None:
         extras = {**extras, "user": user}
     effort = (
         request.reasoning_effort.default_value(None)
-        if profile.emit_reasoning_effort
+        if "reasoning_effort" in emittable
         else None
     )
     if effort is not None:
@@ -96,134 +102,66 @@ def _base_list_gate(provider: str) -> _GateFn:
     return gate
 
 
-TOGETHER_AI = CompatProfile(
-    provider="together_ai",
-    unsupported=p.together_ai_unsupported,
-    drop_text_response_format=True,
+_PROFILE_ROWS: tuple[CompatProfile, ...] = (
+    CompatProfile(
+        provider="together_ai",
+        unsupported=p.together_ai_unsupported,
+        drop_text_response_format=True,
+    ),
+    CompatProfile(
+        provider="cerebras",
+        unsupported=p.cerebras_unsupported,
+        rename_max_completion_tokens=True,
+    ),
+    CompatProfile(
+        provider="nvidia_nim",
+        unsupported=p.nvidia_nim_unsupported,
+        rename_max_completion_tokens=True,
+    ),
+    CompatProfile(provider="lm_studio", unsupported=_base_list_gate("lm_studio")),
+    CompatProfile(provider="llamafile", unsupported=_base_list_gate("llamafile")),
+    CompatProfile(
+        provider="lambda_ai",
+        unsupported=_base_list_gate("lambda_ai"),
+        rename_max_completion_tokens=True,
+    ),
+    CompatProfile(
+        provider="nebius",
+        unsupported=_base_list_gate("nebius"),
+        rename_max_completion_tokens=True,
+    ),
+    CompatProfile(provider="novita", unsupported=_base_list_gate("novita")),
+    CompatProfile(
+        provider="wandb",
+        unsupported=_base_list_gate("wandb"),
+        rename_max_completion_tokens=True,
+    ),
+    CompatProfile(
+        provider="featherless_ai",
+        unsupported=p.featherless_ai_unsupported,
+        rename_max_completion_tokens=True,
+    ),
+    CompatProfile(provider="nscale", unsupported=p.nscale_unsupported),
+    CompatProfile(provider="hyperbolic", unsupported=p.hyperbolic_unsupported),
+    CompatProfile(
+        provider="volcengine",
+        unsupported=p.volcengine_unsupported,
+        rename_max_completion_tokens=True,
+    ),
 )
-CEREBRAS = CompatProfile(
-    provider="cerebras",
-    unsupported=p.cerebras_unsupported,
-    rename_max_completion_tokens=True,
-    emit_user=True,
-    emit_reasoning_effort=True,
-)
-NVIDIA_NIM = CompatProfile(
-    provider="nvidia_nim",
-    unsupported=p.nvidia_nim_unsupported,
-    rename_max_completion_tokens=True,
-)
-LM_STUDIO = CompatProfile(
-    provider="lm_studio", unsupported=_base_list_gate("lm_studio")
-)
-LLAMAFILE = CompatProfile(
-    provider="llamafile", unsupported=_base_list_gate("llamafile")
-)
-LAMBDA_AI = CompatProfile(
-    provider="lambda_ai",
-    unsupported=_base_list_gate("lambda_ai"),
-    rename_max_completion_tokens=True,
-)
-NEBIUS = CompatProfile(
-    provider="nebius",
-    unsupported=_base_list_gate("nebius"),
-    rename_max_completion_tokens=True,
-)
-NOVITA = CompatProfile(provider="novita", unsupported=_base_list_gate("novita"))
-WANDB = CompatProfile(
-    provider="wandb",
-    unsupported=_base_list_gate("wandb"),
-    rename_max_completion_tokens=True,
-)
-FEATHERLESS_AI = CompatProfile(
-    provider="featherless_ai",
-    unsupported=p.featherless_ai_unsupported,
-    rename_max_completion_tokens=True,
-)
-NSCALE = CompatProfile(provider="nscale", unsupported=p.nscale_unsupported)
-HYPERBOLIC = CompatProfile(
-    provider="hyperbolic", unsupported=p.hyperbolic_unsupported, emit_user=True
-)
-VOLCENGINE = CompatProfile(
-    provider="volcengine",
-    unsupported=p.volcengine_unsupported,
-    rename_max_completion_tokens=True,
+
+PROFILES: Mapping[p.CompatSdkProvider, CompatProfile] = MappingProxyType(
+    {profile.provider: profile for profile in _PROFILE_ROWS}
 )
 
 
-def together_ai_serialize_request(
-    request: ChatRequest, deps: TranslationDeps
-) -> _SerializeResult:
-    return serialize_with_profile(request, deps, TOGETHER_AI)
+def _profile_serializer(profile: CompatProfile) -> Serializer:
+    def serialize(request: ChatRequest, deps: TranslationDeps) -> _SerializeResult:
+        return serialize_with_profile(request, deps, profile)
+
+    return serialize
 
 
-def cerebras_serialize_request(
-    request: ChatRequest, deps: TranslationDeps
-) -> _SerializeResult:
-    return serialize_with_profile(request, deps, CEREBRAS)
-
-
-def nvidia_nim_serialize_request(
-    request: ChatRequest, deps: TranslationDeps
-) -> _SerializeResult:
-    return serialize_with_profile(request, deps, NVIDIA_NIM)
-
-
-def lm_studio_serialize_request(
-    request: ChatRequest, deps: TranslationDeps
-) -> _SerializeResult:
-    return serialize_with_profile(request, deps, LM_STUDIO)
-
-
-def llamafile_serialize_request(
-    request: ChatRequest, deps: TranslationDeps
-) -> _SerializeResult:
-    return serialize_with_profile(request, deps, LLAMAFILE)
-
-
-def lambda_ai_serialize_request(
-    request: ChatRequest, deps: TranslationDeps
-) -> _SerializeResult:
-    return serialize_with_profile(request, deps, LAMBDA_AI)
-
-
-def nebius_serialize_request(
-    request: ChatRequest, deps: TranslationDeps
-) -> _SerializeResult:
-    return serialize_with_profile(request, deps, NEBIUS)
-
-
-def novita_serialize_request(
-    request: ChatRequest, deps: TranslationDeps
-) -> _SerializeResult:
-    return serialize_with_profile(request, deps, NOVITA)
-
-
-def wandb_serialize_request(
-    request: ChatRequest, deps: TranslationDeps
-) -> _SerializeResult:
-    return serialize_with_profile(request, deps, WANDB)
-
-
-def featherless_ai_serialize_request(
-    request: ChatRequest, deps: TranslationDeps
-) -> _SerializeResult:
-    return serialize_with_profile(request, deps, FEATHERLESS_AI)
-
-
-def nscale_serialize_request(
-    request: ChatRequest, deps: TranslationDeps
-) -> _SerializeResult:
-    return serialize_with_profile(request, deps, NSCALE)
-
-
-def hyperbolic_serialize_request(
-    request: ChatRequest, deps: TranslationDeps
-) -> _SerializeResult:
-    return serialize_with_profile(request, deps, HYPERBOLIC)
-
-
-def volcengine_serialize_request(
-    request: ChatRequest, deps: TranslationDeps
-) -> _SerializeResult:
-    return serialize_with_profile(request, deps, VOLCENGINE)
+SERIALIZERS: Mapping[p.CompatSdkProvider, Serializer] = MappingProxyType(
+    {provider: _profile_serializer(profile) for provider, profile in PROFILES.items()}
+)

--- a/litellm/translation/providers/compat_sdk/serialize.py
+++ b/litellm/translation/providers/compat_sdk/serialize.py
@@ -1,0 +1,229 @@
+"""Serializers for the SDK-path openai-compat family (wave 1a).
+
+Every provider here rides v1's big openai elif (main.py:2646-2667) into the
+OpenAI SDK: ``get_optional_params`` runs the provider config's param gates,
+``provider_config.transform_request`` (openai.py:727) runs the inherited
+base five-touch assembly, and none of the family overrides it. The v2 body
+is therefore ``openai_compat.assemble_body`` after the provider's gates,
+plus at most three mechanical deltas captured per provider in a frozen
+``CompatProfile``:
+
+- ``rename_max_completion_tokens``: the configs whose map renames mct ->
+  max_tokens (cerebras/nvidia_nim/nebius/wandb/featherless_ai and the
+  OpenAILike-based lambda_ai/volcengine). The IR already collapses mct into
+  ``max_tokens``, so the rename is emitting that collapsed key.
+- ``emit_user``: providers whose own supported list carries ``user``
+  unconditionally (cerebras, hyperbolic) — a typed fallback everywhere else.
+- ``drop_text_response_format``: together_ai's map pops a verbatim
+  ``{"type": "text"}`` response_format.
+- ``emit_reasoning_effort``: cerebras, gated per model in params.py before
+  emission ever happens.
+
+The response side needs NO per-provider code: the live v1 normalizer is the
+same ``convert_to_model_response_object`` the openai_compat parser mirrors,
+and the ``{provider}/{wire_model}`` model re-prefix (openai.py:676-677 +
+cdr:699-710) is the SEAM's ``_to_model_response_openai`` preset arm, pinned
+per provider by the differential's preset-model rows. Streams ride the
+default openai wrapper arm -> the ``"openai"`` chunk dialect (baseten is the
+one would-be member that does NOT, and is dropped from the wave for it).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from expression import Error, Result
+
+from ...deps import TranslationDeps
+from ...errors import TranslationError
+from ...ir import Body, ChatRequest, PlainJson
+from ..openai_compat.serialize import assemble_body
+from . import params as p
+
+_SerializeResult = Result[Body, TranslationError]
+_GateFn = Callable[[ChatRequest, TranslationDeps], str | None]
+
+
+@dataclass(frozen=True)
+class CompatProfile:
+    provider: str
+    unsupported: _GateFn
+    rename_max_completion_tokens: bool = False
+    emit_user: bool = False
+    drop_text_response_format: bool = False
+    emit_reasoning_effort: bool = False
+
+
+def serialize_with_profile(
+    request: ChatRequest, deps: TranslationDeps, profile: CompatProfile
+) -> _SerializeResult:
+    reason = profile.unsupported(request, deps)
+    if reason is not None:
+        return Error(TranslationError.of_unsupported(reason))
+    return assemble_body(request).map(lambda body: _with_deltas(body, request, profile))
+
+
+def _with_deltas(body: Body, request: ChatRequest, profile: CompatProfile) -> Body:
+    if profile.rename_max_completion_tokens and "max_completion_tokens" in body:
+        collapsed = request.params.max_tokens.default_value(None)
+        body = {
+            **{k: v for k, v in body.items() if k != "max_completion_tokens"},
+            "max_tokens": collapsed,
+        }
+    if profile.drop_text_response_format and body.get("response_format") == {
+        "type": "text"
+    }:
+        body = {k: v for k, v in body.items() if k != "response_format"}
+    extras: dict[str, PlainJson] = {}
+    user = request.user.default_value(None) if profile.emit_user else None
+    if user is not None:
+        extras = {**extras, "user": user}
+    effort = (
+        request.reasoning_effort.default_value(None)
+        if profile.emit_reasoning_effort
+        else None
+    )
+    if effort is not None:
+        extras = {**extras, "reasoning_effort": effort}
+    return {**body, **extras} if extras else body
+
+
+def _base_list_gate(provider: str) -> _GateFn:
+    def gate(request: ChatRequest, deps: TranslationDeps) -> str | None:
+        return p.base_list_unsupported(request, deps, provider)
+
+    return gate
+
+
+TOGETHER_AI = CompatProfile(
+    provider="together_ai",
+    unsupported=p.together_ai_unsupported,
+    drop_text_response_format=True,
+)
+CEREBRAS = CompatProfile(
+    provider="cerebras",
+    unsupported=p.cerebras_unsupported,
+    rename_max_completion_tokens=True,
+    emit_user=True,
+    emit_reasoning_effort=True,
+)
+NVIDIA_NIM = CompatProfile(
+    provider="nvidia_nim",
+    unsupported=p.nvidia_nim_unsupported,
+    rename_max_completion_tokens=True,
+)
+LM_STUDIO = CompatProfile(
+    provider="lm_studio", unsupported=_base_list_gate("lm_studio")
+)
+LLAMAFILE = CompatProfile(
+    provider="llamafile", unsupported=_base_list_gate("llamafile")
+)
+LAMBDA_AI = CompatProfile(
+    provider="lambda_ai",
+    unsupported=_base_list_gate("lambda_ai"),
+    rename_max_completion_tokens=True,
+)
+NEBIUS = CompatProfile(
+    provider="nebius",
+    unsupported=_base_list_gate("nebius"),
+    rename_max_completion_tokens=True,
+)
+NOVITA = CompatProfile(provider="novita", unsupported=_base_list_gate("novita"))
+WANDB = CompatProfile(
+    provider="wandb",
+    unsupported=_base_list_gate("wandb"),
+    rename_max_completion_tokens=True,
+)
+FEATHERLESS_AI = CompatProfile(
+    provider="featherless_ai",
+    unsupported=p.featherless_ai_unsupported,
+    rename_max_completion_tokens=True,
+)
+NSCALE = CompatProfile(provider="nscale", unsupported=p.nscale_unsupported)
+HYPERBOLIC = CompatProfile(
+    provider="hyperbolic", unsupported=p.hyperbolic_unsupported, emit_user=True
+)
+VOLCENGINE = CompatProfile(
+    provider="volcengine",
+    unsupported=p.volcengine_unsupported,
+    rename_max_completion_tokens=True,
+)
+
+
+def together_ai_serialize_request(
+    request: ChatRequest, deps: TranslationDeps
+) -> _SerializeResult:
+    return serialize_with_profile(request, deps, TOGETHER_AI)
+
+
+def cerebras_serialize_request(
+    request: ChatRequest, deps: TranslationDeps
+) -> _SerializeResult:
+    return serialize_with_profile(request, deps, CEREBRAS)
+
+
+def nvidia_nim_serialize_request(
+    request: ChatRequest, deps: TranslationDeps
+) -> _SerializeResult:
+    return serialize_with_profile(request, deps, NVIDIA_NIM)
+
+
+def lm_studio_serialize_request(
+    request: ChatRequest, deps: TranslationDeps
+) -> _SerializeResult:
+    return serialize_with_profile(request, deps, LM_STUDIO)
+
+
+def llamafile_serialize_request(
+    request: ChatRequest, deps: TranslationDeps
+) -> _SerializeResult:
+    return serialize_with_profile(request, deps, LLAMAFILE)
+
+
+def lambda_ai_serialize_request(
+    request: ChatRequest, deps: TranslationDeps
+) -> _SerializeResult:
+    return serialize_with_profile(request, deps, LAMBDA_AI)
+
+
+def nebius_serialize_request(
+    request: ChatRequest, deps: TranslationDeps
+) -> _SerializeResult:
+    return serialize_with_profile(request, deps, NEBIUS)
+
+
+def novita_serialize_request(
+    request: ChatRequest, deps: TranslationDeps
+) -> _SerializeResult:
+    return serialize_with_profile(request, deps, NOVITA)
+
+
+def wandb_serialize_request(
+    request: ChatRequest, deps: TranslationDeps
+) -> _SerializeResult:
+    return serialize_with_profile(request, deps, WANDB)
+
+
+def featherless_ai_serialize_request(
+    request: ChatRequest, deps: TranslationDeps
+) -> _SerializeResult:
+    return serialize_with_profile(request, deps, FEATHERLESS_AI)
+
+
+def nscale_serialize_request(
+    request: ChatRequest, deps: TranslationDeps
+) -> _SerializeResult:
+    return serialize_with_profile(request, deps, NSCALE)
+
+
+def hyperbolic_serialize_request(
+    request: ChatRequest, deps: TranslationDeps
+) -> _SerializeResult:
+    return serialize_with_profile(request, deps, HYPERBOLIC)
+
+
+def volcengine_serialize_request(
+    request: ChatRequest, deps: TranslationDeps
+) -> _SerializeResult:
+    return serialize_with_profile(request, deps, VOLCENGINE)

--- a/litellm/translation/providers/openai_compat/guard.py
+++ b/litellm/translation/providers/openai_compat/guard.py
@@ -21,6 +21,20 @@ from ...errors import TranslationError
 _Raw = Mapping[str, object]
 
 
+def explicit_stream_false(raw: _Raw) -> TranslationError | None:
+    """The ONE explicit ``stream: false`` arm the azure / xai / compat_sdk
+    guards compose (critic-wave1a N2): those paths all serialize an
+    explicitly-sent ``false`` onto the wire while absent-vs-false is lost in
+    the IR. openai_compat itself deliberately does NOT run it -- the
+    gap-parity question is integrator scope (wave1a-port.md attack #2)."""
+    if raw.get("stream") is False:
+        return TranslationError.of_unsupported(
+            "explicit stream: false (this path keeps the key on the wire; "
+            "absent-vs-false is lost in the IR)"
+        )
+    return None
+
+
 def unsupported_request_shapes(
     raw: _Raw, *, name_fallback_user_only: bool = False
 ) -> TranslationError | None:

--- a/litellm/translation/providers/openai_compat/params.py
+++ b/litellm/translation/providers/openai_compat/params.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 from ...ir import ChatRequest
 
-_RESPONSE_FORMAT_UNSUPPORTED_MODELS = ("gpt-4", "gpt-3.5-turbo-16k")
+RESPONSE_FORMAT_UNSUPPORTED_MODELS = ("gpt-4", "gpt-3.5-turbo-16k")
 """v1's get_supported_openai_params excludes response_format for exactly
 these two model names (gpt_transformation.py:172-175) and then DROPS or
 RAISES on it in get_optional_params; fail closed instead of re-deriving the
@@ -52,7 +52,7 @@ def unsupported_params(request: ChatRequest) -> str | None:
 def unsupported_response_format(request: ChatRequest) -> str | None:
     if request.response_format.is_none():
         return None
-    if request.model in _RESPONSE_FORMAT_UNSUPPORTED_MODELS:
+    if request.model in RESPONSE_FORMAT_UNSUPPORTED_MODELS:
         return (
             f"response_format on {request.model}: outside v1's supported set "
             "(gpt_transformation.py:172-175); v1 raises or drops it"

--- a/litellm/translation/providers/openai_compat/stream.py
+++ b/litellm/translation/providers/openai_compat/stream.py
@@ -92,6 +92,13 @@ def parse_event(event: PlainJson) -> _EventResult:
         normalized_choices = [normalized]
     identifier = event.get("id")
     chunk: dict[str, PlainJson] = {
+        # The decode seam on this path is the VALIDATED SDK
+        # ChatCompletionChunk, which materializes service_tier=None even when
+        # the wire JSON omits the key, and v1's wrapper copies it onto every
+        # emitted chunk; preset it so the real wire shape (key absent)
+        # matches v1's SDK-materialized null (verifier-wave1a F1). A
+        # wire-carried value overrides via the spread below.
+        "service_tier": None,
         # Keys outside ModelResponseStream's field set ride along verbatim:
         # v1's wrapper setattrs them onto every emitted chunk
         # (preserve_upstream_non_openai_attributes, e.g. service_tier).

--- a/litellm/translation/providers/xai/guard.py
+++ b/litellm/translation/providers/xai/guard.py
@@ -27,6 +27,7 @@ from typing import cast
 from litellm.constants import DEFAULT_MAX_RECURSE_DEPTH
 
 from ...errors import TranslationError
+from ..openai_compat.guard import explicit_stream_false
 from ..openai_compat.guard import (
     unsupported_request_shapes as openai_unsupported_request_shapes,
 )
@@ -56,11 +57,9 @@ def unsupported_request_shapes(raw: _Raw) -> TranslationError | None:
             "use_xai_oauth: v1 runs an interactive browser PKCE flow inside "
             "validate_environment (llms/xai/oauth.py); v1 owns it"
         )
-    if "stream" in raw and raw.get("stream") is False:
-        return TranslationError.of_unsupported(
-            "explicit stream: false (the xai httpx path keeps the key on the "
-            "wire; absent-vs-false is lost in the IR)"
-        )
+    stream_false = explicit_stream_false(raw)
+    if stream_false is not None:
+        return stream_false
     reason = _nested_tool_strict_reason(raw)
     if reason is not None:
         return TranslationError.of_unsupported(reason)

--- a/tests/test_litellm/translation/DIFFERENTIAL_REPORT.md
+++ b/tests/test_litellm/translation/DIFFERENTIAL_REPORT.md
@@ -1,4 +1,4 @@
-# Translation v2 differential report (anthropic + bedrock + openai + google + azure + xai)
+# Translation v2 differential report (anthropic + bedrock + openai + google + azure + xai + the wave-1a compat_sdk family)
 
 v1 and v2 run over the same corpus; every row must be IDENTICAL (or an
 explained FALLBACK that v1 serves) for a provider's flag to turn on.
@@ -6,7 +6,7 @@ Bedrock and google rows additionally pin the characterization-corpus
 snapshot, so each row proves snapshot == v1-at-HEAD == v2. Regenerate with:
 `python -m tests.test_litellm.translation.generate_differential_report`
 
-- commit: ae4643ba8a
+- commit: b64b732772
 
 ## anthropic: request bodies (v1 map_openai_params + transform_request vs v2)
 
@@ -205,6 +205,394 @@ snapshot, so each row proves snapshot == v1-at-HEAD == v2. Regenerate with:
 - IDENTICAL: tools_typeless_continuation
 - SEAM CONTRACT: usage_tail_include_usage (v1's chunk_parser injects a dummy choice so the wrapper swallows the tail and synthesizes the final usage chunk; v2 passes the wire choices=[] chunk through with the FOLDED usage for the streaming seam to synthesize from)
 - IDENTICAL: usage_withheld_on_content_chunks
+
+## cerebras: request bodies (v1 get_optional_params('cerebras') + transform_request vs v2 compat_sdk)
+
+- IDENTICAL: max_completion_tokens
+- IDENTICAL: response_format_json_object
+- IDENTICAL: response_format_json_schema_strict
+- IDENTICAL: stop_list
+- IDENTICAL: stream_true
+- IDENTICAL: system_and_sampling
+- IDENTICAL: temperature_int_stays_int
+- IDENTICAL: text
+- IDENTICAL: tool_call_compact_roundtrip
+- IDENTICAL: tool_choice_specific
+- IDENTICAL: tools_auto
+- IDENTICAL: user_param
+- FALLBACK (v1 raises UnsupportedParamsError): cerebras:parallel_tool_calls (parallel_tool_calls)
+- FALLBACK (v1 raises UnsupportedParamsError): cerebras:reasoning_effort_non_reasoning_model (reasoning_effort on non-reasoning cerebras model)
+- FALLBACK (v1 serves it): cerebras:both_max_tokens_keys (both max_tokens and max_completion_tokens)
+- FALLBACK (v1 serves it): cerebras:explicit_stream_false (explicit stream: false)
+- FALLBACK (v1 serves it): cerebras:message_name_field (message name field)
+- FALLBACK (v1 serves it): cerebras:seed_outside_ir (seed)
+- FALLBACK (v1 serves it): cerebras:string_form_stop (string-form stop)
+
+## featherless_ai: request bodies (v1 get_optional_params('featherless_ai') + transform_request vs v2 compat_sdk)
+
+- IDENTICAL: max_completion_tokens
+- IDENTICAL: stop_list
+- IDENTICAL: stream_true
+- IDENTICAL: system_and_sampling
+- IDENTICAL: temperature_int_stays_int
+- IDENTICAL: text
+- FALLBACK (v1 raises UnsupportedParamsError): featherless_ai:parallel_tool_calls (parallel_tool_calls)
+- FALLBACK (v1 raises UnsupportedParamsError): featherless_ai:reasoning_effort (reasoning_effort)
+- FALLBACK (v1 raises UnsupportedParamsError): featherless_ai:response_format (response_format)
+- FALLBACK (v1 raises UnsupportedParamsError): featherless_ai:tools (tools)
+- FALLBACK (v1 serves it): featherless_ai:both_max_tokens_keys (both max_tokens and max_completion_tokens)
+- FALLBACK (v1 serves it): featherless_ai:explicit_stream_false (explicit stream: false)
+- FALLBACK (v1 serves it): featherless_ai:message_name_field (message name field)
+- FALLBACK (v1 serves it): featherless_ai:seed_outside_ir (seed)
+- FALLBACK (v1 serves it): featherless_ai:string_form_stop (string-form stop)
+- FALLBACK (v1 serves it): featherless_ai:user_model_list_gate (user)
+
+## hyperbolic: request bodies (v1 get_optional_params('hyperbolic') + transform_request vs v2 compat_sdk)
+
+- IDENTICAL: response_format_json_object
+- IDENTICAL: response_format_json_schema_strict
+- IDENTICAL: stop_list
+- IDENTICAL: stream_true
+- IDENTICAL: system_and_sampling
+- IDENTICAL: temperature_int_stays_int
+- IDENTICAL: text
+- IDENTICAL: tool_call_compact_roundtrip
+- IDENTICAL: tool_choice_specific
+- IDENTICAL: tools_auto
+- IDENTICAL: user_param
+- FALLBACK (v1 raises UnsupportedParamsError): hyperbolic:max_completion_tokens (max_completion_tokens)
+- FALLBACK (v1 raises UnsupportedParamsError): hyperbolic:parallel_tool_calls (parallel_tool_calls)
+- FALLBACK (v1 raises UnsupportedParamsError): hyperbolic:reasoning_effort (reasoning_effort)
+- FALLBACK (v1 serves it): hyperbolic:both_max_tokens_keys (both max_tokens and max_completion_tokens)
+- FALLBACK (v1 serves it): hyperbolic:explicit_stream_false (explicit stream: false)
+- FALLBACK (v1 serves it): hyperbolic:message_name_field (message name field)
+- FALLBACK (v1 serves it): hyperbolic:seed_outside_ir (seed)
+- FALLBACK (v1 serves it): hyperbolic:string_form_stop (string-form stop)
+
+## lambda_ai: request bodies (v1 get_optional_params('lambda_ai') + transform_request vs v2 compat_sdk)
+
+- IDENTICAL: max_completion_tokens
+- IDENTICAL: parallel_tool_calls_false
+- IDENTICAL: response_format_json_object
+- IDENTICAL: response_format_json_schema_strict
+- IDENTICAL: stop_list
+- IDENTICAL: stream_true
+- IDENTICAL: system_and_sampling
+- IDENTICAL: temperature_int_stays_int
+- IDENTICAL: text
+- IDENTICAL: tool_call_compact_roundtrip
+- IDENTICAL: tool_choice_specific
+- IDENTICAL: tools_auto
+- FALLBACK (v1 raises UnsupportedParamsError): lambda_ai:reasoning_effort (reasoning_effort)
+- FALLBACK (v1 serves it): lambda_ai:both_max_tokens_keys (both max_tokens and max_completion_tokens)
+- FALLBACK (v1 serves it): lambda_ai:explicit_stream_false (explicit stream: false)
+- FALLBACK (v1 serves it): lambda_ai:message_name_field (message name field)
+- FALLBACK (v1 serves it): lambda_ai:seed_outside_ir (seed)
+- FALLBACK (v1 serves it): lambda_ai:string_form_stop (string-form stop)
+- FALLBACK (v1 serves it): lambda_ai:user_model_list_gate (user)
+
+## llamafile: request bodies (v1 get_optional_params('llamafile') + transform_request vs v2 compat_sdk)
+
+- IDENTICAL: max_completion_tokens
+- IDENTICAL: parallel_tool_calls_false
+- IDENTICAL: response_format_json_object
+- IDENTICAL: response_format_json_schema_strict
+- IDENTICAL: stop_list
+- IDENTICAL: stream_true
+- IDENTICAL: system_and_sampling
+- IDENTICAL: temperature_int_stays_int
+- IDENTICAL: text
+- IDENTICAL: tool_call_compact_roundtrip
+- IDENTICAL: tool_choice_specific
+- IDENTICAL: tools_auto
+- FALLBACK (v1 raises UnsupportedParamsError): llamafile:reasoning_effort (reasoning_effort)
+- FALLBACK (v1 serves it): llamafile:both_max_tokens_keys (both max_tokens and max_completion_tokens)
+- FALLBACK (v1 serves it): llamafile:explicit_stream_false (explicit stream: false)
+- FALLBACK (v1 serves it): llamafile:message_name_field (message name field)
+- FALLBACK (v1 serves it): llamafile:seed_outside_ir (seed)
+- FALLBACK (v1 serves it): llamafile:string_form_stop (string-form stop)
+- FALLBACK (v1 serves it): llamafile:user_model_list_gate (user)
+
+## lm_studio: request bodies (v1 get_optional_params('lm_studio') + transform_request vs v2 compat_sdk)
+
+- IDENTICAL: max_completion_tokens
+- IDENTICAL: parallel_tool_calls_false
+- IDENTICAL: response_format_json_object
+- IDENTICAL: response_format_json_schema_strict
+- IDENTICAL: stop_list
+- IDENTICAL: stream_true
+- IDENTICAL: system_and_sampling
+- IDENTICAL: temperature_int_stays_int
+- IDENTICAL: text
+- IDENTICAL: tool_call_compact_roundtrip
+- IDENTICAL: tool_choice_specific
+- IDENTICAL: tools_auto
+- FALLBACK (v1 raises UnsupportedParamsError): lm_studio:reasoning_effort (reasoning_effort)
+- FALLBACK (v1 raises UnsupportedParamsError): lm_studio:response_format_on_gpt4_name (outside v1's supported set)
+- FALLBACK (v1 serves it): lm_studio:bare_schema_response_format (response_format)
+- FALLBACK (v1 serves it): lm_studio:both_max_tokens_keys (both max_tokens and max_completion_tokens)
+- FALLBACK (v1 serves it): lm_studio:explicit_stream_false (explicit stream: false)
+- FALLBACK (v1 serves it): lm_studio:message_name_field (message name field)
+- FALLBACK (v1 serves it): lm_studio:seed_outside_ir (seed)
+- FALLBACK (v1 serves it): lm_studio:string_form_stop (string-form stop)
+- FALLBACK (v1 serves it): lm_studio:user_model_list_gate (user)
+
+## nebius: request bodies (v1 get_optional_params('nebius') + transform_request vs v2 compat_sdk)
+
+- IDENTICAL: max_completion_tokens
+- IDENTICAL: parallel_tool_calls_false
+- IDENTICAL: response_format_json_object
+- IDENTICAL: response_format_json_schema_strict
+- IDENTICAL: stop_list
+- IDENTICAL: stream_true
+- IDENTICAL: system_and_sampling
+- IDENTICAL: temperature_int_stays_int
+- IDENTICAL: text
+- IDENTICAL: tool_call_compact_roundtrip
+- IDENTICAL: tool_choice_specific
+- IDENTICAL: tools_auto
+- FALLBACK (v1 raises UnsupportedParamsError): nebius:reasoning_effort (reasoning_effort)
+- FALLBACK (v1 serves it): nebius:both_max_tokens_keys (both max_tokens and max_completion_tokens)
+- FALLBACK (v1 serves it): nebius:explicit_stream_false (explicit stream: false)
+- FALLBACK (v1 serves it): nebius:message_name_field (message name field)
+- FALLBACK (v1 serves it): nebius:seed_outside_ir (seed)
+- FALLBACK (v1 serves it): nebius:string_form_stop (string-form stop)
+- FALLBACK (v1 serves it): nebius:user_model_list_gate (user)
+
+## novita: request bodies (v1 get_optional_params('novita') + transform_request vs v2 compat_sdk)
+
+- IDENTICAL: max_completion_tokens
+- IDENTICAL: parallel_tool_calls_false
+- IDENTICAL: response_format_json_object
+- IDENTICAL: response_format_json_schema_strict
+- IDENTICAL: stop_list
+- IDENTICAL: stream_true
+- IDENTICAL: system_and_sampling
+- IDENTICAL: temperature_int_stays_int
+- IDENTICAL: text
+- IDENTICAL: tool_call_compact_roundtrip
+- IDENTICAL: tool_choice_specific
+- IDENTICAL: tools_auto
+- FALLBACK (v1 raises UnsupportedParamsError): novita:reasoning_effort (reasoning_effort)
+- FALLBACK (v1 serves it): novita:both_max_tokens_keys (both max_tokens and max_completion_tokens)
+- FALLBACK (v1 serves it): novita:explicit_stream_false (explicit stream: false)
+- FALLBACK (v1 serves it): novita:message_name_field (message name field)
+- FALLBACK (v1 serves it): novita:seed_outside_ir (seed)
+- FALLBACK (v1 serves it): novita:string_form_stop (string-form stop)
+- FALLBACK (v1 serves it): novita:user_model_list_gate (user)
+
+## nscale: request bodies (v1 get_optional_params('nscale') + transform_request vs v2 compat_sdk)
+
+- IDENTICAL: response_format_json_object
+- IDENTICAL: response_format_json_schema_strict
+- IDENTICAL: stop_list
+- IDENTICAL: stream_true
+- IDENTICAL: system_and_sampling
+- IDENTICAL: temperature_int_stays_int
+- IDENTICAL: text
+- FALLBACK (v1 raises UnsupportedParamsError): nscale:max_completion_tokens (max_completion_tokens)
+- FALLBACK (v1 raises UnsupportedParamsError): nscale:parallel_tool_calls (parallel_tool_calls)
+- FALLBACK (v1 raises UnsupportedParamsError): nscale:reasoning_effort (reasoning_effort)
+- FALLBACK (v1 raises UnsupportedParamsError): nscale:tools (tools)
+- FALLBACK (v1 serves it): nscale:both_max_tokens_keys (both max_tokens and max_completion_tokens)
+- FALLBACK (v1 serves it): nscale:explicit_stream_false (explicit stream: false)
+- FALLBACK (v1 serves it): nscale:message_name_field (message name field)
+- FALLBACK (v1 serves it): nscale:seed_outside_ir (seed)
+- FALLBACK (v1 serves it): nscale:string_form_stop (string-form stop)
+- FALLBACK (v1 serves it): nscale:user_model_list_gate (user)
+
+## nvidia_nim: request bodies (v1 get_optional_params('nvidia_nim') + transform_request vs v2 compat_sdk)
+
+- IDENTICAL: max_completion_tokens
+- IDENTICAL: parallel_tool_calls_false
+- IDENTICAL: response_format_json_object
+- IDENTICAL: response_format_json_schema_strict
+- IDENTICAL: stop_list
+- IDENTICAL: stream_true
+- IDENTICAL: system_and_sampling
+- IDENTICAL: temperature_int_stays_int
+- IDENTICAL: text
+- IDENTICAL: tool_call_compact_roundtrip
+- IDENTICAL: tool_choice_specific
+- IDENTICAL: tools_auto
+- FALLBACK (v1 raises UnsupportedParamsError): nvidia_nim:max_completion_tokens_on_gemma (max_completion_tokens)
+- FALLBACK (v1 raises UnsupportedParamsError): nvidia_nim:reasoning_effort (reasoning_effort)
+- FALLBACK (v1 raises UnsupportedParamsError): nvidia_nim:stop_on_nemotron_instruct (stop)
+- FALLBACK (v1 raises UnsupportedParamsError): nvidia_nim:temperature_on_nemotron_reward (temperature)
+- FALLBACK (v1 raises UnsupportedParamsError): nvidia_nim:tools_on_gemma (tools)
+- FALLBACK (v1 serves it): nvidia_nim:both_max_tokens_keys (both max_tokens and max_completion_tokens)
+- FALLBACK (v1 serves it): nvidia_nim:explicit_stream_false (explicit stream: false)
+- FALLBACK (v1 serves it): nvidia_nim:message_name_field (message name field)
+- FALLBACK (v1 serves it): nvidia_nim:seed_outside_ir (seed)
+- FALLBACK (v1 serves it): nvidia_nim:string_form_stop (string-form stop)
+- FALLBACK (v1 serves it): nvidia_nim:user_model_list_gate (user)
+
+## together_ai: request bodies (v1 get_optional_params('together_ai') + transform_request vs v2 compat_sdk)
+
+- IDENTICAL: max_completion_tokens
+- IDENTICAL: parallel_tool_calls_false
+- IDENTICAL: response_format_json_object
+- IDENTICAL: response_format_json_schema_strict
+- IDENTICAL: stop_list
+- IDENTICAL: stream_true
+- IDENTICAL: system_and_sampling
+- IDENTICAL: temperature_int_stays_int
+- IDENTICAL: text
+- IDENTICAL: tool_call_compact_roundtrip
+- IDENTICAL: tool_choice_specific
+- IDENTICAL: tools_auto
+- FALLBACK (v1 raises UnsupportedParamsError): together_ai:reasoning_effort (reasoning_effort)
+- FALLBACK (v1 raises UnsupportedParamsError): together_ai:response_format_on_non_fc_model (response_format)
+- FALLBACK (v1 raises UnsupportedParamsError): together_ai:tools_on_non_fc_model (tools)
+- FALLBACK (v1 serves it): together_ai:both_max_tokens_keys (both max_tokens and max_completion_tokens)
+- FALLBACK (v1 serves it): together_ai:explicit_stream_false (explicit stream: false)
+- FALLBACK (v1 serves it): together_ai:message_name_field (message name field)
+- FALLBACK (v1 serves it): together_ai:seed_outside_ir (seed)
+- FALLBACK (v1 serves it): together_ai:string_form_stop (string-form stop)
+- FALLBACK (v1 serves it): together_ai:user_model_list_gate (user)
+
+## volcengine: request bodies (v1 get_optional_params('volcengine') + transform_request vs v2 compat_sdk)
+
+- IDENTICAL: max_completion_tokens
+- IDENTICAL: stop_list
+- IDENTICAL: stream_true
+- IDENTICAL: system_and_sampling
+- IDENTICAL: temperature_int_stays_int
+- IDENTICAL: text
+- IDENTICAL: tool_call_compact_roundtrip
+- IDENTICAL: tool_choice_specific
+- IDENTICAL: tools_auto
+- FALLBACK (v1 raises UnsupportedParamsError): volcengine:parallel_tool_calls (parallel_tool_calls)
+- FALLBACK (v1 raises UnsupportedParamsError): volcengine:reasoning_effort (reasoning_effort)
+- FALLBACK (v1 raises UnsupportedParamsError): volcengine:response_format (response_format)
+- FALLBACK (v1 serves it): volcengine:both_max_tokens_keys (both max_tokens and max_completion_tokens)
+- FALLBACK (v1 serves it): volcengine:explicit_stream_false (explicit stream: false)
+- FALLBACK (v1 serves it): volcengine:message_name_field (message name field)
+- FALLBACK (v1 serves it): volcengine:seed_outside_ir (seed)
+- FALLBACK (v1 serves it): volcengine:string_form_stop (string-form stop)
+- FALLBACK (v1 serves it): volcengine:thinking_extra_body_packing (extra_body)
+- FALLBACK (v1 serves it): volcengine:user_model_list_gate (user)
+
+## wandb: request bodies (v1 get_optional_params('wandb') + transform_request vs v2 compat_sdk)
+
+- IDENTICAL: max_completion_tokens
+- IDENTICAL: parallel_tool_calls_false
+- IDENTICAL: response_format_json_object
+- IDENTICAL: response_format_json_schema_strict
+- IDENTICAL: stop_list
+- IDENTICAL: stream_true
+- IDENTICAL: system_and_sampling
+- IDENTICAL: temperature_int_stays_int
+- IDENTICAL: text
+- IDENTICAL: tool_call_compact_roundtrip
+- IDENTICAL: tool_choice_specific
+- IDENTICAL: tools_auto
+- FALLBACK (v1 raises UnsupportedParamsError): wandb:reasoning_effort (reasoning_effort)
+- FALLBACK (v1 serves it): wandb:both_max_tokens_keys (both max_tokens and max_completion_tokens)
+- FALLBACK (v1 serves it): wandb:explicit_stream_false (explicit stream: false)
+- FALLBACK (v1 serves it): wandb:message_name_field (message name field)
+- FALLBACK (v1 serves it): wandb:seed_outside_ir (seed)
+- FALLBACK (v1 serves it): wandb:string_form_stop (string-form stop)
+- FALLBACK (v1 serves it): wandb:user_model_list_gate (user)
+
+## compat_sdk family: responses (v1 convert_to_model_response_object with the SDK-path {provider}/{model} preset vs v2 + seam re-prefix arm)
+
+- IDENTICAL: cerebras cached_and_reasoning_usage_details
+- IDENTICAL: cerebras text
+- IDENTICAL: cerebras tool_calls_rewrites_stop
+- IDENTICAL: featherless_ai cached_and_reasoning_usage_details
+- IDENTICAL: featherless_ai text
+- IDENTICAL: featherless_ai tool_calls_rewrites_stop
+- IDENTICAL: hyperbolic cached_and_reasoning_usage_details
+- IDENTICAL: hyperbolic text
+- IDENTICAL: hyperbolic tool_calls_rewrites_stop
+- IDENTICAL: lambda_ai cached_and_reasoning_usage_details
+- IDENTICAL: lambda_ai text
+- IDENTICAL: lambda_ai tool_calls_rewrites_stop
+- IDENTICAL: llamafile cached_and_reasoning_usage_details
+- IDENTICAL: llamafile text
+- IDENTICAL: llamafile tool_calls_rewrites_stop
+- IDENTICAL: lm_studio cached_and_reasoning_usage_details
+- IDENTICAL: lm_studio text
+- IDENTICAL: lm_studio tool_calls_rewrites_stop
+- IDENTICAL: nebius cached_and_reasoning_usage_details
+- IDENTICAL: nebius text
+- IDENTICAL: nebius tool_calls_rewrites_stop
+- IDENTICAL: novita cached_and_reasoning_usage_details
+- IDENTICAL: novita text
+- IDENTICAL: novita tool_calls_rewrites_stop
+- IDENTICAL: nscale cached_and_reasoning_usage_details
+- IDENTICAL: nscale text
+- IDENTICAL: nscale tool_calls_rewrites_stop
+- IDENTICAL: nvidia_nim cached_and_reasoning_usage_details
+- IDENTICAL: nvidia_nim text
+- IDENTICAL: nvidia_nim tool_calls_rewrites_stop
+- IDENTICAL: together_ai cached_and_reasoning_usage_details
+- IDENTICAL: together_ai text
+- IDENTICAL: together_ai tool_calls_rewrites_stop
+- IDENTICAL: volcengine cached_and_reasoning_usage_details
+- IDENTICAL: volcengine text
+- IDENTICAL: volcengine tool_calls_rewrites_stop
+- IDENTICAL: wandb cached_and_reasoning_usage_details
+- IDENTICAL: wandb text
+- IDENTICAL: wandb tool_calls_rewrites_stop
+
+## compat_sdk family: streams (v1 CustomStreamWrapper(provider) over SDK chunks vs v2 openai dialect)
+
+- IDENTICAL: cerebras empty_keepalive_swallowed
+- IDENTICAL: cerebras text
+- IDENTICAL: cerebras tools
+- IDENTICAL: featherless_ai empty_keepalive_swallowed
+- IDENTICAL: featherless_ai text
+- IDENTICAL: featherless_ai tools
+- IDENTICAL: hyperbolic empty_keepalive_swallowed
+- IDENTICAL: hyperbolic text
+- IDENTICAL: hyperbolic tools
+- IDENTICAL: lambda_ai empty_keepalive_swallowed
+- IDENTICAL: lambda_ai text
+- IDENTICAL: lambda_ai tools
+- IDENTICAL: llamafile empty_keepalive_swallowed
+- IDENTICAL: llamafile text
+- IDENTICAL: llamafile tools
+- IDENTICAL: lm_studio empty_keepalive_swallowed
+- IDENTICAL: lm_studio text
+- IDENTICAL: lm_studio tools
+- IDENTICAL: nebius empty_keepalive_swallowed
+- IDENTICAL: nebius text
+- IDENTICAL: nebius tools
+- IDENTICAL: novita empty_keepalive_swallowed
+- IDENTICAL: novita text
+- IDENTICAL: novita tools
+- IDENTICAL: nscale empty_keepalive_swallowed
+- IDENTICAL: nscale text
+- IDENTICAL: nscale tools
+- IDENTICAL: nvidia_nim empty_keepalive_swallowed
+- IDENTICAL: nvidia_nim text
+- IDENTICAL: nvidia_nim tools
+- IDENTICAL: together_ai empty_keepalive_swallowed
+- IDENTICAL: together_ai text
+- IDENTICAL: together_ai tools
+- IDENTICAL: volcengine empty_keepalive_swallowed
+- IDENTICAL: volcengine text
+- IDENTICAL: volcengine tools
+- IDENTICAL: wandb empty_keepalive_swallowed
+- IDENTICAL: wandb text
+- IDENTICAL: wandb tools
+- SEAM CONTRACT: cerebras usage tail (v2 passes the wire choices=[] usage chunk through; the streaming seam owns v1's synthesized final chunk)
+- SEAM CONTRACT: featherless_ai usage tail (v2 passes the wire choices=[] usage chunk through; the streaming seam owns v1's synthesized final chunk)
+- SEAM CONTRACT: hyperbolic usage tail (v2 passes the wire choices=[] usage chunk through; the streaming seam owns v1's synthesized final chunk)
+- SEAM CONTRACT: lambda_ai usage tail (v2 passes the wire choices=[] usage chunk through; the streaming seam owns v1's synthesized final chunk)
+- SEAM CONTRACT: llamafile usage tail (v2 passes the wire choices=[] usage chunk through; the streaming seam owns v1's synthesized final chunk)
+- SEAM CONTRACT: lm_studio usage tail (v2 passes the wire choices=[] usage chunk through; the streaming seam owns v1's synthesized final chunk)
+- SEAM CONTRACT: nebius usage tail (v2 passes the wire choices=[] usage chunk through; the streaming seam owns v1's synthesized final chunk)
+- SEAM CONTRACT: novita usage tail (v2 passes the wire choices=[] usage chunk through; the streaming seam owns v1's synthesized final chunk)
+- SEAM CONTRACT: nscale usage tail (v2 passes the wire choices=[] usage chunk through; the streaming seam owns v1's synthesized final chunk)
+- SEAM CONTRACT: nvidia_nim usage tail (v2 passes the wire choices=[] usage chunk through; the streaming seam owns v1's synthesized final chunk)
+- SEAM CONTRACT: together_ai usage tail (v2 passes the wire choices=[] usage chunk through; the streaming seam owns v1's synthesized final chunk)
+- SEAM CONTRACT: volcengine usage tail (v2 passes the wire choices=[] usage chunk through; the streaming seam owns v1's synthesized final chunk)
+- SEAM CONTRACT: wandb usage tail (v2 passes the wire choices=[] usage chunk through; the streaming seam owns v1's synthesized final chunk)
+
+- DROPPED FROM WAVE 1A: baseten (streams ride the dedicated legacy handle_baseten_chunk wrapper branch, not the openai dialect; unregistered, typed v1 fallback; canary test_baseten_drop_canary pins the evidence)
 
 ## azure: request bodies (v1 api-version-aware map_openai_params + transform_request vs v2)
 

--- a/tests/test_litellm/translation/DIFFERENTIAL_REPORT.md
+++ b/tests/test_litellm/translation/DIFFERENTIAL_REPORT.md
@@ -6,7 +6,7 @@ Bedrock and google rows additionally pin the characterization-corpus
 snapshot, so each row proves snapshot == v1-at-HEAD == v2. Regenerate with:
 `python -m tests.test_litellm.translation.generate_differential_report`
 
-- commit: b64b732772
+- commit: c6dfb86247
 
 ## anthropic: request bodies (v1 map_openai_params + transform_request vs v2)
 
@@ -129,6 +129,7 @@ snapshot, so each row proves snapshot == v1-at-HEAD == v2. Regenerate with:
 ## openai_compat: streams (v1 CustomStreamWrapper over SDK chunks vs v2 fold)
 
 - IDENTICAL: empty_keepalive_swallowed
+- IDENTICAL: service_tier_wire_carried
 - IDENTICAL: text
 - IDENTICAL: text_no_leading_role
 - IDENTICAL: tools
@@ -444,6 +445,10 @@ snapshot, so each row proves snapshot == v1-at-HEAD == v2. Regenerate with:
 - FALLBACK (v1 raises UnsupportedParamsError): together_ai:reasoning_effort (reasoning_effort)
 - FALLBACK (v1 raises UnsupportedParamsError): together_ai:response_format_on_non_fc_model (response_format)
 - FALLBACK (v1 raises UnsupportedParamsError): together_ai:tools_on_non_fc_model (tools)
+- FALLBACK (v1 raises ValueError): together_ai:plain_text_on_gpt35_16k_name (ValueError)
+- FALLBACK (v1 raises ValueError): together_ai:plain_text_on_gpt4_name (ValueError)
+- FALLBACK (v1 raises ValueError): together_ai:response_format_on_gpt4_name (ValueError)
+- FALLBACK (v1 raises ValueError): together_ai:temperature_only_on_gpt4_name (ValueError)
 - FALLBACK (v1 serves it): together_ai:both_max_tokens_keys (both max_tokens and max_completion_tokens)
 - FALLBACK (v1 serves it): together_ai:explicit_stream_false (explicit stream: false)
 - FALLBACK (v1 serves it): together_ai:message_name_field (message name field)

--- a/tests/test_litellm/translation/_compat_sdk_corpus.py
+++ b/tests/test_litellm/translation/_compat_sdk_corpus.py
@@ -16,121 +16,139 @@ remap).
 """
 
 import copy
-from typing import Any, Dict
+from collections.abc import Mapping
+from types import MappingProxyType
+from typing import Literal, NamedTuple
 
 from litellm.types.utils import LlmProviders
 from litellm.utils import ProviderConfigManager, get_optional_params
 
-# One spec per surviving wave-1a provider: the corpus model, which optional
-# surfaces the provider serves (drives generated corpus/raise/fallback rows),
-# and how max_completion_tokens behaves in v1 ("rename" -> max_tokens,
-# "verbatim" -> passes through, "raise" -> outside the supported list).
-SPECS: Dict[str, Dict[str, Any]] = {
-    "together_ai": {
-        "model": "Qwen/Qwen2.5-72B-Instruct-Turbo",  # model-map: supports_function_calling
-        "tools": True,
-        "response_format": True,
-        "parallel_tool_calls": True,
-        "user": False,
-        "mct": "verbatim",
-    },
-    "cerebras": {
-        "model": "llama3.1-8b",
-        "tools": True,
-        "response_format": True,
-        "parallel_tool_calls": False,
-        "user": True,
-        "mct": "rename",
-    },
-    "nvidia_nim": {
-        "model": "meta/llama3-70b-instruct",  # the default-list arm
-        "tools": True,
-        "response_format": True,
-        "parallel_tool_calls": True,
-        "user": False,
-        "mct": "rename",
-    },
-    "lm_studio": {
-        "model": "qwen2.5-7b-instruct-1m",
-        "tools": True,
-        "response_format": True,
-        "parallel_tool_calls": True,
-        "user": False,
-        "mct": "verbatim",
-    },
-    "llamafile": {
-        "model": "LLaMA_CPP",
-        "tools": True,
-        "response_format": True,
-        "parallel_tool_calls": True,
-        "user": False,
-        "mct": "verbatim",
-    },
-    "lambda_ai": {
-        "model": "llama3.1-70b-instruct-fp8",
-        "tools": True,
-        "response_format": True,
-        "parallel_tool_calls": True,
-        "user": False,
-        "mct": "rename",
-    },
-    "nebius": {
-        "model": "meta-llama/Meta-Llama-3.1-70B-Instruct",
-        "tools": True,
-        "response_format": True,
-        "parallel_tool_calls": True,
-        "user": False,
-        "mct": "rename",
-    },
-    "novita": {
-        "model": "meta-llama/llama-3.1-8b-instruct",
-        "tools": True,
-        "response_format": True,
-        "parallel_tool_calls": True,
-        "user": False,
-        "mct": "verbatim",
-    },
-    "wandb": {
-        "model": "meta-llama/Llama-3.1-8B-Instruct",
-        "tools": True,
-        "response_format": True,
-        "parallel_tool_calls": True,
-        "user": False,
-        "mct": "rename",
-    },
-    "featherless_ai": {
-        "model": "featherless-ai/Qwerky-72B",
-        "tools": False,
-        "response_format": False,
-        "parallel_tool_calls": False,
-        "user": False,
-        "mct": "rename",
-    },
-    "nscale": {
-        "model": "meta-llama/Llama-4-Scout-17B-16E-Instruct",
-        "tools": False,
-        "response_format": True,
-        "parallel_tool_calls": False,
-        "user": False,
-        "mct": "raise",
-    },
-    "hyperbolic": {
-        "model": "meta-llama/Meta-Llama-3-70B-Instruct",
-        "tools": True,
-        "response_format": True,
-        "parallel_tool_calls": False,
-        "user": True,
-        "mct": "raise",
-    },
-    "volcengine": {
-        "model": "doubao-pro-32k-241215",
-        "tools": True,
-        "response_format": False,
-        "parallel_tool_calls": False,
-        "user": False,
-        "mct": "rename",
-    },
-}
+_Case = dict[str, object]
+
+
+class CompatSpec(NamedTuple):
+    """One row per surviving wave-1a provider: the corpus model, which
+    optional surfaces the provider serves (drives generated
+    corpus/raise/fallback rows), and how max_completion_tokens behaves in
+    v1 ("rename" -> max_tokens, "verbatim" -> passes through, "raise" ->
+    outside the supported list)."""
+
+    model: str
+    tools: bool
+    response_format: bool
+    parallel_tool_calls: bool
+    user: bool
+    mct: Literal["rename", "verbatim", "raise"]
+
+
+SPECS: Mapping[str, CompatSpec] = MappingProxyType(
+    {
+        "together_ai": CompatSpec(
+            model="Qwen/Qwen2.5-72B-Instruct-Turbo",  # map: supports_function_calling
+            tools=True,
+            response_format=True,
+            parallel_tool_calls=True,
+            user=False,
+            mct="verbatim",
+        ),
+        "cerebras": CompatSpec(
+            model="llama3.1-8b",
+            tools=True,
+            response_format=True,
+            parallel_tool_calls=False,
+            user=True,
+            mct="rename",
+        ),
+        "nvidia_nim": CompatSpec(
+            model="meta/llama3-70b-instruct",  # the default-list arm
+            tools=True,
+            response_format=True,
+            parallel_tool_calls=True,
+            user=False,
+            mct="rename",
+        ),
+        "lm_studio": CompatSpec(
+            model="qwen2.5-7b-instruct-1m",
+            tools=True,
+            response_format=True,
+            parallel_tool_calls=True,
+            user=False,
+            mct="verbatim",
+        ),
+        "llamafile": CompatSpec(
+            model="LLaMA_CPP",
+            tools=True,
+            response_format=True,
+            parallel_tool_calls=True,
+            user=False,
+            mct="verbatim",
+        ),
+        "lambda_ai": CompatSpec(
+            model="llama3.1-70b-instruct-fp8",
+            tools=True,
+            response_format=True,
+            parallel_tool_calls=True,
+            user=False,
+            mct="rename",
+        ),
+        "nebius": CompatSpec(
+            model="meta-llama/Meta-Llama-3.1-70B-Instruct",
+            tools=True,
+            response_format=True,
+            parallel_tool_calls=True,
+            user=False,
+            mct="rename",
+        ),
+        "novita": CompatSpec(
+            model="meta-llama/llama-3.1-8b-instruct",
+            tools=True,
+            response_format=True,
+            parallel_tool_calls=True,
+            user=False,
+            mct="verbatim",
+        ),
+        "wandb": CompatSpec(
+            model="meta-llama/Llama-3.1-8B-Instruct",
+            tools=True,
+            response_format=True,
+            parallel_tool_calls=True,
+            user=False,
+            mct="rename",
+        ),
+        "featherless_ai": CompatSpec(
+            model="featherless-ai/Qwerky-72B",
+            tools=False,
+            response_format=False,
+            parallel_tool_calls=False,
+            user=False,
+            mct="rename",
+        ),
+        "nscale": CompatSpec(
+            model="meta-llama/Llama-4-Scout-17B-16E-Instruct",
+            tools=False,
+            response_format=True,
+            parallel_tool_calls=False,
+            user=False,
+            mct="raise",
+        ),
+        "hyperbolic": CompatSpec(
+            model="meta-llama/Meta-Llama-3-70B-Instruct",
+            tools=True,
+            response_format=True,
+            parallel_tool_calls=False,
+            user=True,
+            mct="raise",
+        ),
+        "volcengine": CompatSpec(
+            model="doubao-pro-32k-241215",
+            tools=True,
+            response_format=False,
+            parallel_tool_calls=False,
+            user=False,
+            mct="rename",
+        ),
+    }
+)
 
 PROVIDERS = tuple(sorted(SPECS))
 
@@ -154,7 +172,7 @@ def provider_config(provider: str, model: str):
     )
 
 
-def run_v1_request_transform(provider: str, case: Dict[str, Any]) -> Dict[str, Any]:
+def run_v1_request_transform(provider: str, case: _Case) -> dict:
     request = copy.deepcopy(case)
     model = request.pop("model")
     messages = request.pop("messages")
@@ -176,13 +194,13 @@ def run_v1_request_transform(provider: str, case: Dict[str, Any]) -> Dict[str, A
     )
 
 
-def corpus_for(provider: str) -> Dict[str, Dict[str, Any]]:
+def corpus_for(provider: str) -> dict[str, _Case]:
     """The generated served corpus: every row here must be byte-identical
     (normalized JSON) between v1-in-process and v2."""
     spec = SPECS[provider]
-    model = spec["model"]
+    model = spec.model
     user_msg = [{"role": "user", "content": "Hello, world"}]
-    cases: Dict[str, Dict[str, Any]] = {
+    cases: dict[str, _Case] = {
         "text": {"model": model, "messages": user_msg},
         "system_and_sampling": {
             "model": model,
@@ -202,13 +220,13 @@ def corpus_for(provider: str) -> Dict[str, Dict[str, Any]]:
             "messages": user_msg,
         },
     }
-    if spec["mct"] in ("rename", "verbatim"):
+    if spec.mct in ("rename", "verbatim"):
         cases["max_completion_tokens"] = {
             "model": model,
             "max_completion_tokens": 128,
             "messages": user_msg,
         }
-    if spec["tools"]:
+    if spec.tools:
         cases["tools_auto"] = {
             "model": model,
             "tools": [WEATHER_TOOL],
@@ -243,7 +261,7 @@ def corpus_for(provider: str) -> Dict[str, Dict[str, Any]]:
                 {"role": "tool", "tool_call_id": "call_1", "content": "ok"},
             ],
         }
-    if spec["response_format"]:
+    if spec.response_format:
         cases["response_format_json_object"] = {
             "model": model,
             "response_format": {"type": "json_object"},
@@ -266,13 +284,13 @@ def corpus_for(provider: str) -> Dict[str, Dict[str, Any]]:
             },
             "messages": user_msg,
         }
-    if spec["parallel_tool_calls"]:
+    if spec.parallel_tool_calls:
         cases["parallel_tool_calls_false"] = {
             "model": model,
             "tools": [WEATHER_TOOL],
             "parallel_tool_calls": False,
             "messages": [{"role": "user", "content": "Weather in Paris and Rome?"}],
         }
-    if spec["user"]:
+    if spec.user:
         cases["user_param"] = {"model": model, "user": "u-1", "messages": user_msg}
     return cases

--- a/tests/test_litellm/translation/_compat_sdk_corpus.py
+++ b/tests/test_litellm/translation/_compat_sdk_corpus.py
@@ -1,0 +1,278 @@
+"""Shared plumbing for the compat_sdk (wave-1a) differential gates.
+
+The v1 request invoker mirrors the SDK path exactly as production runs it
+for these providers (the big openai elif, main.py:2646-2667):
+``get_optional_params(custom_llm_provider=p)`` — the RAISE-unless-drop_params
+``_check_valid_arg`` gate over the provider config's supported list plus the
+config's ``map_openai_params`` — then the resolved provider config's
+``transform_request`` (openai.py:727; the inherited base five-touch
+assembly). ``extra_body`` is popped after get_optional_params: the injected
+``{}`` merges nothing onto the wire (the SDK spreads its CONTENTS top-level,
+same as the xai corpus invoker documents for hh:398-399).
+
+May RAISE UnsupportedParamsError — that IS the pinned v1 behavior for the
+supported-list gate rows (the xai R2 pattern: assert the raise, never a
+remap).
+"""
+
+import copy
+from typing import Any, Dict
+
+from litellm.types.utils import LlmProviders
+from litellm.utils import ProviderConfigManager, get_optional_params
+
+# One spec per surviving wave-1a provider: the corpus model, which optional
+# surfaces the provider serves (drives generated corpus/raise/fallback rows),
+# and how max_completion_tokens behaves in v1 ("rename" -> max_tokens,
+# "verbatim" -> passes through, "raise" -> outside the supported list).
+SPECS: Dict[str, Dict[str, Any]] = {
+    "together_ai": {
+        "model": "Qwen/Qwen2.5-72B-Instruct-Turbo",  # model-map: supports_function_calling
+        "tools": True,
+        "response_format": True,
+        "parallel_tool_calls": True,
+        "user": False,
+        "mct": "verbatim",
+    },
+    "cerebras": {
+        "model": "llama3.1-8b",
+        "tools": True,
+        "response_format": True,
+        "parallel_tool_calls": False,
+        "user": True,
+        "mct": "rename",
+    },
+    "nvidia_nim": {
+        "model": "meta/llama3-70b-instruct",  # the default-list arm
+        "tools": True,
+        "response_format": True,
+        "parallel_tool_calls": True,
+        "user": False,
+        "mct": "rename",
+    },
+    "lm_studio": {
+        "model": "qwen2.5-7b-instruct-1m",
+        "tools": True,
+        "response_format": True,
+        "parallel_tool_calls": True,
+        "user": False,
+        "mct": "verbatim",
+    },
+    "llamafile": {
+        "model": "LLaMA_CPP",
+        "tools": True,
+        "response_format": True,
+        "parallel_tool_calls": True,
+        "user": False,
+        "mct": "verbatim",
+    },
+    "lambda_ai": {
+        "model": "llama3.1-70b-instruct-fp8",
+        "tools": True,
+        "response_format": True,
+        "parallel_tool_calls": True,
+        "user": False,
+        "mct": "rename",
+    },
+    "nebius": {
+        "model": "meta-llama/Meta-Llama-3.1-70B-Instruct",
+        "tools": True,
+        "response_format": True,
+        "parallel_tool_calls": True,
+        "user": False,
+        "mct": "rename",
+    },
+    "novita": {
+        "model": "meta-llama/llama-3.1-8b-instruct",
+        "tools": True,
+        "response_format": True,
+        "parallel_tool_calls": True,
+        "user": False,
+        "mct": "verbatim",
+    },
+    "wandb": {
+        "model": "meta-llama/Llama-3.1-8B-Instruct",
+        "tools": True,
+        "response_format": True,
+        "parallel_tool_calls": True,
+        "user": False,
+        "mct": "rename",
+    },
+    "featherless_ai": {
+        "model": "featherless-ai/Qwerky-72B",
+        "tools": False,
+        "response_format": False,
+        "parallel_tool_calls": False,
+        "user": False,
+        "mct": "rename",
+    },
+    "nscale": {
+        "model": "meta-llama/Llama-4-Scout-17B-16E-Instruct",
+        "tools": False,
+        "response_format": True,
+        "parallel_tool_calls": False,
+        "user": False,
+        "mct": "raise",
+    },
+    "hyperbolic": {
+        "model": "meta-llama/Meta-Llama-3-70B-Instruct",
+        "tools": True,
+        "response_format": True,
+        "parallel_tool_calls": False,
+        "user": True,
+        "mct": "raise",
+    },
+    "volcengine": {
+        "model": "doubao-pro-32k-241215",
+        "tools": True,
+        "response_format": False,
+        "parallel_tool_calls": False,
+        "user": False,
+        "mct": "rename",
+    },
+}
+
+PROVIDERS = tuple(sorted(SPECS))
+
+WEATHER_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get weather",
+        "parameters": {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+        },
+    },
+}
+
+
+def provider_config(provider: str, model: str):
+    return ProviderConfigManager.get_provider_chat_config(
+        model=model, provider=LlmProviders(provider)
+    )
+
+
+def run_v1_request_transform(provider: str, case: Dict[str, Any]) -> Dict[str, Any]:
+    request = copy.deepcopy(case)
+    model = request.pop("model")
+    messages = request.pop("messages")
+    optional_params = get_optional_params(
+        model=model,
+        custom_llm_provider=provider,
+        messages=copy.deepcopy(messages),
+        stream=request.pop("stream", None),
+        **request,
+    )
+    optional_params.pop("extra_body", None)
+    config = provider_config(provider, model)
+    return config.transform_request(
+        model=model,
+        messages=messages,
+        optional_params=optional_params,
+        litellm_params={},
+        headers={},
+    )
+
+
+def corpus_for(provider: str) -> Dict[str, Dict[str, Any]]:
+    """The generated served corpus: every row here must be byte-identical
+    (normalized JSON) between v1-in-process and v2."""
+    spec = SPECS[provider]
+    model = spec["model"]
+    user_msg = [{"role": "user", "content": "Hello, world"}]
+    cases: Dict[str, Dict[str, Any]] = {
+        "text": {"model": model, "messages": user_msg},
+        "system_and_sampling": {
+            "model": model,
+            "max_tokens": 64,
+            "temperature": 0.5,
+            "top_p": 0.9,
+            "messages": [
+                {"role": "system", "content": "You are helpful"},
+                {"role": "user", "content": "Hi"},
+            ],
+        },
+        "stream_true": {"model": model, "stream": True, "messages": user_msg},
+        "stop_list": {"model": model, "stop": ["END", "STOP"], "messages": user_msg},
+        "temperature_int_stays_int": {
+            "model": model,
+            "temperature": 1,
+            "messages": user_msg,
+        },
+    }
+    if spec["mct"] in ("rename", "verbatim"):
+        cases["max_completion_tokens"] = {
+            "model": model,
+            "max_completion_tokens": 128,
+            "messages": user_msg,
+        }
+    if spec["tools"]:
+        cases["tools_auto"] = {
+            "model": model,
+            "tools": [WEATHER_TOOL],
+            "tool_choice": "auto",
+            "messages": [{"role": "user", "content": "Weather in Paris?"}],
+        }
+        cases["tool_choice_specific"] = {
+            "model": model,
+            "tools": [WEATHER_TOOL],
+            "tool_choice": {"type": "function", "function": {"name": "get_weather"}},
+            "messages": [{"role": "user", "content": "Weather in Paris?"}],
+        }
+        cases["tool_call_compact_roundtrip"] = {
+            "model": model,
+            "tools": [WEATHER_TOOL],
+            "messages": [
+                {"role": "user", "content": "w?"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "arguments": '{"city":"Paris"}',
+                            },
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "call_1", "content": "ok"},
+            ],
+        }
+    if spec["response_format"]:
+        cases["response_format_json_object"] = {
+            "model": model,
+            "response_format": {"type": "json_object"},
+            "messages": user_msg,
+        }
+        cases["response_format_json_schema_strict"] = {
+            "model": model,
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "answer",
+                    "schema": {
+                        "type": "object",
+                        "properties": {"capital": {"type": "string"}},
+                        "required": ["capital"],
+                        "additionalProperties": False,
+                    },
+                    "strict": True,
+                },
+            },
+            "messages": user_msg,
+        }
+    if spec["parallel_tool_calls"]:
+        cases["parallel_tool_calls_false"] = {
+            "model": model,
+            "tools": [WEATHER_TOOL],
+            "parallel_tool_calls": False,
+            "messages": [{"role": "user", "content": "Weather in Paris and Rome?"}],
+        }
+    if spec["user"]:
+        cases["user_param"] = {"model": model, "user": "u-1", "messages": user_msg}
+    return cases

--- a/tests/test_litellm/translation/generate_differential_report.py
+++ b/tests/test_litellm/translation/generate_differential_report.py
@@ -328,7 +328,7 @@ def _compat_sdk_rows(lines: list) -> int:
     ]
     for provider, name in resp._rows():
         raw = resp._RESPONSES[name]
-        preset = f"{provider}/{corpus.SPECS[provider]['model']}"
+        preset = f"{provider}/{corpus.SPECS[provider].model}"
         same = resp._norm(resp._v2_model_response(provider, raw, preset)) == resp._norm(
             resp._v1_model_response(raw, preset)
         )

--- a/tests/test_litellm/translation/generate_differential_report.py
+++ b/tests/test_litellm/translation/generate_differential_report.py
@@ -261,6 +261,109 @@ def _xai_rows(lines: list) -> int:
     return failures
 
 
+def _compat_sdk_rows(lines: list) -> int:
+    from litellm.exceptions import UnsupportedParamsError
+
+    from . import _compat_sdk_corpus as corpus
+    from . import test_differential_compat_sdk_request as req
+    from . import test_differential_compat_sdk_response as resp
+    from . import test_differential_compat_sdk_stream as stream
+
+    failures = 0
+    for provider in corpus.PROVIDERS:
+        lines += [
+            "",
+            f"## {provider}: request bodies (v1 get_optional_params('{provider}')"
+            " + transform_request vs v2 compat_sdk)",
+            "",
+        ]
+        for name in sorted(corpus.corpus_for(provider)):
+            case = corpus.corpus_for(provider)[name]
+            result = req._v2(provider, case)
+            same = result.is_ok() and req._norm(result.ok) == req._norm(
+                corpus.run_v1_request_transform(provider, case)
+            )
+            failures += 0 if same else 1
+            lines.append(f"- {'IDENTICAL' if same else 'DIVERGENT'}: {name}")
+        for name in sorted(k for k in req.V1_RAISES if k.startswith(f"{provider}:")):
+            p, case, reason = req.V1_RAISES[name]
+            result = req._v2(p, case)
+            try:
+                corpus.run_v1_request_transform(p, case)
+                raised = False
+            except UnsupportedParamsError:
+                raised = True
+            ok = result.is_error() and reason in result.error.summary and raised
+            failures += 0 if ok else 1
+            label = "FALLBACK (v1 raises UnsupportedParamsError)" if ok else "DIVERGENT"
+            lines.append(f"- {label}: {name} ({reason})")
+        for name in sorted(
+            k for k in req.EXPECTED_FALLBACKS if k.startswith(f"{provider}:")
+        ):
+            p, case, reason = req.EXPECTED_FALLBACKS[name]
+            result = req._v2(p, case)
+            ok = result.is_error() and reason in result.error.summary
+            failures += 0 if ok else 1
+            label = "FALLBACK (v1 serves it)" if ok else "DIVERGENT"
+            lines.append(f"- {label}: {name} ({reason})")
+    lines += [
+        "",
+        "## compat_sdk family: responses (v1 convert_to_model_response_object"
+        " with the SDK-path {provider}/{model} preset vs v2 + seam re-prefix arm)",
+        "",
+    ]
+    for provider, name in resp._rows():
+        raw = resp._RESPONSES[name]
+        preset = f"{provider}/{corpus.SPECS[provider]['model']}"
+        same = resp._norm(resp._v2_model_response(provider, raw, preset)) == resp._norm(
+            resp._v1_model_response(raw, preset)
+        )
+        failures += 0 if same else 1
+        lines.append(f"- {'IDENTICAL' if same else 'DIVERGENT'}: {provider} {name}")
+    lines += [
+        "",
+        "## compat_sdk family: streams (v1 CustomStreamWrapper(provider) over"
+        " SDK chunks vs v2 openai dialect)",
+        "",
+    ]
+    for provider, name in stream._rows():
+        events = stream.STREAMS[name]
+        same = stream._norm(stream._v2_chunks(events)) == stream._norm(
+            stream._v1_chunks(provider, events)
+        )
+        failures += 0 if same else 1
+        lines.append(f"- {'IDENTICAL' if same else 'DIVERGENT'}: {provider} {name}")
+    for provider in corpus.PROVIDERS:
+        v1 = stream._v1_chunks(
+            provider, stream.USAGE_STREAM, stream_options={"include_usage": True}
+        )
+        v2 = stream._v2_chunks(stream.USAGE_STREAM)
+        tail_ok = (
+            len(v1) == len(v2)
+            and stream._norm(v2[:-1]) == stream._norm(v1[: len(v2) - 1])
+            and v2[-1]["choices"] == []
+            and all(
+                v1[-1]["usage"][k] == v2[-1]["usage"][k]
+                for k in ("prompt_tokens", "completion_tokens", "total_tokens")
+            )
+        )
+        failures += 0 if tail_ok else 1
+        lines.append(
+            ("- SEAM CONTRACT: " if tail_ok else "- DIVERGENT: ")
+            + f"{provider} usage tail (v2 passes the wire choices=[] usage"
+            " chunk through; the streaming seam owns v1's synthesized final"
+            " chunk)"
+        )
+    lines += [
+        "",
+        "- DROPPED FROM WAVE 1A: baseten (streams ride the dedicated legacy"
+        " handle_baseten_chunk wrapper branch, not the openai dialect;"
+        " unregistered, typed v1 fallback; canary"
+        " test_baseten_drop_canary pins the evidence)",
+    ]
+    return failures
+
+
 def _azure_rows(lines: list) -> int:
     import os
 
@@ -732,7 +835,7 @@ def main() -> None:
     _stub_vertex_token()
 
     lines = [
-        "# Translation v2 differential report (anthropic + bedrock + openai + google + azure + xai)",
+        "# Translation v2 differential report (anthropic + bedrock + openai + google + azure + xai + the wave-1a compat_sdk family)",
         "",
         "v1 and v2 run over the same corpus; every row must be IDENTICAL (or an",
         "explained FALLBACK that v1 serves) for a provider's flag to turn on.",
@@ -746,6 +849,7 @@ def main() -> None:
     failures = _anthropic_rows(lines)
     failures += _openai_rows(lines)
     failures += _xai_rows(lines)
+    failures += _compat_sdk_rows(lines)
     failures += _azure_rows(lines)
     failures += _azure_ai_rows(lines)
     failures += _bedrock_request_rows(lines)

--- a/tests/test_litellm/translation/generate_differential_report.py
+++ b/tests/test_litellm/translation/generate_differential_report.py
@@ -298,6 +298,20 @@ def _compat_sdk_rows(lines: list) -> int:
             label = "FALLBACK (v1 raises UnsupportedParamsError)" if ok else "DIVERGENT"
             lines.append(f"- {label}: {name} ({reason})")
         for name in sorted(
+            k for k in req.V1_RAISES_VALUE_ERROR if k.startswith(f"{provider}:")
+        ):
+            p, case, reason = req.V1_RAISES_VALUE_ERROR[name]
+            result = req._v2(p, case)
+            try:
+                corpus.run_v1_request_transform(p, case)
+                raised = False
+            except ValueError as err:
+                raised = type(err) is ValueError
+            ok = result.is_error() and reason in result.error.summary and raised
+            failures += 0 if ok else 1
+            label = "FALLBACK (v1 raises ValueError)" if ok else "DIVERGENT"
+            lines.append(f"- {label}: {name} ({reason})")
+        for name in sorted(
             k for k in req.EXPECTED_FALLBACKS if k.startswith(f"{provider}:")
         ):
             p, case, reason = req.EXPECTED_FALLBACKS[name]

--- a/tests/test_litellm/translation/test_differential_compat_sdk_request.py
+++ b/tests/test_litellm/translation/test_differential_compat_sdk_request.py
@@ -159,6 +159,40 @@ V1_RAISES.update(
     }
 )
 
+# Rows where v1 CRASHES with a bare ValueError BEFORE any param gate:
+# together's non-fc fork runs list.remove("response_format") on a base list
+# that already dropped the key for these model names, inside the
+# get_supported_openai_params call _check_valid_arg makes on EVERY request
+# (verifier-wave1a F2). v2 must fall back typed on every shape, plain text
+# included, so v1 raises its own error instead of v2 serving what v1 crashes
+# on.
+V1_RAISES_VALUE_ERROR = {
+    "together_ai:plain_text_on_gpt4_name": (
+        "together_ai",
+        {"model": "gpt-4", "messages": _USER},
+        "ValueError",
+    ),
+    "together_ai:plain_text_on_gpt35_16k_name": (
+        "together_ai",
+        {"model": "gpt-3.5-turbo-16k", "messages": _USER},
+        "ValueError",
+    ),
+    "together_ai:temperature_only_on_gpt4_name": (
+        "together_ai",
+        {"model": "gpt-4", "temperature": 0.2, "messages": _USER},
+        "ValueError",
+    ),
+    "together_ai:response_format_on_gpt4_name": (
+        "together_ai",
+        {
+            "model": "gpt-4",
+            "response_format": {"type": "json_object"},
+            "messages": _USER,
+        },
+        "ValueError",
+    ),
+}
+
 # Typed fallbacks where v1 SERVES the request (v1 is not invoked: the seam
 # routes these to v1 untouched). Shared raw-guard/parse shapes per provider
 # plus the provider-specific ones.
@@ -294,6 +328,20 @@ def test_v1_raise_rows_fall_back_typed(name: str) -> None:
     assert reason_fragment in result.error.summary, result.error.summary
     with pytest.raises(UnsupportedParamsError):
         run_v1_request_transform(provider, case)
+
+
+@pytest.mark.parametrize("name", sorted(V1_RAISES_VALUE_ERROR))
+def test_v1_value_error_rows_fall_back_typed(name: str) -> None:
+    """The together gpt-4-name corner: v1 crashes with a bare ValueError on
+    EVERY request for these names (not UnsupportedParamsError), asserted
+    in-process; v2 serving any of them would be a parity break."""
+    provider, case, reason_fragment = V1_RAISES_VALUE_ERROR[name]
+    result = _v2(provider, case)
+    assert result.is_error(), f"{name} unexpectedly translated: {result.ok!r}"
+    assert reason_fragment in result.error.summary, result.error.summary
+    with pytest.raises(ValueError) as excinfo:
+        run_v1_request_transform(provider, case)
+    assert type(excinfo.value) is ValueError, excinfo.value
 
 
 @pytest.mark.parametrize("name", sorted(EXPECTED_FALLBACKS))

--- a/tests/test_litellm/translation/test_differential_compat_sdk_request.py
+++ b/tests/test_litellm/translation/test_differential_compat_sdk_request.py
@@ -41,7 +41,7 @@ _TOOLS = [WEATHER_TOOL]
 
 
 def _m(provider: str) -> str:
-    return SPECS[provider]["model"]
+    return SPECS[provider].model
 
 
 # Rows where v1 RAISES UnsupportedParamsError (the supported-list gate); v2
@@ -51,19 +51,19 @@ def _m(provider: str) -> str:
 V1_RAISES = {}
 for _p in PROVIDERS:
     _spec = SPECS[_p]
-    if _spec["mct"] == "raise":
+    if _spec.mct == "raise":
         V1_RAISES[f"{_p}:max_completion_tokens"] = (
             _p,
             {"model": _m(_p), "max_completion_tokens": 128, "messages": _USER},
             "max_completion_tokens",
         )
-    if not _spec["tools"]:
+    if not _spec.tools:
         V1_RAISES[f"{_p}:tools"] = (
             _p,
             {"model": _m(_p), "tools": _TOOLS, "messages": _USER},
             "tools",
         )
-    if not _spec["response_format"]:
+    if not _spec.response_format:
         V1_RAISES[f"{_p}:response_format"] = (
             _p,
             {
@@ -73,7 +73,7 @@ for _p in PROVIDERS:
             },
             "response_format",
         )
-    if not _spec["parallel_tool_calls"]:
+    if not _spec.parallel_tool_calls:
         V1_RAISES[f"{_p}:parallel_tool_calls"] = (
             _p,
             {"model": _m(_p), "parallel_tool_calls": False, "messages": _USER},
@@ -231,7 +231,7 @@ for _p in PROVIDERS:
         {"model": _m(_p), "seed": 42, "messages": _USER},
         "seed",
     )
-    if not SPECS[_p]["user"]:
+    if not SPECS[_p].user:
         EXPECTED_FALLBACKS[f"{_p}:user_model_list_gate"] = (
             _p,
             {"model": _m(_p), "user": "u-1", "messages": _USER},
@@ -268,7 +268,7 @@ EXPECTED_FALLBACKS.update(
 )
 
 
-def _v2(provider: str, case: dict):
+def _v2(provider: str, case: dict[str, object]):
     return translate_chat_request(copy.deepcopy(case), provider, build_real_deps())
 
 
@@ -375,14 +375,14 @@ _MIRROR_KEYS = (
 _RF_NAME_GATED = ("gpt-4", "gpt-3.5-turbo-16k")
 
 
-def _base_family_allowed(model: str) -> frozenset:
+def _base_family_allowed(model: str) -> frozenset[str]:
     allowed = csp._BASE_LIST
     if model in _RF_NAME_GATED:
         return allowed - {"response_format"}
     return allowed
 
 
-def _v2_allowed(provider: str, model: str, deps) -> frozenset:
+def _v2_allowed(provider: str, model: str, deps) -> frozenset[str]:
     """The per-model allowed set, re-derived from the SAME csp.ALLOWED table
     serialization reads, with the three per-model narrowings the gates
     apply (together capability fork, nvidia_nim static table, the base
@@ -450,7 +450,7 @@ def test_supported_list_mirrors_track_v1_at_head(provider: str) -> None:
         )
         for key in _MIRROR_KEYS:
             assert (key in allowed) == (key in supported), (provider, model, key)
-        if SPECS[provider]["user"]:
+        if SPECS[provider].user:
             assert "user" in supported, (provider, model)
         if provider == "cerebras":
             assert csp.supports_cerebras_reasoning(model, deps) == (
@@ -483,9 +483,7 @@ def test_capability_prefix_is_load_bearing() -> None:
     ) == litellm.supports_reasoning(model="qwen-3-32b", custom_llm_provider="cerebras")
 
 
-@pytest.mark.parametrize(
-    "provider", [p for p in PROVIDERS if SPECS[p]["mct"] == "rename"]
-)
+@pytest.mark.parametrize("provider", [p for p in PROVIDERS if SPECS[p].mct == "rename"])
 def test_mct_rename_matches_v1(provider: str) -> None:
     """The renamed key must be exactly what v1's map emits (max_tokens), so
     the rename flag can never silently disagree with the v1 config."""
@@ -499,7 +497,7 @@ def test_mct_rename_matches_v1(provider: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "provider", [p for p in PROVIDERS if SPECS[p]["mct"] == "verbatim"]
+    "provider", [p for p in PROVIDERS if SPECS[p].mct == "verbatim"]
 )
 def test_mct_verbatim_matches_v1(provider: str) -> None:
     case = {"model": _m(provider), "max_completion_tokens": 33, "messages": _USER}
@@ -509,6 +507,20 @@ def test_mct_verbatim_matches_v1(provider: str) -> None:
     assert result.is_ok(), result.error.summary
     assert result.ok.get("max_completion_tokens") == 33
     assert "max_tokens" not in result.ok
+
+
+def test_top_k_fallback_reason_matches_v1_silent_drop() -> None:
+    """v1 silently drops top_k WITHOUT drop_params (it is not an OpenAI
+    param, so _check_valid_arg never sees it) — the fallback reason must say
+    so instead of claiming an UnsupportedParamsError raise (verifier-wave1a
+    F6). Pinned in-process: v1 serves the request with top_k gone."""
+    case = {"model": _m("lambda_ai"), "top_k": 3, "messages": _USER}
+    result = _v2("lambda_ai", case)
+    assert result.is_error()
+    assert "silently drops it" in result.error.summary, result.error.summary
+    assert "UnsupportedParamsError" not in result.error.summary
+    v1 = run_v1_request_transform("lambda_ai", case)
+    assert "top_k" not in v1
 
 
 def test_together_text_response_format_dropped_like_v1() -> None:

--- a/tests/test_litellm/translation/test_differential_compat_sdk_request.py
+++ b/tests/test_litellm/translation/test_differential_compat_sdk_request.py
@@ -13,6 +13,7 @@ the v1 configs at HEAD, over every model-map row where the provider has any.
 
 import copy
 import json
+from typing import get_args
 
 import pytest
 
@@ -20,6 +21,9 @@ import litellm
 from litellm.exceptions import UnsupportedParamsError
 
 from litellm.translation import translate_chat_request
+from litellm.translation.dispatch import Provider
+from litellm.translation.engine import pipeline
+from litellm.translation.providers import compat_sdk
 from litellm.translation.providers.compat_sdk import params as csp
 
 from ._compat_sdk_corpus import (
@@ -242,6 +246,36 @@ def _request_rows():
     return sorted(
         (provider, name) for provider in PROVIDERS for name in corpus_for(provider)
     )
+
+
+def test_registered_providers_have_differential_coverage() -> None:
+    """Green-but-untested registration is impossible (verifier-wave1a F3):
+    every dispatch Literal member is registered in every pipeline table,
+    the compat_sdk family registry equals the corpus SPECS exactly, and a
+    provider outside the family must be in the dedicated-gates set below.
+    Add a provider to that set ONLY in the commit that adds its
+    differential corpus, naming the gate files."""
+    providers = set(get_args(Provider))
+    assert providers == set(pipeline._SERIALIZERS)
+    assert providers == set(pipeline._RESPONSE_PARSERS)
+    assert providers == set(pipeline._RESPONSE_DIALECTS)
+    assert set(pipeline._RAW_GUARDS) <= providers
+    assert set(compat_sdk.PROFILES) == set(SPECS)
+    assert set(compat_sdk.ALLOWED) == set(SPECS)
+    dedicated_gates = {
+        "anthropic",  # test_differential_anthropic_{request,response,stream}
+        "bedrock_converse",  # test_differential_bedrock_*
+        "bedrock_invoke",  # test_differential_bedrock_*
+        "openai_compat",  # test_differential_openai_*
+        "vertex_ai",  # test_differential_google_*
+        "gemini",  # test_differential_google_*
+        "vertex_anthropic",  # test_differential_google_*
+        "azure",  # test_differential_azure_*
+        "azure_ai",  # test_differential_azure_ai_request + azure stream/response
+        "azure_ai_anthropic",  # test_differential_azure_ai_request (Claude route)
+        "xai",  # test_differential_xai_*
+    }
+    assert providers == dedicated_gates | set(SPECS)
 
 
 @pytest.mark.parametrize("provider,name", _request_rows())

--- a/tests/test_litellm/translation/test_differential_compat_sdk_request.py
+++ b/tests/test_litellm/translation/test_differential_compat_sdk_request.py
@@ -1,0 +1,459 @@
+"""Differential parity: v2 compat_sdk (wave-1a) vs the v1 SDK-path chain.
+
+For every surviving wave-1a provider, the served corpus is compared row by
+row against v1 in-process (``_compat_sdk_corpus.run_v1_request_transform``:
+``get_optional_params(custom_llm_provider=p)`` + the resolved config's
+``transform_request``, the chain main.py:2646 -> openai.py:727 runs). Rows
+where v1's supported-list gate RAISES are pinned as raises + typed v2
+fallbacks (the xai R2 pattern), and shapes the IR cannot round-trip are
+typed fallbacks the seam serves through v1. The supported-list mirror drift
+gates (critic-grok M4 pattern) re-derive every hand-copied allowlist from
+the v1 configs at HEAD, over every model-map row where the provider has any.
+"""
+
+import copy
+import json
+
+import pytest
+
+import litellm
+from litellm.exceptions import UnsupportedParamsError
+
+from litellm.translation import translate_chat_request
+from litellm.translation.providers.compat_sdk import params as csp
+
+from ._compat_sdk_corpus import (
+    PROVIDERS,
+    SPECS,
+    WEATHER_TOOL,
+    corpus_for,
+    provider_config,
+    run_v1_request_transform,
+)
+from .conftest import build_real_deps
+
+_USER = [{"role": "user", "content": "x"}]
+_TOOLS = [WEATHER_TOOL]
+
+
+def _m(provider: str) -> str:
+    return SPECS[provider]["model"]
+
+
+# Rows where v1 RAISES UnsupportedParamsError (the supported-list gate); v2
+# must be a typed fallback so v1 serves its own raise (or its drop under
+# drop_params). The reason fragment is asserted on the v2 error; the raise
+# is asserted on v1 in-process.
+V1_RAISES = {}
+for _p in PROVIDERS:
+    _spec = SPECS[_p]
+    if _spec["mct"] == "raise":
+        V1_RAISES[f"{_p}:max_completion_tokens"] = (
+            _p,
+            {"model": _m(_p), "max_completion_tokens": 128, "messages": _USER},
+            "max_completion_tokens",
+        )
+    if not _spec["tools"]:
+        V1_RAISES[f"{_p}:tools"] = (
+            _p,
+            {"model": _m(_p), "tools": _TOOLS, "messages": _USER},
+            "tools",
+        )
+    if not _spec["response_format"]:
+        V1_RAISES[f"{_p}:response_format"] = (
+            _p,
+            {
+                "model": _m(_p),
+                "response_format": {"type": "json_object"},
+                "messages": _USER,
+            },
+            "response_format",
+        )
+    if not _spec["parallel_tool_calls"]:
+        V1_RAISES[f"{_p}:parallel_tool_calls"] = (
+            _p,
+            {"model": _m(_p), "parallel_tool_calls": False, "messages": _USER},
+            "parallel_tool_calls",
+        )
+    # no provider in the family supports reasoning_effort except cerebras
+    # (capability-gated, pinned below)
+    if _p != "cerebras":
+        V1_RAISES[f"{_p}:reasoning_effort"] = (
+            _p,
+            {"model": _m(_p), "reasoning_effort": "high", "messages": _USER},
+            "reasoning_effort",
+        )
+
+V1_RAISES.update(
+    {
+        "cerebras:reasoning_effort_non_reasoning_model": (
+            "cerebras",
+            {"model": "llama3.1-8b", "reasoning_effort": "high", "messages": _USER},
+            "reasoning_effort on non-reasoning cerebras model",
+        ),
+        "together_ai:tools_on_non_fc_model": (
+            "together_ai",
+            {
+                "model": "Qwen/Qwen3-235B-A22B-fp8-tput",
+                "tools": _TOOLS,
+                "messages": _USER,
+            },
+            "tools",
+        ),
+        "together_ai:response_format_on_non_fc_model": (
+            "together_ai",
+            {
+                "model": "Qwen/Qwen3-235B-A22B-fp8-tput",
+                "response_format": {"type": "json_object"},
+                "messages": _USER,
+            },
+            "response_format",
+        ),
+        "nvidia_nim:tools_on_gemma": (
+            "nvidia_nim",
+            {"model": "google/gemma-2-9b-it", "tools": _TOOLS, "messages": _USER},
+            "tools",
+        ),
+        "nvidia_nim:max_completion_tokens_on_gemma": (
+            "nvidia_nim",
+            {
+                "model": "google/gemma-2-9b-it",
+                "max_completion_tokens": 7,
+                "messages": _USER,
+            },
+            "max_completion_tokens",
+        ),
+        "nvidia_nim:stop_on_nemotron_instruct": (
+            "nvidia_nim",
+            {
+                "model": "nvidia/nemotron-4-340b-instruct",
+                "stop": ["END"],
+                "messages": _USER,
+            },
+            "stop",
+        ),
+        "nvidia_nim:temperature_on_nemotron_reward": (
+            "nvidia_nim",
+            {
+                "model": "nvidia/nemotron-4-340b-reward",
+                "temperature": 0.1,
+                "messages": _USER,
+            },
+            "temperature",
+        ),
+        "lm_studio:response_format_on_gpt4_name": (
+            # the base supported list's gpt-4 name gate applies to every
+            # config that inherits it, local providers included
+            "lm_studio",
+            {
+                "model": "gpt-4",
+                "response_format": {"type": "json_object"},
+                "messages": _USER,
+            },
+            "outside v1's supported set",
+        ),
+    }
+)
+
+# Typed fallbacks where v1 SERVES the request (v1 is not invoked: the seam
+# routes these to v1 untouched). Shared raw-guard/parse shapes per provider
+# plus the provider-specific ones.
+EXPECTED_FALLBACKS = {}
+for _p in PROVIDERS:
+    EXPECTED_FALLBACKS[f"{_p}:explicit_stream_false"] = (
+        _p,
+        {"model": _m(_p), "stream": False, "messages": _USER},
+        "explicit stream: false",
+    )
+    EXPECTED_FALLBACKS[f"{_p}:both_max_tokens_keys"] = (
+        _p,
+        {
+            "model": _m(_p),
+            "max_tokens": 5,
+            "max_completion_tokens": 6,
+            "messages": _USER,
+        },
+        "both max_tokens and max_completion_tokens",
+    )
+    EXPECTED_FALLBACKS[f"{_p}:string_form_stop"] = (
+        _p,
+        {"model": _m(_p), "stop": "END", "messages": _USER},
+        "string-form stop",
+    )
+    EXPECTED_FALLBACKS[f"{_p}:message_name_field"] = (
+        _p,
+        {
+            "model": _m(_p),
+            "messages": [{"role": "user", "content": "x", "name": "alice"}],
+        },
+        "message name field",
+    )
+    EXPECTED_FALLBACKS[f"{_p}:seed_outside_ir"] = (
+        _p,
+        {"model": _m(_p), "seed": 42, "messages": _USER},
+        "seed",
+    )
+    if not SPECS[_p]["user"]:
+        EXPECTED_FALLBACKS[f"{_p}:user_model_list_gate"] = (
+            _p,
+            {"model": _m(_p), "user": "u-1", "messages": _USER},
+            "user",
+        )
+
+EXPECTED_FALLBACKS.update(
+    {
+        "volcengine:thinking_extra_body_packing": (
+            "volcengine",
+            {
+                "model": _m("volcengine"),
+                "thinking": {"type": "enabled"},
+                "messages": _USER,
+            },
+            "extra_body",
+        ),
+        "lm_studio:bare_schema_response_format": (
+            # v1's LMStudioChatConfig map wraps {"type": "json_schema",
+            # "schema": ...} into a json_schema envelope; the inbound parse
+            # rejects the non-canonical key, so v1 serves it
+            "lm_studio",
+            {
+                "model": _m("lm_studio"),
+                "response_format": {
+                    "type": "json_schema",
+                    "schema": {"type": "object"},
+                },
+                "messages": _USER,
+            },
+            "response_format",
+        ),
+    }
+)
+
+
+def _v2(provider: str, case: dict):
+    return translate_chat_request(copy.deepcopy(case), provider, build_real_deps())
+
+
+def _norm(body: dict) -> str:
+    return json.dumps(body, sort_keys=True, default=str)
+
+
+def _request_rows():
+    return sorted(
+        (provider, name) for provider in PROVIDERS for name in corpus_for(provider)
+    )
+
+
+@pytest.mark.parametrize("provider,name", _request_rows())
+def test_v2_request_matches_v1(provider: str, name: str) -> None:
+    case = corpus_for(provider)[name]
+    result = _v2(provider, case)
+    assert result.is_ok(), result.error.summary
+    assert _norm(result.ok) == _norm(run_v1_request_transform(provider, case))
+
+
+@pytest.mark.parametrize("name", sorted(V1_RAISES))
+def test_v1_raise_rows_fall_back_typed(name: str) -> None:
+    provider, case, reason_fragment = V1_RAISES[name]
+    result = _v2(provider, case)
+    assert result.is_error(), f"{name} unexpectedly translated: {result.ok!r}"
+    assert reason_fragment in result.error.summary, result.error.summary
+    with pytest.raises(UnsupportedParamsError):
+        run_v1_request_transform(provider, case)
+
+
+@pytest.mark.parametrize("name", sorted(EXPECTED_FALLBACKS))
+def test_unsupported_shape_is_a_typed_fallback(name: str) -> None:
+    provider, case, reason_fragment = EXPECTED_FALLBACKS[name]
+    result = _v2(provider, case)
+    assert result.is_error(), f"{name} unexpectedly translated: {result.ok!r}"
+    assert reason_fragment in result.error.summary, result.error.summary
+
+
+# ---------------------------------------------------------------------------
+# Supported-list mirror drift gates (critic-grok M4 pattern): the hand-copied
+# allowlists in compat_sdk/params.py must track the v1 configs at HEAD, for
+# EVERY chat model the model map knows (fixed name samples where the map has
+# no rows: nvidia_nim's static table models, local lm_studio/llamafile).
+# ---------------------------------------------------------------------------
+
+_MIRROR_KEYS = (
+    "max_tokens",
+    "max_completion_tokens",
+    "temperature",
+    "top_p",
+    "stream",
+    "stop",
+    "tools",
+    "tool_choice",
+    "parallel_tool_calls",
+    "response_format",
+)
+
+_RF_NAME_GATED = ("gpt-4", "gpt-3.5-turbo-16k")
+
+
+def _base_family_allowed(model: str) -> frozenset:
+    allowed = csp._BASE_LIST
+    if model in _RF_NAME_GATED:
+        return allowed - {"response_format"}
+    return allowed
+
+
+def _v2_allowed(provider: str, model: str, deps) -> frozenset:
+    if provider == "together_ai":
+        allowed = (
+            _base_family_allowed(model)
+            if csp.supports_together_tools(model, deps)
+            else _base_family_allowed(model) - csp._FUNCTION_CALLING_KEYS
+        )
+        return allowed
+    if provider == "cerebras":
+        return csp._CEREBRAS_LIST
+    if provider == "nvidia_nim":
+        return csp.nvidia_nim_allowed(model)
+    if provider == "featherless_ai":
+        return csp._FEATHERLESS_LIST
+    if provider == "nscale":
+        return csp._NSCALE_LIST
+    if provider == "hyperbolic":
+        return csp._HYPERBOLIC_LIST
+    if provider == "volcengine":
+        return csp._VOLCENGINE_LIST
+    return _base_family_allowed(model)
+
+
+_SAMPLE_MODELS = {
+    "nvidia_nim": (
+        "google/recurrentgemma-2b",
+        "google/gemma-2-27b-it",
+        "google/gemma-2-9b-it",
+        "gemma-2-9b-it",
+        "nvidia/nemotron-4-340b-instruct",
+        "nvidia/nemotron-4-340b-reward",
+        "google/codegemma-1.1-7b",
+        "meta/llama3-70b-instruct",
+        "mistralai/mistral-large",
+    ),
+    "lm_studio": ("qwen2.5-7b-instruct-1m", "gpt-4", "gpt-3.5-turbo-16k"),
+    "llamafile": ("LLaMA_CPP", "gpt-4"),
+}
+
+
+def _mirror_models(provider: str) -> list:
+    mapped = sorted(
+        key.split("/", 1)[1]
+        for key, info in litellm.model_cost.items()
+        if key.startswith(f"{provider}/") and info.get("mode") == "chat"
+    )
+    return list(_SAMPLE_MODELS.get(provider, ())) + mapped
+
+
+@pytest.mark.parametrize("provider", PROVIDERS)
+def test_supported_list_mirrors_track_v1_at_head(provider: str) -> None:
+    deps = build_real_deps()
+    models = _mirror_models(provider)
+    assert len(models) >= 2, f"no models to mirror for {provider}"
+    for model in models:
+        supported = set(
+            provider_config(provider, model).get_supported_openai_params(model)
+        )
+        allowed = _v2_allowed(provider, model, deps)
+        for key in _MIRROR_KEYS:
+            assert (key in allowed) == (key in supported), (provider, model, key)
+        if SPECS[provider]["user"]:
+            assert "user" in supported, (provider, model)
+        if provider == "cerebras":
+            assert csp.supports_cerebras_reasoning(model, deps) == (
+                "reasoning_effort" in supported
+            ), model
+        else:
+            assert "reasoning_effort" not in supported, (provider, model)
+
+
+def test_capability_prefix_is_load_bearing() -> None:
+    """Bare model-map keys answer False even for capable models; the
+    {provider}/ prefix is what reaches the map row (the xai drift-gate
+    trap, re-pinned here for the two capability gates this family uses)."""
+    deps = build_real_deps()
+    assert deps.supports_capability(
+        "together_ai/Qwen/Qwen2.5-72B-Instruct-Turbo", "supports_function_calling"
+    )
+    assert not deps.supports_capability(
+        "Qwen/Qwen2.5-72B-Instruct-Turbo", "supports_function_calling"
+    )
+    assert deps.supports_capability("cerebras/qwen-3-32b", "supports_reasoning")
+    assert not deps.supports_capability("qwen-3-32b", "supports_reasoning")
+    assert csp.supports_together_tools(
+        "Qwen/Qwen2.5-72B-Instruct-Turbo", deps
+    ) == litellm.utils.supports_function_calling(
+        "Qwen/Qwen2.5-72B-Instruct-Turbo", custom_llm_provider="together_ai"
+    )
+    assert csp.supports_cerebras_reasoning(
+        "qwen-3-32b", deps
+    ) == litellm.supports_reasoning(model="qwen-3-32b", custom_llm_provider="cerebras")
+
+
+@pytest.mark.parametrize(
+    "provider", [p for p in PROVIDERS if SPECS[p]["mct"] == "rename"]
+)
+def test_mct_rename_matches_v1(provider: str) -> None:
+    """The renamed key must be exactly what v1's map emits (max_tokens), so
+    the rename flag can never silently disagree with the v1 config."""
+    case = {"model": _m(provider), "max_completion_tokens": 33, "messages": _USER}
+    v1 = run_v1_request_transform(provider, case)
+    assert v1.get("max_tokens") == 33 and "max_completion_tokens" not in v1
+    result = _v2(provider, case)
+    assert result.is_ok(), result.error.summary
+    assert result.ok.get("max_tokens") == 33
+    assert "max_completion_tokens" not in result.ok
+
+
+@pytest.mark.parametrize(
+    "provider", [p for p in PROVIDERS if SPECS[p]["mct"] == "verbatim"]
+)
+def test_mct_verbatim_matches_v1(provider: str) -> None:
+    case = {"model": _m(provider), "max_completion_tokens": 33, "messages": _USER}
+    v1 = run_v1_request_transform(provider, case)
+    assert v1.get("max_completion_tokens") == 33 and "max_tokens" not in v1
+    result = _v2(provider, case)
+    assert result.is_ok(), result.error.summary
+    assert result.ok.get("max_completion_tokens") == 33
+    assert "max_tokens" not in result.ok
+
+
+def test_together_text_response_format_dropped_like_v1() -> None:
+    case = {
+        "model": _m("together_ai"),
+        "response_format": {"type": "text"},
+        "messages": _USER,
+    }
+    v1 = run_v1_request_transform("together_ai", case)
+    assert "response_format" not in v1
+    result = _v2("together_ai", case)
+    assert result.is_ok(), result.error.summary
+    assert "response_format" not in result.ok
+    assert _norm(result.ok) == _norm(v1)
+
+
+def test_cerebras_reasoning_effort_served_on_capable_model() -> None:
+    case = {"model": "qwen-3-32b", "reasoning_effort": "low", "messages": _USER}
+    v1 = run_v1_request_transform("cerebras", case)
+    assert v1.get("reasoning_effort") == "low"
+    result = _v2("cerebras", case)
+    assert result.is_ok(), result.error.summary
+    assert _norm(result.ok) == _norm(v1)
+
+
+def test_nvidia_gemma_arm_serves_its_reduced_list() -> None:
+    case = {
+        "model": "google/gemma-2-9b-it",
+        "temperature": 0.5,
+        "top_p": 0.9,
+        "max_tokens": 32,
+        "stop": ["END"],
+        "messages": _USER,
+    }
+    result = _v2("nvidia_nim", case)
+    assert result.is_ok(), result.error.summary
+    assert _norm(result.ok) == _norm(run_v1_request_transform("nvidia_nim", case))

--- a/tests/test_litellm/translation/test_differential_compat_sdk_request.py
+++ b/tests/test_litellm/translation/test_differential_compat_sdk_request.py
@@ -301,6 +301,10 @@ def _base_family_allowed(model: str) -> frozenset:
 
 
 def _v2_allowed(provider: str, model: str, deps) -> frozenset:
+    """The per-model allowed set, re-derived from the SAME csp.ALLOWED table
+    serialization reads, with the three per-model narrowings the gates
+    apply (together capability fork, nvidia_nim static table, the base
+    list's gpt-4 name gate)."""
     if provider == "together_ai":
         allowed = (
             _base_family_allowed(model)
@@ -308,19 +312,12 @@ def _v2_allowed(provider: str, model: str, deps) -> frozenset:
             else _base_family_allowed(model) - csp._FUNCTION_CALLING_KEYS
         )
         return allowed
-    if provider == "cerebras":
-        return csp._CEREBRAS_LIST
     if provider == "nvidia_nim":
         return csp.nvidia_nim_allowed(model)
-    if provider == "featherless_ai":
-        return csp._FEATHERLESS_LIST
-    if provider == "nscale":
-        return csp._NSCALE_LIST
-    if provider == "hyperbolic":
-        return csp._HYPERBOLIC_LIST
-    if provider == "volcengine":
-        return csp._VOLCENGINE_LIST
-    return _base_family_allowed(model)
+    allowed = csp.ALLOWED[provider]
+    if allowed == csp._BASE_LIST:
+        return _base_family_allowed(model)
+    return allowed
 
 
 _SAMPLE_MODELS = {
@@ -359,6 +356,16 @@ def test_supported_list_mirrors_track_v1_at_head(provider: str) -> None:
             provider_config(provider, model).get_supported_openai_params(model)
         )
         allowed = _v2_allowed(provider, model, deps)
+        # The mirror's soundness rests on a DIRECTION argument: every key v2
+        # can ever SERVE is either in _MIRROR_KEYS or carries its own assert
+        # below (user, reasoning_effort), so a v1 list growing a key v2 lacks
+        # only widens the typed fallback (v1 serves its own new behavior).
+        # Encode the subset relation so a future allowed set cannot silently
+        # leave that argument (critic-wave1a N6).
+        assert allowed <= set(_MIRROR_KEYS) | {"user", "reasoning_effort"}, (
+            provider,
+            model,
+        )
         for key in _MIRROR_KEYS:
             assert (key in allowed) == (key in supported), (provider, model, key)
         if SPECS[provider]["user"]:

--- a/tests/test_litellm/translation/test_differential_compat_sdk_response.py
+++ b/tests/test_litellm/translation/test_differential_compat_sdk_response.py
@@ -37,7 +37,7 @@ _RESPONSE_ROWS = (
 
 def _request_for(provider: str) -> dict:
     return {
-        "model": SPECS[provider]["model"],
+        "model": SPECS[provider].model,
         "messages": [{"role": "user", "content": "hi"}],
     }
 
@@ -74,7 +74,7 @@ def test_preset_reprefix_matches_v1(provider: str, name: str, frozen_ambient) ->
     """SDK-path preset: {provider}/{request model} in, {provider}/{wire
     model} out, byte-identical dumps both sides."""
     raw = _RESPONSES[name]
-    preset = f"{provider}/{SPECS[provider]['model']}"
+    preset = f"{provider}/{SPECS[provider].model}"
     v1 = _v1_model_response(raw, preset)
     v2 = _v2_model_response(provider, raw, preset)
     assert _norm(v2) == _norm(v1)
@@ -87,7 +87,7 @@ def test_preset_survives_when_wire_model_missing(provider: str, frozen_ambient) 
     """cdr's elif arm needs a non-None wire model; without one the preset
     {provider}/{request model} survives verbatim on both sides."""
     raw = {k: v for k, v in _RESPONSES["text"].items() if k != "model"}
-    preset = f"{provider}/{SPECS[provider]['model']}"
+    preset = f"{provider}/{SPECS[provider].model}"
     v1 = _v1_model_response(raw, preset)
     v2 = _v2_model_response(provider, raw, preset)
     assert _norm(v2) == _norm(v1)

--- a/tests/test_litellm/translation/test_differential_compat_sdk_response.py
+++ b/tests/test_litellm/translation/test_differential_compat_sdk_response.py
@@ -1,0 +1,94 @@
+"""Differential parity for the compat_sdk (wave-1a) response path.
+
+The live v1 normalizer for every provider here is the SAME
+``convert_to_model_response_object`` the openai differential pins in depth —
+the per-provider delta is the envelope preset: openai.py:676-677 sets
+``model_response.model = f"{provider}/{model}"`` for every non-"openai"
+compat consumer BEFORE conversion, and cdr's model arm (cdr:699-710) then
+re-prefixes onto the wire model. These rows pin exactly that, per provider,
+through the seam's ``_to_model_response_openai`` (the path-keyed B1 arm):
+the preset must come out as ``{provider}/{wire_model}``, byte-identical to
+v1. Depth (usage details, finish rewrites, reasoning extraction, unsupported
+shapes) is the openai response differential's job; the parser is shared.
+"""
+
+import copy
+import json
+
+import pytest
+
+from litellm.types.utils import ModelResponse
+from litellm.utils import convert_to_model_response_object
+
+from litellm.translation.inbound.openai_chat import parse_request
+from litellm.translation.inbound.openai_chat.response import serialize_response
+from litellm.translation.providers.openai_compat.response import parse_response
+from litellm.translation_seam import build_translation_deps, to_model_response
+
+from ._compat_sdk_corpus import PROVIDERS, SPECS
+from .test_differential_openai_response import _RESPONSES
+
+_RESPONSE_ROWS = (
+    "text",
+    "tool_calls_rewrites_stop",
+    "cached_and_reasoning_usage_details",
+)
+
+
+def _request_for(provider: str) -> dict:
+    return {
+        "model": SPECS[provider]["model"],
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+
+
+def _v1_model_response(raw: dict, preset_model: str) -> dict:
+    result = convert_to_model_response_object(
+        response_object=copy.deepcopy(raw),
+        model_response_object=ModelResponse(model=preset_model),
+    )
+    return result.model_dump()
+
+
+def _v2_model_response(provider: str, raw: dict, preset_model: str) -> dict:
+    parsed = parse_request(_request_for(provider))
+    assert parsed.is_ok(), parsed.error.summary
+    response = parse_response(copy.deepcopy(raw), parsed.ok)
+    assert response.is_ok(), response.error.summary
+    body = serialize_response(response.ok, build_translation_deps(), "openai")
+    return to_model_response(
+        body, ModelResponse(model=preset_model), usage_style="openai"
+    ).model_dump()
+
+
+def _norm(payload: dict) -> str:
+    return json.dumps(payload, sort_keys=True, default=str)
+
+
+def _rows():
+    return sorted((provider, name) for provider in PROVIDERS for name in _RESPONSE_ROWS)
+
+
+@pytest.mark.parametrize("provider,name", _rows())
+def test_preset_reprefix_matches_v1(provider: str, name: str, frozen_ambient) -> None:
+    """SDK-path preset: {provider}/{request model} in, {provider}/{wire
+    model} out, byte-identical dumps both sides."""
+    raw = _RESPONSES[name]
+    preset = f"{provider}/{SPECS[provider]['model']}"
+    v1 = _v1_model_response(raw, preset)
+    v2 = _v2_model_response(provider, raw, preset)
+    assert _norm(v2) == _norm(v1)
+    wire_model = raw["model"]
+    assert v2["model"] == f"{provider}/{wire_model}"
+
+
+@pytest.mark.parametrize("provider", PROVIDERS)
+def test_preset_survives_when_wire_model_missing(provider: str, frozen_ambient) -> None:
+    """cdr's elif arm needs a non-None wire model; without one the preset
+    {provider}/{request model} survives verbatim on both sides."""
+    raw = {k: v for k, v in _RESPONSES["text"].items() if k != "model"}
+    preset = f"{provider}/{SPECS[provider]['model']}"
+    v1 = _v1_model_response(raw, preset)
+    v2 = _v2_model_response(provider, raw, preset)
+    assert _norm(v2) == _norm(v1)
+    assert v2["model"] == preset

--- a/tests/test_litellm/translation/test_differential_compat_sdk_stream.py
+++ b/tests/test_litellm/translation/test_differential_compat_sdk_stream.py
@@ -16,12 +16,16 @@ the bottom pins the evidence so the drop reason stays true at HEAD.
 import copy
 import json
 import time
+from typing import get_args
 
 import pytest
 from openai.types.chat.chat_completion_chunk import ChatCompletionChunk
 
 from litellm.litellm_core_utils.litellm_logging import Logging
 from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
+
+from litellm.translation.dispatch import Provider
+from litellm.translation.engine import pipeline
 
 from ._compat_sdk_corpus import PROVIDERS
 from .test_differential_openai_stream import MODEL, STREAMS, USAGE_STREAM, _v2_chunks
@@ -85,10 +89,20 @@ def test_baseten_drop_canary(frozen_ambient) -> None:
     dedicated legacy decoder (``handle_baseten_chunk``,
     streaming_handler.py:1246-1248) instead of the default openai arm, so
     its v1 stream behavior is not the openai dialect and cannot be honestly
-    registered. If this canary fails, the legacy branch is gone at HEAD —
+    registered. If the DRIFT half fails, the legacy branch is gone at HEAD —
     re-evaluate porting baseten (request/response sides are trivial:
-    own list, mct rename, user supported)."""
+    own list, mct rename, user supported). The REGISTRATION half makes the
+    steady state loud (critic-wave1a M2 / verifier F3): registering baseten
+    anywhere requires deliberately deleting these negative asserts, which
+    forces the registrar past the evidence above."""
+    # drift half: the legacy branch still exists and still diverges
     assert hasattr(CustomStreamWrapper, "handle_baseten_chunk")
     v1_baseten = _v1_chunks("baseten", STREAMS["text"])
     v1_openai = _v1_chunks("custom_openai", STREAMS["text"])
     assert _norm(v1_baseten) != _norm(v1_openai)
+    # registration half: naive registration fails HERE, corpus row or not
+    assert "baseten" not in get_args(Provider)
+    assert "baseten" not in pipeline._SERIALIZERS
+    assert "baseten" not in pipeline._RESPONSE_PARSERS
+    assert "baseten" not in pipeline._RESPONSE_DIALECTS
+    assert "baseten" not in pipeline._RAW_GUARDS

--- a/tests/test_litellm/translation/test_differential_compat_sdk_stream.py
+++ b/tests/test_litellm/translation/test_differential_compat_sdk_stream.py
@@ -1,0 +1,94 @@
+"""Differential parity for compat_sdk (wave-1a) streams, pinned per provider.
+
+The wave's stream claim is that every surviving provider rides
+``CustomStreamWrapper``'s DEFAULT openai arm (no dedicated branch, not in
+``litellm._custom_providers``) and therefore decodes identically to v2's
+``openai`` chunk dialect. That claim is pinned by replaying the openai SDK
+chunk corpus through the wrapper with each provider's
+``custom_llm_provider`` and requiring byte-identical output to the v2 fold —
+a provider growing a dedicated wrapper branch (the baseten failure mode)
+breaks its row here.
+
+baseten is the dropped 14th provider for exactly that reason; the canary at
+the bottom pins the evidence so the drop reason stays true at HEAD.
+"""
+
+import copy
+import json
+import time
+
+import pytest
+from openai.types.chat.chat_completion_chunk import ChatCompletionChunk
+
+from litellm.litellm_core_utils.litellm_logging import Logging
+from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
+
+from ._compat_sdk_corpus import PROVIDERS
+from .test_differential_openai_stream import MODEL, STREAMS, USAGE_STREAM, _v2_chunks
+
+_STREAM_ROWS = ("text", "tools", "empty_keepalive_swallowed")
+
+
+def _v1_chunks(provider: str, events: list, stream_options=None) -> list:
+    logging = Logging(
+        model=MODEL,
+        messages=[{"role": "user", "content": "stream"}],
+        stream=True,
+        call_type="completion",
+        start_time=time.time(),
+        litellm_call_id=f"diff-{provider}-stream",
+        function_id=f"diff-{provider}-stream",
+    )
+    sdk_chunks = (
+        ChatCompletionChunk.model_validate(event) for event in copy.deepcopy(events)
+    )
+    wrapper = CustomStreamWrapper(
+        completion_stream=sdk_chunks,
+        model=MODEL,
+        custom_llm_provider=provider,
+        logging_obj=logging,
+        stream_options=stream_options,
+    )
+    return [chunk.model_dump() for chunk in wrapper]
+
+
+def _norm(chunks: list) -> str:
+    return json.dumps(chunks, sort_keys=True, default=str)
+
+
+def _rows():
+    return sorted((provider, name) for provider in PROVIDERS for name in _STREAM_ROWS)
+
+
+@pytest.mark.parametrize("provider,name", _rows())
+def test_v2_stream_matches_v1(provider: str, name: str, frozen_ambient) -> None:
+    events = STREAMS[name]
+    assert _norm(_v2_chunks(events)) == _norm(_v1_chunks(provider, events))
+
+
+@pytest.mark.parametrize("provider", PROVIDERS)
+def test_usage_tail_seam_contract(provider: str, frozen_ambient) -> None:
+    """Same contract the openai stream differential pins: byte-identical
+    prefix; v1's tail is the wrapper-synthesized usage chunk, v2's tail is
+    the wire ``choices: []`` usage chunk verbatim with equal numbers."""
+    v1 = _v1_chunks(provider, USAGE_STREAM, stream_options={"include_usage": True})
+    v2 = _v2_chunks(USAGE_STREAM)
+    assert len(v1) == len(v2)
+    assert _norm(v2[:-1]) == _norm(v1[: len(v2) - 1])
+    assert v2[-1]["choices"] == []
+    for key in ("prompt_tokens", "completion_tokens", "total_tokens"):
+        assert v1[-1]["usage"][key] == v2[-1]["usage"][key]
+
+
+def test_baseten_drop_canary(frozen_ambient) -> None:
+    """baseten is DROPPED from wave 1a: the wrapper routes its chunks into a
+    dedicated legacy decoder (``handle_baseten_chunk``,
+    streaming_handler.py:1246-1248) instead of the default openai arm, so
+    its v1 stream behavior is not the openai dialect and cannot be honestly
+    registered. If this canary fails, the legacy branch is gone at HEAD —
+    re-evaluate porting baseten (request/response sides are trivial:
+    own list, mct rename, user supported)."""
+    assert hasattr(CustomStreamWrapper, "handle_baseten_chunk")
+    v1_baseten = _v1_chunks("baseten", STREAMS["text"])
+    v1_openai = _v1_chunks("custom_openai", STREAMS["text"])
+    assert _norm(v1_baseten) != _norm(v1_openai)

--- a/tests/test_litellm/translation/test_differential_openai_stream.py
+++ b/tests/test_litellm/translation/test_differential_openai_stream.py
@@ -35,13 +35,17 @@ MODEL = "gpt-4o"
 
 
 def _chunk(delta=None, finish=None, usage=None, choices=None):
+    # The REAL wire shape: no service_tier key (compat wires essentially
+    # never carry it). v1's validated SDK ChatCompletionChunk materializes
+    # service_tier=None anyway; hard-coding the key here biased every replay
+    # toward that SDK artifact and masked the divergence (verifier-wave1a
+    # F1) -- the v2 parser now presets the key instead.
     payload = {
         "id": "chatcmpl-S1",
         "object": "chat.completion.chunk",
         "created": 1718000000,
         "model": "gpt-4o-2024-08-06",
         "system_fingerprint": "fp_stream",
-        "service_tier": None,
         "choices": [
             {
                 "index": 0,
@@ -187,6 +191,21 @@ def _norm(chunks: list) -> str:
 def test_v2_stream_matches_v1(name: str, frozen_ambient) -> None:
     events = STREAMS[name]
     assert _norm(_v2_chunks(events)) == _norm(_v1_chunks(events))
+
+
+def test_wire_carried_service_tier_overrides_the_preset(frozen_ambient) -> None:
+    """Both directions of the F1 fix: the de-biased STREAMS rows above pin
+    key-absent wire chunks (v1's SDK materializes service_tier=None; the v2
+    parser presets it), and this row pins that a wire-CARRIED value rides
+    through the preset verbatim on both sides."""
+    events = [
+        {**_chunk(_delta(role="assistant", content="hi")), "service_tier": "default"},
+        {**_chunk(_delta(), finish="stop"), "service_tier": "default"},
+    ]
+    v1 = _v1_chunks(events)
+    v2 = _v2_chunks(events)
+    assert _norm(v2) == _norm(v1)
+    assert all(chunk["service_tier"] == "default" for chunk in v2)
 
 
 def test_v2_stream_decodes_sse_lines_identically(frozen_ambient) -> None:

--- a/tests/test_litellm/translation/test_differential_openai_stream.py
+++ b/tests/test_litellm/translation/test_differential_openai_stream.py
@@ -131,6 +131,12 @@ STREAMS = {
         _chunk(_delta(content="ok")),
         _chunk(_delta(), finish="stop"),
     ],
+    "service_tier_wire_carried": [
+        # the other F1 direction: a wire-CARRIED service_tier value must
+        # override the parser's None preset on both sides
+        {**_chunk(_delta(role="assistant", content="hi")), "service_tier": "default"},
+        {**_chunk(_delta(), finish="stop"), "service_tier": "default"},
+    ],
 }
 
 _USAGE = {
@@ -194,17 +200,12 @@ def test_v2_stream_matches_v1(name: str, frozen_ambient) -> None:
 
 
 def test_wire_carried_service_tier_overrides_the_preset(frozen_ambient) -> None:
-    """Both directions of the F1 fix: the de-biased STREAMS rows above pin
+    """Both directions of the F1 fix: the de-biased STREAMS rows pin
     key-absent wire chunks (v1's SDK materializes service_tier=None; the v2
-    parser presets it), and this row pins that a wire-CARRIED value rides
-    through the preset verbatim on both sides."""
-    events = [
-        {**_chunk(_delta(role="assistant", content="hi")), "service_tier": "default"},
-        {**_chunk(_delta(), finish="stop"), "service_tier": "default"},
-    ]
-    v1 = _v1_chunks(events)
-    v2 = _v2_chunks(events)
-    assert _norm(v2) == _norm(v1)
+    parser presets it), and this one pins that a wire-CARRIED value rides
+    through the preset verbatim on both sides (parity itself is the
+    parametrized STREAMS row)."""
+    v2 = _v2_chunks(STREAMS["service_tier_wire_carried"])
     assert all(chunk["service_tier"] == "default" for chunk in v2)
 
 


### PR DESCRIPTION
Stacked on #30283. Ports the 13 verified-trivial SDK-path openai-compat providers — together_ai, cerebras, nvidia_nim, lm_studio, llamafile, lambda_ai, nebius, novita, wandb, featherless_ai, nscale, hyperbolic, volcengine — as one composed family.

## What's here
- `providers/compat_sdk/`: one mechanism, data-driven — frozen per-provider `CompatProfile`s + factory-derived serializers; the three genuinely special gates (together capability, cerebras reasoning, nvidia_nim's static table) quarantined as named functions. No provider names in shared logic.
- Registration compressed to 3 touch points per provider (registry splice + factory; `pipeline.py` *shrank* 391→341 lines, with headroom for the remaining waves under the repo's 720-line gate).
- A Literal↔corpus completeness gate: every registered provider must have differential coverage — naive registration of an unported provider is loud, permanently.
- baseten deliberately NOT ported (its streams ride a dedicated legacy wrapper branch, not the openai dialect) — encoded as negative registry asserts + a drift canary, not a comment.
- Parity guard: a together model literally named `gpt-4`/`gpt-3.5-turbo-16k` falls back typed so v1 raises its own ValueError (v2 serving where v1 crashes is a parity break — caught by the antagonist verifier, pinned with 4 in-process rows).
- Stream fixtures de-biased (`service_tier` no longer hard-coded into replays); the shared openai dialect now presets it exactly like v1's SDK materialization — fixing a base-inherited gap for openai and a latent azure no-model-chunk gap at the same seam.

## Verification
- Differential regenerated: **766 rows, 0 divergent** (556 identical / 42 v1-raises asserted in-process / 149 typed v1-serves fallbacks / 15 seam contracts / 1 documented drop / 4 skipped).
- Gates: full `make lint-translation` exit 0; pyright strict 0 errors; translation pytest 1076 passed / 8 skipped.
- Flag-off: the 9 existing v1 provider test dirs identical to base (66/1).
- Adversarially reviewed: hostile tenet critic (design verdict: genuine composition; its registration-sprawl projection drove the splice refactor) + antagonist verifier (independent 13-provider 98-check sweep; profile fidelity re-derived from v1 for unmapped models). All findings fixed in-history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)