### PR TITLE
fix(token-counter): handle Anthropic tool_reference blocks to stop dropped spend logs

### DIFF
--- a/litellm/litellm_core_utils/token_counter.py
+++ b/litellm/litellm_core_utils/token_counter.py
@@ -752,7 +752,7 @@ def _count_content_list(
                 # token_counter raises on tool-search traffic; on the streaming
                 # anthropic_messages path that nulls response_cost and causes the
                 # proxy to drop the SpendLogs row entirely (silent cost undercount).
-                tool_name = str(c.get("tool_name", ""))
+                tool_name = str(c.get("tool_name") or "")
                 if tool_name:
                     num_tokens += count_function(tool_name)
             else:

--- a/litellm/litellm_core_utils/token_counter.py
+++ b/litellm/litellm_core_utils/token_counter.py
@@ -744,6 +744,17 @@ def _count_content_list(
                 thinking_text = str(c.get("thinking", ""))
                 if thinking_text:
                     num_tokens += count_function(thinking_text)
+            elif c["type"] == "tool_reference":
+                # Anthropic tool-search reference block: a lightweight pointer to
+                # a deferred tool, e.g. {"type": "tool_reference", "tool_name": ...}.
+                # The full tool definition is counted via the `tools` param, so we
+                # only count the referenced name here. Without this branch,
+                # token_counter raises on tool-search traffic; on the streaming
+                # anthropic_messages path that nulls response_cost and causes the
+                # proxy to drop the SpendLogs row entirely (silent cost undercount).
+                tool_name = str(c.get("tool_name", ""))
+                if tool_name:
+                    num_tokens += count_function(tool_name)
             else:
                 content_type = (
                     c.get("type", type(c).__name__)
@@ -752,7 +763,7 @@ def _count_content_list(
                 )
                 raise ValueError(
                     f"Invalid content item type: {content_type}. "
-                    f"Expected str or dict with 'type' field (text, image_url, tool_use, tool_result, thinking)."
+                    f"Expected str or dict with 'type' field (text, image_url, tool_use, tool_result, thinking, tool_reference)."
                 )
         return num_tokens
     except Exception as e:

--- a/tests/test_litellm/litellm_core_utils/test_token_counter.py
+++ b/tests/test_litellm/litellm_core_utils/test_token_counter.py
@@ -523,7 +523,6 @@ from unittest.mock import MagicMock, patch
 
 from litellm.utils import _select_tokenizer_helper, claude_json_str, encoding
 
-
 # Clear the cache at module load to ensure clean state
 _select_tokenizer_helper.cache_clear()
 
@@ -1010,3 +1009,43 @@ def test_token_counter_with_thinking_content():
     assert (
         tokens_no_thinking < 15
     ), f"Expected minimal token count for empty thinking block, got {tokens_no_thinking}"
+
+
+def test_token_counter_with_tool_reference_block():
+    """
+    Regression test: a message containing an Anthropic tool-search
+    `tool_reference` content block must NOT raise.
+
+    Before the fix, token_counter raised
+    `Invalid content item type: tool_reference`. On the streaming
+    anthropic_messages proxy path this nulled response_cost and caused the
+    SpendLogs row to be dropped, silently undercounting cost. token_counter
+    must instead count the referenced tool name and return a positive count.
+    """
+    messages = [
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "Let me look up the right tool."},
+                {"type": "tool_reference", "tool_name": "search_knowledge_base"},
+            ],
+        }
+    ]
+
+    # Must not raise, and must produce a positive token count.
+    tokens = token_counter_new(
+        model="anthropic/claude-sonnet-4-5-20250929", messages=messages
+    )
+    assert tokens > 0, f"Expected positive token count, got {tokens}"
+
+    # A tool_reference with no/empty tool_name must also be handled gracefully.
+    messages_empty = [
+        {
+            "role": "assistant",
+            "content": [{"type": "tool_reference", "tool_name": ""}],
+        }
+    ]
+    tokens_empty = token_counter_new(
+        model="anthropic/claude-sonnet-4-5-20250929", messages=messages_empty
+    )
+    assert tokens_empty >= 0

--- a/tests/test_litellm/litellm_core_utils/test_token_counter.py
+++ b/tests/test_litellm/litellm_core_utils/test_token_counter.py
@@ -1049,3 +1049,24 @@ def test_token_counter_with_tool_reference_block():
         model="anthropic/claude-sonnet-4-5-20250929", messages=messages_empty
     )
     assert tokens_empty >= 0
+
+
+def test_count_content_list_rejects_unknown_type():
+    """
+    An unrecognized content block type must raise, and the error message must
+    enumerate the supported types (including `tool_reference`). This pins the
+    catch-all contract so a future block type isn't silently dropped.
+    """
+    from litellm.litellm_core_utils.token_counter import _count_content_list
+
+    with pytest.raises(ValueError) as exc_info:
+        _count_content_list(
+            count_function=len,
+            content_list=[{"type": "totally_unknown_block"}],
+            use_default_image_token_count=False,
+            default_token_count=None,
+        )
+
+    message = str(exc_info.value)
+    assert "Invalid content item type: totally_unknown_block" in message
+    assert "tool_reference" in message

--- a/tests/test_litellm/litellm_core_utils/test_tool_search_spend_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_tool_search_spend_logging.py
@@ -1,0 +1,131 @@
+"""
+Integration / regression tests for Anthropic tool-search (`tool_reference`)
+content blocks on the cost-calculation and streaming-assembly paths used by
+Claude Code.
+
+Claude Code's tool-search feature emits assistant content blocks of the form
+``{"type": "tool_reference", "tool_name": ...}`` -- a lightweight pointer to a
+deferred tool. Before the fix, `token_counter` did not recognise this block
+type and raised ``Invalid content item type: tool_reference``.
+
+Why this matters (the bug these tests guard against):
+
+  * On the cost path, that exception propagates out of ``completion_cost`` ->
+    ``response_cost_calculator``. The proxy logging layer catches it and nulls
+    ``response_cost``; the spend-tracking callback then skips the request, so
+    the entire SpendLogs row is dropped. The request succeeds for the caller
+    but the spend is silently never recorded -- a cost undercount on ALL
+    tool-search traffic.
+
+  * On the streaming-assembly path, ``stream_chunk_builder`` recomputes the
+    prompt tokens from the request messages when the provider stream does not
+    carry usage. The same exception there was swallowed and prompt tokens
+    silently collapsed to 0 -- a quieter undercount of the same traffic.
+
+These tests exercise the real public entry points (not the private
+``_count_content_list`` helper) so the whole chain is covered end to end.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("../../.."))
+
+import litellm
+from litellm import stream_chunk_builder
+from litellm.types.utils import Delta, ModelResponseStream, StreamingChoices
+
+ANTHROPIC_MODEL = "anthropic/claude-sonnet-4-5-20250929"
+
+# Mirrors a Claude Code tool-search turn: a normal text block followed by a
+# `tool_reference` pointer to a deferred tool.
+TOOL_SEARCH_MESSAGES = [
+    {
+        "role": "assistant",
+        "content": [
+            {"type": "text", "text": "Let me look up the right tool."},
+            {"type": "tool_reference", "tool_name": "search_knowledge_base"},
+        ],
+    }
+]
+
+
+def test_completion_cost_with_tool_reference_records_spend():
+    """
+    ``completion_cost`` must return a real, positive cost for messages that
+    contain a tool-search ``tool_reference`` block.
+
+    This is the exact chain that fails on the streaming anthropic_messages
+    proxy path: before the fix ``completion_cost`` raised, the logging layer
+    caught the exception and set ``response_cost = None``, and the spend
+    callback then dropped the SpendLogs row. A positive cost here means the
+    row is recorded instead of silently dropped.
+    """
+    cost = litellm.completion_cost(model=ANTHROPIC_MODEL, messages=TOOL_SEARCH_MESSAGES)
+
+    assert cost is not None, "response_cost is None -> SpendLogs row would be dropped"
+    assert cost > 0, f"Expected a positive cost for tool-search traffic, got {cost}"
+
+
+def test_completion_cost_with_empty_tool_name_records_spend():
+    """A ``tool_reference`` with an empty/missing ``tool_name`` must also cost
+    out cleanly rather than raising and nulling the spend."""
+    messages = [
+        {
+            "role": "assistant",
+            "content": [{"type": "tool_reference", "tool_name": ""}],
+        }
+    ]
+
+    cost = litellm.completion_cost(model=ANTHROPIC_MODEL, messages=messages)
+
+    assert cost is not None
+    assert cost >= 0
+
+
+def test_stream_chunk_builder_counts_prompt_tokens_for_tool_reference():
+    """
+    On the streaming-assembly path used by Claude Code, when the provider
+    stream carries no prompt-token usage, ``stream_chunk_builder`` recomputes
+    prompt tokens from the request messages via ``token_counter``.
+
+    With a ``tool_reference`` block in those messages the count must be
+    positive. Before the fix the underlying ``token_counter`` call raised and
+    the assembler swallowed it, collapsing ``prompt_tokens`` to 0 -- a silent
+    undercount of every tool-search request.
+    """
+    model = "claude-sonnet-4-5-20250929"
+    # Chunks deliberately carry no usage, forcing the prompt-token fallback.
+    chunks = [
+        ModelResponseStream(
+            id="chatcmpl-tool-search",
+            created=1700000000,
+            model=model,
+            object="chat.completion.chunk",
+            choices=[
+                StreamingChoices(
+                    finish_reason=None,
+                    index=0,
+                    delta=Delta(content="Searching...", role="assistant"),
+                )
+            ],
+        ),
+        ModelResponseStream(
+            id="chatcmpl-tool-search",
+            created=1700000000,
+            model=model,
+            object="chat.completion.chunk",
+            choices=[
+                StreamingChoices(
+                    finish_reason="stop", index=0, delta=Delta(content="")
+                ),
+            ],
+        ),
+    ]
+
+    response = stream_chunk_builder(chunks, messages=TOOL_SEARCH_MESSAGES)
+
+    assert response is not None
+    assert (
+        response.usage.prompt_tokens > 0
+    ), "prompt_tokens collapsed to 0 -> tool-search traffic silently undercounted"


### PR DESCRIPTION
## Type

🐛 Bug Fix

## Changes

`token_counter` did not know about Anthropic tool-search `tool_reference` content blocks — a lightweight pointer to a deferred tool that shows up as `{"type": "tool_reference", "tool_name": ...}`. When such a block appeared in message content, `_count_content_list` fell through to its catch-all branch and raised `Invalid content item type: tool_reference`.

That raise has real spend-tracking impact. On the cost path, `completion_cost` falls back to `token_counter(model=model, messages=messages)` whenever the provider response carries no usage (`cost_calculator.py`). The exception is then swallowed in `_response_cost_calculator` (`litellm_logging.py`), which nulls `response_cost`. In the proxy success callback (`proxy_track_cost_callback.py`) the SpendLogs insert is gated behind `if response_cost is not None:` — when it's `None`, the callback raises instead of inserting, so the **entire SpendLogs row is dropped**. The request succeeds for the caller but the spend is never recorded — a silent cost undercount on tool-search traffic. Verified this drop path is present on both `release/v1.86.2` and `release/v1.87.2`.

This adds a `tool_reference` branch that counts the referenced `tool_name` (the full tool definition is already counted via the `tools` param, so only the name is added here) and handles an empty/missing name gracefully. The catch-all error message is updated to list `tool_reference` among the expected types.

## Tests

- `test_token_counter.py`: `tool_reference` block returns a positive count and no longer raises; empty `tool_name` handled gracefully; catch-all rejects unknown block types with the updated message.
- `test_tool_search_spend_logging.py`: end-to-end coverage on the real spend/cost entry points — `completion_cost` returns a positive cost for a `tool_reference` message (row recorded, not dropped), and `stream_chunk_builder` counts prompt tokens instead of collapsing to 0. Verified these fail without the fix and pass with it.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
