### PR TITLE
fix(cost): bill tiered pricing at the highest threshold a request crosses

### DIFF
--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -191,6 +191,20 @@ def _get_service_tier_cost_key(base_key: str, service_tier: Optional[str]) -> st
     return base_key
 
 
+def _parse_above_tokens_threshold(key: str) -> Optional[float]:
+    """Numeric token count encoded in an ``..._above_<N>[k]_tokens`` pricing key.
+
+    Returns ``None`` when the key does not encode a parseable threshold.
+    """
+    try:
+        threshold_str = key.split("_above_")[1].split("_tokens")[0]
+        return float(threshold_str.replace("k", "")) * (
+            1000 if "k" in threshold_str else 1
+        )
+    except (IndexError, ValueError):
+        return None
+
+
 def _get_token_base_cost(
     model_info: ModelInfo, usage: Usage, service_tier: Optional[str] = None
 ) -> Tuple[float, float, float, float, float]:
@@ -254,18 +268,23 @@ def _get_token_base_cost(
             cache_read_cost,
         )
 
-    # Only sort the threshold keys (typically 1-2 keys instead of 66+)
+    # Visit the tiers highest-first so a request that crosses several tiers is
+    # billed at the highest tier it crosses. Sorting the raw key strings would
+    # order "_above_90k_" after "_above_128k_" (lexicographically "9" > "1") and
+    # stop at the lower tier.
     threshold: Optional[float] = None
-    for key in sorted(threshold_keys, reverse=True):
+    for key in sorted(
+        threshold_keys,
+        key=lambda k: _parse_above_tokens_threshold(k) or -1.0,
+        reverse=True,
+    ):
         value = model_info.get(key)
         if value is not None:
             try:
                 # Handle both formats: _above_128k_tokens and _above_128_tokens
                 threshold_str = key.split("_above_")[1].split("_tokens")[0]
-                threshold = float(threshold_str.replace("k", "")) * (
-                    1000 if "k" in threshold_str else 1
-                )
-                if usage.prompt_tokens > threshold:
+                threshold = _parse_above_tokens_threshold(key)
+                if threshold is not None and usage.prompt_tokens > threshold:
                     # Prefer a service_tier-specific above-threshold key when available,
                     # e.g. input_cost_per_token_priority_above_200k_tokens for Gemini
                     # ON_DEMAND_PRIORITY.  Falls back to the standard key automatically

--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -275,7 +275,9 @@ def _get_token_base_cost(
     threshold: Optional[float] = None
     for key in sorted(
         threshold_keys,
-        key=lambda k: _parse_above_tokens_threshold(k) or -1.0,
+        key=lambda k: (
+            v if (v := _parse_above_tokens_threshold(k)) is not None else -1.0
+        ),
         reverse=True,
     ):
         value = model_info.get(key)

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
@@ -1573,3 +1573,41 @@ def test_data_residency_composes_with_service_tier(_local_model_cost_map):
 
     assert priority_base_total > 0
     assert priority_eu_total == pytest.approx(priority_base_total * 1.10, rel=1e-9)
+
+
+def test_generic_cost_per_token_bills_highest_crossed_tier():
+    """Regression for #30345.
+
+    With graduated tiers at 90k and 128k, a 150k-token request crosses both and
+    must be billed at the highest tier it crosses (128k). The tier keys were
+    sorted lexicographically, so "_above_90k_" wrongly preceded "_above_128k_"
+    ("9" > "1") and billing stopped at the lower 90k tier.
+    """
+    from unittest.mock import patch
+
+    mock_model_info = {
+        "input_cost_per_token": 1e-6,
+        "output_cost_per_token": 2e-6,
+        "input_cost_per_token_above_90k_tokens": 5e-6,
+        "input_cost_per_token_above_128k_tokens": 9e-6,
+        "output_cost_per_token_above_90k_tokens": 6e-6,
+        "output_cost_per_token_above_128k_tokens": 1e-5,
+    }
+    usage = Usage(
+        prompt_tokens=150_000,
+        completion_tokens=100,
+        total_tokens=150_100,
+    )
+
+    with patch(
+        "litellm.litellm_core_utils.llm_cost_calc.utils.get_model_info",
+        return_value=mock_model_info,
+    ):
+        prompt_cost, completion_cost = generic_cost_per_token(
+            model="test-tiered-model",
+            usage=usage,
+            custom_llm_provider="test-provider",
+        )
+
+    assert round(prompt_cost, 12) == round(150_000 * 9e-6, 12)
+    assert round(completion_cost, 12) == round(100 * 1e-5, 12)

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
@@ -1609,5 +1609,5 @@ def test_generic_cost_per_token_bills_highest_crossed_tier():
             custom_llm_provider="test-provider",
         )
 
-    assert round(prompt_cost, 12) == round(150_000 * 9e-6, 12)
-    assert round(completion_cost, 12) == round(100 * 1e-5, 12)
+    assert prompt_cost == pytest.approx(150_000 * 9e-6, rel=1e-9)
+    assert completion_cost == pytest.approx(100 * 1e-5, rel=1e-9)


### PR DESCRIPTION
## Relevant issues

Fixes #30345

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

No real model call is needed; the bug is in the tiered-cost helper, so the repro calls the public cost path directly with two graduated tiers whose thresholds have different digit lengths (90k and 128k). A 150k-token request crosses both and must be billed at the highest tier it crosses (128k).

```python
from unittest.mock import patch
from litellm.types.utils import Usage
from litellm.litellm_core_utils.llm_cost_calc.utils import generic_cost_per_token

model_info = {
    "input_cost_per_token": 1e-6,
    "output_cost_per_token": 2e-6,
    "input_cost_per_token_above_90k_tokens": 5e-6,
    "input_cost_per_token_above_128k_tokens": 9e-6,
}
usage = Usage(prompt_tokens=150_000, completion_tokens=10, total_tokens=150_010)
with patch("litellm.litellm_core_utils.llm_cost_calc.utils.get_model_info", return_value=model_info):
    prompt_cost, _ = generic_cost_per_token(model="m", usage=usage, custom_llm_provider="p")
print("per-token:", prompt_cost / usage.prompt_tokens)
```

Before this change the per-token cost prints `5e-06` (the 90k tier). After this change it prints `9e-06` (the 128k tier the request actually crosses).

The same scenario is locked in as a regression test in `tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py::test_generic_cost_per_token_bills_highest_crossed_tier`, which fails on the old lexicographic sort and passes on the numeric sort.

## Type

🐛 Bug Fix

## Changes

`_get_token_base_cost` selected the tier by iterating `sorted(threshold_keys, reverse=True)`, a lexicographic sort on the raw key strings. When two tiers have thresholds of different digit length the string order diverges from the numeric order, so `input_cost_per_token_above_90k_tokens` sorts after `input_cost_per_token_above_128k_tokens` (because `9` > `1`). The loop applies the first crossed tier and breaks, so a request that crosses both is billed at the lower 90k tier instead of the 128k tier it actually crosses.

The threshold keys are now sorted by their parsed numeric threshold via a small `_parse_above_tokens_threshold` helper, which is reused by the in-loop parse so the threshold formula lives in one place. This is latent on the bundled model map today (its surviving input tiers are 128k/200k/272k/512k, all three or more digits, which happen to sort correctly) but becomes reachable through a custom-registered model or any future map entry whose tiers differ in digit length
