### PR TITLE
fix(anthropic): honor timeout/stream_timeout on /v1/messages passthrough

### DIFF
--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -1885,6 +1885,27 @@ class BaseLLMHTTPHandler:
             logging_obj=logging_obj,
         )
 
+    @staticmethod
+    def _resolve_anthropic_messages_timeout(
+        litellm_params: GenericLiteLLMParams, stream: bool
+    ) -> Optional[Union[float, httpx.Timeout]]:
+        from litellm.secret_managers.main import get_secret_str
+
+        stream_timeout = litellm_params.get("stream_timeout")
+        raw = (
+            stream_timeout
+            if stream and stream_timeout is not None
+            else litellm_params.get("timeout")
+        )
+        if raw is None or isinstance(raw, httpx.Timeout):
+            return raw
+        if isinstance(raw, str) and raw.startswith("os.environ/"):
+            raw = get_secret_str(raw)
+            if raw is None:
+                return None
+        timeout = float(raw)
+        return timeout if timeout > 0 else None
+
     async def _async_post_anthropic_messages_with_http_error_retry(
         self,
         async_httpx_client: AsyncHTTPHandler,
@@ -1900,6 +1921,7 @@ class BaseLLMHTTPHandler:
         litellm_params: GenericLiteLLMParams,
         api_key: Optional[str],
         model: str,
+        timeout: Optional[Union[float, httpx.Timeout]] = None,
     ) -> httpx.Response:
         max_attempts = max(
             provider_config.max_retry_on_anthropic_messages_http_error, 1
@@ -1914,6 +1936,7 @@ class BaseLLMHTTPHandler:
                     data=signed_json_body or json.dumps(request_body),
                     stream=stream or False,
                     logging_obj=logging_obj,
+                    timeout=timeout,
                 )
                 response.raise_for_status()
                 return response
@@ -1972,6 +1995,10 @@ class BaseLLMHTTPHandler:
     ) -> Union[AnthropicMessagesResponse, AsyncIterator]:
         from litellm.litellm_core_utils.get_provider_specific_headers import (
             ProviderSpecificHeaderUtils,
+        )
+
+        resolved_timeout = self._resolve_anthropic_messages_timeout(
+            litellm_params=litellm_params, stream=bool(stream)
         )
 
         if client is None or not isinstance(client, AsyncHTTPHandler):
@@ -2118,6 +2145,7 @@ class BaseLLMHTTPHandler:
             litellm_params=litellm_params,
             api_key=api_key,
             model=model,
+            timeout=resolved_timeout,
         )
 
         # used for logging + cost tracking

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -1889,8 +1889,6 @@ class BaseLLMHTTPHandler:
     def _resolve_anthropic_messages_timeout(
         litellm_params: GenericLiteLLMParams, stream: bool
     ) -> Optional[Union[float, httpx.Timeout]]:
-        from litellm.secret_managers.main import get_secret_str
-
         stream_timeout = litellm_params.get("stream_timeout")
         raw = (
             stream_timeout
@@ -1899,10 +1897,6 @@ class BaseLLMHTTPHandler:
         )
         if raw is None or isinstance(raw, httpx.Timeout):
             return raw
-        if isinstance(raw, str) and raw.startswith("os.environ/"):
-            raw = get_secret_str(raw)
-            if raw is None:
-                return None
         timeout = float(raw)
         return timeout if timeout > 0 else None
 

--- a/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
@@ -1152,21 +1152,21 @@ def test_resolve_anthropic_messages_timeout_passes_httpx_timeout_through():
     assert resolved is explicit
 
 
-def test_resolve_anthropic_messages_timeout_os_environ_string(monkeypatch):
-    """os.environ/ timeout strings are resolved then coerced; an unset env var
-    degrades to None (default) rather than crashing on float(None)."""
-    monkeypatch.setenv("ANTHROPIC_MESSAGES_TIMEOUT", "450")
-    resolved = BaseLLMHTTPHandler._resolve_anthropic_messages_timeout(
-        GenericLiteLLMParams(timeout="os.environ/ANTHROPIC_MESSAGES_TIMEOUT"),
-        stream=False,
-    )
-    assert resolved == 450.0
+def test_resolve_anthropic_messages_timeout_does_not_read_env(monkeypatch):
+    """Security regression: a client-supplied os.environ/ timeout string must NOT
+    resolve a server environment variable. Request-time secret resolution would let
+    a caller exfiltrate env-backed secrets via the float() error message; config-time
+    resolution (router.set_model_list / proxy load_config) already handles the
+    legitimate os.environ/ form before the request. The string is coerced as-is and
+    raises with the literal input, never the secret value."""
+    secret = "sk-ant-super-secret-value"
+    monkeypatch.setenv("ANTHROPIC_API_KEY", secret)
 
-    monkeypatch.delenv("ANTHROPIC_MESSAGES_TIMEOUT", raising=False)
-    assert (
+    with pytest.raises(ValueError) as exc_info:
         BaseLLMHTTPHandler._resolve_anthropic_messages_timeout(
-            GenericLiteLLMParams(timeout="os.environ/ANTHROPIC_MESSAGES_TIMEOUT"),
+            GenericLiteLLMParams(timeout="os.environ/ANTHROPIC_API_KEY"),
             stream=False,
         )
-        is None
-    )
+
+    assert secret not in str(exc_info.value)
+    assert "os.environ/ANTHROPIC_API_KEY" in str(exc_info.value)

--- a/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
@@ -980,3 +980,193 @@ def test_async_compact_handler_sends_json_when_not_signed():
     )
     assert kwargs.get("json") == {"model": "openai.gpt-5.5", "input": "hi"}
     assert "data" not in kwargs
+
+
+async def _post_timeout_for_anthropic_messages(
+    litellm_params: GenericLiteLLMParams,
+    stream: bool,
+):
+    """Drive async_anthropic_messages_handler with the network mocked and return
+    the timeout passed to the per-request .post call (the value that populates
+    aiohttp's sock_read), or None if .post was never reached."""
+    handler = BaseLLMHTTPHandler()
+
+    mock_config = Mock()
+    mock_config.validate_anthropic_messages_environment = Mock(
+        return_value=({"x-api-key": "test-key"}, "https://api.anthropic.com")
+    )
+    mock_config.transform_anthropic_messages_request = Mock(
+        return_value={"model": "claude-sonnet-4-20250514", "messages": []}
+    )
+    mock_config.sign_request = Mock(return_value=({"x-api-key": "test-key"}, None))
+    mock_config.get_complete_url = Mock(
+        return_value="https://api.anthropic.com/v1/messages"
+    )
+    mock_config.max_retry_on_anthropic_messages_http_error = 1
+    mock_config.transform_anthropic_messages_response = Mock(return_value={"ok": True})
+    mock_config.get_async_streaming_response_iterator = Mock(return_value=iter([]))
+
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.raise_for_status = Mock()
+
+    captured = {"post_kwargs": None}
+
+    def fake_get_client(*args, **kwargs):
+        client = AsyncMock()
+
+        async def fake_post(**post_kwargs):
+            captured["post_kwargs"] = post_kwargs
+            return mock_response
+
+        client.post = fake_post
+        return client
+
+    mock_logging_obj = Mock()
+    mock_logging_obj.update_from_kwargs = Mock()
+    mock_logging_obj.pre_call = Mock()
+    mock_logging_obj.model_call_details = {}
+    mock_logging_obj.stream = stream
+    mock_logging_obj.dynamic_success_callbacks = []
+
+    with patch(
+        "litellm.llms.custom_httpx.llm_http_handler.get_async_httpx_client",
+        side_effect=fake_get_client,
+    ):
+        await handler.async_anthropic_messages_handler(
+            model="claude-sonnet-4-20250514",
+            messages=[{"role": "user", "content": "Hello"}],
+            anthropic_messages_provider_config=mock_config,
+            anthropic_messages_optional_request_params={},
+            custom_llm_provider="anthropic",
+            litellm_params=litellm_params,
+            logging_obj=mock_logging_obj,
+            client=None,
+            stream=stream,
+            kwargs={},
+        )
+
+    post_kwargs = captured["post_kwargs"]
+    return post_kwargs.get("timeout") if post_kwargs is not None else None
+
+
+@pytest.mark.asyncio
+async def test_anthropic_messages_honors_configured_timeout():
+    """Regression: /v1/messages must honor litellm_params.timeout instead of the
+    hardcoded 600s default. The per-request .post timeout is what reaches
+    aiohttp's sock_read, so the configured value must land there."""
+    timeout = await _post_timeout_for_anthropic_messages(
+        litellm_params=GenericLiteLLMParams(timeout=1800),
+        stream=False,
+    )
+    assert timeout == 1800.0
+
+
+@pytest.mark.asyncio
+async def test_anthropic_messages_uses_stream_timeout_when_streaming():
+    """stream_timeout wins over timeout when stream=True."""
+    timeout = await _post_timeout_for_anthropic_messages(
+        litellm_params=GenericLiteLLMParams(timeout=1800, stream_timeout=300),
+        stream=True,
+    )
+    assert timeout == 300.0
+
+
+@pytest.mark.asyncio
+async def test_anthropic_messages_ignores_stream_timeout_when_not_streaming():
+    """stream_timeout must not apply to non-streaming calls; timeout is used."""
+    timeout = await _post_timeout_for_anthropic_messages(
+        litellm_params=GenericLiteLLMParams(timeout=1800, stream_timeout=300),
+        stream=False,
+    )
+    assert timeout == 1800.0
+
+
+@pytest.mark.asyncio
+async def test_anthropic_messages_falls_back_to_timeout_when_streaming_without_stream_timeout():
+    """stream=True but only timeout set -> timeout is used for the stream."""
+    timeout = await _post_timeout_for_anthropic_messages(
+        litellm_params=GenericLiteLLMParams(timeout=1800),
+        stream=True,
+    )
+    assert timeout == 1800.0
+
+
+@pytest.mark.asyncio
+async def test_anthropic_messages_no_explicit_timeout_when_unset():
+    """When neither timeout nor stream_timeout is configured, no explicit timeout
+    is forced; .post gets None so the client default path is left untouched."""
+    timeout = await _post_timeout_for_anthropic_messages(
+        litellm_params=GenericLiteLLMParams(),
+        stream=False,
+    )
+    assert timeout is None
+
+
+@pytest.mark.asyncio
+async def test_anthropic_messages_coerces_string_stream_timeout():
+    """Numeric-string stream_timeout (e.g. from YAML) is coerced to float."""
+    timeout = await _post_timeout_for_anthropic_messages(
+        litellm_params=GenericLiteLLMParams(stream_timeout="300"),
+        stream=True,
+    )
+    assert timeout == 300.0
+
+
+@pytest.mark.asyncio
+async def test_anthropic_messages_zero_timeout_treated_as_unset():
+    """A non-positive timeout must not force an immediate-fail 0s read timeout;
+    it falls back to None so the client default applies."""
+    timeout = await _post_timeout_for_anthropic_messages(
+        litellm_params=GenericLiteLLMParams(timeout=0),
+        stream=False,
+    )
+    assert timeout is None
+
+
+def test_resolve_anthropic_messages_timeout_selection_and_coercion():
+    """Unit-level coverage of the resolver: stream selection, float coercion,
+    non-positive -> None, and unset -> None."""
+    resolve = BaseLLMHTTPHandler._resolve_anthropic_messages_timeout
+
+    assert resolve(GenericLiteLLMParams(timeout=1800), stream=False) == 1800.0
+    assert (
+        resolve(GenericLiteLLMParams(timeout=1800, stream_timeout=300), stream=True)
+        == 300.0
+    )
+    assert (
+        resolve(GenericLiteLLMParams(timeout=1800, stream_timeout=300), stream=False)
+        == 1800.0
+    )
+    assert resolve(GenericLiteLLMParams(stream_timeout="300"), stream=True) == 300.0
+    assert resolve(GenericLiteLLMParams(timeout=0), stream=False) is None
+    assert resolve(GenericLiteLLMParams(), stream=False) is None
+
+
+def test_resolve_anthropic_messages_timeout_passes_httpx_timeout_through():
+    """An httpx.Timeout is forwarded untouched, not collapsed to a float."""
+    explicit = httpx.Timeout(timeout=1800.0, connect=5.0)
+    resolved = BaseLLMHTTPHandler._resolve_anthropic_messages_timeout(
+        GenericLiteLLMParams(timeout=explicit), stream=False
+    )
+    assert resolved is explicit
+
+
+def test_resolve_anthropic_messages_timeout_os_environ_string(monkeypatch):
+    """os.environ/ timeout strings are resolved then coerced; an unset env var
+    degrades to None (default) rather than crashing on float(None)."""
+    monkeypatch.setenv("ANTHROPIC_MESSAGES_TIMEOUT", "450")
+    resolved = BaseLLMHTTPHandler._resolve_anthropic_messages_timeout(
+        GenericLiteLLMParams(timeout="os.environ/ANTHROPIC_MESSAGES_TIMEOUT"),
+        stream=False,
+    )
+    assert resolved == 450.0
+
+    monkeypatch.delenv("ANTHROPIC_MESSAGES_TIMEOUT", raising=False)
+    assert (
+        BaseLLMHTTPHandler._resolve_anthropic_messages_timeout(
+            GenericLiteLLMParams(timeout="os.environ/ANTHROPIC_MESSAGES_TIMEOUT"),
+            stream=False,
+        )
+        is None
+    )


### PR DESCRIPTION
## Relevant issues

Reported in #30836

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

The Anthropic `/v1/messages` passthrough route (used by Anthropic-native clients including Claude Code, also against Bedrock-backed deployments) built its request without threading the configured timeout, so the per-request `.post` fell back to the hardcoded `_DEFAULT_TIMEOUT` of `COMPLETION_HTTP_FALLBACK_SECONDS` (600s). Per-deployment `litellm_params.timeout` / `stream_timeout` and `router_settings.timeout` were silently ignored on this route, while `/chat/completions` and `/responses` honored them. The visible symptom was a long-running streaming response with a silent gap over 600s (for example an Opus extended-thinking pause on Bedrock) dying with `httpx.ReadTimeout` mapped from aiohttp's `SocketTimeoutError`:

```
aiohttp.client_exceptions.SocketTimeoutError: Timeout on reading data from socket
  -> mapped to -> httpx.ReadTimeout: Timeout on reading data from socket
```

Root cause: `async_anthropic_messages_handler` created the client and posted with no timeout, so the aiohttp transport built `ClientTimeout(sock_read=600)` regardless of configuration.

The fix mirrors how `async_response_api_handler` already threads `timeout`. A small resolver reads the effective timeout off `litellm_params` (which already carries both fields): `stream_timeout` when the call is streaming and it is set, otherwise `timeout`. A numeric value (including a numeric string) is coerced to float, an `httpx.Timeout` is passed through untouched, and a non-positive or unset value falls back to `None` so the existing 600s default still applies when nothing is configured. The resolved value is passed to the per-request `.post(...)` through the existing retry helper. The per-request value is what populates the aiohttp `sock_read`, so both a freshly created client and a caller-injected client honor it.

The resolver deliberately does not resolve `os.environ/` strings at request time. Deployment `litellm_params` already have `os.environ/` references resolved at load time (`router.set_model_list` and the proxy `load_config`), so a legitimately configured timeout never arrives here as an unresolved `os.environ/` string, and the chat path (`CompletionTimeout.resolve`) does not resolve them at request time either. Resolving an attacker-controlled request-body value would let a caller read server environment variables (the resolved secret would surface through the `float()` error that the proxy reflects back), so a non-numeric client string is just coerced as-is and fails with the literal input, leaking nothing.

The `_DEFAULT_TIMEOUT` / `COMPLETION_HTTP_FALLBACK_SECONDS` fallback is intentionally left untouched; the bug was only that configuration never overrode it on this one route. `/chat/completions` and `/responses` are not touched.

Tests live in `tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py`, mirroring the source path, and are fully mocked (no live calls). They cover that the configured timeout reaches the per-request `.post`, that `stream_timeout` wins on streaming and is ignored otherwise, fallback to `timeout` when streaming without a `stream_timeout`, numeric-string coercion, `httpx.Timeout` pass-through, that a zero / unset timeout does not force an immediate-fail 0s read, and a security regression asserting the resolver does not read the environment for an `os.environ/` request value. The behavioral cases fail on the pre-fix tree and pass after.

## Screenshots / Proof of Fix

Live proxy on `localhost:4000`, real Bedrock provider call (no mocks), `eu-central-1`, `anthropic.claude-haiku-4-5`. The deployment carries a deliberately tiny `timeout: 5` so the cap is observable. The same `/v1/messages` request is run on the parent commit (pre-fix) and on this branch (post-fix); only the source differs.

`config.yaml`

```yaml
model_list:
  - model_name: claude-tiny-timeout
    litellm_params:
      model: bedrock/eu.anthropic.claude-haiku-4-5-20251001-v1:0
      aws_region_name: os.environ/AWS_REGION
      timeout: 5          # tiny on purpose; pre-fix this was ignored and capped at 600
  - model_name: claude-big-timeout
    litellm_params:
      model: bedrock/eu.anthropic.claude-haiku-4-5-20251001-v1:0
      aws_region_name: os.environ/AWS_REGION
      timeout: 1800
general_settings:
  master_key: sk-1234
```

```bash
python litellm/proxy/proxy_cli.py --config config.yaml --detailed_debug
```

The request (a long generation that takes well over 5s to produce on the wire):

```bash
curl -sS -w '\n[http_code=%{http_code} total_time=%{time_total}s]\n' http://127.0.0.1:4000/v1/messages \
  -H 'content-type: application/json' \
  -H 'x-api-key: sk-1234' \
  -H 'anthropic-version: 2023-06-01' \
  -d '{"model":"claude-tiny-timeout","max_tokens":4096,"messages":[{"role":"user","content":"Write a detailed 2000-word essay about the history of maritime shipping. Be thorough and verbose."}]}'
```

Before fix (parent commit), `timeout: 5` is silently ignored and the request runs to completion:

```
... "stop_reason":"end_turn" ... "output_tokens":2436}}
[http_code=200 total_time=23.641753s]
```

After fix (this branch), the same request with the same `timeout: 5` is cut at the configured value:

```
{"error":{"message":"litellm.Timeout: Connection timed out. Timeout passed=5.0, time taken=5.079 seconds. Received Model Group=claude-tiny-timeout ...","code":"408"}}
```

Positive control on this branch, `timeout: 1800`, the same kind of request completes normally:

```
... "stop_reason":"end_turn" ... "output_tokens":223}}
[http_code=200 total_time=3.529548s]
```

So the configured timeout now reaches `/v1/messages` (errors at 5.08s when set to 5) where pre-fix it was dropped and the request ran 23.6s to completion. Swap `timeout` for `stream_timeout` and add `"stream": true` to exercise the streaming path; there `stream_timeout` maps to aiohttp's `sock_read`, bounding the silent gap between chunks rather than the total wall-clock.

