### PR TITLE
fix(router): resolve custom_llm_provider for embeddings in budget limiter

### DIFF
--- a/litellm/router_strategy/budget_limiter.py
+++ b/litellm/router_strategy/budget_limiter.py
@@ -441,13 +441,17 @@ class RouterBudgetLimiting(CustomLogger):
 
         response_cost: float = standard_logging_payload.get("response_cost", 0)
         model_id: str = str(standard_logging_payload.get("model_id", ""))
-        custom_llm_provider: str = kwargs.get("litellm_params", {}).get(
-            "custom_llm_provider", None
+        custom_llm_provider: Optional[str] = (
+            kwargs.get("litellm_params", {}).get("custom_llm_provider")
+            or kwargs.get("custom_llm_provider")
+            or standard_logging_payload.get("custom_llm_provider")
         )
-        if custom_llm_provider is None:
-            raise ValueError("custom_llm_provider is required")
 
-        budget_config = self._get_budget_config_for_provider(custom_llm_provider)
+        budget_config = (
+            self._get_budget_config_for_provider(custom_llm_provider)
+            if custom_llm_provider
+            else None
+        )
         if budget_config:
             # increment spend for provider
             spend_key = (

--- a/tests/test_litellm/router_strategy/test_budget_limiter.py
+++ b/tests/test_litellm/router_strategy/test_budget_limiter.py
@@ -1,0 +1,59 @@
+import pytest
+
+from litellm.caching.caching import DualCache
+from litellm.router_strategy.budget_limiter import RouterBudgetLimiting
+from litellm.types.utils import BudgetConfig
+
+
+@pytest.fixture
+def disable_budget_sync(monkeypatch):
+    async def noop(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(
+        "litellm.router_strategy.budget_limiter.RouterBudgetLimiting.periodic_sync_in_memory_spend_with_redis",
+        noop,
+    )
+
+
+def _embedding_success_kwargs(provider: str, response_cost: float) -> dict:
+    # embedding() builds its logged litellm_params from residual **kwargs, so a
+    # named custom_llm_provider is bound away and logged as None; the resolved
+    # provider only survives at the top level and in the standard logging object.
+    return {
+        "call_type": "aembedding",
+        "litellm_params": {"custom_llm_provider": None},
+        "custom_llm_provider": provider,
+        "standard_logging_object": {
+            "response_cost": response_cost,
+            "model_id": "embed-model-id",
+            "custom_llm_provider": provider,
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_async_log_success_event_resolves_provider_for_embeddings(
+    disable_budget_sync,
+):
+    """Regression for #30276.
+
+    Embedding success events must not raise "custom_llm_provider is required",
+    and the provider budget for the resolved provider must still be enforced
+    even though the logged litellm_params carry custom_llm_provider as None.
+    """
+    provider_budget = RouterBudgetLimiting(
+        dual_cache=DualCache(),
+        provider_budget_config={
+            "openai": BudgetConfig(time_period="1d", budget_limit=100),
+        },
+    )
+
+    kwargs = _embedding_success_kwargs(provider="openai", response_cost=0.5)
+
+    await provider_budget.async_log_success_event(
+        kwargs=kwargs, response_obj=None, start_time=0, end_time=0
+    )
+
+    spend = await provider_budget.dual_cache.async_get_cache("provider_spend:openai:1d")
+    assert spend == 0.5

--- a/tests/test_litellm/router_strategy/test_budget_limiter.py
+++ b/tests/test_litellm/router_strategy/test_budget_limiter.py
@@ -57,3 +57,38 @@ async def test_async_log_success_event_resolves_provider_for_embeddings(
 
     spend = await provider_budget.dual_cache.async_get_cache("provider_spend:openai:1d")
     assert spend == 0.5
+
+
+@pytest.mark.asyncio
+async def test_async_log_success_event_skips_provider_budget_when_unresolved(
+    disable_budget_sync,
+):
+    """The silent-skip branch of #30276.
+
+    When no provider can be resolved from litellm_params, the top-level kwargs,
+    or the standard logging object, provider-budget enforcement must be skipped
+    without raising and without recording any provider spend.
+    """
+    provider_budget = RouterBudgetLimiting(
+        dual_cache=DualCache(),
+        provider_budget_config={
+            "openai": BudgetConfig(time_period="1d", budget_limit=100),
+        },
+    )
+
+    kwargs = {
+        "call_type": "aembedding",
+        "litellm_params": {"custom_llm_provider": None},
+        "standard_logging_object": {
+            "response_cost": 0.5,
+            "model_id": "embed-model-id",
+            "custom_llm_provider": None,
+        },
+    }
+
+    await provider_budget.async_log_success_event(
+        kwargs=kwargs, response_obj=None, start_time=0, end_time=0
+    )
+
+    spend = await provider_budget.dual_cache.async_get_cache("provider_spend:openai:1d")
+    assert spend is None


### PR DESCRIPTION
## Relevant issues

Fixes #30276

## Type

Bug Fix

## Changes

`RouterBudgetLimiting.async_log_success_event` resolved the provider only from `kwargs["litellm_params"]["custom_llm_provider"]`. For embeddings that value is always `None`: `embedding()` builds its logged `litellm_params` from residual `**kwargs`, and because `custom_llm_provider` is a named parameter of `embedding()` it can never appear in `**kwargs`. With `provider_budget_config` set, the following `raise ValueError("custom_llm_provider is required")` fired on every successful embedding and surfaced as a non-blocking `LoggingError`, so log noise scaled with embedding volume even when no embedding provider had a budget configured. Chat completions were unaffected because `completion()` passes the resolved provider explicitly

The limiter now resolves the provider from the locations populated for every call type, preferring `litellm_params` so chat behavior is identical, then falling back to the top-level `kwargs["custom_llm_provider"]` and the standard logging object. When the provider is genuinely absent the limiter skips provider-budget enforcement instead of raising, so deployment-budget and tag-budget enforcement keep running rather than being aborted by the exception

Keeping the fix in the limiter means it also covers the other non-chat entrypoints that share the same residual-kwargs pattern (transcription, speech) without touching each call site

## Screenshots / Proof of Fix

Before, with a provider budget configured, every successful embedding emitted

```
LiteLLM.LoggingError: [Non-Blocking] Exception occurred while success logging
  File ".../litellm/router_strategy/budget_limiter.py", line 448, in async_log_success_event
    raise ValueError("custom_llm_provider is required")
ValueError: custom_llm_provider is required
```

After this change the same embedding success event resolves the provider and logs cleanly. The minimal standalone reproduction in the issue (a `Router` with `provider_budget_config` set plus a single `aembedding` call against any OpenAI-compatible embedding endpoint) no longer emits the `LoggingError`, which is exactly what an operator running a clean-logs gate observes

The behavior is locked in by a regression test at `tests/test_litellm/router_strategy/test_budget_limiter.py`. It drives an embedding-shaped success event whose `litellm_params` carry `custom_llm_provider` as `None`, then asserts that no error is raised and that the resolved provider's budget is still incremented. It fails on the previous code with the exact issue error and passes with this change

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] Ran the mocked `router_strategy` unit suite locally (`tests/test_litellm/router_strategy/`): 339 passed, 4 skipped; full `make test-unit` will run in CI
- [ ] I will request a Greptile review by commenting `@greptileai` and confirm a Confidence Score of at least 4/5 before requesting a maintainer review
