### PR TITLE
Translation v2: wave 2b — eleven own-module heavy providers

### DIFF
--- a/litellm/translation/CLAUDE.md
+++ b/litellm/translation/CLAUDE.md
@@ -942,7 +942,13 @@ gate on the REWRITTEN model; data: urls exempt), cache_control stripped
 (== the IR drop), and user/reasoning_effort verbatim. fireworks_ai fork
 obligations: NO seam preset and the "openai_like" construction arm with
 the parser-owned fireworks_ai/{WIRE model} prefix (NOT the request
-model); the ambient litellm.disable_add_transform_inline_image_block
+model) — the style is machine-readable in
+`engine/pipeline.OWN_MODULE_RESPONSE_STYLES` (the table the fork must
+select usage_style from, asserted complete by the registration gate;
+the wrong arm is a PROVEN byte divergence pinned in the response gate —
+critic-wave2b-alpha MAJOR-4 closed the prose-only gap, and the seam AST
+gate already rejects any fork routed through response_dialect());
+the ambient litellm.disable_add_transform_inline_image_block
 global (and the per-request litellm_params flag) must FORCE v1 at the
 seam before flag-on — the serializer encodes the default-enabled arm
 only; response _hidden_params.additional_headers ride the seam's
@@ -969,7 +975,10 @@ content_list response rewrite (choices[0] text concat + tool_use ->
 OpenAI tool_calls with json.dumps DEFAULT-separator arguments,
 byte-pinned) and the snowflake/{wire-or-EMPTY} response prefix.
 snowflake fork obligations: NO seam preset and the "openai_like"
-construction arm; the request model must ride
+construction arm (machine-readable in
+`engine/pipeline.OWN_MODULE_RESPONSE_STYLES`, wrong-arm divergence
+pinned in the response gate — the fireworks_ai MAJOR-4 shape); the
+request model must ride
 _hidden_params["model"] (v1's cost-calculator feed, dump-invisible —
 gate-pinned); account_id -> URL synthesis and KEYPAIR_JWT/PAT headers
 are pure envelope (header-only auth, researcher-4's correction). Real

--- a/litellm/translation/CLAUDE.md
+++ b/litellm/translation/CLAUDE.md
@@ -384,6 +384,22 @@ translation/
 │   │                    #   httpx_chunk factory (reasoning="rename" + the
 │   │                    #   passthrough_delta_keys axis admitting
 │   │                    #   thinking_blocks); "xai" chunk dialect
+│   ├── sagemaker_chat/  # wave-2b-beta: SageMaker Messages-API endpoints —
+│   │   │                #   the BASE GPT config over SigV4 transport (the
+│   │   │                #   sign-after-body-final bedrock precedent;
+│   │   │                #   endpoint name == model; sagemaker_nova is
+│   │   │                #   deliberately unregistered)
+│   │   ├── guard.py     # explicit stream:false + the shared openai guard
+│   │   ├── params.py    # thinking/reasoning_effort raises, user drop,
+│   │   │                #   the gpt-4-named-endpoint response_format raise
+│   │   ├── serialize.py # assemble_body verbatim + top_k (mct passes
+│   │   │                #   VERBATIM — the widest list in the wave)
+│   │   ├── response.py  # re-export of the shared openai parser (bare
+│   │   │                #   wire model, construction arm "openai")
+│   │   └── stream.py    # openai parser + the litellm-validation post-step
+│   │                    #   (psf:None on every delta, tool type null ->
+│   │                    #   "function") at the AWS event-stream
+│   │                    #   PARSED-event seam; "openai" chunk dialect
 │   ├── watsonx/         # wave-2b-beta: watsonx /ml/v1/text/chat over the
 │   │   │                #   OpenAILikeChatHandler route (auth incl. the
 │   │   │                #   IAM-token network POST is envelope; project/
@@ -567,9 +583,9 @@ A behavior change ships as its own snapshot-diffed PR, never inside a port.
 
 ## Current scope
 
-OpenAI-chat-in to sixty-nine providers out (wave-2b-beta adds
-`cohere`/`cohere_chat` (one module), `mistral`, and `watsonx` — see their
-paragraphs below) —
+OpenAI-chat-in to seventy providers out (wave-2b-beta adds
+`cohere`/`cohere_chat` (one module), `mistral`, `watsonx`, and
+`sagemaker_chat` — see their paragraphs below) —
 `anthropic`,
 `bedrock_converse`, `bedrock_invoke`, `openai_compat`, `vertex_ai` (gemini
 route), `gemini` (AI Studio), `vertex_anthropic`, `azure`, `azure_ai`,
@@ -919,6 +935,29 @@ Watsonx fork obligations (NOT wired; integrator scope): construction arm
 "openai_like" (NEVER "openai" — the construction-arm gate applies), no
 model preset, deps built with the resolved project/space ids, streams fold
 with the "generic" dialect over providers/watsonx.parse_line.
+Deliberate wave-2b-beta sagemaker_chat fallback surfaces
+(providers/sagemaker_chat; each names the v1 path): thinking/
+reasoning_effort (raises — the BASE GPT list, the widest in the wave),
+``user`` (silent drop), response_format on endpoints literally named
+gpt-4/gpt-3.5-turbo-16k (the base-list name gate raises — endpoint names
+are arbitrary so the corner is REACHABLE), explicit stream:false (rides
+the wire), aws_* kwargs (v1 places them in optional_params and the BODY
+carries them — wire-probed aws_region_name; v2's parse rejects the
+unknown key, v1 serves), message ``name`` (forwarded), and the
+parse-level unknowns (n/seed/penalties/logprobs/logit_bias/
+web_search_options — v1 serves all verbatim). SERVED pins:
+max_completion_tokens VERBATIM (no rename), top_k top-level
+(wire-proven), bare wire model on responses (cdr, construction arm
+"openai", NO preset), and streams at the AWS event-stream PARSED-event
+seam (botocore framing is transport — the bedrock precedent): the shared
+openai parser + a post-step mirroring the decoder's litellm validation
+(provider_specific_fields: None materialized on every delta, tool_call
+type missing-or-null -> "function") with wrong-typed delta strings LOUD
+(v1's StreamingChatCompletionChunk validation raises — not the watsonx
+swallow). sagemaker_nova shares the main.py branch but carries its own
+config overrides and stays a typed v1 fallback (canary in the request
+gate). SigV4 + the /invocations[-response-stream] URL split are envelope;
+the fork must sign AFTER wire_body finalizes (the bedrock rule).
 Not yet here, each its own follow-up: streaming seams live; the other
 inbound schemas (`anthropic_messages`, `google_genai`, `responses`,
 `completions`); the same-family fast path (waits on the opaque-body

--- a/litellm/translation/CLAUDE.md
+++ b/litellm/translation/CLAUDE.md
@@ -358,6 +358,23 @@ translation/
 │   │                    #   the real wire sends ``type`` — both regimes
 │   │                    #   pinned (wrapper end-of-stream synthesis = seam
 │   │                    #   scope)
+│   ├── groq/            # wave-2b-beta: groq over openai_compat (httpx
+│   │   │                #   path, bare wire model)
+│   │   ├── guard.py     # explicit stream:false + the shared openai guard
+│   │   ├── params.py    # thinking raise, user drop, reasoning_effort
+│   │   │                #   capability gate (groq/{m}), the json_schema
+│   │   │                #   THREE-WAY fork (native serve / workaround
+│   │   │                #   fallback / BadRequestError fallback)
+│   │   ├── serialize.py # assemble_body + mct rename + reasoning_effort +
+│   │   │                #   top_k (extra_body->wire merge) + assistant
+│   │   │                #   None-strip
+│   │   ├── response.py  # openai parse + verbatim wire + the service_tier
+│   │   │                #   clamp (a MISSING service_tier key fails closed
+│   │   │                #   — v1's getattr crashes); F2 arm; construction
+│   │   │                #   arm "openai_like"
+│   │   └── stream.py    # httpx_chunk factory, reasoning="rename" (groq's
+│   │                    #   pop == rename, verified — no new arm); "xai"
+│   │                    #   chunk dialect
 │   ├── mistral/         # wave-2b-beta: mistral over openai_compat (httpx
 │   │   │                #   path, dedicated elif, bare wire model)
 │   │   ├── guard.py     # own name matrix (tool-role names kept by v1;
@@ -583,9 +600,9 @@ A behavior change ships as its own snapshot-diffed PR, never inside a port.
 
 ## Current scope
 
-OpenAI-chat-in to seventy providers out (wave-2b-beta adds
-`cohere`/`cohere_chat` (one module), `mistral`, `watsonx`, and
-`sagemaker_chat` — see their paragraphs below) —
+OpenAI-chat-in to seventy-one providers out (wave-2b-beta adds
+`cohere`/`cohere_chat` (one module), `mistral`, `watsonx`,
+`sagemaker_chat`, and `groq` — see their paragraphs below) —
 `anthropic`,
 `bedrock_converse`, `bedrock_invoke`, `openai_compat`, `vertex_ai` (gemini
 route), `gemini` (AI Studio), `vertex_anthropic`, `azure`, `azure_ai`,
@@ -958,6 +975,42 @@ swallow). sagemaker_nova shares the main.py branch but carries its own
 config overrides and stays a typed v1 fallback (canary in the request
 gate). SigV4 + the /invocations[-response-stream] URL split are envelope;
 the fork must sign AFTER wire_body finalizes (the bedrock rule).
+Deliberate wave-2b-beta groq fallback surfaces (providers/groq; each names
+the v1 path): ``thinking`` (raises), ``reasoning_effort`` on models
+without the ``groq/{m}`` supports_reasoning flag (raises), ``user``
+(silent drop), ``response_format`` with a json_schema on NON-native models
+(v1 serves its json_tool_call WORKAROUND — tools + forced tool_choice +
+json_mode + fake_stream, the cross-plane rewrite v2 deliberately does not
+reproduce; researcher-4's prescribed shape), the same plus user tools (v1
+raises ``litellm.BadRequestError`` — the wave's one
+non-UnsupportedParamsError request raise, exact type pinned), explicit
+stream:false, message ``name``, and the parse-level unknowns
+(seed/n/penalties/logit_bias/logprobs/top_logprobs/service_tier/
+web_search_options/max_retries — v1 serves or silently drops each).
+SERVED pins: mct->max_tokens (groq's map forwards POSITIONALLY so the
+OpenAILike rename runs — its own replace_...=False default is never
+threaded), top_k via extra_body -> hh's wire merge (wire-equivalent
+top-level emission), response_format json_object verbatim (fake_stream is
+a routing key hh pops), json_schema VERBATIM on native-schema models
+(llama-4 / gpt-oss / kimi-k2-0905 map rows; capability via deps over
+groq/{m}), assistant-message None-strip (content: None never reaches the
+wire), reasoning_effort verbatim on flagged models, responses
+ModelResponse(**json)-direct (BARE wire model — the prefix arm is dead,
+custom_llm_provider=None) with x_groq extras surviving and the
+service_tier CLAMP ({auto,default,flex}, null/unknown -> "auto") — a
+response body MISSING the service_tier key fails closed (v1's clamp reads
+getattr with no default and CRASHES with AttributeError, probed), and
+streams through the httpx_chunk factory reasoning="rename" (groq's pop ==
+the existing mode, verified — no new ReasoningMode arm) with truthy error
+chunks loud on both sides (v1 raises -> MidStreamFallbackError; error:
+null serves, the value-check pin). Groq fork obligations (NOT wired;
+integrator scope): construction arm "openai_like", no model preset,
+streams fold with the "xai" dialect over providers/groq.parse_line, and
+the main.py groq elif merges ``GroqChatConfig.get_config()`` CLASS-ATTR
+state into optional_params (main.py:2338-2344) — ambient module state v2
+cannot see, so the fork MUST fall back to v1 when that config is
+non-empty (the ambient-globals rule: vertex_ai_safety_settings/
+custom_prompt_dict precedent).
 Not yet here, each its own follow-up: streaming seams live; the other
 inbound schemas (`anthropic_messages`, `google_genai`, `responses`,
 `completions`); the same-family fast path (waits on the opaque-body

--- a/litellm/translation/CLAUDE.md
+++ b/litellm/translation/CLAUDE.md
@@ -1142,9 +1142,16 @@ inherits them): a reasoning/refusal-bearing FINISH delta is the LOUD
 finish-chunk fallback (v1's wrapper interleaves it as a separate chunk
 the fold cannot reproduce — the pre-fix factory served an empty finish
 chunk with the text silently GONE; two-sided rows in the openrouter and
-xai stream gates, all base-handler consumers inherit), and a non-string
-non-None reasoning value is a loud error (v1 serves it then RAISES
-APIError at stream end in the chunk builder). One NAMED zero-data
+xai stream gates, all base-handler consumers inherit; groq's v1 wrapper
+DROPS the finish-riding refusal instead of interleaving — same loud
+fallback, pinned in its gate), and a non-string non-None reasoning value
+is a loud error (v1 serves it then RAISES APIError at stream end in the
+chunk builder). Discharged at the wave-2b sibling merge
+(verifier-wave2b-beta F6's refusal half, the named INTEGRATOR-FLIP
+handoff): a delta ``refusal`` VALUE rides VERBATIM, any type — v1's
+Delta forwards non-string refusals and serves the stream end-to-end
+(re-probed two-sided for groq), so the factory's old _string_or_none
+nulling was the divergence, not the fix. One NAMED zero-data
 divergence remains for the streaming seam to inherit deliberately: v1
 serves a mid-stream empty-string reasoning delta as its own chunk while
 the v2 fold swallows the empty delta (byte-identical otherwise) —

--- a/litellm/translation/CLAUDE.md
+++ b/litellm/translation/CLAUDE.md
@@ -325,6 +325,26 @@ translation/
 │   │                    #   two-sided-pinned + a named report row; v1's
 │   │                    #   cometapi handler RAISES instead — its policy
 │   │                    #   row mirrors that raise)
+│   ├── deepseek/        # wave-2b-alpha own module (httpx dedicated elif
+│   │   │                #   main.py:1942, transforms LIVE, bare wire model)
+│   │   ├── guard.py     # explicit stream:false + the shared openai guard
+│   │   │                #   (full message-name fallback: nothing strips)
+│   │   ├── params.py    # base list + thinking/reasoning_effort
+│   │   │                #   (UNCONDITIONAL, every deepseek model);
+│   │   │                #   non-text content lists and thinking-mode
+│   │   │                #   assistant history fall back (v1's lossy
+│   │   │                #   flatten / _fill_reasoning_content rewrites)
+│   │   ├── serialize.py # openai_compat body + the compat_sdk flatten
+│   │   │                #   delta (imported, never copied) + the thinking
+│   │   │                #   rewrite ({"type":"enabled"} only:
+│   │   │                #   budget_tokens discarded, reasoning_effort
+│   │   │                #   rewritten in and its key never on the wire,
+│   │   │                #   a present non-enabled dict shadows it)
+│   │   ├── response.py  # shared openai parser re-export (no v1 override;
+│   │   │                #   NO deepseek/ prefix — the xai R4 shape)
+│   │   └── stream.py    # httpx_chunk family policy (v1 = the BASE
+│   │                    #   OpenAIChatCompletionStreamingHandler) +
+│   │                    #   make_parse_line; "xai" chunk dialect
 │   └── xai/             # Grok over openai_compat (httpx path: NO model
 │       │                #   prefix anywhere, transform_response is LIVE):
 │       ├── guard.py     # web_search_options (v1's Responses-bridge reroute
@@ -484,7 +504,7 @@ A behavior change ships as its own snapshot-diffed PR, never inside a port.
 
 ## Current scope
 
-OpenAI-chat-in to sixty-five providers out — `anthropic`,
+OpenAI-chat-in to sixty-six providers out — `anthropic`,
 `bedrock_converse`, `bedrock_invoke`, `openai_compat`, `vertex_ai` (gemini
 route), `gemini` (AI Studio), `vertex_anthropic`, `azure`, `azure_ai`,
 `azure_ai_anthropic`, `xai`, the thirteen wave-1a compat_sdk providers
@@ -498,9 +518,10 @@ route), `gemini` (AI Studio), `vertex_anthropic`, `azure`, `azure_ai`,
 `poe`, `chutes`, `assemblyai`, `charity_engine`, `neosantara`,
 `tensormesh`, `parasail`), and the nine wave-1b compat_httpx providers
 (`heroku`, `bedrock_mantle`, `minimax`, `compactifai`, `amazon_nova`,
-`datarobot`, `gradient_ai`, `ovhcloud`, `lemonade`), and the five wave-2a
+`datarobot`, `gradient_ai`, `ovhcloud`, `lemonade`), the five wave-2a
 providers (`perplexity`, `sambanova`, `deepinfra`, `moonshot` on the SDK
-path, `cometapi` on the httpx path) — request, response, and stream
+path, `cometapi` on the httpx path), and the wave-2b-alpha own modules
+(`deepseek`) — request, response, and stream
 translation,
 differential-green (anthropic: 46-shape corpus + responses + stream
 replays; bedrock and google: the characterization corpus per route + quirk
@@ -698,6 +719,30 @@ rows, the xai R4 shape), must route streams through
 compat_httpx.LINE_PARSERS["cometapi"] with the "xai" chunk dialect at the
 SSE line seam (NOT the SDK wrapper arm), and inherits the
 synthesized-final-usage contract from the openai/xai ports.
+Deliberate wave-2b-alpha (deepseek) fallback surfaces (each names the v1
+path): non-text content lists (v1's ALWAYS-on flatten drops non-text
+parts and skips the base image transforms — v1 serves its lossy flatten);
+assistant history in thinking mode on supports_reasoning("deepseek/{m}")
+models (v1's _fill_reasoning_content patches every assistant message
+missing reasoning_content with provider_specific_fields promotion or a
+single-space placeholder — v1 serves its rewrite; the fill is INERT on
+non-reasoning models like deepseek-chat, where the same shape SERVES,
+pinned both ways); top_k (the wire-proven extra_body merge — pinned by a
+mock-transport completion() row per the wave-2b wire-prove rule); user
+(model-list gated, v1 silently drops); explicit stream:false (guard arm);
+and the family guard/parse fallbacks (web_search_options is SERVED by
+v1's base list at HEAD — a dossier drift fact — and falls back at the
+inbound boundary like every parse-level unknown). The thinking rewrite
+itself is SERVED, never a fallback: {"type":"enabled"} verbatim-only with
+budget_tokens discarded, reasoning_effort != "none" rewritten to it (the
+key never reaches the wire), a present non-enabled thinking dict shadows
+reasoning_effort entirely — all pinned by IDENTICAL rows. deepseek fork
+obligations (when the integrator wires it): NO model preset (fresh
+ModelResponse, bare wire model — the xai R4 rule, pinned by the no-prefix
+response rows), streams fold providers/deepseek.parse_line with the "xai"
+chunk dialect at the SSE line seam, and the error-chunk PINNED DIVERGENCE
+(v1's base handler swallows; v2 is loud) extends to deepseek exactly like
+the compat_httpx family.
 Streaming-seam obligations carried from wave 2a (verifier-wave2a W1/W2 —
 no impact while streaming stays on v1, pinned by
 `test_reasoning_stream_seam_obligation_canary`): the SDK family's openai

--- a/litellm/translation/CLAUDE.md
+++ b/litellm/translation/CLAUDE.md
@@ -986,9 +986,17 @@ max_completion_tokens VERBATIM (no rename), top_k top-level
 seam (botocore framing is transport — the bedrock precedent): the shared
 openai parser + a post-step mirroring the decoder's litellm validation
 (provider_specific_fields: None materialized on every delta, tool_call
-type missing-or-null -> "function") with wrong-typed delta strings LOUD
-(v1's StreamingChatCompletionChunk validation raises — not the watsonx
-swallow). sagemaker_nova shares the main.py branch but carries its own
+type missing-or-null -> "function") with the FULL validation breadth LOUD
+(v1's StreamingChatCompletionChunk/ChatCompletionDeltaToolCall validation
+raises — not the watsonx swallow — on non-str delta strings, present
+non-dict delta, non-list tool_calls, non-str tool id/name/arguments/type,
+non-coercible tool/choice indexes, non-dict usage and usage values the
+lax coercion rejects; the verifier-F5 fix), a pre-step SERVING v1's lax
+coercions (index bool/digit-str/integral-float -> int) and the wrapper's
+finish semantics (falsy -> no finish, tail synthesis seam scope; truthy
+non-str hashable -> "stop"; unknown strings ride verbatim through the
+live map both sides; truthy unhashable loud — the verifier-F7 fix).
+sagemaker_nova shares the main.py branch but carries its own
 config overrides and stays a typed v1 fallback (canary in the request
 gate). SigV4 + the /invocations[-response-stream] URL split are envelope;
 the fork must sign AFTER wire_body finalizes (the bedrock rule).

--- a/litellm/translation/CLAUDE.md
+++ b/litellm/translation/CLAUDE.md
@@ -325,6 +325,39 @@ translation/
 │   │                    #   two-sided-pinned + a named report row; v1's
 │   │                    #   cometapi handler RAISES instead — its policy
 │   │                    #   row mirrors that raise)
+│   ├── cohere/          # wave-2b-beta: the cohere V2 chat wire — the
+│   │   │                #   DEFAULT route at HEAD for BOTH provider names
+│   │   │                #   ("cohere" and "cohere_chat" resolve to
+│   │   │                #   CohereV2ChatConfig and one main.py elif); the
+│   │   │                #   legacy "v1/" route and the explicit "v2/"
+│   │   │                #   model prefix (an envelope strip) are route
+│   │   │                #   predicates in the guard, never Literal rows
+│   │   ├── guard.py     # v1-route/v2-prefix predicates + explicit
+│   │   │                #   stream:false + the shared openai guard (FULL
+│   │   │                #   message-name fallback: the transform is the
+│   │   │                #   inherited GPT one, names ride verbatim)
+│   │   ├── params.py    # supported-list truths as typed fallbacks
+│   │   │                #   (response_format/parallel_tool_calls/thinking/
+│   │   │                #   reasoning_effort RAISE in v1; user is silently
+│   │   │                #   dropped upstream — fallback, v1 serves)
+│   │   ├── serialize.py # openai_compat assemble_body + renames (top_p->p,
+│   │   │                #   stop->stop_sequences, mct->max_tokens),
+│   │   │                #   tool_choice DROPPED (supported list, no map
+│   │   │                #   arm), top_k emitted verbatim top-level (the
+│   │   │                #   generic passthrough — wire-proven, NOT the
+│   │   │                #   extra_body arm)
+│   │   ├── response.py  # cohere-native body -> normalized chat-completion
+│   │   │                #   body on ChatResponse.wire (content join,
+│   │   │                #   citations->annotations, tool-call message
+│   │   │                #   REPLACEMENT, usage.tokens — finish is ALWAYS
+│   │   │                #   "stop", the wire id/finish are never read)
+│   │   └── stream.py    # bare-JSON line seam (NO data:/[DONE] framing) ->
+│   │                    #   GenericStreamingChunk payloads folded by the
+│   │                    #   inbound "generic" chunk dialect; the v1 parser
+│   │                    #   reads message-end off the ``event`` key while
+│   │                    #   the real wire sends ``type`` — both regimes
+│   │                    #   pinned (wrapper end-of-stream synthesis = seam
+│   │                    #   scope)
 │   └── xai/             # Grok over openai_compat (httpx path: NO model
 │       │                #   prefix anywhere, transform_response is LIVE):
 │       ├── guard.py     # web_search_options (v1's Responses-bridge reroute
@@ -484,7 +517,9 @@ A behavior change ships as its own snapshot-diffed PR, never inside a port.
 
 ## Current scope
 
-OpenAI-chat-in to sixty-five providers out — `anthropic`,
+OpenAI-chat-in to sixty-seven providers out (wave-2b-beta adds
+`cohere`/`cohere_chat`, one module — see the cohere paragraph below) —
+`anthropic`,
 `bedrock_converse`, `bedrock_invoke`, `openai_compat`, `vertex_ai` (gemini
 route), `gemini` (AI Studio), `vertex_anthropic`, `azure`, `azure_ai`,
 `azure_ai_anthropic`, `xai`, the thirteen wave-1a compat_sdk providers
@@ -724,6 +759,43 @@ keep the bare wire model (the B1 re-prefix arm must never fire: xai
 presets no model); synthesize the final stream usage chunk from the
 passthrough `choices: []` tail (non-tail usage is withheld exactly like
 v1's wrapper, so the synthesis covers the tail-chunk shape only).
+Deliberate wave-2b-beta cohere fallback surfaces (providers/cohere — both
+provider names; each names the v1 path): the legacy ``v1/`` route (the v1
+chat wire is DON'T-PORT; route predicate in the guard) and the explicit
+``v2/`` model prefix (main.py strips it before transform — an envelope
+rewrite v2 does not reproduce); every supported-list raise
+(response_format, parallel_tool_calls, thinking, reasoning_effort —
+NOTE the get_optional_params drift: the cohere arm runs the LEGACY
+CohereChatConfig map, byte-equivalent to the v2 config's over the shared
+list, probed at HEAD); ``user`` (silently dropped upstream, v1 serves the
+drop); n/seed/frequency_penalty/presence_penalty (v1 SERVES them — renamed
+n->num_generations — but they are parse-level unknowns, so v1 keeps
+serving); explicit stream:false; message ``name`` (forwarded verbatim by
+the GPT transform, full-name guard arm). SERVED quirks pinned IDENTICAL:
+tool_choice silently dropped (in the supported list with no map arm),
+top_k emitted verbatim top-level (wire-proven — the generic passthrough,
+NOT the extra_body arm), mct->max_tokens, response finish_reason ALWAYS
+"stop" (v1 never reads the wire finish; the fresh-Choices default
+survives even on tool calls), the wire response id IGNORED (ambient
+chatcmpl id), tool-call responses REPLACING the message (text content
+lost, annotations kwarg explicit). Cohere stream/fork obligations (the
+forks are NOT wired; integrator scope): the response construction arm is
+"openai" with NO model preset and the request model riding the body; the
+chunk fold dialect is "generic" (the wrapper's GenericStreamingChunk arm)
+over providers/cohere.parse_line — a BARE-JSON line seam (v1's iterator
+json.loads each line; no data:/[DONE] framing); the generic streaming
+seam must mint a FRESH chunk id per chunk (v1's wrapper does), must NOT
+preset citations/system_fingerprint (to_model_response_stream's openai
+preset would diverge — the cohere stream gate's local adapter is the
+contract), and OWNS v1's end-of-stream synthesis: the real (type-keyed)
+cohere wire never matches the parser's event-keyed message-end arm, so
+v1 synthesizes the trailing finish chunk at StopIteration ("tool_calls"
+when tool deltas were seen, else "stop") and, under include_usage, a
+final usage chunk with token-counter ESTIMATES (the wire usage never
+reaches the wrapper on that regime). One PINNED DIVERGENCE (fail-closed
+on a failure path, the compat_httpx error-chunk precedent): non-str
+stream ``content.text`` — v1 silently swallows the chunk, v2 errors
+loudly (named report row).
 Not yet here, each its own follow-up: streaming seams live; the other
 inbound schemas (`anthropic_messages`, `google_genai`, `responses`,
 `completions`); the same-family fast path (waits on the opaque-body

--- a/litellm/translation/CLAUDE.md
+++ b/litellm/translation/CLAUDE.md
@@ -898,7 +898,10 @@ quirks pinned IDENTICAL: explicit stream:false (v1's map only copies True
 — NO guard arm, the IR collapse IS v1's drop), mct->max_tokens, top_k
 verbatim top-level (wire-proven — researcher-4 listed it as a raise, the
 probe refutes it), tool_choice required->any with the DICT form silently
-dropped, tools $id/$schema strip at v1's exact depth-10 cap
+dropped, tools $id/$schema strip at v1's exact call-site cap —
+``max_depth=DEFAULT_MAX_RECURSE_DEPTH`` (=100 at HEAD; v2 imports the same
+``litellm.constants`` symbol, so the env-overridable value cannot drift;
+the signature's ``max_depth=10`` default is dead there, verifier F2)
 (additionalProperties/strict KEPT — port the code, not the docstring),
 multi-text flatten, MistralToolCallMessage rebuild, empty-assistant
 removal, per-message None strip, the image branch's verbatim

--- a/litellm/translation/CLAUDE.md
+++ b/litellm/translation/CLAUDE.md
@@ -422,6 +422,35 @@ translation/
 │   │                    #   this consumer), key-presence error raise,
 │   │                    #   strict id/created/model/choices envelope +
 │   │                    #   the missing-delta pre-step
+│   ├── snowflake/       # wave-2b-alpha own module (httpx dedicated elif
+│   │   │                #   main.py:4286; a genuine wire mapping; the
+│   │   │                #   response model is snowflake/{wire model}
+│   │   │                #   INSIDE the parser)
+│   │   ├── guard.py     # the shared openai guard ONLY (messages ride
+│   │   │                #   VERBATIM in v1 — no transform); deliberately
+│   │   │                #   NO stream:false arm: stream is ALWAYS a body
+│   │   │                #   key (absent == false on the wire), so v2
+│   │   │                #   SERVES explicit false
+│   │   ├── params.py    # the small static list (mct/stop/n/seed/
+│   │   │                #   parallel RAISE; user silently dropped) +
+│   │   │                #   top_k (non-compat top-level passthrough,
+│   │   │                #   wire-proven via respx — the elif overwrites
+│   │   │                #   the caller's client, so the mock-transport
+│   │   │                #   helper can't reach it)
+│   │   ├── serialize.py # openai_compat body + the ALWAYS-on stream key
+│   │   │                #   + tools -> tool_spec + tool_choice -> object
+│   │   │                #   (required -> any; dict fn -> name ARRAY) +
+│   │   │                #   top_k verbatim
+│   │   ├── response.py  # content_list pre-rewrite (choices[0]: text
+│   │   │                #   concat + tool_use -> tool_calls with
+│   │   │                #   json.dumps(input) DEFAULT-separator
+│   │   │                #   arguments) + the shared direct parser with
+│   │   │                #   the snowflake/{wire-or-empty} prefix policy;
+│   │   │                #   "openai_like" seam arm; the request model in
+│   │   │                #   _hidden_params["model"] is a fork obligation
+│   │   └── stream.py    # httpx_chunk family policy (v1 = the BASE
+│   │                    #   handler); real Cortex delta shapes UNPINNED
+│   │                    #   upstream; joins the ONE PINNED DIVERGENCE
 │   └── xai/             # Grok over openai_compat (httpx path: NO model
 │       │                #   prefix anywhere, transform_response is LIVE):
 │       ├── guard.py     # web_search_options (v1's Responses-bridge reroute
@@ -581,7 +610,7 @@ A behavior change ships as its own snapshot-diffed PR, never inside a port.
 
 ## Current scope
 
-OpenAI-chat-in to sixty-nine providers out — `anthropic`,
+OpenAI-chat-in to seventy providers out — `anthropic`,
 `bedrock_converse`, `bedrock_invoke`, `openai_compat`, `vertex_ai` (gemini
 route), `gemini` (AI Studio), `vertex_anthropic`, `azure`, `azure_ai`,
 `azure_ai_anthropic`, `xai`, the thirteen wave-1a compat_sdk providers
@@ -598,8 +627,8 @@ route), `gemini` (AI Studio), `vertex_anthropic`, `azure`, `azure_ai`,
 `datarobot`, `gradient_ai`, `ovhcloud`, `lemonade`), the five wave-2a
 providers (`perplexity`, `sambanova`, `deepinfra`, `moonshot` on the SDK
 path, `cometapi` on the httpx path), and the wave-2b-alpha own modules
-(`deepseek`, `openrouter`, `hosted_vllm`, `fireworks_ai`) — request,
-response, and stream
+(`deepseek`, `openrouter`, `hosted_vllm`, `fireworks_ai`, `snowflake`) —
+request, response, and stream
 translation,
 differential-green (anthropic: 46-shape corpus + responses + stream
 replays; bedrock and google: the characterization corpus per route + quirk
@@ -900,6 +929,35 @@ global (and the per-request litellm_params flag) must FORCE v1 at the
 seam before flag-on — the serializer encodes the default-enabled arm
 only; response _hidden_params.additional_headers ride the seam's
 headers-passthrough follow-up.
+Deliberate wave-2b-alpha (snowflake) fallback surfaces (each names the
+v1 path): max_completion_tokens / stop / n / seed / penalties /
+parallel_tool_calls (v1's small static list RAISES — no rename arms
+anywhere); user (silently dropped; the list never carries it); message
+`name` and every other openai-guard raw shape (v1 sends messages
+VERBATIM — its transform never calls super, so no flatten and no base
+image transforms; the guard's fallbacks are all the v1-serves kind); on
+the response side, non-string wire models (v1's ModelResponse(**json)
+raises ValidationError). SERVED, never fallbacks: explicit
+`stream: false` (the ONE wave-2b provider where the family guard arm
+would be WRONG — v1 puts `stream` in every body, default false, so
+absent and explicit-false are the same wire byte, pinned); top_k (the
+non-compat TOP-LEVEL passthrough, wire-proven via respx — the snowflake
+elif OVERWRITES the caller's client at main.py:4390, so the
+mock-transport helper cannot reach it); tools -> Snowflake `tool_spec`
+(missing parameters get the empty-object default); tool_choice -> the
+object shape (auto/none verbatim types, required -> any, the dict
+function form -> {"type":"tool","name":[fn]} with the ARRAY); the
+content_list response rewrite (choices[0] text concat + tool_use ->
+OpenAI tool_calls with json.dumps DEFAULT-separator arguments,
+byte-pinned) and the snowflake/{wire-or-EMPTY} response prefix.
+snowflake fork obligations: NO seam preset and the "openai_like"
+construction arm; the request model must ride
+_hidden_params["model"] (v1's cost-calculator feed, dump-invisible —
+gate-pinned); account_id -> URL synthesis and KEYPAIR_JWT/PAT headers
+are pure envelope (header-only auth, researcher-4's correction). Real
+Cortex STREAM delta shapes are unpinned upstream: a content_list delta
+would be a loud v2 error where v1 serves a chunk that silently lost it
+— get real fixtures before flag-on streaming.
 Streaming-seam obligations carried from wave 2a (verifier-wave2a W1/W2 —
 no impact while streaming stays on v1, pinned by
 `test_reasoning_stream_seam_obligation_canary`): the SDK family's openai

--- a/litellm/translation/CLAUDE.md
+++ b/litellm/translation/CLAUDE.md
@@ -1008,6 +1008,21 @@ for reasoning-capable family members; and the line decoders
 (make_parse_line consumers) error loudly on malformed SSE lines that
 v1's BaseModelResponseIterator silently swallows — the PR #30138
 lenient-boundary call belongs to that seam, not the parsers.
+Streaming obligations added at the wave-2b-alpha fix round
+(verifier-wave2b-alpha F1/F2/F3, fixed ONCE in the shared
+`openai_compat/httpx_chunk.py` factory so every dict-path consumer
+inherits them): a reasoning/refusal-bearing FINISH delta is the LOUD
+finish-chunk fallback (v1's wrapper interleaves it as a separate chunk
+the fold cannot reproduce — the pre-fix factory served an empty finish
+chunk with the text silently GONE; two-sided rows in the openrouter and
+xai stream gates, all base-handler consumers inherit), and a non-string
+non-None reasoning value is a loud error (v1 serves it then RAISES
+APIError at stream end in the chunk builder). One NAMED zero-data
+divergence remains for the streaming seam to inherit deliberately: v1
+serves a mid-stream empty-string reasoning delta as its own chunk while
+the v2 fold swallows the empty delta (byte-identical otherwise) —
+pinned by the openrouter gate's named-obligation row; decide
+serve-vs-swallow at the seam before flag-on streaming.
 The xai completion() fork is NOT wired (integrator
 scope, like openai/azure); when it lands these are HARD OBLIGATIONS, not
 notes: the in-package `use_xai_oauth` guard arm is defense-in-depth ONLY

--- a/litellm/translation/CLAUDE.md
+++ b/litellm/translation/CLAUDE.md
@@ -345,6 +345,25 @@ translation/
 │   │   └── stream.py    # httpx_chunk family policy (v1 = the BASE
 │   │                    #   OpenAIChatCompletionStreamingHandler) +
 │   │                    #   make_parse_line; "xai" chunk dialect
+│   ├── hosted_vllm/     # wave-2b-alpha own module (httpx dedicated elif
+│   │   │                #   main.py:2619, transforms LIVE, bare wire model)
+│   │   ├── guard.py     # explicit stream:false + the shared openai guard
+│   │   │                #   (its custom-tool / assistant-thinking_blocks
+│   │   │                #   arms double as this provider's rewrite
+│   │   │                #   fallbacks; file parts fall back inbound)
+│   │   ├── params.py    # base list + thinking/reasoning_effort
+│   │   │                #   (UNCONDITIONAL — no capability fork)
+│   │   ├── serialize.py # openai_compat body + recursive tools cleaning
+│   │   │                #   (strict any-depth; additionalProperties only
+│   │   │                #   when false) + the thinking budget-band rewrite
+│   │   │                #   (>=10000 high / >=5000 medium / >=2000 low /
+│   │   │                #   else minimal; disabled+adaptive dropped;
+│   │   │                #   explicit reasoning_effort WINS)
+│   │   ├── response.py  # shared openai parser re-export (no v1 override;
+│   │   │                #   NO hosted_vllm/ prefix)
+│   │   └── stream.py    # httpx_chunk family policy (v1 = the BASE
+│   │                    #   handler); joins the ONE error-chunk PINNED
+│   │                    #   DIVERGENCE row
 │   ├── openrouter/      # wave-2b-alpha own module (httpx dedicated elif
 │   │   │                #   main.py:3354, transforms LIVE, bare wire model)
 │   │   ├── guard.py     # explicit stream:false + the cache-capable-model
@@ -529,7 +548,7 @@ A behavior change ships as its own snapshot-diffed PR, never inside a port.
 
 ## Current scope
 
-OpenAI-chat-in to sixty-seven providers out — `anthropic`,
+OpenAI-chat-in to sixty-eight providers out — `anthropic`,
 `bedrock_converse`, `bedrock_invoke`, `openai_compat`, `vertex_ai` (gemini
 route), `gemini` (AI Studio), `vertex_anthropic`, `azure`, `azure_ai`,
 `azure_ai_anthropic`, `xai`, the thirteen wave-1a compat_sdk providers
@@ -546,7 +565,7 @@ route), `gemini` (AI Studio), `vertex_anthropic`, `azure`, `azure_ai`,
 `datarobot`, `gradient_ai`, `ovhcloud`, `lemonade`), the five wave-2a
 providers (`perplexity`, `sambanova`, `deepinfra`, `moonshot` on the SDK
 path, `cometapi` on the httpx path), and the wave-2b-alpha own modules
-(`deepseek`, `openrouter`) — request, response, and stream
+(`deepseek`, `openrouter`, `hosted_vllm`) — request, response, and stream
 translation,
 differential-green (anthropic: 46-shape corpus + responses + stream
 replays; bedrock and google: the characterization corpus per route + quirk
@@ -796,6 +815,23 @@ test_v1_cost_hidden_param_is_the_fork_obligation and the report's
 SEAM CONTRACT row). The envelope (HTTP-Referer/X-Title headers, the
 litellm.OpenrouterConfig class-attr extra_body merge in the elif) stays
 fork scope.
+Deliberate wave-2b-alpha (hosted_vllm) fallback surfaces (each names the
+v1 path): custom-type tools (the shared openai guard — v1 synthesizes
+function tools from them, asserted in-process); assistant
+`thinking_blocks` (the shared openai guard — v1 prepends them as content
+blocks); `file` content parts (inbound boundary — v1 converts video files
+to `video_url` blocks); top_k (the extra_body crossing, wire-proven);
+user (model-list gated); explicit stream:false (guard arm). SERVED,
+never fallbacks: reasoning_effort verbatim (UNCONDITIONALLY in v1's
+list — no capability fork), the thinking budget-band rewrite (>=10000
+high / >=5000 medium / >=2000 low / else-incl.-absent minimal; disabled
+and adaptive DROPPED; an explicit reasoning_effort WINS — all pinned by
+IDENTICAL rows), and the recursive tools cleaning (`strict` removed at
+every depth and any value; `additionalProperties` removed ONLY when
+false — contrast xai's function-level-only strip). hosted_vllm fork
+obligations: NO model preset (bare wire model); streams fold
+providers/hosted_vllm.parse_line (the FAMILY policy; the base-handler
+error-chunk PINNED DIVERGENCE covers it) with the "xai" chunk dialect.
 Streaming-seam obligations carried from wave 2a (verifier-wave2a W1/W2 —
 no impact while streaming stays on v1, pinned by
 `test_reasoning_stream_seam_obligation_canary`): the SDK family's openai

--- a/litellm/translation/CLAUDE.md
+++ b/litellm/translation/CLAUDE.md
@@ -1394,3 +1394,35 @@ format: write `providers/<name>/`, register it in
 `engine/pipeline._SERIALIZERS` / `_RESPONSE_PARSERS` / `_RESPONSE_DIALECTS`
 (plus `_RAW_GUARDS` when the inbound schema is the provider's own family),
 add a differential corpus, keep the flag off until differential-green.
+
+## Standing typed-discipline batch ("azure-N5"): the ONE canonical member list
+
+This list is the authoritative enumeration of the deferred typed-discipline
+cleanup batch (critic-wave2b-final NIT-4: the members were scattered across
+six reports with no canonical home). New deferrals into the batch APPEND a
+line here in the same commit and cite this section; the batch executor starts
+from this list, not from a report grep. Every member shares the lineage:
+outcome parity holds, only typed/`Any` discipline or shared-seam structure is
+at stake.
+
+- critic-azure N5 (origin): Any-heavy test plumbing — `_azure_corpus.py`
+  (`Dict[str, Any]` throughout, `load_json -> Any`, `jsonable`),
+  `test_differential_azure_request.py` `_v1_body`/`_v2_body` untyped
+  params, `generate_differential_report.py` `_azure_rows(lines: list)` +
+  the unrestored `os.environ.pop("AZURE_API_VERSION")`.
+- critic-wave1b N3: the corpus-helper untyped-invoker lineage the azure
+  plumbing copied.
+- critic-wave2a N6: the report generator's bare `lines: list` parameter
+  house style (every `_*_rows` signature).
+- critic-longtail NIT-5: the ~70-line normalizer residue batched per that
+  critic's own disposition.
+- verifier-longtail F3: the cdr arm's id guard (`isinstance(body_id, str)
+  and body_id`, `litellm/translation_seam.py`) rewrites non-string/empty
+  wire ids to the ambient chatcmpl id where v1's cdr keeps the wire value
+  — touches already-wired openai-style consumers; re-decide with a probe.
+- critic-wave2b-alpha NIT-3: `_own_module_corpus.py`'s Any-heavy invoker,
+  the generator's newer `lines: list` params, and the per-commit
+  interleaved import blocks in `_wave2b_alpha_error_chunk_pins`.
+- verifier-wave2b-beta F8 residual: watsonx response `id: 7` — both sides
+  raise the same ValidationError but v2's raise escapes from the seam,
+  not as a typed fallback (the F2 fail-closed arm covers only `model`).

--- a/litellm/translation/CLAUDE.md
+++ b/litellm/translation/CLAUDE.md
@@ -384,6 +384,30 @@ translation/
 │   │                    #   httpx_chunk factory (reasoning="rename" + the
 │   │                    #   passthrough_delta_keys axis admitting
 │   │                    #   thinking_blocks); "xai" chunk dialect
+│   ├── watsonx/         # wave-2b-beta: watsonx /ml/v1/text/chat over the
+│   │   │                #   OpenAILikeChatHandler route (auth incl. the
+│   │   │                #   IAM-token network POST is envelope; project/
+│   │   │                #   space ids ride TranslationDeps)
+│   │   ├── guard.py     # the shared openai guard (full name fallback);
+│   │   │                #   NO stream:false arm (the wire ALWAYS carries
+│   │   │                #   the stream key)
+│   │   ├── params.py    # mct/parallel_tool_calls/thinking raises, the
+│   │   │                #   top_k legacy watsonx_text ValueError, user
+│   │   │                #   drop, deployment/ models, missing project+
+│   │   │                #   space (v1 raises 401) — all typed fallbacks
+│   │   ├── serialize.py # assemble_body + stream-always + model_id +
+│   │   │                #   project_id/space_id injection + tools
+│   │   │                #   strict/additionalProperties-False strip +
+│   │   │                #   tool_choice_option split + reasoning_effort
+│   │   │                #   verbatim
+│   │   ├── response.py  # openai parse for validation, verbatim wire with
+│   │   │                #   the LIVE "watsonx/{wire_model}" prefix (the
+│   │   │                #   seam constructs with usage_style
+│   │   │                #   "openai_like"); F2 non-string-model arm
+│   │   └── stream.py    # databricks ModelResponseIterator mirror ->
+│   │                    #   generic payloads ("generic" dialect; data:-
+│   │                    #   OPTIONAL line seam; v1's silent swallows of
+│   │                    #   malformed lines/chunks are PINNED DIVERGENCES)
 │   └── xai/             # Grok over openai_compat (httpx path: NO model
 │       │                #   prefix anywhere, transform_response is LIVE):
 │       ├── guard.py     # web_search_options (v1's Responses-bridge reroute
@@ -543,9 +567,9 @@ A behavior change ships as its own snapshot-diffed PR, never inside a port.
 
 ## Current scope
 
-OpenAI-chat-in to sixty-eight providers out (wave-2b-beta adds
-`cohere`/`cohere_chat` (one module) and `mistral` — see their paragraphs
-below) —
+OpenAI-chat-in to sixty-nine providers out (wave-2b-beta adds
+`cohere`/`cohere_chat` (one module), `mistral`, and `watsonx` — see their
+paragraphs below) —
 `anthropic`,
 `bedrock_converse`, `bedrock_invoke`, `openai_compat`, `vertex_ai` (gemini
 route), `gemini` (AI Studio), `vertex_anthropic`, `azure`, `azure_ai`,
@@ -856,6 +880,45 @@ own dossier). Mistral fork obligations (NOT wired; integrator scope): no
 model preset (bare wire model, the xai R4 rule), construction arm
 "openai", streams fold with the "xai" dialect over
 providers/mistral.parse_line (standard data:/[DONE] SSE).
+Deliberate wave-2b-beta watsonx fallback surfaces (providers/watsonx; each
+names the v1 path): max_completion_tokens (RAISES — the OpenAILike rename
+is dead behind the list gate), parallel_tool_calls/thinking/logit_bias/
+web_search_options (raises), top_k and every legacy watsonx-text param
+(the get_optional_params watsonx-only arm raises a bare ValueError naming
+the watsonx_text provider — a DIFFERENT raise class, pinned), ``user``
+(silent drop), ``deployment/`` models (deployment URLs, api_version pop,
+no model_id/project_id payload — envelope), missing project AND space id
+in deps (v1's _get_api_params raises WatsonXAIError 401), message ``name``
+(forwarded verbatim — full-name guard arm), n/seed/penalties/logprobs/
+top_logprobs (parse-level; v1 serves verbatim). SERVED quirks pinned
+IDENTICAL: the body ALWAYS carries ``stream`` (the openai_like handler
+re-adds ``stream or False`` unconditionally, so explicit false == absent —
+NO guard arm), ``model`` AND ``model_id`` both set to the wire model,
+project_id-or-space_id injection (project wins; ids ride
+``TranslationDeps.watsonx_project_id``/``watsonx_space_id`` — the future
+seam fork must run v1's _get_api_params resolution chain), tools
+``strict`` stripped at every depth + ``additionalProperties`` removed only
+where False, tool_choice auto/none/required -> ``tool_choice_option`` with
+the dict form riding ``tool_choice`` verbatim, response_format (object AND
+json_schema) + reasoning_effort verbatim (json_mode is NEVER set —
+the OpenAILike json_mode machinery is dormant), responses constructed
+ModelResponse(**json)-direct with the LIVE ``watsonx/{wire_model}`` prefix
+(model None -> the literal "watsonx/"; non-string wire model fails closed
+— the verifier-longtail F2 arm), and streams through the databricks
+GenericStreamingChunk iterator (researcher-4 drift: NOT the plain openai
+dialect) folded by the "generic" dialect — wire finish maps through
+map_finish_reason (IBM time_limit/cancelled/error -> stop, max_tokens ->
+length; unknown strings are conservative loud errors), name-only tool
+starts ride with validated arguments "", mid-stream usage is stripped, the
+choices=[] usage tail passes through (seam contract), and a stream without
+a wire finish gets v1's SYNTHESIZED trailing stop (seam scope, the cohere
+contract). PINNED DIVERGENCES (fail-closed on failure paths): non-JSON
+stream lines and chunks failing ModelResponseStream validation — v1's
+iterator swallows both silently, v2 errors loudly (named report rows).
+Watsonx fork obligations (NOT wired; integrator scope): construction arm
+"openai_like" (NEVER "openai" — the construction-arm gate applies), no
+model preset, deps built with the resolved project/space ids, streams fold
+with the "generic" dialect over providers/watsonx.parse_line.
 Not yet here, each its own follow-up: streaming seams live; the other
 inbound schemas (`anthropic_messages`, `google_genai`, `responses`,
 `completions`); the same-family fast path (waits on the opaque-body

--- a/litellm/translation/CLAUDE.md
+++ b/litellm/translation/CLAUDE.md
@@ -397,6 +397,24 @@ translation/
 │   │   └── stream.py    # httpx_chunk family policy (v1 = the BASE
 │   │                    #   handler); joins the ONE error-chunk PINNED
 │   │                    #   DIVERGENCE row
+│   ├── huggingface/     # wave-2b-alpha own module — the api_base
+│   │   │                #   (dedicated endpoint) ROUTE ONLY (httpx elif
+│   │   │                #   main.py:3185, bare wire model)
+│   │   ├── guard.py     # explicit stream:false + the shared openai guard
+│   │   │                #   (the api_base arm sends messages VERBATIM)
+│   │   ├── params.py    # the ROUTE gate first: deps.api_base None ->
+│   │   │                #   EVERYTHING falls back (the router route's
+│   │   │                #   3-segment names fetch the HF provider mapping
+│   │   │                #   over HTTP INSIDE the transform; 1-segment
+│   │   │                #   names crash v1); then the plain base list +
+│   │   │                #   top_k (non-compat top-level passthrough)
+│   │   ├── serialize.py # openai_compat body verbatim (v1's
+│   │   │                #   ChatCompletionRequest passthrough: model and
+│   │   │                #   messages untouched, mct verbatim) + top_k
+│   │   ├── response.py  # shared openai parser re-export (no v1 override;
+│   │   │                #   NO huggingface/ prefix)
+│   │   └── stream.py    # httpx_chunk family policy (v1 = the BASE
+│   │                    #   handler); joins the ONE PINNED DIVERGENCE
 │   ├── openrouter/      # wave-2b-alpha own module (httpx dedicated elif
 │   │   │                #   main.py:3354, transforms LIVE, bare wire model)
 │   │   ├── guard.py     # explicit stream:false + the cache-capable-model
@@ -610,7 +628,7 @@ A behavior change ships as its own snapshot-diffed PR, never inside a port.
 
 ## Current scope
 
-OpenAI-chat-in to seventy providers out — `anthropic`,
+OpenAI-chat-in to seventy-one providers out — `anthropic`,
 `bedrock_converse`, `bedrock_invoke`, `openai_compat`, `vertex_ai` (gemini
 route), `gemini` (AI Studio), `vertex_anthropic`, `azure`, `azure_ai`,
 `azure_ai_anthropic`, `xai`, the thirteen wave-1a compat_sdk providers
@@ -627,8 +645,8 @@ route), `gemini` (AI Studio), `vertex_anthropic`, `azure`, `azure_ai`,
 `datarobot`, `gradient_ai`, `ovhcloud`, `lemonade`), the five wave-2a
 providers (`perplexity`, `sambanova`, `deepinfra`, `moonshot` on the SDK
 path, `cometapi` on the httpx path), and the wave-2b-alpha own modules
-(`deepseek`, `openrouter`, `hosted_vllm`, `fireworks_ai`, `snowflake`) —
-request, response, and stream
+(`deepseek`, `openrouter`, `hosted_vllm`, `fireworks_ai`, `snowflake`,
+`huggingface` on its api_base route) — request, response, and stream
 translation,
 differential-green (anthropic: 46-shape corpus + responses + stream
 replays; bedrock and google: the characterization corpus per route + quirk
@@ -958,6 +976,26 @@ are pure envelope (header-only auth, researcher-4's correction). Real
 Cortex STREAM delta shapes are unpinned upstream: a content_list delta
 would be a loud v2 error where v1 serves a chunk that silently lost it
 — get real fixtures before flag-on streaming.
+Deliberate wave-2b-alpha (huggingface) fallback surfaces (each names the
+v1 path): the WHOLE router route — `deps.api_base` None falls back every
+request typed (v1's 3-segment `provider/org/model` names fetch the HF
+inference-provider mapping over a BLOCKING HTTP GET inside
+transform_request and rewrite the model to providerId; 2-segment names
+skip the fetch but run the base transforms + router URL synthesis;
+1-segment names CRASH v1 with the split ValueError — all pinned); on the
+api_base route, `max_retries` (NOT popped on this arm — v1 serves it
+INTO the body, an oddity the row pins), user (model-list gated), message
+`name` and the other openai-guard raw shapes (v1 sends messages
+VERBATIM), and explicit stream:false (the body carries every
+optional_params key). SERVED: the verbatim body (model untouched, mct
+verbatim, no renames) plus top_k (the non-compat TOP-LEVEL passthrough).
+huggingface fork obligations: the fork MUST thread
+`litellm_params["api_base"]` into `deps.api_base` (the route gate keys
+on it — None means every request falls back; the env
+HF_API_BASE/HUGGINGFACE_API_BASE chain resolves in v1's envelope ABOVE
+the transform and does NOT arm the api_base transform route, so the
+fork must thread exactly the litellm_params value, not the env) and
+keep the bare wire model (no preset, "openai" construction arm).
 Streaming-seam obligations carried from wave 2a (verifier-wave2a W1/W2 —
 no impact while streaming stays on v1, pinned by
 `test_reasoning_stream_seam_obligation_canary`): the SDK family's openai

--- a/litellm/translation/CLAUDE.md
+++ b/litellm/translation/CLAUDE.md
@@ -345,6 +345,31 @@ translation/
 │   │   └── stream.py    # httpx_chunk family policy (v1 = the BASE
 │   │                    #   OpenAIChatCompletionStreamingHandler) +
 │   │                    #   make_parse_line; "xai" chunk dialect
+│   ├── openrouter/      # wave-2b-alpha own module (httpx dedicated elif
+│   │   │                #   main.py:3354, transforms LIVE, bare wire model)
+│   │   ├── guard.py     # explicit stream:false + the cache-capable-model
+│   │   │                #   arm (claude/gemini/minimax/glm/z-ai substrings
+│   │   │                #   KEEP cache_control + get the message-level
+│   │   │                #   move; other models' base strip == the IR drop,
+│   │   │                #   served) + the shared openai guard
+│   │   ├── params.py    # base list + top_k (top-level passthrough:
+│   │   │                #   openrouter is NOT a compat provider — wire-
+│   │   │                #   proven) + reasoning_effort/thinking on DUAL-
+│   │   │                #   keyed reasoning models (openrouter/{m} OR bare
+│   │   │                #   {m}; openrouter/-prefixed ids answer False —
+│   │   │                #   v1's prefix-strip); thinking falls back BOTH
+│   │   │                #   ways (verbatim emission / UPE)
+│   │   ├── serialize.py # openai_compat body + usage:{include:true}
+│   │   │                #   ALWAYS + top_k/reasoning_effort verbatim
+│   │   ├── response.py  # shared openai parser re-export (bare wire
+│   │   │                #   model); usage.cost rides the dump verbatim and
+│   │   │                #   the _hidden_params cost header is a FORK
+│   │   │                #   obligation (gate-pinned)
+│   │   └── stream.py    # OWN v1 handler -> per-provider policy: the
+│   │                    #   "unconditional" ReasoningMode arm (added with
+│   │                    #   this consumer), key-presence error raise,
+│   │                    #   strict id/created/model/choices envelope +
+│   │                    #   the missing-delta pre-step
 │   └── xai/             # Grok over openai_compat (httpx path: NO model
 │       │                #   prefix anywhere, transform_response is LIVE):
 │       ├── guard.py     # web_search_options (v1's Responses-bridge reroute
@@ -504,7 +529,7 @@ A behavior change ships as its own snapshot-diffed PR, never inside a port.
 
 ## Current scope
 
-OpenAI-chat-in to sixty-six providers out — `anthropic`,
+OpenAI-chat-in to sixty-seven providers out — `anthropic`,
 `bedrock_converse`, `bedrock_invoke`, `openai_compat`, `vertex_ai` (gemini
 route), `gemini` (AI Studio), `vertex_anthropic`, `azure`, `azure_ai`,
 `azure_ai_anthropic`, `xai`, the thirteen wave-1a compat_sdk providers
@@ -521,7 +546,7 @@ route), `gemini` (AI Studio), `vertex_anthropic`, `azure`, `azure_ai`,
 `datarobot`, `gradient_ai`, `ovhcloud`, `lemonade`), the five wave-2a
 providers (`perplexity`, `sambanova`, `deepinfra`, `moonshot` on the SDK
 path, `cometapi` on the httpx path), and the wave-2b-alpha own modules
-(`deepseek`) — request, response, and stream
+(`deepseek`, `openrouter`) — request, response, and stream
 translation,
 differential-green (anthropic: 46-shape corpus + responses + stream
 replays; bedrock and google: the characterization corpus per route + quirk
@@ -743,6 +768,34 @@ response rows), streams fold providers/deepseek.parse_line with the "xai"
 chunk dialect at the SSE line seam, and the error-chunk PINNED DIVERGENCE
 (v1's base handler swallows; v2 is loud) extends to deepseek exactly like
 the compat_httpx family.
+Deliberate wave-2b-alpha (openrouter) fallback surfaces (each names the
+v1 path): thinking BOTH ways (reasoning-capable models: v1 serves the
+wire dict VERBATIM, an unported emission — the zai/minimax precedent;
+non-capable models: v1 raises UnsupportedParamsError, like
+reasoning_effort off the dual-keyed capability); cache_control on
+cache-capable models (claude/gemini/minimax/glm/z-ai substrings — v1
+keeps it and moves message-level markers into the last content block;
+on every OTHER model the base strip == the IR drop, SERVED and pinned);
+`transforms`/`models`/`route` (v1's top-level passthrough — the map's
+extra_body packing is DEAD at runtime, a dossier drift fact); user
+(model-list gated); explicit stream:false (guard arm). SERVED, never
+fallbacks: top_k (the top-level passthrough, wire-proven — openrouter is
+NOT in openai_compatible_providers so there is no extra_body crossing),
+reasoning_effort on dual-key-capable models (verbatim emission), and the
+ALWAYS-injected `usage: {"include": true}` body key. openrouter fork
+obligations (when the integrator wires it): NO model preset (fresh
+ModelResponse, bare wire model); streams fold providers/openrouter
+.parse_line (its OWN strict/raising policy row — NOT the family default)
+with the "xai" chunk dialect; and the HARD OBLIGATION from the response
+gate — v1 copies wire `usage.cost` into `_hidden_params
+["additional_headers"]["llm_provider-x-litellm-response-cost"]` as a
+float (the cost-calculator feed); the v2 body retains usage.cost
+verbatim, so the fork MUST rebuild that header from the body before the
+openrouter flag can turn on (pinned by
+test_v1_cost_hidden_param_is_the_fork_obligation and the report's
+SEAM CONTRACT row). The envelope (HTTP-Referer/X-Title headers, the
+litellm.OpenrouterConfig class-attr extra_body merge in the elif) stays
+fork scope.
 Streaming-seam obligations carried from wave 2a (verifier-wave2a W1/W2 —
 no impact while streaming stays on v1, pinned by
 `test_reasoning_stream_seam_obligation_canary`): the SDK family's openai

--- a/litellm/translation/CLAUDE.md
+++ b/litellm/translation/CLAUDE.md
@@ -345,6 +345,39 @@ translation/
 │   │   └── stream.py    # httpx_chunk family policy (v1 = the BASE
 │   │                    #   OpenAIChatCompletionStreamingHandler) +
 │   │                    #   make_parse_line; "xai" chunk dialect
+│   ├── fireworks_ai/    # wave-2b-alpha own module (httpx dedicated elif
+│   │   │                #   main.py:2198; the WIRE model differs from the
+│   │   │                #   request model and the response model carries
+│   │   │                #   the fireworks_ai/ prefix INSIDE the parser)
+│   │   ├── guard.py     # explicit stream:false + the shared openai guard
+│   │   │                #   (cache_control needs NO arm: v1 strips it
+│   │   │                #   recursively == the IR drop, served)
+│   │   ├── params.py    # fireworks' OWN list (user SERVED; top_k mention
+│   │   │                #   dead — extra_body crossing) + three capability
+│   │   │                #   forks over fireworks_ai/{m}; the deps read is
+│   │   │                #   STRICTLY NARROWER than v1's get_provider_info
+│   │   │                #   default-true + hyphen-boundary scan (one-
+│   │   │                #   direction mirror gate; honest drift notes);
+│   │   │                #   response_format WITH tools falls back (v1's
+│   │   │                #   json_mode cross-plane machinery); legacy-defs
+│   │   │                #   tools fall back at the shared inbound arm
+│   │   ├── serialize.py # openai_compat body + accounts/fireworks/models/
+│   │   │                #   model rewrite + mct->max_tokens rename +
+│   │   │                #   tool_choice required->any + function-level
+│   │   │                #   strict strip (shared strip_function_strict) +
+│   │   │                #   the #transform=inline image suffix (literal
+│   │   │                #   "vision" substring gate; data: urls exempt;
+│   │   │                #   the ambient disable global is a SEAM
+│   │   │                #   obligation) + user/reasoning_effort verbatim
+│   │   ├── response.py  # the shared make_direct_parser (OpenAILike
+│   │   │                #   DIRECT construction, "openai_like" seam arm)
+│   │   │                #   with the fireworks_ai/{WIRE model} policy +
+│   │   │                #   the tool-calls-in-content repair fallback
+│   │   │                #   (v1 mints uuid4 ids; the pure parser fails
+│   │   │                #   closed)
+│   │   └── stream.py    # httpx_chunk family policy (v1 = the BASE
+│   │                    #   handler; chunks keep the BARE wire model);
+│   │                    #   joins the ONE error-chunk PINNED DIVERGENCE
 │   ├── hosted_vllm/     # wave-2b-alpha own module (httpx dedicated elif
 │   │   │                #   main.py:2619, transforms LIVE, bare wire model)
 │   │   ├── guard.py     # explicit stream:false + the shared openai guard
@@ -548,7 +581,7 @@ A behavior change ships as its own snapshot-diffed PR, never inside a port.
 
 ## Current scope
 
-OpenAI-chat-in to sixty-eight providers out — `anthropic`,
+OpenAI-chat-in to sixty-nine providers out — `anthropic`,
 `bedrock_converse`, `bedrock_invoke`, `openai_compat`, `vertex_ai` (gemini
 route), `gemini` (AI Studio), `vertex_anthropic`, `azure`, `azure_ai`,
 `azure_ai_anthropic`, `xai`, the thirteen wave-1a compat_sdk providers
@@ -565,7 +598,8 @@ route), `gemini` (AI Studio), `vertex_anthropic`, `azure`, `azure_ai`,
 `datarobot`, `gradient_ai`, `ovhcloud`, `lemonade`), the five wave-2a
 providers (`perplexity`, `sambanova`, `deepinfra`, `moonshot` on the SDK
 path, `cometapi` on the httpx path), and the wave-2b-alpha own modules
-(`deepseek`, `openrouter`, `hosted_vllm`) — request, response, and stream
+(`deepseek`, `openrouter`, `hosted_vllm`, `fireworks_ai`) — request,
+response, and stream
 translation,
 differential-green (anthropic: 46-shape corpus + responses + stream
 replays; bedrock and google: the characterization corpus per route + quirk
@@ -832,6 +866,40 @@ false — contrast xai's function-level-only strip). hosted_vllm fork
 obligations: NO model preset (bare wire model); streams fold
 providers/hosted_vllm.parse_line (the FAMILY policy; the base-handler
 error-chunk PINNED DIVERGENCE covers it) with the "xai" chunk dialect.
+Deliberate wave-2b-alpha (fireworks_ai) fallback surfaces (each names the
+v1 path): tools/parallel_tool_calls/tool_choice/reasoning_effort wherever
+the fireworks_ai/{m} map flag is not explicitly true — the deps read is
+STRICTLY NARROWER than v1's get_provider_info default-true +
+hyphen-boundary scan (one-direction soundness pinned by
+test_capability_mirror_is_one_direction: zero v1-False/v2-True rows at
+HEAD; v1 serves or raises per its own gate, the typed fallback reproduces
+it either way; re-evaluate with a deps map-scan surface if tools fallback
+volume hurts); response_format WITH tools (v1 pops response_format and
+sets the json_mode routing marker — the groq-shape cross-plane
+machinery); legacy-def tool schemas (the SHARED inbound arm; v1 inlines
+$refs via unpack_legacy_defs); assistant provider_specific_fields /
+thinking_blocks (v1 POPS both); pdf/file parts (v1 migrates to
+image_url); n / logprobs / penalties / prompt_truncate_length /
+context_length_exceeded_behavior (v1 serves — top-level for the OpenAI
+ones, extra_body crossing for the provider-native two); top_k (extra_body
+crossing, wire-proven); explicit stream:false; on the response side, the
+tool-calls-in-content repair shape (v1 synthesizes a uuid4 tool_call —
+the pure parser fails closed; reserved json_tool_call contents serve
+verbatim, pinned) and non-string wire models (v1's ModelResponse(**json)
+raises ValidationError). SERVED, never fallbacks: the accounts/fireworks/
+models/{m} model rewrite (kept verbatim for accounts/-prefixed and
+#-bearing ids), mct->max_tokens, tool_choice required->any, the
+function-level strict strip (deeper strict keys ride verbatim — v1 keeps
+them), the #transform=inline image suffix (LITERAL "vision" substring
+gate on the REWRITTEN model; data: urls exempt), cache_control stripped
+(== the IR drop), and user/reasoning_effort verbatim. fireworks_ai fork
+obligations: NO seam preset and the "openai_like" construction arm with
+the parser-owned fireworks_ai/{WIRE model} prefix (NOT the request
+model); the ambient litellm.disable_add_transform_inline_image_block
+global (and the per-request litellm_params flag) must FORCE v1 at the
+seam before flag-on — the serializer encodes the default-enabled arm
+only; response _hidden_params.additional_headers ride the seam's
+headers-passthrough follow-up.
 Streaming-seam obligations carried from wave 2a (verifier-wave2a W1/W2 —
 no impact while streaming stays on v1, pinned by
 `test_reasoning_stream_seam_obligation_canary`): the SDK family's openai

--- a/litellm/translation/CLAUDE.md
+++ b/litellm/translation/CLAUDE.md
@@ -942,15 +942,29 @@ ModelResponse(**json)-direct with the LIVE ``watsonx/{wire_model}`` prefix
 (model None -> the literal "watsonx/"; non-string wire model fails closed
 — the verifier-longtail F2 arm), and streams through the databricks
 GenericStreamingChunk iterator (researcher-4 drift: NOT the plain openai
-dialect) folded by the "generic" dialect — wire finish maps through
-map_finish_reason (IBM time_limit/cancelled/error -> stop, max_tokens ->
-length; unknown strings are conservative loud errors), name-only tool
-starts ride with validated arguments "", mid-stream usage is stripped, the
-choices=[] usage tail passes through (seam contract), and a stream without
-a wire finish gets v1's SYNTHESIZED trailing stop (seam scope, the cohere
-contract). PINNED DIVERGENCES (fail-closed on failure paths): non-JSON
-stream lines and chunks failing ModelResponseStream validation — v1's
-iterator swallows both silently, v2 errors loudly (named report rows).
+dialect) folded by the "generic" dialect — a truthy STRING wire finish
+rides VERBATIM and the chunk envelope runs v1's live map_finish_reason on
+BOTH sides (IBM time_limit/cancelled/error -> stop, max_tokens -> length,
+unknown strings -> stop — the verifier-F7 fix; v1 SERVES "stop", the old
+conservative loud arm is gone), truthy non-str hashable finishes -> stop
+(the map's .get default), falsy finishes ride as NO finish (StreamingChoices'
+truthy gate; the synthesized tail is seam scope), truthy unhashable
+finishes are loud (v1's map raises TypeError -> MidStreamFallbackError);
+name-only tool starts ride with validated arguments "" and tool indexes
+lax-coerce exactly like v1's Delta (str digits, bools, integral floats);
+mid-stream usage is stripped AFTER validation (non-dict usage raises in
+v1 -> loud; values Usage's lax coercion rejects swallow the whole chunk in
+v1 -> pinned divergence); the choices=[] usage tail passes through (seam
+contract — NOTE: v1's include_usage wrapper OVERRIDES null/zero tail
+values with token-counter ESTIMATES; the future streaming seam must
+reproduce the estimate arm), and a stream without a wire finish gets v1's
+SYNTHESIZED trailing stop (seam scope, the cohere contract). PINNED
+DIVERGENCES (fail-closed on failure paths): non-JSON stream lines, chunks
+failing ModelResponseStream validation (incl. non-str tool id/name/type
+and non-coercible tool indexes — v2 never invents id/name None or index 0
+where v1 drops the chunk, critic B1.4), non-str delta content, and
+lax-rejected usage values — v1 swallows each silently, v2 errors loudly
+(named report rows).
 Watsonx fork obligations (NOT wired; integrator scope): construction arm
 "openai_like" (NEVER "openai" — the construction-arm gate applies), no
 model preset, deps built with the resolved project/space ids, streams fold

--- a/litellm/translation/CLAUDE.md
+++ b/litellm/translation/CLAUDE.md
@@ -358,6 +358,32 @@ translation/
 │   │                    #   the real wire sends ``type`` — both regimes
 │   │                    #   pinned (wrapper end-of-stream synthesis = seam
 │   │                    #   scope)
+│   ├── mistral/         # wave-2b-beta: mistral over openai_compat (httpx
+│   │   │                #   path, dedicated elif, bare wire model)
+│   │   ├── guard.py     # own name matrix (tool-role names kept by v1;
+│   │   │                #   the image branch forwards every name) + the
+│   │   │                #   shared openai guard with skip_name_fallback;
+│   │   │                #   NO stream:false arm (v1's map only copies
+│   │   │                #   stream=True — explicit False never reaches
+│   │   │                #   the wire)
+│   │   ├── params.py    # user (silent drop) + thinking/reasoning_effort
+│   │   │                #   (magistral system-prompt injection / raise)
+│   │   │                #   as typed fallbacks
+│   │   ├── serialize.py # assemble_body + mct rename, tool_choice
+│   │   │                #   required->any (dict form silently dropped),
+│   │   │                #   $id/$schema strip at v1's depth cap, top_k
+│   │   │                #   verbatim; two-branch message munge (image ->
+│   │   │                #   verbatim base output; else flatten +
+│   │   │                #   MistralToolCallMessage + empty-assistant
+│   │   │                #   removal + None strip)
+│   │   ├── response.py  # the two raw pre-steps (empty->None FIRST, then
+│   │   │                #   magistral content-list collapse: LAST text
+│   │   │                #   wins, thinking joins -> reasoning_content)
+│   │   │                #   then the shared openai parser
+│   │   └── stream.py    # content-list normalize pre-step over the
+│   │                    #   httpx_chunk factory (reasoning="rename" + the
+│   │                    #   passthrough_delta_keys axis admitting
+│   │                    #   thinking_blocks); "xai" chunk dialect
 │   └── xai/             # Grok over openai_compat (httpx path: NO model
 │       │                #   prefix anywhere, transform_response is LIVE):
 │       ├── guard.py     # web_search_options (v1's Responses-bridge reroute
@@ -517,8 +543,9 @@ A behavior change ships as its own snapshot-diffed PR, never inside a port.
 
 ## Current scope
 
-OpenAI-chat-in to sixty-seven providers out (wave-2b-beta adds
-`cohere`/`cohere_chat`, one module — see the cohere paragraph below) —
+OpenAI-chat-in to sixty-eight providers out (wave-2b-beta adds
+`cohere`/`cohere_chat` (one module) and `mistral` — see their paragraphs
+below) —
 `anthropic`,
 `bedrock_converse`, `bedrock_invoke`, `openai_compat`, `vertex_ai` (gemini
 route), `gemini` (AI Studio), `vertex_anthropic`, `azure`, `azure_ai`,
@@ -796,6 +823,39 @@ reaches the wrapper on that regime). One PINNED DIVERGENCE (fail-closed
 on a failure path, the compat_httpx error-chunk precedent): non-str
 stream ``content.text`` — v1 silently swallows the chunk, v2 errors
 loudly (named report row).
+Deliberate wave-2b-beta mistral fallback surfaces (providers/mistral; each
+names the v1 path): every supported-list raise (frequency_penalty,
+presence_penalty, n, logprobs, web_search_options, and
+thinking/reasoning_effort on NON-magistral models); the magistral
+reasoning-prompt INJECTION (v1 rewrites the message list with a constant
+system prompt at transform time — v2 falls back on thinking/
+reasoning_effort everywhere, one arm for both regimes); ``user`` (silently
+dropped upstream — dossier drift: researcher-4 listed it as a raise);
+``seed`` (v1 packs extra_body.random_seed, parse-level fallback); tool-role
+message ``name`` (v1 keeps it; non-tool names serve through the IR drop);
+ANY message ``name`` beside image/file content (the image branch forwards
+names verbatim); string-form stop; single-text content lists (v1 flattens
+— the conservative shared arm, the sambanova precedent); text lists
+flattening to "" (v1's truthy assignment keeps the LIST form). SERVED
+quirks pinned IDENTICAL: explicit stream:false (v1's map only copies True
+— NO guard arm, the IR collapse IS v1's drop), mct->max_tokens, top_k
+verbatim top-level (wire-proven — researcher-4 listed it as a raise, the
+probe refutes it), tool_choice required->any with the DICT form silently
+dropped, tools $id/$schema strip at v1's exact depth-10 cap
+(additionalProperties/strict KEPT — port the code, not the docstring),
+multi-text flatten, MistralToolCallMessage rebuild, empty-assistant
+removal, per-message None strip, the image branch's verbatim
+base-transform passthrough, response empty-content->None BEFORE the
+magistral content-list collapse (LAST text block wins; thinking texts
+join "\\n" into reasoning_content), bare wire model, and the stream
+content-list normalize (thinking_blocks signature "mistral" riding the
+delta via the httpx_chunk factory's wave-2b-beta passthrough_delta_keys
+axis — mistral is the axis's consumer). codestral reuses MistralConfig in
+v1 but is NOT registered here (stays a v1 fallback; re-evaluate with its
+own dossier). Mistral fork obligations (NOT wired; integrator scope): no
+model preset (bare wire model, the xai R4 rule), construction arm
+"openai", streams fold with the "xai" dialect over
+providers/mistral.parse_line (standard data:/[DONE] SSE).
 Not yet here, each its own follow-up: streaming seams live; the other
 inbound schemas (`anthropic_messages`, `google_genai`, `responses`,
 `completions`); the same-family fast path (waits on the opaque-body

--- a/litellm/translation/deps.py
+++ b/litellm/translation/deps.py
@@ -44,6 +44,14 @@ class TranslationDeps:
     - ``base_model``: the azure deployment's declared base model; v1 detects
       o-series/gpt-5 param families on ``base_model or model``
       (azure.py:245-247). ``None`` for providers without deployment aliasing.
+    - ``api_base``: the request-level api_base (v1: ``litellm_params
+      ["api_base"]``), wave-2b-alpha for huggingface — its transform forks
+      on EXACTLY this value (hf chat/transformation.py:135: the verbatim
+      dedicated-endpoint body vs the router route whose 3-segment names
+      fetch the HF provider mapping over HTTP inside the transform). v2
+      serves ONLY the api_base route; ``None`` means the seam never wired
+      the field and every huggingface request falls back typed. ``None``
+      for providers that never read it.
     """
 
     max_tokens_for_model: Callable[[str], int | None]
@@ -55,3 +63,4 @@ class TranslationDeps:
     modify_params: bool
     api_version: str | None = None
     base_model: str | None = None
+    api_base: str | None = None

--- a/litellm/translation/deps.py
+++ b/litellm/translation/deps.py
@@ -55,3 +55,15 @@ class TranslationDeps:
     modify_params: bool
     api_version: str | None = None
     base_model: str | None = None
+    watsonx_project_id: str | None = None
+    """wave-2b-beta: the resolved watsonx project id. v1 resolves it inside
+    ``_get_api_params`` (param kwargs -> WATSONX_PROJECT_ID/WX_PROJECT_ID/
+    PROJECT_ID env) and ``_prepare_payload`` injects it into the BODY, so it
+    is payload, not envelope; the future watsonx seam fork must run the same
+    resolution before building deps. ``None`` together with
+    ``watsonx_space_id`` means v1 raises WatsonXAIError 401 — the serializer
+    falls back so v1 serves its own raise."""
+    watsonx_space_id: str | None = None
+    """The deployment-space alternative to ``watsonx_project_id`` (same
+    resolution chain, WATSONX_DEPLOYMENT_SPACE_ID/... env); v1 only injects
+    it when the project id is absent."""

--- a/litellm/translation/dispatch.py
+++ b/litellm/translation/dispatch.py
@@ -129,6 +129,10 @@ Provider = Literal[
     # content_list responses); snowflake/{wire model} prefix INSIDE the
     # parser; stream is ALWAYS a body key (absent == false on the wire).
     "snowflake",
+    # huggingface: ONLY the api_base (dedicated endpoint) route is ported —
+    # the router route (provider-mapping HTTP fetch INSIDE the transform)
+    # is a permanent typed fallback keyed on deps.api_base; bare wire model.
+    "huggingface",
 ]
 
 NeverPortProvider = Literal[

--- a/litellm/translation/dispatch.py
+++ b/litellm/translation/dispatch.py
@@ -121,6 +121,10 @@ Provider = Literal[
     # hosted_vllm: bare wire model too; thinking serves through v1's
     # deterministic budget-band rewrite, tools cleaned recursively.
     "hosted_vllm",
+    # fireworks_ai: the ONE wave-2b-alpha prefixing parser so far —
+    # fireworks_ai/{WIRE model} INSIDE its parser (never a seam preset);
+    # request model rewritten to accounts/fireworks/models/{m}.
+    "fireworks_ai",
 ]
 
 NeverPortProvider = Literal[

--- a/litellm/translation/dispatch.py
+++ b/litellm/translation/dispatch.py
@@ -112,9 +112,12 @@ Provider = Literal[
     "cometapi",
     # wave-2b-alpha own-module providers (providers/<name> packages, each
     # with dedicated differential gates; APPEND-ONLY, one line per provider
-    # in its own commit). All are httpx-path dedicated elifs. deepseek keeps
-    # the bare wire model (no seam preset — the xai R4 rule).
+    # in its own commit). All are httpx-path dedicated elifs. deepseek and
+    # openrouter keep the bare wire model (no seam preset — the xai R4
+    # rule); openrouter's usage.cost hidden-params header is a fork
+    # obligation (its response gate pins it).
     "deepseek",
+    "openrouter",
 ]
 
 NeverPortProvider = Literal[

--- a/litellm/translation/dispatch.py
+++ b/litellm/translation/dispatch.py
@@ -121,6 +121,11 @@ Provider = Literal[
     # fallback inside the module — codestral reuses the v1 config but is
     # NOT a wave-2b provider and stays a v1 fallback).
     "mistral",
+    # wave-2b-beta: watsonx (the OpenAILikeChatHandler route; the IAM-token
+    # auth is envelope, project/space ids ride deps; the LIVE
+    # watsonx/{wire_model} response prefix is parser scope; streams ride the
+    # generic dialect via the databricks iterator).
+    "watsonx",
 ]
 
 NeverPortProvider = Literal[

--- a/litellm/translation/dispatch.py
+++ b/litellm/translation/dispatch.py
@@ -110,6 +110,11 @@ Provider = Literal[
     "deepinfra",
     "moonshot",
     "cometapi",
+    # wave-2b-alpha own-module providers (providers/<name> packages, each
+    # with dedicated differential gates; APPEND-ONLY, one line per provider
+    # in its own commit). All are httpx-path dedicated elifs. deepseek keeps
+    # the bare wire model (no seam preset — the xai R4 rule).
+    "deepseek",
 ]
 
 NeverPortProvider = Literal[

--- a/litellm/translation/dispatch.py
+++ b/litellm/translation/dispatch.py
@@ -126,6 +126,12 @@ Provider = Literal[
     # watsonx/{wire_model} response prefix is parser scope; streams ride the
     # generic dialect via the databricks iterator).
     "watsonx",
+    # wave-2b-beta: sagemaker_chat (base GPT config over SigV4 transport;
+    # the endpoint name is the model; streams pinned at the AWS
+    # event-stream PARSED-event seam with the openai dialect).
+    # sagemaker_nova shares the main.py branch but carries its OWN config
+    # overrides and is deliberately ABSENT (stays a typed v1 fallback).
+    "sagemaker_chat",
 ]
 
 NeverPortProvider = Literal[

--- a/litellm/translation/dispatch.py
+++ b/litellm/translation/dispatch.py
@@ -132,6 +132,10 @@ Provider = Literal[
     # sagemaker_nova shares the main.py branch but carries its OWN config
     # overrides and is deliberately ABSENT (stays a typed v1 fallback).
     "sagemaker_chat",
+    # wave-2b-beta: groq (httpx path; bare wire model + the service_tier
+    # clamp on responses; the json_schema workaround/raise arms are typed
+    # fallbacks, native-schema models serve verbatim).
+    "groq",
 ]
 
 NeverPortProvider = Literal[

--- a/litellm/translation/dispatch.py
+++ b/litellm/translation/dispatch.py
@@ -125,6 +125,10 @@ Provider = Literal[
     # fireworks_ai/{WIRE model} INSIDE its parser (never a seam preset);
     # request model rewritten to accounts/fireworks/models/{m}.
     "fireworks_ai",
+    # snowflake: its own wire mapping (tool_spec / tool_choice objects /
+    # content_list responses); snowflake/{wire model} prefix INSIDE the
+    # parser; stream is ALWAYS a body key (absent == false on the wire).
+    "snowflake",
 ]
 
 NeverPortProvider = Literal[

--- a/litellm/translation/dispatch.py
+++ b/litellm/translation/dispatch.py
@@ -110,6 +110,12 @@ Provider = Literal[
     "deepinfra",
     "moonshot",
     "cometapi",
+    # wave-2b-beta: own-module providers (providers/<name>/). cohere and
+    # cohere_chat are ONE module (main.py's elif handles both names; the v2
+    # wire is the DEFAULT route at HEAD — the legacy "v1/" route predicate
+    # is a typed fallback inside the cohere guard, researcher-4 §11).
+    "cohere",
+    "cohere_chat",
 ]
 
 NeverPortProvider = Literal[

--- a/litellm/translation/dispatch.py
+++ b/litellm/translation/dispatch.py
@@ -116,6 +116,11 @@ Provider = Literal[
     # is a typed fallback inside the cohere guard, researcher-4 §11).
     "cohere",
     "cohere_chat",
+    # wave-2b-beta: mistral (httpx path, dedicated elif; bare wire model on
+    # responses; the magistral reasoning-prompt injection is a typed
+    # fallback inside the module — codestral reuses the v1 config but is
+    # NOT a wave-2b provider and stays a v1 fallback).
+    "mistral",
 ]
 
 NeverPortProvider = Literal[

--- a/litellm/translation/dispatch.py
+++ b/litellm/translation/dispatch.py
@@ -118,6 +118,9 @@ Provider = Literal[
     # obligation (its response gate pins it).
     "deepseek",
     "openrouter",
+    # hosted_vllm: bare wire model too; thinking serves through v1's
+    # deterministic budget-band rewrite, tools cleaned recursively.
+    "hosted_vllm",
 ]
 
 NeverPortProvider = Literal[

--- a/litellm/translation/engine/pipeline.py
+++ b/litellm/translation/engine/pipeline.py
@@ -80,6 +80,11 @@ from ..providers.openai_compat import (
 from ..providers.openai_compat import (
     unsupported_request_shapes as openai_compat_unsupported_request_shapes,
 )
+from ..providers.openrouter import parse_response as openrouter_parse_response
+from ..providers.openrouter import serialize_request as openrouter_serialize_request
+from ..providers.openrouter import (
+    unsupported_request_shapes as openrouter_unsupported_request_shapes,
+)
 from ..providers.vertex_anthropic import (
     parse_response as vertex_anthropic_parse_response,
 )
@@ -122,6 +127,7 @@ _SERIALIZERS: Mapping[Provider, _Serializer] = MappingProxyType(
         # wave-2b-alpha own-module providers (per-provider rows: these are
         # NOT family members; each package owns its serializer).
         "deepseek": deepseek_serialize_request,
+        "openrouter": openrouter_serialize_request,
     }
 )
 
@@ -152,10 +158,13 @@ _RESPONSE_PARSERS: Mapping[Provider, _ResponseParser] = MappingProxyType(
         # lemonade request-model prefixes, which are parser scope (the
         # family's PARSERS table carries the per-provider truth).
         **compat_httpx_parsers,
-        # wave-2b-alpha own-module providers. deepseek: the base GPT
-        # transform_response is live on its httpx elif -> the shared openai
-        # parser with NO seam preset (bare wire model, the xai R4 rule).
+        # wave-2b-alpha own-module providers. deepseek/openrouter: the base
+        # GPT transform_response is live on their httpx elifs -> the shared
+        # openai parser with NO seam preset (bare wire model, the xai R4
+        # rule; openrouter's usage.cost hidden-params header is a fork
+        # obligation pinned in its response gate).
         "deepseek": deepseek_parse_response,
+        "openrouter": openrouter_parse_response,
     }
 )
 
@@ -188,6 +197,7 @@ _RESPONSE_DIALECTS: Mapping[Provider, ResponseDialect] = MappingProxyType(
         # outbound bodies (per-provider stream truth lives in each package's
         # stream.py, composed from the shared httpx_chunk factory).
         "deepseek": _OPENAI_DIALECT,
+        "openrouter": _OPENAI_DIALECT,
     }
 )
 
@@ -214,6 +224,7 @@ _RAW_GUARDS: Mapping[Provider, _RawGuard] = MappingProxyType(
         # wave-2b-alpha own-module providers (same-family wire formats; each
         # guard composes the shared openai guard with its provider arms).
         "deepseek": deepseek_unsupported_request_shapes,
+        "openrouter": openrouter_unsupported_request_shapes,
     }
 )
 

--- a/litellm/translation/engine/pipeline.py
+++ b/litellm/translation/engine/pipeline.py
@@ -95,6 +95,11 @@ from ..providers.openrouter import serialize_request as openrouter_serialize_req
 from ..providers.openrouter import (
     unsupported_request_shapes as openrouter_unsupported_request_shapes,
 )
+from ..providers.snowflake import parse_response as snowflake_parse_response
+from ..providers.snowflake import serialize_request as snowflake_serialize_request
+from ..providers.snowflake import (
+    unsupported_request_shapes as snowflake_unsupported_request_shapes,
+)
 from ..providers.vertex_anthropic import (
     parse_response as vertex_anthropic_parse_response,
 )
@@ -140,6 +145,7 @@ _SERIALIZERS: Mapping[Provider, _Serializer] = MappingProxyType(
         "openrouter": openrouter_serialize_request,
         "hosted_vllm": hosted_vllm_serialize_request,
         "fireworks_ai": fireworks_serialize_request,
+        "snowflake": snowflake_serialize_request,
     }
 )
 
@@ -183,6 +189,9 @@ _RESPONSE_PARSERS: Mapping[Provider, _ResponseParser] = MappingProxyType(
         # direct-parser factory with the fireworks policy; the seam fork must
         # use the "openai_like" construction arm (RESPONSE_STYLE, pinned).
         "fireworks_ai": fireworks_parse_response,
+        # snowflake: content_list pre-rewrite + the direct parser with the
+        # snowflake/{wire model} prefix policy ("openai_like" seam arm).
+        "snowflake": snowflake_parse_response,
     }
 )
 
@@ -218,6 +227,7 @@ _RESPONSE_DIALECTS: Mapping[Provider, ResponseDialect] = MappingProxyType(
         "openrouter": _OPENAI_DIALECT,
         "hosted_vllm": _OPENAI_DIALECT,
         "fireworks_ai": _OPENAI_DIALECT,
+        "snowflake": _OPENAI_DIALECT,
     }
 )
 
@@ -247,6 +257,7 @@ _RAW_GUARDS: Mapping[Provider, _RawGuard] = MappingProxyType(
         "openrouter": openrouter_unsupported_request_shapes,
         "hosted_vllm": hosted_vllm_unsupported_request_shapes,
         "fireworks_ai": fireworks_unsupported_request_shapes,
+        "snowflake": snowflake_unsupported_request_shapes,
     }
 )
 

--- a/litellm/translation/engine/pipeline.py
+++ b/litellm/translation/engine/pipeline.py
@@ -85,6 +85,15 @@ from ..providers.openai_compat import (
 from ..providers.openai_compat import (
     unsupported_request_shapes as openai_compat_unsupported_request_shapes,
 )
+from ..providers.sagemaker_chat import (
+    parse_response as sagemaker_chat_parse_response,
+)
+from ..providers.sagemaker_chat import (
+    serialize_request as sagemaker_chat_serialize_request,
+)
+from ..providers.sagemaker_chat import (
+    unsupported_request_shapes as sagemaker_chat_unsupported_request_shapes,
+)
 from ..providers.vertex_anthropic import (
     parse_response as vertex_anthropic_parse_response,
 )
@@ -135,6 +144,7 @@ _SERIALIZERS: Mapping[Provider, _Serializer] = MappingProxyType(
         "cohere_chat": cohere_serialize_request,
         "mistral": mistral_serialize_request,
         "watsonx": watsonx_serialize_request,
+        "sagemaker_chat": sagemaker_chat_serialize_request,
     }
 )
 
@@ -180,6 +190,9 @@ _RESPONSE_PARSERS: Mapping[Provider, _ResponseParser] = MappingProxyType(
         # wave-2b consumer; the seam must construct with usage_style
         # "openai_like", NOT "openai").
         "watsonx": watsonx_parse_response,
+        # sagemaker_chat: the shared openai parser verbatim (base
+        # transform_response is LIVE; bare wire model, no seam preset).
+        "sagemaker_chat": sagemaker_chat_parse_response,
     }
 )
 
@@ -223,6 +236,9 @@ _RESPONSE_DIALECTS: Mapping[Provider, ResponseDialect] = MappingProxyType(
         # "openai_like" — this table is the outbound-body dialect only (the
         # construction-arm gate guards the seam read).
         "watsonx": _OPENAI_DIALECT,
+        # sagemaker_chat: openai everywhere (chunk-fold dialect "openai" at
+        # the AWS event-stream parsed-event seam).
+        "sagemaker_chat": _OPENAI_DIALECT,
     }
 )
 
@@ -259,6 +275,9 @@ _RAW_GUARDS: Mapping[Provider, _RawGuard] = MappingProxyType(
         # watsonx: the shared openai guard (full name fallback); no
         # stream:false arm — the wire ALWAYS carries the stream key.
         "watsonx": watsonx_unsupported_request_shapes,
+        # sagemaker_chat: explicit stream:false + the shared openai guard
+        # (full name fallback).
+        "sagemaker_chat": sagemaker_chat_unsupported_request_shapes,
     }
 )
 

--- a/litellm/translation/engine/pipeline.py
+++ b/litellm/translation/engine/pipeline.py
@@ -271,9 +271,16 @@ OWN_MODULE_RESPONSE_STYLES: Mapping[Provider, ResponseStyle] = MappingProxyType(
         # "openai" = cdr via the base GPT transform_response; "openai_like" =
         # ModelResponse(**json) DIRECT construction (no stop->tool_calls
         # rewrite, different pydantic dump, NO seam preset either way).
-        # Wrong-arm divergence is pinned per openai_like member in the
-        # fireworks_ai/snowflake response gates; the registration gate
-        # asserts every own-module provider has a row. The seam's AST gate
+        # Wrong-arm divergence is pinned per MEMBER in its response gate:
+        # openai_like members ride a verbatim wire index 5 the cdr arm
+        # enumerate-rewrites (the fireworks_ai/snowflake template); openai
+        # members use the INVERTED template — a float wire ``created`` the
+        # cdr arm coerces-and-serves like v1 while the direct construction
+        # raises ValidationError (cohere pins the ambient envelope id its
+        # parser-built body cannot carry instead) — verifier-wave2b-final
+        # F1 closed the eight value-unpinned "openai" rows. The
+        # registration gate asserts every own-module provider has a row.
+        # The seam's AST gate
         # (test_seam_forks_never_select_usage_style_via_response_dialect)
         # already rejects any fork that routes through response_dialect().
         "deepseek": "openai",

--- a/litellm/translation/engine/pipeline.py
+++ b/litellm/translation/engine/pipeline.py
@@ -63,6 +63,11 @@ from ..providers.deepseek import serialize_request as deepseek_serialize_request
 from ..providers.deepseek import (
     unsupported_request_shapes as deepseek_unsupported_request_shapes,
 )
+from ..providers.fireworks_ai import parse_response as fireworks_parse_response
+from ..providers.fireworks_ai import serialize_request as fireworks_serialize_request
+from ..providers.fireworks_ai import (
+    unsupported_request_shapes as fireworks_unsupported_request_shapes,
+)
 from ..providers.google_genai import parse_response as google_parse_response
 from ..providers.google_genai import (
     serialize_request_studio as google_serialize_request_studio,
@@ -134,6 +139,7 @@ _SERIALIZERS: Mapping[Provider, _Serializer] = MappingProxyType(
         "deepseek": deepseek_serialize_request,
         "openrouter": openrouter_serialize_request,
         "hosted_vllm": hosted_vllm_serialize_request,
+        "fireworks_ai": fireworks_serialize_request,
     }
 )
 
@@ -172,6 +178,11 @@ _RESPONSE_PARSERS: Mapping[Provider, _ResponseParser] = MappingProxyType(
         "deepseek": deepseek_parse_response,
         "openrouter": openrouter_parse_response,
         "hosted_vllm": hosted_vllm_parse_response,
+        # fireworks_ai: its OWN transform_response (the OpenAILike DIRECT
+        # construction + the fireworks_ai/{wire model} prefix) -> the shared
+        # direct-parser factory with the fireworks policy; the seam fork must
+        # use the "openai_like" construction arm (RESPONSE_STYLE, pinned).
+        "fireworks_ai": fireworks_parse_response,
     }
 )
 
@@ -206,6 +217,7 @@ _RESPONSE_DIALECTS: Mapping[Provider, ResponseDialect] = MappingProxyType(
         "deepseek": _OPENAI_DIALECT,
         "openrouter": _OPENAI_DIALECT,
         "hosted_vllm": _OPENAI_DIALECT,
+        "fireworks_ai": _OPENAI_DIALECT,
     }
 )
 
@@ -234,6 +246,7 @@ _RAW_GUARDS: Mapping[Provider, _RawGuard] = MappingProxyType(
         "deepseek": deepseek_unsupported_request_shapes,
         "openrouter": openrouter_unsupported_request_shapes,
         "hosted_vllm": hosted_vllm_unsupported_request_shapes,
+        "fireworks_ai": fireworks_unsupported_request_shapes,
     }
 )
 

--- a/litellm/translation/engine/pipeline.py
+++ b/litellm/translation/engine/pipeline.py
@@ -53,6 +53,11 @@ from ..providers.bedrock_invoke import parse_response as bedrock_invoke_parse_re
 from ..providers.bedrock_invoke import (
     serialize_request as bedrock_invoke_serialize_request,
 )
+from ..providers.cohere import parse_response as cohere_parse_response
+from ..providers.cohere import serialize_request as cohere_serialize_request
+from ..providers.cohere import (
+    unsupported_request_shapes as cohere_unsupported_request_shapes,
+)
 from ..providers.compat_httpx import GUARDS as compat_httpx_guards
 from ..providers.compat_httpx import PARSERS as compat_httpx_parsers
 from ..providers.compat_httpx import SERIALIZERS as compat_httpx_serializers
@@ -114,6 +119,10 @@ _SERIALIZERS: Mapping[Provider, _Serializer] = MappingProxyType(
         # compat_httpx family (wave-1b): the dedicated-elif shims; same
         # splice convention, second family variant (no seam model preset).
         **compat_httpx_serializers,
+        # wave-2b-beta own modules: cohere/cohere_chat are ONE module (the
+        # main.py elif serves both provider names; v2 is the default route).
+        "cohere": cohere_serialize_request,
+        "cohere_chat": cohere_serialize_request,
     }
 )
 
@@ -144,6 +153,12 @@ _RESPONSE_PARSERS: Mapping[Provider, _ResponseParser] = MappingProxyType(
         # lemonade request-model prefixes, which are parser scope (the
         # family's PARSERS table carries the per-provider truth).
         **compat_httpx_parsers,
+        # wave-2b-beta: the cohere parser builds the normalized body itself
+        # (cohere-native wire) and rides it on ChatResponse.wire; the seam's
+        # "openai" construction arm reproduces v1's fresh-ModelResponse
+        # mutation byte-for-byte (probed; finish is ALWAYS "stop" in v1).
+        "cohere": cohere_parse_response,
+        "cohere_chat": cohere_parse_response,
     }
 )
 
@@ -172,6 +187,13 @@ _RESPONSE_DIALECTS: Mapping[Provider, ResponseDialect] = MappingProxyType(
         # policy for the rest — selected by the stream gates/future
         # streaming seam, not this outbound-body table)
         **{provider: _OPENAI_DIALECT for provider in compat_httpx_serializers},
+        # wave-2b-beta: the cohere parser rides the normalized
+        # chat-completion body on ChatResponse.wire (the openai outbound
+        # dialect); the chunk-fold dialect is "generic" (the wrapper's
+        # GenericStreamingChunk arm — selected by the stream gates/future
+        # streaming seam, not this outbound-body table).
+        "cohere": _OPENAI_DIALECT,
+        "cohere_chat": _OPENAI_DIALECT,
     }
 )
 
@@ -195,6 +217,11 @@ _RAW_GUARDS: Mapping[Provider, _RawGuard] = MappingProxyType(
         # the shared guard for everyone else)
         **compat_sdk_guards,
         **compat_httpx_guards,
+        # wave-2b-beta: the cohere guard carries the v1-route / explicit-v2-
+        # prefix predicates plus the shared openai guard (full message-name
+        # fallback — cohere's transform is the inherited GPT one).
+        "cohere": cohere_unsupported_request_shapes,
+        "cohere_chat": cohere_unsupported_request_shapes,
     }
 )
 

--- a/litellm/translation/engine/pipeline.py
+++ b/litellm/translation/engine/pipeline.py
@@ -73,6 +73,11 @@ from ..providers.google_genai import (
 from ..providers.google_genai import (
     unsupported_request_shapes as google_unsupported_request_shapes,
 )
+from ..providers.hosted_vllm import parse_response as hosted_vllm_parse_response
+from ..providers.hosted_vllm import serialize_request as hosted_vllm_serialize_request
+from ..providers.hosted_vllm import (
+    unsupported_request_shapes as hosted_vllm_unsupported_request_shapes,
+)
 from ..providers.openai_compat import parse_response as openai_compat_parse_response
 from ..providers.openai_compat import (
     serialize_request as openai_compat_serialize_request,
@@ -128,6 +133,7 @@ _SERIALIZERS: Mapping[Provider, _Serializer] = MappingProxyType(
         # NOT family members; each package owns its serializer).
         "deepseek": deepseek_serialize_request,
         "openrouter": openrouter_serialize_request,
+        "hosted_vllm": hosted_vllm_serialize_request,
     }
 )
 
@@ -165,6 +171,7 @@ _RESPONSE_PARSERS: Mapping[Provider, _ResponseParser] = MappingProxyType(
         # obligation pinned in its response gate).
         "deepseek": deepseek_parse_response,
         "openrouter": openrouter_parse_response,
+        "hosted_vllm": hosted_vllm_parse_response,
     }
 )
 
@@ -198,6 +205,7 @@ _RESPONSE_DIALECTS: Mapping[Provider, ResponseDialect] = MappingProxyType(
         # stream.py, composed from the shared httpx_chunk factory).
         "deepseek": _OPENAI_DIALECT,
         "openrouter": _OPENAI_DIALECT,
+        "hosted_vllm": _OPENAI_DIALECT,
     }
 )
 
@@ -225,6 +233,7 @@ _RAW_GUARDS: Mapping[Provider, _RawGuard] = MappingProxyType(
         # guard composes the shared openai guard with its provider arms).
         "deepseek": deepseek_unsupported_request_shapes,
         "openrouter": openrouter_unsupported_request_shapes,
+        "hosted_vllm": hosted_vllm_unsupported_request_shapes,
     }
 )
 

--- a/litellm/translation/engine/pipeline.py
+++ b/litellm/translation/engine/pipeline.py
@@ -91,6 +91,11 @@ from ..providers.vertex_anthropic import (
 from ..providers.vertex_anthropic import (
     serialize_request as vertex_anthropic_serialize_request,
 )
+from ..providers.watsonx import parse_response as watsonx_parse_response
+from ..providers.watsonx import serialize_request as watsonx_serialize_request
+from ..providers.watsonx import (
+    unsupported_request_shapes as watsonx_unsupported_request_shapes,
+)
 from ..providers.xai import parse_response as xai_parse_response
 from ..providers.xai import serialize_request as xai_serialize_request
 from ..providers.xai import (
@@ -129,6 +134,7 @@ _SERIALIZERS: Mapping[Provider, _Serializer] = MappingProxyType(
         "cohere": cohere_serialize_request,
         "cohere_chat": cohere_serialize_request,
         "mistral": mistral_serialize_request,
+        "watsonx": watsonx_serialize_request,
     }
 )
 
@@ -169,6 +175,11 @@ _RESPONSE_PARSERS: Mapping[Provider, _ResponseParser] = MappingProxyType(
         # content-list collapse) then the shared openai parser (bare wire
         # model — the cdr fresh-ModelResponse arm).
         "mistral": mistral_parse_response,
+        # watsonx: openai parse for validation, then the verbatim body with
+        # the LIVE "watsonx/{wire_model}" prefix (the openai_like arm's one
+        # wave-2b consumer; the seam must construct with usage_style
+        # "openai_like", NOT "openai").
+        "watsonx": watsonx_parse_response,
     }
 )
 
@@ -207,6 +218,11 @@ _RESPONSE_DIALECTS: Mapping[Provider, ResponseDialect] = MappingProxyType(
         # mistral: openai outbound body; the chunk-fold dialect is "xai"
         # (the generic httpx dict path) over the mistral line parser.
         "mistral": _OPENAI_DIALECT,
+        # watsonx: openai outbound body (the parser rides it on wire); the
+        # chunk-fold dialect is "generic" and the seam CONSTRUCTION arm is
+        # "openai_like" — this table is the outbound-body dialect only (the
+        # construction-arm gate guards the seam read).
+        "watsonx": _OPENAI_DIALECT,
     }
 )
 
@@ -240,6 +256,9 @@ _RAW_GUARDS: Mapping[Provider, _RawGuard] = MappingProxyType(
         # skip_name_fallback; deliberately NO explicit stream:false arm
         # (v1's map only copies stream=True).
         "mistral": mistral_unsupported_request_shapes,
+        # watsonx: the shared openai guard (full name fallback); no
+        # stream:false arm — the wire ALWAYS carries the stream key.
+        "watsonx": watsonx_unsupported_request_shapes,
     }
 )
 

--- a/litellm/translation/engine/pipeline.py
+++ b/litellm/translation/engine/pipeline.py
@@ -73,6 +73,11 @@ from ..providers.google_genai import (
 from ..providers.google_genai import (
     unsupported_request_shapes as google_unsupported_request_shapes,
 )
+from ..providers.groq import parse_response as groq_parse_response
+from ..providers.groq import serialize_request as groq_serialize_request
+from ..providers.groq import (
+    unsupported_request_shapes as groq_unsupported_request_shapes,
+)
 from ..providers.mistral import parse_response as mistral_parse_response
 from ..providers.mistral import serialize_request as mistral_serialize_request
 from ..providers.mistral import (
@@ -145,6 +150,7 @@ _SERIALIZERS: Mapping[Provider, _Serializer] = MappingProxyType(
         "mistral": mistral_serialize_request,
         "watsonx": watsonx_serialize_request,
         "sagemaker_chat": sagemaker_chat_serialize_request,
+        "groq": groq_serialize_request,
     }
 )
 
@@ -193,6 +199,10 @@ _RESPONSE_PARSERS: Mapping[Provider, _ResponseParser] = MappingProxyType(
         # sagemaker_chat: the shared openai parser verbatim (base
         # transform_response is LIVE; bare wire model, no seam preset).
         "sagemaker_chat": sagemaker_chat_parse_response,
+        # groq: openai parse for validation, verbatim wire + the
+        # service_tier clamp (bare wire model; construction arm
+        # "openai_like" — the direct ModelResponse(**json) style).
+        "groq": groq_parse_response,
     }
 )
 
@@ -239,6 +249,10 @@ _RESPONSE_DIALECTS: Mapping[Provider, ResponseDialect] = MappingProxyType(
         # sagemaker_chat: openai everywhere (chunk-fold dialect "openai" at
         # the AWS event-stream parsed-event seam).
         "sagemaker_chat": _OPENAI_DIALECT,
+        # groq: openai outbound body; chunk-fold dialect "xai" (the httpx
+        # dict path) over the groq line parser; seam construction arm
+        # "openai_like".
+        "groq": _OPENAI_DIALECT,
     }
 )
 
@@ -278,6 +292,9 @@ _RAW_GUARDS: Mapping[Provider, _RawGuard] = MappingProxyType(
         # sagemaker_chat: explicit stream:false + the shared openai guard
         # (full name fallback).
         "sagemaker_chat": sagemaker_chat_unsupported_request_shapes,
+        # groq: explicit stream:false + the shared openai guard (full name
+        # fallback).
+        "groq": groq_unsupported_request_shapes,
     }
 )
 

--- a/litellm/translation/engine/pipeline.py
+++ b/litellm/translation/engine/pipeline.py
@@ -56,6 +56,7 @@ from ..providers.bedrock_invoke import (
 from ..providers.compat_httpx import GUARDS as compat_httpx_guards
 from ..providers.compat_httpx import PARSERS as compat_httpx_parsers
 from ..providers.compat_httpx import SERIALIZERS as compat_httpx_serializers
+from ..providers.compat_httpx.response import ResponseStyle
 from ..providers.compat_sdk import GUARDS as compat_sdk_guards
 from ..providers.compat_sdk import SERIALIZERS as compat_sdk_serializers
 from ..providers.deepseek import parse_response as deepseek_parse_response
@@ -199,6 +200,29 @@ _RESPONSE_PARSERS: Mapping[Provider, _ResponseParser] = MappingProxyType(
         # snowflake/{wire model} prefix policy ("openai_like" seam arm).
         "snowflake": snowflake_parse_response,
         "huggingface": huggingface_parse_response,
+    }
+)
+
+OWN_MODULE_RESPONSE_STYLES: Mapping[Provider, ResponseStyle] = MappingProxyType(
+    {
+        # The v1 response-CONSTRUCTION style per own-module provider — the
+        # machine-readable truth any future completion() fork must select
+        # ``usage_style`` from, exactly like compat_httpx.RESPONSE_STYLES
+        # (critic-wave2b-alpha MAJOR-4: this obligation lived in prose).
+        # "openai" = cdr via the base GPT transform_response; "openai_like" =
+        # ModelResponse(**json) DIRECT construction (no stop->tool_calls
+        # rewrite, different pydantic dump, NO seam preset either way).
+        # Wrong-arm divergence is pinned per openai_like member in the
+        # fireworks_ai/snowflake response gates; the registration gate
+        # asserts every own-module provider has a row. The seam's AST gate
+        # (test_seam_forks_never_select_usage_style_via_response_dialect)
+        # already rejects any fork that routes through response_dialect().
+        "deepseek": "openai",
+        "openrouter": "openai",
+        "hosted_vllm": "openai",
+        "huggingface": "openai",
+        "fireworks_ai": "openai_like",
+        "snowflake": "openai_like",
     }
 )
 

--- a/litellm/translation/engine/pipeline.py
+++ b/litellm/translation/engine/pipeline.py
@@ -282,6 +282,20 @@ OWN_MODULE_RESPONSE_STYLES: Mapping[Provider, ResponseStyle] = MappingProxyType(
         "huggingface": "openai",
         "fireworks_ai": "openai_like",
         "snowflake": "openai_like",
+        # wave-2b-beta own modules, registered at the sibling merge
+        # (integrator consistency sweep — the gate's coverage now spans ALL
+        # eleven wave-2b own modules). cohere/mistral/sagemaker_chat ride
+        # the cdr arm ("openai"); watsonx and groq are DIRECT
+        # ModelResponse(**json) construction ("openai_like") with wrong-arm
+        # divergence pins in their response gates (the fireworks/snowflake
+        # template: wire index 5 rides verbatim on the correct arm, the cdr
+        # arm enumerate-rewrites it to 0).
+        "cohere": "openai",
+        "cohere_chat": "openai",
+        "mistral": "openai",
+        "sagemaker_chat": "openai",
+        "watsonx": "openai_like",
+        "groq": "openai_like",
     }
 )
 

--- a/litellm/translation/engine/pipeline.py
+++ b/litellm/translation/engine/pipeline.py
@@ -73,6 +73,11 @@ from ..providers.google_genai import (
 from ..providers.google_genai import (
     unsupported_request_shapes as google_unsupported_request_shapes,
 )
+from ..providers.mistral import parse_response as mistral_parse_response
+from ..providers.mistral import serialize_request as mistral_serialize_request
+from ..providers.mistral import (
+    unsupported_request_shapes as mistral_unsupported_request_shapes,
+)
 from ..providers.openai_compat import parse_response as openai_compat_parse_response
 from ..providers.openai_compat import (
     serialize_request as openai_compat_serialize_request,
@@ -123,6 +128,7 @@ _SERIALIZERS: Mapping[Provider, _Serializer] = MappingProxyType(
         # main.py elif serves both provider names; v2 is the default route).
         "cohere": cohere_serialize_request,
         "cohere_chat": cohere_serialize_request,
+        "mistral": mistral_serialize_request,
     }
 )
 
@@ -159,6 +165,10 @@ _RESPONSE_PARSERS: Mapping[Provider, _ResponseParser] = MappingProxyType(
         # mutation byte-for-byte (probed; finish is ALWAYS "stop" in v1).
         "cohere": cohere_parse_response,
         "cohere_chat": cohere_parse_response,
+        # mistral: two raw-body pre-steps (empty-content -> None, magistral
+        # content-list collapse) then the shared openai parser (bare wire
+        # model — the cdr fresh-ModelResponse arm).
+        "mistral": mistral_parse_response,
     }
 )
 
@@ -194,6 +204,9 @@ _RESPONSE_DIALECTS: Mapping[Provider, ResponseDialect] = MappingProxyType(
         # streaming seam, not this outbound-body table).
         "cohere": _OPENAI_DIALECT,
         "cohere_chat": _OPENAI_DIALECT,
+        # mistral: openai outbound body; the chunk-fold dialect is "xai"
+        # (the generic httpx dict path) over the mistral line parser.
+        "mistral": _OPENAI_DIALECT,
     }
 )
 
@@ -222,6 +235,11 @@ _RAW_GUARDS: Mapping[Provider, _RawGuard] = MappingProxyType(
         # fallback — cohere's transform is the inherited GPT one).
         "cohere": cohere_unsupported_request_shapes,
         "cohere_chat": cohere_unsupported_request_shapes,
+        # mistral: own name-matrix arm (tool-role names kept by v1; image
+        # branch forwards every name) + the shared openai guard with
+        # skip_name_fallback; deliberately NO explicit stream:false arm
+        # (v1's map only copies stream=True).
+        "mistral": mistral_unsupported_request_shapes,
     }
 )
 

--- a/litellm/translation/engine/pipeline.py
+++ b/litellm/translation/engine/pipeline.py
@@ -58,6 +58,11 @@ from ..providers.compat_httpx import PARSERS as compat_httpx_parsers
 from ..providers.compat_httpx import SERIALIZERS as compat_httpx_serializers
 from ..providers.compat_sdk import GUARDS as compat_sdk_guards
 from ..providers.compat_sdk import SERIALIZERS as compat_sdk_serializers
+from ..providers.deepseek import parse_response as deepseek_parse_response
+from ..providers.deepseek import serialize_request as deepseek_serialize_request
+from ..providers.deepseek import (
+    unsupported_request_shapes as deepseek_unsupported_request_shapes,
+)
 from ..providers.google_genai import parse_response as google_parse_response
 from ..providers.google_genai import (
     serialize_request_studio as google_serialize_request_studio,
@@ -114,6 +119,9 @@ _SERIALIZERS: Mapping[Provider, _Serializer] = MappingProxyType(
         # compat_httpx family (wave-1b): the dedicated-elif shims; same
         # splice convention, second family variant (no seam model preset).
         **compat_httpx_serializers,
+        # wave-2b-alpha own-module providers (per-provider rows: these are
+        # NOT family members; each package owns its serializer).
+        "deepseek": deepseek_serialize_request,
     }
 )
 
@@ -144,6 +152,10 @@ _RESPONSE_PARSERS: Mapping[Provider, _ResponseParser] = MappingProxyType(
         # lemonade request-model prefixes, which are parser scope (the
         # family's PARSERS table carries the per-provider truth).
         **compat_httpx_parsers,
+        # wave-2b-alpha own-module providers. deepseek: the base GPT
+        # transform_response is live on its httpx elif -> the shared openai
+        # parser with NO seam preset (bare wire model, the xai R4 rule).
+        "deepseek": deepseek_parse_response,
     }
 )
 
@@ -172,6 +184,10 @@ _RESPONSE_DIALECTS: Mapping[Provider, ResponseDialect] = MappingProxyType(
         # policy for the rest — selected by the stream gates/future
         # streaming seam, not this outbound-body table)
         **{provider: _OPENAI_DIALECT for provider in compat_httpx_serializers},
+        # wave-2b-alpha own-module providers: httpx path, wire-derived
+        # outbound bodies (per-provider stream truth lives in each package's
+        # stream.py, composed from the shared httpx_chunk factory).
+        "deepseek": _OPENAI_DIALECT,
     }
 )
 
@@ -195,6 +211,9 @@ _RAW_GUARDS: Mapping[Provider, _RawGuard] = MappingProxyType(
         # the shared guard for everyone else)
         **compat_sdk_guards,
         **compat_httpx_guards,
+        # wave-2b-alpha own-module providers (same-family wire formats; each
+        # guard composes the shared openai guard with its provider arms).
+        "deepseek": deepseek_unsupported_request_shapes,
     }
 )
 

--- a/litellm/translation/engine/pipeline.py
+++ b/litellm/translation/engine/pipeline.py
@@ -83,6 +83,11 @@ from ..providers.hosted_vllm import serialize_request as hosted_vllm_serialize_r
 from ..providers.hosted_vllm import (
     unsupported_request_shapes as hosted_vllm_unsupported_request_shapes,
 )
+from ..providers.huggingface import parse_response as huggingface_parse_response
+from ..providers.huggingface import serialize_request as huggingface_serialize_request
+from ..providers.huggingface import (
+    unsupported_request_shapes as huggingface_unsupported_request_shapes,
+)
 from ..providers.openai_compat import parse_response as openai_compat_parse_response
 from ..providers.openai_compat import (
     serialize_request as openai_compat_serialize_request,
@@ -146,6 +151,7 @@ _SERIALIZERS: Mapping[Provider, _Serializer] = MappingProxyType(
         "hosted_vllm": hosted_vllm_serialize_request,
         "fireworks_ai": fireworks_serialize_request,
         "snowflake": snowflake_serialize_request,
+        "huggingface": huggingface_serialize_request,
     }
 )
 
@@ -192,6 +198,7 @@ _RESPONSE_PARSERS: Mapping[Provider, _ResponseParser] = MappingProxyType(
         # snowflake: content_list pre-rewrite + the direct parser with the
         # snowflake/{wire model} prefix policy ("openai_like" seam arm).
         "snowflake": snowflake_parse_response,
+        "huggingface": huggingface_parse_response,
     }
 )
 
@@ -228,6 +235,7 @@ _RESPONSE_DIALECTS: Mapping[Provider, ResponseDialect] = MappingProxyType(
         "hosted_vllm": _OPENAI_DIALECT,
         "fireworks_ai": _OPENAI_DIALECT,
         "snowflake": _OPENAI_DIALECT,
+        "huggingface": _OPENAI_DIALECT,
     }
 )
 
@@ -258,6 +266,7 @@ _RAW_GUARDS: Mapping[Provider, _RawGuard] = MappingProxyType(
         "hosted_vllm": hosted_vllm_unsupported_request_shapes,
         "fireworks_ai": fireworks_unsupported_request_shapes,
         "snowflake": snowflake_unsupported_request_shapes,
+        "huggingface": huggingface_unsupported_request_shapes,
     }
 )
 

--- a/litellm/translation/inbound/openai_chat/stream.py
+++ b/litellm/translation/inbound/openai_chat/stream.py
@@ -341,7 +341,12 @@ def _step_generic(state: StreamState, payload: PlainJson) -> _StepResult:
       else "stop") and, under include_usage, a usage chunk with
       token-counter ESTIMATES — re-derive both before flag-on streaming."""
     if not isinstance(payload, dict):
-        return state, ()  # the generic parsers only emit dict payloads
+        # the generic parsers only emit dict payloads: anything else is a
+        # wiring bug and must be loud, never silently dropped (the
+        # _as_block_dialect rule; critic-wave2b-beta N1)
+        return TranslationError.of_unsupported(
+            "generic chunk dialect received a non-object payload; wiring bug"
+        )
     text = payload.get("text")
     tool_call = payload.get("tool_call")
     provider_fields = payload.get("provider_fields")

--- a/litellm/translation/inbound/openai_chat/stream.py
+++ b/litellm/translation/inbound/openai_chat/stream.py
@@ -55,7 +55,25 @@ xai) fold ``wire_chunk`` events and gemini folds composite ``chunk`` events;
 their parsers can never produce a per-block delta, and the step surfaces a
 loud error (never a fabricated placeholder body) if one ever arrives."""
 
-ChunkDialect = Literal[BlockDialect, "openai", "azure", "gemini", "xai"]
+ChunkDialect = Literal[
+    BlockDialect,
+    "openai",
+    "azure",
+    "gemini",
+    "xai",
+    # wave-2b-beta: the GENERIC arm of CustomStreamWrapper (providers whose
+    # v1 iterators yield GenericStreamingChunk dicts — cohere/cohere_chat is
+    # the consumer; watsonx streams ride the openai_like SSE path, NOT this
+    # arm). The wire_chunk blob carries the normalized generic payload
+    # {text, tool_call, finish, usage, provider_fields}; the fold mirrors
+    # the wrapper's PER-CHUNK behavior only (role on first emitted chunk,
+    # provider fields BOTH in the delta and top-level, the wire finish flush
+    # VERBATIM, usage only on a trailing choices: [] chunk). The wrapper's
+    # end-of-stream synthesis (finish stop/tool_calls when the wire never
+    # finished; include_usage estimate chunk) is seam scope — see
+    # _step_generic's docstring.
+    "generic",
+]
 
 
 @dataclass(frozen=True)
@@ -107,6 +125,8 @@ def step(state: StreamState, event: StreamEvent) -> _StepResult:
         case "stop":
             return state, ()
         case "wire_chunk":
+            if state.dialect == "generic":
+                return _step_generic(state, event.wire_chunk.value)
             return _step_openai(state, event.wire_chunk.value)
         case "chunk":
             return _gemini_chunk_step(state, event.chunk)
@@ -134,7 +154,7 @@ def _as_block_dialect(
     match dialect:
         case "anthropic" | "bedrock_converse":
             return dialect
-        case "openai" | "azure" | "gemini" | "xai":
+        case "openai" | "azure" | "gemini" | "xai" | "generic":
             # wire/composite dialects fold whole chunks; a per-block delta
             # here is a wiring bug and must be loud, never a fabricated
             # anthropic-shaped placeholder (critic-google M5 / critic-azure M3).
@@ -292,6 +312,85 @@ def _step_openai(state: StreamState, chunk: PlainJson) -> _StepResult:
         ],
     }
     return replace(next_state, sent_role=True), (body,)
+
+
+def _step_generic(state: StreamState, payload: PlainJson) -> _StepResult:
+    """wave-2b-beta: mirror CustomStreamWrapper's GenericStreamingChunk arm
+    PER PARSED CHUNK (cohere is the consumer — its v1 iterator yields generic
+    dicts; the wrapper builds each emitted chunk from a FRESH
+    ModelResponseStream with an ambient per-chunk id/created and the request
+    model — per-chunk id minting is a seam/envelope contract, pinned by the
+    cohere stream gate). Probed in-process at HEAD:
+
+    - content/tool/provider-field chunks: role rides the FIRST emitted chunk
+      only; ``content`` is the parser text verbatim (``""`` on tool/field
+      chunks); provider fields ride the delta's ``provider_specific_fields``
+      AND the chunk top level (v1 setattrs each key onto model_response);
+      empty generic chunks are dropped.
+    - a wire-carried finish flushes as its own empty-delta chunk with the
+      parser-mapped reason VERBATIM — the wrapper applies NO seen-tool-calls
+      rewrite to a received finish (probed: an event-keyed cohere
+      ``message-end`` after tool deltas emits "stop", not "tool_calls").
+    - usage passes through ONLY on a trailing ``choices: []`` chunk (the
+      family usage-tail contract); v1 swallows it without
+      ``stream_options.include_usage`` and emits its own final usage chunk.
+    - the wrapper's END-OF-STREAM synthesis is SEAM scope, not fold scope:
+      when the wire never carried a finish (cohere's REAL ``type``-keyed
+      message-end is swallowed by v1's parser), v1 synthesizes the trailing
+      finish chunk at StopIteration ("tool_calls" when tool calls were seen,
+      else "stop") and, under include_usage, a usage chunk with
+      token-counter ESTIMATES — re-derive both before flag-on streaming."""
+    if not isinstance(payload, dict):
+        return state, ()  # the generic parsers only emit dict payloads
+    text = payload.get("text")
+    tool_call = payload.get("tool_call")
+    provider_fields = payload.get("provider_fields")
+    finish = payload.get("finish")
+    usage = payload.get("usage")
+    bodies: tuple[Body, ...] = ()
+    sent_role = state.sent_role
+    has_payload = (
+        (isinstance(text, str) and len(text) > 0)
+        or tool_call is not None
+        or isinstance(provider_fields, dict)
+    )
+    if has_payload:
+        delta: dict[str, PlainJson] = {
+            "role": None if sent_role else "assistant",
+            "content": text if isinstance(text, str) else "",
+        }
+        if tool_call is not None:
+            delta = {**delta, "tool_calls": [tool_call]}
+        top_fields: dict[str, PlainJson] = {}
+        if isinstance(provider_fields, dict):
+            delta = {**delta, "provider_specific_fields": provider_fields}
+            top_fields = dict(provider_fields)
+        body: Body = {
+            "model": state.model,
+            "object": "chat.completion.chunk",
+            **top_fields,
+            "choices": [{"index": 0, "delta": delta, "finish_reason": None}],
+        }
+        bodies = (body,)
+        sent_role = True
+    if isinstance(finish, str):
+        final: Body = {
+            "model": state.model,
+            "object": "chat.completion.chunk",
+            "choices": [{"index": 0, "delta": {}, "finish_reason": finish}],
+        }
+        bodies = (*bodies, final)
+    if isinstance(usage, dict):
+        bodies = (
+            *bodies,
+            {
+                "model": state.model,
+                "object": "chat.completion.chunk",
+                "choices": [],
+                "usage": usage,
+            },
+        )
+    return replace(state, sent_role=sent_role), bodies
 
 
 def _content_filter_field(choice: dict[str, PlainJson]) -> dict[str, PlainJson]:

--- a/litellm/translation/providers/azure/guard.py
+++ b/litellm/translation/providers/azure/guard.py
@@ -15,14 +15,11 @@ two azure-only fidelity holes:
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
-from typing import cast
-
-from litellm.constants import DEFAULT_MAX_RECURSE_DEPTH
+from collections.abc import Mapping
 
 from ...errors import TranslationError
 from ..openai_compat import unsupported_request_shapes as openai_unsupported_shapes
-from ..openai_compat.guard import explicit_stream_false
+from ..openai_compat.guard import carries_cache_control, explicit_stream_false
 
 _Raw = Mapping[str, object]
 
@@ -41,28 +38,13 @@ def unsupported_request_shapes(raw: _Raw) -> TranslationError | None:
 
 
 def _azure_reason(raw: _Raw) -> str | None:
+    # the recursive scan is openai_compat.guard.carries_cache_control (lifted
+    # there at wave-2b-alpha; openrouter composes the same mechanism behind
+    # its cache-capable-model policy)
     for field in ("messages", "tools"):
-        if _carries_cache_control(raw.get(field), 0):
+        if carries_cache_control(raw.get(field)):
             return (
                 f"cache_control inside {field} (azure forwards it verbatim, "
                 "az gpt_transformation.py:250-263; the IR strips it)"
             )
     return None
-
-
-def _carries_cache_control(value: object, depth: int) -> bool:
-    if depth > DEFAULT_MAX_RECURSE_DEPTH:
-        # exhaustion must never ADMIT a request: treat the unscannable tail
-        # as if it carried the marker (fall back to v1)
-        return True
-    if isinstance(value, Mapping):
-        mapping = cast(Mapping[str, object], value)
-        if "cache_control" in mapping:
-            return True
-        return any(_carries_cache_control(item, depth + 1) for item in mapping.values())
-    if isinstance(value, Sequence) and not isinstance(value, str):
-        return any(
-            _carries_cache_control(item, depth + 1)
-            for item in cast(Sequence[object], value)
-        )
-    return False

--- a/litellm/translation/providers/cohere/__init__.py
+++ b/litellm/translation/providers/cohere/__init__.py
@@ -1,0 +1,12 @@
+from .guard import unsupported_request_shapes
+from .response import parse_response
+from .serialize import serialize_request
+from .stream import parse_event, parse_line
+
+__all__ = (
+    "parse_event",
+    "parse_line",
+    "parse_response",
+    "serialize_request",
+    "unsupported_request_shapes",
+)

--- a/litellm/translation/providers/cohere/guard.py
+++ b/litellm/translation/providers/cohere/guard.py
@@ -1,0 +1,47 @@
+"""Raw-shape fidelity guard for the cohere v2 chat serializer.
+
+Route predicates first (researcher-4 §11 — provider Literals cannot carry a
+route, so the predicate lives HERE, asserted by the differential gates):
+
+- ``"v1/" in model``: the legacy Cohere v1 wire (message/chat_history/
+  tool_results) is DON'T-PORT — permanent typed fallback; v1 owns it.
+- ``"v2/" in model``: main.py's cohere elif strips the ``v2/`` prefix from
+  the wire model BEFORE transform (main.py, cohere branch). That rewrite is
+  envelope scope; serving it here would put the prefixed model on the wire.
+
+Then ``explicit_stream_false`` (the httpx path keeps the key on the wire —
+v1's map copies ``stream`` verbatim, False included) and the shared openai
+guard with the FULL message-name fallback: cohere v2's transform_request is
+the inherited OpenAI GPT transform, so message ``name`` is forwarded
+verbatim and the IR's name-drop would diverge.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from ...errors import TranslationError
+from ..openai_compat.guard import explicit_stream_false
+from ..openai_compat.guard import (
+    unsupported_request_shapes as openai_unsupported_request_shapes,
+)
+
+_Raw = Mapping[str, object]
+
+
+def unsupported_request_shapes(raw: _Raw) -> TranslationError | None:
+    model = raw.get("model")
+    if isinstance(model, str) and "v1/" in model:
+        return TranslationError.of_unsupported(
+            "cohere v1 route (explicit 'v1/' in the model): the legacy v1 "
+            "chat wire is a permanent typed fallback; v1 owns it"
+        )
+    if isinstance(model, str) and "v2/" in model:
+        return TranslationError.of_unsupported(
+            "explicit 'v2/' model prefix: v1's cohere completion() branch "
+            "strips it before transform (envelope rewrite); v1 owns it"
+        )
+    stream_false = explicit_stream_false(raw)
+    if stream_false is not None:
+        return stream_false
+    return openai_unsupported_request_shapes(raw)

--- a/litellm/translation/providers/cohere/guard.py
+++ b/litellm/translation/providers/cohere/guard.py
@@ -21,10 +21,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 
 from ...errors import TranslationError
-from ..openai_compat.guard import explicit_stream_false
-from ..openai_compat.guard import (
-    unsupported_request_shapes as openai_unsupported_request_shapes,
-)
+from ..openai_compat.guard import stream_false_then_unsupported_shapes
 
 _Raw = Mapping[str, object]
 
@@ -41,7 +38,6 @@ def unsupported_request_shapes(raw: _Raw) -> TranslationError | None:
             "explicit 'v2/' model prefix: v1's cohere completion() branch "
             "strips it before transform (envelope rewrite); v1 owns it"
         )
-    stream_false = explicit_stream_false(raw)
-    if stream_false is not None:
-        return stream_false
-    return openai_unsupported_request_shapes(raw)
+    # the ONE shared composition after the route predicates
+    # (critic-wave2b-alpha NIT-1; sibling-merge sweep)
+    return stream_false_then_unsupported_shapes(raw)

--- a/litellm/translation/providers/cohere/params.py
+++ b/litellm/translation/providers/cohere/params.py
@@ -1,0 +1,45 @@
+"""Parameter gates for the cohere v2 chat serializer.
+
+v1's gate is ``_check_valid_arg`` over ``CohereV2ChatConfig.
+get_supported_openai_params`` (stream/temperature/max_tokens/mct/top_p/
+frequency_penalty/presence_penalty/stop/n/tools/tool_choice/seed/
+extra_headers): an unsupported OPENAI param RAISES UnsupportedParamsError
+unless drop_params. v2 mirrors the supported-list truth as typed fallbacks
+so v1 serves its own raise (the grok R2 rule).
+
+Verified in-process at HEAD (dossier drift): ``top_k`` does NOT raise — it
+is a non-openai param the generic passthrough places top-level in
+optional_params, so v1 SERVES it on the wire verbatim (the serializer emits
+it; differential row pins the wire merge). ``user`` is silently dropped
+upstream (never raised) — typed fallback, v1 serves its own drop.
+``tool_choice`` is IN the supported list but has NO map arm: v1 silently
+drops it (serializer delta, not a fallback).
+"""
+
+from __future__ import annotations
+
+from ...ir import ChatRequest
+
+
+def unsupported_params(request: ChatRequest) -> str | None:
+    if request.response_format.is_some():
+        return (
+            "response_format is outside cohere v2's supported list; v1's "
+            "get_optional_params raises UnsupportedParamsError (or drops it "
+            "under drop_params)"
+        )
+    if request.parallel_tool_calls.is_some():
+        return (
+            "parallel_tool_calls is outside cohere v2's supported list; "
+            "v1 raises or drops it"
+        )
+    if request.thinking.is_some():
+        return "thinking is not a cohere v2 chat param; v1 raises or drops it"
+    if request.reasoning_effort.is_some():
+        return "reasoning_effort is not a cohere v2 chat param; v1 raises or drops it"
+    if request.user.is_some():
+        return (
+            "user is model-list gated upstream and silently dropped for "
+            "cohere v2; v1 serves its own drop"
+        )
+    return None

--- a/litellm/translation/providers/cohere/params.py
+++ b/litellm/translation/providers/cohere/params.py
@@ -18,10 +18,14 @@ drops it (serializer delta, not a fallback).
 
 from __future__ import annotations
 
+from ...deps import TranslationDeps
 from ...ir import ChatRequest
 
 
-def unsupported_params(request: ChatRequest) -> str | None:
+def unsupported_params(request: ChatRequest, deps: TranslationDeps) -> str | None:
+    # deps is unused here — the uniform own-module gate signature
+    # (critic-wave2b-beta N5's recorded convention), which lets the
+    # serializer compose openai_compat.make_gated_serializer directly
     if request.response_format.is_some():
         return (
             "response_format is outside cohere v2's supported list; v1's "

--- a/litellm/translation/providers/cohere/response.py
+++ b/litellm/translation/providers/cohere/response.py
@@ -26,7 +26,13 @@ stays litellm's — v1 ignores the cohere response id and stamps
 Fail-closed arms reproduce v1's raises: a non-dict body (v1's TypedDict
 splat raises -> CohereError 422), a missing ``message`` or ``usage`` key
 (v1 KeyErrors out of the transform), non-dict content items (v1
-AttributeErrors on ``.get``).
+AttributeErrors on ``.get``), the hostile citation shapes (truthy non-list
+citations/sources, non-dict citation/source/document entries — v1's
+unguarded ``.get`` chain AttributeErrors on each), and a tool_call without
+a ``function`` key (v1's Message constructor TypeErrors). Citation VALUE
+types the typed construction rejects (non-int start/end, non-str
+title/url) fall back instead — v1 attaches the unvalidated TypedDict via
+plain setattr and SERVES it, bytes v2's pydantic seam cannot reproduce.
 """
 
 from __future__ import annotations
@@ -74,23 +80,15 @@ def parse_response(raw: PlainJson, request: ChatRequest) -> _ParseResult:
     if isinstance(text, TranslationError):
         return Error(text)
     annotations = _annotations(message.get("citations"))
+    if isinstance(annotations, TranslationError):
+        return Error(annotations)
     tool_calls = _indexed_tool_calls(message.get("tool_calls"))
     if isinstance(tool_calls, TranslationError):
         return Error(tool_calls)
-    tokens_raw = usage.get("tokens", {})
-    if not isinstance(tokens_raw, dict):
-        return Error(
-            _boundary(
-                "cohere v2 usage.tokens is present but not an object (v1 "
-                "AttributeErrors on .get)"
-            )
-        )
-    prompt = _int_token(tokens_raw, "input_tokens")
-    if isinstance(prompt, TranslationError):
-        return Error(prompt)
-    completion = _int_token(tokens_raw, "output_tokens")
-    if isinstance(completion, TranslationError):
-        return Error(completion)
+    counts = _usage_counts(usage)
+    if isinstance(counts, TranslationError):
+        return Error(counts)
+    prompt, completion = counts
     wire_message = _wire_message(text, tool_calls, annotations)
     body: dict[str, PlainJson] = {
         "object": "chat.completion",
@@ -148,6 +146,22 @@ def _joined_text(content: PlainJson) -> str | None | TranslationError:
     return "".join(parts)
 
 
+def _usage_counts(usage: dict[str, PlainJson]) -> tuple[int, int] | TranslationError:
+    tokens_raw = usage.get("tokens", {})
+    if not isinstance(tokens_raw, dict):
+        return _boundary(
+            "cohere v2 usage.tokens is present but not an object (v1 "
+            "AttributeErrors on .get)"
+        )
+    prompt = _int_token(tokens_raw, "input_tokens")
+    if isinstance(prompt, TranslationError):
+        return prompt
+    completion = _int_token(tokens_raw, "output_tokens")
+    if isinstance(completion, TranslationError):
+        return completion
+    return prompt, completion
+
+
 def _int_token(tokens: dict[str, PlainJson], key: str) -> int | TranslationError:
     """v1 reads ``usage.tokens.get(key, 0)`` and feeds the value into
     ``prompt + completion`` and ``Usage(...)``: an ABSENT key is 0; ints and
@@ -178,6 +192,12 @@ def _indexed_tool_calls(
     for index, tool in enumerate(tool_calls):
         if not isinstance(tool, dict):
             return _boundary("cohere v2 tool_call is not an object (v1 raises)")
+        if "function" not in tool:
+            return _boundary(
+                "cohere v2 tool_call has no 'function' key (v1's Message "
+                "constructor raises TypeError; typed here so the raise "
+                "never escapes the seam untyped)"
+            )
         indexed = [*indexed, {**tool, "index": index}]
     return indexed
 
@@ -202,45 +222,105 @@ def _wire_message(
     return message
 
 
-def _annotations(citations: PlainJson) -> list[PlainJson] | None:
-    """Mirror ``_translate_citations_to_openai_annotations`` (one annotation
-    per document source; non-document sources skipped; sources-less
-    citations skipped). Falsy citations (None/[]) yield None — v1 only
-    attaches annotations when the citations list is truthy."""
-    if not isinstance(citations, list) or not citations:
+def _annotations(citations: PlainJson) -> list[PlainJson] | None | TranslationError:
+    """Mirror ``_translate_citations_to_openai_annotations`` FAIL-CLOSED (one
+    annotation per document source; non-document and document-less sources
+    skipped; sources-less citations skipped). Falsy citations (None/[]/"")
+    yield None — v1 only attaches annotations when the value is truthy. Every
+    shape v1's unguarded ``.get`` chain AttributeErrors on is a typed
+    boundary error here (truthy non-list citations, non-dict citation entry,
+    truthy non-list sources, non-dict source, present non-dict document
+    under type "document"), and annotation VALUE types the seam's typed
+    Message construction validates (start/end int, title/url str) fall back
+    where v1 serves the unvalidated TypedDict via plain setattr."""
+    if not citations:
         return None
+    if not isinstance(citations, list):
+        return _boundary(
+            "cohere v2 message.citations is truthy but not a list (v1 "
+            "iterates it and AttributeErrors on citation.get)"
+        )
     annotations: list[PlainJson] = []
     for citation in citations:
         if not isinstance(citation, dict):
-            continue
-        sources = citation.get("sources")
-        if not isinstance(sources, list) or not sources:
-            continue
+            return _boundary(
+                "cohere v2 citation entry is not an object (v1 "
+                "AttributeErrors on citation.get)"
+            )
+        sources = citation.get("sources", [])
+        if not sources:
+            continue  # v1's falsy gate: the citation is skipped, served
+        if not isinstance(sources, list):
+            return _boundary(
+                "cohere v2 citation.sources is truthy but not a list (v1 "
+                "iterates it and AttributeErrors on source.get)"
+            )
         for source in sources:
-            if not isinstance(source, dict):
-                continue
-            document = source.get("document")
-            if source.get("type") != "document" or not isinstance(document, dict):
-                continue
-            url = source.get("url") or f"source:{source.get('id', 'unknown')}"
-            annotations = [
-                *annotations,
-                {
-                    "type": "url_citation",
-                    "url_citation": {
-                        "start_index": citation.get("start", 0),
-                        "end_index": citation.get("end", 0),
-                        "title": document.get("title", ""),
-                        "url": url,
-                    },
-                },
-            ]
+            annotation = _source_annotation(citation, source)
+            if isinstance(annotation, TranslationError):
+                return annotation
+            if annotation is not None:
+                annotations = [*annotations, annotation]
     return annotations or None
+
+
+def _source_annotation(
+    citation: dict[str, PlainJson], source: PlainJson
+) -> PlainJson | None | TranslationError:
+    if not isinstance(source, dict):
+        return _boundary(
+            "cohere v2 citation source is not an object (v1 AttributeErrors "
+            "on source.get)"
+        )
+    if source.get("type") != "document" or "document" not in source:
+        return None  # v1 skips non-document and document-less sources, served
+    document = source["document"]
+    if not isinstance(document, dict):
+        return _boundary(
+            "cohere v2 citation document is not an object (v1 "
+            "AttributeErrors on document.get)"
+        )
+    start = citation.get("start", 0)
+    end = citation.get("end", 0)
+    title = document.get("title", "")
+    url = source.get("url") or f"source:{source.get('id', 'unknown')}"
+    if not _is_int(start) or not _is_int(end) or not isinstance(title, str):
+        return _boundary(
+            "cohere v2 citation start/end/title value type fails the typed "
+            "annotation construction (v1 SERVES the unvalidated TypedDict "
+            "via plain setattr; v2's Message validation would raise)"
+        )
+    if not isinstance(url, str):
+        return _boundary(
+            "cohere v2 citation source url is truthy but not a string (v1 "
+            "SERVES the unvalidated TypedDict via plain setattr; v2's "
+            "Message validation would raise)"
+        )
+    return {
+        "type": "url_citation",
+        "url_citation": {
+            "start_index": start,
+            "end_index": end,
+            "title": title,
+            "url": url,
+        },
+    }
+
+
+def _is_int(value: PlainJson) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
 
 
 def _semantic_blocks(
     text: str | None, tool_calls: list[dict[str, PlainJson]] | None
 ) -> list[ContentBlock] | TranslationError:
+    """The IR blocks are deliberately LENIENT where the wire body beside them
+    is strict (critic-wave2b-beta N3): v1 SERVES non-str tool id/name and
+    unparseable argument strings VERBATIM on the wire (probed — only a
+    missing ``function`` key raises, gated in ``_indexed_tool_calls``), so
+    failing closed here would fall back on shapes v1 serves. Nothing reads
+    ``ChatResponse.content`` on the openai construction arm today; a future
+    consumer must re-derive these defaults against the wire truth."""
     blocks: list[ContentBlock] = []
     if tool_calls is None and isinstance(text, str) and text:
         blocks = [ContentBlock.of_text(Text(text=text, cache=Nothing))]

--- a/litellm/translation/providers/cohere/response.py
+++ b/litellm/translation/providers/cohere/response.py
@@ -1,0 +1,270 @@
+"""Cohere v2 ``/v2/chat`` response JSON -> IR ``ChatResponse``.
+
+Mirrors ``CohereV2ChatConfig.transform_response`` (LIVE on the httpx path),
+which mutates a FRESH ``ModelResponse``. The normalized chat-completion body
+rides ``ChatResponse.wire`` and the seam's ``openai`` construction arm
+reproduces v1's assembly byte-for-byte (probed in-process at HEAD; the wire
+body deliberately carries NO ``id``/``created`` so the ambient envelope
+stays litellm's — v1 ignores the cohere response id and stamps
+``int(time.time())``):
+
+- content: ``"".join(text of message.content items)`` when the key is
+  present and non-null (an EMPTY list joins to ``""``, not None); ``None``
+  when absent/null.
+- ``finish_reason`` is ALWAYS ``"stop"`` — v1 never reads the wire
+  ``finish_reason``; the fresh Choices default survives even for tool-call
+  responses (quirk pinned by the differential rows).
+- tool calls: each wire entry rides verbatim plus an ``index``; text content
+  is DISCARDED when tool_calls are present (v1 replaces the whole message
+  with ``Message(tool_calls=..., content=None, annotations=...)`` — the
+  explicit ``annotations`` kwarg, ``None`` included, is reproduced).
+- citations -> OpenAI ``url_citation`` annotations (one per document
+  source; ``url`` falls back to ``source:{id}``).
+- usage from ``usage.tokens.input_tokens/output_tokens`` (defaults 0; NOT
+  billed_units), ``total = prompt + completion``.
+
+Fail-closed arms reproduce v1's raises: a non-dict body (v1's TypedDict
+splat raises -> CohereError 422), a missing ``message`` or ``usage`` key
+(v1 KeyErrors out of the transform), non-dict content items (v1
+AttributeErrors on ``.get``).
+"""
+
+from __future__ import annotations
+
+import json
+
+from expression import Error, Nothing, Ok, Result, Some
+from expression.collections import Block
+
+from ...errors import BoundaryError, TranslationError
+from ...ir import (
+    ChatRequest,
+    ChatResponse,
+    ContentBlock,
+    JsonBlob,
+    PlainJson,
+    ResponseUsage,
+    Text,
+    ToolUse,
+)
+
+_ParseResult = Result[ChatResponse, TranslationError]
+
+
+def _boundary(reason: str) -> TranslationError:
+    return TranslationError.of_boundary(BoundaryError.of(Block.of_seq([reason])))
+
+
+def parse_response(raw: PlainJson, request: ChatRequest) -> _ParseResult:
+    if not isinstance(raw, dict):
+        return Error(
+            _boundary("cohere v2 response is not an object (v1 raises CohereError 422)")
+        )
+    message = raw.get("message")
+    if "message" not in raw or not isinstance(message, dict):
+        return Error(
+            _boundary("cohere v2 response has no 'message' object (v1 KeyErrors)")
+        )
+    usage = raw.get("usage")
+    if "usage" not in raw or not isinstance(usage, dict):
+        return Error(
+            _boundary("cohere v2 response has no 'usage' object (v1 KeyErrors)")
+        )
+    text = _joined_text(message.get("content"))
+    if isinstance(text, TranslationError):
+        return Error(text)
+    annotations = _annotations(message.get("citations"))
+    tool_calls = _indexed_tool_calls(message.get("tool_calls"))
+    if isinstance(tool_calls, TranslationError):
+        return Error(tool_calls)
+    tokens_raw = usage.get("tokens", {})
+    if not isinstance(tokens_raw, dict):
+        return Error(
+            _boundary(
+                "cohere v2 usage.tokens is present but not an object (v1 "
+                "AttributeErrors on .get)"
+            )
+        )
+    prompt = _int_token(tokens_raw, "input_tokens")
+    if isinstance(prompt, TranslationError):
+        return Error(prompt)
+    completion = _int_token(tokens_raw, "output_tokens")
+    if isinstance(completion, TranslationError):
+        return Error(completion)
+    wire_message = _wire_message(text, tool_calls, annotations)
+    body: dict[str, PlainJson] = {
+        "object": "chat.completion",
+        "model": request.model,
+        "choices": [{"index": 0, "finish_reason": "stop", "message": wire_message}],
+        "usage": {
+            "prompt_tokens": prompt,
+            "completion_tokens": completion,
+            "total_tokens": prompt + completion,
+        },
+    }
+    blocks = _semantic_blocks(text, tool_calls)
+    if isinstance(blocks, TranslationError):
+        return Error(blocks)
+    return Ok(
+        ChatResponse(
+            id="",  # v1 keeps the ambient chatcmpl id; the cohere wire id is ignored
+            model=request.model,
+            content=Block.of_seq(blocks),
+            finish="stop",  # v1 never reads the wire finish_reason (fresh-Choices default)
+            usage=ResponseUsage(
+                input_tokens=prompt,
+                output_tokens=completion,
+                cache_creation_input_tokens=0,
+                cache_read_input_tokens=0,
+                cache_creation=Nothing,
+                total_tokens=Some(prompt + completion),
+            ),
+            synthesized_json_content=False,
+            wire=Some(JsonBlob(value=body)),
+        )
+    )
+
+
+def _joined_text(content: PlainJson) -> str | None | TranslationError:
+    if content is None:
+        return None
+    if not isinstance(content, list):
+        return _boundary("cohere v2 message.content is not a list (v1 raises)")
+    parts: list[str] = []
+    for item in content:
+        if item is None:
+            continue  # v1 filters None items
+        if not isinstance(item, dict):
+            return _boundary(
+                "cohere v2 content item is not an object (v1 AttributeErrors)"
+            )
+        part = item.get("text", "")
+        if not isinstance(part, str):
+            return _boundary(
+                "cohere v2 content item text is not a string (v1's "
+                "str.join raises TypeError)"
+            )
+        parts = [*parts, part]
+    return "".join(parts)
+
+
+def _int_token(tokens: dict[str, PlainJson], key: str) -> int | TranslationError:
+    """v1 reads ``usage.tokens.get(key, 0)`` and feeds the value into
+    ``prompt + completion`` and ``Usage(...)``: an ABSENT key is 0; ints and
+    integral floats serve (pydantic's lax coercion); anything else raises in
+    v1 (a present null/str hits the ``+`` TypeError or the Usage validation
+    — incl. the str+str concatenation corner, which v2 deliberately leaves
+    to v1) — typed boundary error here."""
+    if key not in tokens:
+        return 0
+    value = tokens.get(key)
+    if isinstance(value, (bool, int)):
+        return int(value)
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    return _boundary(
+        f"cohere v2 usage.tokens.{key} is not an integer: {value!r} (v1 raises)"
+    )
+
+
+def _indexed_tool_calls(
+    tool_calls: PlainJson,
+) -> list[dict[str, PlainJson]] | None | TranslationError:
+    if tool_calls is None or tool_calls == []:
+        return None
+    if not isinstance(tool_calls, list):
+        return _boundary("cohere v2 message.tool_calls is not a list (v1 raises)")
+    indexed: list[dict[str, PlainJson]] = []
+    for index, tool in enumerate(tool_calls):
+        if not isinstance(tool, dict):
+            return _boundary("cohere v2 tool_call is not an object (v1 raises)")
+        indexed = [*indexed, {**tool, "index": index}]
+    return indexed
+
+
+def _wire_message(
+    text: str | None,
+    tool_calls: list[dict[str, PlainJson]] | None,
+    annotations: list[PlainJson] | None,
+) -> dict[str, PlainJson]:
+    if tool_calls is not None:
+        # v1 REPLACES the message: Message(tool_calls=..., content=None,
+        # annotations=...) — text content is lost, annotations explicit.
+        return {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": list(tool_calls),
+            "annotations": annotations,
+        }
+    message: dict[str, PlainJson] = {"role": "assistant", "content": text}
+    if annotations:
+        message = {**message, "annotations": annotations}
+    return message
+
+
+def _annotations(citations: PlainJson) -> list[PlainJson] | None:
+    """Mirror ``_translate_citations_to_openai_annotations`` (one annotation
+    per document source; non-document sources skipped; sources-less
+    citations skipped). Falsy citations (None/[]) yield None — v1 only
+    attaches annotations when the citations list is truthy."""
+    if not isinstance(citations, list) or not citations:
+        return None
+    annotations: list[PlainJson] = []
+    for citation in citations:
+        if not isinstance(citation, dict):
+            continue
+        sources = citation.get("sources")
+        if not isinstance(sources, list) or not sources:
+            continue
+        for source in sources:
+            if not isinstance(source, dict):
+                continue
+            document = source.get("document")
+            if source.get("type") != "document" or not isinstance(document, dict):
+                continue
+            url = source.get("url") or f"source:{source.get('id', 'unknown')}"
+            annotations = [
+                *annotations,
+                {
+                    "type": "url_citation",
+                    "url_citation": {
+                        "start_index": citation.get("start", 0),
+                        "end_index": citation.get("end", 0),
+                        "title": document.get("title", ""),
+                        "url": url,
+                    },
+                },
+            ]
+    return annotations or None
+
+
+def _semantic_blocks(
+    text: str | None, tool_calls: list[dict[str, PlainJson]] | None
+) -> list[ContentBlock] | TranslationError:
+    blocks: list[ContentBlock] = []
+    if tool_calls is None and isinstance(text, str) and text:
+        blocks = [ContentBlock.of_text(Text(text=text, cache=Nothing))]
+    for call in tool_calls or []:
+        function_raw = call.get("function")
+        function = function_raw if isinstance(function_raw, dict) else {}
+        name = function.get("name")
+        identifier = call.get("id")
+        arguments = function.get("arguments")
+        raw_args = arguments if isinstance(arguments, str) else ""
+        try:
+            parsed: PlainJson = json.loads(raw_args) if raw_args else {}
+        except ValueError:
+            parsed = {}
+        blocks = [
+            *blocks,
+            ContentBlock.of_tool_use(
+                ToolUse(
+                    id=identifier if isinstance(identifier, str) else "",
+                    name=name if isinstance(name, str) else "",
+                    arguments=JsonBlob(value=parsed),
+                    cache=Nothing,
+                    arguments_raw=Some(raw_args) if raw_args else Nothing,
+                )
+            ),
+        ]
+    return blocks

--- a/litellm/translation/providers/cohere/serialize.py
+++ b/litellm/translation/providers/cohere/serialize.py
@@ -1,0 +1,61 @@
+"""Serialize the IR into a Cohere v2 ``/v2/chat`` request body.
+
+v1's chain is ``CohereV2ChatConfig.map_openai_params`` (rename arms) then
+the inherited OpenAI GPT ``transform_request`` — the wire body is the
+openai_compat assembly with the cohere renames applied (verified in-process
+at HEAD):
+
+- ``top_p`` -> ``p``; ``stop`` -> ``stop_sequences``;
+- ``max_completion_tokens`` -> ``max_tokens`` (mct wins; the raw guard
+  rejects requests carrying both keys);
+- ``tool_choice`` DROPPED silently (in v1's supported list, no map arm);
+- ``top_k`` emitted verbatim (v1's generic non-openai passthrough places it
+  top-level in optional_params — dossier drift, re-verified at HEAD);
+- ``n``/``seed``/penalties are served by v1 but are not IR params: they fall
+  back at the inbound parse, so v1 serves them (typed fallback rows).
+"""
+
+from __future__ import annotations
+
+from expression import Error, Result
+
+from ...deps import TranslationDeps
+from ...errors import TranslationError
+from ...ir import Body, ChatRequest, PlainJson
+from ..openai_compat.serialize import assemble_body
+from . import params as p
+
+_SerializeResult = Result[Body, TranslationError]
+
+_RENAMES = (
+    ("top_p", "p"),
+    ("stop", "stop_sequences"),
+    ("max_completion_tokens", "max_tokens"),
+)
+
+
+def serialize_request(request: ChatRequest, deps: TranslationDeps) -> _SerializeResult:
+    reason = p.unsupported_params(request)
+    if reason is not None:
+        return Error(TranslationError.of_unsupported(reason))
+    return assemble_body(request).map(lambda body: _with_cohere_deltas(body, request))
+
+
+def _with_cohere_deltas(body: Body, request: ChatRequest) -> Body:
+    renamed: dict[str, PlainJson] = {
+        _renamed_key(key): value
+        for key, value in body.items()
+        # v1 silently drops tool_choice (supported list, no map arm)
+        if key != "tool_choice"
+    }
+    top_k = request.params.top_k.default_value(None)
+    if top_k is not None:
+        renamed = {**renamed, "top_k": top_k}
+    return renamed
+
+
+def _renamed_key(key: str) -> str:
+    for original, wire in _RENAMES:
+        if key == original:
+            return wire
+    return key

--- a/litellm/translation/providers/cohere/serialize.py
+++ b/litellm/translation/providers/cohere/serialize.py
@@ -17,15 +17,9 @@ at HEAD):
 
 from __future__ import annotations
 
-from expression import Error, Result
-
-from ...deps import TranslationDeps
-from ...errors import TranslationError
 from ...ir import Body, ChatRequest, PlainJson
-from ..openai_compat.serialize import assemble_body
+from ..openai_compat.serialize import make_gated_serializer
 from . import params as p
-
-_SerializeResult = Result[Body, TranslationError]
 
 _RENAMES = (
     ("top_p", "p"),
@@ -34,11 +28,6 @@ _RENAMES = (
 )
 
 
-def serialize_request(request: ChatRequest, deps: TranslationDeps) -> _SerializeResult:
-    reason = p.unsupported_params(request)
-    if reason is not None:
-        return Error(TranslationError.of_unsupported(reason))
-    return assemble_body(request).map(lambda body: _with_cohere_deltas(body, request))
 
 
 def _with_cohere_deltas(body: Body, request: ChatRequest) -> Body:
@@ -59,3 +48,6 @@ def _renamed_key(key: str) -> str:
         if key == original:
             return wire
     return key
+
+
+serialize_request = make_gated_serializer(p.unsupported_params, _with_cohere_deltas)

--- a/litellm/translation/providers/cohere/stream.py
+++ b/litellm/translation/providers/cohere/stream.py
@@ -10,7 +10,9 @@ arm; each cohere event maps to one ``wire_chunk`` carrying the generic
 payload the shared ``generic`` chunk dialect folds:
 
 - ``type == "content-delta"`` -> text (v1's dict/str content fork; a non-str
-  ``text`` value is loud — v1's Delta validation raises on it);
+  ``text`` value is loud — v1 SILENTLY SWALLOWS the chunk, the named
+  PINNED DIVERGENCE row, critic M2: the old prose claiming "v1's Delta
+  validation raises" contradicted the branch's own pin);
 - ``type == "tool-call-delta"`` -> one tool_call entry, id/name/arguments
   defaulting to ``""`` (v1's ``.get(..., "")``); ``tool-call-start`` events
   match NO v1 arm and are swallowed;
@@ -36,6 +38,7 @@ v1's chunk_parser raises ValueError out of the iterator on each.
 from __future__ import annotations
 
 import json
+import math
 from types import MappingProxyType
 
 from expression import Error, Ok, Result
@@ -155,6 +158,10 @@ def _index_reason(event: dict[str, PlainJson]) -> str | None:
     if "index" not in event:
         return None
     index = event.get("index")
+    if isinstance(index, float) and not math.isfinite(index):
+        # json.loads ACCEPTS NaN/Infinity literals, so the corner is
+        # wire-reachable: v1's int() raises ValueError/OverflowError
+        return f"non-finite cohere chunk index {index!r} (v1 raises)"
     if isinstance(index, (bool, int, float)):
         return None
     if isinstance(index, str):
@@ -196,8 +203,9 @@ def _content_delta_text(event: dict[str, PlainJson]) -> str | TranslationError:
         text = content.get("text")
         if not isinstance(text, str):
             return _boundary(
-                "cohere content-delta text is not a string (v1's Delta "
-                "validation raises on it)"
+                "cohere content-delta text is not a string (v1 silently "
+                "swallows the chunk — the named PINNED DIVERGENCE row; "
+                "fail-closed on a failure path)"
             )
         return text
     if isinstance(content, str):
@@ -295,16 +303,43 @@ def _message_end(
         return _boundary("cohere message-end usage.tokens is not an object (v1 raises)")
     prompt = tokens.get("input_tokens", 0)
     completion = tokens.get("output_tokens", 0)
-    if not isinstance(prompt, (bool, int, float)) or not isinstance(
-        completion, (bool, int, float)
-    ):
-        return _boundary(
-            "cohere message-end token counts are not numeric (v1 raises "
-            "building ChatCompletionUsageBlock)"
-        )
+    total = _added_tokens(prompt, completion)
+    if isinstance(total, TranslationError):
+        return total
     usage: PlainJson = {
         "prompt_tokens": prompt,
         "completion_tokens": completion,
-        "total_tokens": prompt + completion,
+        "total_tokens": total,
     }
     return finish, usage
+
+
+def _added_tokens(
+    prompt: PlainJson, completion: PlainJson
+) -> PlainJson | TranslationError:
+    """Mirror v1's raw ``input_tokens + output_tokens`` (the
+    ChatCompletionUsageBlock is a TypedDict — NO validation): numeric pairs
+    add and SERVE. A str+str pair CONCATENATES in v1 ("5" + "3" -> "53")
+    and v1 SERVES the stream end to end (the include_usage final chunk
+    lax-coerces the parts and re-sums the total) — that corner falls back
+    so v1 serves it, the SAME deliberate decision as the response-side
+    ``_int_token`` (critic M1: the old reason here falsely claimed
+    "v1 raises building ChatCompletionUsageBlock"). Pairs the ``+`` itself
+    rejects (str+int, None, objects) are loud — that TypeError IS v1's
+    raise."""
+    if isinstance(prompt, (bool, int, float)) and isinstance(
+        completion, (bool, int, float)
+    ):
+        return prompt + completion
+    if isinstance(prompt, str) and isinstance(completion, str):
+        return _boundary(
+            "cohere message-end token counts are both strings (v1 SERVES "
+            "the concatenated total through its TypedDict and re-summed "
+            "include_usage chunk; deliberately left to v1, the response "
+            "side's _int_token decision)"
+        )
+    return _boundary(
+        "cohere message-end token counts are neither numeric nor a str+str "
+        "pair (v1 raises — the raw input_tokens + output_tokens TypeError, "
+        "or the wrapper's Usage validation on non-scalar values)"
+    )

--- a/litellm/translation/providers/cohere/stream.py
+++ b/litellm/translation/providers/cohere/stream.py
@@ -1,0 +1,310 @@
+"""Cohere v2 chat stream lines -> IR stream events.
+
+v1 decodes through ``CohereV2ModelResponseIterator`` (llms/cohere/
+common_utils.py): each wire LINE is ``json.loads``-ed directly — there is no
+``data:`` strip for str lines and no ``[DONE]`` sentinel, so ``parse_line``
+here mirrors that bare-JSON line seam (a non-JSON line is a loud error where
+v1 raises RuntimeError out of the iterator). ``chunk_parser`` yields
+``GenericStreamingChunk`` dicts that ride ``CustomStreamWrapper``'s generic
+arm; each cohere event maps to one ``wire_chunk`` carrying the generic
+payload the shared ``generic`` chunk dialect folds:
+
+- ``type == "content-delta"`` -> text (v1's dict/str content fork; a non-str
+  ``text`` value is loud — v1's Delta validation raises on it);
+- ``type == "tool-call-delta"`` -> one tool_call entry, id/name/arguments
+  defaulting to ``""`` (v1's ``.get(..., "")``); ``tool-call-start`` events
+  match NO v1 arm and are swallowed;
+- ``event == "tool-plan-delta"`` / ``event == "citation-start"`` ->
+  provider fields (v1 setattrs them top-level AND the delta carries them);
+- ``event == "message-end"`` -> finish (mapped exactly like v1's
+  ``map_finish_reason``: COMPLETE -> stop, MAX_TOKENS -> length,
+  ERROR_TOXIC -> content_filter, anything else -> stop, probed in-process)
+  + usage from ``usage.tokens``;
+- any other event -> swallowed (v1 yields an empty GenericStreamingChunk
+  the wrapper drops).
+
+NOTE the v1 quirk this mirrors verbatim: chunk_parser reads the
+``message-end``/tool-plan/citation shapes off the ``event`` key, while the
+Cohere v2 wire sends ``type`` for every event — so on REAL traffic those
+arms never fire, the message-end is swallowed, and v1's WRAPPER synthesizes
+the trailing finish chunk at StopIteration (seam scope; the differential
+replays pin both regimes). Wrong-TYPED intermediates (non-dict ``delta``,
+non-dict ``tool_calls[0]``, null ``usage.tokens``…) are loud errors —
+v1's chunk_parser raises ValueError out of the iterator on each.
+"""
+
+from __future__ import annotations
+
+import json
+from types import MappingProxyType
+
+from expression import Error, Ok, Result
+from expression.collections import Block
+
+from ...errors import BoundaryError, TranslationError
+from ...ir import JsonBlob, PlainJson, StreamEvent
+
+_EventResult = Result[StreamEvent | None, TranslationError]
+
+_FINISH_MAP = MappingProxyType(
+    {
+        "COMPLETE": "stop",
+        "MAX_TOKENS": "length",
+        "ERROR_TOXIC": "content_filter",
+    }
+)
+
+
+def _boundary(reason: str) -> TranslationError:
+    return TranslationError.of_boundary(BoundaryError.of(Block.of_seq([reason])))
+
+
+def parse_line(line: str) -> _EventResult:
+    stripped = line.strip()
+    if not stripped:
+        return Error(
+            _boundary(
+                "empty cohere stream line: v1's iterator json.loads every "
+                "line and raises RuntimeError on it"
+            )
+        )
+    try:
+        event: PlainJson = json.loads(stripped)
+    except ValueError:
+        return Error(
+            _boundary(
+                f"non-JSON cohere stream line {stripped[:80]!r}: v1's "
+                "iterator raises RuntimeError (no data:/[DONE] framing on "
+                "this wire)"
+            )
+        )
+    return parse_event(event)
+
+
+_Fields = tuple[str, PlainJson, PlainJson, PlainJson, PlainJson]
+"""(text, tool_call, finish, usage, provider_fields) — one GenericStreamingChunk."""
+
+
+def parse_event(event: PlainJson) -> _EventResult:
+    if not isinstance(event, dict):
+        return Error(_boundary("cohere stream event is not an object (v1 raises)"))
+    index_reason = _index_reason(event)
+    if index_reason is not None:
+        return Error(_boundary(index_reason))
+    fields = _event_fields(event)
+    if isinstance(fields, TranslationError):
+        return Error(fields)
+    text, tool_call, finish, usage, provider_fields = fields
+    if "citations" in event:
+        seeded = provider_fields if isinstance(provider_fields, dict) else {}
+        provider_fields = {**seeded, "citations": event.get("citations")}
+    if not text and tool_call is None and provider_fields is None and finish is None:
+        return Ok(None)  # v1 yields an empty GenericStreamingChunk the wrapper drops
+    payload: dict[str, PlainJson] = {
+        "text": text,
+        "tool_call": tool_call,
+        "finish": finish,
+        "usage": usage,
+        "provider_fields": provider_fields,
+    }
+    return Ok(StreamEvent.of_wire_chunk(JsonBlob(value=payload)))
+
+
+def _event_fields(event: dict[str, PlainJson]) -> _Fields | TranslationError:
+    """Mirror chunk_parser's arm order: the ``type``-keyed content/tool arms
+    first, then the ``event``-keyed plan/citation/message-end arms."""
+    chunk_type = event.get("type", "")
+    if chunk_type == "content-delta":
+        text = _content_delta_text(event)
+        if isinstance(text, TranslationError):
+            return text
+        return (text, None, None, None, None)
+    if chunk_type == "tool-call-delta":
+        tool_call = _tool_call_delta(event)
+        if isinstance(tool_call, TranslationError):
+            return tool_call
+        return ("", tool_call, None, None, None)
+    return _keyed_event_fields(event)
+
+
+def _keyed_event_fields(event: dict[str, PlainJson]) -> _Fields | TranslationError:
+    event_type = event.get("event", "")
+    if event_type == "tool-plan-delta":
+        plan = _message_field(event, "tool_plan")
+        if isinstance(plan, TranslationError):
+            return plan
+        return ("", None, None, None, plan)
+    if event_type == "citation-start":
+        citation = _citation_fields(event)
+        if isinstance(citation, TranslationError):
+            return citation
+        return ("", None, None, None, citation)
+    if event_type == "message-end":
+        ended = _message_end(event)
+        if isinstance(ended, TranslationError):
+            return ended
+        finish, usage = ended
+        return ("", None, finish, usage, None)
+    return ("", None, None, None, None)
+
+
+def _index_reason(event: dict[str, PlainJson]) -> str | None:
+    """v1 runs ``int(chunk.get("index", 0))`` first; a non-coercible value
+    raises ValueError out of the iterator (the value itself is never used —
+    the emitted choice index is always 0)."""
+    if "index" not in event:
+        return None
+    index = event.get("index")
+    if isinstance(index, (bool, int, float)):
+        return None
+    if isinstance(index, str):
+        try:
+            int(index)
+        except ValueError:
+            return f"non-numeric cohere chunk index {index!r} (v1 raises)"
+        return None
+    return f"non-numeric cohere chunk index {index!r} (v1 raises)"
+
+
+def _delta_message(
+    event: dict[str, PlainJson], *, nested_data: bool
+) -> dict[str, PlainJson] | TranslationError:
+    """Walk ``[data.]delta.message`` exactly like v1's ``.get(key, {})``
+    chains: a MISSING level is ``{}``; a PRESENT non-dict level is an
+    AttributeError -> ValueError raise in v1 (loud here)."""
+    source: PlainJson = event
+    keys = ("data", "delta", "message") if nested_data else ("delta", "message")
+    for key in keys:
+        if not isinstance(source, dict):
+            return _boundary(
+                f"cohere stream {key!r} parent is not an object (v1 raises)"
+            )
+        source = source.get(key, {})
+    if not isinstance(source, dict):
+        return _boundary("cohere stream delta.message is not an object (v1 raises)")
+    return source
+
+
+def _content_delta_text(event: dict[str, PlainJson]) -> str | TranslationError:
+    message = _delta_message(event, nested_data=False)
+    if isinstance(message, TranslationError):
+        return message
+    content = message.get("content", {})
+    if isinstance(content, dict):
+        if "text" not in content:
+            return ""
+        text = content.get("text")
+        if not isinstance(text, str):
+            return _boundary(
+                "cohere content-delta text is not a string (v1's Delta "
+                "validation raises on it)"
+            )
+        return text
+    if isinstance(content, str):
+        return content
+    return ""  # v1's fork returns "" for any other content shape
+
+
+def _tool_call_delta(event: dict[str, PlainJson]) -> PlainJson | TranslationError:
+    delta = event.get("delta", {})
+    if not isinstance(delta, dict):
+        return _boundary("cohere tool-call-delta delta is not an object (v1 raises)")
+    tool_calls = delta.get("tool_calls", [])
+    if not tool_calls:
+        return None  # v1's truthiness gate
+    if not isinstance(tool_calls, list):
+        return _boundary("cohere delta.tool_calls is not a list (v1 raises)")
+    first = tool_calls[0]
+    if not isinstance(first, dict):
+        return _boundary("cohere tool_calls[0] is not an object (v1 raises)")
+    identifier = first.get("id", "")
+    name = first.get("name", "")
+    arguments = first.get("arguments", "")
+    if (
+        not isinstance(identifier, str)
+        or not isinstance(name, str)
+        or not isinstance(arguments, str)
+    ):
+        return _boundary(
+            "cohere tool-call-delta id/name/arguments is not a string "
+            "(v1's Delta tool-call validation raises)"
+        )
+    return {
+        "id": identifier,
+        "type": "function",
+        "function": {"name": name, "arguments": arguments},
+    }
+
+
+def _message_field(
+    event: dict[str, PlainJson], key: str
+) -> PlainJson | TranslationError:
+    message = _delta_message(event, nested_data=True)
+    if isinstance(message, TranslationError):
+        return message
+    value = message.get(key, "")
+    if not value:
+        return None  # v1's truthiness gate
+    return {key: value}
+
+
+def _citation_fields(event: dict[str, PlainJson]) -> PlainJson | TranslationError:
+    message = _delta_message(event, nested_data=True)
+    if isinstance(message, TranslationError):
+        return message
+    citations = message.get("citations", {})
+    if not citations:
+        return None  # v1's truthiness gate
+    if not isinstance(citations, dict):
+        return _boundary("cohere citation-start citations is not an object (v1 raises)")
+    return {
+        "citations": [
+            {
+                "start": citations.get("start", 0),
+                "end": citations.get("end", 0),
+                "text": citations.get("text", ""),
+                "sources": citations.get("sources", []),
+                "type": citations.get("type", "TEXT_CONTENT"),
+            }
+        ]
+    }
+
+
+def _message_end(
+    event: dict[str, PlainJson],
+) -> tuple[PlainJson, PlainJson] | TranslationError:
+    data = event.get("data", {})
+    if not isinstance(data, dict):
+        return _boundary("cohere message-end data is not an object (v1 raises)")
+    delta = data.get("delta", {})
+    if not isinstance(delta, dict):
+        return _boundary("cohere message-end delta is not an object (v1 raises)")
+    raw_finish = delta.get("finish_reason", "stop")
+    # v1's map_finish_reason defaults EVERY unmapped value — non-strings,
+    # null, "" included — to "stop" (probed in-process).
+    finish = (
+        _FINISH_MAP.get(raw_finish, "stop") if isinstance(raw_finish, str) else "stop"
+    )
+    usage_data = delta.get("usage", {})
+    if not usage_data:
+        return finish, None  # v1's truthiness gate
+    if not isinstance(usage_data, dict):
+        return _boundary("cohere message-end usage is not an object (v1 raises)")
+    tokens = usage_data.get("tokens", {})
+    if not isinstance(tokens, dict):
+        return _boundary("cohere message-end usage.tokens is not an object (v1 raises)")
+    prompt = tokens.get("input_tokens", 0)
+    completion = tokens.get("output_tokens", 0)
+    if not isinstance(prompt, (bool, int, float)) or not isinstance(
+        completion, (bool, int, float)
+    ):
+        return _boundary(
+            "cohere message-end token counts are not numeric (v1 raises "
+            "building ChatCompletionUsageBlock)"
+        )
+    usage: PlainJson = {
+        "prompt_tokens": prompt,
+        "completion_tokens": completion,
+        "total_tokens": prompt + completion,
+    }
+    return finish, usage

--- a/litellm/translation/providers/compat_httpx/response.py
+++ b/litellm/translation/providers/compat_httpx/response.py
@@ -36,15 +36,14 @@ config in this family ever sets json_mode).
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping
-from dataclasses import replace
 from types import MappingProxyType
 from typing import Literal
 
-from expression import Error, Ok, Result, Some
-from expression.collections import Block
+from expression import Result
 
-from ...errors import BoundaryError, TranslationError
-from ...ir import ChatRequest, ChatResponse, JsonBlob, PlainJson
+from ...errors import TranslationError
+from ...ir import ChatRequest, ChatResponse, PlainJson
+from ..openai_compat.response import make_direct_parser
 from ..openai_compat.response import parse_response as openai_parse_response
 from .params import CompatHttpxProvider
 from .serialize import PROFILES
@@ -67,57 +66,17 @@ RESPONSE_STYLES: Mapping[CompatHttpxProvider, ResponseStyle] = MappingProxyType(
 
 
 def _direct_parser(prefix: str | None) -> ResponseParser:
-    def parse(raw: PlainJson, request: ChatRequest) -> _ParseResult:
-        return openai_parse_response(raw, request).bind(
-            lambda response: _verbatim_wire(response, raw, request, prefix)
-        )
+    # the direct-construction machinery is openai_compat.response.
+    # make_direct_parser (lifted there when fireworks_ai became the second
+    # consumer); this family's policy is the {prefix}/{REQUEST model}
+    # overwrite (wire model ignored) or no rewrite at all. The non-string
+    # wire model F2 arm and the unreachable non-dict arm live in the factory.
+    def rewrite(wire_model: str | None, request_model: str) -> str | None:
+        if prefix is None:
+            return None
+        return f"{prefix}/{request_model}"
 
-    return parse
-
-
-def _verbatim_wire(
-    response: ChatResponse, raw: PlainJson, request: ChatRequest, prefix: str | None
-) -> _ParseResult:
-    if not isinstance(raw, dict):
-        # Unreachable: openai_parse_response rejected non-dict bodies before
-        # this bind runs. Fail CLOSED if it ever becomes reachable — the old
-        # `else {}` arm would have ridden an empty wire body into
-        # ModelResponse(**{}) (critic-wave1b N5).
-        return Error(
-            TranslationError.of_boundary(
-                BoundaryError.of(
-                    Block.of_seq(["non-dict response body reached _verbatim_wire"])
-                )
-            )
-        )
-    wire_model = raw.get("model")
-    if wire_model is not None and not isinstance(wire_model, str):
-        # v1's OpenAILike construction is ModelResponse(**response_json)
-        # BEFORE any model overwrite, so a non-string wire model raises
-        # pydantic ValidationError there — while the prefix rewrite below
-        # would hide the bad value from the constructor and SERVE
-        # (verifier-longtail F2: compactifai/amazon_nova/lemonade). Fail
-        # closed so the typed v1 fallback reproduces v1's raise; model:
-        # None is constructible in v1 and stays served.
-        return Error(
-            TranslationError.of_boundary(
-                BoundaryError.of(
-                    Block.of_seq(
-                        [
-                            "non-string wire model "
-                            f"({type(wire_model).__name__}): v1's OpenAILike "
-                            "construction raises ValidationError on it"
-                        ]
-                    )
-                )
-            )
-        )
-    body: dict[str, PlainJson] = dict(raw)
-    if prefix is not None:
-        model = f"{prefix}/{request.model}"
-        body = {**body, "model": model}
-        return Ok(replace(response, model=model, wire=Some(JsonBlob(value=body))))
-    return Ok(replace(response, wire=Some(JsonBlob(value=body))))
+    return make_direct_parser(rewrite)
 
 
 PARSERS: Mapping[CompatHttpxProvider, ResponseParser] = MappingProxyType(

--- a/litellm/translation/providers/compat_httpx/stream.py
+++ b/litellm/translation/providers/compat_httpx/stream.py
@@ -44,6 +44,7 @@ from expression import Result
 from ...errors import TranslationError
 from ...ir import StreamEvent
 from ..openai_compat.httpx_chunk import (
+    BASE_HANDLER_POLICY,
     HttpxChunkPolicy,
     StrictEnvelope,
     make_parse_event,
@@ -53,7 +54,7 @@ from .params import CompatHttpxProvider
 
 ParseLine = Callable[[str], Result[StreamEvent | None, TranslationError]]
 
-parse_event = make_parse_event(HttpxChunkPolicy(reasoning="rename"))
+parse_event = make_parse_event(BASE_HANDLER_POLICY)
 parse_line = make_parse_line(parse_event)
 
 

--- a/litellm/translation/providers/compat_sdk/guard.py
+++ b/litellm/translation/providers/compat_sdk/guard.py
@@ -36,18 +36,16 @@ from types import MappingProxyType
 from typing import cast
 
 from ...errors import TranslationError
-from ..openai_compat.guard import carries_cache_control, explicit_stream_false
 from ..openai_compat.guard import (
-    unsupported_request_shapes as openai_unsupported_request_shapes,
+    carries_cache_control,
+    stream_false_then_unsupported_shapes,
 )
 from .params import ALLOWED, CompatSdkProvider
 
 _Raw = Mapping[str, object]
 _RawGuardFn = Callable[[_Raw], TranslationError | None]
 
-
-def unsupported_request_shapes(raw: _Raw) -> TranslationError | None:
-    return explicit_stream_false(raw) or openai_unsupported_request_shapes(raw)
+unsupported_request_shapes = stream_false_then_unsupported_shapes
 
 
 def cache_control_preserved(raw: _Raw, provider: str) -> TranslationError | None:

--- a/litellm/translation/providers/compat_sdk/guard.py
+++ b/litellm/translation/providers/compat_sdk/guard.py
@@ -36,7 +36,7 @@ from types import MappingProxyType
 from typing import cast
 
 from ...errors import TranslationError
-from ..openai_compat.guard import explicit_stream_false
+from ..openai_compat.guard import carries_cache_control, explicit_stream_false
 from ..openai_compat.guard import (
     unsupported_request_shapes as openai_unsupported_request_shapes,
 )
@@ -44,29 +44,10 @@ from .params import ALLOWED, CompatSdkProvider
 
 _Raw = Mapping[str, object]
 _RawGuardFn = Callable[[_Raw], TranslationError | None]
-_MAX_DEPTH = 16
 
 
 def unsupported_request_shapes(raw: _Raw) -> TranslationError | None:
     return explicit_stream_false(raw) or openai_unsupported_request_shapes(raw)
-
-
-def carries_cache_control(value: object, depth: int = 0) -> bool:
-    if depth > _MAX_DEPTH:
-        # exhaustion must never ADMIT a request: treat the unscannable tail
-        # as if it carried the marker (fall back to v1)
-        return True
-    if isinstance(value, Mapping):
-        mapping = cast(Mapping[str, object], value)
-        if "cache_control" in mapping:
-            return True
-        return any(carries_cache_control(item, depth + 1) for item in mapping.values())
-    if isinstance(value, Sequence) and not isinstance(value, str):
-        return any(
-            carries_cache_control(item, depth + 1)
-            for item in cast(Sequence[object], value)
-        )
-    return False
 
 
 def cache_control_preserved(raw: _Raw, provider: str) -> TranslationError | None:

--- a/litellm/translation/providers/compat_sdk/serialize.py
+++ b/litellm/translation/providers/compat_sdk/serialize.py
@@ -366,3 +366,10 @@ def _profile_serializer(profile: CompatProfile) -> Serializer:
 SERIALIZERS: Mapping[p.CompatSdkProvider, Serializer] = MappingProxyType(
     {provider: _profile_serializer(profile) for provider, profile in PROFILES.items()}
 )
+
+# wave-2b-alpha: the deepseek own module composes the same flatten delta
+# (its v1 _transform_messages runs the content-list-to-str conversion
+# unconditionally before super). Public alias so cross-package consumers
+# IMPORT the one mechanism — the checks.py paste-revocation rule applies
+# to this helper too.
+flatten_text_lists = _flatten_text_content_lists

--- a/litellm/translation/providers/deepseek/__init__.py
+++ b/litellm/translation/providers/deepseek/__init__.py
@@ -1,0 +1,12 @@
+from .guard import unsupported_request_shapes
+from .response import parse_response
+from .serialize import serialize_request
+from .stream import parse_event, parse_line
+
+__all__ = (
+    "parse_event",
+    "parse_line",
+    "parse_response",
+    "serialize_request",
+    "unsupported_request_shapes",
+)

--- a/litellm/translation/providers/deepseek/guard.py
+++ b/litellm/translation/providers/deepseek/guard.py
@@ -1,0 +1,24 @@
+"""Raw-shape fidelity guard for the deepseek serializer.
+
+The httpx path serializes an explicitly-sent ``stream: false`` onto the wire
+(the shared family fact), so that arm runs first; then the shared openai
+guard with the FULL message-``name`` fallback — v1's deepseek transform
+chains the base ``_transform_messages`` after its flatten and nothing strips
+names, so v1 forwards ``name`` verbatim on every role.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from ...errors import TranslationError
+from ..openai_compat.guard import explicit_stream_false
+from ..openai_compat.guard import (
+    unsupported_request_shapes as openai_unsupported_request_shapes,
+)
+
+_Raw = Mapping[str, object]
+
+
+def unsupported_request_shapes(raw: _Raw) -> TranslationError | None:
+    return explicit_stream_false(raw) or openai_unsupported_request_shapes(raw)

--- a/litellm/translation/providers/deepseek/guard.py
+++ b/litellm/translation/providers/deepseek/guard.py
@@ -9,16 +9,6 @@ names, so v1 forwards ``name`` verbatim on every role.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from ..openai_compat.guard import stream_false_then_unsupported_shapes
 
-from ...errors import TranslationError
-from ..openai_compat.guard import explicit_stream_false
-from ..openai_compat.guard import (
-    unsupported_request_shapes as openai_unsupported_request_shapes,
-)
-
-_Raw = Mapping[str, object]
-
-
-def unsupported_request_shapes(raw: _Raw) -> TranslationError | None:
-    return explicit_stream_false(raw) or openai_unsupported_request_shapes(raw)
+unsupported_request_shapes = stream_false_then_unsupported_shapes

--- a/litellm/translation/providers/deepseek/params.py
+++ b/litellm/translation/providers/deepseek/params.py
@@ -1,0 +1,85 @@
+"""Parameter gates for the deepseek serializer.
+
+v1's gate is ``_check_valid_arg`` over ``DeepSeekChatConfig.
+get_supported_openai_params`` — the OpenAI base list plus ``thinking`` and
+``reasoning_effort``, appended UNCONDITIONALLY for every deepseek model
+(deepseek/chat/transformation.py:19-25; the map's thinking rewrite is not
+model-gated either, only the history fill is). Two body-rewriting v1
+transforms fall back typed so v1 serves its own rewrite:
+
+- the ALWAYS-on content-list flatten
+  (``handle_messages_with_content_list_to_str_conversion`` runs before
+  super, :122-136): text-only lists are the serializer's flatten delta;
+  any non-text part is lossily flattened by v1 (the sambanova shape), so
+  those fall back.
+- thinking-mode history fill (``_fill_reasoning_content``, :67-107): when
+  ``supports_reasoning(model, "deepseek")`` AND the EFFECTIVE thinking is
+  enabled (the verbatim dict or the reasoning_effort rewrite), v1 patches
+  EVERY assistant message missing ``reasoning_content`` (promote from
+  provider_specific_fields, else a single-space placeholder). Messages
+  that already carry ``reasoning_content`` fall back at the inbound
+  boundary, so every v2-visible assistant message would be patched.
+"""
+
+from __future__ import annotations
+
+from ...deps import TranslationDeps
+from ...ir import ChatRequest
+from ..compat_sdk.checks import BASE_LIST, unsupported_against, user_note
+from ..openai_compat.params import unsupported_response_format
+
+_DEEPSEEK_LIST = BASE_LIST | frozenset({"thinking", "reasoning_effort"})
+
+
+def supports_deepseek_reasoning(model: str, deps: TranslationDeps) -> bool:
+    return deps.supports_capability(f"deepseek/{model}", "supports_reasoning")
+
+
+def thinking_mode_requested(request: ChatRequest) -> bool:
+    """The post-map ``thinking == {"type": "enabled"}`` truth: the verbatim
+    dict wins; only when it is absent does ``reasoning_effort != "none"``
+    rewrite into thinking-enabled (map_openai_params:49-63, elif chain)."""
+    thinking = request.thinking.default_value(None)
+    if thinking is not None:
+        return thinking.tag == "enabled"
+    effort = request.reasoning_effort.default_value(None)
+    return effort is not None and effort != "none"
+
+
+def _has_non_text_content_block(request: ChatRequest) -> bool:
+    return any(
+        block.tag not in ("text", "tool_use", "tool_result")
+        for message in request.messages
+        for block in message.content
+    )
+
+
+def _has_assistant_message(request: ChatRequest) -> bool:
+    return any(message.role == "assistant" for message in request.messages)
+
+
+def unsupported_params(request: ChatRequest, deps: TranslationDeps) -> str | None:
+    if _has_non_text_content_block(request):
+        return (
+            "non-text content block on deepseek: v1's always-on content-list "
+            "flatten drops non-text parts and skips the base image transforms "
+            "(deepseek/chat/transformation.py _transform_messages); v1 serves "
+            "its lossy flatten"
+        )
+    if (
+        thinking_mode_requested(request)
+        and supports_deepseek_reasoning(request.model, deps)
+        and _has_assistant_message(request)
+    ):
+        return (
+            "assistant history in deepseek thinking mode: v1's "
+            "_fill_reasoning_content injects reasoning_content (a "
+            "single-space placeholder) into every assistant message missing "
+            "it; v1 serves its rewrite"
+        )
+    return unsupported_against(
+        request,
+        provider="deepseek",
+        allowed=_DEEPSEEK_LIST,
+        notes={"user": user_note("deepseek")},
+    ) or unsupported_response_format(request)

--- a/litellm/translation/providers/deepseek/response.py
+++ b/litellm/translation/providers/deepseek/response.py
@@ -1,0 +1,15 @@
+"""deepseek chat-completion response JSON -> IR ``ChatResponse``.
+
+deepseek rides the httpx path with NO ``transform_response`` override: the
+inherited base GPT transform runs ``convert_to_model_response_object`` over
+a FRESH ``ModelResponse`` (model=None), so the response model is the BARE
+wire model (the xai R4 / cometapi pattern; no ``deepseek/`` prefix —
+pinned by test_differential_deepseek_response.py). The shared openai parser
+is that normalizer's mirror, verbatim.
+"""
+
+from __future__ import annotations
+
+from ..openai_compat.response import parse_response
+
+__all__ = ("parse_response",)

--- a/litellm/translation/providers/deepseek/serialize.py
+++ b/litellm/translation/providers/deepseek/serialize.py
@@ -27,23 +27,10 @@ prefix) — response/stream gates pin it.
 
 from __future__ import annotations
 
-from expression import Error, Result
-
-from ...deps import TranslationDeps
-from ...errors import TranslationError
 from ...ir import Body, ChatRequest
 from ..compat_sdk.serialize import flatten_text_lists
-from ..openai_compat.serialize import assemble_body
+from ..openai_compat.serialize import make_gated_serializer
 from . import params as p
-
-_SerializeResult = Result[Body, TranslationError]
-
-
-def serialize_request(request: ChatRequest, deps: TranslationDeps) -> _SerializeResult:
-    reason = p.unsupported_params(request, deps)
-    if reason is not None:
-        return Error(TranslationError.of_unsupported(reason))
-    return assemble_body(request).map(lambda body: _with_deepseek_deltas(body, request))
 
 
 def _with_deepseek_deltas(body: Body, request: ChatRequest) -> Body:
@@ -55,3 +42,6 @@ def _with_deepseek_deltas(body: Body, request: ChatRequest) -> Body:
 
 def _thinking_enabled_after_map(request: ChatRequest) -> bool:
     return p.thinking_mode_requested(request)
+
+
+serialize_request = make_gated_serializer(p.unsupported_params, _with_deepseek_deltas)

--- a/litellm/translation/providers/deepseek/serialize.py
+++ b/litellm/translation/providers/deepseek/serialize.py
@@ -1,0 +1,57 @@
+"""Serialize the IR into a deepseek ``/chat/completions`` request body.
+
+v1's chain (httpx path, main.py:1942 dedicated elif): ``DeepSeekChatConfig.
+map_openai_params`` = the base copy plus the thinking rewrite, then
+``transform_request`` = the always-on content-list flatten + the inherited
+base five-touch assembly (the thinking-mode history fill falls back in
+params.py). The body is the openai_compat assembly with two deltas:
+
+- text-only content lists are flattened to one concatenated string (the
+  same ``handle_messages_with_content_list_to_str_conversion`` truth the
+  compat_sdk flatten delta mirrors — IMPORTED, never copied; non-text
+  shapes fell back at the gate so the helper's multimodal skip is inert
+  here, exactly the sambanova configuration).
+- the thinking rewrite (map_openai_params:49-63, verified in-process at
+  HEAD): a verbatim ``thinking`` dict is accepted ONLY as
+  ``{"type": "enabled"}`` (budget_tokens silently discarded, disabled and
+  adaptive dropped — and a present-but-not-enabled dict SHADOWS
+  reasoning_effort, the elif chain); otherwise ``reasoning_effort`` other
+  than "none" becomes ``{"type": "enabled"}`` and the reasoning_effort key
+  never reaches the wire. The rewrite is NOT model-gated.
+
+``max_completion_tokens`` passes VERBATIM (no rename arm anywhere) and
+``top_k`` falls back at the gate (extra_body packing, wire-proven in the
+request gate). v1 keeps the wire model bare on this path (no ``deepseek/``
+prefix) — response/stream gates pin it.
+"""
+
+from __future__ import annotations
+
+from expression import Error, Result
+
+from ...deps import TranslationDeps
+from ...errors import TranslationError
+from ...ir import Body, ChatRequest
+from ..compat_sdk.serialize import flatten_text_lists
+from ..openai_compat.serialize import assemble_body
+from . import params as p
+
+_SerializeResult = Result[Body, TranslationError]
+
+
+def serialize_request(request: ChatRequest, deps: TranslationDeps) -> _SerializeResult:
+    reason = p.unsupported_params(request, deps)
+    if reason is not None:
+        return Error(TranslationError.of_unsupported(reason))
+    return assemble_body(request).map(lambda body: _with_deepseek_deltas(body, request))
+
+
+def _with_deepseek_deltas(body: Body, request: ChatRequest) -> Body:
+    flattened = flatten_text_lists(body)
+    if not _thinking_enabled_after_map(request):
+        return flattened
+    return {**flattened, "thinking": {"type": "enabled"}}
+
+
+def _thinking_enabled_after_map(request: ChatRequest) -> bool:
+    return p.thinking_mode_requested(request)

--- a/litellm/translation/providers/deepseek/stream.py
+++ b/litellm/translation/providers/deepseek/stream.py
@@ -16,8 +16,8 @@ Folds use the ``"xai"`` ChunkDialect (the generic httpx dict path).
 
 from __future__ import annotations
 
-from ..openai_compat.httpx_chunk import HttpxChunkPolicy, make_parse_event
+from ..openai_compat.httpx_chunk import BASE_HANDLER_POLICY, make_parse_event
 from ..openai_compat.stream import make_parse_line
 
-parse_event = make_parse_event(HttpxChunkPolicy(reasoning="rename"))
+parse_event = make_parse_event(BASE_HANDLER_POLICY)
 parse_line = make_parse_line(parse_event)

--- a/litellm/translation/providers/deepseek/stream.py
+++ b/litellm/translation/providers/deepseek/stream.py
@@ -1,0 +1,23 @@
+"""deepseek SSE ``chat.completion.chunk`` payloads -> IR stream events.
+
+v1 decodes deepseek streams through the BASE
+``OpenAIChatCompletionStreamingHandler`` (``DeepSeekChatConfig`` has no
+iterator override; verified in-process at HEAD) into ``CustomStreamWrapper``'s
+default openai branch — exactly the compat_httpx FAMILY policy over the ONE
+shared httpx chunk normalizer: ``reasoning="rename"`` (the base handler's
+unconditional pop-rename), value-checked error chunks, no required envelope
+keys, wire usage verbatim on the ``choices: []`` tail only. Provider error
+chunks are a LOUD v2 boundary error where v1's base handler silently
+swallows them — the SAME deliberate fail-closed divergence the compat_httpx
+family pinned (two-sided rows in test_differential_deepseek_stream.py; the
+report's single PINNED DIVERGENCE row names every base-handler consumer).
+Folds use the ``"xai"`` ChunkDialect (the generic httpx dict path).
+"""
+
+from __future__ import annotations
+
+from ..openai_compat.httpx_chunk import HttpxChunkPolicy, make_parse_event
+from ..openai_compat.stream import make_parse_line
+
+parse_event = make_parse_event(HttpxChunkPolicy(reasoning="rename"))
+parse_line = make_parse_line(parse_event)

--- a/litellm/translation/providers/fireworks_ai/__init__.py
+++ b/litellm/translation/providers/fireworks_ai/__init__.py
@@ -1,0 +1,12 @@
+from .guard import unsupported_request_shapes
+from .response import parse_response
+from .serialize import serialize_request
+from .stream import parse_event, parse_line
+
+__all__ = (
+    "parse_event",
+    "parse_line",
+    "parse_response",
+    "serialize_request",
+    "unsupported_request_shapes",
+)

--- a/litellm/translation/providers/fireworks_ai/guard.py
+++ b/litellm/translation/providers/fireworks_ai/guard.py
@@ -1,0 +1,28 @@
+"""Raw-shape fidelity guard for the fireworks_ai serializer.
+
+The httpx path serializes an explicitly-sent ``stream: false`` onto the
+wire (the shared family fact), then the shared openai guard with the FULL
+message-``name`` fallback — nothing on the fireworks chain strips names.
+The guard's existing custom-tool / assistant-``thinking_blocks`` /
+``provider_specific_fields`` arms double as this provider's rewrite
+fallbacks (v1 pops or converts them; pinned in the request gate), and
+``file`` parts fall back at the inbound boundary (v1 migrates pdf files to
+``image_url``). ``cache_control`` needs NO arm: v1 strips it recursively
+(``filter_value_from_dict``) — the IR drop IS v1, served and pinned.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from ...errors import TranslationError
+from ..openai_compat.guard import explicit_stream_false
+from ..openai_compat.guard import (
+    unsupported_request_shapes as openai_unsupported_request_shapes,
+)
+
+_Raw = Mapping[str, object]
+
+
+def unsupported_request_shapes(raw: _Raw) -> TranslationError | None:
+    return explicit_stream_false(raw) or openai_unsupported_request_shapes(raw)

--- a/litellm/translation/providers/fireworks_ai/guard.py
+++ b/litellm/translation/providers/fireworks_ai/guard.py
@@ -13,16 +13,6 @@ fallbacks (v1 pops or converts them; pinned in the request gate), and
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from ..openai_compat.guard import stream_false_then_unsupported_shapes
 
-from ...errors import TranslationError
-from ..openai_compat.guard import explicit_stream_false
-from ..openai_compat.guard import (
-    unsupported_request_shapes as openai_unsupported_request_shapes,
-)
-
-_Raw = Mapping[str, object]
-
-
-def unsupported_request_shapes(raw: _Raw) -> TranslationError | None:
-    return explicit_stream_false(raw) or openai_unsupported_request_shapes(raw)
+unsupported_request_shapes = stream_false_then_unsupported_shapes

--- a/litellm/translation/providers/fireworks_ai/params.py
+++ b/litellm/translation/providers/fireworks_ai/params.py
@@ -1,0 +1,115 @@
+"""Parameter gates for the fireworks_ai serializer.
+
+v1's gate is ``_check_valid_arg`` over ``FireworksAIConfig.
+get_supported_openai_params`` — its OWN static list (stream, max_tokens,
+mct, temperature, top_p, top_k, penalties, n, stop, response_format, user,
+logprobs, prompt_truncate_length, context_length_exceeded_behavior) plus
+THREE capability forks over the ``fireworks_ai/{model}`` map keys:
+``tools``+``parallel_tool_calls`` iff supports_function_calling,
+``tool_choice`` iff supports_tool_choice, ``reasoning_effort`` iff
+supports_reasoning. ``user`` is SERVED verbatim (explicitly listed —
+contrast the base-list providers). The list's ``top_k`` mention is DEAD at
+runtime: top_k is not an OpenAI param so it never reaches
+``_check_valid_arg``/the map — fireworks_ai IS in
+``openai_compatible_providers``, so it rides the extra_body crossing
+(wire-proven in the request gate), the shared default fallback arm.
+
+CAPABILITY DRIFT (probed at HEAD, the gate's one-direction soundness):
+v1's ``supports_function_calling`` answer for fireworks is NOT the map-row
+flag — ``FireworksAIConfig.get_provider_info`` defaults it TRUE (even for
+unknown models) and ``_get_model_cost_capability`` overrides it via a
+hyphen-boundary longest-match SCAN over the whole fireworks map index. The
+deps read (the map flag) is strictly NARROWER: 215/246 chat rows answer
+v1-True/v2-False and ZERO rows answer v1-False/v2-True (probed; the mirror
+gate pins the direction). v2 therefore serves tools only on the
+explicitly-flagged rows and falls back elsewhere with a note naming this
+drift — v1 serves OR raises per its own gate, so the fallback reproduces
+v1 either way. Porting the scan would need a deps surface over the whole
+model map (re-evaluate if fireworks tools fallback volume hurts).
+
+Two v1 rewrites fall back typed so v1 serves its own machinery:
+
+- ``response_format`` WITH tools: v1's ``_add_response_format_to_tools``
+  (is_response_format_supported=False) pops response_format and sets the
+  ``json_mode`` routing marker — the groq-precedent cross-plane feature
+  (request map + response tool->content conversion).
+- tool ``parameters`` carrying legacy def blocks (top-level ``definitions``
+  or ``components.schemas`` — v1's ``_has_legacy_defs``): v1 inlines the
+  ``$ref``s via ``unpack_legacy_defs`` (byte-capped schema surgery). That
+  fallback fires at the SHARED inbound boundary (parse.py's "legacy $defs
+  ... need v1's schema inlining" semantic check) — no provider arm needed,
+  pinned in the request gate.
+"""
+
+from __future__ import annotations
+
+from ...deps import TranslationDeps
+from ...ir import ChatRequest
+from ..compat_sdk.checks import unsupported_against
+from ..openai_compat.params import unsupported_response_format
+
+_FIREWORKS_BASE = frozenset(
+    {
+        "stream",
+        "max_tokens",
+        "max_completion_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "response_format",
+        "user",
+    }
+)
+_FC_KEYS = frozenset({"tools", "parallel_tool_calls"})
+
+
+def supports_fireworks_tools(model: str, deps: TranslationDeps) -> bool:
+    return deps.supports_capability(
+        f"fireworks_ai/{model}", "supports_function_calling"
+    )
+
+
+def supports_fireworks_tool_choice(model: str, deps: TranslationDeps) -> bool:
+    return deps.supports_capability(f"fireworks_ai/{model}", "supports_tool_choice")
+
+
+def supports_fireworks_reasoning(model: str, deps: TranslationDeps) -> bool:
+    return deps.supports_capability(f"fireworks_ai/{model}", "supports_reasoning")
+
+
+def fireworks_allowed(model: str, deps: TranslationDeps) -> frozenset[str]:
+    allowed = _FIREWORKS_BASE
+    if supports_fireworks_tools(model, deps):
+        allowed = allowed | _FC_KEYS
+    if supports_fireworks_tool_choice(model, deps):
+        allowed = allowed | {"tool_choice"}
+    if supports_fireworks_reasoning(model, deps):
+        allowed = allowed | {"reasoning_effort"}
+    return allowed
+
+
+def unsupported_params(request: ChatRequest, deps: TranslationDeps) -> str | None:
+    if request.response_format.is_some() and len(request.tools) > 0:
+        return (
+            "response_format together with tools on fireworks_ai: v1's "
+            "_add_response_format_to_tools pops response_format and sets the "
+            "json_mode routing marker (request+response cross-plane "
+            "machinery); v1 serves it"
+        )
+    capability_note = (
+        "on fireworks_ai: v2's capability read (the fireworks_ai/{m} map "
+        "flag) is strictly narrower than v1's get_provider_info default-true "
+        "+ hyphen-boundary scan — v1 serves or raises per its own gate, and "
+        "the typed fallback reproduces it either way"
+    )
+    return unsupported_against(
+        request,
+        provider="fireworks_ai",
+        allowed=fireworks_allowed(request.model, deps),
+        notes={
+            "tools": f"tools {capability_note}",
+            "parallel_tool_calls": f"parallel_tool_calls {capability_note}",
+            "tool_choice": f"tool_choice {capability_note}",
+            "reasoning_effort": f"reasoning_effort {capability_note}",
+        },
+    ) or unsupported_response_format(request)

--- a/litellm/translation/providers/fireworks_ai/response.py
+++ b/litellm/translation/providers/fireworks_ai/response.py
@@ -1,0 +1,91 @@
+"""fireworks_ai chat-completion response JSON -> IR ``ChatResponse``.
+
+``FireworksAIConfig.transform_response`` REPLACES the base entirely:
+``ModelResponse(**completion_response)`` — the OpenAILike DIRECT
+construction, NOT cdr — then ``response.model = "fireworks_ai/" + WIRE
+model`` (skipped when the wire model is None), the tool-calls-in-content
+repair, and ``_hidden_params = {"additional_headers": ...}`` (envelope —
+the seam's response-headers-passthrough follow-up owns it; the
+transform-seam rows cannot see hidden params).
+
+Parser = the shared ``make_direct_parser`` with the fireworks policy
+(``fireworks_ai/{WIRE model}``; the seam's ``openai_like``
+construction arm reproduces v1's dump byte-for-byte — RESPONSE_STYLE
+"openai_like", the compat_httpx direct-style shape), behind ONE
+fail-closed pre-step: bodies eligible for v1's tool-calls-in-content
+repair (string content that JSON-parses to a dict whose ``name`` matches
+a REQUESTED tool — minus the json_tool_call reserved name — with no
+``tool_calls`` on the message) fall back typed, because v1's repair mints
+a ``uuid4`` tool-call id (nondeterministic, an ambient effect the pure
+parser must not reproduce); v1 serves its repair. The trigger is
+deliberately a hair WIDER than v1's (v1 also requires the JSON to
+construct a litellm ``Function``): extra-key dicts v1 would leave
+verbatim fall back instead — fallback can only widen, never diverge.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import cast
+
+from expression import Error, Result
+
+from ...errors import TranslationError
+from ...ir import ChatRequest, ChatResponse, PlainJson
+from ..openai_compat.response import make_direct_parser
+
+_ParseResult = Result[ChatResponse, TranslationError]
+
+_RESPONSE_FORMAT_TOOL_NAME = "json_tool_call"
+
+
+def _rewrite_model(wire_model: str | None, request_model: str) -> str | None:
+    if wire_model is None:
+        return None  # v1's `if response.model is not None` arm: no prefix
+    return f"fireworks_ai/{wire_model}"
+
+
+_direct_parse = make_direct_parser(_rewrite_model)
+
+
+def parse_response(raw: PlainJson, request: ChatRequest) -> _ParseResult:
+    reason = _repair_eligible_reason(raw, request)
+    if reason is not None:
+        return Error(TranslationError.of_unsupported(reason))
+    return _direct_parse(raw, request)
+
+
+def _repair_eligible_reason(raw: PlainJson, request: ChatRequest) -> str | None:
+    if len(request.tools) == 0 or not isinstance(raw, dict):
+        return None
+    requested = {tool.name for tool in request.tools} - {_RESPONSE_FORMAT_TOOL_NAME}
+    choices = raw.get("choices")
+    if not isinstance(choices, list):
+        return None
+    for choice in choices:
+        if not isinstance(choice, dict):
+            continue
+        message = choice.get("message")
+        if not isinstance(message, dict) or message.get("tool_calls") is not None:
+            continue
+        content = message.get("content")
+        if not isinstance(content, str):
+            continue
+        if _parses_to_requested_function(content, requested):
+            return (
+                "tool-call-in-content response shape: v1's "
+                "_handle_message_content_with_tool_calls synthesizes a "
+                "tool_call with a fresh uuid4 id; v1 serves its repair"
+            )
+    return None
+
+
+def _parses_to_requested_function(content: str, requested: set[str]) -> bool:
+    try:
+        parsed: object = json.loads(content)
+    except ValueError:
+        return False
+    if not isinstance(parsed, dict):
+        return False
+    mapping = cast("dict[str, PlainJson]", parsed)
+    return mapping.get("name") in requested

--- a/litellm/translation/providers/fireworks_ai/response.py
+++ b/litellm/translation/providers/fireworks_ai/response.py
@@ -87,5 +87,8 @@ def _parses_to_requested_function(content: str, requested: set[str]) -> bool:
         return False
     if not isinstance(parsed, dict):
         return False
+    # deliberately narrowing (critic NIT-2): isinstance proved dict; the cast
+    # only fixes the key/value parameters — json.loads keys are always str
+    # and its values are PlainJson by construction
     mapping = cast("dict[str, PlainJson]", parsed)
     return mapping.get("name") in requested

--- a/litellm/translation/providers/fireworks_ai/serialize.py
+++ b/litellm/translation/providers/fireworks_ai/serialize.py
@@ -34,26 +34,11 @@ model is ``fireworks_ai/{WIRE model}`` — response.py owns that prefix.
 
 from __future__ import annotations
 
-from expression import Error, Result
-
-from ...deps import TranslationDeps
-from ...errors import TranslationError
 from ...ir import Body, ChatRequest, PlainJson
-from ..openai_compat.serialize import assemble_body, strip_function_strict
+from ..openai_compat.serialize import make_gated_serializer, strip_function_strict
 from . import params as p
 
-_SerializeResult = Result[Body, TranslationError]
-
 _MODEL_PREFIX = "accounts/fireworks/models/"
-
-
-def serialize_request(request: ChatRequest, deps: TranslationDeps) -> _SerializeResult:
-    reason = p.unsupported_params(request, deps)
-    if reason is not None:
-        return Error(TranslationError.of_unsupported(reason))
-    return assemble_body(request).map(
-        lambda body: _with_fireworks_deltas(body, request)
-    )
 
 
 def _wire_model(model: str) -> str:
@@ -110,3 +95,6 @@ def _with_inline_suffix(part: PlainJson) -> PlainJson:
     if not isinstance(url, str) or url.lower().startswith("data:"):
         return part
     return {**part, "image_url": {**image, "url": f"{url}#transform=inline"}}
+
+
+serialize_request = make_gated_serializer(p.unsupported_params, _with_fireworks_deltas)

--- a/litellm/translation/providers/fireworks_ai/serialize.py
+++ b/litellm/translation/providers/fireworks_ai/serialize.py
@@ -1,0 +1,112 @@
+"""Serialize the IR into a fireworks_ai ``/chat/completions`` request body.
+
+v1's chain (httpx path, main.py:2198 dedicated elif): the EXPLICIT-arm
+``map_openai_params`` (tool_choice required->any, mct->max_tokens rename,
+copy-if-supported) then ``transform_request`` = the model rewrite + the
+message/tools helper + the base five-touch assembly. The body is the
+openai_compat assembly with these deltas (all verified in-process at HEAD):
+
+- model rewritten to ``accounts/fireworks/models/{model}`` UNLESS it
+  already starts with ``accounts/`` or contains ``#`` (deployment ids).
+- ``max_completion_tokens`` -> ``max_tokens`` (fireworks HAS the rename
+  arm, unlike its wave-2b siblings).
+- ``tool_choice`` ``"required"`` -> ``"any"``.
+- tools: the FUNCTION-LEVEL ``strict`` pop (the shared
+  ``strip_function_strict``; deeper strict keys ride verbatim — v1 keeps
+  them too, contrast hosted_vllm). Legacy-def unpacking fell back at the
+  gate, so the serializer never sees those schemas.
+- image ``#transform=inline`` suffix appended to every non-``data:``
+  image url when ``"vision"`` is NOT a substring of the REWRITTEN model
+  (the literal check — VL models without "vision" in the name get the
+  suffix too, pinned). The ambient
+  ``litellm.disable_add_transform_inline_image_block`` global and the
+  per-request litellm_params flag are SEAM scope: the fork must force v1
+  when either is set (CLAUDE.md HARD OBLIGATION) — this serializer encodes
+  the default (enabled) arm.
+- ``user`` and capability-gated ``reasoning_effort`` emitted verbatim
+  (both in v1's own list).
+
+v1 also strips ``cache_control`` recursively (== the IR drop, served) and
+pops ``provider_specific_fields``/``thinking_blocks`` from messages (both
+fall back at the shared boundaries; v1 serves the pops). The response
+model is ``fireworks_ai/{WIRE model}`` — response.py owns that prefix.
+"""
+
+from __future__ import annotations
+
+from expression import Error, Result
+
+from ...deps import TranslationDeps
+from ...errors import TranslationError
+from ...ir import Body, ChatRequest, PlainJson
+from ..openai_compat.serialize import assemble_body, strip_function_strict
+from . import params as p
+
+_SerializeResult = Result[Body, TranslationError]
+
+_MODEL_PREFIX = "accounts/fireworks/models/"
+
+
+def serialize_request(request: ChatRequest, deps: TranslationDeps) -> _SerializeResult:
+    reason = p.unsupported_params(request, deps)
+    if reason is not None:
+        return Error(TranslationError.of_unsupported(reason))
+    return assemble_body(request).map(
+        lambda body: _with_fireworks_deltas(body, request)
+    )
+
+
+def _wire_model(model: str) -> str:
+    if model.startswith("accounts/") or "#" in model:
+        return model
+    return f"{_MODEL_PREFIX}{model}"
+
+
+def _with_fireworks_deltas(body: Body, request: ChatRequest) -> Body:
+    model = _wire_model(request.model)
+    patched: dict[str, PlainJson] = {**body, "model": model}
+    if "max_completion_tokens" in patched:
+        patched = {
+            key: value
+            for key, value in patched.items()
+            if key != "max_completion_tokens"
+        } | {"max_tokens": patched["max_completion_tokens"]}
+    if patched.get("tool_choice") == "required":
+        patched = {**patched, "tool_choice": "any"}
+    tools = patched.get("tools")
+    if isinstance(tools, list):
+        patched = {**patched, "tools": [strip_function_strict(tool) for tool in tools]}
+    messages = patched.get("messages")
+    if isinstance(messages, list) and "vision" not in model:
+        patched = {
+            **patched,
+            "messages": [_with_inline_images(message) for message in messages],
+        }
+    user = request.user.default_value(None)
+    if user is not None:
+        patched = {**patched, "user": user}
+    effort = request.reasoning_effort.default_value(None)
+    if effort is not None:
+        patched = {**patched, "reasoning_effort": effort}
+    return patched
+
+
+def _with_inline_images(message: PlainJson) -> PlainJson:
+    if not isinstance(message, dict) or message.get("role") != "user":
+        return message
+    content = message.get("content")
+    if not isinstance(content, list):
+        return message
+    return {**message, "content": [_with_inline_suffix(part) for part in content]}
+
+
+def _with_inline_suffix(part: PlainJson) -> PlainJson:
+    if not isinstance(part, dict) or part.get("type") != "image_url":
+        return part
+    image = part.get("image_url")
+    if not isinstance(image, dict):
+        return part
+    url = image.get("url")
+    if not isinstance(url, str) or url.lower().startswith("data:"):
+        return part
+    return {**part, "image_url": {**image, "url": f"{url}#transform=inline"}}

--- a/litellm/translation/providers/fireworks_ai/stream.py
+++ b/litellm/translation/providers/fireworks_ai/stream.py
@@ -1,0 +1,22 @@
+"""fireworks_ai SSE ``chat.completion.chunk`` payloads -> IR stream events.
+
+v1 decodes fireworks streams through the BASE
+``OpenAIChatCompletionStreamingHandler`` (no iterator override;
+canary-pinned — ``transform_response``'s ``fireworks_ai/`` prefix and the
+content repair never run on chunks, so stream chunk models are the BARE
+wire model) into ``CustomStreamWrapper``'s default openai branch — the
+compat_httpx FAMILY policy over the ONE shared httpx chunk normalizer:
+``reasoning="rename"``, value-checked error chunks, no required envelope
+keys, wire usage verbatim on the ``choices: []`` tail only. Provider error
+chunks are the family's LOUD fail-closed PINNED DIVERGENCE (v1's base
+handler silently swallows them) — fireworks_ai joins the report's single
+named row. Folds use the ``"xai"`` ChunkDialect.
+"""
+
+from __future__ import annotations
+
+from ..openai_compat.httpx_chunk import HttpxChunkPolicy, make_parse_event
+from ..openai_compat.stream import make_parse_line
+
+parse_event = make_parse_event(HttpxChunkPolicy(reasoning="rename"))
+parse_line = make_parse_line(parse_event)

--- a/litellm/translation/providers/fireworks_ai/stream.py
+++ b/litellm/translation/providers/fireworks_ai/stream.py
@@ -15,8 +15,8 @@ named row. Folds use the ``"xai"`` ChunkDialect.
 
 from __future__ import annotations
 
-from ..openai_compat.httpx_chunk import HttpxChunkPolicy, make_parse_event
+from ..openai_compat.httpx_chunk import BASE_HANDLER_POLICY, make_parse_event
 from ..openai_compat.stream import make_parse_line
 
-parse_event = make_parse_event(HttpxChunkPolicy(reasoning="rename"))
+parse_event = make_parse_event(BASE_HANDLER_POLICY)
 parse_line = make_parse_line(parse_event)

--- a/litellm/translation/providers/google_genai/guard.py
+++ b/litellm/translation/providers/google_genai/guard.py
@@ -21,9 +21,8 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from typing import cast
 
-from litellm.constants import DEFAULT_MAX_RECURSE_DEPTH
-
 from ...errors import TranslationError
+from ..openai_compat.guard import carries_cache_control
 
 _Raw = Mapping[str, object]
 
@@ -36,28 +35,10 @@ def unsupported_request_shapes(raw: _Raw) -> TranslationError | None:
     has_name = any(isinstance(entry, Mapping) and "name" in entry for entry in entries)
     if not has_name:
         return None
-    if _carries_cache_control(entries, 0):
+    if carries_cache_control(entries):
         return TranslationError.of_unsupported(
             "message 'name' beside cache_control markers: the IR drops 'name'"
             " so its bytes are invisible to the cache-marker token bound,"
             " while v1's check_and_create_cache token-counts them"
         )
     return None
-
-
-def _carries_cache_control(value: object, depth: int) -> bool:
-    if depth > DEFAULT_MAX_RECURSE_DEPTH:
-        # exhaustion must never ADMIT a request: treat the unscannable tail
-        # as if it carried the marker (fall back to v1)
-        return True
-    if isinstance(value, Mapping):
-        mapping = cast(Mapping[str, object], value)
-        if "cache_control" in mapping:
-            return True
-        return any(_carries_cache_control(item, depth + 1) for item in mapping.values())
-    if isinstance(value, Sequence) and not isinstance(value, str):
-        return any(
-            _carries_cache_control(item, depth + 1)
-            for item in cast(Sequence[object], value)
-        )
-    return False

--- a/litellm/translation/providers/groq/__init__.py
+++ b/litellm/translation/providers/groq/__init__.py
@@ -1,0 +1,12 @@
+from .guard import unsupported_request_shapes
+from .response import parse_response
+from .serialize import serialize_request
+from .stream import parse_event, parse_line
+
+__all__ = (
+    "parse_event",
+    "parse_line",
+    "parse_response",
+    "serialize_request",
+    "unsupported_request_shapes",
+)

--- a/litellm/translation/providers/groq/guard.py
+++ b/litellm/translation/providers/groq/guard.py
@@ -1,0 +1,23 @@
+"""Raw-shape fidelity guard for the groq chat serializer.
+
+The explicit ``stream: false`` arm (the httpx path keeps the key on the
+wire — probed), then the shared openai guard with the FULL message-name
+fallback (groq's transform chains into the base GPT one; names ride
+verbatim).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from ...errors import TranslationError
+from ..openai_compat.guard import explicit_stream_false
+from ..openai_compat.guard import (
+    unsupported_request_shapes as openai_unsupported_request_shapes,
+)
+
+_Raw = Mapping[str, object]
+
+
+def unsupported_request_shapes(raw: _Raw) -> TranslationError | None:
+    return explicit_stream_false(raw) or openai_unsupported_request_shapes(raw)

--- a/litellm/translation/providers/groq/guard.py
+++ b/litellm/translation/providers/groq/guard.py
@@ -11,13 +11,12 @@ from __future__ import annotations
 from collections.abc import Mapping
 
 from ...errors import TranslationError
-from ..openai_compat.guard import explicit_stream_false
-from ..openai_compat.guard import (
-    unsupported_request_shapes as openai_unsupported_request_shapes,
-)
+from ..openai_compat.guard import stream_false_then_unsupported_shapes
 
 _Raw = Mapping[str, object]
 
 
 def unsupported_request_shapes(raw: _Raw) -> TranslationError | None:
-    return explicit_stream_false(raw) or openai_unsupported_request_shapes(raw)
+    # the ONE shared composition (critic-wave2b-alpha NIT-1; sibling-merge
+    # sweep: this body re-declared it)
+    return stream_false_then_unsupported_shapes(raw)

--- a/litellm/translation/providers/groq/params.py
+++ b/litellm/translation/providers/groq/params.py
@@ -1,0 +1,76 @@
+"""Parameter gates for the groq chat serializer.
+
+v1's gate is ``_check_valid_arg`` over ``GroqChatConfig.
+get_supported_openai_params`` (the base list minus ``max_retries``, plus
+``reasoning_effort`` iff ``litellm.supports_reasoning(model, "groq")``) and
+the json_schema THREE-WAY fork in ``map_openai_params`` (probed in-process
+at HEAD):
+
+- a model with the ``groq/{m}`` ``supports_response_schema`` map flag
+  (llama-4, gpt-oss, kimi-k2-0905 rows) passes ``response_format`` with a
+  ``json_schema`` VERBATIM — served;
+- a NON-native model + json_schema + user ``tools`` raises
+  ``litellm.BadRequestError`` (NOT UnsupportedParamsError — the wave's one
+  different request raise class, pinned in the gate);
+- a non-native model + json_schema alone gets the json_tool_call
+  WORKAROUND (tools + forced tool_choice + json_mode + fake_stream — a
+  cross-plane rewrite spanning request, response, and routing): typed
+  fallback, v1 serves it end-to-end (researcher-4's recommended shape).
+
+``response_format: json_object`` is served verbatim (the fake_stream it
+sets is a routing key hh pops before the wire). ``thinking`` raises;
+``user`` is silently dropped; n/seed/penalties/logit_bias/logprobs/
+top_logprobs/service_tier/web_search_options pass through in v1 but are
+parse-level unknowns in v2 (typed fallback, v1 serves).
+"""
+
+from __future__ import annotations
+
+from ...deps import TranslationDeps
+from ...ir import ChatRequest
+
+
+def supports_reasoning(model: str, deps: TranslationDeps) -> bool:
+    return deps.supports_capability(f"groq/{model}", "supports_reasoning")
+
+
+def _supports_response_schema(model: str, deps: TranslationDeps) -> bool:
+    return deps.supports_capability(f"groq/{model}", "supports_response_schema")
+
+
+def unsupported_params(request: ChatRequest, deps: TranslationDeps) -> str | None:
+    if request.thinking.is_some():
+        return "thinking is not a groq chat param; v1 raises or drops it"
+    if request.user.is_some():
+        return (
+            "user is model-list gated upstream and silently dropped for "
+            "groq; v1 serves its own drop"
+        )
+    if request.reasoning_effort.is_some() and not supports_reasoning(
+        request.model, deps
+    ):
+        return (
+            f"reasoning_effort on non-reasoning groq model {request.model}; "
+            "v1 raises or drops it"
+        )
+    return _response_format_reason(request, deps)
+
+
+def _response_format_reason(request: ChatRequest, deps: TranslationDeps) -> str | None:
+    response_format = request.response_format.default_value(None)
+    if response_format is None or response_format.tag != "json_schema":
+        return None
+    if _supports_response_schema(request.model, deps):
+        return None  # native passthrough — served verbatim
+    if len(request.tools) > 0:
+        return (
+            f"response_format json_schema with tools on non-native groq "
+            f"model {request.model}: v1 raises litellm.BadRequestError "
+            "(structured outputs are incompatible with user tools there)"
+        )
+    return (
+        f"response_format json_schema on non-native groq model "
+        f"{request.model}: v1 serves its json_tool_call workaround (tools + "
+        "forced tool_choice + json_mode + fake_stream — a cross-plane "
+        "rewrite v2 deliberately does not reproduce); v1 owns it"
+    )

--- a/litellm/translation/providers/groq/response.py
+++ b/litellm/translation/providers/groq/response.py
@@ -1,0 +1,86 @@
+"""groq chat-completion response JSON -> IR ``ChatResponse``.
+
+v1 is ``GroqChatConfig.transform_response``: the OpenAILike DIRECT
+construction (``ModelResponse(**response_json)``, ``custom_llm_provider=
+None`` -> the prefix arm is DEAD, BARE wire model — researcher-4 verified)
+plus the groq ``service_tier`` post-step: the response's service_tier is
+CLAMPED to {auto, default, flex} with None/unknown -> "auto", setattr'd on
+every response. Unknown top-level keys (``x_groq``) survive onto the
+ModelResponse via the direct construction.
+
+v2 mirrors the compat_httpx "openai_like" convention: the shared openai
+parser for fail-closed validation, then the VERBATIM raw body rides
+``ChatResponse.wire`` with the clamped ``service_tier`` attached, so the
+seam's ``openai_like`` construction arm reproduces v1 byte-for-byte. The
+verifier-longtail F2 arm applies (non-string wire model raises
+ValidationError inside v1's construction; ``model: None`` constructs and
+serves).
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from expression import Error, Ok, Result, Some
+from expression.collections import Block
+
+from ...errors import BoundaryError, TranslationError
+from ...ir import ChatRequest, ChatResponse, JsonBlob, PlainJson
+from ..openai_compat.response import parse_response as openai_parse_response
+
+_ParseResult = Result[ChatResponse, TranslationError]
+
+_SERVICE_TIERS = frozenset({"auto", "default", "flex"})
+
+
+def parse_response(raw: PlainJson, request: ChatRequest) -> _ParseResult:
+    return openai_parse_response(raw, request).bind(
+        lambda response: _groq_wire(response, raw)
+    )
+
+
+def _groq_wire(response: ChatResponse, raw: PlainJson) -> _ParseResult:
+    if not isinstance(raw, dict):
+        return Error(
+            TranslationError.of_boundary(
+                BoundaryError.of(
+                    Block.of_seq(["non-dict response body reached _groq_wire"])
+                )
+            )
+        )
+    wire_model = raw.get("model")
+    if wire_model is not None and not isinstance(wire_model, str):
+        return Error(
+            TranslationError.of_boundary(
+                BoundaryError.of(
+                    Block.of_seq(
+                        [
+                            "non-string wire model "
+                            f"({type(wire_model).__name__}): v1's OpenAILike "
+                            "construction raises ValidationError on it"
+                        ]
+                    )
+                )
+            )
+        )
+    if "service_tier" not in raw:
+        # v1's post-step reads getattr(model_response, "service_tier") with
+        # NO default: a response body without the key crashes v1 with
+        # AttributeError (probed in-process) — fail closed, never serve a
+        # synthesized "auto" where v1 errors.
+        return Error(
+            TranslationError.of_boundary(
+                BoundaryError.of(
+                    Block.of_seq(
+                        [
+                            "groq response without a service_tier key: v1's "
+                            "clamp post-step raises AttributeError on it"
+                        ]
+                    )
+                )
+            )
+        )
+    tier = raw.get("service_tier")
+    clamped = tier if isinstance(tier, str) and tier in _SERVICE_TIERS else "auto"
+    body: dict[str, PlainJson] = {**raw, "service_tier": clamped}
+    return Ok(replace(response, wire=Some(JsonBlob(value=body))))

--- a/litellm/translation/providers/groq/serialize.py
+++ b/litellm/translation/providers/groq/serialize.py
@@ -23,16 +23,9 @@ openai_compat assembly with:
 
 from __future__ import annotations
 
-from expression import Result
-
-from ...errors import TranslationError
 from ...ir import Body, ChatRequest, PlainJson
 from ..openai_compat.serialize import make_gated_serializer
 from . import params as p
-
-_SerializeResult = Result[Body, TranslationError]
-
-
 
 
 def _with_groq_deltas(body: Body, request: ChatRequest) -> Body:

--- a/litellm/translation/providers/groq/serialize.py
+++ b/litellm/translation/providers/groq/serialize.py
@@ -23,22 +23,16 @@ openai_compat assembly with:
 
 from __future__ import annotations
 
-from expression import Error, Result
+from expression import Result
 
-from ...deps import TranslationDeps
 from ...errors import TranslationError
 from ...ir import Body, ChatRequest, PlainJson
-from ..openai_compat.serialize import assemble_body
+from ..openai_compat.serialize import make_gated_serializer
 from . import params as p
 
 _SerializeResult = Result[Body, TranslationError]
 
 
-def serialize_request(request: ChatRequest, deps: TranslationDeps) -> _SerializeResult:
-    reason = p.unsupported_params(request, deps)
-    if reason is not None:
-        return Error(TranslationError.of_unsupported(reason))
-    return assemble_body(request).map(lambda body: _with_groq_deltas(body, request))
 
 
 def _with_groq_deltas(body: Body, request: ChatRequest) -> Body:
@@ -66,3 +60,6 @@ def _without_assistant_nones(message: PlainJson) -> PlainJson:
     if not isinstance(message, dict) or message.get("role") != "assistant":
         return message
     return {key: value for key, value in message.items() if value is not None}
+
+
+serialize_request = make_gated_serializer(p.unsupported_params, _with_groq_deltas)

--- a/litellm/translation/providers/groq/serialize.py
+++ b/litellm/translation/providers/groq/serialize.py
@@ -1,0 +1,68 @@
+"""Serialize the IR into a groq ``/openai/v1/chat/completions`` request body.
+
+v1's chain is ``GroqChatConfig.map_openai_params`` -> ``transform_request``
+(the assistant None-strip pre-step, then the base GPT assembly) on the
+dedicated httpx elif (probed in-process at HEAD). The body is the
+openai_compat assembly with:
+
+- ``max_completion_tokens`` -> ``max_tokens`` (groq's map forwards to the
+  OpenAILike rename positionally, so the rename DOES run — its own
+  signature's ``replace_...=False`` default is never threaded);
+- ``reasoning_effort`` emitted verbatim on capability-flagged models (the
+  params gate already fell back elsewhere);
+- ``top_k`` top-level: v1 packs it into ``extra_body`` and hh merges
+  extra_body into the wire body — wire-equivalent emission (the gate
+  mirrors hh's merge);
+- assistant messages rebuilt WITHOUT None-valued keys (issue #5839 —
+  ``content: None`` on tool-call messages never reaches the wire);
+- ``response_format`` verbatim (json_object always; json_schema only on
+  native-schema models — the params gate owns the other arms). The
+  fake_stream/json_mode keys v1's map sets are ROUTING keys hh pops
+  before the wire; they never appear here.
+"""
+
+from __future__ import annotations
+
+from expression import Error, Result
+
+from ...deps import TranslationDeps
+from ...errors import TranslationError
+from ...ir import Body, ChatRequest, PlainJson
+from ..openai_compat.serialize import assemble_body
+from . import params as p
+
+_SerializeResult = Result[Body, TranslationError]
+
+
+def serialize_request(request: ChatRequest, deps: TranslationDeps) -> _SerializeResult:
+    reason = p.unsupported_params(request, deps)
+    if reason is not None:
+        return Error(TranslationError.of_unsupported(reason))
+    return assemble_body(request).map(lambda body: _with_groq_deltas(body, request))
+
+
+def _with_groq_deltas(body: Body, request: ChatRequest) -> Body:
+    reshaped: dict[str, PlainJson] = {}
+    for key, value in body.items():
+        if key == "max_completion_tokens":
+            reshaped = {**reshaped, "max_tokens": value}
+        elif key == "messages" and isinstance(value, list):
+            reshaped = {
+                **reshaped,
+                "messages": [_without_assistant_nones(message) for message in value],
+            }
+        else:
+            reshaped = {**reshaped, key: value}
+    effort = request.reasoning_effort.default_value(None)
+    if effort is not None:
+        reshaped = {**reshaped, "reasoning_effort": effort}
+    top_k = request.params.top_k.default_value(None)
+    if top_k is not None:
+        reshaped = {**reshaped, "top_k": top_k}
+    return reshaped
+
+
+def _without_assistant_nones(message: PlainJson) -> PlainJson:
+    if not isinstance(message, dict) or message.get("role") != "assistant":
+        return message
+    return {key: value for key, value in message.items() if value is not None}

--- a/litellm/translation/providers/groq/stream.py
+++ b/litellm/translation/providers/groq/stream.py
@@ -31,13 +31,16 @@ from expression.collections import Block
 
 from ...errors import BoundaryError, TranslationError
 from ...ir import PlainJson, StreamEvent
-from ..openai_compat.httpx_chunk import HttpxChunkPolicy, make_parse_event
+from ..openai_compat.httpx_chunk import BASE_HANDLER_POLICY, make_parse_event
 from ..openai_compat.stream import make_parse_line
 
 _EventResult = Result[StreamEvent | None, TranslationError]
 
-_POLICY = HttpxChunkPolicy(reasoning="rename")
-_family_parse_event = make_parse_event(_POLICY)
+# groq's v1 handler is its OWN class, but its policy VALUE is exactly the
+# family truth (rename + value-checked errors + no envelope keys) — ONE
+# name, never a re-declared HttpxChunkPolicy(reasoning="rename") copy
+# (sibling-merge consistency sweep; critic-wave2b-alpha NIT-1's rule).
+_family_parse_event = make_parse_event(BASE_HANDLER_POLICY)
 
 
 def parse_event(event: PlainJson) -> _EventResult:

--- a/litellm/translation/providers/groq/stream.py
+++ b/litellm/translation/providers/groq/stream.py
@@ -1,0 +1,23 @@
+"""groq SSE ``chat.completion.chunk`` payloads -> IR stream events.
+
+v1's decode is ``GroqChatCompletionStreamingHandler(
+OpenAIChatCompletionStreamingHandler)`` over standard ``data:``/[DONE] SSE:
+a TRUTHY ``error`` value raises OpenAIError (the xai-style VALUE check, not
+cometapi's key-presence check), ``delta.reasoning`` is POPPED into
+``reasoning_content``, then the BASE rebuild runs. That is EXACTLY the
+shared httpx_chunk factory with ``reasoning="rename"`` — the longtail
+guidance's prediction ("groq's pop semantics == the existing rename mode"),
+verified against the v1 source: the pre-step pop followed by the base
+handler's own rename is output-identical to one rename. NO new
+ReasoningMode arm was needed (the no-consumer-no-arm rule holds).
+"""
+
+from __future__ import annotations
+
+from ..openai_compat.httpx_chunk import HttpxChunkPolicy, make_parse_event
+from ..openai_compat.stream import make_parse_line
+
+_POLICY = HttpxChunkPolicy(reasoning="rename")
+
+parse_event = make_parse_event(_POLICY)
+parse_line = make_parse_line(parse_event)

--- a/litellm/translation/providers/groq/stream.py
+++ b/litellm/translation/providers/groq/stream.py
@@ -10,14 +10,66 @@ guidance's prediction ("groq's pop semantics == the existing rename mode"),
 verified against the v1 source: the pre-step pop followed by the base
 handler's own rename is output-identical to one rename. NO new
 ReasoningMode arm was needed (the no-consumer-no-arm rule holds).
+
+verifier-wave2b-beta F6: a NON-STR truthy ``reasoning``/
+``reasoning_content`` delta value is a groq-local LOUD pre-step — the
+factory's ``_string_or_none`` quietly nulled it where v1 RAISES (the
+wrapper's stream_chunk_builder epilogue ``"".join`` TypeErrors ->
+APIError). Null reasoning stays served (verified identical). The
+refusal-value half of F6 lives in the SHARED factory
+(``_string_or_none`` nulls a non-str refusal v1 forwards on the wire) —
+that file is the alpha fix round's concurrent edit
+(verifier-wave2b-alpha F1, same machinery), so the groq-side obligation
+rides the sibling-merge handoff: see the INTEGRATOR-FLIP row in
+test_differential_groq_stream.py and this branch's merge notes.
 """
 
 from __future__ import annotations
 
+from expression import Error, Result
+from expression.collections import Block
+
+from ...errors import BoundaryError, TranslationError
+from ...ir import PlainJson, StreamEvent
 from ..openai_compat.httpx_chunk import HttpxChunkPolicy, make_parse_event
 from ..openai_compat.stream import make_parse_line
 
-_POLICY = HttpxChunkPolicy(reasoning="rename")
+_EventResult = Result[StreamEvent | None, TranslationError]
 
-parse_event = make_parse_event(_POLICY)
+_POLICY = HttpxChunkPolicy(reasoning="rename")
+_family_parse_event = make_parse_event(_POLICY)
+
+
+def parse_event(event: PlainJson) -> _EventResult:
+    reason = _reasoning_reason(event)
+    if reason is not None:
+        return Error(
+            TranslationError.of_boundary(BoundaryError.of(Block.of_seq([reason])))
+        )
+    return _family_parse_event(event)
+
+
+def _reasoning_reason(event: PlainJson) -> str | None:
+    if not isinstance(event, dict):
+        return None  # the factory owns the non-object error
+    choices = event.get("choices")
+    if not isinstance(choices, list):
+        return None
+    for choice in choices:
+        if not isinstance(choice, dict):
+            continue
+        delta = choice.get("delta")
+        if not isinstance(delta, dict):
+            continue
+        for key in ("reasoning", "reasoning_content"):
+            value = delta.get(key)
+            if value is not None and not isinstance(value, str):
+                return (
+                    f"groq delta {key} is not a string (v1's wrapper "
+                    'stream_chunk_builder epilogue "".join raises '
+                    "TypeError -> APIError)"
+                )
+    return None
+
+
 parse_line = make_parse_line(parse_event)

--- a/litellm/translation/providers/groq/stream.py
+++ b/litellm/translation/providers/groq/stream.py
@@ -16,12 +16,12 @@ verifier-wave2b-beta F6: a NON-STR truthy ``reasoning``/
 factory's ``_string_or_none`` quietly nulled it where v1 RAISES (the
 wrapper's stream_chunk_builder epilogue ``"".join`` TypeErrors ->
 APIError). Null reasoning stays served (verified identical). The
-refusal-value half of F6 lives in the SHARED factory
-(``_string_or_none`` nulls a non-str refusal v1 forwards on the wire) —
-that file is the alpha fix round's concurrent edit
-(verifier-wave2b-alpha F1, same machinery), so the groq-side obligation
-rides the sibling-merge handoff: see the INTEGRATOR-FLIP row in
-test_differential_groq_stream.py and this branch's merge notes.
+refusal-value half of F6 was DISCHARGED at the wave-2b sibling merge
+(the named INTEGRATOR-FLIP handoff): the shared factory now forwards a
+non-str refusal VERBATIM exactly like v1's Delta (re-probed two-sided);
+a refusal riding the FINISH chunk is the loud finish-chunk fallback
+where groq's v1 wrapper silently drops the value — both pinned in
+test_differential_groq_stream.py.
 """
 
 from __future__ import annotations

--- a/litellm/translation/providers/hosted_vllm/__init__.py
+++ b/litellm/translation/providers/hosted_vllm/__init__.py
@@ -1,0 +1,12 @@
+from .guard import unsupported_request_shapes
+from .response import parse_response
+from .serialize import serialize_request
+from .stream import parse_event, parse_line
+
+__all__ = (
+    "parse_event",
+    "parse_line",
+    "parse_response",
+    "serialize_request",
+    "unsupported_request_shapes",
+)

--- a/litellm/translation/providers/hosted_vllm/guard.py
+++ b/litellm/translation/providers/hosted_vllm/guard.py
@@ -10,16 +10,6 @@ rewrite fallbacks (v1 converts both; pinned in the request gate).
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from ..openai_compat.guard import stream_false_then_unsupported_shapes
 
-from ...errors import TranslationError
-from ..openai_compat.guard import explicit_stream_false
-from ..openai_compat.guard import (
-    unsupported_request_shapes as openai_unsupported_request_shapes,
-)
-
-_Raw = Mapping[str, object]
-
-
-def unsupported_request_shapes(raw: _Raw) -> TranslationError | None:
-    return explicit_stream_false(raw) or openai_unsupported_request_shapes(raw)
+unsupported_request_shapes = stream_false_then_unsupported_shapes

--- a/litellm/translation/providers/hosted_vllm/guard.py
+++ b/litellm/translation/providers/hosted_vllm/guard.py
@@ -1,0 +1,25 @@
+"""Raw-shape fidelity guard for the hosted_vllm serializer.
+
+The httpx path serializes an explicitly-sent ``stream: false`` onto the wire
+(the shared family fact), then the shared openai guard with the FULL
+message-``name`` fallback — v1's hosted_vllm transform chains the base
+``_transform_messages`` and nothing strips names. The guard's existing
+custom-tool and assistant-``thinking_blocks`` arms double as this provider's
+rewrite fallbacks (v1 converts both; pinned in the request gate).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from ...errors import TranslationError
+from ..openai_compat.guard import explicit_stream_false
+from ..openai_compat.guard import (
+    unsupported_request_shapes as openai_unsupported_request_shapes,
+)
+
+_Raw = Mapping[str, object]
+
+
+def unsupported_request_shapes(raw: _Raw) -> TranslationError | None:
+    return explicit_stream_false(raw) or openai_unsupported_request_shapes(raw)

--- a/litellm/translation/providers/hosted_vllm/params.py
+++ b/litellm/translation/providers/hosted_vllm/params.py
@@ -1,0 +1,32 @@
+"""Parameter gates for the hosted_vllm serializer.
+
+v1's gate is ``_check_valid_arg`` over ``HostedVLLMChatConfig.
+get_supported_openai_params`` — the OpenAI base list plus ``thinking`` and
+``reasoning_effort``, appended UNCONDITIONALLY for every model (no
+capability fork; hosted_vllm/chat/transformation.py:90-93). Both are
+SERVED: ``reasoning_effort`` verbatim, ``thinking`` through v1's
+deterministic budget-band rewrite (serialize.py). The provider-shaped v1
+rewrites that fall back here do so at the SHARED boundaries, no provider
+arm needed (pinned in the request gate): custom-type tools (openai guard;
+v1 synthesizes function tools), assistant ``thinking_blocks`` (openai
+guard; v1 prepends them as content blocks), and ``file`` content parts
+(inbound boundary; v1 converts video files to ``video_url`` blocks).
+"""
+
+from __future__ import annotations
+
+from ...deps import TranslationDeps
+from ...ir import ChatRequest
+from ..compat_sdk.checks import BASE_LIST, unsupported_against, user_note
+from ..openai_compat.params import unsupported_response_format
+
+_HOSTED_VLLM_LIST = BASE_LIST | frozenset({"thinking", "reasoning_effort"})
+
+
+def unsupported_params(request: ChatRequest, deps: TranslationDeps) -> str | None:
+    return unsupported_against(
+        request,
+        provider="hosted_vllm",
+        allowed=_HOSTED_VLLM_LIST,
+        notes={"user": user_note("hosted_vllm")},
+    ) or unsupported_response_format(request)

--- a/litellm/translation/providers/hosted_vllm/response.py
+++ b/litellm/translation/providers/hosted_vllm/response.py
@@ -1,0 +1,15 @@
+"""hosted_vllm chat-completion response JSON -> IR ``ChatResponse``.
+
+``HostedVLLMChatConfig`` has no ``transform_response`` override: the
+inherited base GPT transform is LIVE on the dedicated elif over a FRESH
+``ModelResponse`` (model=None), so the response model is the BARE wire
+model (the xai R4 / deepseek pattern; no ``hosted_vllm/`` prefix — pinned
+by test_differential_hosted_vllm_response.py). The shared openai parser is
+that normalizer's mirror, verbatim.
+"""
+
+from __future__ import annotations
+
+from ..openai_compat.response import parse_response
+
+__all__ = ("parse_response",)

--- a/litellm/translation/providers/hosted_vllm/serialize.py
+++ b/litellm/translation/providers/hosted_vllm/serialize.py
@@ -26,24 +26,9 @@ wire-proven in the request gate). v1 keeps the wire model bare on this path
 
 from __future__ import annotations
 
-from expression import Error, Result
-
-from ...deps import TranslationDeps
-from ...errors import TranslationError
 from ...ir import Body, ChatRequest, PlainJson, ThinkingParam
-from ..openai_compat.serialize import assemble_body
+from ..openai_compat.serialize import make_gated_serializer
 from . import params as p
-
-_SerializeResult = Result[Body, TranslationError]
-
-
-def serialize_request(request: ChatRequest, deps: TranslationDeps) -> _SerializeResult:
-    reason = p.unsupported_params(request, deps)
-    if reason is not None:
-        return Error(TranslationError.of_unsupported(reason))
-    return assemble_body(request).map(
-        lambda body: _with_hosted_vllm_deltas(body, request)
-    )
 
 
 def _with_hosted_vllm_deltas(body: Body, request: ChatRequest) -> Body:
@@ -92,3 +77,6 @@ def _cleaned(value: PlainJson) -> PlainJson:
     if isinstance(value, list):
         return [_cleaned(item) for item in value]
     return value
+
+
+serialize_request = make_gated_serializer(p.unsupported_params, _with_hosted_vllm_deltas)

--- a/litellm/translation/providers/hosted_vllm/serialize.py
+++ b/litellm/translation/providers/hosted_vllm/serialize.py
@@ -1,0 +1,94 @@
+"""Serialize the IR into a hosted_vllm ``/chat/completions`` request body.
+
+v1's chain (httpx path, main.py:2619 dedicated elif): ``HostedVLLMChatConfig.
+map_openai_params`` = tools cleaning + the thinking->reasoning_effort budget
+rewrite, then the base copy; ``_transform_messages`` handles shapes that
+fall back at the shared boundaries (params.py). The body is the
+openai_compat assembly with three deltas (all verified in-process at HEAD):
+
+- tools cleaned: ``additionalProperties: false`` removed at EVERY depth
+  (only the ``false`` value — v1's ``_remove_additional_properties``) and
+  ``strict`` removed at EVERY depth (v1's ``_remove_strict_from_schema``;
+  contrast xai, which strips function-level strict only and falls back on
+  deeper keys).
+- ``thinking`` rewritten to ``reasoning_effort`` by v1's budget bands —
+  enabled: >=10000 high / >=5000 medium / >=2000 low / else (incl. absent)
+  minimal; disabled and adaptive DROPPED; an explicit ``reasoning_effort``
+  WINS over thinking (v1's "not already set" arm). The thinking key never
+  reaches the wire.
+- ``reasoning_effort`` emitted verbatim (unconditionally supported).
+
+``max_completion_tokens`` passes VERBATIM and ``top_k`` falls back at the
+gate (hosted_vllm IS in openai_compatible_providers: extra_body packing,
+wire-proven in the request gate). v1 keeps the wire model bare on this path
+(no ``hosted_vllm/`` prefix) — response/stream gates pin it.
+"""
+
+from __future__ import annotations
+
+from expression import Error, Result
+
+from ...deps import TranslationDeps
+from ...errors import TranslationError
+from ...ir import Body, ChatRequest, PlainJson, ThinkingParam
+from ..openai_compat.serialize import assemble_body
+from . import params as p
+
+_SerializeResult = Result[Body, TranslationError]
+
+
+def serialize_request(request: ChatRequest, deps: TranslationDeps) -> _SerializeResult:
+    reason = p.unsupported_params(request, deps)
+    if reason is not None:
+        return Error(TranslationError.of_unsupported(reason))
+    return assemble_body(request).map(
+        lambda body: _with_hosted_vllm_deltas(body, request)
+    )
+
+
+def _with_hosted_vllm_deltas(body: Body, request: ChatRequest) -> Body:
+    extras: dict[str, PlainJson] = {}
+    effort = _effective_reasoning_effort(request)
+    if effort is not None:
+        extras = {**extras, "reasoning_effort": effort}
+    tools = body.get("tools")
+    if isinstance(tools, list):
+        return {**body, "tools": [_cleaned(tool) for tool in tools], **extras}
+    return {**body, **extras}
+
+
+def _effective_reasoning_effort(request: ChatRequest) -> PlainJson:
+    effort = request.reasoning_effort.default_value(None)
+    if effort is not None:
+        return effort
+    thinking = request.thinking.default_value(None)
+    if thinking is None:
+        return None
+    return _band(thinking)
+
+
+def _band(thinking: ThinkingParam) -> str | None:
+    if thinking.tag != "enabled":
+        return None  # v1 pops disabled/adaptive without a rewrite
+    budget = thinking.enabled.budget_tokens.default_value(0)
+    if budget >= 10000:
+        return "high"
+    if budget >= 5000:
+        return "medium"
+    if budget >= 2000:
+        return "low"
+    return "minimal"
+
+
+def _cleaned(value: PlainJson) -> PlainJson:
+    """v1's two recursive walks in one pass: drop ``strict`` (any value) and
+    ``additionalProperties`` ONLY when false, at every depth."""
+    if isinstance(value, dict):
+        return {
+            key: _cleaned(item)
+            for key, item in value.items()
+            if key != "strict" and not (key == "additionalProperties" and item is False)
+        }
+    if isinstance(value, list):
+        return [_cleaned(item) for item in value]
+    return value

--- a/litellm/translation/providers/hosted_vllm/stream.py
+++ b/litellm/translation/providers/hosted_vllm/stream.py
@@ -13,8 +13,8 @@ named row. Folds use the ``"xai"`` ChunkDialect.
 
 from __future__ import annotations
 
-from ..openai_compat.httpx_chunk import HttpxChunkPolicy, make_parse_event
+from ..openai_compat.httpx_chunk import BASE_HANDLER_POLICY, make_parse_event
 from ..openai_compat.stream import make_parse_line
 
-parse_event = make_parse_event(HttpxChunkPolicy(reasoning="rename"))
+parse_event = make_parse_event(BASE_HANDLER_POLICY)
 parse_line = make_parse_line(parse_event)

--- a/litellm/translation/providers/hosted_vllm/stream.py
+++ b/litellm/translation/providers/hosted_vllm/stream.py
@@ -1,0 +1,20 @@
+"""hosted_vllm SSE ``chat.completion.chunk`` payloads -> IR stream events.
+
+v1 decodes hosted_vllm streams through the BASE
+``OpenAIChatCompletionStreamingHandler`` (no iterator override;
+canary-pinned) into ``CustomStreamWrapper``'s default openai branch — the
+compat_httpx FAMILY policy over the ONE shared httpx chunk normalizer:
+``reasoning="rename"``, value-checked error chunks, no required envelope
+keys, wire usage verbatim on the ``choices: []`` tail only. Provider error
+chunks are the family's LOUD fail-closed PINNED DIVERGENCE (v1's base
+handler silently swallows them) — hosted_vllm joins the report's single
+named row. Folds use the ``"xai"`` ChunkDialect.
+"""
+
+from __future__ import annotations
+
+from ..openai_compat.httpx_chunk import HttpxChunkPolicy, make_parse_event
+from ..openai_compat.stream import make_parse_line
+
+parse_event = make_parse_event(HttpxChunkPolicy(reasoning="rename"))
+parse_line = make_parse_line(parse_event)

--- a/litellm/translation/providers/huggingface/__init__.py
+++ b/litellm/translation/providers/huggingface/__init__.py
@@ -1,0 +1,12 @@
+from .guard import unsupported_request_shapes
+from .response import parse_response
+from .serialize import serialize_request
+from .stream import parse_event, parse_line
+
+__all__ = (
+    "parse_event",
+    "parse_line",
+    "parse_response",
+    "serialize_request",
+    "unsupported_request_shapes",
+)

--- a/litellm/translation/providers/huggingface/guard.py
+++ b/litellm/translation/providers/huggingface/guard.py
@@ -10,16 +10,6 @@ fallback.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from ..openai_compat.guard import stream_false_then_unsupported_shapes
 
-from ...errors import TranslationError
-from ..openai_compat.guard import explicit_stream_false
-from ..openai_compat.guard import (
-    unsupported_request_shapes as openai_unsupported_request_shapes,
-)
-
-_Raw = Mapping[str, object]
-
-
-def unsupported_request_shapes(raw: _Raw) -> TranslationError | None:
-    return explicit_stream_false(raw) or openai_unsupported_request_shapes(raw)
+unsupported_request_shapes = stream_false_then_unsupported_shapes

--- a/litellm/translation/providers/huggingface/guard.py
+++ b/litellm/translation/providers/huggingface/guard.py
@@ -1,0 +1,25 @@
+"""Raw-shape fidelity guard for the huggingface serializer.
+
+The httpx path serializes an explicitly-sent ``stream: false`` onto the
+wire (the api_base arm's body carries every optional_params key), so that
+arm runs first; then the shared openai guard with the FULL
+message-``name`` fallback — the api_base route sends messages VERBATIM,
+so every raw shape the IR cannot round-trip losslessly is a v1-serves
+fallback.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from ...errors import TranslationError
+from ..openai_compat.guard import explicit_stream_false
+from ..openai_compat.guard import (
+    unsupported_request_shapes as openai_unsupported_request_shapes,
+)
+
+_Raw = Mapping[str, object]
+
+
+def unsupported_request_shapes(raw: _Raw) -> TranslationError | None:
+    return explicit_stream_false(raw) or openai_unsupported_request_shapes(raw)

--- a/litellm/translation/providers/huggingface/params.py
+++ b/litellm/translation/providers/huggingface/params.py
@@ -1,0 +1,48 @@
+"""Parameter gates for the huggingface serializer (api_base route ONLY).
+
+v1's ``HuggingFaceChatConfig.transform_request`` forks on
+``litellm_params["api_base"]`` (chat/transformation.py:135):
+
+- api_base SET (a dedicated endpoint / TGI server): the body is VERBATIM
+  ``{model, messages, **optional_params}`` — no message transforms, no
+  model rewrite, ``max_retries`` NOT popped. This is the ONE route v2
+  ports (``deps.api_base`` carries the value; the fork must thread
+  ``litellm_params["api_base"]`` into deps — CLAUDE.md HARD OBLIGATION).
+- api_base UNSET (the router route): 3-segment ``provider/org/model``
+  names trigger ``_fetch_inference_provider_mapping`` — a BLOCKING HTTP
+  GET to the HF hub INSIDE the transform — and a providerId model
+  rewrite; 2-segment names skip the fetch but run the base message
+  transforms and the router URL synthesis; 1-segment names CRASH v1
+  (ValueError on the split). I/O cannot live in a pure serializer and
+  the route fans out per shape: the WHOLE router route falls back typed.
+
+The param gate itself is the plain OpenAI base list (no map override):
+mct passes VERBATIM, user is model-list gated (silently dropped), and
+top_k rides the TOP-LEVEL passthrough (huggingface is NOT in
+openai_compatible_providers) — v1 SERVES it, so v2 emits it verbatim.
+"""
+
+from __future__ import annotations
+
+from ...deps import TranslationDeps
+from ...ir import ChatRequest
+from ..compat_sdk.checks import BASE_LIST, unsupported_against, user_note
+from ..openai_compat.params import unsupported_response_format
+
+_HUGGINGFACE_LIST = BASE_LIST | frozenset({"top_k"})
+
+
+def unsupported_params(request: ChatRequest, deps: TranslationDeps) -> str | None:
+    if deps.api_base is None:
+        return (
+            "huggingface router route (no api_base): v1 synthesizes router."
+            "huggingface.co URLs and 3-segment names fetch the HF inference-"
+            "provider mapping over HTTP inside transform_request; only the "
+            "api_base route is ported — v1 handles the router route"
+        )
+    return unsupported_against(
+        request,
+        provider="huggingface",
+        allowed=_HUGGINGFACE_LIST,
+        notes={"user": user_note("huggingface")},
+    ) or unsupported_response_format(request)

--- a/litellm/translation/providers/huggingface/response.py
+++ b/litellm/translation/providers/huggingface/response.py
@@ -1,0 +1,15 @@
+"""huggingface chat-completion response JSON -> IR ``ChatResponse``.
+
+``HuggingFaceChatConfig`` has no ``transform_response`` override: the
+inherited base GPT transform is LIVE on the dedicated elif over a FRESH
+``ModelResponse`` (model=None), so the response model is the BARE wire
+model (the xai R4 / deepseek pattern; no ``huggingface/`` prefix — pinned
+by test_differential_huggingface_response.py). The shared openai parser is
+that normalizer's mirror, verbatim.
+"""
+
+from __future__ import annotations
+
+from ..openai_compat.response import parse_response
+
+__all__ = ("parse_response",)

--- a/litellm/translation/providers/huggingface/serialize.py
+++ b/litellm/translation/providers/huggingface/serialize.py
@@ -1,0 +1,40 @@
+"""Serialize the IR into a huggingface dedicated-endpoint request body.
+
+The api_base route's v1 body is VERBATIM ``ChatCompletionRequest(model,
+messages, **optional_params)`` — the request model untouched, messages
+untouched (no flatten, no base image transforms; the openai guard's
+fallbacks are all the v1-serves kind), no renames anywhere
+(``max_completion_tokens`` passes verbatim). The openai_compat assembly
+reproduces it, plus ``top_k`` verbatim (the non-compat top-level
+passthrough, wire-proven in the request gate). The router route never
+reaches here (params.py falls back on it). v1 keeps the wire model bare
+on this path — response/stream gates pin it.
+"""
+
+from __future__ import annotations
+
+from expression import Error, Result
+
+from ...deps import TranslationDeps
+from ...errors import TranslationError
+from ...ir import Body, ChatRequest
+from ..openai_compat.serialize import assemble_body
+from . import params as p
+
+_SerializeResult = Result[Body, TranslationError]
+
+
+def serialize_request(request: ChatRequest, deps: TranslationDeps) -> _SerializeResult:
+    reason = p.unsupported_params(request, deps)
+    if reason is not None:
+        return Error(TranslationError.of_unsupported(reason))
+    return assemble_body(request).map(
+        lambda body: _with_huggingface_deltas(body, request)
+    )
+
+
+def _with_huggingface_deltas(body: Body, request: ChatRequest) -> Body:
+    top_k = request.params.top_k.default_value(None)
+    if top_k is None:
+        return body
+    return {**body, "top_k": top_k}

--- a/litellm/translation/providers/huggingface/serialize.py
+++ b/litellm/translation/providers/huggingface/serialize.py
@@ -13,24 +13,9 @@ on this path — response/stream gates pin it.
 
 from __future__ import annotations
 
-from expression import Error, Result
-
-from ...deps import TranslationDeps
-from ...errors import TranslationError
 from ...ir import Body, ChatRequest
-from ..openai_compat.serialize import assemble_body
+from ..openai_compat.serialize import make_gated_serializer
 from . import params as p
-
-_SerializeResult = Result[Body, TranslationError]
-
-
-def serialize_request(request: ChatRequest, deps: TranslationDeps) -> _SerializeResult:
-    reason = p.unsupported_params(request, deps)
-    if reason is not None:
-        return Error(TranslationError.of_unsupported(reason))
-    return assemble_body(request).map(
-        lambda body: _with_huggingface_deltas(body, request)
-    )
 
 
 def _with_huggingface_deltas(body: Body, request: ChatRequest) -> Body:
@@ -38,3 +23,6 @@ def _with_huggingface_deltas(body: Body, request: ChatRequest) -> Body:
     if top_k is None:
         return body
     return {**body, "top_k": top_k}
+
+
+serialize_request = make_gated_serializer(p.unsupported_params, _with_huggingface_deltas)

--- a/litellm/translation/providers/huggingface/stream.py
+++ b/litellm/translation/providers/huggingface/stream.py
@@ -11,8 +11,8 @@ report's single named row. Folds use the ``"xai"`` ChunkDialect.
 
 from __future__ import annotations
 
-from ..openai_compat.httpx_chunk import HttpxChunkPolicy, make_parse_event
+from ..openai_compat.httpx_chunk import BASE_HANDLER_POLICY, make_parse_event
 from ..openai_compat.stream import make_parse_line
 
-parse_event = make_parse_event(HttpxChunkPolicy(reasoning="rename"))
+parse_event = make_parse_event(BASE_HANDLER_POLICY)
 parse_line = make_parse_line(parse_event)

--- a/litellm/translation/providers/huggingface/stream.py
+++ b/litellm/translation/providers/huggingface/stream.py
@@ -1,0 +1,18 @@
+"""huggingface SSE ``chat.completion.chunk`` payloads -> IR stream events.
+
+v1 decodes huggingface streams through the BASE
+``OpenAIChatCompletionStreamingHandler`` (no iterator override;
+canary-pinned) into ``CustomStreamWrapper``'s default openai branch — the
+compat_httpx FAMILY policy over the ONE shared httpx chunk normalizer.
+Provider error chunks are the family's LOUD fail-closed PINNED DIVERGENCE
+(v1's base handler silently swallows them) — huggingface joins the
+report's single named row. Folds use the ``"xai"`` ChunkDialect.
+"""
+
+from __future__ import annotations
+
+from ..openai_compat.httpx_chunk import HttpxChunkPolicy, make_parse_event
+from ..openai_compat.stream import make_parse_line
+
+parse_event = make_parse_event(HttpxChunkPolicy(reasoning="rename"))
+parse_line = make_parse_line(parse_event)

--- a/litellm/translation/providers/mistral/__init__.py
+++ b/litellm/translation/providers/mistral/__init__.py
@@ -1,0 +1,12 @@
+from .guard import unsupported_request_shapes
+from .response import parse_response
+from .serialize import serialize_request
+from .stream import parse_event, parse_line
+
+__all__ = (
+    "parse_event",
+    "parse_line",
+    "parse_response",
+    "serialize_request",
+    "unsupported_request_shapes",
+)

--- a/litellm/translation/providers/mistral/guard.py
+++ b/litellm/translation/providers/mistral/guard.py
@@ -1,0 +1,87 @@
+"""Raw-shape fidelity guard for the mistral chat serializer.
+
+Mistral's name semantics are a per-role/per-branch matrix, so this guard
+runs its OWN name arm and composes the shared openai guard with
+``skip_name_fallback`` (probed in-process at HEAD):
+
+- the non-image transform branch strips ``name`` from every non-tool role
+  (and from tool messages whose name strip-blanks) — the IR's name-drop IS
+  v1 there, so those serve;
+- a TOOL-role message with a non-blank ``name`` keeps it on the wire — the
+  IR drops it, fall back;
+- the IMAGE/FILE branch returns base-transformed messages with EVERY name
+  forwarded verbatim — any name beside image/file content falls back.
+
+There is NO explicit ``stream: false`` arm: mistral's map only copies
+``stream`` when the value is True (probed: explicit False never reaches
+optional_params), so the IR's absent-vs-false collapse IS v1's drop.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import cast
+
+from ...errors import TranslationError
+from ..openai_compat.guard import (
+    unsupported_request_shapes as openai_unsupported_request_shapes,
+)
+
+_Raw = Mapping[str, object]
+
+
+def unsupported_request_shapes(raw: _Raw) -> TranslationError | None:
+    reason = _name_reason(raw)
+    if reason is not None:
+        return TranslationError.of_unsupported(reason)
+    return openai_unsupported_request_shapes(raw, skip_name_fallback=True)
+
+
+def _name_reason(raw: _Raw) -> str | None:
+    messages = _as_seq(raw.get("messages"))
+    if messages is None:
+        return None
+    entries = [entry for item in messages if (entry := _as_map(item)) is not None]
+    has_media = any(_carries_media(entry) for entry in entries)
+    for entry in entries:
+        name = entry.get("name")
+        if name is None:
+            continue
+        if has_media:
+            return (
+                "message name beside image/file content: v1's mistral image "
+                "branch forwards every name verbatim; v1 serves it"
+            )
+        if entry.get("role") == "tool" and not _blank_string(name):
+            return (
+                "tool-message name: v1 keeps it on the wire (the only role "
+                "whose name survives); the IR drops it, v1 serves"
+            )
+    return None
+
+
+def _carries_media(entry: _Raw) -> bool:
+    content = _as_seq(entry.get("content"))
+    if content is None:
+        return False
+    return any(
+        (part := _as_map(item)) is not None
+        and part.get("type") in ("image_url", "file")
+        for item in content
+    )
+
+
+def _blank_string(name: object) -> bool:
+    return isinstance(name, str) and len(name.strip()) == 0
+
+
+def _as_map(value: object) -> _Raw | None:
+    if isinstance(value, Mapping):
+        return cast(_Raw, value)
+    return None
+
+
+def _as_seq(value: object) -> Sequence[object] | None:
+    if isinstance(value, Sequence) and not isinstance(value, str):
+        return cast(Sequence[object], value)
+    return None

--- a/litellm/translation/providers/mistral/guard.py
+++ b/litellm/translation/providers/mistral/guard.py
@@ -31,10 +31,34 @@ _Raw = Mapping[str, object]
 
 
 def unsupported_request_shapes(raw: _Raw) -> TranslationError | None:
-    reason = _name_reason(raw)
+    reason = _name_reason(raw) or _malformed_entry_reason(raw)
     if reason is not None:
         return TranslationError.of_unsupported(reason)
     return openai_unsupported_request_shapes(raw, skip_name_fallback=True)
+
+
+def _malformed_entry_reason(raw: _Raw) -> str | None:
+    """verifier-wave2b-beta F10: the shared guard's 'v1 forwards the
+    original shape' suffix is FALSE for mistral's non-object content-list
+    entries — v1's ``_transform_messages`` fork check reads ``part.get``
+    over the raw list and raises AttributeError. Fallback-safe either way;
+    this arm fires first so the reason names mistral's real v1 path."""
+    messages = _as_seq(raw.get("messages"))
+    if messages is None:
+        return None
+    for item in messages:
+        entry = _as_map(item)
+        if entry is None:
+            continue
+        content = _as_seq(entry.get("content"))
+        if content is None:
+            continue
+        if any(_as_map(part) is None for part in content):
+            return (
+                "non-object content-list entry: v1's mistral "
+                "_transform_messages fork check raises AttributeError on it"
+            )
+    return None
 
 
 def _name_reason(raw: _Raw) -> str | None:

--- a/litellm/translation/providers/mistral/params.py
+++ b/litellm/translation/providers/mistral/params.py
@@ -1,0 +1,47 @@
+"""Parameter gates for the mistral chat serializer.
+
+v1's gate is ``_check_valid_arg`` over ``MistralConfig.
+get_supported_openai_params`` (stream/temperature/top_p/max_tokens/mct/
+tools/tool_choice/seed/stop/response_format/parallel_tool_calls; +
+thinking/reasoning_effort iff "magistral" in the model). Everything the IR
+carries that v1 raises or rewrites out-of-band falls back typed so v1
+serves its own behavior (probed in-process at HEAD):
+
+- ``user``: SILENTLY DROPPED upstream (dossier drift — researcher-4 listed
+  it as a raise; the probe shows the model-list special case eats it) —
+  typed fallback, v1 serves the drop.
+- ``thinking``/``reasoning_effort``: on magistral models v1 sets an internal
+  ``_add_reasoning_prompt`` flag and INJECTS a reasoning system prompt at
+  transform time (a body rewrite v2 deliberately does not reproduce); on
+  every other model v1 raises — one fallback arm covers both, v1 serves.
+- ``top_k`` is NOT a raise (second dossier drift): the generic passthrough
+  places it top-level in optional_params and the body carries it verbatim —
+  SERVED by the serializer, wire-proven in the request gate.
+- n/seed/penalties/logprobs are parse-level unknowns (typed fallback at the
+  inbound boundary; v1 serves seed via ``extra_body.random_seed``).
+"""
+
+from __future__ import annotations
+
+from ...ir import ChatRequest
+
+
+def unsupported_params(request: ChatRequest) -> str | None:
+    if request.user.is_some():
+        return (
+            "user is model-list gated upstream and silently dropped for "
+            "mistral; v1 serves its own drop"
+        )
+    if request.thinking.is_some():
+        return (
+            "thinking on mistral: v1 injects a reasoning system prompt on "
+            "magistral models (a transform-time body rewrite) and raises "
+            "UnsupportedParamsError elsewhere; v1 owns both"
+        )
+    if request.reasoning_effort.is_some():
+        return (
+            "reasoning_effort on mistral: v1 injects a reasoning system "
+            "prompt on magistral models (a transform-time body rewrite) and "
+            "raises UnsupportedParamsError elsewhere; v1 owns both"
+        )
+    return None

--- a/litellm/translation/providers/mistral/response.py
+++ b/litellm/translation/providers/mistral/response.py
@@ -15,9 +15,12 @@ in-process at HEAD):
   (v1 overwrites, never joins — the two_text_blocks pin); blocks of any
   other type are silently ignored.
 
-Malformed list shapes (non-dict blocks, a non-list ``thinking`` value) are
-loud boundary errors — v1's unguarded ``.get`` chains raise out of the
-transform on each.
+Malformed list shapes are loud boundary errors naming v1's raise: non-dict
+blocks and a non-list ``thinking`` value (v1's unguarded ``.get`` chains),
+a non-str thinking ``text`` (v1's ``"\\n".join`` TypeError), and an EMPTY
+content list (v1's truthiness gate skips the collapse and
+``convert_to_model_response_object`` raises "Invalid response object" on
+``Message(content=[])`` — verifier-wave2b-beta F3).
 """
 
 from __future__ import annotations
@@ -71,6 +74,12 @@ def _pre_step_choice(choice: PlainJson) -> PlainJson | TranslationError:
         return {**choice, "message": {**message, "content": None}}
     if not isinstance(content, list):
         return choice
+    if not content:
+        # v1's truthiness gate SKIPS the collapse on an empty list and the
+        # un-collapsed Message(content=[]) raises out of
+        # convert_to_model_response_object ("Invalid response object") —
+        # the old isinstance-only arm collapsed [] to "" and SERVED it.
+        return _boundary("response content list is empty")
     collapsed = _collapse_content_list(content)
     if isinstance(collapsed, TranslationError):
         return collapsed
@@ -113,5 +122,9 @@ def _collapse_thinking(block: dict[str, PlainJson]) -> str | TranslationError:
             return _boundary("response thinking item is not an object")
         if item.get("type") == "text":
             text = item.get("text", "")
-            texts = [*texts, text if isinstance(text, str) else ""]
+            if not isinstance(text, str):
+                # the old arm coerced to "" and SERVED; v1's "\n".join
+                # raises TypeError out of the transform
+                return _boundary("response thinking text is not a string")
+            texts = [*texts, text]
     return "\n".join(texts)

--- a/litellm/translation/providers/mistral/response.py
+++ b/litellm/translation/providers/mistral/response.py
@@ -1,0 +1,117 @@
+"""Mistral chat-completion response JSON -> IR ``ChatResponse``.
+
+v1's ``MistralConfig.transform_response`` (LIVE on the httpx path) applies
+two raw-body pre-steps, then the shared ``convert_to_model_response_object``
+(fresh ModelResponse, model None -> BARE wire model). v2 mirrors the same
+chain: the two pre-steps here, then the shared openai parser (probed
+in-process at HEAD):
+
+- ``_handle_empty_content_response``: a message ``content == ""`` becomes
+  None — and it runs FIRST, so a content LIST that later flattens to ""
+  STAYS ``""`` (the blocks_no_text pin);
+- ``_handle_content_list_to_str_conversion``: a content LIST is collapsed —
+  thinking blocks' text items join with ``\\n`` into ``reasoning_content``
+  (set only when truthy), and the LAST text block WINS as ``content``
+  (v1 overwrites, never joins — the two_text_blocks pin); blocks of any
+  other type are silently ignored.
+
+Malformed list shapes (non-dict blocks, a non-list ``thinking`` value) are
+loud boundary errors — v1's unguarded ``.get`` chains raise out of the
+transform on each.
+"""
+
+from __future__ import annotations
+
+from expression import Error, Result
+from expression.collections import Block
+
+from ...errors import BoundaryError, TranslationError
+from ...ir import ChatRequest, ChatResponse, PlainJson
+from ..openai_compat.response import parse_response as openai_parse_response
+
+_ParseResult = Result[ChatResponse, TranslationError]
+
+
+def _boundary(reason: str) -> TranslationError:
+    return TranslationError.of_boundary(
+        BoundaryError.of(Block.of_seq([f"mistral {reason} (v1 raises)"]))
+    )
+
+
+def parse_response(raw: PlainJson, request: ChatRequest) -> _ParseResult:
+    pre_stepped = _with_mistral_pre_steps(raw)
+    if isinstance(pre_stepped, TranslationError):
+        return Error(pre_stepped)
+    return openai_parse_response(pre_stepped, request)
+
+
+def _with_mistral_pre_steps(raw: PlainJson) -> PlainJson | TranslationError:
+    if not isinstance(raw, dict):
+        return raw  # the openai parser owns the non-object boundary error
+    choices = raw.get("choices")
+    if not isinstance(choices, list) or not choices:
+        return raw
+    reshaped: list[PlainJson] = []
+    for choice in choices:
+        stepped = _pre_step_choice(choice)
+        if isinstance(stepped, TranslationError):
+            return stepped
+        reshaped = [*reshaped, stepped]
+    return {**raw, "choices": reshaped}
+
+
+def _pre_step_choice(choice: PlainJson) -> PlainJson | TranslationError:
+    if not isinstance(choice, dict):
+        return choice
+    message = choice.get("message")
+    if not isinstance(message, dict):
+        return choice
+    content = message.get("content")
+    if content == "":
+        return {**choice, "message": {**message, "content": None}}
+    if not isinstance(content, list):
+        return choice
+    collapsed = _collapse_content_list(content)
+    if isinstance(collapsed, TranslationError):
+        return collapsed
+    text, reasoning = collapsed
+    stepped: dict[str, PlainJson] = {**message, "content": text}
+    if reasoning:
+        stepped = {**stepped, "reasoning_content": reasoning}
+    return {**choice, "message": stepped}
+
+
+def _collapse_content_list(
+    content: list[PlainJson],
+) -> tuple[str, str] | TranslationError:
+    thinking_content = ""
+    text_content = ""
+    for block in content:
+        if not isinstance(block, dict):
+            return _boundary("response content block is not an object")
+        block_type = block.get("type")
+        if block_type == "thinking":
+            collapsed = _collapse_thinking(block)
+            if isinstance(collapsed, TranslationError):
+                return collapsed
+            thinking_content = collapsed
+        elif block_type == "text":
+            text = block.get("text", "")
+            if not isinstance(text, str):
+                return _boundary("response text block is not a string")
+            text_content = text  # v1 overwrites: the LAST text block wins
+    return text_content, thinking_content
+
+
+def _collapse_thinking(block: dict[str, PlainJson]) -> str | TranslationError:
+    thinking = block.get("thinking", [])
+    if not isinstance(thinking, list):
+        return _boundary("response thinking value is not a list")
+    texts: list[str] = []
+    for item in thinking:
+        if not isinstance(item, dict):
+            return _boundary("response thinking item is not an object")
+        if item.get("type") == "text":
+            text = item.get("text", "")
+            texts = [*texts, text if isinstance(text, str) else ""]
+    return "\n".join(texts)

--- a/litellm/translation/providers/mistral/serialize.py
+++ b/litellm/translation/providers/mistral/serialize.py
@@ -1,0 +1,168 @@
+"""Serialize the IR into a Mistral ``/v1/chat/completions`` request body.
+
+v1's chain is ``MistralConfig.map_openai_params`` (explicit arms, no
+supported-list loop) then ``transform_request`` -> ``_transform_messages``
+(probed in-process at HEAD). The body is the openai_compat assembly with:
+
+- ``max_completion_tokens`` -> ``max_tokens`` (mct wins over max_tokens);
+- ``tool_choice``: strings only — ``required`` -> ``any`` (auto/none pass);
+  a dict tool_choice is SILENTLY DROPPED by v1's ``isinstance(value, str)``
+  arm, so the IR's ``specific`` tag is dropped here too (served delta);
+- tools: ``$id``/``$schema`` stripped recursively with v1's EXACT depth cap
+  (``_remove_json_schema_refs(max_depth=10)`` — levels deeper than the cap
+  keep their keys; additionalProperties/strict are KEPT, the v1 docstring
+  notwithstanding);
+- ``top_k`` emitted verbatim top-level (the generic passthrough);
+- ``stream`` only when True (assemble_body already matches v1's
+  value-is-True arm).
+
+Message munging mirrors ``_transform_messages``' two branches:
+
+- ANY image content block in the request -> the base-transform branch:
+  openai_compat's messages ride verbatim (no flatten, no name drop, no
+  tool-call rebuild, no empty-assistant removal; ``file`` parts fall back
+  at the inbound parse before reaching here);
+- otherwise: text content lists FLATTEN to one string (v1's
+  ``convert_content_list_to_str`` only assigns a TRUTHY join, so a list
+  flattening to "" keeps its list form in v1 — typed fallback), tool_calls
+  are already in the MistralToolCallMessage shape (id/type/function — the
+  IR admits nothing else), EMPTY assistant messages are REMOVED (every
+  key None/absent except role, content "" included), and None values are
+  stripped from every message (v1's extra_forbidden prevention).
+"""
+
+from __future__ import annotations
+
+from expression import Error, Ok, Result
+
+from ...deps import TranslationDeps
+from ...errors import TranslationError
+from ...ir import Body, ChatRequest, PlainJson
+from ..openai_compat.serialize import assemble_body
+from . import params as p
+
+_SerializeResult = Result[Body, TranslationError]
+
+_REFS_MAX_DEPTH = 10  # v1 _remove_json_schema_refs default, NOT the shared cap
+
+
+def serialize_request(request: ChatRequest, deps: TranslationDeps) -> _SerializeResult:
+    reason = p.unsupported_params(request)
+    if reason is not None:
+        return Error(TranslationError.of_unsupported(reason))
+    return assemble_body(request).bind(lambda body: _with_mistral_deltas(body, request))
+
+
+def _with_mistral_deltas(body: Body, request: ChatRequest) -> _SerializeResult:
+    reshaped: dict[str, PlainJson] = {}
+    for key, value in body.items():
+        if key == "max_completion_tokens":
+            reshaped = {**reshaped, "max_tokens": value}
+        elif key == "tool_choice":
+            choice = _mapped_tool_choice(value)
+            if choice is not None:
+                reshaped = {**reshaped, "tool_choice": choice}
+        elif key == "tools":
+            reshaped = {**reshaped, "tools": _without_schema_refs(value, 0)}
+        else:
+            reshaped = {**reshaped, key: value}
+    top_k = request.params.top_k.default_value(None)
+    if top_k is not None:
+        reshaped = {**reshaped, "top_k": top_k}
+    messages = _mistral_messages(reshaped.get("messages"), request)
+    if isinstance(messages, TranslationError):
+        return Error(messages)
+    return Ok({**reshaped, "messages": messages})
+
+
+def _mapped_tool_choice(value: PlainJson) -> PlainJson | None:
+    """v1 ``_map_tool_choice`` behind an ``isinstance(value, str)`` gate: a
+    dict tool_choice (the IR's ``specific`` tag) is silently dropped;
+    ``required`` -> ``any``; auto/none pass (any other string also maps to
+    ``any``, but the inbound parse admits only the four canonical tags)."""
+    if not isinstance(value, str):
+        return None
+    return "any" if value == "required" else value
+
+
+def _without_schema_refs(value: PlainJson, depth: int) -> PlainJson:
+    """Mirror v1's ``_remove_json_schema_refs`` exactly: ``$id``/``$schema``
+    removed from dicts down to depth 10; DEEPER levels keep their keys (the
+    cap returns the subtree untouched)."""
+    if depth >= _REFS_MAX_DEPTH:
+        return value
+    if isinstance(value, dict):
+        return {
+            key: _without_schema_refs(item, depth + 1)
+            for key, item in value.items()
+            if key not in ("$id", "$schema")
+        }
+    if isinstance(value, list):
+        return [_without_schema_refs(item, depth + 1) for item in value]
+    return value
+
+
+def _mistral_messages(
+    messages: PlainJson, request: ChatRequest
+) -> list[PlainJson] | TranslationError:
+    if not isinstance(messages, list):
+        return TranslationError.of_unsupported(
+            "mistral serializer received no message list; wiring bug"
+        )
+    if _request_has_image(request):
+        return messages  # v1's base-transform branch: verbatim passthrough
+    reshaped: list[PlainJson] = []
+    for message in messages:
+        if not isinstance(message, dict):
+            return TranslationError.of_unsupported(
+                "mistral serializer received a non-object message; wiring bug"
+            )
+        flattened = _flatten_content(message)
+        if isinstance(flattened, TranslationError):
+            return flattened
+        if _is_empty_assistant(flattened):
+            continue
+        reshaped = [
+            *reshaped,
+            {key: value for key, value in flattened.items() if value is not None},
+        ]
+    return reshaped
+
+
+def _request_has_image(request: ChatRequest) -> bool:
+    return any(
+        block.tag == "image"
+        for message in request.messages
+        for block in message.content
+    )
+
+
+def _flatten_content(
+    message: dict[str, PlainJson],
+) -> dict[str, PlainJson] | TranslationError:
+    content = message.get("content")
+    if not isinstance(content, list):
+        return message
+    texts = "".join(
+        text
+        for item in content
+        if isinstance(item, dict) and isinstance(text := item.get("text"), str)
+    )
+    if not texts:
+        return TranslationError.of_unsupported(
+            "text content list flattening to an empty string: v1's truthy "
+            "assignment keeps the LIST form on the wire; v1 serves it"
+        )
+    return {**message, "content": texts}
+
+
+def _is_empty_assistant(message: dict[str, PlainJson]) -> bool:
+    """v1 ``_is_empty_assistant_message``: every assistant-message key is
+    None/absent except role, with content ``""`` counting as empty."""
+    if message.get("role") != "assistant":
+        return False
+    return all(
+        value is None or (key == "content" and value == "")
+        for key, value in message.items()
+        if key != "role"
+    )

--- a/litellm/translation/providers/mistral/serialize.py
+++ b/litellm/translation/providers/mistral/serialize.py
@@ -9,9 +9,13 @@ supported-list loop) then ``transform_request`` -> ``_transform_messages``
   a dict tool_choice is SILENTLY DROPPED by v1's ``isinstance(value, str)``
   arm, so the IR's ``specific`` tag is dropped here too (served delta);
 - tools: ``$id``/``$schema`` stripped recursively with v1's EXACT depth cap
-  (``_remove_json_schema_refs(max_depth=10)`` — levels deeper than the cap
-  keep their keys; additionalProperties/strict are KEPT, the v1 docstring
-  notwithstanding);
+  — ``_remove_json_schema_refs(max_depth=DEFAULT_MAX_RECURSE_DEPTH)``
+  (= 100 at HEAD; the ``max_depth=10`` signature default is dead at this
+  call site, verifier-wave2b-beta F2). Levels deeper than the cap keep
+  their keys; additionalProperties/strict are KEPT, the v1 docstring
+  notwithstanding. v2 imports the SAME ``litellm.constants`` symbol v1
+  reads (the allowed env-seeded leaf), so the env-overridable cap can
+  never drift between the two sides;
 - ``top_k`` emitted verbatim top-level (the generic passthrough);
 - ``stream`` only when True (assemble_body already matches v1's
   value-is-True arm).
@@ -35,6 +39,8 @@ from __future__ import annotations
 
 from expression import Error, Ok, Result
 
+from litellm.constants import DEFAULT_MAX_RECURSE_DEPTH
+
 from ...deps import TranslationDeps
 from ...errors import TranslationError
 from ...ir import Body, ChatRequest, PlainJson
@@ -42,8 +48,6 @@ from ..openai_compat.serialize import assemble_body
 from . import params as p
 
 _SerializeResult = Result[Body, TranslationError]
-
-_REFS_MAX_DEPTH = 10  # v1 _remove_json_schema_refs default, NOT the shared cap
 
 
 def serialize_request(request: ChatRequest, deps: TranslationDeps) -> _SerializeResult:
@@ -86,10 +90,13 @@ def _mapped_tool_choice(value: PlainJson) -> PlainJson | None:
 
 
 def _without_schema_refs(value: PlainJson, depth: int) -> PlainJson:
-    """Mirror v1's ``_remove_json_schema_refs`` exactly: ``$id``/``$schema``
-    removed from dicts down to depth 10; DEEPER levels keep their keys (the
-    cap returns the subtree untouched)."""
-    if depth >= _REFS_MAX_DEPTH:
+    """Mirror v1's ``_remove_json_schema_refs(max_depth=
+    DEFAULT_MAX_RECURSE_DEPTH)`` exactly: v1 counts max_depth DOWN from the
+    constant starting at the tools list and strips while ``max_depth > 0``;
+    v2 counts UP from 0 at the same list, so a dict at v2-depth ``d`` is
+    stripped iff ``d < DEFAULT_MAX_RECURSE_DEPTH`` — the same node set.
+    DEEPER levels keep their keys (the cap returns the subtree untouched)."""
+    if depth >= DEFAULT_MAX_RECURSE_DEPTH:
         return value
     if isinstance(value, dict):
         return {

--- a/litellm/translation/providers/mistral/stream.py
+++ b/litellm/translation/providers/mistral/stream.py
@@ -139,7 +139,12 @@ def _thinking_text(thinking: list[PlainJson]) -> str | TranslationError:
             return _boundary("stream thinking item is not an object")
         if item.get("type") == "text":
             text = item.get("text", "")
-            parts = [*parts, text if isinstance(text, str) else ""]
+            if not isinstance(text, str):
+                # the old arm coerced to "" and SERVED a stripped chunk;
+                # v1's pre-step except-arm replays the still-list content
+                # and the wrapper raises MidStreamFallbackError
+                return _boundary("stream thinking text is not a string")
+            parts = [*parts, text]
     return "".join(parts)
 
 

--- a/litellm/translation/providers/mistral/stream.py
+++ b/litellm/translation/providers/mistral/stream.py
@@ -1,0 +1,146 @@
+"""Mistral SSE ``chat.completion.chunk`` payloads -> IR stream events.
+
+v1's decode is ``MistralChatResponseIterator(
+OpenAIChatCompletionStreamingHandler)`` over standard ``data:``/[DONE] SSE
+lines: a pre-step normalizes magistral content-LIST deltas into
+``content`` (None when no text segments) + ``thinking_blocks`` (signature
+``"mistral"``) + ``reasoning_content`` (set only when a thinking text
+exists), then the BASE handler rebuild runs — which is exactly the shared
+httpx_chunk factory's behavior (``reasoning="rename"``: the base handler
+pops ``delta.reasoning`` into ``reasoning_content``). The factory's new
+``passthrough_delta_keys`` axis admits the pre-step's ``thinking_blocks``
+(wave-2b-beta; mistral is the consumer, rows in
+test_differential_mistral_stream.py).
+
+v1's pre-step wraps itself in ``except Exception: return super().
+chunk_parser(chunk)`` — but the base rebuild then raises on the still-list
+content (Delta validation), so malformed content lists are LOUD here too
+(boundary errors naming the v1 raise).
+"""
+
+from __future__ import annotations
+
+from expression import Error, Result
+from expression.collections import Block
+
+from ...errors import BoundaryError, TranslationError
+from ...ir import PlainJson, StreamEvent
+from ..openai_compat.httpx_chunk import HttpxChunkPolicy, make_parse_event
+from ..openai_compat.stream import make_parse_line
+
+_EventResult = Result[StreamEvent | None, TranslationError]
+
+_POLICY = HttpxChunkPolicy(
+    reasoning="rename", passthrough_delta_keys=("thinking_blocks",)
+)
+_family_parse_event = make_parse_event(_POLICY)
+
+
+def _boundary(reason: str) -> TranslationError:
+    return TranslationError.of_boundary(
+        BoundaryError.of(Block.of_seq([f"mistral {reason} (v1 raises)"]))
+    )
+
+
+def parse_event(event: PlainJson) -> _EventResult:
+    pre_stepped = _with_content_list_pre_step(event)
+    if isinstance(pre_stepped, TranslationError):
+        return Error(pre_stepped)
+    return _family_parse_event(pre_stepped)
+
+
+def _with_content_list_pre_step(event: PlainJson) -> PlainJson | TranslationError:
+    if not isinstance(event, dict):
+        return event  # the factory owns the non-object boundary error
+    choices = event.get("choices")
+    if not isinstance(choices, list):
+        return event
+    reshaped: list[PlainJson] = []
+    for choice in choices:
+        stepped = _pre_step_choice(choice)
+        if isinstance(stepped, TranslationError):
+            return stepped
+        reshaped = [*reshaped, stepped]
+    return {**event, "choices": reshaped}
+
+
+def _pre_step_choice(choice: PlainJson) -> PlainJson | TranslationError:
+    if not isinstance(choice, dict):
+        return choice
+    delta = choice.get("delta")
+    if not isinstance(delta, dict):
+        return choice
+    content = delta.get("content")
+    if not isinstance(content, list):
+        return choice
+    normalized = _normalize_content_blocks(content)
+    if isinstance(normalized, TranslationError):
+        return normalized
+    text, thinking_blocks, reasoning = normalized
+    stepped: dict[str, PlainJson] = {
+        key: value
+        for key, value in delta.items()
+        if key not in ("thinking_blocks", "reasoning_content")
+    }
+    stepped = {**stepped, "content": text}
+    if thinking_blocks:
+        stepped = {
+            **stepped,
+            "thinking_blocks": thinking_blocks,
+            "reasoning_content": reasoning,
+        }
+    return {**choice, "delta": stepped}
+
+
+def _normalize_content_blocks(
+    content: list[PlainJson],
+) -> tuple[PlainJson, list[PlainJson], PlainJson] | TranslationError:
+    """Mirror ``MistralChatResponseIterator._normalize_content_blocks``:
+    text segments JOIN (None when none exist), thinking texts join with
+    ``""`` per block and ``"\\n"`` across blocks."""
+    text_segments: list[str] = []
+    thinking_blocks: list[PlainJson] = []
+    reasoning_segments: list[str] = []
+    for block in content:
+        if not isinstance(block, dict):
+            return _boundary("stream content block is not an object")
+        block_type = block.get("type")
+        if block_type == "thinking":
+            thinking = block.get("thinking", [])
+            if not isinstance(thinking, list):
+                return _boundary("stream thinking value is not a list")
+            collected = _thinking_text(thinking)
+            if isinstance(collected, TranslationError):
+                return collected
+            if collected:
+                reasoning_segments = [*reasoning_segments, collected]
+                thinking_blocks = [
+                    *thinking_blocks,
+                    {
+                        "type": "thinking",
+                        "thinking": collected,
+                        "signature": "mistral",
+                    },
+                ]
+        elif block_type == "text":
+            text = block.get("text", "")
+            if not isinstance(text, str):
+                return _boundary("stream text block is not a string")
+            text_segments = [*text_segments, text]
+    normalized_text: PlainJson = "".join(text_segments) if text_segments else None
+    reasoning: PlainJson = "\n".join(reasoning_segments) if reasoning_segments else None
+    return normalized_text, thinking_blocks, reasoning
+
+
+def _thinking_text(thinking: list[PlainJson]) -> str | TranslationError:
+    parts: list[str] = []
+    for item in thinking:
+        if not isinstance(item, dict):
+            return _boundary("stream thinking item is not an object")
+        if item.get("type") == "text":
+            text = item.get("text", "")
+            parts = [*parts, text if isinstance(text, str) else ""]
+    return "".join(parts)
+
+
+parse_line = make_parse_line(parse_event)

--- a/litellm/translation/providers/openai_compat/guard.py
+++ b/litellm/translation/providers/openai_compat/guard.py
@@ -73,9 +73,13 @@ def stream_false_then_unsupported_shapes(raw: _Raw) -> TranslationError | None:
     this module's guard with the FULL message-``name`` fallback. ONE home
     for the shared composition (critic-wave2b-alpha NIT-1: it was four
     byte-identical bodies): compat_sdk's family default and the deepseek /
-    hosted_vllm / fireworks_ai / huggingface own modules all bind it
-    (snowflake deliberately does NOT — stream is always a body key there,
-    so explicit false SERVES)."""
+    hosted_vllm / fireworks_ai / huggingface / sagemaker_chat / groq own
+    modules all bind it, and cohere's guard runs it after its route
+    predicates (sibling-merge sweep: sagemaker_chat/groq/cohere had
+    re-declared the composition). snowflake deliberately does NOT — stream
+    is always a body key there, so explicit false SERVES; mistral and
+    watsonx have no stream:false arm (v1's map only copies stream=True /
+    the wire always carries the key)."""
     return explicit_stream_false(raw) or unsupported_request_shapes(raw)
 
 

--- a/litellm/translation/providers/openai_compat/guard.py
+++ b/litellm/translation/providers/openai_compat/guard.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from typing import cast
 
+from litellm.constants import DEFAULT_MAX_RECURSE_DEPTH
+
 from ...errors import TranslationError
 
 _Raw = Mapping[str, object]
@@ -33,6 +35,28 @@ def explicit_stream_false(raw: _Raw) -> TranslationError | None:
             "absent-vs-false is lost in the IR)"
         )
     return None
+
+
+def carries_cache_control(value: object, depth: int = 0) -> bool:
+    """Recursive ``cache_control`` scan over a raw subtree (messages/tools).
+    The shared mechanism behind the azure guard's verbatim-forward arm and
+    the openrouter guard's cache-capable-model arm (wave-2b-alpha lift of
+    azure/guard.py's private copy — one scan, two policies)."""
+    if depth > DEFAULT_MAX_RECURSE_DEPTH:
+        # exhaustion must never ADMIT a request: treat the unscannable tail
+        # as if it carried the marker (fall back to v1)
+        return True
+    if isinstance(value, Mapping):
+        mapping = cast(_Raw, value)
+        if "cache_control" in mapping:
+            return True
+        return any(carries_cache_control(item, depth + 1) for item in mapping.values())
+    if isinstance(value, Sequence) and not isinstance(value, str):
+        return any(
+            carries_cache_control(item, depth + 1)
+            for item in cast(Sequence[object], value)
+        )
+    return False
 
 
 def unsupported_request_shapes(

--- a/litellm/translation/providers/openai_compat/guard.py
+++ b/litellm/translation/providers/openai_compat/guard.py
@@ -50,16 +50,33 @@ def carries_cache_control(value: object, depth: int = 0) -> bool:
         # as if it carried the marker (fall back to v1)
         return True
     if isinstance(value, Mapping):
+        # deliberately narrowing (critic NIT-2): isinstance proved Mapping;
+        # the cast only fixes the unparameterized key/value types to the
+        # untrusted-raw shape (str keys, object values) this guard scans
         mapping = cast(_Raw, value)
         if "cache_control" in mapping:
             return True
         return any(carries_cache_control(item, depth + 1) for item in mapping.values())
     if isinstance(value, Sequence) and not isinstance(value, str):
+        # deliberately narrowing: isinstance proved Sequence (non-str); the
+        # cast fixes the element type to object for the recursive scan
         return any(
             carries_cache_control(item, depth + 1)
             for item in cast(Sequence[object], value)
         )
     return False
+
+
+def stream_false_then_unsupported_shapes(raw: _Raw) -> TranslationError | None:
+    """The composed DEFAULT guard for paths that keep an explicitly-sent
+    ``stream: false`` on the wire and strip nothing: the stream arm, then
+    this module's guard with the FULL message-``name`` fallback. ONE home
+    for the shared composition (critic-wave2b-alpha NIT-1: it was four
+    byte-identical bodies): compat_sdk's family default and the deepseek /
+    hosted_vllm / fireworks_ai / huggingface own modules all bind it
+    (snowflake deliberately does NOT — stream is always a body key there,
+    so explicit false SERVES)."""
+    return explicit_stream_false(raw) or unsupported_request_shapes(raw)
 
 
 def unsupported_request_shapes(

--- a/litellm/translation/providers/openai_compat/guard.py
+++ b/litellm/translation/providers/openai_compat/guard.py
@@ -39,9 +39,12 @@ def explicit_stream_false(raw: _Raw) -> TranslationError | None:
 
 def carries_cache_control(value: object, depth: int = 0) -> bool:
     """Recursive ``cache_control`` scan over a raw subtree (messages/tools).
-    The shared mechanism behind the azure guard's verbatim-forward arm and
-    the openrouter guard's cache-capable-model arm (wave-2b-alpha lift of
-    azure/guard.py's private copy — one scan, two policies)."""
+    The ONE mechanism behind every marker-policy guard arm: azure's
+    verbatim-forward arm, openrouter's cache-capable-model arm, compat_sdk's
+    ``cache_control_preserved`` (dashscope/zai, and minimax via compat_httpx),
+    and google_genai's name-beside-marker arm (critic-wave2b-alpha MAJOR-1
+    completed the lift: the former compat_sdk and google_genai copies import
+    this one — never re-fork it)."""
     if depth > DEFAULT_MAX_RECURSE_DEPTH:
         # exhaustion must never ADMIT a request: treat the unscannable tail
         # as if it carried the marker (fall back to v1)

--- a/litellm/translation/providers/openai_compat/guard.py
+++ b/litellm/translation/providers/openai_compat/guard.py
@@ -36,16 +36,26 @@ def explicit_stream_false(raw: _Raw) -> TranslationError | None:
 
 
 def unsupported_request_shapes(
-    raw: _Raw, *, name_fallback_user_only: bool = False
+    raw: _Raw,
+    *,
+    name_fallback_user_only: bool = False,
+    skip_name_fallback: bool = False,
 ) -> TranslationError | None:
     """``name_fallback_user_only``: providers whose v1 transform STRIPS the
     message ``name`` from non-user roles (xai ``strip_name_from_messages``)
     only need the fallback for user messages, where v1 forwards it verbatim;
-    the IR's name-drop IS v1's behavior on the other roles."""
+    the IR's name-drop IS v1's behavior on the other roles.
+
+    ``skip_name_fallback`` (wave-2b-beta): providers whose name semantics are
+    a per-role/per-branch matrix (mistral keeps TOOL-role names and forwards
+    every name on its image branch) run their OWN name arm first and skip the
+    shared one entirely."""
     reason = (
         _params_reason(raw)
         or _tools_reason(raw)
-        or _messages_reason(raw, name_fallback_user_only)
+        or _messages_reason(
+            raw, name_fallback_user_only, skip_name_fallback=skip_name_fallback
+        )
     )
     if reason is None:
         return None
@@ -95,7 +105,12 @@ def _tools_reason(raw: _Raw) -> str | None:
     return None
 
 
-def _messages_reason(raw: _Raw, name_fallback_user_only: bool = False) -> str | None:
+def _messages_reason(
+    raw: _Raw,
+    name_fallback_user_only: bool = False,
+    *,
+    skip_name_fallback: bool = False,
+) -> str | None:
     messages = _as_seq(raw.get("messages"))
     if messages is None:
         return None
@@ -108,8 +123,10 @@ def _messages_reason(raw: _Raw, name_fallback_user_only: bool = False) -> str | 
             # keep scanning so the guard stays locally conservative too
             continue
         role = entry.get("role")
-        if entry.get("name") is not None and (
-            not name_fallback_user_only or role == "user"
+        if (
+            not skip_name_fallback
+            and entry.get("name") is not None
+            and (not name_fallback_user_only or role == "user")
         ):
             return "message name field (not carried by the IR)"
         reason = _message_reason(entry, role, seen_non_system)

--- a/litellm/translation/providers/openai_compat/httpx_chunk.py
+++ b/litellm/translation/providers/openai_compat/httpx_chunk.py
@@ -39,6 +39,7 @@ from typing import Literal
 
 from expression import Error, Ok, Result
 from expression.collections import Block
+from typing_extensions import assert_never
 
 from ...errors import BoundaryError, TranslationError
 from ...ir import JsonBlob, PlainJson, StreamEvent
@@ -252,17 +253,36 @@ def _normalize_delta(
 def _reasoning_tail(
     mode: ReasoningMode, delta: dict[str, PlainJson], base: dict[str, PlainJson]
 ) -> dict[str, PlainJson]:
+    # every ReasoningMode member named, assert_never on the residual: a new
+    # Literal value without an arm here is a pyright error at this line, not
+    # silent rename semantics (critic-wave2b-alpha MAJOR-3, the UsageStyle/M2
+    # precedent — "rename" used to be the implicit else)
     if mode == "unconditional":
         value = _string_or_none(delta.get("reasoning"))
         if "reasoning" in delta:
             return {**base, "reasoning": value, "reasoning_content": value}
         return {**base, "reasoning_content": value}
-    if "reasoning" in delta:
-        value = _string_or_none(delta.get("reasoning"))
-        if mode == "copy_both":
+    if mode == "copy_both":
+        if "reasoning" in delta:
+            value = _string_or_none(delta.get("reasoning"))
             # v1 cometapi assigns without popping: both keys reach the Delta
             return {**base, "reasoning": value, "reasoning_content": value}
-        return {**base, "reasoning_content": value}
+        return _native_reasoning_tail(delta, base)
+    if mode == "rename":
+        if "reasoning" in delta:
+            return {
+                **base,
+                "reasoning_content": _string_or_none(delta.get("reasoning")),
+            }
+        return _native_reasoning_tail(delta, base)
+    assert_never(mode)
+
+
+def _native_reasoning_tail(
+    delta: dict[str, PlainJson], base: dict[str, PlainJson]
+) -> dict[str, PlainJson]:
+    """A native wire ``reasoning_content`` passes through verbatim in the
+    rename and copy_both modes (the unconditional mode CLOBBERS it instead)."""
     if "reasoning_content" in delta:
         return {
             **base,

--- a/litellm/translation/providers/openai_compat/httpx_chunk.py
+++ b/litellm/translation/providers/openai_compat/httpx_chunk.py
@@ -17,11 +17,15 @@ trajectory, applied one level up at the chunk seam). Consumers compose
 - cometapi: ``reasoning="copy_both"`` (v1 assigns WITHOUT popping, so both
   keys reach the Delta), key-presence error chunks, strict
   id/created/model/choices envelope (v1 KeyErrors -> CometAPIException).
-- wave 2b (groq: rename with pop semantics == "rename"; openrouter:
-  UNCONDITIONAL — every delta gains the key): extend ``ReasoningMode`` with
-  the new Literal value and its arm IN THE SAME COMMIT as the consumer and
-  its differential rows — never a third copy of this file's machinery, and
-  never an arm without a consumer (the placeholder-arm rule).
+- openrouter (wave-2b-alpha): ``reasoning="unconditional"`` — every delta
+  gains ``reasoning_content`` (None when ``reasoning`` is absent; a native
+  ``reasoning_content`` clobbered), key-presence error chunks, strict
+  id/created/model/choices envelope (v1 KeyErrors -> OpenRouterException).
+- wave 2b remaining (groq: rename with pop semantics == "rename"): extend
+  ``ReasoningMode`` with the new Literal value and its arm IN THE SAME
+  COMMIT as the consumer and its differential rows — never a third copy of
+  this file's machinery, and never an arm without a consumer (the
+  placeholder-arm rule).
 
 Shapes a v2-sent request cannot trigger (multiple choices, ``function_call``
 deltas, logprobs, unknown delta/tool_call keys) are loud error values.
@@ -42,11 +46,17 @@ from ...ir import JsonBlob, PlainJson, StreamEvent
 _EventResult = Result[StreamEvent | None, TranslationError]
 ParseEvent = Callable[[PlainJson], _EventResult]
 
-ReasoningMode = Literal["rename", "copy_both"]
+ReasoningMode = Literal["rename", "copy_both", "unconditional"]
 """How a wire ``delta.reasoning`` reaches the emitted delta: "rename" emits
 ``reasoning_content`` only (xai; groq's pop has the same output), "copy_both"
 keeps the original key beside the copy (cometapi). Native
-``reasoning_content`` deltas pass through verbatim in every mode."""
+``reasoning_content`` deltas pass through verbatim in those two modes.
+"unconditional" is openrouter's variant (wave-2b-alpha, added with its
+consumer per the no-consumer-no-arm rule): EVERY delta gains
+``reasoning_content = delta.get("reasoning")`` — ``None`` when ``reasoning``
+is absent, the original ``reasoning`` key kept beside it when present, and a
+native wire ``reasoning_content`` CLOBBERED by the assignment (v1
+openrouter's chunk_parser, replay-pinned)."""
 
 _DELTA_KEYS = (
     "content",
@@ -242,6 +252,11 @@ def _normalize_delta(
 def _reasoning_tail(
     mode: ReasoningMode, delta: dict[str, PlainJson], base: dict[str, PlainJson]
 ) -> dict[str, PlainJson]:
+    if mode == "unconditional":
+        value = _string_or_none(delta.get("reasoning"))
+        if "reasoning" in delta:
+            return {**base, "reasoning": value, "reasoning_content": value}
+        return {**base, "reasoning_content": value}
     if "reasoning" in delta:
         value = _string_or_none(delta.get("reasoning"))
         if mode == "copy_both":

--- a/litellm/translation/providers/openai_compat/httpx_chunk.py
+++ b/litellm/translation/providers/openai_compat/httpx_chunk.py
@@ -247,7 +247,36 @@ def _normalize_delta(
     }
     if "refusal" in delta:
         base = {**base, "refusal": _string_or_none(delta.get("refusal"))}
+    reasoning_error = _non_string_reasoning_error(policy.reasoning, delta)
+    if reasoning_error is not None:
+        return reasoning_error
     return _reasoning_tail(policy.reasoning, delta, base)
+
+
+def _non_string_reasoning_error(
+    mode: ReasoningMode, delta: dict[str, PlainJson]
+) -> TranslationError | None:
+    """verifier-wave2b-alpha F3: v1's chunk_parsers serve a non-string
+    reasoning value verbatim, then the stream CRASHES at the end (APIError
+    out of the chunk builder's reasoning join) — never serve what v1 raises
+    on, so the coercion-to-None that silently swallowed the chunk is now a
+    loud error. The native ``reasoning_content`` key is exempt in the
+    unconditional mode only: there v1's assignment clobbers it to None
+    before it can reach the join (replay-pinned), so v1 never crashes."""
+    checked = (
+        ("reasoning",)
+        if mode == "unconditional"
+        else ("reasoning", "reasoning_content")
+    )
+    for key in checked:
+        value = delta.get(key)
+        if value is not None and not isinstance(value, str):
+            return _boundary(
+                f"non-string stream delta {key!r} ({type(value).__name__}): "
+                "v1 serves the verbatim value, then raises APIError at stream "
+                "end joining reasoning for the chunk builder"
+            )
+    return None
 
 
 def _reasoning_tail(
@@ -316,7 +345,20 @@ def _normalize_tool_call(call: PlainJson) -> PlainJson | TranslationError:
 
 
 def _delta_bears_content(delta: dict[str, PlainJson]) -> bool:
+    """Does a NORMALIZED delta carry payload v1's wrapper would interleave
+    as its own chunk ahead of the finish chunk? Non-empty content,
+    tool_calls — and the refusal/reasoning keys (verifier-wave2b-alpha F1:
+    a reasoning-bearing finish delta used to be served as an EMPTY finish
+    chunk, silently dropping text v1 serves; now it takes the loud
+    finish-chunk fallback above). Those keys count only on non-None values:
+    the unconditional mode stamps ``reasoning_content: None`` onto every
+    delta, including the bare finish chunks v1 serves."""
     content = delta.get("content")
-    return (isinstance(content, str) and len(content) > 0) or delta.get(
-        "tool_calls"
-    ) is not None
+    if isinstance(content, str) and len(content) > 0:
+        return True
+    if delta.get("tool_calls") is not None:
+        return True
+    return any(
+        delta.get(key) is not None
+        for key in ("refusal", "reasoning", "reasoning_content")
+    )

--- a/litellm/translation/providers/openai_compat/httpx_chunk.py
+++ b/litellm/translation/providers/openai_compat/httpx_chunk.py
@@ -222,7 +222,9 @@ def _normalize_choice(
         return normalized_delta
     if finish is not None and _delta_bears_content(normalized_delta):
         return TranslationError.of_unsupported(
-            "finish chunk with a non-empty delta; v1's wrapper interleaves it"
+            "finish chunk with a non-empty delta; the v2 fold cannot"
+            " reproduce v1 (the base wrapper interleaves it as its own"
+            " chunk; groq's own v1 wrapper silently DROPS the value)"
         )
     index = choice.get("index")
     return {
@@ -298,6 +300,22 @@ def _copy_passthrough_keys(
     return {**base, **extra} if extra else base
 
 
+def _crash_checked_reasoning_keys(mode: ReasoningMode) -> tuple[str, ...]:
+    """Which delta keys can feed v1's crashing reasoning join, one named arm
+    per ReasoningMode member + ``assert_never`` (critic-wave2b-final NIT-2:
+    this was the implicit-else shape critic-wave2b-alpha MAJOR-3 banned from
+    ``_reasoning_tail``). The native ``reasoning_content`` key is exempt in
+    the unconditional mode only: there v1's assignment clobbers it to None
+    before it can reach the join (replay-pinned), so v1 never crashes."""
+    if mode == "unconditional":
+        return ("reasoning",)
+    if mode == "copy_both":
+        return ("reasoning", "reasoning_content")
+    if mode == "rename":
+        return ("reasoning", "reasoning_content")
+    assert_never(mode)
+
+
 def _non_string_reasoning_error(
     mode: ReasoningMode, delta: dict[str, PlainJson]
 ) -> TranslationError | None:
@@ -305,15 +323,8 @@ def _non_string_reasoning_error(
     reasoning value verbatim, then the stream CRASHES at the end (APIError
     out of the chunk builder's reasoning join) — never serve what v1 raises
     on, so the coercion-to-None that silently swallowed the chunk is now a
-    loud error. The native ``reasoning_content`` key is exempt in the
-    unconditional mode only: there v1's assignment clobbers it to None
-    before it can reach the join (replay-pinned), so v1 never crashes."""
-    checked = (
-        ("reasoning",)
-        if mode == "unconditional"
-        else ("reasoning", "reasoning_content")
-    )
-    for key in checked:
+    loud error."""
+    for key in _crash_checked_reasoning_keys(mode):
         value = delta.get(key)
         if value is not None and not isinstance(value, str):
             return _boundary(

--- a/litellm/translation/providers/openai_compat/httpx_chunk.py
+++ b/litellm/translation/providers/openai_compat/httpx_chunk.py
@@ -115,7 +115,10 @@ on the ``choices: []`` tail only). ONE name for the shared truth
 five base-handler own modules (deepseek, hosted_vllm, fireworks_ai,
 snowflake, huggingface) all compose ``make_parse_event(BASE_HANDLER_POLICY)``
 — a family-policy fix is a one-site edit here, and each consumer's docstring
-stays the provider-specific pinned truth (v1 = the base handler)."""
+stays the provider-specific pinned truth (v1 = the base handler). groq also
+composes it (sibling-merge sweep): its v1 handler is its OWN class whose
+pop-rename + value-checked-error behavior is output-identical to this
+policy — the groq stream gate's replays pin that equivalence."""
 
 
 def _envelope_error(

--- a/litellm/translation/providers/openai_compat/httpx_chunk.py
+++ b/litellm/translation/providers/openai_compat/httpx_chunk.py
@@ -260,7 +260,14 @@ def _normalize_delta(
     # null provider field on content-bearing deltas); refusal and the
     # reasoning keys ride set-only, mirroring Delta's set-field serialization
     # on the dict path — v1 FORWARDS a refusal that rides a role/content
-    # delta and swallows refusal-only deltas (verifier-grok F1).
+    # delta and swallows refusal-only deltas (verifier-grok F1). The refusal
+    # VALUE rides VERBATIM, any type: v1's Delta forwards non-string
+    # refusals on the wire and serves the stream end-to-end (probed two-sided
+    # for groq), so the old _string_or_none nulling diverged on every
+    # non-string value (verifier-wave2b-beta F6's refusal half — the named
+    # INTEGRATOR-FLIP handoff, discharged at the wave-2b sibling merge). A
+    # refusal-bearing FINISH delta stays the loud finish-chunk fallback via
+    # _delta_bears_content (non-None values count).
     base: dict[str, PlainJson] = {
         "content": _string_or_none(delta.get("content")),
         "function_call": None,
@@ -269,7 +276,7 @@ def _normalize_delta(
         "tool_calls": normalized_calls,
     }
     if "refusal" in delta:
-        base = {**base, "refusal": _string_or_none(delta.get("refusal"))}
+        base = {**base, "refusal": delta.get("refusal")}
     reasoning_error = _non_string_reasoning_error(policy.reasoning, delta)
     if reasoning_error is not None:
         return reasoning_error

--- a/litellm/translation/providers/openai_compat/httpx_chunk.py
+++ b/litellm/translation/providers/openai_compat/httpx_chunk.py
@@ -97,6 +97,18 @@ class HttpxChunkPolicy:
     content/finish chunk and re-synthesizes the final usage chunk."""
 
 
+BASE_HANDLER_POLICY = HttpxChunkPolicy(reasoning="rename")
+"""The compat_httpx FAMILY policy — v1's BASE
+``OpenAIChatCompletionStreamingHandler`` rebuild (reasoning rename,
+value-checked error chunks, no required envelope keys, wire usage verbatim
+on the ``choices: []`` tail only). ONE name for the shared truth
+(critic-wave2b-alpha NIT-1: it was declared six times): compat_httpx and the
+five base-handler own modules (deepseek, hosted_vllm, fireworks_ai,
+snowflake, huggingface) all compose ``make_parse_event(BASE_HANDLER_POLICY)``
+— a family-policy fix is a one-site edit here, and each consumer's docstring
+stays the provider-specific pinned truth (v1 = the base handler)."""
+
+
 def _envelope_error(
     policy: HttpxChunkPolicy, event: dict[str, PlainJson]
 ) -> TranslationError | None:

--- a/litellm/translation/providers/openai_compat/httpx_chunk.py
+++ b/litellm/translation/providers/openai_compat/httpx_chunk.py
@@ -84,6 +84,15 @@ class HttpxChunkPolicy:
     usage through verbatim. Either way usage is attached ONLY to the
     ``choices: []`` tail — v1's wrapper strips it from every emitted
     content/finish chunk and re-synthesizes the final usage chunk."""
+    passthrough_delta_keys: tuple[str, ...] = ()
+    """wave-2b-beta: delta keys (beyond the shared ``_DELTA_KEYS``) a
+    consumer's own pre-step deliberately emits, admitted and copied SET-ONLY
+    verbatim (mistral: ``thinking_blocks`` — its v1 chunk_parser normalizes
+    magistral content-list deltas into content + thinking_blocks +
+    reasoning_content BEFORE the base rebuild, so they are reachable, not
+    "unreachable for v2-sent requests"). The no-consumer-no-arm rule
+    applies: never add a key without the pre-step that emits it and its
+    differential rows in the same commit."""
 
 
 def _envelope_error(
@@ -201,7 +210,9 @@ def _normalize_choice(
 def _normalize_delta(
     policy: HttpxChunkPolicy, delta: dict[str, PlainJson]
 ) -> dict[str, PlainJson] | TranslationError:
-    extra_keys = set(delta.keys()) - set(_DELTA_KEYS)
+    extra_keys = (
+        set(delta.keys()) - set(_DELTA_KEYS) - set(policy.passthrough_delta_keys)
+    )
     if extra_keys:
         return TranslationError.of_unsupported(
             f"stream delta keys {sorted(extra_keys)!r}; unreachable for v2-sent requests"
@@ -236,6 +247,9 @@ def _normalize_delta(
     }
     if "refusal" in delta:
         base = {**base, "refusal": _string_or_none(delta.get("refusal"))}
+    for key in policy.passthrough_delta_keys:
+        if key in delta:
+            base = {**base, key: delta[key]}
     return _reasoning_tail(policy.reasoning, delta, base)
 
 

--- a/litellm/translation/providers/openai_compat/response.py
+++ b/litellm/translation/providers/openai_compat/response.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 
 import json
 import re
+from collections.abc import Callable
+from dataclasses import replace
 
 from expression import Error, Nothing, Ok, Result, Some
 from expression.collections import Block
@@ -356,3 +358,55 @@ def _int_of(value: PlainJson) -> int:
     if isinstance(value, (int, float)):
         return int(value)
     return 0
+
+
+RewriteWireModel = Callable[[str | None, str], str | None]
+"""(wire model, request model) -> the final model field, or None to leave the
+body untouched. The per-provider half of ``make_direct_parser``."""
+
+
+def make_direct_parser(
+    rewrite_model: RewriteWireModel,
+) -> Callable[[PlainJson, ChatRequest], _ParseResult]:
+    """v1's OpenAILike-style DIRECT construction (``ModelResponse(**json)``)
+    as a parser factory: the openai parse runs first for fail-closed shape
+    validation, then the VERBATIM raw body rides ``ChatResponse.wire`` with
+    the model rewritten by the per-provider policy (compat_httpx's
+    ``{prefix}/{REQUEST model}`` overwrite; fireworks_ai's
+    ``fireworks_ai/{WIRE model}`` prefix). Lifted from compat_httpx/response
+    .py when fireworks_ai became the second consumer (the httpx_chunk
+    factory precedent: no copies). A non-string wire model fails CLOSED —
+    v1's construction raises pydantic ValidationError BEFORE any overwrite
+    (verifier-longtail F2); ``model: None`` is constructible in v1 and stays
+    served."""
+
+    def parse(raw: PlainJson, request: ChatRequest) -> _ParseResult:
+        return parse_response(raw, request).bind(
+            lambda response: _verbatim_wire(response, raw, request)
+        )
+
+    def _verbatim_wire(
+        response: ChatResponse, raw: PlainJson, request: ChatRequest
+    ) -> _ParseResult:
+        if not isinstance(raw, dict):
+            # Unreachable: parse_response rejected non-dict bodies before
+            # this bind runs. Fail CLOSED if it ever becomes reachable
+            # (critic-wave1b N5).
+            return Error(_boundary("non-dict response body reached the direct parser"))
+        wire_model = raw.get("model")
+        if wire_model is not None and not isinstance(wire_model, str):
+            return Error(
+                _boundary(
+                    "non-string wire model "
+                    f"({type(wire_model).__name__}): v1's OpenAILike "
+                    "construction raises ValidationError on it"
+                )
+            )
+        body: dict[str, PlainJson] = dict(raw)
+        model = rewrite_model(wire_model, request.model)
+        if model is not None:
+            body = {**body, "model": model}
+            return Ok(replace(response, model=model, wire=Some(JsonBlob(value=body))))
+        return Ok(replace(response, wire=Some(JsonBlob(value=body))))
+
+    return parse

--- a/litellm/translation/providers/openai_compat/serialize.py
+++ b/litellm/translation/providers/openai_compat/serialize.py
@@ -14,6 +14,8 @@ losslessly; o-series and gpt-5 models fail closed until their param families
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
 from expression import Error, Ok, Option, Result
 from expression.collections import Block
 from typing_extensions import assert_never
@@ -27,6 +29,29 @@ from . import params as p
 from .messages import serialize_messages
 
 _SerializeResult = Result[Body, TranslationError]
+
+_GateFn = Callable[[ChatRequest, TranslationDeps], str | None]
+_DeltasFn = Callable[[Body, ChatRequest], Body]
+_Serializer = Callable[[ChatRequest, TranslationDeps], _SerializeResult]
+
+
+def make_gated_serializer(gate: _GateFn, with_deltas: _DeltasFn) -> _Serializer:
+    """The own-module ``serialize_request`` shape — params gate ->
+    ``assemble_body`` -> provider deltas — as ONE factory instead of five
+    identical wrappers (critic-wave2b-alpha NIT-1). Consumers: deepseek,
+    openrouter, hosted_vllm, fireworks_ai, huggingface. snowflake binds the
+    chain explicitly: its deltas return a Result (the fail-closed tool arm),
+    so it is deliberately not a row here."""
+
+    def serialize_request(
+        request: ChatRequest, deps: TranslationDeps
+    ) -> _SerializeResult:
+        reason = gate(request, deps)
+        if reason is not None:
+            return Error(TranslationError.of_unsupported(reason))
+        return assemble_body(request).map(lambda body: with_deltas(body, request))
+
+    return serialize_request
 
 
 def serialize_request(request: ChatRequest, deps: TranslationDeps) -> _SerializeResult:

--- a/litellm/translation/providers/openai_compat/serialize.py
+++ b/litellm/translation/providers/openai_compat/serialize.py
@@ -39,9 +39,11 @@ def make_gated_serializer(gate: _GateFn, with_deltas: _DeltasFn) -> _Serializer:
     """The own-module ``serialize_request`` shape — params gate ->
     ``assemble_body`` -> provider deltas — as ONE factory instead of five
     identical wrappers (critic-wave2b-alpha NIT-1). Consumers: deepseek,
-    openrouter, hosted_vllm, fireworks_ai, huggingface. snowflake binds the
-    chain explicitly: its deltas return a Result (the fail-closed tool arm),
-    so it is deliberately not a row here."""
+    openrouter, hosted_vllm, fireworks_ai, huggingface, and (sibling-merge
+    sweep) cohere, sagemaker_chat, groq. Deliberately NOT rows: snowflake
+    and mistral bind the chain explicitly (their deltas return a Result —
+    the fail-closed tool arm / the two-branch message munge), and watsonx
+    does too (its deltas read deps for the project/space injection)."""
 
     def serialize_request(
         request: ChatRequest, deps: TranslationDeps

--- a/litellm/translation/providers/openai_compat/serialize.py
+++ b/litellm/translation/providers/openai_compat/serialize.py
@@ -174,3 +174,20 @@ def _response_format_json(
                     pass
             return {"type": "json_schema", "json_schema": inner}
     assert_never(response_format.tag)
+
+
+def strip_function_strict(tool: PlainJson) -> PlainJson:
+    """Drop the FUNCTION-LEVEL ``strict`` key from one tool (deeper
+    ``strict`` keys untouched) — v1's ``function.pop("strict", None)``
+    shape shared by xai (filter_value_from_dict at the function level) and
+    fireworks_ai (_transform_tools). Lifted from xai/serialize.py when
+    fireworks_ai became the second consumer."""
+    if not isinstance(tool, dict):
+        return tool
+    function = tool.get("function")
+    if not isinstance(function, dict):
+        return tool
+    return {
+        **tool,
+        "function": {key: value for key, value in function.items() if key != "strict"},
+    }

--- a/litellm/translation/providers/openrouter/__init__.py
+++ b/litellm/translation/providers/openrouter/__init__.py
@@ -1,0 +1,12 @@
+from .guard import unsupported_request_shapes
+from .response import parse_response
+from .serialize import serialize_request
+from .stream import parse_event, parse_line
+
+__all__ = (
+    "parse_event",
+    "parse_line",
+    "parse_response",
+    "serialize_request",
+    "unsupported_request_shapes",
+)

--- a/litellm/translation/providers/openrouter/guard.py
+++ b/litellm/translation/providers/openrouter/guard.py
@@ -1,0 +1,52 @@
+"""Raw-shape fidelity guard for the openrouter serializer.
+
+The httpx path serializes an explicitly-sent ``stream: false`` onto the wire
+(the shared family fact), so that arm runs first. Then the cache-capable arm:
+for models matching v1's CacheControlSupportedModels substrings, v1 KEEPS
+``cache_control`` on the wire and MOVES message-level markers into the last
+content block (``_move_cache_control_to_content``) — any marker on those
+models falls back. Every OTHER model gets the base recursive strip, which
+the IR's silent drop reproduces byte-identically, so markers there SERVE
+(pinned by the cache_control_stripped row). Last, the shared openai guard
+with the FULL message-``name`` fallback — nothing on the openrouter chain
+strips names.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from ...errors import TranslationError
+from ..openai_compat.guard import (
+    carries_cache_control,
+    explicit_stream_false,
+)
+from ..openai_compat.guard import (
+    unsupported_request_shapes as openai_unsupported_request_shapes,
+)
+from .params import supports_cache_control_in_content
+
+_Raw = Mapping[str, object]
+
+
+def unsupported_request_shapes(raw: _Raw) -> TranslationError | None:
+    return (
+        explicit_stream_false(raw)
+        or _cache_capable_model_reason(raw)
+        or openai_unsupported_request_shapes(raw)
+    )
+
+
+def _cache_capable_model_reason(raw: _Raw) -> TranslationError | None:
+    model = raw.get("model")
+    if not isinstance(model, str) or not supports_cache_control_in_content(model):
+        return None
+    for field in ("messages", "tools"):
+        if carries_cache_control(raw.get(field)):
+            return TranslationError.of_unsupported(
+                f"cache_control inside {field} on a cache-capable openrouter "
+                "model: v1 keeps it on the wire and moves message-level "
+                "markers into the last content block "
+                "(_move_cache_control_to_content); v1 serves that rewrite"
+            )
+    return None

--- a/litellm/translation/providers/openrouter/params.py
+++ b/litellm/translation/providers/openrouter/params.py
@@ -1,0 +1,82 @@
+"""Parameter gates for the openrouter serializer.
+
+v1's gate is ``_check_valid_arg`` over ``OpenrouterConfig.
+get_supported_openai_params`` — the OpenAI base list plus ``thinking`` and
+``reasoning_effort`` for reasoning-capable models (DUAL-keyed lookup:
+``supports_reasoning(model, "openrouter") OR supports_reasoning(model)``,
+error-swallowed; openrouter/chat/transformation.py:36-49). openrouter is NOT
+in ``litellm.openai_compatible_providers``, so ``get_optional_params`` packs
+non-OpenAI kwargs TOP-LEVEL (the else arm of
+``add_provider_specific_params_to_optional_params``) — ``top_k`` rides
+verbatim onto the wire (NOT extra_body; a dossier-drift fact, wire-proven in
+the request gate), so it is SERVED here.
+
+``thinking`` falls back BOTH ways: on capable models v1 serves the wire dict
+VERBATIM (an unported emission — the zai/minimax precedent: the IR's
+ThinkingParam cannot round-trip explicit-null/extra-key shapes
+byte-identically) and on non-capable models v1 raises UnsupportedParamsError.
+``reasoning_effort`` is SERVED on capable models (verbatim key emission, the
+xai shape) and falls back where v1 raises.
+"""
+
+from __future__ import annotations
+
+from ...deps import TranslationDeps
+from ...ir import ChatRequest
+from ..compat_sdk.checks import BASE_LIST, unsupported_against, user_note
+from ..openai_compat.params import unsupported_response_format
+
+_OPENROUTER_LIST = BASE_LIST | frozenset({"top_k", "reasoning_effort"})
+
+CACHE_CONTROL_MODEL_SUBSTRINGS = ("claude", "gemini", "minimax", "glm", "z-ai")
+"""v1's CacheControlSupportedModels enum (lower-cased substring match):
+these models KEEP cache_control on the wire and get message-level
+cache_control MOVED into the last content block — the guard falls back on
+them; every other model gets the base recursive strip, which the IR's
+cache_control drop reproduces byte-identically."""
+
+
+def supports_cache_control_in_content(model: str) -> bool:
+    lowered = model.lower()
+    return any(part in lowered for part in CACHE_CONTROL_MODEL_SUBSTRINGS)
+
+
+def supports_openrouter_reasoning(model: str, deps: TranslationDeps) -> bool:
+    """v1's dual-keyed lookup. Models whose id ALREADY starts with
+    ``openrouter/`` answer False in v1 (get_model_info strips the duplicate
+    provider prefix, so the openrouter/openrouter/{auto,free} map rows are
+    unreachable — probed at HEAD); mirror that instead of reading the map
+    rows v1 cannot reach."""
+    if model.startswith("openrouter/"):
+        return False
+    return deps.supports_capability(
+        f"openrouter/{model}", "supports_reasoning"
+    ) or deps.supports_capability(model, "supports_reasoning")
+
+
+def unsupported_params(request: ChatRequest, deps: TranslationDeps) -> str | None:
+    reasoning_capable = supports_openrouter_reasoning(request.model, deps)
+    if request.thinking.is_some():
+        if reasoning_capable:
+            return (
+                "thinking on a reasoning-capable openrouter model: v1 serves "
+                "the wire dict VERBATIM (an unported emission; the IR cannot "
+                "round-trip every accepted shape byte-identically)"
+            )
+        return (
+            "thinking on openrouter: outside v1's supported list for "
+            "non-reasoning models; get_optional_params raises "
+            "UnsupportedParamsError (or drops it under drop_params)"
+        )
+    if request.reasoning_effort.is_some() and not reasoning_capable:
+        return (
+            "reasoning_effort on openrouter: outside v1's supported list for "
+            "non-reasoning models; get_optional_params raises "
+            "UnsupportedParamsError (or drops it under drop_params)"
+        )
+    return unsupported_against(
+        request,
+        provider="openrouter",
+        allowed=_OPENROUTER_LIST,
+        notes={"user": user_note("openrouter")},
+    ) or unsupported_response_format(request)

--- a/litellm/translation/providers/openrouter/response.py
+++ b/litellm/translation/providers/openrouter/response.py
@@ -1,0 +1,21 @@
+"""openrouter chat-completion response JSON -> IR ``ChatResponse``.
+
+``OpenrouterConfig.transform_response`` is super() — the base GPT transform
+over a FRESH ``ModelResponse`` (model=None), so the response model is the
+BARE wire model (no ``openrouter/`` prefix; the xai R4 / deepseek pattern) —
+PLUS one envelope post-step: ``usage.cost`` from the raw body is copied into
+``_hidden_params["additional_headers"]["llm_provider-x-litellm-response-cost"]``
+as a float (the cost-calculator feed). The body itself is untouched —
+``usage.cost``/``cost_details`` ride the unknown-usage-key mirror verbatim
+through BOTH sides (parity-pinned), so the shared openai parser is exact for
+the dump and the hidden-params header is a SEAM/FORK OBLIGATION: the future
+openrouter completion() fork must read ``usage.cost`` off the v2 body and
+set the same header (pinned by
+test_differential_openrouter_response.test_v1_cost_hidden_param_is_the_fork_obligation).
+"""
+
+from __future__ import annotations
+
+from ..openai_compat.response import parse_response
+
+__all__ = ("parse_response",)

--- a/litellm/translation/providers/openrouter/serialize.py
+++ b/litellm/translation/providers/openrouter/serialize.py
@@ -1,0 +1,59 @@
+"""Serialize the IR into an openrouter ``/chat/completions`` request body.
+
+v1's chain (httpx path, main.py:3354 dedicated elif): ``OpenrouterConfig.
+map_openai_params`` = the base copy plus an always-set ``extra_body`` (its
+transforms/models/route packing is DEAD at runtime — those kwargs ride the
+top-level passthrough instead, openrouter not being in
+``openai_compatible_providers``; the empty dict is popped back out by
+``transform_request``), then ``transform_request`` = the cache_control
+keep/move for cache-capable models (guard fallback), the base five-touch
+assembly, the extra_body merge (a no-op for v2-visible shapes) and the
+ALWAYS-injected ``"usage": {"include": true}``. The body is the
+openai_compat assembly with three deltas:
+
+- ``usage: {"include": true}`` injected unconditionally (v1's ``if "usage"
+  not in response`` arm is unreachable for v2-sent shapes: no accepted
+  param produces a ``usage`` body key).
+- ``top_k`` emitted verbatim top-level (the non-compat passthrough,
+  wire-proven in the request gate).
+- ``reasoning_effort`` emitted verbatim (the gate already restricted it to
+  reasoning-capable models, mirroring v1's dual-keyed supported list).
+
+``max_completion_tokens`` passes VERBATIM (no rename arm). v1 keeps the wire
+model bare on this path (no ``openrouter/`` prefix) — response/stream gates
+pin it. The HTTP-Referer/X-Title headers and the litellm.OpenrouterConfig
+class-attr extra_body merge live in completion()'s elif — envelope scope,
+never here.
+"""
+
+from __future__ import annotations
+
+from expression import Error, Result
+
+from ...deps import TranslationDeps
+from ...errors import TranslationError
+from ...ir import Body, ChatRequest, PlainJson
+from ..openai_compat.serialize import assemble_body
+from . import params as p
+
+_SerializeResult = Result[Body, TranslationError]
+
+
+def serialize_request(request: ChatRequest, deps: TranslationDeps) -> _SerializeResult:
+    reason = p.unsupported_params(request, deps)
+    if reason is not None:
+        return Error(TranslationError.of_unsupported(reason))
+    return assemble_body(request).map(
+        lambda body: _with_openrouter_deltas(body, request)
+    )
+
+
+def _with_openrouter_deltas(body: Body, request: ChatRequest) -> Body:
+    extras: dict[str, PlainJson] = {"usage": {"include": True}}
+    top_k = request.params.top_k.default_value(None)
+    if top_k is not None:
+        extras = {**extras, "top_k": top_k}
+    effort = request.reasoning_effort.default_value(None)
+    if effort is not None:
+        extras = {**extras, "reasoning_effort": effort}
+    return {**body, **extras}

--- a/litellm/translation/providers/openrouter/serialize.py
+++ b/litellm/translation/providers/openrouter/serialize.py
@@ -28,24 +28,9 @@ never here.
 
 from __future__ import annotations
 
-from expression import Error, Result
-
-from ...deps import TranslationDeps
-from ...errors import TranslationError
 from ...ir import Body, ChatRequest, PlainJson
-from ..openai_compat.serialize import assemble_body
+from ..openai_compat.serialize import make_gated_serializer
 from . import params as p
-
-_SerializeResult = Result[Body, TranslationError]
-
-
-def serialize_request(request: ChatRequest, deps: TranslationDeps) -> _SerializeResult:
-    reason = p.unsupported_params(request, deps)
-    if reason is not None:
-        return Error(TranslationError.of_unsupported(reason))
-    return assemble_body(request).map(
-        lambda body: _with_openrouter_deltas(body, request)
-    )
 
 
 def _with_openrouter_deltas(body: Body, request: ChatRequest) -> Body:
@@ -57,3 +42,6 @@ def _with_openrouter_deltas(body: Body, request: ChatRequest) -> Body:
     if effort is not None:
         extras = {**extras, "reasoning_effort": effort}
     return {**body, **extras}
+
+
+serialize_request = make_gated_serializer(p.unsupported_params, _with_openrouter_deltas)

--- a/litellm/translation/providers/openrouter/stream.py
+++ b/litellm/translation/providers/openrouter/stream.py
@@ -1,0 +1,93 @@
+"""openrouter SSE ``chat.completion.chunk`` payloads -> IR stream events.
+
+v1 decodes through its OWN ``OpenRouterChatCompletionStreamingHandler``
+(NOT the base handler), so openrouter gets a per-provider policy over the
+ONE shared httpx chunk normalizer:
+
+- ``reasoning="unconditional"`` (the ReasoningMode arm added WITH this
+  consumer): v1 assigns ``delta["reasoning_content"] =
+  delta.get("reasoning")`` on EVERY delta — ``None`` when absent, the
+  original ``reasoning`` key kept beside it, a native wire
+  ``reasoning_content`` CLOBBERED.
+- key-PRESENCE error chunks (``"error" in chunk`` -> OpenRouterException;
+  the policy row mirrors that RAISE, like cometapi — openrouter is NOT part
+  of the base-handler PINNED DIVERGENCE).
+- the strict id/created/model/choices envelope (v1 subscripts them;
+  KeyError -> OpenRouterException 400).
+
+One pre-step the policy cannot express: v1 ALSO subscripts
+``choice["delta"]`` inside the choices loop, so a choice MISSING ``delta``
+raises in v1 while the shared normalizer would default it to ``{}`` and
+serve — ``parse_event`` errors loudly on that shape first (v2 never serves
+what v1 raises on; two-sided-pinned in the stream gate).
+
+Folds use the ``"xai"`` ChunkDialect (the generic httpx dict path).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from expression import Error, Result
+from expression.collections import Block
+
+from ...errors import BoundaryError, TranslationError
+from ...ir import PlainJson, StreamEvent
+from ..openai_compat.httpx_chunk import (
+    HttpxChunkPolicy,
+    StrictEnvelope,
+    make_parse_event,
+)
+from ..openai_compat.stream import make_parse_line
+
+_EventResult = Result[StreamEvent | None, TranslationError]
+
+
+def _missing_keys_reason(missing: Sequence[str]) -> str:
+    return (
+        f"stream chunk missing {list(missing)!r}; v1's chunk_parser raises "
+        "KeyError (OpenRouterException 400) on it"
+    )
+
+
+_policy_parse_event = make_parse_event(
+    HttpxChunkPolicy(
+        reasoning="unconditional",
+        error_on_key_presence=True,
+        strict_envelope=StrictEnvelope(
+            keys=("id", "created", "model", "choices"),
+            reason=_missing_keys_reason,
+        ),
+    )
+)
+
+
+def parse_event(event: PlainJson) -> _EventResult:
+    delta_error = _choice_missing_delta(event)
+    if delta_error is not None:
+        return Error(delta_error)
+    return _policy_parse_event(event)
+
+
+def _choice_missing_delta(event: PlainJson) -> TranslationError | None:
+    if not isinstance(event, dict):
+        return None  # the policy parser owns the non-object error
+    choices = event.get("choices")
+    if not isinstance(choices, list):
+        return None
+    for choice in choices:
+        if isinstance(choice, dict) and "delta" not in choice:
+            return TranslationError.of_boundary(
+                BoundaryError.of(
+                    Block.of_seq(
+                        [
+                            "stream choice missing 'delta'; v1's chunk_parser "
+                            "subscripts it (KeyError -> OpenRouterException 400)"
+                        ]
+                    )
+                )
+            )
+    return None
+
+
+parse_line = make_parse_line(parse_event)

--- a/litellm/translation/providers/sagemaker_chat/__init__.py
+++ b/litellm/translation/providers/sagemaker_chat/__init__.py
@@ -1,0 +1,11 @@
+from .guard import unsupported_request_shapes
+from .response import parse_response
+from .serialize import serialize_request
+from .stream import parse_event
+
+__all__ = (
+    "parse_event",
+    "parse_response",
+    "serialize_request",
+    "unsupported_request_shapes",
+)

--- a/litellm/translation/providers/sagemaker_chat/guard.py
+++ b/litellm/translation/providers/sagemaker_chat/guard.py
@@ -19,13 +19,12 @@ from __future__ import annotations
 from collections.abc import Mapping
 
 from ...errors import TranslationError
-from ..openai_compat.guard import explicit_stream_false
-from ..openai_compat.guard import (
-    unsupported_request_shapes as openai_unsupported_request_shapes,
-)
+from ..openai_compat.guard import stream_false_then_unsupported_shapes
 
 _Raw = Mapping[str, object]
 
 
 def unsupported_request_shapes(raw: _Raw) -> TranslationError | None:
-    return explicit_stream_false(raw) or openai_unsupported_request_shapes(raw)
+    # the ONE shared composition (critic-wave2b-alpha NIT-1; sibling-merge
+    # sweep: this body re-declared it)
+    return stream_false_then_unsupported_shapes(raw)

--- a/litellm/translation/providers/sagemaker_chat/guard.py
+++ b/litellm/translation/providers/sagemaker_chat/guard.py
@@ -1,0 +1,31 @@
+"""Raw-shape fidelity guard for the sagemaker_chat serializer.
+
+``SagemakerChatConfig`` is a pure ``OpenAIGPTConfig`` over SigV4 transport:
+the explicit ``stream: false`` arm applies (an explicitly-sent False rides
+optional_params into the body — probed), then the shared openai guard with
+the FULL message-``name`` fallback (the base transform forwards names).
+
+SigV4 (``sign_request`` -> ``BaseAWSLLM._sign_request``, service
+"sagemaker") signs the EXACT serialized body AFTER assembly — envelope
+scope, the bedrock sign-after-body-final precedent; nothing here touches
+credentials (semgrep-enforced). aws_* params ride v1's optional_params
+INTO THE BODY (probed: ``aws_region_name`` appears in the wire body); in
+v2 they are unknown inbound keys, so any aws-kwarg-bearing request falls
+back at parse and v1 serves it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from ...errors import TranslationError
+from ..openai_compat.guard import explicit_stream_false
+from ..openai_compat.guard import (
+    unsupported_request_shapes as openai_unsupported_request_shapes,
+)
+
+_Raw = Mapping[str, object]
+
+
+def unsupported_request_shapes(raw: _Raw) -> TranslationError | None:
+    return explicit_stream_false(raw) or openai_unsupported_request_shapes(raw)

--- a/litellm/translation/providers/sagemaker_chat/params.py
+++ b/litellm/translation/providers/sagemaker_chat/params.py
@@ -17,12 +17,16 @@ v1's gate is ``_check_valid_arg`` over the BASE OpenAI GPT supported list
 
 from __future__ import annotations
 
+from ...deps import TranslationDeps
 from ...ir import ChatRequest
 
 _RESPONSE_FORMAT_RAISE_NAMES = ("gpt-4", "gpt-3.5-turbo-16k")
 
 
-def unsupported_params(request: ChatRequest) -> str | None:
+def unsupported_params(request: ChatRequest, deps: TranslationDeps) -> str | None:
+    # deps is unused here — the uniform own-module gate signature
+    # (critic-wave2b-beta N5's recorded convention), which lets the
+    # serializer compose openai_compat.make_gated_serializer directly
     if request.thinking.is_some():
         return "thinking is not a sagemaker_chat param; v1 raises or drops it"
     if request.reasoning_effort.is_some():

--- a/litellm/translation/providers/sagemaker_chat/params.py
+++ b/litellm/translation/providers/sagemaker_chat/params.py
@@ -1,0 +1,43 @@
+"""Parameter gates for the sagemaker_chat serializer.
+
+v1's gate is ``_check_valid_arg`` over the BASE OpenAI GPT supported list
+(no override — the widest wave-2b list). Probed in-process at HEAD:
+
+- ``thinking``/``reasoning_effort`` RAISE (outside the base list);
+- ``user`` is silently dropped (model-list gated upstream);
+- ``response_format`` RAISES on endpoint names literally ``gpt-4`` /
+  ``gpt-3.5-turbo-16k`` (the base-list name gate — SageMaker endpoint
+  names are arbitrary, so the corner is reachable);
+- ``max_completion_tokens`` passes VERBATIM (no rename — the widest-list
+  exception in the wave) and ``top_k`` rides top-level via the generic
+  passthrough (both served);
+- n/seed/penalties/logprobs/logit_bias/web_search_options pass through in
+  v1 but are parse-level unknowns in v2 (typed fallback, v1 serves).
+"""
+
+from __future__ import annotations
+
+from ...ir import ChatRequest
+
+_RESPONSE_FORMAT_RAISE_NAMES = ("gpt-4", "gpt-3.5-turbo-16k")
+
+
+def unsupported_params(request: ChatRequest) -> str | None:
+    if request.thinking.is_some():
+        return "thinking is not a sagemaker_chat param; v1 raises or drops it"
+    if request.reasoning_effort.is_some():
+        return "reasoning_effort is not a sagemaker_chat param; v1 raises or drops it"
+    if request.user.is_some():
+        return (
+            "user is model-list gated upstream and silently dropped for "
+            "sagemaker_chat; v1 serves its own drop"
+        )
+    if (
+        request.response_format.is_some()
+        and request.model in _RESPONSE_FORMAT_RAISE_NAMES
+    ):
+        return (
+            f"response_format on an endpoint literally named {request.model}: "
+            "v1's base-list name gate raises UnsupportedParamsError"
+        )
+    return None

--- a/litellm/translation/providers/sagemaker_chat/response.py
+++ b/litellm/translation/providers/sagemaker_chat/response.py
@@ -1,0 +1,12 @@
+"""sagemaker_chat response parsing: the shared openai parser verbatim.
+
+``SagemakerChatConfig`` inherits the base ``transform_response`` (LIVE on
+the httpx path) -> ``convert_to_model_response_object`` over a fresh
+ModelResponse with model None: the BARE wire model rides (the
+cometapi/xai R4 shape; NO seam preset, construction arm "openai")."""
+
+from __future__ import annotations
+
+from ..openai_compat.response import parse_response
+
+__all__ = ("parse_response",)

--- a/litellm/translation/providers/sagemaker_chat/serialize.py
+++ b/litellm/translation/providers/sagemaker_chat/serialize.py
@@ -1,0 +1,39 @@
+"""Serialize the IR into a SageMaker Messages-API ``/invocations`` body.
+
+v1's chain is the BASE ``OpenAIGPTConfig.map_openai_params`` +
+``transform_request`` with no overrides: the body IS the openai_compat
+assembly (the model field carries the SageMaker ENDPOINT NAME — it also
+routes the URL, envelope scope), plus ``top_k`` riding the generic
+passthrough top-level (wire-proven) and ``max_completion_tokens`` verbatim
+(no rename — assemble_body already re-emits the caller's key). SigV4 and
+the ``/invocations[-response-stream]`` URL split are envelope; the
+``supports_stream_param_in_request_body = False`` property only governs
+the handler's stream-key ADD for streaming sends — the serialized body
+mirrors v1's transform output exactly.
+"""
+
+from __future__ import annotations
+
+from expression import Error, Result
+
+from ...deps import TranslationDeps
+from ...errors import TranslationError
+from ...ir import Body, ChatRequest
+from ..openai_compat.serialize import assemble_body
+from . import params as p
+
+_SerializeResult = Result[Body, TranslationError]
+
+
+def serialize_request(request: ChatRequest, deps: TranslationDeps) -> _SerializeResult:
+    reason = p.unsupported_params(request)
+    if reason is not None:
+        return Error(TranslationError.of_unsupported(reason))
+    return assemble_body(request).map(lambda body: _with_top_k(body, request))
+
+
+def _with_top_k(body: Body, request: ChatRequest) -> Body:
+    top_k = request.params.top_k.default_value(None)
+    if top_k is None:
+        return body
+    return {**body, "top_k": top_k}

--- a/litellm/translation/providers/sagemaker_chat/serialize.py
+++ b/litellm/translation/providers/sagemaker_chat/serialize.py
@@ -14,22 +14,9 @@ mirrors v1's transform output exactly.
 
 from __future__ import annotations
 
-from expression import Error, Result
-
-from ...deps import TranslationDeps
-from ...errors import TranslationError
 from ...ir import Body, ChatRequest
-from ..openai_compat.serialize import assemble_body
+from ..openai_compat.serialize import make_gated_serializer
 from . import params as p
-
-_SerializeResult = Result[Body, TranslationError]
-
-
-def serialize_request(request: ChatRequest, deps: TranslationDeps) -> _SerializeResult:
-    reason = p.unsupported_params(request)
-    if reason is not None:
-        return Error(TranslationError.of_unsupported(reason))
-    return assemble_body(request).map(lambda body: _with_top_k(body, request))
 
 
 def _with_top_k(body: Body, request: ChatRequest) -> Body:
@@ -37,3 +24,6 @@ def _with_top_k(body: Body, request: ChatRequest) -> Body:
     if top_k is None:
         return body
     return {**body, "top_k": top_k}
+
+
+serialize_request = make_gated_serializer(p.unsupported_params, _with_top_k)

--- a/litellm/translation/providers/sagemaker_chat/stream.py
+++ b/litellm/translation/providers/sagemaker_chat/stream.py
@@ -14,11 +14,32 @@ effects the SDK wire never shows (probed in-process at HEAD):
 - a tool_call ``type`` that is missing OR explicit-null validates to
   ``"function"`` (the dict-path default; the SDK parser keeps None).
 
-So ``parse_event`` composes the shared openai parser with a post-step
-applying exactly those two normalizations. A chunk failing validation
-RAISES out of v1's decoder (not swallowed — unlike watsonx's iterator),
-matching the parser's loud errors. There is no SSE line form (no
-``parse_line``).
+``parse_event`` therefore composes THREE steps mirroring that validation
+(verifier-wave2b-beta F5 widened the original content/role/refusal-only
+pre-check):
+
+1. ``_validation_reason`` — every shape the pydantic construction REJECTS
+   is a loud typed error (v1 raises out of the decoder, no watsonx-style
+   swallow): non-str delta content/role/refusal, a present non-dict delta
+   (the validated model requires the field), non-list ``tool_calls``,
+   tool entries with non-str id/name/arguments/type or non-coercible
+   index, non-lax-int choice indexes (None included — pydantic rejects
+   it), non-dict ``usage``, and usage dicts missing any of the three
+   token keys or carrying values the lax coercion rejects (None and
+   fractional floats RAISE; digit strings, bools and integral floats
+   coerce — all probed);
+2. ``_normalized_event`` — the SERVING lax coercions v1's validation
+   applies (choice/tool index bool -> int, digit-str -> int, integral
+   float -> int) plus v1's finish_reason semantics at the wrapper
+   (verifier F7): a FALSY finish ("", 0, {}) fails the truthy gate — no
+   finish rides and the synthesized trailing stop is seam scope; a truthy
+   non-str hashable finish maps to "stop" (map_finish_reason's .get
+   default — v1 SERVES it, the old parser erred); a truthy UNHASHABLE
+   finish is loud in step 1 (v1's map raises TypeError); truthy strings
+   ride verbatim (the envelope runs v1's live map on both sides);
+3. the shared openai parser + the litellm-validation post-step.
+
+There is no SSE line form (no ``parse_line``).
 """
 
 from __future__ import annotations
@@ -32,46 +53,198 @@ from ..openai_compat.stream import parse_event as openai_parse_event
 
 _EventResult = Result[StreamEvent | None, TranslationError]
 
+_USAGE_KEYS = ("prompt_tokens", "completion_tokens", "total_tokens")
+
 
 def parse_event(event: PlainJson) -> _EventResult:
     reason = _validation_reason(event)
     if reason is not None:
         return Error(
             TranslationError.of_boundary(
-                BoundaryError.of(
-                    Block.of_seq(
-                        [
-                            f"sagemaker_chat {reason} (v1's "
-                            "StreamingChatCompletionChunk validation raises)"
-                        ]
-                    )
-                )
+                BoundaryError.of(Block.of_seq([f"sagemaker_chat {reason}"]))
             )
         )
-    return openai_parse_event(event).map(_with_validation_defaults)
+    return openai_parse_event(_normalized_event(event)).map(_with_validation_defaults)
 
 
 def _validation_reason(event: PlainJson) -> str | None:
-    """The shared openai parser leniently coerces non-string delta fields to
-    None (safe on the SDK path, where upstream validation guarantees
-    strings), but v1's decoder VALIDATES each event here and raises — so
-    wrong-typed delta strings must be loud, never coerced-and-served."""
     if not isinstance(event, dict):
         return None  # the parser owns the non-object error
+    usage_reason = _usage_reason(event.get("usage"), "usage" in event)
+    if usage_reason is not None:
+        return usage_reason
     choices = event.get("choices")
     if not isinstance(choices, list):
-        return None
+        return None  # the parser owns the missing-choices error (v1 KeyErrors)
     for choice in choices:
         if not isinstance(choice, dict):
             continue
-        delta = choice.get("delta")
-        if not isinstance(delta, dict):
-            continue
-        for field in ("content", "role", "refusal"):
-            value = delta.get(field)
-            if value is not None and not isinstance(value, str):
-                return f"stream delta {field} is not a string"
+        reason = _choice_reason(choice)
+        if reason is not None:
+            return reason
     return None
+
+
+def _choice_reason(choice: dict[str, PlainJson]) -> str | None:
+    index = choice.get("index")
+    if "index" in choice and _lax_int(index) is None:
+        return (
+            "stream choice index is not an integer (v1's "
+            "StreamingChatCompletionChunk validation raises — None included)"
+        )
+    finish = choice.get("finish_reason")
+    if finish and not isinstance(finish, (str, bool, int, float)):
+        return (
+            "stream finish_reason is a truthy unhashable value (v1's "
+            "map_finish_reason raises TypeError)"
+        )
+    delta = choice.get("delta")
+    if delta is not None and not isinstance(delta, dict):
+        return (
+            "stream delta is not an object (v1's StreamingChatCompletionChunk "
+            "validation raises — delta Field required)"
+        )
+    if not isinstance(delta, dict):
+        return None
+    return _delta_reason(delta)
+
+
+def _delta_reason(delta: dict[str, PlainJson]) -> str | None:
+    for field in ("content", "role", "refusal"):
+        value = delta.get(field)
+        if value is not None and not isinstance(value, str):
+            return (
+                f"stream delta {field} is not a string (v1's "
+                "StreamingChatCompletionChunk validation raises)"
+            )
+    tool_calls = delta.get("tool_calls")
+    if tool_calls is None:
+        return None
+    if not isinstance(tool_calls, list):
+        return (
+            "stream delta tool_calls is not a list (v1's "
+            "StreamingChatCompletionChunk validation raises)"
+        )
+    for call in tool_calls:
+        if not isinstance(call, dict):
+            continue  # v1's validation DROPS non-dict entries and serves
+        reason = _tool_call_reason(call)
+        if reason is not None:
+            return reason
+    return None
+
+
+def _tool_call_reason(call: dict[str, PlainJson]) -> str | None:
+    function = call.get("function")
+    if not isinstance(function, dict):
+        return (
+            "stream tool_call function is missing or not an object (v1's "
+            "ChatCompletionDeltaToolCall validation raises)"
+        )
+    if (
+        "index" in call
+        and call.get("index") is not None
+        and _lax_int(call.get("index")) is None
+    ):
+        return (
+            "stream tool_call index is not an integer (v1's "
+            "ChatCompletionDeltaToolCall validation raises)"
+        )
+    for field, value in (
+        ("id", call.get("id")),
+        ("type", call.get("type")),
+        ("name", function.get("name")),
+        ("arguments", function.get("arguments")),
+    ):
+        if value is not None and not isinstance(value, str):
+            return (
+                f"stream tool_call {field} is not a string (v1's "
+                "ChatCompletionDeltaToolCall validation raises)"
+            )
+    return None
+
+
+def _usage_reason(usage: PlainJson, present: bool) -> str | None:
+    if not present or usage is None:
+        return None
+    if not isinstance(usage, dict):
+        return (
+            "stream usage is not an object (v1's StreamingChatCompletionChunk "
+            "validation raises)"
+        )
+    for key in _USAGE_KEYS:
+        if key not in usage or _lax_int(usage.get(key)) is None:
+            return (
+                f"stream usage {key} is missing or not an integer (v1's "
+                "Usage validation raises — None and fractional values "
+                "included; digit strings/bools/integral floats coerce)"
+            )
+    return None
+
+
+def _lax_int(value: PlainJson) -> int | None:
+    """pydantic's lax int: bool/int, integral floats, numeric strings."""
+    if isinstance(value, (bool, int)):
+        return int(value)
+    if isinstance(value, float):
+        return int(value) if value.is_integer() else None
+    if not isinstance(value, str):
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        pass
+    try:
+        as_float = float(value)
+    except ValueError:
+        return None
+    return int(as_float) if as_float.is_integer() else None
+
+
+def _normalized_event(event: PlainJson) -> PlainJson:
+    if not isinstance(event, dict):
+        return event
+    choices = event.get("choices")
+    if not isinstance(choices, list):
+        return event
+    reshaped = [_normalized_choice(choice) for choice in choices]
+    return {**event, "choices": reshaped}
+
+
+def _normalized_choice(choice: PlainJson) -> PlainJson:
+    if not isinstance(choice, dict):
+        return choice
+    stepped: dict[str, PlainJson] = {**choice, "finish_reason": _finish(choice)}
+    if "index" in choice:
+        coerced = _lax_int(choice.get("index"))
+        if coerced is not None:
+            stepped = {**stepped, "index": coerced}
+    delta = choice.get("delta")
+    if isinstance(delta, dict):
+        tool_calls = delta.get("tool_calls")
+        if isinstance(tool_calls, list):
+            calls = [_normalized_tool_call(call) for call in tool_calls]
+            stepped = {**stepped, "delta": {**delta, "tool_calls": calls}}
+    return stepped
+
+
+def _finish(choice: dict[str, PlainJson]) -> PlainJson:
+    finish = choice.get("finish_reason")
+    if not finish:
+        # v1's wrapper truthy-gates the finish: falsy values ride as NO
+        # finish and the synthesized trailing stop is seam scope (F7)
+        return None
+    if not isinstance(finish, str):
+        # truthy non-str hashable: v1 serves map_finish_reason's default
+        return "stop"
+    return finish
+
+
+def _normalized_tool_call(call: PlainJson) -> PlainJson:
+    if not isinstance(call, dict) or "index" not in call:
+        return call
+    coerced = _lax_int(call.get("index"))
+    return call if coerced is None else {**call, "index": coerced}
 
 
 def _with_validation_defaults(event: StreamEvent | None) -> StreamEvent | None:

--- a/litellm/translation/providers/sagemaker_chat/stream.py
+++ b/litellm/translation/providers/sagemaker_chat/stream.py
@@ -1,0 +1,111 @@
+"""sagemaker_chat stream events, pinned at the AWS event-stream
+PARSED-EVENT seam (the bedrock precedent: botocore framing is transport).
+
+v1 decodes AWS event-stream BYTES through ``AWSEventStreamDecoder(model="",
+is_messages_api=True)`` and each decoded JSON event becomes a VALIDATED
+``StreamingChatCompletionChunk`` riding ``CustomStreamWrapper``'s default
+openai branch. The validated-chunk materialization is the SDK-dump shape
+the shared openai parser normalizes — PLUS two litellm-Delta validation
+effects the SDK wire never shows (probed in-process at HEAD):
+
+- every emitted content delta carries ``provider_specific_fields: None``
+  (the litellm Delta rebuild materializes it on the FIRST chunk too, where
+  the SDK path's role-bearing delta lacks it);
+- a tool_call ``type`` that is missing OR explicit-null validates to
+  ``"function"`` (the dict-path default; the SDK parser keeps None).
+
+So ``parse_event`` composes the shared openai parser with a post-step
+applying exactly those two normalizations. A chunk failing validation
+RAISES out of v1's decoder (not swallowed — unlike watsonx's iterator),
+matching the parser's loud errors. There is no SSE line form (no
+``parse_line``).
+"""
+
+from __future__ import annotations
+
+from expression import Error, Result
+from expression.collections import Block
+
+from ...errors import BoundaryError, TranslationError
+from ...ir import JsonBlob, PlainJson, StreamEvent
+from ..openai_compat.stream import parse_event as openai_parse_event
+
+_EventResult = Result[StreamEvent | None, TranslationError]
+
+
+def parse_event(event: PlainJson) -> _EventResult:
+    reason = _validation_reason(event)
+    if reason is not None:
+        return Error(
+            TranslationError.of_boundary(
+                BoundaryError.of(
+                    Block.of_seq(
+                        [
+                            f"sagemaker_chat {reason} (v1's "
+                            "StreamingChatCompletionChunk validation raises)"
+                        ]
+                    )
+                )
+            )
+        )
+    return openai_parse_event(event).map(_with_validation_defaults)
+
+
+def _validation_reason(event: PlainJson) -> str | None:
+    """The shared openai parser leniently coerces non-string delta fields to
+    None (safe on the SDK path, where upstream validation guarantees
+    strings), but v1's decoder VALIDATES each event here and raises — so
+    wrong-typed delta strings must be loud, never coerced-and-served."""
+    if not isinstance(event, dict):
+        return None  # the parser owns the non-object error
+    choices = event.get("choices")
+    if not isinstance(choices, list):
+        return None
+    for choice in choices:
+        if not isinstance(choice, dict):
+            continue
+        delta = choice.get("delta")
+        if not isinstance(delta, dict):
+            continue
+        for field in ("content", "role", "refusal"):
+            value = delta.get(field)
+            if value is not None and not isinstance(value, str):
+                return f"stream delta {field} is not a string"
+    return None
+
+
+def _with_validation_defaults(event: StreamEvent | None) -> StreamEvent | None:
+    if event is None or event.tag != "wire_chunk":
+        return event
+    chunk = event.wire_chunk.value
+    if not isinstance(chunk, dict):
+        return event
+    choices = chunk.get("choices")
+    if not isinstance(choices, list):
+        return event
+    reshaped = [_choice_with_defaults(choice) for choice in choices]
+    return StreamEvent.of_wire_chunk(JsonBlob(value={**chunk, "choices": reshaped}))
+
+
+def _choice_with_defaults(choice: PlainJson) -> PlainJson:
+    if not isinstance(choice, dict):
+        return choice
+    delta = choice.get("delta")
+    if not isinstance(delta, dict):
+        return choice
+    stepped: dict[str, PlainJson] = {"provider_specific_fields": None, **delta}
+    tool_calls = stepped.get("tool_calls")
+    if isinstance(tool_calls, list):
+        stepped = {
+            **stepped,
+            "tool_calls": [_tool_call_with_type(call) for call in tool_calls],
+        }
+    return {**choice, "delta": stepped}
+
+
+def _tool_call_with_type(call: PlainJson) -> PlainJson:
+    if not isinstance(call, dict):
+        return call
+    if call.get("type") is None:
+        return {**call, "type": "function"}
+    return call

--- a/litellm/translation/providers/snowflake/__init__.py
+++ b/litellm/translation/providers/snowflake/__init__.py
@@ -1,0 +1,12 @@
+from .guard import unsupported_request_shapes
+from .response import parse_response
+from .serialize import serialize_request
+from .stream import parse_event, parse_line
+
+__all__ = (
+    "parse_event",
+    "parse_line",
+    "parse_response",
+    "serialize_request",
+    "unsupported_request_shapes",
+)

--- a/litellm/translation/providers/snowflake/guard.py
+++ b/litellm/translation/providers/snowflake/guard.py
@@ -1,0 +1,25 @@
+"""Raw-shape fidelity guard for the snowflake serializer.
+
+Just the shared openai guard with the FULL message-``name`` fallback — v1
+sends messages VERBATIM (its transform_request never calls super), so
+every raw shape the IR cannot round-trip losslessly is a v1-serves
+fallback. Deliberately NO explicit-stream-false arm: v1 puts ``stream``
+in EVERY body (default false), so absent-vs-false is the same wire byte
+and v2 serves both (the one wave-2b provider where that arm would be
+wrong).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from ...errors import TranslationError
+from ..openai_compat.guard import (
+    unsupported_request_shapes as openai_unsupported_request_shapes,
+)
+
+_Raw = Mapping[str, object]
+
+
+def unsupported_request_shapes(raw: _Raw) -> TranslationError | None:
+    return openai_unsupported_request_shapes(raw)

--- a/litellm/translation/providers/snowflake/params.py
+++ b/litellm/translation/providers/snowflake/params.py
@@ -1,0 +1,41 @@
+"""Parameter gates for the snowflake (Cortex REST) serializer.
+
+v1's gate is ``_check_valid_arg`` over ``SnowflakeBaseConfig.
+get_supported_openai_params`` — a SMALL static list (temperature,
+max_tokens, top_p, stream, response_format, tools, tool_choice; no
+capability forks, no name gates). ``max_completion_tokens`` RAISES (no
+rename arm — researcher-4 confirmed), as do stop/n/seed/penalties/
+parallel_tool_calls. ``user`` is silently dropped (``_check_valid_arg``
+skips it and the list never carries it). snowflake is NOT in
+``openai_compatible_providers``, so ``top_k`` rides the TOP-LEVEL
+passthrough into the body — v1 SERVES it (wire-proven in the request
+gate), so v2 emits it verbatim.
+"""
+
+from __future__ import annotations
+
+from ...deps import TranslationDeps
+from ...ir import ChatRequest
+from ..compat_sdk.checks import unsupported_against, user_never_note
+
+_SNOWFLAKE_LIST = frozenset(
+    {
+        "temperature",
+        "max_tokens",
+        "top_p",
+        "stream",
+        "response_format",
+        "tools",
+        "tool_choice",
+        "top_k",
+    }
+)
+
+
+def unsupported_params(request: ChatRequest, deps: TranslationDeps) -> str | None:
+    return unsupported_against(
+        request,
+        provider="snowflake",
+        allowed=_SNOWFLAKE_LIST,
+        notes={"user": user_never_note("snowflake")},
+    )

--- a/litellm/translation/providers/snowflake/response.py
+++ b/litellm/translation/providers/snowflake/response.py
@@ -12,17 +12,22 @@ request model rides ``_hidden_params["model"]`` (envelope; dump-invisible
 
 Parser = the same content_list pre-rewrite + the shared
 ``make_direct_parser`` with the snowflake prefix policy. The seam fork
-must use the ``openai_like`` construction arm.
+must use the ``openai_like`` construction arm
+(``engine/pipeline.OWN_MODULE_RESPONSE_STYLES``). Malformed content_list
+shapes FAIL CLOSED (verifier-wave2b-alpha F5): v1's rewrite crashes on
+them (non-list content_list and non-dict items/tool_use ->
+AttributeError; non-string text -> TypeError), so the typed error here
+mirrors the raise — never serve what v1 raises on.
 """
 
 from __future__ import annotations
 
 import json
-from typing import cast
 
-from expression import Result
+from expression import Error, Result
+from expression.collections import Block
 
-from ...errors import TranslationError
+from ...errors import BoundaryError, TranslationError
 from ...ir import ChatRequest, ChatResponse, PlainJson
 from ..openai_compat.response import make_direct_parser
 
@@ -37,11 +42,15 @@ _direct_parse = make_direct_parser(_rewrite_model)
 
 
 def parse_response(raw: PlainJson, request: ChatRequest) -> _ParseResult:
-    return _direct_parse(_with_openai_message(raw), request)
+    rewritten = _with_openai_message(raw)
+    if isinstance(rewritten, TranslationError):
+        return Error(rewritten)
+    return _direct_parse(rewritten, request)
 
 
-def _with_openai_message(raw: PlainJson) -> PlainJson:
-    """v1's choices[0]-only content_list rewrite, immutably."""
+def _with_openai_message(raw: PlainJson) -> PlainJson | TranslationError:
+    """v1's choices[0]-only content_list rewrite, immutably; malformed
+    shapes are a typed error (the module docstring's F5 contract)."""
     if not isinstance(raw, dict):
         return raw
     choices = raw.get("choices")
@@ -53,15 +62,13 @@ def _with_openai_message(raw: PlainJson) -> PlainJson:
     message = first.get("message")
     if not isinstance(message, dict) or "content_list" not in message:
         return raw
-    content_list = message.get("content_list")
-    items = content_list if isinstance(content_list, list) else []
-    text = "".join(
-        cast(str, item.get("text", ""))
-        for item in items
-        if isinstance(item, dict)
-        and item.get("type") == "text"
-        and isinstance(item.get("text", ""), str)
-    )
+    items = message.get("content_list")
+    if not isinstance(items, list):
+        return _malformed("non-list content_list")
+    malformed = _malformed_item_reason(items)
+    if malformed is not None:
+        return _malformed(malformed)
+    text = "".join(part for item in items if (part := _text_value(item)) is not None)
     tool_calls: list[PlainJson] = [
         _openai_tool_call(item)
         for item in items
@@ -78,6 +85,44 @@ def _with_openai_message(raw: PlainJson) -> PlainJson:
         "choices": [patched_first, *choices[1:]],
     }
     return patched
+
+
+def _malformed_item_reason(items: list[PlainJson]) -> str | None:
+    for item in items:
+        if not isinstance(item, dict):
+            return "non-object content_list item"
+        if item.get("type") == "text" and not isinstance(item.get("text", ""), str):
+            return "non-string text in a content_list text item"
+        if item.get("type") == "tool_use" and not isinstance(
+            item.get("tool_use", {}), dict
+        ):
+            return "non-object tool_use in a content_list item"
+    return None
+
+
+def _malformed(reason: str) -> TranslationError:
+    return TranslationError.of_boundary(
+        BoundaryError.of(
+            Block.of_seq(
+                [
+                    f"{reason}: v1's content_list rewrite crashes on it "
+                    "(TypeError/AttributeError in "
+                    "_transform_tool_calls_from_snowflake_to_openai); "
+                    "never serve what v1 raises on"
+                ]
+            )
+        )
+    )
+
+
+def _text_value(item: PlainJson) -> str | None:
+    """The str-or-skip read for a content_list item; structural narrowing,
+    no cast (the non-string arm is unreachable behind _malformed_item_reason
+    but keeps this function locally total)."""
+    if not isinstance(item, dict) or item.get("type") != "text":
+        return None
+    text = item.get("text", "")
+    return text if isinstance(text, str) else None
 
 
 def _openai_tool_call(item: dict[str, PlainJson]) -> PlainJson:

--- a/litellm/translation/providers/snowflake/response.py
+++ b/litellm/translation/providers/snowflake/response.py
@@ -1,0 +1,94 @@
+"""snowflake Cortex response JSON -> IR ``ChatResponse``.
+
+v1's ``transform_response`` rewrites Snowflake's native ``content_list``
+on choices[0] (text items concatenated into ``content``; ``tool_use``
+items into OpenAI tool_calls with ``json.dumps(input)`` arguments —
+default separators, byte-pinned), deletes ``content_list``, then builds
+``ModelResponse(**response_json)`` — the OpenAILike DIRECT construction —
+and overwrites ``model = "snowflake/" + (wire model or "")`` (a PREFIXED
+model, and the empty-string arm when the wire model is missing). The
+request model rides ``_hidden_params["model"]`` (envelope; dump-invisible
+— a fork obligation pinned in the response gate).
+
+Parser = the same content_list pre-rewrite + the shared
+``make_direct_parser`` with the snowflake prefix policy. The seam fork
+must use the ``openai_like`` construction arm.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import cast
+
+from expression import Result
+
+from ...errors import TranslationError
+from ...ir import ChatRequest, ChatResponse, PlainJson
+from ..openai_compat.response import make_direct_parser
+
+_ParseResult = Result[ChatResponse, TranslationError]
+
+
+def _rewrite_model(wire_model: str | None, request_model: str) -> str:
+    return f"snowflake/{wire_model if wire_model is not None else ''}"
+
+
+_direct_parse = make_direct_parser(_rewrite_model)
+
+
+def parse_response(raw: PlainJson, request: ChatRequest) -> _ParseResult:
+    return _direct_parse(_with_openai_message(raw), request)
+
+
+def _with_openai_message(raw: PlainJson) -> PlainJson:
+    """v1's choices[0]-only content_list rewrite, immutably."""
+    if not isinstance(raw, dict):
+        return raw
+    choices = raw.get("choices")
+    if not isinstance(choices, list) or len(choices) == 0:
+        return raw
+    first = choices[0]
+    if not isinstance(first, dict):
+        return raw
+    message = first.get("message")
+    if not isinstance(message, dict) or "content_list" not in message:
+        return raw
+    content_list = message.get("content_list")
+    items = content_list if isinstance(content_list, list) else []
+    text = "".join(
+        cast(str, item.get("text", ""))
+        for item in items
+        if isinstance(item, dict)
+        and item.get("type") == "text"
+        and isinstance(item.get("text", ""), str)
+    )
+    tool_calls: list[PlainJson] = [
+        _openai_tool_call(item)
+        for item in items
+        if isinstance(item, dict) and item.get("type") == "tool_use"
+    ]
+    patched_message: dict[str, PlainJson] = {
+        key: value for key, value in message.items() if key != "content_list"
+    } | {"content": text}
+    if tool_calls:
+        patched_message = {**patched_message, "tool_calls": tool_calls}
+    patched_first: dict[str, PlainJson] = {**first, "message": patched_message}
+    patched: dict[str, PlainJson] = {
+        **raw,
+        "choices": [patched_first, *choices[1:]],
+    }
+    return patched
+
+
+def _openai_tool_call(item: dict[str, PlainJson]) -> PlainJson:
+    tool_use = item.get("tool_use")
+    data = tool_use if isinstance(tool_use, dict) else {}
+    return {
+        "id": data.get("tool_use_id", ""),
+        "type": "function",
+        "function": {
+            "name": data.get("name", ""),
+            # v1: json.dumps(input or {}) with DEFAULT separators
+            "arguments": json.dumps(data.get("input", {})),
+        },
+    }

--- a/litellm/translation/providers/snowflake/serialize.py
+++ b/litellm/translation/providers/snowflake/serialize.py
@@ -1,0 +1,89 @@
+"""Serialize the IR into a snowflake Cortex ``inference:complete`` body.
+
+v1's ``transform_request`` does NOT call super(): messages go out VERBATIM
+(no content-list flatten, no base image transforms, no name strip — the
+openai guard's full-name fallback covers the IR's name drop), ``stream``
+is ALWAYS in the body (``optional_params.pop("stream", None) or False`` —
+so absent and explicit-false are the SAME wire byte, and the family's
+explicit-stream-false guard arm is deliberately NOT composed here: v2
+serves it), tools are rewritten to Snowflake's ``tool_spec`` shape and
+tool_choice to its object shape (both pure, verified in-process at HEAD):
+
+- tool -> ``{"tool_spec": {"type": "generic", "name", "input_schema"
+  (parameters, default {"type":"object","properties":{}}), "description"?}}``
+- tool_choice ``"auto"``/``"none"`` -> ``{"type": <same>}``;
+  ``"required"`` -> ``{"type": "any"}``; the dict-function form ->
+  ``{"type": "tool", "name": [<fn>]}`` (an ARRAY).
+
+``top_k`` rides verbatim (the non-compat top-level passthrough). The
+account_id -> URL synthesis and the KEYPAIR_JWT/PAT auth headers are pure
+envelope (validate_environment sets headers only — researcher-4's
+correction to researcher-3 stands at HEAD). The response model is
+``snowflake/{WIRE model}`` — response.py owns that prefix.
+"""
+
+from __future__ import annotations
+
+from expression import Error, Result
+
+from ...deps import TranslationDeps
+from ...errors import TranslationError
+from ...ir import Body, ChatRequest, PlainJson
+from ..openai_compat.serialize import assemble_body
+from . import params as p
+
+_SerializeResult = Result[Body, TranslationError]
+
+
+def serialize_request(request: ChatRequest, deps: TranslationDeps) -> _SerializeResult:
+    reason = p.unsupported_params(request, deps)
+    if reason is not None:
+        return Error(TranslationError.of_unsupported(reason))
+    return assemble_body(request).map(
+        lambda body: _with_snowflake_deltas(body, request)
+    )
+
+
+def _with_snowflake_deltas(body: Body, request: ChatRequest) -> Body:
+    patched: dict[str, PlainJson] = {**body, "stream": request.stream}
+    tools = patched.get("tools")
+    if isinstance(tools, list):
+        patched = {**patched, "tools": [_tool_spec(tool) for tool in tools]}
+    tool_choice = patched.get("tool_choice")
+    if tool_choice is not None:
+        patched = {**patched, "tool_choice": _tool_choice_object(tool_choice)}
+    top_k = request.params.top_k.default_value(None)
+    if top_k is not None:
+        patched = {**patched, "top_k": top_k}
+    return patched
+
+
+def _tool_spec(tool: PlainJson) -> PlainJson:
+    function = tool.get("function") if isinstance(tool, dict) else None
+    if not isinstance(function, dict):
+        return tool  # unreachable: the inbound parse admits function tools only
+    spec: dict[str, PlainJson] = {
+        "type": "generic",
+        "name": function.get("name"),
+        "input_schema": function.get(
+            "parameters", {"type": "object", "properties": {}}
+        ),
+    }
+    description = function.get("description")
+    if description is not None:
+        spec = {**spec, "description": description}
+    return {"tool_spec": spec}
+
+
+def _tool_choice_object(tool_choice: PlainJson) -> PlainJson:
+    if isinstance(tool_choice, str):
+        mapped = {"auto": "auto", "required": "any", "none": "none"}.get(
+            tool_choice, tool_choice
+        )
+        return {"type": mapped}
+    if isinstance(tool_choice, dict) and tool_choice.get("type") == "function":
+        function = tool_choice.get("function")
+        name = function.get("name") if isinstance(function, dict) else None
+        if name:
+            return {"type": "tool", "name": [name]}
+    return tool_choice  # v1's trailing verbatim arm (unreachable shapes)

--- a/litellm/translation/providers/snowflake/serialize.py
+++ b/litellm/translation/providers/snowflake/serialize.py
@@ -24,7 +24,7 @@ correction to researcher-3 stands at HEAD). The response model is
 
 from __future__ import annotations
 
-from expression import Error, Result
+from expression import Error, Ok, Result
 
 from ...deps import TranslationDeps
 from ...errors import TranslationError
@@ -39,29 +39,43 @@ def serialize_request(request: ChatRequest, deps: TranslationDeps) -> _Serialize
     reason = p.unsupported_params(request, deps)
     if reason is not None:
         return Error(TranslationError.of_unsupported(reason))
-    return assemble_body(request).map(
+    return assemble_body(request).bind(
         lambda body: _with_snowflake_deltas(body, request)
     )
 
 
-def _with_snowflake_deltas(body: Body, request: ChatRequest) -> Body:
+def _with_snowflake_deltas(body: Body, request: ChatRequest) -> _SerializeResult:
     patched: dict[str, PlainJson] = {**body, "stream": request.stream}
     tools = patched.get("tools")
     if isinstance(tools, list):
-        patched = {**patched, "tools": [_tool_spec(tool) for tool in tools]}
+        specs: list[PlainJson] = []
+        for tool in tools:
+            spec = _tool_spec(tool)
+            if isinstance(spec, TranslationError):
+                return Error(spec)
+            specs = [*specs, spec]
+        patched = {**patched, "tools": specs}
     tool_choice = patched.get("tool_choice")
     if tool_choice is not None:
         patched = {**patched, "tool_choice": _tool_choice_object(tool_choice)}
     top_k = request.params.top_k.default_value(None)
     if top_k is not None:
         patched = {**patched, "top_k": top_k}
-    return patched
+    return Ok(patched)
 
 
-def _tool_spec(tool: PlainJson) -> PlainJson:
+def _tool_spec(tool: PlainJson) -> PlainJson | TranslationError:
     function = tool.get("function") if isinstance(tool, dict) else None
-    if not isinstance(function, dict):
-        return tool  # unreachable: the inbound parse admits function tools only
+    if not isinstance(function, dict) or not isinstance(function.get("name"), str):
+        # Unreachable: the inbound parse admits function tools only (string
+        # name required). Fail CLOSED if it ever becomes reachable
+        # (critic-1b N5 / critic-wave2b-alpha NIT-4): the old verbatim return
+        # silently emitted an unmapped tool — possibly with a null name —
+        # where v1's rewrite KeyErrors.
+        return TranslationError.of_unsupported(
+            "non-function tool (or non-string tool name) reached the "
+            "snowflake tool_spec rewrite; unreachable for v2-sent requests"
+        )
     spec: dict[str, PlainJson] = {
         "type": "generic",
         "name": function.get("name"),

--- a/litellm/translation/providers/snowflake/stream.py
+++ b/litellm/translation/providers/snowflake/stream.py
@@ -1,0 +1,23 @@
+"""snowflake Cortex SSE chunk payloads -> IR stream events.
+
+v1 decodes snowflake streams through the BASE
+``OpenAIChatCompletionStreamingHandler`` (no iterator override;
+canary-pinned — neither the content_list rewrite nor the ``snowflake/``
+prefix ever runs on chunks) into ``CustomStreamWrapper``'s default openai
+branch — the compat_httpx FAMILY policy over the ONE shared httpx chunk
+normalizer. Whether real Cortex deltas ever carry ``content_list`` is
+UNPINNED upstream (researcher-4 §9): the differential is two-sided against
+v1's decode, so a content_list delta would be an unknown-delta-key typed
+error in v2 where v1 serves a chunk that silently lost it — get real
+fixtures before flag-on streaming. Provider error chunks are the family's
+LOUD fail-closed PINNED DIVERGENCE — snowflake joins the report's single
+named row. Folds use the ``"xai"`` ChunkDialect.
+"""
+
+from __future__ import annotations
+
+from ..openai_compat.httpx_chunk import HttpxChunkPolicy, make_parse_event
+from ..openai_compat.stream import make_parse_line
+
+parse_event = make_parse_event(HttpxChunkPolicy(reasoning="rename"))
+parse_line = make_parse_line(parse_event)

--- a/litellm/translation/providers/snowflake/stream.py
+++ b/litellm/translation/providers/snowflake/stream.py
@@ -16,8 +16,8 @@ named row. Folds use the ``"xai"`` ChunkDialect.
 
 from __future__ import annotations
 
-from ..openai_compat.httpx_chunk import HttpxChunkPolicy, make_parse_event
+from ..openai_compat.httpx_chunk import BASE_HANDLER_POLICY, make_parse_event
 from ..openai_compat.stream import make_parse_line
 
-parse_event = make_parse_event(HttpxChunkPolicy(reasoning="rename"))
+parse_event = make_parse_event(BASE_HANDLER_POLICY)
 parse_line = make_parse_line(parse_event)

--- a/litellm/translation/providers/watsonx/__init__.py
+++ b/litellm/translation/providers/watsonx/__init__.py
@@ -1,0 +1,12 @@
+from .guard import unsupported_request_shapes
+from .response import parse_response
+from .serialize import serialize_request
+from .stream import parse_event, parse_line
+
+__all__ = (
+    "parse_event",
+    "parse_line",
+    "parse_response",
+    "serialize_request",
+    "unsupported_request_shapes",
+)

--- a/litellm/translation/providers/watsonx/guard.py
+++ b/litellm/translation/providers/watsonx/guard.py
@@ -1,0 +1,32 @@
+"""Raw-shape fidelity guard for the watsonx chat serializer.
+
+The shared openai guard with the FULL message-``name`` fallback: watsonx's
+transform is the inherited base ``_transform_messages`` (the openai_like
+handler calls it directly), so names ride the wire verbatim.
+
+Deliberately NO explicit ``stream: false`` arm: the openai_like handler
+pops ``stream`` and re-adds it UNCONDITIONALLY (``stream or False``), so
+the wire body carries ``stream: false`` whether the caller sent False or
+nothing — the v2 serializer emits the key on every request, and the IR's
+absent-vs-false collapse is invisible on this wire (probed in-process).
+
+Auth is pure envelope (Authorization passthrough -> token/ZenApiKey -> the
+``generate_iam_token`` NETWORK POST with its in-memory cache, all inside
+``validate_environment``): the v1 resolution stays at the seam; nothing
+here touches it (semgrep-enforced — no ambient I/O outside deps/engine).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from ...errors import TranslationError
+from ..openai_compat.guard import (
+    unsupported_request_shapes as openai_unsupported_request_shapes,
+)
+
+_Raw = Mapping[str, object]
+
+
+def unsupported_request_shapes(raw: _Raw) -> TranslationError | None:
+    return openai_unsupported_request_shapes(raw)

--- a/litellm/translation/providers/watsonx/params.py
+++ b/litellm/translation/providers/watsonx/params.py
@@ -1,0 +1,70 @@
+"""Parameter gates for the watsonx chat serializer.
+
+v1's gate is ``_check_valid_arg`` over ``IBMWatsonXChatConfig.
+get_supported_openai_params`` (temperature/max_tokens/top_p/
+frequency_penalty/stop/seed/stream/tools/tool_choice/logprobs/top_logprobs/
+n/presence_penalty/response_format/reasoning_effort) PLUS the watsonx-only
+extra arm in get_optional_params: any legacy watsonx-TEXT param (top_k,
+decoding_method, ...) raises a bare ValueError telling you to use the
+``watsonx_text`` provider. Probed in-process at HEAD:
+
+- ``max_completion_tokens`` RAISES (NOT renamed — the OpenAILike rename is
+  dead behind the list gate);
+- ``top_k`` hits the legacy-text ValueError (a DIFFERENT raise class than
+  UnsupportedParamsError — pinned in the request gate);
+- ``parallel_tool_calls``/``thinking`` RAISE; ``user`` is silently dropped;
+- ``reasoning_effort`` is served VERBATIM (unconditionally in the list);
+- penalties/n/seed/logprobs/top_logprobs are served by v1 but are
+  parse-level unknowns in v2 (typed fallback, v1 serves).
+
+Two payload gates live here too (probed):
+
+- ``deployment/`` models: v1 routes them to deployment URLs, POPS
+  ``api_version`` from optional_params into the URL, and injects NO
+  model_id/project_id — envelope behavior v2 does not reproduce;
+- missing project AND space id in deps: v1's ``_get_api_params`` raises
+  WatsonXAIError 401 — fall back so v1 serves its own raise.
+"""
+
+from __future__ import annotations
+
+from ...deps import TranslationDeps
+from ...ir import ChatRequest
+
+
+def unsupported_params(request: ChatRequest, deps: TranslationDeps) -> str | None:
+    if request.model.startswith("deployment/"):
+        return (
+            "watsonx deployment/ model: v1 routes it to the deployment URL "
+            "with no model_id/project_id payload and pops api_version into "
+            "the URL (envelope); v1 owns it"
+        )
+    if deps.watsonx_project_id is None and deps.watsonx_space_id is None:
+        return (
+            "watsonx project_id/space_id unresolved: v1's _get_api_params "
+            "raises WatsonXAIError 401; v1 serves its own raise"
+        )
+    if request.params.max_completion_tokens.is_some():
+        return (
+            "max_completion_tokens is outside watsonx's supported list; "
+            "v1's get_optional_params raises UnsupportedParamsError (the "
+            "OpenAILike rename arm is dead behind the list gate)"
+        )
+    if request.params.top_k.is_some():
+        return (
+            "top_k is a legacy watsonx-text param: v1's get_optional_params "
+            "raises ValueError pointing at the watsonx_text provider"
+        )
+    if request.parallel_tool_calls.is_some():
+        return (
+            "parallel_tool_calls is outside watsonx's supported list; "
+            "v1 raises or drops it"
+        )
+    if request.thinking.is_some():
+        return "thinking is not a watsonx chat param; v1 raises or drops it"
+    if request.user.is_some():
+        return (
+            "user is model-list gated upstream and silently dropped for "
+            "watsonx; v1 serves its own drop"
+        )
+    return None

--- a/litellm/translation/providers/watsonx/response.py
+++ b/litellm/translation/providers/watsonx/response.py
@@ -1,0 +1,70 @@
+"""watsonx chat-completion response JSON -> IR ``ChatResponse``.
+
+v1 is ``OpenAILikeChatConfig._transform_response`` called by the
+``OpenAILikeChatHandler`` with ``custom_llm_provider="watsonx"`` — the ONE
+wave-2b path where the openai_like prefix arm is LIVE:
+``ModelResponse(**response_json)`` DIRECTLY (no cdr) and then
+``model = "watsonx/" + (wire model or "")``. v2 mirrors the compat_httpx
+"openai_like" convention: the shared openai parser for fail-closed shape
+validation, then the VERBATIM raw body rides ``ChatResponse.wire`` with the
+model overwritten to the PREFIXED WIRE model (NOT the request model — the
+compactifai/amazon-nova/lemonade profiles differ here), so the seam's
+``openai_like`` construction arm reproduces v1 byte-for-byte.
+
+The verifier-longtail F2 arm carries over: a present NON-STRING wire model
+raises pydantic ValidationError inside v1's construction BEFORE the prefix
+overwrite, so it fails closed here; ``model: None``/absent constructs in v1
+and serves as the literal ``"watsonx/"``. The OpenAILike usage-null
+sanitize (``*_tokens: None`` -> 0) is observationally dead (``Usage``
+coerces None -> 0 in the constructor — the family pin, re-pinned in the
+watsonx response gate); the json_mode tool->content conversion is dormant
+(watsonx never sets json_mode — probed).
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from expression import Error, Ok, Result, Some
+from expression.collections import Block
+
+from ...errors import BoundaryError, TranslationError
+from ...ir import ChatRequest, ChatResponse, JsonBlob, PlainJson
+from ..openai_compat.response import parse_response as openai_parse_response
+
+_ParseResult = Result[ChatResponse, TranslationError]
+
+
+def parse_response(raw: PlainJson, request: ChatRequest) -> _ParseResult:
+    return openai_parse_response(raw, request).bind(
+        lambda response: _prefixed_wire(response, raw)
+    )
+
+
+def _prefixed_wire(response: ChatResponse, raw: PlainJson) -> _ParseResult:
+    if not isinstance(raw, dict):
+        return Error(
+            TranslationError.of_boundary(
+                BoundaryError.of(
+                    Block.of_seq(["non-dict response body reached _prefixed_wire"])
+                )
+            )
+        )
+    wire_model = raw.get("model")
+    if wire_model is not None and not isinstance(wire_model, str):
+        return Error(
+            TranslationError.of_boundary(
+                BoundaryError.of(
+                    Block.of_seq(
+                        [
+                            "non-string wire model "
+                            f"({type(wire_model).__name__}): v1's OpenAILike "
+                            "construction raises ValidationError on it"
+                        ]
+                    )
+                )
+            )
+        )
+    model = f"watsonx/{wire_model if isinstance(wire_model, str) else ''}"
+    body: dict[str, PlainJson] = {**raw, "model": model}
+    return Ok(replace(response, model=model, wire=Some(JsonBlob(value=body))))

--- a/litellm/translation/providers/watsonx/serialize.py
+++ b/litellm/translation/providers/watsonx/serialize.py
@@ -1,0 +1,108 @@
+"""Serialize the IR into a watsonx ``/ml/v1/text/chat`` request body.
+
+v1's chain is ``IBMWatsonXChatConfig.map_openai_params`` then the
+``WatsonXChatHandler`` -> ``OpenAILikeChatHandler`` body assembly
+``{"model": model_id, "messages": <base-transformed>, **optional_params}``
+with the ``_prepare_payload`` injection merged into optional_params first
+(probed in-process at HEAD). The body is the openai_compat assembly with:
+
+- ``stream`` ALWAYS present: the handler pops it and re-adds
+  ``stream or False`` unconditionally, so absent and explicit-false both
+  serialize ``false``;
+- ``model_id``: the wire model duplicated next to ``model`` (the handler
+  passes ``watsonx_auth_payload["model_id"]`` as the data model AND the key
+  rides optional_params);
+- ``project_id`` (or ``space_id`` when no project) from deps —
+  ``_prepare_payload`` injects exactly one;
+- tools: ``additionalProperties`` removed ONLY where its value is False,
+  and ``strict`` removed at EVERY depth (``_remove_additional_properties``
+  + ``_remove_strict_from_schema``, both uncapped in v1; the shared
+  recursion cap here returns the subtree untouched past depth 16 — the
+  xai ``_strip_cache`` precedent);
+- ``tool_choice``: the string options auto/none/required move to
+  ``tool_choice_option``; the dict form rides ``tool_choice`` verbatim;
+- ``response_format``/``reasoning_effort`` verbatim (both in the list;
+  json_mode is NEVER set for watsonx, so the OpenAILike json_mode
+  machinery stays dormant — probed).
+"""
+
+from __future__ import annotations
+
+from expression import Error, Result
+from typing_extensions import assert_never
+
+from litellm.constants import DEFAULT_MAX_RECURSE_DEPTH
+
+from ...deps import TranslationDeps
+from ...errors import TranslationError
+from ...ir import Body, ChatRequest, PlainJson
+from ..openai_compat.serialize import assemble_body
+from . import params as p
+
+_SerializeResult = Result[Body, TranslationError]
+
+
+def serialize_request(request: ChatRequest, deps: TranslationDeps) -> _SerializeResult:
+    reason = p.unsupported_params(request, deps)
+    if reason is not None:
+        return Error(TranslationError.of_unsupported(reason))
+    return assemble_body(request).map(
+        lambda body: _with_watsonx_deltas(body, request, deps)
+    )
+
+
+def _with_watsonx_deltas(
+    body: Body, request: ChatRequest, deps: TranslationDeps
+) -> Body:
+    reshaped: dict[str, PlainJson] = {}
+    for key, value in body.items():
+        if key == "tools":
+            reshaped = {**reshaped, "tools": _cleaned_tools(value, 0)}
+        elif key == "tool_choice":
+            reshaped = {**reshaped, **_tool_choice_fields(request, value)}
+        elif key == "stream":
+            pass  # re-emitted unconditionally below
+        else:
+            reshaped = {**reshaped, key: value}
+    effort = request.reasoning_effort.default_value(None)
+    if effort is not None:
+        # in the supported list unconditionally; the base map passes it
+        # verbatim (assemble_body treats it as a typed-fallback param, so
+        # the emission is a watsonx delta — the xai precedent)
+        reshaped = {**reshaped, "reasoning_effort": effort}
+    payload: dict[str, PlainJson] = {"model_id": request.model}
+    if deps.watsonx_project_id is not None:
+        payload = {**payload, "project_id": deps.watsonx_project_id}
+    else:
+        payload = {**payload, "space_id": deps.watsonx_space_id}
+    return {**reshaped, "stream": request.stream, **payload}
+
+
+def _tool_choice_fields(
+    request: ChatRequest, serialized: PlainJson
+) -> dict[str, PlainJson]:
+    choice = request.tool_choice.default_value(None)
+    if choice is None:
+        return {}
+    match choice.tag:
+        case "auto" | "required" | "none":
+            return {"tool_choice_option": serialized}
+        case "specific":
+            return {"tool_choice": serialized}
+    assert_never(choice.tag)
+
+
+def _cleaned_tools(value: PlainJson, depth: int) -> PlainJson:
+    """Mirror v1's two uncapped sweeps in one pass: drop
+    ``additionalProperties`` only when False, drop ``strict`` everywhere."""
+    if depth > DEFAULT_MAX_RECURSE_DEPTH:
+        return value
+    if isinstance(value, dict):
+        return {
+            key: _cleaned_tools(item, depth + 1)
+            for key, item in value.items()
+            if key != "strict" and not (key == "additionalProperties" and item is False)
+        }
+    if isinstance(value, list):
+        return [_cleaned_tools(item, depth + 1) for item in value]
+    return value

--- a/litellm/translation/providers/watsonx/serialize.py
+++ b/litellm/translation/providers/watsonx/serialize.py
@@ -16,9 +16,12 @@ with the ``_prepare_payload`` injection merged into optional_params first
   ``_prepare_payload`` injects exactly one;
 - tools: ``additionalProperties`` removed ONLY where its value is False,
   and ``strict`` removed at EVERY depth (``_remove_additional_properties``
-  + ``_remove_strict_from_schema``, both uncapped in v1; the shared
-  recursion cap here returns the subtree untouched past depth 16 — the
-  xai ``_strip_cache`` precedent);
+  + ``_remove_strict_from_schema``, both UNCAPPED in v1; the shared
+  recursion cap here returns the subtree untouched past depth
+  ``DEFAULT_MAX_RECURSE_DEPTH`` = 100 at HEAD — the xai ``_strip_cache``
+  precedent. Residual divergence, recorded honestly (critic N2): a
+  >100-deep tool schema keeps ``strict``/``additionalProperties: false``
+  keys v1 strips — served, unpinned, depth-100+ only);
 - ``tool_choice``: the string options auto/none/required move to
   ``tool_choice_option``; the dict form rides ``tool_choice`` verbatim;
 - ``response_format``/``reasoning_effort`` verbatim (both in the list;

--- a/litellm/translation/providers/watsonx/stream.py
+++ b/litellm/translation/providers/watsonx/stream.py
@@ -13,28 +13,48 @@ GENERIC arm — the same arm cohere uses, so the fold dialect is the shared
 - ``choices: []`` -> a usage-only payload (``or 0`` coercions);
 - delta content -> text; role-only and name-only-tool-call deltas yield
   EMPTY chunks v1 swallows (a tool_call without non-None ``arguments``
-  never reaches the wire chunk — pinned);
+  never reaches the wire chunk — pinned); a PRESENT non-dict delta is
+  LOUD — v1's StreamingChoices sets no ``.delta`` attribute and the
+  iterator AttributeErrors -> MidStreamFallbackError (verifier F4);
 - only the FIRST tool call rides, as id/type/function/INDEX (the index key
-  is part of v1's GChunk here, unlike cohere's);
-- finish_reason maps through the wrapper's ``map_finish_reason``: the
-  OpenAI four ride verbatim, IBM's time_limit/cancelled/error -> "stop",
-  max_tokens -> "length"; anything else is a LOUD error (conservative —
-  v1 defaults unknowns to "stop");
+  is part of v1's GChunk here, unlike cohere's); tool-call value types
+  mirror the validated Delta — lax index coercion serves (str "3" -> 3,
+  bool -> int, integral float; v1's pydantic does the same), everything
+  the validation rejects (non-str id/name/type, non-coercible index) is a
+  LOUD pinned divergence: v1 swallows the whole chunk and v2 never
+  invents id/name None or index 0 in its place (critic B1.4);
+- finish_reason: a truthy STRING rides VERBATIM — the chunk envelope
+  (``ModelResponseStream`` -> ``StreamingChoices``) runs v1's live
+  ``map_finish_reason`` on BOTH sides, so the OpenAI four, IBM's
+  time_limit/cancelled/error -> "stop", max_tokens -> "length" AND every
+  unknown string -> "stop" normalize identically (verifier F7 refuted the
+  old conservative loud arm: v1 SERVES "stop"); a truthy non-str hashable
+  value -> "stop" (v1's map .get default); a FALSY value -> no finish
+  (StreamingChoices' truthy gate; the synthesized trailing finish is seam
+  scope); a truthy unhashable value is LOUD (v1's map .get raises
+  TypeError -> MidStreamFallbackError);
 - usage rides ONLY on the ``choices: []`` tail payload (v1's wrapper
   strips mid-stream usage from emitted chunks; the include_usage final
-  chunk is seam scope).
+  chunk is seam scope — NOTE the wrapper OVERRIDES null/zero tail values
+  with token-counter ESTIMATES there, so the future streaming seam must
+  reproduce the estimate arm, not just pass the tail through); a PRESENT
+  non-dict usage is LOUD on any chunk (v1 reads ``.prompt_tokens`` off it
+  raw and AttributeErrors -> MidStreamFallbackError); usage VALUES mirror
+  litellm ``Usage``'s lax coercion (None -> 0, digit strings, bools,
+  integral floats — probed) and non-coercible values are LOUD pinned
+  divergences (validation fails, v1 swallows the WHOLE chunk).
 
 PINNED DIVERGENCES (fail-closed on failure paths, the compat_httpx
-error-chunk precedent): v1's iterator SILENTLY SWALLOWS non-JSON lines and
-chunks that fail ``ModelResponseStream`` validation (pydantic
-ValidationError is a ValueError, caught by the iterator's except arm) —
-v2 errors loudly on both, named report rows.
+error-chunk precedent): v1 SILENTLY SWALLOWS non-JSON lines, chunks that
+fail ``ModelResponseStream`` validation (pydantic ValidationError is a
+ValueError, caught by the iterator's except arm), and non-str delta
+content (the wrapper's generic arm drops it) — v2 errors loudly on each,
+named report rows.
 """
 
 from __future__ import annotations
 
 import json
-from types import MappingProxyType
 
 from expression import Error, Ok, Result
 from expression.collections import Block
@@ -43,19 +63,6 @@ from ...errors import BoundaryError, TranslationError
 from ...ir import JsonBlob, PlainJson, StreamEvent
 
 _EventResult = Result[StreamEvent | None, TranslationError]
-
-_FINISH_MAP = MappingProxyType(
-    {
-        "stop": "stop",
-        "length": "length",
-        "tool_calls": "tool_calls",
-        "content_filter": "content_filter",
-        "time_limit": "stop",
-        "cancelled": "stop",
-        "error": "stop",
-        "max_tokens": "length",
-    }
-)
 
 
 def _boundary(reason: str) -> TranslationError:
@@ -108,8 +115,16 @@ def parse_event(event: PlainJson) -> _EventResult:
     choice = choices[0]
     if not isinstance(choice, dict):
         return Error(_boundary("watsonx stream choice is not an object (v1 swallows)"))
-    raw_delta = choice.get("delta", {})
-    delta = raw_delta if isinstance(raw_delta, dict) else {}
+    mid_usage = _mid_usage_check(event)
+    if isinstance(mid_usage, TranslationError):
+        return Error(mid_usage)
+    return _choice_payload(choice)
+
+
+def _choice_payload(choice: dict[str, PlainJson]) -> _EventResult:
+    delta = _delta_value(choice)
+    if isinstance(delta, TranslationError):
+        return Error(delta)
     text = _text_value(delta)
     if isinstance(text, TranslationError):
         return Error(text)
@@ -125,10 +140,50 @@ def parse_event(event: PlainJson) -> _EventResult:
         "text": text,
         "tool_call": tool_call,
         "finish": finish,
-        "usage": None,
+        "usage": None,  # valid mid-stream usage is STRIPPED (v1's wrapper)
         "provider_fields": None,
     }
     return Ok(StreamEvent.of_wire_chunk(JsonBlob(value=payload)))
+
+
+def _delta_value(
+    choice: dict[str, PlainJson],
+) -> dict[str, PlainJson] | TranslationError:
+    raw_delta = choice.get("delta")
+    if raw_delta is None:
+        return {}  # StreamingChoices defaults a missing/null delta to Delta()
+    if not isinstance(raw_delta, dict):
+        return _boundary(
+            "watsonx delta is present but not an object (v1's "
+            "StreamingChoices sets no .delta and the iterator "
+            "AttributeErrors -> MidStreamFallbackError)"
+        )
+    return raw_delta
+
+
+def _mid_usage_check(event: dict[str, PlainJson]) -> None | TranslationError:
+    """Mirror v1 on a content/tool chunk carrying ``usage``: a present
+    non-dict raises out of the iterator (raw ``.prompt_tokens`` read ->
+    AttributeError -> MidStreamFallbackError); a dict failing ``Usage``'s
+    lax validation fails ModelResponseStream construction and v1 SWALLOWS
+    the whole chunk (pinned divergence); a valid dict is stripped from the
+    emitted chunk (the wrapper withholds mid-stream usage)."""
+    if "usage" not in event:
+        return None
+    usage = event.get("usage")
+    if usage is None:
+        return None
+    if not isinstance(usage, dict):
+        return _boundary(
+            "watsonx mid-stream usage is not an object (v1 reads "
+            ".prompt_tokens off it and AttributeErrors -> "
+            "MidStreamFallbackError)"
+        )
+    for key in ("prompt_tokens", "completion_tokens", "total_tokens"):
+        value = _int_or_zero(usage.get(key), key)
+        if isinstance(value, TranslationError):
+            return value
+    return None
 
 
 def _usage_only_payload(event: dict[str, PlainJson]) -> _EventResult:
@@ -138,8 +193,9 @@ def _usage_only_payload(event: dict[str, PlainJson]) -> _EventResult:
     if not isinstance(usage, dict):
         return Error(
             _boundary(
-                "watsonx usage tail is not an object (v1's validation "
-                "swallows the chunk — pinned divergence)"
+                "watsonx usage tail is not an object (v1 reads "
+                ".prompt_tokens off it and AttributeErrors -> "
+                "MidStreamFallbackError)"
             )
         )
     coerced: dict[str, PlainJson] = {}
@@ -159,17 +215,37 @@ def _usage_only_payload(event: dict[str, PlainJson]) -> _EventResult:
 
 
 def _int_or_zero(value: PlainJson, key: str) -> int | TranslationError:
-    """v1's ``final_usage.prompt_tokens or 0`` over the VALIDATED Usage."""
+    """v1's ``final_usage.prompt_tokens or 0`` over the VALIDATED Usage —
+    litellm ``Usage`` lax-coerces None -> 0, bools, integral floats and
+    numeric strings (probed); anything it rejects fails ModelResponseStream
+    construction and v1 swallows the whole chunk."""
     if value is None:
         return 0
     if isinstance(value, (bool, int)):
         return int(value) or 0
     if isinstance(value, float) and value.is_integer():
         return int(value) or 0
+    if isinstance(value, str):
+        coerced = _lax_int(value)
+        if coerced is not None:
+            return coerced or 0
     return _boundary(
         f"watsonx usage {key} is not an integer (v1's Usage validation "
         "swallows the chunk — pinned divergence)"
     )
+
+
+def _lax_int(value: str) -> int | None:
+    """pydantic's lax str -> int (digit strings, integral float strings)."""
+    try:
+        return int(value)
+    except ValueError:
+        pass
+    try:
+        as_float = float(value)
+    except ValueError:
+        return None
+    return int(as_float) if as_float.is_integer() else None
 
 
 def _text_value(delta: dict[str, PlainJson]) -> str | TranslationError:
@@ -178,8 +254,9 @@ def _text_value(delta: dict[str, PlainJson]) -> str | TranslationError:
         return ""
     if not isinstance(content, str):
         return _boundary(
-            "watsonx delta content is not a string (v1's validation "
-            "swallows the chunk — pinned divergence)"
+            "watsonx delta content is not a string (v1 silently swallows "
+            "the chunk — probed: the non-str text never reaches an emitted "
+            "chunk — pinned divergence)"
         )
     return content
 
@@ -196,16 +273,18 @@ def _first_tool_call(delta: dict[str, PlainJson]) -> PlainJson | TranslationErro
         return None
     if not isinstance(tool_calls, list):
         return _boundary(
-            "watsonx delta tool_calls is malformed (v1's validation "
-            "swallows the chunk — pinned divergence)"
+            "watsonx delta tool_calls is not a list (the validated Delta "
+            "keeps it verbatim and v1's iterator subscript raises -> "
+            "MidStreamFallbackError)"
         )
     if len(tool_calls) == 0:
         return None
     first = tool_calls[0]
     if not isinstance(first, dict):
         return _boundary(
-            "watsonx delta tool_calls is malformed (v1's validation "
-            "swallows the chunk — pinned divergence)"
+            "watsonx tool_calls entry is not an object (v1's Delta "
+            "validation drops it and swallows the tool content — pinned "
+            "divergence)"
         )
     function = first.get("function")
     if not isinstance(function, dict):
@@ -219,34 +298,84 @@ def _first_tool_call(delta: dict[str, PlainJson]) -> PlainJson | TranslationErro
             "watsonx tool_call arguments is not a string (v1's validation "
             "swallows the chunk — pinned divergence)"
         )
+    field_reason = _tool_field_reason(first, function)
+    if field_reason is not None:
+        return _boundary(field_reason)
+    index = _tool_index(first.get("index"))
+    if isinstance(index, TranslationError):
+        return index
     identifier = first.get("id")
     name = function.get("name")
-    index = first.get("index")
     return {
         "id": identifier if isinstance(identifier, str) else None,
-        "type": "function",
+        "type": "function",  # v1's GChunk hardcodes the type
         "function": {
             "name": name if isinstance(name, str) else None,
             "arguments": arguments if isinstance(arguments, str) else "",
         },
-        "index": index if isinstance(index, int) else 0,
+        "index": index,
     }
 
 
+def _tool_field_reason(
+    first: dict[str, PlainJson], function: dict[str, PlainJson]
+) -> str | None:
+    """Non-str id/name/type fail v1's Delta validation and the iterator
+    SWALLOWS the whole chunk — the old tail coerced id/name to None and
+    SERVED an invented tool call on a chunk v1 drops (critic B1.4)."""
+    for field, value in (
+        ("id", first.get("id")),
+        ("name", function.get("name")),
+        ("type", first.get("type")),
+    ):
+        if value is not None and not isinstance(value, str):
+            return (
+                f"watsonx tool_call {field} is not a string (v1's Delta "
+                "validation swallows the chunk — pinned divergence; v2 "
+                "never invents a value in its place)"
+            )
+    return None
+
+
+def _tool_index(index: PlainJson) -> int | TranslationError:
+    """The validated Delta lax-coerces the index (str "3" -> 3, bool -> int,
+    integral float -> int; absent/None -> 0 — all probed served by v1); a
+    non-coercible value fails validation and v1 swallows the whole chunk.
+    The old arm rewrote every non-int to 0 — a value invention."""
+    if index is None:
+        return 0
+    if isinstance(index, (bool, int)):
+        return int(index)
+    if isinstance(index, float) and index.is_integer():
+        return int(index)
+    if isinstance(index, str):
+        coerced = _lax_int(index)
+        if coerced is not None:
+            return coerced
+    return _boundary(
+        "watsonx tool_call index is not an integer (v1's Delta validation "
+        "swallows the chunk — pinned divergence; v2 never rewrites it to 0)"
+    )
+
+
 def _finish_value(choice: dict[str, PlainJson]) -> PlainJson | TranslationError:
+    """Mirror StreamingChoices' finish handling inside v1's
+    ``ModelResponseStream(**chunk)`` validation (probed at HEAD, verifier
+    F7): a FALSY value (None/""/0/{}/[]/false) fails the truthy gate — no
+    finish rides, the wrapper's synthesized trailing finish is seam scope;
+    a truthy STRING rides VERBATIM (the chunk envelope runs v1's live
+    ``map_finish_reason`` on BOTH sides — known members map, unknown
+    strings default to "stop", identically); a truthy non-str hashable
+    value maps to "stop" (the same ``.get`` default); a truthy UNHASHABLE
+    value raises TypeError out of v1's map -> MidStreamFallbackError."""
     finish = choice.get("finish_reason")
-    if finish is None:
+    if not finish:
         return None
-    if not isinstance(finish, str):
-        return _boundary(
-            "watsonx finish_reason is not a string (v1's validation "
-            "swallows the chunk — pinned divergence)"
-        )
-    mapped = _FINISH_MAP.get(finish)
-    if mapped is None:
-        return _boundary(
-            f"watsonx finish_reason {finish!r} outside the pinned map "
-            "(conservative: v1's map_finish_reason defaults unknowns to "
-            "'stop'; re-derive before serving it)"
-        )
-    return mapped
+    if isinstance(finish, str):
+        return finish
+    if isinstance(finish, (bool, int, float)):
+        return "stop"
+    return _boundary(
+        "watsonx finish_reason is a truthy unhashable value (v1's "
+        "map_finish_reason raises TypeError -> MidStreamFallbackError)"
+    )

--- a/litellm/translation/providers/watsonx/stream.py
+++ b/litellm/translation/providers/watsonx/stream.py
@@ -1,0 +1,252 @@
+"""watsonx SSE stream lines -> IR stream events (the GENERIC dialect).
+
+researcher-4 classified the watsonx stream as "openai dialect over SSE" —
+DRIFT: the openai_like handler decodes through the databricks
+``ModelResponseIterator`` (llms/databricks/streaming_utils.py), which
+yields ``GenericStreamingChunk`` dicts that ride ``CustomStreamWrapper``'s
+GENERIC arm — the same arm cohere uses, so the fold dialect is the shared
+``generic`` one. Mirrored per chunk (probed in-process at HEAD):
+
+- line decode = ``_strip_sse_data_from_chunk``: the ``data:`` prefix is
+  OPTIONAL (raw JSON lines parse too), empty lines yield empty chunks the
+  wrapper drops, ``[DONE]`` is a stop marker;
+- ``choices: []`` -> a usage-only payload (``or 0`` coercions);
+- delta content -> text; role-only and name-only-tool-call deltas yield
+  EMPTY chunks v1 swallows (a tool_call without non-None ``arguments``
+  never reaches the wire chunk — pinned);
+- only the FIRST tool call rides, as id/type/function/INDEX (the index key
+  is part of v1's GChunk here, unlike cohere's);
+- finish_reason maps through the wrapper's ``map_finish_reason``: the
+  OpenAI four ride verbatim, IBM's time_limit/cancelled/error -> "stop",
+  max_tokens -> "length"; anything else is a LOUD error (conservative —
+  v1 defaults unknowns to "stop");
+- usage rides ONLY on the ``choices: []`` tail payload (v1's wrapper
+  strips mid-stream usage from emitted chunks; the include_usage final
+  chunk is seam scope).
+
+PINNED DIVERGENCES (fail-closed on failure paths, the compat_httpx
+error-chunk precedent): v1's iterator SILENTLY SWALLOWS non-JSON lines and
+chunks that fail ``ModelResponseStream`` validation (pydantic
+ValidationError is a ValueError, caught by the iterator's except arm) —
+v2 errors loudly on both, named report rows.
+"""
+
+from __future__ import annotations
+
+import json
+from types import MappingProxyType
+
+from expression import Error, Ok, Result
+from expression.collections import Block
+
+from ...errors import BoundaryError, TranslationError
+from ...ir import JsonBlob, PlainJson, StreamEvent
+
+_EventResult = Result[StreamEvent | None, TranslationError]
+
+_FINISH_MAP = MappingProxyType(
+    {
+        "stop": "stop",
+        "length": "length",
+        "tool_calls": "tool_calls",
+        "content_filter": "content_filter",
+        "time_limit": "stop",
+        "cancelled": "stop",
+        "error": "stop",
+        "max_tokens": "length",
+    }
+)
+
+
+def _boundary(reason: str) -> TranslationError:
+    return TranslationError.of_boundary(BoundaryError.of(Block.of_seq([reason])))
+
+
+def parse_line(line: str) -> _EventResult:
+    stripped = line.strip()
+    if not stripped:
+        return Ok(None)  # v1 yields an empty GenericStreamingChunk
+    if stripped.startswith("data:"):
+        stripped = stripped[len("data:") :].strip()
+    if not stripped:
+        return Ok(None)
+    if stripped == "[DONE]":
+        return Ok(StreamEvent.of_stop())
+    try:
+        event: PlainJson = json.loads(stripped)
+    except ValueError:
+        return Error(
+            _boundary(
+                f"non-JSON watsonx stream line {stripped[:80]!r}: v1's "
+                "iterator SWALLOWS it silently (pinned divergence — "
+                "fail-closed on a failure path)"
+            )
+        )
+    return parse_event(event)
+
+
+def parse_event(event: PlainJson) -> _EventResult:
+    if not isinstance(event, dict):
+        return Error(_boundary("watsonx stream chunk is not an object"))
+    choices = event.get("choices")
+    if not isinstance(choices, list):
+        return Error(
+            _boundary(
+                "watsonx stream chunk has no choices list (v1's "
+                "ModelResponseStream validation swallows it — pinned "
+                "divergence)"
+            )
+        )
+    if len(choices) == 0:
+        return _usage_only_payload(event)
+    if len(choices) > 1:
+        return Error(
+            TranslationError.of_unsupported(
+                "multiple stream choices (n > 1); unreachable for v2-sent requests"
+            )
+        )
+    choice = choices[0]
+    if not isinstance(choice, dict):
+        return Error(_boundary("watsonx stream choice is not an object (v1 swallows)"))
+    raw_delta = choice.get("delta", {})
+    delta = raw_delta if isinstance(raw_delta, dict) else {}
+    text = _text_value(delta)
+    if isinstance(text, TranslationError):
+        return Error(text)
+    tool_call = _first_tool_call(delta)
+    if isinstance(tool_call, TranslationError):
+        return Error(tool_call)
+    finish = _finish_value(choice)
+    if isinstance(finish, TranslationError):
+        return Error(finish)
+    if not text and tool_call is None and finish is None:
+        return Ok(None)  # empty GenericStreamingChunk; the wrapper drops it
+    payload: dict[str, PlainJson] = {
+        "text": text,
+        "tool_call": tool_call,
+        "finish": finish,
+        "usage": None,
+        "provider_fields": None,
+    }
+    return Ok(StreamEvent.of_wire_chunk(JsonBlob(value=payload)))
+
+
+def _usage_only_payload(event: dict[str, PlainJson]) -> _EventResult:
+    usage = event.get("usage")
+    if usage is None:
+        return Ok(None)
+    if not isinstance(usage, dict):
+        return Error(
+            _boundary(
+                "watsonx usage tail is not an object (v1's validation "
+                "swallows the chunk — pinned divergence)"
+            )
+        )
+    coerced: dict[str, PlainJson] = {}
+    for key in ("prompt_tokens", "completion_tokens", "total_tokens"):
+        value = _int_or_zero(usage.get(key), key)
+        if isinstance(value, TranslationError):
+            return Error(value)
+        coerced = {**coerced, key: value}
+    payload: dict[str, PlainJson] = {
+        "text": "",
+        "tool_call": None,
+        "finish": None,
+        "usage": coerced,
+        "provider_fields": None,
+    }
+    return Ok(StreamEvent.of_wire_chunk(JsonBlob(value=payload)))
+
+
+def _int_or_zero(value: PlainJson, key: str) -> int | TranslationError:
+    """v1's ``final_usage.prompt_tokens or 0`` over the VALIDATED Usage."""
+    if value is None:
+        return 0
+    if isinstance(value, (bool, int)):
+        return int(value) or 0
+    if isinstance(value, float) and value.is_integer():
+        return int(value) or 0
+    return _boundary(
+        f"watsonx usage {key} is not an integer (v1's Usage validation "
+        "swallows the chunk — pinned divergence)"
+    )
+
+
+def _text_value(delta: dict[str, PlainJson]) -> str | TranslationError:
+    content = delta.get("content")
+    if content is None:
+        return ""
+    if not isinstance(content, str):
+        return _boundary(
+            "watsonx delta content is not a string (v1's validation "
+            "swallows the chunk — pinned divergence)"
+        )
+    return content
+
+
+def _first_tool_call(delta: dict[str, PlainJson]) -> PlainJson | TranslationError:
+    """Mirror the iterator over the VALIDATED Delta: ``function`` is a
+    REQUIRED field (a tool_call without it fails ModelResponseStream
+    validation and v1 swallows the whole chunk — pinned divergence) and
+    missing/null ``arguments`` validates to ``""``, so the iterator's
+    ``arguments is not None`` check never fails post-validation: name-only
+    tool starts ride with arguments ``""``."""
+    tool_calls = delta.get("tool_calls")
+    if tool_calls is None:
+        return None
+    if not isinstance(tool_calls, list):
+        return _boundary(
+            "watsonx delta tool_calls is malformed (v1's validation "
+            "swallows the chunk — pinned divergence)"
+        )
+    if len(tool_calls) == 0:
+        return None
+    first = tool_calls[0]
+    if not isinstance(first, dict):
+        return _boundary(
+            "watsonx delta tool_calls is malformed (v1's validation "
+            "swallows the chunk — pinned divergence)"
+        )
+    function = first.get("function")
+    if not isinstance(function, dict):
+        return _boundary(
+            "watsonx tool_call without a function object (v1's validation "
+            "swallows the chunk — pinned divergence)"
+        )
+    arguments = function.get("arguments")
+    if arguments is not None and not isinstance(arguments, str):
+        return _boundary(
+            "watsonx tool_call arguments is not a string (v1's validation "
+            "swallows the chunk — pinned divergence)"
+        )
+    identifier = first.get("id")
+    name = function.get("name")
+    index = first.get("index")
+    return {
+        "id": identifier if isinstance(identifier, str) else None,
+        "type": "function",
+        "function": {
+            "name": name if isinstance(name, str) else None,
+            "arguments": arguments if isinstance(arguments, str) else "",
+        },
+        "index": index if isinstance(index, int) else 0,
+    }
+
+
+def _finish_value(choice: dict[str, PlainJson]) -> PlainJson | TranslationError:
+    finish = choice.get("finish_reason")
+    if finish is None:
+        return None
+    if not isinstance(finish, str):
+        return _boundary(
+            "watsonx finish_reason is not a string (v1's validation "
+            "swallows the chunk — pinned divergence)"
+        )
+    mapped = _FINISH_MAP.get(finish)
+    if mapped is None:
+        return _boundary(
+            f"watsonx finish_reason {finish!r} outside the pinned map "
+            "(conservative: v1's map_finish_reason defaults unknowns to "
+            "'stop'; re-derive before serving it)"
+        )
+    return mapped

--- a/litellm/translation/providers/xai/serialize.py
+++ b/litellm/translation/providers/xai/serialize.py
@@ -19,7 +19,7 @@ from expression import Error, Result
 from ...deps import TranslationDeps
 from ...errors import TranslationError
 from ...ir import Body, ChatRequest, PlainJson
-from ..openai_compat.serialize import assemble_body
+from ..openai_compat.serialize import assemble_body, strip_function_strict
 from . import params as p
 
 _SerializeResult = Result[Body, TranslationError]
@@ -43,16 +43,7 @@ def _with_xai_deltas(body: Body, request: ChatRequest) -> Body:
     tools = body.get("tools")
     if not isinstance(tools, list):
         return {**body, **extras}
-    return {**body, "tools": [_without_strict(tool) for tool in tools], **extras}
-
-
-def _without_strict(tool: PlainJson) -> PlainJson:
-    if not isinstance(tool, dict):
-        return tool
-    function = tool.get("function")
-    if not isinstance(function, dict):
-        return tool
-    return {
-        **tool,
-        "function": {key: value for key, value in function.items() if key != "strict"},
-    }
+    # the function-level strict strip is openai_compat.serialize.
+    # strip_function_strict (lifted there when fireworks_ai became the
+    # second consumer)
+    return {**body, "tools": [strip_function_strict(tool) for tool in tools], **extras}

--- a/tests/test_litellm/translation/DIFFERENTIAL_REPORT.md
+++ b/tests/test_litellm/translation/DIFFERENTIAL_REPORT.md
@@ -1,4 +1,4 @@
-# Translation v2 differential report (anthropic + bedrock + openai + google + azure + xai + the compat_sdk family (waves 1a+1b+2a) + the wave-1b compat_httpx family)
+# Translation v2 differential report (anthropic + bedrock + openai + google + azure + xai + the compat_sdk family (waves 1a+1b+2a) + the wave-1b compat_httpx family + the wave-2b-alpha own modules)
 
 v1 and v2 run over the same corpus; every row must be IDENTICAL (or an
 explained FALLBACK that v1 serves) for a provider's flag to turn on.
@@ -6,7 +6,7 @@ Bedrock and google rows additionally pin the characterization-corpus
 snapshot, so each row proves snapshot == v1-at-HEAD == v2. Regenerate with:
 `python -m tests.test_litellm.translation.generate_differential_report`
 
-- commit: 86697f4aa3
+- commit: 71da3c71c9
 
 ## anthropic: request bodies (v1 map_openai_params + transform_request vs v2)
 
@@ -1810,7 +1810,7 @@ snapshot, so each row proves snapshot == v1-at-HEAD == v2. Regenerate with:
 - SEAM CONTRACT: lemonade usage tail (v2 passes the wire choices=[] usage chunk through; the streaming seam owns v1's synthesized final chunk)
 - SEAM CONTRACT: minimax usage tail (v2 passes the wire choices=[] usage chunk through; the streaming seam owns v1's synthesized final chunk)
 - SEAM CONTRACT: ovhcloud usage tail (v2 passes the wire choices=[] usage chunk through; the streaming seam owns v1's synthesized final chunk)
-- PINNED DIVERGENCE (fail-closed on a failure path): mid-stream {'error': ...} chunks — v1's BASE handler silently swallows them (no error surface in the emitted sequence; asserted in-process for all nine base-handler members), v2's family parser surfaces a LOUD typed boundary error naming the chunk (test_error_chunk_divergence_two_sided; cometapi differs: its v1 handler RAISES and its policy row mirrors the raise — see the cometapi stream rows below)
+- PINNED DIVERGENCE (fail-closed on a failure path): mid-stream {'error': ...} chunks — v1's BASE handler silently swallows them (no error surface in the emitted sequence; asserted in-process for all nine base-handler members AND the wave-2b-alpha own-module base-handler consumers, per their dedicated stream gates), v2's family parser surfaces a LOUD typed boundary error naming the chunk (test_error_chunk_divergence_two_sided; cometapi differs: its v1 handler RAISES and its policy row mirrors the raise — see the cometapi stream rows below)
 
 ## cometapi: responses (v1 CometAPIConfig.transform_response over httpx — LIVE on the dedicated elif, main.py:2547 — vs v2 shared openai parser with NO model preset; bare wire model, the xai R4 pin)
 
@@ -1821,6 +1821,269 @@ snapshot, so each row proves snapshot == v1-at-HEAD == v2. Regenerate with:
 ## cometapi: streams (v1 line-seam replay through CometAPIChatCompletionStreamingHandler + CustomStreamWrapper('cometapi') vs v2 cometapi parser + the shared xai chunk dialect)
 
 - IDENTICAL: extras_dropped
+- IDENTICAL: native_reasoning_content
+- IDENTICAL: reasoning_rename
+- IDENTICAL: text
+- IDENTICAL: tools
+- SEAM CONTRACT: usage tail (v2 passes the wire choices=[] usage chunk through; the streaming seam owns v1's synthesized final chunk)
+
+## deepseek: request bodies (v1 get_optional_params('deepseek') + the LIVE httpx transform_request — dedicated elif main.py:1942 — vs v2 providers/deepseek)
+
+- IDENTICAL: content_list_flattened
+- IDENTICAL: max_completion_tokens_verbatim
+- IDENTICAL: parallel_tool_calls_false
+- IDENTICAL: reasoner_thinking_without_history
+- IDENTICAL: reasoning_effort_none_dropped
+- IDENTICAL: reasoning_effort_rewrites_to_thinking
+- IDENTICAL: response_format_json_object
+- IDENTICAL: response_format_json_schema_strict
+- IDENTICAL: stop_list
+- IDENTICAL: stream_true
+- IDENTICAL: system_and_sampling
+- IDENTICAL: temperature_int_stays_int
+- IDENTICAL: text
+- IDENTICAL: thinking_disabled_dropped
+- IDENTICAL: thinking_disabled_shadows_reasoning_effort
+- IDENTICAL: thinking_enabled_budget_discarded
+- IDENTICAL: thinking_history_inert_on_non_reasoning_model
+- IDENTICAL: tool_call_compact_roundtrip
+- IDENTICAL: tool_choice_none_verbatim
+- IDENTICAL: tool_choice_specific
+- IDENTICAL: tools_auto
+- FALLBACK (v1 serves it): non_text_content (lossy flatten)
+- FALLBACK (v1 serves it): reasoning_effort_fill_history (_fill_reasoning_content)
+- FALLBACK (v1 serves it): stream_false (stream)
+- FALLBACK (v1 serves it): thinking_fill_history (_fill_reasoning_content)
+- FALLBACK (v1 serves it): top_k (extra_body)
+- FALLBACK (v1 serves it): user (user)
+- FALLBACK (v1 serves it): web_search_options (web_search_options)
+
+## deepseek: responses (v1 base GPT transform_response over httpx — LIVE on the dedicated elif — vs v2 shared openai parser with NO model preset; bare wire model, the xai R4 pin)
+
+- IDENTICAL: reasoning_content (no prefix)
+- IDENTICAL: text (no prefix)
+- IDENTICAL: tool_calls (no prefix)
+
+## deepseek: streams (v1 base OpenAIChatCompletionStreamingHandler + CustomStreamWrapper('deepseek') over SSE lines vs v2 deepseek parser — the httpx_chunk family policy — with the xai chunk dialect)
+
+- IDENTICAL: empty_keepalive_swallowed
+- IDENTICAL: native_reasoning_content
+- IDENTICAL: reasoning_rename
+- IDENTICAL: text
+- IDENTICAL: tools
+- SEAM CONTRACT: usage tail (v2 passes the wire choices=[] usage chunk through; the streaming seam owns v1's synthesized final chunk)
+
+## openrouter: request bodies (v1 get_optional_params('openrouter') + the LIVE httpx transform_request — dedicated elif main.py:3354, incl. the always-injected usage:{include:true} — vs v2 providers/openrouter)
+
+- IDENTICAL: cache_control_stripped_on_non_cache_model
+- IDENTICAL: max_completion_tokens_verbatim
+- IDENTICAL: parallel_tool_calls_false
+- IDENTICAL: reasoning_effort_on_reasoner
+- IDENTICAL: response_format_json_object
+- IDENTICAL: response_format_json_schema_strict
+- IDENTICAL: stop_list
+- IDENTICAL: stream_true
+- IDENTICAL: system_and_sampling
+- IDENTICAL: temperature_int_stays_int
+- IDENTICAL: text
+- IDENTICAL: tool_call_compact_roundtrip
+- IDENTICAL: tool_choice_specific
+- IDENTICAL: tools_auto
+- IDENTICAL: top_k_top_level
+- FALLBACK (v1 raises UnsupportedParamsError): reasoning_effort_on_non_reasoning_model (reasoning_effort)
+- FALLBACK (v1 raises UnsupportedParamsError): thinking_on_non_reasoning_model (thinking)
+- FALLBACK (v1 serves it): cache_control_on_claude (cache-capable)
+- FALLBACK (v1 serves it): route (route)
+- FALLBACK (v1 serves it): stream_false (stream)
+- FALLBACK (v1 serves it): thinking_on_reasoner (VERBATIM)
+- FALLBACK (v1 serves it): transforms (transforms)
+- FALLBACK (v1 serves it): user (user)
+
+## openrouter: responses (v1 base GPT transform_response + the usage.cost hidden-params post-step vs v2 shared openai parser; NO model preset, bare wire model)
+
+- IDENTICAL: message_reasoning (no prefix)
+- IDENTICAL: text (no prefix)
+- IDENTICAL: tool_calls (no prefix)
+- IDENTICAL: usage_cost (no prefix)
+- SEAM CONTRACT: usage.cost hidden-params header (v1's transform copies the wire usage.cost into _hidden_params additional_headers; the v2 body retains usage.cost verbatim and the future completion() fork must rebuild the header — CLAUDE.md HARD OBLIGATION)
+
+## openrouter: streams (v1 line-seam replay through OpenRouterChatCompletionStreamingHandler + CustomStreamWrapper('openrouter') vs v2 openrouter parser — the 'unconditional' ReasoningMode policy + missing-delta pre-step — with the xai chunk dialect)
+
+- IDENTICAL: empty_keepalive_swallowed
+- IDENTICAL: native_reasoning_content_clobbered
+- IDENTICAL: reasoning_both_keys
+- IDENTICAL: text
+- IDENTICAL: tools
+- SEAM CONTRACT: usage tail (v2 passes the wire choices=[] usage chunk through; the streaming seam owns v1's synthesized final chunk)
+
+## hosted_vllm: request bodies (v1 get_optional_params('hosted_vllm') + the LIVE httpx transform_request — dedicated elif main.py:2619, incl. the recursive tools cleaning and the thinking budget-band rewrite — vs v2 providers/hosted_vllm)
+
+- IDENTICAL: max_completion_tokens_verbatim
+- IDENTICAL: parallel_tool_calls_false
+- IDENTICAL: reasoning_effort_verbatim
+- IDENTICAL: reasoning_effort_wins_over_thinking
+- IDENTICAL: response_format_json_object
+- IDENTICAL: response_format_json_schema_strict
+- IDENTICAL: stop_list
+- IDENTICAL: stream_true
+- IDENTICAL: system_and_sampling
+- IDENTICAL: temperature_int_stays_int
+- IDENTICAL: text
+- IDENTICAL: thinking_adaptive_dropped
+- IDENTICAL: thinking_band_high
+- IDENTICAL: thinking_band_low
+- IDENTICAL: thinking_band_medium
+- IDENTICAL: thinking_band_minimal_no_budget
+- IDENTICAL: thinking_disabled_dropped
+- IDENTICAL: tool_call_compact_roundtrip
+- IDENTICAL: tool_choice_specific
+- IDENTICAL: tools_cleaned_recursively
+- FALLBACK (v1 serves it): assistant_thinking_blocks (thinking_blocks)
+- FALLBACK (v1 serves it): custom_tool (custom-type tool)
+- FALLBACK (v1 serves it): stream_false (stream)
+- FALLBACK (v1 serves it): top_k (extra_body)
+- FALLBACK (v1 serves it): user (user)
+- FALLBACK (v1 serves it): video_file_part (not yet supported)
+
+## hosted_vllm: responses (v1 base GPT transform_response over httpx — LIVE on the dedicated elif — vs v2 shared openai parser with NO model preset; bare wire model, the xai R4 pin)
+
+- IDENTICAL: reasoning_content (no prefix)
+- IDENTICAL: text (no prefix)
+- IDENTICAL: tool_calls (no prefix)
+
+## hosted_vllm: streams (v1 base OpenAIChatCompletionStreamingHandler + CustomStreamWrapper('hosted_vllm') over SSE lines vs v2 hosted_vllm parser — the httpx_chunk family policy — with the xai chunk dialect)
+
+- IDENTICAL: empty_keepalive_swallowed
+- IDENTICAL: native_reasoning_content
+- IDENTICAL: reasoning_rename
+- IDENTICAL: text
+- IDENTICAL: tools
+- SEAM CONTRACT: usage tail (v2 passes the wire choices=[] usage chunk through; the streaming seam owns v1's synthesized final chunk)
+
+## fireworks_ai: request bodies (v1 get_optional_params('fireworks_ai') + the LIVE httpx transform_request — dedicated elif main.py:2198, incl. the accounts/fireworks/models/ rewrite, the required->any tool_choice arm and the #transform=inline image suffix — vs v2 providers/fireworks_ai)
+
+- IDENTICAL: cache_control_stripped
+- IDENTICAL: image_data_url_exempt
+- IDENTICAL: image_inline_suffix_on_non_vision_name
+- IDENTICAL: image_no_suffix_on_vision_named_model
+- IDENTICAL: max_completion_tokens_renamed
+- IDENTICAL: parallel_tool_calls_false
+- IDENTICAL: reasoning_effort_on_flagged_model
+- IDENTICAL: response_format_json_object
+- IDENTICAL: response_format_json_schema_strict
+- IDENTICAL: stop_list
+- IDENTICAL: stream_true
+- IDENTICAL: system_and_sampling
+- IDENTICAL: temperature_int_stays_int
+- IDENTICAL: text_accounts_model_kept
+- IDENTICAL: text_bare_model_rewritten
+- IDENTICAL: text_hash_model_kept
+- IDENTICAL: tool_call_compact_roundtrip
+- IDENTICAL: tool_choice_required_to_any
+- IDENTICAL: tool_choice_specific
+- IDENTICAL: tools_auto_on_flagged_model
+- IDENTICAL: user_verbatim
+- FALLBACK (v1 raises UnsupportedParamsError): reasoning_effort_on_non_reasoning_model (strictly narrower)
+- FALLBACK (v1 raises UnsupportedParamsError): tools_on_explicit_no_fc_model (strictly narrower)
+- FALLBACK (v1 serves it): assistant_thinking_blocks (thinking_blocks)
+- FALLBACK (v1 serves it): legacy_defs_tool (schema inlining)
+- FALLBACK (v1 serves it): n (n)
+- FALLBACK (v1 serves it): pdf_file_part (not yet supported)
+- FALLBACK (v1 serves it): prompt_truncate_length (prompt_truncate_length)
+- FALLBACK (v1 serves it): provider_specific_fields_message (provider_specific_fields)
+- FALLBACK (v1 serves it): response_format_with_tools (json_mode)
+- FALLBACK (v1 serves it): stream_false (stream)
+- FALLBACK (v1 serves it): tools_on_unflagged_model_drift (strictly narrower)
+- FALLBACK (v1 serves it): top_k (extra_body)
+
+## fireworks_ai: responses (v1's OWN transform_response — the OpenAILike DIRECT construction + the fireworks_ai/{WIRE model} prefix + the tool-calls-in-content repair — vs v2 direct parser with the openai_like seam arm)
+
+- IDENTICAL: plain_content_with_tools (prefixed)
+- IDENTICAL: text (prefixed)
+- IDENTICAL: tool_calls (prefixed)
+- FALLBACK (v1 serves it): tool_call_in_content_repair (v1 synthesizes the tool_call with a fresh uuid4; the pure parser fails closed)
+- FALLBACK (v1 raises ValidationError): non_string_wire_model
+
+## fireworks_ai: streams (v1 base OpenAIChatCompletionStreamingHandler + CustomStreamWrapper('fireworks_ai') over SSE lines vs v2 fireworks parser — the httpx_chunk family policy — with the xai chunk dialect; chunk models stay the BARE wire model, no prefix)
+
+- IDENTICAL: empty_keepalive_swallowed
+- IDENTICAL: native_reasoning_content
+- IDENTICAL: reasoning_rename
+- IDENTICAL: text
+- IDENTICAL: tools
+- SEAM CONTRACT: usage tail (v2 passes the wire choices=[] usage chunk through; the streaming seam owns v1's synthesized final chunk)
+
+## snowflake: request bodies (v1 get_optional_params('snowflake') + the LIVE httpx transform_request — dedicated elif main.py:4286, incl. the tool_spec/tool_choice wire mapping, the ALWAYS-on stream key and the verbatim messages — vs v2 providers/snowflake)
+
+- IDENTICAL: content_list_verbatim
+- IDENTICAL: response_format_json_object
+- IDENTICAL: response_format_json_schema_strict
+- IDENTICAL: sampling
+- IDENTICAL: stream_false_served
+- IDENTICAL: stream_true
+- IDENTICAL: temperature_int_stays_int
+- IDENTICAL: text
+- IDENTICAL: tool_call_compact_roundtrip
+- IDENTICAL: tool_choice_auto
+- IDENTICAL: tool_choice_none_object
+- IDENTICAL: tool_choice_required_to_any
+- IDENTICAL: tool_choice_specific_to_name_array
+- IDENTICAL: tools_to_tool_spec
+- IDENTICAL: top_k_top_level
+- FALLBACK (v1 raises UnsupportedParamsError): max_completion_tokens (max_completion_tokens)
+- FALLBACK (v1 raises UnsupportedParamsError): parallel_tool_calls (parallel_tool_calls)
+- FALLBACK (v1 raises UnsupportedParamsError): stop (stop)
+- FALLBACK (v1 serves it): message_name (name)
+- FALLBACK (v1 serves it): user (user)
+
+## snowflake: responses (v1's OWN transform_response — the content_list rewrite + OpenAILike DIRECT construction + the snowflake/{wire model} prefix — vs v2 pre-rewrite + direct parser with the openai_like seam arm)
+
+- IDENTICAL: content_list_text (prefixed)
+- IDENTICAL: content_list_tool_use (prefixed)
+- IDENTICAL: plain_content (prefixed)
+- FALLBACK (v1 raises ValidationError): non_string_wire_model
+- SEAM CONTRACT: request model in _hidden_params['model'] (v1's cost-calculator feed; dump-invisible — the future completion() fork must set it, CLAUDE.md HARD OBLIGATION)
+
+## snowflake: streams (v1 base OpenAIChatCompletionStreamingHandler + CustomStreamWrapper('snowflake') over Cortex SSE lines vs v2 snowflake parser — the httpx_chunk family policy — with the xai chunk dialect; real Cortex delta shapes are UNPINNED upstream)
+
+- IDENTICAL: empty_keepalive_swallowed
+- IDENTICAL: native_reasoning_content
+- IDENTICAL: reasoning_rename
+- IDENTICAL: text
+- IDENTICAL: tools
+- SEAM CONTRACT: usage tail (v2 passes the wire choices=[] usage chunk through; the streaming seam owns v1's synthesized final chunk)
+
+## huggingface: request bodies — the api_base (dedicated endpoint) route ONLY (v1 get_optional_params('huggingface') + the LIVE httpx transform_request's VERBATIM ChatCompletionRequest arm vs v2 providers/huggingface; the router route is a typed fallback whole)
+
+- IDENTICAL: content_list_verbatim
+- IDENTICAL: max_completion_tokens_verbatim
+- IDENTICAL: parallel_tool_calls_false
+- IDENTICAL: response_format_json_object
+- IDENTICAL: response_format_json_schema_strict
+- IDENTICAL: sampling
+- IDENTICAL: stop_list
+- IDENTICAL: stream_true
+- IDENTICAL: temperature_int_stays_int
+- IDENTICAL: text
+- IDENTICAL: tool_call_compact_roundtrip
+- IDENTICAL: tool_choice_specific
+- IDENTICAL: tools_auto
+- IDENTICAL: top_k_top_level
+- FALLBACK (v1 serves it): max_retries (max_retries)
+- FALLBACK (v1 serves it): message_name (name)
+- FALLBACK (v1 serves it): stream_false (stream)
+- FALLBACK (v1 serves it): user (user)
+- FALLBACK (v1 serves it): router_route_whole (no api_base: v1 synthesizes router.huggingface.co URLs; 3-segment names fetch the HF provider mapping over HTTP inside the transform — the in-transform I/O the port refuses; 1-segment names CRASH v1)
+
+## huggingface: responses (v1 base GPT transform_response over httpx — LIVE on the dedicated elif — vs v2 shared openai parser with NO model preset; bare wire model, the xai R4 pin)
+
+- IDENTICAL: reasoning_content (no prefix)
+- IDENTICAL: text (no prefix)
+- IDENTICAL: tool_calls (no prefix)
+
+## huggingface: streams (v1 base OpenAIChatCompletionStreamingHandler + CustomStreamWrapper('huggingface') over SSE lines vs v2 huggingface parser — the httpx_chunk family policy — with the xai chunk dialect)
+
+- IDENTICAL: empty_keepalive_swallowed
 - IDENTICAL: native_reasoning_content
 - IDENTICAL: reasoning_rename
 - IDENTICAL: text

--- a/tests/test_litellm/translation/DIFFERENTIAL_REPORT.md
+++ b/tests/test_litellm/translation/DIFFERENTIAL_REPORT.md
@@ -6,7 +6,7 @@ Bedrock and google rows additionally pin the characterization-corpus
 snapshot, so each row proves snapshot == v1-at-HEAD == v2. Regenerate with:
 `python -m tests.test_litellm.translation.generate_differential_report`
 
-- commit: 71da3c71c9
+- commit: ac3edc764f
 
 ## anthropic: request bodies (v1 map_openai_params + transform_request vs v2)
 
@@ -1931,8 +1931,11 @@ snapshot, so each row proves snapshot == v1-at-HEAD == v2. Regenerate with:
 - IDENTICAL: text
 - IDENTICAL: thinking_adaptive_dropped
 - IDENTICAL: thinking_band_high
+- IDENTICAL: thinking_band_high_exact_boundary
 - IDENTICAL: thinking_band_low
+- IDENTICAL: thinking_band_low_exact_boundary
 - IDENTICAL: thinking_band_medium
+- IDENTICAL: thinking_band_medium_exact_boundary
 - IDENTICAL: thinking_band_minimal_no_budget
 - IDENTICAL: thinking_disabled_dropped
 - IDENTICAL: tool_call_compact_roundtrip

--- a/tests/test_litellm/translation/DIFFERENTIAL_REPORT.md
+++ b/tests/test_litellm/translation/DIFFERENTIAL_REPORT.md
@@ -6,7 +6,7 @@ Bedrock and google rows additionally pin the characterization-corpus
 snapshot, so each row proves snapshot == v1-at-HEAD == v2. Regenerate with:
 `python -m tests.test_litellm.translation.generate_differential_report`
 
-- commit: 39d7fbb630
+- commit: 466e271f69
 
 ## anthropic: request bodies (v1 map_openai_params + transform_request vs v2)
 
@@ -1881,13 +1881,26 @@ snapshot, so each row proves snapshot == v1-at-HEAD == v2. Regenerate with:
 - IDENTICAL: text
 - IDENTICAL: tool_calls
 - IDENTICAL: tool_calls_discard_text_keep_annotations
+- FALLBACK (v1 raises): citation_entry_int
+- FALLBACK (v1 raises): citation_entry_string
+- FALLBACK (v1 raises): citations_dict
+- FALLBACK (v1 raises): citations_string
+- FALLBACK (v1 raises): document_non_dict
 - FALLBACK (v1 raises): missing_message
 - FALLBACK (v1 raises): missing_usage
 - FALLBACK (v1 raises): non_object_body
 - FALLBACK (v1 raises): non_string_text
 - FALLBACK (v1 raises): null_tokens_object
+- FALLBACK (v1 raises): source_entry_int
+- FALLBACK (v1 raises): sources_dict
+- FALLBACK (v1 raises): sources_string
 - FALLBACK (v1 raises): string_content
 - FALLBACK (v1 raises): string_token_count
+- FALLBACK (v1 raises): tool_call_missing_function
+- FALLBACK (v1 serves the unvalidated annotation): citation_end_bool
+- FALLBACK (v1 serves the unvalidated annotation): citation_start_string
+- FALLBACK (v1 serves the unvalidated annotation): citation_title_int
+- FALLBACK (v1 serves the unvalidated annotation): citation_url_int
 
 ## cohere v2: streams (v1 bare-JSON line replay through CohereV2ModelResponseIterator + CustomStreamWrapper('cohere_chat') generic arm vs v2 cohere parser + the generic chunk dialect; ids normalized — v1 mints a fresh chatcmpl id per chunk)
 
@@ -1899,6 +1912,13 @@ snapshot, so each row proves snapshot == v1-at-HEAD == v2. Regenerate with:
 - IDENTICAL: event-keyed tool_then_event_end_no_rewrite
 - SEAM CONTRACT: usage tail (v2 passes the wire choices=[] usage chunk through; the streaming seam owns v1's synthesized final chunk)
 - PINNED DIVERGENCE (fail-closed on a failure path): non-str content.text — v1 silently swallows the chunk, v2 errors loudly naming the shape (re-decide if either half stops holding)
+- FALLBACK (v1 raises): mixed_type_token_counts
+- FALLBACK (v1 raises): non_dict_delta
+- FALLBACK (v1 raises): non_dict_tool_call_entry
+- FALLBACK (v1 raises): non_finite_index
+- FALLBACK (v1 raises): non_numeric_index
+- FALLBACK (v1 raises): null_usage_tokens
+- FALLBACK (v1 serves): str+str message-end token counts (v1 concatenates then re-sums in its include_usage chunk; deliberately left to v1 — the response-side _int_token decision, critic M1)
 
 ## mistral (wave-2b-beta): requests (v1 get_optional_params + MistralConfig.transform_request — the two-branch message munge — vs v2 providers/mistral)
 
@@ -1919,6 +1939,7 @@ snapshot, so each row proves snapshot == v1-at-HEAD == v2. Regenerate with:
 - IDENTICAL: tool_choice_required_to_any
 - IDENTICAL: tools_auto
 - IDENTICAL: tools_schema_refs_stripped
+- IDENTICAL: tools_schema_refs_stripped_4_levels_deep
 - IDENTICAL: top_k_wire_proven
 - IDENTICAL: user_name_dropped_both_sides
 - FALLBACK (v1 raises UnsupportedParamsError): frequency_penalty
@@ -1944,8 +1965,10 @@ snapshot, so each row proves snapshot == v1-at-HEAD == v2. Regenerate with:
 - IDENTICAL: text
 - IDENTICAL: thinking_only_keeps_empty_string
 - IDENTICAL: tool_calls
+- FALLBACK (v1 raises): empty_content_list
 - FALLBACK (v1 raises): non_dict_content_block
 - FALLBACK (v1 raises): non_list_thinking
+- FALLBACK (v1 raises): non_string_thinking_text
 
 ## mistral: streams (v1 SSE line replay through MistralChatResponseIterator + CustomStreamWrapper('mistral') vs v2 mistral pre-step + the httpx_chunk factory (rename + passthrough thinking_blocks) + the xai chunk dialect)
 
@@ -1955,6 +1978,11 @@ snapshot, so each row proves snapshot == v1-at-HEAD == v2. Regenerate with:
 - IDENTICAL: text
 - IDENTICAL: tools
 - SEAM CONTRACT: usage tail (v2 passes the wire choices=[] usage chunk through; the streaming seam owns v1's synthesized final chunk)
+- FALLBACK (v1 raises MidStreamFallbackError): non_dict_content_block
+- FALLBACK (v1 raises MidStreamFallbackError): non_list_thinking
+- FALLBACK (v1 raises MidStreamFallbackError): non_string_thinking_text
+- FALLBACK (v1 raises MidStreamFallbackError): non_string_thinking_text_beside_ok_text
+- FALLBACK (unreachable for v2-sent requests): unknown_delta_key
 
 ## watsonx (wave-2b-beta): requests (v1 get_optional_params + _get_api_params/_prepare_payload + the openai_like body assembly vs v2 providers/watsonx with deps-borne project/space ids)
 
@@ -1996,14 +2024,34 @@ snapshot, so each row proves snapshot == v1-at-HEAD == v2. Regenerate with:
 - IDENTICAL: ibm_time_limit_maps_to_stop
 - IDENTICAL: mid_stream_usage_stripped
 - IDENTICAL: name_only_tool_start_rides_with_empty_arguments
+- IDENTICAL: non_str_finish_bool_serves_stop
+- IDENTICAL: non_str_finish_int_serves_stop
 - IDENTICAL: text
+- IDENTICAL: tool_index_bool_lax_coerces
+- IDENTICAL: tool_index_str_lax_coerces
 - IDENTICAL: tools
+- IDENTICAL: unknown_finish_eos_token_serves_stop
+- IDENTICAL: unknown_finish_string_serves_stop
 - SEAM CONTRACT: usage tail (v2 passes the wire choices=[] usage chunk through; the streaming seam owns v1's synthesized final chunk)
 - SEAM CONTRACT: no-wire-finish stream (v2 == v1 minus the wrapper's synthesized stop tail — the generic streaming seam owns it)
+- PINNED DIVERGENCE (fail-closed on a failure path): mid_stream_usage_bad_values — v1's iterator silently swallows it, v2 errors loudly
 - PINNED DIVERGENCE (fail-closed on a failure path): missing_choices — v1's iterator silently swallows it, v2 errors loudly
 - PINNED DIVERGENCE (fail-closed on a failure path): non_json_line — v1's iterator silently swallows it, v2 errors loudly
 - PINNED DIVERGENCE (fail-closed on a failure path): non_string_content — v1's iterator silently swallows it, v2 errors loudly
+- PINNED DIVERGENCE (fail-closed on a failure path): tool_call_id_non_str — v1's iterator silently swallows it, v2 errors loudly
+- PINNED DIVERGENCE (fail-closed on a failure path): tool_call_index_fractional — v1's iterator silently swallows it, v2 errors loudly
+- PINNED DIVERGENCE (fail-closed on a failure path): tool_call_index_non_coercible — v1's iterator silently swallows it, v2 errors loudly
+- PINNED DIVERGENCE (fail-closed on a failure path): tool_call_name_non_str — v1's iterator silently swallows it, v2 errors loudly
+- PINNED DIVERGENCE (fail-closed on a failure path): tool_call_type_non_str — v1's iterator silently swallows it, v2 errors loudly
 - PINNED DIVERGENCE (fail-closed on a failure path): tool_call_without_function — v1's iterator silently swallows it, v2 errors loudly
+- PINNED DIVERGENCE (fail-closed on a failure path): usage_tail_bad_values — v1's iterator silently swallows it, v2 errors loudly
+- FALLBACK (v1 raises MidStreamFallbackError): delta_non_dict
+- FALLBACK (v1 raises MidStreamFallbackError): finish_truthy_unhashable
+- FALLBACK (v1 raises MidStreamFallbackError): mid_stream_usage_non_dict
+- FALLBACK (v1 raises MidStreamFallbackError): tool_calls_non_list
+- FALLBACK (v1 raises MidStreamFallbackError): usage_tail_non_dict
+- SEAM CONTRACT: falsy (empty-string) finish_reason — no finish rides (v1's truthy gate); v2 == v1 minus the wrapper's synthesized stop tail
+- SEAM CONTRACT: falsy (empty-object) finish_reason — no finish rides (v1's truthy gate); v2 == v1 minus the wrapper's synthesized stop tail
 
 ## sagemaker_chat (wave-2b-beta): requests (v1 get_optional_params + the base GPT transform_request vs v2 providers/sagemaker_chat; SigV4 signs after assembly — envelope)
 
@@ -2035,10 +2083,29 @@ snapshot, so each row proves snapshot == v1-at-HEAD == v2. Regenerate with:
 
 ## sagemaker_chat: streams (v1 AWS event-stream PARSED-event replay through AWSEventStreamDecoder(is_messages_api) + CustomStreamWrapper('sagemaker_chat') vs v2 openai parser + the litellm-validation post-step, 'openai' dialect)
 
+- IDENTICAL: choice_index_bool_coerces
+- IDENTICAL: non_str_finish_bool_serves_stop
+- IDENTICAL: non_str_finish_int_serves_stop
 - IDENTICAL: text
+- IDENTICAL: tool_index_str_coerces
 - IDENTICAL: tools
+- IDENTICAL: unknown_finish_string_serves_stop
 - SEAM CONTRACT: usage tail (v2 passes the wire choices=[] usage chunk through; the streaming seam owns v1's synthesized final chunk)
-- FALLBACK (v1 raises ValidationError): non-string delta content (loud on both sides)
+- FALLBACK (v1 raises ValidationError): choice_index_null (loud on both sides)
+- FALLBACK (v1 raises ValidationError): content_non_str (loud on both sides)
+- FALLBACK (v1 raises ValidationError): delta_non_dict (loud on both sides)
+- FALLBACK (v1 raises ValidationError): finish_truthy_unhashable (loud on both sides)
+- FALLBACK (v1 raises ValidationError): mid_usage_bad_values (loud on both sides)
+- FALLBACK (v1 raises ValidationError): mid_usage_non_dict (loud on both sides)
+- FALLBACK (v1 raises ValidationError): tool_arguments_non_str (loud on both sides)
+- FALLBACK (v1 raises ValidationError): tool_calls_non_list (loud on both sides)
+- FALLBACK (v1 raises ValidationError): tool_function_missing (loud on both sides)
+- FALLBACK (v1 raises ValidationError): tool_id_non_str (loud on both sides)
+- FALLBACK (v1 raises ValidationError): tool_index_non_coercible (loud on both sides)
+- FALLBACK (v1 raises ValidationError): tool_name_non_str (loud on both sides)
+- FALLBACK (v1 raises ValidationError): tool_type_non_str (loud on both sides)
+- SEAM CONTRACT: falsy (empty-string) finish_reason — no finish rides (v1's truthy gate); v2 == v1 minus the wrapper's synthesized stop tail
+- SEAM CONTRACT: falsy (empty-object) finish_reason — no finish rides (v1's truthy gate); v2 == v1 minus the wrapper's synthesized stop tail
 
 ## groq (wave-2b-beta): requests (v1 get_optional_params + GroqChatConfig.transform_request + hh's extra_body merge vs v2 providers/groq; the json_schema three-way fork)
 
@@ -2083,6 +2150,9 @@ snapshot, so each row proves snapshot == v1-at-HEAD == v2. Regenerate with:
 - IDENTICAL: x_groq_extras_dropped
 - SEAM CONTRACT: usage tail (v2 passes the wire choices=[] usage chunk through; the streaming seam owns v1's synthesized final chunk)
 - FALLBACK (v1 raises MidStreamFallbackError): error chunk (loud on both sides — the truthy-value check)
+- FALLBACK (v1 raises APIError): non-str delta reasoning (the F6 groq-local pre-step; the wrapper epilogue join TypeErrors in v1)
+- FALLBACK (v1 raises APIError): non-str delta reasoning_content (the F6 groq-local pre-step; the wrapper epilogue join TypeErrors in v1)
+- INTEGRATOR-FLIP HANDOFF (current behavior guarded): non-str refusal — v1 forwards 7, the SHARED httpx_chunk factory nulls it; the fix belongs to the alpha fix round's concurrent httpx_chunk edit (verifier-wave2b-alpha F1) — the sibling-merge integrator flips this row and the gate test to v1 parity
 
 ## azure: request bodies (v1 api-version-aware map_openai_params + transform_request vs v2)
 

--- a/tests/test_litellm/translation/DIFFERENTIAL_REPORT.md
+++ b/tests/test_litellm/translation/DIFFERENTIAL_REPORT.md
@@ -6,7 +6,7 @@ Bedrock and google rows additionally pin the characterization-corpus
 snapshot, so each row proves snapshot == v1-at-HEAD == v2. Regenerate with:
 `python -m tests.test_litellm.translation.generate_differential_report`
 
-- commit: 5eae6d3e55
+- commit: 0c6531018c
 
 ## anthropic: request bodies (v1 map_openai_params + transform_request vs v2)
 
@@ -1810,7 +1810,7 @@ snapshot, so each row proves snapshot == v1-at-HEAD == v2. Regenerate with:
 - SEAM CONTRACT: lemonade usage tail (v2 passes the wire choices=[] usage chunk through; the streaming seam owns v1's synthesized final chunk)
 - SEAM CONTRACT: minimax usage tail (v2 passes the wire choices=[] usage chunk through; the streaming seam owns v1's synthesized final chunk)
 - SEAM CONTRACT: ovhcloud usage tail (v2 passes the wire choices=[] usage chunk through; the streaming seam owns v1's synthesized final chunk)
-- PINNED DIVERGENCE (fail-closed on a failure path): mid-stream {'error': ...} chunks — v1's BASE handler silently swallows them (no error surface in the emitted sequence; asserted in-process for all nine base-handler members AND the wave-2b-alpha own-module base-handler consumers, per their dedicated stream gates), v2's family parser surfaces a LOUD typed boundary error naming the chunk (test_error_chunk_divergence_two_sided; cometapi differs: its v1 handler RAISES and its policy row mirrors the raise — see the cometapi stream rows below)
+- PINNED DIVERGENCE (fail-closed on a failure path): mid-stream {'error': ...} chunks — v1's BASE handler silently swallows them (no error surface in the emitted sequence; asserted in-process for all nine base-handler members AND the wave-2b-alpha own-module base-handler consumers AND mistral, whose v1 iterator subclasses the base handler — sibling-merge sweep — per their dedicated stream gates), v2's family parser surfaces a LOUD typed boundary error naming the chunk (test_error_chunk_divergence_two_sided; cometapi differs: its v1 handler RAISES and its policy row mirrors the raise — see the cometapi stream rows below)
 
 ## cometapi: responses (v1 CometAPIConfig.transform_response over httpx — LIVE on the dedicated elif, main.py:2547 — vs v2 shared openai parser with NO model preset; bare wire model, the xai R4 pin)
 
@@ -2418,7 +2418,7 @@ snapshot, so each row proves snapshot == v1-at-HEAD == v2. Regenerate with:
 - FALLBACK (v1 raises MidStreamFallbackError): error chunk (loud on both sides — the truthy-value check)
 - FALLBACK (v1 raises APIError): non-str delta reasoning (the F6 groq-local pre-step; the wrapper epilogue join TypeErrors in v1)
 - FALLBACK (v1 raises APIError): non-str delta reasoning_content (the F6 groq-local pre-step; the wrapper epilogue join TypeErrors in v1)
-- INTEGRATOR-FLIP HANDOFF (current behavior guarded): non-str refusal — v1 forwards 7, the SHARED httpx_chunk factory nulls it; the fix belongs to the alpha fix round's concurrent httpx_chunk edit (verifier-wave2b-alpha F1) — the sibling-merge integrator flips this row and the gate test to v1 parity
+- IDENTICAL: non-str refusal forwarded VERBATIM (the wave-2b-beta F6 INTEGRATOR-FLIP handoff, discharged at the sibling merge: the shared httpx_chunk factory used to null what v1 forwards; the refusal-on-finish half is the loud finish-chunk fallback where v1 silently drops the value — test_refusal_on_finish_chunk_is_loud_where_v1_drops_it)
 
 ## azure: request bodies (v1 api-version-aware map_openai_params + transform_request vs v2)
 

--- a/tests/test_litellm/translation/DIFFERENTIAL_REPORT.md
+++ b/tests/test_litellm/translation/DIFFERENTIAL_REPORT.md
@@ -6,7 +6,7 @@ Bedrock and google rows additionally pin the characterization-corpus
 snapshot, so each row proves snapshot == v1-at-HEAD == v2. Regenerate with:
 `python -m tests.test_litellm.translation.generate_differential_report`
 
-- commit: 0c6531018c
+- commit: 4aacbce04a
 
 ## anthropic: request bodies (v1 map_openai_params + transform_request vs v2)
 
@@ -2418,7 +2418,8 @@ snapshot, so each row proves snapshot == v1-at-HEAD == v2. Regenerate with:
 - FALLBACK (v1 raises MidStreamFallbackError): error chunk (loud on both sides — the truthy-value check)
 - FALLBACK (v1 raises APIError): non-str delta reasoning (the F6 groq-local pre-step; the wrapper epilogue join TypeErrors in v1)
 - FALLBACK (v1 raises APIError): non-str delta reasoning_content (the F6 groq-local pre-step; the wrapper epilogue join TypeErrors in v1)
-- IDENTICAL: non-str refusal forwarded VERBATIM (the wave-2b-beta F6 INTEGRATOR-FLIP handoff, discharged at the sibling merge: the shared httpx_chunk factory used to null what v1 forwards; the refusal-on-finish half is the loud finish-chunk fallback where v1 silently drops the value — test_refusal_on_finish_chunk_is_loud_where_v1_drops_it)
+- IDENTICAL: non-str refusal forwarded VERBATIM (the wave-2b-beta F6 INTEGRATOR-FLIP handoff, discharged at the sibling merge: the shared httpx_chunk factory used to null what v1 forwards; the refusal-on-finish half is the failure-counted PINNED DIVERGENCE row below)
+- PINNED DIVERGENCE (fail-closed where v1 serves the lossy finish): refusal-on-finish: groq's v1 wrapper silently DROPS a refusal value riding the finish chunk and serves the lossy finish; v2 takes the loud finish-chunk fallback for any value type (test_refusal_on_finish_chunk_is_loud_where_v1_drops_it; critic-wave2b-final MAJOR-2 made the gate-pinned divergence a failure-counted report row)
 
 ## azure: request bodies (v1 api-version-aware map_openai_params + transform_request vs v2)
 

--- a/tests/test_litellm/translation/DIFFERENTIAL_REPORT.md
+++ b/tests/test_litellm/translation/DIFFERENTIAL_REPORT.md
@@ -1,4 +1,4 @@
-# Translation v2 differential report (anthropic + bedrock + openai + google + azure + xai + the compat_sdk family (waves 1a+1b+2a) + the wave-1b compat_httpx family)
+# Translation v2 differential report (anthropic + bedrock + openai + google + azure + xai + the compat_sdk family (waves 1a+1b+2a) + the wave-1b compat_httpx family + the wave-2b-beta own modules)
 
 v1 and v2 run over the same corpus; every row must be IDENTICAL (or an
 explained FALLBACK that v1 serves) for a provider's flag to turn on.
@@ -6,7 +6,7 @@ Bedrock and google rows additionally pin the characterization-corpus
 snapshot, so each row proves snapshot == v1-at-HEAD == v2. Regenerate with:
 `python -m tests.test_litellm.translation.generate_differential_report`
 
-- commit: 86697f4aa3
+- commit: 39d7fbb630
 
 ## anthropic: request bodies (v1 map_openai_params + transform_request vs v2)
 
@@ -1826,6 +1826,263 @@ snapshot, so each row proves snapshot == v1-at-HEAD == v2. Regenerate with:
 - IDENTICAL: text
 - IDENTICAL: tools
 - SEAM CONTRACT: usage tail (v2 passes the wire choices=[] usage chunk through; the streaming seam owns v1's synthesized final chunk)
+
+## cohere v2 (wave-2b-beta): requests (v1 get_optional_params + CohereV2ChatConfig.transform_request vs v2 providers/cohere — both provider names, cohere and cohere_chat)
+
+- IDENTICAL: cohere/mct_renamed
+- IDENTICAL: cohere/plain
+- IDENTICAL: cohere/sampling
+- IDENTICAL: cohere/stream_true
+- IDENTICAL: cohere/system_history
+- IDENTICAL: cohere/tool_choice_required_dropped
+- IDENTICAL: cohere/tools
+- IDENTICAL: cohere/top_k_wire_proven
+- IDENTICAL: cohere_chat/mct_renamed
+- IDENTICAL: cohere_chat/plain
+- IDENTICAL: cohere_chat/sampling
+- IDENTICAL: cohere_chat/stream_true
+- IDENTICAL: cohere_chat/system_history
+- IDENTICAL: cohere_chat/tool_choice_required_dropped
+- IDENTICAL: cohere_chat/tools
+- IDENTICAL: cohere_chat/top_k_wire_proven
+- FALLBACK (v1 raises UnsupportedParamsError): cohere/parallel_tool_calls
+- FALLBACK (v1 raises UnsupportedParamsError): cohere/reasoning_effort
+- FALLBACK (v1 raises UnsupportedParamsError): cohere/response_format
+- FALLBACK (v1 raises UnsupportedParamsError): cohere/thinking
+- FALLBACK (v1 raises UnsupportedParamsError): cohere_chat/parallel_tool_calls
+- FALLBACK (v1 raises UnsupportedParamsError): cohere_chat/reasoning_effort
+- FALLBACK (v1 raises UnsupportedParamsError): cohere_chat/response_format
+- FALLBACK (v1 raises UnsupportedParamsError): cohere_chat/thinking
+- FALLBACK (v1 serves): cohere/explicit_stream_false
+- FALLBACK (v1 serves): cohere/frequency_penalty_parse_level
+- FALLBACK (v1 serves): cohere/message_name_forwarded
+- FALLBACK (v1 serves): cohere/n_parse_level
+- FALLBACK (v1 serves): cohere/presence_penalty_parse_level
+- FALLBACK (v1 serves): cohere/seed_parse_level
+- FALLBACK (v1 serves): cohere/user_silent_drop
+- FALLBACK (v1 serves): cohere/v1_route_predicate
+- FALLBACK (v1 serves): cohere/v2_prefix_envelope_strip
+- FALLBACK (v1 serves): cohere_chat/explicit_stream_false
+- FALLBACK (v1 serves): cohere_chat/frequency_penalty_parse_level
+- FALLBACK (v1 serves): cohere_chat/message_name_forwarded
+- FALLBACK (v1 serves): cohere_chat/n_parse_level
+- FALLBACK (v1 serves): cohere_chat/presence_penalty_parse_level
+- FALLBACK (v1 serves): cohere_chat/seed_parse_level
+- FALLBACK (v1 serves): cohere_chat/user_silent_drop
+- FALLBACK (v1 serves): cohere_chat/v1_route_predicate
+- FALLBACK (v1 serves): cohere_chat/v2_prefix_envelope_strip
+
+## cohere v2: responses (v1 CohereV2ChatConfig.transform_response — fresh-ModelResponse mutation, request model verbatim, finish always stop — vs v2 cohere parser + the seam's openai construction arm)
+
+- IDENTICAL: billed_units_ignored
+- IDENTICAL: citations_to_annotations
+- IDENTICAL: missing_tokens_defaults_zero
+- IDENTICAL: null_content
+- IDENTICAL: text
+- IDENTICAL: tool_calls
+- IDENTICAL: tool_calls_discard_text_keep_annotations
+- FALLBACK (v1 raises): missing_message
+- FALLBACK (v1 raises): missing_usage
+- FALLBACK (v1 raises): non_object_body
+- FALLBACK (v1 raises): non_string_text
+- FALLBACK (v1 raises): null_tokens_object
+- FALLBACK (v1 raises): string_content
+- FALLBACK (v1 raises): string_token_count
+
+## cohere v2: streams (v1 bare-JSON line replay through CohereV2ModelResponseIterator + CustomStreamWrapper('cohere_chat') generic arm vs v2 cohere parser + the generic chunk dialect; ids normalized — v1 mints a fresh chatcmpl id per chunk)
+
+- SEAM CONTRACT: real-wire text (v2 == v1 minus the wrapper's synthesized stop tail — the generic streaming seam owns it)
+- SEAM CONTRACT: real-wire tools (v2 == v1 minus the wrapper's synthesized tool_calls tail — the generic streaming seam owns it)
+- IDENTICAL: event-keyed error_toxic_maps_to_content_filter
+- IDENTICAL: event-keyed max_tokens_maps_to_length
+- IDENTICAL: event-keyed plan_citation_content
+- IDENTICAL: event-keyed tool_then_event_end_no_rewrite
+- SEAM CONTRACT: usage tail (v2 passes the wire choices=[] usage chunk through; the streaming seam owns v1's synthesized final chunk)
+- PINNED DIVERGENCE (fail-closed on a failure path): non-str content.text — v1 silently swallows the chunk, v2 errors loudly naming the shape (re-decide if either half stops holding)
+
+## mistral (wave-2b-beta): requests (v1 get_optional_params + MistralConfig.transform_request — the two-branch message munge — vs v2 providers/mistral)
+
+- IDENTICAL: assistant_tool_history
+- IDENTICAL: empty_assistant_removed
+- IDENTICAL: explicit_stream_false_dropped
+- IDENTICAL: flatten_multi_text_list
+- IDENTICAL: image_branch_verbatim
+- IDENTICAL: image_branch_with_tool_history
+- IDENTICAL: mct_renamed
+- IDENTICAL: parallel_tool_calls
+- IDENTICAL: plain
+- IDENTICAL: response_format_json_object
+- IDENTICAL: sampling
+- IDENTICAL: stream_true
+- IDENTICAL: system_first
+- IDENTICAL: tool_choice_dict_dropped
+- IDENTICAL: tool_choice_required_to_any
+- IDENTICAL: tools_auto
+- IDENTICAL: tools_schema_refs_stripped
+- IDENTICAL: top_k_wire_proven
+- IDENTICAL: user_name_dropped_both_sides
+- FALLBACK (v1 raises UnsupportedParamsError): frequency_penalty
+- FALLBACK (v1 raises UnsupportedParamsError): logprobs
+- FALLBACK (v1 raises UnsupportedParamsError): n
+- FALLBACK (v1 raises UnsupportedParamsError): presence_penalty
+- FALLBACK (v1 raises UnsupportedParamsError): reasoning_effort_non_magistral
+- FALLBACK (v1 raises UnsupportedParamsError): thinking_non_magistral
+- FALLBACK (v1 serves): image_branch_name_forwarded
+- FALLBACK (v1 serves): magistral_reasoning_prompt_injection
+- FALLBACK (v1 serves): magistral_thinking_prompt_injection
+- FALLBACK (v1 serves): seed_random_seed_extra_body
+- FALLBACK (v1 serves): single_text_list_flatten
+- FALLBACK (v1 serves): string_stop_verbatim
+- FALLBACK (v1 serves): tool_name_kept_by_v1
+- FALLBACK (v1 serves): user_silent_drop
+
+## mistral: responses (v1 transform_response pre-steps + cdr vs v2 mistral pre-steps + the shared openai parser; bare wire model)
+
+- IDENTICAL: empty_content_to_none
+- IDENTICAL: last_text_block_wins
+- IDENTICAL: magistral_thinking_blocks
+- IDENTICAL: text
+- IDENTICAL: thinking_only_keeps_empty_string
+- IDENTICAL: tool_calls
+- FALLBACK (v1 raises): non_dict_content_block
+- FALLBACK (v1 raises): non_list_thinking
+
+## mistral: streams (v1 SSE line replay through MistralChatResponseIterator + CustomStreamWrapper('mistral') vs v2 mistral pre-step + the httpx_chunk factory (rename + passthrough thinking_blocks) + the xai chunk dialect)
+
+- IDENTICAL: empty_thinking_role_only_chunk
+- IDENTICAL: magistral_thinking_blocks
+- IDENTICAL: reasoning_rename
+- IDENTICAL: text
+- IDENTICAL: tools
+- SEAM CONTRACT: usage tail (v2 passes the wire choices=[] usage chunk through; the streaming seam owns v1's synthesized final chunk)
+
+## watsonx (wave-2b-beta): requests (v1 get_optional_params + _get_api_params/_prepare_payload + the openai_like body assembly vs v2 providers/watsonx with deps-borne project/space ids)
+
+- IDENTICAL: explicit_stream_false
+- IDENTICAL: plain
+- IDENTICAL: reasoning_effort
+- IDENTICAL: response_format_json_object
+- IDENTICAL: response_format_json_schema
+- IDENTICAL: sampling
+- IDENTICAL: stream_true
+- IDENTICAL: tool_choice_dict_rides_verbatim
+- IDENTICAL: tool_choice_required_to_option
+- IDENTICAL: tool_history
+- IDENTICAL: tools_strict_and_additional_properties_stripped
+- FALLBACK (v1 raises UnsupportedParamsError): max_completion_tokens
+- FALLBACK (v1 raises UnsupportedParamsError): parallel_tool_calls
+- FALLBACK (v1 raises UnsupportedParamsError): thinking
+- FALLBACK: top_k (v1 raises the legacy watsonx_text ValueError)
+- FALLBACK: missing project/space ids (v1 raises WatsonXAIError 401)
+- FALLBACK: deployment/ model (envelope routing; v1 serves)
+- FALLBACK (v1 serves): frequency_penalty_parse_level
+- FALLBACK (v1 serves): logprobs_parse_level
+- FALLBACK (v1 serves): message_name_forwarded
+- FALLBACK (v1 serves): n_parse_level
+- FALLBACK (v1 serves): seed_parse_level
+- FALLBACK (v1 serves): user_silent_drop
+
+## watsonx: responses (v1 OpenAILike _transform_response with the LIVE watsonx/{wire_model} prefix vs v2 watsonx parser + the seam's openai_like construction arm)
+
+- IDENTICAL: missing_model_prefixes_empty
+- IDENTICAL: null_usage_tokens_sanitized
+- IDENTICAL: text
+- IDENTICAL: tool_calls
+- FALLBACK (v1 raises ValidationError): non-string wire model
+
+## watsonx: streams (v1 line replay through the databricks ModelResponseIterator + CustomStreamWrapper('watsonx') generic arm vs v2 watsonx parser + the generic chunk dialect; ids normalized)
+
+- IDENTICAL: content_and_finish_in_one_wire_chunk
+- IDENTICAL: ibm_time_limit_maps_to_stop
+- IDENTICAL: mid_stream_usage_stripped
+- IDENTICAL: name_only_tool_start_rides_with_empty_arguments
+- IDENTICAL: text
+- IDENTICAL: tools
+- SEAM CONTRACT: usage tail (v2 passes the wire choices=[] usage chunk through; the streaming seam owns v1's synthesized final chunk)
+- SEAM CONTRACT: no-wire-finish stream (v2 == v1 minus the wrapper's synthesized stop tail — the generic streaming seam owns it)
+- PINNED DIVERGENCE (fail-closed on a failure path): missing_choices — v1's iterator silently swallows it, v2 errors loudly
+- PINNED DIVERGENCE (fail-closed on a failure path): non_json_line — v1's iterator silently swallows it, v2 errors loudly
+- PINNED DIVERGENCE (fail-closed on a failure path): non_string_content — v1's iterator silently swallows it, v2 errors loudly
+- PINNED DIVERGENCE (fail-closed on a failure path): tool_call_without_function — v1's iterator silently swallows it, v2 errors loudly
+
+## sagemaker_chat (wave-2b-beta): requests (v1 get_optional_params + the base GPT transform_request vs v2 providers/sagemaker_chat; SigV4 signs after assembly — envelope)
+
+- IDENTICAL: mct_verbatim_no_rename
+- IDENTICAL: parallel_tool_calls
+- IDENTICAL: plain
+- IDENTICAL: response_format_json_object
+- IDENTICAL: sampling
+- IDENTICAL: stream_true
+- IDENTICAL: tool_history
+- IDENTICAL: tools
+- IDENTICAL: top_k_wire_proven
+- FALLBACK (v1 raises UnsupportedParamsError): reasoning_effort
+- FALLBACK (v1 raises UnsupportedParamsError): response_format_on_gpt4_named_endpoint
+- FALLBACK (v1 raises UnsupportedParamsError): thinking
+- FALLBACK (v1 serves): aws_kwarg_rides_v1_body
+- FALLBACK (v1 serves): explicit_stream_false
+- FALLBACK (v1 serves): logit_bias_parse_level
+- FALLBACK (v1 serves): message_name_forwarded
+- FALLBACK (v1 serves): n_parse_level
+- FALLBACK (v1 serves): seed_parse_level
+- FALLBACK (v1 serves): user_silent_drop
+
+## sagemaker_chat: responses (v1 base transform_response/cdr vs the shared openai parser; bare wire model, no seam preset)
+
+- IDENTICAL: stop_to_tool_calls_rewrite
+- IDENTICAL: text
+- IDENTICAL: tool_calls
+
+## sagemaker_chat: streams (v1 AWS event-stream PARSED-event replay through AWSEventStreamDecoder(is_messages_api) + CustomStreamWrapper('sagemaker_chat') vs v2 openai parser + the litellm-validation post-step, 'openai' dialect)
+
+- IDENTICAL: text
+- IDENTICAL: tools
+- SEAM CONTRACT: usage tail (v2 passes the wire choices=[] usage chunk through; the streaming seam owns v1's synthesized final chunk)
+- FALLBACK (v1 raises ValidationError): non-string delta content (loud on both sides)
+
+## groq (wave-2b-beta): requests (v1 get_optional_params + GroqChatConfig.transform_request + hh's extra_body merge vs v2 providers/groq; the json_schema three-way fork)
+
+- IDENTICAL: assistant_none_strip
+- IDENTICAL: mct_renamed
+- IDENTICAL: parallel_tool_calls
+- IDENTICAL: plain
+- IDENTICAL: reasoning_effort_capable_model
+- IDENTICAL: response_format_json_object
+- IDENTICAL: response_format_schema_native_passthrough
+- IDENTICAL: sampling
+- IDENTICAL: stream_true
+- IDENTICAL: tools
+- IDENTICAL: top_k_extra_body_merged
+- FALLBACK (v1 raises UnsupportedParamsError): reasoning_effort_non_reasoning_model
+- FALLBACK (v1 raises UnsupportedParamsError): thinking
+- FALLBACK (v1 raises BadRequestError): response_format json_schema + tools on a non-native model
+- FALLBACK (v1 serves): explicit_stream_false
+- FALLBACK (v1 serves): logit_bias_parse_level
+- FALLBACK (v1 serves): message_name_forwarded
+- FALLBACK (v1 serves): n_parse_level
+- FALLBACK (v1 serves): response_format_schema_workaround
+- FALLBACK (v1 serves): seed_parse_level
+- FALLBACK (v1 serves): service_tier_parse_level
+- FALLBACK (v1 serves): user_silent_drop
+
+## groq: responses (v1 OpenAILike direct construction + the service_tier clamp vs v2 groq parser + the seam's openai_like arm; bare wire model)
+
+- IDENTICAL: flex_tier_kept
+- IDENTICAL: null_tier_to_auto
+- IDENTICAL: text_tier_clamped_to_auto
+- IDENTICAL: tool_calls
+- IDENTICAL: x_groq_extra_survives
+- FALLBACK (v1 raises AttributeError): response without service_tier (v1's clamp post-step crashes)
+- FALLBACK (v1 raises ValidationError): non-string wire model
+
+## groq: streams (v1 SSE line replay through GroqChatCompletionStreamingHandler + CustomStreamWrapper('groq') vs v2 httpx_chunk factory (rename) + the xai chunk dialect)
+
+- IDENTICAL: reasoning_pop_rename
+- IDENTICAL: text
+- IDENTICAL: tools
+- IDENTICAL: x_groq_extras_dropped
+- SEAM CONTRACT: usage tail (v2 passes the wire choices=[] usage chunk through; the streaming seam owns v1's synthesized final chunk)
+- FALLBACK (v1 raises MidStreamFallbackError): error chunk (loud on both sides — the truthy-value check)
 
 ## azure: request bodies (v1 api-version-aware map_openai_params + transform_request vs v2)
 

--- a/tests/test_litellm/translation/DIFFERENTIAL_REPORT.md
+++ b/tests/test_litellm/translation/DIFFERENTIAL_REPORT.md
@@ -6,7 +6,7 @@ Bedrock and google rows additionally pin the characterization-corpus
 snapshot, so each row proves snapshot == v1-at-HEAD == v2. Regenerate with:
 `python -m tests.test_litellm.translation.generate_differential_report`
 
-- commit: 4aacbce04a
+- commit: 76bb3a6a77
 
 ## anthropic: request bodies (v1 map_openai_params + transform_request vs v2)
 

--- a/tests/test_litellm/translation/_own_module_corpus.py
+++ b/tests/test_litellm/translation/_own_module_corpus.py
@@ -1,0 +1,182 @@
+"""Shared v1 invokers for the wave-2b own-module differential gates.
+
+Each wave-2b-alpha provider (deepseek, openrouter, hosted_vllm,
+fireworks_ai, snowflake, huggingface) rides a dedicated httpx
+``completion()`` elif into ``base_llm_http_handler``, so the v1 side is the
+xai/compat_httpx invoker shape, parameterized by provider:
+
+- requests: ``get_optional_params(custom_llm_provider=p)`` with
+  completion()'s ``stream=None`` default, then the handler's ``extra_body``
+  pop (hh:399 pops it BEFORE transform and merges its CONTENTS top-level
+  AFTER, hh:448 — callers that need the wire-level merge pin it with the
+  mock-transport helper below), then the LIVE ``transform_request`` of the
+  config production threads (``litellm_params`` passes through for the
+  providers whose transform reads it — huggingface's api_base arm).
+- responses: the config's ``transform_response`` over an ``httpx.Response``
+  with a FRESH ``ModelResponse`` (no model preset on this path — xai R4).
+- streams: SSE ``data:`` lines through the config's
+  ``get_model_response_iterator`` + ``CustomStreamWrapper``.
+
+May RAISE UnsupportedParamsError — that IS the pinned v1 behavior for the
+supported-list gate rows.
+"""
+
+import copy
+import json
+import time
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+import litellm
+from litellm.litellm_core_utils.litellm_logging import Logging
+from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
+from litellm.llms.custom_httpx.http_handler import HTTPHandler
+from litellm.types.utils import LlmProviders, ModelResponse
+from litellm.utils import ProviderConfigManager, get_optional_params
+
+_Case = dict[str, object]
+
+
+def provider_config(provider: str, model: str):
+    return ProviderConfigManager.get_provider_chat_config(
+        model=model, provider=LlmProviders(provider)
+    )
+
+
+def run_v1_request_transform(
+    provider: str, case: _Case, litellm_params: Optional[dict] = None
+) -> dict:
+    request = copy.deepcopy(case)
+    model = request.pop("model")
+    messages = request.pop("messages")
+    optional_params = get_optional_params(
+        model=model,
+        custom_llm_provider=provider,
+        messages=copy.deepcopy(messages),
+        stream=request.pop("stream", None),
+        **request,
+    )
+    optional_params.pop("extra_body", None)
+    config = provider_config(provider, model)
+    return config.transform_request(
+        model=model,
+        messages=messages,
+        optional_params=optional_params,
+        litellm_params=litellm_params or {},
+        headers={},
+    )
+
+
+def make_logging(model: str, messages: List[dict], stream: bool = False) -> Logging:
+    logging_obj = Logging(
+        model=model,
+        messages=messages,
+        stream=stream,
+        call_type="completion",
+        start_time=time.time(),
+        litellm_call_id="diff-own-module-call-id",
+        function_id="diff-own-module-function-id",
+    )
+    logging_obj.update_environment_variables(
+        model=model, user=None, optional_params={}, litellm_params={}
+    )
+    return logging_obj
+
+
+def run_v1_response_transform(
+    provider: str,
+    provider_response: Dict[str, Any],
+    model: str,
+    optional_params: Optional[dict] = None,
+) -> ModelResponse:
+    messages = [{"role": "user", "content": "hi"}]
+    raw_response = httpx.Response(
+        status_code=200,
+        json=copy.deepcopy(provider_response),
+        request=httpx.Request("POST", "https://example.test/v1/chat/completions"),
+    )
+    return provider_config(provider, model).transform_response(
+        model=model,
+        raw_response=raw_response,
+        model_response=ModelResponse(),
+        logging_obj=make_logging(model, messages),
+        request_data={},
+        messages=messages,
+        optional_params=optional_params or {},
+        litellm_params={},
+        encoding=litellm.encoding,
+        api_key=None,
+        json_mode=None,
+    )
+
+
+def replay_v1_sse_lines(
+    provider: str,
+    events: List[dict],
+    stream_model: str,
+    stream_options: Optional[dict] = None,
+) -> List[dict]:
+    lines = [f"data: {json.dumps(event)}" for event in copy.deepcopy(events)]
+    lines.append("data: [DONE]")
+    handler = provider_config(provider, stream_model).get_model_response_iterator(
+        streaming_response=iter(lines), sync_stream=True
+    )
+    wrapper = CustomStreamWrapper(
+        completion_stream=handler,
+        model=stream_model,
+        custom_llm_provider=provider,
+        logging_obj=make_logging(
+            stream_model, [{"role": "user", "content": "stream"}], stream=True
+        ),
+        stream_options=stream_options,
+    )
+    return [chunk.model_dump() for chunk in wrapper]
+
+
+def capture_v1_wire_body(
+    model: str, api_base: Optional[str] = None, **kwargs: object
+) -> dict:
+    """The full v1 stack (completion() -> hh) against a mock transport,
+    returning the EXACT JSON body POSTed to the wire. This is the
+    wire-level truth the transform-seam invoker cannot see (hh merges
+    ``extra_body`` contents top-level AFTER transform_request, hh:448) —
+    the top_k extra_body rows pin against it."""
+    captured: dict = {}
+
+    def transport_handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content.decode())
+        return httpx.Response(
+            200,
+            json={
+                "id": "wire-1",
+                "object": "chat.completion",
+                "created": 1718000000,
+                "model": "m",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "ok"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 1,
+                    "completion_tokens": 1,
+                    "total_tokens": 2,
+                },
+            },
+        )
+
+    client = HTTPHandler(
+        client=httpx.Client(transport=httpx.MockTransport(transport_handler))
+    )
+    litellm.completion(
+        model=model,
+        messages=[{"role": "user", "content": "hi"}],
+        api_key="wire-test-key",
+        api_base=api_base,
+        client=client,
+        **kwargs,
+    )
+    return captured["body"]

--- a/tests/test_litellm/translation/conftest.py
+++ b/tests/test_litellm/translation/conftest.py
@@ -38,6 +38,7 @@ def build_real_deps(
     modify_params: bool = False,
     api_version: Optional[str] = None,
     base_model: Optional[str] = None,
+    api_base: Optional[str] = None,
 ) -> TranslationDeps:
     return TranslationDeps(
         max_tokens_for_model=_max_tokens_for_model,
@@ -51,6 +52,7 @@ def build_real_deps(
         modify_params=modify_params,
         api_version=api_version,
         base_model=base_model,
+        api_base=api_base,
     )
 
 

--- a/tests/test_litellm/translation/generate_differential_report.py
+++ b/tests/test_litellm/translation/generate_differential_report.py
@@ -807,6 +807,50 @@ def _cohere_rows(lines: list) -> int:
         + "non-str content.text — v1 silently swallows the chunk, v2 errors"
         " loudly naming the shape (re-decide if either half stops holding)"
     )
+    for name in sorted(stream._LOUD_CHUNKS):
+        event, fragment = stream._LOUD_CHUNKS[name]
+        result = stream.parse_event(copy.deepcopy(event))
+        ok = result.is_error() and fragment in result.error.summary
+        if ok:
+            try:
+                stream._v1_chunks([copy.deepcopy(event)])
+                ok = False
+            except Exception:
+                pass
+        failures += 0 if ok else 1
+        lines.append(f"- {'FALLBACK (v1 raises)' if ok else 'DIVERGENT'}: {name}")
+    str_tokens_event = {
+        "event": "message-end",
+        "data": {
+            "delta": {
+                "finish_reason": "COMPLETE",
+                "usage": {"tokens": {"input_tokens": "5", "output_tokens": "3"}},
+            }
+        },
+    }
+    result = stream.parse_event(copy.deepcopy(str_tokens_event))
+    served = stream._v1_chunks(
+        [
+            {
+                "type": "content-delta",
+                "delta": {"message": {"content": {"text": "Hi"}}},
+            },
+            copy.deepcopy(str_tokens_event),
+        ],
+        stream_options={"include_usage": True},
+    )
+    ok = (
+        result.is_error()
+        and "v1 SERVES" in result.error.summary
+        and served[-1]["usage"]["total_tokens"] == 8
+    )
+    failures += 0 if ok else 1
+    lines.append(
+        f"- {'FALLBACK (v1 serves)' if ok else 'DIVERGENT'}: str+str"
+        " message-end token counts (v1 concatenates then re-sums in its"
+        " include_usage chunk; deliberately left to v1 — the response-side"
+        " _int_token decision, critic M1)"
+    )
     return failures
 
 

--- a/tests/test_litellm/translation/generate_differential_report.py
+++ b/tests/test_litellm/translation/generate_differential_report.py
@@ -2204,9 +2204,34 @@ def _groq_rows(lines: list) -> int:
         + "non-str refusal forwarded VERBATIM (the wave-2b-beta F6"
         " INTEGRATOR-FLIP handoff, discharged at the sibling merge: the"
         " shared httpx_chunk factory used to null what v1 forwards; the"
-        " refusal-on-finish half is the loud finish-chunk fallback where"
-        " v1 silently drops the value —"
-        " test_refusal_on_finish_chunk_is_loud_where_v1_drops_it)"
+        " refusal-on-finish half is the failure-counted PINNED DIVERGENCE"
+        " row below)"
+    )
+    finish_refusal = [
+        stream._chunk({"role": "assistant", "content": "x"}),
+        stream._chunk({"refusal": 7}, finish="stop"),
+    ]
+    v1 = stream._v1_chunks(finish_refusal)
+    dropped = "refusal" not in v1[-1]["choices"][0]["delta"]
+    loud = stream.parse_event(copy.deepcopy(finish_refusal[-1]))
+    ok = (
+        dropped
+        and loud.is_error()
+        and "finish chunk with a non-empty delta" in loud.error.summary
+    )
+    failures += 0 if ok else 1
+    lines.append(
+        (
+            "- PINNED DIVERGENCE (fail-closed where v1 serves the lossy finish): "
+            if ok
+            else "- DIVERGENT: "
+        )
+        + "refusal-on-finish: groq's v1 wrapper silently DROPS a refusal"
+        " value riding the finish chunk and serves the lossy finish; v2"
+        " takes the loud finish-chunk fallback for any value type"
+        " (test_refusal_on_finish_chunk_is_loud_where_v1_drops_it;"
+        " critic-wave2b-final MAJOR-2 made the gate-pinned divergence a"
+        " failure-counted report row)"
     )
     return failures
 

--- a/tests/test_litellm/translation/generate_differential_report.py
+++ b/tests/test_litellm/translation/generate_differential_report.py
@@ -1173,6 +1173,160 @@ def _sagemaker_chat_rows(lines: list) -> int:
     return failures
 
 
+def _groq_rows(lines: list) -> int:
+    """wave-2b-beta: groq (httpx path; bare wire model + service_tier
+    clamp; the json_schema fork rows)."""
+    import pytest
+
+    from . import test_differential_groq_request as req
+    from . import test_differential_groq_response as resp
+    from . import test_differential_groq_stream as stream
+
+    failures = 0
+    lines += [
+        "",
+        "## groq (wave-2b-beta): requests (v1 get_optional_params +"
+        " GroqChatConfig.transform_request + hh's extra_body merge vs v2"
+        " providers/groq; the json_schema three-way fork)",
+        "",
+    ]
+    for name in sorted(req.CASES):
+        case = req.CASES[name]
+        result = req._v2(case)
+        same = result.is_ok() and req._norm(result.ok) == req._norm(
+            req.run_v1_request_transform(case)
+        )
+        failures += 0 if same else 1
+        lines.append(f"- {'IDENTICAL' if same else 'DIVERGENT'}: {name}")
+    for name in sorted(req.V1_RAISES):
+        case, fragment = req.V1_RAISES[name]
+        result = req._v2(case)
+        ok = result.is_error() and fragment in result.error.summary
+        if ok:
+            try:
+                req.run_v1_request_transform(case)
+                ok = False
+            except Exception:
+                pass
+        failures += 0 if ok else 1
+        lines.append(
+            f"- {'FALLBACK (v1 raises UnsupportedParamsError)' if ok else 'DIVERGENT'}:"
+            f" {name}"
+        )
+    schema_tools_case = {
+        "model": req.MODEL,
+        "messages": req._U,
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "s",
+                "schema": {"type": "object", "properties": {}},
+                "strict": True,
+            },
+        },
+        "tools": [{"type": "function", "function": {"name": "f", "parameters": {}}}],
+    }
+    bad_request = req._v2(schema_tools_case)
+    ok = bad_request.is_error() and "BadRequestError" in bad_request.error.summary
+    if ok:
+        try:
+            req.run_v1_request_transform(schema_tools_case)
+            ok = False
+        except Exception:
+            pass
+    failures += 0 if ok else 1
+    lines.append(
+        f"- {'FALLBACK (v1 raises BadRequestError)' if ok else 'DIVERGENT'}:"
+        " response_format json_schema + tools on a non-native model"
+    )
+    for name in sorted(req.V1_SERVES_FALLBACKS):
+        case, fragment = req.V1_SERVES_FALLBACKS[name]
+        result = req._v2(case)
+        ok = result.is_error() and fragment in result.error.summary
+        failures += 0 if ok else 1
+        lines.append(f"- {'FALLBACK (v1 serves)' if ok else 'DIVERGENT'}: {name}")
+    lines += [
+        "",
+        "## groq: responses (v1 OpenAILike direct construction + the"
+        " service_tier clamp vs v2 groq parser + the seam's openai_like"
+        " arm; bare wire model)",
+        "",
+    ]
+    for name in sorted(resp._RESPONSES):
+        raw = resp._RESPONSES[name]
+        v1 = resp._v1_model_response(raw)
+        v2 = resp._v2_model_response(raw)
+        same = resp._norm(v2) == resp._norm(v1) and v2["model"] == resp.MODEL
+        failures += 0 if same else 1
+        lines.append(f"- {'IDENTICAL' if same else 'DIVERGENT'}: {name}")
+    missing_tier = {
+        **{k: v for k, v in resp._BASE.items() if k != "service_tier"},
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "x"},
+                "finish_reason": "stop",
+            }
+        ],
+    }
+    tier_result = resp._v2_parse(missing_tier)
+    ok = tier_result.is_error() and "service_tier" in tier_result.error.summary
+    if ok:
+        with pytest.raises(AttributeError):
+            resp._v1_model_response(missing_tier)
+    failures += 0 if ok else 1
+    lines.append(
+        f"- {'FALLBACK (v1 raises AttributeError)' if ok else 'DIVERGENT'}:"
+        " response without service_tier (v1's clamp post-step crashes)"
+    )
+    f2 = resp._v2_parse({**resp._RESPONSES["text_tier_clamped_to_auto"], "model": 7})
+    ok = f2.is_error() and "non-string wire model" in f2.error.summary
+    failures += 0 if ok else 1
+    lines.append(
+        f"- {'FALLBACK (v1 raises ValidationError)' if ok else 'DIVERGENT'}:"
+        " non-string wire model"
+    )
+    lines += [
+        "",
+        "## groq: streams (v1 SSE line replay through"
+        " GroqChatCompletionStreamingHandler + CustomStreamWrapper('groq')"
+        " vs v2 httpx_chunk factory (rename) + the xai chunk dialect)",
+        "",
+    ]
+    for name in sorted(stream.STREAMS):
+        events = stream.STREAMS[name]
+        same = stream._norm(stream._v2_chunks(events)) == stream._norm(
+            stream._v1_chunks(events)
+        )
+        failures += 0 if same else 1
+        lines.append(f"- {'IDENTICAL' if same else 'DIVERGENT'}: {name}")
+    v1 = stream._v1_chunks(stream.USAGE_STREAM, stream_options={"include_usage": True})
+    v2 = stream._v2_chunks(stream.USAGE_STREAM)
+    tail_ok = (
+        len(v1) == len(v2)
+        and stream._norm(v2[:-1]) == stream._norm(v1[: len(v2) - 1])
+        and v2[-1]["choices"] == []
+        and all(
+            v1[-1]["usage"][k] == v2[-1]["usage"][k]
+            for k in ("prompt_tokens", "completion_tokens", "total_tokens")
+        )
+    )
+    failures += 0 if tail_ok else 1
+    lines.append(
+        ("- SEAM CONTRACT: " if tail_ok else "- DIVERGENT: ")
+        + "usage tail (v2 passes the wire choices=[] usage chunk through;"
+        " the streaming seam owns v1's synthesized final chunk)"
+    )
+    err = {"error": {"message": "boom", "code": 500}}
+    loud = stream.parse_event(dict(err)).is_error()
+    failures += 0 if loud else 1
+    lines.append(
+        f"- {'FALLBACK (v1 raises MidStreamFallbackError)' if loud else 'DIVERGENT'}:"
+        " error chunk (loud on both sides — the truthy-value check)"
+    )
+    return failures
+
+
 def _azure_rows(lines: list) -> int:
     import os
 
@@ -1665,6 +1819,7 @@ def main() -> None:
     failures += _mistral_rows(lines)
     failures += _watsonx_rows(lines)
     failures += _sagemaker_chat_rows(lines)
+    failures += _groq_rows(lines)
     failures += _azure_rows(lines)
     failures += _azure_ai_rows(lines)
     failures += _bedrock_request_rows(lines)

--- a/tests/test_litellm/translation/generate_differential_report.py
+++ b/tests/test_litellm/translation/generate_differential_report.py
@@ -2166,21 +2166,18 @@ def _groq_rows(lines: list) -> int:
     ]
     v1 = stream._v1_chunks(refusal_events)
     v2 = stream._v2_chunks(refusal_events)
-    handoff = (
+    discharged = stream._norm(v2) == stream._norm(v1) and (
         v1[0]["choices"][0]["delta"]["refusal"] == 7
-        and v2[0]["choices"][0]["delta"]["refusal"] is None
     )
-    failures += 0 if handoff else 1
+    failures += 0 if discharged else 1
     lines.append(
-        (
-            "- INTEGRATOR-FLIP HANDOFF (current behavior guarded): "
-            if handoff
-            else "- DIVERGENT: "
-        )
-        + "non-str refusal — v1 forwards 7, the SHARED httpx_chunk factory"
-        " nulls it; the fix belongs to the alpha fix round's concurrent"
-        " httpx_chunk edit (verifier-wave2b-alpha F1) — the sibling-merge"
-        " integrator flips this row and the gate test to v1 parity"
+        ("- IDENTICAL: " if discharged else "- DIVERGENT: ")
+        + "non-str refusal forwarded VERBATIM (the wave-2b-beta F6"
+        " INTEGRATOR-FLIP handoff, discharged at the sibling merge: the"
+        " shared httpx_chunk factory used to null what v1 forwards; the"
+        " refusal-on-finish half is the loud finish-chunk fallback where"
+        " v1 silently drops the value —"
+        " test_refusal_on_finish_chunk_is_loud_where_v1_drops_it)"
     )
     return failures
 

--- a/tests/test_litellm/translation/generate_differential_report.py
+++ b/tests/test_litellm/translation/generate_differential_report.py
@@ -1078,6 +1078,39 @@ def _watsonx_rows(lines: list) -> int:
             )
             + f"{name} — v1's iterator silently swallows it, v2 errors loudly"
         )
+    for name in sorted(stream._V1_RAISES_LOUD):
+        events, fragment = stream._V1_RAISES_LOUD[name]
+        result = stream.parse_event(copy.deepcopy(events[0]))
+        ok = result.is_error() and fragment in result.error.summary
+        if ok:
+            try:
+                stream._v1_chunks(events)
+                ok = False
+            except Exception:
+                pass
+        failures += 0 if ok else 1
+        lines.append(
+            f"- {'FALLBACK (v1 raises MidStreamFallbackError)' if ok else 'DIVERGENT'}:"
+            f" {name}"
+        )
+    for falsy, label in (("", "empty-string"), ({}, "empty-object")):
+        events = [
+            stream._chunk({"role": "assistant", "content": "Hi"}),
+            stream._chunk({}, finish=falsy),
+        ]
+        v1 = stream._v1_chunks(events)
+        v2 = stream._v2_chunks(events)
+        ok = (
+            len(v1) == len(v2) + 1
+            and stream._norm(v2) == stream._norm(v1[:-1])
+            and v1[-1]["choices"][0]["finish_reason"] == "stop"
+        )
+        failures += 0 if ok else 1
+        lines.append(
+            ("- SEAM CONTRACT: " if ok else "- DIVERGENT: ")
+            + f"falsy ({label}) finish_reason — no finish rides (v1's truthy"
+            " gate); v2 == v1 minus the wrapper's synthesized stop tail"
+        )
     return failures
 
 

--- a/tests/test_litellm/translation/generate_differential_report.py
+++ b/tests/test_litellm/translation/generate_differential_report.py
@@ -1069,6 +1069,110 @@ def _watsonx_rows(lines: list) -> int:
     return failures
 
 
+def _sagemaker_chat_rows(lines: list) -> int:
+    """wave-2b-beta: sagemaker_chat (base GPT config over SigV4 transport;
+    sagemaker_nova deliberately unregistered)."""
+    import pytest
+
+    from . import test_differential_sagemaker_chat_request as req
+    from . import test_differential_sagemaker_chat_response as resp
+    from . import test_differential_sagemaker_chat_stream as stream
+
+    failures = 0
+    lines += [
+        "",
+        "## sagemaker_chat (wave-2b-beta): requests (v1 get_optional_params"
+        " + the base GPT transform_request vs v2 providers/sagemaker_chat;"
+        " SigV4 signs after assembly — envelope)",
+        "",
+    ]
+    for name in sorted(req.CASES):
+        case = req.CASES[name]
+        result = req._v2(case)
+        same = result.is_ok() and req._norm(result.ok) == req._norm(
+            req.run_v1_request_transform(case)
+        )
+        failures += 0 if same else 1
+        lines.append(f"- {'IDENTICAL' if same else 'DIVERGENT'}: {name}")
+    for name in sorted(req.V1_RAISES):
+        case, fragment = req.V1_RAISES[name]
+        result = req._v2(case)
+        ok = result.is_error() and fragment in result.error.summary
+        if ok:
+            try:
+                req.run_v1_request_transform(case)
+                ok = False
+            except Exception:
+                pass
+        failures += 0 if ok else 1
+        lines.append(
+            f"- {'FALLBACK (v1 raises UnsupportedParamsError)' if ok else 'DIVERGENT'}:"
+            f" {name}"
+        )
+    for name in sorted(req.V1_SERVES_FALLBACKS):
+        case, fragment = req.V1_SERVES_FALLBACKS[name]
+        result = req._v2(case)
+        ok = result.is_error() and fragment in result.error.summary
+        failures += 0 if ok else 1
+        lines.append(f"- {'FALLBACK (v1 serves)' if ok else 'DIVERGENT'}: {name}")
+    lines += [
+        "",
+        "## sagemaker_chat: responses (v1 base transform_response/cdr vs the"
+        " shared openai parser; bare wire model, no seam preset)",
+        "",
+    ]
+    for name in sorted(resp._RESPONSES):
+        raw = resp._RESPONSES[name]
+        v1 = resp._v1_model_response(raw)
+        v2 = resp._v2_model_response(raw)
+        same = resp._norm(v2) == resp._norm(v1) and v2["model"] == resp.WIRE_MODEL
+        failures += 0 if same else 1
+        lines.append(f"- {'IDENTICAL' if same else 'DIVERGENT'}: {name}")
+    lines += [
+        "",
+        "## sagemaker_chat: streams (v1 AWS event-stream PARSED-event replay"
+        " through AWSEventStreamDecoder(is_messages_api) +"
+        " CustomStreamWrapper('sagemaker_chat') vs v2 openai parser + the"
+        " litellm-validation post-step, 'openai' dialect)",
+        "",
+    ]
+    for name in sorted(stream.STREAMS):
+        events = stream.STREAMS[name]
+        same = stream._norm(stream._v2_chunks(events)) == stream._norm(
+            stream._v1_chunks(events)
+        )
+        failures += 0 if same else 1
+        lines.append(f"- {'IDENTICAL' if same else 'DIVERGENT'}: {name}")
+    v1 = stream._v1_chunks(stream.USAGE_STREAM, stream_options={"include_usage": True})
+    v2 = stream._v2_chunks(stream.USAGE_STREAM)
+    tail_ok = (
+        len(v1) == len(v2)
+        and stream._norm(v2[:-1]) == stream._norm(v1[: len(v2) - 1])
+        and v2[-1]["choices"] == []
+        and all(
+            v1[-1]["usage"][k] == v2[-1]["usage"][k]
+            for k in ("prompt_tokens", "completion_tokens", "total_tokens")
+        )
+    )
+    failures += 0 if tail_ok else 1
+    lines.append(
+        ("- SEAM CONTRACT: " if tail_ok else "- DIVERGENT: ")
+        + "usage tail (v2 passes the wire choices=[] usage chunk through;"
+        " the streaming seam owns v1's synthesized final chunk)"
+    )
+    bad = stream._chunk({"content": 5})
+    loud = stream.parse_event(dict(bad)).is_error()
+    if loud:
+        with pytest.raises(Exception):
+            stream._v1_chunks([bad])
+    failures += 0 if loud else 1
+    lines.append(
+        f"- {'FALLBACK (v1 raises ValidationError)' if loud else 'DIVERGENT'}:"
+        " non-string delta content (loud on both sides)"
+    )
+    return failures
+
+
 def _azure_rows(lines: list) -> int:
     import os
 
@@ -1560,6 +1664,7 @@ def main() -> None:
     failures += _cohere_rows(lines)
     failures += _mistral_rows(lines)
     failures += _watsonx_rows(lines)
+    failures += _sagemaker_chat_rows(lines)
     failures += _azure_rows(lines)
     failures += _azure_ai_rows(lines)
     failures += _bedrock_request_rows(lines)

--- a/tests/test_litellm/translation/generate_differential_report.py
+++ b/tests/test_litellm/translation/generate_differential_report.py
@@ -621,11 +621,16 @@ def _wave2b_alpha_error_chunk_pins() -> bool:
 
     from . import test_differential_snowflake_stream as _sf_stream
 
+    from litellm.translation.providers import huggingface as _huggingface_pkg
+
+    from . import test_differential_huggingface_stream as _hf_stream
+
     consumers = (
         (_ds_stream, _deepseek_pkg.parse_line),
         (_hv_stream, _hosted_vllm_pkg.parse_line),
         (_fw_stream, _fireworks_pkg.parse_line),
         (_sf_stream, _snowflake_pkg.parse_line),
+        (_hf_stream, _huggingface_pkg.parse_line),
     )
     for mod, line_parser in consumers:
         v1 = mod._v1_chunks(mod._ERROR_CHUNK_STREAM)
@@ -1172,6 +1177,99 @@ def _snowflake_rows(lines: list) -> int:
     return failures
 
 
+def _huggingface_rows(lines: list) -> int:
+    from . import _own_module_corpus as own
+    from . import test_differential_huggingface_request as req
+    from . import test_differential_huggingface_response as resp
+    from . import test_differential_huggingface_stream as stream
+
+    failures = 0
+    lines += [
+        "",
+        "## huggingface: request bodies — the api_base (dedicated endpoint)"
+        " route ONLY (v1 get_optional_params('huggingface') + the LIVE httpx"
+        " transform_request's VERBATIM ChatCompletionRequest arm vs v2"
+        " providers/huggingface; the router route is a typed fallback whole)",
+        "",
+    ]
+    for name in sorted(req.CASES):
+        case = req.CASES[name]
+        result = req._v2(case)
+        same = result.is_ok() and req._norm(result.ok) == req._norm(req._v1(case))
+        failures += 0 if same else 1
+        lines.append(f"- {'IDENTICAL' if same else 'DIVERGENT'}: {name}")
+    for name in sorted(req.EXPECTED_FALLBACKS):
+        case, reason = req.EXPECTED_FALLBACKS[name]
+        result = req._v2(case)
+        ok = result.is_error() and reason in result.error.summary
+        failures += 0 if ok else 1
+        label = "FALLBACK (v1 serves it)" if ok else "DIVERGENT"
+        lines.append(f"- {label}: {name} ({reason})")
+    router = req._v2(req.CASES["text"], api_base=None)
+    router_ok = (
+        router.is_error() and req._ROUTER_FALLBACK_REASON in router.error.summary
+    )
+    failures += 0 if router_ok else 1
+    label = "FALLBACK (v1 serves it)" if router_ok else "DIVERGENT"
+    lines.append(
+        f"- {label}: router_route_whole (no api_base: v1 synthesizes router"
+        ".huggingface.co URLs; 3-segment names fetch the HF provider mapping"
+        " over HTTP inside the transform — the in-transform I/O the port"
+        " refuses; 1-segment names CRASH v1)"
+    )
+    lines += [
+        "",
+        "## huggingface: responses (v1 base GPT transform_response over httpx"
+        " — LIVE on the dedicated elif — vs v2 shared openai parser with NO"
+        " model preset; bare wire model, the xai R4 pin)",
+        "",
+    ]
+    for name in sorted(resp._RESPONSES):
+        raw = resp._RESPONSES[name]
+        v1 = resp._v1_model_response(raw)
+        v2 = resp._v2_model_response(raw)
+        same = (
+            resp._norm(v2) == resp._norm(v1)
+            and v2["model"] == raw["model"]
+            and not str(v2["model"]).startswith("huggingface/")
+        )
+        failures += 0 if same else 1
+        lines.append(f"- {'IDENTICAL' if same else 'DIVERGENT'}: {name} (no prefix)")
+    lines += [
+        "",
+        "## huggingface: streams (v1 base OpenAIChatCompletionStreamingHandler"
+        " + CustomStreamWrapper('huggingface') over SSE lines vs v2"
+        " huggingface parser — the httpx_chunk family policy — with the xai"
+        " chunk dialect)",
+        "",
+    ]
+    for name in sorted(stream.STREAMS):
+        events = stream.STREAMS[name]
+        same = stream._norm(stream._v2_chunks(events)) == stream._norm(
+            stream._v1_chunks(events)
+        )
+        failures += 0 if same else 1
+        lines.append(f"- {'IDENTICAL' if same else 'DIVERGENT'}: {name}")
+    v1 = stream._v1_chunks(stream.USAGE_STREAM, stream_options={"include_usage": True})
+    v2 = stream._v2_chunks(stream.USAGE_STREAM)
+    tail_ok = (
+        len(v1) == len(v2)
+        and stream._norm(v2[:-1]) == stream._norm(v1[: len(v2) - 1])
+        and v2[-1]["choices"] == []
+        and all(
+            v1[-1]["usage"][k] == v2[-1]["usage"][k]
+            for k in ("prompt_tokens", "completion_tokens", "total_tokens")
+        )
+    )
+    failures += 0 if tail_ok else 1
+    lines.append(
+        ("- SEAM CONTRACT: " if tail_ok else "- DIVERGENT: ")
+        + "usage tail (v2 passes the wire choices=[] usage chunk through;"
+        " the streaming seam owns v1's synthesized final chunk)"
+    )
+    return failures
+
+
 def _wave2b_alpha_rows(lines: list) -> int:
     """wave-2b-alpha own-module providers, researcher-4 ascending-risk
     order. APPEND-ONLY: each provider's row function lands in its own
@@ -1182,6 +1280,7 @@ def _wave2b_alpha_rows(lines: list) -> int:
         + _hosted_vllm_rows(lines)
         + _fireworks_ai_rows(lines)
         + _snowflake_rows(lines)
+        + _huggingface_rows(lines)
     )
 
 

--- a/tests/test_litellm/translation/generate_differential_report.py
+++ b/tests/test_litellm/translation/generate_differential_report.py
@@ -573,6 +573,9 @@ def _compat_httpx_rows(lines: list) -> int:
         "error" not in _json.dumps(v1_swallow)
         and v2_loud.is_error()
         and "provider stream error" in v2_loud.error.summary
+        # wave-2b-alpha: the own-module base-handler consumers share this
+        # exact divergence — ONE named row covers them all, failure-counted
+        and _wave2b_alpha_error_chunk_pins()
     )
     failures += 0 if divergence_pinned else 1
     lines.append(
@@ -583,13 +586,129 @@ def _compat_httpx_rows(lines: list) -> int:
         )
         + "mid-stream {'error': ...} chunks — v1's BASE handler silently"
         " swallows them (no error surface in the emitted sequence; asserted"
-        " in-process for all nine base-handler members), v2's family parser"
+        " in-process for all nine base-handler members AND the wave-2b-alpha"
+        " own-module base-handler consumers, per their dedicated stream"
+        " gates), v2's family parser"
         " surfaces a LOUD typed boundary error naming the chunk"
         " (test_error_chunk_divergence_two_sided; cometapi differs: its v1"
         " handler RAISES and its policy row mirrors the raise — see the"
         " cometapi stream rows below)"
     )
     return failures
+
+
+def _wave2b_alpha_error_chunk_pins() -> bool:
+    """wave-2b-alpha base-handler consumers' halves of the family's ONE
+    pinned divergence (each provider's stream gate pins it two-sided; this
+    keeps the report row failure-counted for them without a second PINNED
+    DIVERGENCE row). APPEND-ONLY: each base-handler provider adds its
+    (module, parser) pair in its own commit."""
+    import json as _json
+
+    from litellm.translation.engine.stream import fold_lines
+    from litellm.translation.inbound.openai_chat.stream import initial_state
+    from litellm.translation.providers import deepseek as _deepseek_pkg
+
+    from . import test_differential_deepseek_stream as _ds_stream
+
+    consumers = ((_ds_stream, _deepseek_pkg.parse_line),)
+    for mod, line_parser in consumers:
+        v1 = mod._v1_chunks(mod._ERROR_CHUNK_STREAM)
+        if "error" in _json.dumps(v1):
+            return False
+        lines = [f"data: {_json.dumps(e)}" for e in mod._ERROR_CHUNK_STREAM]
+        folded = fold_lines(lines, line_parser, initial_state(mod.MODEL, dialect="xai"))
+        if not (folded.is_error() and "provider stream error" in folded.error.summary):
+            return False
+    return True
+
+
+def _deepseek_rows(lines: list) -> int:
+    from . import _own_module_corpus as own
+    from . import test_differential_deepseek_request as req
+    from . import test_differential_deepseek_response as resp
+    from . import test_differential_deepseek_stream as stream
+
+    failures = 0
+    lines += [
+        "",
+        "## deepseek: request bodies (v1 get_optional_params('deepseek') + the"
+        " LIVE httpx transform_request — dedicated elif main.py:1942 — vs v2"
+        " providers/deepseek)",
+        "",
+    ]
+    for name in sorted(req.CASES):
+        case = req.CASES[name]
+        result = req._v2(case)
+        same = result.is_ok() and req._norm(result.ok) == req._norm(
+            own.run_v1_request_transform("deepseek", case)
+        )
+        failures += 0 if same else 1
+        lines.append(f"- {'IDENTICAL' if same else 'DIVERGENT'}: {name}")
+    for name in sorted(req.EXPECTED_FALLBACKS):
+        case, reason = req.EXPECTED_FALLBACKS[name]
+        result = req._v2(case)
+        ok = result.is_error() and reason in result.error.summary
+        failures += 0 if ok else 1
+        label = "FALLBACK (v1 serves it)" if ok else "DIVERGENT"
+        lines.append(f"- {label}: {name} ({reason})")
+    lines += [
+        "",
+        "## deepseek: responses (v1 base GPT transform_response over httpx —"
+        " LIVE on the dedicated elif — vs v2 shared openai parser with NO"
+        " model preset; bare wire model, the xai R4 pin)",
+        "",
+    ]
+    for name in sorted(resp._RESPONSES):
+        raw = resp._RESPONSES[name]
+        v1 = resp._v1_model_response(raw)
+        v2 = resp._v2_model_response(raw)
+        same = (
+            resp._norm(v2) == resp._norm(v1)
+            and v2["model"] == raw["model"]
+            and not str(v2["model"]).startswith("deepseek/")
+        )
+        failures += 0 if same else 1
+        lines.append(f"- {'IDENTICAL' if same else 'DIVERGENT'}: {name} (no prefix)")
+    lines += [
+        "",
+        "## deepseek: streams (v1 base OpenAIChatCompletionStreamingHandler +"
+        " CustomStreamWrapper('deepseek') over SSE lines vs v2 deepseek parser"
+        " — the httpx_chunk family policy — with the xai chunk dialect)",
+        "",
+    ]
+    for name in sorted(stream.STREAMS):
+        events = stream.STREAMS[name]
+        same = stream._norm(stream._v2_chunks(events)) == stream._norm(
+            stream._v1_chunks(events)
+        )
+        failures += 0 if same else 1
+        lines.append(f"- {'IDENTICAL' if same else 'DIVERGENT'}: {name}")
+    v1 = stream._v1_chunks(stream.USAGE_STREAM, stream_options={"include_usage": True})
+    v2 = stream._v2_chunks(stream.USAGE_STREAM)
+    tail_ok = (
+        len(v1) == len(v2)
+        and stream._norm(v2[:-1]) == stream._norm(v1[: len(v2) - 1])
+        and v2[-1]["choices"] == []
+        and all(
+            v1[-1]["usage"][k] == v2[-1]["usage"][k]
+            for k in ("prompt_tokens", "completion_tokens", "total_tokens")
+        )
+    )
+    failures += 0 if tail_ok else 1
+    lines.append(
+        ("- SEAM CONTRACT: " if tail_ok else "- DIVERGENT: ")
+        + "usage tail (v2 passes the wire choices=[] usage chunk through;"
+        " the streaming seam owns v1's synthesized final chunk)"
+    )
+    return failures
+
+
+def _wave2b_alpha_rows(lines: list) -> int:
+    """wave-2b-alpha own-module providers, researcher-4 ascending-risk
+    order. APPEND-ONLY: each provider's row function lands in its own
+    commit; the beta sibling appends its own section function."""
+    return _deepseek_rows(lines)
 
 
 def _cometapi_rows(lines: list) -> int:
@@ -1120,7 +1239,7 @@ def main() -> None:
     _stub_vertex_token()
 
     lines = [
-        "# Translation v2 differential report (anthropic + bedrock + openai + google + azure + xai + the compat_sdk family (waves 1a+1b+2a) + the wave-1b compat_httpx family)",
+        "# Translation v2 differential report (anthropic + bedrock + openai + google + azure + xai + the compat_sdk family (waves 1a+1b+2a) + the wave-1b compat_httpx family + the wave-2b-alpha own modules)",
         "",
         "v1 and v2 run over the same corpus; every row must be IDENTICAL (or an",
         "explained FALLBACK that v1 serves) for a provider's flag to turn on.",
@@ -1137,6 +1256,7 @@ def main() -> None:
     failures += _compat_sdk_rows(lines)
     failures += _compat_httpx_rows(lines)
     failures += _cometapi_rows(lines)
+    failures += _wave2b_alpha_rows(lines)
     failures += _azure_rows(lines)
     failures += _azure_ai_rows(lines)
     failures += _bedrock_request_rows(lines)

--- a/tests/test_litellm/translation/generate_differential_report.py
+++ b/tests/test_litellm/translation/generate_differential_report.py
@@ -617,10 +617,15 @@ def _wave2b_alpha_error_chunk_pins() -> bool:
 
     from . import test_differential_fireworks_ai_stream as _fw_stream
 
+    from litellm.translation.providers import snowflake as _snowflake_pkg
+
+    from . import test_differential_snowflake_stream as _sf_stream
+
     consumers = (
         (_ds_stream, _deepseek_pkg.parse_line),
         (_hv_stream, _hosted_vllm_pkg.parse_line),
         (_fw_stream, _fireworks_pkg.parse_line),
+        (_sf_stream, _snowflake_pkg.parse_line),
     )
     for mod, line_parser in consumers:
         v1 = mod._v1_chunks(mod._ERROR_CHUNK_STREAM)
@@ -1042,6 +1047,131 @@ def _fireworks_ai_rows(lines: list) -> int:
     return failures
 
 
+def _snowflake_rows(lines: list) -> int:
+    import pydantic
+
+    from litellm.exceptions import UnsupportedParamsError
+
+    from . import _own_module_corpus as own
+    from . import test_differential_snowflake_request as req
+    from . import test_differential_snowflake_response as resp
+    from . import test_differential_snowflake_stream as stream
+
+    failures = 0
+    lines += [
+        "",
+        "## snowflake: request bodies (v1 get_optional_params('snowflake') +"
+        " the LIVE httpx transform_request — dedicated elif main.py:4286,"
+        " incl. the tool_spec/tool_choice wire mapping, the ALWAYS-on stream"
+        " key and the verbatim messages — vs v2 providers/snowflake)",
+        "",
+    ]
+    for name in sorted(req.CASES):
+        case = req.CASES[name]
+        result = req._v2(case)
+        same = result.is_ok() and req._norm(result.ok) == req._norm(
+            own.run_v1_request_transform("snowflake", case)
+        )
+        failures += 0 if same else 1
+        lines.append(f"- {'IDENTICAL' if same else 'DIVERGENT'}: {name}")
+    for name in sorted(req.V1_RAISES):
+        case, reason = req.V1_RAISES[name]
+        result = req._v2(case)
+        try:
+            own.run_v1_request_transform("snowflake", case)
+            raised = False
+        except UnsupportedParamsError:
+            raised = True
+        ok = result.is_error() and reason in result.error.summary and raised
+        failures += 0 if ok else 1
+        label = "FALLBACK (v1 raises UnsupportedParamsError)" if ok else "DIVERGENT"
+        lines.append(f"- {label}: {name} ({reason})")
+    for name in sorted(req.EXPECTED_FALLBACKS):
+        case, reason = req.EXPECTED_FALLBACKS[name]
+        result = req._v2(case)
+        ok = result.is_error() and reason in result.error.summary
+        failures += 0 if ok else 1
+        label = "FALLBACK (v1 serves it)" if ok else "DIVERGENT"
+        lines.append(f"- {label}: {name} ({reason})")
+    lines += [
+        "",
+        "## snowflake: responses (v1's OWN transform_response — the"
+        " content_list rewrite + OpenAILike DIRECT construction + the"
+        " snowflake/{wire model} prefix — vs v2 pre-rewrite + direct parser"
+        " with the openai_like seam arm)",
+        "",
+    ]
+    for name in sorted(resp._RESPONSES):
+        raw = resp._RESPONSES[name]
+        v1 = resp._v1_model_response(raw)
+        v2 = resp._v2_model_response(raw)
+        same = resp._norm(v2) == resp._norm(v1) and v2["model"] == (
+            f"snowflake/{resp.WIRE_MODEL}"
+        )
+        failures += 0 if same else 1
+        lines.append(f"- {'IDENTICAL' if same else 'DIVERGENT'}: {name} (prefixed)")
+    from litellm.translation.inbound.openai_chat import parse_request as _parse_req
+    from litellm.translation.providers.snowflake import parse_response as _sf_parse
+
+    parsed = _parse_req(dict(resp._REQUEST))
+    try:
+        resp._v1_model_response(resp._NON_STRING_MODEL_BODY)
+        raised = False
+    except pydantic.ValidationError:
+        raised = True
+    ns_result = _sf_parse(dict(resp._NON_STRING_MODEL_BODY), parsed.ok)
+    ns_ok = (
+        raised
+        and ns_result.is_error()
+        and "non-string wire model" in ns_result.error.summary
+    )
+    failures += 0 if ns_ok else 1
+    label = "FALLBACK (v1 raises ValidationError)" if ns_ok else "DIVERGENT"
+    lines.append(f"- {label}: non_string_wire_model")
+    v1_hidden = resp._v1_full(resp._RESPONSES["plain_content"])
+    hidden_ok = v1_hidden._hidden_params.get("model") == resp.REQUEST_MODEL
+    failures += 0 if hidden_ok else 1
+    lines.append(
+        ("- SEAM CONTRACT: " if hidden_ok else "- DIVERGENT: ")
+        + "request model in _hidden_params['model'] (v1's cost-calculator"
+        " feed; dump-invisible — the future completion() fork must set it,"
+        " CLAUDE.md HARD OBLIGATION)"
+    )
+    lines += [
+        "",
+        "## snowflake: streams (v1 base OpenAIChatCompletionStreamingHandler"
+        " + CustomStreamWrapper('snowflake') over Cortex SSE lines vs v2"
+        " snowflake parser — the httpx_chunk family policy — with the xai"
+        " chunk dialect; real Cortex delta shapes are UNPINNED upstream)",
+        "",
+    ]
+    for name in sorted(stream.STREAMS):
+        events = stream.STREAMS[name]
+        same = stream._norm(stream._v2_chunks(events)) == stream._norm(
+            stream._v1_chunks(events)
+        )
+        failures += 0 if same else 1
+        lines.append(f"- {'IDENTICAL' if same else 'DIVERGENT'}: {name}")
+    v1 = stream._v1_chunks(stream.USAGE_STREAM, stream_options={"include_usage": True})
+    v2 = stream._v2_chunks(stream.USAGE_STREAM)
+    tail_ok = (
+        len(v1) == len(v2)
+        and stream._norm(v2[:-1]) == stream._norm(v1[: len(v2) - 1])
+        and v2[-1]["choices"] == []
+        and all(
+            v1[-1]["usage"][k] == v2[-1]["usage"][k]
+            for k in ("prompt_tokens", "completion_tokens", "total_tokens")
+        )
+    )
+    failures += 0 if tail_ok else 1
+    lines.append(
+        ("- SEAM CONTRACT: " if tail_ok else "- DIVERGENT: ")
+        + "usage tail (v2 passes the wire choices=[] usage chunk through;"
+        " the streaming seam owns v1's synthesized final chunk)"
+    )
+    return failures
+
+
 def _wave2b_alpha_rows(lines: list) -> int:
     """wave-2b-alpha own-module providers, researcher-4 ascending-risk
     order. APPEND-ONLY: each provider's row function lands in its own
@@ -1051,6 +1181,7 @@ def _wave2b_alpha_rows(lines: list) -> int:
         + _openrouter_rows(lines)
         + _hosted_vllm_rows(lines)
         + _fireworks_ai_rows(lines)
+        + _snowflake_rows(lines)
     )
 
 

--- a/tests/test_litellm/translation/generate_differential_report.py
+++ b/tests/test_litellm/translation/generate_differential_report.py
@@ -704,11 +704,124 @@ def _deepseek_rows(lines: list) -> int:
     return failures
 
 
+def _openrouter_rows(lines: list) -> int:
+    from litellm.exceptions import UnsupportedParamsError
+
+    from . import _own_module_corpus as own
+    from . import test_differential_openrouter_request as req
+    from . import test_differential_openrouter_response as resp
+    from . import test_differential_openrouter_stream as stream
+
+    failures = 0
+    lines += [
+        "",
+        "## openrouter: request bodies (v1 get_optional_params('openrouter')"
+        " + the LIVE httpx transform_request — dedicated elif main.py:3354,"
+        " incl. the always-injected usage:{include:true} — vs v2"
+        " providers/openrouter)",
+        "",
+    ]
+    for name in sorted(req.CASES):
+        case = req.CASES[name]
+        result = req._v2(case)
+        same = result.is_ok() and req._norm(result.ok) == req._norm(
+            own.run_v1_request_transform("openrouter", case)
+        )
+        failures += 0 if same else 1
+        lines.append(f"- {'IDENTICAL' if same else 'DIVERGENT'}: {name}")
+    for name in sorted(req.V1_RAISES):
+        case, reason = req.V1_RAISES[name]
+        result = req._v2(case)
+        try:
+            own.run_v1_request_transform("openrouter", case)
+            raised = False
+        except UnsupportedParamsError:
+            raised = True
+        ok = result.is_error() and reason in result.error.summary and raised
+        failures += 0 if ok else 1
+        label = "FALLBACK (v1 raises UnsupportedParamsError)" if ok else "DIVERGENT"
+        lines.append(f"- {label}: {name} ({reason})")
+    for name in sorted(req.EXPECTED_FALLBACKS):
+        case, reason = req.EXPECTED_FALLBACKS[name]
+        result = req._v2(case)
+        ok = result.is_error() and reason in result.error.summary
+        failures += 0 if ok else 1
+        label = "FALLBACK (v1 serves it)" if ok else "DIVERGENT"
+        lines.append(f"- {label}: {name} ({reason})")
+    lines += [
+        "",
+        "## openrouter: responses (v1 base GPT transform_response + the"
+        " usage.cost hidden-params post-step vs v2 shared openai parser; NO"
+        " model preset, bare wire model)",
+        "",
+    ]
+    for name in sorted(resp._RESPONSES):
+        raw = resp._RESPONSES[name]
+        v1 = resp._v1_model_response(raw).model_dump()
+        v2 = resp._v2_model_response(raw)
+        same = (
+            resp._norm(v2) == resp._norm(v1)
+            and v2["model"] == raw["model"]
+            and not str(v2["model"]).startswith("openrouter/")
+        )
+        failures += 0 if same else 1
+        lines.append(f"- {'IDENTICAL' if same else 'DIVERGENT'}: {name} (no prefix)")
+    v1_cost = resp._v1_model_response(resp._RESPONSES["usage_cost"])
+    v2_cost = resp._v2_model_response(resp._RESPONSES["usage_cost"])
+    cost_ok = (
+        v1_cost._hidden_params.get("additional_headers", {}).get(resp._COST_HEADER)
+        == 0.0015
+        and v2_cost["usage"]["cost"] == 0.0015
+    )
+    failures += 0 if cost_ok else 1
+    lines.append(
+        ("- SEAM CONTRACT: " if cost_ok else "- DIVERGENT: ")
+        + "usage.cost hidden-params header (v1's transform copies the wire"
+        " usage.cost into _hidden_params additional_headers; the v2 body"
+        " retains usage.cost verbatim and the future completion() fork must"
+        " rebuild the header — CLAUDE.md HARD OBLIGATION)"
+    )
+    lines += [
+        "",
+        "## openrouter: streams (v1 line-seam replay through"
+        " OpenRouterChatCompletionStreamingHandler + CustomStreamWrapper"
+        "('openrouter') vs v2 openrouter parser — the 'unconditional'"
+        " ReasoningMode policy + missing-delta pre-step — with the xai chunk"
+        " dialect)",
+        "",
+    ]
+    for name in sorted(stream.STREAMS):
+        events = stream.STREAMS[name]
+        same = stream._norm(stream._v2_chunks(events)) == stream._norm(
+            stream._v1_chunks(events)
+        )
+        failures += 0 if same else 1
+        lines.append(f"- {'IDENTICAL' if same else 'DIVERGENT'}: {name}")
+    v1 = stream._v1_chunks(stream.USAGE_STREAM, stream_options={"include_usage": True})
+    v2 = stream._v2_chunks(stream.USAGE_STREAM)
+    tail_ok = (
+        len(v1) == len(v2)
+        and stream._norm(v2[:-1]) == stream._norm(v1[: len(v2) - 1])
+        and v2[-1]["choices"] == []
+        and all(
+            v1[-1]["usage"][k] == v2[-1]["usage"][k]
+            for k in ("prompt_tokens", "completion_tokens", "total_tokens")
+        )
+    )
+    failures += 0 if tail_ok else 1
+    lines.append(
+        ("- SEAM CONTRACT: " if tail_ok else "- DIVERGENT: ")
+        + "usage tail (v2 passes the wire choices=[] usage chunk through;"
+        " the streaming seam owns v1's synthesized final chunk)"
+    )
+    return failures
+
+
 def _wave2b_alpha_rows(lines: list) -> int:
     """wave-2b-alpha own-module providers, researcher-4 ascending-risk
     order. APPEND-ONLY: each provider's row function lands in its own
     commit; the beta sibling appends its own section function."""
-    return _deepseek_rows(lines)
+    return _deepseek_rows(lines) + _openrouter_rows(lines)
 
 
 def _cometapi_rows(lines: list) -> int:

--- a/tests/test_litellm/translation/generate_differential_report.py
+++ b/tests/test_litellm/translation/generate_differential_report.py
@@ -798,6 +798,115 @@ def _cohere_rows(lines: list) -> int:
     return failures
 
 
+def _mistral_rows(lines: list) -> int:
+    """wave-2b-beta: mistral (httpx path, bare wire model)."""
+    import copy
+
+    from . import test_differential_mistral_request as req
+    from . import test_differential_mistral_response as resp
+    from . import test_differential_mistral_stream as stream
+
+    failures = 0
+    lines += [
+        "",
+        "## mistral (wave-2b-beta): requests (v1 get_optional_params +"
+        " MistralConfig.transform_request — the two-branch message munge —"
+        " vs v2 providers/mistral)",
+        "",
+    ]
+    for name in sorted(req.CASES):
+        case = req.CASES[name]
+        result = req._v2(case)
+        same = result.is_ok() and req._norm(result.ok) == req._norm(
+            req.run_v1_request_transform(case)
+        )
+        failures += 0 if same else 1
+        lines.append(f"- {'IDENTICAL' if same else 'DIVERGENT'}: {name}")
+    for name in sorted(req.V1_RAISES):
+        case, fragment = req.V1_RAISES[name]
+        result = req._v2(case)
+        ok = result.is_error() and fragment in result.error.summary
+        if ok:
+            try:
+                req.run_v1_request_transform(case)
+                ok = False
+            except Exception:
+                pass
+        failures += 0 if ok else 1
+        lines.append(
+            f"- {'FALLBACK (v1 raises UnsupportedParamsError)' if ok else 'DIVERGENT'}:"
+            f" {name}"
+        )
+    for name in sorted(req.V1_SERVES_FALLBACKS):
+        case, fragment = req.V1_SERVES_FALLBACKS[name]
+        result = req._v2(case)
+        ok = result.is_error() and fragment in result.error.summary
+        failures += 0 if ok else 1
+        lines.append(f"- {'FALLBACK (v1 serves)' if ok else 'DIVERGENT'}: {name}")
+    lines += [
+        "",
+        "## mistral: responses (v1 transform_response pre-steps + cdr vs v2"
+        " mistral pre-steps + the shared openai parser; bare wire model)",
+        "",
+    ]
+    for name in sorted(resp._RESPONSES):
+        raw = resp._RESPONSES[name]
+        v1 = resp._v1_model_response(raw)
+        v2 = resp._v2_model_response(raw)
+        same = (
+            resp._norm(v2) == resp._norm(v1)
+            and v2["model"] == resp.WIRE_MODEL
+            and not str(v2["model"]).startswith("mistral/")
+        )
+        failures += 0 if same else 1
+        lines.append(f"- {'IDENTICAL' if same else 'DIVERGENT'}: {name}")
+    for name in sorted(resp._LOUD):
+        raw, fragment = resp._LOUD[name]
+        result = resp._v2_parse(raw)
+        ok = result.is_error() and fragment in result.error.summary
+        if ok:
+            try:
+                resp._v1_model_response(copy.deepcopy(raw))
+                ok = False
+            except Exception:
+                pass
+        failures += 0 if ok else 1
+        lines.append(f"- {'FALLBACK (v1 raises)' if ok else 'DIVERGENT'}: {name}")
+    lines += [
+        "",
+        "## mistral: streams (v1 SSE line replay through"
+        " MistralChatResponseIterator + CustomStreamWrapper('mistral') vs v2"
+        " mistral pre-step + the httpx_chunk factory (rename +"
+        " passthrough thinking_blocks) + the xai chunk dialect)",
+        "",
+    ]
+    for name in sorted(stream.STREAMS):
+        events = stream.STREAMS[name]
+        same = stream._norm(stream._v2_chunks(events)) == stream._norm(
+            stream._v1_chunks(events)
+        )
+        failures += 0 if same else 1
+        lines.append(f"- {'IDENTICAL' if same else 'DIVERGENT'}: {name}")
+    v1 = stream._v1_chunks(stream.USAGE_STREAM, stream_options={"include_usage": True})
+    v2 = stream._v2_chunks(stream.USAGE_STREAM)
+    tail_ok = (
+        len(v1) == len(v2)
+        and stream._norm(v2[:-1]) == stream._norm(v1[: len(v2) - 1])
+        and v2[-1]["choices"] == []
+        and all(
+            v1[-1]["usage"][k] == v2[-1]["usage"][k]
+            for k in ("prompt_tokens", "completion_tokens", "total_tokens")
+        )
+    )
+    failures += 0 if tail_ok else 1
+    lines.append(
+        ("- SEAM CONTRACT: " if tail_ok else "- DIVERGENT: ")
+        + "usage tail (v2 passes the wire choices=[] usage chunk through;"
+        " the streaming seam owns v1's synthesized final chunk)"
+    )
+    return failures
+
+
 def _azure_rows(lines: list) -> int:
     import os
 
@@ -1287,6 +1396,7 @@ def main() -> None:
     failures += _compat_httpx_rows(lines)
     failures += _cometapi_rows(lines)
     failures += _cohere_rows(lines)
+    failures += _mistral_rows(lines)
     failures += _azure_rows(lines)
     failures += _azure_ai_rows(lines)
     failures += _bedrock_request_rows(lines)

--- a/tests/test_litellm/translation/generate_differential_report.py
+++ b/tests/test_litellm/translation/generate_differential_report.py
@@ -1205,16 +1205,36 @@ def _sagemaker_chat_rows(lines: list) -> int:
         + "usage tail (v2 passes the wire choices=[] usage chunk through;"
         " the streaming seam owns v1's synthesized final chunk)"
     )
-    bad = stream._chunk({"content": 5})
-    loud = stream.parse_event(dict(bad)).is_error()
-    if loud:
-        with pytest.raises(Exception):
-            stream._v1_chunks([bad])
-    failures += 0 if loud else 1
-    lines.append(
-        f"- {'FALLBACK (v1 raises ValidationError)' if loud else 'DIVERGENT'}:"
-        " non-string delta content (loud on both sides)"
-    )
+    for name in sorted(stream._V1_RAISES):
+        bad, fragment = stream._V1_RAISES[name]
+        result = stream.parse_event(dict(bad))
+        loud = result.is_error() and fragment in result.error.summary
+        if loud:
+            with pytest.raises(Exception):
+                stream._v1_chunks([bad])
+        failures += 0 if loud else 1
+        lines.append(
+            f"- {'FALLBACK (v1 raises ValidationError)' if loud else 'DIVERGENT'}:"
+            f" {name} (loud on both sides)"
+        )
+    for falsy, label in (("", "empty-string"), ({}, "empty-object")):
+        events = [
+            stream._chunk({"role": "assistant", "content": "x"}),
+            stream._chunk({}, finish=falsy),
+        ]
+        v1 = stream._v1_chunks(events)
+        v2 = stream._v2_chunks(events)
+        ok = (
+            len(v1) == len(v2) + 1
+            and stream._norm(v2) == stream._norm(v1[:-1])
+            and v1[-1]["choices"][0]["finish_reason"] == "stop"
+        )
+        failures += 0 if ok else 1
+        lines.append(
+            ("- SEAM CONTRACT: " if ok else "- DIVERGENT: ")
+            + f"falsy ({label}) finish_reason — no finish rides (v1's truthy"
+            " gate); v2 == v1 minus the wrapper's synthesized stop tail"
+        )
     return failures
 
 

--- a/tests/test_litellm/translation/generate_differential_report.py
+++ b/tests/test_litellm/translation/generate_differential_report.py
@@ -727,6 +727,18 @@ def _cohere_rows(lines: list) -> int:
                 pass
         failures += 0 if ok else 1
         lines.append(f"- {'FALLBACK (v1 raises)' if ok else 'DIVERGENT'}: {name}")
+    for name in sorted(resp._V1_SERVES_FALLBACKS):
+        raw, fragment = resp._V1_SERVES_FALLBACKS[name]
+        result = resp._v2_parse(raw)
+        ok = result.is_error() and fragment in result.error.summary
+        if ok:
+            v1 = resp._v1_model_response(copy.deepcopy(raw))
+            ok = bool(v1["choices"][0]["message"].get("annotations"))
+        failures += 0 if ok else 1
+        lines.append(
+            f"- {'FALLBACK (v1 serves the unvalidated annotation)' if ok else 'DIVERGENT'}:"
+            f" {name}"
+        )
     lines += [
         "",
         "## cohere v2: streams (v1 bare-JSON line replay through"

--- a/tests/test_litellm/translation/generate_differential_report.py
+++ b/tests/test_litellm/translation/generate_differential_report.py
@@ -3,7 +3,6 @@
 Run:  python -m tests.test_litellm.translation.generate_differential_report
 """
 
-import json
 import pathlib
 import subprocess
 import sys
@@ -576,6 +575,9 @@ def _compat_httpx_rows(lines: list) -> int:
         # wave-2b-alpha: the own-module base-handler consumers share this
         # exact divergence — ONE named row covers them all, failure-counted
         and _wave2b_alpha_error_chunk_pins()
+        # wave-2b-beta (sibling-merge sweep): mistral inherits the base
+        # handler's swallow through MistralChatResponseIterator
+        and _wave2b_beta_error_chunk_pins()
     )
     failures += 0 if divergence_pinned else 1
     lines.append(
@@ -587,8 +589,9 @@ def _compat_httpx_rows(lines: list) -> int:
         + "mid-stream {'error': ...} chunks — v1's BASE handler silently"
         " swallows them (no error surface in the emitted sequence; asserted"
         " in-process for all nine base-handler members AND the wave-2b-alpha"
-        " own-module base-handler consumers, per their dedicated stream"
-        " gates), v2's family parser"
+        " own-module base-handler consumers AND mistral, whose v1 iterator"
+        " subclasses the base handler — sibling-merge sweep — per their"
+        " dedicated stream gates), v2's family parser"
         " surfaces a LOUD typed boundary error naming the chunk"
         " (test_error_chunk_divergence_two_sided; cometapi differs: its v1"
         " handler RAISES and its policy row mirrors the raise — see the"
@@ -641,6 +644,33 @@ def _wave2b_alpha_error_chunk_pins() -> bool:
         if not (folded.is_error() and "provider stream error" in folded.error.summary):
             return False
     return True
+
+
+def _wave2b_beta_error_chunk_pins() -> bool:
+    """The wave-2b-beta half of the family's ONE pinned divergence (the
+    sibling-merge consistency sweep): MistralChatResponseIterator subclasses
+    the base handler and inherits the silent error-chunk swallow — mistral
+    is the only beta provider on the base-handler swallow (cohere/watsonx
+    have their own pinned iterator-swallow rows; groq/sagemaker v1 handlers
+    RAISE — policy rows). APPEND-ONLY, the alpha twin's convention."""
+    import json as _json
+
+    from litellm.translation.engine.stream import fold_lines
+    from litellm.translation.inbound.openai_chat.stream import initial_state
+    from litellm.translation.providers import mistral as _mistral_pkg
+
+    from . import test_differential_mistral_stream as _mi_stream
+
+    v1 = _mi_stream._v1_chunks(_mi_stream._ERROR_CHUNK_STREAM)
+    if "error" in _json.dumps(v1, default=str):
+        return False
+    lines = [
+        f"data: {_json.dumps(e)}" for e in _mi_stream._ERROR_CHUNK_STREAM
+    ]
+    folded = fold_lines(
+        lines, _mistral_pkg.parse_line, initial_state(_mi_stream.MODEL, dialect="xai")
+    )
+    return folded.is_error() and "provider stream error" in folded.error.summary
 
 
 def _deepseek_rows(lines: list) -> int:
@@ -1178,7 +1208,6 @@ def _snowflake_rows(lines: list) -> int:
 
 
 def _huggingface_rows(lines: list) -> int:
-    from . import _own_module_corpus as own
     from . import test_differential_huggingface_request as req
     from . import test_differential_huggingface_response as resp
     from . import test_differential_huggingface_stream as stream

--- a/tests/test_litellm/translation/generate_differential_report.py
+++ b/tests/test_litellm/translation/generate_differential_report.py
@@ -1285,6 +1285,8 @@ def _sagemaker_chat_rows(lines: list) -> int:
 def _groq_rows(lines: list) -> int:
     """wave-2b-beta: groq (httpx path; bare wire model + service_tier
     clamp; the json_schema fork rows)."""
+    import copy
+
     import pytest
 
     from . import test_differential_groq_request as req
@@ -1432,6 +1434,44 @@ def _groq_rows(lines: list) -> int:
     lines.append(
         f"- {'FALLBACK (v1 raises MidStreamFallbackError)' if loud else 'DIVERGENT'}:"
         " error chunk (loud on both sides — the truthy-value check)"
+    )
+    for key in ("reasoning", "reasoning_content"):
+        bad = stream._chunk({"role": "assistant", key: 5})
+        result = stream.parse_event(copy.deepcopy(bad))
+        ok = result.is_error() and "is not a string" in result.error.summary
+        if ok:
+            try:
+                stream._v1_chunks([bad, stream._chunk({}, finish="stop")])
+                ok = False
+            except Exception:
+                pass
+        failures += 0 if ok else 1
+        lines.append(
+            f"- {'FALLBACK (v1 raises APIError)' if ok else 'DIVERGENT'}:"
+            f" non-str delta {key} (the F6 groq-local pre-step; the wrapper"
+            " epilogue join TypeErrors in v1)"
+        )
+    refusal_events = [
+        stream._chunk({"role": "assistant", "refusal": 7, "content": "x"}),
+        stream._chunk({}, finish="stop"),
+    ]
+    v1 = stream._v1_chunks(refusal_events)
+    v2 = stream._v2_chunks(refusal_events)
+    handoff = (
+        v1[0]["choices"][0]["delta"]["refusal"] == 7
+        and v2[0]["choices"][0]["delta"]["refusal"] is None
+    )
+    failures += 0 if handoff else 1
+    lines.append(
+        (
+            "- INTEGRATOR-FLIP HANDOFF (current behavior guarded): "
+            if handoff
+            else "- DIVERGENT: "
+        )
+        + "non-str refusal — v1 forwards 7, the SHARED httpx_chunk factory"
+        " nulls it; the fix belongs to the alpha fix round's concurrent"
+        " httpx_chunk edit (verifier-wave2b-alpha F1) — the sibling-merge"
+        " integrator flips this row and the gate test to v1 parity"
     )
     return failures
 

--- a/tests/test_litellm/translation/generate_differential_report.py
+++ b/tests/test_litellm/translation/generate_differential_report.py
@@ -907,6 +907,168 @@ def _mistral_rows(lines: list) -> int:
     return failures
 
 
+def _watsonx_rows(lines: list) -> int:
+    """wave-2b-beta: watsonx (the OpenAILikeChatHandler route; live
+    watsonx/{wire} response prefix; generic stream dialect)."""
+    import copy
+
+    import pytest
+
+    from . import test_differential_watsonx_request as req
+    from . import test_differential_watsonx_response as resp
+    from . import test_differential_watsonx_stream as stream
+
+    failures = 0
+    lines += [
+        "",
+        "## watsonx (wave-2b-beta): requests (v1 get_optional_params +"
+        " _get_api_params/_prepare_payload + the openai_like body assembly"
+        " vs v2 providers/watsonx with deps-borne project/space ids)",
+        "",
+    ]
+    for name in sorted(req.CASES):
+        case = req.CASES[name]
+        result = req._v2(case)
+        same = result.is_ok() and req._norm(result.ok) == req._norm(
+            req.run_v1_request_transform(case)
+        )
+        failures += 0 if same else 1
+        lines.append(f"- {'IDENTICAL' if same else 'DIVERGENT'}: {name}")
+    for name in sorted(req.V1_RAISES):
+        case, fragment = req.V1_RAISES[name]
+        result = req._v2(case)
+        ok = result.is_error() and fragment in result.error.summary
+        if ok:
+            try:
+                req.run_v1_request_transform(case)
+                ok = False
+            except Exception:
+                pass
+        failures += 0 if ok else 1
+        lines.append(
+            f"- {'FALLBACK (v1 raises UnsupportedParamsError)' if ok else 'DIVERGENT'}:"
+            f" {name}"
+        )
+    for label, case_fn in (
+        (
+            "top_k (v1 raises the legacy watsonx_text ValueError)",
+            lambda: req._v2({"model": req.MODEL, "messages": req._U, "top_k": 5}),
+        ),
+        (
+            "missing project/space ids (v1 raises WatsonXAIError 401)",
+            lambda: req._v2(
+                req.CASES["plain"], deps=req._deps(project_id=None, space_id=None)
+            ),
+        ),
+        (
+            "deployment/ model (envelope routing; v1 serves)",
+            lambda: req._v2({"model": "deployment/dep-1", "messages": req._U}),
+        ),
+    ):
+        ok = case_fn().is_error()
+        failures += 0 if ok else 1
+        lines.append(f"- {'FALLBACK' if ok else 'DIVERGENT'}: {label}")
+    for name in sorted(req.V1_SERVES_FALLBACKS):
+        case, fragment = req.V1_SERVES_FALLBACKS[name]
+        result = req._v2(case)
+        ok = result.is_error() and fragment in result.error.summary
+        failures += 0 if ok else 1
+        lines.append(f"- {'FALLBACK (v1 serves)' if ok else 'DIVERGENT'}: {name}")
+    lines += [
+        "",
+        "## watsonx: responses (v1 OpenAILike _transform_response with the"
+        " LIVE watsonx/{wire_model} prefix vs v2 watsonx parser + the seam's"
+        " openai_like construction arm)",
+        "",
+    ]
+    for name in sorted(resp._RESPONSES):
+        raw = resp._RESPONSES[name]
+        same = resp._norm(resp._v2_model_response(raw)) == resp._norm(
+            resp._v1_model_response(raw)
+        )
+        failures += 0 if same else 1
+        lines.append(f"- {'IDENTICAL' if same else 'DIVERGENT'}: {name}")
+    f2 = resp._v2_parse({**resp._RESPONSES["text"], "model": 7})
+    ok = f2.is_error() and "non-string wire model" in f2.error.summary
+    if ok:
+        with pytest.raises(Exception):
+            resp._v1_model_response({**resp._RESPONSES["text"], "model": 7})
+    failures += 0 if ok else 1
+    lines.append(
+        f"- {'FALLBACK (v1 raises ValidationError)' if ok else 'DIVERGENT'}:"
+        " non-string wire model"
+    )
+    lines += [
+        "",
+        "## watsonx: streams (v1 line replay through the databricks"
+        " ModelResponseIterator + CustomStreamWrapper('watsonx') generic arm"
+        " vs v2 watsonx parser + the generic chunk dialect; ids normalized)",
+        "",
+    ]
+    for name in sorted(stream.STREAMS):
+        events = stream.STREAMS[name]
+        same = stream._norm(stream._v2_chunks(events)) == stream._norm(
+            stream._v1_chunks(events)
+        )
+        failures += 0 if same else 1
+        lines.append(f"- {'IDENTICAL' if same else 'DIVERGENT'}: {name}")
+    v1 = stream._v1_chunks(stream.USAGE_STREAM, stream_options={"include_usage": True})
+    v2 = stream._v2_chunks(stream.USAGE_STREAM)
+    tail_ok = (
+        len(v1) == len(v2)
+        and stream._norm(v2[:-1]) == stream._norm(v1[: len(v2) - 1])
+        and v2[-1]["choices"] == []
+        and all(
+            v1[-1]["usage"][k] == v2[-1]["usage"][k]
+            for k in ("prompt_tokens", "completion_tokens", "total_tokens")
+        )
+    )
+    failures += 0 if tail_ok else 1
+    lines.append(
+        ("- SEAM CONTRACT: " if tail_ok else "- DIVERGENT: ")
+        + "usage tail (v2 passes the wire choices=[] usage chunk through;"
+        " the streaming seam owns v1's synthesized final chunk)"
+    )
+    no_finish = [stream._chunk({"role": "assistant", "content": "Hi"})]
+    v1 = stream._v1_chunks(no_finish)
+    v2 = stream._v2_chunks(no_finish)
+    synth_ok = (
+        len(v1) == len(v2) + 1
+        and stream._norm(v2) == stream._norm(v1[:-1])
+        and v1[-1]["choices"][0]["finish_reason"] == "stop"
+    )
+    failures += 0 if synth_ok else 1
+    lines.append(
+        ("- SEAM CONTRACT: " if synth_ok else "- DIVERGENT: ")
+        + "no-wire-finish stream (v2 == v1 minus the wrapper's synthesized"
+        " stop tail — the generic streaming seam owns it)"
+    )
+    for name in sorted(stream._PINNED_DIVERGENCES):
+        events, raw_lines, fragment = stream._PINNED_DIVERGENCES[name]
+        v1 = stream._v1_chunks(events, raw_lines=raw_lines)
+        swallows = all(
+            choice["delta"]["content"] in (None, "")
+            and not choice["delta"]["tool_calls"]
+            for chunk in v1
+            for choice in chunk["choices"]
+        )
+        if raw_lines is not None:
+            result = stream.parse_line(raw_lines[0])
+        else:
+            result = stream.parse_event(copy.deepcopy(events[0]))
+        pinned = swallows and result.is_error() and fragment in result.error.summary
+        failures += 0 if pinned else 1
+        lines.append(
+            (
+                "- PINNED DIVERGENCE (fail-closed on a failure path): "
+                if pinned
+                else "- DIVERGENT: "
+            )
+            + f"{name} — v1's iterator silently swallows it, v2 errors loudly"
+        )
+    return failures
+
+
 def _azure_rows(lines: list) -> int:
     import os
 
@@ -1397,6 +1559,7 @@ def main() -> None:
     failures += _cometapi_rows(lines)
     failures += _cohere_rows(lines)
     failures += _mistral_rows(lines)
+    failures += _watsonx_rows(lines)
     failures += _azure_rows(lines)
     failures += _azure_ai_rows(lines)
     failures += _bedrock_request_rows(lines)

--- a/tests/test_litellm/translation/generate_differential_report.py
+++ b/tests/test_litellm/translation/generate_differential_report.py
@@ -960,6 +960,23 @@ def _mistral_rows(lines: list) -> int:
         + "usage tail (v2 passes the wire choices=[] usage chunk through;"
         " the streaming seam owns v1's synthesized final chunk)"
     )
+    for name in sorted(stream._LOUD_CHUNKS):
+        event, fragment = stream._LOUD_CHUNKS[name]
+        result = stream.parse_event(copy.deepcopy(event))
+        ok = result.is_error() and fragment in result.error.summary
+        if ok and name != "unknown_delta_key":
+            try:
+                stream._v1_chunks([copy.deepcopy(event)])
+                ok = False
+            except Exception:
+                pass
+        failures += 0 if ok else 1
+        label = (
+            "FALLBACK (unreachable for v2-sent requests)"
+            if name == "unknown_delta_key"
+            else "FALLBACK (v1 raises MidStreamFallbackError)"
+        )
+        lines.append(f"- {label if ok else 'DIVERGENT'}: {name}")
     return failures
 
 

--- a/tests/test_litellm/translation/generate_differential_report.py
+++ b/tests/test_litellm/translation/generate_differential_report.py
@@ -608,10 +608,15 @@ def _wave2b_alpha_error_chunk_pins() -> bool:
     from litellm.translation.engine.stream import fold_lines
     from litellm.translation.inbound.openai_chat.stream import initial_state
     from litellm.translation.providers import deepseek as _deepseek_pkg
+    from litellm.translation.providers import hosted_vllm as _hosted_vllm_pkg
 
     from . import test_differential_deepseek_stream as _ds_stream
+    from . import test_differential_hosted_vllm_stream as _hv_stream
 
-    consumers = ((_ds_stream, _deepseek_pkg.parse_line),)
+    consumers = (
+        (_ds_stream, _deepseek_pkg.parse_line),
+        (_hv_stream, _hosted_vllm_pkg.parse_line),
+    )
     for mod, line_parser in consumers:
         v1 = mod._v1_chunks(mod._ERROR_CHUNK_STREAM)
         if "error" in _json.dumps(v1):
@@ -817,11 +822,94 @@ def _openrouter_rows(lines: list) -> int:
     return failures
 
 
+def _hosted_vllm_rows(lines: list) -> int:
+    from . import _own_module_corpus as own
+    from . import test_differential_hosted_vllm_request as req
+    from . import test_differential_hosted_vllm_response as resp
+    from . import test_differential_hosted_vllm_stream as stream
+
+    failures = 0
+    lines += [
+        "",
+        "## hosted_vllm: request bodies (v1 get_optional_params('hosted_vllm')"
+        " + the LIVE httpx transform_request — dedicated elif main.py:2619,"
+        " incl. the recursive tools cleaning and the thinking budget-band"
+        " rewrite — vs v2 providers/hosted_vllm)",
+        "",
+    ]
+    for name in sorted(req.CASES):
+        case = req.CASES[name]
+        result = req._v2(case)
+        same = result.is_ok() and req._norm(result.ok) == req._norm(
+            own.run_v1_request_transform("hosted_vllm", case)
+        )
+        failures += 0 if same else 1
+        lines.append(f"- {'IDENTICAL' if same else 'DIVERGENT'}: {name}")
+    for name in sorted(req.EXPECTED_FALLBACKS):
+        case, reason = req.EXPECTED_FALLBACKS[name]
+        result = req._v2(case)
+        ok = result.is_error() and reason in result.error.summary
+        failures += 0 if ok else 1
+        label = "FALLBACK (v1 serves it)" if ok else "DIVERGENT"
+        lines.append(f"- {label}: {name} ({reason})")
+    lines += [
+        "",
+        "## hosted_vllm: responses (v1 base GPT transform_response over httpx"
+        " — LIVE on the dedicated elif — vs v2 shared openai parser with NO"
+        " model preset; bare wire model, the xai R4 pin)",
+        "",
+    ]
+    for name in sorted(resp._RESPONSES):
+        raw = resp._RESPONSES[name]
+        v1 = resp._v1_model_response(raw)
+        v2 = resp._v2_model_response(raw)
+        same = (
+            resp._norm(v2) == resp._norm(v1)
+            and v2["model"] == raw["model"]
+            and not str(v2["model"]).startswith("hosted_vllm/")
+        )
+        failures += 0 if same else 1
+        lines.append(f"- {'IDENTICAL' if same else 'DIVERGENT'}: {name} (no prefix)")
+    lines += [
+        "",
+        "## hosted_vllm: streams (v1 base OpenAIChatCompletionStreamingHandler"
+        " + CustomStreamWrapper('hosted_vllm') over SSE lines vs v2"
+        " hosted_vllm parser — the httpx_chunk family policy — with the xai"
+        " chunk dialect)",
+        "",
+    ]
+    for name in sorted(stream.STREAMS):
+        events = stream.STREAMS[name]
+        same = stream._norm(stream._v2_chunks(events)) == stream._norm(
+            stream._v1_chunks(events)
+        )
+        failures += 0 if same else 1
+        lines.append(f"- {'IDENTICAL' if same else 'DIVERGENT'}: {name}")
+    v1 = stream._v1_chunks(stream.USAGE_STREAM, stream_options={"include_usage": True})
+    v2 = stream._v2_chunks(stream.USAGE_STREAM)
+    tail_ok = (
+        len(v1) == len(v2)
+        and stream._norm(v2[:-1]) == stream._norm(v1[: len(v2) - 1])
+        and v2[-1]["choices"] == []
+        and all(
+            v1[-1]["usage"][k] == v2[-1]["usage"][k]
+            for k in ("prompt_tokens", "completion_tokens", "total_tokens")
+        )
+    )
+    failures += 0 if tail_ok else 1
+    lines.append(
+        ("- SEAM CONTRACT: " if tail_ok else "- DIVERGENT: ")
+        + "usage tail (v2 passes the wire choices=[] usage chunk through;"
+        " the streaming seam owns v1's synthesized final chunk)"
+    )
+    return failures
+
+
 def _wave2b_alpha_rows(lines: list) -> int:
     """wave-2b-alpha own-module providers, researcher-4 ascending-risk
     order. APPEND-ONLY: each provider's row function lands in its own
     commit; the beta sibling appends its own section function."""
-    return _deepseek_rows(lines) + _openrouter_rows(lines)
+    return _deepseek_rows(lines) + _openrouter_rows(lines) + _hosted_vllm_rows(lines)
 
 
 def _cometapi_rows(lines: list) -> int:

--- a/tests/test_litellm/translation/generate_differential_report.py
+++ b/tests/test_litellm/translation/generate_differential_report.py
@@ -613,9 +613,14 @@ def _wave2b_alpha_error_chunk_pins() -> bool:
     from . import test_differential_deepseek_stream as _ds_stream
     from . import test_differential_hosted_vllm_stream as _hv_stream
 
+    from litellm.translation.providers import fireworks_ai as _fireworks_pkg
+
+    from . import test_differential_fireworks_ai_stream as _fw_stream
+
     consumers = (
         (_ds_stream, _deepseek_pkg.parse_line),
         (_hv_stream, _hosted_vllm_pkg.parse_line),
+        (_fw_stream, _fireworks_pkg.parse_line),
     )
     for mod, line_parser in consumers:
         v1 = mod._v1_chunks(mod._ERROR_CHUNK_STREAM)
@@ -905,11 +910,148 @@ def _hosted_vllm_rows(lines: list) -> int:
     return failures
 
 
+def _fireworks_ai_rows(lines: list) -> int:
+    import pydantic
+
+    from litellm.exceptions import UnsupportedParamsError
+
+    from . import _own_module_corpus as own
+    from . import test_differential_fireworks_ai_request as req
+    from . import test_differential_fireworks_ai_response as resp
+    from . import test_differential_fireworks_ai_stream as stream
+
+    failures = 0
+    lines += [
+        "",
+        "## fireworks_ai: request bodies (v1 get_optional_params"
+        "('fireworks_ai') + the LIVE httpx transform_request — dedicated elif"
+        " main.py:2198, incl. the accounts/fireworks/models/ rewrite, the"
+        " required->any tool_choice arm and the #transform=inline image"
+        " suffix — vs v2 providers/fireworks_ai)",
+        "",
+    ]
+    for name in sorted(req.CASES):
+        case = req.CASES[name]
+        result = req._v2(case)
+        same = result.is_ok() and req._norm(result.ok) == req._norm(
+            own.run_v1_request_transform("fireworks_ai", case)
+        )
+        failures += 0 if same else 1
+        lines.append(f"- {'IDENTICAL' if same else 'DIVERGENT'}: {name}")
+    for name in sorted(req.V1_RAISES):
+        case, reason = req.V1_RAISES[name]
+        result = req._v2(case)
+        try:
+            own.run_v1_request_transform("fireworks_ai", case)
+            raised = False
+        except UnsupportedParamsError:
+            raised = True
+        ok = result.is_error() and reason in result.error.summary and raised
+        failures += 0 if ok else 1
+        label = "FALLBACK (v1 raises UnsupportedParamsError)" if ok else "DIVERGENT"
+        lines.append(f"- {label}: {name} ({reason})")
+    for name in sorted(req.EXPECTED_FALLBACKS):
+        case, reason = req.EXPECTED_FALLBACKS[name]
+        result = req._v2(case)
+        ok = result.is_error() and reason in result.error.summary
+        failures += 0 if ok else 1
+        label = "FALLBACK (v1 serves it)" if ok else "DIVERGENT"
+        lines.append(f"- {label}: {name} ({reason})")
+    lines += [
+        "",
+        "## fireworks_ai: responses (v1's OWN transform_response — the"
+        " OpenAILike DIRECT construction + the fireworks_ai/{WIRE model}"
+        " prefix + the tool-calls-in-content repair — vs v2 direct parser"
+        " with the openai_like seam arm)",
+        "",
+    ]
+    for name in sorted(resp._RESPONSES):
+        raw = resp._RESPONSES[name]
+        v1 = resp._v1_model_response(raw)
+        v2 = resp._v2_model_response(raw)
+        same = resp._norm(v2) == resp._norm(v1) and v2["model"] == (
+            f"fireworks_ai/{resp.WIRE_MODEL}"
+        )
+        failures += 0 if same else 1
+        lines.append(f"- {'IDENTICAL' if same else 'DIVERGENT'}: {name} (prefixed)")
+    from litellm.translation.inbound.openai_chat import parse_request as _parse_req
+    from litellm.translation.providers.fireworks_ai import (
+        parse_response as _fw_parse,
+    )
+
+    parsed = _parse_req(dict(resp._REQUEST))
+    repair_result = _fw_parse(dict(resp._REPAIR_BODY), parsed.ok)
+    repair_v1 = resp._v1_model_response(resp._REPAIR_BODY)
+    repair_ok = (
+        repair_result.is_error()
+        and "uuid4" in repair_result.error.summary
+        and repair_v1["choices"][0]["message"]["content"] is None
+    )
+    failures += 0 if repair_ok else 1
+    label = "FALLBACK (v1 serves it)" if repair_ok else "DIVERGENT"
+    lines.append(
+        f"- {label}: tool_call_in_content_repair (v1 synthesizes the"
+        " tool_call with a fresh uuid4; the pure parser fails closed)"
+    )
+    try:
+        resp._v1_model_response(resp._NON_STRING_MODEL_BODY)
+        raised = False
+    except pydantic.ValidationError:
+        raised = True
+    ns_result = _fw_parse(dict(resp._NON_STRING_MODEL_BODY), parsed.ok)
+    ns_ok = (
+        raised
+        and ns_result.is_error()
+        and "non-string wire model" in ns_result.error.summary
+    )
+    failures += 0 if ns_ok else 1
+    label = "FALLBACK (v1 raises ValidationError)" if ns_ok else "DIVERGENT"
+    lines.append(f"- {label}: non_string_wire_model")
+    lines += [
+        "",
+        "## fireworks_ai: streams (v1 base OpenAIChatCompletionStreamingHandler"
+        " + CustomStreamWrapper('fireworks_ai') over SSE lines vs v2 fireworks"
+        " parser — the httpx_chunk family policy — with the xai chunk dialect;"
+        " chunk models stay the BARE wire model, no prefix)",
+        "",
+    ]
+    for name in sorted(stream.STREAMS):
+        events = stream.STREAMS[name]
+        same = stream._norm(stream._v2_chunks(events)) == stream._norm(
+            stream._v1_chunks(events)
+        )
+        failures += 0 if same else 1
+        lines.append(f"- {'IDENTICAL' if same else 'DIVERGENT'}: {name}")
+    v1 = stream._v1_chunks(stream.USAGE_STREAM, stream_options={"include_usage": True})
+    v2 = stream._v2_chunks(stream.USAGE_STREAM)
+    tail_ok = (
+        len(v1) == len(v2)
+        and stream._norm(v2[:-1]) == stream._norm(v1[: len(v2) - 1])
+        and v2[-1]["choices"] == []
+        and all(
+            v1[-1]["usage"][k] == v2[-1]["usage"][k]
+            for k in ("prompt_tokens", "completion_tokens", "total_tokens")
+        )
+    )
+    failures += 0 if tail_ok else 1
+    lines.append(
+        ("- SEAM CONTRACT: " if tail_ok else "- DIVERGENT: ")
+        + "usage tail (v2 passes the wire choices=[] usage chunk through;"
+        " the streaming seam owns v1's synthesized final chunk)"
+    )
+    return failures
+
+
 def _wave2b_alpha_rows(lines: list) -> int:
     """wave-2b-alpha own-module providers, researcher-4 ascending-risk
     order. APPEND-ONLY: each provider's row function lands in its own
     commit; the beta sibling appends its own section function."""
-    return _deepseek_rows(lines) + _openrouter_rows(lines) + _hosted_vllm_rows(lines)
+    return (
+        _deepseek_rows(lines)
+        + _openrouter_rows(lines)
+        + _hosted_vllm_rows(lines)
+        + _fireworks_ai_rows(lines)
+    )
 
 
 def _cometapi_rows(lines: list) -> int:

--- a/tests/test_litellm/translation/generate_differential_report.py
+++ b/tests/test_litellm/translation/generate_differential_report.py
@@ -649,6 +649,155 @@ def _cometapi_rows(lines: list) -> int:
     return failures
 
 
+def _cohere_rows(lines: list) -> int:
+    """wave-2b-beta: cohere/cohere_chat (the v2 chat wire, the DEFAULT
+    route at HEAD)."""
+    import copy
+
+    from . import test_differential_cohere_request as req
+    from . import test_differential_cohere_response as resp
+    from . import test_differential_cohere_stream as stream
+
+    failures = 0
+    lines += [
+        "",
+        "## cohere v2 (wave-2b-beta): requests (v1 get_optional_params +"
+        " CohereV2ChatConfig.transform_request vs v2 providers/cohere — both"
+        " provider names, cohere and cohere_chat)",
+        "",
+    ]
+    for provider, name in req._rows(req.CASES):
+        case = req.CASES[name]
+        result = req._v2(provider, case)
+        same = result.is_ok() and req._norm(result.ok) == req._norm(
+            req.run_v1_request_transform(provider, case)
+        )
+        failures += 0 if same else 1
+        lines.append(f"- {'IDENTICAL' if same else 'DIVERGENT'}: {provider}/{name}")
+    for provider, name in req._rows(req.V1_RAISES):
+        case, fragment = req.V1_RAISES[name]
+        result = req._v2(provider, case)
+        ok = result.is_error() and fragment in result.error.summary
+        if ok:
+            try:
+                req.run_v1_request_transform(provider, case)
+                ok = False
+            except Exception:
+                pass
+        failures += 0 if ok else 1
+        lines.append(
+            f"- {'FALLBACK (v1 raises UnsupportedParamsError)' if ok else 'DIVERGENT'}:"
+            f" {provider}/{name}"
+        )
+    for provider, name in req._rows(req.V1_SERVES_FALLBACKS):
+        case, fragment = req.V1_SERVES_FALLBACKS[name]
+        result = req._v2(provider, case)
+        ok = result.is_error() and fragment in result.error.summary
+        failures += 0 if ok else 1
+        lines.append(
+            f"- {'FALLBACK (v1 serves)' if ok else 'DIVERGENT'}: {provider}/{name}"
+        )
+    lines += [
+        "",
+        "## cohere v2: responses (v1 CohereV2ChatConfig.transform_response —"
+        " fresh-ModelResponse mutation, request model verbatim, finish always"
+        " stop — vs v2 cohere parser + the seam's openai construction arm)",
+        "",
+    ]
+    for name in sorted(resp._RESPONSES):
+        raw = resp._RESPONSES[name]
+        v1 = resp._v1_model_response(raw)
+        v2 = resp._v2_model_response(raw)
+        same = (
+            resp._norm(v2) == resp._norm(v1)
+            and v2["model"] == resp.MODEL
+            and v2["choices"][0]["finish_reason"] == "stop"
+        )
+        failures += 0 if same else 1
+        lines.append(f"- {'IDENTICAL' if same else 'DIVERGENT'}: {name}")
+    for name in sorted(resp._LOUD):
+        raw, fragment = resp._LOUD[name]
+        result = resp._v2_parse(raw)
+        ok = result.is_error() and fragment in result.error.summary
+        if ok:
+            try:
+                resp._v1_model_response(copy.deepcopy(raw))
+                ok = False
+            except Exception:
+                pass
+        failures += 0 if ok else 1
+        lines.append(f"- {'FALLBACK (v1 raises)' if ok else 'DIVERGENT'}: {name}")
+    lines += [
+        "",
+        "## cohere v2: streams (v1 bare-JSON line replay through"
+        " CohereV2ModelResponseIterator + CustomStreamWrapper('cohere_chat')"
+        " generic arm vs v2 cohere parser + the generic chunk dialect; ids"
+        " normalized — v1 mints a fresh chatcmpl id per chunk)",
+        "",
+    ]
+    for name in sorted(stream.REAL_WIRE_STREAMS):
+        events, synth_finish = stream.REAL_WIRE_STREAMS[name]
+        v1 = stream._v1_chunks(events)
+        v2 = stream._v2_chunks(events)
+        ok = (
+            len(v1) == len(v2) + 1
+            and stream._norm(v2) == stream._norm(v1[:-1])
+            and v1[-1]["choices"][0]["finish_reason"] == synth_finish
+        )
+        failures += 0 if ok else 1
+        lines.append(
+            ("- SEAM CONTRACT: " if ok else "- DIVERGENT: ")
+            + f"real-wire {name} (v2 == v1 minus the wrapper's synthesized"
+            f" {synth_finish} tail — the generic streaming seam owns it)"
+        )
+    for name in sorted(stream.EVENT_KEYED_STREAMS):
+        events = stream.EVENT_KEYED_STREAMS[name]
+        same = stream._norm(stream._v2_chunks(events)) == stream._norm(
+            stream._v1_chunks(events)
+        )
+        failures += 0 if same else 1
+        lines.append(f"- {'IDENTICAL' if same else 'DIVERGENT'}: event-keyed {name}")
+    v1 = stream._v1_chunks(stream.USAGE_STREAM, stream_options={"include_usage": True})
+    v2 = stream._v2_chunks(stream.USAGE_STREAM)
+    tail_ok = (
+        len(v1) == len(v2)
+        and stream._norm(v2[:-1]) == stream._norm(v1[: len(v2) - 1])
+        and v2[-1]["choices"] == []
+        and all(
+            v1[-1]["usage"][k] == v2[-1]["usage"][k]
+            for k in ("prompt_tokens", "completion_tokens", "total_tokens")
+        )
+    )
+    failures += 0 if tail_ok else 1
+    lines.append(
+        ("- SEAM CONTRACT: " if tail_ok else "- DIVERGENT: ")
+        + "usage tail (v2 passes the wire choices=[] usage chunk through;"
+        " the streaming seam owns v1's synthesized final chunk)"
+    )
+    divergence_event = {
+        "type": "content-delta",
+        "delta": {"message": {"content": {"text": 5}}},
+    }
+    v1_swallows = all(
+        choice["delta"]["content"] in (None, "")
+        for chunk in stream._v1_chunks([copy.deepcopy(divergence_event)])
+        for choice in chunk["choices"]
+    )
+    v2_loud = stream.parse_event(copy.deepcopy(divergence_event)).is_error()
+    pinned = v1_swallows and v2_loud
+    failures += 0 if pinned else 1
+    lines.append(
+        (
+            "- PINNED DIVERGENCE (fail-closed on a failure path): "
+            if pinned
+            else "- DIVERGENT: "
+        )
+        + "non-str content.text — v1 silently swallows the chunk, v2 errors"
+        " loudly naming the shape (re-decide if either half stops holding)"
+    )
+    return failures
+
+
 def _azure_rows(lines: list) -> int:
     import os
 
@@ -1120,7 +1269,7 @@ def main() -> None:
     _stub_vertex_token()
 
     lines = [
-        "# Translation v2 differential report (anthropic + bedrock + openai + google + azure + xai + the compat_sdk family (waves 1a+1b+2a) + the wave-1b compat_httpx family)",
+        "# Translation v2 differential report (anthropic + bedrock + openai + google + azure + xai + the compat_sdk family (waves 1a+1b+2a) + the wave-1b compat_httpx family + the wave-2b-beta own modules)",
         "",
         "v1 and v2 run over the same corpus; every row must be IDENTICAL (or an",
         "explained FALLBACK that v1 serves) for a provider's flag to turn on.",
@@ -1137,6 +1286,7 @@ def main() -> None:
     failures += _compat_sdk_rows(lines)
     failures += _compat_httpx_rows(lines)
     failures += _cometapi_rows(lines)
+    failures += _cohere_rows(lines)
     failures += _azure_rows(lines)
     failures += _azure_ai_rows(lines)
     failures += _bedrock_request_rows(lines)

--- a/tests/test_litellm/translation/test_differential_cohere_request.py
+++ b/tests/test_litellm/translation/test_differential_cohere_request.py
@@ -1,0 +1,265 @@
+"""Differential parity for the cohere v2 chat request path (wave-2b-beta).
+
+v2 is the DEFAULT cohere route at HEAD (``CohereModelInfo.get_cohere_route``:
+"v1" only when the model carries "v1/"), and BOTH provider names —
+"cohere" and "cohere_chat" — resolve to ``CohereV2ChatConfig`` and the same
+main.py elif, so both dispatch names run every row here.
+
+v1 side, invoked the way main.py's cohere elif runs: ``get_optional_params``
+(NOTE the drift probe: its cohere arm calls the LEGACY
+``CohereChatConfig().map_openai_params``, not the v2 config's — the two maps
+are byte-equivalent over the shared supported list, re-verified in-process
+at HEAD) with completion()'s ``stream=None`` default, then
+``CohereV2ChatConfig.transform_request`` (the inherited OpenAI GPT
+assembly). The serializer deltas pinned IDENTICAL: top_p -> p,
+stop -> stop_sequences, max_completion_tokens -> max_tokens, tool_choice
+silently DROPPED (supported list, no map arm), and ``top_k`` emitted
+verbatim top-level (the generic non-openai passthrough places it in
+optional_params for cohere — wire-proven here, NOT the extra_body arm).
+"""
+
+import copy
+import json
+
+import pytest
+
+from litellm.exceptions import UnsupportedParamsError
+from litellm.llms.cohere.chat.v2_transformation import CohereV2ChatConfig
+from litellm.utils import get_optional_params
+
+from litellm.translation.engine.pipeline import translate_chat_request
+from litellm.translation_seam import build_translation_deps
+
+PROVIDERS = ("cohere", "cohere_chat")
+
+_BASE_MESSAGES = [{"role": "user", "content": "hi"}]
+
+CASES = {
+    "plain": {"model": "command-r", "messages": _BASE_MESSAGES},
+    "sampling": {
+        "model": "command-r",
+        "messages": _BASE_MESSAGES,
+        "temperature": 0.5,
+        "top_p": 0.9,
+        "max_tokens": 100,
+        "stop": ["x", "y"],
+    },
+    "mct_renamed": {
+        "model": "command-r-plus",
+        "messages": _BASE_MESSAGES,
+        "max_completion_tokens": 50,
+    },
+    "tools": {
+        "model": "command-r",
+        "messages": _BASE_MESSAGES,
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "d",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ],
+        "tool_choice": "auto",
+    },
+    "tool_choice_required_dropped": {
+        "model": "command-r",
+        "messages": _BASE_MESSAGES,
+        "tools": [{"type": "function", "function": {"name": "f", "parameters": {}}}],
+        "tool_choice": "required",
+    },
+    "top_k_wire_proven": {
+        "model": "command-r",
+        "messages": _BASE_MESSAGES,
+        "top_k": 7,
+    },
+    "stream_true": {"model": "command-r", "messages": _BASE_MESSAGES, "stream": True},
+    "system_history": {
+        "model": "command-r",
+        "messages": [
+            {"role": "system", "content": "be nice"},
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+            {"role": "user", "content": "again"},
+        ],
+    },
+}
+
+# v1 RAISES UnsupportedParamsError (outside the supported list), probed
+# in-process at HEAD; v2 must be a typed fallback naming the raise.
+V1_RAISES = {
+    "response_format": (
+        {
+            "model": "command-r",
+            "messages": _BASE_MESSAGES,
+            "response_format": {"type": "json_object"},
+        },
+        "response_format",
+    ),
+    "parallel_tool_calls": (
+        {
+            "model": "command-r",
+            "messages": _BASE_MESSAGES,
+            "parallel_tool_calls": True,
+        },
+        "parallel_tool_calls",
+    ),
+    "thinking": (
+        {
+            "model": "command-r",
+            "messages": _BASE_MESSAGES,
+            "thinking": {"type": "enabled", "budget_tokens": 1024},
+        },
+        "thinking",
+    ),
+    "reasoning_effort": (
+        {
+            "model": "command-r",
+            "messages": _BASE_MESSAGES,
+            "reasoning_effort": "high",
+        },
+        "reasoning_effort",
+    ),
+}
+
+# v1 SERVES these (drop / passthrough / envelope rewrite); v2 falls back
+# typed so v1 keeps serving its own behavior.
+V1_SERVES_FALLBACKS = {
+    "user_silent_drop": (
+        {"model": "command-r", "messages": _BASE_MESSAGES, "user": "u1"},
+        "user",
+    ),
+    "n_parse_level": (
+        {"model": "command-r", "messages": _BASE_MESSAGES, "n": 2},
+        "n",
+    ),
+    "seed_parse_level": (
+        {"model": "command-r", "messages": _BASE_MESSAGES, "seed": 42},
+        "seed",
+    ),
+    "frequency_penalty_parse_level": (
+        {"model": "command-r", "messages": _BASE_MESSAGES, "frequency_penalty": 0.1},
+        "frequency_penalty",
+    ),
+    "presence_penalty_parse_level": (
+        {"model": "command-r", "messages": _BASE_MESSAGES, "presence_penalty": 0.2},
+        "presence_penalty",
+    ),
+    "v1_route_predicate": (
+        {"model": "v1/command-r", "messages": _BASE_MESSAGES},
+        "v1",
+    ),
+    "v2_prefix_envelope_strip": (
+        {"model": "v2/command-r", "messages": _BASE_MESSAGES},
+        "v2/",
+    ),
+    "explicit_stream_false": (
+        {"model": "command-r", "messages": _BASE_MESSAGES, "stream": False},
+        "stream",
+    ),
+    "message_name_forwarded": (
+        {
+            "model": "command-r",
+            "messages": [{"role": "user", "content": "hi", "name": "bob"}],
+        },
+        "name",
+    ),
+}
+
+
+def run_v1_request_transform(provider: str, case: dict) -> dict:
+    """May RAISE UnsupportedParamsError: that IS the pinned v1 behavior for
+    the raise rows."""
+    request = copy.deepcopy(case)
+    model = request.pop("model")
+    messages = request.pop("messages")
+    optional_params = get_optional_params(
+        model=model,
+        custom_llm_provider=provider,
+        messages=copy.deepcopy(messages),
+        stream=request.pop("stream", None),
+        **request,
+    )
+    optional_params.pop("extra_body", None)
+    return CohereV2ChatConfig().transform_request(
+        model=model,
+        messages=messages,
+        optional_params=optional_params,
+        litellm_params={},
+        headers={},
+    )
+
+
+def _v2(provider: str, case: dict):
+    return translate_chat_request(
+        copy.deepcopy(case), provider, build_translation_deps()
+    )
+
+
+def _norm(body: dict) -> str:
+    return json.dumps(body, sort_keys=True, default=str)
+
+
+def _rows(table: dict):
+    return sorted((provider, name) for provider in PROVIDERS for name in table)
+
+
+@pytest.mark.parametrize("provider,name", _rows(CASES))
+def test_v2_request_matches_v1(provider: str, name: str) -> None:
+    case = CASES[name]
+    result = _v2(provider, case)
+    assert result.is_ok(), result.error.summary
+    assert _norm(result.ok) == _norm(run_v1_request_transform(provider, case))
+
+
+@pytest.mark.parametrize("provider,name", _rows(V1_RAISES))
+def test_v1_raise_rows_fall_back_typed(provider: str, name: str) -> None:
+    case, fragment = V1_RAISES[name]
+    result = _v2(provider, case)
+    assert result.is_error(), f"{name} unexpectedly translated: {result.ok!r}"
+    assert fragment in result.error.summary, result.error.summary
+    with pytest.raises(UnsupportedParamsError):
+        run_v1_request_transform(provider, case)
+
+
+@pytest.mark.parametrize("provider,name", _rows(V1_SERVES_FALLBACKS))
+def test_v1_serves_fallback_rows(provider: str, name: str) -> None:
+    case, fragment = V1_SERVES_FALLBACKS[name]
+    result = _v2(provider, case)
+    assert result.is_error(), f"{name} unexpectedly translated: {result.ok!r}"
+    assert fragment in result.error.summary, result.error.summary
+    # v1 serves the same request without raising (drop/passthrough/envelope).
+    run_v1_request_transform(provider, case)
+
+
+def test_top_k_rides_the_wire_top_level() -> None:
+    """The wire-prove rule (longtail guidance): cohere's top_k is NOT the
+    extra_body arm — v1's generic passthrough places it top-level in
+    optional_params and the GPT assembly emits it verbatim."""
+    case = CASES["top_k_wire_proven"]
+    v1_body = run_v1_request_transform("cohere_chat", case)
+    assert v1_body["top_k"] == 7
+    assert "extra_body" not in v1_body
+    result = _v2("cohere_chat", case)
+    assert result.is_ok() and result.ok["top_k"] == 7
+
+
+def test_tool_choice_never_reaches_the_wire() -> None:
+    case = CASES["tool_choice_required_dropped"]
+    v1_body = run_v1_request_transform("cohere", case)
+    assert "tool_choice" not in v1_body
+    result = _v2("cohere", case)
+    assert result.is_ok() and "tool_choice" not in result.ok
+
+
+def test_both_provider_names_share_one_config() -> None:
+    from litellm.types.utils import LlmProviders
+    from litellm.utils import ProviderConfigManager
+
+    for provider in PROVIDERS:
+        config = ProviderConfigManager.get_provider_chat_config(
+            model="command-r", provider=LlmProviders(provider)
+        )
+        assert type(config).__name__ == "CohereV2ChatConfig"

--- a/tests/test_litellm/translation/test_differential_cohere_response.py
+++ b/tests/test_litellm/translation/test_differential_cohere_response.py
@@ -1,0 +1,260 @@
+"""Differential parity for the cohere v2 response path (wave-2b-beta).
+
+v1 side: ``CohereV2ChatConfig.transform_response`` (LIVE on the httpx path)
+mutating a pre-allocated ``ModelResponse`` — content joined from
+``message.content[].text``, citations -> url_citation annotations,
+tool-call responses REPLACE the message (text content lost, ``content=None``,
+explicit ``annotations`` kwarg), usage from ``usage.tokens`` (NOT
+billed_units), ``model`` = the request model, the wire id IGNORED (ambient
+chatcmpl id kept) and ``finish_reason`` NEVER read (the fresh-Choices
+default "stop" survives even for tool calls — quirk-pinned below).
+
+v2 side: the cohere parser builds the normalized body on
+``ChatResponse.wire``; the seam's ``openai`` construction arm reproduces
+v1's assembly byte-for-byte. Both sides get the SAME pre-allocated
+``ModelResponse(id=...)`` because v1 keeps the ambient envelope id (v1 mints
+it fresh per call in production — envelope nondeterminism, not parser
+scope).
+"""
+
+import copy
+import json
+import time
+
+import httpx
+import pytest
+
+from litellm.litellm_core_utils.litellm_logging import Logging
+from litellm.llms.cohere.chat.v2_transformation import CohereV2ChatConfig
+from litellm.types.utils import ModelResponse
+
+from litellm.translation.inbound.openai_chat import parse_request
+from litellm.translation.inbound.openai_chat.response import serialize_response
+from litellm.translation.providers.cohere import parse_response
+from litellm.translation_seam import build_translation_deps, to_model_response
+
+MODEL = "command-r"
+_AMBIENT_ID = "chatcmpl-cohere-diff"
+
+_REQUEST = {"model": MODEL, "messages": [{"role": "user", "content": "hi"}]}
+
+_RESPONSES = {
+    "text": {
+        "id": "wire-id-ignored",
+        "finish_reason": "COMPLETE",
+        "message": {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "hel"},
+                {"type": "text", "text": "lo"},
+            ],
+        },
+        "usage": {"tokens": {"input_tokens": 3, "output_tokens": 2}},
+        "logprobs": {"token_ids": []},
+    },
+    "tool_calls": {
+        "id": "wire-id-ignored",
+        "finish_reason": "TOOL_CALL",
+        "message": {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "f", "arguments": '{"a":1}'},
+                }
+            ],
+        },
+        "usage": {"tokens": {"input_tokens": 5, "output_tokens": 4}},
+    },
+    "citations_to_annotations": {
+        "id": "x",
+        "finish_reason": "COMPLETE",
+        "message": {
+            "role": "assistant",
+            "content": [{"type": "text", "text": "hi"}],
+            "citations": [
+                {
+                    "start": 0,
+                    "end": 2,
+                    "text": "hi",
+                    "sources": [
+                        {"type": "document", "id": "d1", "document": {"title": "T"}}
+                    ],
+                }
+            ],
+        },
+        "usage": {"tokens": {"input_tokens": 1, "output_tokens": 1}},
+    },
+    "tool_calls_discard_text_keep_annotations": {
+        "id": "x",
+        "finish_reason": "TOOL_CALL",
+        "message": {
+            "role": "assistant",
+            "content": [{"type": "text", "text": "discarded by v1"}],
+            "tool_calls": [
+                {
+                    "id": "c",
+                    "type": "function",
+                    "function": {"name": "f", "arguments": "{}"},
+                }
+            ],
+            "citations": [
+                {
+                    "start": 0,
+                    "end": 1,
+                    "text": "i",
+                    "sources": [
+                        {"type": "document", "id": "d", "document": {"title": "T"}}
+                    ],
+                }
+            ],
+        },
+        "usage": {"tokens": {"input_tokens": 1, "output_tokens": 1}},
+    },
+    "missing_tokens_defaults_zero": {
+        "id": "x",
+        "finish_reason": "COMPLETE",
+        "message": {"role": "assistant", "content": []},
+        "usage": {},
+    },
+    "null_content": {
+        "id": "x",
+        "finish_reason": "COMPLETE",
+        "message": {"role": "assistant", "content": None},
+        "usage": {"tokens": {"input_tokens": 1, "output_tokens": 1}},
+    },
+    "billed_units_ignored": {
+        "id": "x",
+        "finish_reason": "COMPLETE",
+        "message": {"role": "assistant", "content": [{"type": "text", "text": "hi"}]},
+        "usage": {"billed_units": {"input_tokens": 9, "output_tokens": 9}},
+    },
+}
+
+# v1 RAISES out of transform_response on these shapes (KeyError /
+# AttributeError / TypeError / the TypedDict-splat CohereError 422); v2 must
+# be a loud typed error, never a served response.
+_LOUD = {
+    "non_object_body": ([1, 2], "not an object"),
+    "missing_message": (
+        {"id": "x", "usage": {"tokens": {}}},
+        "message",
+    ),
+    "missing_usage": (
+        {"id": "x", "message": {"role": "assistant", "content": []}},
+        "usage",
+    ),
+    "non_string_text": (
+        {
+            "id": "x",
+            "message": {"role": "assistant", "content": [{"text": 5}]},
+            "usage": {"tokens": {}},
+        },
+        "not a string",
+    ),
+    "string_content": (
+        {
+            "id": "x",
+            "message": {"role": "assistant", "content": "plain"},
+            "usage": {"tokens": {}},
+        },
+        "not a list",
+    ),
+    "null_tokens_object": (
+        {
+            "id": "x",
+            "message": {"role": "assistant", "content": []},
+            "usage": {"tokens": None},
+        },
+        "tokens",
+    ),
+    "string_token_count": (
+        {
+            "id": "x",
+            "message": {"role": "assistant", "content": []},
+            "usage": {"tokens": {"input_tokens": "3"}},
+        },
+        "not an integer",
+    ),
+}
+
+
+def _v1_model_response(raw: dict) -> dict:
+    logging = Logging(
+        model=MODEL,
+        messages=copy.deepcopy(_REQUEST["messages"]),
+        stream=False,
+        call_type="completion",
+        start_time=time.time(),
+        litellm_call_id="diff-cohere-response",
+        function_id="diff-cohere-response",
+    )
+    response = httpx.Response(
+        200,
+        json=copy.deepcopy(raw),
+        request=httpx.Request("POST", "https://api.cohere.com/v2/chat"),
+    )
+    return (
+        CohereV2ChatConfig()
+        .transform_response(
+            model=MODEL,
+            raw_response=response,
+            model_response=ModelResponse(id=_AMBIENT_ID),
+            logging_obj=logging,
+            request_data={},
+            messages=copy.deepcopy(_REQUEST["messages"]),
+            optional_params={},
+            litellm_params={},
+            encoding=None,
+        )
+        .model_dump()
+    )
+
+
+def _v2_parse(raw: dict):
+    parsed = parse_request(copy.deepcopy(_REQUEST))
+    assert parsed.is_ok(), parsed.error.summary
+    return parse_response(copy.deepcopy(raw), parsed.ok)
+
+
+def _v2_model_response(raw: dict) -> dict:
+    response = _v2_parse(raw)
+    assert response.is_ok(), response.error.summary
+    body = serialize_response(response.ok, build_translation_deps(), "openai")
+    return to_model_response(
+        body, ModelResponse(id=_AMBIENT_ID), usage_style="openai"
+    ).model_dump()
+
+
+def _norm(payload: dict) -> str:
+    return json.dumps(payload, sort_keys=True, default=str)
+
+
+@pytest.mark.parametrize("name", sorted(_RESPONSES))
+def test_v2_response_matches_v1(name: str, frozen_ambient) -> None:
+    raw = _RESPONSES[name]
+    assert _norm(_v2_model_response(raw)) == _norm(_v1_model_response(raw))
+
+
+@pytest.mark.parametrize("name", sorted(_RESPONSES))
+def test_request_model_and_stop_finish_quirks(name: str, frozen_ambient) -> None:
+    """v1 never reads the wire finish_reason (fresh-Choices "stop" survives
+    even for tool calls), keeps the REQUEST model verbatim (no prefix, no
+    wire model), and ignores the wire response id."""
+    v1 = _v1_model_response(_RESPONSES[name])
+    v2 = _v2_model_response(_RESPONSES[name])
+    for dump in (v1, v2):
+        assert dump["model"] == MODEL
+        assert dump["choices"][0]["finish_reason"] == "stop"
+        assert dump["id"] == _AMBIENT_ID
+
+
+@pytest.mark.parametrize("name", sorted(_LOUD))
+def test_loud_shapes_error_on_both_sides(name: str, frozen_ambient) -> None:
+    raw, fragment = _LOUD[name]
+    result = _v2_parse(raw)
+    assert result.is_error(), f"{name} unexpectedly parsed"
+    assert fragment in result.error.summary, result.error.summary
+    with pytest.raises(Exception):
+        _v1_model_response(copy.deepcopy(raw))

--- a/tests/test_litellm/translation/test_differential_cohere_response.py
+++ b/tests/test_litellm/translation/test_differential_cohere_response.py
@@ -132,6 +132,19 @@ _RESPONSES = {
     },
 }
 
+
+def _with_citations(citations) -> dict:
+    return {
+        "id": "x",
+        "message": {
+            "role": "assistant",
+            "content": [{"type": "text", "text": "ok"}],
+            "citations": citations,
+        },
+        "usage": {"tokens": {"input_tokens": 1, "output_tokens": 2}},
+    }
+
+
 # v1 RAISES out of transform_response on these shapes (KeyError /
 # AttributeError / TypeError / the TypedDict-splat CohereError 422); v2 must
 # be a loud typed error, never a served response.
@@ -176,6 +189,123 @@ _LOUD = {
             "usage": {"tokens": {"input_tokens": "3"}},
         },
         "not an integer",
+    ),
+    # The verifier-wave2b-beta F1 class: hostile citation shapes where v1's
+    # _translate_citations_to_openai_annotations AttributeErrors out of
+    # transform_response while the old skip-arms silently served an
+    # annotation-less body.
+    "citation_entry_int": (_with_citations([5]), "citation entry is not an object"),
+    "citation_entry_string": (
+        _with_citations(["x"]),
+        "citation entry is not an object",
+    ),
+    "citations_dict": (_with_citations({"a": 1}), "not a list"),
+    "citations_string": (_with_citations("abc"), "not a list"),
+    "sources_dict": (
+        _with_citations([{"start": 0, "end": 1, "sources": {"k": "v"}}]),
+        "sources is truthy but not a list",
+    ),
+    "sources_string": (
+        _with_citations([{"start": 0, "end": 1, "sources": "xy"}]),
+        "sources is truthy but not a list",
+    ),
+    "source_entry_int": (
+        _with_citations([{"start": 0, "end": 1, "sources": [7]}]),
+        "source is not an object",
+    ),
+    "document_non_dict": (
+        _with_citations(
+            [
+                {
+                    "start": 0,
+                    "end": 1,
+                    "sources": [{"type": "document", "document": 9, "id": "s"}],
+                }
+            ]
+        ),
+        "document is not an object",
+    ),
+    # F8's untyped escape: a tool_call without a function key crashes BOTH
+    # sides with the identical Message TypeError — typed here so the raise
+    # never escapes v2's parse as a seam crash.
+    "tool_call_missing_function": (
+        {
+            "id": "x",
+            "message": {
+                "role": "assistant",
+                "tool_calls": [{"id": "t1", "type": "function"}],
+            },
+            "usage": {"tokens": {"input_tokens": 1, "output_tokens": 1}},
+        },
+        "no 'function' key",
+    ),
+}
+
+# verifier-wave2b-beta F8: citation VALUE types v1 SERVES (the annotations
+# ride a TypedDict attached by plain setattr — no validation on the non-tool
+# path) but v2's typed Message construction would reject with a raw
+# ValidationError. v2 falls back at the typed boundary instead; v1 serves.
+_V1_SERVES_FALLBACKS = {
+    "citation_start_string": (
+        _with_citations(
+            [
+                {
+                    "start": "a",
+                    "end": 1,
+                    "sources": [
+                        {"type": "document", "document": {"title": "t"}, "id": "s"}
+                    ],
+                }
+            ]
+        ),
+        "start/end/title value type",
+    ),
+    "citation_end_bool": (
+        _with_citations(
+            [
+                {
+                    "start": 0,
+                    "end": True,
+                    "sources": [
+                        {"type": "document", "document": {"title": "t"}, "id": "s"}
+                    ],
+                }
+            ]
+        ),
+        "start/end/title value type",
+    ),
+    "citation_title_int": (
+        _with_citations(
+            [
+                {
+                    "start": 0,
+                    "end": 1,
+                    "sources": [
+                        {"type": "document", "document": {"title": 7}, "id": "s"}
+                    ],
+                }
+            ]
+        ),
+        "start/end/title value type",
+    ),
+    "citation_url_int": (
+        _with_citations(
+            [
+                {
+                    "start": 0,
+                    "end": 1,
+                    "sources": [
+                        {
+                            "type": "document",
+                            "document": {"title": "t"},
+                            "id": "s",
+                            "url": 5,
+                        }
+                    ],
+                }
+            ]
+        ),
+        "url is truthy but not a string",
     ),
 }
 
@@ -258,3 +388,20 @@ def test_loud_shapes_error_on_both_sides(name: str, frozen_ambient) -> None:
     assert fragment in result.error.summary, result.error.summary
     with pytest.raises(Exception):
         _v1_model_response(copy.deepcopy(raw))
+
+
+@pytest.mark.parametrize("name", sorted(_V1_SERVES_FALLBACKS))
+def test_unvalidated_citation_values_fall_back_where_v1_serves(
+    name: str, frozen_ambient
+) -> None:
+    """F8: v1 serves the unvalidated annotation (plain setattr); v2's typed
+    Message construction would raise a RAW ValidationError out of the seam —
+    so the parse falls back typed and v1 keeps serving. If v1 ever starts
+    validating, the serve assertion fails and the row must be re-decided."""
+    raw, fragment = _V1_SERVES_FALLBACKS[name]
+    result = _v2_parse(raw)
+    assert result.is_error(), f"{name} unexpectedly parsed"
+    assert fragment in result.error.summary, result.error.summary
+    v1 = _v1_model_response(copy.deepcopy(raw))
+    annotations = v1["choices"][0]["message"].get("annotations")
+    assert annotations, f"{name}: v1 stopped serving the annotation; re-decide"

--- a/tests/test_litellm/translation/test_differential_cohere_response.py
+++ b/tests/test_litellm/translation/test_differential_cohere_response.py
@@ -31,7 +31,11 @@ from litellm.types.utils import ModelResponse
 from litellm.translation.inbound.openai_chat import parse_request
 from litellm.translation.inbound.openai_chat.response import serialize_response
 from litellm.translation.providers.cohere import parse_response
-from litellm.translation_seam import build_translation_deps, to_model_response
+from litellm.translation_seam import (
+    UsageStyle,
+    build_translation_deps,
+    to_model_response,
+)
 
 MODEL = "command-r"
 _AMBIENT_ID = "chatcmpl-cohere-diff"
@@ -348,13 +352,20 @@ def _v2_parse(raw: dict):
     return parse_response(copy.deepcopy(raw), parsed.ok)
 
 
-def _v2_model_response(raw: dict) -> dict:
+def _v2_with_style(raw: dict, style: UsageStyle) -> dict:
     response = _v2_parse(raw)
     assert response.is_ok(), response.error.summary
     body = serialize_response(response.ok, build_translation_deps(), "openai")
     return to_model_response(
-        body, ModelResponse(id=_AMBIENT_ID), usage_style="openai"
+        body, ModelResponse(id=_AMBIENT_ID), usage_style=style
     ).model_dump()
+
+
+def _v2_model_response(raw: dict) -> dict:
+    # both cohere provider names ride the cdr arm — the truth is
+    # pipeline.OWN_MODULE_RESPONSE_STYLES["cohere"]/["cohere_chat"],
+    # divergence-pinned below
+    return _v2_with_style(raw, "openai")
 
 
 def _norm(payload: dict) -> str:
@@ -405,3 +416,32 @@ def test_unvalidated_citation_values_fall_back_where_v1_serves(
     v1 = _v1_model_response(copy.deepcopy(raw))
     annotations = v1["choices"][0]["message"].get("annotations")
     assert annotations, f"{name}: v1 stopped serving the annotation; re-decide"
+
+
+def test_wrong_construction_arm_diverges_and_the_table_pins_it(
+    frozen_ambient,
+) -> None:
+    """verifier-wave2b-final F1: the "openai"-arm OWN_MODULE_RESPONSE_STYLES
+    values were enforced by NOTHING — a wrong-arm value flip survived the
+    whole suite. The wrong-arm template for a provider whose normalized
+    body the parser BUILDS (no wire index/created can ride through): the
+    cohere body deliberately carries NO id, so the correct cdr ("openai")
+    arm keeps the ambient chatcmpl id exactly like v1's fresh-ModelResponse
+    mutation, while the wrong "openai_like" arm (ModelResponse(**json))
+    IGNORES the pre-allocated envelope and mints a fresh id. Both provider
+    names pin the one module's rows."""
+    from litellm.translation.engine.pipeline import OWN_MODULE_RESPONSE_STYLES
+
+    assert OWN_MODULE_RESPONSE_STYLES["cohere"] == "openai"
+    assert OWN_MODULE_RESPONSE_STYLES["cohere_chat"] == "openai"
+    raw = _RESPONSES["text"]
+    v1 = _v1_model_response(raw)
+    correct = _v2_with_style(raw, OWN_MODULE_RESPONSE_STYLES["cohere"])
+    wrong = _v2_with_style(raw, "openai_like")
+    assert _norm(correct) == _norm(v1)
+    assert correct["id"] == _AMBIENT_ID
+    assert wrong["id"] != _AMBIENT_ID
+    assert _norm(wrong) != _norm(v1), (
+        "the construction arms stopped diverging on the envelope id — "
+        "the F1 gate lost its discriminator; re-decide before relying on it"
+    )

--- a/tests/test_litellm/translation/test_differential_cohere_stream.py
+++ b/tests/test_litellm/translation/test_differential_cohere_stream.py
@@ -1,0 +1,362 @@
+"""Differential parity for cohere v2 streaming (wave-2b-beta), pinned at the
+bare-JSON line seam.
+
+v1 side: raw JSON lines (NO ``data:`` framing, NO ``[DONE]`` — v1's
+``CohereV2ModelResponseIterator`` json.loads each line directly) through the
+iterator into ``CustomStreamWrapper("cohere_chat")``'s GENERIC arm. v2 side:
+``fold_lines`` with the cohere parser and the shared ``generic`` chunk
+dialect.
+
+The v1 wire-vs-parser quirk drives TWO regimes, both pinned:
+
+- REAL-WIRE (``type``-keyed events, what Cohere v2 actually sends): the
+  parser's message-end arm never fires (it reads ``event``), so the wrapper
+  SYNTHESIZES the trailing finish chunk at StopIteration — "tool_calls"
+  when tool deltas were seen, else "stop". v2 == v1 minus that synthesized
+  tail; the tail is the streaming seam's obligation (asserted per row).
+- EVENT-keyed message-end (the shape the parser was written for): finish is
+  mapped (COMPLETE -> stop, MAX_TOKENS -> length, ERROR_TOXIC ->
+  content_filter, anything else -> stop) and emitted VERBATIM — no
+  seen-tool-calls rewrite — and wire usage rides; v1 swallows it without
+  ``stream_options.include_usage`` and emits a final usage chunk with the
+  WIRE values under it, while v2 passes a ``choices: []`` usage tail through
+  (the family seam contract).
+
+Envelope contracts the adapter below documents (generic-arm seam
+obligations, distinct from the openai/xai dialect): v1 mints a FRESH
+chatcmpl id per chunk (ids are normalized here and the freshness pinned),
+sets NO ``system_fingerprint``/``citations`` keys, and re-reads no wire id.
+"""
+
+import copy
+import json
+import time
+
+import pytest
+
+from litellm.litellm_core_utils.litellm_logging import Logging
+from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
+from litellm.llms.cohere.common_utils import CohereV2ModelResponseIterator
+from litellm.types.utils import ModelResponseStream, Usage
+
+from litellm.translation.engine.stream import fold_events, fold_lines
+from litellm.translation.inbound.openai_chat.stream import initial_state
+from litellm.translation.providers.cohere import parse_event, parse_line
+
+MODEL = "command-r"
+
+_USAGE_EVENT = {
+    "event": "message-end",
+    "data": {
+        "delta": {
+            "finish_reason": "COMPLETE",
+            "usage": {"tokens": {"input_tokens": 3, "output_tokens": 2}},
+        }
+    },
+}
+
+# regime 1: type-keyed (real wire) — v1 synthesizes the trailing finish.
+REAL_WIRE_STREAMS = {
+    "text": (
+        [
+            {"type": "message-start", "delta": {"message": {"role": "assistant"}}},
+            {
+                "type": "content-delta",
+                "delta": {"message": {"content": {"text": "Hel"}}},
+            },
+            {
+                "type": "content-delta",
+                "delta": {"message": {"content": {"text": "lo"}}},
+            },
+            {
+                "type": "message-end",
+                "data": {
+                    "delta": {
+                        "finish_reason": "COMPLETE",
+                        "usage": {"tokens": {"input_tokens": 3, "output_tokens": 2}},
+                    }
+                },
+            },
+        ],
+        "stop",
+    ),
+    "tools": (
+        [
+            {
+                "type": "tool-call-start",
+                "delta": {"message": {"tool_calls": {"id": "c1", "type": "function"}}},
+            },
+            {
+                "type": "tool-call-delta",
+                "delta": {
+                    "tool_calls": [
+                        {"id": "c1", "name": "get_weather", "arguments": '{"city"'}
+                    ]
+                },
+            },
+            {
+                "type": "tool-call-delta",
+                "delta": {"tool_calls": [{"arguments": ':"Paris"}'}]},
+            },
+            {"type": "message-end", "data": {"delta": {"finish_reason": "TOOL_CALL"}}},
+        ],
+        "tool_calls",
+    ),
+}
+
+# regime 2: event-keyed shapes — exact parity (and the usage-tail contract).
+EVENT_KEYED_STREAMS = {
+    "plan_citation_content": [
+        {
+            "event": "tool-plan-delta",
+            "data": {"delta": {"message": {"tool_plan": "plan"}}},
+        },
+        {"type": "content-delta", "delta": {"message": {"content": {"text": "Hi"}}}},
+        {
+            "event": "citation-start",
+            "data": {
+                "delta": {
+                    "message": {
+                        "citations": {
+                            "start": 0,
+                            "end": 2,
+                            "text": "Hi",
+                            "sources": [
+                                {
+                                    "type": "document",
+                                    "id": "d1",
+                                    "document": {"title": "T"},
+                                }
+                            ],
+                        }
+                    }
+                }
+            },
+        },
+        {"event": "message-end", "data": {"delta": {"finish_reason": "COMPLETE"}}},
+    ],
+    "max_tokens_maps_to_length": [
+        {"type": "content-delta", "delta": {"message": {"content": {"text": "Hi"}}}},
+        {"event": "message-end", "data": {"delta": {"finish_reason": "MAX_TOKENS"}}},
+    ],
+    "error_toxic_maps_to_content_filter": [
+        {"type": "content-delta", "delta": {"message": {"content": {"text": "Hi"}}}},
+        {"event": "message-end", "data": {"delta": {"finish_reason": "ERROR_TOXIC"}}},
+    ],
+    "tool_then_event_end_no_rewrite": [
+        {
+            "type": "tool-call-delta",
+            "delta": {"tool_calls": [{"id": "c", "name": "f", "arguments": "{}"}]},
+        },
+        {"event": "message-end", "data": {"delta": {"finish_reason": "TOOL_CALL"}}},
+    ],
+}
+
+USAGE_STREAM = [
+    {"type": "content-delta", "delta": {"message": {"content": {"text": "Hi"}}}},
+    _USAGE_EVENT,
+]
+
+
+def _make_logging() -> Logging:
+    return Logging(
+        model=MODEL,
+        messages=[{"role": "user", "content": "stream"}],
+        stream=True,
+        call_type="completion",
+        start_time=time.time(),
+        litellm_call_id="diff-cohere-stream",
+        function_id="diff-cohere-stream",
+    )
+
+
+def _v1_chunks(events: list, stream_options: dict | None = None) -> list:
+    lines = [json.dumps(event) for event in copy.deepcopy(events)]
+    handler = CohereV2ModelResponseIterator(
+        streaming_response=iter(lines), sync_stream=True
+    )
+    wrapper = CustomStreamWrapper(
+        completion_stream=handler,
+        model=MODEL,
+        custom_llm_provider="cohere_chat",
+        logging_obj=_make_logging(),
+        stream_options=stream_options,
+    )
+    return [chunk.model_dump() for chunk in wrapper]
+
+
+def _to_stream_chunk(body: dict) -> dict:
+    """The generic-arm chunk envelope a future cohere streaming seam must
+    build (and the reason ``to_model_response_stream`` is NOT used here):
+    v1's wrapper constructs a FRESH ModelResponseStream per chunk — ambient
+    per-chunk id and created, NO citations/system_fingerprint presets — and
+    a body-carried usage becomes the verbatim ``Usage(**dict)``."""
+    payload = dict(body)
+    usage_payload = payload.pop("usage", None)
+    chunk = ModelResponseStream(**payload)
+    if isinstance(usage_payload, dict):
+        setattr(chunk, "usage", Usage(**usage_payload))
+    return chunk.model_dump()
+
+
+def _v2_chunks(events: list) -> list:
+    lines = [json.dumps(event) for event in copy.deepcopy(events)]
+    folded = fold_lines(lines, parse_line, initial_state(MODEL, dialect="generic"))
+    assert folded.is_ok(), folded.error.summary
+    return [_to_stream_chunk(chunk) for chunk in folded.ok]
+
+
+def _norm(chunks: list) -> str:
+    """Byte-compare with ids normalized: v1 mints a FRESH chatcmpl id per
+    chunk (envelope nondeterminism, pinned by
+    test_v1_mints_fresh_ids_per_chunk); everything else must be identical."""
+    normalized = []
+    for chunk in chunks:
+        assert str(chunk["id"]).startswith("chatcmpl-")
+        normalized.append({**chunk, "id": "ID"})
+    return json.dumps(normalized, sort_keys=True, default=str)
+
+
+@pytest.mark.parametrize("name", sorted(REAL_WIRE_STREAMS))
+def test_real_wire_v2_matches_v1_minus_synthesized_tail(
+    name: str, frozen_ambient
+) -> None:
+    events, synth_finish = REAL_WIRE_STREAMS[name]
+    v1 = _v1_chunks(events)
+    v2 = _v2_chunks(events)
+    assert len(v1) == len(v2) + 1
+    assert _norm(v2) == _norm(v1[:-1])
+    tail = v1[-1]["choices"][0]
+    assert tail["finish_reason"] == synth_finish
+    assert tail["delta"]["content"] is None and tail["delta"]["tool_calls"] is None
+
+
+@pytest.mark.parametrize("name", sorted(EVENT_KEYED_STREAMS))
+def test_event_keyed_v2_matches_v1(name: str, frozen_ambient) -> None:
+    events = EVENT_KEYED_STREAMS[name]
+    assert _norm(_v2_chunks(events)) == _norm(_v1_chunks(events))
+
+
+def test_usage_tail_pins_the_seam_contract(frozen_ambient) -> None:
+    """v2 passes the wire usage through on a ``choices: []`` tail; v1
+    swallows it without include_usage and emits its final usage chunk (the
+    WIRE values for this event-keyed shape) under it."""
+    v1 = _v1_chunks(USAGE_STREAM, stream_options={"include_usage": True})
+    v2 = _v2_chunks(USAGE_STREAM)
+    assert len(v1) == len(v2)
+    assert _norm(v2[:-1]) == _norm(v1[: len(v2) - 1])
+    assert v2[-1]["choices"] == []
+    for key in ("prompt_tokens", "completion_tokens", "total_tokens"):
+        assert v1[-1]["usage"][key] == v2[-1]["usage"][key], key
+
+
+def test_usage_tail_swallowed_without_stream_options(frozen_ambient) -> None:
+    v1 = _v1_chunks(USAGE_STREAM, None)
+    v2 = _v2_chunks(USAGE_STREAM)
+    assert len(v1) == len(v2) - 1
+    assert _norm(v1) == _norm(v2[:-1])
+
+
+def test_real_wire_include_usage_synthesis_is_estimated(frozen_ambient) -> None:
+    """On the real (type-keyed) wire the message-end usage NEVER reaches the
+    wrapper, so v1's include_usage final chunk carries token-counter
+    ESTIMATES, not the wire 3/2 — the seam obligation the docstring names."""
+    events, _ = REAL_WIRE_STREAMS["text"]
+    v1 = _v1_chunks(events, stream_options={"include_usage": True})
+    usage = v1[-1]["usage"]
+    assert usage is not None
+    assert (usage["prompt_tokens"], usage["completion_tokens"]) != (3, 2)
+
+
+def test_v1_mints_fresh_ids_per_chunk(frozen_ambient) -> None:
+    v1 = _v1_chunks(EVENT_KEYED_STREAMS["plan_citation_content"])
+    ids = [chunk["id"] for chunk in v1]
+    assert len(set(ids)) == len(ids)
+
+
+def test_v2_line_and_event_folds_agree(frozen_ambient) -> None:
+    events = EVENT_KEYED_STREAMS["plan_citation_content"]
+    folded = fold_events(
+        copy.deepcopy(events), parse_event, initial_state(MODEL, dialect="generic")
+    )
+    assert folded.is_ok(), folded.error.summary
+    via_events = [_to_stream_chunk(chunk) for chunk in folded.ok]
+    assert _norm(via_events) == _norm(_v2_chunks(events))
+
+
+_LOUD_CHUNKS = {
+    "non_dict_tool_call_entry": (
+        {"type": "tool-call-delta", "delta": {"tool_calls": ["bare"]}},
+        "tool_calls[0]",
+    ),
+    "non_dict_delta": (
+        {"type": "tool-call-delta", "delta": "x"},
+        "not an object",
+    ),
+    "null_usage_tokens": (
+        {
+            "event": "message-end",
+            "data": {"delta": {"finish_reason": "COMPLETE", "usage": {"tokens": None}}},
+        },
+        "tokens",
+    ),
+    "non_numeric_index": (
+        {"index": "x", "type": "content-delta"},
+        "index",
+    ),
+}
+
+
+@pytest.mark.parametrize("name", sorted(_LOUD_CHUNKS))
+def test_loud_chunk_shapes_error_on_both_sides(name: str, frozen_ambient) -> None:
+    """v1's chunk_parser raises ValueError -> RuntimeError out of the
+    iterator on each of these; v2 is a loud typed error, never a served
+    chunk."""
+    event, fragment = _LOUD_CHUNKS[name]
+    result = parse_event(copy.deepcopy(event))
+    assert result.is_error(), f"{name} unexpectedly parsed"
+    assert fragment in result.error.summary, result.error.summary
+    with pytest.raises(Exception):
+        _v1_chunks([event])
+
+
+def test_non_string_text_pinned_divergence(frozen_ambient) -> None:
+    """PINNED DIVERGENCE (fail-closed on a failure path, the compat_httpx
+    error-chunk precedent): a non-str ``content.text`` is SILENTLY SWALLOWED
+    by v1 (the wrapper drops the chunk and only the synthesized finish
+    emerges); v2 errors loudly naming the shape. If v1 ever starts serving
+    or raising on it, the first assertion fails and the row must be
+    re-decided."""
+    event = {"type": "content-delta", "delta": {"message": {"content": {"text": 5}}}}
+    v1 = _v1_chunks([event])
+    assert all(
+        choice["delta"]["content"] in (None, "")
+        for chunk in v1
+        for choice in chunk["choices"]
+    ), "v1 started serving the non-str text; re-decide the pinned divergence"
+    result = parse_event(copy.deepcopy(event))
+    assert result.is_error()
+    assert "not a string" in result.error.summary
+
+
+def test_non_string_finish_defaults_to_stop_like_v1(frozen_ambient) -> None:
+    """v1's map_finish_reason defaults every unmapped value — non-strings
+    included — to "stop" (probed); the v2 parser mirrors the default."""
+    events = [{"event": "message-end", "data": {"delta": {"finish_reason": 5}}}]
+    v1 = _v1_chunks(events)
+    v2 = _v2_chunks(events)
+    assert _norm(v2) == _norm(v1)
+    assert v2[-1]["choices"][0]["finish_reason"] == "stop"
+
+
+def test_non_json_line_is_loud_on_both_sides(frozen_ambient) -> None:
+    """No data:/[DONE] framing on this wire: v1 json.loads every line and
+    raises RuntimeError on a non-JSON one."""
+    result = parse_line("data: {}")
+    assert result.is_error()
+    assert "non-JSON" in result.error.summary
+    handler = CohereV2ModelResponseIterator(
+        streaming_response=iter(["data: {}"]), sync_stream=True
+    )
+    with pytest.raises(Exception):
+        next(handler)

--- a/tests/test_litellm/translation/test_differential_cohere_stream.py
+++ b/tests/test_litellm/translation/test_differential_cohere_stream.py
@@ -304,6 +304,27 @@ _LOUD_CHUNKS = {
         {"index": "x", "type": "content-delta"},
         "index",
     ),
+    # critic-wave2b-beta N4: json.loads accepts NaN/Infinity literals, so
+    # the corner is wire-reachable — v1's int(chunk.get("index", 0)) raises
+    # ValueError/OverflowError on them.
+    "non_finite_index": (
+        {"index": float("inf"), "type": "content-delta"},
+        "non-finite",
+    ),
+    # critic M1's flip side: only pairs the raw + (or the wrapper's Usage
+    # validation) rejects stay loud — a str+int mix TypeErrors in v1.
+    "mixed_type_token_counts": (
+        {
+            "event": "message-end",
+            "data": {
+                "delta": {
+                    "finish_reason": "COMPLETE",
+                    "usage": {"tokens": {"input_tokens": "5", "output_tokens": 3}},
+                }
+            },
+        },
+        "neither numeric nor a str+str pair",
+    ),
 }
 
 
@@ -337,6 +358,35 @@ def test_non_string_text_pinned_divergence(frozen_ambient) -> None:
     result = parse_event(copy.deepcopy(event))
     assert result.is_error()
     assert "not a string" in result.error.summary
+
+
+def test_string_token_counts_fall_back_where_v1_serves(frozen_ambient) -> None:
+    """critic M1: ChatCompletionUsageBlock is a TypedDict — v1's raw ``+``
+    CONCATENATES a str+str pair (input "5" + output "3" -> "53") and v1
+    SERVES the stream end to end (the include_usage final chunk lax-coerces
+    the parts and RE-SUMS the total: 5/3/8 — probed; the "53" never
+    survives the wrapper). v2 falls back so v1 serves it — the SAME
+    deliberate decision as the response side's _int_token — and the old
+    FALSE "v1 raises building ChatCompletionUsageBlock" reason is gone."""
+    events = [
+        {"type": "content-delta", "delta": {"message": {"content": {"text": "Hi"}}}},
+        {
+            "event": "message-end",
+            "data": {
+                "delta": {
+                    "finish_reason": "COMPLETE",
+                    "usage": {"tokens": {"input_tokens": "5", "output_tokens": "3"}},
+                }
+            },
+        },
+    ]
+    v1 = _v1_chunks(events, stream_options={"include_usage": True})
+    assert v1[-1]["usage"]["prompt_tokens"] == 5
+    assert v1[-1]["usage"]["completion_tokens"] == 3
+    assert v1[-1]["usage"]["total_tokens"] == 8, "v1 stopped re-summing; re-decide"
+    result = parse_event(copy.deepcopy(events[1]))
+    assert result.is_error()
+    assert "v1 SERVES" in result.error.summary, result.error.summary
 
 
 def test_non_string_finish_defaults_to_stop_like_v1(frozen_ambient) -> None:

--- a/tests/test_litellm/translation/test_differential_cohere_stream.py
+++ b/tests/test_litellm/translation/test_differential_cohere_stream.py
@@ -399,6 +399,20 @@ def test_non_string_finish_defaults_to_stop_like_v1(frozen_ambient) -> None:
     assert v2[-1]["choices"][0]["finish_reason"] == "stop"
 
 
+def test_generic_dialect_non_dict_payload_is_a_loud_wiring_bug() -> None:
+    """critic-wave2b-beta N1: the generic fold step must never silently
+    drop a non-dict payload — an impossible shape is a wiring bug and must
+    be loud (the _as_block_dialect rule two screens up in the same file)."""
+    from litellm.translation.errors import TranslationError
+    from litellm.translation.inbound.openai_chat.stream import step as _step
+    from litellm.translation.ir import JsonBlob, StreamEvent
+
+    state = initial_state(MODEL, dialect="generic")
+    stepped = _step(state, StreamEvent.of_wire_chunk(JsonBlob(value=5)))
+    assert isinstance(stepped, TranslationError)
+    assert "wiring bug" in stepped.summary
+
+
 def test_non_json_line_is_loud_on_both_sides(frozen_ambient) -> None:
     """No data:/[DONE] framing on this wire: v1 json.loads every line and
     raises RuntimeError on a non-JSON one."""

--- a/tests/test_litellm/translation/test_differential_compat_httpx_response.py
+++ b/tests/test_litellm/translation/test_differential_compat_httpx_response.py
@@ -234,9 +234,7 @@ def _v2_with_style(
     response = PARSERS[provider](copy.deepcopy(raw), parsed.ok)
     assert response.is_ok(), response.error.summary
     body = serialize_response(response.ok, build_translation_deps(), "openai")
-    return to_model_response(
-        body, model_response, usage_style=style
-    ).model_dump()
+    return to_model_response(body, model_response, usage_style=style).model_dump()
 
 
 @pytest.mark.parametrize("provider", PROVIDERS)
@@ -319,9 +317,7 @@ _INDEX_REWRITE_BODY = {
 }
 
 _OPENAI_LIKE_MEMBERS = sorted(
-    provider
-    for provider in PROVIDERS
-    if RESPONSE_STYLES[provider] == "openai_like"
+    provider for provider in PROVIDERS if RESPONSE_STYLES[provider] == "openai_like"
 )
 
 
@@ -401,16 +397,16 @@ def test_seam_forks_never_select_usage_style_via_response_dialect() -> None:
     )
 
 
-_DODGE_LOCAL_VARIABLE = '''
+_DODGE_LOCAL_VARIABLE = """
 def _send_v2_family(provider_key, body, model_response):
     style = response_dialect(provider_key)
     return to_model_response(body, model_response, usage_style=style)
-'''
+"""
 
-_DODGE_POSITIONAL_ARGUMENT = '''
+_DODGE_POSITIONAL_ARGUMENT = """
 def _send_v2_family(provider_key, body, model_response):
     return to_model_response(body, model_response, response_dialect(provider_key))
-'''
+"""
 
 
 @pytest.mark.parametrize(

--- a/tests/test_litellm/translation/test_differential_compat_sdk_request.py
+++ b/tests/test_litellm/translation/test_differential_compat_sdk_request.py
@@ -610,6 +610,7 @@ def test_registered_providers_have_differential_coverage() -> None:
         # wave-2b-alpha own-module providers
         "deepseek",  # test_differential_deepseek_{request,response,stream}
         "openrouter",  # test_differential_openrouter_{request,response,stream}
+        "hosted_vllm",  # test_differential_hosted_vllm_{request,response,stream}
     }
     assert providers == dedicated_gates | set(SPECS) | set(HTTPX_SPECS)
 

--- a/tests/test_litellm/translation/test_differential_compat_sdk_request.py
+++ b/tests/test_litellm/translation/test_differential_compat_sdk_request.py
@@ -611,6 +611,7 @@ def test_registered_providers_have_differential_coverage() -> None:
         "cohere",  # test_differential_cohere_{request,response,stream}
         "cohere_chat",  # same gates: both names run every request row
         "mistral",  # test_differential_mistral_{request,response,stream}
+        "watsonx",  # test_differential_watsonx_{request,response,stream}
     }
     assert providers == dedicated_gates | set(SPECS) | set(HTTPX_SPECS)
 

--- a/tests/test_litellm/translation/test_differential_compat_sdk_request.py
+++ b/tests/test_litellm/translation/test_differential_compat_sdk_request.py
@@ -616,6 +616,22 @@ def test_registered_providers_have_differential_coverage() -> None:
         "huggingface",  # test_differential_huggingface_{request,response,stream}
     }
     assert providers == dedicated_gates | set(SPECS) | set(HTTPX_SPECS)
+    own_modules = {
+        "deepseek",
+        "openrouter",
+        "hosted_vllm",
+        "fireworks_ai",
+        "snowflake",
+        "huggingface",
+    }
+    # critic-wave2b-alpha MAJOR-4: every own-module provider must carry a row
+    # in pipeline.OWN_MODULE_RESPONSE_STYLES (the construction-style truth the
+    # future completion() fork selects usage_style from — the compat_httpx
+    # RESPONSE_STYLES shape). Add the row in the commit that adds the module;
+    # an "openai_like" row additionally needs a wrong-arm divergence pin in
+    # its response gate (the fireworks_ai/snowflake template).
+    assert set(pipeline.OWN_MODULE_RESPONSE_STYLES) == own_modules
+    assert own_modules <= dedicated_gates
 
 
 @pytest.mark.parametrize("provider,name", _request_rows())

--- a/tests/test_litellm/translation/test_differential_compat_sdk_request.py
+++ b/tests/test_litellm/translation/test_differential_compat_sdk_request.py
@@ -610,6 +610,7 @@ def test_registered_providers_have_differential_coverage() -> None:
         # wave-2b-beta own modules:
         "cohere",  # test_differential_cohere_{request,response,stream}
         "cohere_chat",  # same gates: both names run every request row
+        "mistral",  # test_differential_mistral_{request,response,stream}
     }
     assert providers == dedicated_gates | set(SPECS) | set(HTTPX_SPECS)
 

--- a/tests/test_litellm/translation/test_differential_compat_sdk_request.py
+++ b/tests/test_litellm/translation/test_differential_compat_sdk_request.py
@@ -630,6 +630,14 @@ def test_registered_providers_have_differential_coverage() -> None:
         "fireworks_ai",
         "snowflake",
         "huggingface",
+        # wave-2b-beta own modules (sibling-merge consistency sweep): the
+        # construction-style truth covers ALL eleven wave-2b own modules
+        "cohere",
+        "cohere_chat",
+        "mistral",
+        "watsonx",
+        "sagemaker_chat",
+        "groq",
     }
     # critic-wave2b-alpha MAJOR-4: every own-module provider must carry a row
     # in pipeline.OWN_MODULE_RESPONSE_STYLES (the construction-style truth the

--- a/tests/test_litellm/translation/test_differential_compat_sdk_request.py
+++ b/tests/test_litellm/translation/test_differential_compat_sdk_request.py
@@ -609,6 +609,7 @@ def test_registered_providers_have_differential_coverage() -> None:
         "xai",  # test_differential_xai_*
         # wave-2b-alpha own-module providers
         "deepseek",  # test_differential_deepseek_{request,response,stream}
+        "openrouter",  # test_differential_openrouter_{request,response,stream}
     }
     assert providers == dedicated_gates | set(SPECS) | set(HTTPX_SPECS)
 

--- a/tests/test_litellm/translation/test_differential_compat_sdk_request.py
+++ b/tests/test_litellm/translation/test_differential_compat_sdk_request.py
@@ -613,6 +613,7 @@ def test_registered_providers_have_differential_coverage() -> None:
         "mistral",  # test_differential_mistral_{request,response,stream}
         "watsonx",  # test_differential_watsonx_{request,response,stream}
         "sagemaker_chat",  # test_differential_sagemaker_chat_{request,response,stream}
+        "groq",  # test_differential_groq_{request,response,stream}
     }
     assert providers == dedicated_gates | set(SPECS) | set(HTTPX_SPECS)
 

--- a/tests/test_litellm/translation/test_differential_compat_sdk_request.py
+++ b/tests/test_litellm/translation/test_differential_compat_sdk_request.py
@@ -642,9 +642,11 @@ def test_registered_providers_have_differential_coverage() -> None:
     # critic-wave2b-alpha MAJOR-4: every own-module provider must carry a row
     # in pipeline.OWN_MODULE_RESPONSE_STYLES (the construction-style truth the
     # future completion() fork selects usage_style from — the compat_httpx
-    # RESPONSE_STYLES shape). Add the row in the commit that adds the module;
-    # an "openai_like" row additionally needs a wrong-arm divergence pin in
-    # its response gate (the fireworks_ai/snowflake template).
+    # RESPONSE_STYLES shape). Add the row in the commit that adds the module,
+    # WITH a wrong-arm divergence pin in its response gate ("openai_like":
+    # the fireworks_ai/snowflake wire-index template; "openai": the inverted
+    # float-created template — verifier-wave2b-final F1: this gate asserts
+    # KEY membership only, so an unpinned VALUE is enforced by nothing).
     assert set(pipeline.OWN_MODULE_RESPONSE_STYLES) == own_modules
     assert own_modules <= dedicated_gates
 

--- a/tests/test_litellm/translation/test_differential_compat_sdk_request.py
+++ b/tests/test_litellm/translation/test_differential_compat_sdk_request.py
@@ -607,6 +607,8 @@ def test_registered_providers_have_differential_coverage() -> None:
         "azure_ai",  # test_differential_azure_ai_request + azure stream/response
         "azure_ai_anthropic",  # test_differential_azure_ai_request (Claude route)
         "xai",  # test_differential_xai_*
+        # wave-2b-alpha own-module providers
+        "deepseek",  # test_differential_deepseek_{request,response,stream}
     }
     assert providers == dedicated_gates | set(SPECS) | set(HTTPX_SPECS)
 

--- a/tests/test_litellm/translation/test_differential_compat_sdk_request.py
+++ b/tests/test_litellm/translation/test_differential_compat_sdk_request.py
@@ -613,6 +613,7 @@ def test_registered_providers_have_differential_coverage() -> None:
         "hosted_vllm",  # test_differential_hosted_vllm_{request,response,stream}
         "fireworks_ai",  # test_differential_fireworks_ai_{request,response,stream}
         "snowflake",  # test_differential_snowflake_{request,response,stream}
+        "huggingface",  # test_differential_huggingface_{request,response,stream}
     }
     assert providers == dedicated_gates | set(SPECS) | set(HTTPX_SPECS)
 

--- a/tests/test_litellm/translation/test_differential_compat_sdk_request.py
+++ b/tests/test_litellm/translation/test_differential_compat_sdk_request.py
@@ -612,6 +612,7 @@ def test_registered_providers_have_differential_coverage() -> None:
         "cohere_chat",  # same gates: both names run every request row
         "mistral",  # test_differential_mistral_{request,response,stream}
         "watsonx",  # test_differential_watsonx_{request,response,stream}
+        "sagemaker_chat",  # test_differential_sagemaker_chat_{request,response,stream}
     }
     assert providers == dedicated_gates | set(SPECS) | set(HTTPX_SPECS)
 

--- a/tests/test_litellm/translation/test_differential_compat_sdk_request.py
+++ b/tests/test_litellm/translation/test_differential_compat_sdk_request.py
@@ -607,6 +607,9 @@ def test_registered_providers_have_differential_coverage() -> None:
         "azure_ai",  # test_differential_azure_ai_request + azure stream/response
         "azure_ai_anthropic",  # test_differential_azure_ai_request (Claude route)
         "xai",  # test_differential_xai_*
+        # wave-2b-beta own modules:
+        "cohere",  # test_differential_cohere_{request,response,stream}
+        "cohere_chat",  # same gates: both names run every request row
     }
     assert providers == dedicated_gates | set(SPECS) | set(HTTPX_SPECS)
 

--- a/tests/test_litellm/translation/test_differential_compat_sdk_request.py
+++ b/tests/test_litellm/translation/test_differential_compat_sdk_request.py
@@ -611,6 +611,7 @@ def test_registered_providers_have_differential_coverage() -> None:
         "deepseek",  # test_differential_deepseek_{request,response,stream}
         "openrouter",  # test_differential_openrouter_{request,response,stream}
         "hosted_vllm",  # test_differential_hosted_vllm_{request,response,stream}
+        "fireworks_ai",  # test_differential_fireworks_ai_{request,response,stream}
     }
     assert providers == dedicated_gates | set(SPECS) | set(HTTPX_SPECS)
 

--- a/tests/test_litellm/translation/test_differential_compat_sdk_request.py
+++ b/tests/test_litellm/translation/test_differential_compat_sdk_request.py
@@ -612,6 +612,7 @@ def test_registered_providers_have_differential_coverage() -> None:
         "openrouter",  # test_differential_openrouter_{request,response,stream}
         "hosted_vllm",  # test_differential_hosted_vllm_{request,response,stream}
         "fireworks_ai",  # test_differential_fireworks_ai_{request,response,stream}
+        "snowflake",  # test_differential_snowflake_{request,response,stream}
     }
     assert providers == dedicated_gates | set(SPECS) | set(HTTPX_SPECS)
 

--- a/tests/test_litellm/translation/test_differential_deepseek_request.py
+++ b/tests/test_litellm/translation/test_differential_deepseek_request.py
@@ -1,0 +1,422 @@
+"""Differential parity for the deepseek request path (httpx dedicated elif,
+main.py:1942; transform LIVE; no model prefix).
+
+Two-sided: every served row is byte-identical (normalized JSON) between v1
+in-process at HEAD (get_optional_params + DeepSeekChatConfig.transform_request,
+the _own_module_corpus invoker) and v2; every fallback row asserts BOTH the
+typed v2 error and v1's own behavior (serve or rewrite, asserted in-process).
+The thinking rewrite and the content-list flatten are v1 facts re-verified
+here, not dossier trust. Two dossier-drift pins recorded in
+wave2b-alpha-port.md: (1) deepseek does NOT drop tool_choice auto/none (that
+fact was deepinfra's); tool_choice rides the base list verbatim, pinned by
+the tools rows below; (2) web_search_options is SERVED by v1's base list at
+HEAD (researcher-4 listed it as a raise) — the inbound boundary falls back
+either way, and the row pins v1's serve so the reason stays honest.
+"""
+
+import copy
+import json
+
+import pytest
+
+from litellm.translation.dispatch import NEVER_PORT
+from litellm.translation.engine import pipeline
+from litellm.translation.engine.pipeline import translate_chat_request
+from litellm.utils import get_optional_params
+
+from ._own_module_corpus import capture_v1_wire_body, run_v1_request_transform
+from .conftest import build_real_deps
+
+MODEL = "deepseek-chat"
+REASONER = "deepseek-reasoner"
+_USER = [{"role": "user", "content": "Hello, world"}]
+
+WEATHER_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get weather",
+        "parameters": {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+        },
+    },
+}
+
+CASES: dict[str, dict] = {
+    "text": {"model": MODEL, "messages": _USER},
+    "system_and_sampling": {
+        "model": MODEL,
+        "max_tokens": 64,
+        "temperature": 0.5,
+        "top_p": 0.9,
+        "messages": [
+            {"role": "system", "content": "You are helpful"},
+            {"role": "user", "content": "Hi"},
+        ],
+    },
+    "stream_true": {"model": MODEL, "stream": True, "messages": _USER},
+    "stop_list": {"model": MODEL, "stop": ["END", "STOP"], "messages": _USER},
+    # mct passes VERBATIM: no rename arm anywhere on the deepseek chain
+    "max_completion_tokens_verbatim": {
+        "model": MODEL,
+        "max_completion_tokens": 128,
+        "messages": _USER,
+    },
+    "temperature_int_stays_int": {"model": MODEL, "temperature": 1, "messages": _USER},
+    "tools_auto": {
+        "model": MODEL,
+        "tools": [WEATHER_TOOL],
+        "tool_choice": "auto",
+        "messages": [{"role": "user", "content": "Weather in Paris?"}],
+    },
+    # the dossier-drift pin: tool_choice "none" rides the base list verbatim
+    # (the claimed deepseek auto/none drop was deepinfra's fact)
+    "tool_choice_none_verbatim": {
+        "model": MODEL,
+        "tools": [WEATHER_TOOL],
+        "tool_choice": "none",
+        "messages": [{"role": "user", "content": "Weather in Paris?"}],
+    },
+    "tool_choice_specific": {
+        "model": MODEL,
+        "tools": [WEATHER_TOOL],
+        "tool_choice": {"type": "function", "function": {"name": "get_weather"}},
+        "messages": [{"role": "user", "content": "Weather in Paris?"}],
+    },
+    "tool_call_compact_roundtrip": {
+        "model": MODEL,
+        "tools": [WEATHER_TOOL],
+        "messages": [
+            {"role": "user", "content": "w?"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": '{"city":"Paris"}',
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "ok"},
+        ],
+    },
+    "parallel_tool_calls_false": {
+        "model": MODEL,
+        "tools": [WEATHER_TOOL],
+        "parallel_tool_calls": False,
+        "messages": [{"role": "user", "content": "Weather in Paris and Rome?"}],
+    },
+    "response_format_json_object": {
+        "model": MODEL,
+        "response_format": {"type": "json_object"},
+        "messages": _USER,
+    },
+    "response_format_json_schema_strict": {
+        "model": MODEL,
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {"name": "a", "schema": {"type": "object"}, "strict": True},
+        },
+        "messages": _USER,
+    },
+    # the always-on flatten: text-only content lists join ("ab")
+    "content_list_flattened": {
+        "model": MODEL,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "a"},
+                    {"type": "text", "text": "b"},
+                ],
+            }
+        ],
+    },
+    # thinking rewrite laws (map_openai_params:49-63), not model-gated:
+    "thinking_enabled_budget_discarded": {
+        "model": MODEL,
+        "thinking": {"type": "enabled", "budget_tokens": 5000},
+        "messages": _USER,
+    },
+    "thinking_disabled_dropped": {
+        "model": MODEL,
+        "thinking": {"type": "disabled"},
+        "messages": _USER,
+    },
+    "reasoning_effort_rewrites_to_thinking": {
+        "model": MODEL,
+        "reasoning_effort": "high",
+        "messages": _USER,
+    },
+    "reasoning_effort_none_dropped": {
+        "model": MODEL,
+        "reasoning_effort": "none",
+        "messages": _USER,
+    },
+    # the elif shadow: a present-but-disabled thinking dict suppresses the
+    # reasoning_effort rewrite entirely
+    "thinking_disabled_shadows_reasoning_effort": {
+        "model": MODEL,
+        "thinking": {"type": "disabled"},
+        "reasoning_effort": "high",
+        "messages": _USER,
+    },
+    # thinking mode on a reasoning model with NO assistant history: the
+    # fill has nothing to patch, so the request serves
+    "reasoner_thinking_without_history": {
+        "model": REASONER,
+        "thinking": {"type": "enabled"},
+        "messages": _USER,
+    },
+    # the fill is capability-gated: deepseek-chat (supports_reasoning False)
+    # with thinking enabled and assistant history SERVES untouched
+    "thinking_history_inert_on_non_reasoning_model": {
+        "model": MODEL,
+        "thinking": {"type": "enabled"},
+        "messages": [
+            {"role": "user", "content": "q"},
+            {"role": "assistant", "content": "prev"},
+            {"role": "user", "content": "next"},
+        ],
+    },
+}
+
+# name -> (case, v2 reason fragment). Every row's v1 side (serve or rewrite)
+# is asserted in-process by the dedicated tests below; the generator emits
+# these as FALLBACK (v1 serves it) rows.
+EXPECTED_FALLBACKS: dict[str, tuple[dict, str]] = {
+    "thinking_fill_history": (
+        {
+            "model": REASONER,
+            "thinking": {"type": "enabled"},
+            "messages": [
+                {"role": "user", "content": "q"},
+                {"role": "assistant", "content": "prev"},
+                {"role": "user", "content": "next"},
+            ],
+        },
+        "_fill_reasoning_content",
+    ),
+    "reasoning_effort_fill_history": (
+        # the rewrite path arms the fill too: reasoning_effort -> thinking
+        # enabled happens at map time, BEFORE transform reads it
+        {
+            "model": REASONER,
+            "reasoning_effort": "low",
+            "messages": [
+                {"role": "user", "content": "q"},
+                {"role": "assistant", "content": "prev"},
+                {"role": "user", "content": "next"},
+            ],
+        },
+        "_fill_reasoning_content",
+    ),
+    "non_text_content": (
+        {
+            "model": MODEL,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "look"},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "https://x/i.png"},
+                        },
+                    ],
+                }
+            ],
+        },
+        "lossy flatten",
+    ),
+    "top_k": ({"model": MODEL, "top_k": 5, "messages": _USER}, "extra_body"),
+    "user": ({"model": MODEL, "user": "u1", "messages": _USER}, "user"),
+    "stream_false": ({"model": MODEL, "stream": False, "messages": _USER}, "stream"),
+    # dossier drift: v1 SERVES web_search_options at HEAD (base list grew
+    # it); v2's inbound boundary falls back typed like every parse-level
+    # unknown — v1 serves, so the fallback is safe
+    "web_search_options": (
+        {
+            "model": MODEL,
+            "web_search_options": {"search_context_size": "medium"},
+            "messages": _USER,
+        },
+        "web_search_options",
+    ),
+}
+
+
+def _v2(case: dict):
+    return translate_chat_request(copy.deepcopy(case), "deepseek", build_real_deps())
+
+
+def _norm(body: dict) -> str:
+    return json.dumps(body, sort_keys=True, default=str)
+
+
+@pytest.mark.parametrize("name", sorted(CASES))
+def test_v2_request_matches_v1(name: str) -> None:
+    case = CASES[name]
+    result = _v2(case)
+    assert result.is_ok(), result.error.summary
+    assert _norm(result.ok) == _norm(run_v1_request_transform("deepseek", case))
+
+
+@pytest.mark.parametrize("name", sorted(EXPECTED_FALLBACKS))
+def test_expected_fallbacks_are_typed(name: str) -> None:
+    case, reason = EXPECTED_FALLBACKS[name]
+    result = _v2(case)
+    assert result.is_error(), f"{name} unexpectedly served"
+    assert reason in result.error.summary, result.error.summary
+
+
+def test_thinking_rewrite_emits_enabled_only() -> None:
+    """Semantic pin on top of the byte rows: the wire thinking value is
+    exactly {"type": "enabled"} (budget_tokens discarded)."""
+    result = _v2(CASES["thinking_enabled_budget_discarded"])
+    assert result.is_ok()
+    assert result.ok["thinking"] == {"type": "enabled"}
+    result = _v2(CASES["reasoning_effort_rewrites_to_thinking"])
+    assert result.is_ok()
+    assert result.ok["thinking"] == {"type": "enabled"}
+    assert "reasoning_effort" not in result.ok
+
+
+def test_thinking_fill_v1_serves_its_rewrite() -> None:
+    """Thinking mode + assistant history on a reasoning model: v1 injects
+    reasoning_content ' ' into every assistant message missing it (asserted
+    in-process) — for BOTH arming paths (verbatim thinking dict and the
+    reasoning_effort rewrite, which lands before transform reads it)."""
+    for name in ("thinking_fill_history", "reasoning_effort_fill_history"):
+        case, _ = EXPECTED_FALLBACKS[name]
+        v1 = run_v1_request_transform("deepseek", case)
+        assert v1["messages"][1]["reasoning_content"] == " ", name
+
+
+def test_thinking_fill_inert_on_non_reasoning_models() -> None:
+    """The fill is capability-gated: deepseek-chat with thinking enabled and
+    assistant history SERVES (v1 leaves the history untouched)."""
+    case = CASES["thinking_history_inert_on_non_reasoning_model"]
+    result = _v2(case)
+    assert result.is_ok(), result.error.summary
+    v1 = run_v1_request_transform("deepseek", case)
+    assert "reasoning_content" not in v1["messages"][1]
+    assert _norm(result.ok) == _norm(v1)
+
+
+def test_non_text_content_v1_flatten_is_lossy() -> None:
+    case, _ = EXPECTED_FALLBACKS["non_text_content"]
+    v1 = run_v1_request_transform("deepseek", case)
+    assert v1["messages"][0]["content"] == "look"  # the image part is GONE
+
+
+def test_top_k_fallback_reason_matches_the_wire_proven_extra_body_merge() -> None:
+    """deepseek is in litellm.openai_compatible_providers, so top_k rides
+    the extra_body packing (never the top-level passthrough); hh merges the
+    contents onto the wire AFTER transform (hh:448). All three claims
+    pinned: the packing, the transform-output absence, and the WIRE merge
+    via the full completion() stack against a mock transport (the wave-2b
+    wire-prove rule: never inherit the reason text without a pinned row)."""
+    case, _ = EXPECTED_FALLBACKS["top_k"]
+    packed = get_optional_params(
+        model=MODEL, custom_llm_provider="deepseek", stream=None, top_k=5
+    )
+    assert packed["extra_body"] == {"top_k": 5}
+    assert "top_k" not in run_v1_request_transform("deepseek", copy.deepcopy(case))
+    wire = capture_v1_wire_body("deepseek/deepseek-chat", top_k=5)
+    assert wire["top_k"] == 5
+    assert "extra_body" not in wire
+
+
+def test_user_v1_drops_it() -> None:
+    case, _ = EXPECTED_FALLBACKS["user"]
+    assert "user" not in run_v1_request_transform("deepseek", case)
+
+
+def test_web_search_options_v1_serves_it() -> None:
+    """The drift pin: researcher-4 listed web_search_options as a deepseek
+    RAISE; at HEAD the base list carries it and v1 serves it verbatim. The
+    v2 fallback (inbound boundary) is therefore the v1-serves kind."""
+    case, _ = EXPECTED_FALLBACKS["web_search_options"]
+    v1 = run_v1_request_transform("deepseek", copy.deepcopy(case))
+    assert v1["web_search_options"] == {"search_context_size": "medium"}
+
+
+def test_supported_list_mirror_over_model_map() -> None:
+    """The hand-copied _DEEPSEEK_LIST must track v1's
+    get_supported_openai_params at HEAD for every deepseek chat map row
+    (critic-grok M4 / compat_sdk mirror shape): base keys row-for-row, and
+    thinking/reasoning_effort UNCONDITIONAL on every model. Direction
+    argument: every key v2 can serve is in the mirror set; a v1 list
+    growing a key v2 lacks only widens the typed fallback."""
+    import litellm
+
+    from litellm.translation.providers.deepseek.params import _DEEPSEEK_LIST
+
+    from ._own_module_corpus import provider_config
+
+    mirror_keys = (
+        "max_tokens",
+        "max_completion_tokens",
+        "temperature",
+        "top_p",
+        "stream",
+        "stop",
+        "tools",
+        "tool_choice",
+        "parallel_tool_calls",
+        "response_format",
+    )
+    assert _DEEPSEEK_LIST <= set(mirror_keys) | {"thinking", "reasoning_effort"}
+    models = [MODEL, REASONER] + sorted(
+        key.split("/", 1)[1]
+        for key, info in litellm.model_cost.items()
+        if key.startswith("deepseek/")
+        and isinstance(info, dict)
+        and info.get("mode") == "chat"
+    )
+    assert len(models) >= 2
+    for model in models:
+        supported = set(
+            provider_config("deepseek", model).get_supported_openai_params(model)
+        )
+        for key in mirror_keys:
+            assert (key in _DEEPSEEK_LIST) == (key in supported), (model, key)
+        assert {"thinking", "reasoning_effort"} <= supported, model
+
+
+def test_reasoning_capability_mirror_over_model_map() -> None:
+    """The fill gate reads deps over deepseek/{m}: assert the deps read
+    agrees with v1's supports_reasoning for every deepseek chat map row
+    (drift gate, the wave-2a mirror shape)."""
+    import litellm
+    from litellm.utils import supports_reasoning
+
+    deps = build_real_deps()
+    rows = [
+        key.split("/", 1)[1]
+        for key, info in litellm.model_cost.items()
+        if key.startswith("deepseek/")
+        and isinstance(info, dict)
+        and info.get("mode") == "chat"
+    ]
+    assert len(rows) > 0
+    for short in rows:
+        assert deps.supports_capability(
+            f"deepseek/{short}", "supports_reasoning"
+        ) == supports_reasoning(short, custom_llm_provider="deepseek"), short
+
+
+def test_registration_facts() -> None:
+    assert "deepseek" in pipeline._SERIALIZERS
+    assert "deepseek" in pipeline._RESPONSE_PARSERS
+    assert "deepseek" in pipeline._RAW_GUARDS
+    assert pipeline.response_dialect("deepseek") == "openai"
+    assert "deepseek" not in NEVER_PORT

--- a/tests/test_litellm/translation/test_differential_deepseek_response.py
+++ b/tests/test_litellm/translation/test_differential_deepseek_response.py
@@ -1,0 +1,141 @@
+"""Differential parity for the deepseek response path (httpx, NO prefix).
+
+DeepSeekChatConfig has no ``transform_response`` override: the inherited
+base GPT transform is LIVE on the dedicated elif and runs
+``convert_to_model_response_object`` over a fresh ``ModelResponse``
+(model=None) — the bare-wire-model cometapi/xai shape. These rows run that
+exact v1 chain against v2's shared openai parser, byte-identical dumps,
+and pin that no ``deepseek/`` prefix ever appears.
+"""
+
+import copy
+import json
+
+import pytest
+
+from litellm.types.utils import ModelResponse
+
+from litellm.translation.inbound.openai_chat import parse_request
+from litellm.translation.inbound.openai_chat.response import serialize_response
+from litellm.translation.providers.deepseek import parse_response
+from litellm.translation_seam import build_translation_deps, to_model_response
+
+from ._own_module_corpus import run_v1_response_transform
+
+_REQUEST = {
+    "model": "deepseek-chat",
+    "messages": [{"role": "user", "content": "hi"}],
+    "tools": [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ],
+}
+
+_RESPONSES = {
+    "text": {
+        "id": "chatcmpl-ds1",
+        "object": "chat.completion",
+        "created": 1718000000,
+        "model": "deepseek-chat",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "hello"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5},
+    },
+    "tool_calls": {
+        "id": "chatcmpl-ds2",
+        "object": "chat.completion",
+        "created": 1718000000,
+        "model": "deepseek-chat",
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "arguments": '{"city":"Paris"}',
+                            },
+                        }
+                    ],
+                },
+                "finish_reason": "tool_calls",
+            }
+        ],
+        "usage": {"prompt_tokens": 9, "completion_tokens": 5, "total_tokens": 14},
+    },
+    # deepseek-reasoner bodies carry reasoning_content on the message plus
+    # cache-hit prompt detail keys — the unknown-usage-key verbatim ride
+    "reasoning_content": {
+        "id": "chatcmpl-ds3",
+        "object": "chat.completion",
+        "created": 1718000000,
+        "model": "deepseek-reasoner",
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": "answer",
+                    "reasoning_content": "step by step",
+                },
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 11,
+            "completion_tokens": 9,
+            "total_tokens": 20,
+            "prompt_cache_hit_tokens": 4,
+            "prompt_cache_miss_tokens": 7,
+            "completion_tokens_details": {"reasoning_tokens": 6},
+        },
+    },
+}
+
+
+def _v1_model_response(raw: dict) -> dict:
+    return run_v1_response_transform("deepseek", raw, "deepseek-chat").model_dump()
+
+
+def _v2_model_response(raw: dict) -> dict:
+    parsed = parse_request(copy.deepcopy(_REQUEST))
+    assert parsed.is_ok(), parsed.error.summary
+    response = parse_response(copy.deepcopy(raw), parsed.ok)
+    assert response.is_ok(), response.error.summary
+    body = serialize_response(response.ok, build_translation_deps(), "openai")
+    return to_model_response(body, ModelResponse(), usage_style="openai").model_dump()
+
+
+def _norm(payload: dict) -> str:
+    return json.dumps(payload, sort_keys=True, default=str)
+
+
+@pytest.mark.parametrize("name", sorted(_RESPONSES))
+def test_v2_response_matches_v1(name: str, frozen_ambient) -> None:
+    raw = _RESPONSES[name]
+    assert _norm(_v2_model_response(raw)) == _norm(_v1_model_response(raw))
+
+
+@pytest.mark.parametrize("name", sorted(_RESPONSES))
+def test_no_deepseek_prefix_on_the_response_model(name: str, frozen_ambient) -> None:
+    raw = _RESPONSES[name]
+    v1 = _v1_model_response(raw)
+    v2 = _v2_model_response(raw)
+    assert v1["model"] == raw["model"]
+    assert v2["model"] == raw["model"]
+    assert not v2["model"].startswith("deepseek/")

--- a/tests/test_litellm/translation/test_differential_deepseek_response.py
+++ b/tests/test_litellm/translation/test_differential_deepseek_response.py
@@ -11,6 +11,7 @@ and pin that no ``deepseek/`` prefix ever appears.
 import copy
 import json
 
+import pydantic
 import pytest
 
 from litellm.types.utils import ModelResponse
@@ -18,7 +19,11 @@ from litellm.types.utils import ModelResponse
 from litellm.translation.inbound.openai_chat import parse_request
 from litellm.translation.inbound.openai_chat.response import serialize_response
 from litellm.translation.providers.deepseek import parse_response
-from litellm.translation_seam import build_translation_deps, to_model_response
+from litellm.translation_seam import (
+    UsageStyle,
+    build_translation_deps,
+    to_model_response,
+)
 
 from ._own_module_corpus import run_v1_response_transform
 
@@ -112,13 +117,19 @@ def _v1_model_response(raw: dict) -> dict:
     return run_v1_response_transform("deepseek", raw, "deepseek-chat").model_dump()
 
 
-def _v2_model_response(raw: dict) -> dict:
+def _v2_with_style(raw: dict, style: UsageStyle) -> dict:
     parsed = parse_request(copy.deepcopy(_REQUEST))
     assert parsed.is_ok(), parsed.error.summary
     response = parse_response(copy.deepcopy(raw), parsed.ok)
     assert response.is_ok(), response.error.summary
     body = serialize_response(response.ok, build_translation_deps(), "openai")
-    return to_model_response(body, ModelResponse(), usage_style="openai").model_dump()
+    return to_model_response(body, ModelResponse(), usage_style=style).model_dump()
+
+
+def _v2_model_response(raw: dict) -> dict:
+    # deepseek rides the cdr arm — the truth is
+    # pipeline.OWN_MODULE_RESPONSE_STYLES["deepseek"], divergence-pinned below
+    return _v2_with_style(raw, "openai")
 
 
 def _norm(payload: dict) -> str:
@@ -139,3 +150,30 @@ def test_no_deepseek_prefix_on_the_response_model(name: str, frozen_ambient) -> 
     assert v1["model"] == raw["model"]
     assert v2["model"] == raw["model"]
     assert not v2["model"].startswith("deepseek/")
+
+
+def test_wrong_construction_arm_diverges_and_the_table_pins_it(
+    frozen_ambient,
+) -> None:
+    """verifier-wave2b-final F1: the "openai"-arm OWN_MODULE_RESPONSE_STYLES
+    values were enforced by NOTHING — a wrong-arm value flip survived the
+    whole suite. The watsonx/groq wrong-arm template INVERTED for a
+    cdr-parser member (the v2 parser already cdr-normalizes choices, so the
+    openai_like members' index-5 discriminator dies before the seam): a
+    FLOAT wire ``created`` rides the normalized body; the correct cdr
+    ("openai") arm coerces it via _safe_convert_created_field and serves
+    exactly like v1, while the wrong "openai_like" arm
+    (ModelResponse(**json)) raises ValidationError on traffic v1 serves —
+    if the arms stop diverging here, the raises assert fails: re-decide
+    before relying on the pin."""
+    from litellm.translation.engine.pipeline import OWN_MODULE_RESPONSE_STYLES
+
+    assert OWN_MODULE_RESPONSE_STYLES["deepseek"] == "openai"
+    raw = copy.deepcopy(_RESPONSES["text"])
+    raw["created"] = raw["created"] + 0.5
+    v1 = _v1_model_response(raw)
+    correct = _v2_with_style(raw, OWN_MODULE_RESPONSE_STYLES["deepseek"])
+    assert _norm(correct) == _norm(v1)
+    assert correct["created"] == _RESPONSES["text"]["created"]
+    with pytest.raises(pydantic.ValidationError):
+        _v2_with_style(raw, "openai_like")

--- a/tests/test_litellm/translation/test_differential_deepseek_stream.py
+++ b/tests/test_litellm/translation/test_differential_deepseek_stream.py
@@ -1,0 +1,230 @@
+"""Differential parity for deepseek streaming, pinned at the SSE line seam.
+
+v1 side: raw ``data:`` lines through the BASE
+``OpenAIChatCompletionStreamingHandler`` (DeepSeekChatConfig has no iterator
+override — canary-pinned below) into ``CustomStreamWrapper("deepseek")``.
+v2 side: ``fold_lines`` with the deepseek parser (the httpx_chunk FAMILY
+policy: ``reasoning="rename"``) and the shared ``xai`` chunk dialect (the
+generic httpx dict path). deepseek-reasoner wire streams carry NATIVE
+``reasoning_content`` deltas — pinned verbatim alongside the base handler's
+``reasoning`` pop-rename.
+
+The usage tail is the pinned seam contract inherited from the openai/xai
+ports; the mid-stream ``{"error": ...}`` chunk is the SAME deliberate
+fail-closed PINNED DIVERGENCE the compat_httpx family carries (v1's base
+handler silently swallows it, v2 is loud) — the report's single PINNED
+DIVERGENCE row names deepseek among the base-handler consumers.
+"""
+
+import copy
+import json
+
+import pytest
+
+from litellm.llms.openai.chat.gpt_transformation import (
+    OpenAIChatCompletionStreamingHandler,
+)
+
+from litellm.translation.engine.stream import fold_events, fold_lines
+from litellm.translation.inbound.openai_chat.stream import initial_state
+from litellm.translation.providers.deepseek import parse_event, parse_line
+from litellm.translation_seam import to_model_response_stream
+
+from ._own_module_corpus import provider_config, replay_v1_sse_lines
+
+MODEL = "deepseek-chat"
+WIRE_MODEL = "deepseek-chat"
+
+
+def _chunk(delta, finish=None, usage=None, choices=None):
+    payload = {
+        "id": "ds-chunk-1",
+        "object": "chat.completion.chunk",
+        "created": 1718000000,
+        "model": WIRE_MODEL,
+        "choices": [
+            {"index": 0, "delta": delta, "logprobs": None, "finish_reason": finish}
+        ],
+        "usage": usage,
+    }
+    if choices is not None:
+        payload["choices"] = choices
+    return payload
+
+
+STREAMS = {
+    "text": [
+        _chunk({"role": "assistant", "content": ""}),
+        _chunk({"content": "Hello"}),
+        _chunk({"content": " world"}),
+        _chunk({}, finish="stop"),
+    ],
+    "tools": [
+        _chunk({"role": "assistant", "content": None}),
+        _chunk(
+            {
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "get_weather", "arguments": ""},
+                    }
+                ]
+            }
+        ),
+        _chunk(
+            {
+                "tool_calls": [
+                    {"index": 0, "function": {"arguments": '{"city":"Paris"}'}}
+                ]
+            }
+        ),
+        _chunk({}, finish="tool_calls"),
+    ],
+    # deepseek-reasoner's real wire shape: native reasoning_content deltas
+    # interleaved before content
+    "native_reasoning_content": [
+        _chunk({"role": "assistant", "reasoning_content": "step "}),
+        _chunk({"reasoning_content": "by step"}),
+        _chunk({"content": "answer"}),
+        _chunk({}, finish="stop"),
+    ],
+    # the base handler's unconditional delta.reasoning pop-rename
+    "reasoning_rename": [
+        _chunk({"role": "assistant", "content": ""}),
+        _chunk({"reasoning": "thinking..."}),
+        _chunk({"content": "answer"}),
+        _chunk({}, finish="stop"),
+    ],
+    "empty_keepalive_swallowed": [
+        _chunk({"role": "assistant", "content": ""}),
+        _chunk({}),
+        _chunk({"content": "hi"}),
+        _chunk({}, finish="stop"),
+    ],
+}
+
+USAGE_STREAM = [
+    _chunk({"role": "assistant", "content": ""}),
+    _chunk({"content": "Hi"}),
+    _chunk({}, finish="stop"),
+    _chunk(
+        {},
+        choices=[],
+        usage={
+            "prompt_tokens": 7,
+            "completion_tokens": 2,
+            "total_tokens": 9,
+            "prompt_cache_hit_tokens": 3,
+            "prompt_cache_miss_tokens": 4,
+        },
+    ),
+]
+
+
+def _v1_chunks(events, stream_options=None):
+    return replay_v1_sse_lines("deepseek", events, MODEL, stream_options)
+
+
+def _v2_chunks(events: list) -> list:
+    lines = [f"data: {json.dumps(event)}" for event in copy.deepcopy(events)]
+    lines.append("data: [DONE]")
+    folded = fold_lines(lines, parse_line, initial_state(MODEL, dialect="xai"))
+    assert folded.is_ok(), folded.error.summary
+    return [
+        to_model_response_stream(chunk, "chatcmpl-AMBIENT").model_dump()
+        for chunk in folded.ok
+    ]
+
+
+def _norm(chunks: list) -> str:
+    return json.dumps(chunks, sort_keys=True, default=str)
+
+
+@pytest.mark.parametrize("name", sorted(STREAMS))
+def test_v2_stream_matches_v1(name: str, frozen_ambient) -> None:
+    events = STREAMS[name]
+    assert _norm(_v2_chunks(events)) == _norm(_v1_chunks(events))
+
+
+def test_reasoning_rename_pops_the_wire_key(frozen_ambient) -> None:
+    """Semantic pin: the emitted delta carries reasoning_content ONLY (the
+    base handler POPS delta.reasoning — cometapi's copy_both differs)."""
+    v2 = _v2_chunks(STREAMS["reasoning_rename"])
+    delta = v2[1]["choices"][0]["delta"]
+    assert delta["reasoning_content"] == "thinking..."
+    assert "reasoning" not in delta
+
+
+def test_usage_tail_pins_the_seam_contract(frozen_ambient) -> None:
+    v1 = _v1_chunks(USAGE_STREAM, stream_options={"include_usage": True})
+    v2 = _v2_chunks(USAGE_STREAM)
+    assert len(v1) == len(v2)
+    assert _norm(v2[:-1]) == _norm(v1[: len(v2) - 1])
+    assert v2[-1]["choices"] == []
+    for key in ("prompt_tokens", "completion_tokens", "total_tokens"):
+        assert v1[-1]["usage"][key] == v2[-1]["usage"][key], key
+
+
+def test_usage_tail_swallowed_without_stream_options(frozen_ambient) -> None:
+    v1 = _v1_chunks(USAGE_STREAM, None)
+    v2 = _v2_chunks(USAGE_STREAM)
+    assert len(v1) == len(v2) - 1
+    assert _norm(v1) == _norm(v2[:-1])
+
+
+def test_v2_line_and_event_folds_agree(frozen_ambient) -> None:
+    events = STREAMS["native_reasoning_content"]
+    folded = fold_events(
+        copy.deepcopy(events), parse_event, initial_state(MODEL, dialect="xai")
+    )
+    assert folded.is_ok(), folded.error.summary
+    via_events = [
+        to_model_response_stream(chunk, "chatcmpl-AMBIENT").model_dump()
+        for chunk in folded.ok
+    ]
+    assert _norm(via_events) == _norm(_v2_chunks(events))
+
+
+_ERROR_CHUNK_STREAM = [
+    _chunk({"role": "assistant", "content": ""}),
+    {
+        "id": "ds-chunk-1",
+        "object": "chat.completion.chunk",
+        "created": 1718000000,
+        "model": WIRE_MODEL,
+        "error": {"message": "upstream exploded", "code": 502},
+    },
+    _chunk({"content": "after"}),
+    _chunk({}, finish="stop"),
+]
+
+
+def test_error_chunk_divergence_two_sided(frozen_ambient) -> None:
+    """The compat_httpx family's deliberate fail-closed divergence extends
+    to deepseek (same BASE handler): a mid-stream ``{"error": {...}}`` chunk
+    is SILENTLY SWALLOWED by v1 (no error surface in the emitted sequence),
+    while v2's parse_line surfaces a LOUD typed boundary error naming the
+    chunk. Flag-on cannot lose data (v2 is louder, not quieter). If the v1
+    half fails, the base handler learned to raise: re-decide the divergence
+    and update the report row in the same commit."""
+    v1 = _v1_chunks(_ERROR_CHUNK_STREAM)
+    assert "error" not in json.dumps(v1), v1
+    assert [c["choices"][0]["delta"].get("content") for c in v1[:2]] == ["", "after"]
+    lines = [f"data: {json.dumps(e)}" for e in copy.deepcopy(_ERROR_CHUNK_STREAM)]
+    folded = fold_lines(lines, parse_line, initial_state(MODEL, dialect="xai"))
+    assert folded.is_error()
+    assert "provider stream error" in folded.error.summary, folded.error.summary
+    assert "upstream exploded" in folded.error.summary
+
+
+def test_iterator_is_the_base_openai_handler() -> None:
+    """The one-dialect claim: DeepSeekChatConfig streams through the base
+    OpenAIChatCompletionStreamingHandler (no override). If this canary
+    fails, deepseek grew a custom dialect: re-pin every stream row against
+    the new handler before trusting the family policy."""
+    handler = provider_config("deepseek", MODEL).get_model_response_iterator(
+        streaming_response=iter(()), sync_stream=True
+    )
+    assert type(handler) is OpenAIChatCompletionStreamingHandler

--- a/tests/test_litellm/translation/test_differential_fireworks_ai_request.py
+++ b/tests/test_litellm/translation/test_differential_fireworks_ai_request.py
@@ -1,0 +1,542 @@
+"""Differential parity for the fireworks_ai request path (httpx dedicated
+elif, main.py:2198; transform LIVE; the WIRE model differs from the request
+model — the accounts/fireworks/models/ rewrite).
+
+Two-sided: every served row is byte-identical (normalized JSON) between v1
+in-process at HEAD and v2; every fallback row asserts BOTH the typed v2
+error and v1's own behavior. Dossier-drift pins recorded in
+wave2b-alpha-port.md: (1) the supported list's top_k mention is DEAD at
+runtime — top_k rides the extra_body crossing (fireworks IS a compat
+provider), wire-proven; (2) v1's tools capability is get_provider_info's
+default-TRUE + a hyphen-boundary map scan, NOT the map flag — the v2 gate
+is strictly narrower (one-direction mirror below), so tools serve only on
+explicitly-flagged rows and fall back elsewhere with an honest drift note;
+(3) the #transform=inline vision gate is a LITERAL substring check — VL
+models without "vision" in the name get the suffix.
+"""
+
+import copy
+import json
+
+import pytest
+
+from litellm.exceptions import UnsupportedParamsError
+
+from litellm.translation.dispatch import NEVER_PORT
+from litellm.translation.engine import pipeline
+from litellm.translation.engine.pipeline import translate_chat_request
+from litellm.utils import get_optional_params
+
+from ._own_module_corpus import capture_v1_wire_body, run_v1_request_transform
+from .conftest import build_real_deps
+
+# explicitly map-flagged: fc + tool_choice + reasoning all True in BOTH v1
+# and the deps read (the served-tools corpus model)
+FLAGGED = "accounts/fireworks/models/deepseek-v3p2"
+# bare name: the model-rewrite row (no explicit map flags -> tools fall back)
+BARE = "llama-v3p3-70b-instruct"
+# vision-NAMED model (the literal substring gate)
+VISION = "accounts/fireworks/models/llama-v3p2-11b-vision-instruct"
+# explicit map fc=False: v1 RAISES on tools
+NO_FC = "accounts/fireworks/models/deepseek-coder-v2-instruct"
+_USER = [{"role": "user", "content": "Hello, world"}]
+
+CLEAN_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get weather",
+        "strict": True,
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "city": {"type": "string"},
+                "nested": {"type": "object", "strict": True, "properties": {}},
+            },
+            "required": ["city"],
+        },
+    },
+}
+
+CASES: dict[str, dict] = {
+    # bare model name -> accounts/fireworks/models/ rewrite
+    "text_bare_model_rewritten": {"model": BARE, "messages": _USER},
+    "text_accounts_model_kept": {"model": FLAGGED, "messages": _USER},
+    "text_hash_model_kept": {"model": "my-model#deployment", "messages": _USER},
+    "system_and_sampling": {
+        "model": BARE,
+        "max_tokens": 64,
+        "temperature": 0.5,
+        "top_p": 0.9,
+        "messages": [
+            {"role": "system", "content": "You are helpful"},
+            {"role": "user", "content": "Hi"},
+        ],
+    },
+    "stream_true": {"model": BARE, "stream": True, "messages": _USER},
+    "stop_list": {"model": BARE, "stop": ["END"], "messages": _USER},
+    # fireworks HAS the rename arm (unlike its wave-2b siblings)
+    "max_completion_tokens_renamed": {
+        "model": BARE,
+        "max_completion_tokens": 128,
+        "messages": _USER,
+    },
+    "temperature_int_stays_int": {"model": BARE, "temperature": 1, "messages": _USER},
+    "user_verbatim": {"model": BARE, "user": "u1", "messages": _USER},
+    "tools_auto_on_flagged_model": {
+        "model": FLAGGED,
+        "tools": [CLEAN_TOOL],
+        "tool_choice": "auto",
+        "messages": [{"role": "user", "content": "Weather in Paris?"}],
+    },
+    # the required -> any rewrite
+    "tool_choice_required_to_any": {
+        "model": FLAGGED,
+        "tools": [CLEAN_TOOL],
+        "tool_choice": "required",
+        "messages": [{"role": "user", "content": "Weather in Paris?"}],
+    },
+    "tool_choice_specific": {
+        "model": FLAGGED,
+        "tools": [CLEAN_TOOL],
+        "tool_choice": {"type": "function", "function": {"name": "get_weather"}},
+        "messages": [{"role": "user", "content": "Weather in Paris?"}],
+    },
+    "tool_call_compact_roundtrip": {
+        "model": FLAGGED,
+        "tools": [CLEAN_TOOL],
+        "messages": [
+            {"role": "user", "content": "w?"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": '{"city":"Paris"}',
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "ok"},
+        ],
+    },
+    "parallel_tool_calls_false": {
+        "model": FLAGGED,
+        "tools": [CLEAN_TOOL],
+        "parallel_tool_calls": False,
+        "messages": [{"role": "user", "content": "Weather?"}],
+    },
+    "response_format_json_object": {
+        "model": BARE,
+        "response_format": {"type": "json_object"},
+        "messages": _USER,
+    },
+    "response_format_json_schema_strict": {
+        "model": BARE,
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {"name": "a", "schema": {"type": "object"}, "strict": True},
+        },
+        "messages": _USER,
+    },
+    "reasoning_effort_on_flagged_model": {
+        "model": FLAGGED,
+        "reasoning_effort": "high",
+        "messages": _USER,
+    },
+    # the literal "vision" substring gate: non-vision-NAMED models get the
+    # suffix on https urls; data: urls exempt
+    "image_inline_suffix_on_non_vision_name": {
+        "model": BARE,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "look"},
+                    {"type": "image_url", "image_url": {"url": "https://x/i.png"}},
+                ],
+            }
+        ],
+    },
+    "image_data_url_exempt": {
+        "model": BARE,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "look"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "data:image/png;base64,AAAA"},
+                    },
+                ],
+            }
+        ],
+    },
+    "image_no_suffix_on_vision_named_model": {
+        "model": VISION,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "look"},
+                    {"type": "image_url", "image_url": {"url": "https://x/i.png"}},
+                ],
+            }
+        ],
+    },
+    # v1 strips cache_control recursively == the IR drop, byte-identical
+    "cache_control_stripped": {
+        "model": BARE,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "a",
+                        "cache_control": {"type": "ephemeral"},
+                    },
+                    {"type": "text", "text": "b"},
+                ],
+                "cache_control": {"type": "ephemeral"},
+            }
+        ],
+    },
+}
+
+# name -> (case, v2 reason fragment); generator emits FALLBACK (v1 serves it)
+EXPECTED_FALLBACKS: dict[str, tuple[dict, str]] = {
+    "response_format_with_tools": (
+        {
+            "model": FLAGGED,
+            "tools": [CLEAN_TOOL],
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {"name": "a", "schema": {"type": "object"}},
+            },
+            "messages": _USER,
+        },
+        "json_mode",
+    ),
+    "legacy_defs_tool": (
+        {
+            "model": FLAGGED,
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "f",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"a": {"$ref": "#/definitions/A"}},
+                            "definitions": {"A": {"type": "string"}},
+                        },
+                    },
+                }
+            ],
+            "messages": _USER,
+        },
+        "schema inlining",
+    ),
+    # the capability drift: tools on a row WITHOUT explicit map flags — v1
+    # SERVES (default-true), v2's narrower read falls back with the honest
+    # drift note
+    "tools_on_unflagged_model_drift": (
+        {
+            "model": BARE,
+            "tools": [CLEAN_TOOL],
+            "messages": [{"role": "user", "content": "Weather?"}],
+        },
+        "strictly narrower",
+    ),
+    "top_k": ({"model": BARE, "top_k": 5, "messages": _USER}, "extra_body"),
+    "n": ({"model": BARE, "n": 2, "messages": _USER}, "n"),
+    "prompt_truncate_length": (
+        {"model": BARE, "prompt_truncate_length": 512, "messages": _USER},
+        "prompt_truncate_length",
+    ),
+    "provider_specific_fields_message": (
+        {
+            "model": BARE,
+            "messages": [
+                {"role": "user", "content": "q"},
+                {
+                    "role": "assistant",
+                    "content": "a",
+                    "provider_specific_fields": {"x": 1},
+                },
+            ],
+        },
+        "provider_specific_fields",
+    ),
+    "assistant_thinking_blocks": (
+        {
+            "model": BARE,
+            "messages": [
+                {"role": "user", "content": "q"},
+                {
+                    "role": "assistant",
+                    "content": "a",
+                    "thinking_blocks": [
+                        {"type": "thinking", "thinking": "hmm", "signature": "s"}
+                    ],
+                },
+            ],
+        },
+        "thinking_blocks",
+    ),
+    "pdf_file_part": (
+        {
+            "model": BARE,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "read"},
+                        {"type": "file", "file": {"file_id": "https://x/d.pdf"}},
+                    ],
+                }
+            ],
+        },
+        "not yet supported",
+    ),
+    "stream_false": ({"model": BARE, "stream": False, "messages": _USER}, "stream"),
+}
+
+# name -> (case, v2 reason fragment); v1 raises UnsupportedParamsError
+V1_RAISES: dict[str, tuple[dict, str]] = {
+    "tools_on_explicit_no_fc_model": (
+        {
+            "model": NO_FC,
+            "tools": [CLEAN_TOOL],
+            "messages": [{"role": "user", "content": "Weather?"}],
+        },
+        "strictly narrower",
+    ),
+    "reasoning_effort_on_non_reasoning_model": (
+        {"model": BARE, "reasoning_effort": "high", "messages": _USER},
+        "strictly narrower",
+    ),
+}
+
+
+def _v2(case: dict):
+    return translate_chat_request(
+        copy.deepcopy(case), "fireworks_ai", build_real_deps()
+    )
+
+
+def _norm(body: dict) -> str:
+    return json.dumps(body, sort_keys=True, default=str)
+
+
+@pytest.mark.parametrize("name", sorted(CASES))
+def test_v2_request_matches_v1(name: str) -> None:
+    case = CASES[name]
+    result = _v2(case)
+    assert result.is_ok(), result.error.summary
+    assert _norm(result.ok) == _norm(run_v1_request_transform("fireworks_ai", case))
+
+
+@pytest.mark.parametrize("name", sorted(EXPECTED_FALLBACKS))
+def test_expected_fallbacks_are_typed(name: str) -> None:
+    case, reason = EXPECTED_FALLBACKS[name]
+    result = _v2(case)
+    assert result.is_error(), f"{name} unexpectedly served"
+    assert reason in result.error.summary, result.error.summary
+
+
+@pytest.mark.parametrize("name", sorted(V1_RAISES))
+def test_v1_raise_rows_are_two_sided(name: str) -> None:
+    case, reason = V1_RAISES[name]
+    result = _v2(case)
+    assert result.is_error(), f"{name} unexpectedly served"
+    assert reason in result.error.summary, result.error.summary
+    with pytest.raises(UnsupportedParamsError):
+        run_v1_request_transform("fireworks_ai", case)
+
+
+def test_model_rewrite_pins() -> None:
+    assert (
+        _v2(CASES["text_bare_model_rewritten"]).ok["model"]
+        == f"accounts/fireworks/models/{BARE}"
+    )
+    assert _v2(CASES["text_accounts_model_kept"]).ok["model"] == FLAGGED
+    assert _v2(CASES["text_hash_model_kept"]).ok["model"] == "my-model#deployment"
+
+
+def test_required_to_any_and_strict_strip_pins() -> None:
+    body = _v2(CASES["tool_choice_required_to_any"]).ok
+    assert body["tool_choice"] == "any"
+    function = body["tools"][0]["function"]
+    assert "strict" not in function
+    # deeper strict keys ride VERBATIM (contrast hosted_vllm)
+    assert function["parameters"]["properties"]["nested"]["strict"] is True
+
+
+def test_image_suffix_pins() -> None:
+    served = _v2(CASES["image_inline_suffix_on_non_vision_name"]).ok
+    assert (
+        served["messages"][0]["content"][1]["image_url"]["url"]
+        == "https://x/i.png#transform=inline"
+    )
+    data_url = _v2(CASES["image_data_url_exempt"]).ok
+    assert (
+        data_url["messages"][0]["content"][1]["image_url"]["url"]
+        == "data:image/png;base64,AAAA"
+    )
+    vision = _v2(CASES["image_no_suffix_on_vision_named_model"]).ok
+    assert vision["messages"][0]["content"][1]["image_url"]["url"] == "https://x/i.png"
+
+
+def test_rf_with_tools_v1_serves_json_mode_machinery() -> None:
+    case, _ = EXPECTED_FALLBACKS["response_format_with_tools"]
+    request = copy.deepcopy(case)
+    optional = get_optional_params(
+        model=request.pop("model"),
+        custom_llm_provider="fireworks_ai",
+        stream=None,
+        **{k: v for k, v in request.items() if k != "messages"},
+    )
+    assert optional.get("json_mode") is True
+    assert "response_format" not in optional
+
+
+def test_legacy_defs_v1_serves_its_inlining() -> None:
+    case, _ = EXPECTED_FALLBACKS["legacy_defs_tool"]
+    v1 = run_v1_request_transform("fireworks_ai", case)
+    parameters = v1["tools"][0]["function"]["parameters"]
+    assert parameters["properties"]["a"] == {"type": "string"}  # $ref inlined
+    assert "definitions" not in parameters
+
+
+def test_capability_drift_v1_serves_tools_on_unflagged_model() -> None:
+    case, _ = EXPECTED_FALLBACKS["tools_on_unflagged_model_drift"]
+    v1 = run_v1_request_transform("fireworks_ai", case)
+    assert v1["tools"]  # v1's default-true gate SERVES the tools
+
+
+def test_psf_and_thinking_blocks_v1_serves_the_pops() -> None:
+    for name in ("provider_specific_fields_message", "assistant_thinking_blocks"):
+        case, _ = EXPECTED_FALLBACKS[name]
+        v1 = run_v1_request_transform("fireworks_ai", case)
+        assert v1["messages"][1] == {"role": "assistant", "content": "a"}, name
+
+
+def test_pdf_file_v1_serves_the_image_url_migration() -> None:
+    case, _ = EXPECTED_FALLBACKS["pdf_file_part"]
+    v1 = run_v1_request_transform("fireworks_ai", case)
+    migrated = v1["messages"][0]["content"][1]
+    assert migrated["type"] == "image_url"
+    assert migrated["image_url"]["url"].startswith("https://x/d.pdf")
+
+
+def test_n_and_truncate_v1_serves_them() -> None:
+    """n is in v1's supported list (top-level serve); prompt_truncate_length
+    is a NON-OpenAI param despite the list mention — it rides the extra_body
+    crossing like top_k (probed; the list mention is dead at runtime)."""
+    case, _ = EXPECTED_FALLBACKS["n"]
+    assert run_v1_request_transform("fireworks_ai", case)["n"] == 2
+    packed = get_optional_params(
+        model=BARE,
+        custom_llm_provider="fireworks_ai",
+        stream=None,
+        prompt_truncate_length=512,
+    )
+    assert packed["extra_body"] == {"prompt_truncate_length": 512}
+
+
+def test_top_k_fallback_reason_matches_the_wire_proven_extra_body_merge() -> None:
+    """The supported list's top_k mention is DEAD: top_k never reaches
+    _check_valid_arg (not an OpenAI param) and rides the extra_body packing
+    (fireworks IS a compat provider); hh merges it onto the wire."""
+    case, _ = EXPECTED_FALLBACKS["top_k"]
+    packed = get_optional_params(
+        model=BARE, custom_llm_provider="fireworks_ai", stream=None, top_k=5
+    )
+    assert packed["extra_body"] == {"top_k": 5}
+    assert "top_k" not in run_v1_request_transform("fireworks_ai", copy.deepcopy(case))
+    wire = capture_v1_wire_body(f"fireworks_ai/{BARE}", top_k=5)
+    assert wire["top_k"] == 5
+    assert "extra_body" not in wire
+
+
+def test_capability_mirror_is_one_direction() -> None:
+    """The soundness pin for the drift note: over EVERY fireworks chat map
+    row, the v2 capability read NEVER answers True where v1 answers False
+    (v2 may only be narrower — fallback-safe), and the explicitly-flagged
+    serve set is non-trivial. If a v1-False/v2-True row ever appears, v2
+    would serve what v1 raises on: re-derive the gate."""
+    import litellm
+    from litellm.utils import (
+        supports_function_calling,
+        supports_reasoning,
+        supports_tool_choice,
+    )
+
+    from litellm.translation.providers.fireworks_ai.params import (
+        supports_fireworks_reasoning,
+        supports_fireworks_tool_choice,
+        supports_fireworks_tools,
+    )
+
+    deps = build_real_deps()
+    rows = [
+        key.split("/", 1)[1]
+        for key, info in litellm.model_cost.items()
+        if key.startswith("fireworks_ai/")
+        and isinstance(info, dict)
+        and info.get("mode") == "chat"
+    ]
+    assert len(rows) > 100
+    served_fc = 0
+    for model in rows:
+        if supports_fireworks_tools(model, deps):
+            served_fc += 1
+            assert supports_function_calling(model, "fireworks_ai"), model
+        if supports_fireworks_tool_choice(model, deps):
+            assert supports_tool_choice(
+                model=model, custom_llm_provider="fireworks_ai"
+            ), model
+        if supports_fireworks_reasoning(model, deps):
+            assert supports_reasoning(model, "fireworks_ai"), model
+    assert served_fc >= 10  # the explicit-flag serve set stays non-trivial
+
+
+def test_supported_base_list_mirror() -> None:
+    """The static half of v1's list: every key v2's base allowed set carries
+    must be in v1's list for every model (user included — fireworks lists it
+    explicitly), and the list carries the keys v2 deliberately leaves to the
+    inbound fallback (n, logprobs, penalties, top_k, the two provider-native
+    params) so those fallbacks stay the v1-serves kind."""
+    from litellm.translation.providers.fireworks_ai.params import _FIREWORKS_BASE
+
+    from ._own_module_corpus import provider_config
+
+    for model in (BARE, FLAGGED, NO_FC):
+        supported = set(
+            provider_config("fireworks_ai", model).get_supported_openai_params(model)
+        )
+        assert _FIREWORKS_BASE <= supported, model
+        assert {
+            "n",
+            "logprobs",
+            "frequency_penalty",
+            "presence_penalty",
+            "top_k",
+            "prompt_truncate_length",
+            "context_length_exceeded_behavior",
+        } <= supported, model
+
+
+def test_registration_facts() -> None:
+    assert "fireworks_ai" in pipeline._SERIALIZERS
+    assert "fireworks_ai" in pipeline._RESPONSE_PARSERS
+    assert "fireworks_ai" in pipeline._RAW_GUARDS
+    assert pipeline.response_dialect("fireworks_ai") == "openai"
+    assert "fireworks_ai" not in NEVER_PORT

--- a/tests/test_litellm/translation/test_differential_fireworks_ai_response.py
+++ b/tests/test_litellm/translation/test_differential_fireworks_ai_response.py
@@ -1,0 +1,236 @@
+"""Differential parity for the fireworks_ai response path (httpx; the ONE
+wave-2b-alpha prefixing parser so far).
+
+v1's ``transform_response`` REPLACES the base: ``ModelResponse(**json)`` —
+the OpenAILike DIRECT construction (NOT cdr; different pydantic dump, no
+stop->tool_calls rewrite) — then ``model = "fireworks_ai/" + WIRE model``
+and the tool-calls-in-content repair. These rows run that exact v1 chain
+against v2's direct-parser policy with the seam's ``openai_like``
+construction arm (the compat_httpx RESPONSE_STYLES shape — the future fork
+MUST use it, never the "openai" arm or a seam preset). The repair shape and
+the non-string wire model are two-sided fallback rows.
+"""
+
+import copy
+import json
+
+import pydantic
+import pytest
+
+from litellm.types.utils import ModelResponse
+
+from litellm.translation.inbound.openai_chat import parse_request
+from litellm.translation.inbound.openai_chat.response import serialize_response
+from litellm.translation.providers.fireworks_ai import parse_response
+from litellm.translation_seam import build_translation_deps, to_model_response
+
+from ._own_module_corpus import run_v1_response_transform
+
+REQUEST_MODEL = "accounts/fireworks/models/deepseek-v3p2"
+WIRE_MODEL = "accounts/fireworks/models/deepseek-v3p2"
+
+_REQUEST = {
+    "model": REQUEST_MODEL,
+    "messages": [{"role": "user", "content": "hi"}],
+    "tools": [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ],
+}
+
+_RESPONSES = {
+    "text": {
+        "id": "fw-1",
+        "object": "chat.completion",
+        "created": 1718000000,
+        "model": WIRE_MODEL,
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "hello"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5},
+    },
+    "tool_calls": {
+        "id": "fw-2",
+        "object": "chat.completion",
+        "created": 1718000000,
+        "model": WIRE_MODEL,
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "arguments": '{"city":"Paris"}',
+                            },
+                        }
+                    ],
+                },
+                "finish_reason": "tool_calls",
+            }
+        ],
+        "usage": {"prompt_tokens": 9, "completion_tokens": 5, "total_tokens": 14},
+    },
+    # tool-bearing request whose content does NOT parse as a requested
+    # function: NO repair fires in v1; the verbatim ride serves
+    "plain_content_with_tools": {
+        "id": "fw-3",
+        "object": "chat.completion",
+        "created": 1718000000,
+        "model": WIRE_MODEL,
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "just text"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5},
+    },
+}
+
+_REPAIR_BODY = {
+    "id": "fw-repair",
+    "object": "chat.completion",
+    "created": 1718000000,
+    "model": WIRE_MODEL,
+    "choices": [
+        {
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": '{"name": "get_weather", "arguments": "{\\"city\\": \\"Paris\\"}"}',
+            },
+            "finish_reason": "stop",
+        }
+    ],
+    "usage": {"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5},
+}
+
+_NON_STRING_MODEL_BODY = {**_RESPONSES["text"], "model": 7}
+
+
+def _v1_model_response(raw: dict) -> dict:
+    return run_v1_response_transform(
+        "fireworks_ai",
+        raw,
+        REQUEST_MODEL,
+        optional_params={"tools": copy.deepcopy(_REQUEST["tools"])},
+    ).model_dump()
+
+
+def _v2_model_response(raw: dict) -> dict:
+    parsed = parse_request(copy.deepcopy(_REQUEST))
+    assert parsed.is_ok(), parsed.error.summary
+    response = parse_response(copy.deepcopy(raw), parsed.ok)
+    assert response.is_ok(), response.error.summary
+    body = serialize_response(response.ok, build_translation_deps(), "openai")
+    # fireworks is DIRECT construction: the seam fork must use the
+    # "openai_like" arm (never "openai", never a model preset)
+    return to_model_response(
+        body, ModelResponse(), usage_style="openai_like"
+    ).model_dump()
+
+
+def _norm(payload: dict) -> str:
+    return json.dumps(payload, sort_keys=True, default=str)
+
+
+@pytest.mark.parametrize("name", sorted(_RESPONSES))
+def test_v2_response_matches_v1(name: str, frozen_ambient) -> None:
+    raw = _RESPONSES[name]
+    assert _norm(_v2_model_response(raw)) == _norm(_v1_model_response(raw))
+
+
+@pytest.mark.parametrize("name", sorted(_RESPONSES))
+def test_fireworks_prefix_on_the_response_model(name: str, frozen_ambient) -> None:
+    raw = _RESPONSES[name]
+    v1 = _v1_model_response(raw)
+    v2 = _v2_model_response(raw)
+    assert v1["model"] == f"fireworks_ai/{WIRE_MODEL}"
+    assert v2["model"] == f"fireworks_ai/{WIRE_MODEL}"
+
+
+def test_repair_shape_falls_back_and_v1_serves_its_repair(frozen_ambient) -> None:
+    """Two-sided: v1 synthesizes a tool_call (uuid4 id, content -> None);
+    v2 fails closed naming the repair (the pure parser cannot mint ids)."""
+    parsed = parse_request(copy.deepcopy(_REQUEST))
+    assert parsed.is_ok()
+    result = parse_response(copy.deepcopy(_REPAIR_BODY), parsed.ok)
+    assert result.is_error()
+    assert "uuid4" in result.error.summary, result.error.summary
+    v1 = _v1_model_response(_REPAIR_BODY)
+    message = v1["choices"][0]["message"]
+    assert message["content"] is None
+    assert message["tool_calls"][0]["function"]["name"] == "get_weather"
+    assert message["tool_calls"][0]["id"]  # freshly minted
+
+
+def test_repair_skips_the_reserved_json_tool_name(frozen_ambient) -> None:
+    """content parsing to the reserved json_tool_call name is NOT repaired
+    by v1 (served verbatim) — and v2 serves it too (the trigger excludes the
+    reserved name)."""
+    body = copy.deepcopy(_REPAIR_BODY)
+    body["choices"][0]["message"][
+        "content"
+    ] = '{"name": "json_tool_call", "arguments": "{}"}'
+    request = {**copy.deepcopy(_REQUEST)}
+    request["tools"] = [
+        {
+            "type": "function",
+            "function": {
+                "name": "json_tool_call",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+    parsed = parse_request(request)
+    assert parsed.is_ok()
+    result = parse_response(copy.deepcopy(body), parsed.ok)
+    assert result.is_ok(), result.error.summary
+    v1 = run_v1_response_transform(
+        "fireworks_ai", body, REQUEST_MODEL, optional_params={"tools": request["tools"]}
+    ).model_dump()
+    assert (
+        v1["choices"][0]["message"]["content"]
+        == body["choices"][0]["message"]["content"]
+    )
+
+
+def test_non_string_wire_model_falls_back_where_v1_raises(frozen_ambient) -> None:
+    """v1's ModelResponse(**json) raises pydantic ValidationError BEFORE the
+    prefix rewrite; the direct parser's F2 arm fails closed (the family
+    rule: v2 never serves what v1 raises on)."""
+    with pytest.raises(pydantic.ValidationError):
+        _v1_model_response(_NON_STRING_MODEL_BODY)
+    parsed = parse_request(copy.deepcopy(_REQUEST))
+    assert parsed.is_ok()
+    result = parse_response(copy.deepcopy(_NON_STRING_MODEL_BODY), parsed.ok)
+    assert result.is_error()
+    assert "non-string wire model" in result.error.summary
+
+
+def test_missing_wire_model_keeps_none_on_both_sides(frozen_ambient) -> None:
+    """v1's `if response.model is not None` arm: a body WITHOUT a model key
+    constructs model=None and skips the prefix — v2's rewrite policy returns
+    None and leaves the body untouched."""
+    body = {k: v for k, v in _RESPONSES["text"].items() if k != "model"}
+    v1 = _v1_model_response(body)
+    v2 = _v2_model_response(body)
+    assert v1["model"] is None
+    assert v2["model"] is None
+    assert _norm(v2) == _norm(v1)

--- a/tests/test_litellm/translation/test_differential_fireworks_ai_response.py
+++ b/tests/test_litellm/translation/test_differential_fireworks_ai_response.py
@@ -22,7 +22,11 @@ from litellm.types.utils import ModelResponse
 from litellm.translation.inbound.openai_chat import parse_request
 from litellm.translation.inbound.openai_chat.response import serialize_response
 from litellm.translation.providers.fireworks_ai import parse_response
-from litellm.translation_seam import build_translation_deps, to_model_response
+from litellm.translation_seam import (
+    UsageStyle,
+    build_translation_deps,
+    to_model_response,
+)
 
 from ._own_module_corpus import run_v1_response_transform
 
@@ -133,17 +137,21 @@ def _v1_model_response(raw: dict) -> dict:
     ).model_dump()
 
 
-def _v2_model_response(raw: dict) -> dict:
+def _v2_with_style(raw: dict, style: UsageStyle) -> dict:
     parsed = parse_request(copy.deepcopy(_REQUEST))
     assert parsed.is_ok(), parsed.error.summary
     response = parse_response(copy.deepcopy(raw), parsed.ok)
     assert response.is_ok(), response.error.summary
     body = serialize_response(response.ok, build_translation_deps(), "openai")
+    return to_model_response(body, ModelResponse(), usage_style=style).model_dump()
+
+
+def _v2_model_response(raw: dict) -> dict:
     # fireworks is DIRECT construction: the seam fork must use the
-    # "openai_like" arm (never "openai", never a model preset)
-    return to_model_response(
-        body, ModelResponse(), usage_style="openai_like"
-    ).model_dump()
+    # "openai_like" arm (never "openai", never a model preset) — the truth is
+    # pipeline.OWN_MODULE_RESPONSE_STYLES["fireworks_ai"], divergence-pinned
+    # below
+    return _v2_with_style(raw, "openai_like")
 
 
 def _norm(payload: dict) -> str:
@@ -222,6 +230,35 @@ def test_non_string_wire_model_falls_back_where_v1_raises(frozen_ambient) -> Non
     result = parse_response(copy.deepcopy(_NON_STRING_MODEL_BODY), parsed.ok)
     assert result.is_error()
     assert "non-string wire model" in result.error.summary
+
+
+def test_wrong_construction_arm_diverges_and_the_table_pins_it(
+    frozen_ambient,
+) -> None:
+    """critic-wave2b-alpha MAJOR-4: the obligated construction style used to
+    live in prose ("using 'openai' or a preset breaks byte parity") with no
+    frozen inequality — a fork-wirer who selected the wrong arm shipped
+    green. Now the style is machine-readable
+    (pipeline.OWN_MODULE_RESPONSE_STYLES, asserted by the registration gate)
+    and the wrong arm is a PROVEN divergence on a parser-admissible body
+    (the 091bfd72cb / verifier-longtail F1 shape): the openai (cdr) arm
+    rebuilds choices under enumerate, rewriting a verbatim wire index 5 to
+    0, while v1's ModelResponse(**json) keeps it."""
+    from litellm.translation.engine.pipeline import OWN_MODULE_RESPONSE_STYLES
+
+    assert OWN_MODULE_RESPONSE_STYLES["fireworks_ai"] == "openai_like"
+    raw = copy.deepcopy(_RESPONSES["text"])
+    raw["choices"][0]["index"] = 5
+    v1 = _v1_model_response(raw)
+    correct = _v2_with_style(raw, OWN_MODULE_RESPONSE_STYLES["fireworks_ai"])
+    wrong = _v2_with_style(raw, "openai")
+    assert _norm(correct) == _norm(v1)
+    assert correct["choices"][0]["index"] == 5
+    assert wrong["choices"][0]["index"] == 0
+    assert _norm(wrong) != _norm(v1), (
+        "the construction arms stopped diverging on the index-rewrite body — "
+        "the MAJOR-4 gate lost its discriminator; re-decide before relying on it"
+    )
 
 
 def test_missing_wire_model_keeps_none_on_both_sides(frozen_ambient) -> None:

--- a/tests/test_litellm/translation/test_differential_fireworks_ai_stream.py
+++ b/tests/test_litellm/translation/test_differential_fireworks_ai_stream.py
@@ -1,0 +1,196 @@
+"""Differential parity for fireworks_ai streaming, pinned at the SSE line
+seam.
+
+v1 side: raw ``data:`` lines through the BASE
+``OpenAIChatCompletionStreamingHandler`` (FireworksAIConfig has no iterator
+override — canary-pinned; ``transform_response``'s ``fireworks_ai/`` prefix
+and content repair NEVER run on chunks, so stream models are the BARE wire
+model, pinned) into ``CustomStreamWrapper("fireworks_ai")``. v2 side:
+``fold_lines`` with the fireworks parser (the httpx_chunk FAMILY policy)
+and the shared ``xai`` chunk dialect. The mid-stream error chunk is the
+family's single PINNED DIVERGENCE — fireworks_ai joins the report's one
+named row.
+"""
+
+import copy
+import json
+
+import pytest
+
+from litellm.llms.openai.chat.gpt_transformation import (
+    OpenAIChatCompletionStreamingHandler,
+)
+
+from litellm.translation.engine.stream import fold_lines
+from litellm.translation.inbound.openai_chat.stream import initial_state
+from litellm.translation.providers.fireworks_ai import parse_line
+from litellm.translation_seam import to_model_response_stream
+
+from ._own_module_corpus import provider_config, replay_v1_sse_lines
+
+MODEL = "accounts/fireworks/models/deepseek-v3p2"
+WIRE_MODEL = "accounts/fireworks/models/deepseek-v3p2"
+
+
+def _chunk(delta, finish=None, usage=None, choices=None):
+    payload = {
+        "id": "fw-chunk-1",
+        "object": "chat.completion.chunk",
+        "created": 1718000000,
+        "model": WIRE_MODEL,
+        "choices": [
+            {"index": 0, "delta": delta, "logprobs": None, "finish_reason": finish}
+        ],
+        "usage": usage,
+    }
+    if choices is not None:
+        payload["choices"] = choices
+    return payload
+
+
+STREAMS = {
+    "text": [
+        _chunk({"role": "assistant", "content": ""}),
+        _chunk({"content": "Hello"}),
+        _chunk({"content": " world"}),
+        _chunk({}, finish="stop"),
+    ],
+    "tools": [
+        _chunk({"role": "assistant", "content": None}),
+        _chunk(
+            {
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "get_weather", "arguments": ""},
+                    }
+                ]
+            }
+        ),
+        _chunk(
+            {
+                "tool_calls": [
+                    {"index": 0, "function": {"arguments": '{"city":"Paris"}'}}
+                ]
+            }
+        ),
+        _chunk({}, finish="tool_calls"),
+    ],
+    # fireworks reasoning models stream native reasoning_content deltas
+    "native_reasoning_content": [
+        _chunk({"role": "assistant", "reasoning_content": "step "}),
+        _chunk({"reasoning_content": "by step"}),
+        _chunk({"content": "answer"}),
+        _chunk({}, finish="stop"),
+    ],
+    "reasoning_rename": [
+        _chunk({"role": "assistant", "content": ""}),
+        _chunk({"reasoning": "thinking..."}),
+        _chunk({"content": "answer"}),
+        _chunk({}, finish="stop"),
+    ],
+    "empty_keepalive_swallowed": [
+        _chunk({"role": "assistant", "content": ""}),
+        _chunk({}),
+        _chunk({"content": "hi"}),
+        _chunk({}, finish="stop"),
+    ],
+}
+
+USAGE_STREAM = [
+    _chunk({"role": "assistant", "content": ""}),
+    _chunk({"content": "Hi"}),
+    _chunk({}, finish="stop"),
+    _chunk(
+        {},
+        choices=[],
+        usage={"prompt_tokens": 7, "completion_tokens": 2, "total_tokens": 9},
+    ),
+]
+
+
+def _v1_chunks(events, stream_options=None):
+    return replay_v1_sse_lines("fireworks_ai", events, MODEL, stream_options)
+
+
+def _v2_chunks(events: list) -> list:
+    lines = [f"data: {json.dumps(event)}" for event in copy.deepcopy(events)]
+    lines.append("data: [DONE]")
+    folded = fold_lines(lines, parse_line, initial_state(MODEL, dialect="xai"))
+    assert folded.is_ok(), folded.error.summary
+    return [
+        to_model_response_stream(chunk, "chatcmpl-AMBIENT").model_dump()
+        for chunk in folded.ok
+    ]
+
+
+def _norm(chunks: list) -> str:
+    return json.dumps(chunks, sort_keys=True, default=str)
+
+
+@pytest.mark.parametrize("name", sorted(STREAMS))
+def test_v2_stream_matches_v1(name: str, frozen_ambient) -> None:
+    events = STREAMS[name]
+    assert _norm(_v2_chunks(events)) == _norm(_v1_chunks(events))
+
+
+def test_stream_chunks_keep_the_bare_wire_model(frozen_ambient) -> None:
+    """transform_response's fireworks_ai/ prefix NEVER runs on chunks: both
+    sides emit the bare wire model."""
+    v1 = _v1_chunks(STREAMS["text"])
+    v2 = _v2_chunks(STREAMS["text"])
+    for chunk in (*v1, *v2):
+        assert chunk["model"] == WIRE_MODEL
+        assert not str(chunk["model"]).startswith("fireworks_ai/")
+
+
+def test_usage_tail_pins_the_seam_contract(frozen_ambient) -> None:
+    v1 = _v1_chunks(USAGE_STREAM, stream_options={"include_usage": True})
+    v2 = _v2_chunks(USAGE_STREAM)
+    assert len(v1) == len(v2)
+    assert _norm(v2[:-1]) == _norm(v1[: len(v2) - 1])
+    assert v2[-1]["choices"] == []
+    for key in ("prompt_tokens", "completion_tokens", "total_tokens"):
+        assert v1[-1]["usage"][key] == v2[-1]["usage"][key], key
+
+
+def test_usage_tail_swallowed_without_stream_options(frozen_ambient) -> None:
+    v1 = _v1_chunks(USAGE_STREAM, None)
+    v2 = _v2_chunks(USAGE_STREAM)
+    assert len(v1) == len(v2) - 1
+    assert _norm(v1) == _norm(v2[:-1])
+
+
+_ERROR_CHUNK_STREAM = [
+    _chunk({"role": "assistant", "content": ""}),
+    {
+        "id": "fw-chunk-1",
+        "object": "chat.completion.chunk",
+        "created": 1718000000,
+        "model": WIRE_MODEL,
+        "error": {"message": "upstream exploded", "code": 502},
+    },
+    _chunk({"content": "after"}),
+    _chunk({}, finish="stop"),
+]
+
+
+def test_error_chunk_divergence_two_sided(frozen_ambient) -> None:
+    """Same BASE handler => same single PINNED DIVERGENCE: v1 silently
+    swallows the error chunk, v2's parse_line is loud."""
+    v1 = _v1_chunks(_ERROR_CHUNK_STREAM)
+    assert "error" not in json.dumps(v1), v1
+    lines = [f"data: {json.dumps(e)}" for e in copy.deepcopy(_ERROR_CHUNK_STREAM)]
+    folded = fold_lines(lines, parse_line, initial_state(MODEL, dialect="xai"))
+    assert folded.is_error()
+    assert "provider stream error" in folded.error.summary
+    assert "upstream exploded" in folded.error.summary
+
+
+def test_iterator_is_the_base_openai_handler() -> None:
+    handler = provider_config("fireworks_ai", MODEL).get_model_response_iterator(
+        streaming_response=iter(()), sync_stream=True
+    )
+    assert type(handler) is OpenAIChatCompletionStreamingHandler

--- a/tests/test_litellm/translation/test_differential_groq_request.py
+++ b/tests/test_litellm/translation/test_differential_groq_request.py
@@ -1,0 +1,260 @@
+"""Differential parity for the groq chat request path (wave-2b-beta).
+
+v1 side, invoked the way main.py's dedicated groq elif runs:
+``get_optional_params("groq")`` then ``GroqChatConfig.transform_request``
+(assistant None-strip + the base GPT assembly), with hh's envelope pops
+mirrored (fake_stream/json_mode are routing keys; ``extra_body`` is popped
+and MERGED into the wire body — groq's map packs ``top_k`` there, unlike
+the cohere/mistral top-level passthrough).
+
+The json_schema three-way fork (the wave's cross-plane feature, ported as
+researcher-4 prescribed): native-schema models (the ``groq/{m}``
+``supports_response_schema`` map flag) serve response_format VERBATIM;
+non-native models fall back (v1 serves its json_tool_call workaround);
+non-native + tools falls back where v1 raises ``litellm.BadRequestError``
+(the exact raise class pinned — NOT UnsupportedParamsError).
+
+NOTE for the fork wirer (main.py:2338-2344): the groq elif merges
+``GroqChatConfig.get_config()`` class attrs into optional_params — ambient
+module state v2 cannot see; the seam must fall back when that config is
+non-empty (the ambient-globals rule; CLAUDE.md fork obligations).
+"""
+
+import copy
+import json
+
+import pytest
+
+import litellm
+from litellm.exceptions import BadRequestError, UnsupportedParamsError
+from litellm.llms.groq.chat.transformation import GroqChatConfig
+from litellm.utils import get_optional_params
+
+from litellm.translation.engine.pipeline import translate_chat_request
+from litellm.translation_seam import build_translation_deps
+
+MODEL = "llama-3.3-70b-versatile"
+NATIVE_SCHEMA_MODEL = "openai/gpt-oss-120b"
+REASONING_MODEL = "qwen/qwen3-32b"
+_U = [{"role": "user", "content": "hi"}]
+
+_SCHEMA_RF = {
+    "type": "json_schema",
+    "json_schema": {
+        "name": "s",
+        "schema": {"type": "object", "properties": {}},
+        "strict": True,
+    },
+}
+
+CASES = {
+    "plain": {"model": MODEL, "messages": _U},
+    "sampling": {
+        "model": MODEL,
+        "messages": _U,
+        "temperature": 0.5,
+        "top_p": 0.9,
+        "max_tokens": 10,
+        "stop": ["x"],
+    },
+    "mct_renamed": {"model": MODEL, "messages": _U, "max_completion_tokens": 50},
+    "top_k_extra_body_merged": {"model": MODEL, "messages": _U, "top_k": 7},
+    "stream_true": {"model": MODEL, "messages": _U, "stream": True},
+    "tools": {
+        "model": MODEL,
+        "messages": _U,
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ],
+        "tool_choice": "auto",
+    },
+    "parallel_tool_calls": {
+        "model": MODEL,
+        "messages": _U,
+        "tools": [{"type": "function", "function": {"name": "f", "parameters": {}}}],
+        "parallel_tool_calls": True,
+    },
+    "response_format_json_object": {
+        "model": MODEL,
+        "messages": _U,
+        "response_format": {"type": "json_object"},
+    },
+    "response_format_schema_native_passthrough": {
+        "model": NATIVE_SCHEMA_MODEL,
+        "messages": _U,
+        "response_format": copy.deepcopy(_SCHEMA_RF),
+    },
+    "reasoning_effort_capable_model": {
+        "model": REASONING_MODEL,
+        "messages": _U,
+        "reasoning_effort": "high",
+    },
+    "assistant_none_strip": {
+        "model": MODEL,
+        "messages": [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "c1",
+                        "type": "function",
+                        "function": {"name": "f", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "c1", "content": "r"},
+        ],
+    },
+}
+
+V1_RAISES = {
+    "thinking": (
+        {"model": MODEL, "messages": _U, "thinking": {"type": "enabled"}},
+        "thinking",
+    ),
+    "reasoning_effort_non_reasoning_model": (
+        {"model": MODEL, "messages": _U, "reasoning_effort": "high"},
+        "reasoning_effort",
+    ),
+}
+
+V1_SERVES_FALLBACKS = {
+    "user_silent_drop": ({"model": MODEL, "messages": _U, "user": "u1"}, "user"),
+    "response_format_schema_workaround": (
+        {
+            "model": MODEL,
+            "messages": _U,
+            "response_format": copy.deepcopy(_SCHEMA_RF),
+        },
+        "json_tool_call workaround",
+    ),
+    "seed_parse_level": ({"model": MODEL, "messages": _U, "seed": 42}, "seed"),
+    "n_parse_level": ({"model": MODEL, "messages": _U, "n": 2}, "n"),
+    "service_tier_parse_level": (
+        {"model": MODEL, "messages": _U, "service_tier": "flex"},
+        "service_tier",
+    ),
+    "logit_bias_parse_level": (
+        {"model": MODEL, "messages": _U, "logit_bias": {"1": 1}},
+        "logit_bias",
+    ),
+    "explicit_stream_false": (
+        {"model": MODEL, "messages": _U, "stream": False},
+        "stream",
+    ),
+    "message_name_forwarded": (
+        {"model": MODEL, "messages": [{"role": "user", "content": "hi", "name": "b"}]},
+        "name",
+    ),
+}
+
+
+def run_v1_request_transform(case: dict) -> dict:
+    """May RAISE (UnsupportedParamsError / BadRequestError): pinned v1
+    behavior for the raise rows."""
+    request = copy.deepcopy(case)
+    model = request.pop("model")
+    messages = request.pop("messages")
+    optional_params = get_optional_params(
+        model=model,
+        custom_llm_provider="groq",
+        messages=copy.deepcopy(messages),
+        stream=request.pop("stream", None),
+        **request,
+    )
+    optional_params.pop("fake_stream", None)
+    optional_params.pop("json_mode", None)
+    extra_body = optional_params.pop("extra_body", {}) or {}
+    body = GroqChatConfig().transform_request(
+        model=model,
+        messages=messages,
+        optional_params=optional_params,
+        litellm_params={},
+        headers={},
+    )
+    return {**body, **extra_body}
+
+
+def _v2(case: dict):
+    return translate_chat_request(copy.deepcopy(case), "groq", build_translation_deps())
+
+
+def _norm(body: dict) -> str:
+    return json.dumps(body, sort_keys=True, default=str)
+
+
+@pytest.mark.parametrize("name", sorted(CASES))
+def test_v2_request_matches_v1(name: str) -> None:
+    case = CASES[name]
+    result = _v2(case)
+    assert result.is_ok(), result.error.summary
+    assert _norm(result.ok) == _norm(run_v1_request_transform(case))
+
+
+@pytest.mark.parametrize("name", sorted(V1_RAISES))
+def test_v1_raise_rows_fall_back_typed(name: str) -> None:
+    case, fragment = V1_RAISES[name]
+    result = _v2(case)
+    assert result.is_error(), f"{name} unexpectedly translated: {result.ok!r}"
+    assert fragment in result.error.summary, result.error.summary
+    with pytest.raises(UnsupportedParamsError):
+        run_v1_request_transform(case)
+
+
+def test_schema_with_tools_falls_back_where_v1_raises_bad_request() -> None:
+    """The wave's one non-UnsupportedParamsError request raise: pinned exact
+    type (litellm.BadRequestError)."""
+    case = {
+        "model": MODEL,
+        "messages": _U,
+        "response_format": copy.deepcopy(_SCHEMA_RF),
+        "tools": [{"type": "function", "function": {"name": "f", "parameters": {}}}],
+    }
+    result = _v2(case)
+    assert result.is_error()
+    assert "BadRequestError" in result.error.summary
+    with pytest.raises(BadRequestError):
+        run_v1_request_transform(case)
+
+
+@pytest.mark.parametrize("name", sorted(V1_SERVES_FALLBACKS))
+def test_v1_serves_fallback_rows(name: str) -> None:
+    case, fragment = V1_SERVES_FALLBACKS[name]
+    result = _v2(case)
+    assert result.is_error(), f"{name} unexpectedly translated: {result.ok!r}"
+    assert fragment in result.error.summary, result.error.summary
+    run_v1_request_transform(case)
+
+
+def test_native_schema_capability_is_the_fork_truth() -> None:
+    """The three-way fork keys off the groq/{m} supports_response_schema map
+    flag — pin that the chosen models disagree so the fork rows stay live."""
+    assert litellm.supports_response_schema(
+        model=NATIVE_SCHEMA_MODEL, custom_llm_provider="groq"
+    )
+    assert not litellm.supports_response_schema(model=MODEL, custom_llm_provider="groq")
+    native = _v2(CASES["response_format_schema_native_passthrough"])
+    assert native.is_ok()
+    assert native.ok["response_format"]["type"] == "json_schema"
+
+
+def test_top_k_rides_extra_body_then_the_wire() -> None:
+    """groq's map packs top_k into extra_body (NOT the cohere/mistral
+    top-level passthrough); hh merges extra_body into the wire body, so the
+    emission is wire-equivalent — the wire-prove rule."""
+    request = copy.deepcopy(CASES["top_k_extra_body_merged"])
+    model = request.pop("model")
+    optional_params = get_optional_params(
+        model=model, custom_llm_provider="groq", stream=None, top_k=7
+    )
+    assert optional_params["extra_body"] == {"top_k": 7}
+    result = _v2(CASES["top_k_extra_body_merged"])
+    assert result.is_ok() and result.ok["top_k"] == 7

--- a/tests/test_litellm/translation/test_differential_groq_response.py
+++ b/tests/test_litellm/translation/test_differential_groq_response.py
@@ -1,0 +1,197 @@
+"""Differential parity for the groq response path (wave-2b-beta).
+
+v1 side: ``GroqChatConfig.transform_response`` — the OpenAILike DIRECT
+construction (``custom_llm_provider=None`` -> the prefix arm is DEAD, BARE
+wire model) plus the service_tier clamp post-step ({auto, default, flex},
+None/unknown -> "auto"). The post-step reads ``getattr(model_response,
+"service_tier")`` with NO default, so a response body WITHOUT the key
+crashes v1 with AttributeError — v2 fails closed on it (pinned). Unknown
+top-level keys (``x_groq``) survive the direct construction.
+"""
+
+import copy
+import json
+import time
+
+import httpx
+import pytest
+
+from litellm.litellm_core_utils.litellm_logging import Logging
+from litellm.llms.groq.chat.transformation import GroqChatConfig
+from litellm.types.utils import ModelResponse
+
+from litellm.translation.inbound.openai_chat import parse_request
+from litellm.translation.inbound.openai_chat.response import serialize_response
+from litellm.translation.providers.groq import parse_response
+from litellm.translation_seam import build_translation_deps, to_model_response
+
+MODEL = "llama-3.3-70b-versatile"
+_REQUEST = {"model": MODEL, "messages": [{"role": "user", "content": "hi"}]}
+
+_BASE = {
+    "id": "chatcmpl-1",
+    "object": "chat.completion",
+    "created": 1718000000,
+    "model": MODEL,
+    "service_tier": "on_demand",
+    "usage": {"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5},
+}
+
+_RESPONSES = {
+    "text_tier_clamped_to_auto": {
+        **_BASE,
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "hello"},
+                "finish_reason": "stop",
+            }
+        ],
+    },
+    "tool_calls": {
+        **_BASE,
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "c1",
+                            "type": "function",
+                            "function": {"name": "f", "arguments": '{"a":1}'},
+                        }
+                    ],
+                },
+                "finish_reason": "tool_calls",
+            }
+        ],
+    },
+    "x_groq_extra_survives": {
+        **_BASE,
+        "x_groq": {"id": "req_1"},
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "x"},
+                "finish_reason": "stop",
+            }
+        ],
+    },
+    "flex_tier_kept": {
+        **_BASE,
+        "service_tier": "flex",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "x"},
+                "finish_reason": "stop",
+            }
+        ],
+    },
+    "null_tier_to_auto": {
+        **_BASE,
+        "service_tier": None,
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "x"},
+                "finish_reason": "stop",
+            }
+        ],
+    },
+}
+
+
+def _v1_model_response(raw: dict) -> dict:
+    logging = Logging(
+        model=MODEL,
+        messages=copy.deepcopy(_REQUEST["messages"]),
+        stream=False,
+        call_type="completion",
+        start_time=time.time(),
+        litellm_call_id="diff-groq-response",
+        function_id="diff-groq-response",
+    )
+    response = httpx.Response(
+        200,
+        json=copy.deepcopy(raw),
+        request=httpx.Request(
+            "POST", "https://api.groq.com/openai/v1/chat/completions"
+        ),
+    )
+    return (
+        GroqChatConfig()
+        .transform_response(
+            model=MODEL,
+            raw_response=response,
+            model_response=ModelResponse(),
+            logging_obj=logging,
+            request_data={},
+            messages=copy.deepcopy(_REQUEST["messages"]),
+            optional_params={},
+            litellm_params={},
+            encoding=None,
+        )
+        .model_dump()
+    )
+
+
+def _v2_parse(raw: dict):
+    parsed = parse_request(copy.deepcopy(_REQUEST))
+    assert parsed.is_ok(), parsed.error.summary
+    return parse_response(copy.deepcopy(raw), parsed.ok)
+
+
+def _v2_model_response(raw: dict) -> dict:
+    response = _v2_parse(raw)
+    assert response.is_ok(), response.error.summary
+    body = serialize_response(response.ok, build_translation_deps(), "openai")
+    return to_model_response(body, None, usage_style="openai_like").model_dump()
+
+
+def _norm(payload: dict) -> str:
+    return json.dumps(payload, sort_keys=True, default=str)
+
+
+@pytest.mark.parametrize("name", sorted(_RESPONSES))
+def test_v2_response_matches_v1(name: str, frozen_ambient) -> None:
+    raw = _RESPONSES[name]
+    assert _norm(_v2_model_response(raw)) == _norm(_v1_model_response(raw))
+
+
+@pytest.mark.parametrize("name", sorted(_RESPONSES))
+def test_bare_wire_model_no_prefix(name: str, frozen_ambient) -> None:
+    v1 = _v1_model_response(_RESPONSES[name])
+    v2 = _v2_model_response(_RESPONSES[name])
+    assert v1["model"] == MODEL
+    assert v2["model"] == MODEL
+    assert not str(v2["model"]).startswith("groq/")
+
+
+def test_missing_service_tier_fails_closed_where_v1_crashes(frozen_ambient) -> None:
+    raw = {
+        **{k: v for k, v in _BASE.items() if k != "service_tier"},
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "x"},
+                "finish_reason": "stop",
+            }
+        ],
+    }
+    result = _v2_parse(raw)
+    assert result.is_error()
+    assert "service_tier" in result.error.summary
+    with pytest.raises(AttributeError):
+        _v1_model_response(raw)
+
+
+def test_non_string_wire_model_falls_back_where_v1_raises(frozen_ambient) -> None:
+    raw = {**_RESPONSES["text_tier_clamped_to_auto"], "model": 7}
+    result = _v2_parse(raw)
+    assert result.is_error()
+    assert "non-string wire model" in result.error.summary
+    with pytest.raises(Exception):
+        _v1_model_response(raw)

--- a/tests/test_litellm/translation/test_differential_groq_response.py
+++ b/tests/test_litellm/translation/test_differential_groq_response.py
@@ -23,7 +23,11 @@ from litellm.types.utils import ModelResponse
 from litellm.translation.inbound.openai_chat import parse_request
 from litellm.translation.inbound.openai_chat.response import serialize_response
 from litellm.translation.providers.groq import parse_response
-from litellm.translation_seam import build_translation_deps, to_model_response
+from litellm.translation_seam import (
+    UsageStyle,
+    build_translation_deps,
+    to_model_response,
+)
 
 MODEL = "llama-3.3-70b-versatile"
 _REQUEST = {"model": MODEL, "messages": [{"role": "user", "content": "hi"}]}
@@ -144,11 +148,18 @@ def _v2_parse(raw: dict):
     return parse_response(copy.deepcopy(raw), parsed.ok)
 
 
-def _v2_model_response(raw: dict) -> dict:
+def _v2_with_style(raw: dict, style: UsageStyle) -> dict:
     response = _v2_parse(raw)
     assert response.is_ok(), response.error.summary
     body = serialize_response(response.ok, build_translation_deps(), "openai")
-    return to_model_response(body, None, usage_style="openai_like").model_dump()
+    return to_model_response(body, None, usage_style=style).model_dump()
+
+
+def _v2_model_response(raw: dict) -> dict:
+    # groq is DIRECT construction (bare wire model, x_groq extras survive) —
+    # the truth is pipeline.OWN_MODULE_RESPONSE_STYLES["groq"],
+    # divergence-pinned below
+    return _v2_with_style(raw, "openai_like")
 
 
 def _norm(payload: dict) -> str:
@@ -195,3 +206,29 @@ def test_non_string_wire_model_falls_back_where_v1_raises(frozen_ambient) -> Non
     assert "non-string wire model" in result.error.summary
     with pytest.raises(Exception):
         _v1_model_response(raw)
+
+
+def test_wrong_construction_arm_diverges_and_the_table_pins_it(
+    frozen_ambient,
+) -> None:
+    """Sibling-merge consistency sweep: alpha's MAJOR-4 table
+    (pipeline.OWN_MODULE_RESPONSE_STYLES) now covers the beta own modules;
+    groq is an openai_like member, so the wrong arm must be a PROVEN
+    divergence, not prose (the fireworks_ai/snowflake template): the openai
+    (cdr) arm rebuilds choices under enumerate, rewriting a verbatim wire
+    index 5 to 0, while v1's ModelResponse(**json) keeps it."""
+    from litellm.translation.engine.pipeline import OWN_MODULE_RESPONSE_STYLES
+
+    assert OWN_MODULE_RESPONSE_STYLES["groq"] == "openai_like"
+    raw = copy.deepcopy(_RESPONSES["text_tier_clamped_to_auto"])
+    raw["choices"][0]["index"] = 5
+    v1 = _v1_model_response(raw)
+    correct = _v2_with_style(raw, OWN_MODULE_RESPONSE_STYLES["groq"])
+    wrong = _v2_with_style(raw, "openai")
+    assert _norm(correct) == _norm(v1)
+    assert correct["choices"][0]["index"] == 5
+    assert wrong["choices"][0]["index"] == 0
+    assert _norm(wrong) != _norm(v1), (
+        "the construction arms stopped diverging on the index-rewrite body — "
+        "the MAJOR-4 gate lost its discriminator; re-decide before relying on it"
+    )

--- a/tests/test_litellm/translation/test_differential_groq_stream.py
+++ b/tests/test_litellm/translation/test_differential_groq_stream.py
@@ -206,3 +206,55 @@ def test_falsy_error_value_is_served_like_v1(frozen_ambient) -> None:
         _chunk({}, finish="stop"),
     ]
     assert _norm(_v2_chunks(events)) == _norm(_v1_chunks(events))
+
+
+@pytest.mark.parametrize("key", ["reasoning", "reasoning_content"])
+def test_non_str_reasoning_is_loud_where_v1_raises(key: str, frozen_ambient) -> None:
+    """verifier-wave2b-beta F6: a non-str truthy reasoning value reaches
+    v1's wrapper epilogue, whose stream_chunk_builder ``"".join`` raises
+    TypeError -> APIError; the factory's _string_or_none quietly nulled it.
+    Null reasoning stays served (the reasoning_null parity row holds)."""
+    events = [
+        _chunk({"role": "assistant", **{key: 5}}),
+        _chunk({}, finish="stop"),
+    ]
+    result = parse_event(copy.deepcopy(events[0]))
+    assert result.is_error()
+    assert "is not a string" in result.error.summary
+    with pytest.raises(Exception):
+        _v1_chunks(events)
+
+
+def test_null_reasoning_still_serves(frozen_ambient) -> None:
+    """The F6 pre-step must not widen: null reasoning serves identically
+    (the verifier's reasoning-null parity probe)."""
+    events = [
+        _chunk({"role": "assistant", "content": "", "reasoning": None}),
+        _chunk({"content": "hi"}),
+        _chunk({}, finish="stop"),
+    ]
+    assert _norm(_v2_chunks(events)) == _norm(_v1_chunks(events))
+
+
+def test_non_str_refusal_nulling_handoff_to_the_factory_fix(frozen_ambient) -> None:
+    """INTEGRATOR-FLIP (wave-2b-beta F6 handoff — sibling merge): a non-str
+    ``refusal`` is nulled by the SHARED factory's _string_or_none
+    (openai_compat/httpx_chunk.py) while v1 FORWARDS it on the wire — both
+    serve, bodies differ. That file is the alpha fix round's concurrent
+    edit (verifier-wave2b-alpha F1, same machinery), so this branch does
+    NOT touch it; this row GUARDS THE CURRENT (divergent) behavior so the
+    sibling-merge integrator flips the assertions to v1 parity (refusal
+    forwarded verbatim) when the factory fix lands. See the merge notes in
+    ~/sprint/reports/wave2b-beta-port.md (Fix round section)."""
+    events = [
+        _chunk({"role": "assistant", "refusal": 7, "content": "x"}),
+        _chunk({}, finish="stop"),
+    ]
+    v1 = _v1_chunks(events)
+    v2 = _v2_chunks(events)
+    assert (
+        v1[0]["choices"][0]["delta"]["refusal"] == 7
+    ), "v1 stopped forwarding the non-str refusal; re-decide the handoff"
+    # CURRENT factory behavior — the integrator flips this to == 7 with the
+    # alpha httpx_chunk fix:
+    assert v2[0]["choices"][0]["delta"]["refusal"] is None

--- a/tests/test_litellm/translation/test_differential_groq_stream.py
+++ b/tests/test_litellm/translation/test_differential_groq_stream.py
@@ -236,25 +236,46 @@ def test_null_reasoning_still_serves(frozen_ambient) -> None:
     assert _norm(_v2_chunks(events)) == _norm(_v1_chunks(events))
 
 
-def test_non_str_refusal_nulling_handoff_to_the_factory_fix(frozen_ambient) -> None:
-    """INTEGRATOR-FLIP (wave-2b-beta F6 handoff — sibling merge): a non-str
-    ``refusal`` is nulled by the SHARED factory's _string_or_none
-    (openai_compat/httpx_chunk.py) while v1 FORWARDS it on the wire — both
-    serve, bodies differ. That file is the alpha fix round's concurrent
-    edit (verifier-wave2b-alpha F1, same machinery), so this branch does
-    NOT touch it; this row GUARDS THE CURRENT (divergent) behavior so the
-    sibling-merge integrator flips the assertions to v1 parity (refusal
-    forwarded verbatim) when the factory fix lands. See the merge notes in
-    ~/sprint/reports/wave2b-beta-port.md (Fix round section)."""
+@pytest.mark.parametrize("refusal", [7, {"a": 1}], ids=["int", "dict"])
+def test_non_str_refusal_forwarded_verbatim_like_v1(refusal, frozen_ambient) -> None:
+    """wave-2b-beta F6 refusal half, DISCHARGED at the sibling merge (the
+    named INTEGRATOR-FLIP handoff): the SHARED factory used to null a
+    non-str ``refusal`` (_string_or_none) that v1 FORWARDS on the wire and
+    serves end-to-end (re-probed two-sided at the merge: v1's wrapper
+    emits the verbatim value and the stream completes without the
+    reasoning-style epilogue crash). The factory now forwards the refusal
+    VALUE verbatim — full byte parity, the marker row in _groq_rows
+    flipped with this test."""
     events = [
-        _chunk({"role": "assistant", "refusal": 7, "content": "x"}),
+        _chunk({"role": "assistant", "refusal": refusal, "content": "x"}),
         _chunk({}, finish="stop"),
     ]
     v1 = _v1_chunks(events)
     v2 = _v2_chunks(events)
-    assert (
-        v1[0]["choices"][0]["delta"]["refusal"] == 7
-    ), "v1 stopped forwarding the non-str refusal; re-decide the handoff"
-    # CURRENT factory behavior — the integrator flips this to == 7 with the
-    # alpha httpx_chunk fix:
-    assert v2[0]["choices"][0]["delta"]["refusal"] is None
+    assert v1[0]["choices"][0]["delta"]["refusal"] == refusal, (
+        "v1 stopped forwarding the non-str refusal; re-decide the discharge"
+    )
+    assert _norm(v2) == _norm(v1)
+
+
+def test_refusal_on_finish_chunk_is_loud_where_v1_drops_it(frozen_ambient) -> None:
+    """The finish-chunk half of the refusal discharge, named: groq's v1
+    wrapper silently DROPS a refusal riding the finish chunk (the served
+    finish delta carries no refusal key — probed; unlike openrouter/xai,
+    whose wrappers interleave a separate chunk, verifier-wave2b-alpha F1).
+    With the value now riding verbatim, _delta_bears_content counts it and
+    v2 takes the LOUD finish-chunk fallback — fail-closed where v1 serves
+    a body that silently LOST the refusal (before the discharge a non-str
+    value was nulled first and v2 accidentally served the same lossy
+    finish; the str case was already loud)."""
+    events = [
+        _chunk({"role": "assistant", "content": "x"}),
+        _chunk({"refusal": 7}, finish="stop"),
+    ]
+    v1 = _v1_chunks(events)
+    assert "refusal" not in v1[-1]["choices"][0]["delta"], (
+        "v1 stopped dropping refusal-on-finish; re-derive this row"
+    )
+    result = parse_event(copy.deepcopy(events[-1]))
+    assert result.is_error(), "refusal-on-finish must be loud, never lossy"
+    assert "finish chunk with a non-empty delta" in result.error.summary

--- a/tests/test_litellm/translation/test_differential_groq_stream.py
+++ b/tests/test_litellm/translation/test_differential_groq_stream.py
@@ -1,0 +1,208 @@
+"""Differential parity for groq streaming (wave-2b-beta), pinned at the
+SSE line seam.
+
+v1 side: ``data:``/[DONE] lines through ``GroqChatCompletionStreamingHandler``
+(truthy-``error`` raise, the ``delta.reasoning`` POP rename, then the base
+rebuild) into ``CustomStreamWrapper("groq")``. v2 side: the shared
+httpx_chunk factory with ``reasoning="rename"`` — the longtail guidance's
+prediction verified (groq's pop == the existing rename mode; NO new
+ReasoningMode arm) — folded by the shared ``xai`` chunk dialect.
+"""
+
+import copy
+import json
+import time
+
+import pytest
+
+from litellm.exceptions import MidStreamFallbackError
+from litellm.litellm_core_utils.litellm_logging import Logging
+from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
+from litellm.llms.groq.chat.transformation import GroqChatCompletionStreamingHandler
+
+from litellm.translation.engine.stream import fold_events, fold_lines
+from litellm.translation.inbound.openai_chat.stream import initial_state
+from litellm.translation.providers.groq import parse_event, parse_line
+from litellm.translation_seam import to_model_response_stream
+
+MODEL = "llama-3.3-70b-versatile"
+
+_USAGE = {"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5}
+
+
+def _chunk(
+    delta: dict | None = None,
+    finish: str | None = None,
+    usage: dict | None = None,
+    choices: list | None = None,
+    **extra: object,
+) -> dict:
+    payload: dict = {
+        "id": "chunk-1",
+        "object": "chat.completion.chunk",
+        "created": 1718000000,
+        "model": MODEL,
+        **extra,
+    }
+    payload["choices"] = (
+        choices
+        if choices is not None
+        else [
+            {
+                "index": 0,
+                "delta": delta if delta is not None else {},
+                "finish_reason": finish,
+            }
+        ]
+    )
+    if usage is not None:
+        payload["usage"] = usage
+    return payload
+
+
+STREAMS = {
+    "text": [
+        _chunk({"role": "assistant", "content": "He"}),
+        _chunk({"content": "llo"}),
+        _chunk({}, finish="stop"),
+    ],
+    "reasoning_pop_rename": [
+        _chunk({"role": "assistant", "reasoning": "think"}),
+        _chunk({"content": "x"}),
+        _chunk({}, finish="stop"),
+    ],
+    "tools": [
+        _chunk(
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "c1",
+                        "type": "function",
+                        "function": {"name": "f", "arguments": ""},
+                    }
+                ],
+            }
+        ),
+        _chunk({"tool_calls": [{"index": 0, "function": {"arguments": "{}"}}]}),
+        _chunk({}, finish="tool_calls"),
+    ],
+    "x_groq_extras_dropped": [
+        _chunk({"role": "assistant", "content": "Hi"}, x_groq={"id": "r"}),
+        _chunk({}, finish="stop"),
+    ],
+}
+
+USAGE_STREAM = [
+    _chunk({"role": "assistant", "content": "Hi"}),
+    _chunk({}, finish="stop"),
+    _chunk(choices=[], usage=_USAGE),
+]
+
+
+def _v1_chunks(events: list, stream_options: dict | None = None) -> list:
+    lines = [f"data: {json.dumps(event)}" for event in copy.deepcopy(events)]
+    lines.append("data: [DONE]")
+    handler = GroqChatCompletionStreamingHandler(
+        streaming_response=iter(lines), sync_stream=True
+    )
+    logging = Logging(
+        model=MODEL,
+        messages=[{"role": "user", "content": "stream"}],
+        stream=True,
+        call_type="completion",
+        start_time=time.time(),
+        litellm_call_id="diff-groq-stream",
+        function_id="diff-groq-stream",
+    )
+    wrapper = CustomStreamWrapper(
+        completion_stream=handler,
+        model=MODEL,
+        custom_llm_provider="groq",
+        logging_obj=logging,
+        stream_options=stream_options,
+    )
+    return [chunk.model_dump() for chunk in wrapper]
+
+
+def _v2_chunks(events: list) -> list:
+    lines = [f"data: {json.dumps(event)}" for event in copy.deepcopy(events)]
+    lines.append("data: [DONE]")
+    folded = fold_lines(lines, parse_line, initial_state(MODEL, dialect="xai"))
+    assert folded.is_ok(), folded.error.summary
+    return [
+        to_model_response_stream(chunk, "chatcmpl-AMBIENT").model_dump()
+        for chunk in folded.ok
+    ]
+
+
+def _norm(chunks: list) -> str:
+    return json.dumps(chunks, sort_keys=True, default=str)
+
+
+@pytest.mark.parametrize("name", sorted(STREAMS))
+def test_v2_stream_matches_v1(name: str, frozen_ambient) -> None:
+    events = STREAMS[name]
+    assert _norm(_v2_chunks(events)) == _norm(_v1_chunks(events))
+
+
+def test_reasoning_pop_emits_only_reasoning_content(frozen_ambient) -> None:
+    """Semantic pin: groq POPS (the original ``reasoning`` key never reaches
+    the delta — the cometapi copy_both variant differs here)."""
+    v2 = _v2_chunks(STREAMS["reasoning_pop_rename"])
+    delta = v2[0]["choices"][0]["delta"]
+    assert delta["reasoning_content"] == "think"
+    assert "reasoning" not in delta
+
+
+def test_usage_tail_pins_the_seam_contract(frozen_ambient) -> None:
+    v1 = _v1_chunks(USAGE_STREAM, stream_options={"include_usage": True})
+    v2 = _v2_chunks(USAGE_STREAM)
+    assert len(v1) == len(v2)
+    assert _norm(v2[:-1]) == _norm(v1[: len(v2) - 1])
+    assert v2[-1]["choices"] == []
+    for key in ("prompt_tokens", "completion_tokens", "total_tokens"):
+        assert v1[-1]["usage"][key] == v2[-1]["usage"][key], key
+
+
+def test_usage_tail_swallowed_without_stream_options(frozen_ambient) -> None:
+    v1 = _v1_chunks(USAGE_STREAM, None)
+    v2 = _v2_chunks(USAGE_STREAM)
+    assert len(v1) == len(v2) - 1
+    assert _norm(v1) == _norm(v2[:-1])
+
+
+def test_v2_line_and_event_folds_agree(frozen_ambient) -> None:
+    events = STREAMS["reasoning_pop_rename"]
+    folded = fold_events(
+        copy.deepcopy(events), parse_event, initial_state(MODEL, dialect="xai")
+    )
+    assert folded.is_ok(), folded.error.summary
+    via_events = [
+        to_model_response_stream(chunk, "chatcmpl-AMBIENT").model_dump()
+        for chunk in folded.ok
+    ]
+    assert _norm(via_events) == _norm(_v2_chunks(events))
+
+
+def test_error_chunk_loud_on_both_sides(frozen_ambient) -> None:
+    """v1 raises OpenAIError -> the wrapper maps it onto
+    MidStreamFallbackError (the truthy-VALUE check, the xai shape); v2 is a
+    loud typed error."""
+    event = {"error": {"message": "boom", "code": 500}}
+    result = parse_event(copy.deepcopy(event))
+    assert result.is_error()
+    assert "provider stream error" in result.error.summary
+    with pytest.raises(MidStreamFallbackError):
+        _v1_chunks([event])
+
+
+def test_falsy_error_value_is_served_like_v1(frozen_ambient) -> None:
+    """The value-check pin: ``error: null`` does NOT raise in v1 (groq
+    checks truthiness, not key presence — cometapi differs)."""
+    events = [
+        _chunk({"role": "assistant", "content": "Hi"}, error=None),
+        _chunk({}, finish="stop"),
+    ]
+    assert _norm(_v2_chunks(events)) == _norm(_v1_chunks(events))

--- a/tests/test_litellm/translation/test_differential_hosted_vllm_request.py
+++ b/tests/test_litellm/translation/test_differential_hosted_vllm_request.py
@@ -1,0 +1,394 @@
+"""Differential parity for the hosted_vllm request path (httpx dedicated
+elif, main.py:2619; transform LIVE; no model prefix).
+
+Two-sided: every served row is byte-identical (normalized JSON) between v1
+in-process at HEAD (get_optional_params + HostedVLLMChatConfig
+.transform_request, the _own_module_corpus invoker) and v2; every fallback
+row asserts BOTH the typed v2 error and v1's own behavior (serve or
+rewrite, asserted in-process). The thinking budget bands and the recursive
+tools cleaning are v1 facts re-verified here, not dossier trust.
+"""
+
+import copy
+import json
+
+import pytest
+
+from litellm.translation.dispatch import NEVER_PORT
+from litellm.translation.engine import pipeline
+from litellm.translation.engine.pipeline import translate_chat_request
+from litellm.utils import get_optional_params
+
+from ._own_module_corpus import capture_v1_wire_body, run_v1_request_transform
+from .conftest import build_real_deps
+
+MODEL = "qwen2.5-7b-instruct"
+_USER = [{"role": "user", "content": "Hello, world"}]
+
+DIRTY_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get weather",
+        "strict": True,
+        "parameters": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "city": {"type": "string"},
+                "nested": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "strict": True,
+                    "properties": {"zip": {"type": "string"}},
+                },
+            },
+            "required": ["city"],
+        },
+    },
+}
+
+CASES: dict[str, dict] = {
+    "text": {"model": MODEL, "messages": _USER},
+    "system_and_sampling": {
+        "model": MODEL,
+        "max_tokens": 64,
+        "temperature": 0.5,
+        "top_p": 0.9,
+        "messages": [
+            {"role": "system", "content": "You are helpful"},
+            {"role": "user", "content": "Hi"},
+        ],
+    },
+    "stream_true": {"model": MODEL, "stream": True, "messages": _USER},
+    "stop_list": {"model": MODEL, "stop": ["END"], "messages": _USER},
+    "max_completion_tokens_verbatim": {
+        "model": MODEL,
+        "max_completion_tokens": 128,
+        "messages": _USER,
+    },
+    "temperature_int_stays_int": {"model": MODEL, "temperature": 1, "messages": _USER},
+    # the recursive cleaning: strict (any depth, any value) and
+    # additionalProperties:false (any depth) removed
+    "tools_cleaned_recursively": {
+        "model": MODEL,
+        "tools": [DIRTY_TOOL],
+        "tool_choice": "auto",
+        "messages": [{"role": "user", "content": "Weather in Paris?"}],
+    },
+    "tool_choice_specific": {
+        "model": MODEL,
+        "tools": [DIRTY_TOOL],
+        "tool_choice": {"type": "function", "function": {"name": "get_weather"}},
+        "messages": [{"role": "user", "content": "Weather in Paris?"}],
+    },
+    "tool_call_compact_roundtrip": {
+        "model": MODEL,
+        "tools": [DIRTY_TOOL],
+        "messages": [
+            {"role": "user", "content": "w?"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": '{"city":"Paris"}',
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "ok"},
+        ],
+    },
+    "parallel_tool_calls_false": {
+        "model": MODEL,
+        "tools": [DIRTY_TOOL],
+        "parallel_tool_calls": False,
+        "messages": [{"role": "user", "content": "Weather?"}],
+    },
+    "response_format_json_object": {
+        "model": MODEL,
+        "response_format": {"type": "json_object"},
+        "messages": _USER,
+    },
+    "response_format_json_schema_strict": {
+        "model": MODEL,
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {"name": "a", "schema": {"type": "object"}, "strict": True},
+        },
+        "messages": _USER,
+    },
+    # reasoning_effort is UNCONDITIONALLY supported, emitted verbatim
+    "reasoning_effort_verbatim": {
+        "model": MODEL,
+        "reasoning_effort": "high",
+        "messages": _USER,
+    },
+    # the budget-band rewrite (map_openai_params; in-process re-verified):
+    "thinking_band_high": {
+        "model": MODEL,
+        "thinking": {"type": "enabled", "budget_tokens": 12000},
+        "messages": _USER,
+    },
+    "thinking_band_medium": {
+        "model": MODEL,
+        "thinking": {"type": "enabled", "budget_tokens": 6000},
+        "messages": _USER,
+    },
+    "thinking_band_low": {
+        "model": MODEL,
+        "thinking": {"type": "enabled", "budget_tokens": 3000},
+        "messages": _USER,
+    },
+    "thinking_band_minimal_no_budget": {
+        "model": MODEL,
+        "thinking": {"type": "enabled"},
+        "messages": _USER,
+    },
+    "thinking_disabled_dropped": {
+        "model": MODEL,
+        "thinking": {"type": "disabled"},
+        "messages": _USER,
+    },
+    "thinking_adaptive_dropped": {
+        "model": MODEL,
+        "thinking": {"type": "adaptive"},
+        "messages": _USER,
+    },
+    # explicit reasoning_effort WINS over the thinking rewrite
+    "reasoning_effort_wins_over_thinking": {
+        "model": MODEL,
+        "thinking": {"type": "enabled", "budget_tokens": 12000},
+        "reasoning_effort": "low",
+        "messages": _USER,
+    },
+}
+
+# name -> (case, v2 reason fragment); generator emits FALLBACK (v1 serves it)
+EXPECTED_FALLBACKS: dict[str, tuple[dict, str]] = {
+    # v1 synthesizes a function tool from a custom-type tool; the shared
+    # openai guard falls back
+    "custom_tool": (
+        {
+            "model": MODEL,
+            "messages": _USER,
+            "tools": [
+                {
+                    "type": "custom",
+                    "custom": {
+                        "name": "ct",
+                        "description": "d",
+                        "input_schema": {"type": "object", "properties": {}},
+                    },
+                }
+            ],
+        },
+        "custom-type tool",
+    ),
+    # v1 prepends assistant thinking_blocks as content blocks; the shared
+    # openai guard falls back
+    "assistant_thinking_blocks": (
+        {
+            "model": MODEL,
+            "messages": [
+                {"role": "user", "content": "q"},
+                {
+                    "role": "assistant",
+                    "content": "ans",
+                    "thinking_blocks": [
+                        {"type": "thinking", "thinking": "hmm", "signature": "s"}
+                    ],
+                },
+                {"role": "user", "content": "n"},
+            ],
+        },
+        "thinking_blocks",
+    ),
+    # v1 converts video file parts to video_url blocks; the inbound boundary
+    # falls back on every file part
+    "video_file_part": (
+        {
+            "model": MODEL,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "watch"},
+                        {"type": "file", "file": {"file_id": "https://x/v.mp4"}},
+                    ],
+                }
+            ],
+        },
+        "not yet supported",
+    ),
+    "top_k": ({"model": MODEL, "top_k": 5, "messages": _USER}, "extra_body"),
+    "user": ({"model": MODEL, "user": "u1", "messages": _USER}, "user"),
+    "stream_false": ({"model": MODEL, "stream": False, "messages": _USER}, "stream"),
+}
+
+
+def _v2(case: dict):
+    return translate_chat_request(copy.deepcopy(case), "hosted_vllm", build_real_deps())
+
+
+def _norm(body: dict) -> str:
+    return json.dumps(body, sort_keys=True, default=str)
+
+
+@pytest.mark.parametrize("name", sorted(CASES))
+def test_v2_request_matches_v1(name: str) -> None:
+    case = CASES[name]
+    result = _v2(case)
+    assert result.is_ok(), result.error.summary
+    assert _norm(result.ok) == _norm(run_v1_request_transform("hosted_vllm", case))
+
+
+@pytest.mark.parametrize("name", sorted(EXPECTED_FALLBACKS))
+def test_expected_fallbacks_are_typed(name: str) -> None:
+    case, reason = EXPECTED_FALLBACKS[name]
+    result = _v2(case)
+    assert result.is_error(), f"{name} unexpectedly served"
+    assert reason in result.error.summary, result.error.summary
+
+
+def test_thinking_bands_semantic_pins() -> None:
+    """The wire reasoning_effort value per band, the disabled/adaptive
+    drops, and the thinking key never reaching the wire."""
+    expectations = {
+        "thinking_band_high": "high",
+        "thinking_band_medium": "medium",
+        "thinking_band_low": "low",
+        "thinking_band_minimal_no_budget": "minimal",
+        "reasoning_effort_wins_over_thinking": "low",
+    }
+    for name, effort in expectations.items():
+        result = _v2(CASES[name])
+        assert result.is_ok(), (name, result.error.summary)
+        assert result.ok["reasoning_effort"] == effort, name
+        assert "thinking" not in result.ok, name
+    for name in ("thinking_disabled_dropped", "thinking_adaptive_dropped"):
+        result = _v2(CASES[name])
+        assert result.is_ok()
+        assert "reasoning_effort" not in result.ok, name
+        assert "thinking" not in result.ok, name
+
+
+def test_tools_cleaning_semantic_pins() -> None:
+    """strict gone at every depth; additionalProperties:false gone at every
+    depth; everything else intact."""
+    result = _v2(CASES["tools_cleaned_recursively"])
+    assert result.is_ok()
+    dumped = json.dumps(result.ok["tools"])
+    assert "strict" not in dumped
+    assert "additionalProperties" not in dumped
+    assert result.ok["tools"][0]["function"]["parameters"]["properties"]["nested"][
+        "properties"
+    ] == {"zip": {"type": "string"}}
+
+
+def test_custom_tool_v1_serves_its_conversion() -> None:
+    case, _ = EXPECTED_FALLBACKS["custom_tool"]
+    v1 = run_v1_request_transform("hosted_vllm", case)
+    assert v1["tools"] == [
+        {
+            "type": "function",
+            "function": {
+                "name": "ct",
+                "parameters": {"type": "object", "properties": {}},
+                "description": "d",
+            },
+        }
+    ]
+
+
+def test_thinking_blocks_v1_serves_its_prepend() -> None:
+    case, _ = EXPECTED_FALLBACKS["assistant_thinking_blocks"]
+    v1 = run_v1_request_transform("hosted_vllm", case)
+    assert v1["messages"][1]["content"] == [
+        {"type": "thinking", "thinking": "hmm"},
+        {"type": "text", "text": "ans"},
+    ]
+    assert "thinking_blocks" not in v1["messages"][1]
+
+
+def test_video_file_v1_serves_its_conversion() -> None:
+    case, _ = EXPECTED_FALLBACKS["video_file_part"]
+    v1 = run_v1_request_transform("hosted_vllm", case)
+    assert v1["messages"][0]["content"][1] == {
+        "type": "video_url",
+        "video_url": {"url": "https://x/v.mp4"},
+    }
+
+
+def test_top_k_fallback_reason_matches_the_wire_proven_extra_body_merge() -> None:
+    """hosted_vllm IS in openai_compatible_providers: top_k rides the
+    extra_body packing and hh merges it onto the wire (the wave-2b
+    wire-prove rule — never inherit the reason text without a pinned
+    row)."""
+    case, _ = EXPECTED_FALLBACKS["top_k"]
+    packed = get_optional_params(
+        model=MODEL, custom_llm_provider="hosted_vllm", stream=None, top_k=5
+    )
+    assert packed["extra_body"] == {"top_k": 5}
+    assert "top_k" not in run_v1_request_transform("hosted_vllm", copy.deepcopy(case))
+    wire = capture_v1_wire_body(
+        f"hosted_vllm/{MODEL}", api_base="https://vllm.example.test/v1", top_k=5
+    )
+    assert wire["top_k"] == 5
+    assert "extra_body" not in wire
+
+
+def test_user_v1_drops_it() -> None:
+    case, _ = EXPECTED_FALLBACKS["user"]
+    assert "user" not in run_v1_request_transform("hosted_vllm", case)
+
+
+def test_supported_list_mirror() -> None:
+    """v1's list is the base list + thinking/reasoning_effort appended
+    UNCONDITIONALLY (no capability fork, no model map needed — fixed name
+    samples, the lm_studio precedent)."""
+    from litellm.translation.providers.hosted_vllm.params import _HOSTED_VLLM_LIST
+
+    from ._own_module_corpus import provider_config
+
+    mirror_keys = (
+        "max_tokens",
+        "max_completion_tokens",
+        "temperature",
+        "top_p",
+        "stream",
+        "stop",
+        "tools",
+        "tool_choice",
+        "parallel_tool_calls",
+        "response_format",
+    )
+    assert _HOSTED_VLLM_LIST <= set(mirror_keys) | {"thinking", "reasoning_effort"}
+    for model in (MODEL, "meta-llama/Llama-3.1-8B-Instruct", "gpt-4"):
+        supported = set(
+            provider_config("hosted_vllm", model).get_supported_openai_params(model)
+        )
+        # the inherited base list's gpt-4/gpt-3.5-turbo-16k response_format
+        # name gate; v2 composes openai_compat.unsupported_response_format
+        # for exactly these names
+        allowed = (
+            _HOSTED_VLLM_LIST - {"response_format"}
+            if model in ("gpt-4", "gpt-3.5-turbo-16k")
+            else _HOSTED_VLLM_LIST
+        )
+        for key in mirror_keys:
+            assert (key in allowed) == (key in supported), (model, key)
+        assert {"thinking", "reasoning_effort"} <= supported, model
+
+
+def test_registration_facts() -> None:
+    assert "hosted_vllm" in pipeline._SERIALIZERS
+    assert "hosted_vllm" in pipeline._RESPONSE_PARSERS
+    assert "hosted_vllm" in pipeline._RAW_GUARDS
+    assert pipeline.response_dialect("hosted_vllm") == "openai"
+    assert "hosted_vllm" not in NEVER_PORT

--- a/tests/test_litellm/translation/test_differential_hosted_vllm_request.py
+++ b/tests/test_litellm/translation/test_differential_hosted_vllm_request.py
@@ -150,6 +150,24 @@ CASES: dict[str, dict] = {
         "thinking": {"type": "enabled"},
         "messages": _USER,
     },
+    # the EXACT >= boundaries (verifier-wave2b-alpha F4: the interior-point
+    # rows above let a >= -> > band mutation survive; these three kill it —
+    # 10000 -> high, 5000 -> medium, 2000 -> low on BOTH sides)
+    "thinking_band_high_exact_boundary": {
+        "model": MODEL,
+        "thinking": {"type": "enabled", "budget_tokens": 10000},
+        "messages": _USER,
+    },
+    "thinking_band_medium_exact_boundary": {
+        "model": MODEL,
+        "thinking": {"type": "enabled", "budget_tokens": 5000},
+        "messages": _USER,
+    },
+    "thinking_band_low_exact_boundary": {
+        "model": MODEL,
+        "thinking": {"type": "enabled", "budget_tokens": 2000},
+        "messages": _USER,
+    },
     "thinking_disabled_dropped": {
         "model": MODEL,
         "thinking": {"type": "disabled"},

--- a/tests/test_litellm/translation/test_differential_hosted_vllm_response.py
+++ b/tests/test_litellm/translation/test_differential_hosted_vllm_response.py
@@ -10,6 +10,7 @@ byte-identical dumps, and pin that no ``hosted_vllm/`` prefix ever appears.
 import copy
 import json
 
+import pydantic
 import pytest
 
 from litellm.types.utils import ModelResponse
@@ -17,7 +18,11 @@ from litellm.types.utils import ModelResponse
 from litellm.translation.inbound.openai_chat import parse_request
 from litellm.translation.inbound.openai_chat.response import serialize_response
 from litellm.translation.providers.hosted_vllm import parse_response
-from litellm.translation_seam import build_translation_deps, to_model_response
+from litellm.translation_seam import (
+    UsageStyle,
+    build_translation_deps,
+    to_model_response,
+)
 
 from ._own_module_corpus import run_v1_response_transform
 
@@ -105,13 +110,19 @@ def _v1_model_response(raw: dict) -> dict:
     ).model_dump()
 
 
-def _v2_model_response(raw: dict) -> dict:
+def _v2_with_style(raw: dict, style: UsageStyle) -> dict:
     parsed = parse_request(copy.deepcopy(_REQUEST))
     assert parsed.is_ok(), parsed.error.summary
     response = parse_response(copy.deepcopy(raw), parsed.ok)
     assert response.is_ok(), response.error.summary
     body = serialize_response(response.ok, build_translation_deps(), "openai")
-    return to_model_response(body, ModelResponse(), usage_style="openai").model_dump()
+    return to_model_response(body, ModelResponse(), usage_style=style).model_dump()
+
+
+def _v2_model_response(raw: dict) -> dict:
+    # hosted_vllm rides the cdr arm — the truth is
+    # pipeline.OWN_MODULE_RESPONSE_STYLES["hosted_vllm"], divergence-pinned below
+    return _v2_with_style(raw, "openai")
 
 
 def _norm(payload: dict) -> str:
@@ -132,3 +143,30 @@ def test_no_hosted_vllm_prefix_on_the_response_model(name: str, frozen_ambient) 
     assert v1["model"] == raw["model"]
     assert v2["model"] == raw["model"]
     assert not v2["model"].startswith("hosted_vllm/")
+
+
+def test_wrong_construction_arm_diverges_and_the_table_pins_it(
+    frozen_ambient,
+) -> None:
+    """verifier-wave2b-final F1: the "openai"-arm OWN_MODULE_RESPONSE_STYLES
+    values were enforced by NOTHING — a wrong-arm value flip survived the
+    whole suite. The watsonx/groq wrong-arm template INVERTED for a
+    cdr-parser member (the v2 parser already cdr-normalizes choices, so the
+    openai_like members' index-5 discriminator dies before the seam): a
+    FLOAT wire ``created`` rides the normalized body; the correct cdr
+    ("openai") arm coerces it via _safe_convert_created_field and serves
+    exactly like v1, while the wrong "openai_like" arm
+    (ModelResponse(**json)) raises ValidationError on traffic v1 serves —
+    if the arms stop diverging here, the raises assert fails: re-decide
+    before relying on the pin."""
+    from litellm.translation.engine.pipeline import OWN_MODULE_RESPONSE_STYLES
+
+    assert OWN_MODULE_RESPONSE_STYLES["hosted_vllm"] == "openai"
+    raw = copy.deepcopy(_RESPONSES["text"])
+    raw["created"] = raw["created"] + 0.5
+    v1 = _v1_model_response(raw)
+    correct = _v2_with_style(raw, OWN_MODULE_RESPONSE_STYLES["hosted_vllm"])
+    assert _norm(correct) == _norm(v1)
+    assert correct["created"] == _RESPONSES["text"]["created"]
+    with pytest.raises(pydantic.ValidationError):
+        _v2_with_style(raw, "openai_like")

--- a/tests/test_litellm/translation/test_differential_hosted_vllm_response.py
+++ b/tests/test_litellm/translation/test_differential_hosted_vllm_response.py
@@ -1,0 +1,134 @@
+"""Differential parity for the hosted_vllm response path (httpx, NO prefix).
+
+``HostedVLLMChatConfig`` has no ``transform_response`` override: the
+inherited base GPT transform is LIVE on the dedicated elif over a FRESH
+``ModelResponse`` (model=None) — the bare-wire-model deepseek/xai shape.
+These rows run that exact v1 chain against v2's shared openai parser,
+byte-identical dumps, and pin that no ``hosted_vllm/`` prefix ever appears.
+"""
+
+import copy
+import json
+
+import pytest
+
+from litellm.types.utils import ModelResponse
+
+from litellm.translation.inbound.openai_chat import parse_request
+from litellm.translation.inbound.openai_chat.response import serialize_response
+from litellm.translation.providers.hosted_vllm import parse_response
+from litellm.translation_seam import build_translation_deps, to_model_response
+
+from ._own_module_corpus import run_v1_response_transform
+
+_REQUEST = {
+    "model": "qwen2.5-7b-instruct",
+    "messages": [{"role": "user", "content": "hi"}],
+    "tools": [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ],
+}
+
+_RESPONSES = {
+    "text": {
+        "id": "chatcmpl-vllm1",
+        "object": "chat.completion",
+        "created": 1718000000,
+        "model": "qwen2.5-7b-instruct",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "hello"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5},
+    },
+    "tool_calls": {
+        "id": "chatcmpl-vllm2",
+        "object": "chat.completion",
+        "created": 1718000000,
+        "model": "qwen2.5-7b-instruct",
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "arguments": '{"city":"Paris"}',
+                            },
+                        }
+                    ],
+                },
+                "finish_reason": "tool_calls",
+            }
+        ],
+        "usage": {"prompt_tokens": 9, "completion_tokens": 5, "total_tokens": 14},
+    },
+    # vLLM reasoning-parser responses carry reasoning_content on the message
+    "reasoning_content": {
+        "id": "chatcmpl-vllm3",
+        "object": "chat.completion",
+        "created": 1718000000,
+        "model": "qwen3-8b",
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": "answer",
+                    "reasoning_content": "step by step",
+                },
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 11, "completion_tokens": 9, "total_tokens": 20},
+    },
+}
+
+
+def _v1_model_response(raw: dict) -> dict:
+    return run_v1_response_transform(
+        "hosted_vllm", raw, "qwen2.5-7b-instruct"
+    ).model_dump()
+
+
+def _v2_model_response(raw: dict) -> dict:
+    parsed = parse_request(copy.deepcopy(_REQUEST))
+    assert parsed.is_ok(), parsed.error.summary
+    response = parse_response(copy.deepcopy(raw), parsed.ok)
+    assert response.is_ok(), response.error.summary
+    body = serialize_response(response.ok, build_translation_deps(), "openai")
+    return to_model_response(body, ModelResponse(), usage_style="openai").model_dump()
+
+
+def _norm(payload: dict) -> str:
+    return json.dumps(payload, sort_keys=True, default=str)
+
+
+@pytest.mark.parametrize("name", sorted(_RESPONSES))
+def test_v2_response_matches_v1(name: str, frozen_ambient) -> None:
+    raw = _RESPONSES[name]
+    assert _norm(_v2_model_response(raw)) == _norm(_v1_model_response(raw))
+
+
+@pytest.mark.parametrize("name", sorted(_RESPONSES))
+def test_no_hosted_vllm_prefix_on_the_response_model(name: str, frozen_ambient) -> None:
+    raw = _RESPONSES[name]
+    v1 = _v1_model_response(raw)
+    v2 = _v2_model_response(raw)
+    assert v1["model"] == raw["model"]
+    assert v2["model"] == raw["model"]
+    assert not v2["model"].startswith("hosted_vllm/")

--- a/tests/test_litellm/translation/test_differential_hosted_vllm_stream.py
+++ b/tests/test_litellm/translation/test_differential_hosted_vllm_stream.py
@@ -1,0 +1,202 @@
+"""Differential parity for hosted_vllm streaming, pinned at the SSE line seam.
+
+v1 side: raw ``data:`` lines through the BASE
+``OpenAIChatCompletionStreamingHandler`` (HostedVLLMChatConfig has no
+iterator override — canary-pinned below) into
+``CustomStreamWrapper("hosted_vllm")``. v2 side: ``fold_lines`` with the
+hosted_vllm parser (the httpx_chunk FAMILY policy: ``reasoning="rename"``)
+and the shared ``xai`` chunk dialect. vLLM reasoning-parser streams carry
+NATIVE ``reasoning_content`` deltas — pinned verbatim alongside the base
+handler's ``reasoning`` pop-rename. The mid-stream error chunk is the
+family's single PINNED DIVERGENCE (v1 swallows, v2 is loud) — hosted_vllm
+joins the report's one named row.
+"""
+
+import copy
+import json
+
+import pytest
+
+from litellm.llms.openai.chat.gpt_transformation import (
+    OpenAIChatCompletionStreamingHandler,
+)
+
+from litellm.translation.engine.stream import fold_events, fold_lines
+from litellm.translation.inbound.openai_chat.stream import initial_state
+from litellm.translation.providers.hosted_vllm import parse_event, parse_line
+from litellm.translation_seam import to_model_response_stream
+
+from ._own_module_corpus import provider_config, replay_v1_sse_lines
+
+MODEL = "qwen2.5-7b-instruct"
+WIRE_MODEL = "qwen2.5-7b-instruct"
+
+
+def _chunk(delta, finish=None, usage=None, choices=None):
+    payload = {
+        "id": "vllm-chunk-1",
+        "object": "chat.completion.chunk",
+        "created": 1718000000,
+        "model": WIRE_MODEL,
+        "choices": [
+            {"index": 0, "delta": delta, "logprobs": None, "finish_reason": finish}
+        ],
+        "usage": usage,
+    }
+    if choices is not None:
+        payload["choices"] = choices
+    return payload
+
+
+STREAMS = {
+    "text": [
+        _chunk({"role": "assistant", "content": ""}),
+        _chunk({"content": "Hello"}),
+        _chunk({"content": " world"}),
+        _chunk({}, finish="stop"),
+    ],
+    "tools": [
+        _chunk({"role": "assistant", "content": None}),
+        _chunk(
+            {
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "get_weather", "arguments": ""},
+                    }
+                ]
+            }
+        ),
+        _chunk(
+            {
+                "tool_calls": [
+                    {"index": 0, "function": {"arguments": '{"city":"Paris"}'}}
+                ]
+            }
+        ),
+        _chunk({}, finish="tool_calls"),
+    ],
+    "native_reasoning_content": [
+        _chunk({"role": "assistant", "reasoning_content": "step "}),
+        _chunk({"reasoning_content": "by step"}),
+        _chunk({"content": "answer"}),
+        _chunk({}, finish="stop"),
+    ],
+    "reasoning_rename": [
+        _chunk({"role": "assistant", "content": ""}),
+        _chunk({"reasoning": "thinking..."}),
+        _chunk({"content": "answer"}),
+        _chunk({}, finish="stop"),
+    ],
+    "empty_keepalive_swallowed": [
+        _chunk({"role": "assistant", "content": ""}),
+        _chunk({}),
+        _chunk({"content": "hi"}),
+        _chunk({}, finish="stop"),
+    ],
+}
+
+USAGE_STREAM = [
+    _chunk({"role": "assistant", "content": ""}),
+    _chunk({"content": "Hi"}),
+    _chunk({}, finish="stop"),
+    _chunk(
+        {},
+        choices=[],
+        usage={"prompt_tokens": 7, "completion_tokens": 2, "total_tokens": 9},
+    ),
+]
+
+
+def _v1_chunks(events, stream_options=None):
+    return replay_v1_sse_lines("hosted_vllm", events, MODEL, stream_options)
+
+
+def _v2_chunks(events: list) -> list:
+    lines = [f"data: {json.dumps(event)}" for event in copy.deepcopy(events)]
+    lines.append("data: [DONE]")
+    folded = fold_lines(lines, parse_line, initial_state(MODEL, dialect="xai"))
+    assert folded.is_ok(), folded.error.summary
+    return [
+        to_model_response_stream(chunk, "chatcmpl-AMBIENT").model_dump()
+        for chunk in folded.ok
+    ]
+
+
+def _norm(chunks: list) -> str:
+    return json.dumps(chunks, sort_keys=True, default=str)
+
+
+@pytest.mark.parametrize("name", sorted(STREAMS))
+def test_v2_stream_matches_v1(name: str, frozen_ambient) -> None:
+    events = STREAMS[name]
+    assert _norm(_v2_chunks(events)) == _norm(_v1_chunks(events))
+
+
+def test_usage_tail_pins_the_seam_contract(frozen_ambient) -> None:
+    v1 = _v1_chunks(USAGE_STREAM, stream_options={"include_usage": True})
+    v2 = _v2_chunks(USAGE_STREAM)
+    assert len(v1) == len(v2)
+    assert _norm(v2[:-1]) == _norm(v1[: len(v2) - 1])
+    assert v2[-1]["choices"] == []
+    for key in ("prompt_tokens", "completion_tokens", "total_tokens"):
+        assert v1[-1]["usage"][key] == v2[-1]["usage"][key], key
+
+
+def test_usage_tail_swallowed_without_stream_options(frozen_ambient) -> None:
+    v1 = _v1_chunks(USAGE_STREAM, None)
+    v2 = _v2_chunks(USAGE_STREAM)
+    assert len(v1) == len(v2) - 1
+    assert _norm(v1) == _norm(v2[:-1])
+
+
+def test_v2_line_and_event_folds_agree(frozen_ambient) -> None:
+    events = STREAMS["native_reasoning_content"]
+    folded = fold_events(
+        copy.deepcopy(events), parse_event, initial_state(MODEL, dialect="xai")
+    )
+    assert folded.is_ok(), folded.error.summary
+    via_events = [
+        to_model_response_stream(chunk, "chatcmpl-AMBIENT").model_dump()
+        for chunk in folded.ok
+    ]
+    assert _norm(via_events) == _norm(_v2_chunks(events))
+
+
+_ERROR_CHUNK_STREAM = [
+    _chunk({"role": "assistant", "content": ""}),
+    {
+        "id": "vllm-chunk-1",
+        "object": "chat.completion.chunk",
+        "created": 1718000000,
+        "model": WIRE_MODEL,
+        "error": {"message": "upstream exploded", "code": 502},
+    },
+    _chunk({"content": "after"}),
+    _chunk({}, finish="stop"),
+]
+
+
+def test_error_chunk_divergence_two_sided(frozen_ambient) -> None:
+    """The compat_httpx family's deliberate fail-closed divergence extends
+    to hosted_vllm (same BASE handler): v1 silently swallows the error
+    chunk, v2's parse_line is a loud typed boundary error. If the v1 half
+    fails, the base handler learned to raise: re-decide the divergence and
+    update the report row in the same commit."""
+    v1 = _v1_chunks(_ERROR_CHUNK_STREAM)
+    assert "error" not in json.dumps(v1), v1
+    assert [c["choices"][0]["delta"].get("content") for c in v1[:2]] == ["", "after"]
+    lines = [f"data: {json.dumps(e)}" for e in copy.deepcopy(_ERROR_CHUNK_STREAM)]
+    folded = fold_lines(lines, parse_line, initial_state(MODEL, dialect="xai"))
+    assert folded.is_error()
+    assert "provider stream error" in folded.error.summary, folded.error.summary
+    assert "upstream exploded" in folded.error.summary
+
+
+def test_iterator_is_the_base_openai_handler() -> None:
+    handler = provider_config("hosted_vllm", MODEL).get_model_response_iterator(
+        streaming_response=iter(()), sync_stream=True
+    )
+    assert type(handler) is OpenAIChatCompletionStreamingHandler

--- a/tests/test_litellm/translation/test_differential_huggingface_request.py
+++ b/tests/test_litellm/translation/test_differential_huggingface_request.py
@@ -206,6 +206,24 @@ def test_router_route_falls_back_whole() -> None:
         )
 
 
+def test_seam_deps_never_arm_api_base_from_env(monkeypatch) -> None:
+    """critic-wave2b-alpha MAJOR-5: deps.api_base may ONLY ever come from
+    litellm_params["api_base"]. The env HF_API_BASE/HUGGINGFACE_API_BASE
+    chain resolves in v1's envelope ABOVE the transform and does NOT arm the
+    api_base transform route (v1 takes the ROUTER arm there — env-probed by
+    the verifier), so a fork that threads env values into deps.api_base
+    would serve bodies v1 never builds — the one unsafe direction of this
+    port. This canary freezes the rule: build_translation_deps answers
+    api_base None even with both env vars armed. The future fork-wirer who
+    threads api_base MUST extend this test with the litellm_params-only
+    source (and keep the env arms asserting None), not delete it."""
+    from litellm.translation_seam import build_translation_deps
+
+    monkeypatch.setenv("HF_API_BASE", "https://env.example/v1")
+    monkeypatch.setenv("HUGGINGFACE_API_BASE", "https://env2.example/v1")
+    assert build_translation_deps().api_base is None
+
+
 def test_api_base_body_is_verbatim() -> None:
     """The api_base arm: model verbatim, messages verbatim, no renames —
     v1's ChatCompletionRequest passthrough."""

--- a/tests/test_litellm/translation/test_differential_huggingface_request.py
+++ b/tests/test_litellm/translation/test_differential_huggingface_request.py
@@ -1,0 +1,276 @@
+"""Differential parity for the huggingface request path — the api_base
+(dedicated endpoint) ROUTE ONLY (httpx dedicated elif, main.py:3185).
+
+v1's transform forks on ``litellm_params["api_base"]``: SET means a
+VERBATIM ``{model, messages, **optional_params}`` body (the route v2
+ports, ``deps.api_base`` carrying the value); UNSET means the router
+route, which v2 falls back on WHOLE — its 3-segment names fetch the HF
+provider mapping over HTTP inside the transform, 2-segment names run the
+base transforms + router URL synthesis, and 1-segment names CRASH v1
+(ValueError on the split; all three pinned in-process below).
+"""
+
+import copy
+import json
+
+import pytest
+
+from litellm.translation.dispatch import NEVER_PORT
+from litellm.translation.engine import pipeline
+from litellm.translation.engine.pipeline import translate_chat_request
+
+from ._own_module_corpus import run_v1_request_transform
+from .conftest import build_real_deps
+
+MODEL = "meta-llama/Llama-3.3-70B-Instruct"
+API_BASE = "https://my-tgi.example/v1"
+_LP = {"api_base": API_BASE}
+_USER = [{"role": "user", "content": "Hello, world"}]
+
+WEATHER_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get weather",
+        "parameters": {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+        },
+    },
+}
+
+CASES: dict[str, dict] = {
+    "text": {"model": MODEL, "messages": _USER},
+    "sampling": {
+        "model": MODEL,
+        "max_tokens": 64,
+        "temperature": 0.5,
+        "top_p": 0.9,
+        "messages": [
+            {"role": "system", "content": "You are helpful"},
+            {"role": "user", "content": "Hi"},
+        ],
+    },
+    "stream_true": {"model": MODEL, "stream": True, "messages": _USER},
+    "stop_list": {"model": MODEL, "stop": ["END"], "messages": _USER},
+    # mct passes VERBATIM (base list, no rename anywhere)
+    "max_completion_tokens_verbatim": {
+        "model": MODEL,
+        "max_completion_tokens": 128,
+        "messages": _USER,
+    },
+    "temperature_int_stays_int": {"model": MODEL, "temperature": 1, "messages": _USER},
+    # top_k: the non-compat TOP-LEVEL passthrough (v1 serves; pinned below)
+    "top_k_top_level": {"model": MODEL, "top_k": 5, "messages": _USER},
+    "tools_auto": {
+        "model": MODEL,
+        "tools": [WEATHER_TOOL],
+        "tool_choice": "auto",
+        "messages": [{"role": "user", "content": "Weather in Paris?"}],
+    },
+    "tool_choice_specific": {
+        "model": MODEL,
+        "tools": [WEATHER_TOOL],
+        "tool_choice": {"type": "function", "function": {"name": "get_weather"}},
+        "messages": [{"role": "user", "content": "Weather?"}],
+    },
+    "tool_call_compact_roundtrip": {
+        "model": MODEL,
+        "tools": [WEATHER_TOOL],
+        "messages": [
+            {"role": "user", "content": "w?"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": '{"city":"Paris"}',
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "ok"},
+        ],
+    },
+    "parallel_tool_calls_false": {
+        "model": MODEL,
+        "tools": [WEATHER_TOOL],
+        "parallel_tool_calls": False,
+        "messages": [{"role": "user", "content": "Weather?"}],
+    },
+    "response_format_json_object": {
+        "model": MODEL,
+        "response_format": {"type": "json_object"},
+        "messages": _USER,
+    },
+    "response_format_json_schema_strict": {
+        "model": MODEL,
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {"name": "a", "schema": {"type": "object"}, "strict": True},
+        },
+        "messages": _USER,
+    },
+    # messages ride VERBATIM on the api_base arm (no transforms at all)
+    "content_list_verbatim": {
+        "model": MODEL,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "a"},
+                    {"type": "text", "text": "b"},
+                ],
+            }
+        ],
+    },
+}
+
+# name -> (case, v2 reason fragment); generator emits FALLBACK (v1 serves it)
+EXPECTED_FALLBACKS: dict[str, tuple[dict, str]] = {
+    "user": ({"model": MODEL, "user": "u1", "messages": _USER}, "user"),
+    # max_retries is NOT popped on the api_base arm: v1 serves it INTO the
+    # body (a v1 oddity — the pop lives on the router arm only)
+    "max_retries": (
+        {"model": MODEL, "max_retries": 3, "messages": _USER},
+        "max_retries",
+    ),
+    # v1 forwards message name VERBATIM on this arm
+    "message_name": (
+        {
+            "model": MODEL,
+            "messages": [{"role": "user", "content": "hi", "name": "alice"}],
+        },
+        "name",
+    ),
+    "stream_false": ({"model": MODEL, "stream": False, "messages": _USER}, "stream"),
+}
+
+_ROUTER_FALLBACK_REASON = "router route"
+
+
+def _v2(case: dict, api_base: str | None = API_BASE):
+    return translate_chat_request(
+        copy.deepcopy(case), "huggingface", build_real_deps(api_base=api_base)
+    )
+
+
+def _v1(case: dict) -> dict:
+    return run_v1_request_transform("huggingface", case, litellm_params=dict(_LP))
+
+
+def _norm(body: dict) -> str:
+    return json.dumps(body, sort_keys=True, default=str)
+
+
+@pytest.mark.parametrize("name", sorted(CASES))
+def test_v2_request_matches_v1(name: str) -> None:
+    case = CASES[name]
+    result = _v2(case)
+    assert result.is_ok(), result.error.summary
+    assert _norm(result.ok) == _norm(_v1(case))
+
+
+@pytest.mark.parametrize("name", sorted(EXPECTED_FALLBACKS))
+def test_expected_fallbacks_are_typed(name: str) -> None:
+    case, reason = EXPECTED_FALLBACKS[name]
+    result = _v2(case)
+    assert result.is_error(), f"{name} unexpectedly served"
+    assert reason in result.error.summary, result.error.summary
+
+
+def test_router_route_falls_back_whole() -> None:
+    """deps.api_base None -> EVERY huggingface request falls back typed,
+    naming the router route. The three v1 router shapes are pinned
+    in-process: 2-segment names SERVE locally (no fetch — base transforms
+    + the router URL), 1-segment names CRASH (ValueError on the split),
+    and 3-segment names would fetch the provider mapping over HTTP (NOT
+    exercised here — that is the in-transform I/O the port refuses)."""
+    result = _v2(CASES["text"], api_base=None)
+    assert result.is_error()
+    assert _ROUTER_FALLBACK_REASON in result.error.summary
+    # 2-segment: v1 serves WITHOUT fetching (no network in this test)
+    v1 = run_v1_request_transform("huggingface", CASES["text"], litellm_params={})
+    assert v1["model"] == MODEL
+    # 1-segment: v1 crashes on the split
+    with pytest.raises(ValueError):
+        run_v1_request_transform(
+            "huggingface",
+            {"model": "gpt2", "messages": [{"role": "user", "content": "hi"}]},
+            litellm_params={},
+        )
+
+
+def test_api_base_body_is_verbatim() -> None:
+    """The api_base arm: model verbatim, messages verbatim, no renames —
+    v1's ChatCompletionRequest passthrough."""
+    v1 = _v1(CASES["content_list_verbatim"])
+    assert v1["messages"] == CASES["content_list_verbatim"]["messages"]
+    assert v1["model"] == MODEL
+    v1_mct = _v1(CASES["max_completion_tokens_verbatim"])
+    assert v1_mct["max_completion_tokens"] == 128
+
+
+def test_top_k_v1_serves_top_level() -> None:
+    """huggingface is NOT in openai_compatible_providers: top_k rides the
+    top-level passthrough into the verbatim body (the api_base arm IS the
+    wire body — hh posts the transform output for this provider, no
+    extra_body crossing exists)."""
+    v1 = _v1(CASES["top_k_top_level"])
+    assert v1["top_k"] == 5
+    result = _v2(CASES["top_k_top_level"])
+    assert result.is_ok()
+    assert result.ok["top_k"] == 5
+
+
+def test_max_retries_and_user_v1_behavior() -> None:
+    case, _ = EXPECTED_FALLBACKS["max_retries"]
+    assert _v1(case)["max_retries"] == 3  # NOT popped on the api_base arm
+    case, _ = EXPECTED_FALLBACKS["user"]
+    assert "user" not in _v1(case)  # silently dropped upstream
+
+
+def test_supported_list_mirror() -> None:
+    """The plain OpenAI base list (no override) — fixed name samples, with
+    the base list's gpt-4/gpt-3.5-turbo-16k response_format name gate."""
+    from litellm.translation.providers.huggingface.params import _HUGGINGFACE_LIST
+
+    from ._own_module_corpus import provider_config
+
+    mirror_keys = (
+        "max_tokens",
+        "max_completion_tokens",
+        "temperature",
+        "top_p",
+        "stream",
+        "stop",
+        "tools",
+        "tool_choice",
+        "parallel_tool_calls",
+        "response_format",
+    )
+    assert _HUGGINGFACE_LIST <= set(mirror_keys) | {"top_k"}
+    for model in (MODEL, "tgi", "gpt-4"):
+        supported = set(
+            provider_config("huggingface", model).get_supported_openai_params(model)
+        )
+        allowed = (
+            _HUGGINGFACE_LIST - {"response_format"}
+            if model in ("gpt-4", "gpt-3.5-turbo-16k")
+            else _HUGGINGFACE_LIST
+        )
+        for key in mirror_keys:
+            assert (key in allowed) == (key in supported), (model, key)
+
+
+def test_registration_facts() -> None:
+    assert "huggingface" in pipeline._SERIALIZERS
+    assert "huggingface" in pipeline._RESPONSE_PARSERS
+    assert "huggingface" in pipeline._RAW_GUARDS
+    assert pipeline.response_dialect("huggingface") == "openai"
+    assert "huggingface" not in NEVER_PORT

--- a/tests/test_litellm/translation/test_differential_huggingface_response.py
+++ b/tests/test_litellm/translation/test_differential_huggingface_response.py
@@ -11,6 +11,7 @@ and pin that no ``huggingface/`` prefix ever appears.
 import copy
 import json
 
+import pydantic
 import pytest
 
 from litellm.types.utils import ModelResponse
@@ -18,7 +19,11 @@ from litellm.types.utils import ModelResponse
 from litellm.translation.inbound.openai_chat import parse_request
 from litellm.translation.inbound.openai_chat.response import serialize_response
 from litellm.translation.providers.huggingface import parse_response
-from litellm.translation_seam import build_translation_deps, to_model_response
+from litellm.translation_seam import (
+    UsageStyle,
+    build_translation_deps,
+    to_model_response,
+)
 
 from ._own_module_corpus import run_v1_response_transform
 
@@ -112,13 +117,19 @@ def _v1_model_response(raw: dict) -> dict:
     ).model_dump()
 
 
-def _v2_model_response(raw: dict) -> dict:
+def _v2_with_style(raw: dict, style: UsageStyle) -> dict:
     parsed = parse_request(copy.deepcopy(_REQUEST))
     assert parsed.is_ok(), parsed.error.summary
     response = parse_response(copy.deepcopy(raw), parsed.ok)
     assert response.is_ok(), response.error.summary
     body = serialize_response(response.ok, build_translation_deps(), "openai")
-    return to_model_response(body, ModelResponse(), usage_style="openai").model_dump()
+    return to_model_response(body, ModelResponse(), usage_style=style).model_dump()
+
+
+def _v2_model_response(raw: dict) -> dict:
+    # huggingface rides the cdr arm — the truth is
+    # pipeline.OWN_MODULE_RESPONSE_STYLES["huggingface"], divergence-pinned below
+    return _v2_with_style(raw, "openai")
 
 
 def _norm(payload: dict) -> str:
@@ -139,3 +150,30 @@ def test_no_huggingface_prefix_on_the_response_model(name: str, frozen_ambient) 
     assert v1["model"] == raw["model"]
     assert v2["model"] == raw["model"]
     assert not v2["model"].startswith("huggingface/")
+
+
+def test_wrong_construction_arm_diverges_and_the_table_pins_it(
+    frozen_ambient,
+) -> None:
+    """verifier-wave2b-final F1: the "openai"-arm OWN_MODULE_RESPONSE_STYLES
+    values were enforced by NOTHING — a wrong-arm value flip survived the
+    whole suite. The watsonx/groq wrong-arm template INVERTED for a
+    cdr-parser member (the v2 parser already cdr-normalizes choices, so the
+    openai_like members' index-5 discriminator dies before the seam): a
+    FLOAT wire ``created`` rides the normalized body; the correct cdr
+    ("openai") arm coerces it via _safe_convert_created_field and serves
+    exactly like v1, while the wrong "openai_like" arm
+    (ModelResponse(**json)) raises ValidationError on traffic v1 serves —
+    if the arms stop diverging here, the raises assert fails: re-decide
+    before relying on the pin."""
+    from litellm.translation.engine.pipeline import OWN_MODULE_RESPONSE_STYLES
+
+    assert OWN_MODULE_RESPONSE_STYLES["huggingface"] == "openai"
+    raw = copy.deepcopy(_RESPONSES["text"])
+    raw["created"] = raw["created"] + 0.5
+    v1 = _v1_model_response(raw)
+    correct = _v2_with_style(raw, OWN_MODULE_RESPONSE_STYLES["huggingface"])
+    assert _norm(correct) == _norm(v1)
+    assert correct["created"] == _RESPONSES["text"]["created"]
+    with pytest.raises(pydantic.ValidationError):
+        _v2_with_style(raw, "openai_like")

--- a/tests/test_litellm/translation/test_differential_huggingface_response.py
+++ b/tests/test_litellm/translation/test_differential_huggingface_response.py
@@ -1,0 +1,141 @@
+"""Differential parity for the huggingface response path (httpx, NO prefix).
+
+HuggingFaceChatConfig has no ``transform_response`` override: the inherited
+base GPT transform is LIVE on the dedicated elif and runs
+``convert_to_model_response_object`` over a fresh ``ModelResponse``
+(model=None) — the bare-wire-model cometapi/xai shape. These rows run that
+exact v1 chain against v2's shared openai parser, byte-identical dumps,
+and pin that no ``huggingface/`` prefix ever appears.
+"""
+
+import copy
+import json
+
+import pytest
+
+from litellm.types.utils import ModelResponse
+
+from litellm.translation.inbound.openai_chat import parse_request
+from litellm.translation.inbound.openai_chat.response import serialize_response
+from litellm.translation.providers.huggingface import parse_response
+from litellm.translation_seam import build_translation_deps, to_model_response
+
+from ._own_module_corpus import run_v1_response_transform
+
+_REQUEST = {
+    "model": "meta-llama/Llama-3.3-70B-Instruct",
+    "messages": [{"role": "user", "content": "hi"}],
+    "tools": [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ],
+}
+
+_RESPONSES = {
+    "text": {
+        "id": "chatcmpl-hf1",
+        "object": "chat.completion",
+        "created": 1718000000,
+        "model": "meta-llama/Llama-3.3-70B-Instruct",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "hello"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5},
+    },
+    "tool_calls": {
+        "id": "chatcmpl-hf2",
+        "object": "chat.completion",
+        "created": 1718000000,
+        "model": "meta-llama/Llama-3.3-70B-Instruct",
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "arguments": '{"city":"Paris"}',
+                            },
+                        }
+                    ],
+                },
+                "finish_reason": "tool_calls",
+            }
+        ],
+        "usage": {"prompt_tokens": 9, "completion_tokens": 5, "total_tokens": 14},
+    },
+    # reasoning models served via HF endpoints carry reasoning_content on
+    # the message — the unknown-key verbatim ride
+    "reasoning_content": {
+        "id": "chatcmpl-hf3",
+        "object": "chat.completion",
+        "created": 1718000000,
+        "model": "deepseek-ai/DeepSeek-R1",
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": "answer",
+                    "reasoning_content": "step by step",
+                },
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 11,
+            "completion_tokens": 9,
+            "total_tokens": 20,
+            "completion_tokens_details": {"reasoning_tokens": 6},
+        },
+    },
+}
+
+
+def _v1_model_response(raw: dict) -> dict:
+    return run_v1_response_transform(
+        "huggingface", raw, "meta-llama/Llama-3.3-70B-Instruct"
+    ).model_dump()
+
+
+def _v2_model_response(raw: dict) -> dict:
+    parsed = parse_request(copy.deepcopy(_REQUEST))
+    assert parsed.is_ok(), parsed.error.summary
+    response = parse_response(copy.deepcopy(raw), parsed.ok)
+    assert response.is_ok(), response.error.summary
+    body = serialize_response(response.ok, build_translation_deps(), "openai")
+    return to_model_response(body, ModelResponse(), usage_style="openai").model_dump()
+
+
+def _norm(payload: dict) -> str:
+    return json.dumps(payload, sort_keys=True, default=str)
+
+
+@pytest.mark.parametrize("name", sorted(_RESPONSES))
+def test_v2_response_matches_v1(name: str, frozen_ambient) -> None:
+    raw = _RESPONSES[name]
+    assert _norm(_v2_model_response(raw)) == _norm(_v1_model_response(raw))
+
+
+@pytest.mark.parametrize("name", sorted(_RESPONSES))
+def test_no_huggingface_prefix_on_the_response_model(name: str, frozen_ambient) -> None:
+    raw = _RESPONSES[name]
+    v1 = _v1_model_response(raw)
+    v2 = _v2_model_response(raw)
+    assert v1["model"] == raw["model"]
+    assert v2["model"] == raw["model"]
+    assert not v2["model"].startswith("huggingface/")

--- a/tests/test_litellm/translation/test_differential_huggingface_stream.py
+++ b/tests/test_litellm/translation/test_differential_huggingface_stream.py
@@ -1,0 +1,200 @@
+"""Differential parity for huggingface streaming, pinned at the SSE line seam.
+
+v1 side: raw ``data:`` lines through the BASE
+``OpenAIChatCompletionStreamingHandler`` (HuggingFaceChatConfig has no
+iterator override — canary-pinned below) into
+``CustomStreamWrapper("huggingface")``. v2 side: ``fold_lines`` with the
+huggingface parser (the httpx_chunk FAMILY policy: ``reasoning="rename"``)
+and the shared ``xai`` chunk dialect. The mid-stream error chunk is the
+family's single PINNED DIVERGENCE (v1 swallows, v2 is loud) — huggingface
+joins the report's one named row.
+"""
+
+import copy
+import json
+
+import pytest
+
+from litellm.llms.openai.chat.gpt_transformation import (
+    OpenAIChatCompletionStreamingHandler,
+)
+
+from litellm.translation.engine.stream import fold_events, fold_lines
+from litellm.translation.inbound.openai_chat.stream import initial_state
+from litellm.translation.providers.huggingface import parse_event, parse_line
+from litellm.translation_seam import to_model_response_stream
+
+from ._own_module_corpus import provider_config, replay_v1_sse_lines
+
+MODEL = "meta-llama/Llama-3.3-70B-Instruct"
+WIRE_MODEL = "meta-llama/Llama-3.3-70B-Instruct"
+
+
+def _chunk(delta, finish=None, usage=None, choices=None):
+    payload = {
+        "id": "hf-chunk-1",
+        "object": "chat.completion.chunk",
+        "created": 1718000000,
+        "model": WIRE_MODEL,
+        "choices": [
+            {"index": 0, "delta": delta, "logprobs": None, "finish_reason": finish}
+        ],
+        "usage": usage,
+    }
+    if choices is not None:
+        payload["choices"] = choices
+    return payload
+
+
+STREAMS = {
+    "text": [
+        _chunk({"role": "assistant", "content": ""}),
+        _chunk({"content": "Hello"}),
+        _chunk({"content": " world"}),
+        _chunk({}, finish="stop"),
+    ],
+    "tools": [
+        _chunk({"role": "assistant", "content": None}),
+        _chunk(
+            {
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "get_weather", "arguments": ""},
+                    }
+                ]
+            }
+        ),
+        _chunk(
+            {
+                "tool_calls": [
+                    {"index": 0, "function": {"arguments": '{"city":"Paris"}'}}
+                ]
+            }
+        ),
+        _chunk({}, finish="tool_calls"),
+    ],
+    "native_reasoning_content": [
+        _chunk({"role": "assistant", "reasoning_content": "step "}),
+        _chunk({"reasoning_content": "by step"}),
+        _chunk({"content": "answer"}),
+        _chunk({}, finish="stop"),
+    ],
+    "reasoning_rename": [
+        _chunk({"role": "assistant", "content": ""}),
+        _chunk({"reasoning": "thinking..."}),
+        _chunk({"content": "answer"}),
+        _chunk({}, finish="stop"),
+    ],
+    "empty_keepalive_swallowed": [
+        _chunk({"role": "assistant", "content": ""}),
+        _chunk({}),
+        _chunk({"content": "hi"}),
+        _chunk({}, finish="stop"),
+    ],
+}
+
+USAGE_STREAM = [
+    _chunk({"role": "assistant", "content": ""}),
+    _chunk({"content": "Hi"}),
+    _chunk({}, finish="stop"),
+    _chunk(
+        {},
+        choices=[],
+        usage={"prompt_tokens": 7, "completion_tokens": 2, "total_tokens": 9},
+    ),
+]
+
+
+def _v1_chunks(events, stream_options=None):
+    return replay_v1_sse_lines("huggingface", events, MODEL, stream_options)
+
+
+def _v2_chunks(events: list) -> list:
+    lines = [f"data: {json.dumps(event)}" for event in copy.deepcopy(events)]
+    lines.append("data: [DONE]")
+    folded = fold_lines(lines, parse_line, initial_state(MODEL, dialect="xai"))
+    assert folded.is_ok(), folded.error.summary
+    return [
+        to_model_response_stream(chunk, "chatcmpl-AMBIENT").model_dump()
+        for chunk in folded.ok
+    ]
+
+
+def _norm(chunks: list) -> str:
+    return json.dumps(chunks, sort_keys=True, default=str)
+
+
+@pytest.mark.parametrize("name", sorted(STREAMS))
+def test_v2_stream_matches_v1(name: str, frozen_ambient) -> None:
+    events = STREAMS[name]
+    assert _norm(_v2_chunks(events)) == _norm(_v1_chunks(events))
+
+
+def test_usage_tail_pins_the_seam_contract(frozen_ambient) -> None:
+    v1 = _v1_chunks(USAGE_STREAM, stream_options={"include_usage": True})
+    v2 = _v2_chunks(USAGE_STREAM)
+    assert len(v1) == len(v2)
+    assert _norm(v2[:-1]) == _norm(v1[: len(v2) - 1])
+    assert v2[-1]["choices"] == []
+    for key in ("prompt_tokens", "completion_tokens", "total_tokens"):
+        assert v1[-1]["usage"][key] == v2[-1]["usage"][key], key
+
+
+def test_usage_tail_swallowed_without_stream_options(frozen_ambient) -> None:
+    v1 = _v1_chunks(USAGE_STREAM, None)
+    v2 = _v2_chunks(USAGE_STREAM)
+    assert len(v1) == len(v2) - 1
+    assert _norm(v1) == _norm(v2[:-1])
+
+
+def test_v2_line_and_event_folds_agree(frozen_ambient) -> None:
+    events = STREAMS["native_reasoning_content"]
+    folded = fold_events(
+        copy.deepcopy(events), parse_event, initial_state(MODEL, dialect="xai")
+    )
+    assert folded.is_ok(), folded.error.summary
+    via_events = [
+        to_model_response_stream(chunk, "chatcmpl-AMBIENT").model_dump()
+        for chunk in folded.ok
+    ]
+    assert _norm(via_events) == _norm(_v2_chunks(events))
+
+
+_ERROR_CHUNK_STREAM = [
+    _chunk({"role": "assistant", "content": ""}),
+    {
+        "id": "hf-chunk-1",
+        "object": "chat.completion.chunk",
+        "created": 1718000000,
+        "model": WIRE_MODEL,
+        "error": {"message": "upstream exploded", "code": 502},
+    },
+    _chunk({"content": "after"}),
+    _chunk({}, finish="stop"),
+]
+
+
+def test_error_chunk_divergence_two_sided(frozen_ambient) -> None:
+    """The compat_httpx family's deliberate fail-closed divergence extends
+    to huggingface (same BASE handler): v1 silently swallows the error
+    chunk, v2's parse_line is a loud typed boundary error. If the v1 half
+    fails, the base handler learned to raise: re-decide the divergence and
+    update the report row in the same commit."""
+    v1 = _v1_chunks(_ERROR_CHUNK_STREAM)
+    assert "error" not in json.dumps(v1), v1
+    assert [c["choices"][0]["delta"].get("content") for c in v1[:2]] == ["", "after"]
+    lines = [f"data: {json.dumps(e)}" for e in copy.deepcopy(_ERROR_CHUNK_STREAM)]
+    folded = fold_lines(lines, parse_line, initial_state(MODEL, dialect="xai"))
+    assert folded.is_error()
+    assert "provider stream error" in folded.error.summary, folded.error.summary
+    assert "upstream exploded" in folded.error.summary
+
+
+def test_iterator_is_the_base_openai_handler() -> None:
+    handler = provider_config("huggingface", MODEL).get_model_response_iterator(
+        streaming_response=iter(()), sync_stream=True
+    )
+    assert type(handler) is OpenAIChatCompletionStreamingHandler

--- a/tests/test_litellm/translation/test_differential_mistral_request.py
+++ b/tests/test_litellm/translation/test_differential_mistral_request.py
@@ -464,6 +464,23 @@ def test_refs_depth_cap_is_v1s_default_max_recurse_depth(levels: int) -> None:
     assert stripped == (levels < 96), "the cap boundary moved; re-derive"
 
 
+def test_non_object_content_entry_reason_names_v1s_attribute_error() -> None:
+    """verifier-wave2b-beta F10: the old reason inherited the family's
+    'v1 forwards the original shape' suffix — for mistral, v1's
+    _transform_messages fork check raises AttributeError on a non-object
+    content entry (two-sided here)."""
+    case = {
+        "model": MODEL,
+        "messages": [{"role": "user", "content": [{"type": "text", "text": "a"}, 5]}],
+    }
+    result = _v2(case)
+    assert result.is_error()
+    assert "raises AttributeError" in result.error.summary
+    assert "forwards the original shape" not in result.error.summary
+    with pytest.raises(AttributeError):
+        run_v1_request_transform(case)
+
+
 def test_empty_text_list_falls_back_v1_keeps_list_form() -> None:
     """v1's flatten only assigns a TRUTHY join: a list flattening to ""
     keeps its LIST form on the wire, which the IR cannot reproduce."""

--- a/tests/test_litellm/translation/test_differential_mistral_request.py
+++ b/tests/test_litellm/translation/test_differential_mistral_request.py
@@ -93,6 +93,41 @@ CASES = {
             }
         ],
     },
+    "tools_schema_refs_stripped_4_levels_deep": {
+        # verifier-wave2b-beta F2: an ordinary $id four object levels inside
+        # parameters — v1's call site passes
+        # max_depth=DEFAULT_MAX_RECURSE_DEPTH (=100), NOT the signature
+        # default 10 the old _REFS_MAX_DEPTH pinned; both sides must strip.
+        "model": MODEL,
+        "messages": _U,
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "f",
+                    "parameters": {
+                        "$id": "root",
+                        "type": "object",
+                        "properties": {
+                            "a": {
+                                "$id": "l1",
+                                "type": "object",
+                                "properties": {
+                                    "b": {
+                                        "$id": "l2",
+                                        "type": "object",
+                                        "properties": {
+                                            "c": {"$id": "l3", "type": "string"}
+                                        },
+                                    }
+                                },
+                            }
+                        },
+                    },
+                },
+            }
+        ],
+    },
     "response_format_json_object": {
         "model": MODEL,
         "messages": _U,
@@ -383,6 +418,50 @@ def test_schema_refs_strip_keeps_additional_properties_and_strict() -> None:
     assert function["parameters"]["additionalProperties"] is False
     assert "$id" not in function["parameters"]
     assert "$id" not in function["parameters"]["properties"]["a"]
+
+
+def _nested_id_schema(levels: int) -> dict:
+    nest: dict = {"$id": "deep", "type": "string"}
+    for _ in range(levels):
+        nest = {"type": "object", "child": nest}
+    return {"type": "object", "outer": nest}
+
+
+@pytest.mark.parametrize("levels", [40, 101])
+def test_refs_depth_cap_is_v1s_default_max_recurse_depth(levels: int) -> None:
+    """verifier-wave2b-beta F2 + the drift gate: v1 strips at
+    _remove_json_schema_refs(max_depth=DEFAULT_MAX_RECURSE_DEPTH) — 40
+    levels strip BOTH sides (the old cap of 10 left v2 keeping them), and
+    past the constant both sides keep the key. v2 imports the same
+    litellm.constants symbol, pinned here against v1's constant at HEAD so
+    neither the call-site argument nor the constant can drift unseen."""
+    from litellm.constants import DEFAULT_MAX_RECURSE_DEPTH
+
+    from litellm.translation.providers.mistral import serialize as mistral_serialize
+
+    assert DEFAULT_MAX_RECURSE_DEPTH == 100
+    assert (
+        mistral_serialize.DEFAULT_MAX_RECURSE_DEPTH is DEFAULT_MAX_RECURSE_DEPTH
+    ), "the serializer stopped reading v1's constant; re-pin the cap"
+    case = {
+        "model": MODEL,
+        "messages": _U,
+        "tools": [
+            {
+                "type": "function",
+                "function": {"name": "f", "parameters": _nested_id_schema(levels)},
+            }
+        ],
+    }
+    v1_body = run_v1_request_transform(case)
+    result = _v2(case)
+    assert result.is_ok(), result.error.summary
+    assert _norm(result.ok) == _norm(v1_body)
+    deep = result.ok["tools"][0]["function"]["parameters"]
+    for _ in range(levels + 1):
+        deep = deep["outer"] if "outer" in deep else deep["child"]
+    stripped = "$id" not in deep
+    assert stripped == (levels < 96), "the cap boundary moved; re-derive"
 
 
 def test_empty_text_list_falls_back_v1_keeps_list_form() -> None:

--- a/tests/test_litellm/translation/test_differential_mistral_request.py
+++ b/tests/test_litellm/translation/test_differential_mistral_request.py
@@ -1,0 +1,407 @@
+"""Differential parity for the mistral chat request path (wave-2b-beta).
+
+v1 side, invoked the way main.py's mistral elif runs:
+``get_optional_params(custom_llm_provider="mistral")`` (explicit map arms,
+drop_params threaded) with completion()'s ``stream=None`` default, the
+handler's ``extra_body`` pop (seed -> random_seed is envelope-merged there,
+but ``seed`` is a parse-level fallback in v2 anyway), then
+``MistralConfig.transform_request`` — the reasoning-prompt injection for
+magistral models and the two-branch ``_transform_messages``.
+
+Served deltas pinned IDENTICAL: mct -> max_tokens, tool_choice required ->
+any with the DICT form silently dropped, tools ``$id``/``$schema`` strip
+(depth-capped; additionalProperties/strict KEPT — the v1 docstring lies),
+top_k verbatim top-level (wire-proven), the text-list flatten, the
+MistralToolCallMessage shape, empty-assistant removal, per-message None
+strip, the name matrix (user names dropped, tool names kept -> fallback),
+and the image branch's verbatim base-transform passthrough.
+"""
+
+import copy
+import json
+
+import pytest
+
+from litellm.exceptions import UnsupportedParamsError
+from litellm.llms.mistral.chat.transformation import MistralConfig
+from litellm.utils import get_optional_params
+
+from litellm.translation.engine.pipeline import translate_chat_request
+from litellm.translation_seam import build_translation_deps
+
+MODEL = "mistral-large-latest"
+_U = [{"role": "user", "content": "hi"}]
+
+CASES = {
+    "plain": {"model": MODEL, "messages": _U},
+    "sampling": {
+        "model": MODEL,
+        "messages": _U,
+        "temperature": 0.5,
+        "top_p": 0.9,
+        "max_tokens": 10,
+        "stop": ["x"],
+    },
+    "mct_renamed": {"model": MODEL, "messages": _U, "max_completion_tokens": 50},
+    "top_k_wire_proven": {"model": MODEL, "messages": _U, "top_k": 7},
+    "stream_true": {"model": MODEL, "messages": _U, "stream": True},
+    "explicit_stream_false_dropped": {"model": MODEL, "messages": _U, "stream": False},
+    "tools_auto": {
+        "model": MODEL,
+        "messages": _U,
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "d",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ],
+        "tool_choice": "auto",
+    },
+    "tool_choice_required_to_any": {
+        "model": MODEL,
+        "messages": _U,
+        "tools": [{"type": "function", "function": {"name": "f", "parameters": {}}}],
+        "tool_choice": "required",
+    },
+    "tool_choice_dict_dropped": {
+        "model": MODEL,
+        "messages": _U,
+        "tools": [{"type": "function", "function": {"name": "f", "parameters": {}}}],
+        "tool_choice": {"type": "function", "function": {"name": "f"}},
+    },
+    "tools_schema_refs_stripped": {
+        "model": MODEL,
+        "messages": _U,
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "f",
+                    "strict": True,
+                    "parameters": {
+                        "$id": "root",
+                        "$schema": "draft-07",
+                        "type": "object",
+                        "additionalProperties": False,
+                        "properties": {"a": {"$id": "nested", "type": "string"}},
+                    },
+                },
+            }
+        ],
+    },
+    "response_format_json_object": {
+        "model": MODEL,
+        "messages": _U,
+        "response_format": {"type": "json_object"},
+    },
+    "parallel_tool_calls": {
+        "model": MODEL,
+        "messages": _U,
+        "tools": [{"type": "function", "function": {"name": "f", "parameters": {}}}],
+        "parallel_tool_calls": True,
+    },
+    "flatten_multi_text_list": {
+        "model": MODEL,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "a"},
+                    {"type": "text", "text": "b"},
+                ],
+            }
+        ],
+    },
+    "assistant_tool_history": {
+        "model": MODEL,
+        "messages": [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "c1",
+                        "type": "function",
+                        "function": {"name": "f", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "c1", "content": "result"},
+        ],
+    },
+    "empty_assistant_removed": {
+        "model": MODEL,
+        "messages": [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": ""},
+            {"role": "user", "content": "again"},
+        ],
+    },
+    "user_name_dropped_both_sides": {
+        "model": MODEL,
+        "messages": [{"role": "user", "content": "hi", "name": "bob"}],
+    },
+    "system_first": {
+        "model": MODEL,
+        "messages": [
+            {"role": "system", "content": "be nice"},
+            {"role": "user", "content": "hi"},
+        ],
+    },
+    "image_branch_verbatim": {
+        "model": "pixtral-12b",
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "what"},
+                    {"type": "image_url", "image_url": {"url": "https://x/y.png"}},
+                ],
+            }
+        ],
+    },
+    "image_branch_with_tool_history": {
+        "model": "pixtral-12b",
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "what"},
+                    {"type": "image_url", "image_url": {"url": "https://x/y.png"}},
+                ],
+            },
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "c1",
+                        "type": "function",
+                        "function": {"name": "f", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "c1", "content": "res"},
+        ],
+    },
+}
+
+# v1 RAISES UnsupportedParamsError; v2 must be a typed fallback.
+V1_RAISES = {
+    "frequency_penalty": (
+        {"model": MODEL, "messages": _U, "frequency_penalty": 0.1},
+        "frequency_penalty",
+    ),
+    "presence_penalty": (
+        {"model": MODEL, "messages": _U, "presence_penalty": 0.1},
+        "presence_penalty",
+    ),
+    "n": ({"model": MODEL, "messages": _U, "n": 2}, "n"),
+    "logprobs": ({"model": MODEL, "messages": _U, "logprobs": True}, "logprobs"),
+    "reasoning_effort_non_magistral": (
+        {"model": MODEL, "messages": _U, "reasoning_effort": "high"},
+        "reasoning_effort",
+    ),
+    "thinking_non_magistral": (
+        {"model": MODEL, "messages": _U, "thinking": {"type": "enabled"}},
+        "thinking",
+    ),
+}
+
+# v1 SERVES these; v2 falls back typed so v1 keeps serving its own behavior.
+V1_SERVES_FALLBACKS = {
+    "user_silent_drop": (
+        {"model": MODEL, "messages": _U, "user": "u1"},
+        "user",
+    ),
+    "seed_random_seed_extra_body": (
+        {"model": MODEL, "messages": _U, "seed": 42},
+        "seed",
+    ),
+    "magistral_reasoning_prompt_injection": (
+        {
+            "model": "magistral-medium-latest",
+            "messages": [{"role": "user", "content": "solve"}],
+            "reasoning_effort": "high",
+        },
+        "reasoning",
+    ),
+    "magistral_thinking_prompt_injection": (
+        {
+            "model": "magistral-medium-latest",
+            "messages": [{"role": "user", "content": "solve"}],
+            "thinking": {"type": "enabled", "budget_tokens": 1024},
+        },
+        "thinking",
+    ),
+    "tool_name_kept_by_v1": (
+        {
+            "model": MODEL,
+            "messages": [
+                {"role": "user", "content": "hi"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "c1",
+                            "type": "function",
+                            "function": {"name": "f", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "c1", "name": "f", "content": "r"},
+            ],
+        },
+        "tool-message name",
+    ),
+    "image_branch_name_forwarded": (
+        {
+            "model": "pixtral-12b",
+            "messages": [
+                {
+                    "role": "user",
+                    "name": "bob",
+                    "content": [
+                        {"type": "text", "text": "what"},
+                        {"type": "image_url", "image_url": {"url": "https://x/y.png"}},
+                    ],
+                }
+            ],
+        },
+        "image/file",
+    ),
+    "string_stop_verbatim": (
+        {"model": MODEL, "messages": _U, "stop": "x"},
+        "string-form stop",
+    ),
+    "single_text_list_flatten": (
+        # v1 flattens it and the IR collapse + flatten WOULD equal v1, but
+        # the shared single-text-list arm is conservative (the sambanova
+        # precedent); v1 serves its flatten.
+        {
+            "model": MODEL,
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": "only"}]}
+            ],
+        },
+        "single-text content list",
+    ),
+}
+
+
+def run_v1_request_transform(case: dict) -> dict:
+    request = copy.deepcopy(case)
+    model = request.pop("model")
+    messages = request.pop("messages")
+    optional_params = get_optional_params(
+        model=model,
+        custom_llm_provider="mistral",
+        messages=copy.deepcopy(messages),
+        stream=request.pop("stream", None),
+        **request,
+    )
+    optional_params.pop("extra_body", None)
+    return MistralConfig().transform_request(
+        model=model,
+        messages=messages,
+        optional_params=optional_params,
+        litellm_params={},
+        headers={},
+    )
+
+
+def _v2(case: dict):
+    return translate_chat_request(
+        copy.deepcopy(case), "mistral", build_translation_deps()
+    )
+
+
+def _norm(body: dict) -> str:
+    return json.dumps(body, sort_keys=True, default=str)
+
+
+@pytest.mark.parametrize("name", sorted(CASES))
+def test_v2_request_matches_v1(name: str) -> None:
+    case = CASES[name]
+    result = _v2(case)
+    assert result.is_ok(), result.error.summary
+    assert _norm(result.ok) == _norm(run_v1_request_transform(case))
+
+
+@pytest.mark.parametrize("name", sorted(V1_RAISES))
+def test_v1_raise_rows_fall_back_typed(name: str) -> None:
+    case, fragment = V1_RAISES[name]
+    result = _v2(case)
+    assert result.is_error(), f"{name} unexpectedly translated: {result.ok!r}"
+    assert fragment in result.error.summary, result.error.summary
+    with pytest.raises(UnsupportedParamsError):
+        run_v1_request_transform(case)
+
+
+@pytest.mark.parametrize("name", sorted(V1_SERVES_FALLBACKS))
+def test_v1_serves_fallback_rows(name: str) -> None:
+    case, fragment = V1_SERVES_FALLBACKS[name]
+    result = _v2(case)
+    assert result.is_error(), f"{name} unexpectedly translated: {result.ok!r}"
+    assert fragment in result.error.summary, result.error.summary
+    run_v1_request_transform(case)
+
+
+def test_top_k_rides_the_wire_top_level() -> None:
+    """The wire-prove rule: mistral's top_k is NOT the extra_body arm — the
+    generic passthrough places it top-level and the body carries it
+    (researcher-4 listed top_k as a RAISE; the probe refutes that)."""
+    v1_body = run_v1_request_transform(CASES["top_k_wire_proven"])
+    assert v1_body["top_k"] == 7
+    assert "extra_body" not in v1_body
+    result = _v2(CASES["top_k_wire_proven"])
+    assert result.is_ok() and result.ok["top_k"] == 7
+
+
+def test_explicit_stream_false_never_reaches_the_wire() -> None:
+    """Unlike the compat families, mistral's map only copies stream=True —
+    explicit False is dropped by v1 itself, so v2 SERVES the shape (the IR's
+    absent-vs-false collapse IS v1's behavior; no guard arm)."""
+    v1_body = run_v1_request_transform(CASES["explicit_stream_false_dropped"])
+    assert "stream" not in v1_body
+    result = _v2(CASES["explicit_stream_false_dropped"])
+    assert result.is_ok() and "stream" not in result.ok
+
+
+def test_schema_refs_strip_keeps_additional_properties_and_strict() -> None:
+    """The code-not-docstring pin: only $id/$schema are removed."""
+    result = _v2(CASES["tools_schema_refs_stripped"])
+    assert result.is_ok()
+    function = result.ok["tools"][0]["function"]
+    assert function["strict"] is True
+    assert function["parameters"]["additionalProperties"] is False
+    assert "$id" not in function["parameters"]
+    assert "$id" not in function["parameters"]["properties"]["a"]
+
+
+def test_empty_text_list_falls_back_v1_keeps_list_form() -> None:
+    """v1's flatten only assigns a TRUTHY join: a list flattening to ""
+    keeps its LIST form on the wire, which the IR cannot reproduce."""
+    case = {
+        "model": MODEL,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": ""},
+                    {"type": "text", "text": ""},
+                ],
+            }
+        ],
+    }
+    result = _v2(case)
+    assert result.is_error()
+    assert "empty" in result.error.summary
+    v1_body = run_v1_request_transform(case)
+    assert isinstance(v1_body["messages"][0]["content"], list)

--- a/tests/test_litellm/translation/test_differential_mistral_response.py
+++ b/tests/test_litellm/translation/test_differential_mistral_response.py
@@ -14,6 +14,7 @@ import json
 import time
 
 import httpx
+import pydantic
 import pytest
 
 from litellm.litellm_core_utils.litellm_logging import Logging
@@ -23,7 +24,11 @@ from litellm.types.utils import ModelResponse
 from litellm.translation.inbound.openai_chat import parse_request
 from litellm.translation.inbound.openai_chat.response import serialize_response
 from litellm.translation.providers.mistral import parse_response
-from litellm.translation_seam import build_translation_deps, to_model_response
+from litellm.translation_seam import (
+    UsageStyle,
+    build_translation_deps,
+    to_model_response,
+)
 
 MODEL = "mistral-large-latest"
 WIRE_MODEL = "mistral-large-2411"
@@ -250,13 +255,19 @@ def _v2_parse(raw: dict):
     return parse_response(copy.deepcopy(raw), parsed.ok)
 
 
-def _v2_model_response(raw: dict) -> dict:
+def _v2_with_style(raw: dict, style: UsageStyle) -> dict:
     response = _v2_parse(raw)
     assert response.is_ok(), response.error.summary
     body = serialize_response(response.ok, build_translation_deps(), "openai")
     return to_model_response(
-        body, ModelResponse(id=_AMBIENT_ID), usage_style="openai"
+        body, ModelResponse(id=_AMBIENT_ID), usage_style=style
     ).model_dump()
+
+
+def _v2_model_response(raw: dict) -> dict:
+    # mistral rides the cdr arm — the truth is
+    # pipeline.OWN_MODULE_RESPONSE_STYLES["mistral"], divergence-pinned below
+    return _v2_with_style(raw, "openai")
 
 
 def _norm(payload: dict) -> str:
@@ -300,3 +311,30 @@ def test_loud_shapes_error_on_both_sides(name: str, frozen_ambient) -> None:
     assert fragment in result.error.summary, result.error.summary
     with pytest.raises(Exception):
         _v1_model_response(copy.deepcopy(raw))
+
+
+def test_wrong_construction_arm_diverges_and_the_table_pins_it(
+    frozen_ambient,
+) -> None:
+    """verifier-wave2b-final F1: the "openai"-arm OWN_MODULE_RESPONSE_STYLES
+    values were enforced by NOTHING — a wrong-arm value flip on THIS row was
+    the verifier's proof (it survived the whole 3038 suite). The watsonx/
+    groq wrong-arm template INVERTED for a cdr-parser member (the v2 parser
+    already cdr-normalizes choices, so the openai_like members' index-5
+    discriminator dies before the seam): a FLOAT wire ``created`` rides the
+    normalized body; the correct cdr ("openai") arm coerces it via
+    _safe_convert_created_field and serves exactly like v1, while the wrong
+    "openai_like" arm (ModelResponse(**json)) raises ValidationError on
+    traffic v1 serves — if the arms stop diverging here, the raises assert
+    fails: re-decide before relying on the pin."""
+    from litellm.translation.engine.pipeline import OWN_MODULE_RESPONSE_STYLES
+
+    assert OWN_MODULE_RESPONSE_STYLES["mistral"] == "openai"
+    raw = copy.deepcopy(_RESPONSES["text"])
+    raw["created"] = raw["created"] + 0.5
+    v1 = _v1_model_response(raw)
+    correct = _v2_with_style(raw, OWN_MODULE_RESPONSE_STYLES["mistral"])
+    assert _norm(correct) == _norm(v1)
+    assert correct["created"] == _RESPONSES["text"]["created"]
+    with pytest.raises(pydantic.ValidationError):
+        _v2_with_style(raw, "openai_like")

--- a/tests/test_litellm/translation/test_differential_mistral_response.py
+++ b/tests/test_litellm/translation/test_differential_mistral_response.py
@@ -1,0 +1,263 @@
+"""Differential parity for the mistral response path (wave-2b-beta).
+
+v1 side: ``MistralConfig.transform_response`` (LIVE on the httpx path) —
+the two raw-body pre-steps (empty content -> None FIRST, then the magistral
+content-list collapse where the LAST text block wins and thinking texts
+join with newlines into ``reasoning_content``) and then
+``convert_to_model_response_object`` over a fresh ModelResponse (model None
+-> BARE wire model). v2: the mistral pre-steps + the shared openai parser
++ the seam's openai construction arm, byte-identical dumps.
+"""
+
+import copy
+import json
+import time
+
+import httpx
+import pytest
+
+from litellm.litellm_core_utils.litellm_logging import Logging
+from litellm.llms.mistral.chat.transformation import MistralConfig
+from litellm.types.utils import ModelResponse
+
+from litellm.translation.inbound.openai_chat import parse_request
+from litellm.translation.inbound.openai_chat.response import serialize_response
+from litellm.translation.providers.mistral import parse_response
+from litellm.translation_seam import build_translation_deps, to_model_response
+
+MODEL = "mistral-large-latest"
+WIRE_MODEL = "mistral-large-2411"
+_AMBIENT_ID = "chatcmpl-mistral-diff"
+
+_REQUEST = {"model": MODEL, "messages": [{"role": "user", "content": "hi"}]}
+
+_BASE = {
+    "id": "cmpl-1",
+    "object": "chat.completion",
+    "created": 1718000000,
+    "model": WIRE_MODEL,
+    "usage": {"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5},
+}
+
+_RESPONSES = {
+    "text": {
+        **_BASE,
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "hello"},
+                "finish_reason": "stop",
+            }
+        ],
+    },
+    "empty_content_to_none": {
+        **_BASE,
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": ""},
+                "finish_reason": "stop",
+            }
+        ],
+    },
+    "magistral_thinking_blocks": {
+        **_BASE,
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "thinking",
+                            "thinking": [
+                                {"type": "text", "text": "step1"},
+                                {"type": "text", "text": "step2"},
+                            ],
+                        },
+                        {"type": "text", "text": "answer"},
+                    ],
+                },
+                "finish_reason": "stop",
+            }
+        ],
+    },
+    "thinking_only_keeps_empty_string": {
+        # the pre-step ORDER pin: empty->None runs FIRST, so the collapsed
+        # "" content from a text-less list STAYS "" (never None)
+        **_BASE,
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "thinking",
+                            "thinking": [{"type": "text", "text": "only think"}],
+                        }
+                    ],
+                },
+                "finish_reason": "stop",
+            }
+        ],
+    },
+    "last_text_block_wins": {
+        **_BASE,
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "text", "text": "first"},
+                        {"type": "text", "text": "second"},
+                    ],
+                },
+                "finish_reason": "stop",
+            }
+        ],
+    },
+    "tool_calls": {
+        **_BASE,
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "c1",
+                            "type": "function",
+                            "function": {"name": "f", "arguments": '{"a":1}'},
+                        }
+                    ],
+                },
+                "finish_reason": "tool_calls",
+            }
+        ],
+    },
+}
+
+_LOUD = {
+    "non_dict_content_block": (
+        {
+            **_BASE,
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": ["bare"]},
+                    "finish_reason": "stop",
+                }
+            ],
+        },
+        "not an object",
+    ),
+    "non_list_thinking": (
+        {
+            **_BASE,
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": [{"type": "thinking", "thinking": "bare"}],
+                    },
+                    "finish_reason": "stop",
+                }
+            ],
+        },
+        "not a list",
+    ),
+}
+
+
+def _v1_model_response(raw: dict) -> dict:
+    logging = Logging(
+        model=MODEL,
+        messages=copy.deepcopy(_REQUEST["messages"]),
+        stream=False,
+        call_type="completion",
+        start_time=time.time(),
+        litellm_call_id="diff-mistral-response",
+        function_id="diff-mistral-response",
+    )
+    response = httpx.Response(
+        200,
+        json=copy.deepcopy(raw),
+        request=httpx.Request("POST", "https://api.mistral.ai/v1/chat/completions"),
+    )
+    return (
+        MistralConfig()
+        .transform_response(
+            model=MODEL,
+            raw_response=response,
+            model_response=ModelResponse(id=_AMBIENT_ID),
+            logging_obj=logging,
+            request_data={},
+            messages=copy.deepcopy(_REQUEST["messages"]),
+            optional_params={},
+            litellm_params={},
+            encoding=None,
+        )
+        .model_dump()
+    )
+
+
+def _v2_parse(raw: dict):
+    parsed = parse_request(copy.deepcopy(_REQUEST))
+    assert parsed.is_ok(), parsed.error.summary
+    return parse_response(copy.deepcopy(raw), parsed.ok)
+
+
+def _v2_model_response(raw: dict) -> dict:
+    response = _v2_parse(raw)
+    assert response.is_ok(), response.error.summary
+    body = serialize_response(response.ok, build_translation_deps(), "openai")
+    return to_model_response(
+        body, ModelResponse(id=_AMBIENT_ID), usage_style="openai"
+    ).model_dump()
+
+
+def _norm(payload: dict) -> str:
+    return json.dumps(payload, sort_keys=True, default=str)
+
+
+@pytest.mark.parametrize("name", sorted(_RESPONSES))
+def test_v2_response_matches_v1(name: str, frozen_ambient) -> None:
+    raw = _RESPONSES[name]
+    assert _norm(_v2_model_response(raw)) == _norm(_v1_model_response(raw))
+
+
+@pytest.mark.parametrize("name", sorted(_RESPONSES))
+def test_bare_wire_model_no_prefix(name: str, frozen_ambient) -> None:
+    v1 = _v1_model_response(_RESPONSES[name])
+    v2 = _v2_model_response(_RESPONSES[name])
+    assert v1["model"] == WIRE_MODEL
+    assert v2["model"] == WIRE_MODEL
+    assert not str(v2["model"]).startswith("mistral/")
+
+
+def test_reasoning_content_extracted(frozen_ambient) -> None:
+    v2 = _v2_model_response(_RESPONSES["magistral_thinking_blocks"])
+    message = v2["choices"][0]["message"]
+    assert message["content"] == "answer"
+    assert message["reasoning_content"] == "step1\nstep2"
+
+
+def test_thinking_only_content_stays_empty_string(frozen_ambient) -> None:
+    v1 = _v1_model_response(_RESPONSES["thinking_only_keeps_empty_string"])
+    v2 = _v2_model_response(_RESPONSES["thinking_only_keeps_empty_string"])
+    assert v1["choices"][0]["message"]["content"] == ""
+    assert v2["choices"][0]["message"]["content"] == ""
+
+
+@pytest.mark.parametrize("name", sorted(_LOUD))
+def test_loud_shapes_error_on_both_sides(name: str, frozen_ambient) -> None:
+    raw, fragment = _LOUD[name]
+    result = _v2_parse(raw)
+    assert result.is_error(), f"{name} unexpectedly parsed"
+    assert fragment in result.error.summary, result.error.summary
+    with pytest.raises(Exception):
+        _v1_model_response(copy.deepcopy(raw))

--- a/tests/test_litellm/translation/test_differential_mistral_response.py
+++ b/tests/test_litellm/translation/test_differential_mistral_response.py
@@ -170,6 +170,45 @@ _LOUD = {
         },
         "not a list",
     ),
+    # verifier-wave2b-beta F3: the old arms coerced-and-served both shapes —
+    # a non-str thinking text (v1's "\n".join TypeError) and an empty
+    # content list (v1's truthy gate skips the collapse; cdr raises
+    # "Invalid response object" on Message(content=[])).
+    "non_string_thinking_text": (
+        {
+            **_BASE,
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "thinking",
+                                "thinking": [{"type": "text", "text": 5}],
+                            },
+                            {"type": "text", "text": "answer"},
+                        ],
+                    },
+                    "finish_reason": "stop",
+                }
+            ],
+        },
+        "thinking text is not a string",
+    ),
+    "empty_content_list": (
+        {
+            **_BASE,
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": []},
+                    "finish_reason": "stop",
+                }
+            ],
+        },
+        "content list is empty",
+    ),
 }
 
 

--- a/tests/test_litellm/translation/test_differential_mistral_stream.py
+++ b/tests/test_litellm/translation/test_differential_mistral_stream.py
@@ -241,6 +241,38 @@ _LOUD_CHUNKS = {
         _chunk({"content": "x", "made_up_key": 1}),
         "stream delta keys",
     ),
+    # verifier-wave2b-beta F3: the old arm coerced the non-str thinking text
+    # to "" and SERVED a stripped chunk (with the mixed shape it served
+    # reasoning_content "ok"); v1's pre-step except-arm replays the
+    # still-list content and the wrapper raises MidStreamFallbackError.
+    "non_string_thinking_text": (
+        _chunk(
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": [{"type": "text", "text": 5}]}
+                ],
+            }
+        ),
+        "thinking text is not a string",
+    ),
+    "non_string_thinking_text_beside_ok_text": (
+        _chunk(
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "thinking",
+                        "thinking": [
+                            {"type": "text", "text": 5},
+                            {"type": "text", "text": "ok"},
+                        ],
+                    }
+                ],
+            }
+        ),
+        "thinking text is not a string",
+    ),
 }
 
 

--- a/tests/test_litellm/translation/test_differential_mistral_stream.py
+++ b/tests/test_litellm/translation/test_differential_mistral_stream.py
@@ -1,0 +1,259 @@
+"""Differential parity for mistral streaming (wave-2b-beta), pinned at the
+SSE line seam.
+
+v1 side: ``data:``/[DONE] lines through ``MistralChatResponseIterator``
+(the magistral content-list pre-step, then the BASE
+``OpenAIChatCompletionStreamingHandler`` rebuild) into
+``CustomStreamWrapper("mistral")``. v2 side: ``fold_lines`` with the
+mistral parser — the same pre-step composed over the shared httpx_chunk
+factory (``reasoning="rename"`` + the NEW ``passthrough_delta_keys`` axis
+admitting the pre-step's ``thinking_blocks``; mistral is the axis's
+consumer, per the no-consumer-no-arm rule) — and the shared ``xai`` chunk
+dialect.
+"""
+
+import copy
+import json
+import time
+
+import pytest
+
+from litellm.litellm_core_utils.litellm_logging import Logging
+from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
+from litellm.llms.mistral.chat.transformation import MistralChatResponseIterator
+
+from litellm.translation.engine.stream import fold_events, fold_lines
+from litellm.translation.inbound.openai_chat.stream import initial_state
+from litellm.translation.providers.mistral import parse_event, parse_line
+from litellm.translation_seam import to_model_response_stream
+
+MODEL = "magistral-medium-latest"
+WIRE_MODEL = "magistral-medium-2506"
+
+
+def _chunk(
+    delta: dict | None = None,
+    finish: str | None = None,
+    usage: dict | None = None,
+    **extra: object,
+) -> dict:
+    payload = {
+        "id": "chunk-1",
+        "object": "chat.completion.chunk",
+        "created": 1718000000,
+        "model": WIRE_MODEL,
+        "choices": [
+            {
+                "index": 0,
+                "delta": delta if delta is not None else {},
+                "finish_reason": finish,
+            }
+        ],
+        **extra,
+    }
+    if usage is not None:
+        payload["usage"] = usage
+    return payload
+
+
+_USAGE = {"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5}
+
+STREAMS = {
+    "text": [
+        _chunk({"role": "assistant", "content": "He"}),
+        _chunk({"content": "llo"}),
+        _chunk({}, finish="stop"),
+    ],
+    "magistral_thinking_blocks": [
+        _chunk(
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "thinking",
+                        "thinking": [{"type": "text", "text": "think1"}],
+                    }
+                ],
+            }
+        ),
+        _chunk(
+            {
+                "content": [
+                    {
+                        "type": "thinking",
+                        "thinking": [{"type": "text", "text": "think2"}],
+                    },
+                    {"type": "text", "text": "ans"},
+                ]
+            }
+        ),
+        _chunk({"content": "tail"}),
+        _chunk({}, finish="stop"),
+    ],
+    "reasoning_rename": [
+        _chunk({"role": "assistant", "reasoning": "r1"}),
+        _chunk({"content": "x"}),
+        _chunk({}, finish="stop"),
+    ],
+    "empty_thinking_role_only_chunk": [
+        # the normalize pops empty thinking_blocks: v1 still emits the
+        # role-only chunk (content None) — pinned byte-for-byte
+        _chunk(
+            {"role": "assistant", "content": [{"type": "thinking", "thinking": []}]}
+        ),
+        _chunk({"content": "x"}),
+        _chunk({}, finish="stop"),
+    ],
+    "tools": [
+        _chunk(
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "c1",
+                        "type": "function",
+                        "function": {"name": "f", "arguments": ""},
+                    }
+                ],
+            }
+        ),
+        _chunk({"tool_calls": [{"index": 0, "function": {"arguments": "{}"}}]}),
+        _chunk({}, finish="tool_calls"),
+    ],
+}
+
+USAGE_STREAM = [
+    _chunk({"role": "assistant", "content": "Hi"}),
+    _chunk({}, finish="stop"),
+    {
+        "id": "chunk-1",
+        "object": "chat.completion.chunk",
+        "created": 1718000000,
+        "model": WIRE_MODEL,
+        "choices": [],
+        "usage": _USAGE,
+    },
+]
+
+
+def _v1_chunks(events: list, stream_options: dict | None = None) -> list:
+    lines = [f"data: {json.dumps(event)}" for event in copy.deepcopy(events)]
+    lines.append("data: [DONE]")
+    handler = MistralChatResponseIterator(
+        streaming_response=iter(lines), sync_stream=True
+    )
+    logging = Logging(
+        model=MODEL,
+        messages=[{"role": "user", "content": "stream"}],
+        stream=True,
+        call_type="completion",
+        start_time=time.time(),
+        litellm_call_id="diff-mistral-stream",
+        function_id="diff-mistral-stream",
+    )
+    wrapper = CustomStreamWrapper(
+        completion_stream=handler,
+        model=MODEL,
+        custom_llm_provider="mistral",
+        logging_obj=logging,
+        stream_options=stream_options,
+    )
+    return [chunk.model_dump() for chunk in wrapper]
+
+
+def _v2_chunks(events: list) -> list:
+    lines = [f"data: {json.dumps(event)}" for event in copy.deepcopy(events)]
+    lines.append("data: [DONE]")
+    folded = fold_lines(lines, parse_line, initial_state(MODEL, dialect="xai"))
+    assert folded.is_ok(), folded.error.summary
+    return [
+        to_model_response_stream(chunk, "chatcmpl-AMBIENT").model_dump()
+        for chunk in folded.ok
+    ]
+
+
+def _norm(chunks: list) -> str:
+    return json.dumps(chunks, sort_keys=True, default=str)
+
+
+@pytest.mark.parametrize("name", sorted(STREAMS))
+def test_v2_stream_matches_v1(name: str, frozen_ambient) -> None:
+    events = STREAMS[name]
+    assert _norm(_v2_chunks(events)) == _norm(_v1_chunks(events))
+
+
+def test_thinking_blocks_ride_the_delta(frozen_ambient) -> None:
+    """Semantic pin on top of the byte rows: the emitted delta carries the
+    normalized thinking_blocks (signature "mistral") AND reasoning_content,
+    and the request model (not the wire model) names every chunk."""
+    v2 = _v2_chunks(STREAMS["magistral_thinking_blocks"])
+    delta = v2[0]["choices"][0]["delta"]
+    assert delta["reasoning_content"] == "think1"
+    assert delta["thinking_blocks"] == [
+        {"type": "thinking", "thinking": "think1", "signature": "mistral"}
+    ]
+    assert all(chunk["model"] == MODEL for chunk in v2)
+
+
+def test_usage_tail_pins_the_seam_contract(frozen_ambient) -> None:
+    v1 = _v1_chunks(USAGE_STREAM, stream_options={"include_usage": True})
+    v2 = _v2_chunks(USAGE_STREAM)
+    assert len(v1) == len(v2)
+    assert _norm(v2[:-1]) == _norm(v1[: len(v2) - 1])
+    assert v2[-1]["choices"] == []
+    for key in ("prompt_tokens", "completion_tokens", "total_tokens"):
+        assert v1[-1]["usage"][key] == v2[-1]["usage"][key], key
+
+
+def test_usage_tail_swallowed_without_stream_options(frozen_ambient) -> None:
+    v1 = _v1_chunks(USAGE_STREAM, None)
+    v2 = _v2_chunks(USAGE_STREAM)
+    assert len(v1) == len(v2) - 1
+    assert _norm(v1) == _norm(v2[:-1])
+
+
+def test_v2_line_and_event_folds_agree(frozen_ambient) -> None:
+    events = STREAMS["magistral_thinking_blocks"]
+    folded = fold_events(
+        copy.deepcopy(events), parse_event, initial_state(MODEL, dialect="xai")
+    )
+    assert folded.is_ok(), folded.error.summary
+    via_events = [
+        to_model_response_stream(chunk, "chatcmpl-AMBIENT").model_dump()
+        for chunk in folded.ok
+    ]
+    assert _norm(via_events) == _norm(_v2_chunks(events))
+
+
+_LOUD_CHUNKS = {
+    "non_dict_content_block": (
+        _chunk({"role": "assistant", "content": ["bare"]}),
+        "not an object",
+    ),
+    "non_list_thinking": (
+        _chunk(
+            {"role": "assistant", "content": [{"type": "thinking", "thinking": "x"}]}
+        ),
+        "not a list",
+    ),
+    "unknown_delta_key": (
+        _chunk({"content": "x", "made_up_key": 1}),
+        "stream delta keys",
+    ),
+}
+
+
+@pytest.mark.parametrize("name", sorted(_LOUD_CHUNKS))
+def test_loud_chunk_shapes(name: str, frozen_ambient) -> None:
+    """The malformed content-list shapes raise in v1 too (its pre-step's
+    except-arm replays the ORIGINAL chunk through the base rebuild, whose
+    Delta validation rejects list content); unknown delta keys are the
+    family's standard unreachable-shape typed error."""
+    event, fragment = _LOUD_CHUNKS[name]
+    result = parse_event(copy.deepcopy(event))
+    assert result.is_error(), f"{name} unexpectedly parsed"
+    assert fragment in result.error.summary, result.error.summary
+    if name != "unknown_delta_key":
+        with pytest.raises(Exception):
+            _v1_chunks([event])

--- a/tests/test_litellm/translation/test_differential_mistral_stream.py
+++ b/tests/test_litellm/translation/test_differential_mistral_stream.py
@@ -289,3 +289,40 @@ def test_loud_chunk_shapes(name: str, frozen_ambient) -> None:
     if name != "unknown_delta_key":
         with pytest.raises(Exception):
             _v1_chunks([event])
+
+
+_ERROR_CHUNK_STREAM = [
+    _chunk({"role": "assistant", "content": "He"}),
+    {
+        "id": "chunk-1",
+        "object": "chat.completion.chunk",
+        "created": 1718000000,
+        "model": MODEL,
+        "error": {"message": "upstream exploded", "code": 502},
+    },
+    _chunk({"content": "llo"}),
+    _chunk({}, finish="stop"),
+]
+
+
+def test_error_chunk_divergence_two_sided(frozen_ambient) -> None:
+    """Sibling-merge consistency sweep: MistralChatResponseIterator SUBCLASSES
+    the base OpenAIChatCompletionStreamingHandler, so mistral INHERITS the
+    family's silent error-chunk swallow (probed two-sided at the merge: v1
+    serves 3 chunks with no error surface; v2's parse_line is a LOUD typed
+    boundary error naming the chunk). Mistral therefore joins the report's
+    ONE failure-counted PINNED DIVERGENCE row via
+    _wave2b_beta_error_chunk_pins — the wave-2b-alpha merge-notes obligation
+    ("any beta provider riding the BASE handler with the silent swallow
+    joins the same row; never a second PINNED row"). Flag-on cannot lose
+    data (v2 is louder, not quieter). If the v1 half fails, the iterator
+    learned to raise: re-decide the divergence and update the report row in
+    the same commit."""
+    v1 = _v1_chunks(_ERROR_CHUNK_STREAM)
+    assert "error" not in json.dumps(v1, default=str), v1
+    assert [c["choices"][0]["delta"].get("content") for c in v1[:2]] == ["He", "llo"]
+    lines = [f"data: {json.dumps(e)}" for e in copy.deepcopy(_ERROR_CHUNK_STREAM)]
+    folded = fold_lines(lines, parse_line, initial_state(MODEL, dialect="xai"))
+    assert folded.is_error()
+    assert "provider stream error" in folded.error.summary, folded.error.summary
+    assert "upstream exploded" in folded.error.summary

--- a/tests/test_litellm/translation/test_differential_openrouter_request.py
+++ b/tests/test_litellm/translation/test_differential_openrouter_request.py
@@ -1,0 +1,335 @@
+"""Differential parity for the openrouter request path (httpx dedicated
+elif, main.py:3354; transform LIVE; no model prefix).
+
+Two-sided: every served row is byte-identical (normalized JSON) between v1
+in-process at HEAD (get_optional_params + OpenrouterConfig.transform_request,
+the _own_module_corpus invoker) and v2; every fallback row asserts BOTH the
+typed v2 error and v1's own behavior (serve, rewrite, or raise — asserted
+in-process). Dossier-drift pins recorded in wave2b-alpha-port.md: openrouter
+is NOT in openai_compatible_providers, so top_k (and transforms/models/route)
+ride the TOP-LEVEL passthrough — researcher-4 read the map's extra_body
+packing, which is DEAD at runtime (those kwargs never reach
+non_default_params); top_k is therefore SERVED verbatim, wire-proven below.
+"""
+
+import copy
+import json
+
+import pytest
+
+from litellm.exceptions import UnsupportedParamsError
+
+from litellm.translation.dispatch import NEVER_PORT
+from litellm.translation.engine import pipeline
+from litellm.translation.engine.pipeline import translate_chat_request
+
+from ._own_module_corpus import capture_v1_wire_body, run_v1_request_transform
+from .conftest import build_real_deps
+
+MODEL = "openai/gpt-4o"  # not reasoning-capable on the openrouter map
+REASONER = "anthropic/claude-3.7-sonnet"  # openrouter/{m} supports_reasoning
+_USER = [{"role": "user", "content": "Hello, world"}]
+
+WEATHER_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get weather",
+        "parameters": {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+        },
+    },
+}
+
+CASES: dict[str, dict] = {
+    "text": {"model": MODEL, "messages": _USER},
+    "system_and_sampling": {
+        "model": MODEL,
+        "max_tokens": 64,
+        "temperature": 0.5,
+        "top_p": 0.9,
+        "messages": [
+            {"role": "system", "content": "You are helpful"},
+            {"role": "user", "content": "Hi"},
+        ],
+    },
+    "stream_true": {"model": MODEL, "stream": True, "messages": _USER},
+    "stop_list": {"model": MODEL, "stop": ["END", "STOP"], "messages": _USER},
+    # mct passes VERBATIM (no rename arm on the openrouter chain)
+    "max_completion_tokens_verbatim": {
+        "model": MODEL,
+        "max_completion_tokens": 128,
+        "messages": _USER,
+    },
+    "temperature_int_stays_int": {"model": MODEL, "temperature": 1, "messages": _USER},
+    # the drift pin: top_k rides the TOP-LEVEL passthrough (openrouter is
+    # not a compat provider), so v2 serves it as a delta
+    "top_k_top_level": {"model": MODEL, "top_k": 5, "messages": _USER},
+    "tools_auto": {
+        "model": MODEL,
+        "tools": [WEATHER_TOOL],
+        "tool_choice": "auto",
+        "messages": [{"role": "user", "content": "Weather in Paris?"}],
+    },
+    "tool_choice_specific": {
+        "model": MODEL,
+        "tools": [WEATHER_TOOL],
+        "tool_choice": {"type": "function", "function": {"name": "get_weather"}},
+        "messages": [{"role": "user", "content": "Weather in Paris?"}],
+    },
+    "tool_call_compact_roundtrip": {
+        "model": MODEL,
+        "tools": [WEATHER_TOOL],
+        "messages": [
+            {"role": "user", "content": "w?"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": '{"city":"Paris"}',
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "ok"},
+        ],
+    },
+    "parallel_tool_calls_false": {
+        "model": MODEL,
+        "tools": [WEATHER_TOOL],
+        "parallel_tool_calls": False,
+        "messages": [{"role": "user", "content": "Weather in Paris and Rome?"}],
+    },
+    "response_format_json_object": {
+        "model": MODEL,
+        "response_format": {"type": "json_object"},
+        "messages": _USER,
+    },
+    "response_format_json_schema_strict": {
+        "model": MODEL,
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {"name": "a", "schema": {"type": "object"}, "strict": True},
+        },
+        "messages": _USER,
+    },
+    # reasoning_effort SERVED verbatim on dual-key reasoning-capable models
+    "reasoning_effort_on_reasoner": {
+        "model": REASONER,
+        "reasoning_effort": "high",
+        "messages": _USER,
+    },
+    # cache_control on a NON-cache-capable model: v1's base recursive strip
+    # == the IR's silent drop, byte-identical (block + message level)
+    "cache_control_stripped_on_non_cache_model": {
+        "model": MODEL,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "a",
+                        "cache_control": {"type": "ephemeral"},
+                    },
+                    {"type": "text", "text": "b"},
+                ],
+                "cache_control": {"type": "ephemeral"},
+            }
+        ],
+    },
+}
+
+# name -> (case, v2 reason fragment); generator emits FALLBACK (v1 serves it)
+EXPECTED_FALLBACKS: dict[str, tuple[dict, str]] = {
+    "thinking_on_reasoner": (
+        {
+            "model": REASONER,
+            "thinking": {"type": "enabled", "budget_tokens": 1024},
+            "messages": _USER,
+        },
+        "VERBATIM",
+    ),
+    "cache_control_on_claude": (
+        {
+            "model": REASONER,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "plain",
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+        },
+        "cache-capable",
+    ),
+    "user": ({"model": MODEL, "user": "u1", "messages": _USER}, "user"),
+    "stream_false": ({"model": MODEL, "stream": False, "messages": _USER}, "stream"),
+    # openrouter-native routing params ride the top-level passthrough in v1;
+    # inbound unknowns in v2
+    "transforms": (
+        {"model": MODEL, "transforms": ["middle-out"], "messages": _USER},
+        "transforms",
+    ),
+    "route": ({"model": MODEL, "route": "fallback", "messages": _USER}, "route"),
+}
+
+# name -> (case, v2 reason fragment); generator emits FALLBACK (v1 raises UPE)
+V1_RAISES: dict[str, tuple[dict, str]] = {
+    "reasoning_effort_on_non_reasoning_model": (
+        {"model": MODEL, "reasoning_effort": "high", "messages": _USER},
+        "reasoning_effort",
+    ),
+    "thinking_on_non_reasoning_model": (
+        {"model": MODEL, "thinking": {"type": "enabled"}, "messages": _USER},
+        "thinking",
+    ),
+}
+
+
+def _v2(case: dict):
+    return translate_chat_request(copy.deepcopy(case), "openrouter", build_real_deps())
+
+
+def _norm(body: dict) -> str:
+    return json.dumps(body, sort_keys=True, default=str)
+
+
+@pytest.mark.parametrize("name", sorted(CASES))
+def test_v2_request_matches_v1(name: str) -> None:
+    case = CASES[name]
+    result = _v2(case)
+    assert result.is_ok(), result.error.summary
+    assert _norm(result.ok) == _norm(run_v1_request_transform("openrouter", case))
+
+
+@pytest.mark.parametrize("name", sorted(EXPECTED_FALLBACKS))
+def test_expected_fallbacks_are_typed(name: str) -> None:
+    case, reason = EXPECTED_FALLBACKS[name]
+    result = _v2(case)
+    assert result.is_error(), f"{name} unexpectedly served"
+    assert reason in result.error.summary, result.error.summary
+
+
+@pytest.mark.parametrize("name", sorted(V1_RAISES))
+def test_v1_raise_rows_are_two_sided(name: str) -> None:
+    case, reason = V1_RAISES[name]
+    result = _v2(case)
+    assert result.is_error(), f"{name} unexpectedly served"
+    assert reason in result.error.summary, result.error.summary
+    with pytest.raises(UnsupportedParamsError):
+        run_v1_request_transform("openrouter", case)
+
+
+def test_usage_include_is_injected_on_every_body() -> None:
+    """The always-on delta: v1 injects usage:{include:true} into EVERY body
+    (its 'if "usage" not in response' arm is unreachable for v2 shapes)."""
+    for name in ("text", "stream_true", "tools_auto"):
+        result = _v2(CASES[name])
+        assert result.is_ok()
+        assert result.ok["usage"] == {"include": True}, name
+
+
+def test_top_k_wire_proven_top_level() -> None:
+    """openrouter is NOT in openai_compatible_providers: top_k rides the
+    top-level passthrough (never extra_body) and reaches the wire verbatim —
+    pinned at the transform seam AND the wire via the full completion()
+    stack against a mock transport (the wave-2b wire-prove rule)."""
+    v1 = run_v1_request_transform("openrouter", CASES["top_k_top_level"])
+    assert v1["top_k"] == 5
+    wire = capture_v1_wire_body("openrouter/openai/gpt-4o", top_k=5)
+    assert wire["top_k"] == 5
+    assert "extra_body" not in wire
+    assert wire["usage"] == {"include": True}
+
+
+def test_thinking_on_reasoner_v1_serves_verbatim() -> None:
+    case, _ = EXPECTED_FALLBACKS["thinking_on_reasoner"]
+    v1 = run_v1_request_transform("openrouter", case)
+    assert v1["thinking"] == {"type": "enabled", "budget_tokens": 1024}
+
+
+def test_cache_control_move_v1_serves_its_rewrite() -> None:
+    """Cache-capable models: v1 moves the message-level marker into the last
+    content block (string content becomes a one-block list)."""
+    case, _ = EXPECTED_FALLBACKS["cache_control_on_claude"]
+    v1 = run_v1_request_transform("openrouter", case)
+    assert v1["messages"][0]["content"] == [
+        {"type": "text", "text": "plain", "cache_control": {"type": "ephemeral"}}
+    ]
+    assert "cache_control" not in v1["messages"][0]
+
+
+def test_user_v1_drops_it() -> None:
+    case, _ = EXPECTED_FALLBACKS["user"]
+    assert "user" not in run_v1_request_transform("openrouter", case)
+
+
+def test_transforms_route_v1_serves_top_level() -> None:
+    for name in ("transforms", "route"):
+        case, key = EXPECTED_FALLBACKS[name]
+        v1 = run_v1_request_transform("openrouter", case)
+        assert key in v1, name
+
+
+def test_supported_list_mirror_over_model_map() -> None:
+    """The hand-copied gate must track v1's get_supported_openai_params at
+    HEAD for every openrouter chat map row: base keys row-for-row, and
+    thinking/reasoning_effort exactly on the DUAL-key reasoning-capable
+    models (incl. the openrouter/-prefixed ids v1's prefix-strip makes
+    UNREACHABLE in the map — they answer False)."""
+    import litellm
+
+    from litellm.translation.providers.openrouter.params import (
+        _OPENROUTER_LIST,
+        supports_openrouter_reasoning,
+    )
+
+    from ._own_module_corpus import provider_config
+
+    deps = build_real_deps()
+    mirror_keys = (
+        "max_tokens",
+        "max_completion_tokens",
+        "temperature",
+        "top_p",
+        "stream",
+        "stop",
+        "tools",
+        "tool_choice",
+        "parallel_tool_calls",
+        "response_format",
+    )
+    assert _OPENROUTER_LIST <= set(mirror_keys) | {"top_k", "reasoning_effort"}
+    models = [MODEL, REASONER, "openrouter/auto", "openrouter/free"] + sorted(
+        key.split("/", 1)[1]
+        for key, info in litellm.model_cost.items()
+        if key.startswith("openrouter/")
+        and isinstance(info, dict)
+        and info.get("mode") == "chat"
+    )
+    assert len(models) > 50
+    for model in models:
+        supported = set(
+            provider_config("openrouter", model).get_supported_openai_params(model)
+        )
+        for key in mirror_keys:
+            assert (key in _OPENROUTER_LIST) == (key in supported), (model, key)
+        capable = supports_openrouter_reasoning(model, deps)
+        assert capable == ("reasoning_effort" in supported), model
+        assert capable == ("thinking" in supported), model
+
+
+def test_registration_facts() -> None:
+    assert "openrouter" in pipeline._SERIALIZERS
+    assert "openrouter" in pipeline._RESPONSE_PARSERS
+    assert "openrouter" in pipeline._RAW_GUARDS
+    assert pipeline.response_dialect("openrouter") == "openai"
+    assert "openrouter" not in NEVER_PORT

--- a/tests/test_litellm/translation/test_differential_openrouter_request.py
+++ b/tests/test_litellm/translation/test_differential_openrouter_request.py
@@ -327,6 +327,44 @@ def test_supported_list_mirror_over_model_map() -> None:
         assert capable == ("thinking" in supported), model
 
 
+def test_cache_control_substrings_mirror_v1_enum() -> None:
+    """critic-wave2b-alpha MAJOR-2: CACHE_CONTROL_MODEL_SUBSTRINGS hand-copies
+    v1's CacheControlSupportedModels enum, and drift here is byte-DIVERGENT
+    served traffic, not a safe fallback — if v1's enum grows a substring, v1
+    keeps cache_control and moves message-level markers while v2 keeps serving
+    the recursive-strip body for that model. This mirror makes the drift a
+    test failure instead of corpus luck (the grok-M4 registry-fact pattern
+    every other hand-copied table on this branch already follows)."""
+    from litellm.llms.openrouter.chat.transformation import (
+        CacheControlSupportedModels,
+    )
+
+    from litellm.translation.providers.openrouter.params import (
+        CACHE_CONTROL_MODEL_SUBSTRINGS,
+        supports_cache_control_in_content,
+    )
+
+    from ._own_module_corpus import provider_config
+
+    assert set(CACHE_CONTROL_MODEL_SUBSTRINGS) == {
+        member.value.lower() for member in CacheControlSupportedModels
+    }
+    # the lower-casing fact the table mirrors: v1 lowercases the MODEL and
+    # substring-matches the enum values verbatim, so those values must already
+    # be lower-case for v2's lowered match to be the same predicate
+    assert all(
+        member.value == member.value.lower() for member in CacheControlSupportedModels
+    )
+    # live predicate check against v1's own gate, per enum member (mixed-case
+    # model ids exercise the lowering on both sides)
+    config = provider_config("openrouter", MODEL)
+    for member in CacheControlSupportedModels:
+        for probe in (f"vendor/{member.value.upper()}-x", MODEL, "mistral-large"):
+            assert supports_cache_control_in_content(
+                probe
+            ) == config._supports_cache_control_in_content(probe), (member, probe)
+
+
 def test_registration_facts() -> None:
     assert "openrouter" in pipeline._SERIALIZERS
     assert "openrouter" in pipeline._RESPONSE_PARSERS

--- a/tests/test_litellm/translation/test_differential_openrouter_response.py
+++ b/tests/test_litellm/translation/test_differential_openrouter_response.py
@@ -15,6 +15,7 @@ litellm/translation/CLAUDE.md records the obligation).
 import copy
 import json
 
+import pydantic
 import pytest
 
 from litellm.types.utils import ModelResponse
@@ -22,7 +23,11 @@ from litellm.types.utils import ModelResponse
 from litellm.translation.inbound.openai_chat import parse_request
 from litellm.translation.inbound.openai_chat.response import serialize_response
 from litellm.translation.providers.openrouter import parse_response
-from litellm.translation_seam import build_translation_deps, to_model_response
+from litellm.translation_seam import (
+    UsageStyle,
+    build_translation_deps,
+    to_model_response,
+)
 
 from ._own_module_corpus import run_v1_response_transform
 
@@ -132,13 +137,19 @@ def _v1_model_response(raw: dict) -> ModelResponse:
     return run_v1_response_transform("openrouter", raw, "openai/gpt-4o")
 
 
-def _v2_model_response(raw: dict) -> dict:
+def _v2_with_style(raw: dict, style: UsageStyle) -> dict:
     parsed = parse_request(copy.deepcopy(_REQUEST))
     assert parsed.is_ok(), parsed.error.summary
     response = parse_response(copy.deepcopy(raw), parsed.ok)
     assert response.is_ok(), response.error.summary
     body = serialize_response(response.ok, build_translation_deps(), "openai")
-    return to_model_response(body, ModelResponse(), usage_style="openai").model_dump()
+    return to_model_response(body, ModelResponse(), usage_style=style).model_dump()
+
+
+def _v2_model_response(raw: dict) -> dict:
+    # openrouter rides the cdr arm — the truth is
+    # pipeline.OWN_MODULE_RESPONSE_STYLES["openrouter"], divergence-pinned below
+    return _v2_with_style(raw, "openai")
 
 
 def _norm(payload: dict) -> str:
@@ -176,3 +187,28 @@ def test_v1_cost_hidden_param_is_the_fork_obligation(frozen_ambient) -> None:
     assert _COST_HEADER not in v1_plain._hidden_params.get("additional_headers", {})
     v2 = _v2_model_response(_RESPONSES["usage_cost"])
     assert v2["usage"]["cost"] == 0.0015
+def test_wrong_construction_arm_diverges_and_the_table_pins_it(
+    frozen_ambient,
+) -> None:
+    """verifier-wave2b-final F1: the "openai"-arm OWN_MODULE_RESPONSE_STYLES
+    values were enforced by NOTHING — a wrong-arm value flip survived the
+    whole suite. The watsonx/groq wrong-arm template INVERTED for a
+    cdr-parser member (the v2 parser already cdr-normalizes choices, so the
+    openai_like members' index-5 discriminator dies before the seam): a
+    FLOAT wire ``created`` rides the normalized body; the correct cdr
+    ("openai") arm coerces it via _safe_convert_created_field and serves
+    exactly like v1, while the wrong "openai_like" arm
+    (ModelResponse(**json)) raises ValidationError on traffic v1 serves —
+    if the arms stop diverging here, the raises assert fails: re-decide
+    before relying on the pin."""
+    from litellm.translation.engine.pipeline import OWN_MODULE_RESPONSE_STYLES
+
+    assert OWN_MODULE_RESPONSE_STYLES["openrouter"] == "openai"
+    raw = copy.deepcopy(_RESPONSES["text"])
+    raw["created"] = raw["created"] + 0.5
+    v1 = _v1_model_response(raw).model_dump()
+    correct = _v2_with_style(raw, OWN_MODULE_RESPONSE_STYLES["openrouter"])
+    assert _norm(correct) == _norm(v1)
+    assert correct["created"] == _RESPONSES["text"]["created"]
+    with pytest.raises(pydantic.ValidationError):
+        _v2_with_style(raw, "openai_like")

--- a/tests/test_litellm/translation/test_differential_openrouter_response.py
+++ b/tests/test_litellm/translation/test_differential_openrouter_response.py
@@ -1,0 +1,178 @@
+"""Differential parity for the openrouter response path (httpx, NO prefix).
+
+``OpenrouterConfig.transform_response`` is super() — the base GPT transform,
+LIVE on the dedicated elif, over a FRESH ``ModelResponse`` (model=None; bare
+wire model, the xai R4 / deepseek pattern) — plus the ``usage.cost`` ->
+``_hidden_params`` post-step. These rows run that exact v1 chain against
+v2's shared openai parser: byte-identical dumps (``usage.cost`` and
+``cost_details`` ride the unknown-usage-key mirror through BOTH sides), no
+``openrouter/`` prefix, and the hidden-params cost header pinned as the
+FORK OBLIGATION (the dump cannot see ``_hidden_params``; the future
+completion() fork must rebuild the header from the v2 body's usage.cost —
+litellm/translation/CLAUDE.md records the obligation).
+"""
+
+import copy
+import json
+
+import pytest
+
+from litellm.types.utils import ModelResponse
+
+from litellm.translation.inbound.openai_chat import parse_request
+from litellm.translation.inbound.openai_chat.response import serialize_response
+from litellm.translation.providers.openrouter import parse_response
+from litellm.translation_seam import build_translation_deps, to_model_response
+
+from ._own_module_corpus import run_v1_response_transform
+
+_REQUEST = {
+    "model": "openai/gpt-4o",
+    "messages": [{"role": "user", "content": "hi"}],
+    "tools": [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ],
+}
+
+_RESPONSES = {
+    "text": {
+        "id": "gen-or-1",
+        "object": "chat.completion",
+        "created": 1718000000,
+        "model": "openai/gpt-4o",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "hello"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5},
+    },
+    "tool_calls": {
+        "id": "gen-or-2",
+        "object": "chat.completion",
+        "created": 1718000000,
+        "model": "openai/gpt-4o",
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "arguments": '{"city":"Paris"}',
+                            },
+                        }
+                    ],
+                },
+                "finish_reason": "tool_calls",
+            }
+        ],
+        "usage": {"prompt_tokens": 9, "completion_tokens": 5, "total_tokens": 14},
+    },
+    # openrouter reasoning responses carry message.reasoning (NOT
+    # reasoning_content) — the unknown-message-key ride, untouched by v1
+    "message_reasoning": {
+        "id": "gen-or-3",
+        "object": "chat.completion",
+        "created": 1718000000,
+        "model": "anthropic/claude-3.7-sonnet",
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": "answer",
+                    "reasoning": "step by step",
+                },
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 11, "completion_tokens": 9, "total_tokens": 20},
+    },
+    # the usage.include=true echo: cost + cost_details in usage
+    "usage_cost": {
+        "id": "gen-or-4",
+        "object": "chat.completion",
+        "created": 1718000000,
+        "model": "openai/gpt-4o",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "ok"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 3,
+            "completion_tokens": 2,
+            "total_tokens": 5,
+            "cost": 0.0015,
+            "cost_details": {"upstream_inference_cost": None},
+        },
+    },
+}
+
+_COST_HEADER = "llm_provider-x-litellm-response-cost"
+
+
+def _v1_model_response(raw: dict) -> ModelResponse:
+    return run_v1_response_transform("openrouter", raw, "openai/gpt-4o")
+
+
+def _v2_model_response(raw: dict) -> dict:
+    parsed = parse_request(copy.deepcopy(_REQUEST))
+    assert parsed.is_ok(), parsed.error.summary
+    response = parse_response(copy.deepcopy(raw), parsed.ok)
+    assert response.is_ok(), response.error.summary
+    body = serialize_response(response.ok, build_translation_deps(), "openai")
+    return to_model_response(body, ModelResponse(), usage_style="openai").model_dump()
+
+
+def _norm(payload: dict) -> str:
+    return json.dumps(payload, sort_keys=True, default=str)
+
+
+@pytest.mark.parametrize("name", sorted(_RESPONSES))
+def test_v2_response_matches_v1(name: str, frozen_ambient) -> None:
+    raw = _RESPONSES[name]
+    assert _norm(_v2_model_response(raw)) == _norm(_v1_model_response(raw).model_dump())
+
+
+@pytest.mark.parametrize("name", sorted(_RESPONSES))
+def test_no_openrouter_prefix_on_the_response_model(name: str, frozen_ambient) -> None:
+    raw = _RESPONSES[name]
+    v1 = _v1_model_response(raw).model_dump()
+    v2 = _v2_model_response(raw)
+    assert v1["model"] == raw["model"]
+    assert v2["model"] == raw["model"]
+    assert not v2["model"].startswith("openrouter/")
+
+
+def test_v1_cost_hidden_param_is_the_fork_obligation(frozen_ambient) -> None:
+    """The one envelope post-step: v1 copies usage.cost into
+    _hidden_params['additional_headers'][cost-header] as a FLOAT. The dump
+    rows above cannot see it; this pins (a) v1 sets it, (b) v1 does NOT set
+    it when the wire carries no cost, and (c) the v2 dump retains usage.cost
+    byte-identically so the future fork can rebuild the exact header
+    (CLAUDE.md HARD OBLIGATION)."""
+    v1 = _v1_model_response(_RESPONSES["usage_cost"])
+    headers = v1._hidden_params.get("additional_headers", {})
+    assert headers.get(_COST_HEADER) == 0.0015
+    assert isinstance(headers.get(_COST_HEADER), float)
+    v1_plain = _v1_model_response(_RESPONSES["text"])
+    assert _COST_HEADER not in v1_plain._hidden_params.get("additional_headers", {})
+    v2 = _v2_model_response(_RESPONSES["usage_cost"])
+    assert v2["usage"]["cost"] == 0.0015

--- a/tests/test_litellm/translation/test_differential_openrouter_stream.py
+++ b/tests/test_litellm/translation/test_differential_openrouter_stream.py
@@ -20,7 +20,7 @@ import json
 
 import pytest
 
-from litellm.exceptions import BadRequestError, MidStreamFallbackError
+from litellm.exceptions import APIError, BadRequestError, MidStreamFallbackError
 from litellm.llms.openrouter.chat.transformation import (
     OpenRouterChatCompletionStreamingHandler,
 )
@@ -280,6 +280,84 @@ def test_loud_chunk_shapes_error_on_both_sides(name: str, frozen_ambient) -> Non
         assert name == "multiple_choices"
         served = _v1_chunks([event, _chunk({}, finish="stop")])
         assert len(served) >= 1  # v1 serves the multi-choice chunk
+
+
+def test_reasoning_on_finish_chunk_is_loud_where_v1_interleaves(
+    frozen_ambient,
+) -> None:
+    """verifier-wave2b-alpha F1: v1's wrapper splits a reasoning-bearing
+    finish chunk into a separate reasoning delta chunk + a bare finish chunk
+    (4 emitted chunks); the v2 fold cannot reproduce the interleave, so
+    _delta_bears_content now counts reasoning/refusal and the shape takes the
+    existing LOUD finish-chunk fallback — before the fix v2 served 3 chunks
+    with the reasoning text silently GONE. Streaming flag-on obligation: the
+    seam falls back to v1 on this typed error like every other stream error."""
+    events = [
+        _chunk({"role": "assistant", "content": ""}),
+        _chunk({"content": "answer"}),
+        _chunk({"reasoning": "tail-think"}, finish="stop"),
+    ]
+    v1 = _v1_chunks(events)
+    assert len(v1) == len(events) + 1  # the interleaved reasoning chunk
+    interleaved = v1[2]["choices"][0]["delta"]
+    assert interleaved["reasoning_content"] == "tail-think"
+    assert v1[3]["choices"][0]["finish_reason"] == "stop"
+    result = parse_event(copy.deepcopy(events[-1]))
+    assert result.is_error(), "reasoning-on-finish must be loud, never dropped"
+    assert "finish chunk with a non-empty delta" in result.error.summary
+    folded = fold_lines(
+        [f"data: {json.dumps(e)}" for e in events] + ["data: [DONE]"],
+        parse_line,
+        initial_state(MODEL, dialect="xai"),
+    )
+    assert folded.is_error()
+
+
+def test_empty_string_reasoning_chunk_swallow_is_a_named_obligation(
+    frozen_ambient,
+) -> None:
+    """verifier-wave2b-alpha F2 (NOTE), pinned as a NAMED divergence on a
+    zero-data shape: v1 serves a mid-stream ``{"reasoning": ""}`` delta as a
+    chunk with reasoning_content="" (4 chunks); v2's fold swallows the empty
+    delta (3 chunks, byte-identical otherwise). No bytes are lost — the
+    falsy-swallow family the wrapper itself applies to empty deltas — but the
+    chunk-shape divergence is recorded here so flag-on streaming inherits it
+    deliberately, not by accident."""
+    events = [
+        _chunk({"role": "assistant", "content": ""}),
+        _chunk({"reasoning": ""}),
+        _chunk({"content": "hi"}),
+        _chunk({}, finish="stop"),
+    ]
+    v1 = _v1_chunks(events)
+    v2 = _v2_chunks(events)
+    assert len(v1) == len(v2) + 1
+    swallowed = v1[1]["choices"][0]["delta"]
+    assert swallowed["reasoning_content"] == ""  # zero bytes of data
+    assert _norm([v1[0], *v1[2:]]) == _norm(v2)
+
+
+def test_non_string_reasoning_is_loud_where_v1_crashes_at_stream_end(
+    frozen_ambient,
+) -> None:
+    """verifier-wave2b-alpha F3: v1 serves the non-string reasoning value
+    verbatim (pydantic serializer warning) and then RAISES APIError at stream
+    end (TypeError joining non-str in the chunk builder); v2 used to coerce
+    to None and serve a CLEAN stream — a letter violation of 'never serve
+    what v1 raises on'. The normalizer now errors loudly on non-string,
+    non-None reasoning values (explicit null stays served: v1 serves it and
+    never crashes, replay-pinned by the canonical rows)."""
+    events = [
+        _chunk({"role": "assistant", "content": ""}),
+        _chunk({"reasoning": 42}),
+        _chunk({"content": "hi"}),
+        _chunk({}, finish="stop"),
+    ]
+    with pytest.raises(APIError):
+        _v1_chunks(events)
+    result = parse_event(copy.deepcopy(events[1]))
+    assert result.is_error(), "non-string reasoning must be loud, never a clean stream"
+    assert "non-string stream delta 'reasoning'" in result.error.summary
 
 
 def test_iterator_is_the_openrouter_handler() -> None:

--- a/tests/test_litellm/translation/test_differential_openrouter_stream.py
+++ b/tests/test_litellm/translation/test_differential_openrouter_stream.py
@@ -1,0 +1,291 @@
+"""Differential parity for openrouter streaming, pinned at the SSE line seam.
+
+v1 side: raw ``data:`` lines through ``OpenRouterChatCompletionStreamingHandler``
+(its OWN handler: key-presence error-chunk RAISE, strict id/created/model/
+choices envelope via KeyError -> OpenRouterException 400, the UNCONDITIONAL
+``delta["reasoning_content"] = delta.get("reasoning")`` assignment — the
+original ``reasoning`` key kept, a native ``reasoning_content`` CLOBBERED to
+None, and the ``choice["delta"]`` subscript) into
+``CustomStreamWrapper("openrouter")``. v2 side: ``fold_lines`` with the
+openrouter parser (the "unconditional" ReasoningMode arm added with this
+consumer + the missing-delta pre-step) and the shared ``xai`` chunk dialect.
+
+openrouter is NOT part of the base-handler PINNED DIVERGENCE: its v1 handler
+RAISES on error chunks, and the policy row mirrors that raise (the cometapi
+shape).
+"""
+
+import copy
+import json
+
+import pytest
+
+from litellm.exceptions import BadRequestError, MidStreamFallbackError
+from litellm.llms.openrouter.chat.transformation import (
+    OpenRouterChatCompletionStreamingHandler,
+)
+
+from litellm.translation.engine.stream import fold_events, fold_lines
+from litellm.translation.inbound.openai_chat.stream import initial_state
+from litellm.translation.providers.openrouter import parse_event, parse_line
+from litellm.translation_seam import to_model_response_stream
+
+from ._own_module_corpus import provider_config, replay_v1_sse_lines
+
+MODEL = "openai/gpt-4o"
+WIRE_MODEL = "openai/gpt-4o"
+
+
+def _chunk(delta, finish=None, usage=None, choices=None):
+    payload = {
+        "id": "or-chunk-1",
+        "object": "chat.completion.chunk",
+        "created": 1718000000,
+        "model": WIRE_MODEL,
+        "choices": [
+            {"index": 0, "delta": delta, "logprobs": None, "finish_reason": finish}
+        ],
+        "usage": usage,
+    }
+    if choices is not None:
+        payload["choices"] = choices
+    return payload
+
+
+STREAMS = {
+    "text": [
+        _chunk({"role": "assistant", "content": ""}),
+        _chunk({"content": "Hello"}),
+        _chunk({"content": " world"}),
+        _chunk({}, finish="stop"),
+    ],
+    "tools": [
+        _chunk({"role": "assistant", "content": None}),
+        _chunk(
+            {
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "get_weather", "arguments": ""},
+                    }
+                ]
+            }
+        ),
+        _chunk(
+            {
+                "tool_calls": [
+                    {"index": 0, "function": {"arguments": '{"city":"Paris"}'}}
+                ]
+            }
+        ),
+        _chunk({}, finish="tool_calls"),
+    ],
+    # the unconditional assignment: delta.reasoning -> reasoning_content with
+    # the original key KEPT (v1 assigns without popping)
+    "reasoning_both_keys": [
+        _chunk({"role": "assistant", "content": ""}),
+        _chunk({"reasoning": "thinking..."}),
+        _chunk({"content": "answer"}),
+        _chunk({}, finish="stop"),
+    ],
+    # a NATIVE reasoning_content delta is CLOBBERED to None by v1's
+    # assignment -> the emptied delta chunk is swallowed by the wrapper on
+    # both sides
+    "native_reasoning_content_clobbered": [
+        _chunk({"role": "assistant", "content": ""}),
+        _chunk({"reasoning_content": "native"}),
+        _chunk({"content": "answer"}),
+        _chunk({}, finish="stop"),
+    ],
+    "empty_keepalive_swallowed": [
+        _chunk({"role": "assistant", "content": ""}),
+        _chunk({}),
+        _chunk({"content": "hi"}),
+        _chunk({}, finish="stop"),
+    ],
+}
+
+USAGE_STREAM = [
+    _chunk({"role": "assistant", "content": ""}),
+    _chunk({"content": "Hi"}),
+    _chunk({}, finish="stop"),
+    _chunk(
+        {},
+        choices=[],
+        usage={
+            "prompt_tokens": 7,
+            "completion_tokens": 2,
+            "total_tokens": 9,
+            "cost": 0.0002,
+        },
+    ),
+]
+
+
+def _v1_chunks(events, stream_options=None):
+    return replay_v1_sse_lines("openrouter", events, MODEL, stream_options)
+
+
+def _v2_chunks(events: list) -> list:
+    lines = [f"data: {json.dumps(event)}" for event in copy.deepcopy(events)]
+    lines.append("data: [DONE]")
+    folded = fold_lines(lines, parse_line, initial_state(MODEL, dialect="xai"))
+    assert folded.is_ok(), folded.error.summary
+    return [
+        to_model_response_stream(chunk, "chatcmpl-AMBIENT").model_dump()
+        for chunk in folded.ok
+    ]
+
+
+def _norm(chunks: list) -> str:
+    return json.dumps(chunks, sort_keys=True, default=str)
+
+
+@pytest.mark.parametrize("name", sorted(STREAMS))
+def test_v2_stream_matches_v1(name: str, frozen_ambient) -> None:
+    events = STREAMS[name]
+    assert _norm(_v2_chunks(events)) == _norm(_v1_chunks(events))
+
+
+def test_reasoning_delta_keeps_both_keys(frozen_ambient) -> None:
+    v2 = _v2_chunks(STREAMS["reasoning_both_keys"])
+    delta = v2[1]["choices"][0]["delta"]
+    assert delta["reasoning"] == "thinking..."
+    assert delta["reasoning_content"] == "thinking..."
+
+
+def test_native_reasoning_content_chunk_is_swallowed(frozen_ambient) -> None:
+    """The clobber pin: v1 turns a native reasoning_content delta into an
+    empty delta (reasoning_content = .get('reasoning') = None) and the
+    wrapper swallows it — both sides emit one fewer chunk and NO 'native'
+    text anywhere."""
+    events = STREAMS["native_reasoning_content_clobbered"]
+    v1 = _v1_chunks(events)
+    v2 = _v2_chunks(events)
+    assert len(v1) == len(v2) == len(events) - 1
+    assert "native" not in _norm(v1)
+    assert "native" not in _norm(v2)
+
+
+def test_usage_tail_pins_the_seam_contract(frozen_ambient) -> None:
+    v1 = _v1_chunks(USAGE_STREAM, stream_options={"include_usage": True})
+    v2 = _v2_chunks(USAGE_STREAM)
+    assert len(v1) == len(v2)
+    assert _norm(v2[:-1]) == _norm(v1[: len(v2) - 1])
+    assert v2[-1]["choices"] == []
+    for key in ("prompt_tokens", "completion_tokens", "total_tokens"):
+        assert v1[-1]["usage"][key] == v2[-1]["usage"][key], key
+
+
+def test_usage_tail_swallowed_without_stream_options(frozen_ambient) -> None:
+    v1 = _v1_chunks(USAGE_STREAM, None)
+    v2 = _v2_chunks(USAGE_STREAM)
+    assert len(v1) == len(v2) - 1
+    assert _norm(v1) == _norm(v2[:-1])
+
+
+def test_v2_line_and_event_folds_agree(frozen_ambient) -> None:
+    events = STREAMS["reasoning_both_keys"]
+    folded = fold_events(
+        copy.deepcopy(events), parse_event, initial_state(MODEL, dialect="xai")
+    )
+    assert folded.is_ok(), folded.error.summary
+    via_events = [
+        to_model_response_stream(chunk, "chatcmpl-AMBIENT").model_dump()
+        for chunk in folded.ok
+    ]
+    assert _norm(via_events) == _norm(_v2_chunks(events))
+
+
+_LOUD_CHUNKS = {
+    "error_chunk": (
+        {"error": {"message": "boom", "code": 500}},
+        "provider stream error",
+    ),
+    "missing_id": (
+        {
+            "object": "chat.completion.chunk",
+            "created": 1718000000,
+            "model": WIRE_MODEL,
+            "choices": [{"index": 0, "delta": {"content": "x"}, "finish_reason": None}],
+        },
+        "KeyError",
+    ),
+    "missing_created": (
+        {
+            "id": "or-chunk-1",
+            "object": "chat.completion.chunk",
+            "model": WIRE_MODEL,
+            "choices": [{"index": 0, "delta": {"content": "x"}, "finish_reason": None}],
+        },
+        "KeyError",
+    ),
+    "missing_model": (
+        {
+            "id": "or-chunk-1",
+            "object": "chat.completion.chunk",
+            "created": 1718000000,
+            "choices": [{"index": 0, "delta": {"content": "x"}, "finish_reason": None}],
+        },
+        "KeyError",
+    ),
+    "missing_choices": (
+        {
+            "id": "or-chunk-1",
+            "object": "chat.completion.chunk",
+            "created": 1718000000,
+            "model": WIRE_MODEL,
+        },
+        "KeyError",
+    ),
+    "missing_delta": (
+        _chunk({}, choices=[{"index": 0, "finish_reason": None}]),
+        "missing 'delta'",
+    ),
+    "multiple_choices": (
+        _chunk(
+            {},
+            choices=[
+                {"index": 0, "delta": {"content": "a"}, "finish_reason": None},
+                {"index": 1, "delta": {"content": "b"}, "finish_reason": None},
+            ],
+        ),
+        "multiple stream choices",
+    ),
+}
+
+
+@pytest.mark.parametrize("name", sorted(_LOUD_CHUNKS))
+def test_loud_chunk_shapes_error_on_both_sides(name: str, frozen_ambient) -> None:
+    """v1 RAISES out of the iterator on error chunks (MidStreamFallbackError
+    at the wrapper) and on missing envelope keys INCLUDING choices[].delta
+    (KeyError -> OpenRouterException 400 -> BadRequestError); v2 is a loud
+    typed error value, never a served chunk. multiple_choices is the one
+    v1-SERVES shape here (its loop passes both through) — v2's typed
+    'unreachable for v2-sent requests' error is the family convention, and
+    n>1 cannot leave the inbound boundary."""
+    event, reason_fragment = _LOUD_CHUNKS[name]
+    result = parse_event(copy.deepcopy(event))
+    assert result.is_error(), f"{name} unexpectedly parsed"
+    assert reason_fragment in result.error.summary, result.error.summary
+    if name == "error_chunk":
+        with pytest.raises(MidStreamFallbackError):
+            _v1_chunks([event])
+    elif name.startswith("missing_"):
+        with pytest.raises(BadRequestError):
+            _v1_chunks([event])
+    else:
+        assert name == "multiple_choices"
+        served = _v1_chunks([event, _chunk({}, finish="stop")])
+        assert len(served) >= 1  # v1 serves the multi-choice chunk
+
+
+def test_iterator_is_the_openrouter_handler() -> None:
+    """openrouter's stream truth is its OWN handler (NOT the base) — if this
+    canary fails, re-derive the policy row against the new handler."""
+    handler = provider_config("openrouter", MODEL).get_model_response_iterator(
+        streaming_response=iter(()), sync_stream=True
+    )
+    assert type(handler) is OpenRouterChatCompletionStreamingHandler

--- a/tests/test_litellm/translation/test_differential_sagemaker_chat_request.py
+++ b/tests/test_litellm/translation/test_differential_sagemaker_chat_request.py
@@ -1,0 +1,223 @@
+"""Differential parity for the sagemaker_chat request path (wave-2b-beta).
+
+v1 side: ``get_optional_params("sagemaker_chat")`` (the BASE OpenAI GPT
+list — the widest wave-2b surface) + the base ``transform_request`` (no
+overrides). SigV4 signs the assembled body AFTER transform (envelope, the
+bedrock sign-after-body precedent) and the endpoint name doubles as the
+model field. sagemaker_nova shares the main.py branch but carries its own
+config and is deliberately NOT registered (v1 fallback).
+"""
+
+import copy
+import json
+
+import pytest
+
+from litellm.exceptions import UnsupportedParamsError
+from litellm.llms.sagemaker.chat.transformation import SagemakerChatConfig
+from litellm.utils import get_optional_params
+
+from litellm.translation.engine.pipeline import translate_chat_request
+from litellm.translation_seam import build_translation_deps
+
+MODEL = "my-endpoint"
+_U = [{"role": "user", "content": "hi"}]
+
+CASES = {
+    "plain": {"model": MODEL, "messages": _U},
+    "sampling": {
+        "model": MODEL,
+        "messages": _U,
+        "temperature": 0.5,
+        "top_p": 0.9,
+        "max_tokens": 10,
+        "stop": ["x"],
+    },
+    "mct_verbatim_no_rename": {
+        "model": MODEL,
+        "messages": _U,
+        "max_completion_tokens": 50,
+    },
+    "top_k_wire_proven": {"model": MODEL, "messages": _U, "top_k": 7},
+    "stream_true": {"model": MODEL, "messages": _U, "stream": True},
+    "tools": {
+        "model": MODEL,
+        "messages": _U,
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ],
+        "tool_choice": "auto",
+    },
+    "response_format_json_object": {
+        "model": MODEL,
+        "messages": _U,
+        "response_format": {"type": "json_object"},
+    },
+    "parallel_tool_calls": {
+        "model": MODEL,
+        "messages": _U,
+        "tools": [{"type": "function", "function": {"name": "f", "parameters": {}}}],
+        "parallel_tool_calls": True,
+    },
+    "tool_history": {
+        "model": MODEL,
+        "messages": [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "c1",
+                        "type": "function",
+                        "function": {"name": "f", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "c1", "content": "res"},
+        ],
+    },
+}
+
+V1_RAISES = {
+    "thinking": (
+        {"model": MODEL, "messages": _U, "thinking": {"type": "enabled"}},
+        "thinking",
+    ),
+    "reasoning_effort": (
+        {"model": MODEL, "messages": _U, "reasoning_effort": "high"},
+        "reasoning_effort",
+    ),
+    "response_format_on_gpt4_named_endpoint": (
+        {
+            "model": "gpt-4",
+            "messages": _U,
+            "response_format": {"type": "json_object"},
+        },
+        "gpt-4",
+    ),
+}
+
+V1_SERVES_FALLBACKS = {
+    "user_silent_drop": ({"model": MODEL, "messages": _U, "user": "u1"}, "user"),
+    "seed_parse_level": ({"model": MODEL, "messages": _U, "seed": 42}, "seed"),
+    "n_parse_level": ({"model": MODEL, "messages": _U, "n": 2}, "n"),
+    "logit_bias_parse_level": (
+        {"model": MODEL, "messages": _U, "logit_bias": {"1": 1}},
+        "logit_bias",
+    ),
+    "aws_kwarg_rides_v1_body": (
+        # v1 places aws_* kwargs in optional_params and the BODY carries
+        # them (wire-probed); v2 rejects the unknown inbound key
+        {"model": MODEL, "messages": _U, "aws_region_name": "us-east-1"},
+        "aws_region_name",
+    ),
+    "explicit_stream_false": (
+        {"model": MODEL, "messages": _U, "stream": False},
+        "stream",
+    ),
+    "message_name_forwarded": (
+        {"model": MODEL, "messages": [{"role": "user", "content": "hi", "name": "b"}]},
+        "name",
+    ),
+}
+
+
+def run_v1_request_transform(case: dict) -> dict:
+    request = copy.deepcopy(case)
+    model = request.pop("model")
+    messages = request.pop("messages")
+    optional_params = get_optional_params(
+        model=model,
+        custom_llm_provider="sagemaker_chat",
+        messages=copy.deepcopy(messages),
+        stream=request.pop("stream", None),
+        **request,
+    )
+    optional_params.pop("extra_body", None)
+    return SagemakerChatConfig().transform_request(
+        model=model,
+        messages=messages,
+        optional_params=optional_params,
+        litellm_params={},
+        headers={},
+    )
+
+
+def _v2(case: dict):
+    return translate_chat_request(
+        copy.deepcopy(case), "sagemaker_chat", build_translation_deps()
+    )
+
+
+def _norm(body: dict) -> str:
+    return json.dumps(body, sort_keys=True, default=str)
+
+
+@pytest.mark.parametrize("name", sorted(CASES))
+def test_v2_request_matches_v1(name: str) -> None:
+    case = CASES[name]
+    result = _v2(case)
+    assert result.is_ok(), result.error.summary
+    assert _norm(result.ok) == _norm(run_v1_request_transform(case))
+
+
+@pytest.mark.parametrize("name", sorted(V1_RAISES))
+def test_v1_raise_rows_fall_back_typed(name: str) -> None:
+    case, fragment = V1_RAISES[name]
+    result = _v2(case)
+    assert result.is_error(), f"{name} unexpectedly translated: {result.ok!r}"
+    assert fragment in result.error.summary, result.error.summary
+    with pytest.raises(UnsupportedParamsError):
+        run_v1_request_transform(case)
+
+
+@pytest.mark.parametrize("name", sorted(V1_SERVES_FALLBACKS))
+def test_v1_serves_fallback_rows(name: str) -> None:
+    case, fragment = V1_SERVES_FALLBACKS[name]
+    result = _v2(case)
+    assert result.is_error(), f"{name} unexpectedly translated: {result.ok!r}"
+    assert fragment in result.error.summary, result.error.summary
+    run_v1_request_transform(case)
+
+
+def test_mct_passes_verbatim_no_rename() -> None:
+    v1_body = run_v1_request_transform(CASES["mct_verbatim_no_rename"])
+    result = _v2(CASES["mct_verbatim_no_rename"])
+    assert result.is_ok()
+    assert v1_body["max_completion_tokens"] == 50
+    assert result.ok["max_completion_tokens"] == 50
+    assert "max_tokens" not in result.ok
+
+
+def test_top_k_rides_the_wire_top_level() -> None:
+    v1_body = run_v1_request_transform(CASES["top_k_wire_proven"])
+    assert v1_body["top_k"] == 7 and "extra_body" not in v1_body
+    result = _v2(CASES["top_k_wire_proven"])
+    assert result.is_ok() and result.ok["top_k"] == 7
+
+
+def test_aws_kwargs_reach_v1_wire_body() -> None:
+    """The quirk behind the aws fallback row: v1's body literally carries
+    aws_region_name (SigV4 then signs it); v2's parse rejects the unknown
+    key so v1 keeps serving those requests."""
+    v1_body = run_v1_request_transform(
+        V1_SERVES_FALLBACKS["aws_kwarg_rides_v1_body"][0]
+    )
+    assert v1_body["aws_region_name"] == "us-east-1"
+
+
+def test_sagemaker_nova_stays_unregistered() -> None:
+    from litellm.translation.engine import pipeline
+
+    assert "sagemaker_nova" not in pipeline._SERIALIZERS
+    result = translate_chat_request(
+        copy.deepcopy(CASES["plain"]), "sagemaker_nova", build_translation_deps()  # type: ignore[arg-type]
+    )
+    assert result.is_error()

--- a/tests/test_litellm/translation/test_differential_sagemaker_chat_response.py
+++ b/tests/test_litellm/translation/test_differential_sagemaker_chat_response.py
@@ -12,6 +12,7 @@ import json
 import time
 
 import httpx
+import pydantic
 import pytest
 
 from litellm.litellm_core_utils.litellm_logging import Logging
@@ -21,7 +22,11 @@ from litellm.types.utils import ModelResponse
 from litellm.translation.inbound.openai_chat import parse_request
 from litellm.translation.inbound.openai_chat.response import serialize_response
 from litellm.translation.providers.sagemaker_chat import parse_response
-from litellm.translation_seam import build_translation_deps, to_model_response
+from litellm.translation_seam import (
+    UsageStyle,
+    build_translation_deps,
+    to_model_response,
+)
 
 MODEL = "my-endpoint"
 WIRE_MODEL = "tgi"
@@ -125,13 +130,19 @@ def _v1_model_response(raw: dict) -> dict:
     )
 
 
-def _v2_model_response(raw: dict) -> dict:
+def _v2_with_style(raw: dict, style: UsageStyle) -> dict:
     parsed = parse_request(copy.deepcopy(_REQUEST))
     assert parsed.is_ok(), parsed.error.summary
     response = parse_response(copy.deepcopy(raw), parsed.ok)
     assert response.is_ok(), response.error.summary
     body = serialize_response(response.ok, build_translation_deps(), "openai")
-    return to_model_response(body, ModelResponse(), usage_style="openai").model_dump()
+    return to_model_response(body, ModelResponse(), usage_style=style).model_dump()
+
+
+def _v2_model_response(raw: dict) -> dict:
+    # sagemaker_chat rides the cdr arm — the truth is
+    # pipeline.OWN_MODULE_RESPONSE_STYLES["sagemaker_chat"], divergence-pinned below
+    return _v2_with_style(raw, "openai")
 
 
 def _norm(payload: dict) -> str:
@@ -151,3 +162,30 @@ def test_bare_wire_model_no_prefix(name: str, frozen_ambient) -> None:
     assert v1["model"] == WIRE_MODEL
     assert v2["model"] == WIRE_MODEL
     assert not str(v2["model"]).startswith("sagemaker")
+
+
+def test_wrong_construction_arm_diverges_and_the_table_pins_it(
+    frozen_ambient,
+) -> None:
+    """verifier-wave2b-final F1: the "openai"-arm OWN_MODULE_RESPONSE_STYLES
+    values were enforced by NOTHING — a wrong-arm value flip survived the
+    whole suite. The watsonx/groq wrong-arm template INVERTED for a
+    cdr-parser member (the v2 parser already cdr-normalizes choices, so the
+    openai_like members' index-5 discriminator dies before the seam): a
+    FLOAT wire ``created`` rides the normalized body; the correct cdr
+    ("openai") arm coerces it via _safe_convert_created_field and serves
+    exactly like v1, while the wrong "openai_like" arm
+    (ModelResponse(**json)) raises ValidationError on traffic v1 serves —
+    if the arms stop diverging here, the raises assert fails: re-decide
+    before relying on the pin."""
+    from litellm.translation.engine.pipeline import OWN_MODULE_RESPONSE_STYLES
+
+    assert OWN_MODULE_RESPONSE_STYLES["sagemaker_chat"] == "openai"
+    raw = copy.deepcopy(_RESPONSES["text"])
+    raw["created"] = raw["created"] + 0.5
+    v1 = _v1_model_response(raw)
+    correct = _v2_with_style(raw, OWN_MODULE_RESPONSE_STYLES["sagemaker_chat"])
+    assert _norm(correct) == _norm(v1)
+    assert correct["created"] == _RESPONSES["text"]["created"]
+    with pytest.raises(pydantic.ValidationError):
+        _v2_with_style(raw, "openai_like")

--- a/tests/test_litellm/translation/test_differential_sagemaker_chat_response.py
+++ b/tests/test_litellm/translation/test_differential_sagemaker_chat_response.py
@@ -1,0 +1,153 @@
+"""Differential parity for the sagemaker_chat response path (wave-2b-beta).
+
+v1 side: the BASE ``transform_response`` (LIVE on the httpx path) ->
+``convert_to_model_response_object`` over a fresh ModelResponse — the
+cometapi shape: bare wire model, NO seam preset, construction arm
+"openai". v2: the shared openai parser verbatim (the sagemaker_chat module
+re-exports it).
+"""
+
+import copy
+import json
+import time
+
+import httpx
+import pytest
+
+from litellm.litellm_core_utils.litellm_logging import Logging
+from litellm.llms.sagemaker.chat.transformation import SagemakerChatConfig
+from litellm.types.utils import ModelResponse
+
+from litellm.translation.inbound.openai_chat import parse_request
+from litellm.translation.inbound.openai_chat.response import serialize_response
+from litellm.translation.providers.sagemaker_chat import parse_response
+from litellm.translation_seam import build_translation_deps, to_model_response
+
+MODEL = "my-endpoint"
+WIRE_MODEL = "tgi"
+_REQUEST = {"model": MODEL, "messages": [{"role": "user", "content": "hi"}]}
+
+_BASE = {
+    "id": "chat-1",
+    "object": "chat.completion",
+    "created": 1718000000,
+    "model": WIRE_MODEL,
+    "usage": {"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5},
+}
+
+_RESPONSES = {
+    "text": {
+        **_BASE,
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "hello"},
+                "finish_reason": "stop",
+            }
+        ],
+    },
+    "tool_calls": {
+        **_BASE,
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "c1",
+                            "type": "function",
+                            "function": {"name": "f", "arguments": '{"a":1}'},
+                        }
+                    ],
+                },
+                "finish_reason": "tool_calls",
+            }
+        ],
+    },
+    "stop_to_tool_calls_rewrite": {
+        # cdr rewrites finish stop -> tool_calls when tool calls are present
+        **_BASE,
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "c2",
+                            "type": "function",
+                            "function": {"name": "f", "arguments": "{}"},
+                        }
+                    ],
+                },
+                "finish_reason": "stop",
+            }
+        ],
+    },
+}
+
+
+def _v1_model_response(raw: dict) -> dict:
+    logging = Logging(
+        model=MODEL,
+        messages=copy.deepcopy(_REQUEST["messages"]),
+        stream=False,
+        call_type="completion",
+        start_time=time.time(),
+        litellm_call_id="diff-sagemaker-response",
+        function_id="diff-sagemaker-response",
+    )
+    response = httpx.Response(
+        200,
+        json=copy.deepcopy(raw),
+        request=httpx.Request(
+            "POST",
+            "https://runtime.sagemaker.us-east-1.amazonaws.com/endpoints/my-endpoint/invocations",
+        ),
+    )
+    return (
+        SagemakerChatConfig()
+        .transform_response(
+            model=MODEL,
+            raw_response=response,
+            model_response=ModelResponse(),
+            logging_obj=logging,
+            request_data={},
+            messages=copy.deepcopy(_REQUEST["messages"]),
+            optional_params={},
+            litellm_params={},
+            encoding=None,
+        )
+        .model_dump()
+    )
+
+
+def _v2_model_response(raw: dict) -> dict:
+    parsed = parse_request(copy.deepcopy(_REQUEST))
+    assert parsed.is_ok(), parsed.error.summary
+    response = parse_response(copy.deepcopy(raw), parsed.ok)
+    assert response.is_ok(), response.error.summary
+    body = serialize_response(response.ok, build_translation_deps(), "openai")
+    return to_model_response(body, ModelResponse(), usage_style="openai").model_dump()
+
+
+def _norm(payload: dict) -> str:
+    return json.dumps(payload, sort_keys=True, default=str)
+
+
+@pytest.mark.parametrize("name", sorted(_RESPONSES))
+def test_v2_response_matches_v1(name: str, frozen_ambient) -> None:
+    raw = _RESPONSES[name]
+    assert _norm(_v2_model_response(raw)) == _norm(_v1_model_response(raw))
+
+
+@pytest.mark.parametrize("name", sorted(_RESPONSES))
+def test_bare_wire_model_no_prefix(name: str, frozen_ambient) -> None:
+    v1 = _v1_model_response(_RESPONSES[name])
+    v2 = _v2_model_response(_RESPONSES[name])
+    assert v1["model"] == WIRE_MODEL
+    assert v2["model"] == WIRE_MODEL
+    assert not str(v2["model"]).startswith("sagemaker")

--- a/tests/test_litellm/translation/test_differential_sagemaker_chat_stream.py
+++ b/tests/test_litellm/translation/test_differential_sagemaker_chat_stream.py
@@ -82,6 +82,44 @@ STREAMS = {
         _chunk({"tool_calls": [{"index": 0, "function": {"arguments": "{}"}}]}),
         _chunk({}, finish="tool_calls"),
     ],
+    # verifier-wave2b-beta F5/F7: shapes v1's lax validation SERVES — the
+    # pre-step mirrors the coercions (index bool -> 1, tool index "1" -> 1)
+    # and the wrapper's finish semantics (truthy non-str -> "stop", unknown
+    # strings -> "stop" through the live map both sides).
+    "choice_index_bool_coerces": [
+        _chunk(
+            choices=[{"index": True, "delta": {"content": "x"}, "finish_reason": None}]
+        ),
+        _chunk({}, finish="stop"),
+    ],
+    "tool_index_str_coerces": [
+        _chunk(
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "index": "1",
+                        "id": "t",
+                        "type": "function",
+                        "function": {"name": "f", "arguments": "{}"},
+                    }
+                ],
+            }
+        ),
+        _chunk({}, finish="tool_calls"),
+    ],
+    "non_str_finish_int_serves_stop": [
+        _chunk({"role": "assistant", "content": "x"}),
+        _chunk({}, finish=5),
+    ],
+    "non_str_finish_bool_serves_stop": [
+        _chunk({"role": "assistant", "content": "x"}),
+        _chunk({}, finish=True),
+    ],
+    "unknown_finish_string_serves_stop": [
+        _chunk({"role": "assistant", "content": "x"}),
+        _chunk({}, finish="eos_token"),
+    ],
 }
 
 USAGE_STREAM = [
@@ -154,11 +192,148 @@ def test_usage_tail_swallowed_without_stream_options(frozen_ambient) -> None:
     assert _norm(v1) == _norm(v2[:-1])
 
 
-def test_invalid_chunk_raises_on_both_sides(frozen_ambient) -> None:
+# verifier-wave2b-beta F5: every shape the StreamingChatCompletionChunk /
+# ChatCompletionDeltaToolCall validation REJECTS raises out of v1's decoder
+# (no watsonx-style swallow); v2 is a loud typed error on each — the old
+# pre-check covered content/role/refusal only and SERVED the rest.
+_V1_RAISES = {
+    "content_non_str": (_chunk({"content": 5}), "content is not a string"),
+    "delta_non_dict": (
+        _chunk(choices=[{"index": 0, "delta": "oops", "finish_reason": None}]),
+        "delta is not an object",
+    ),
+    "tool_arguments_non_str": (
+        _chunk(
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "t",
+                        "type": "function",
+                        "function": {"name": "f", "arguments": 5},
+                    }
+                ],
+            }
+        ),
+        "arguments is not a string",
+    ),
+    "tool_id_non_str": (
+        _chunk(
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": 42,
+                        "type": "function",
+                        "function": {"name": "f", "arguments": ""},
+                    }
+                ],
+            }
+        ),
+        "id is not a string",
+    ),
+    "tool_name_non_str": (
+        _chunk(
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "t",
+                        "type": "function",
+                        "function": {"name": 5, "arguments": ""},
+                    }
+                ],
+            }
+        ),
+        "name is not a string",
+    ),
+    "tool_type_non_str": (
+        _chunk(
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "t",
+                        "type": 7,
+                        "function": {"name": "f", "arguments": ""},
+                    }
+                ],
+            }
+        ),
+        "type is not a string",
+    ),
+    "tool_function_missing": (
+        _chunk(
+            {"role": "assistant", "tool_calls": [{"index": 0, "id": "t"}]},
+        ),
+        "function is missing",
+    ),
+    "tool_index_non_coercible": (
+        _chunk(
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "index": "x",
+                        "id": "t",
+                        "type": "function",
+                        "function": {"name": "f", "arguments": ""},
+                    }
+                ],
+            }
+        ),
+        "tool_call index is not an integer",
+    ),
+    "tool_calls_non_list": (
+        _chunk({"role": "assistant", "tool_calls": "x"}),
+        "tool_calls is not a list",
+    ),
+    "choice_index_null": (
+        _chunk(choices=[{"index": None, "delta": {"content": "x"}}]),
+        "choice index is not an integer",
+    ),
+    "mid_usage_non_dict": (
+        _chunk({"role": "assistant", "content": "x"}, usage="oops"),
+        "usage is not an object",
+    ),
+    "mid_usage_bad_values": (
+        _chunk({"role": "assistant", "content": "x"}, usage={"prompt_tokens": "abc"}),
+        "missing or not an integer",
+    ),
+    "finish_truthy_unhashable": (
+        _chunk({}, finish=[1]),
+        "truthy unhashable",
+    ),
+}
+
+
+@pytest.mark.parametrize("name", sorted(_V1_RAISES))
+def test_invalid_chunk_raises_on_both_sides(name: str, frozen_ambient) -> None:
     """Decoder validation RAISES out of v1 (unlike watsonx's swallowing
     iterator); v2's parser is a loud error value."""
-    bad = _chunk({"content": 5})
+    bad, fragment = _V1_RAISES[name]
     result = parse_event(copy.deepcopy(bad))
-    assert result.is_error()
+    assert result.is_error(), f"{name} unexpectedly parsed"
+    assert fragment in result.error.summary, result.error.summary
     with pytest.raises(Exception):
         _v1_chunks([bad])
+
+
+def test_falsy_finish_is_no_finish_with_the_synthesized_tail(frozen_ambient) -> None:
+    """F7: a falsy finish ("", {}) fails the wrapper's truthy gate in v1 —
+    no finish rides and v1 synthesizes the trailing stop; v2 strips it and
+    the synthesized tail is seam scope (tail-only difference)."""
+    for falsy in ("", {}):
+        events = [
+            _chunk({"role": "assistant", "content": "x"}),
+            _chunk({}, finish=falsy),
+        ]
+        v1 = _v1_chunks(events)
+        v2 = _v2_chunks(events)
+        assert len(v1) == len(v2) + 1, falsy
+        assert _norm(v2) == _norm(v1[:-1]), falsy
+        assert v1[-1]["choices"][0]["finish_reason"] == "stop", falsy

--- a/tests/test_litellm/translation/test_differential_sagemaker_chat_stream.py
+++ b/tests/test_litellm/translation/test_differential_sagemaker_chat_stream.py
@@ -1,0 +1,164 @@
+"""Differential parity for sagemaker_chat streaming (wave-2b-beta), pinned
+at the AWS event-stream PARSED-EVENT seam (the bedrock precedent: botocore
+framing is transport).
+
+v1 side: each decoded JSON event through
+``AWSEventStreamDecoder(model="", is_messages_api=True).
+_chunk_parser_messages_api`` (a VALIDATED StreamingChatCompletionChunk)
+into ``CustomStreamWrapper("sagemaker_chat")``'s default openai branch.
+v2 side: ``fold_events`` with the shared openai chunk parser and the
+"openai" dialect — the validated-chunk materialization (service_tier None,
+refusal None) IS the SDK-dump shape that parser normalizes.
+"""
+
+import copy
+import json
+import time
+
+import pytest
+
+from litellm.litellm_core_utils.litellm_logging import Logging
+from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
+from litellm.llms.sagemaker.common_utils import AWSEventStreamDecoder
+
+from litellm.translation.engine.stream import fold_events
+from litellm.translation.inbound.openai_chat.stream import initial_state
+from litellm.translation.providers.sagemaker_chat import parse_event
+from litellm.translation_seam import to_model_response_stream
+
+MODEL = "my-endpoint"
+
+_USAGE = {"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5}
+
+
+def _chunk(
+    delta: dict | None = None,
+    finish: str | None = None,
+    usage: dict | None = None,
+    choices: list | None = None,
+) -> dict:
+    payload: dict = {
+        "id": "chunk-1",
+        "object": "chat.completion.chunk",
+        "created": 1718000000,
+        "model": "tgi",
+    }
+    payload["choices"] = (
+        choices
+        if choices is not None
+        else [
+            {
+                "index": 0,
+                "delta": delta if delta is not None else {},
+                "finish_reason": finish,
+            }
+        ]
+    )
+    if usage is not None:
+        payload["usage"] = usage
+    return payload
+
+
+STREAMS = {
+    "text": [
+        _chunk({"role": "assistant", "content": "He"}),
+        _chunk({"content": "llo"}),
+        _chunk({}, finish="stop"),
+    ],
+    "tools": [
+        _chunk(
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "t1",
+                        "type": "function",
+                        "function": {"name": "f", "arguments": ""},
+                    }
+                ],
+            }
+        ),
+        _chunk({"tool_calls": [{"index": 0, "function": {"arguments": "{}"}}]}),
+        _chunk({}, finish="tool_calls"),
+    ],
+}
+
+USAGE_STREAM = [
+    _chunk({"role": "assistant", "content": "Hi"}),
+    _chunk({}, finish="stop"),
+    _chunk(choices=[], usage=_USAGE),
+]
+
+
+def _v1_chunks(events: list, stream_options: dict | None = None) -> list:
+    decoder = AWSEventStreamDecoder(model="", is_messages_api=True)
+    chunks = [
+        decoder._chunk_parser_messages_api(chunk_data=copy.deepcopy(event))
+        for event in events
+    ]
+    logging = Logging(
+        model=MODEL,
+        messages=[{"role": "user", "content": "stream"}],
+        stream=True,
+        call_type="completion",
+        start_time=time.time(),
+        litellm_call_id="diff-sagemaker-stream",
+        function_id="diff-sagemaker-stream",
+    )
+    wrapper = CustomStreamWrapper(
+        completion_stream=iter(chunks),
+        model=MODEL,
+        custom_llm_provider="sagemaker_chat",
+        logging_obj=logging,
+        stream_options=stream_options,
+    )
+    return [chunk.model_dump() for chunk in wrapper]
+
+
+def _v2_chunks(events: list) -> list:
+    folded = fold_events(
+        copy.deepcopy(events), parse_event, initial_state(MODEL, dialect="openai")
+    )
+    assert folded.is_ok(), folded.error.summary
+    return [
+        to_model_response_stream(chunk, "chatcmpl-AMBIENT").model_dump()
+        for chunk in folded.ok
+    ]
+
+
+def _norm(chunks: list) -> str:
+    return json.dumps(chunks, sort_keys=True, default=str)
+
+
+@pytest.mark.parametrize("name", sorted(STREAMS))
+def test_v2_stream_matches_v1(name: str, frozen_ambient) -> None:
+    events = STREAMS[name]
+    assert _norm(_v2_chunks(events)) == _norm(_v1_chunks(events))
+
+
+def test_usage_tail_pins_the_seam_contract(frozen_ambient) -> None:
+    v1 = _v1_chunks(USAGE_STREAM, stream_options={"include_usage": True})
+    v2 = _v2_chunks(USAGE_STREAM)
+    assert len(v1) == len(v2)
+    assert _norm(v2[:-1]) == _norm(v1[: len(v2) - 1])
+    assert v2[-1]["choices"] == []
+    for key in ("prompt_tokens", "completion_tokens", "total_tokens"):
+        assert v1[-1]["usage"][key] == v2[-1]["usage"][key], key
+
+
+def test_usage_tail_swallowed_without_stream_options(frozen_ambient) -> None:
+    v1 = _v1_chunks(USAGE_STREAM, None)
+    v2 = _v2_chunks(USAGE_STREAM)
+    assert len(v1) == len(v2) - 1
+    assert _norm(v1) == _norm(v2[:-1])
+
+
+def test_invalid_chunk_raises_on_both_sides(frozen_ambient) -> None:
+    """Decoder validation RAISES out of v1 (unlike watsonx's swallowing
+    iterator); v2's parser is a loud error value."""
+    bad = _chunk({"content": 5})
+    result = parse_event(copy.deepcopy(bad))
+    assert result.is_error()
+    with pytest.raises(Exception):
+        _v1_chunks([bad])

--- a/tests/test_litellm/translation/test_differential_snowflake_request.py
+++ b/tests/test_litellm/translation/test_differential_snowflake_request.py
@@ -1,0 +1,348 @@
+"""Differential parity for the snowflake request path (httpx dedicated
+elif, main.py:4286; transform LIVE; a genuine wire mapping — tool_spec /
+tool_choice objects — and the one wave-2b provider whose body ALWAYS
+carries ``stream``).
+
+Two-sided: every served row is byte-identical (normalized JSON) between v1
+in-process at HEAD (get_optional_params + SnowflakeConfig.transform_request)
+and v2; every fallback row asserts BOTH the typed v2 error and v1's own
+behavior. Dossier confirmations: auth is HEADER-ONLY envelope
+(researcher-4's correction stands), mct/stop/n/seed RAISE, and — beyond the
+dossier — top_k rides the TOP-LEVEL passthrough (snowflake is NOT a compat
+provider) so v1 SERVES it, wire-proven below.
+"""
+
+import copy
+import json
+
+import pytest
+
+from litellm.exceptions import UnsupportedParamsError
+
+from litellm.translation.dispatch import NEVER_PORT
+from litellm.translation.engine import pipeline
+from litellm.translation.engine.pipeline import translate_chat_request
+
+from ._own_module_corpus import run_v1_request_transform
+from .conftest import build_real_deps
+
+MODEL = "claude-3-5-sonnet"
+_USER = [{"role": "user", "content": "Hello, world"}]
+
+WEATHER_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get weather",
+        "parameters": {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+        },
+    },
+}
+NO_PARAMS_TOOL = {"type": "function", "function": {"name": "ping"}}
+
+CASES: dict[str, dict] = {
+    "text": {"model": MODEL, "messages": _USER},
+    "sampling": {
+        "model": MODEL,
+        "max_tokens": 64,
+        "temperature": 0.5,
+        "top_p": 0.9,
+        "messages": [
+            {"role": "system", "content": "You are helpful"},
+            {"role": "user", "content": "Hi"},
+        ],
+    },
+    "stream_true": {"model": MODEL, "stream": True, "messages": _USER},
+    # the snowflake-only serve: stream is ALWAYS a body key, so an explicit
+    # false is byte-identical to absent — v1 emits {"stream": false} both
+    # ways and v2 serves it (the family guard arm is deliberately absent)
+    "stream_false_served": {"model": MODEL, "stream": False, "messages": _USER},
+    "temperature_int_stays_int": {"model": MODEL, "temperature": 1, "messages": _USER},
+    # top_k: the non-compat top-level passthrough (v1 serves; wire-proven)
+    "top_k_top_level": {"model": MODEL, "top_k": 5, "messages": _USER},
+    "response_format_json_object": {
+        "model": MODEL,
+        "response_format": {"type": "json_object"},
+        "messages": _USER,
+    },
+    "response_format_json_schema_strict": {
+        "model": MODEL,
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {"name": "a", "schema": {"type": "object"}, "strict": True},
+        },
+        "messages": _USER,
+    },
+    # the tool_spec mapping (description kept; missing parameters default)
+    "tools_to_tool_spec": {
+        "model": MODEL,
+        "tools": [WEATHER_TOOL, NO_PARAMS_TOOL],
+        "messages": [{"role": "user", "content": "Weather in Paris?"}],
+    },
+    "tool_choice_auto": {
+        "model": MODEL,
+        "tools": [WEATHER_TOOL],
+        "tool_choice": "auto",
+        "messages": [{"role": "user", "content": "Weather?"}],
+    },
+    "tool_choice_required_to_any": {
+        "model": MODEL,
+        "tools": [WEATHER_TOOL],
+        "tool_choice": "required",
+        "messages": [{"role": "user", "content": "Weather?"}],
+    },
+    "tool_choice_none_object": {
+        "model": MODEL,
+        "tools": [WEATHER_TOOL],
+        "tool_choice": "none",
+        "messages": [{"role": "user", "content": "Weather?"}],
+    },
+    "tool_choice_specific_to_name_array": {
+        "model": MODEL,
+        "tools": [WEATHER_TOOL],
+        "tool_choice": {"type": "function", "function": {"name": "get_weather"}},
+        "messages": [{"role": "user", "content": "Weather?"}],
+    },
+    # messages ride VERBATIM in v1 (no flatten, no base transforms): a
+    # multi-block text list round-trips byte-identically through the IR
+    "content_list_verbatim": {
+        "model": MODEL,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "a"},
+                    {"type": "text", "text": "b"},
+                ],
+            }
+        ],
+    },
+    "tool_call_compact_roundtrip": {
+        "model": MODEL,
+        "tools": [WEATHER_TOOL],
+        "messages": [
+            {"role": "user", "content": "w?"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "tooluse_1",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": '{"city":"Paris"}',
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "tooluse_1", "content": "ok"},
+        ],
+    },
+}
+
+# name -> (case, v2 reason fragment); generator emits FALLBACK (v1 serves it)
+EXPECTED_FALLBACKS: dict[str, tuple[dict, str]] = {
+    "user": ({"model": MODEL, "user": "u1", "messages": _USER}, "user"),
+    # v1 forwards message name VERBATIM (no strip anywhere on this chain)
+    "message_name": (
+        {
+            "model": MODEL,
+            "messages": [{"role": "user", "content": "hi", "name": "alice"}],
+        },
+        "name",
+    ),
+}
+
+# name -> (case, v2 reason fragment); v1 raises UnsupportedParamsError
+V1_RAISES: dict[str, tuple[dict, str]] = {
+    "max_completion_tokens": (
+        {"model": MODEL, "max_completion_tokens": 99, "messages": _USER},
+        "max_completion_tokens",
+    ),
+    "stop": ({"model": MODEL, "stop": ["END"], "messages": _USER}, "stop"),
+    "parallel_tool_calls": (
+        {
+            "model": MODEL,
+            "tools": [WEATHER_TOOL],
+            "parallel_tool_calls": False,
+            "messages": _USER,
+        },
+        "parallel_tool_calls",
+    ),
+}
+
+
+def _v2(case: dict):
+    return translate_chat_request(copy.deepcopy(case), "snowflake", build_real_deps())
+
+
+def _norm(body: dict) -> str:
+    return json.dumps(body, sort_keys=True, default=str)
+
+
+@pytest.mark.parametrize("name", sorted(CASES))
+def test_v2_request_matches_v1(name: str) -> None:
+    case = CASES[name]
+    result = _v2(case)
+    assert result.is_ok(), result.error.summary
+    assert _norm(result.ok) == _norm(run_v1_request_transform("snowflake", case))
+
+
+@pytest.mark.parametrize("name", sorted(EXPECTED_FALLBACKS))
+def test_expected_fallbacks_are_typed(name: str) -> None:
+    case, reason = EXPECTED_FALLBACKS[name]
+    result = _v2(case)
+    assert result.is_error(), f"{name} unexpectedly served"
+    assert reason in result.error.summary, result.error.summary
+
+
+@pytest.mark.parametrize("name", sorted(V1_RAISES))
+def test_v1_raise_rows_are_two_sided(name: str) -> None:
+    case, reason = V1_RAISES[name]
+    result = _v2(case)
+    assert result.is_error(), f"{name} unexpectedly served"
+    assert reason in result.error.summary, result.error.summary
+    with pytest.raises(UnsupportedParamsError):
+        run_v1_request_transform("snowflake", case)
+
+
+def test_stream_is_always_a_body_key() -> None:
+    """The pin behind dropping the explicit-stream-false guard arm: absent
+    and explicit-false produce the SAME wire byte on both sides."""
+    absent = _v2(CASES["text"]).ok
+    explicit = _v2(CASES["stream_false_served"]).ok
+    assert absent["stream"] is False
+    assert explicit["stream"] is False
+    assert _norm(absent) == _norm(explicit)
+    assert _v2(CASES["stream_true"]).ok["stream"] is True
+
+
+def test_tool_spec_semantic_pins() -> None:
+    body = _v2(CASES["tools_to_tool_spec"]).ok
+    assert body["tools"][0] == {
+        "tool_spec": {
+            "type": "generic",
+            "name": "get_weather",
+            "input_schema": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+            "description": "Get weather",
+        }
+    }
+    # missing parameters -> the default empty object schema
+    assert body["tools"][1] == {
+        "tool_spec": {
+            "type": "generic",
+            "name": "ping",
+            "input_schema": {"type": "object", "properties": {}},
+        }
+    }
+
+
+def test_tool_choice_object_pins() -> None:
+    assert _v2(CASES["tool_choice_auto"]).ok["tool_choice"] == {"type": "auto"}
+    assert _v2(CASES["tool_choice_required_to_any"]).ok["tool_choice"] == {
+        "type": "any"
+    }
+    assert _v2(CASES["tool_choice_none_object"]).ok["tool_choice"] == {"type": "none"}
+    assert _v2(CASES["tool_choice_specific_to_name_array"]).ok["tool_choice"] == {
+        "type": "tool",
+        "name": ["get_weather"],
+    }
+
+
+def test_top_k_wire_proven_top_level() -> None:
+    """snowflake is NOT in openai_compatible_providers: top_k rides the
+    top-level passthrough into the body (the wave-2b wire-prove rule).
+    The mock-transport helper cannot reach this elif — main.py:4390
+    OVERWRITES the caller's client with a fresh HTTPHandler (an envelope
+    quirk, recorded in wave2b-alpha-port.md) — so the wire is pinned with
+    respx instead, over the full completion() stack."""
+    import respx as _respx
+    import httpx as _httpx
+
+    import litellm as _litellm
+
+    v1 = run_v1_request_transform("snowflake", CASES["top_k_top_level"])
+    assert v1["top_k"] == 5
+    captured: dict = {}
+    ok_body = {
+        "id": "wire-1",
+        "object": "chat.completion",
+        "created": 1718000000,
+        "model": MODEL,
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "ok"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    }
+
+    def _capture(request: _httpx.Request) -> _httpx.Response:
+        captured["body"] = json.loads(request.content.decode())
+        return _httpx.Response(200, json=ok_body)
+
+    with _respx.mock(assert_all_called=True) as router:
+        router.post(
+            "https://acct.snowflakecomputing.com/api/v2/cortex/inference:complete"
+        ).mock(side_effect=_capture)
+        _litellm.completion(
+            model=f"snowflake/{MODEL}",
+            messages=[{"role": "user", "content": "hi"}],
+            api_key="wire-test-key",
+            api_base="https://acct.snowflakecomputing.com/api/v2",
+            top_k=5,
+        )
+    wire = captured["body"]
+    assert wire["top_k"] == 5
+    assert wire["stream"] is False  # the always-on stream key, on the wire
+
+
+def test_user_v1_drops_it_and_name_v1_forwards_it() -> None:
+    case, _ = EXPECTED_FALLBACKS["user"]
+    assert "user" not in run_v1_request_transform("snowflake", case)
+    case, _ = EXPECTED_FALLBACKS["message_name"]
+    v1 = run_v1_request_transform("snowflake", case)
+    assert v1["messages"][0]["name"] == "alice"  # verbatim forward
+
+
+def test_supported_list_mirror() -> None:
+    """v1's small static list, row-for-row (fixed name samples — snowflake
+    has its own model list, no per-model forks). top_k is in v2's allowed
+    set but NOT v1's list — it is the non-compat passthrough, not a list
+    member (the wire-prove test above pins the serve)."""
+    from litellm.translation.providers.snowflake.params import _SNOWFLAKE_LIST
+
+    from ._own_module_corpus import provider_config
+
+    for model in (MODEL, "mistral-large2", "snowflake-arctic"):
+        supported = set(
+            provider_config("snowflake", model).get_supported_openai_params(model)
+        )
+        assert supported == {
+            "temperature",
+            "max_tokens",
+            "top_p",
+            "stream",
+            "response_format",
+            "tools",
+            "tool_choice",
+        }, model
+        assert _SNOWFLAKE_LIST - {"top_k"} == supported, model
+
+
+def test_registration_facts() -> None:
+    assert "snowflake" in pipeline._SERIALIZERS
+    assert "snowflake" in pipeline._RESPONSE_PARSERS
+    assert "snowflake" in pipeline._RAW_GUARDS
+    assert pipeline.response_dialect("snowflake") == "openai"
+    assert "snowflake" not in NEVER_PORT

--- a/tests/test_litellm/translation/test_differential_snowflake_response.py
+++ b/tests/test_litellm/translation/test_differential_snowflake_response.py
@@ -1,0 +1,194 @@
+"""Differential parity for the snowflake response path (httpx; prefixed).
+
+v1's ``transform_response`` rewrites choices[0]'s ``content_list`` (text
+concat + tool_use -> OpenAI tool_calls with ``json.dumps(input)``
+arguments), deletes it, builds ``ModelResponse(**json)`` — the OpenAILike
+DIRECT construction — and overwrites ``model = "snowflake/" + (wire model
+or "")``. The request model rides ``_hidden_params["model"]`` (envelope,
+dump-invisible — pinned below as a fork obligation). These rows run that
+exact v1 chain against v2's pre-rewrite + direct parser with the seam's
+``openai_like`` construction arm.
+"""
+
+import copy
+import json
+
+import pydantic
+import pytest
+
+from litellm.types.utils import ModelResponse
+
+from litellm.translation.inbound.openai_chat import parse_request
+from litellm.translation.inbound.openai_chat.response import serialize_response
+from litellm.translation.providers.snowflake import parse_response
+from litellm.translation_seam import build_translation_deps, to_model_response
+
+from ._own_module_corpus import run_v1_response_transform
+
+REQUEST_MODEL = "claude-3-5-sonnet"
+WIRE_MODEL = "claude-3-5-sonnet"
+
+_REQUEST = {
+    "model": REQUEST_MODEL,
+    "messages": [{"role": "user", "content": "hi"}],
+    "tools": [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ],
+}
+
+_RESPONSES = {
+    "content_list_text": {
+        "id": "sf-1",
+        "object": "chat.completion",
+        "created": 1718000000,
+        "model": WIRE_MODEL,
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content_list": [
+                        {"type": "text", "text": "I will "},
+                        {"type": "text", "text": "check."},
+                    ],
+                },
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 5, "completion_tokens": 7, "total_tokens": 12},
+    },
+    "content_list_tool_use": {
+        "id": "sf-2",
+        "object": "chat.completion",
+        "created": 1718000000,
+        "model": WIRE_MODEL,
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content_list": [
+                        {"type": "text", "text": "Checking."},
+                        {
+                            "type": "tool_use",
+                            "tool_use": {
+                                "tool_use_id": "tooluse_1",
+                                "name": "get_weather",
+                                "input": {"city": "Paris", "unit": "C"},
+                            },
+                        },
+                    ],
+                },
+                "finish_reason": "tool_calls",
+            }
+        ],
+        "usage": {"prompt_tokens": 9, "completion_tokens": 5, "total_tokens": 14},
+    },
+    # bodies WITHOUT content_list ride verbatim (plain content key)
+    "plain_content": {
+        "id": "sf-3",
+        "object": "chat.completion",
+        "created": 1718000000,
+        "model": WIRE_MODEL,
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "hello"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5},
+    },
+}
+
+_NON_STRING_MODEL_BODY = {**_RESPONSES["plain_content"], "model": 7}
+
+
+def _v1_full(raw: dict) -> ModelResponse:
+    return run_v1_response_transform("snowflake", raw, REQUEST_MODEL)
+
+
+def _v1_model_response(raw: dict) -> dict:
+    return _v1_full(raw).model_dump()
+
+
+def _v2_model_response(raw: dict) -> dict:
+    parsed = parse_request(copy.deepcopy(_REQUEST))
+    assert parsed.is_ok(), parsed.error.summary
+    response = parse_response(copy.deepcopy(raw), parsed.ok)
+    assert response.is_ok(), response.error.summary
+    body = serialize_response(response.ok, build_translation_deps(), "openai")
+    # snowflake is DIRECT construction: the seam fork must use the
+    # "openai_like" arm (never "openai", never a model preset)
+    return to_model_response(
+        body, ModelResponse(), usage_style="openai_like"
+    ).model_dump()
+
+
+def _norm(payload: dict) -> str:
+    return json.dumps(payload, sort_keys=True, default=str)
+
+
+@pytest.mark.parametrize("name", sorted(_RESPONSES))
+def test_v2_response_matches_v1(name: str, frozen_ambient) -> None:
+    raw = _RESPONSES[name]
+    assert _norm(_v2_model_response(raw)) == _norm(_v1_model_response(raw))
+
+
+@pytest.mark.parametrize("name", sorted(_RESPONSES))
+def test_snowflake_prefix_on_the_response_model(name: str, frozen_ambient) -> None:
+    raw = _RESPONSES[name]
+    v1 = _v1_model_response(raw)
+    v2 = _v2_model_response(raw)
+    assert v1["model"] == f"snowflake/{WIRE_MODEL}"
+    assert v2["model"] == f"snowflake/{WIRE_MODEL}"
+
+
+def test_tool_use_arguments_keep_v1_json_dumps_bytes(frozen_ambient) -> None:
+    """The arguments string is json.dumps(input) with DEFAULT separators
+    (space after colon and comma) — byte-pinned, because the dump comparison
+    normalizes whole payloads but the arguments value is itself a string."""
+    v2 = _v2_model_response(_RESPONSES["content_list_tool_use"])
+    arguments = v2["choices"][0]["message"]["tool_calls"][0]["function"]["arguments"]
+    assert arguments == '{"city": "Paris", "unit": "C"}'
+    v1 = _v1_model_response(_RESPONSES["content_list_tool_use"])
+    assert (
+        v1["choices"][0]["message"]["tool_calls"][0]["function"]["arguments"]
+        == arguments
+    )
+
+
+def test_missing_wire_model_prefixes_the_empty_string(frozen_ambient) -> None:
+    """v1: "snowflake/" + (None or "") == "snowflake/" — pinned both sides."""
+    body = {k: v for k, v in _RESPONSES["plain_content"].items() if k != "model"}
+    v1 = _v1_model_response(body)
+    v2 = _v2_model_response(body)
+    assert v1["model"] == "snowflake/"
+    assert v2["model"] == "snowflake/"
+    assert _norm(v2) == _norm(v1)
+
+
+def test_non_string_wire_model_falls_back_where_v1_raises(frozen_ambient) -> None:
+    """v1's ModelResponse(**json) raises pydantic ValidationError BEFORE the
+    prefix overwrite; the direct parser's F2 arm fails closed."""
+    with pytest.raises(pydantic.ValidationError):
+        _v1_model_response(_NON_STRING_MODEL_BODY)
+    parsed = parse_request(copy.deepcopy(_REQUEST))
+    assert parsed.is_ok()
+    result = parse_response(copy.deepcopy(_NON_STRING_MODEL_BODY), parsed.ok)
+    assert result.is_error()
+    assert "non-string wire model" in result.error.summary
+
+
+def test_v1_hidden_request_model_is_the_fork_obligation(frozen_ambient) -> None:
+    """v1 stores the REQUEST model in _hidden_params['model'] (the cost
+    calculator's key); dump-invisible, so the future fork must set it —
+    recorded in CLAUDE.md."""
+    v1 = _v1_full(_RESPONSES["plain_content"])
+    assert v1._hidden_params.get("model") == REQUEST_MODEL

--- a/tests/test_litellm/translation/test_differential_snowflake_response.py
+++ b/tests/test_litellm/translation/test_differential_snowflake_response.py
@@ -21,7 +21,11 @@ from litellm.types.utils import ModelResponse
 from litellm.translation.inbound.openai_chat import parse_request
 from litellm.translation.inbound.openai_chat.response import serialize_response
 from litellm.translation.providers.snowflake import parse_response
-from litellm.translation_seam import build_translation_deps, to_model_response
+from litellm.translation_seam import (
+    UsageStyle,
+    build_translation_deps,
+    to_model_response,
+)
 
 from ._own_module_corpus import run_v1_response_transform
 
@@ -118,17 +122,20 @@ def _v1_model_response(raw: dict) -> dict:
     return _v1_full(raw).model_dump()
 
 
-def _v2_model_response(raw: dict) -> dict:
+def _v2_with_style(raw: dict, style: UsageStyle) -> dict:
     parsed = parse_request(copy.deepcopy(_REQUEST))
     assert parsed.is_ok(), parsed.error.summary
     response = parse_response(copy.deepcopy(raw), parsed.ok)
     assert response.is_ok(), response.error.summary
     body = serialize_response(response.ok, build_translation_deps(), "openai")
+    return to_model_response(body, ModelResponse(), usage_style=style).model_dump()
+
+
+def _v2_model_response(raw: dict) -> dict:
     # snowflake is DIRECT construction: the seam fork must use the
-    # "openai_like" arm (never "openai", never a model preset)
-    return to_model_response(
-        body, ModelResponse(), usage_style="openai_like"
-    ).model_dump()
+    # "openai_like" arm (never "openai", never a model preset) — the truth is
+    # pipeline.OWN_MODULE_RESPONSE_STYLES["snowflake"], divergence-pinned below
+    return _v2_with_style(raw, "openai_like")
 
 
 def _norm(payload: dict) -> str:
@@ -184,6 +191,32 @@ def test_non_string_wire_model_falls_back_where_v1_raises(frozen_ambient) -> Non
     result = parse_response(copy.deepcopy(_NON_STRING_MODEL_BODY), parsed.ok)
     assert result.is_error()
     assert "non-string wire model" in result.error.summary
+
+
+def test_wrong_construction_arm_diverges_and_the_table_pins_it(
+    frozen_ambient,
+) -> None:
+    """critic-wave2b-alpha MAJOR-4 (the snowflake half — see the fireworks_ai
+    twin for the full rationale): the obligated "openai_like" style is
+    machine-readable in pipeline.OWN_MODULE_RESPONSE_STYLES and the wrong
+    (openai/cdr) arm provably diverges from v1 on a parser-admissible body —
+    cdr's enumerate rebuild rewrites a verbatim wire choice index 5 to 0
+    while v1's ModelResponse(**json) keeps it."""
+    from litellm.translation.engine.pipeline import OWN_MODULE_RESPONSE_STYLES
+
+    assert OWN_MODULE_RESPONSE_STYLES["snowflake"] == "openai_like"
+    raw = copy.deepcopy(_RESPONSES["plain_content"])
+    raw["choices"][0]["index"] = 5
+    v1 = _v1_model_response(raw)
+    correct = _v2_with_style(raw, OWN_MODULE_RESPONSE_STYLES["snowflake"])
+    wrong = _v2_with_style(raw, "openai")
+    assert _norm(correct) == _norm(v1)
+    assert correct["choices"][0]["index"] == 5
+    assert wrong["choices"][0]["index"] == 0
+    assert _norm(wrong) != _norm(v1), (
+        "the construction arms stopped diverging on the index-rewrite body — "
+        "the MAJOR-4 gate lost its discriminator; re-decide before relying on it"
+    )
 
 
 def test_v1_hidden_request_model_is_the_fork_obligation(frozen_ambient) -> None:

--- a/tests/test_litellm/translation/test_differential_snowflake_response.py
+++ b/tests/test_litellm/translation/test_differential_snowflake_response.py
@@ -181,6 +181,59 @@ def test_missing_wire_model_prefixes_the_empty_string(frozen_ambient) -> None:
     assert _norm(v2) == _norm(v1)
 
 
+_MALFORMED_CONTENT_LIST = {
+    # (body, the exception v1's rewrite crashes with)
+    "non_string_text_item": (
+        {
+            **_RESPONSES["content_list_text"],
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content_list": [{"type": "text", "text": 42}],
+                    },
+                    "finish_reason": "stop",
+                }
+            ],
+        },
+        TypeError,  # str + int concat in v1's text accumulation
+    ),
+    "non_list_content_list": (
+        {
+            **_RESPONSES["content_list_text"],
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content_list": "oops"},
+                    "finish_reason": "stop",
+                }
+            ],
+        },
+        AttributeError,  # v1 iterates the string; str has no .get
+    ),
+}
+
+
+@pytest.mark.parametrize("name", sorted(_MALFORMED_CONTENT_LIST))
+def test_malformed_content_list_is_loud_where_v1_crashes(
+    name: str, frozen_ambient
+) -> None:
+    """verifier-wave2b-alpha F5: the old isinstance filters quietly SERVED
+    content "" for these shapes (the 42 silently gone) where v1's rewrite
+    crashes with an unhandled TypeError/AttributeError. Fail-closed now:
+    the typed error mirrors v1's raise, two-sided."""
+    body, v1_error = _MALFORMED_CONTENT_LIST[name]
+    with pytest.raises(v1_error):
+        _v1_model_response(body)
+    parsed = parse_request(copy.deepcopy(_REQUEST))
+    assert parsed.is_ok()
+    result = parse_response(copy.deepcopy(body), parsed.ok)
+    assert result.is_error(), f"{name} unexpectedly served"
+    assert "content_list" in result.error.summary, result.error.summary
+    assert "never serve what v1 raises on" in result.error.summary
+
+
 def test_non_string_wire_model_falls_back_where_v1_raises(frozen_ambient) -> None:
     """v1's ModelResponse(**json) raises pydantic ValidationError BEFORE the
     prefix overwrite; the direct parser's F2 arm fails closed."""

--- a/tests/test_litellm/translation/test_differential_snowflake_stream.py
+++ b/tests/test_litellm/translation/test_differential_snowflake_stream.py
@@ -1,0 +1,204 @@
+"""Differential parity for snowflake streaming, pinned at the SSE line seam.
+
+v1 side: raw ``data:`` lines through the BASE
+``OpenAIChatCompletionStreamingHandler`` (SnowflakeConfig has no iterator
+override — canary-pinned below; neither the content_list response rewrite
+nor the snowflake/ prefix ever runs on chunks) into
+``CustomStreamWrapper("snowflake")``. v2 side: ``fold_lines`` with the
+snowflake parser (the httpx_chunk FAMILY policy) and the shared ``xai``
+chunk dialect. Whether real Cortex deltas carry ``content_list`` is
+UNPINNED upstream (researcher-4 §9) — these replays pin v1-decode parity,
+and a content_list delta would be a LOUD unknown-delta-key error in v2
+(get real fixtures before flag-on streaming). The mid-stream error chunk
+is the family's single PINNED DIVERGENCE — snowflake joins the report's
+one named row.
+"""
+
+import copy
+import json
+
+import pytest
+
+from litellm.llms.openai.chat.gpt_transformation import (
+    OpenAIChatCompletionStreamingHandler,
+)
+
+from litellm.translation.engine.stream import fold_events, fold_lines
+from litellm.translation.inbound.openai_chat.stream import initial_state
+from litellm.translation.providers.snowflake import parse_event, parse_line
+from litellm.translation_seam import to_model_response_stream
+
+from ._own_module_corpus import provider_config, replay_v1_sse_lines
+
+MODEL = "claude-3-5-sonnet"
+WIRE_MODEL = "claude-3-5-sonnet"
+
+
+def _chunk(delta, finish=None, usage=None, choices=None):
+    payload = {
+        "id": "sf-chunk-1",
+        "object": "chat.completion.chunk",
+        "created": 1718000000,
+        "model": WIRE_MODEL,
+        "choices": [
+            {"index": 0, "delta": delta, "logprobs": None, "finish_reason": finish}
+        ],
+        "usage": usage,
+    }
+    if choices is not None:
+        payload["choices"] = choices
+    return payload
+
+
+STREAMS = {
+    "text": [
+        _chunk({"role": "assistant", "content": ""}),
+        _chunk({"content": "Hello"}),
+        _chunk({"content": " world"}),
+        _chunk({}, finish="stop"),
+    ],
+    "tools": [
+        _chunk({"role": "assistant", "content": None}),
+        _chunk(
+            {
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "get_weather", "arguments": ""},
+                    }
+                ]
+            }
+        ),
+        _chunk(
+            {
+                "tool_calls": [
+                    {"index": 0, "function": {"arguments": '{"city":"Paris"}'}}
+                ]
+            }
+        ),
+        _chunk({}, finish="tool_calls"),
+    ],
+    "native_reasoning_content": [
+        _chunk({"role": "assistant", "reasoning_content": "step "}),
+        _chunk({"reasoning_content": "by step"}),
+        _chunk({"content": "answer"}),
+        _chunk({}, finish="stop"),
+    ],
+    "reasoning_rename": [
+        _chunk({"role": "assistant", "content": ""}),
+        _chunk({"reasoning": "thinking..."}),
+        _chunk({"content": "answer"}),
+        _chunk({}, finish="stop"),
+    ],
+    "empty_keepalive_swallowed": [
+        _chunk({"role": "assistant", "content": ""}),
+        _chunk({}),
+        _chunk({"content": "hi"}),
+        _chunk({}, finish="stop"),
+    ],
+}
+
+USAGE_STREAM = [
+    _chunk({"role": "assistant", "content": ""}),
+    _chunk({"content": "Hi"}),
+    _chunk({}, finish="stop"),
+    _chunk(
+        {},
+        choices=[],
+        usage={"prompt_tokens": 7, "completion_tokens": 2, "total_tokens": 9},
+    ),
+]
+
+
+def _v1_chunks(events, stream_options=None):
+    return replay_v1_sse_lines("snowflake", events, MODEL, stream_options)
+
+
+def _v2_chunks(events: list) -> list:
+    lines = [f"data: {json.dumps(event)}" for event in copy.deepcopy(events)]
+    lines.append("data: [DONE]")
+    folded = fold_lines(lines, parse_line, initial_state(MODEL, dialect="xai"))
+    assert folded.is_ok(), folded.error.summary
+    return [
+        to_model_response_stream(chunk, "chatcmpl-AMBIENT").model_dump()
+        for chunk in folded.ok
+    ]
+
+
+def _norm(chunks: list) -> str:
+    return json.dumps(chunks, sort_keys=True, default=str)
+
+
+@pytest.mark.parametrize("name", sorted(STREAMS))
+def test_v2_stream_matches_v1(name: str, frozen_ambient) -> None:
+    events = STREAMS[name]
+    assert _norm(_v2_chunks(events)) == _norm(_v1_chunks(events))
+
+
+def test_usage_tail_pins_the_seam_contract(frozen_ambient) -> None:
+    v1 = _v1_chunks(USAGE_STREAM, stream_options={"include_usage": True})
+    v2 = _v2_chunks(USAGE_STREAM)
+    assert len(v1) == len(v2)
+    assert _norm(v2[:-1]) == _norm(v1[: len(v2) - 1])
+    assert v2[-1]["choices"] == []
+    for key in ("prompt_tokens", "completion_tokens", "total_tokens"):
+        assert v1[-1]["usage"][key] == v2[-1]["usage"][key], key
+
+
+def test_usage_tail_swallowed_without_stream_options(frozen_ambient) -> None:
+    v1 = _v1_chunks(USAGE_STREAM, None)
+    v2 = _v2_chunks(USAGE_STREAM)
+    assert len(v1) == len(v2) - 1
+    assert _norm(v1) == _norm(v2[:-1])
+
+
+def test_v2_line_and_event_folds_agree(frozen_ambient) -> None:
+    events = STREAMS["native_reasoning_content"]
+    folded = fold_events(
+        copy.deepcopy(events), parse_event, initial_state(MODEL, dialect="xai")
+    )
+    assert folded.is_ok(), folded.error.summary
+    via_events = [
+        to_model_response_stream(chunk, "chatcmpl-AMBIENT").model_dump()
+        for chunk in folded.ok
+    ]
+    assert _norm(via_events) == _norm(_v2_chunks(events))
+
+
+_ERROR_CHUNK_STREAM = [
+    _chunk({"role": "assistant", "content": ""}),
+    {
+        "id": "sf-chunk-1",
+        "object": "chat.completion.chunk",
+        "created": 1718000000,
+        "model": WIRE_MODEL,
+        "error": {"message": "upstream exploded", "code": 502},
+    },
+    _chunk({"content": "after"}),
+    _chunk({}, finish="stop"),
+]
+
+
+def test_error_chunk_divergence_two_sided(frozen_ambient) -> None:
+    """The compat_httpx family's deliberate fail-closed divergence extends
+    to snowflake (same BASE handler): v1 silently swallows the error
+    chunk, v2's parse_line is a loud typed boundary error. If the v1 half
+    fails, the base handler learned to raise: re-decide the divergence and
+    update the report row in the same commit."""
+    v1 = _v1_chunks(_ERROR_CHUNK_STREAM)
+    assert "error" not in json.dumps(v1), v1
+    assert [c["choices"][0]["delta"].get("content") for c in v1[:2]] == ["", "after"]
+    lines = [f"data: {json.dumps(e)}" for e in copy.deepcopy(_ERROR_CHUNK_STREAM)]
+    folded = fold_lines(lines, parse_line, initial_state(MODEL, dialect="xai"))
+    assert folded.is_error()
+    assert "provider stream error" in folded.error.summary, folded.error.summary
+    assert "upstream exploded" in folded.error.summary
+
+
+def test_iterator_is_the_base_openai_handler() -> None:
+    handler = provider_config("snowflake", MODEL).get_model_response_iterator(
+        streaming_response=iter(()), sync_stream=True
+    )
+    assert type(handler) is OpenAIChatCompletionStreamingHandler

--- a/tests/test_litellm/translation/test_differential_watsonx_request.py
+++ b/tests/test_litellm/translation/test_differential_watsonx_request.py
@@ -1,0 +1,288 @@
+"""Differential parity for the watsonx chat request path (wave-2b-beta).
+
+v1 side, invoked the way ``WatsonXChatHandler`` -> ``OpenAILikeChatHandler``
+runs (NOT base_llm_http_handler): ``get_optional_params("watsonx")``, then
+``_get_api_params`` (auth-key pops) + ``_prepare_payload`` (model_id +
+project_id-or-space_id injection) merged into optional_params, then the
+openai_like body assembly ``{"model": model_id, "messages":
+<base-transformed>, **optional_params}`` with the UNCONDITIONAL
+``stream: <bool>`` re-add. Auth (Authorization passthrough -> token ->
+ZenApiKey -> the IAM-token network POST) is envelope and never appears
+here; project/space ids ride ``TranslationDeps`` (the future seam fork
+must run v1's resolution chain — deps.py docstring).
+"""
+
+import copy
+import dataclasses
+import json
+
+import pytest
+
+from litellm.exceptions import UnsupportedParamsError
+from litellm.llms.watsonx.chat.transformation import IBMWatsonXChatConfig
+from litellm.llms.watsonx.common_utils import _get_api_params
+from litellm.utils import get_optional_params
+
+from litellm.translation.engine.pipeline import translate_chat_request
+from litellm.translation_seam import build_translation_deps
+
+MODEL = "ibm/granite-3-8b-instruct"
+_U = [{"role": "user", "content": "hi"}]
+_CONFIG = IBMWatsonXChatConfig()
+
+CASES = {
+    "plain": {"model": MODEL, "messages": _U},
+    "sampling": {
+        "model": MODEL,
+        "messages": _U,
+        "temperature": 0.5,
+        "top_p": 0.9,
+        "max_tokens": 10,
+        "stop": ["x"],
+    },
+    "stream_true": {"model": MODEL, "messages": _U, "stream": True},
+    "explicit_stream_false": {"model": MODEL, "messages": _U, "stream": False},
+    "reasoning_effort": {
+        "model": MODEL,
+        "messages": _U,
+        "reasoning_effort": "high",
+    },
+    "response_format_json_object": {
+        "model": MODEL,
+        "messages": _U,
+        "response_format": {"type": "json_object"},
+    },
+    "response_format_json_schema": {
+        "model": MODEL,
+        "messages": _U,
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "s",
+                "schema": {"type": "object", "properties": {}},
+                "strict": True,
+            },
+        },
+    },
+    "tools_strict_and_additional_properties_stripped": {
+        "model": MODEL,
+        "messages": _U,
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "f",
+                    "strict": True,
+                    "parameters": {
+                        "type": "object",
+                        "additionalProperties": False,
+                        "properties": {
+                            "a": {"type": "string", "strict": True},
+                            "b": {"type": "object", "additionalProperties": True},
+                        },
+                    },
+                },
+            }
+        ],
+        "tool_choice": "auto",
+    },
+    "tool_choice_required_to_option": {
+        "model": MODEL,
+        "messages": _U,
+        "tools": [{"type": "function", "function": {"name": "f", "parameters": {}}}],
+        "tool_choice": "required",
+    },
+    "tool_choice_dict_rides_verbatim": {
+        "model": MODEL,
+        "messages": _U,
+        "tools": [{"type": "function", "function": {"name": "f", "parameters": {}}}],
+        "tool_choice": {"type": "function", "function": {"name": "f"}},
+    },
+    "tool_history": {
+        "model": MODEL,
+        "messages": [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "c1",
+                        "type": "function",
+                        "function": {"name": "f", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "c1", "content": "res"},
+        ],
+    },
+}
+
+V1_RAISES = {
+    "max_completion_tokens": (
+        {"model": MODEL, "messages": _U, "max_completion_tokens": 5},
+        "max_completion_tokens",
+    ),
+    "parallel_tool_calls": (
+        {"model": MODEL, "messages": _U, "parallel_tool_calls": True},
+        "parallel_tool_calls",
+    ),
+    "thinking": (
+        {"model": MODEL, "messages": _U, "thinking": {"type": "enabled"}},
+        "thinking",
+    ),
+}
+
+V1_SERVES_FALLBACKS = {
+    "user_silent_drop": (
+        {"model": MODEL, "messages": _U, "user": "u1"},
+        "user",
+    ),
+    "seed_parse_level": (
+        {"model": MODEL, "messages": _U, "seed": 42},
+        "seed",
+    ),
+    "n_parse_level": ({"model": MODEL, "messages": _U, "n": 2}, "n"),
+    "frequency_penalty_parse_level": (
+        {"model": MODEL, "messages": _U, "frequency_penalty": 0.1},
+        "frequency_penalty",
+    ),
+    "logprobs_parse_level": (
+        {"model": MODEL, "messages": _U, "logprobs": True},
+        "logprobs",
+    ),
+    "message_name_forwarded": (
+        {"model": MODEL, "messages": [{"role": "user", "content": "hi", "name": "b"}]},
+        "name",
+    ),
+}
+
+
+def _deps(project_id: str | None = "proj-1", space_id: str | None = None):
+    return dataclasses.replace(
+        build_translation_deps(),
+        watsonx_project_id=project_id,
+        watsonx_space_id=space_id,
+    )
+
+
+def run_v1_request_transform(
+    case: dict, project_id: str | None = "proj-1", space_id: str | None = None
+) -> dict:
+    """May RAISE (UnsupportedParamsError, the legacy-text ValueError, or
+    WatsonXAIError 401): each raise IS pinned v1 behavior."""
+    request = copy.deepcopy(case)
+    model = request.pop("model")
+    messages = request.pop("messages")
+    optional_params = get_optional_params(
+        model=model,
+        custom_llm_provider="watsonx",
+        messages=copy.deepcopy(messages),
+        stream=request.pop("stream", None),
+        **request,
+    )
+    optional_params["project_id"] = project_id
+    optional_params["space_id"] = space_id
+    api_params = _get_api_params(params=optional_params, model=model)
+    payload = _CONFIG._prepare_payload(model=model, api_params=api_params)
+    optional_params.update(payload)
+    stream = optional_params.pop("stream", None) or False
+    extra_body = optional_params.pop("extra_body", {})
+    optional_params.pop("json_mode", None)
+    optional_params.pop("max_retries", None)
+    optional_params["stream"] = stream
+    messages = _CONFIG._transform_messages(messages=messages, model=model)
+    return {
+        "model": payload.get("model_id") or "",
+        "messages": messages,
+        **optional_params,
+        **extra_body,
+    }
+
+
+def _v2(case: dict, deps=None):
+    return translate_chat_request(
+        copy.deepcopy(case), "watsonx", deps if deps is not None else _deps()
+    )
+
+
+def _norm(body: dict) -> str:
+    return json.dumps(body, sort_keys=True, default=str)
+
+
+@pytest.mark.parametrize("name", sorted(CASES))
+def test_v2_request_matches_v1(name: str) -> None:
+    case = CASES[name]
+    result = _v2(case)
+    assert result.is_ok(), result.error.summary
+    assert _norm(result.ok) == _norm(run_v1_request_transform(case))
+
+
+def test_space_id_arm_matches_v1() -> None:
+    result = _v2(CASES["plain"], deps=_deps(project_id=None, space_id="space-9"))
+    assert result.is_ok(), result.error.summary
+    v1 = run_v1_request_transform(CASES["plain"], project_id=None, space_id="space-9")
+    assert _norm(result.ok) == _norm(v1)
+    assert result.ok["space_id"] == "space-9" and "project_id" not in result.ok
+
+
+@pytest.mark.parametrize("name", sorted(V1_RAISES))
+def test_v1_raise_rows_fall_back_typed(name: str) -> None:
+    case, fragment = V1_RAISES[name]
+    result = _v2(case)
+    assert result.is_error(), f"{name} unexpectedly translated: {result.ok!r}"
+    assert fragment in result.error.summary, result.error.summary
+    with pytest.raises(UnsupportedParamsError):
+        run_v1_request_transform(case)
+
+
+def test_top_k_falls_back_where_v1_raises_the_legacy_value_error() -> None:
+    """top_k hits the watsonx-only legacy-text arm in get_optional_params —
+    a bare ValueError naming the watsonx_text provider, NOT
+    UnsupportedParamsError (pinned exact type)."""
+    case = {"model": MODEL, "messages": _U, "top_k": 5}
+    result = _v2(case)
+    assert result.is_error()
+    assert "watsonx_text" in result.error.summary
+    with pytest.raises(ValueError, match="watsonx_text"):
+        run_v1_request_transform(case)
+
+
+def test_missing_project_and_space_fall_back_where_v1_raises_401() -> None:
+    result = _v2(CASES["plain"], deps=_deps(project_id=None, space_id=None))
+    assert result.is_error()
+    assert "WatsonXAIError" in result.error.summary
+    with pytest.raises(Exception, match="project_id and space_id"):
+        run_v1_request_transform(CASES["plain"], project_id=None, space_id=None)
+
+
+def test_deployment_model_falls_back() -> None:
+    """v1 routes deployment/ models to deployment URLs with NO
+    model_id/project_id payload and pops api_version into the URL —
+    envelope behavior v2 does not reproduce; v1 serves."""
+    case = {"model": "deployment/dep-1", "messages": _U}
+    result = _v2(case)
+    assert result.is_error()
+    assert "deployment" in result.error.summary
+    v1_body = run_v1_request_transform(case)
+    assert v1_body["model"] == "" and "model_id" not in v1_body
+
+
+@pytest.mark.parametrize("name", sorted(V1_SERVES_FALLBACKS))
+def test_v1_serves_fallback_rows(name: str) -> None:
+    case, fragment = V1_SERVES_FALLBACKS[name]
+    result = _v2(case)
+    assert result.is_error(), f"{name} unexpectedly translated: {result.ok!r}"
+    assert fragment in result.error.summary, result.error.summary
+    run_v1_request_transform(case)
+
+
+def test_stream_key_always_on_the_wire() -> None:
+    """The openai_like handler re-adds ``stream or False`` unconditionally:
+    absent and explicit-false both serialize ``false`` — v2 serves BOTH
+    (no stream:false guard arm; the IR collapse is invisible here)."""
+    for case in (CASES["plain"], CASES["explicit_stream_false"]):
+        v1_body = run_v1_request_transform(case)
+        result = _v2(case)
+        assert result.is_ok()
+        assert v1_body["stream"] is False and result.ok["stream"] is False

--- a/tests/test_litellm/translation/test_differential_watsonx_response.py
+++ b/tests/test_litellm/translation/test_differential_watsonx_response.py
@@ -25,7 +25,11 @@ from litellm.types.utils import ModelResponse
 from litellm.translation.inbound.openai_chat import parse_request
 from litellm.translation.inbound.openai_chat.response import serialize_response
 from litellm.translation.providers.watsonx import parse_response
-from litellm.translation_seam import build_translation_deps, to_model_response
+from litellm.translation_seam import (
+    UsageStyle,
+    build_translation_deps,
+    to_model_response,
+)
 
 MODEL = "ibm/granite-3-8b-instruct"
 _REQUEST = {"model": MODEL, "messages": [{"role": "user", "content": "hi"}]}
@@ -134,11 +138,18 @@ def _v2_parse(raw: dict):
     return parse_response(copy.deepcopy(raw), parsed.ok)
 
 
-def _v2_model_response(raw: dict) -> dict:
+def _v2_with_style(raw: dict, style: UsageStyle) -> dict:
     response = _v2_parse(raw)
     assert response.is_ok(), response.error.summary
     body = serialize_response(response.ok, build_translation_deps(), "openai")
-    return to_model_response(body, None, usage_style="openai_like").model_dump()
+    return to_model_response(body, None, usage_style=style).model_dump()
+
+
+def _v2_model_response(raw: dict) -> dict:
+    # watsonx is DIRECT construction (the ONE wave-2b path where the
+    # openai_like prefix arm is LIVE) — the truth is
+    # pipeline.OWN_MODULE_RESPONSE_STYLES["watsonx"], divergence-pinned below
+    return _v2_with_style(raw, "openai_like")
 
 
 def _norm(payload: dict) -> str:
@@ -172,3 +183,29 @@ def test_non_string_wire_model_falls_back_where_v1_raises(frozen_ambient) -> Non
     assert "non-string wire model" in result.error.summary
     with pytest.raises(Exception):
         _v1_model_response(raw)
+
+
+def test_wrong_construction_arm_diverges_and_the_table_pins_it(
+    frozen_ambient,
+) -> None:
+    """Sibling-merge consistency sweep: alpha's MAJOR-4 table
+    (pipeline.OWN_MODULE_RESPONSE_STYLES) now covers the beta own modules;
+    watsonx is an openai_like member, so the wrong arm must be a PROVEN
+    divergence, not prose (the fireworks_ai/snowflake template): the openai
+    (cdr) arm rebuilds choices under enumerate, rewriting a verbatim wire
+    index 5 to 0, while v1's ModelResponse(**json) keeps it."""
+    from litellm.translation.engine.pipeline import OWN_MODULE_RESPONSE_STYLES
+
+    assert OWN_MODULE_RESPONSE_STYLES["watsonx"] == "openai_like"
+    raw = copy.deepcopy(_RESPONSES["text"])
+    raw["choices"][0]["index"] = 5
+    v1 = _v1_model_response(raw)
+    correct = _v2_with_style(raw, OWN_MODULE_RESPONSE_STYLES["watsonx"])
+    wrong = _v2_with_style(raw, "openai")
+    assert _norm(correct) == _norm(v1)
+    assert correct["choices"][0]["index"] == 5
+    assert wrong["choices"][0]["index"] == 0
+    assert _norm(wrong) != _norm(v1), (
+        "the construction arms stopped diverging on the index-rewrite body — "
+        "the MAJOR-4 gate lost its discriminator; re-decide before relying on it"
+    )

--- a/tests/test_litellm/translation/test_differential_watsonx_response.py
+++ b/tests/test_litellm/translation/test_differential_watsonx_response.py
@@ -1,0 +1,174 @@
+"""Differential parity for the watsonx response path (wave-2b-beta).
+
+v1 side: ``OpenAILikeChatConfig._transform_response`` invoked the way
+``OpenAILikeChatHandler`` calls it — ``custom_llm_provider="watsonx"``, the
+ONE wave-2b path where the openai_like PREFIX arm is LIVE:
+``ModelResponse(**response_json)`` directly, then
+``model = "watsonx/" + (wire model or "")``. v2: the watsonx parser
+(openai validation + verbatim wire with the prefixed WIRE model) + the
+seam's ``openai_like`` construction arm. v1 ignores the pre-allocated
+model_response on this path, so no shared-id plumbing is needed: both
+sides derive every byte from the wire body.
+"""
+
+import copy
+import json
+import time
+
+import httpx
+import pytest
+
+from litellm.litellm_core_utils.litellm_logging import Logging
+from litellm.llms.openai_like.chat.transformation import OpenAILikeChatConfig
+from litellm.types.utils import ModelResponse
+
+from litellm.translation.inbound.openai_chat import parse_request
+from litellm.translation.inbound.openai_chat.response import serialize_response
+from litellm.translation.providers.watsonx import parse_response
+from litellm.translation_seam import build_translation_deps, to_model_response
+
+MODEL = "ibm/granite-3-8b-instruct"
+_REQUEST = {"model": MODEL, "messages": [{"role": "user", "content": "hi"}]}
+
+_BASE = {
+    "id": "chat-1",
+    "object": "chat.completion",
+    "created": 1718000000,
+    "model": MODEL,
+    "usage": {"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5},
+}
+
+_RESPONSES = {
+    "text": {
+        **_BASE,
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "hello"},
+                "finish_reason": "stop",
+            }
+        ],
+    },
+    "tool_calls": {
+        **_BASE,
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "c1",
+                            "type": "function",
+                            "function": {"name": "f", "arguments": '{"a":1}'},
+                        }
+                    ],
+                },
+                "finish_reason": "tool_calls",
+            }
+        ],
+    },
+    "null_usage_tokens_sanitized": {
+        # the OpenAILike *_tokens-None sanitize is observationally dead:
+        # Usage coerces None -> 0 in the constructor (the family pin)
+        **_BASE,
+        "usage": {"prompt_tokens": None, "completion_tokens": 2, "total_tokens": None},
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "x"},
+                "finish_reason": "stop",
+            }
+        ],
+    },
+    "missing_model_prefixes_empty": {
+        **{key: value for key, value in _BASE.items() if key != "model"},
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "x"},
+                "finish_reason": "stop",
+            }
+        ],
+    },
+}
+
+
+def _v1_model_response(raw: dict) -> dict:
+    logging = Logging(
+        model=MODEL,
+        messages=copy.deepcopy(_REQUEST["messages"]),
+        stream=False,
+        call_type="completion",
+        start_time=time.time(),
+        litellm_call_id="diff-watsonx-response",
+        function_id="diff-watsonx-response",
+    )
+    response = httpx.Response(
+        200,
+        json=copy.deepcopy(raw),
+        request=httpx.Request("POST", "https://x/ml/v1/text/chat"),
+    )
+    return OpenAILikeChatConfig._transform_response(
+        model=MODEL,
+        response=response,
+        model_response=ModelResponse(),
+        stream=False,
+        logging_obj=logging,
+        optional_params={},
+        api_key=None,
+        data={},
+        messages=copy.deepcopy(_REQUEST["messages"]),
+        print_verbose=None,
+        encoding=None,
+        json_mode=None,
+        custom_llm_provider="watsonx",
+        base_model=None,
+    ).model_dump()
+
+
+def _v2_parse(raw: dict):
+    parsed = parse_request(copy.deepcopy(_REQUEST))
+    assert parsed.is_ok(), parsed.error.summary
+    return parse_response(copy.deepcopy(raw), parsed.ok)
+
+
+def _v2_model_response(raw: dict) -> dict:
+    response = _v2_parse(raw)
+    assert response.is_ok(), response.error.summary
+    body = serialize_response(response.ok, build_translation_deps(), "openai")
+    return to_model_response(body, None, usage_style="openai_like").model_dump()
+
+
+def _norm(payload: dict) -> str:
+    return json.dumps(payload, sort_keys=True, default=str)
+
+
+@pytest.mark.parametrize("name", sorted(_RESPONSES))
+def test_v2_response_matches_v1(name: str, frozen_ambient) -> None:
+    raw = _RESPONSES[name]
+    assert _norm(_v2_model_response(raw)) == _norm(_v1_model_response(raw))
+
+
+def test_live_prefix_uses_the_wire_model(frozen_ambient) -> None:
+    v1 = _v1_model_response(_RESPONSES["text"])
+    v2 = _v2_model_response(_RESPONSES["text"])
+    assert v1["model"] == f"watsonx/{MODEL}"
+    assert v2["model"] == f"watsonx/{MODEL}"
+
+
+def test_missing_model_serves_bare_prefix(frozen_ambient) -> None:
+    v2 = _v2_model_response(_RESPONSES["missing_model_prefixes_empty"])
+    assert v2["model"] == "watsonx/"
+
+
+def test_non_string_wire_model_falls_back_where_v1_raises(frozen_ambient) -> None:
+    """The verifier-longtail F2 arm: v1's ModelResponse(**json) raises
+    pydantic ValidationError BEFORE the prefix overwrite."""
+    raw = {**_RESPONSES["text"], "model": 7}
+    result = _v2_parse(raw)
+    assert result.is_error()
+    assert "non-string wire model" in result.error.summary
+    with pytest.raises(Exception):
+        _v1_model_response(raw)

--- a/tests/test_litellm/translation/test_differential_watsonx_stream.py
+++ b/tests/test_litellm/translation/test_differential_watsonx_stream.py
@@ -119,6 +119,62 @@ STREAMS = {
         _chunk({"role": "assistant", "content": "Hi"}),
         _chunk({}, finish="time_limit"),
     ],
+    # verifier-wave2b-beta F7: v1 SERVES "stop" for unknown finish strings
+    # (the live map_finish_reason default, run by the chunk envelope on
+    # BOTH sides now that v2 rides the wire string verbatim) and for truthy
+    # non-str hashable values (StreamingChoices maps them at validation) —
+    # the old conservative loud arm diverged on every one of these.
+    "unknown_finish_eos_token_serves_stop": [
+        _chunk({"role": "assistant", "content": "Hi"}),
+        _chunk({}, finish="eos_token"),
+    ],
+    "unknown_finish_string_serves_stop": [
+        _chunk({"role": "assistant", "content": "Hi"}),
+        _chunk({}, finish="totally_unknown_xyz"),
+    ],
+    "non_str_finish_int_serves_stop": [
+        _chunk({"role": "assistant", "content": "Hi"}),
+        _chunk({}, finish=5),
+    ],
+    "non_str_finish_bool_serves_stop": [
+        _chunk({"role": "assistant", "content": "Hi"}),
+        _chunk({}, finish=True),
+    ],
+    # critic-wave2b-beta B1.4: the validated Delta lax-coerces tool indexes
+    # (str "3" -> 3, bool -> 1) — the old tail rewrote both to 0, a served
+    # value rewrite.
+    "tool_index_str_lax_coerces": [
+        _chunk(
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "index": "3",
+                        "id": "c",
+                        "type": "function",
+                        "function": {"name": "f", "arguments": "{}"},
+                    }
+                ],
+            }
+        ),
+        _chunk({}, finish="tool_calls"),
+    ],
+    "tool_index_bool_lax_coerces": [
+        _chunk(
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "index": True,
+                        "id": "c",
+                        "type": "function",
+                        "function": {"name": "f", "arguments": "{}"},
+                    }
+                ],
+            }
+        ),
+        _chunk({}, finish="tool_calls"),
+    ],
 }
 
 USAGE_STREAM = [
@@ -265,6 +321,122 @@ _PINNED_DIVERGENCES = {
         None,
         "function",
     ),
+    # critic B1.4 / verifier F4: v1's Delta validation swallows each of
+    # these whole chunks; the old tail coerced id/name to None and index to
+    # 0 and SERVED an invented tool call in their place.
+    "tool_call_id_non_str": (
+        [
+            _chunk(
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "index": 0,
+                            "id": 42,
+                            "type": "function",
+                            "function": {"name": "f", "arguments": ""},
+                        }
+                    ],
+                }
+            )
+        ],
+        None,
+        "id is not a string",
+    ),
+    "tool_call_name_non_str": (
+        [
+            _chunk(
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "index": 0,
+                            "id": "c",
+                            "type": "function",
+                            "function": {"name": 5, "arguments": ""},
+                        }
+                    ],
+                }
+            )
+        ],
+        None,
+        "name is not a string",
+    ),
+    "tool_call_type_non_str": (
+        [
+            _chunk(
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "index": 0,
+                            "id": "c",
+                            "type": 7,
+                            "function": {"name": "f", "arguments": ""},
+                        }
+                    ],
+                }
+            )
+        ],
+        None,
+        "type is not a string",
+    ),
+    "tool_call_index_non_coercible": (
+        [
+            _chunk(
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "index": "x",
+                            "id": "c",
+                            "type": "function",
+                            "function": {"name": "f", "arguments": ""},
+                        }
+                    ],
+                }
+            )
+        ],
+        None,
+        "index is not an integer",
+    ),
+    "tool_call_index_fractional": (
+        [
+            _chunk(
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "index": 1.5,
+                            "id": "c",
+                            "type": "function",
+                            "function": {"name": "f", "arguments": ""},
+                        }
+                    ],
+                }
+            )
+        ],
+        None,
+        "index is not an integer",
+    ),
+    # verifier F4: usage VALUES Usage's lax coercion rejects fail the
+    # ModelResponseStream construction — v1 swallows the WHOLE chunk
+    # (content lost) where the old arm served the content chunk.
+    "mid_stream_usage_bad_values": (
+        [
+            _chunk(
+                {"role": "assistant", "content": "Hi"},
+                usage={"prompt_tokens": "abc"},
+            )
+        ],
+        None,
+        "not an integer",
+    ),
+    "usage_tail_bad_values": (
+        [_chunk(choices=[], usage={"prompt_tokens": "abc"})],
+        None,
+        "not an integer",
+    ),
 }
 
 
@@ -289,3 +461,58 @@ def test_pinned_divergences_v1_swallows_v2_loud(name: str, frozen_ambient) -> No
         result = parse_event(copy.deepcopy(events[0]))
     assert result.is_error(), f"{name} unexpectedly parsed"
     assert fragment in result.error.summary, result.error.summary
+
+
+# verifier F4/F7/F10: shapes v1 does NOT swallow — the iterator/wrapper
+# RAISES out of the stream (AttributeError or TypeError escapes the
+# except-ValueError arm -> MidStreamFallbackError); v2 is a typed error
+# naming that raise, never a served chunk.
+_V1_RAISES_LOUD = {
+    "delta_non_dict": (
+        [_chunk(choices=[{"index": 0, "delta": "oops", "finish_reason": None}])],
+        "not an object",
+    ),
+    "mid_stream_usage_non_dict": (
+        [_chunk({"role": "assistant", "content": "Hi"}, usage="oops")],
+        "usage is not an object",
+    ),
+    "usage_tail_non_dict": (
+        [_chunk(choices=[], usage="oops")],
+        "usage tail is not an object",
+    ),
+    "finish_truthy_unhashable": (
+        [_chunk({}, finish={"reason": "stop"})],
+        "unhashable",
+    ),
+    "tool_calls_non_list": (
+        [_chunk({"role": "assistant", "tool_calls": {"a": 1}})],
+        "not a list",
+    ),
+}
+
+
+@pytest.mark.parametrize("name", sorted(_V1_RAISES_LOUD))
+def test_v1_raising_shapes_are_loud_typed_errors(name: str, frozen_ambient) -> None:
+    events, fragment = _V1_RAISES_LOUD[name]
+    result = parse_event(copy.deepcopy(events[0]))
+    assert result.is_error(), f"{name} unexpectedly parsed"
+    assert fragment in result.error.summary, result.error.summary
+    with pytest.raises(Exception):
+        _v1_chunks(events)
+
+
+def test_falsy_finish_is_no_finish_with_the_synthesized_tail(frozen_ambient) -> None:
+    """F7: a falsy finish_reason ("", {}) fails StreamingChoices' truthy
+    gate in v1 — NO finish rides the chunk and the wrapper synthesizes the
+    trailing stop at StopIteration (seam scope, the no-wire-finish
+    contract); the old arm errored on "" and served "stop" inline for {}."""
+    for falsy in ("", {}):
+        events = [
+            _chunk({"role": "assistant", "content": "Hi"}),
+            _chunk({}, finish=falsy),
+        ]
+        v1 = _v1_chunks(events)
+        v2 = _v2_chunks(events)
+        assert len(v1) == len(v2) + 1, falsy
+        assert _norm(v2) == _norm(v1[:-1]), falsy
+        assert v1[-1]["choices"][0]["finish_reason"] == "stop", falsy

--- a/tests/test_litellm/translation/test_differential_watsonx_stream.py
+++ b/tests/test_litellm/translation/test_differential_watsonx_stream.py
@@ -1,0 +1,291 @@
+"""Differential parity for watsonx streaming (wave-2b-beta), pinned at the
+SSE line seam.
+
+v1 side: lines through the databricks ``ModelResponseIterator`` (researcher-4
+DRIFT: watsonx streams yield ``GenericStreamingChunk`` dicts, NOT the plain
+openai dialect) into ``CustomStreamWrapper("watsonx")``'s GENERIC arm —
+constructed by the openai_like handler with the BARE wire model. v2 side:
+``fold_lines`` with the watsonx parser and the shared ``generic`` chunk
+dialect, adapted by the same gate-local envelope the cohere gate documents
+(per-chunk fresh ids — normalized here — and no citations preset).
+
+Streams that end without a wire finish get the wrapper's SYNTHESIZED
+trailing finish chunk (seam scope, the cohere precedent); streams with an
+explicit finish chunk match byte-for-byte. PINNED DIVERGENCES: v1's
+iterator SILENTLY SWALLOWS non-JSON lines and chunks failing
+ModelResponseStream validation (pydantic ValidationError is a ValueError,
+eaten by the iterator's except arm) — v2 errors loudly on both.
+"""
+
+import copy
+import json
+import time
+
+import pytest
+
+from litellm.litellm_core_utils.litellm_logging import Logging
+from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
+from litellm.llms.databricks.streaming_utils import ModelResponseIterator
+from litellm.types.utils import ModelResponseStream, Usage
+
+from litellm.translation.engine.stream import fold_events, fold_lines
+from litellm.translation.inbound.openai_chat.stream import initial_state
+from litellm.translation.providers.watsonx import parse_event, parse_line
+
+MODEL = "ibm/granite-3-8b-instruct"
+
+_USAGE = {"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5}
+
+
+def _chunk(
+    delta: dict | None = None,
+    finish: str | None = None,
+    usage: dict | None = None,
+    choices: list | None = None,
+) -> dict:
+    payload: dict = {
+        "id": "c1",
+        "object": "chat.completion.chunk",
+        "created": 1718000000,
+        "model": MODEL,
+    }
+    payload["choices"] = (
+        choices
+        if choices is not None
+        else [
+            {
+                "index": 0,
+                "delta": delta if delta is not None else {},
+                "finish_reason": finish,
+            }
+        ]
+    )
+    if usage is not None:
+        payload["usage"] = usage
+    return payload
+
+
+STREAMS = {
+    "text": [
+        _chunk({"role": "assistant", "content": "He"}),
+        _chunk({"content": "llo"}),
+        _chunk({}, finish="stop"),
+    ],
+    "content_and_finish_in_one_wire_chunk": [
+        # v1 emits the content chunk, then the finish flush as its own chunk
+        _chunk({"role": "assistant", "content": "Hi"}, finish="stop"),
+    ],
+    "tools": [
+        _chunk(
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "f", "arguments": ""},
+                    }
+                ],
+            }
+        ),
+        _chunk({"tool_calls": [{"index": 0, "function": {"arguments": "{}"}}]}),
+        _chunk({}, finish="tool_calls"),
+    ],
+    "name_only_tool_start_rides_with_empty_arguments": [
+        # validation defaults missing/null arguments to "", so the
+        # iterator's `arguments is not None` check never fails
+        _chunk(
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "c",
+                        "type": "function",
+                        "function": {"name": "f"},
+                    }
+                ],
+            }
+        ),
+        _chunk({"tool_calls": [{"index": 0, "function": {"arguments": "{}"}}]}),
+        _chunk({}, finish="tool_calls"),
+    ],
+    "mid_stream_usage_stripped": [
+        _chunk({"role": "assistant", "content": "Hi"}, usage=_USAGE),
+        _chunk({}, finish="stop"),
+    ],
+    "ibm_time_limit_maps_to_stop": [
+        _chunk({"role": "assistant", "content": "Hi"}),
+        _chunk({}, finish="time_limit"),
+    ],
+}
+
+USAGE_STREAM = [
+    _chunk({"role": "assistant", "content": "Hi"}),
+    _chunk({}, finish="stop"),
+    _chunk(choices=[], usage=_USAGE),
+]
+
+
+def _v1_chunks(
+    events: list | None,
+    stream_options: dict | None = None,
+    raw_lines: list | None = None,
+) -> list:
+    lines = (
+        raw_lines
+        if raw_lines is not None
+        else [f"data: {json.dumps(event)}" for event in copy.deepcopy(events or [])]
+        + ["data: [DONE]"]
+    )
+    handler = ModelResponseIterator(streaming_response=iter(lines), sync_stream=True)
+    logging = Logging(
+        model=MODEL,
+        messages=[{"role": "user", "content": "stream"}],
+        stream=True,
+        call_type="completion",
+        start_time=time.time(),
+        litellm_call_id="diff-watsonx-stream",
+        function_id="diff-watsonx-stream",
+    )
+    wrapper = CustomStreamWrapper(
+        completion_stream=handler,
+        model=MODEL,
+        custom_llm_provider="watsonx",
+        logging_obj=logging,
+        stream_options=stream_options,
+    )
+    return [chunk.model_dump() for chunk in wrapper]
+
+
+def _to_stream_chunk(body: dict) -> dict:
+    """The generic-arm chunk envelope (the cohere gate precedent): fresh
+    ModelResponseStream per chunk, no citations/system_fingerprint preset,
+    usage as the verbatim ``Usage(**dict)``."""
+    payload = dict(body)
+    usage_payload = payload.pop("usage", None)
+    chunk = ModelResponseStream(**payload)
+    if isinstance(usage_payload, dict):
+        setattr(chunk, "usage", Usage(**usage_payload))
+    return chunk.model_dump()
+
+
+def _v2_chunks(events: list | None, raw_lines: list | None = None) -> list:
+    lines = (
+        raw_lines
+        if raw_lines is not None
+        else [f"data: {json.dumps(event)}" for event in copy.deepcopy(events or [])]
+        + ["data: [DONE]"]
+    )
+    folded = fold_lines(lines, parse_line, initial_state(MODEL, dialect="generic"))
+    assert folded.is_ok(), folded.error.summary
+    return [_to_stream_chunk(chunk) for chunk in folded.ok]
+
+
+def _norm(chunks: list) -> str:
+    normalized = []
+    for chunk in chunks:
+        assert str(chunk["id"]).startswith("chatcmpl-")
+        normalized.append({**chunk, "id": "ID"})
+    return json.dumps(normalized, sort_keys=True, default=str)
+
+
+@pytest.mark.parametrize("name", sorted(STREAMS))
+def test_v2_stream_matches_v1(name: str, frozen_ambient) -> None:
+    events = STREAMS[name]
+    assert _norm(_v2_chunks(events)) == _norm(_v1_chunks(events))
+
+
+def test_no_wire_finish_gets_the_synthesized_tail(frozen_ambient) -> None:
+    """A stream ending without a finish chunk: v1 synthesizes the trailing
+    "stop" at StopIteration (seam scope, the cohere contract)."""
+    events = [_chunk({"role": "assistant", "content": "Hi"})]
+    v1 = _v1_chunks(events)
+    v2 = _v2_chunks(events)
+    assert len(v1) == len(v2) + 1
+    assert _norm(v2) == _norm(v1[:-1])
+    assert v1[-1]["choices"][0]["finish_reason"] == "stop"
+
+
+def test_raw_json_lines_parse_without_data_prefix(frozen_ambient) -> None:
+    """v1's _strip_sse_data_from_chunk leaves non-prefixed lines alone and
+    the iterator json.loads them — the line seam is data:-OPTIONAL."""
+    raw = [
+        json.dumps(_chunk({"role": "assistant", "content": "raw"})),
+        json.dumps(_chunk({}, finish="stop")),
+        "data: [DONE]",
+    ]
+    assert _norm(_v2_chunks(None, raw_lines=raw)) == _norm(
+        _v1_chunks(None, raw_lines=raw)
+    )
+
+
+def test_usage_tail_pins_the_seam_contract(frozen_ambient) -> None:
+    v1 = _v1_chunks(USAGE_STREAM, stream_options={"include_usage": True})
+    v2 = _v2_chunks(USAGE_STREAM)
+    assert len(v1) == len(v2)
+    assert _norm(v2[:-1]) == _norm(v1[: len(v2) - 1])
+    assert v2[-1]["choices"] == []
+    for key in ("prompt_tokens", "completion_tokens", "total_tokens"):
+        assert v1[-1]["usage"][key] == v2[-1]["usage"][key], key
+
+
+def test_usage_tail_swallowed_without_stream_options(frozen_ambient) -> None:
+    v1 = _v1_chunks(USAGE_STREAM, None)
+    v2 = _v2_chunks(USAGE_STREAM)
+    assert len(v1) == len(v2) - 1
+    assert _norm(v1) == _norm(v2[:-1])
+
+
+def test_v2_line_and_event_folds_agree(frozen_ambient) -> None:
+    events = STREAMS["tools"]
+    folded = fold_events(
+        copy.deepcopy(events), parse_event, initial_state(MODEL, dialect="generic")
+    )
+    assert folded.is_ok(), folded.error.summary
+    via_events = [_to_stream_chunk(chunk) for chunk in folded.ok]
+    assert _norm(via_events) == _norm(_v2_chunks(events))
+
+
+_PINNED_DIVERGENCES = {
+    "non_json_line": (None, ["data: {notjson", "data: [DONE]"], "non-JSON"),
+    "non_string_content": (
+        [_chunk({"role": "assistant", "content": 5})],
+        None,
+        "not a string",
+    ),
+    "missing_choices": (
+        [{"id": "c1", "object": "chat.completion.chunk", "created": 1, "model": MODEL}],
+        None,
+        "choices",
+    ),
+    "tool_call_without_function": (
+        [_chunk({"role": "assistant", "tool_calls": [{"index": 0, "id": "c"}]})],
+        None,
+        "function",
+    ),
+}
+
+
+@pytest.mark.parametrize("name", sorted(_PINNED_DIVERGENCES))
+def test_pinned_divergences_v1_swallows_v2_loud(name: str, frozen_ambient) -> None:
+    """PINNED DIVERGENCE rows (fail-closed on failure paths): v1's iterator
+    silently swallows each shape (the except-ValueError arm eats pydantic
+    ValidationErrors and JSON decode errors alike) and the stream serves on
+    with the chunk LOST; v2 is a loud typed error. If v1 ever starts
+    serving or raising, the swallow assertion fails and the rows must be
+    re-decided."""
+    events, raw_lines, fragment = _PINNED_DIVERGENCES[name]
+    v1 = _v1_chunks(events, raw_lines=raw_lines)
+    assert all(
+        choice["delta"]["content"] in (None, "") and not choice["delta"]["tool_calls"]
+        for chunk in v1
+        for choice in chunk["choices"]
+    ), f"{name}: v1 stopped swallowing; re-decide the pinned divergence"
+    if raw_lines is not None:
+        result = parse_line(raw_lines[0])
+    else:
+        result = parse_event(copy.deepcopy(events[0]))
+    assert result.is_error(), f"{name} unexpectedly parsed"
+    assert fragment in result.error.summary, result.error.summary

--- a/tests/test_litellm/translation/test_differential_xai_stream.py
+++ b/tests/test_litellm/translation/test_differential_xai_stream.py
@@ -173,6 +173,32 @@ def test_unreachable_chunk_shape_is_a_typed_error(name: str) -> None:
     assert reason_fragment in result.error.summary, result.error.summary
 
 
+def test_reasoning_on_finish_chunk_is_loud_where_v1_interleaves(
+    frozen_ambient,
+) -> None:
+    """verifier-wave2b-alpha F1, the PRE-EXISTING xai hole: v1's wrapper
+    splits a reasoning-bearing finish chunk into a separate delta chunk
+    carrying reasoning_content + a bare finish chunk (4 emitted chunks); v2
+    used to serve an EMPTY finish chunk with the reasoning text silently
+    GONE. _delta_bears_content now counts reasoning/refusal, so the shape is
+    the existing loud finish-chunk fallback (typed error -> seam falls back
+    to v1) — fixed once in the shared httpx_chunk factory, inherited by
+    every consumer. Streaming flag-on obligation updated in CLAUDE.md."""
+    events = [
+        _chunk({"role": "assistant", "content": ""}),
+        _chunk({"content": "hi"}),
+        _chunk({"reasoning": "tail"}, finish="stop"),
+    ]
+    v1 = [dict(chunk) for chunk in replay_xai_sse_lines(events, None)]
+    assert len(v1) == len(events) + 1  # the interleaved reasoning chunk
+    interleaved = dict(v1[2]["choices"][0]["delta"])
+    assert interleaved["reasoning_content"] == "tail"
+    assert v1[3]["choices"][0]["finish_reason"] == "stop"
+    result = parse_event(copy.deepcopy(events[-1]))
+    assert result.is_error(), "reasoning-on-finish must be loud, never dropped"
+    assert "finish chunk with a non-empty delta" in result.error.summary
+
+
 def test_numeric_string_usage_folds_like_v1s_own_arithmetic() -> None:
     """v1's dict-path fold is int(x or 0): numeric strings fold
     (completion 2+7 -> 9, untouched keys keep their original values).

--- a/tests/test_litellm/translation/test_import_contract.py
+++ b/tests/test_litellm/translation/test_import_contract.py
@@ -94,29 +94,119 @@ def test_every_depth_cap_reads_v1s_one_constant() -> None:
         )
 
 
+def _is_depth_named(name: str) -> bool:
+    return "depth" in name.lower()
+
+
+def _is_int_literal(node: ast.expr | None) -> bool:
+    return (
+        isinstance(node, ast.Constant)
+        and isinstance(node.value, int)
+        and not isinstance(node.value, bool)
+    )
+
+
+def _is_positive_int_literal(node: ast.expr | None) -> bool:
+    return _is_int_literal(node) and isinstance(node, ast.Constant) and node.value > 0
+
+
+def _compare_offends(node: ast.Compare) -> bool:
+    operands = (node.left, *node.comparators)
+    named = any(
+        isinstance(n, ast.Name) and _is_depth_named(n.id) for n in operands
+    )
+    return named and any(_is_int_literal(n) for n in operands)
+
+
+def _binding_offends(node: ast.Assign | ast.AnnAssign) -> bool:
+    targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+    named = any(
+        isinstance(t, ast.Name) and _is_depth_named(t.id) for t in targets
+    )
+    return named and _is_positive_int_literal(node.value)
+
+
+def _arg_default_offends(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    positional = [*node.args.posonlyargs, *node.args.args]
+    defaulted = positional[len(positional) - len(node.args.defaults) :]
+    pairs = [
+        *zip(defaulted, node.args.defaults),
+        *zip(node.args.kwonlyargs, node.args.kw_defaults),
+    ]
+    return any(
+        _is_depth_named(arg.arg) and _is_positive_int_literal(default)
+        for arg, default in pairs
+    )
+
+
+def _hand_rolled_depth_caps(tree: ast.AST) -> list[int]:
+    """Line numbers of int-literal depth caps in any of the three shapes the
+    gate bans (extracted so the negative tests below can probe planted
+    sources without mutating the tree)."""
+    offences: list[int] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Compare) and _compare_offends(node):
+            offences.append(node.lineno)
+        elif isinstance(node, (ast.Assign, ast.AnnAssign)) and _binding_offends(node):
+            offences.append(node.lineno)
+        elif isinstance(
+            node, (ast.FunctionDef, ast.AsyncFunctionDef)
+        ) and _arg_default_offends(node):
+            offences.append(node.lineno)
+    return offences
+
+
 def test_no_module_hand_rolls_a_numeric_depth_cap() -> None:
-    """No comparison of a ``*depth*`` name against an int literal anywhere in
-    the package: caps must compare against the imported constant (the rule
-    that makes the unification stick — a literal 10/16/100 is exactly the
-    drift shape F2 refuted)."""
+    """No int-literal depth cap anywhere in the package, in ANY of the three
+    shapes: a ``*depth*`` name compared against an int literal, an
+    int-literal ASSIGNMENT to a ``*depth*``-named binding (beta F2's
+    renamed-constant shape, ``_REFS_MAX_DEPTH = 10``), or a positive
+    int-literal DEFAULT on a ``*depth*``-named parameter (the dead
+    ``max_depth: int = 10`` shape). Caps must read the imported constant.
+    critic-wave2b-final MAJOR-1: the compare-only scan missed the two
+    binding-routed shapes — both are now negative-tested below. A ``0``
+    default/binding stays allowed: it is a recursion COUNTER's start, not a
+    cap (openai_compat.guard.carries_cache_control). Disclosed residual
+    (verifier-wave2b-final F5): a cap whose name avoids "depth" (e.g.
+    ``level``) slips this name heuristic — review scope; the identity gate
+    above still catches all import drift."""
     offenders = []
     for path in sorted(_PACKAGE_ROOT.rglob("*.py")):
         tree = ast.parse(path.read_text(), filename=str(path))
-        for node in ast.walk(tree):
-            if not isinstance(node, ast.Compare):
-                continue
-            named = [
-                n
-                for n in (node.left, *node.comparators)
-                if isinstance(n, ast.Name) and "depth" in n.id.lower()
-            ]
-            literal_int = [
-                n
-                for n in (node.left, *node.comparators)
-                if isinstance(n, ast.Constant) and isinstance(n.value, int)
-            ]
-            if named and literal_int:
-                offenders.append(
-                    f"{path.relative_to(_PACKAGE_ROOT)}:{node.lineno}"
-                )
+        offenders.extend(
+            f"{path.relative_to(_PACKAGE_ROOT)}:{lineno}"
+            for lineno in _hand_rolled_depth_caps(tree)
+        )
     assert offenders == [], "hand-rolled depth caps: " + "; ".join(offenders)
+
+
+def test_depth_gate_catches_a_renamed_constant_binding() -> None:
+    """critic-wave2b-final MAJOR-1 probe 1, now a pinned negative test: the
+    historical mistral ``_REFS_MAX_DEPTH = 10`` shape routes the literal
+    through a module binding and compares name-vs-name — the compare-only
+    scan passed it; the binding scan must flag it."""
+    planted = ast.parse(
+        "_REFS_MAX_DEPTH = 10\n"
+        "def _walk(value, depth):\n"
+        "    if depth >= _REFS_MAX_DEPTH:\n"
+        "        return None\n"
+        "    return _walk(value, depth + 1)\n"
+    )
+    assert _hand_rolled_depth_caps(planted) == [1]
+
+
+def test_depth_gate_catches_an_int_literal_parameter_default() -> None:
+    """critic-wave2b-final MAJOR-1 probe 2, now a pinned negative test: the
+    dead ``max_depth: int = 10`` default with name-vs-name compares only —
+    the exact F2 drift shape the original gate claimed to ban but missed.
+    A ``depth: int = 0`` start counter stays green (the live
+    carries_cache_control signature)."""
+    planted = ast.parse(
+        "def _mut_strip(value, max_depth: int = 10):\n"
+        "    if max_depth <= len(str(value)):\n"
+        "        return value\n"
+        "    return _mut_strip(value, max_depth - 1)\n"
+    )
+    assert _hand_rolled_depth_caps(planted) == [1]
+    counter = ast.parse("def _scan(value, depth: int = 0):\n    return depth\n")
+    assert _hand_rolled_depth_caps(counter) == []

--- a/tests/test_litellm/translation/test_import_contract.py
+++ b/tests/test_litellm/translation/test_import_contract.py
@@ -40,3 +40,83 @@ def test_no_module_imports_a_forbidden_v1_surface() -> None:
             if module.startswith(_FORBIDDEN_PREFIXES):
                 offenders.append(f"{path.relative_to(_PACKAGE_ROOT)} -> {module}")
     assert offenders == [], "forbidden imports: " + "; ".join(offenders)
+
+
+# --- the ONE recursion-depth-cap truth (wave-2b sibling-merge unification) ---
+#
+# verifier-wave2b-beta F2's lesson generalized: a hand-copied depth cap (the
+# old mistral _REFS_MAX_DEPTH = 10, the old compat_sdk cache scan cap of 16)
+# drifts from the constant v1's call sites actually read. The beta pattern —
+# import litellm.constants.DEFAULT_MAX_RECURSE_DEPTH directly, drift
+# impossible by construction — is now the package rule, and this gate covers
+# EVERY consumer instead of mistral alone (the integrator queue's depth-cap
+# unification item). APPEND a module name below when a new consumer lands.
+
+_DEPTH_CAP_CONSUMERS = (
+    "providers.google_genai.schema",
+    "providers.mistral.serialize",
+    "providers.openai_compat.guard",
+    "providers.openai_compat.serialize",
+    "providers.watsonx.serialize",
+    "providers.xai.guard",
+)
+
+
+def test_every_depth_cap_reads_v1s_one_constant() -> None:
+    """Each consumer's binding must BE litellm.constants'
+    DEFAULT_MAX_RECURSE_DEPTH (identity, not equality) and arrive via a
+    direct ``from litellm.constants import`` — and the discovered consumer
+    set must match the pinned table, so both adding a hand-rolled cap and
+    silently dropping the constant are loud."""
+    import importlib
+
+    from litellm.constants import DEFAULT_MAX_RECURSE_DEPTH
+
+    discovered = []
+    for path in sorted(_PACKAGE_ROOT.rglob("*.py")):
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.ImportFrom)
+                and node.module == "litellm.constants"
+                and any(a.name == "DEFAULT_MAX_RECURSE_DEPTH" for a in node.names)
+            ):
+                rel = path.relative_to(_PACKAGE_ROOT).with_suffix("")
+                discovered.append(".".join(rel.parts))
+    assert tuple(sorted(discovered)) == _DEPTH_CAP_CONSUMERS, (
+        f"depth-cap consumer drift: discovered {sorted(discovered)!r}; update "
+        "the pinned table in the same commit as the consumer"
+    )
+    for name in _DEPTH_CAP_CONSUMERS:
+        module = importlib.import_module(f"litellm.translation.{name}")
+        assert module.DEFAULT_MAX_RECURSE_DEPTH is DEFAULT_MAX_RECURSE_DEPTH, (
+            f"{name} stopped reading v1's constant"
+        )
+
+
+def test_no_module_hand_rolls_a_numeric_depth_cap() -> None:
+    """No comparison of a ``*depth*`` name against an int literal anywhere in
+    the package: caps must compare against the imported constant (the rule
+    that makes the unification stick — a literal 10/16/100 is exactly the
+    drift shape F2 refuted)."""
+    offenders = []
+    for path in sorted(_PACKAGE_ROOT.rglob("*.py")):
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Compare):
+                continue
+            named = [
+                n
+                for n in (node.left, *node.comparators)
+                if isinstance(n, ast.Name) and "depth" in n.id.lower()
+            ]
+            literal_int = [
+                n
+                for n in (node.left, *node.comparators)
+                if isinstance(n, ast.Constant) and isinstance(n.value, int)
+            ]
+            if named and literal_int:
+                offenders.append(
+                    f"{path.relative_to(_PACKAGE_ROOT)}:{node.lineno}"
+                )
+    assert offenders == [], "hand-rolled depth caps: " + "; ".join(offenders)


### PR DESCRIPTION
Stacks on #30305 (long-tail waves 1b+2a). Part of the translation v2 series: #30253 → #30254 → #30255 → #30275 → #30283 → #30290 → #30305 → this.

## What this adds

**Eleven own-module providers ported to v2**, built as two parallel waves and integrated:

- **Alpha** (ascending dossier risk): deepseek, openrouter, hosted_vllm, fireworks_ai, snowflake, huggingface (api_base route; the router route stays a typed v1 fallback wholesale).
- **Beta** (the heavier half): cohere + cohere_chat (one module with route predicates — the first non-openai-shaped own module since google, full serializer/parser pair against the IR), mistral, watsonx, sagemaker_chat (sagemaker_nova deliberately unregistered, canaried), groq (json_schema three-way fork: native serve / typed workaround fallback / exact BadRequestError parity).

Each provider is its own `providers/<name>/` package registered in the pipeline tables with dedicated differential gates in the same commit.

## Cross-cutting work

- The httpx chunk factory gained an "unconditional" reasoning arm (openrouter) and now treats reasoning/refusal on finish chunks as content-bearing — closing a pre-existing silent-drop hole that reached back to xai.
- Depth caps unified on `litellm.constants.DEFAULT_MAX_RECURSE_DEPTH` (the constant v1 reads) with AST drift gates that ban literal re-bindings and parameter-default copies.
- `OWN_MODULE_RESPONSE_STYLES` registration gate covers all eleven modules, every value pinned per member (wrong-arm wiring fails the suite).
- 13 new named, failure-counted PINNED DIVERGENCE rows (watsonx stream strictness ×11, cohere non-string text, groq refusal-on-finish) — every deliberate fail-closed divergence is a live computation in the report, not prose.

## Review trail

Full adversarial pipeline per branch (reports in the sprint archive): hostile critic + antagonist verifier on each build, fix rounds (beta's verifier initially REFUTED the branch with hostile probes — cohere fail-open citations, a mistral recursion-cap divergence on ordinary 4-deep tool schemas, coercions serving where v1 raises — all fixed and re-proven with the verifier's own repros), sibling-merge integrator, then a publication critic + verifier round on the merged result (0 BLOCKERs; 24-stream hostile corpus through all 19 factory consumers showed zero merge drift; every parent fix re-verified to have survived the merge). All MAJORs fixed in-history.

## Verification (reproduced independently at aa2b84f101)

- `make lint-translation` exit 0: ruff, pyright strict (0 errors, no `Any`), semgrep, import-linter, size caps, CLAUDE.md freshness; pytest **3047 passed / 8 skipped**.
- Differential report: **0 divergent**, exactly **14 pinned** failure-counted rows, regen byte-identical.
- Flag-off: all eleven providers' v1 surfaces + xai — **529 passed / 4 skipped**, equal to the per-branch baselines exactly (byte-for-byte v1 behavior with the flag off).
- Diff confined to `litellm/translation/`, `litellm/translation_seam.py`, the size-gate script, and translation tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)