### PR TITLE
fix(cloudflare): correct content-type header in validate_environment

### DIFF
--- a/litellm/llms/cloudflare/chat/transformation.py
+++ b/litellm/llms/cloudflare/chat/transformation.py
@@ -71,7 +71,7 @@ class CloudflareChatConfig(BaseConfig):
             )
         headers = {
             "accept": "application/json",
-            "content-type": "apbplication/json",
+            "content-type": "application/json",
             "Authorization": "Bearer " + api_key,
         }
         return headers


### PR DESCRIPTION
## Relevant issues

Fixes the empty-response issue when proxying Cloudflare Workers AI chat models (e.g. `cloudflare/@cf/zai-org/glm-4.7-flash`) through litellm.

## Pre-Submission checklist

- [ ] I have added meaningful tests
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

### Before the fix

The `validate_environment` method in `CloudflareChatConfig` sets the outgoing `Content-Type` header to `apbplication/json`:

```python
headers = {
    "accept": "application/json",
    "content-type": "apbplication/json",
    "Authorization": "Bearer " + api_key,
}
```

`apbplication/json` is not a valid media type. Cloudflare Workers AI rejects the request with a 4xx, and the error body has no `result.response` key. `CloudflareChatConfig.transform_response` then falls through to `result.get("response_text", "")` and silently sets `choices[0].message.content = ""`. The caller sees a 200-shaped response with empty content even though Cloudflare never actually answered.

A direct `curl` to the same endpoint works because `curl -d` defaults to `application/x-www-form-urlencoded`, which Cloudflare accepts and parses the JSON body content-agnostically.

### After the fix

```diff
-            "content-type": "apbplication/json",
+            "content-type": "application/json",
```

With the corrected `Content-Type`, Cloudflare accepts the request, the response body contains `result.response`, and the chat completion returns the model's actual output.

## Type

🐛 Bug Fix

## Changes

- `litellm/llms/cloudflare/chat/transformation.py`: fix mistyped `content-type` value in `CloudflareChatConfig.validate_environment` (`apbplication/json` -> `application/json`).