### PR TITLE
feat(ui): migrate agents and router-settings to path routes

### DIFF
--- a/ui/litellm-dashboard/e2e_tests/fixtures/migratedPages.ts
+++ b/ui/litellm-dashboard/e2e_tests/fixtures/migratedPages.ts
@@ -37,6 +37,8 @@ export const MIGRATED_E2E_PAGES: Record<string, string> = {
   "logging-and-alerts": "logging-and-alerts",
   "model-hub-table": "model-hub-table",
   new_usage: "usage",
+  agents: "agents",
+  "router-settings": "router-settings",
 };
 
 export const MIGRATED_E2E_SEGMENTS: string[] = [...new Set(Object.values(MIGRATED_E2E_PAGES))];

--- a/ui/litellm-dashboard/src/app/(dashboard)/agents/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/agents/page.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import AgentsPanel from "@/components/agents";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+import { useTeams } from "@/app/(dashboard)/hooks/teams/useTeams";
+
+export default function Agents() {
+  const { accessToken, userRole } = useAuthorized();
+  const { data: teams } = useTeams();
+  return <AgentsPanel accessToken={accessToken} userRole={userRole} teams={teams ?? null} />;
+}

--- a/ui/litellm-dashboard/src/app/(dashboard)/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/page.tsx
@@ -1,11 +1,9 @@
 "use client";
 
 import ModelsAndEndpointsView from "@/app/(dashboard)/models-and-endpoints/ModelsAndEndpointsView";
-import AgentsPanel from "@/components/agents";
 import { teamListCall as v2TeamListCall } from "@/app/(dashboard)/hooks/teams/useTeams";
 import { useUISettings } from "@/app/(dashboard)/hooks/uiSettings/useUISettings";
 import LoadingScreen from "@/components/common_components/LoadingScreen";
-import GeneralSettings from "@/components/general_settings";
 import { Team } from "@/components/key_team_helpers/key_list";
 import { Organization, proxyBaseUrl, getInProductNudgesCall } from "@/components/networking";
 import OldTeams from "@/components/OldTeams";
@@ -355,10 +353,6 @@ function CreateKeyPageContent() {
               userRole={userRole}
               premiumUser={premiumUser}
             />
-          ) : page == "agents" ? (
-            <AgentsPanel accessToken={accessToken} userRole={userRole} teams={teams} />
-          ) : page == "router-settings" ? (
-            <GeneralSettings userID={userID} userRole={userRole} accessToken={accessToken} modelData={modelData} />
           ) : page == "pass-through-settings" ? (
             <PassThroughSettings
               userID={userID}

--- a/ui/litellm-dashboard/src/app/(dashboard)/router-settings/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/router-settings/page.tsx
@@ -2,11 +2,8 @@
 
 import GeneralSettings from "@/components/general_settings";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
-import { useAllProxyModels } from "@/app/(dashboard)/hooks/models/useModels";
 
 export default function RouterSettingsPage() {
   const { accessToken, userRole, userId } = useAuthorized();
-  const { data: models } = useAllProxyModels();
-  const modelData = { data: (models?.data ?? []).map((m) => ({ model_name: m.id })) };
-  return <GeneralSettings userID={userId} userRole={userRole} accessToken={accessToken} modelData={modelData} />;
+  return <GeneralSettings userID={userId} userRole={userRole} accessToken={accessToken} />;
 }

--- a/ui/litellm-dashboard/src/app/(dashboard)/router-settings/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/router-settings/page.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import GeneralSettings from "@/components/general_settings";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+import { useAllProxyModels } from "@/app/(dashboard)/hooks/models/useModels";
+
+export default function RouterSettingsPage() {
+  const { accessToken, userRole, userId } = useAuthorized();
+  const { data: models } = useAllProxyModels();
+  const modelData = { data: (models?.data ?? []).map((m) => ({ model_name: m.id })) };
+  return <GeneralSettings userID={userId} userRole={userRole} accessToken={accessToken} modelData={modelData} />;
+}

--- a/ui/litellm-dashboard/src/components/Settings/RouterSettings/Fallbacks/AddFallbacks.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/RouterSettings/Fallbacks/AddFallbacks.tsx
@@ -18,13 +18,12 @@ export type FallbackEntry = { [modelName: string]: string[] };
 export type Fallbacks = FallbackEntry[];
 
 interface AddFallbacksProps {
-  models?: string[];
   accessToken: string;
   value?: Fallbacks; // Current fallbacks value from form
   onChange?: (fallbacks: Fallbacks) => Promise<void>; // Callback to update form value
 }
 
-export default function AddFallbacks({ models, accessToken, value = [], onChange }: AddFallbacksProps) {
+export default function AddFallbacks({ accessToken, value = [], onChange }: AddFallbacksProps) {
   const [isModalVisible, setIsModalVisible] = useState(false);
   const [modelInfo, setModelInfo] = useState<ModelGroup[]>([]);
   const [modalKey, setModalKey] = useState(0); // Key to force remount of form when modal opens

--- a/ui/litellm-dashboard/src/components/Settings/RouterSettings/Fallbacks/Fallbacks.test.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/RouterSettings/Fallbacks/Fallbacks.test.tsx
@@ -79,10 +79,6 @@ describe("Fallbacks", () => {
   const mockAccessToken = "test-token";
   const mockUserRole = "Admin";
   const mockUserID = "user-123";
-  const mockModelData = {
-    data: [{ model_name: "gpt-4" }, { model_name: "gpt-3.5-turbo" }, { model_name: "claude-3-opus" }],
-  };
-
   const mockRouterSettings = {
     fallbacks: [{ "gpt-4": ["gpt-3.5-turbo", "claude-3-opus"] }, { "claude-3-opus": ["gpt-4"] }],
   };
@@ -91,7 +87,6 @@ describe("Fallbacks", () => {
     accessToken: mockAccessToken,
     userRole: mockUserRole,
     userID: mockUserID,
-    modelData: mockModelData,
   };
 
   const getFirstRowDeleteButton = () => {

--- a/ui/litellm-dashboard/src/components/Settings/RouterSettings/Fallbacks/Fallbacks.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/RouterSettings/Fallbacks/Fallbacks.tsx
@@ -65,7 +65,6 @@ interface FallbacksProps {
   accessToken: string | null;
   userRole: string | null;
   userID: string | null;
-  modelData: any;
 }
 
 async function testFallbackModelResponse(selectedModel: string, accessToken: string) {
@@ -115,7 +114,7 @@ async function testFallbackModelResponse(selectedModel: string, accessToken: str
   }
 }
 
-const Fallbacks: React.FC<FallbacksProps> = ({ accessToken, userRole, userID, modelData }) => {
+const Fallbacks: React.FC<FallbacksProps> = ({ accessToken, userRole, userID }) => {
   const [routerSettings, setRouterSettings] = useState<{ [key: string]: any }>({});
   const [isDeleting, setIsDeleting] = useState(false);
   const [fallbackToDelete, setFallbackToDelete] = useState<FallbackEntry | null>(null);
@@ -243,7 +242,6 @@ const Fallbacks: React.FC<FallbacksProps> = ({ accessToken, userRole, userID, mo
     <>
       {canModify && (
         <AddFallbacks
-          models={modelData?.data ? modelData.data.map((data: any) => data.model_name) : []}
           accessToken={accessToken || ""}
           value={routerSettings.fallbacks || []}
           onChange={handleFallbacksChange}

--- a/ui/litellm-dashboard/src/components/general_settings.tsx
+++ b/ui/litellm-dashboard/src/components/general_settings.tsx
@@ -25,7 +25,6 @@ interface GeneralSettingsPageProps {
   accessToken: string | null;
   userRole: string | null;
   userID: string | null;
-  modelData: any;
 }
 
 interface generalSettingsItem {
@@ -36,7 +35,7 @@ interface generalSettingsItem {
   stored_in_db: boolean | null;
 }
 
-const GeneralSettings: React.FC<GeneralSettingsPageProps> = ({ accessToken, userRole, userID, modelData }) => {
+const GeneralSettings: React.FC<GeneralSettingsPageProps> = ({ accessToken, userRole, userID }) => {
   const [generalSettings, setGeneralSettings] = useState<generalSettingsItem[]>([]);
 
   useEffect(() => {
@@ -113,13 +112,13 @@ const GeneralSettings: React.FC<GeneralSettingsPageProps> = ({ accessToken, user
         </TabList>
         <TabPanels className="px-8 py-6">
           <TabPanel>
-            <RouterSettings accessToken={accessToken} userRole={userRole} userID={userID} modelData={modelData} />
+            <RouterSettings accessToken={accessToken} userRole={userRole} userID={userID} />
           </TabPanel>
           <TabPanel>
             <RoutingGroups />
           </TabPanel>
           <TabPanel>
-            <Fallbacks accessToken={accessToken} userRole={userRole} userID={userID} modelData={modelData} />
+            <Fallbacks accessToken={accessToken} userRole={userRole} userID={userID} />
           </TabPanel>
           <TabPanel>
             <Card>

--- a/ui/litellm-dashboard/src/components/router_settings/index.tsx
+++ b/ui/litellm-dashboard/src/components/router_settings/index.tsx
@@ -8,7 +8,6 @@ interface RouterSettingsProps {
   accessToken: string | null;
   userRole: string | null;
   userID: string | null;
-  modelData: any;
 }
 
 interface routingStrategyArgs {
@@ -16,7 +15,7 @@ interface routingStrategyArgs {
   lowest_latency_buffer?: number;
 }
 
-const RouterSettings: React.FC<RouterSettingsProps> = ({ accessToken, userRole, userID, modelData }) => {
+const RouterSettings: React.FC<RouterSettingsProps> = ({ accessToken, userRole, userID }) => {
   const [formValue, setFormValue] = useState<RouterSettingsFormValue>({
     routerSettings: {},
     selectedStrategy: null,

--- a/ui/litellm-dashboard/src/utils/migratedPages.test.ts
+++ b/ui/litellm-dashboard/src/utils/migratedPages.test.ts
@@ -111,6 +111,14 @@ describe("migratedHref / legacyPageHref", () => {
     expect(MIGRATED_PAGES.new_usage).toBe("usage");
     expect(MIGRATED_PAGES.usage).toBeUndefined();
   });
+
+  it("maps the agents and router-settings ids to their routes", async () => {
+    vi.doMock("@/components/networking", () => ({ serverRootPath: "/" }));
+    const { MIGRATED_PAGES } = await import("./migratedPages");
+
+    expect(MIGRATED_PAGES.agents).toBe("agents");
+    expect(MIGRATED_PAGES["router-settings"]).toBe("router-settings");
+  });
 });
 
 describe("dev server (NODE_ENV=development)", () => {

--- a/ui/litellm-dashboard/src/utils/migratedPages.ts
+++ b/ui/litellm-dashboard/src/utils/migratedPages.ts
@@ -40,6 +40,8 @@ export const MIGRATED_PAGES: Record<string, string> = {
   "model-hub-table": "model-hub-table",
   // The modern usage dashboard; the old ?page=usage report stays on the legacy switch.
   new_usage: "usage",
+  agents: "agents",
+  "router-settings": "router-settings",
 };
 
 function uiBase(): string {


### PR DESCRIPTION
## Summary

The router-settings cutover surfaced that the entire modelData chain was dead code: AddFallbacks (the model dropdown) fetches its own model list when its modal opens and never reads the models prop, RouterSettings declared modelData without using it, and PassThroughSettings does the same. So instead of adapting the shell state to a hook, the second commit deletes the chain end to end (the props in GeneralSettings, RouterSettings, Fallbacks, and AddFallbacks) and the router-settings wrapper passes nothing. This also retracts the earlier revision's claim that the cutover fixed an empty-dropdown bug; the dropdown was never affected by the shell state because the component self-fetches.

The router-settings swap fixes a real bug as a side effect: the shell's `modelData` copy started as `{data: []}` and was only populated by visiting the Models page first in the same session, so the Fallbacks tab's model dropdown was empty on a fresh load of router-settings. The hook fetches the model list directly, so the dropdown now populates regardless of navigation history.

Deliberately not in this PR: `pass-through-settings` was in the original batch plan, but it has no sidebar entry and no in-app link anywhere; it is reachable only by hand-typing `?page=pass-through-settings`. Migrating it would break the sidebar-driven migration smoke, and given the precedent of removing the unreachable `/chat` page (#30178) it may be a deletion candidate instead; flagging for a separate decision. Its switch arm (and the shell's `modelData` state, which it and the Models page still read) stays for now.

## Test plan
- [x] `src/utils/migratedPages.test.ts` — new case mapping both ids to their routes
- [x] `npm run build` passes locally with both routes in the export
- [x] `tsc --noEmit --incremental false` — zero errors in touched files
- [x] `prettier --check` and `eslint` exit 0 on all six touched files
- [x] e2e migration smoke and sidebar spec pick both pages up from `MIGRATED_E2E_PAGES`; both have sidebar entries (agents under its submenu, router-settings under Settings)

Refs LIT-3687
