### PR TITLE
feat(ui): cut the users page over to the /ui/users path route

### DIFF
--- a/ui/litellm-dashboard/e2e_tests/fixtures/migratedPages.ts
+++ b/ui/litellm-dashboard/e2e_tests/fixtures/migratedPages.ts
@@ -39,6 +39,7 @@ export const MIGRATED_E2E_PAGES: Record<string, string> = {
   new_usage: "usage",
   agents: "agents",
   "router-settings": "router-settings",
+  users: "users",
 };
 
 export const MIGRATED_E2E_SEGMENTS: string[] = [...new Set(Object.values(MIGRATED_E2E_PAGES))];

--- a/ui/litellm-dashboard/src/app/(dashboard)/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/page.tsx
@@ -13,7 +13,6 @@ import PassThroughSettings from "@/components/pass_through_settings";
 import { SurveyPrompt, SurveyModal, ClaudeCodePrompt, ClaudeCodeModal } from "@/components/survey";
 import Usage from "@/components/usage";
 import UserDashboard from "@/components/user_dashboard";
-import ViewUserDashboard from "@/components/view_users";
 import { useAuth } from "@/contexts/AuthContext";
 import {
   buildLoginUrlWithReturn,
@@ -322,16 +321,6 @@ function CreateKeyPageContent() {
               setModelData={setModelData}
               premiumUser={premiumUser}
               teams={teams}
-            />
-          ) : page == "users" ? (
-            <ViewUserDashboard
-              userID={userID}
-              userRole={userRole}
-              token={token}
-              keys={keys}
-              teams={teams}
-              accessToken={accessToken}
-              setKeys={setKeys}
             />
           ) : page == "teams" ? (
             <OldTeams

--- a/ui/litellm-dashboard/src/app/(dashboard)/users/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/users/page.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import ViewUserDashboard from "@/components/view_users";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+import { useTeams } from "@/app/(dashboard)/hooks/teams/useTeams";
+
+export default function UsersPage() {
+  const { accessToken, token, userRole, userId } = useAuthorized();
+  const { data: teams } = useTeams();
+  return (
+    <ViewUserDashboard
+      userID={userId}
+      userRole={userRole}
+      token={token}
+      teams={teams ?? null}
+      accessToken={accessToken}
+    />
+  );
+}

--- a/ui/litellm-dashboard/src/components/view_users.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_users.test.tsx
@@ -66,11 +66,9 @@ describe("ViewUserDashboard", () => {
   const defaultProps = {
     accessToken: "test-token",
     token: "test-token",
-    keys: null,
     userRole: "Admin",
     userID: "admin-user-id",
     teams: [],
-    setKeys: vi.fn(),
   };
 
   beforeEach(() => {

--- a/ui/litellm-dashboard/src/components/view_users.tsx
+++ b/ui/litellm-dashboard/src/components/view_users.tsx
@@ -34,11 +34,9 @@ const { Text, Title } = Typography;
 interface ViewUserDashboardProps {
   accessToken: string | null;
   token: string | null;
-  keys: any[] | null;
   userRole: string | null;
   userID: string | null;
   teams: any[] | null;
-  setKeys: React.Dispatch<React.SetStateAction<object[] | null>>;
   orgAdminOrgIds?: Array<{ organization_id: string; organization_alias: string }> | null;
 }
 

--- a/ui/litellm-dashboard/src/utils/migratedPages.test.ts
+++ b/ui/litellm-dashboard/src/utils/migratedPages.test.ts
@@ -119,6 +119,13 @@ describe("migratedHref / legacyPageHref", () => {
     expect(MIGRATED_PAGES.agents).toBe("agents");
     expect(MIGRATED_PAGES["router-settings"]).toBe("router-settings");
   });
+
+  it("maps the users id to its route", async () => {
+    vi.doMock("@/components/networking", () => ({ serverRootPath: "/" }));
+    const { MIGRATED_PAGES } = await import("./migratedPages");
+
+    expect(MIGRATED_PAGES.users).toBe("users");
+  });
 });
 
 describe("dev server (NODE_ENV=development)", () => {

--- a/ui/litellm-dashboard/src/utils/migratedPages.ts
+++ b/ui/litellm-dashboard/src/utils/migratedPages.ts
@@ -42,6 +42,7 @@ export const MIGRATED_PAGES: Record<string, string> = {
   new_usage: "usage",
   agents: "agents",
   "router-settings": "router-settings",
+  users: "users",
 };
 
 function uiBase(): string {


### PR DESCRIPTION
## Relevant issues

Part of the App Router migration: page-by-page cutover from the legacy `?page=` switch to path routes.

## Linear ticket

Refs LIT-3687

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

With the dev stack running (`litellm --config ... --port 4000` plus `npm run dev` in ui/litellm-dashboard), log in at http://localhost:4000/ui once, then:

1. Go to http://localhost:3000/users; the Internal Users dashboard renders, filters and pagination work
2. Go to http://localhost:3000/?page=users; it redirects to /users (old bookmarks keep working)
3. Click "Internal Users" in the sidebar; the URL is the path route and the item stays highlighted after a hard refresh

## Type

🆕 New Feature

## Changes

Same recipe as the previous batches (#30323 and earlier). ViewUserDashboard now renders from `app/(dashboard)/users/page.tsx`, a thin wrapper that reads auth from `useAuthorized` and teams from the `useTeams` React Query hook. The `users` entry is added to `MIGRATED_PAGES` (sidebar links, deep links, and the legacy `?page=users` redirect all derive from it) and to the e2e fixture so the migration smoke and sidebar specs cover the new route. The switch arm and import come out of the legacy shell.

One cleanup rode along because the cutover surfaced it: the shell passed `keys` and `setKeys` to ViewUserDashboard, but the component declares them in its props interface without ever destructuring them; the component manages its own data via React Query internally. They are deleted from the interface and the test fixture instead of being wired into the new wrapper.
