### PR TITLE
fix(ui): gate dashboard layout on ui config load so deep links work under SERVER_ROOT_PATH

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/layout.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/layout.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { AuthProvider } from "@/contexts/AuthContext";
+import Layout from "./layout";
+
+vi.mock("next/navigation", () => ({
+  useRouter: vi.fn(() => ({ push: vi.fn(), replace: vi.fn() })),
+  useSearchParams: vi.fn(() => new URLSearchParams()),
+  usePathname: vi.fn(() => "/ui/guardrails"),
+}));
+
+vi.mock("@/components/navbar", () => ({
+  default: () => <div data-testid="navbar" />,
+}));
+
+vi.mock("@/app/(dashboard)/components/SidebarProvider", () => ({
+  default: () => <div data-testid="sidebar" />,
+}));
+
+vi.mock("@/components/DebugWarningBanner", () => ({
+  DebugWarningBanner: () => null,
+}));
+
+vi.mock("@/contexts/ThemeContext", () => ({
+  ThemeProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/common_components/LoadingScreen", () => ({
+  default: () => <div data-testid="loading-screen" />,
+}));
+
+const deferred = (() => {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+})();
+
+vi.mock("@/components/networking", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/components/networking")>();
+  return {
+    ...actual,
+    getUiConfig: vi.fn(() => deferred.promise),
+    setGlobalLitellmHeaderName: vi.fn(),
+  };
+});
+
+describe("(dashboard) Layout", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not mount route content until getUiConfig has resolved", async () => {
+    render(
+      <AuthProvider>
+        <Layout>
+          <div data-testid="page-content" />
+        </Layout>
+      </AuthProvider>,
+    );
+
+    // While getUiConfig is in flight, proxyBaseUrl/serverRootPath still hold their
+    // module defaults; mounting pages now would fire fetches without the
+    // SERVER_ROOT_PATH prefix. The layout must hold them back.
+    await waitFor(() => expect(screen.getByTestId("loading-screen")).toBeTruthy());
+    expect(screen.queryByTestId("page-content")).toBeNull();
+    expect(screen.queryByTestId("navbar")).toBeNull();
+
+    deferred.resolve();
+
+    await waitFor(() => expect(screen.getByTestId("page-content")).toBeTruthy());
+    expect(screen.getByTestId("navbar")).toBeTruthy();
+    expect(screen.queryByTestId("loading-screen")).toBeNull();
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/layout.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/layout.test.tsx
@@ -29,19 +29,23 @@ vi.mock("@/components/common_components/LoadingScreen", () => ({
   default: () => <div data-testid="loading-screen" />,
 }));
 
-const deferred = (() => {
+type Deferred = { promise: Promise<void>; resolve: () => void };
+
+const createDeferred = (): Deferred => {
   let resolve!: () => void;
   const promise = new Promise<void>((r) => {
     resolve = r;
   });
   return { promise, resolve };
-})();
+};
+
+let pendingUiConfig: Deferred;
 
 vi.mock("@/components/networking", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/components/networking")>();
   return {
     ...actual,
-    getUiConfig: vi.fn(() => deferred.promise),
+    getUiConfig: vi.fn(() => pendingUiConfig.promise),
     setGlobalLitellmHeaderName: vi.fn(),
   };
 });
@@ -49,6 +53,7 @@ vi.mock("@/components/networking", async (importOriginal) => {
 describe("(dashboard) Layout", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    pendingUiConfig = createDeferred();
   });
 
   it("does not mount route content until getUiConfig has resolved", async () => {
@@ -60,14 +65,11 @@ describe("(dashboard) Layout", () => {
       </AuthProvider>,
     );
 
-    // While getUiConfig is in flight, proxyBaseUrl/serverRootPath still hold their
-    // module defaults; mounting pages now would fire fetches without the
-    // SERVER_ROOT_PATH prefix. The layout must hold them back.
     await waitFor(() => expect(screen.getByTestId("loading-screen")).toBeTruthy());
     expect(screen.queryByTestId("page-content")).toBeNull();
     expect(screen.queryByTestId("navbar")).toBeNull();
 
-    deferred.resolve();
+    pendingUiConfig.resolve();
 
     await waitFor(() => expect(screen.getByTestId("page-content")).toBeTruthy());
     expect(screen.getByTestId("navbar")).toBeTruthy();

--- a/ui/litellm-dashboard/src/app/(dashboard)/layout.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/layout.tsx
@@ -48,10 +48,6 @@ function LayoutContent({ children }: { children: React.ReactNode }) {
   const { accessToken, authLoading } = useAuth();
   const isInvitationFlow = Boolean(searchParams.get("invitation_id"));
 
-  // Block rendering until getUiConfig() has resolved proxyBaseUrl/serverRootPath
-  // (AuthContext clears authLoading only after that). Pages fetch on mount with a
-  // cookie-decoded token, so rendering earlier sends API calls without the
-  // SERVER_ROOT_PATH prefix and they 404 behind a path-routing reverse proxy.
   if (authLoading) {
     return <LoadingScreen />;
   }

--- a/ui/litellm-dashboard/src/app/(dashboard)/layout.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/layout.tsx
@@ -45,8 +45,16 @@ function DashboardShell({ children }: { children: React.ReactNode }) {
 
 function LayoutContent({ children }: { children: React.ReactNode }) {
   const searchParams = useSearchParams();
-  const { accessToken } = useAuth();
+  const { accessToken, authLoading } = useAuth();
   const isInvitationFlow = Boolean(searchParams.get("invitation_id"));
+
+  // Block rendering until getUiConfig() has resolved proxyBaseUrl/serverRootPath
+  // (AuthContext clears authLoading only after that). Pages fetch on mount with a
+  // cookie-decoded token, so rendering earlier sends API calls without the
+  // SERVER_ROOT_PATH prefix and they 404 behind a path-routing reverse proxy.
+  if (authLoading) {
+    return <LoadingScreen />;
+  }
 
   return (
     <ThemeProvider accessToken={accessToken}>


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Refs LIT-3687

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Repro needs a proxy running with a server root path and a built UI. From the repo root:

1. `cd ui/litellm-dashboard && npm run build && rm -rf ../../litellm/proxy/_experimental/out/* && cp -r ./out/* ../../litellm/proxy/_experimental/out/`
2. `SERVER_ROOT_PATH=/litellm python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log`
3. Log in at http://localhost:4000/litellm/ui
4. Open devtools Network tab, then deep load http://localhost:4000/litellm/ui/mcp-servers (paste the URL or hit refresh on it; client side navigation does not reproduce the bug)

Before this change the initial burst of API calls goes out without the root path prefix (`GET /user/available_users`, `GET /team/list`, `GET /v1/mcp/server`, ...). Locally they return 200 because uvicorn treats root_path as advisory and answers unprefixed routes anyway, but behind a reverse proxy that only forwards `/litellm/*` to LiteLLM those requests never reach the backend and the page loads empty. After this change every request in the Network tab is prefixed with `/litellm`

The contrast that pins it to the path-routed pages: deep loading a legacy page like http://localhost:4000/litellm/ui/?page=models sends every call prefixed even without this fix, because the legacy root page already waits for `authLoading` before rendering any panel

## Type

🐛 Bug Fix

## Changes

Pages migrated to path routes under `app/(dashboard)/` fire their data fetches on mount via `useAuthorized`, which decodes the access token synchronously from the cookie. On a hard load of a deep link those fetches race `getUiConfig()`, which is what populates `proxyBaseUrl` and `serverRootPath` in `networking.tsx` from `/.well-known/litellm-ui-config`. Fetches that win the race are built from the module defaults, i.e. relative URLs with no `SERVER_ROOT_PATH` prefix

`AuthContext` already sequences this correctly: it awaits `getUiConfig()` before clearing `authLoading`. The legacy `?page=` switch in the root page consumes that flag and renders a loading screen until it clears, which is why legacy pages never had this problem. The `(dashboard)` layout never consulted it

This PR makes `LayoutContent` in `app/(dashboard)/layout.tsx` return the existing `LoadingScreen` while `authLoading` is true, so every path-routed page (navbar and sidebar included, since the navbar fetches too) mounts only after the prefix is known. The regression test renders the layout inside the real `AuthProvider` with `getUiConfig` held pending and asserts children stay unmounted until it resolves; it fails if the gate is removed from the layout or if `AuthContext` stops awaiting `getUiConfig` before clearing `authLoading`
