### PR TITLE
fix(cost): sort token pricing tiers numerically

### DIFF
--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -255,8 +255,19 @@ def _get_token_base_cost(
         )
 
     # Only sort the threshold keys (typically 1-2 keys instead of 66+)
+    threshold_key_pairs = []
+    for key in threshold_keys:
+        try:
+            threshold_str_for_sort = key.split("_above_")[1].split("_tokens")[0]
+            threshold_for_sort = float(threshold_str_for_sort.replace("k", "")) * (
+                1000 if "k" in threshold_str_for_sort else 1
+            )
+            threshold_key_pairs.append((threshold_for_sort, key))
+        except (IndexError, ValueError):
+            continue
+
     threshold: Optional[float] = None
-    for key in sorted(threshold_keys, reverse=True):
+    for _, key in sorted(threshold_key_pairs, reverse=True):
         value = model_info.get(key)
         if value is not None:
             try:

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
@@ -1,6 +1,7 @@
 import json
 import os
 import sys
+from typing import cast
 
 import pytest
 from fastapi.testclient import TestClient
@@ -34,6 +35,7 @@ sys.path.insert(
 
 from litellm.litellm_core_utils.llm_cost_calc.utils import (
     PromptTokensDetailsResult,
+    _get_token_base_cost,
     _calculate_input_cost,
     calculate_cache_writing_cost,
     generic_cost_per_token,
@@ -265,6 +267,26 @@ def test_image_tokens_fallback_to_base_cost():
 
     assert round(prompt_cost, 12) == round(expected_prompt_cost, 12)
     assert round(completion_cost, 12) == round(expected_completion_cost, 12)
+
+
+def test_token_base_cost_sorts_tier_thresholds_numerically():
+    model_info = cast(
+        ModelInfo,
+        {
+            "input_cost_per_token": 1e-6,
+            "output_cost_per_token": 2e-6,
+            "input_cost_per_token_above_90k_tokens": 5e-6,
+            "output_cost_per_token_above_90k_tokens": 7e-6,
+            "input_cost_per_token_above_128k_tokens": 9e-6,
+            "output_cost_per_token_above_128k_tokens": 11e-6,
+        },
+    )
+    usage = Usage(prompt_tokens=150_000, completion_tokens=10, total_tokens=150_010)
+
+    prompt_cost, completion_cost, *_ = _get_token_base_cost(model_info, usage)
+
+    assert prompt_cost == 9e-6
+    assert completion_cost == 11e-6
 
 
 def test_generic_cost_per_token_above_200k_tokens():

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
@@ -289,6 +289,28 @@ def test_token_base_cost_sorts_tier_thresholds_numerically():
     assert completion_cost == 11e-6
 
 
+def test_token_base_cost_skips_malformed_threshold_keys():
+    model_info = cast(
+        ModelInfo,
+        {
+            "input_cost_per_token": 1e-6,
+            "output_cost_per_token": 2e-6,
+            "input_cost_per_token_above_90k_tokens": 5e-6,
+            "output_cost_per_token_above_90k_tokens": 7e-6,
+            "input_cost_per_token_above_128k_tokens": 9e-6,
+            "output_cost_per_token_above_128k_tokens": 11e-6,
+            "input_cost_per_token_above_": 99e-6,
+            "input_cost_per_token_above_bad_tokens": 99e-6,
+        },
+    )
+    usage = Usage(prompt_tokens=150_000, completion_tokens=10, total_tokens=150_010)
+
+    prompt_cost, completion_cost, *_ = _get_token_base_cost(model_info, usage)
+
+    assert prompt_cost == 9e-6
+    assert completion_cost == 11e-6
+
+
 def test_generic_cost_per_token_above_200k_tokens():
     # gemini-2.5-pro-exp-03-25 was removed; gemini-2.5-pro has same above-200k pricing
     model = "gemini-2.5-pro"

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from typing import cast
 
 import pytest
 
@@ -19,8 +20,29 @@ from litellm.cost_calculator import (
     response_cost_calculator,
 )
 from litellm.types.llms.openai import OpenAIRealtimeStreamList
-from litellm.types.utils import ModelResponse, PromptTokensDetailsWrapper, Usage
+from litellm.types.utils import ModelInfo, ModelResponse, PromptTokensDetailsWrapper, Usage
 from litellm.utils import TranscriptionResponse
+
+
+def test_token_base_cost_sorts_tier_thresholds_numerically():
+    from litellm.litellm_core_utils.llm_cost_calc.utils import _get_token_base_cost
+
+    model_info = {
+        "input_cost_per_token": 1e-6,
+        "output_cost_per_token": 2e-6,
+        "input_cost_per_token_above_90k_tokens": 5e-6,
+        "output_cost_per_token_above_90k_tokens": 7e-6,
+        "input_cost_per_token_above_128k_tokens": 9e-6,
+        "output_cost_per_token_above_128k_tokens": 11e-6,
+    }
+    usage = Usage(prompt_tokens=150_000, completion_tokens=10, total_tokens=150_010)
+
+    prompt_cost, completion_cost, *_ = _get_token_base_cost(
+        cast(ModelInfo, model_info), usage
+    )
+
+    assert prompt_cost == 9e-6
+    assert completion_cost == 11e-6
 
 
 def test_cost_per_token_duplicate_openai_prefix_matches_model_cost(monkeypatch):

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -1,6 +1,5 @@
 import os
 import sys
-from typing import cast
 
 import pytest
 
@@ -20,29 +19,8 @@ from litellm.cost_calculator import (
     response_cost_calculator,
 )
 from litellm.types.llms.openai import OpenAIRealtimeStreamList
-from litellm.types.utils import ModelInfo, ModelResponse, PromptTokensDetailsWrapper, Usage
+from litellm.types.utils import ModelResponse, PromptTokensDetailsWrapper, Usage
 from litellm.utils import TranscriptionResponse
-
-
-def test_token_base_cost_sorts_tier_thresholds_numerically():
-    from litellm.litellm_core_utils.llm_cost_calc.utils import _get_token_base_cost
-
-    model_info = {
-        "input_cost_per_token": 1e-6,
-        "output_cost_per_token": 2e-6,
-        "input_cost_per_token_above_90k_tokens": 5e-6,
-        "output_cost_per_token_above_90k_tokens": 7e-6,
-        "input_cost_per_token_above_128k_tokens": 9e-6,
-        "output_cost_per_token_above_128k_tokens": 11e-6,
-    }
-    usage = Usage(prompt_tokens=150_000, completion_tokens=10, total_tokens=150_010)
-
-    prompt_cost, completion_cost, *_ = _get_token_base_cost(
-        cast(ModelInfo, model_info), usage
-    )
-
-    assert prompt_cost == 9e-6
-    assert completion_cost == 11e-6
 
 
 def test_cost_per_token_duplicate_openai_prefix_matches_model_cost(monkeypatch):


### PR DESCRIPTION
## Relevant issues

Fixes #30345

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## CI (LiteLLM team)

- [ ] Branch creation CI run
       Link:
- [ ] CI run for the last commit
       Link:
- [ ] Merge / cherry-pick CI run
       Links:

## Screenshots / Proof of Fix

Before the fix, `python3 -m pytest tests/test_litellm/test_cost_calculator.py::test_token_base_cost_sorts_tier_thresholds_numerically -q` failed because a 150k-token request selected the 90k tier instead of the 128k tier

After the fix:

```text
python3 -m pytest \
  tests/test_litellm/test_cost_calculator.py::test_token_base_cost_sorts_tier_thresholds_numerically \
  tests/test_litellm/test_cost_calculator.py::test_log_context_cost_calculation \
  tests/test_litellm/test_cost_calculator.py::test_completion_cost_service_tier_priority \
  tests/test_litellm/test_cost_calculator.py::test_custom_pricing_applies_cache_read_input_cost -q
....                                                                     [100%]
4 passed in 0.38s
```

Also run:

```text
python3 -m ruff check litellm/litellm_core_utils/llm_cost_calc/utils.py
All checks passed!

git diff --check
python3 -m py_compile litellm/litellm_core_utils/llm_cost_calc/utils.py tests/test_litellm/test_cost_calculator.py
```

Note: `ruff check --select E,F,I tests/test_litellm/test_cost_calculator.py` still reports pre-existing E501 lines outside this diff

## Type

Bug Fix
Test

## Changes

Sort tier keys by their parsed numeric threshold before selecting the highest crossed `input_cost_per_token_above_<N>_tokens` tier. This preserves existing invalid-key skipping behavior and adds a regression test for mixed-width thresholds such as 90k and 128k
