### PR TITLE
fix(gateway): keep prometheus /metrics mount when trimming gateway routes

### DIFF
--- a/gateway/main.py
+++ b/gateway/main.py
@@ -25,7 +25,11 @@ DatabaseURLSettings.from_env().apply_to_env()
 
 from litellm.proxy.proxy_server import app
 
-from gateway.routes.allowlist import GATEWAY_EXACT_PATHS, GATEWAY_PATH_PREFIXES
+from gateway.routes.allowlist import (
+    GATEWAY_EXACT_PATHS,
+    GATEWAY_MOUNT_PATHS,
+    GATEWAY_PATH_PREFIXES,
+)
 
 
 def _is_gateway_route(route) -> bool:
@@ -34,8 +38,10 @@ def _is_gateway_route(route) -> bool:
     if path is None:
         return False
     if isinstance(route, Mount):
-        # Gateway never serves the static UI or its asset bundles.
-        return False
+        # The static UI mounts are served by the dedicated UI container. Only
+        # Mounts in the gateway allowlist (e.g. the Prometheus /metrics scrape,
+        # registered via make_asgi_app) remain on the gateway.
+        return path in GATEWAY_MOUNT_PATHS
     if path in GATEWAY_EXACT_PATHS:
         return True
     return any(path.startswith(prefix) for prefix in GATEWAY_PATH_PREFIXES)

--- a/gateway/routes/allowlist.py
+++ b/gateway/routes/allowlist.py
@@ -120,3 +120,9 @@ GATEWAY_EXACT_PATHS: frozenset[str] = frozenset(
         "/test",
     }
 )
+
+GATEWAY_MOUNT_PATHS: frozenset[str] = frozenset(
+    {
+        "/metrics",  # Prometheus scrape endpoint, registered as an ASGI Mount
+    }
+)

--- a/tests/test_litellm/proxy/test_component_allowlists.py
+++ b/tests/test_litellm/proxy/test_component_allowlists.py
@@ -47,8 +47,19 @@ from backend.routes.allowlist import (
     BACKEND_MOUNT_PATHS,
     BACKEND_PATH_PREFIXES,
 )
-from gateway.routes.allowlist import GATEWAY_EXACT_PATHS, GATEWAY_PATH_PREFIXES
+from gateway.routes.allowlist import (
+    GATEWAY_EXACT_PATHS,
+    GATEWAY_MOUNT_PATHS,
+    GATEWAY_PATH_PREFIXES,
+)
 from litellm.proxy.proxy_server import app
+
+# Importing gateway.main wraps the shared app's lifespan_context; save and
+# restore it so the wrapper does not leak into the other tests in this module.
+_PRE_IMPORT_LIFESPAN = app.router.lifespan_context
+from gateway.main import _is_gateway_route
+
+app.router.lifespan_context = _PRE_IMPORT_LIFESPAN
 
 for _key, _previous in _PRE_EXISTING_ENV.items():
     if _previous is None:
@@ -133,3 +144,37 @@ def test_backend_drops_non_allowlisted_mounts():
     for mount_path in non_backend_mounts:
         assert mount_path not in BACKEND_MOUNT_PATHS, \
             f"Mount {mount_path} should not be in BACKEND_MOUNT_PATHS"
+
+
+def test_gateway_mount_paths_defined():
+    """GATEWAY_MOUNT_PATHS constant must exist and be a frozenset."""
+    assert isinstance(GATEWAY_MOUNT_PATHS, frozenset), \
+        f"GATEWAY_MOUNT_PATHS must be a frozenset, got {type(GATEWAY_MOUNT_PATHS)}"
+    assert len(GATEWAY_MOUNT_PATHS) > 0, \
+        "GATEWAY_MOUNT_PATHS must contain at least one Mount path"
+
+
+def test_metrics_mount_in_gateway_allowlist():
+    """The /metrics Mount must be in GATEWAY_MOUNT_PATHS."""
+    assert "/metrics" in GATEWAY_MOUNT_PATHS, \
+        "/metrics Mount path must be in GATEWAY_MOUNT_PATHS"
+
+
+async def _asgi_noop(scope, receive, send) -> None:
+    return None
+
+
+def test_gateway_keeps_prometheus_metrics_mount():
+    """Regression for #30291.
+
+    Prometheus registers /metrics as a Mount (``make_asgi_app``), not an
+    APIRoute. The gateway trim used to drop every Mount, so /metrics returned
+    404 on ``gateway.main`` even though the allowlist lists it.
+    """
+    assert _is_gateway_route(Mount("/metrics", app=_asgi_noop)) is True
+
+
+def test_gateway_drops_non_allowlisted_mounts():
+    """Keeping /metrics must not leak the UI static or MCP catch-all Mounts."""
+    for path in ("/", "/ui", "/_next", "/swagger", "/mcp", "/sse"):
+        assert _is_gateway_route(Mount(path, app=_asgi_noop)) is False, path


### PR DESCRIPTION
## Relevant issues

Fixes #30291

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Gateway started with the componentized entrypoint and prometheus enabled in the config:

```yaml
litellm_settings:
  success_callback: ["prometheus"]
  require_auth_for_metrics_endpoint: false
```

```bash
WORKER_CONFIG=config.yaml LITELLM_MASTER_KEY=sk-1234 python -m uvicorn gateway.main:app --host 127.0.0.1 --port 4000
```

Before this change the gateway is healthy but /metrics is gone:

```
$ curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:4000/health/liveliness
200
$ curl -s -w "\nHTTP %{http_code}\n" http://127.0.0.1:4000/metrics
{"detail":"Not Found"}
HTTP 404
```

After this change the same commands serve the Prometheus exposition:

```
$ curl -sL http://127.0.0.1:4000/metrics | head -4
# HELP python_gc_objects_collected_total Objects collected during gc
# TYPE python_gc_objects_collected_total counter
python_gc_objects_collected_total{generation="0"} 1981.0
python_gc_objects_collected_total{generation="1"} 536.0
$ curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:4000/metrics/
200
```

The trim still drops everything it is supposed to drop on the same run:

```
$ curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:4000/ui/
404
$ curl -s -o /dev/null -w "%{http_code}\n" -H "Authorization: Bearer sk-1234" http://127.0.0.1:4000/key/list
404
```

The 307 on the bare /metrics path is the standard Starlette Mount trailing-slash redirect and matches what the monolithic entrypoint does on the same version; that behavior is tracked separately in #30079

## Type

🐛 Bug Fix

## Changes

`_is_gateway_route` rejected every `Mount` before the allowlist check, which kept UI static mounts off the gateway. Prometheus registers /metrics as `app.mount("/metrics", make_asgi_app())`, a `Mount` rather than an `APIRoute`, so the lifespan trim removed it and scrapes got 404 on `gateway.main` even with /metrics listed in `gateway/routes/allowlist.py`.

This mirrors the `BACKEND_MOUNT_PATHS` allowlist the backend component already uses for its kept Mounts: a new `GATEWAY_MOUNT_PATHS` frozenset in `gateway/routes/allowlist.py` holds `/metrics`, and `_is_gateway_route` keeps a Mount only when its path is in that set. The UI static mounts and the MCP catch-all `Mount("/")` stay dropped.

`tests/test_litellm/proxy/test_component_allowlists.py` gains gateway Mount coverage in the same shape as the existing backend Mount tests: the `GATEWAY_MOUNT_PATHS` constant is validated, and `_is_gateway_route` is asserted to keep the /metrics Mount while dropping the UI and MCP mounts. The import of `gateway.main` saves and restores the shared app's `lifespan_context` so the module's lifespan wrapper does not leak into sibling tests. The /metrics predicate test fails on the previous drop-all-Mounts behavior and passes with this change
