### PR TITLE
fix(caching): exclude prompt content from semantic cache scope keys

### DIFF
--- a/litellm/caching/caching.py
+++ b/litellm/caching/caching.py
@@ -273,6 +273,12 @@ class Cache:
         if self.namespace is not None and isinstance(self.cache, RedisCache):
             self.cache.namespace = self.namespace
 
+    def _is_semantic_cache(self) -> bool:
+        return self.type in (
+            LiteLLMCacheType.REDIS_SEMANTIC,
+            LiteLLMCacheType.QDRANT_SEMANTIC,
+        )
+
     def get_cache_key(self, **kwargs) -> str:
         """
         Get the cache key for the given arguments.
@@ -293,7 +299,18 @@ class Cache:
 
         combined_kwargs = ModelParamHelper._get_all_llm_api_params()
         litellm_param_kwargs = all_litellm_params
+        # Semantic caches match on prompt embeddings, not on the prompt text in
+        # the key. Including prompt content here would scope every distinct
+        # wording into its own bucket and defeat similarity matching, so the
+        # scope key is built from non-prompt params only.
+        scope_excluded_params = (
+            ModelParamHelper.get_exclude_params_for_model_parameters()
+            if self._is_semantic_cache()
+            else set()
+        )
         for param in kwargs:
+            if param in scope_excluded_params:
+                continue
             if param in combined_kwargs:
                 param_value: Optional[str] = self._get_param_value(param, kwargs)
                 if param_value is not None:

--- a/litellm/caching/caching.py
+++ b/litellm/caching/caching.py
@@ -273,11 +273,50 @@ class Cache:
         if self.namespace is not None and isinstance(self.cache, RedisCache):
             self.cache.namespace = self.namespace
 
+    # Params whose values carry prompt content. Excluded from semantic cache
+    # scope keys so differently worded but semantically similar prompts share a
+    # bucket (matching happens via vector similarity, not the scope key). Kept
+    # separate from logging-exclusion lists so the two concerns evolve apart.
+    _SEMANTIC_CACHE_SCOPE_EXCLUDED_PARAMS: frozenset = frozenset(
+        {"messages", "prompt", "input"}
+    )
+
+    # Server-set identity fields (from proxy auth) used to isolate semantic
+    # cache buckets per tenant, preventing one key/team/org from reading
+    # another's cached response via a semantically similar prompt.
+    _SEMANTIC_CACHE_TENANT_SCOPE_FIELDS: Tuple[str, ...] = (
+        "user_api_key",
+        "user_api_key_team_id",
+        "user_api_key_org_id",
+    )
+
     def _is_semantic_cache(self) -> bool:
         return self.type in (
             LiteLLMCacheType.REDIS_SEMANTIC,
             LiteLLMCacheType.QDRANT_SEMANTIC,
         )
+
+    def _get_semantic_cache_tenant_scope(self, kwargs: dict) -> str:
+        """
+        Build a tenant scope from proxy-auth identity so semantically similar
+        prompts from different keys/teams/orgs never share a cache bucket.
+
+        Only server-set metadata is used (the hashed key and its team/org),
+        never request-supplied prompt content. Returns "" for non-proxy (SDK)
+        calls that carry no auth identity.
+        """
+        metadata: Dict = kwargs.get("metadata") or {}
+        litellm_params: Dict = kwargs.get("litellm_params") or {}
+        metadata_in_litellm_params: Dict = litellm_params.get("metadata") or {}
+
+        scope = ""
+        for field in self._SEMANTIC_CACHE_TENANT_SCOPE_FIELDS:
+            value = metadata.get(field)
+            if value is None:
+                value = metadata_in_litellm_params.get(field)
+            if value is not None:
+                scope += f"{field}: {value}"
+        return scope
 
     def get_cache_key(self, **kwargs) -> str:
         """
@@ -299,14 +338,15 @@ class Cache:
 
         combined_kwargs = ModelParamHelper._get_all_llm_api_params()
         litellm_param_kwargs = all_litellm_params
+        is_semantic_cache = self._is_semantic_cache()
         # Semantic caches match on prompt embeddings, not on the prompt text in
         # the key. Including prompt content here would scope every distinct
         # wording into its own bucket and defeat similarity matching, so the
         # scope key is built from non-prompt params only.
         scope_excluded_params = (
-            ModelParamHelper.get_exclude_params_for_model_parameters()
-            if self._is_semantic_cache()
-            else set()
+            self._SEMANTIC_CACHE_SCOPE_EXCLUDED_PARAMS
+            if is_semantic_cache
+            else frozenset()
         )
         for param in kwargs:
             if param in scope_excluded_params:
@@ -325,6 +365,12 @@ class Cache:
                         continue  # ignore None params
                     param_value = kwargs[param]
                     cache_key += f"{str(param)}: {str(param_value)}"
+
+        # Without prompt content in the key, semantic buckets must be isolated
+        # by the authenticated tenant or a similar prompt from another key could
+        # return this tenant's cached response.
+        if is_semantic_cache:
+            cache_key += self._get_semantic_cache_tenant_scope(kwargs)
 
         hashed_cache_key = Cache._get_hashed_cache_key(cache_key)
         hashed_cache_key = self._add_namespace_to_cache_key(hashed_cache_key, **kwargs)

--- a/tests/test_litellm/caching/test_caching.py
+++ b/tests/test_litellm/caching/test_caching.py
@@ -56,9 +56,10 @@ def _make_semantic_cache(cache_type):
     # Semantic backends need a live Redis/Qdrant connection to construct; the
     # scope-key logic under test lives entirely in Cache.get_cache_key, so the
     # backend is stubbed out.
-    with patch(
-        "litellm.caching.caching.RedisSemanticCache", return_value=MagicMock()
-    ), patch("litellm.caching.caching.QdrantSemanticCache", return_value=MagicMock()):
+    with (
+        patch("litellm.caching.caching.RedisSemanticCache", return_value=MagicMock()),
+        patch("litellm.caching.caching.QdrantSemanticCache", return_value=MagicMock()),
+    ):
         return Cache(type=cache_type)
 
 
@@ -92,6 +93,63 @@ def test_semantic_cache_key_excludes_prompt_content():
             messages=[{"role": "user", "content": "What is the capital of France?"}],
         )
         assert key_a != key_other_model, f"{cache_type} ignored model in scope key"
+
+
+def test_semantic_cache_key_isolated_by_authenticated_tenant():
+    """Without prompt content in the key, semantic buckets must be isolated by
+    the proxy-authenticated identity; otherwise a similar prompt from a
+    different key/team could return another tenant's cached response."""
+    for cache_type in (
+        LiteLLMCacheType.REDIS_SEMANTIC,
+        LiteLLMCacheType.QDRANT_SEMANTIC,
+    ):
+        cache = _make_semantic_cache(cache_type)
+
+        messages = [{"role": "user", "content": "What is the capital of France?"}]
+
+        key_tenant_a = cache.get_cache_key(
+            model="gpt-4o-mini",
+            messages=messages,
+            metadata={"user_api_key": "hash-a", "user_api_key_team_id": "team-a"},
+        )
+        key_tenant_b = cache.get_cache_key(
+            model="gpt-4o-mini",
+            messages=messages,
+            metadata={"user_api_key": "hash-b", "user_api_key_team_id": "team-b"},
+        )
+
+        assert key_tenant_a != key_tenant_b, f"{cache_type} leaked across tenants"
+
+        # Same tenant + same params still shares a bucket so similar prompts hit.
+        key_tenant_a_again = cache.get_cache_key(
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "Which city is France's capital?"}],
+            metadata={"user_api_key": "hash-a", "user_api_key_team_id": "team-a"},
+        )
+        assert key_tenant_a == key_tenant_a_again, f"{cache_type} split same tenant"
+
+
+def test_semantic_cache_tenant_scope_reads_server_metadata_not_prompt():
+    """Tenant scope must come from server-set auth metadata (including the
+    litellm_params copy), never from request-supplied prompt content."""
+    cache = _make_semantic_cache(LiteLLMCacheType.QDRANT_SEMANTIC)
+
+    scope = cache._get_semantic_cache_tenant_scope(
+        {
+            "litellm_params": {
+                "metadata": {
+                    "user_api_key": "hash-z",
+                    "user_api_key_org_id": "org-z",
+                }
+            }
+        }
+    )
+
+    assert "hash-z" in scope
+    assert "org-z" in scope
+
+    # SDK calls without auth identity produce an empty (shared) scope.
+    assert cache._get_semantic_cache_tenant_scope({}) == ""
 
 
 def test_non_semantic_cache_key_includes_prompt_content():

--- a/tests/test_litellm/caching/test_caching.py
+++ b/tests/test_litellm/caching/test_caching.py
@@ -1,5 +1,6 @@
 import logging
 import re
+from unittest.mock import MagicMock, patch
 
 from litellm.caching.caching import Cache
 from litellm.types.caching import LiteLLMCacheType
@@ -49,6 +50,65 @@ def test_cache_key_debug_log_does_not_include_prompt_material(caplog):
     assert created_cache_key_logs
     assert all(prompt_marker not in message for message in created_cache_key_logs)
     assert any(cache_key in message for message in created_cache_key_logs)
+
+
+def _make_semantic_cache(cache_type):
+    # Semantic backends need a live Redis/Qdrant connection to construct; the
+    # scope-key logic under test lives entirely in Cache.get_cache_key, so the
+    # backend is stubbed out.
+    with patch(
+        "litellm.caching.caching.RedisSemanticCache", return_value=MagicMock()
+    ), patch("litellm.caching.caching.QdrantSemanticCache", return_value=MagicMock()):
+        return Cache(type=cache_type)
+
+
+def test_semantic_cache_key_excludes_prompt_content():
+    """Semantic caches must scope on params, not prompt text, so that
+    semantically similar but differently worded prompts share a bucket and can
+    match via vector similarity instead of landing in separate exact-prompt
+    buckets."""
+    for cache_type in (
+        LiteLLMCacheType.REDIS_SEMANTIC,
+        LiteLLMCacheType.QDRANT_SEMANTIC,
+    ):
+        cache = _make_semantic_cache(cache_type)
+
+        key_a = cache.get_cache_key(
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "What is the capital of France?"}],
+        )
+        key_b = cache.get_cache_key(
+            model="gpt-4o-mini",
+            messages=[
+                {"role": "user", "content": "Which city is the capital of France?"}
+            ],
+        )
+
+        assert key_a == key_b, f"{cache_type} scoped distinct prompts apart"
+
+        # Non-prompt params must still scope entries apart.
+        key_other_model = cache.get_cache_key(
+            model="gpt-4o",
+            messages=[{"role": "user", "content": "What is the capital of France?"}],
+        )
+        assert key_a != key_other_model, f"{cache_type} ignored model in scope key"
+
+
+def test_non_semantic_cache_key_includes_prompt_content():
+    """Exact caches must keep prompt content in the key so distinct prompts
+    don't collide."""
+    cache = Cache(type=LiteLLMCacheType.LOCAL)
+
+    key_a = cache.get_cache_key(
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": "What is the capital of France?"}],
+    )
+    key_b = cache.get_cache_key(
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": "Which city is the capital of France?"}],
+    )
+
+    assert key_a != key_b
 
 
 def _embedding_response(prompt_tokens, num_items):


### PR DESCRIPTION
## Summary
Semantic cache (`qdrant-semantic` / `redis-semantic`) only worked for identical prompts. Reworded prompts with the same meaning always missed, even when vector similarity was well above the configured threshold.
## Cause
`Cache.get_cache_key()` hashed `messages` / `prompt` / `input` into `litellm_cache_key`. Qdrant and Redis semantic caches filter vector search by that key before similarity scoring. Each distinct wording therefore landed in its own bucket, so semantic matching never ran across reworded prompts. Identical requests still hit (`x-litellm-semantic-similarity: 1.0`); fuzzy requests always returned `0.0` and called the provider again.
This behavior came from the "isolate semantic cache entries" work (`7bda5c7cac`), which added per-key scoping without excluding prompt content from the scope key.
## Fix
For `redis-semantic` and `qdrant-semantic` only:
1. Exclude prompt-bearing params (`messages`, `prompt`, `input`) from the scope key via a dedicated `_SEMANTIC_CACHE_SCOPE_EXCLUDED_PARAMS` set, separate from logging-exclusion helpers.
2. Append proxy-authenticated tenant identity (`user_api_key`, `user_api_key_team_id`, `user_api_key_org_id`) from server-set metadata so dropping prompt content cannot let one virtual key read another tenant's cached response.
Exact caches (`redis`, `local`, etc.) are unchanged and still include prompt content in the key.


After:
First request was a cache miss.
<img width="1107" height="822" alt="Screenshot 2026-06-13 at 11 35 20 AM" src="https://github.com/user-attachments/assets/52cf6088-bcab-4135-9e69-d8ac2846426a" />
Second related query was a cach hit with semantic score of  0.9663038.
<img width="577" height="445" alt="Screenshot 2026-06-13 at 11 34 11 AM" src="https://github.com/user-attachments/assets/4a852f06-b95f-46d2-b79c-b51baa1f4480" />