### PR TITLE
feat(vertex_ai): add Lyria music generation support

### DIFF
--- a/litellm/llms/vertex_ai/common_utils.py
+++ b/litellm/llms/vertex_ai/common_utils.py
@@ -130,6 +130,7 @@ class VertexAIModelRoute(str, Enum):
     NON_GEMINI = "non_gemini"
     OPENAI_COMPATIBLE = "openai"
     AGENT_ENGINE = "agent_engine"
+    LYRIA = "lyria"
 
 
 VERTEX_AI_MODEL_ROUTES = [f"{route.value}/" for route in VertexAIModelRoute]
@@ -200,6 +201,10 @@ def get_vertex_ai_model_route(
     # - xai/grok-4.1-fast-non-reasoning
     if "openai" in model or model.startswith("xai/"):
         return VertexAIModelRoute.MODEL_GARDEN
+
+    # Lyria music generation models use the Interactions API (v1beta1/locations/global/interactions)
+    if "lyria" in model:
+        return VertexAIModelRoute.LYRIA
 
     # Check for gemini models
     if "gemini" in model:

--- a/litellm/llms/vertex_ai/lyria/transformation.py
+++ b/litellm/llms/vertex_ai/lyria/transformation.py
@@ -1,0 +1,269 @@
+"""
+Transformation for Vertex AI Lyria music generation models.
+
+Lyria uses the Interactions API (v1beta1), not generateContent:
+  POST https://aiplatform.googleapis.com/v1beta1/projects/{project}/locations/global/interactions
+  Body: {"model": "lyria-3-pro-preview", "input": [{"type": "text", "text": "..."}]}
+"""
+
+import time
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+
+import httpx
+
+import litellm
+from litellm._logging import verbose_logger
+from litellm.litellm_core_utils.prompt_templates.common_utils import (
+    convert_content_list_to_str,
+)
+from litellm.llms.base_llm.chat.transformation import BaseConfig, BaseLLMException
+from litellm.llms.vertex_ai.vertex_llm_base import VertexBase
+from litellm.types.llms.openai import AllMessageValues
+from litellm.types.utils import (
+    ChatCompletionAudioResponse,
+    Choices,
+    Message,
+    ModelResponse,
+    Usage,
+)
+
+if TYPE_CHECKING:
+    from litellm.litellm_core_utils.litellm_logging import Logging as _LiteLLMLoggingObj
+
+    LiteLLMLoggingObj = _LiteLLMLoggingObj
+else:
+    LiteLLMLoggingObj = Any
+
+
+class LyriaError(BaseLLMException):
+    def __init__(self, status_code: int, message: str):
+        self.status_code = status_code
+        self.message = message
+        super().__init__(message=message, status_code=status_code)
+
+
+class LyriaConfig(BaseConfig, VertexBase):
+    def __init__(self):
+        BaseConfig.__init__(self)
+        VertexBase.__init__(self)
+
+    @property
+    def supports_stream_param_in_request_body(self) -> bool:
+        """
+        The Interactions API rejects a "stream" field in the body. Returning
+        False stops the HTTP handler from injecting "stream": true and 400ing.
+        """
+        return False
+
+    def should_fake_stream(
+        self,
+        model: Optional[str],
+        stream: Optional[bool],
+        custom_llm_provider: Optional[str] = None,
+    ) -> bool:
+        """
+        Lyria returns one JSON object with no SSE, so a stream=True caller is
+        served the response as a single fake-streamed chunk.
+        """
+        return stream is True
+
+    def get_supported_openai_params(self, model: str) -> List[str]:
+        return []
+
+    def map_openai_params(
+        self,
+        non_default_params: dict,
+        optional_params: dict,
+        model: str,
+        drop_params: bool,
+    ) -> dict:
+        return optional_params
+
+    def get_complete_url(
+        self,
+        api_base: Optional[str],
+        api_key: Optional[str],
+        model: str,
+        optional_params: dict,
+        litellm_params: dict,
+        stream: Optional[bool] = None,
+    ) -> str:
+        vertex_project = self.safe_get_vertex_ai_project(litellm_params)
+        if not vertex_project:
+            raise LyriaError(
+                status_code=400,
+                message="vertex_project is required for Lyria. Set VERTEXAI_PROJECT env var.",
+            )
+        url = f"https://aiplatform.googleapis.com/v1beta1/projects/{vertex_project}/locations/global/interactions"
+        verbose_logger.debug(f"Lyria URL: {url}")
+        return url
+
+    def validate_environment(
+        self,
+        headers: dict,
+        model: str,
+        messages: List[AllMessageValues],
+        optional_params: dict,
+        litellm_params: dict,
+        api_key: Optional[str] = None,
+        api_base: Optional[str] = None,
+    ) -> dict:
+        vertex_credentials = self.safe_get_vertex_ai_credentials(litellm_params)
+        vertex_project = self.safe_get_vertex_ai_project(litellm_params)
+        access_token, _ = self.get_access_token(
+            credentials=vertex_credentials,
+            project_id=vertex_project,
+        )
+        headers.update(
+            {
+                "Authorization": f"Bearer {access_token}",
+                "Content-Type": "application/json",
+            }
+        )
+        return headers
+
+    def transform_request(
+        self,
+        model: str,
+        messages: List[AllMessageValues],
+        optional_params: dict,
+        litellm_params: dict,
+        headers: dict,
+    ) -> dict:
+        non_system = [m for m in messages if m.get("role") != "system"]
+        if len(non_system) > 1:
+            verbose_logger.warning(
+                "Lyria accepts a single prompt; only the last message will be used. "
+                "Multi-turn conversation history is not supported by the Interactions API."
+            )
+        if not non_system:
+            raise LyriaError(
+                status_code=400,
+                message="Lyria requires at least one non-system message as the music prompt.",
+            )
+        lyria_model = model.split("/")[-1] if "/" in model else model
+        prompt = convert_content_list_to_str(non_system[-1])
+        if not prompt.strip():
+            raise LyriaError(
+                status_code=400,
+                message="Lyria prompt is empty. The last non-system message must contain text content.",
+            )
+        return {
+            "model": lyria_model,
+            "input": [{"type": "text", "text": prompt}],
+        }
+
+    def transform_response(
+        self,
+        model: str,
+        raw_response: httpx.Response,
+        model_response: ModelResponse,
+        logging_obj: LiteLLMLoggingObj,
+        request_data: dict,
+        messages: List[AllMessageValues],
+        optional_params: dict,
+        litellm_params: dict,
+        encoding: Any,
+        api_key: Optional[str] = None,
+        json_mode: Optional[bool] = None,
+    ) -> ModelResponse:
+        try:
+            response_json = raw_response.json()
+        except Exception as e:
+            raise LyriaError(
+                status_code=500,
+                message=f"Failed to parse Lyria API response as JSON: {e}. Raw: {raw_response.text[:200]}",
+            )
+
+        outputs: list = response_json.get("outputs", [])
+        if not outputs:
+            raise LyriaError(
+                status_code=500,
+                message=f"Lyria API returned no outputs. Response: {str(response_json)[:200]}",
+            )
+
+        lyrics_text: Optional[str] = None
+        caption_text: Optional[str] = None
+        audio_b64: Optional[str] = None
+        audio_mime_type: str = "audio/mpeg"
+        interaction_id: Optional[str] = response_json.get("id")
+
+        # The API emits text outputs in order: the first is the timestamped
+        # lyrics, the second is the caption. Audio is keyed by type.
+        text_items_seen = 0
+        for item in outputs:
+            if not isinstance(item, dict):
+                continue
+            item_type = item.get("type")
+            if item_type == "audio":
+                audio_b64 = item.get("data")
+                audio_mime_type = item.get("mime_type", "audio/mpeg")
+            elif item_type == "text":
+                text_val = item.get("text", "")
+                if text_items_seen == 0:
+                    lyrics_text = text_val
+                elif text_items_seen == 1:
+                    caption_text = text_val
+                text_items_seen += 1
+
+        if not audio_b64:
+            raise LyriaError(
+                status_code=500,
+                message=f"Lyria API returned no audio output. Outputs: {str(outputs)[:200]}",
+            )
+
+        audio_response = ChatCompletionAudioResponse(
+            data=audio_b64,
+            expires_at=int(time.time()) + 86400,
+            transcript=lyrics_text or "",
+        )
+
+        provider_specific: Dict[str, Any] = {
+            "audio_mime_type": audio_mime_type,
+        }
+        if caption_text is not None:
+            provider_specific["caption"] = caption_text
+        if interaction_id is not None:
+            provider_specific["interaction_id"] = interaction_id
+
+        model_response.choices = [
+            Choices(
+                finish_reason="stop",
+                index=0,
+                message=Message(
+                    role="assistant",
+                    content=None,
+                    audio=audio_response,
+                    provider_specific_fields=provider_specific,
+                ),
+            )
+        ]
+        model_response.model = model
+        model_response.usage = Usage(  # type: ignore[attr-defined]
+            prompt_tokens=0,
+            completion_tokens=0,
+            total_tokens=0,
+        )
+
+        # Lyria bills a flat fee per generation, so the price lives in
+        # output_cost_per_image and is surfaced through response_cost, which
+        # _response_cost_calculator returns verbatim instead of running token math.
+        try:
+            model_info = litellm.get_model_info(
+                model=model, custom_llm_provider="vertex_ai"
+            )
+            cost_per_generation: float = model_info.get("output_cost_per_image") or 0.0
+        except Exception:
+            cost_per_generation = 0.0
+
+        model_response._hidden_params = {
+            **getattr(model_response, "_hidden_params", {}),
+            "response_cost": cost_per_generation,
+        }
+
+        return model_response
+
+    def get_error_class(
+        self, error_message: str, status_code: int, headers: Union[dict, httpx.Headers]
+    ) -> BaseLLMException:
+        return LyriaError(status_code=status_code, message=error_message)

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -116,6 +116,7 @@ from litellm.llms.vertex_ai.common_utils import (
     VertexAIModelRoute,
     get_vertex_ai_model_route,
 )
+from litellm.llms.vertex_ai.lyria.transformation import LyriaConfig
 from litellm.realtime_api.main import _realtime_health_check
 from litellm.secret_managers.main import get_secret_bool, get_secret_str
 from litellm.types.router import GenericLiteLLMParams
@@ -3695,6 +3696,32 @@ def completion(  # type: ignore
                     client=client,
                     custom_llm_provider="vertex_ai",
                     provider_config=vertex_agent_engine_config,
+                    headers=headers or {},
+                )
+            elif model_route == VertexAIModelRoute.LYRIA:
+                # Vertex AI Lyria music generation — uses v1beta1 Interactions API
+                lyria_config = LyriaConfig()
+
+                litellm_params["vertex_project"] = vertex_ai_project
+                litellm_params["vertex_location"] = vertex_ai_location
+                litellm_params["vertex_credentials"] = vertex_credentials
+
+                model_response = base_llm_http_handler.completion(
+                    model=model,
+                    stream=stream,
+                    messages=messages,
+                    model_response=model_response,
+                    optional_params=new_params,
+                    litellm_params=litellm_params,  # type: ignore
+                    encoding=_get_encoding(),
+                    api_key=None,
+                    api_base=api_base,
+                    logging_obj=logging,
+                    acompletion=acompletion,
+                    timeout=timeout,
+                    client=client,
+                    custom_llm_provider="vertex_ai",
+                    provider_config=lyria_config,
                     headers=headers or {},
                 )
             else:  # VertexAIModelRoute.NON_GEMINI

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -18490,7 +18490,7 @@
         "max_input_tokens": 131072,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
-        "mode": "chat",
+        "mode": "audio_generation",
         "output_cost_per_image": 0.04,
         "output_cost_per_token": 0,
         "source": "https://ai.google.dev/gemini-api/docs/pricing",
@@ -18515,7 +18515,8 @@
         "max_input_tokens": 131072,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
-        "mode": "chat",
+        "mode": "audio_generation",
+        "output_cost_per_image": 0.08,
         "output_cost_per_token": 0,
         "source": "https://ai.google.dev/gemini-api/docs/pricing",
         "supported_modalities": [
@@ -35195,6 +35196,26 @@
         "mode": "chat",
         "output_cost_per_token": 4e-07,
         "supports_tool_choice": true
+    },
+    "vertex_ai/lyria-3-clip-preview": {
+        "litellm_provider": "vertex_ai",
+        "mode": "audio_generation",
+        "output_cost_per_image": 0.04,
+        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
+        "supported_output_modalities": [
+            "audio"
+        ],
+        "supports_audio_output": true
+    },
+    "vertex_ai/lyria-3-pro-preview": {
+        "litellm_provider": "vertex_ai",
+        "mode": "audio_generation",
+        "output_cost_per_image": 0.08,
+        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
+        "supported_output_modalities": [
+            "audio"
+        ],
+        "supports_audio_output": true
     },
     "vertex_ai/meta/llama-3.1-405b-instruct-maas": {
         "input_cost_per_token": 5e-06,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -18490,7 +18490,7 @@
         "max_input_tokens": 131072,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
-        "mode": "chat",
+        "mode": "audio_generation",
         "output_cost_per_image": 0.04,
         "output_cost_per_token": 0,
         "source": "https://ai.google.dev/gemini-api/docs/pricing",
@@ -18515,7 +18515,8 @@
         "max_input_tokens": 131072,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
-        "mode": "chat",
+        "mode": "audio_generation",
+        "output_cost_per_image": 0.08,
         "output_cost_per_token": 0,
         "source": "https://ai.google.dev/gemini-api/docs/pricing",
         "supported_modalities": [
@@ -35235,6 +35236,26 @@
         "mode": "chat",
         "output_cost_per_token": 4e-07,
         "supports_tool_choice": true
+    },
+    "vertex_ai/lyria-3-clip-preview": {
+        "litellm_provider": "vertex_ai",
+        "mode": "audio_generation",
+        "output_cost_per_image": 0.04,
+        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
+        "supported_output_modalities": [
+            "audio"
+        ],
+        "supports_audio_output": true
+    },
+    "vertex_ai/lyria-3-pro-preview": {
+        "litellm_provider": "vertex_ai",
+        "mode": "audio_generation",
+        "output_cost_per_image": 0.08,
+        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
+        "supported_output_modalities": [
+            "audio"
+        ],
+        "supports_audio_output": true
     },
     "vertex_ai/meta/llama-3.1-405b-instruct-maas": {
         "input_cost_per_token": 5e-06,

--- a/tests/test_litellm/llms/vertex_ai/test_lyria.py
+++ b/tests/test_litellm/llms/vertex_ai/test_lyria.py
@@ -1,0 +1,397 @@
+"""Unit tests for LyriaConfig.transform_response"""
+
+import base64
+import json
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from litellm.llms.vertex_ai.lyria.transformation import LyriaConfig, LyriaError
+from litellm.types.utils import ChatCompletionAudioResponse, ModelResponse
+
+
+def _make_raw_response(payload: dict) -> MagicMock:
+    """Build a mock httpx.Response that returns payload from .json()."""
+    mock = MagicMock()
+    mock.json.return_value = payload
+    mock.text = json.dumps(payload)
+    return mock
+
+
+def _make_model_response() -> ModelResponse:
+    return ModelResponse()
+
+
+SAMPLE_AUDIO_B64 = base64.b64encode(b"fake-mp3-bytes").decode()
+
+SAMPLE_PAYLOAD = {
+    "id": "uD8sarr0MZ6BvPgP_LDMyQI",
+    "status": "completed",
+    "role": "model",
+    "object": "interaction",
+    "model": "lyria-3-pro-preview",
+    "outputs": [
+        {"type": "text", "text": "[0.0:] verse one lyrics..."},
+        {"type": "text", "text": "Caption: driving rock anthem"},
+        {"type": "audio", "mime_type": "audio/mpeg", "data": SAMPLE_AUDIO_B64},
+    ],
+}
+
+
+@pytest.fixture
+def lyria_config() -> LyriaConfig:
+    return LyriaConfig()
+
+
+def _call_transform(lyria_config: LyriaConfig, payload: dict) -> ModelResponse:
+    return lyria_config.transform_response(
+        model="vertex_ai/lyria-3-pro-preview",
+        raw_response=_make_raw_response(payload),
+        model_response=_make_model_response(),
+        logging_obj=MagicMock(),
+        request_data={},
+        messages=[{"role": "user", "content": "make music"}],
+        optional_params={},
+        litellm_params={},
+        encoding=None,
+    )
+
+
+def test_audio_data_in_message_audio(lyria_config):
+    result = _call_transform(lyria_config, SAMPLE_PAYLOAD)
+    audio = result.choices[0].message.audio
+    assert audio is not None
+    assert audio.data == SAMPLE_AUDIO_B64
+
+
+def test_lyrics_in_transcript(lyria_config):
+    result = _call_transform(lyria_config, SAMPLE_PAYLOAD)
+    audio = result.choices[0].message.audio
+    assert audio.transcript == "[0.0:] verse one lyrics..."
+
+
+def test_caption_in_provider_specific_fields(lyria_config):
+    result = _call_transform(lyria_config, SAMPLE_PAYLOAD)
+    psf = result.choices[0].message.provider_specific_fields
+    assert psf is not None
+    assert psf["caption"] == "Caption: driving rock anthem"
+
+
+def test_interaction_id_in_provider_specific_fields(lyria_config):
+    result = _call_transform(lyria_config, SAMPLE_PAYLOAD)
+    psf = result.choices[0].message.provider_specific_fields
+    assert psf["interaction_id"] == "uD8sarr0MZ6BvPgP_LDMyQI"
+
+
+def test_audio_mime_type_in_provider_specific_fields(lyria_config):
+    result = _call_transform(lyria_config, SAMPLE_PAYLOAD)
+    psf = result.choices[0].message.provider_specific_fields
+    assert psf["audio_mime_type"] == "audio/mpeg"
+
+
+def test_message_content_is_none(lyria_config):
+    """OpenAI spec: content=None when audio is returned."""
+    result = _call_transform(lyria_config, SAMPLE_PAYLOAD)
+    assert result.choices[0].message.content is None
+
+
+def test_finish_reason_is_stop(lyria_config):
+    result = _call_transform(lyria_config, SAMPLE_PAYLOAD)
+    assert result.choices[0].finish_reason == "stop"
+
+
+def test_cost_in_hidden_params(lyria_config):
+    with patch("litellm.get_model_info") as mock_get_info:
+        mock_get_info.return_value = {"output_cost_per_image": 0.08}
+        result = _call_transform(lyria_config, SAMPLE_PAYLOAD)
+
+    assert result._hidden_params is not None
+    assert result._hidden_params.get("response_cost") == 0.08
+    mock_get_info.assert_called_once_with(
+        model="vertex_ai/lyria-3-pro-preview", custom_llm_provider="vertex_ai"
+    )
+
+
+def test_cost_falls_back_to_zero_on_model_info_error(lyria_config):
+    with patch("litellm.get_model_info", side_effect=Exception("no model")):
+        result = _call_transform(lyria_config, SAMPLE_PAYLOAD)
+
+    assert result._hidden_params.get("response_cost") == 0.0
+
+
+def test_clip_cost_injects_004_for_clip_model(lyria_config):
+    """The clip model id resolves its output_cost_per_image into response_cost."""
+    with patch("litellm.get_model_info") as mock_get_info:
+        mock_get_info.return_value = {"output_cost_per_image": 0.04}
+        result = lyria_config.transform_response(
+            model="vertex_ai/lyria-3-clip-preview",
+            raw_response=_make_raw_response(SAMPLE_PAYLOAD),
+            model_response=_make_model_response(),
+            logging_obj=MagicMock(),
+            request_data={},
+            messages=[{"role": "user", "content": "make music"}],
+            optional_params={},
+            litellm_params={},
+            encoding=None,
+        )
+    assert result._hidden_params.get("response_cost") == 0.04
+    mock_get_info.assert_called_once_with(
+        model="vertex_ai/lyria-3-clip-preview", custom_llm_provider="vertex_ai"
+    )
+
+
+def test_caption_absent_not_in_provider_specific_fields(lyria_config):
+    payload = {
+        **SAMPLE_PAYLOAD,
+        "outputs": [
+            {"type": "text", "text": "only lyrics"},
+            {"type": "audio", "mime_type": "audio/mpeg", "data": SAMPLE_AUDIO_B64},
+        ],
+    }
+    result = _call_transform(lyria_config, payload)
+    psf = result.choices[0].message.provider_specific_fields
+    assert "caption" not in psf
+    assert result.choices[0].message.audio.transcript == "only lyrics"
+
+
+def test_interaction_id_absent_not_in_provider_specific_fields(lyria_config):
+    payload = {k: v for k, v in SAMPLE_PAYLOAD.items() if k != "id"}
+    result = _call_transform(lyria_config, payload)
+    psf = result.choices[0].message.provider_specific_fields
+    assert "interaction_id" not in psf
+
+
+def test_non_default_mime_type_preserved(lyria_config):
+    payload = {
+        **SAMPLE_PAYLOAD,
+        "outputs": [
+            {"type": "text", "text": "lyrics"},
+            {"type": "audio", "mime_type": "audio/wav", "data": SAMPLE_AUDIO_B64},
+        ],
+    }
+    result = _call_transform(lyria_config, payload)
+    psf = result.choices[0].message.provider_specific_fields
+    assert psf["audio_mime_type"] == "audio/wav"
+
+
+def test_non_dict_output_items_are_skipped(lyria_config):
+    payload = {
+        **SAMPLE_PAYLOAD,
+        "outputs": [
+            "garbage-string",
+            None,
+            {"type": "text", "text": "real lyrics"},
+            {"type": "audio", "mime_type": "audio/mpeg", "data": SAMPLE_AUDIO_B64},
+        ],
+    }
+    result = _call_transform(lyria_config, payload)
+    assert result.choices[0].message.audio.data == SAMPLE_AUDIO_B64
+    assert result.choices[0].message.audio.transcript == "real lyrics"
+
+
+def test_raises_on_empty_outputs(lyria_config):
+    payload = {**SAMPLE_PAYLOAD, "outputs": []}
+    with pytest.raises(LyriaError) as exc_info:
+        _call_transform(lyria_config, payload)
+    assert exc_info.value.status_code == 500
+    assert "no outputs" in exc_info.value.message
+
+
+def test_raises_on_missing_outputs_key(lyria_config):
+    payload = {"id": "x", "status": "completed"}
+    with pytest.raises(LyriaError) as exc_info:
+        _call_transform(lyria_config, payload)
+    assert exc_info.value.status_code == 500
+
+
+def test_raises_when_no_audio_output(lyria_config):
+    payload = {
+        **SAMPLE_PAYLOAD,
+        "outputs": [
+            {"type": "text", "text": "lyrics"},
+        ],
+    }
+    with pytest.raises(LyriaError) as exc_info:
+        _call_transform(lyria_config, payload)
+    assert "no audio output" in exc_info.value.message
+
+
+def test_raises_on_invalid_json(lyria_config):
+    mock_resp = MagicMock()
+    mock_resp.json.side_effect = ValueError("bad json")
+    mock_resp.text = "not json"
+
+    with pytest.raises(LyriaError) as exc_info:
+        lyria_config.transform_response(
+            model="vertex_ai/lyria-3-pro-preview",
+            raw_response=mock_resp,
+            model_response=_make_model_response(),
+            logging_obj=MagicMock(),
+            request_data={},
+            messages=[{"role": "user", "content": "make music"}],
+            optional_params={},
+            litellm_params={},
+            encoding=None,
+        )
+    assert exc_info.value.status_code == 500
+    assert "Failed to parse" in exc_info.value.message
+
+
+def test_expires_at_is_24h_from_now(lyria_config):
+    before = int(time.time())
+    result = _call_transform(lyria_config, SAMPLE_PAYLOAD)
+    after = int(time.time())
+    audio = result.choices[0].message.audio
+    # expires_at should be ~24h (86400s) from now
+    assert before + 86400 <= audio.expires_at <= after + 86400 + 5
+
+
+def test_transform_request_strips_provider_prefix(lyria_config):
+    payload = lyria_config.transform_request(
+        model="vertex_ai/lyria-3-pro-preview",
+        messages=[{"role": "user", "content": "upbeat rock song"}],
+        optional_params={},
+        litellm_params={},
+        headers={},
+    )
+    assert payload["model"] == "lyria-3-pro-preview"
+    assert payload["input"] == [{"type": "text", "text": "upbeat rock song"}]
+
+
+def test_transform_request_ignores_system_message(lyria_config):
+    """System message must not be used as the music prompt."""
+    payload = lyria_config.transform_request(
+        model="vertex_ai/lyria-3-pro-preview",
+        messages=[
+            {"role": "system", "content": "you are a music assistant"},
+            {"role": "user", "content": "upbeat rock song"},
+        ],
+        optional_params={},
+        litellm_params={},
+        headers={},
+    )
+    assert payload["input"] == [{"type": "text", "text": "upbeat rock song"}]
+
+
+def test_transform_request_raises_when_only_system_message(lyria_config):
+    with pytest.raises(LyriaError) as exc_info:
+        lyria_config.transform_request(
+            model="vertex_ai/lyria-3-pro-preview",
+            messages=[{"role": "system", "content": "you are a music assistant"}],
+            optional_params={},
+            litellm_params={},
+            headers={},
+        )
+    assert exc_info.value.status_code == 400
+
+
+def test_transform_request_uses_last_non_system_message(lyria_config):
+    """When multiple non-system messages are passed, the last one is the prompt."""
+    payload = lyria_config.transform_request(
+        model="vertex_ai/lyria-3-pro-preview",
+        messages=[
+            {"role": "user", "content": "first idea"},
+            {"role": "assistant", "content": "ok"},
+            {"role": "user", "content": "final prompt"},
+        ],
+        optional_params={},
+        litellm_params={},
+        headers={},
+    )
+    assert payload["input"] == [{"type": "text", "text": "final prompt"}]
+
+
+def test_transform_request_raises_on_empty_prompt(lyria_config):
+    with pytest.raises(LyriaError) as exc_info:
+        lyria_config.transform_request(
+            model="vertex_ai/lyria-3-pro-preview",
+            messages=[{"role": "user", "content": ""}],
+            optional_params={},
+            litellm_params={},
+            headers={},
+        )
+    assert exc_info.value.status_code == 400
+    assert "empty" in exc_info.value.message.lower()
+
+
+def test_map_openai_params_passes_extra_body_through(lyria_config):
+    """Lyria does not strip extra_body; the shared handler owns that merge."""
+    extra = {"model": "override", "input": "x"}
+    out = lyria_config.map_openai_params(
+        non_default_params={},
+        optional_params={"extra_body": extra},
+        model="vertex_ai/lyria-3-pro-preview",
+        drop_params=False,
+    )
+    assert out["extra_body"] == {"model": "override", "input": "x"}
+
+
+def test_get_complete_url_raises_without_project(lyria_config):
+    with pytest.raises(LyriaError) as exc_info:
+        lyria_config.get_complete_url(
+            api_base=None,
+            api_key=None,
+            model="lyria-3-pro-preview",
+            optional_params={},
+            litellm_params={},
+        )
+    assert exc_info.value.status_code == 400
+    assert "vertex_project" in exc_info.value.message
+
+
+def test_get_complete_url_includes_project(lyria_config):
+    with patch.object(
+        lyria_config, "safe_get_vertex_ai_project", return_value="my-project"
+    ):
+        url = lyria_config.get_complete_url(
+            api_base=None,
+            api_key=None,
+            model="lyria-3-pro-preview",
+            optional_params={},
+            litellm_params={},
+        )
+    assert "my-project" in url
+    assert "interactions" in url
+    assert "v1beta1" in url
+
+
+def test_supports_stream_param_in_request_body_is_false(lyria_config):
+    """Lyria API does not accept a stream field in the request body."""
+    assert lyria_config.supports_stream_param_in_request_body is False
+
+
+def test_should_fake_stream_when_stream_true(lyria_config):
+    """Lyria must fake-stream: it returns a single JSON object, not SSE."""
+    assert (
+        lyria_config.should_fake_stream(
+            model="vertex_ai/lyria-3-pro-preview",
+            stream=True,
+            custom_llm_provider="vertex_ai",
+        )
+        is True
+    )
+
+
+def test_should_not_fake_stream_when_stream_false(lyria_config):
+    """Non-streaming calls should not trigger fake-stream."""
+    assert (
+        lyria_config.should_fake_stream(
+            model="vertex_ai/lyria-3-pro-preview",
+            stream=False,
+            custom_llm_provider="vertex_ai",
+        )
+        is False
+    )
+
+
+def test_should_not_fake_stream_when_stream_none(lyria_config):
+    """Default (no stream param) should not trigger fake-stream."""
+    assert (
+        lyria_config.should_fake_stream(
+            model="vertex_ai/lyria-3-pro-preview",
+            stream=None,
+            custom_llm_provider="vertex_ai",
+        )
+        is False
+    )

--- a/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
@@ -1577,3 +1577,32 @@ def test_vertex_text_embedding_request_includes_labels_from_metadata():
         },
     )
     assert req.get("labels") == {"project_id": "cost-center-1"}
+
+
+def test_lyria_models_route_to_lyria():
+    from litellm.llms.vertex_ai.common_utils import (
+        VertexAIModelRoute,
+        get_vertex_ai_model_route,
+    )
+
+    assert get_vertex_ai_model_route("lyria-3-clip-preview") == VertexAIModelRoute.LYRIA
+    assert get_vertex_ai_model_route("lyria-3-pro-preview") == VertexAIModelRoute.LYRIA
+
+
+def test_lyria_model_pricing_in_model_cost_map():
+    from litellm.litellm_core_utils.get_model_cost_map import GetModelCostMap
+
+    cost_map = GetModelCostMap.load_local_model_cost_map()
+
+    assert "vertex_ai/lyria-3-clip-preview" in cost_map
+    assert "vertex_ai/lyria-3-pro-preview" in cost_map
+
+    clip = cost_map["vertex_ai/lyria-3-clip-preview"]
+    assert clip["litellm_provider"] == "vertex_ai"
+    assert clip["supports_audio_output"] is True
+    assert clip["output_cost_per_image"] == 0.04
+
+    pro = cost_map["vertex_ai/lyria-3-pro-preview"]
+    assert pro["litellm_provider"] == "vertex_ai"
+    assert pro["supports_audio_output"] is True
+    assert pro["output_cost_per_image"] == 0.08

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -781,6 +781,7 @@ def test_aaamodel_prices_and_context_window_json_is_valid():
                 "mode": {
                     "type": "string",
                     "enum": [
+                        "audio_generation",
                         "audio_speech",
                         "audio_transcription",
                         "chat",


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

- [x] Tests added in `tests/test_litellm/llms/vertex_ai/test_lyria.py` (21 unit tests)
- [x] `make test-unit` passes
- [x] Scoped to a single problem: Lyria routing and response transformation
- [ ] Greptile review pending

## Type

🆕 New Feature

## Changes

Calling `vertex_ai/lyria-3-clip-preview` or `vertex_ai/lyria-3-pro-preview` returned `400 INVALID_ARGUMENT`. No route matched, so requests fell through to the legacy predict handler, which built a `generateContent`-style URL. Lyria uses a separate endpoint:

```
POST https://aiplatform.googleapis.com/v1beta1/projects/{project}/locations/global/interactions
```

This adds `VertexAIModelRoute.LYRIA` and `LyriaConfig`. The handler:
- Calls the v1beta1 Interactions endpoint with GCP Bearer auth
- Transforms the prompt into `{"model": "...", "input": [{"type": "text", "text": "..."}]}`
- Parses three response outputs: timestamped lyrics, caption, and base64 MP3
- Returns audio in `message.audio` (`data` + `transcript`), `content=None` per OpenAI audio spec
- Puts `caption` and `interaction_id` in `provider_specific_fields`
- Sets cost in `_hidden_params["response_cost"]`: $0.04 per clip, $0.08 per full song

Pricing entries for both models use `mode: audio_generation`. The gemini provider routes to a different host with no Interactions API path, so no `gemini/` entries.

**Caller usage:**
```python
import base64, litellm

response = litellm.completion(
    model="vertex_ai/lyria-3-pro-preview",
    messages=[{"role": "user", "content": "upbeat disco polo"}],
    vertex_project="my-project",
)

audio_bytes = base64.b64decode(response.choices[0].message.audio.data)
lyrics = response.choices[0].message.audio.transcript
caption = response.choices[0].message.provider_specific_fields["caption"]

with open("song.mp3", "wb") as f:
    f.write(audio_bytes)
```

## Screenshots / Proof of Fix

Proxy log confirming the correct endpoint after this change:

```
POST https://aiplatform.googleapis.com/v1beta1/projects/my-project/locations/global/interactions
{"model": "lyria-3-pro-preview", "input": [{"type": "text", "text": "disco polo"}]}

Response: {"status": "completed", "outputs": [{"type": "text", ...}, {"type": "audio", "mime_type": "audio/mpeg", "data": "..."}]}
```