### PR TITLE
fix(utils): prefer regional inference-profile price over stripped base price

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -5902,9 +5902,9 @@ def _get_model_info_helper(  # noqa: PLR0915
             Check if: (in order of specificity)
             1. 'custom_llm_provider/model' in litellm.model_cost. Checks "groq/llama3-8b-8192" if model="llama3-8b-8192" and custom_llm_provider="groq"
             2. 'model' in litellm.model_cost. Checks "gemini-1.5-pro-002" in  litellm.model_cost if model="gemini-1.5-pro-002" and custom_llm_provider=None
-            3. 'combined_stripped_model_name' in litellm.model_cost. Checks if 'gemini/gemini-1.5-flash' in model map, if 'gemini/gemini-1.5-flash-001' given.
-            4. 'stripped_model_name' in litellm.model_cost. Checks if 'ft:gpt-3.5-turbo' in model map, if 'ft:gpt-3.5-turbo:my-org:custom_suffix:id' given.
-            5. 'split_model' in litellm.model_cost. Checks "llama3-8b-8192" in litellm.model_cost if model="groq/llama3-8b-8192"
+            3. 'split_model' in litellm.model_cost. Checks "au.anthropic.claude-3" in litellm.model_cost if model="bedrock/au.anthropic.claude-3". Tried before the stripped names so a regional inference profile keeps its region-specific price instead of falling back to the stripped base price.
+            4. 'combined_stripped_model_name' in litellm.model_cost. Checks if 'gemini/gemini-1.5-flash' in model map, if 'gemini/gemini-1.5-flash-001' given.
+            5. 'stripped_model_name' in litellm.model_cost. Checks if 'ft:gpt-3.5-turbo' in model map, if 'ft:gpt-3.5-turbo:my-org:custom_suffix:id' given.
             """
 
             _model_info: Optional[Dict[str, Any]] = None
@@ -5931,6 +5931,16 @@ def _get_model_info_helper(  # noqa: PLR0915
                     ):
                         _model_info = None
             if _model_info is None:
+                _matched_key = _get_model_cost_key(split_model)
+                if _matched_key is not None:
+                    key = _matched_key
+                    _model_info = _get_model_info_from_model_cost(key=cast(str, key))
+                    if not _check_provider_match(
+                        model_info=_model_info,
+                        custom_llm_provider=model_cost_custom_llm_provider,
+                    ):
+                        _model_info = None
+            if _model_info is None:
                 _matched_key = _get_model_cost_key(combined_stripped_model_name)
                 if _matched_key is not None:
                     key = _matched_key
@@ -5942,16 +5952,6 @@ def _get_model_info_helper(  # noqa: PLR0915
                         _model_info = None
             if _model_info is None:
                 _matched_key = _get_model_cost_key(stripped_model_name)
-                if _matched_key is not None:
-                    key = _matched_key
-                    _model_info = _get_model_info_from_model_cost(key=cast(str, key))
-                    if not _check_provider_match(
-                        model_info=_model_info,
-                        custom_llm_provider=model_cost_custom_llm_provider,
-                    ):
-                        _model_info = None
-            if _model_info is None:
-                _matched_key = _get_model_cost_key(split_model)
                 if _matched_key is not None:
                     key = _matched_key
                     _model_info = _get_model_info_from_model_cost(key=cast(str, key))

--- a/tests/local_testing/test_get_model_info.py
+++ b/tests/local_testing/test_get_model_info.py
@@ -128,6 +128,21 @@ def test_get_model_info_bedrock_region():
     assert info["litellm_provider"] == "bedrock_converse"
 
 
+def test_get_model_info_bedrock_region_uses_regional_price():
+    """A regional inference-profile model keeps its region-specific price instead
+    of falling back to the stripped base-model price (issue #27612)."""
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+    regional_key = "au.anthropic.claude-sonnet-4-5-20250929-v1:0"
+    info = litellm.get_model_info(model="bedrock/" + regional_key)
+    print("info", info)
+    assert info["key"] == regional_key
+    assert (
+        info["input_cost_per_token"]
+        == litellm.model_cost[regional_key]["input_cost_per_token"]
+    )
+
+
 @pytest.mark.parametrize(
     "model",
     [


### PR DESCRIPTION
## Summary
`get_model_info()` returned the base (us) price for a Bedrock regional inference profile even when a region-specific entry exists in the cost map.

For example, `bedrock/au.anthropic.claude-sonnet-4-5-20250929-v1:0` resolved to `anthropic.claude-sonnet-4-5-20250929-v1:0` (us, $3.0/M input) instead of `au.anthropic.claude-sonnet-4-5-20250929-v1:0` (au, $3.3/M input), which IS present in the map.

## Root cause
In `_get_model_info_helper`, the candidate lookup tried the region-**stripped** names (`combined_stripped_model_name`, `stripped_model_name`) before `split_model`, which keeps the regional prefix. The stripped base key matched first, so the regional entry (checked last) was never reached.

## Fix
Move the `split_model` lookup ahead of the stripped lookups, so a region-specific price wins — falling back to the stripped base price only when no regional entry exists. The provider-match guard is preserved on each branch, and the stripped fallback (fine-tuned models, or regions without a dedicated entry) is unchanged.

## Test
Added `test_get_model_info_bedrock_region_uses_regional_price`, which asserts the regional key and its price are returned. It fails on the current base and passes with this change; the rest of `tests/local_testing/test_get_model_info.py` stays green.

Fixes #27612
