### PR TITLE
fix(proxy): grace-period key rotation 401s; return deprecated-key lookup result directly

### DIFF
--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -3692,7 +3692,10 @@ class PrismaClient:
                             db=self.db, hashed_token=hashed_token
                         )
                         if active_token_id:
-                            response = await self.get_data(
+                            # The recursive call returns a finished
+                            # LiteLLM_VerificationTokenView; the dict
+                            # normalization below would crash subscripting it.
+                            deprecated_response = await self.get_data(
                                 token=active_token_id,
                                 table_name="combined_view",
                                 query_type="find_unique",
@@ -3700,10 +3703,11 @@ class PrismaClient:
                                 proxy_logging_obj=proxy_logging_obj,
                                 check_deprecated=False,
                             )
-                            if response is not None:
+                            if deprecated_response is not None:
                                 verbose_proxy_logger.debug(
                                     "Deprecated key used during grace period"
                                 )
+                            return deprecated_response
 
                     if response is not None:
                         if response["team_models"] is None:

--- a/tests/test_litellm/proxy/utils/prisma_and_spend/test_prisma_client_get_data.py
+++ b/tests/test_litellm/proxy/utils/prisma_and_spend/test_prisma_client_get_data.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -22,6 +23,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from fastapi import HTTPException
 
+from litellm.proxy._types import LiteLLM_VerificationTokenView
 from litellm.proxy.utils import PrismaClient
 
 
@@ -476,3 +478,39 @@ async def test_get_data_logs_and_raises_on_db_error(
     )
     with pytest.raises(RuntimeError, match="network split"):
         await prisma_client.get_data(token="sk-broken", table_name="key")
+
+
+@pytest.mark.asyncio
+async def test_get_data_combined_view_returns_view_for_deprecated_key(
+    prisma_client: PrismaClient,
+) -> None:
+    """Grace-period rotation, full get_data flow: the old hash misses the
+    combined view, the deprecated-key table resolves it to the active token,
+    and get_data must return the recursive lookup's finished view instead of
+    re-running dict normalization on it (which raised TypeError and turned
+    every grace-period request into a 401)."""
+    old_hash = "hashed-old-token-grace-e2e"
+    active_hash = "hashed-active-token-grace-e2e"
+    active_row = {
+        "token": active_hash,
+        "team_models": None,
+        "team_blocked": None,
+        "team_members_with_roles": None,
+        "user_id": None,
+        "expires": None,
+    }
+    prisma_client.db.query_first = AsyncMock(side_effect=[None, active_row])
+    prisma_client.db.litellm_deprecatedverificationtoken = MagicMock()
+    prisma_client.db.litellm_deprecatedverificationtoken.find_first = AsyncMock(
+        return_value=SimpleNamespace(
+            active_token_id=active_hash,
+            revoke_at=datetime.now(timezone.utc) + timedelta(hours=1),
+        )
+    )
+
+    response = await prisma_client.get_data(
+        token=old_hash, table_name="combined_view", query_type="find_unique"
+    )
+
+    assert isinstance(response, LiteLLM_VerificationTokenView)
+    assert response.token == active_hash


### PR DESCRIPTION
## Relevant issues

Completes the grace-period key rotation fix started in #27756. That PR fixed the tuple-shape crash inside `_lookup_deprecated_key`, but the end-to-end flow still failed: in `PrismaClient.get_data`, the combined-view deprecated-key branch assigns the recursive `get_data` result (a finished `LiteLLM_VerificationTokenView`) back into the variable that the dict-normalization block then subscripts. That raises `TypeError: 'LiteLLM_VerificationTokenView' object is not subscriptable` on every request made with a rotated key during its grace window, and auth surfaces it as a 401. The customer-reported symptom ("old key rejected with 401 on every request during the grace window, including the first") reproduces against a live proxy on current staging.

The fix returns the recursive lookup's result directly instead of falling through into the dict normalization that the raw-SQL path needs.

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Reproduced against a live proxy (key generated, regenerated with `grace_period: "1h"`, then the old key used twice):

```
curl -s -X POST "http://localhost:4001/key/regenerate" -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" -d '{"key":"<old-key>","grace_period":"1h"}'

curl -s -o /dev/null -w "HTTP %{http_code}\n" "http://localhost:4001/v1/models" -H "Authorization: Bearer <old-key>"
HTTP 401   # before this fix, despite the deprecated-key row existing with revoke_at 1h out
```

Direct driver of the same code path shows the underlying error before the fix:

```
_lookup_deprecated_key -> 216a00ea11c3d522ede77c33a4ec1a20ac7e1e39199572f96a062c2da14441cc
TypeError: 'LiteLLM_VerificationTokenView' object is not subscriptable   # litellm/proxy/utils.py get_data combined view
```

The new regression test drives the full `get_data` flow (old hash misses the view, deprecated table resolves to the active token) and fails with that TypeError on current staging, passes with this change.

## Type

🐛 Bug Fix

## Changes

One-line behavior change in `PrismaClient.get_data` (return the deprecated-key recursive lookup result directly) plus a regression test in `tests/test_litellm/proxy/utils/prisma_and_spend/test_prisma_client_get_data.py`
