### PR TITLE
fix(helm): wire envFrom secrets and configmaps into migrations job (closes #30311)

### DIFF
--- a/helm/litellm-helm/templates/migrations-job.yaml
+++ b/helm/litellm-helm/templates/migrations-job.yaml
@@ -89,6 +89,15 @@ spec:
             {{- end }}
             - name: DISABLE_SCHEMA_UPDATE
               value: "false" # always run the migration from the Helm PreSync hook, override the value set
+          envFrom:
+          {{- range .Values.environmentSecrets }}
+            - secretRef:
+                name: {{ . }}
+          {{- end }}
+          {{- range .Values.environmentConfigMaps }}
+            - configMapRef:
+                name: {{ . }}
+          {{- end }}
           {{- with .Values.volumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 12 }}

--- a/helm/litellm-helm/tests/migrations-job_tests.yaml
+++ b/helm/litellm-helm/tests/migrations-job_tests.yaml
@@ -223,6 +223,61 @@ tests:
             name: init-tpl
             image: "ghcr.io/berriai/litellm-database:test"
             command: ["echo", "hello"]
+  - it: should work with environmentSecrets
+    template: migrations-job.yaml
+    set:
+      migrationJob:
+        enabled: true
+      environmentSecrets:
+        - litellm-env-secret
+        - litellm-extra-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: litellm-env-secret
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: litellm-extra-secret
+
+  - it: should work with environmentConfigMaps
+    template: migrations-job.yaml
+    set:
+      migrationJob:
+        enabled: true
+      environmentConfigMaps:
+        - litellm-env-configmap
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            configMapRef:
+              name: litellm-env-configmap
+
+  - it: should work with both environmentSecrets and environmentConfigMaps
+    template: migrations-job.yaml
+    set:
+      migrationJob:
+        enabled: true
+      environmentSecrets:
+        - litellm-env-secret
+      environmentConfigMaps:
+        - litellm-env-configmap
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: litellm-env-secret
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            configMapRef:
+              name: litellm-env-configmap
+
   - it: should work with extraContainers
     template: migrations-job.yaml
     set:


### PR DESCRIPTION
## Relevant issues

Closes #30311

## Linear ticket

n/a (community contribution)

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] Greptile review complete: **5/5 Confidence Score** ([review link](https://github.com/BerriAI/litellm/pull/30325#issuecomment-4696689895)), Greptile flagged no issues and notes the change is a minimal copy of the existing pattern with no behavioural side-effects

## Screenshots / Proof of Fix

Render the migrations Job with two env secrets and one configmap set via the standard chart values

```
helm template test deploy/charts/litellm-helm \
  --set environmentSecrets='{litellm-env-secret,extra-secret}' \
  --set environmentConfigMaps='{litellm-env-configmap}' \
  --set 'migrationJob.enabled=true' \
  --set 'db.useExisting=true' \
  --set 'db.secret.name=litellm-db-secret' \
  --set 'db.secret.usernameKey=username' \
  --set 'db.secret.passwordKey=password' \
  --set 'db.secret.endpointKey=endpoint' \
  --set 'db.database=litellm' \
  --set 'db.url=postgresql://user:pass@host:5432/litellm' \
  --show-only templates/migrations-job.yaml
```

Output (relevant slice)

```
            - name: DISABLE_SCHEMA_UPDATE
              value: "false"
          envFrom:
            - secretRef:
                name: litellm-env-secret
            - secretRef:
                name: extra-secret
            - configMapRef:
                name: litellm-env-configmap
      restartPolicy: OnFailure
```

Empty case still parses cleanly (matches the existing `deployment.yaml` behavior)

```
helm template test deploy/charts/litellm-helm \
  --set 'migrationJob.enabled=true' \
  --show-only templates/migrations-job.yaml | grep -B1 -A1 envFrom
```

Output

```
              value: "false"
          envFrom:
      restartPolicy: OnFailure
```

Unit tests via helm-unittest

```
helm unittest -f 'tests/migrations-job_tests.yaml' deploy/charts/litellm-helm
```

Output

```
 PASS  test migrations job  tests/migrations-job_tests.yaml

Charts:      1 passed, 1 total
Test Suites: 1 passed, 1 total
Tests:       17 passed, 17 total
```

Three new regression cases cover the three failure modes of the bug (environmentSecrets only, environmentConfigMaps only, both together)

## Type

Bug Fix

## Changes

Adds the same `envFrom:` block already present in `templates/deployment.yaml` to `templates/migrations-job.yaml`, ranging over `.Values.environmentSecrets` and `.Values.environmentConfigMaps`. The migrations Job container now sees the same Secret and ConfigMap references the main Deployment does, so a `DATABASE_*` var that lives in a referenced Secret (the common production pattern) reaches the Prisma migration step. Mirroring keeps the two surfaces from drifting on future value-key additions

Test file adds three new cases following the existing style: secrets-only, configmaps-only, and both, each asserting the rendered `envFrom` list contains the expected refs

