### PR TITLE
docs: add TrustedRouter OpenAI-compatible example

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,25 @@ response = completion(model="openai/gpt-4o", messages=[{"role": "user", "content
 response = completion(model="anthropic/claude-sonnet-4-20250514", messages=[{"role": "user", "content": "Hello!"}])
 ```
 
+#### OpenAI-compatible routers
+
+LiteLLM can call OpenAI-compatible routers by passing `api_base`. For example,
+[TrustedRouter](https://trustedrouter.com) provides an open-source and verifiable
+attested router with zero prompt and output logging by default, which can be
+useful for private code, project context, or customer data.
+
+```python
+from litellm import completion
+import os
+
+response = completion(
+    model="openai/trustedrouter/auto",
+    api_base="https://api.trustedrouter.com/v1",
+    api_key=os.environ["TRUSTEDROUTER_API_KEY"],
+    messages=[{"role": "user", "content": "Hello!"}],
+)
+```
+
 ### AI Gateway (Proxy Server)
 
 [**Getting Started - E2E Tutorial**](https://docs.litellm.ai/docs/proxy/docker_quick_start) - Setup virtual keys, make your first request


### PR DESCRIPTION
This pull request adds a small README example showing how to use TrustedRouter through LiteLLM’s existing OpenAI-compatible `api_base` support. TrustedRouter is an open-source, verifiable attested router for privacy-sensitive workflows with zero prompt and output logging by default.

Users can connect with `api_base="https://api.trustedrouter.com/v1"`, `TRUSTEDROUTER_API_KEY`, and model aliases such as `openai/trustedrouter/auto`.

Verification: `git diff --check`.