### PR TITLE
fix(cost): select highest crossed token tier by numeric threshold

### DIFF
--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -191,6 +191,16 @@ def _get_service_tier_cost_key(base_key: str, service_tier: Optional[str]) -> st
     return base_key
 
 
+def _parse_above_threshold_tokens(key: str) -> Optional[float]:
+    try:
+        threshold_str = key.split("_above_")[1].split("_tokens")[0]
+        return float(threshold_str.replace("k", "")) * (
+            1000 if "k" in threshold_str else 1
+        )
+    except (IndexError, ValueError):
+        return None
+
+
 def _get_token_base_cost(
     model_info: ModelInfo, usage: Usage, service_tier: Optional[str] = None
 ) -> Tuple[float, float, float, float, float]:
@@ -254,18 +264,20 @@ def _get_token_base_cost(
             cache_read_cost,
         )
 
-    # Only sort the threshold keys (typically 1-2 keys instead of 66+)
+    # Sort by the parsed numeric threshold so the highest tier the request crosses
+    # wins; sorting the raw key strings ordered e.g. 90k after 128k.
     threshold: Optional[float] = None
-    for key in sorted(threshold_keys, reverse=True):
+    for key in sorted(
+        threshold_keys,
+        key=lambda k: _parse_above_threshold_tokens(k) or float("-inf"),
+        reverse=True,
+    ):
         value = model_info.get(key)
         if value is not None:
             try:
-                # Handle both formats: _above_128k_tokens and _above_128_tokens
                 threshold_str = key.split("_above_")[1].split("_tokens")[0]
-                threshold = float(threshold_str.replace("k", "")) * (
-                    1000 if "k" in threshold_str else 1
-                )
-                if usage.prompt_tokens > threshold:
+                threshold = _parse_above_threshold_tokens(key)
+                if threshold is not None and usage.prompt_tokens > threshold:
                     # Prefer a service_tier-specific above-threshold key when available,
                     # e.g. input_cost_per_token_priority_above_200k_tokens for Gemini
                     # ON_DEMAND_PRIORITY.  Falls back to the standard key automatically

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
@@ -1,6 +1,7 @@
 import json
 import os
 import sys
+from typing import cast
 
 import pytest
 from fastapi.testclient import TestClient
@@ -35,6 +36,7 @@ sys.path.insert(
 from litellm.litellm_core_utils.llm_cost_calc.utils import (
     PromptTokensDetailsResult,
     _calculate_input_cost,
+    _get_token_base_cost,
     calculate_cache_writing_cost,
     generic_cost_per_token,
 )
@@ -361,6 +363,32 @@ def test_generic_cost_per_token_minimax_m3_above_512k_tokens():
     )
     assert round(prompt_cost, 10) == round(expected_prompt, 10)
     assert round(completion_cost, 10) == round(expected_completion, 10)
+
+
+def test_get_token_base_cost_selects_highest_crossed_tier():
+    """A request crossing both the 90k and 128k tiers must bill at the higher 128k
+    tier. Tier selection sorted the threshold keys lexicographically, so "90k" sorted
+    after "128k" and the lower 90k tier was wrongly applied."""
+    model_info = cast(
+        ModelInfo,
+        {
+            "input_cost_per_token": 1e-6,
+            "input_cost_per_token_above_90k_tokens": 2e-6,
+            "input_cost_per_token_above_128k_tokens": 3e-6,
+        },
+    )
+
+    def prompt_cost(prompt_tokens: int) -> float:
+        usage = Usage(
+            prompt_tokens=prompt_tokens,
+            completion_tokens=0,
+            total_tokens=prompt_tokens,
+        )
+        return _get_token_base_cost(model_info, usage)[0]
+
+    assert prompt_cost(150000) == 3e-6
+    assert prompt_cost(100000) == 2e-6
+    assert prompt_cost(50000) == 1e-6
 
 
 def test_generic_cost_per_token_gpt55():


### PR DESCRIPTION
## Relevant issues

Fixes #30345

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

This is a cost-calculation bug that is latent on the bundled model map: the only shipped thresholds (128k, 200k, 272k) are all three digits, so they happen to sort correctly as strings. It becomes reachable through custom model pricing that mixes tier widths, for example a model defining both `input_cost_per_token_above_90k_tokens` and `input_cost_per_token_above_128k_tokens`, so there is no real provider request that exercises it today.

The added regression test reproduces it directly against `_get_token_base_cost`. Before the fix, a 150k-token request asserts `2e-06 == 3e-06` and fails because it picks the lower 90k tier; after the fix it bills the 128k tier. Run it with:

```
pytest tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py::test_get_token_base_cost_selects_highest_crossed_tier
```

## Type

🐛 Bug Fix

## Changes

`_get_token_base_cost` chose which tiered price to apply by iterating `sorted(threshold_keys, reverse=True)`, which sorts the raw key strings lexicographically rather than by the numeric token threshold they encode. When two tiers have different digit lengths the string order diverges from the numeric order, so `input_cost_per_token_above_90k_tokens` sorts after `input_cost_per_token_above_128k_tokens`; a request crossing both boundaries then stops at the 90k tier and is billed below the highest tier it actually crosses.

The fix extracts the existing inline threshold parsing into `_parse_above_threshold_tokens` and sorts the keys by that parsed numeric value, so the highest crossed tier is selected. Malformed keys parse to `None` and sort last, preserving the existing skip behavior.
