### PR TITLE
chore(release): cherry-pick MCP fixes onto v1.89.0-rc.2 toward rc.3

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/db.py
+++ b/litellm/proxy/_experimental/mcp_server/db.py
@@ -557,10 +557,12 @@ async def delete_mcp_server(
     """
     Delete the mcp server from the db by server_id
 
-    The server-row delete is the commit point. Per-user env var rows have no FK
-    cascade, so they are cleaned up afterwards on a best-effort basis: a transient
-    failure there leaves only orphaned rows pointing at a now-missing server and
-    must not turn a successful delete into a caller-visible error.
+    The server-row delete is the commit point. Per-user credential and env var
+    rows have no FK cascade, so they are cleaned up afterwards on a best-effort
+    basis: a transient failure there leaves only orphaned rows pointing at a
+    now-missing server and must not turn a successful delete into a
+    caller-visible error. Each table is cleaned independently so a failure on one
+    still attempts the other.
 
     Returns the deleted mcp server record if it exists, otherwise None
     """
@@ -570,17 +572,20 @@ async def delete_mcp_server(
         },
     )
     if deleted_server is not None:
-        try:
-            await prisma_client.db.litellm_mcpuserenvvars.delete_many(
-                where={"server_id": server_id}
-            )
-        except Exception as e:
-            verbose_proxy_logger.warning(
-                "MCP server %s deleted but per-user env var cleanup failed; "
-                "orphaned rows can be removed on a later delete: %s",
-                server_id,
-                e,
-            )
+        for model, label in (
+            (prisma_client.db.litellm_mcpusercredentials, "credential"),
+            (prisma_client.db.litellm_mcpuserenvvars, "env var"),
+        ):
+            try:
+                await model.delete_many(where={"server_id": server_id})
+            except Exception as e:
+                verbose_proxy_logger.warning(
+                    "MCP server %s deleted but per-user %s cleanup failed; "
+                    "orphaned rows can be removed on a later delete: %s",
+                    server_id,
+                    label,
+                    e,
+                )
     return deleted_server
 
 

--- a/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
@@ -512,12 +512,13 @@ async def exchange_token_with_server(
     result = {
         "access_token": access_token,
         "token_type": token_response.get("token_type", "Bearer"),
-        "expires_in": token_response.get("expires_in", 3600),
     }
 
-    if "refresh_token" in token_response and token_response["refresh_token"]:
+    if token_response.get("expires_in") is not None:
+        result["expires_in"] = token_response["expires_in"]
+    if token_response.get("refresh_token"):
         result["refresh_token"] = token_response["refresh_token"]
-    if "scope" in token_response and token_response["scope"]:
+    if token_response.get("scope"):
         result["scope"] = token_response["scope"]
 
     # RFC 6749 §5.1: token responses must not be cached.

--- a/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
@@ -386,8 +386,15 @@ if MCP_AVAILABLE:
         raw_headers: Optional[Dict[str, str]] = None,
         user_api_key_auth: Optional[UserAPIKeyAuth] = None,
         extra_headers: Optional[Dict[str, str]] = None,
+        apply_tool_filters: bool = True,
     ):
-        """Helper function to get tools for a single server."""
+        """Helper function to get tools for a single server.
+
+        When ``apply_tool_filters`` is False the raw server catalog is returned
+        without the allowed_tools/disallowed_tools gate or the per-key tool
+        permissions. This is the admin-only configuration view; every runtime
+        path keeps the default True so callable tools stay filtered.
+        """
         tools = await global_mcp_server_manager._get_tools_from_server(
             server=server,
             mcp_auth_header=server_auth_header,
@@ -396,6 +403,9 @@ if MCP_AVAILABLE:
             raw_headers=raw_headers,
             user_api_key_auth=user_api_key_auth,
         )
+
+        if not apply_tool_filters:
+            return _create_tool_response_objects(tools, server.mcp_info)
 
         # Always apply allowed_tools/disallowed_tools so the blacklist is
         # enforced even when no allowlist is set (matches the SSE/HTTP path).
@@ -463,6 +473,7 @@ if MCP_AVAILABLE:
         mcp_auth_header: Optional[str],
         raw_headers_from_request: dict,
         user_api_key_dict: UserAPIKeyAuth,
+        apply_tool_filters: bool = True,
     ) -> dict:
         """Handle tool listing for a single server_id request."""
         # Resolve a server name to its UUID if needed
@@ -527,6 +538,7 @@ if MCP_AVAILABLE:
                 raw_headers_from_request,
                 user_api_key_dict,
                 extra_headers=user_oauth_extra_headers,
+                apply_tool_filters=apply_tool_filters,
             )
         except MCPUpstreamAuthError:
             # Surface the upstream 401/403 to the caller so it can emit the
@@ -551,6 +563,14 @@ if MCP_AVAILABLE:
         request: Request,
         server_id: Optional[str] = Query(
             None, description="The server id to list tools for"
+        ),
+        include_disabled_tools: bool = Query(
+            False,
+            description=(
+                "Admin only. Return the full server tool catalog without the "
+                "allowed_tools filter or per-key tool permissions, so the MCP "
+                "settings UI can configure the allowlist. Ignored for non-admins."
+            ),
         ),
         user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
     ) -> dict:
@@ -579,6 +599,13 @@ if MCP_AVAILABLE:
         )
 
         try:
+            # The full catalog (allowlist filter skipped) is admin-only so the
+            # REST endpoint can't be used to enumerate deliberately-disabled tools.
+            apply_tool_filters = not (
+                include_disabled_tools
+                and user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN
+            )
+
             # Extract auth headers from request
             headers = request.headers
             raw_headers_from_request = dict(headers)
@@ -620,6 +647,7 @@ if MCP_AVAILABLE:
                     mcp_auth_header=mcp_auth_header,
                     raw_headers_from_request=raw_headers_from_request,
                     user_api_key_dict=user_api_key_dict,
+                    apply_tool_filters=apply_tool_filters,
                 )
             else:
                 if not allowed_server_ids:
@@ -677,6 +705,7 @@ if MCP_AVAILABLE:
                             raw_headers_from_request,
                             user_api_key_dict,
                             extra_headers=user_oauth_extra_headers,
+                            apply_tool_filters=apply_tool_filters,
                         )
                         list_tools_result.extend(tools_result)
                     except Exception as e:

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -21,7 +21,7 @@ import json
 import os
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, Iterable, List, Literal, Optional
+from typing import Any, Dict, Iterable, List, Literal, Optional, Set
 
 from fastapi import (
     APIRouter,
@@ -1714,11 +1714,13 @@ if MCP_AVAILABLE:
                     status_code=status.HTTP_403_FORBIDDEN,
                     detail={"error": f"Access denied to MCP server {server_id}"},
                 )
-            allowed_server_ids = (
-                await global_mcp_server_manager.get_allowed_mcp_servers(
-                    user_api_key_dict
+            allowed_server_ids: Set[str] = set()
+            for auth_context in await build_effective_auth_contexts(user_api_key_dict):
+                allowed_server_ids.update(
+                    await global_mcp_server_manager.get_allowed_mcp_servers(
+                        auth_context
+                    )
                 )
-            )
             if server.server_id not in allowed_server_ids:
                 raise HTTPException(
                     status_code=status.HTTP_403_FORBIDDEN,

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
@@ -1,5 +1,6 @@
 """Tests for MCP OAuth discoverable endpoints"""
 
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -2661,3 +2662,74 @@ async def test_token_endpoint_sets_no_store_cache_control():
 
     assert response.headers["cache-control"] == "no-store"
     assert response.headers["pragma"] == "no-cache"
+
+
+async def _exchange_with_upstream_token_response(upstream_body):
+    from fastapi import Request
+
+    from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+        exchange_token_with_server,
+    )
+    from litellm.proxy._types import MCPTransport
+    from litellm.types.mcp import MCPAuth
+    from litellm.types.mcp_server.mcp_server_manager import MCPServer
+
+    server = MCPServer(
+        server_id="t",
+        name="t",
+        server_name="t",
+        alias="t",
+        transport=MCPTransport.http,
+        auth_type=MCPAuth.oauth2,
+        client_id="cid",
+        client_secret="cs",
+        authorization_url="https://provider.com/oauth/authorize",
+        token_url="https://provider.com/oauth/token",
+    )
+    mock_request = MagicMock(spec=Request)
+    mock_request.base_url = "https://litellm.example.com/"
+    mock_request.headers = {}
+
+    fake_http_response = MagicMock()
+    fake_http_response.json.return_value = upstream_body
+    fake_http_response.raise_for_status = MagicMock()
+    fake_http_client = MagicMock()
+    fake_http_client.post = AsyncMock(return_value=fake_http_response)
+
+    with patch(
+        "litellm.proxy._experimental.mcp_server.discoverable_endpoints.get_async_httpx_client",
+        return_value=fake_http_client,
+    ):
+        response = await exchange_token_with_server(
+            request=mock_request,
+            mcp_server=server,
+            grant_type="authorization_code",
+            code="c",
+            redirect_uri="http://127.0.0.1:3000/cb",
+            client_id="cid",
+            client_secret=None,
+            code_verifier=None,
+        )
+    return json.loads(response.body)
+
+
+@pytest.mark.asyncio
+async def test_token_exchange_omits_expires_in_when_upstream_omits_it():
+    """A provider that issues a non-expiring token (e.g. Slack without token
+    rotation) returns no ``expires_in``. The exchange must mirror that and omit
+    ``expires_in`` rather than fabricate a 1-hour TTL, so the stored credential
+    is treated as non-expiring instead of dying after an hour."""
+    body = await _exchange_with_upstream_token_response(
+        {"access_token": "tok", "token_type": "Bearer"}
+    )
+    assert "expires_in" not in body
+
+
+@pytest.mark.asyncio
+async def test_token_exchange_passes_through_upstream_expires_in():
+    """When the provider does send ``expires_in`` (e.g. Slack with token
+    rotation), the exchange forwards the real value unchanged."""
+    body = await _exchange_with_upstream_token_response(
+        {"access_token": "tok", "token_type": "Bearer", "expires_in": 43200}
+    )
+    assert body["expires_in"] == 43200

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_env_vars.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_env_vars.py
@@ -872,6 +872,7 @@ def _mock_env_vars_prisma(row=None):
     prisma.db.litellm_mcpuserenvvars.find_many = AsyncMock(return_value=[])
     prisma.db.litellm_mcpuserenvvars.upsert = AsyncMock()
     prisma.db.litellm_mcpuserenvvars.delete_many = AsyncMock()
+    prisma.db.litellm_mcpusercredentials.delete_many = AsyncMock()
     return prisma
 
 
@@ -1249,6 +1250,64 @@ async def test_delete_mcp_server_succeeds_when_orphan_cleanup_fails():
     result = await delete_mcp_server(prisma, "srv-1")
 
     assert result is deleted
+    prisma.db.litellm_mcpuserenvvars.delete_many.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_delete_mcp_server_removes_orphaned_user_credentials():
+    """Deleting a server must also drop every user's stored BYOK/OAuth credential
+    rows for it; there is no FK cascade, so skipping this leaves encrypted secrets
+    pointing at a now-missing server."""
+    from unittest.mock import AsyncMock
+
+    from litellm.proxy._experimental.mcp_server.db import delete_mcp_server
+
+    prisma = _mock_env_vars_prisma()
+    prisma.db.litellm_mcpservertable.delete = AsyncMock(return_value=object())
+
+    await delete_mcp_server(prisma, "srv-1")
+
+    prisma.db.litellm_mcpusercredentials.delete_many.assert_awaited_once()
+    call = prisma.db.litellm_mcpusercredentials.delete_many.call_args
+    assert call.kwargs["where"] == {"server_id": "srv-1"}
+
+
+@pytest.mark.asyncio
+async def test_delete_mcp_server_skips_credential_cleanup_when_server_missing():
+    """A no-op delete (server not found) must not touch the credential table."""
+    from unittest.mock import AsyncMock
+
+    from litellm.proxy._experimental.mcp_server.db import delete_mcp_server
+
+    prisma = _mock_env_vars_prisma()
+    prisma.db.litellm_mcpservertable.delete = AsyncMock(return_value=None)
+
+    result = await delete_mcp_server(prisma, "srv-1")
+
+    assert result is None
+    prisma.db.litellm_mcpusercredentials.delete_many.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_delete_mcp_server_credential_cleanup_failure_still_cleans_env_vars():
+    """Each per-user table is cleaned independently: a failure dropping credential
+    rows must not skip the env var cleanup (or vice versa), and the delete must
+    still succeed for the caller."""
+    from unittest.mock import AsyncMock
+
+    from litellm.proxy._experimental.mcp_server.db import delete_mcp_server
+
+    deleted = object()
+    prisma = _mock_env_vars_prisma()
+    prisma.db.litellm_mcpservertable.delete = AsyncMock(return_value=deleted)
+    prisma.db.litellm_mcpusercredentials.delete_many = AsyncMock(
+        side_effect=Exception("connection pool exhausted")
+    )
+
+    result = await delete_mcp_server(prisma, "srv-1")
+
+    assert result is deleted
+    prisma.db.litellm_mcpusercredentials.delete_many.assert_awaited_once()
     prisma.db.litellm_mcpuserenvvars.delete_many.assert_awaited_once()
 
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
@@ -501,6 +501,7 @@ class TestListToolsRestAPI:
             raw_headers=None,
             user_api_key_auth=None,
             extra_headers=None,
+            apply_tool_filters=True,
         ):
             captured["called"] = True
             captured["server"] = server
@@ -544,6 +545,78 @@ class TestListToolsRestAPI:
         assert result["tools"] == ["tool-1"]
         assert result["error"] is None
         assert result["message"] == "Successfully retrieved tools"
+
+    async def test_include_disabled_tools_is_admin_only(self, monkeypatch):
+        """include_disabled_tools skips the allowlist filter only for PROXY_ADMIN;
+        a non-admin passing it stays filtered so the REST endpoint can't be used
+        to enumerate deliberately-disabled tools."""
+        from litellm.proxy._types import LitellmUserRoles
+
+        async def fake_contexts(user_api_key_auth):
+            return [user_api_key_auth]
+
+        async def fake_get_allowed_mcp_servers(*args, **kwargs):
+            return ["server-1"]
+
+        class StubServer:
+            alias = "server-1"
+            server_name = "server-1"
+            name = "stub"
+            allowed_tools = ["tool1"]
+            mcp_info = {"server_name": "stub"}
+            available_on_public_internet = True
+
+        stub_server = StubServer()
+        captured = {}
+
+        async def fake_get_tools(
+            server, server_auth_header, *args, apply_tool_filters=True, **kwargs
+        ):
+            captured["apply_tool_filters"] = apply_tool_filters
+            return ["tool-1"]
+
+        monkeypatch.setattr(
+            rest_endpoints,
+            "build_effective_auth_contexts",
+            fake_contexts,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            rest_endpoints.global_mcp_server_manager,
+            "get_allowed_mcp_servers",
+            fake_get_allowed_mcp_servers,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            rest_endpoints.global_mcp_server_manager,
+            "get_mcp_server_by_id",
+            lambda server_id: stub_server if server_id == "server-1" else None,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            rest_endpoints,
+            "_get_tools_for_single_server",
+            fake_get_tools,
+            raising=False,
+        )
+
+        request = _build_request(path="/mcp-rest/tools/list", method="GET")
+
+        await rest_endpoints.list_tool_rest_api(
+            request,
+            server_id="server-1",
+            include_disabled_tools=True,
+            user_api_key_dict=UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN),
+        )
+        assert captured["apply_tool_filters"] is False
+
+        await rest_endpoints.list_tool_rest_api(
+            request,
+            server_id="server-1",
+            include_disabled_tools=True,
+            user_api_key_dict=UserAPIKeyAuth(),
+        )
+        assert captured["apply_tool_filters"] is True
 
     @pytest.mark.parametrize("upstream_status", [401, 403])
     async def test_upstream_auth_failure_surfaces_status_and_challenge(
@@ -649,6 +722,7 @@ class TestListToolsRestAPI:
             raw_headers=None,
             user_api_key_auth=None,
             extra_headers=None,
+            apply_tool_filters=True,
         ):
             captured["called"] = True
             captured["server_arg"] = server
@@ -792,6 +866,7 @@ class TestListToolsRestAPI:
             raw_headers=None,
             user_api_key_auth=None,
             extra_headers=None,
+            apply_tool_filters=True,
         ):
             captured["server"] = server
             captured["auth_header"] = server_auth_header
@@ -1283,6 +1358,56 @@ class TestGetToolsForSingleServer:
         assert "tool3" in tool_names
         assert "tool1" not in tool_names
         assert "tool4" not in tool_names
+
+    async def test_apply_tool_filters_false_returns_full_catalog(self, monkeypatch):
+        """apply_tool_filters=False returns the raw catalog without the server
+        allowed_tools gate, so the config UI can render disabled tools as off."""
+        from litellm.proxy._experimental.mcp_server.server import MCPServer
+        from litellm.types.mcp import MCPTransport
+
+        class MockTool:
+            def __init__(self, name):
+                self.name = name
+                self.description = name
+                self.inputSchema = {}
+
+        mock_tools = [MockTool("tool1"), MockTool("tool2"), MockTool("tool3")]
+
+        async def fake_get_tools_from_server(**kwargs):
+            return mock_tools
+
+        monkeypatch.setattr(
+            rest_endpoints.global_mcp_server_manager,
+            "_get_tools_from_server",
+            fake_get_tools_from_server,
+            raising=False,
+        )
+
+        # Server enforces an allowlist of just tool1.
+        server = MCPServer(
+            server_id="test-server-id",
+            name="test-server",
+            transport=MCPTransport.sse,
+            allowed_tools=["tool1"],
+        )
+        user_api_key_dict = UserAPIKeyAuth(api_key="test-key", object_permission=None)
+
+        # Runtime default: only the allowed tool comes back.
+        filtered = await rest_endpoints._get_tools_for_single_server(
+            server=server,
+            server_auth_header=None,
+            user_api_key_auth=user_api_key_dict,
+        )
+        assert [t.name for t in filtered] == ["tool1"]
+
+        # Config view: full catalog, including the disabled tools.
+        full = await rest_endpoints._get_tools_for_single_server(
+            server=server,
+            server_auth_header=None,
+            user_api_key_auth=user_api_key_dict,
+            apply_tool_filters=False,
+        )
+        assert {t.name for t in full} == {"tool1", "tool2", "tool3"}
 
 
 class TestStdioCommandAllowlist:

--- a/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
@@ -1482,6 +1482,10 @@ class TestTemporaryMCPSessionEndpoints:
                 "litellm.proxy.management_endpoints.mcp_management_endpoints.global_mcp_server_manager",
                 mock_manager,
             ),
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.build_effective_auth_contexts",
+                AsyncMock(return_value=[non_admin]),
+            ),
         ):
             with pytest.raises(HTTPException) as exc_info:
                 await _get_cached_temporary_mcp_server_or_404("server-x", non_admin)
@@ -1514,12 +1518,68 @@ class TestTemporaryMCPSessionEndpoints:
                 "litellm.proxy.management_endpoints.mcp_management_endpoints.global_mcp_server_manager",
                 mock_manager,
             ),
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.build_effective_auth_contexts",
+                AsyncMock(return_value=[non_admin]),
+            ),
         ):
             result = await _get_cached_temporary_mcp_server_or_404(
                 "server-x", non_admin
             )
 
         assert result is registry_server
+
+    @pytest.mark.asyncio
+    async def test_get_cached_temporary_mcp_server_non_admin_allowed_via_team_access_group(
+        self,
+    ):
+        """Internal user whose only grant to the server flows through a team
+        access-group must pass the authorize/token access check. The check has to
+        expand the UI session into per-team contexts (build_effective_auth_contexts),
+        the same way the server-list grid does; checking only the bare session
+        context leaves the team grant invisible and 403s the user."""
+        from litellm.constants import UI_SESSION_TOKEN_TEAM_ID
+        from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+            _get_cached_temporary_mcp_server_or_404,
+        )
+
+        registry_server = generate_mock_mcp_server_config_record(server_id="server-x")
+        ui_session_auth = generate_mock_user_api_key_auth(
+            user_role=LitellmUserRoles.INTERNAL_USER,
+            team_id=UI_SESSION_TOKEN_TEAM_ID,
+        )
+        team_context = ui_session_auth.model_copy()
+        team_context.team_id = "team-with-mcp-grant"
+
+        mock_manager = MagicMock()
+        mock_manager.get_mcp_server_by_id.return_value = registry_server
+        mock_manager.get_mcp_server_by_name.return_value = None
+
+        def allowed_for(auth):
+            return ["server-x"] if auth.team_id == "team-with-mcp-grant" else []
+
+        mock_manager.get_allowed_mcp_servers = AsyncMock(side_effect=allowed_for)
+
+        with (
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.get_cached_temporary_mcp_server",
+                return_value=None,
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.global_mcp_server_manager",
+                mock_manager,
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.build_effective_auth_contexts",
+                AsyncMock(return_value=[ui_session_auth, team_context]),
+            ),
+        ):
+            result = await _get_cached_temporary_mcp_server_or_404(
+                "server-x", ui_session_auth
+            )
+
+        assert result is registry_server
+        assert mock_manager.get_allowed_mcp_servers.await_count == 2
 
     @pytest.mark.asyncio
     async def test_get_cached_temporary_mcp_server_temp_cache_non_admin_denied(self):

--- a/ui/litellm-dashboard/eslint-suppressions.json
+++ b/ui/litellm-dashboard/eslint-suppressions.json
@@ -1351,11 +1351,6 @@
       "count": 1
     }
   },
-  "src/components/mcp_tools/mcp_server_edit.test.tsx": {
-    "unused-imports/no-unused-imports": {
-      "count": 1
-    }
-  },
   "src/components/mcp_tools/mcp_server_edit.tsx": {
     "no-restricted-imports": {
       "count": 1
@@ -1514,11 +1509,6 @@
   },
   "src/components/onboarding_link.tsx": {
     "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/components/organisms/RegenerateKeyModal.tsx": {
-    "react-hooks/set-state-in-effect": {
       "count": 1
     }
   },

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
@@ -17,15 +17,23 @@ vi.mock("@/utils/mcpTokenStore", () => ({
 }));
 
 // Mutable holder so individual tests can simulate "Authorize & Fetch" having
-// produced a token before submit.
-const oauthHook = vi.hoisted(() => ({ tokenResponse: null as Record<string, unknown> | null }));
+// produced a token before submit, and inspect the reset wiring.
+const oauthHook = vi.hoisted(() => ({
+  tokenResponse: null as Record<string, unknown> | null,
+  reset: vi.fn(),
+  onTokenReceived: null as ((token: Record<string, unknown> | null) => void) | null,
+}));
 vi.mock("@/hooks/useMcpOAuthFlow", () => ({
-  useMcpOAuthFlow: () => ({
-    startOAuthFlow: vi.fn(),
-    status: "idle",
-    error: null,
-    tokenResponse: oauthHook.tokenResponse,
-  }),
+  useMcpOAuthFlow: (opts: { onTokenReceived: (token: Record<string, unknown> | null) => void }) => {
+    oauthHook.onTokenReceived = opts.onTokenReceived;
+    return {
+      startOAuthFlow: vi.fn(),
+      status: "idle",
+      error: null,
+      tokenResponse: oauthHook.tokenResponse,
+      reset: oauthHook.reset,
+    };
+  },
 }));
 
 vi.mock("./mcp_server_cost_config", () => ({
@@ -59,7 +67,9 @@ vi.mock("./mcp_tool_configuration", () => ({
 }));
 
 vi.mock("./mcp_connection_status", () => ({
-  default: () => <div data-testid="mcp-connection-status" />,
+  default: ({ tools }: { tools?: any[] }) => (
+    <div data-testid="mcp-connection-status" data-tool-count={tools?.length ?? 0} />
+  ),
 }));
 
 vi.mock("./StdioConfiguration", () => ({
@@ -121,6 +131,7 @@ describe("CreateMCPServer", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     oauthHook.tokenResponse = null;
+    oauthHook.onTokenReceived = null;
   });
 
   it("should render the modal with title when visible", () => {
@@ -613,6 +624,100 @@ describe("CreateMCPServer", () => {
       });
 
       expect(defaultProps.setModalVisible).toHaveBeenCalledWith(false);
+    });
+
+    it("does not leak a previous server's OAuth token into the next add-server session", async () => {
+      const usedToken = (token: string) =>
+        vi.mocked(networking.testMCPToolsListRequest).mock.calls.some((call) => call[2] === token);
+
+      const { rerender } = render(<CreateMCPServer {...defaultProps} />);
+
+      await selectAntOption("Transport Type", "Streamable HTTP");
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText("https://your-mcp-server.com")).toBeInTheDocument();
+      });
+      await selectAntOption("Authentication", "OAuth");
+      await waitFor(() => {
+        expect(screen.getByText("OAuth Flow Type")).toBeInTheDocument();
+      });
+
+      const urlInput = screen.getByPlaceholderText("https://your-mcp-server.com");
+      await act(async () => {
+        fireEvent.change(urlInput, { target: { value: "https://server-a.example.com/mcp" } });
+      });
+
+      // Simulate "Authorize & Fetch Token" completing for server A.
+      await act(async () => {
+        oauthHook.onTokenReceived?.({ access_token: "stale-token-A", expires_in: 3600 });
+      });
+
+      // Precondition: the freshly fetched token drives the tool preview for server A.
+      await waitFor(() => {
+        expect(usedToken("stale-token-A")).toBe(true);
+      });
+
+      // Parent hides the modal (Cancel / successful create both flip this prop).
+      rerender(<CreateMCPServer {...defaultProps} isModalVisible={false} />);
+
+      // The OAuth flow state (source of the "Token fetched" badge) is reset on close.
+      expect(oauthHook.reset).toHaveBeenCalled();
+
+      vi.mocked(networking.testMCPToolsListRequest).mockClear();
+
+      // Reopen for a brand-new server and enter a different URL without re-authorizing.
+      rerender(<CreateMCPServer {...defaultProps} isModalVisible={true} />);
+      const reopenedUrlInput = screen.getByPlaceholderText("https://your-mcp-server.com");
+      await act(async () => {
+        fireEvent.change(reopenedUrlInput, { target: { value: "https://server-b.example.com/mcp" } });
+      });
+
+      // The previous server's token must never be replayed for the new session.
+      expect(usedToken("stale-token-A")).toBe(false);
+    });
+
+    it("clears the tool list and form fields when a parent dismisses the modal", async () => {
+      vi.mocked(networking.testMCPToolsListRequest).mockResolvedValue({
+        tools: [{ name: "tool_a" }],
+        error: null,
+      });
+      const toolCount = () => screen.getByTestId("mcp-connection-status").getAttribute("data-tool-count");
+
+      const { rerender } = render(<CreateMCPServer {...defaultProps} />);
+
+      await selectAntOption("Transport Type", "Streamable HTTP");
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText("https://your-mcp-server.com")).toBeInTheDocument();
+      });
+      await selectAntOption("Authentication", "OAuth");
+      await waitFor(() => {
+        expect(screen.getByText("OAuth Flow Type")).toBeInTheDocument();
+      });
+
+      const urlInput = screen.getByPlaceholderText("https://your-mcp-server.com");
+      await act(async () => {
+        fireEvent.change(urlInput, { target: { value: "https://server-a.example.com/mcp" } });
+      });
+      await act(async () => {
+        oauthHook.onTokenReceived?.({ access_token: "stale-token-A", expires_in: 3600 });
+      });
+
+      // Precondition: a tool list is shown for server A.
+      await waitFor(() => {
+        expect(toolCount()).toBe("1");
+      });
+
+      // Parent dismisses the modal without routing through Cancel or create.
+      rerender(<CreateMCPServer {...defaultProps} isModalVisible={false} />);
+
+      // Stale tools are cleared even though neither handler ran.
+      await waitFor(() => {
+        expect(toolCount()).toBe("0");
+      });
+
+      // Reopening starts clean: the URL the prior server left in the Ant form store is gone.
+      rerender(<CreateMCPServer {...defaultProps} isModalVisible={true} />);
+      const reopenedUrlInput = screen.getByPlaceholderText("https://your-mcp-server.com") as HTMLInputElement;
+      expect(reopenedUrlInput.value).toBe("");
     });
   });
 

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
@@ -134,6 +134,7 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
     status: oauthStatus,
     error: oauthError,
     tokenResponse: oauthTokenResponse,
+    reset: resetOAuthFlow,
   } = useMcpOAuthFlow({
     accessToken,
     getCredentials: () => form.getFieldValue("credentials"),
@@ -554,12 +555,19 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
     }
   }, [formValues.server_name]);
 
-  // Clear formValues when modal closes to reset child components
+  // Clear form, tools, and OAuth state when the modal closes so a previous server's
+  // authorization, credentials, or tool list never bleed into the next "Add New MCP
+  // Server" session, including when a parent dismisses the modal without routing
+  // through handleCancel or handleCreate.
   React.useEffect(() => {
     if (!isModalVisible) {
+      form.resetFields();
       setFormValues({});
+      setOauthAccessToken(null);
+      clearTools();
+      resetOAuthFlow();
     }
-  }, [isModalVisible]);
+  }, [isModalVisible, form, clearTools, resetOAuthFlow]);
 
   const isAdmin = isAdminRole(userRole);
 

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
@@ -188,6 +188,7 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
       }
     },
     onBeforeRedirect: persistCreateUiState,
+    flowSource: "create",
   });
 
   React.useEffect(() => {
@@ -1088,7 +1089,6 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
           <div className="mt-6">
             <MCPToolConfiguration
               accessToken={accessToken}
-              oauthAccessToken={oauthAccessToken}
               formValues={formValues}
               allowedTools={allowedTools}
               existingAllowedTools={null}

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.test.tsx
@@ -8,6 +8,7 @@ import NotificationsManager from "../molecules/notifications_manager";
 vi.mock("../networking", () => ({
   updateMCPServer: vi.fn(),
   listMCPTools: vi.fn().mockResolvedValue({ tools: [], error: null }),
+  storeMCPOAuthUserCredential: vi.fn().mockResolvedValue({}),
 }));
 
 vi.mock("../molecules/notifications_manager", () => ({
@@ -17,12 +18,13 @@ vi.mock("../molecules/notifications_manager", () => ({
   },
 }));
 
+const mockOauth: { tokenResponse: any } = { tokenResponse: null };
 vi.mock("@/hooks/useMcpOAuthFlow", () => ({
   useMcpOAuthFlow: () => ({
     startOAuthFlow: vi.fn(),
     status: "idle",
     error: null,
-    tokenResponse: null,
+    tokenResponse: mockOauth.tokenResponse,
   }),
 }));
 
@@ -37,12 +39,19 @@ vi.mock("./MCPPermissionManagement", () => ({
 vi.mock("./mcp_tool_configuration", () => ({
   default: ({
     existingAllowedTools,
+    externalTools,
+    externalError,
     onAllowedToolsChange,
     onToolAllowlistInteraction,
     onToolNameToDisplayNameChange,
     onToolNameToDescriptionChange,
   }: any) => (
-    <div data-testid="mcp-tool-config" data-existing-allowed-tools={JSON.stringify(existingAllowedTools)}>
+    <div
+      data-testid="mcp-tool-config"
+      data-existing-allowed-tools={JSON.stringify(existingAllowedTools)}
+      data-external-tools={JSON.stringify(externalTools)}
+      data-external-error={externalError ?? ""}
+    >
       <button
         type="button"
         onClick={() => {
@@ -63,6 +72,15 @@ vi.mock("./mcp_tool_configuration", () => ({
       </button>
     </div>
   ),
+}));
+
+const mockGetToken = vi.fn();
+const mockIsTokenValid = vi.fn();
+const mockSetToken = vi.fn();
+vi.mock("@/utils/mcpTokenStore", () => ({
+  getToken: (...args: any[]) => mockGetToken(...args),
+  isTokenValid: (...args: any[]) => mockIsTokenValid(...args),
+  setToken: (...args: any[]) => mockSetToken(...args),
 }));
 
 // ── fixtures ──────────────────────────────────────────────────────────────────
@@ -624,5 +642,301 @@ describe("MCPServerEdit (interactive OAuth)", () => {
 
     const [, payload] = vi.mocked(networking.updateMCPServer).mock.calls[0];
     expect(payload.token_storage_ttl_seconds).toBe(7200);
+  });
+});
+
+describe("MCPServerEdit (tool list fetch)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(networking.listMCPTools).mockResolvedValue({ tools: [], error: null });
+    mockOauth.tokenResponse = null;
+  });
+
+  it("loads an OBO server's tools via GET listMCPTools with no passthrough headers", async () => {
+    vi.mocked(networking.listMCPTools).mockResolvedValue({
+      tools: [{ name: "read_user" }],
+      error: null,
+    });
+
+    render(
+      <MCPServerEdit
+        mcpServer={interactiveOAuthServer}
+        accessToken="access-token"
+        userID="user-1"
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+        availableAccessGroups={[]}
+      />,
+    );
+
+    await waitFor(() => {
+      // includeDisabledTools=true so the config screen gets the full catalog.
+      expect(networking.listMCPTools).toHaveBeenCalledWith("access-token", "oauth_server_1", undefined, true);
+    });
+    // OBO uses the backend-stored token; the browser passthrough store is never consulted.
+    expect(mockIsTokenValid).not.toHaveBeenCalled();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("mcp-tool-config")).toHaveAttribute(
+        "data-external-tools",
+        JSON.stringify([{ name: "read_user" }]),
+      );
+    });
+  });
+
+  it("forwards the sessionStorage token as the x-mcp passthrough header for a passthrough server", async () => {
+    mockIsTokenValid.mockReturnValue(true);
+    mockGetToken.mockReturnValue({ access_token: "browser-token" });
+
+    render(
+      <MCPServerEdit
+        mcpServer={{ ...interactiveOAuthServer, delegate_auth_to_upstream: true }}
+        accessToken="access-token"
+        userID="user-1"
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+        availableAccessGroups={[]}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(networking.listMCPTools).toHaveBeenCalledWith(
+        "access-token",
+        "oauth_server_1",
+        { "x-mcp-oauth_server-authorization": "Bearer browser-token" },
+        true,
+      );
+    });
+    expect(mockGetToken).toHaveBeenCalledWith("oauth_server_1", "user-1");
+  });
+
+  it("uses the staged OAuth token to load passthrough tools after authorize", async () => {
+    const passthroughServer = { ...interactiveOAuthServer, delegate_auth_to_upstream: true };
+    mockIsTokenValid.mockReturnValue(false);
+    vi.mocked(networking.listMCPTools).mockResolvedValue({
+      tools: [{ name: "read_user" }],
+      error: null,
+    });
+
+    const props = {
+      mcpServer: passthroughServer,
+      accessToken: "access-token",
+      userID: "user-1",
+      onCancel: vi.fn(),
+      onSuccess: vi.fn(),
+      availableAccessGroups: [],
+    };
+
+    const { rerender } = render(<MCPServerEdit {...props} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("mcp-tool-config").getAttribute("data-external-error")).toContain(
+        "Authenticate with this server in the Tools tab",
+      );
+    });
+    expect(networking.listMCPTools).not.toHaveBeenCalled();
+
+    mockOauth.tokenResponse = { access_token: "staged-token", expires_in: 1800 };
+    rerender(<MCPServerEdit {...props} />);
+
+    await waitFor(() => {
+      expect(networking.listMCPTools).toHaveBeenCalledWith(
+        "access-token",
+        "oauth_server_1",
+        { "x-mcp-oauth_server-authorization": "Bearer staged-token" },
+        true,
+      );
+    });
+    expect(mockGetToken).not.toHaveBeenCalled();
+  });
+
+  it("prompts to authenticate and does not fetch when a passthrough server has no session token", async () => {
+    mockIsTokenValid.mockReturnValue(false);
+
+    render(
+      <MCPServerEdit
+        mcpServer={{ ...interactiveOAuthServer, delegate_auth_to_upstream: true }}
+        accessToken="access-token"
+        userID="user-1"
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+        availableAccessGroups={[]}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("mcp-tool-config").getAttribute("data-external-error")).toContain(
+        "Authenticate with this server in the Tools tab",
+      );
+    });
+    expect(networking.listMCPTools).not.toHaveBeenCalled();
+  });
+});
+
+describe("MCPServerEdit (form resync)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(networking.listMCPTools).mockResolvedValue({ tools: [], error: null });
+  });
+
+  it("repopulates the form when the server data arrives after mount", async () => {
+    const props = {
+      accessToken: "access-token",
+      onCancel: vi.fn(),
+      onSuccess: vi.fn(),
+      availableAccessGroups: [],
+    };
+
+    // Mount before the server is loaded (mirrors landing on the page mid OAuth return).
+    const { rerender } = render(<MCPServerEdit mcpServer={{ server_id: "" } as any} {...props} />);
+    expect(screen.queryByDisplayValue("https://example.com/mcp")).not.toBeInTheDocument();
+
+    // Server data arrives; the form must repopulate rather than staying blank.
+    rerender(<MCPServerEdit mcpServer={interactiveOAuthServer} {...props} />);
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("https://example.com/mcp")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("MCPServerEdit (OAuth token persistence on save)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(networking.listMCPTools).mockResolvedValue({ tools: [], error: null });
+    mockOauth.tokenResponse = null;
+  });
+
+  it("persists the OBO token to the DB on save after authorize", async () => {
+    mockOauth.tokenResponse = {
+      access_token: "obo-tok",
+      refresh_token: "obo-refresh",
+      expires_in: 3600,
+      scope: "read write",
+    };
+    vi.mocked(networking.updateMCPServer).mockResolvedValue({ ...interactiveOAuthServer });
+
+    render(
+      <MCPServerEdit
+        mcpServer={interactiveOAuthServer}
+        accessToken="access-token"
+        userID="user-1"
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+        availableAccessGroups={[]}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getAllByRole("button", { name: "Save Changes" })[0]);
+    });
+
+    await waitFor(() => {
+      expect(networking.storeMCPOAuthUserCredential).toHaveBeenCalledWith(
+        "access-token",
+        "oauth_server_1",
+        expect.objectContaining({
+          access_token: "obo-tok",
+          refresh_token: "obo-refresh",
+          expires_in: 3600,
+          scopes: ["read", "write"],
+        }),
+      );
+    });
+    expect(mockSetToken).not.toHaveBeenCalled();
+  });
+
+  it("does not show success when OBO token persistence fails after update", async () => {
+    mockOauth.tokenResponse = {
+      access_token: "obo-tok",
+      refresh_token: "obo-refresh",
+      expires_in: 3600,
+      scope: "read write",
+    };
+    vi.mocked(networking.updateMCPServer).mockResolvedValue({ ...interactiveOAuthServer });
+    vi.mocked(networking.storeMCPOAuthUserCredential).mockRejectedValueOnce(new Error("write failed"));
+    const onSuccess = vi.fn();
+
+    render(
+      <MCPServerEdit
+        mcpServer={interactiveOAuthServer}
+        accessToken="access-token"
+        userID="user-1"
+        onCancel={vi.fn()}
+        onSuccess={onSuccess}
+        availableAccessGroups={[]}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getAllByRole("button", { name: "Save Changes" })[0]);
+    });
+
+    await waitFor(() => {
+      expect(networking.storeMCPOAuthUserCredential).toHaveBeenCalled();
+    });
+    expect(NotificationsManager.fromBackend).toHaveBeenCalledWith(
+      "MCP Server updated, but failed to persist OAuth token: write failed",
+    );
+    expect(NotificationsManager.success).not.toHaveBeenCalledWith("MCP Server updated successfully");
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it("persists the passthrough token to sessionStorage on save after authorize", async () => {
+    mockOauth.tokenResponse = { access_token: "pt-tok", expires_in: 1800, token_type: "bearer" };
+    vi.mocked(networking.updateMCPServer).mockResolvedValue({
+      ...interactiveOAuthServer,
+      delegate_auth_to_upstream: true,
+    });
+
+    render(
+      <MCPServerEdit
+        mcpServer={{ ...interactiveOAuthServer, delegate_auth_to_upstream: true }}
+        accessToken="access-token"
+        userID="user-1"
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+        availableAccessGroups={[]}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getAllByRole("button", { name: "Save Changes" })[0]);
+    });
+
+    await waitFor(() => {
+      expect(mockSetToken).toHaveBeenCalledWith(
+        "oauth_server_1",
+        expect.objectContaining({ access_token: "pt-tok", expires_in: 1800, token_type: "bearer" }),
+        "user-1",
+      );
+    });
+    expect(networking.storeMCPOAuthUserCredential).not.toHaveBeenCalled();
+  });
+
+  it("persists nothing on save when no token was fetched", async () => {
+    mockOauth.tokenResponse = null;
+    vi.mocked(networking.updateMCPServer).mockResolvedValue({ ...interactiveOAuthServer });
+
+    render(
+      <MCPServerEdit
+        mcpServer={interactiveOAuthServer}
+        accessToken="access-token"
+        userID="user-1"
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+        availableAccessGroups={[]}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getAllByRole("button", { name: "Save Changes" })[0]);
+    });
+
+    await waitFor(() => {
+      expect(networking.updateMCPServer).toHaveBeenCalled();
+    });
+    expect(networking.storeMCPOAuthUserCredential).not.toHaveBeenCalled();
+    expect(mockSetToken).not.toHaveBeenCalled();
   });
 });

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
@@ -2,8 +2,18 @@ import React, { useState, useEffect } from "react";
 import { Form, Select, Button as AntdButton, Tooltip, Input, InputNumber } from "antd";
 import { InfoCircleOutlined } from "@ant-design/icons";
 import { Button, TabGroup, TabList, Tab, TabPanels, TabPanel } from "@tremor/react";
-import { AUTH_TYPE, OAUTH_FLOW, MCPServer, MCPServerCostInfo, TRANSPORT } from "./types";
-import { updateMCPServer, listMCPTools } from "../networking";
+import {
+  AUTH_TYPE,
+  OAUTH_FLOW,
+  MCP_OAUTH2_FLOW_M2M,
+  MCPServer,
+  MCPServerCostInfo,
+  TRANSPORT,
+  getMcpOAuthMode,
+} from "./types";
+import { updateMCPServer, listMCPTools, storeMCPOAuthUserCredential } from "../networking";
+import { getToken, isTokenValid, setToken } from "@/utils/mcpTokenStore";
+import { buildMcpPassthroughAuthHeader } from "@/utils/mcpHeaderUtils";
 import MCPServerCostConfig from "./mcp_server_cost_config";
 import MCPPermissionManagement from "./MCPPermissionManagement";
 import MCPToolConfiguration from "./mcp_tool_configuration";
@@ -18,6 +28,7 @@ import { getSecureItem, setSecureItem } from "@/utils/secureStorage";
 interface MCPServerEditProps {
   mcpServer: MCPServer;
   accessToken: string | null;
+  userID?: string | null;
   onCancel: () => void;
   onSuccess: (server: MCPServer) => void;
   availableAccessGroups: string[];
@@ -25,11 +36,12 @@ interface MCPServerEditProps {
 
 const AUTH_TYPES_REQUIRING_AUTH_VALUE = [AUTH_TYPE.API_KEY, AUTH_TYPE.BEARER_TOKEN, AUTH_TYPE.TOKEN, AUTH_TYPE.BASIC];
 const AUTH_TYPES_REQUIRING_CREDENTIALS = [...AUTH_TYPES_REQUIRING_AUTH_VALUE, AUTH_TYPE.OAUTH2, AUTH_TYPE.AWS_SIGV4];
-const EDIT_OAUTH_UI_STATE_KEY = "litellm-mcp-oauth-edit-state";
+export const EDIT_OAUTH_UI_STATE_KEY = "litellm-mcp-oauth-edit-state";
 
 const MCPServerEdit: React.FC<MCPServerEditProps> = ({
   mcpServer,
   accessToken,
+  userID,
   onCancel,
   onSuccess,
   availableAccessGroups,
@@ -57,8 +69,6 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
   const isAwsSigV4AuthType = authType === AUTH_TYPE.AWS_SIGV4;
   const oauthFlowTypeValue = Form.useWatch("oauth_flow_type", form) as string | undefined;
   const isM2MFlow = isOAuthAuthType && oauthFlowTypeValue === OAUTH_FLOW.M2M;
-
-  const [oauthAccessToken, setOauthAccessToken] = useState<string | null>(null);
 
   // Watch form fields that affect tool fetching
   const currentUrl = Form.useWatch("url", form);
@@ -140,8 +150,6 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
       };
     },
     onTokenReceived: (token) => {
-      setOauthAccessToken(token?.access_token ?? null);
-
       if (token?.access_token) {
         const credentials = {
           access_token: token.access_token,
@@ -158,6 +166,7 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
       }
     },
     onBeforeRedirect: persistEditUiState,
+    flowSource: "edit",
   });
 
   const initialStaticHeaders = React.useMemo(() => {
@@ -216,6 +225,20 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
     }),
     [mcpServer, effectiveTransport, initialStaticHeaders, initialEnvVars, initialEnvJson],
   );
+
+  // antd applies `initialValues` only at first mount. When the server loads after
+  // mount (e.g. returning from the OAuth redirect lands on Overview and the form
+  // mounts before the server data is ready), the form would stay blank. Re-sync it
+  // from the loaded server once per server_id so it always reflects the saved config;
+  // the OAuth-restore effect below then overlays any in-progress edits on top.
+  const syncedServerIdRef = React.useRef<string | null>(null);
+  useEffect(() => {
+    if (!mcpServer.server_id || syncedServerIdRef.current === mcpServer.server_id) {
+      return;
+    }
+    syncedServerIdRef.current = mcpServer.server_id;
+    form.setFieldsValue(initialValues);
+  }, [mcpServer.server_id, initialValues, form]);
 
   // Initialize cost config from existing server data
   useEffect(() => {
@@ -280,6 +303,9 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
     if (!pendingRestoredValues) {
       return;
     }
+    // Set transport first so transport-dependent fields render, then apply the rest
+    // on the re-run triggered by the transportType watch (without it the effect's
+    // deps never change and the second pass never runs, leaving fields blank).
     const transport = pendingRestoredValues.transport || mcpServer.transport;
     if (transport && transport !== form.getFieldValue("transport")) {
       form.setFieldsValue({ transport });
@@ -287,7 +313,7 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
     }
     form.setFieldsValue(pendingRestoredValues);
     setPendingRestoredValues(null);
-  }, [pendingRestoredValues, form, mcpServer.transport]);
+  }, [pendingRestoredValues, form, mcpServer.transport, transportType]);
 
   // Transform string array to object array for initial form values
   useEffect(() => {
@@ -304,28 +330,52 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
       return;
     }
     fetchTools();
-  }, [mcpServer, accessToken]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mcpServer, accessToken, userID, oauthTokenResponse?.access_token]);
 
   const fetchTools = async () => {
     if (!accessToken || !mcpServer.server_id) return;
+
+    // OBO/M2M/static auth is attached server-side from the stored credential, so
+    // a plain GET /tools/list?server_id suffices. PKCE passthrough holds the token
+    // in the browser, so forward it from sessionStorage as the x-mcp header the
+    // same way the Tools playground does.
+    let customHeaders: Record<string, string> | undefined;
+    const isPassthrough =
+      getMcpOAuthMode({
+        auth_type: mcpServer.auth_type,
+        oauth2_flow: mcpServer.oauth2_flow,
+        delegate_auth_to_upstream: mcpServer.delegate_auth_to_upstream,
+      }) === "passthrough";
+    if (isPassthrough) {
+      const token =
+        oauthTokenResponse?.access_token ??
+        (isTokenValid(mcpServer.server_id, userID)
+          ? getToken(mcpServer.server_id, userID)?.access_token ?? null
+          : null);
+      if (!token) {
+        setTools([]);
+        setToolsError("Authenticate with this server in the Tools tab to load and configure its tools.");
+        return;
+      }
+      customHeaders = buildMcpPassthroughAuthHeader(mcpServer.alias, token);
+    }
 
     setIsLoadingTools(true);
     setToolsError(null);
 
     try {
-      // Use the GET endpoint which looks up stored credentials by server_id,
-      // rather than POST /test/tools/list which requires inline credentials.
-      const toolsResponse = await listMCPTools(accessToken, mcpServer.server_id);
+      // include_disabled_tools: configuring the allowlist needs the full server
+      // catalog, so tools toggled off still render (as unchecked) instead of vanishing.
+      const toolsResponse = await listMCPTools(accessToken, mcpServer.server_id, customHeaders, true);
 
       if (toolsResponse.tools && !toolsResponse.error) {
         setTools(toolsResponse.tools);
       } else {
-        console.error("Failed to fetch tools:", toolsResponse.message);
         setTools([]);
         setToolsError(toolsResponse.message || "Failed to load tools");
       }
     } catch (error) {
-      console.error("Tools fetch error:", error);
       setTools([]);
       setToolsError(error instanceof Error ? error.message : "Failed to load tools");
     } finally {
@@ -627,6 +677,46 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
       }
 
       const updated = await updateMCPServer(accessToken, payload);
+
+      // Persist the token staged via "Authorize & Fetch" (mirrors the create flow's
+      // commit-on-submit): OBO writes the per-user token to the DB, passthrough keeps
+      // it in sessionStorage. M2M/static auth resolve server-side and need neither.
+      if (oauthTokenResponse?.access_token) {
+        const oauthMode = getMcpOAuthMode({
+          auth_type: restValues.auth_type,
+          oauth2_flow: isM2MFlow ? MCP_OAUTH2_FLOW_M2M : null,
+          delegate_auth_to_upstream: Boolean(delegateAuthToUpstreamRaw ?? mcpServer.delegate_auth_to_upstream),
+        });
+        try {
+          if (oauthMode === "obo") {
+            const scope = oauthTokenResponse.scope;
+            await storeMCPOAuthUserCredential(accessToken, mcpServer.server_id, {
+              access_token: oauthTokenResponse.access_token,
+              refresh_token: oauthTokenResponse.refresh_token,
+              expires_in: oauthTokenResponse.expires_in,
+              scopes: typeof scope === "string" && scope ? scope.split(" ") : undefined,
+            });
+          } else if (oauthMode === "passthrough") {
+            setToken(
+              mcpServer.server_id,
+              {
+                access_token: oauthTokenResponse.access_token,
+                expires_in: oauthTokenResponse.expires_in,
+                refresh_token: oauthTokenResponse.refresh_token,
+                token_type: oauthTokenResponse.token_type,
+              },
+              userID,
+            );
+          }
+        } catch (error: unknown) {
+          const message = error instanceof Error ? error.message : "";
+          NotificationsManager.fromBackend(
+            "MCP Server updated, but failed to persist OAuth token" + (message ? `: ${message}` : ""),
+          );
+          return;
+        }
+      }
+
       NotificationsManager.success("MCP Server updated successfully");
       onSuccess(updated);
     } catch (error: any) {
@@ -1146,7 +1236,6 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
             <div className="mt-6">
               <MCPToolConfiguration
                 accessToken={accessToken}
-                oauthAccessToken={oauthAccessToken}
                 formValues={{
                   server_id: mcpServer.server_id,
                   server_name: currentServerName ?? mcpServer.server_name,
@@ -1172,6 +1261,10 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
                 toolNameToDescription={toolNameToDescription}
                 onToolNameToDisplayNameChange={setToolNameToDisplayName}
                 onToolNameToDescriptionChange={setToolNameToDescription}
+                externalTools={tools}
+                externalIsLoading={isLoadingTools}
+                externalError={toolsError}
+                externalCanFetch={true}
               />
             </div>
 

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_view.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_view.tsx
@@ -21,6 +21,7 @@ interface MCPServerViewProps {
   userRole: string | null;
   userID: string | null;
   availableAccessGroups: string[];
+  initialTabIndex?: number;
 }
 
 export const MCPServerView: React.FC<MCPServerViewProps> = ({
@@ -32,11 +33,12 @@ export const MCPServerView: React.FC<MCPServerViewProps> = ({
   userRole,
   userID,
   availableAccessGroups,
+  initialTabIndex = 0,
 }) => {
   const [editing, setEditing] = useState(isEditing);
   const [showFullUrl, setShowFullUrl] = useState(false);
   const [copiedStates, setCopiedStates] = useState<Record<string, boolean>>({});
-  const [selectedTabIndex, setSelectedTabIndex] = useState(0);
+  const [selectedTabIndex, setSelectedTabIndex] = useState(initialTabIndex);
 
   const handleSuccess = (updated: MCPServer) => {
     setEditing(false);

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_view.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_view.tsx
@@ -5,7 +5,8 @@ import { Title, Card, Button, Text, Grid, TabGroup, TabList, TabPanel, TabPanels
 import { MCPServer, handleTransport, handleAuth } from "./types";
 // TODO: Move Tools viewer from index file
 import { MCPToolsViewer } from ".";
-import MCPServerEdit from "./mcp_server_edit";
+import MCPServerEdit, { EDIT_OAUTH_UI_STATE_KEY } from "./mcp_server_edit";
+import { getSecureItem } from "@/utils/secureStorage";
 import MCPServerCostDisplay from "./mcp_server_cost_display";
 import { getMaskedAndFullUrl } from "./utils";
 import { copyToClipboard as utilCopyToClipboard } from "@/utils/dataUtils";
@@ -24,6 +25,24 @@ interface MCPServerViewProps {
   initialTabIndex?: number;
 }
 
+// True when this render is the return from the edit-settings OAuth redirect for this
+// server: the edit form wrote its UI-state snapshot before redirecting. Used to open
+// the editing Settings tab on first render instead of defaulting to Overview.
+function isReturningFromEditOAuth(isProxyAdmin: boolean, serverId: string): boolean {
+  if (typeof window === "undefined" || !isProxyAdmin) {
+    return false;
+  }
+  const stored = getSecureItem(EDIT_OAUTH_UI_STATE_KEY);
+  if (!stored) {
+    return false;
+  }
+  try {
+    return JSON.parse(stored)?.serverId === serverId;
+  } catch {
+    return false;
+  }
+}
+
 export const MCPServerView: React.FC<MCPServerViewProps> = ({
   mcpServer,
   onBack,
@@ -35,10 +54,13 @@ export const MCPServerView: React.FC<MCPServerViewProps> = ({
   availableAccessGroups,
   initialTabIndex = 0,
 }) => {
-  const [editing, setEditing] = useState(isEditing);
+  // Open the editing Settings tab on first render when returning from the edit OAuth
+  // redirect, so the "token fetched" feedback shows where the user left off (Settings=2).
+  const returningFromEditOAuth = isReturningFromEditOAuth(isProxyAdmin, mcpServer.server_id);
+  const [editing, setEditing] = useState(isEditing || returningFromEditOAuth);
   const [showFullUrl, setShowFullUrl] = useState(false);
   const [copiedStates, setCopiedStates] = useState<Record<string, boolean>>({});
-  const [selectedTabIndex, setSelectedTabIndex] = useState(initialTabIndex);
+  const [selectedTabIndex, setSelectedTabIndex] = useState(returningFromEditOAuth ? 2 : initialTabIndex);
 
   const handleSuccess = (updated: MCPServer) => {
     setEditing(false);
@@ -212,6 +234,7 @@ export const MCPServerView: React.FC<MCPServerViewProps> = ({
                 <MCPServerEdit
                   mcpServer={mcpServer}
                   accessToken={accessToken}
+                  userID={userID}
                   onCancel={() => setEditing(false)}
                   onSuccess={handleSuccess}
                   availableAccessGroups={availableAccessGroups}

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_servers.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_servers.tsx
@@ -21,6 +21,7 @@ import MCPNetworkSettings from "./MCPNetworkSettings";
 import MCPDiscovery from "./mcp_discovery";
 import { ByokCredentialModal } from "./ByokCredentialModal";
 import { getSecureItem } from "@/utils/secureStorage";
+import { TOOLS_OAUTH_UI_STATE_KEY } from "@/hooks/mcpOAuthUtils";
 import UserEnvVarsModal from "./UserEnvVarsModal";
 import { listMCPUserEnvVarStatus } from "../networking";
 
@@ -71,6 +72,23 @@ const compareServers = (a: MCPServer, b: MCPServer, sort: SortKey): number => {
 const { Text: AntdText, Title: AntdTitle } = Typography;
 const EDIT_OAUTH_UI_STATE_KEY = "litellm-mcp-oauth-edit-state";
 
+// Server id stashed by the Tools tab before an OBO OAuth redirect, read once at
+// mount so the redirect returns straight to that server's Tools tab.
+const readToolsOAuthServerId = (): string | null => {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  try {
+    const stored = getSecureItem(TOOLS_OAUTH_UI_STATE_KEY);
+    if (!stored) {
+      return null;
+    }
+    return JSON.parse(stored)?.serverId ?? null;
+  } catch {
+    return null;
+  }
+};
+
 const { Option } = Select;
 
 const MCPServers: React.FC<MCPServerProps> = ({ accessToken, userRole, userID }) => {
@@ -103,7 +121,12 @@ const MCPServers: React.FC<MCPServerProps> = ({ accessToken, userRole, userID })
   // state
   const [serverIdToDelete, setServerToDelete] = useState<string | null>(null);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
-  const [selectedServerId, setSelectedServerId] = useState<string | null>(null);
+  // Server whose Tools tab should be reopened after an OBO OAuth redirect; read
+  // once from sessionStorage so the restored server selection is correct on the
+  // first render. Cleared when the user navigates back to the list (handleBack)
+  // so a later visit to the same server defaults to Overview, not the Tools tab.
+  const [toolsTabServerId, setToolsTabServerId] = useState<string | null>(readToolsOAuthServerId);
+  const [selectedServerId, setSelectedServerId] = useState<string | null>(toolsTabServerId);
   const [editServer, setEditServer] = useState(false);
   const [selectedTeam, setSelectedTeam] = useState<string>("all");
   const [selectedMcpAccessGroup, setSelectedMcpAccessGroup] = useState<string>("all");
@@ -175,6 +198,19 @@ const MCPServers: React.FC<MCPServerProps> = ({ accessToken, userRole, userID })
       }
     } catch (err) {
       console.error("Failed to restore MCP edit view state", err);
+    }
+  }, []);
+
+  // The restored server id was consumed by the initializer above; remove the
+  // one-shot sessionStorage key so a full page reload doesn't reopen the Tools
+  // tab (removeItem only, no setState).
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      try {
+        window.sessionStorage.removeItem(TOOLS_OAUTH_UI_STATE_KEY);
+      } catch {
+        // ignore storage errors
+      }
     }
   }, []);
 
@@ -338,6 +374,8 @@ const MCPServers: React.FC<MCPServerProps> = ({ accessToken, userRole, userID })
   const handleBack = React.useCallback(() => {
     setEditServer(false);
     setSelectedServerId(null);
+    // Drop the post-redirect one-shot so re-selecting that server opens Overview.
+    setToolsTabServerId(null);
     refetch();
   }, [refetch]);
 
@@ -483,6 +521,7 @@ const MCPServers: React.FC<MCPServerProps> = ({ accessToken, userRole, userID })
                 userID={userID}
                 userRole={userRole}
                 availableAccessGroups={uniqueMcpAccessGroups}
+                initialTabIndex={selectedServerId === toolsTabServerId ? 1 : 0}
               />
             ) : (
               <div className="w-full h-full">

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_tool_configuration.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_tool_configuration.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import { Card, Title, Text } from "@tremor/react";
 import { ToolOutlined, CheckCircleOutlined, SearchOutlined, EditOutlined } from "@ant-design/icons";
 import { Badge, Spin, Checkbox, Input, Radio } from "antd";
-import { useTestMCPConnection } from "../../hooks/useTestMCPConnection";
 import McpCrudPermissionPanel from "./McpCrudPermissionPanel";
 
 interface KeyTool {
@@ -12,7 +11,6 @@ interface KeyTool {
 
 interface MCPToolConfigurationProps {
   accessToken: string | null;
-  oauthAccessToken?: string | null;
   formValues: Record<string, any>;
   allowedTools: string[];
   existingAllowedTools: string[] | null;
@@ -144,7 +142,6 @@ const ToolRow: React.FC<ToolRowProps> = ({
 
 const MCPToolConfiguration: React.FC<MCPToolConfigurationProps> = ({
   accessToken,
-  oauthAccessToken,
   formValues,
   allowedTools,
   existingAllowedTools,
@@ -169,19 +166,13 @@ const MCPToolConfiguration: React.FC<MCPToolConfigurationProps> = ({
   const previousSuggestedToolNamesRef = useRef<string>("");
   const [expandedTools, setExpandedTools] = useState<Set<string>>(new Set());
 
-  // Use external tool state when provided (avoids duplicate fetch with MCPConnectionStatus).
-  // Fall back to internal hook when used standalone (e.g., edit flow).
-  const hasExternalState = externalTools !== undefined;
-  const internalHook = useTestMCPConnection({
-    accessToken,
-    oauthAccessToken,
-    formValues,
-    enabled: !hasExternalState,
-  });
-  const tools: ToolEntry[] = hasExternalState ? externalTools : internalHook.tools;
-  const isLoadingTools = hasExternalState ? externalIsLoading ?? false : internalHook.isLoadingTools;
-  const toolsError = hasExternalState ? externalError ?? null : internalHook.toolsError;
-  const canFetchTools = hasExternalState ? externalCanFetch ?? false : internalHook.canFetchTools;
+  // Tool list is fetched by the parent (create/edit flow) and passed in. This
+  // component renders that state; it never fetches on its own, so there is a
+  // single source of truth and no risk of falling back to a different endpoint.
+  const tools: ToolEntry[] = externalTools ?? [];
+  const isLoadingTools = externalIsLoading ?? false;
+  const toolsError = externalError ?? null;
+  const canFetchTools = externalCanFetch ?? false;
 
   // Fuzzy-match curated key tool names against actual loaded tool names
   const suggestedTools = useMemo(() => {

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_tools.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_tools.test.tsx
@@ -2,12 +2,13 @@ import { render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import MCPToolsViewer from "./mcp_tools";
-import { listMCPTools } from "../networking";
+import { listMCPTools, getMCPOAuthUserCredentialStatus } from "../networking";
 import { isTokenValid, getToken } from "@/utils/mcpTokenStore";
 
 vi.mock("../networking", () => ({
   listMCPTools: vi.fn(),
   callMCPTool: vi.fn(),
+  getMCPOAuthUserCredentialStatus: vi.fn(),
 }));
 
 vi.mock("@/utils/mcpTokenStore", () => ({
@@ -18,6 +19,10 @@ vi.mock("@/utils/mcpTokenStore", () => ({
 
 vi.mock("@/hooks/useToolsOAuthFlow", () => ({
   useToolsOAuthFlow: () => ({ startOAuthFlow: vi.fn(), status: "idle", error: null }),
+}));
+
+vi.mock("@/hooks/useUserMcpOAuthFlow", () => ({
+  useUserMcpOAuthFlow: () => ({ startOAuthFlow: vi.fn(), status: "idle", error: null }),
 }));
 
 const GATE_TEXT = "Authentication required";
@@ -42,6 +47,13 @@ const renderViewer = (props: Record<string, unknown>) =>
     </QueryClientProvider>,
   );
 
+const credStatus = (overrides: Record<string, unknown> = {}) => ({
+  server_id: "srv-1",
+  has_credential: true,
+  is_expired: false,
+  ...overrides,
+});
+
 describe("MCPToolsViewer auth gate routing", () => {
   beforeEach(() => {
     vi.mocked(listMCPTools).mockReset().mockResolvedValue({ tools: [], error: null });
@@ -49,6 +61,8 @@ describe("MCPToolsViewer auth gate routing", () => {
     vi.mocked(getToken)
       .mockReset()
       .mockReturnValue(undefined as any);
+    // Default: the OBO credential exists and is valid, so OBO servers list tools.
+    vi.mocked(getMCPOAuthUserCredentialStatus).mockReset().mockResolvedValue(credStatus());
   });
 
   it("shows the Authorize gate for a passthrough server with a token endpoint and does not list tools", async () => {
@@ -57,6 +71,8 @@ describe("MCPToolsViewer auth gate routing", () => {
     expect(await screen.findByText(GATE_TEXT)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Authorize" })).toBeInTheDocument();
     expect(vi.mocked(listMCPTools)).not.toHaveBeenCalled();
+    // Passthrough must not consult the per-user DB credential.
+    expect(vi.mocked(getMCPOAuthUserCredentialStatus)).not.toHaveBeenCalled();
   });
 
   it("forwards the session token via the x-mcp header for a passthrough server that has one", async () => {
@@ -75,7 +91,40 @@ describe("MCPToolsViewer auth gate routing", () => {
     expect(screen.queryByText(GATE_TEXT)).not.toBeInTheDocument();
   });
 
-  it("does not gate an OBO server with a token endpoint; lists with the LiteLLM key and no x-mcp header", async () => {
+  it("lists tools for an OBO server when the user has a DB credential, with no x-mcp header", async () => {
+    renderViewer({ oauth2_flow: null, delegate_auth_to_upstream: false });
+
+    await waitFor(() => expect(vi.mocked(listMCPTools)).toHaveBeenCalledWith("litellm-key", "srv-1", undefined));
+    expect(screen.queryByText(GATE_TEXT)).not.toBeInTheDocument();
+  });
+
+  it("shows the Authorize gate for an OBO server when the user has no DB credential and does not list tools", async () => {
+    vi.mocked(getMCPOAuthUserCredentialStatus).mockResolvedValue(credStatus({ has_credential: false }));
+
+    renderViewer({ oauth2_flow: null, delegate_auth_to_upstream: false });
+
+    expect(await screen.findByText(GATE_TEXT)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Authorize" })).toBeInTheDocument();
+    expect(vi.mocked(listMCPTools)).not.toHaveBeenCalled();
+  });
+
+  it("shows the Authorize gate for an OBO server when the credential-status check fails", async () => {
+    vi.mocked(getMCPOAuthUserCredentialStatus).mockRejectedValue(new Error("network down"));
+
+    renderViewer({ oauth2_flow: null, delegate_auth_to_upstream: false });
+
+    expect(await screen.findByText(GATE_TEXT)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Authorize" })).toBeInTheDocument();
+    expect(vi.mocked(listMCPTools)).not.toHaveBeenCalled();
+  });
+
+  it("does not gate an OBO server whose stored token is expired; the list call refreshes it server-side", async () => {
+    // has_credential=true with is_expired=true must NOT gate: resolve_valid_user_oauth_token
+    // refreshes from the stored refresh_token on the list call, so the user never reauthorizes.
+    vi.mocked(getMCPOAuthUserCredentialStatus).mockResolvedValue(
+      credStatus({ has_credential: true, is_expired: true }),
+    );
+
     renderViewer({ oauth2_flow: null, delegate_auth_to_upstream: false });
 
     await waitFor(() => expect(vi.mocked(listMCPTools)).toHaveBeenCalledWith("litellm-key", "srv-1", undefined));
@@ -87,5 +136,7 @@ describe("MCPToolsViewer auth gate routing", () => {
 
     await waitFor(() => expect(vi.mocked(listMCPTools)).toHaveBeenCalledWith("litellm-key", "srv-1", undefined));
     expect(screen.queryByText(GATE_TEXT)).not.toBeInTheDocument();
+    // M2M uses the backend service token, not a per-user DB credential.
+    expect(vi.mocked(getMCPOAuthUserCredentialStatus)).not.toHaveBeenCalled();
   });
 });

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_tools.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_tools.tsx
@@ -1,11 +1,14 @@
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { ToolTestPanel } from "./ToolTestPanel";
 import { MCPTool, MCPToolsViewerProps, MCPContent, CallMCPToolResponse, getMcpOAuthMode } from "./types";
-import { listMCPTools, callMCPTool } from "../networking";
+import { listMCPTools, callMCPTool, getMCPOAuthUserCredentialStatus } from "../networking";
 import { isTokenValid, getToken, removeToken } from "@/utils/mcpTokenStore";
 import { sanitizeMcpAliasForHeader } from "@/utils/mcpHeaderUtils";
 import { useToolsOAuthFlow } from "@/hooks/useToolsOAuthFlow";
+import { useUserMcpOAuthFlow } from "@/hooks/useUserMcpOAuthFlow";
+import { TOOLS_OAUTH_UI_STATE_KEY } from "@/hooks/mcpOAuthUtils";
+import { setSecureItem } from "@/utils/secureStorage";
 
 import { Card, Title, Text } from "@tremor/react";
 import { RobotOutlined, ToolOutlined, SearchOutlined, KeyOutlined, LockOutlined } from "@ant-design/icons";
@@ -31,11 +34,14 @@ const MCPToolsViewer = ({
   const [passthroughHeaders, setPassthroughHeaders] = useState<Record<string, string>>({});
   const [showHeaderInput, setShowHeaderInput] = useState(false);
 
-  // Only PKCE passthrough uses a browser-held session token (sessionStorage,
-  // cleared on tab/browser close) and a user-facing auth gate. OBO uses the
-  // backend-stored per-user token and M2M uses the backend's own service token,
-  // so neither needs a gate — they list tools with just the LiteLLM key.
-  const isPassthrough = getMcpOAuthMode({ auth_type, oauth2_flow, delegate_auth_to_upstream }) === "passthrough";
+  // PKCE passthrough holds a browser-side session token (sessionStorage) and
+  // gates tool listing behind it. OBO uses a backend-stored per-user token that
+  // the user must establish once via an interactive login; we gate on whether
+  // that DB credential exists. M2M uses the backend's own service token and
+  // needs no gate.
+  const oauthMode = getMcpOAuthMode({ auth_type, oauth2_flow, delegate_auth_to_upstream });
+  const isPassthrough = oauthMode === "passthrough";
+  const isObo = oauthMode === "obo";
   const [oauthToken, setOauthToken] = useState<string | null>(() =>
     isPassthrough && isTokenValid(serverId, userID) ? getToken(serverId, userID)?.access_token ?? null : null,
   );
@@ -60,6 +66,31 @@ const MCPToolsViewer = ({
     userId: userID,
     onSuccess: setOauthToken,
   });
+
+  // OBO servers list tools using a per-user token the backend stores in the DB;
+  // check whether the current user has a valid one so we can prompt them to
+  // authorize when they don't (otherwise the backend silently returns no tools).
+  const {
+    data: oboCredStatus,
+    isLoading: isLoadingOboCred,
+    isError: isOboCredError,
+    refetch: refetchOboCred,
+  } = useQuery({
+    queryKey: ["mcpOauthUserCredStatus", serverId, userID],
+    queryFn: () => getMCPOAuthUserCredentialStatus(accessToken ?? "", serverId),
+    enabled: !!accessToken && isObo,
+    staleTime: 30000,
+  });
+
+  // A stored credential is sufficient: the backend proactively refreshes an
+  // expired or near-expiry token from the stored refresh_token on the next list
+  // call, so the user only needs to authorize when no credential row exists. If
+  // the status check itself fails we can't confirm a credential, so surface the
+  // Authorize gate rather than a silent empty tool list; re-authorizing only
+  // overwrites the user's own row, so it is safe when a credential did exist.
+  const hasOboCred = !!oboCredStatus?.has_credential;
+  const oboNeedsAuth = isObo && !isLoadingOboCred && (isOboCredError || (!!oboCredStatus && !hasOboCred));
+  const oboStatusLoading = isObo && isLoadingOboCred;
 
   // Check if this server has extra headers configured
   const hasExtraHeaders = extraHeaders && extraHeaders.length > 0;
@@ -135,8 +166,9 @@ const MCPToolsViewer = ({
       }
       return result;
     },
-    // For OAuth servers, block the query until a session token is available
-    enabled: !!accessToken && (!isPassthrough || oauthToken !== null),
+    // Passthrough blocks until a browser session token exists; OBO blocks until
+    // the user has a valid DB credential (else the backend returns no tools).
+    enabled: !!accessToken && (isPassthrough ? oauthToken !== null : isObo ? hasOboCred : true),
     staleTime: 30000, // Consider data fresh for 30 seconds
     retry: (failureCount, error: any) => {
       // Don't retry on 401 — token is invalid, user must re-authenticate
@@ -144,6 +176,33 @@ const MCPToolsViewer = ({
       return failureCount < 2;
     },
   });
+
+  // OBO authorize: same redirect+exchange flow as the admin "Authorize & Fetch"
+  // and the chat "Connect" button, but persists the token to the per-user DB.
+  const onOboAuthSuccess = useCallback(() => {
+    refetchOboCred();
+    refetchTools();
+  }, [refetchOboCred, refetchTools]);
+
+  const {
+    startOAuthFlow: startDbOAuthFlow,
+    status: dbOAuthStatus,
+    error: dbOAuthError,
+  } = useUserMcpOAuthFlow({
+    accessToken: accessToken ?? "",
+    serverId,
+    serverAlias,
+    onSuccess: onOboAuthSuccess,
+  });
+
+  // Stash which server started the redirect so the MCP Servers page can reopen
+  // this Tools tab on return and let the flow resume to persist the credential.
+  const startOboAuthorize = useCallback(() => {
+    try {
+      setSecureItem(TOOLS_OAUTH_UI_STATE_KEY, JSON.stringify({ serverId }));
+    } catch (_) {}
+    startDbOAuthFlow();
+  }, [serverId, startDbOAuthFlow]);
 
   // If the tools query fails with 401, the cached OAuth token is invalid —
   // clear it so the auth gate is shown again and the user can re-authenticate.
@@ -186,6 +245,13 @@ const MCPToolsViewer = ({
   });
 
   const toolsData = mcpToolsResponse?.tools || [];
+
+  // An auth gate replaces the tool list when the user must authenticate first:
+  // passthrough needs a browser token, OBO needs a stored DB credential.
+  const authGateActive = (isPassthrough && !oauthToken) || oboNeedsAuth;
+  // Treat OBO credential-status loading as "tools loading" so the empty state
+  // doesn't flash before we know whether the user needs to authorize.
+  const toolsAreaLoading = isLoadingTools || oboStatusLoading;
 
   // Filter tools based on search term
   const filteredTools = toolsData.filter((tool: MCPTool) => {
@@ -287,7 +353,7 @@ const MCPToolsViewer = ({
                   )}
                 </Text>
 
-                {/* OAuth Auth Gate — shown when token is absent for OAuth servers */}
+                {/* Passthrough auth gate — browser session token absent */}
                 {isPassthrough && !oauthToken && (
                   <div className="p-4 text-center bg-white border border-gray-200 rounded-lg">
                     <LockOutlined className="text-2xl text-gray-400 mb-2" />
@@ -306,8 +372,31 @@ const MCPToolsViewer = ({
                   </div>
                 )}
 
+                {/* OBO auth gate — only when no credential row exists for this user.
+                    An existing-but-expired token is refreshed server-side on the
+                    list call, so the gate never appears for a stored credential. */}
+                {oboNeedsAuth && (
+                  <div className="p-4 text-center bg-white border border-gray-200 rounded-lg">
+                    <LockOutlined className="text-2xl text-gray-400 mb-2" />
+                    <p className="text-xs font-medium text-gray-700 mb-1">Authentication required</p>
+                    <p className="text-xs text-gray-500 mb-3">
+                      Authenticate with the upstream provider to view available tools
+                    </p>
+                    <AntdButton
+                      size="small"
+                      type="primary"
+                      loading={dbOAuthStatus === "authorizing" || dbOAuthStatus === "exchanging"}
+                      onClick={startOboAuthorize}
+                      disabled={!accessToken}
+                    >
+                      Authorize
+                    </AntdButton>
+                    {dbOAuthError && <p className="text-xs text-red-500 mt-2">{dbOAuthError}</p>}
+                  </div>
+                )}
+
                 {/* Search Bar — only shown when tools are loaded */}
-                {!isPassthrough || oauthToken ? (
+                {!authGateActive ? (
                   <>
                     {toolsData.length > 0 && (
                       <div className="mb-3">
@@ -324,7 +413,7 @@ const MCPToolsViewer = ({
                     )}
 
                     {/* Loading State */}
-                    {isLoadingTools && (
+                    {toolsAreaLoading && (
                       <div className="flex flex-col items-center justify-center py-8 bg-white border border-gray-200 rounded-lg">
                         <div className="relative mb-3">
                           <div className="animate-spin rounded-full h-6 w-6 border-2 border-gray-200"></div>
@@ -335,7 +424,7 @@ const MCPToolsViewer = ({
                     )}
 
                     {/* Error State */}
-                    {(mcpToolsResponse?.error || mcpToolsError) && !isLoadingTools && !toolsData.length && (
+                    {(mcpToolsResponse?.error || mcpToolsError) && !toolsAreaLoading && !toolsData.length && (
                       <div className="p-3 text-xs text-red-800 rounded-lg bg-red-50 border border-red-200">
                         <p className="font-medium">
                           Error: {mcpToolsResponse?.message || (mcpToolsError as Error)?.message}
@@ -344,7 +433,7 @@ const MCPToolsViewer = ({
                     )}
 
                     {/* No Tools State */}
-                    {!isLoadingTools &&
+                    {!toolsAreaLoading &&
                       !mcpToolsResponse?.error &&
                       !mcpToolsError &&
                       (!toolsData || toolsData.length === 0) && (
@@ -370,7 +459,7 @@ const MCPToolsViewer = ({
                       )}
 
                     {/* Tools List */}
-                    {!isLoadingTools && !mcpToolsResponse?.error && toolsData.length > 0 && (
+                    {!toolsAreaLoading && !mcpToolsResponse?.error && toolsData.length > 0 && (
                       <>
                         {filteredTools.length === 0 ? (
                           <div className="p-4 text-center bg-white border border-gray-200 rounded-lg">

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_tools.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_tools.tsx
@@ -4,7 +4,7 @@ import { ToolTestPanel } from "./ToolTestPanel";
 import { MCPTool, MCPToolsViewerProps, MCPContent, CallMCPToolResponse, getMcpOAuthMode } from "./types";
 import { listMCPTools, callMCPTool, getMCPOAuthUserCredentialStatus } from "../networking";
 import { isTokenValid, getToken, removeToken } from "@/utils/mcpTokenStore";
-import { sanitizeMcpAliasForHeader } from "@/utils/mcpHeaderUtils";
+import { sanitizeMcpAliasForHeader, buildMcpPassthroughAuthHeader } from "@/utils/mcpHeaderUtils";
 import { useToolsOAuthFlow } from "@/hooks/useToolsOAuthFlow";
 import { useUserMcpOAuthFlow } from "@/hooks/useUserMcpOAuthFlow";
 import { TOOLS_OAUTH_UI_STATE_KEY } from "@/hooks/mcpOAuthUtils";
@@ -106,16 +106,7 @@ const MCPToolsViewer = ({
     // When no alias is available, fall back to x-mcp-auth (legacy but still supported).
     // Passthrough only: OBO/M2M tokens are attached server-side, not from the browser.
     if (isPassthrough && oauthToken) {
-      if (serverAlias) {
-        const safeAlias = sanitizeMcpAliasForHeader(serverAlias);
-        if (safeAlias) {
-          customHeaders[`x-mcp-${safeAlias}-authorization`] = `Bearer ${oauthToken}`;
-        } else {
-          customHeaders["x-mcp-auth"] = `Bearer ${oauthToken}`;
-        }
-      } else {
-        customHeaders["x-mcp-auth"] = `Bearer ${oauthToken}`;
-      }
+      Object.assign(customHeaders, buildMcpPassthroughAuthHeader(serverAlias, oauthToken));
     }
 
     // Add passthrough headers with server-specific prefix

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -5225,11 +5225,16 @@ export const testSearchToolConnection = async (accessToken: string, litellmParam
   }
 };
 
-export const listMCPTools = async (accessToken: string, serverId: string, customHeaders?: Record<string, string>) => {
-  // Construct base URL
-  let url = proxyBaseUrl
-    ? `${proxyBaseUrl}/mcp-rest/tools/list?server_id=${serverId}`
-    : `/mcp-rest/tools/list?server_id=${serverId}`;
+export const listMCPTools = async (
+  accessToken: string,
+  serverId: string,
+  customHeaders?: Record<string, string>,
+  includeDisabledTools?: boolean,
+) => {
+  // Construct base URL. include_disabled_tools returns the full server catalog
+  // (admin-only, backend-enforced) so the settings UI can configure the allowlist.
+  const query = `server_id=${serverId}${includeDisabledTools ? "&include_disabled_tools=true" : ""}`;
+  let url = proxyBaseUrl ? `${proxyBaseUrl}/mcp-rest/tools/list?${query}` : `/mcp-rest/tools/list?${query}`;
 
   console.log("Fetching MCP tools from:", url);
 

--- a/ui/litellm-dashboard/src/hooks/mcpOAuthUtils.ts
+++ b/ui/litellm-dashboard/src/hooks/mcpOAuthUtils.ts
@@ -8,6 +8,15 @@
 import { getProxyBaseUrl, serverRootPath } from "@/components/networking";
 
 /**
+ * sessionStorage key used to restore the MCP server detail view on the Tools
+ * tab after a full-page OAuth redirect. The OBO authorize flow redirects to the
+ * IdP and back to the MCP Servers page; without this the user lands on the
+ * server list and useUserMcpOAuthFlow never re-mounts to persist the credential.
+ * Mirrors the admin edit flow's EDIT_OAUTH_UI_STATE_KEY.
+ */
+export const TOOLS_OAUTH_UI_STATE_KEY = "litellm-mcp-oauth-tools-state";
+
+/**
  * Build the OAuth callback URL for the current UI deployment.
  *
  * In the browser, derive the `/ui` prefix from the current pathname so the

--- a/ui/litellm-dashboard/src/hooks/useMcpOAuthFlow.test.tsx
+++ b/ui/litellm-dashboard/src/hooks/useMcpOAuthFlow.test.tsx
@@ -1,0 +1,117 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as networking from "@/components/networking";
+import { setSecureItem } from "@/utils/secureStorage";
+import { useMcpOAuthFlow } from "./useMcpOAuthFlow";
+
+vi.mock("@/components/networking", () => ({
+  exchangeMcpOAuthToken: vi.fn(),
+  cacheTemporaryMcpServer: vi.fn(),
+  registerMcpOAuthClient: vi.fn(),
+  buildMcpOAuthAuthorizeUrl: vi.fn(),
+  getProxyBaseUrl: vi.fn(() => ""),
+  serverRootPath: "",
+}));
+
+vi.mock("@/components/molecules/notifications_manager", () => ({
+  default: { success: vi.fn(), error: vi.fn() },
+}));
+
+const FLOW_STATE_KEY = "litellm-mcp-oauth-flow-state";
+const RESULT_KEY = "litellm-mcp-oauth-result";
+
+/** Seed the redirect result (the code returned by the IdP callback). */
+function seedResult(code: string) {
+  setSecureItem(RESULT_KEY, JSON.stringify({ state: "state-1", code }));
+}
+
+/** Seed the flow state stored before the redirect. */
+function seedFlowState() {
+  setSecureItem(
+    FLOW_STATE_KEY,
+    JSON.stringify({
+      state: "state-1",
+      codeVerifier: "verifier-1",
+      serverId: "server-1",
+      clientId: "client-1",
+      redirectUri: "https://app.example.com/ui/mcp/oauth/callback",
+      flowSource: "create",
+    }),
+  );
+}
+
+/** Seed storage so the hook's on-mount resume flow exchanges a code for a token. */
+function seedCompletedRedirect() {
+  seedResult("code-1");
+  seedFlowState();
+}
+
+function renderFlow(onTokenReceived = vi.fn()) {
+  return renderHook(
+    ({ onTokenReceived: cb }: { onTokenReceived: (t: any) => void }) =>
+      useMcpOAuthFlow({
+        accessToken: "admin-token",
+        getCredentials: () => ({}),
+        getTemporaryPayload: () => ({ url: "https://server-1.example.com/mcp", transport: "http" }),
+        onTokenReceived: cb,
+        flowSource: "create",
+      }),
+    { initialProps: { onTokenReceived } },
+  );
+}
+
+describe("useMcpOAuthFlow reset", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.sessionStorage.clear();
+    window.localStorage.clear();
+  });
+
+  it("clears a successfully fetched token so it cannot leak into the next session", async () => {
+    const token = { access_token: "tok-123", expires_in: 3600 };
+    vi.mocked(networking.exchangeMcpOAuthToken).mockResolvedValue(token);
+    seedCompletedRedirect();
+
+    const onTokenReceived = vi.fn();
+    const { result } = renderFlow(onTokenReceived);
+
+    await waitFor(() => expect(result.current.status).toBe("success"));
+    expect(result.current.tokenResponse).toEqual(token);
+    expect(onTokenReceived).toHaveBeenCalledWith(token);
+
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.status).toBe("idle");
+    expect(result.current.tokenResponse).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it("clears the in-flight guard so a callback after a mid-exchange close is not swallowed", async () => {
+    // First exchange hangs, mimicking the modal being closed while the token
+    // endpoint is still in flight. processingRef is left true at that point.
+    vi.mocked(networking.exchangeMcpOAuthToken).mockReturnValueOnce(new Promise<any>(() => {}));
+    seedFlowState();
+    seedResult("code-1");
+
+    const onTokenReceived1 = vi.fn();
+    const { result, rerender } = renderFlow(onTokenReceived1);
+
+    await waitFor(() => expect(result.current.status).toBe("exchanging"));
+
+    act(() => {
+      result.current.reset();
+    });
+
+    // The reopened modal receives a fresh callback; it must be processed, not
+    // dropped by a stale in-flight guard.
+    const token = { access_token: "tok-2" };
+    vi.mocked(networking.exchangeMcpOAuthToken).mockResolvedValueOnce(token);
+    seedResult("code-2");
+    const onTokenReceived2 = vi.fn();
+    rerender({ onTokenReceived: onTokenReceived2 });
+
+    await waitFor(() => expect(onTokenReceived2).toHaveBeenCalledWith(token));
+  });
+});

--- a/ui/litellm-dashboard/src/hooks/useMcpOAuthFlow.tsx
+++ b/ui/litellm-dashboard/src/hooks/useMcpOAuthFlow.tsx
@@ -28,6 +28,11 @@ interface UseMcpOAuthFlowOptions {
   getTemporaryPayload: () => Record<string, any> | null;
   onTokenReceived: (tokenResponse: Record<string, any>) => void;
   onBeforeRedirect?: () => void;
+  // Distinguishes which form started the flow (e.g. "create" vs "edit"). Both forms
+  // mount this hook with shared storage keys, so the return handler only processes a
+  // callback whose stored flowSource matches, preventing one form from grabbing the
+  // other's OAuth result.
+  flowSource: string;
 }
 
 interface UseMcpOAuthFlowResult {
@@ -43,6 +48,7 @@ export const useMcpOAuthFlow = ({
   getTemporaryPayload,
   onTokenReceived,
   onBeforeRedirect,
+  flowSource,
 }: UseMcpOAuthFlowOptions): UseMcpOAuthFlowResult => {
   const [status, setStatus] = useState<McpOAuthStatus>("idle");
   const [error, setError] = useState<string | null>(null);
@@ -60,6 +66,7 @@ export const useMcpOAuthFlow = ({
     clientSecret?: string;
     serverId: string;
     redirectUri: string;
+    flowSource?: string;
   };
 
   const setStorageItem = (key: string, value: string) => {
@@ -179,6 +186,7 @@ export const useMcpOAuthFlow = ({
         clientSecret: registeredClient.clientSecret || credentials.client_secret,
         serverId,
         redirectUri: callbackUrl(),
+        flowSource,
       };
 
       if (typeof window === "undefined") {
@@ -253,6 +261,16 @@ export const useMcpOAuthFlow = ({
     }
 
     if (!payload) {
+      processingRef.current = false;
+      return;
+    }
+
+    // Only the form that started this redirect should consume the result. The create
+    // form and the edit form both mount this hook with shared storage keys, so without
+    // this another instance (e.g. the always-mounted create form) would grab and handle
+    // an edit-page authorization. Bail out without clearing RESULT_KEY so the matching
+    // instance can still process it.
+    if (flowState?.flowSource !== flowSource) {
       processingRef.current = false;
       return;
     }

--- a/ui/litellm-dashboard/src/hooks/useMcpOAuthFlow.tsx
+++ b/ui/litellm-dashboard/src/hooks/useMcpOAuthFlow.tsx
@@ -40,6 +40,7 @@ interface UseMcpOAuthFlowResult {
   status: McpOAuthStatus;
   error: string | null;
   tokenResponse: Record<string, any> | null;
+  reset: () => void;
 }
 
 export const useMcpOAuthFlow = ({
@@ -336,10 +337,18 @@ export const useMcpOAuthFlow = ({
     resumeOAuthFlow();
   }, [resumeOAuthFlow]);
 
+  const reset = useCallback(() => {
+    setStatus("idle");
+    setError(null);
+    setTokenResponse(null);
+    processingRef.current = false;
+  }, []);
+
   return {
     startOAuthFlow,
     status,
     error,
     tokenResponse,
+    reset,
   };
 };

--- a/ui/litellm-dashboard/src/hooks/useTestMCPConnection.tsx
+++ b/ui/litellm-dashboard/src/hooks/useTestMCPConnection.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { testMCPToolsListRequest } from "../components/networking";
 import { AUTH_TYPE, OAUTH_FLOW, TRANSPORT } from "@/components/mcp_tools/types";
 
@@ -177,12 +177,12 @@ export const useTestMCPConnection = ({
     }
   };
 
-  const clearTools = () => {
+  const clearTools = useCallback(() => {
     setTools([]);
     setToolsError(null);
     setToolsErrorStackTrace(null);
     setHasShownSuccessMessage(false);
-  };
+  }, []);
 
   // Auto-fetch tools when form values change and required fields are available
   useEffect(() => {

--- a/ui/litellm-dashboard/src/utils/mcpHeaderUtils.ts
+++ b/ui/litellm-dashboard/src/utils/mcpHeaderUtils.ts
@@ -12,3 +12,18 @@ export function sanitizeMcpAliasForHeader(alias: string): string {
     .replace(/_+/g, "_")
     .replace(/^_|_$/g, "");
 }
+
+/**
+ * Build the passthrough auth header that forwards a browser-held PKCE token to
+ * the upstream MCP server. The backend picks up the x-mcp-{alias}-authorization
+ * pattern and forwards it; without a usable alias it falls back to the legacy
+ * x-mcp-auth header.
+ */
+export function buildMcpPassthroughAuthHeader(
+  serverAlias: string | null | undefined,
+  token: string,
+): Record<string, string> {
+  const safeAlias = serverAlias ? sanitizeMcpAliasForHeader(serverAlias) : "";
+  const headerName = safeAlias ? `x-mcp-${safeAlias}-authorization` : "x-mcp-auth";
+  return { [headerName]: `Bearer ${token}` };
+}


### PR DESCRIPTION
## Relevant issues

Cherry-picks of merged MCP fixes from `litellm_internal_staging` onto the `patch/v1.89.0-rc.2` release branch, toward v1.89.0-rc.3.

## Linear ticket

## Pre-Submission checklist

- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem (cherry-picks toward the next rc)

## Changes

These six commits cherry-pick cleanly (no manual conflict resolution) onto rc.2, in the same order they were merged to staging:

1. #29867 fix(mcp): let non-creator users OAuth into OBO-mode MCP servers from the Tools page
2. #29951 changing expires_in default to use actual slack return details
3. #29960 fix(mcp): load MCP tool configuration tools via the OBO/passthrough-aware GET path
4. #30000 fix(ui/mcp): reset OAuth state on create-server modal close so a prior server's token no longer leaks into the next add-server session
5. #30041 fix(mcp): allow team access-group grants in OAuth authorize/token access check
6. #30141 fix(mcp): drop orphaned per-user credential rows when an MCP server is deleted

Each original PR carried its own tests; those tests come along with the cherry-picks.

## Type

🐛 Bug Fix
