### PR TITLE
fix(proxy): store budget reservations as expiring holds, never on the spend counter

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -1508,6 +1508,12 @@ SPEND_LOG_QUEUE_POLL_INTERVAL = float(os.getenv("SPEND_LOG_QUEUE_POLL_INTERVAL",
 SPEND_COUNTER_RESEED_LOCKS_MAX_SIZE = int(
     os.getenv("SPEND_COUNTER_RESEED_LOCKS_MAX_SIZE", 10000)
 )
+# Lifetime of an in-flight budget reservation ("hold"). A hold that outlives
+# this (e.g. its pod was OOMKilled before the request settled) is pruned at the
+# next admission, so an orphaned reservation cannot pin a shared budget counter.
+# Set above the longest possible single request; hosted providers terminate
+# streams at/under ~60 min, so 1 hour covers effectively all real requests.
+BUDGET_HOLD_TTL_SECONDS = int(os.getenv("BUDGET_HOLD_TTL", 3600))
 DEFAULT_CRON_JOB_LOCK_TTL_SECONDS = int(
     os.getenv("DEFAULT_CRON_JOB_LOCK_TTL_SECONDS", 60)
 )  # 1 minute

--- a/litellm/proxy/hooks/max_budget_limiter.py
+++ b/litellm/proxy/hooks/max_budget_limiter.py
@@ -35,11 +35,11 @@ class _PROXY_MaxBudgetLimiter(CustomLogger):
             if user_api_key_dict.team_id is not None:
                 return
 
-            # The reservation path admits at the strict-`<` boundary and
-            # atomically pre-fills the same counter we'd read here. Re-checking
-            # with `>=` would reject a request the reservation already admitted
-            # when the reservation fills the counter to exactly max_budget.
-            # Imported lazily to avoid a circular import via proxy.utils.
+            # The reservation path already admitted this counter at the
+            # strict-`<` boundary (committed spend + live holds <= max_budget),
+            # so a redundant `>=` re-check here could reject a request it
+            # already let through. Imported lazily to avoid a circular import
+            # via proxy.utils.
             from litellm.proxy.spend_tracking.budget_reservation import (
                 get_reserved_counter_keys,
             )

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -218,6 +218,7 @@ from litellm.constants import (
     APSCHEDULER_MAX_INSTANCES,
     APSCHEDULER_MISFIRE_GRACE_TIME,
     APSCHEDULER_REPLACE_EXISTING,
+    BUDGET_HOLD_TTL_SECONDS,
     DAYS_IN_A_MONTH,
     DEFAULT_HEALTH_CHECK_INTERVAL,
     DEFAULT_MODEL_CREATED_AT_TIME,
@@ -452,6 +453,7 @@ from litellm.proxy.response_api_endpoints.endpoints import router as response_ro
 from litellm.proxy.route_llm_request import route_request
 from litellm.proxy.search_endpoints.endpoints import router as search_router
 from litellm.proxy.shutdown.graceful_shutdown_manager import GracefulShutdownManager
+from litellm.proxy.spend_tracking.budget_hold_store import BudgetHoldStore
 from litellm.proxy.spend_tracking.spend_management_endpoints import (
     router as spend_management_router,
 )
@@ -1876,6 +1878,10 @@ user_api_key_cache: UserApiKeyCache = UserApiKeyCache(
 spend_counter_cache = DualCache(
     default_in_memory_ttl=UserAPIKeyCacheTTLEnum.in_memory_cache_ttl.value
 )
+budget_hold_store = BudgetHoldStore(
+    dual_cache=spend_counter_cache,
+    ttl_seconds=BUDGET_HOLD_TTL_SECONDS,
+)
 model_max_budget_limiter = _PROXY_VirtualKeyModelMaxBudgetLimiter(
     dual_cache=user_api_key_cache
 )
@@ -2084,9 +2090,8 @@ async def increment_spend_counters(
     Awaited (not create_task) in the cost callback, so the counter is
     updated before the next request's auth check runs.
     """
-    reserved_counter_keys = await _reconcile_budget_reservation_for_counter_update(
+    await _reconcile_budget_reservation_for_counter_update(
         budget_reservation=budget_reservation,
-        response_cost=response_cost,
     )
 
     if response_cost is None or response_cost == 0:
@@ -2106,13 +2111,11 @@ async def increment_spend_counters(
             if isinstance(token, str) and token.startswith("sk-")
             else token
         )
-        key_counter_key = f"spend:key:{hashed_token}"
-        if key_counter_key not in reserved_counter_keys:
-            await _init_and_increment_spend_counter(
-                counter_key=key_counter_key,
-                source_cache_key=hashed_token,
-                increment=response_cost,
-            )
+        await _init_and_increment_spend_counter(
+            counter_key=f"spend:key:{hashed_token}",
+            source_cache_key=hashed_token,
+            increment=response_cost,
+        )
 
         # Increment per-window budget counters for multi-budget keys
         key_obj = await user_api_key_cache.async_get_cache(key=hashed_token)
@@ -2129,28 +2132,24 @@ async def increment_spend_counters(
                         if isinstance(window, dict)
                         else window.budget_duration
                     )
-                    key_window_counter = f"spend:key:{hashed_token}:window:{duration}"
-                    if key_window_counter not in reserved_counter_keys:
-                        from litellm.proxy.spend_tracking.budget_reservation import (
-                            get_budget_window_start,
-                        )
+                    from litellm.proxy.spend_tracking.budget_reservation import (
+                        get_budget_window_start,
+                    )
 
-                        await _init_and_increment_window_spend_counter(
-                            counter_key=key_window_counter,
-                            entity_type="Key",
-                            entity_id=hashed_token,
-                            window_start=get_budget_window_start(window),
-                            increment=response_cost,
-                        )
+                    await _init_and_increment_window_spend_counter(
+                        counter_key=f"spend:key:{hashed_token}:window:{duration}",
+                        entity_type="Key",
+                        entity_id=hashed_token,
+                        window_start=get_budget_window_start(window),
+                        increment=response_cost,
+                    )
 
     if team_id is not None:
-        team_counter_key = f"spend:team:{team_id}"
-        if team_counter_key not in reserved_counter_keys:
-            await _init_and_increment_spend_counter(
-                counter_key=team_counter_key,
-                source_cache_key=f"team_id:{team_id}",
-                increment=response_cost,
-            )
+        await _init_and_increment_spend_counter(
+            counter_key=f"spend:team:{team_id}",
+            source_cache_key=f"team_id:{team_id}",
+            increment=response_cost,
+        )
 
         # Increment per-window budget counters for multi-budget teams
         team_obj = await user_api_key_cache.async_get_cache(key=f"team_id:{team_id}")
@@ -2167,49 +2166,41 @@ async def increment_spend_counters(
                         if isinstance(window, dict)
                         else window.budget_duration
                     )
-                    team_window_counter = f"spend:team:{team_id}:window:{duration}"
-                    if team_window_counter not in reserved_counter_keys:
-                        from litellm.proxy.spend_tracking.budget_reservation import (
-                            get_budget_window_start,
-                        )
+                    from litellm.proxy.spend_tracking.budget_reservation import (
+                        get_budget_window_start,
+                    )
 
-                        await _init_and_increment_window_spend_counter(
-                            counter_key=team_window_counter,
-                            entity_type="Team",
-                            entity_id=team_id,
-                            window_start=get_budget_window_start(window),
-                            increment=response_cost,
-                        )
+                    await _init_and_increment_window_spend_counter(
+                        counter_key=f"spend:team:{team_id}:window:{duration}",
+                        entity_type="Team",
+                        entity_id=team_id,
+                        window_start=get_budget_window_start(window),
+                        increment=response_cost,
+                    )
 
     if user_id is not None and team_id is not None:
-        team_member_counter_key = f"spend:team_member:{user_id}:{team_id}"
-        if team_member_counter_key not in reserved_counter_keys:
-            await _init_and_increment_spend_counter(
-                counter_key=team_member_counter_key,
-                source_cache_key=f"team_membership:{user_id}:{team_id}",
-                increment=response_cost,
-            )
+        await _init_and_increment_spend_counter(
+            counter_key=f"spend:team_member:{user_id}:{team_id}",
+            source_cache_key=f"team_membership:{user_id}:{team_id}",
+            increment=response_cost,
+        )
 
     if user_id is not None:
-        user_counter_key = f"spend:user:{user_id}"
-        if user_counter_key not in reserved_counter_keys:
-            await _init_and_increment_spend_counter(
-                counter_key=user_counter_key,
-                source_cache_key=user_id,
-                increment=response_cost,
-            )
+        await _init_and_increment_spend_counter(
+            counter_key=f"spend:user:{user_id}",
+            source_cache_key=user_id,
+            increment=response_cost,
+        )
 
     await _increment_end_user_and_tag_spend_counters(
         end_user_id=end_user_id,
         tags=tags,
         response_cost=response_cost,
-        reserved_counter_keys=reserved_counter_keys,
     )
 
     await _increment_org_spend_counter(
         org_id=org_id,
         response_cost=response_cost,
-        reserved_counter_keys=reserved_counter_keys,
     )
     if budget_reservation is not None:
         budget_reservation["finalized"] = True
@@ -2217,55 +2208,39 @@ async def increment_spend_counters(
 
 async def _reconcile_budget_reservation_for_counter_update(
     budget_reservation: Optional[dict],
-    response_cost: Optional[float],
-) -> Set[str]:
+) -> None:
+    """Release this request's holds. Committed spend is incremented separately
+    by the caller; holds and committed spend are distinct, so removing a hold
+    cannot fail in a way that corrupts the shared counter."""
     if budget_reservation is None:
-        return set()
+        return
 
     from litellm.proxy.spend_tracking.budget_reservation import (
-        get_reserved_counter_keys,
-        invalidate_budget_reservation_counters,
         reconcile_budget_reservation,
     )
 
-    reserved_counter_keys = get_reserved_counter_keys(
-        budget_reservation=budget_reservation
-    )
     try:
         await reconcile_budget_reservation(
             budget_reservation=budget_reservation,
-            actual_cost=response_cost or 0.0,
             finalize=False,
         )
     except Exception:
         verbose_proxy_logger.warning(
-            "Failed to reconcile budget reservation after persisted spend; invalidating reserved counters and falling back to direct increment",
+            "Failed to release budget reservation holds after persisted spend",
             exc_info=True,
         )
-        try:
-            await invalidate_budget_reservation_counters(
-                budget_reservation=budget_reservation
-            )
-        except Exception:
-            verbose_proxy_logger.exception(
-                "Failed to invalidate reserved counters after reservation reconciliation failed"
-            )
-        return set()
-    return reserved_counter_keys
 
 
 async def _increment_end_user_and_tag_spend_counters(
     end_user_id: Optional[str],
     tags: Optional[List[str]],
     response_cost: float,
-    reserved_counter_keys: Set[str],
 ) -> None:
     if end_user_id is not None:
-        await _init_and_increment_unreserved_spend_counter(
+        await _init_and_increment_spend_counter(
             counter_key=f"spend:end_user:{end_user_id}",
             source_cache_key=f"end_user_id:{end_user_id}",
             increment=response_cost,
-            reserved_counter_keys=reserved_counter_keys,
         )
 
     if tags is None:
@@ -2276,43 +2251,24 @@ async def _increment_end_user_and_tag_spend_counters(
         if not tag_name or not isinstance(tag_name, str) or tag_name in seen_tags:
             continue
         seen_tags.add(tag_name)
-        await _init_and_increment_unreserved_spend_counter(
+        await _init_and_increment_spend_counter(
             counter_key=f"spend:tag:{tag_name}",
             source_cache_key=f"tag:{tag_name}",
             increment=response_cost,
-            reserved_counter_keys=reserved_counter_keys,
         )
 
 
 async def _increment_org_spend_counter(
     org_id: Optional[str],
     response_cost: float,
-    reserved_counter_keys: Set[str],
 ) -> None:
     if org_id is None:
         return
 
-    await _init_and_increment_unreserved_spend_counter(
+    await _init_and_increment_spend_counter(
         counter_key=f"spend:org:{org_id}",
         source_cache_key=[f"org_id:{org_id}:with_budget", f"org_id:{org_id}"],
         increment=response_cost,
-        reserved_counter_keys=reserved_counter_keys,
-    )
-
-
-async def _init_and_increment_unreserved_spend_counter(
-    counter_key: str,
-    source_cache_key: Union[str, List[str]],
-    increment: float,
-    reserved_counter_keys: Set[str],
-) -> None:
-    if counter_key in reserved_counter_keys:
-        return
-
-    await _init_and_increment_spend_counter(
-        counter_key=counter_key,
-        source_cache_key=source_cache_key,
-        increment=increment,
     )
 
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -2090,11 +2090,11 @@ async def increment_spend_counters(
     Awaited (not create_task) in the cost callback, so the counter is
     updated before the next request's auth check runs.
     """
-    await _reconcile_budget_reservation_for_counter_update(
-        budget_reservation=budget_reservation,
-    )
-
     if response_cost is None or response_cost == 0:
+        # Nothing to commit; release this request's holds and finalize.
+        await _reconcile_budget_reservation_for_counter_update(
+            budget_reservation=budget_reservation,
+        )
         if budget_reservation is not None:
             budget_reservation["finalized"] = True
         return
@@ -2201,6 +2201,14 @@ async def increment_spend_counters(
     await _increment_org_spend_counter(
         org_id=org_id,
         response_cost=response_cost,
+    )
+
+    # Release holds only after committed spend is written. A concurrent
+    # admission then never sees a window with neither the hold nor the cost
+    # counted; the brief overlap double-counts (hold + committed), which blocks
+    # early rather than over-admitting.
+    await _reconcile_budget_reservation_for_counter_update(
+        budget_reservation=budget_reservation,
     )
     if budget_reservation is not None:
         budget_reservation["finalized"] = True

--- a/litellm/proxy/spend_tracking/budget_hold_store.py
+++ b/litellm/proxy/spend_tracking/budget_hold_store.py
@@ -1,0 +1,131 @@
+"""
+Storage for in-flight budget reservations ("holds").
+
+A hold is one request's optimistic reservation against a budget counter. Holds
+are kept separate from the committed spend counter and each one expires on its
+own, so a pod that dies before settling a request (OOMKill, SIGKILL) cannot
+leave a reservation pinned on the shared counter. The committed spend counter is
+only ever incremented by real cost; it is never decremented to "give back" a
+reservation, which is what made the previous design corrupt under pod churn.
+
+Redis backend (multi-pod): one sorted set per counter, member ``<hold_id>:<cost>``
+scored by expiry. Admission prunes expired members (``ZREMRANGEBYSCORE``), adds
+its own hold, and sums the live members in a single atomic script, so an
+orphaned hold ages out within ``ttl_seconds``.
+
+In-memory backend (single pod, no Redis): a per-counter dict of
+``hold_id -> (cost, expiry)``. A single pod has no cross-pod orphan to recover,
+so losing this dict on pod death is the correct, complete cleanup.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING, Dict, List, Tuple
+
+if TYPE_CHECKING:
+    from litellm.caching.redis_cache import RedisCache
+    from litellm.caching.dual_cache import DualCache
+
+_HOLD_KEY_PREFIX = "budget_holds:"
+
+# Atomic admission against the per-counter sorted set: prune expired holds, add
+# this request's hold, bound the set's lifetime, then return the live total.
+_PLACE_AND_TOTAL_LUA = """
+redis.call('ZREMRANGEBYSCORE', KEYS[1], '-inf', ARGV[1])
+redis.call('ZADD', KEYS[1], ARGV[2], ARGV[3])
+redis.call('EXPIRE', KEYS[1], ARGV[4])
+local members = redis.call('ZRANGE', KEYS[1], 0, -1)
+local total = 0.0
+for i = 1, #members do
+  local pos = string.find(members[i], ':[^:]*$')
+  if pos then
+    local c = tonumber(string.sub(members[i], pos + 1))
+    if c then total = total + c end
+  end
+end
+return tostring(total)
+"""
+
+
+def _member(hold_id: str, cost: float) -> str:
+    return f"{hold_id}:{cost!r}"
+
+
+class BudgetHoldStore:
+    def __init__(self, dual_cache: "DualCache", ttl_seconds: int) -> None:
+        self._dual_cache = dual_cache
+        self._ttl_seconds = ttl_seconds
+        self._memory_holds: Dict[str, Dict[str, Tuple[float, float]]] = {}
+
+    def _redis(self) -> "RedisCache | None":
+        return self._dual_cache.redis_cache
+
+    def _zkey(self, counter_key: str) -> str:
+        return f"{_HOLD_KEY_PREFIX}{counter_key}"
+
+    async def place_and_total(
+        self, counter_key: str, hold_id: str, cost: float
+    ) -> float:
+        """Record a hold of ``cost`` and return the sum of all live holds (this one included)."""
+        redis = self._redis()
+        if redis is not None:
+            client = redis.init_async_client()
+            zkey = redis.check_and_fix_namespace(key=self._zkey(counter_key))
+            now = time.time()
+            total = await client.eval(
+                _PLACE_AND_TOTAL_LUA,
+                1,
+                zkey,
+                now,
+                now + self._ttl_seconds,
+                _member(hold_id, cost),
+                self._ttl_seconds,
+            )
+            return float(total)
+        return self._memory_place_and_total(counter_key, hold_id, cost)
+
+    async def resize(
+        self, counter_key: str, hold_id: str, old_cost: float, new_cost: float
+    ) -> None:
+        redis = self._redis()
+        if redis is not None:
+            client = redis.init_async_client()
+            zkey = redis.check_and_fix_namespace(key=self._zkey(counter_key))
+            await client.zrem(zkey, _member(hold_id, old_cost))
+            await client.zadd(
+                zkey, {_member(hold_id, new_cost): time.time() + self._ttl_seconds}
+            )
+            # ZREM of the last member drops the set and its TTL, so the ZADD
+            # above can recreate it without one; refresh so an idle counter's
+            # holds key still expires.
+            await client.expire(zkey, self._ttl_seconds)
+            return
+        holds = self._memory_holds.get(counter_key)
+        if holds is not None and hold_id in holds:
+            _, expiry = holds[hold_id]
+            holds[hold_id] = (new_cost, expiry)
+
+    async def remove(self, counter_key: str, hold_id: str, cost: float) -> None:
+        redis = self._redis()
+        if redis is not None:
+            client = redis.init_async_client()
+            zkey = redis.check_and_fix_namespace(key=self._zkey(counter_key))
+            await client.zrem(zkey, _member(hold_id, cost))
+            return
+        holds = self._memory_holds.get(counter_key)
+        if holds is not None:
+            holds.pop(hold_id, None)
+            if not holds:
+                self._memory_holds.pop(counter_key, None)
+
+    def _memory_place_and_total(
+        self, counter_key: str, hold_id: str, cost: float
+    ) -> float:
+        holds = self._memory_holds.setdefault(counter_key, {})
+        now = time.time()
+        expired: List[str] = [hid for hid, (_, exp) in holds.items() if exp <= now]
+        for hid in expired:
+            del holds[hid]
+        holds[hold_id] = (cost, now + self._ttl_seconds)
+        return sum(c for c, _ in holds.values())

--- a/litellm/proxy/spend_tracking/budget_hold_store.py
+++ b/litellm/proxy/spend_tracking/budget_hold_store.py
@@ -49,6 +49,14 @@ end
 return tostring(total)
 """
 
+# Atomic resize: swap this hold's member for its resized cost in one step so a
+# concurrent admission's sum never runs while the hold is momentarily absent.
+_RESIZE_LUA = """
+redis.call('ZREM', KEYS[1], ARGV[1])
+redis.call('ZADD', KEYS[1], ARGV[2], ARGV[3])
+redis.call('EXPIRE', KEYS[1], ARGV[4])
+"""
+
 
 def _member(hold_id: str, cost: float) -> str:
     return f"{hold_id}:{cost!r}"
@@ -94,14 +102,18 @@ class BudgetHoldStore:
         if redis is not None:
             client: "Redis" = redis.init_async_client()  # type: ignore[assignment]
             zkey = redis.check_and_fix_namespace(key=self._zkey(counter_key))
-            await client.zrem(zkey, _member(hold_id, old_cost))
-            await client.zadd(
-                zkey, {_member(hold_id, new_cost): time.time() + self._ttl_seconds}
+            # ZREM of the last member would drop the set and its key TTL, so the
+            # script re-sets EXPIRE; doing it atomically also keeps a concurrent
+            # admission from summing while the resized hold is absent.
+            await client.eval(
+                _RESIZE_LUA,
+                1,
+                zkey,
+                _member(hold_id, old_cost),
+                time.time() + self._ttl_seconds,
+                _member(hold_id, new_cost),
+                self._ttl_seconds,
             )
-            # ZREM of the last member drops the set and its TTL, so the ZADD
-            # above can recreate it without one; refresh so an idle counter's
-            # holds key still expires.
-            await client.expire(zkey, self._ttl_seconds)
             return
         holds = self._memory_holds.get(counter_key)
         if holds is not None and hold_id in holds:

--- a/litellm/proxy/spend_tracking/budget_hold_store.py
+++ b/litellm/proxy/spend_tracking/budget_hold_store.py
@@ -24,6 +24,8 @@ import time
 from typing import TYPE_CHECKING, Dict, List, Tuple
 
 if TYPE_CHECKING:
+    from redis.asyncio import Redis
+
     from litellm.caching.redis_cache import RedisCache
     from litellm.caching.dual_cache import DualCache
 
@@ -70,7 +72,7 @@ class BudgetHoldStore:
         """Record a hold of ``cost`` and return the sum of all live holds (this one included)."""
         redis = self._redis()
         if redis is not None:
-            client = redis.init_async_client()
+            client: "Redis" = redis.init_async_client()  # type: ignore[assignment]
             zkey = redis.check_and_fix_namespace(key=self._zkey(counter_key))
             now = time.time()
             total = await client.eval(
@@ -90,7 +92,7 @@ class BudgetHoldStore:
     ) -> None:
         redis = self._redis()
         if redis is not None:
-            client = redis.init_async_client()
+            client: "Redis" = redis.init_async_client()  # type: ignore[assignment]
             zkey = redis.check_and_fix_namespace(key=self._zkey(counter_key))
             await client.zrem(zkey, _member(hold_id, old_cost))
             await client.zadd(
@@ -109,7 +111,7 @@ class BudgetHoldStore:
     async def remove(self, counter_key: str, hold_id: str, cost: float) -> None:
         redis = self._redis()
         if redis is not None:
-            client = redis.init_async_client()
+            client: "Redis" = redis.init_async_client()  # type: ignore[assignment]
             zkey = redis.check_and_fix_namespace(key=self._zkey(counter_key))
             await client.zrem(zkey, _member(hold_id, cost))
             return

--- a/litellm/proxy/spend_tracking/budget_reservation.py
+++ b/litellm/proxy/spend_tracking/budget_reservation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, Sequence, cast
@@ -34,14 +35,8 @@ class _BudgetCounter:
 
 
 class _CounterReservationUnavailable(Exception):
-    def __init__(
-        self,
-        touched_counter: bool = False,
-        counter_invalidated: bool = False,
-    ) -> None:
-        self.touched_counter = touched_counter
-        self.counter_invalidated = counter_invalidated
-        super().__init__("Counter reservation unavailable")
+    """Raised when a counter cannot be reserved against (cold window spend, Redis
+    error); the caller skips it and falls back to read-time enforcement."""
 
 
 def get_reserved_counter_keys(budget_reservation: Optional[dict]) -> set:
@@ -89,7 +84,6 @@ async def reserve_budget_for_request(
     if not counters:
         return None
 
-    current_spend_by_counter_key: Dict[str, float] = {}
     reservation_cost = estimate_request_max_cost(
         request_body=request_body,
         route=route,
@@ -102,42 +96,30 @@ async def reserve_budget_for_request(
         return None
 
     applied_entries: List[Dict[str, Any]] = []
+    hold_id = uuid.uuid4().hex
     try:
         for counter in counters:
             entry = _counter_to_reservation_entry(
                 counter=counter,
                 reserved_cost=reservation_cost,
             )
-            applied_entries.append(entry)
             try:
-                reserved_value = await _reserve_counter(
+                current_spend = await _reserve_counter(
                     counter=counter,
+                    hold_id=hold_id,
                     reservation_cost=reservation_cost,
                 )
-            except _CounterReservationUnavailable as exc:
-                if exc.touched_counter and not exc.counter_invalidated:
-                    await _release_applied_entries_best_effort(
-                        entries=[entry],
-                        default_reserved_cost=reservation_cost,
-                    )
-                applied_entries.remove(entry)
+            except _CounterReservationUnavailable:
                 continue
-
-            if reserved_value is not None:
-                current_spend = reserved_value
-            else:
-                cached_spend = current_spend_by_counter_key.get(counter.counter_key)
-                if cached_spend is None:
-                    cached_spend = await _get_current_counter_value(counter=counter)
-                current_spend = cached_spend + reservation_cost
+            applied_entries.append(entry)
             if current_spend > counter.max_budget:
                 remaining_before_reservation = counter.max_budget - (
                     current_spend - reservation_cost
                 )
                 if remaining_before_reservation > 1e-12:
                     await _resize_applied_reservation(
+                        hold_id=hold_id,
                         entries=applied_entries,
-                        current_reserved_cost=reservation_cost,
                         new_reserved_cost=remaining_before_reservation,
                     )
                     reservation_cost = remaining_before_reservation
@@ -154,8 +136,8 @@ async def reserve_budget_for_request(
                 )
     except Exception:
         await _release_applied_entries_best_effort(
+            hold_id=hold_id,
             entries=applied_entries,
-            default_reserved_cost=reservation_cost,
         )
         raise
 
@@ -163,6 +145,7 @@ async def reserve_budget_for_request(
         return None
 
     return {
+        "hold_id": hold_id,
         "reserved_cost": reservation_cost,
         "entries": applied_entries,
         "finalized": False,
@@ -171,40 +154,49 @@ async def reserve_budget_for_request(
 
 async def reconcile_budget_reservation(
     budget_reservation: Optional[dict],
-    actual_cost: Optional[float],
     finalize: bool = True,
 ) -> None:
     if not budget_reservation or budget_reservation.get("finalized") is True:
         return
 
-    reserved_cost = float(budget_reservation.get("reserved_cost") or 0.0)
-    actual = float(actual_cost or 0.0)
-    await _set_reserved_entries_actual_cost(
-        entries=budget_reservation.get("entries") or [],
-        actual_cost=actual,
-        default_reserved_cost=reserved_cost,
-    )
+    await _remove_all_holds(budget_reservation=budget_reservation)
     if finalize:
         budget_reservation["finalized"] = True
 
 
 async def release_budget_reservation(budget_reservation: Optional[dict]) -> None:
-    await reconcile_budget_reservation(
-        budget_reservation=budget_reservation,
-        actual_cost=0.0,
-    )
+    await reconcile_budget_reservation(budget_reservation=budget_reservation)
 
 
 async def invalidate_budget_reservation_counters(
     budget_reservation: Optional[dict],
 ) -> None:
-    if budget_reservation is None:
+    await _remove_all_holds(budget_reservation=budget_reservation)
+
+
+async def _remove_all_holds(budget_reservation: Optional[dict]) -> None:
+    if not budget_reservation:
         return
 
-    from litellm.proxy.proxy_server import _invalidate_spend_counter
+    from litellm.proxy.proxy_server import budget_hold_store
 
-    for counter_key in get_reserved_counter_keys(budget_reservation=budget_reservation):
-        await _invalidate_spend_counter(counter_key=counter_key)
+    hold_id = budget_reservation.get("hold_id")
+    if hold_id is None:
+        return
+    for entry in budget_reservation.get("entries") or []:
+        counter_key = entry.get("counter_key")
+        if counter_key is None:
+            continue
+        try:
+            await budget_hold_store.remove(
+                counter_key=counter_key,
+                hold_id=hold_id,
+                cost=_get_entry_reserved_cost(entry=entry, default_reserved_cost=0.0),
+            )
+        except Exception:
+            verbose_proxy_logger.warning(
+                "Failed to remove budget hold for %s", counter_key, exc_info=True
+            )
 
 
 async def _get_budget_counters(
@@ -553,16 +545,19 @@ def _coerce_window(window: Any) -> dict:
 
 async def _reserve_counter(
     counter: _BudgetCounter,
+    hold_id: str,
     reservation_cost: float,
-) -> Optional[float]:
+) -> float:
+    """Place this request's hold on ``counter`` and return the effective spend
+    (committed spend + every live hold, including this one). Raises
+    ``_CounterReservationUnavailable`` to skip the counter when its committed
+    spend cannot be loaded or the hold cannot be placed."""
     from litellm.proxy.proxy_server import (
         _ensure_spend_counter_initialized,
         _ensure_window_spend_counter_initialized,
-        _invalidate_spend_counter,
-        _increment_spend_counter_cache,
+        budget_hold_store,
     )
 
-    attempted_increment = False
     try:
         if counter.source_cache_key is not None:
             await _ensure_spend_counter_initialized(
@@ -584,35 +579,31 @@ async def _reserve_counter(
                     counter.counter_key,
                 )
                 raise _CounterReservationUnavailable
-
-        attempted_increment = True
-        reserved_value = await _increment_spend_counter_cache(
-            counter_key=counter.counter_key,
-            increment=reservation_cost,
-        )
-        return float(reserved_value) if reserved_value is not None else None
     except _CounterReservationUnavailable:
         raise
     except Exception:
         verbose_proxy_logger.warning(
-            "Skipping budget reservation for %s because spend counter reservation failed",
+            "Skipping budget reservation for %s because spend counter could not be initialized",
             counter.counter_key,
             exc_info=True,
         )
-        counter_invalidated = False
-        try:
-            await _invalidate_spend_counter(counter_key=counter.counter_key)
-            counter_invalidated = True
-        except Exception:
-            verbose_proxy_logger.warning(
-                "Failed to invalidate spend counter after budget reservation failure for %s",
-                counter.counter_key,
-                exc_info=True,
-            )
-        raise _CounterReservationUnavailable(
-            touched_counter=attempted_increment,
-            counter_invalidated=counter_invalidated,
+        raise _CounterReservationUnavailable
+
+    committed_spend = await _get_current_counter_value(counter=counter)
+    try:
+        live_holds = await budget_hold_store.place_and_total(
+            counter_key=counter.counter_key,
+            hold_id=hold_id,
+            cost=reservation_cost,
         )
+    except Exception:
+        verbose_proxy_logger.warning(
+            "Skipping budget reservation for %s because the hold could not be placed",
+            counter.counter_key,
+            exc_info=True,
+        )
+        raise _CounterReservationUnavailable
+    return committed_spend + live_holds
 
 
 async def _get_current_counter_value(counter: _BudgetCounter) -> float:
@@ -624,121 +615,46 @@ async def _get_current_counter_value(counter: _BudgetCounter) -> float:
     )
 
 
-async def _set_reserved_entries_actual_cost(
-    entries: List[dict],
-    actual_cost: float,
-    default_reserved_cost: float,
-) -> None:
-    for entry in entries:
-        await _set_reserved_entry_actual_cost(
-            entry=entry,
-            actual_cost=actual_cost,
-            default_reserved_cost=default_reserved_cost,
-        )
-
-
-async def _set_reserved_entry_actual_cost(
-    entry: dict,
-    actual_cost: float,
-    default_reserved_cost: float,
-) -> None:
-    from litellm.proxy.proxy_server import _increment_spend_counter_cache
-
-    counter_key = entry.get("counter_key")
-    if counter_key is None:
-        return
-    reserved_cost = _get_entry_reserved_cost(
-        entry=entry,
-        default_reserved_cost=default_reserved_cost,
-    )
-    target_adjustment = actual_cost - reserved_cost
-    applied_adjustment = float(entry.get("applied_adjustment") or 0.0)
-    adjustment = target_adjustment - applied_adjustment
-    if adjustment == 0:
-        return
-    await _ensure_counter_can_apply_adjustment(
-        counter_key=counter_key,
-        adjustment=adjustment,
-    )
-    await _increment_spend_counter_cache(
-        counter_key=counter_key,
-        increment=adjustment,
-    )
-    entry["applied_adjustment"] = target_adjustment
-
-
-async def _ensure_counter_can_apply_adjustment(
-    counter_key: str,
-    adjustment: float,
-) -> None:
-    from litellm.proxy.proxy_server import (
-        _invalidate_spend_counter,
-        spend_counter_cache,
-    )
-
-    current_value = await spend_counter_cache.async_get_cache(key=counter_key)
-    if current_value is None:
-        await _invalidate_spend_counter(counter_key=counter_key)
-        raise RuntimeError(
-            f"Cannot apply budget reservation adjustment to missing counter {counter_key}"
-        )
-
-    try:
-        current_float = float(current_value)
-    except (TypeError, ValueError):
-        await _invalidate_spend_counter(counter_key=counter_key)
-        raise RuntimeError(
-            f"Cannot apply budget reservation adjustment to non-numeric counter {counter_key}"
-        )
-
-    if adjustment < 0 and current_float + adjustment < -1e-12:
-        await _invalidate_spend_counter(counter_key=counter_key)
-        raise RuntimeError(
-            f"Budget reservation adjustment would make counter negative {counter_key}"
-        )
-
-
 async def _release_applied_entries_best_effort(
+    hold_id: str,
     entries: List[dict],
-    default_reserved_cost: float,
 ) -> None:
+    from litellm.proxy.proxy_server import budget_hold_store
+
     for entry in entries:
+        counter_key = entry.get("counter_key")
+        if counter_key is None:
+            continue
         try:
-            await _set_reserved_entry_actual_cost(
-                entry=entry,
-                actual_cost=0.0,
-                default_reserved_cost=default_reserved_cost,
+            await budget_hold_store.remove(
+                counter_key=counter_key,
+                hold_id=hold_id,
+                cost=_get_entry_reserved_cost(entry=entry, default_reserved_cost=0.0),
             )
         except Exception:
-            counter_key = entry.get("counter_key")
             verbose_proxy_logger.exception(
-                "Failed to release partial budget reservation during exception cleanup"
+                "Failed to release budget hold during exception cleanup"
             )
-            if counter_key is None:
-                continue
-            try:
-                from litellm.proxy.proxy_server import _invalidate_spend_counter
-
-                await _invalidate_spend_counter(counter_key=counter_key)
-            except Exception:
-                verbose_proxy_logger.exception(
-                    "Failed to invalidate partial budget reservation counter during exception cleanup"
-                )
 
 
 async def _resize_applied_reservation(
+    hold_id: str,
     entries: List[dict],
-    current_reserved_cost: float,
     new_reserved_cost: float,
 ) -> None:
-    await _set_reserved_entries_actual_cost(
-        entries=entries,
-        actual_cost=new_reserved_cost,
-        default_reserved_cost=current_reserved_cost,
-    )
+    from litellm.proxy.proxy_server import budget_hold_store
+
     for entry in entries:
+        counter_key = entry.get("counter_key")
+        if counter_key is None:
+            continue
+        await budget_hold_store.resize(
+            counter_key=counter_key,
+            hold_id=hold_id,
+            old_cost=_get_entry_reserved_cost(entry=entry, default_reserved_cost=0.0),
+            new_cost=new_reserved_cost,
+        )
         entry["reserved_cost"] = new_reserved_cost
-        entry["applied_adjustment"] = 0.0
 
 
 def _counter_to_reservation_entry(
@@ -750,7 +666,6 @@ def _counter_to_reservation_entry(
         "entity_type": counter.entity_type,
         "entity_id": counter.entity_id,
         "reserved_cost": reserved_cost,
-        "applied_adjustment": 0.0,
     }
 
 

--- a/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
+++ b/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
@@ -2973,12 +2973,12 @@ async def test_centralized_common_checks_reserves_request_end_user_budget():
             "entity_type": "EndUser",
             "entity_id": "alice",
             "reserved_cost": 0.6,
-            "applied_adjustment": 0.0,
         }
     ]
-    assert counter_cache.in_memory_cache.get_cache(
-        key="spend:end_user:alice"
-    ) == pytest.approx(0.6)
+    import litellm.proxy.proxy_server as _ps
+
+    holds = _ps.budget_hold_store._memory_holds.get("spend:end_user:alice", {})
+    assert sum(cost for cost, _ in holds.values()) == pytest.approx(0.6)
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/hooks/test_max_budget_limiter.py
+++ b/tests/test_litellm/proxy/hooks/test_max_budget_limiter.py
@@ -98,7 +98,6 @@ async def test_skips_when_user_counter_is_reserved():
                     "entity_type": "User",
                     "entity_id": "user-1",
                     "reserved_cost": 10.0,
-                    "applied_adjustment": 0.0,
                 }
             ],
             "finalized": False,
@@ -140,7 +139,6 @@ async def test_does_not_skip_when_reservation_covers_a_different_counter():
                     "entity_type": "Team",
                     "entity_id": "team-x",
                     "reserved_cost": 5.0,
-                    "applied_adjustment": 0.0,
                 }
             ],
             "finalized": False,

--- a/tests/test_litellm/proxy/proxy_server/test_spend_counters.py
+++ b/tests/test_litellm/proxy/proxy_server/test_spend_counters.py
@@ -6,7 +6,6 @@ Pins covered:
 - ``_reconcile_budget_reservation_for_counter_update``
 - ``_increment_end_user_and_tag_spend_counters``
 - ``_increment_org_spend_counter``
-- ``_init_and_increment_unreserved_spend_counter``
 - ``_init_and_increment_spend_counter``
 - ``_init_and_increment_window_spend_counter``
 - ``_ensure_spend_counter_initialized``
@@ -181,41 +180,33 @@ async def test_increment_spend_counters_zero_cost_is_noop_finalizes_reservation(
 
 
 @pytest.mark.asyncio
-async def test_reconcile_budget_reservation_for_counter_update_returns_empty_set_when_none():
+async def test_reconcile_budget_reservation_for_counter_update_noop_when_none():
     result = await ps._reconcile_budget_reservation_for_counter_update(
-        budget_reservation=None, response_cost=1.0
+        budget_reservation=None
     )
-    assert result == set()
+    assert result is None
 
 
 @pytest.mark.asyncio
-async def test_reconcile_budget_reservation_for_counter_update_failure_invalidates(
+async def test_reconcile_budget_reservation_for_counter_update_swallows_failure(
     monkeypatch,
 ):
-    """Reservation reconcile raising must invalidate reserved counters, swallow
-    the exception, and return an empty set so the caller falls back to the
-    direct spend-counter increment instead of skipping it."""
+    """Removing this request's holds is best-effort: a failure is logged and
+    swallowed so the committed-spend increment that follows still runs. The
+    holds and the committed counter are distinct, so this cannot corrupt spend."""
     import litellm.proxy.spend_tracking.budget_reservation as br
 
-    monkeypatch.setattr(
-        br,
-        "get_reserved_counter_keys",
-        MagicMock(return_value={"spend:key:abc"}),
-    )
     monkeypatch.setattr(
         br,
         "reconcile_budget_reservation",
         AsyncMock(side_effect=RuntimeError("boom")),
     )
-    fake_invalidate = AsyncMock()
-    monkeypatch.setattr(br, "invalidate_budget_reservation_counters", fake_invalidate)
 
     result = await ps._reconcile_budget_reservation_for_counter_update(
-        budget_reservation={"foo": "bar"}, response_cost=1.0
+        budget_reservation={"hold_id": "abc", "entries": []}
     )
 
-    assert result == set()
-    assert fake_invalidate.called is True
+    assert result is None
 
 
 # ---------------------------------------------------------------------------
@@ -242,7 +233,6 @@ async def test_increment_end_user_and_tag_spend_counters_increments_each_unique_
         end_user_id="eu1",
         tags=["a", "b", "a", "", None],
         response_cost=3.0,
-        reserved_counter_keys=set(),
     )
 
     observed = {
@@ -268,7 +258,6 @@ async def test_increment_end_user_and_tag_spend_counters_no_end_user_no_tags_inv
         end_user_id=None,
         tags=None,
         response_cost=1.0,
-        reserved_counter_keys=set(),
     )
 
     assert fake_cache.redis_cache.async_increment.called is False
@@ -295,7 +284,6 @@ async def test_increment_org_spend_counter_increments_when_org_present(monkeypat
     await ps._increment_org_spend_counter(
         org_id="org-1",
         response_cost=10.0,
-        reserved_counter_keys=set(),
     )
 
     observed = {
@@ -320,66 +308,9 @@ async def test_increment_org_spend_counter_no_org_is_noop_invalid_id(monkeypatch
     await ps._increment_org_spend_counter(
         org_id=None,
         response_cost=1.0,
-        reserved_counter_keys=set(),
     )
 
     assert fake_cache.redis_cache.async_increment.called is False
-
-
-# ---------------------------------------------------------------------------
-# _init_and_increment_unreserved_spend_counter
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_init_and_increment_unreserved_spend_counter_skips_reserved_keys(
-    monkeypatch,
-):
-    fake_cache = _make_spend_counter_cache()
-    monkeypatch.setattr(ps, "spend_counter_cache", fake_cache)
-
-    await ps._init_and_increment_unreserved_spend_counter(
-        counter_key="spend:tag:x",
-        source_cache_key="tag:x",
-        increment=1.0,
-        reserved_counter_keys={"spend:tag:x"},
-    )
-
-    assert fake_cache.redis_cache.async_increment.called is False
-
-
-@pytest.mark.asyncio
-async def test_init_and_increment_unreserved_spend_counter_proceeds_when_not_reserved(
-    monkeypatch,
-):
-    fake_cache = _make_spend_counter_cache(
-        redis_get_value=None, redis_increment_value=2.0
-    )
-    fake_user_cache = _make_user_api_key_cache()
-    monkeypatch.setattr(ps, "spend_counter_cache", fake_cache)
-    monkeypatch.setattr(ps, "user_api_key_cache", fake_user_cache)
-    monkeypatch.setattr(ps, "prisma_client", None)
-    monkeypatch.setattr(
-        ps.SpendCounterReseed, "coalesced", AsyncMock(return_value=None)
-    )
-
-    await ps._init_and_increment_unreserved_spend_counter(
-        counter_key="spend:tag:y",
-        source_cache_key="tag:y",
-        increment=2.0,
-        reserved_counter_keys=set(),
-    )
-
-    observed = {
-        "increment_called": fake_cache.redis_cache.async_increment.called,
-        "redis_get_called": fake_cache.redis_cache.async_get_cache.called,
-        "reseed_consulted": True,
-    }
-    assert observed == {
-        "increment_called": True,
-        "redis_get_called": True,
-        "reseed_consulted": True,
-    }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_litellm/proxy/spend_tracking/test_budget_hold_store.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_budget_hold_store.py
@@ -1,0 +1,74 @@
+"""Unit tests for BudgetHoldStore (in-memory backend).
+
+The store is the heart of the orphan-proof budget design: in-flight
+reservations are tracked as individually expiring holds, summed at admission,
+and never folded into the committed spend counter. The key invariant is that an
+orphaned hold (pod died before settle) is pruned once its TTL elapses, so it
+cannot pin a budget counter forever.
+"""
+
+import time
+
+import pytest
+
+from litellm.caching.dual_cache import DualCache
+from litellm.proxy.spend_tracking.budget_hold_store import BudgetHoldStore
+
+
+def _store(ttl_seconds: int = 3600) -> BudgetHoldStore:
+    # No Redis configured -> in-memory backend.
+    return BudgetHoldStore(dual_cache=DualCache(), ttl_seconds=ttl_seconds)
+
+
+@pytest.mark.asyncio
+async def test_place_and_total_sums_live_holds():
+    store = _store()
+    assert await store.place_and_total("spend:key:k", "h1", 0.4) == pytest.approx(0.4)
+    assert await store.place_and_total("spend:key:k", "h2", 0.3) == pytest.approx(0.7)
+
+
+@pytest.mark.asyncio
+async def test_remove_drops_only_that_hold():
+    store = _store()
+    await store.place_and_total("spend:key:k", "h1", 0.4)
+    await store.place_and_total("spend:key:k", "h2", 0.3)
+
+    await store.remove("spend:key:k", "h1", 0.4)
+
+    # Only h2 remains; admitting a new hold sums 0.3 + 0.1.
+    assert await store.place_and_total("spend:key:k", "h3", 0.1) == pytest.approx(0.4)
+
+
+@pytest.mark.asyncio
+async def test_resize_updates_hold_cost():
+    store = _store()
+    await store.place_and_total("spend:key:k", "h1", 0.6)
+
+    await store.resize("spend:key:k", "h1", 0.6, 0.4)
+
+    assert await store.place_and_total("spend:key:k", "h2", 0.1) == pytest.approx(0.5)
+
+
+@pytest.mark.asyncio
+async def test_orphaned_hold_is_pruned_after_ttl():
+    """A hold that is never removed (its pod was killed before settle) must be
+    pruned at the next admission once its TTL has elapsed, so it stops counting
+    against the budget."""
+    store = _store()
+    await store.place_and_total("spend:key:k", "orphan", 0.5)
+
+    # Simulate the orphan's lifetime having elapsed.
+    cost, _ = store._memory_holds["spend:key:k"]["orphan"]
+    store._memory_holds["spend:key:k"]["orphan"] = (cost, time.time() - 1)
+
+    # The next admission prunes the expired orphan; only the fresh hold counts.
+    assert await store.place_and_total("spend:key:k", "fresh", 0.2) == pytest.approx(
+        0.2
+    )
+
+
+@pytest.mark.asyncio
+async def test_holds_are_isolated_per_counter():
+    store = _store()
+    await store.place_and_total("spend:key:k1", "h1", 0.4)
+    assert await store.place_and_total("spend:key:k2", "h2", 0.3) == pytest.approx(0.3)

--- a/tests/test_litellm/proxy/spend_tracking/test_budget_reservation_redis_failure.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_budget_reservation_redis_failure.py
@@ -1,16 +1,12 @@
 """
-Regression test for enforced-spend underreporting when Redis fails during the
-budget-reservation reconcile step of ``increment_spend_counters``.
+Regression test for the budget-reservation settle path under Redis trouble.
 
-Production failure mode: a managed Redis returns an intermittent timeout on the
-reconcile increment. Reconcile deletes (invalidates) the shared counter and
-gives up, but ``increment_spend_counters`` still treats the counter as
-"already reconciled" and skips the direct increment. The actual call cost never
-lands in the enforced counter, so budgets stop gating until the next cold
-reseed pulls a lagging value from the DB.
-
-The fix makes the reconcile path fall back to the direct increment when it
-fails, so the actual cost is always written to the shared counter.
+Holds (in-flight reservations) live separately from the committed spend
+counter, and the committed counter is only ever incremented by actual cost.
+So even if removing this request's holds fails (a Redis blip during settle),
+``increment_spend_counters`` must still write the real cost to the committed
+counter — the two operations are independent and a hold-removal failure cannot
+suppress the spend increment or corrupt the shared counter.
 """
 
 import pytest
@@ -19,58 +15,33 @@ from litellm.caching import DualCache
 from litellm.proxy import proxy_server
 
 
-class _FlakyRedisCache:
-    def __init__(self) -> None:
-        self._store: dict = {}
-        self._increment_calls = 0
-
-    async def async_increment(self, key, value, **kwargs):
-        self._increment_calls += 1
-        if self._increment_calls == 1:
-            raise Exception("Redis timeout")
-        self._store[key] = float(self._store.get(key, 0.0)) + float(value)
-        return self._store[key]
-
-    async def async_get_cache(self, key, *args, **kwargs):
-        return self._store.get(key)
-
-    async def async_delete_cache(self, key, *args, **kwargs):
-        self._store.pop(key, None)
-
-    async def async_set_cache(self, key, value, *args, **kwargs):
-        self._store[key] = float(value)
-        return True
-
-
 @pytest.mark.asyncio
-async def test_direct_increment_runs_when_reservation_reconcile_hits_redis_failure(
-    monkeypatch,
-):
+async def test_committed_spend_increments_even_when_hold_removal_fails(monkeypatch):
     hashed_token = "hashed_test_token"
     counter_key = f"spend:key:{hashed_token}"
     reserved_cost = 0.5
     response_cost = 1.0
 
-    flaky_redis = _FlakyRedisCache()
-    flaky_redis._store[counter_key] = reserved_cost
-
+    counter_cache = DualCache()
     monkeypatch.setattr(proxy_server, "prisma_client", None)
     monkeypatch.setattr(proxy_server, "user_api_key_cache", DualCache())
-    monkeypatch.setattr(proxy_server.spend_counter_cache, "redis_cache", flaky_redis)
-    proxy_server.spend_counter_cache.in_memory_cache.set_cache(
-        key=counter_key, value=reserved_cost
-    )
+    monkeypatch.setattr(proxy_server, "spend_counter_cache", counter_cache)
+
+    async def fail_remove(*args, **kwargs):
+        raise Exception("Redis timeout")
+
+    monkeypatch.setattr(proxy_server.budget_hold_store, "remove", fail_remove)
 
     budget_reservation = {
-        "reserved_cost": reserved_cost,
+        "hold_id": "hold-redis-failure",
         "finalized": False,
+        "reserved_cost": reserved_cost,
         "entries": [
             {
                 "counter_key": counter_key,
                 "entity_type": "Key",
                 "entity_id": hashed_token,
                 "reserved_cost": reserved_cost,
-                "applied_adjustment": 0.0,
             }
         ],
     }
@@ -83,5 +54,6 @@ async def test_direct_increment_runs_when_reservation_reconcile_hits_redis_failu
         budget_reservation=budget_reservation,
     )
 
-    enforced_spend = await flaky_redis.async_get_cache(key=counter_key)
-    assert enforced_spend == response_cost
+    enforced_spend = counter_cache.in_memory_cache.get_cache(key=counter_key)
+    assert enforced_spend == pytest.approx(response_cost)
+    assert budget_reservation["finalized"] is True

--- a/tests/test_litellm/proxy/test_budget_reservation.py
+++ b/tests/test_litellm/proxy/test_budget_reservation.py
@@ -28,16 +28,22 @@ from litellm.proxy.utils import ProxyLogging
 @pytest.fixture()
 def spend_counter_state():
     import litellm.proxy.proxy_server as ps
+    from litellm.constants import BUDGET_HOLD_TTL_SECONDS
+    from litellm.proxy.spend_tracking.budget_hold_store import BudgetHoldStore
 
     original_counter_cache = ps.spend_counter_cache
     original_key_cache = ps.user_api_key_cache
     original_prisma_client = ps.prisma_client
+    original_hold_store = ps.budget_hold_store
 
     counter_cache = DualCache()
     key_cache = DualCache()
     ps.spend_counter_cache = counter_cache
     ps.user_api_key_cache = key_cache
     ps.prisma_client = None
+    ps.budget_hold_store = BudgetHoldStore(
+        dual_cache=counter_cache, ttl_seconds=BUDGET_HOLD_TTL_SECONDS
+    )
 
     try:
         yield counter_cache, key_cache
@@ -45,6 +51,15 @@ def spend_counter_state():
         ps.spend_counter_cache = original_counter_cache
         ps.user_api_key_cache = original_key_cache
         ps.prisma_client = original_prisma_client
+        ps.budget_hold_store = original_hold_store
+
+
+def _live_hold_total(counter_key: str) -> float:
+    """Sum the live reservation holds for a counter (no-Redis in-memory backend)."""
+    import litellm.proxy.proxy_server as ps
+
+    holds = ps.budget_hold_store._memory_holds.get(counter_key, {})
+    return sum(cost for cost, _ in holds.values())
 
 
 def _request_body() -> dict:
@@ -97,10 +112,12 @@ async def test_should_shrink_second_key_reservation_to_remaining_budget(
             proxy_logging_obj=proxy_logging_obj,
         )
         assert reservation is not None
+        # The reservation is a hold, not a write to the committed spend counter.
         assert (
             counter_cache.in_memory_cache.get_cache(key="spend:key:key-budget-race")
-            == 0.6
+            is None
         )
+        assert _live_hold_total("spend:key:key-budget-race") == pytest.approx(0.6)
 
         second_reservation = await reserve_budget_for_request(
             request_body=_request_body(),
@@ -115,9 +132,7 @@ async def test_should_shrink_second_key_reservation_to_remaining_budget(
         )
         assert second_reservation is not None
         assert second_reservation["reserved_cost"] == pytest.approx(0.4)
-        assert counter_cache.in_memory_cache.get_cache(
-            key="spend:key:key-budget-race"
-        ) == pytest.approx(1.0)
+        assert _live_hold_total("spend:key:key-budget-race") == pytest.approx(1.0)
 
         with pytest.raises(litellm.BudgetExceededError):
             await reserve_budget_for_request(
@@ -132,15 +147,13 @@ async def test_should_shrink_second_key_reservation_to_remaining_budget(
                 proxy_logging_obj=proxy_logging_obj,
             )
 
-    assert counter_cache.in_memory_cache.get_cache(
-        key="spend:key:key-budget-race"
-    ) == pytest.approx(1.0)
+    # The rejected request's hold is released, leaving only the two admitted ones.
+    assert _live_hold_total("spend:key:key-budget-race") == pytest.approx(1.0)
 
     await release_budget_reservation(second_reservation)
-    assert counter_cache.in_memory_cache.get_cache(
-        key="spend:key:key-budget-race"
-    ) == pytest.approx(0.6)
+    assert _live_hold_total("spend:key:key-budget-race") == pytest.approx(0.6)
     await release_budget_reservation(reservation)
+    assert _live_hold_total("spend:key:key-budget-race") == pytest.approx(0.0)
 
 
 @pytest.mark.asyncio
@@ -177,9 +190,9 @@ async def test_should_shrink_second_end_user_reservation_to_remaining_budget(
             end_user_object=end_user_object,
         )
         assert reservation is not None
-        assert counter_cache.in_memory_cache.get_cache(
-            key="spend:end_user:end-user-budget-race"
-        ) == pytest.approx(0.6)
+        assert _live_hold_total("spend:end_user:end-user-budget-race") == pytest.approx(
+            0.6
+        )
 
         second_reservation = await reserve_budget_for_request(
             request_body=_request_body(),
@@ -195,9 +208,9 @@ async def test_should_shrink_second_end_user_reservation_to_remaining_budget(
         )
         assert second_reservation is not None
         assert second_reservation["reserved_cost"] == pytest.approx(0.4)
-        assert counter_cache.in_memory_cache.get_cache(
-            key="spend:end_user:end-user-budget-race"
-        ) == pytest.approx(1.0)
+        assert _live_hold_total("spend:end_user:end-user-budget-race") == pytest.approx(
+            1.0
+        )
 
         with pytest.raises(litellm.BudgetExceededError):
             await reserve_budget_for_request(
@@ -213,14 +226,10 @@ async def test_should_shrink_second_end_user_reservation_to_remaining_budget(
                 end_user_object=end_user_object,
             )
 
-    assert counter_cache.in_memory_cache.get_cache(
-        key="spend:end_user:end-user-budget-race"
-    ) == pytest.approx(1.0)
+    assert _live_hold_total("spend:end_user:end-user-budget-race") == pytest.approx(1.0)
 
     await release_budget_reservation(second_reservation)
-    assert counter_cache.in_memory_cache.get_cache(
-        key="spend:end_user:end-user-budget-race"
-    ) == pytest.approx(0.6)
+    assert _live_hold_total("spend:end_user:end-user-budget-race") == pytest.approx(0.6)
 
     from litellm.proxy.proxy_server import increment_spend_counters
 
@@ -233,6 +242,8 @@ async def test_should_shrink_second_end_user_reservation_to_remaining_budget(
         end_user_id="end-user-budget-race",
     )
 
+    # Settle: the hold is removed and the committed counter records actual spend.
+    assert _live_hold_total("spend:end_user:end-user-budget-race") == pytest.approx(0.0)
     assert counter_cache.in_memory_cache.get_cache(
         key="spend:end_user:end-user-budget-race"
     ) == pytest.approx(0.2)
@@ -290,16 +301,10 @@ async def test_should_shrink_second_tag_reservation_to_remaining_budget(
                 "entity_type": "Tag",
                 "entity_id": "tag-budget-race",
                 "reserved_cost": 0.6,
-                "applied_adjustment": 0.0,
             }
         ]
-        assert counter_cache.in_memory_cache.get_cache(
-            key="spend:tag:tag-budget-race"
-        ) == pytest.approx(0.6)
-        assert (
-            counter_cache.in_memory_cache.get_cache(key="spend:tag:tag-without-budget")
-            is None
-        )
+        assert _live_hold_total("spend:tag:tag-budget-race") == pytest.approx(0.6)
+        assert _live_hold_total("spend:tag:tag-without-budget") == pytest.approx(0.0)
 
         second_reservation = await reserve_budget_for_request(
             request_body=request_body,
@@ -314,9 +319,7 @@ async def test_should_shrink_second_tag_reservation_to_remaining_budget(
         )
         assert second_reservation is not None
         assert second_reservation["reserved_cost"] == pytest.approx(0.4)
-        assert counter_cache.in_memory_cache.get_cache(
-            key="spend:tag:tag-budget-race"
-        ) == pytest.approx(1.0)
+        assert _live_hold_total("spend:tag:tag-budget-race") == pytest.approx(1.0)
 
         with pytest.raises(litellm.BudgetExceededError):
             await reserve_budget_for_request(
@@ -331,14 +334,10 @@ async def test_should_shrink_second_tag_reservation_to_remaining_budget(
                 proxy_logging_obj=proxy_logging_obj,
             )
 
-    assert counter_cache.in_memory_cache.get_cache(
-        key="spend:tag:tag-budget-race"
-    ) == pytest.approx(1.0)
+    assert _live_hold_total("spend:tag:tag-budget-race") == pytest.approx(1.0)
 
     await release_budget_reservation(second_reservation)
-    assert counter_cache.in_memory_cache.get_cache(
-        key="spend:tag:tag-budget-race"
-    ) == pytest.approx(0.6)
+    assert _live_hold_total("spend:tag:tag-budget-race") == pytest.approx(0.6)
 
     from litellm.proxy.proxy_server import increment_spend_counters
 
@@ -351,6 +350,7 @@ async def test_should_shrink_second_tag_reservation_to_remaining_budget(
         tags=["tag-budget-race"],
     )
 
+    assert _live_hold_total("spend:tag:tag-budget-race") == pytest.approx(0.0)
     assert counter_cache.in_memory_cache.get_cache(
         key="spend:tag:tag-budget-race"
     ) == pytest.approx(0.2)
@@ -467,14 +467,21 @@ async def test_should_reserve_team_member_and_org_budget_counters(spend_counter_
             proxy_logging_obj=proxy_logging_obj,
         )
 
+    # Committed counters hold only the seeded base spend (0.1); the 0.3
+    # reservation lives as a separate hold on each counter.
     assert counter_cache.in_memory_cache.get_cache(
         key="spend:team_member:user-budget-shared:team-budget-shared"
-    ) == pytest.approx(0.4)
+    ) == pytest.approx(0.1)
     assert counter_cache.in_memory_cache.get_cache(
         key="spend:org:org-budget-shared"
-    ) == pytest.approx(0.4)
+    ) == pytest.approx(0.1)
+    assert _live_hold_total(
+        "spend:team_member:user-budget-shared:team-budget-shared"
+    ) == pytest.approx(0.3)
+    assert _live_hold_total("spend:org:org-budget-shared") == pytest.approx(0.3)
 
     await release_budget_reservation(reservation)
+    assert _live_hold_total("spend:org:org-budget-shared") == pytest.approx(0.0)
 
 
 @pytest.mark.asyncio
@@ -574,14 +581,18 @@ async def test_should_cap_known_estimate_to_remaining_budget(
 
     assert reservation is not None
     assert reservation["reserved_cost"] == pytest.approx(0.1)
-    assert counter_cache.in_memory_cache.get_cache(
-        key="spend:key:key-budget-known-estimate-cap"
-    ) == pytest.approx(1.0)
-
-    await release_budget_reservation(reservation)
+    # Committed spend is untouched at 0.9; the hold fills the 0.1 of headroom.
     assert counter_cache.in_memory_cache.get_cache(
         key="spend:key:key-budget-known-estimate-cap"
     ) == pytest.approx(0.9)
+    assert _live_hold_total("spend:key:key-budget-known-estimate-cap") == pytest.approx(
+        0.1
+    )
+
+    await release_budget_reservation(reservation)
+    assert _live_hold_total("spend:key:key-budget-known-estimate-cap") == pytest.approx(
+        0.0
+    )
 
 
 @pytest.mark.asyncio
@@ -1003,20 +1014,22 @@ async def test_should_skip_budget_window_with_unparseable_duration(
     assert [entry["counter_key"] for entry in reservation["entries"]] == [
         "spend:key:key-budget-malformed-window"
     ]
-    assert counter_cache.in_memory_cache.get_cache(
-        key="spend:key:key-budget-malformed-window"
-    ) == pytest.approx(1.1)
-    assert (
-        counter_cache.in_memory_cache.get_cache(
-            key="spend:key:key-budget-malformed-window:window:not-a-duration"
-        )
-        is None
-    )
-
-    await release_budget_reservation(reservation)
+    # The base counter keeps its committed 0.9; the 0.2 reservation is a hold.
+    # The malformed window counter is skipped entirely (no hold, no counter).
     assert counter_cache.in_memory_cache.get_cache(
         key="spend:key:key-budget-malformed-window"
     ) == pytest.approx(0.9)
+    assert _live_hold_total("spend:key:key-budget-malformed-window") == pytest.approx(
+        0.2
+    )
+    assert _live_hold_total(
+        "spend:key:key-budget-malformed-window:window:not-a-duration"
+    ) == pytest.approx(0.0)
+
+    await release_budget_reservation(reservation)
+    assert _live_hold_total("spend:key:key-budget-malformed-window") == pytest.approx(
+        0.0
+    )
 
 
 @pytest.mark.asyncio
@@ -1061,10 +1074,12 @@ async def test_should_skip_window_reservation_when_db_baseline_unavailable(
 
 
 @pytest.mark.asyncio
-async def test_should_skip_reservation_when_counter_increment_fails(
+async def test_should_skip_reservation_when_hold_placement_fails(
     spend_counter_state,
     monkeypatch,
 ):
+    import litellm.proxy.proxy_server as ps
+
     counter_cache, key_cache = spend_counter_state
     proxy_logging_obj = ProxyLogging(user_api_key_cache=key_cache)
     valid_token = UserAPIKeyAuth(
@@ -1073,10 +1088,10 @@ async def test_should_skip_reservation_when_counter_increment_fails(
         max_budget=1.0,
     )
 
-    async def fail_increment_cache(*args, **kwargs):
-        raise RuntimeError("counter unavailable")
+    async def fail_place(*args, **kwargs):
+        raise RuntimeError("hold store unavailable")
 
-    monkeypatch.setattr(counter_cache, "async_increment_cache", fail_increment_cache)
+    monkeypatch.setattr(ps.budget_hold_store, "place_and_total", fail_place)
 
     with (
         patch(
@@ -1101,12 +1116,9 @@ async def test_should_skip_reservation_when_counter_increment_fails(
 
     assert reservation is None
     assert mock_warning.call_count >= 1
-    assert (
-        counter_cache.in_memory_cache.get_cache(
-            key="spend:key:key-budget-reserve-unavailable"
-        )
-        is None
-    )
+    assert _live_hold_total(
+        "spend:key:key-budget-reserve-unavailable"
+    ) == pytest.approx(0.0)
 
 
 @pytest.mark.asyncio
@@ -1154,66 +1166,6 @@ async def test_should_skip_reservation_when_counter_initialization_fails(
         )
         is None
     )
-
-
-@pytest.mark.asyncio
-async def test_should_release_tracked_entry_when_reservation_fails_after_increment(
-    spend_counter_state,
-):
-    counter_cache, key_cache = spend_counter_state
-    proxy_logging_obj = ProxyLogging(user_api_key_cache=key_cache)
-    valid_token = UserAPIKeyAuth(
-        token="key-budget-reserve-after-increment-failure",
-        spend=0.0,
-        max_budget=1.0,
-    )
-
-    import litellm.proxy.proxy_server as ps
-
-    original_increment_counter = ps._increment_spend_counter_cache
-    first_increment = True
-
-    async def fail_after_increment(counter_key: str, increment: float):
-        nonlocal first_increment
-        if first_increment:
-            first_increment = False
-            await counter_cache.async_increment_cache(key=counter_key, value=increment)
-            raise RuntimeError("lost increment response")
-        return await original_increment_counter(
-            counter_key=counter_key,
-            increment=increment,
-        )
-
-    with (
-        patch(
-            "litellm.proxy.spend_tracking.budget_reservation.estimate_request_max_cost",
-            return_value=0.5,
-        ),
-        patch(
-            "litellm.proxy.proxy_server._increment_spend_counter_cache",
-            side_effect=fail_after_increment,
-        ),
-        patch(
-            "litellm.proxy.proxy_server._invalidate_spend_counter",
-            side_effect=RuntimeError("invalidate unavailable"),
-        ),
-    ):
-        reservation = await reserve_budget_for_request(
-            request_body=_request_body(),
-            route="/chat/completions",
-            llm_router=None,
-            valid_token=valid_token,
-            team_object=None,
-            user_object=None,
-            prisma_client=None,
-            user_api_key_cache=key_cache,
-            proxy_logging_obj=proxy_logging_obj,
-        )
-
-    assert reservation is None
-    assert counter_cache.in_memory_cache.get_cache(
-        key="spend:key:key-budget-reserve-after-increment-failure"
-    ) == pytest.approx(0.0)
 
 
 @pytest.mark.asyncio
@@ -1288,83 +1240,17 @@ async def test_should_release_reservation_on_failure(spend_counter_state):
             proxy_logging_obj=proxy_logging_obj,
         )
 
+    assert _live_hold_total("spend:key:key-budget-release") == pytest.approx(0.4)
+
     await release_budget_reservation(reservation)
     await release_budget_reservation(reservation)
 
-    assert counter_cache.in_memory_cache.get_cache(
-        key="spend:key:key-budget-release"
-    ) == pytest.approx(0.0)
-
-
-@pytest.mark.asyncio
-async def test_should_retry_partial_release_without_double_decrement(
-    spend_counter_state,
-    monkeypatch,
-):
-    counter_cache, key_cache = spend_counter_state
-    proxy_logging_obj = ProxyLogging(user_api_key_cache=key_cache)
-    valid_token = UserAPIKeyAuth(
-        token="key-budget-partial-release",
-        spend=0.0,
-        max_budget=1.0,
-        team_id="team-budget-partial-release",
+    # Release is idempotent: the hold is gone and the committed counter is clean.
+    assert _live_hold_total("spend:key:key-budget-release") == pytest.approx(0.0)
+    assert (
+        counter_cache.in_memory_cache.get_cache(key="spend:key:key-budget-release")
+        is None
     )
-    team_object = LiteLLM_TeamTable(
-        team_id="team-budget-partial-release",
-        spend=0.0,
-        max_budget=1.0,
-    )
-
-    with patch(
-        "litellm.proxy.spend_tracking.budget_reservation.estimate_request_max_cost",
-        return_value=0.4,
-    ):
-        reservation = await reserve_budget_for_request(
-            request_body=_request_body(),
-            route="/chat/completions",
-            llm_router=None,
-            valid_token=valid_token,
-            team_object=team_object,
-            user_object=None,
-            prisma_client=None,
-            user_api_key_cache=key_cache,
-            proxy_logging_obj=proxy_logging_obj,
-        )
-
-    original_increment_cache = counter_cache.async_increment_cache
-    fail_next_team_release = True
-
-    async def flaky_increment_cache(key, value, *args, **kwargs):
-        nonlocal fail_next_team_release
-        if (
-            key == "spend:team:team-budget-partial-release"
-            and value < 0
-            and fail_next_team_release
-        ):
-            fail_next_team_release = False
-            raise RuntimeError("simulated counter failure")
-        return await original_increment_cache(key=key, value=value, *args, **kwargs)
-
-    monkeypatch.setattr(counter_cache, "async_increment_cache", flaky_increment_cache)
-
-    with pytest.raises(RuntimeError):
-        await release_budget_reservation(reservation)
-
-    assert counter_cache.in_memory_cache.get_cache(
-        key="spend:key:key-budget-partial-release"
-    ) == pytest.approx(0.0)
-    assert counter_cache.in_memory_cache.get_cache(
-        key="spend:team:team-budget-partial-release"
-    ) == pytest.approx(0.4)
-
-    await release_budget_reservation(reservation)
-
-    assert counter_cache.in_memory_cache.get_cache(
-        key="spend:key:key-budget-partial-release"
-    ) == pytest.approx(0.0)
-    assert counter_cache.in_memory_cache.get_cache(
-        key="spend:team:team-budget-partial-release"
-    ) == pytest.approx(0.0)
 
 
 @pytest.mark.asyncio
@@ -1390,18 +1276,12 @@ async def test_should_preserve_budget_error_and_continue_partial_cleanup(
         value=team_object,
     )
 
-    original_increment_cache = counter_cache.async_increment_cache
-    fail_key_cleanup = True
+    import litellm.proxy.proxy_server as ps
 
-    async def flaky_increment_cache(key, value, *args, **kwargs):
-        nonlocal fail_key_cleanup
-        if key == "spend:key:key-budget-cleanup-failure" and value < 0:
-            if fail_key_cleanup:
-                fail_key_cleanup = False
-                raise RuntimeError("simulated cleanup failure")
-        return await original_increment_cache(key=key, value=value, *args, **kwargs)
+    async def fail_remove(*args, **kwargs):
+        raise RuntimeError("simulated cleanup failure")
 
-    monkeypatch.setattr(counter_cache, "async_increment_cache", flaky_increment_cache)
+    monkeypatch.setattr(ps.budget_hold_store, "remove", fail_remove)
 
     with (
         patch(
@@ -1425,6 +1305,8 @@ async def test_should_preserve_budget_error_and_continue_partial_cleanup(
                 proxy_logging_obj=proxy_logging_obj,
             )
 
+    # The BudgetExceededError is preserved even though best-effort hold cleanup
+    # failed; committed counters are never touched by the reservation path.
     assert (
         counter_cache.in_memory_cache.get_cache(
             key="spend:key:key-budget-cleanup-failure"
@@ -1438,132 +1320,42 @@ async def test_should_preserve_budget_error_and_continue_partial_cleanup(
 
 
 @pytest.mark.asyncio
-async def test_should_not_create_negative_counter_when_release_counter_is_missing(
+async def test_should_invalidate_reserved_counters_removes_holds_not_committed_spend(
     spend_counter_state,
 ):
-    counter_cache, _ = spend_counter_state
-    reservation = {
-        "reserved_cost": 0.4,
-        "entries": [
-            {
-                "counter_key": "spend:key:key-budget-missing-release",
-                "reserved_cost": 0.4,
-                "applied_adjustment": 0.0,
-            }
-        ],
-        "finalized": False,
-    }
-
-    with pytest.raises(RuntimeError, match="missing counter"):
-        await release_budget_reservation(reservation)
-
-    assert (
-        counter_cache.in_memory_cache.get_cache(
-            key="spend:key:key-budget-missing-release"
-        )
-        is None
-    )
-    assert reservation["finalized"] is False
-
-
-@pytest.mark.asyncio
-async def test_should_invalidate_counter_when_release_would_underflow(
-    spend_counter_state,
-):
+    """invalidate_budget_reservation_counters drops this request's holds and
+    must never delete the committed spend counter (which would let other pods'
+    reservations corrupt the shared budget)."""
     counter_cache, _ = spend_counter_state
     await counter_cache.async_increment_cache(
-        key="spend:key:key-budget-underflow-release",
-        value=0.1,
+        key="spend:key:key-budget-invalidate", value=0.4
     )
-    reservation = {
-        "reserved_cost": 0.4,
-        "entries": [
-            {
-                "counter_key": "spend:key:key-budget-underflow-release",
-                "reserved_cost": 0.4,
-                "applied_adjustment": 0.0,
-            }
-        ],
-        "finalized": False,
-    }
 
-    with pytest.raises(RuntimeError, match="negative"):
-        await release_budget_reservation(reservation)
+    import litellm.proxy.proxy_server as ps
 
-    assert (
-        counter_cache.in_memory_cache.get_cache(
-            key="spend:key:key-budget-underflow-release"
-        )
-        is None
+    hold_id = "hold-invalidate"
+    await ps.budget_hold_store.place_and_total(
+        counter_key="spend:key:key-budget-invalidate", hold_id=hold_id, cost=0.4
     )
-    assert reservation["finalized"] is False
-
-
-@pytest.mark.asyncio
-async def test_should_invalidate_non_numeric_counter_during_release(
-    spend_counter_state,
-):
-    counter_cache, _ = spend_counter_state
-    counter_cache.in_memory_cache.set_cache(
-        key="spend:key:key-budget-nonnumeric-release",
-        value="stale",
-    )
-    reservation = {
-        "reserved_cost": 0.4,
-        "entries": [
-            {
-                "counter_key": "spend:key:key-budget-nonnumeric-release",
-                "reserved_cost": 0.4,
-                "applied_adjustment": 0.0,
-            }
-        ],
-        "finalized": False,
-    }
-
-    with pytest.raises(RuntimeError, match="non-numeric"):
-        await release_budget_reservation(reservation)
-
-    assert (
-        counter_cache.in_memory_cache.get_cache(
-            key="spend:key:key-budget-nonnumeric-release"
-        )
-        is None
-    )
-    assert reservation["finalized"] is False
-
-
-@pytest.mark.asyncio
-async def test_should_invalidate_reserved_counters_after_persisted_spend_failure(
-    spend_counter_state,
-):
-    counter_cache, _ = spend_counter_state
-    await counter_cache.async_increment_cache(
-        key="spend:key:key-budget-invalidate",
-        value=0.4,
-    )
-    await counter_cache.async_increment_cache(
-        key="spend:team:team-budget-invalidate",
-        value=0.4,
-    )
+    assert _live_hold_total("spend:key:key-budget-invalidate") == pytest.approx(0.4)
 
     await invalidate_budget_reservation_counters(
         {
-            "reserved_cost": 0.4,
+            "hold_id": hold_id,
             "entries": [
-                {"counter_key": "spend:key:key-budget-invalidate"},
-                {"counter_key": "spend:team:team-budget-invalidate"},
+                {
+                    "counter_key": "spend:key:key-budget-invalidate",
+                    "reserved_cost": 0.4,
+                },
             ],
         }
     )
 
-    assert (
-        counter_cache.in_memory_cache.get_cache(key="spend:key:key-budget-invalidate")
-        is None
-    )
-    assert (
-        counter_cache.in_memory_cache.get_cache(key="spend:team:team-budget-invalidate")
-        is None
-    )
+    assert _live_hold_total("spend:key:key-budget-invalidate") == pytest.approx(0.0)
+    # Committed spend is untouched.
+    assert counter_cache.in_memory_cache.get_cache(
+        key="spend:key:key-budget-invalidate"
+    ) == pytest.approx(0.4)
 
 
 @pytest.mark.asyncio
@@ -1598,11 +1390,15 @@ async def test_should_reserve_all_budgeted_counters(spend_counter_state):
             proxy_logging_obj=proxy_logging_obj,
         )
 
+    assert _live_hold_total("spend:key:key-budget-all") == pytest.approx(0.3)
+    assert _live_hold_total("spend:team:team-budget-all") == pytest.approx(0.3)
+    # Reservations never touch the committed spend counters.
     assert (
-        counter_cache.in_memory_cache.get_cache(key="spend:key:key-budget-all") == 0.3
+        counter_cache.in_memory_cache.get_cache(key="spend:key:key-budget-all") is None
     )
     assert (
-        counter_cache.in_memory_cache.get_cache(key="spend:team:team-budget-all") == 0.3
+        counter_cache.in_memory_cache.get_cache(key="spend:team:team-budget-all")
+        is None
     )
 
 

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -6512,16 +6512,17 @@ async def test_window_spend_counter_does_not_seed_zero_when_db_unavailable():
 
 
 @pytest.mark.asyncio
-async def test_increment_spend_counters_finalizes_after_unreserved_increments():
+async def test_increment_spend_counters_finalizes_after_all_increments():
+    """Holds are separate from committed spend, so every entity's committed
+    counter (key + team) is incremented by the actual cost — there is no
+    reserved-counter skip — and the reservation is finalized only after all of
+    them have run."""
     from litellm.caching.dual_cache import DualCache
     from litellm.proxy.proxy_server import increment_spend_counters
 
     counter_cache = DualCache()
-    counter_cache.in_memory_cache.set_cache(
-        key="spend:key:key-finalize-after-increments",
-        value=0.5,
-    )
     budget_reservation = {
+        "hold_id": "hold-finalize-after-increments",
         "reserved_cost": 0.5,
         "entries": [
             {
@@ -6529,14 +6530,13 @@ async def test_increment_spend_counters_finalizes_after_unreserved_increments():
                 "entity_type": "Key",
                 "entity_id": "key-finalize-after-increments",
                 "reserved_cost": 0.5,
-                "applied_adjustment": 0.0,
             }
         ],
         "finalized": False,
     }
     incremented_counters = []
 
-    async def assert_reservation_not_finalized_yet(**kwargs):
+    async def record_not_finalized_yet(**kwargs):
         assert budget_reservation["finalized"] is False
         incremented_counters.append(kwargs["counter_key"])
 
@@ -6548,7 +6548,7 @@ async def test_increment_spend_counters_finalizes_after_unreserved_increments():
     try:
         with patch(
             "litellm.proxy.proxy_server._init_and_increment_spend_counter",
-            new=AsyncMock(side_effect=assert_reservation_not_finalized_yet),
+            new=AsyncMock(side_effect=record_not_finalized_yet),
         ):
             await increment_spend_counters(
                 token="key-finalize-after-increments",
@@ -6558,45 +6558,42 @@ async def test_increment_spend_counters_finalizes_after_unreserved_increments():
                 budget_reservation=budget_reservation,
             )
 
-        assert incremented_counters == ["spend:team:team-finalize-after-increments"]
+        assert incremented_counters == [
+            "spend:key:key-finalize-after-increments",
+            "spend:team:team-finalize-after-increments",
+        ]
         assert budget_reservation["finalized"] is True
-        assert counter_cache.in_memory_cache.get_cache(
-            key="spend:key:key-finalize-after-increments"
-        ) == pytest.approx(0.25)
     finally:
         ps.spend_counter_cache = orig_counter
         ps.user_api_key_cache = orig_user
 
 
 @pytest.mark.asyncio
-async def test_increment_spend_counters_finalizes_none_cost_reservation():
+async def test_increment_spend_counters_finalizes_and_releases_hold_on_none_cost():
     from litellm.caching.dual_cache import DualCache
+    from litellm.constants import BUDGET_HOLD_TTL_SECONDS
     from litellm.proxy.proxy_server import increment_spend_counters
+    from litellm.proxy.spend_tracking.budget_hold_store import BudgetHoldStore
 
     counter_cache = DualCache()
-    counter_cache.in_memory_cache.set_cache(
-        key="spend:key:key-finalize-none-cost",
-        value=0.5,
-    )
-    budget_reservation = {
-        "reserved_cost": 0.5,
-        "entries": [
-            {
-                "counter_key": "spend:key:key-finalize-none-cost",
-                "entity_type": "Key",
-                "entity_id": "key-finalize-none-cost",
-                "reserved_cost": 0.5,
-                "applied_adjustment": 0.0,
-            }
-        ],
-        "finalized": False,
-    }
+    counter_key = "spend:key:key-finalize-none-cost"
 
     import litellm.proxy.proxy_server as ps
 
-    orig_counter = ps.spend_counter_cache
+    orig_counter, orig_hold = ps.spend_counter_cache, ps.budget_hold_store
     ps.spend_counter_cache = counter_cache
+    ps.budget_hold_store = BudgetHoldStore(
+        dual_cache=counter_cache, ttl_seconds=BUDGET_HOLD_TTL_SECONDS
+    )
     try:
+        await ps.budget_hold_store.place_and_total(counter_key, "hold-none", 0.5)
+        budget_reservation = {
+            "hold_id": "hold-none",
+            "reserved_cost": 0.5,
+            "entries": [{"counter_key": counter_key, "reserved_cost": 0.5}],
+            "finalized": False,
+        }
+
         await increment_spend_counters(
             token="key-finalize-none-cost",
             team_id=None,
@@ -6606,64 +6603,11 @@ async def test_increment_spend_counters_finalizes_none_cost_reservation():
         )
 
         assert budget_reservation["finalized"] is True
-        assert counter_cache.in_memory_cache.get_cache(
-            key="spend:key:key-finalize-none-cost"
-        ) == pytest.approx(0.0)
+        holds = ps.budget_hold_store._memory_holds.get(counter_key, {})
+        assert sum(cost for cost, _ in holds.values()) == pytest.approx(0.0)
     finally:
         ps.spend_counter_cache = orig_counter
-
-
-@pytest.mark.asyncio
-async def test_increment_spend_counters_falls_back_to_direct_increment_on_bad_reserved_counter():
-    """When the reservation reconcile fails, the reserved counters are
-    invalidated and the actual response cost must still be written via the
-    direct increment fallback. Leaving the counter at ``None`` lets the next
-    request reseed a stale value from the DB and silently stops budget gating,
-    which is the bug this fix addresses."""
-    from litellm.caching.dual_cache import DualCache
-    from litellm.proxy.proxy_server import increment_spend_counters
-
-    counter_cache = DualCache()
-    budget_reservation = {
-        "reserved_cost": 0.5,
-        "entries": [
-            {
-                "counter_key": "spend:key:key-bad-reserved-counter",
-                "entity_type": "Key",
-                "entity_id": "key-bad-reserved-counter",
-                "reserved_cost": 0.5,
-                "applied_adjustment": 0.0,
-            }
-        ],
-        "finalized": False,
-    }
-
-    import litellm.proxy.proxy_server as ps
-
-    orig_counter = ps.spend_counter_cache
-    ps.spend_counter_cache = counter_cache
-    try:
-        with patch(
-            "litellm.proxy.proxy_server.verbose_proxy_logger.warning"
-        ) as mock_warning:
-            await increment_spend_counters(
-                token="key-bad-reserved-counter",
-                team_id=None,
-                user_id=None,
-                response_cost=0.25,
-                budget_reservation=budget_reservation,
-            )
-
-        mock_warning.assert_called_once()
-        assert budget_reservation["finalized"] is True
-        assert (
-            counter_cache.in_memory_cache.get_cache(
-                key="spend:key:key-bad-reserved-counter"
-            )
-            == 0.25
-        )
-    finally:
-        ps.spend_counter_cache = orig_counter
+        ps.budget_hold_store = orig_hold
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -6611,6 +6611,75 @@ async def test_increment_spend_counters_finalizes_and_releases_hold_on_none_cost
 
 
 @pytest.mark.asyncio
+async def test_increment_spend_counters_commits_spend_before_releasing_hold(
+    monkeypatch,
+):
+    """The committed counter must already hold the actual cost at the moment the
+    hold is released, so a concurrent admission never sees a window with neither
+    the hold nor the cost counted (veria-ai budget admission gap)."""
+    from litellm.caching.dual_cache import DualCache
+    from litellm.constants import BUDGET_HOLD_TTL_SECONDS
+    from litellm.proxy.proxy_server import increment_spend_counters
+    from litellm.proxy.spend_tracking.budget_hold_store import BudgetHoldStore
+
+    counter_cache = DualCache()
+    counter_key = "spend:key:key-order"
+
+    import litellm.proxy.proxy_server as ps
+
+    orig_counter, orig_user, orig_hold, orig_prisma = (
+        ps.spend_counter_cache,
+        ps.user_api_key_cache,
+        ps.budget_hold_store,
+        ps.prisma_client,
+    )
+    ps.spend_counter_cache = counter_cache
+    ps.user_api_key_cache = DualCache()
+    ps.prisma_client = None
+    ps.budget_hold_store = BudgetHoldStore(
+        dual_cache=counter_cache, ttl_seconds=BUDGET_HOLD_TTL_SECONDS
+    )
+    monkeypatch.setattr(
+        ps.SpendCounterReseed, "coalesced", AsyncMock(return_value=None)
+    )
+
+    committed_at_release = {}
+    real_remove = ps.budget_hold_store.remove
+
+    async def capture_remove(**kwargs):
+        committed_at_release["value"] = counter_cache.in_memory_cache.get_cache(
+            key=kwargs["counter_key"]
+        )
+        await real_remove(**kwargs)
+
+    monkeypatch.setattr(ps.budget_hold_store, "remove", capture_remove)
+
+    try:
+        await ps.budget_hold_store.place_and_total(counter_key, "hold-order", 0.5)
+        budget_reservation = {
+            "hold_id": "hold-order",
+            "reserved_cost": 0.5,
+            "entries": [{"counter_key": counter_key, "reserved_cost": 0.5}],
+            "finalized": False,
+        }
+
+        await increment_spend_counters(
+            token="key-order",
+            team_id=None,
+            user_id=None,
+            response_cost=0.25,
+            budget_reservation=budget_reservation,
+        )
+
+        assert committed_at_release["value"] == pytest.approx(0.25)
+    finally:
+        ps.spend_counter_cache = orig_counter
+        ps.user_api_key_cache = orig_user
+        ps.budget_hold_store = orig_hold
+        ps.prisma_client = orig_prisma
+
+
+@pytest.mark.asyncio
 async def test_increment_spend_counter_invalidates_stale_cache_on_redis_failure():
     from litellm.caching.dual_cache import DualCache
     from litellm.proxy.proxy_server import _increment_spend_counter_cache


### PR DESCRIPTION
## Relevant issues

Budget reservations (added in 1.87.0) could pin a shared budget counter and produce false ExceededBudget rejections after pod restarts, and could drive the shared counter negative when a reset landed while a request was in flight.

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Live proxy on localhost with Redis caching enabled, real gpt-4o calls.

Orphan ratchet (a pod dying mid-request used to leave its reservation pinned on the shared counter):

```
# reserve worst-case against a $0.005 budget, then kill the proxy mid-stream
# (simulates OOMKill) so the request never settles, then bring it back and probe
```

Before this change, the next request was rejected even though real spend was zero:

```
{"error":{"message":"Budget has been exceeded! Current cost: 0.005, Max budget: 0.005","type":"budget_exceeded","code":"429"}}
db spend: 0.0 | redis counter: 0.005
```

After this change, the orphaned hold expires and the key is admitted again, with committed spend reflecting only real usage:

```
probe 1: OK
probe 2: OK
probe 3: OK
db spend: 4.25e-05 | redis counter: 4.25e-05
```

Reset-mid-flight (a budget reset zeroing the shared counter while a reservation was in flight used to drive it negative on settle):

```
# before: shared counter after settle: -0.03463
# after:  shared counter after settle:  0.005345   (committed = actual only)
```

Normal cost tracking and the concurrent admission gate are unchanged: a budgeted key still tracks spend, and four parallel worst-case requests against a small budget still admit some and reject the rest.

## Type

🐛 Bug Fix

## Changes

Reservations were incremented straight into the same Redis spend counter as real spend, and the give-back that should cancel them lived only in the request's in-process state. A pod dying mid-request orphaned the increment, so the counter ratcheted toward the cap; because the poisoned value was shared, adding memory or replicas did not help. A counter that changed underneath an in-flight reservation made the give-back either drive the counter negative or trip a guard that deleted the shared counter and cascaded into further reconcile failures.

Each reservation is now a self-expiring hold kept separate from the committed spend counter. With Redis it is a member in a per-counter sorted set scored by expiry; without Redis it is an in-memory entry. Admission prunes expired holds, adds its own, and reads committed spend plus the sum of live holds. Settling a request removes its own hold and increments the committed counter by the actual cost only; the committed counter is never decremented to give a reservation back, so the negative-counter and counter-delete cascades are gone by construction. A hold whose pod died is pruned at the next admission once `BUDGET_HOLD_TTL` (default 3600s, env-overridable) elapses, so an orphan can no longer pin a budget
