### PR TITLE
fix(spend): treat None token and request counts as 0 when aggregating daily spend

### DIFF
--- a/litellm/proxy/db/db_transaction_queue/daily_spend_update_queue.py
+++ b/litellm/proxy/db/db_transaction_queue/daily_spend_update_queue.py
@@ -115,15 +115,24 @@ class DailySpendUpdateQueue(BaseUpdateQueue):
                 if _key in aggregated_daily_spend_update_transactions:
                     daily_transaction = aggregated_daily_spend_update_transactions[_key]
                     daily_transaction["spend"] += payload["spend"]
-                    daily_transaction["prompt_tokens"] += payload["prompt_tokens"]
-                    daily_transaction["completion_tokens"] += payload[
-                        "completion_tokens"
-                    ]
-                    daily_transaction["api_requests"] += payload["api_requests"]
-                    daily_transaction["successful_requests"] += payload[
-                        "successful_requests"
-                    ]
-                    daily_transaction["failed_requests"] += payload["failed_requests"]
+                    # Token and request counts can be None when a provider (e.g.
+                    # some embedding backends) reports usage without them, so
+                    # coerce None to 0 the same way the cache-token fields below do.
+                    daily_transaction["prompt_tokens"] = (
+                        daily_transaction["prompt_tokens"] or 0
+                    ) + (payload["prompt_tokens"] or 0)
+                    daily_transaction["completion_tokens"] = (
+                        daily_transaction["completion_tokens"] or 0
+                    ) + (payload["completion_tokens"] or 0)
+                    daily_transaction["api_requests"] = (
+                        daily_transaction["api_requests"] or 0
+                    ) + (payload["api_requests"] or 0)
+                    daily_transaction["successful_requests"] = (
+                        daily_transaction["successful_requests"] or 0
+                    ) + (payload["successful_requests"] or 0)
+                    daily_transaction["failed_requests"] = (
+                        daily_transaction["failed_requests"] or 0
+                    ) + (payload["failed_requests"] or 0)
 
                     # Add optional metrics cache_read_input_tokens and cache_creation_input_tokens
                     daily_transaction["cache_read_input_tokens"] = (

--- a/tests/test_litellm/proxy/db/db_transaction_queue/test_daily_spend_update_queue.py
+++ b/tests/test_litellm/proxy/db/db_transaction_queue/test_daily_spend_update_queue.py
@@ -221,6 +221,61 @@ async def test_get_aggregated_daily_spend_update_transactions_same_key():
 
 
 @pytest.mark.asyncio
+async def test_get_aggregated_daily_spend_update_transactions_none_token_fields():
+    """Regression for #30307.
+
+    Some providers (e.g. certain embedding backends) report usage with the token
+    and request counts as None. Aggregating two such transactions under the same
+    key used to raise "unsupported operand type(s) for +=: 'NoneType' and
+    'NoneType'", which dropped the entire flush tick. None counts must be treated
+    as 0, the same way the cache-token fields already are.
+    """
+    test_key = "user1_2023-01-01_key123_jina-embeddings-v4_openai"
+    none_transaction1 = {
+        "spend": 0.0,
+        "prompt_tokens": None,
+        "completion_tokens": None,
+        "api_requests": None,
+        "successful_requests": None,
+        "failed_requests": None,
+    }
+    none_transaction2 = {
+        "spend": 0.0,
+        "prompt_tokens": None,
+        "completion_tokens": None,
+        "api_requests": None,
+        "successful_requests": None,
+        "failed_requests": None,
+    }
+    real_transaction = {
+        "spend": 1.0,
+        "prompt_tokens": 100,
+        "completion_tokens": 50,
+        "api_requests": 1,
+        "successful_requests": 1,
+        "failed_requests": 0,
+    }
+
+    updates = [
+        {test_key: none_transaction1},
+        {test_key: none_transaction2},
+        {test_key: real_transaction},
+    ]
+
+    result = DailySpendUpdateQueue.get_aggregated_daily_spend_update_transactions(
+        updates
+    )
+
+    agg = result[test_key]
+    assert agg["spend"] == 1.0
+    assert agg["prompt_tokens"] == 100
+    assert agg["completion_tokens"] == 50
+    assert agg["api_requests"] == 1
+    assert agg["successful_requests"] == 1
+    assert agg["failed_requests"] == 0
+
+
+@pytest.mark.asyncio
 async def test_flush_and_get_aggregated_daily_spend_update_transactions(
     daily_spend_update_queue,
 ):

--- a/tests/test_litellm/proxy/db/db_transaction_queue/test_daily_spend_update_queue.py
+++ b/tests/test_litellm/proxy/db/db_transaction_queue/test_daily_spend_update_queue.py
@@ -220,8 +220,7 @@ async def test_get_aggregated_daily_spend_update_transactions_same_key():
     assert result[test_key] == expected_transaction
 
 
-@pytest.mark.asyncio
-async def test_get_aggregated_daily_spend_update_transactions_none_token_fields():
+def test_get_aggregated_daily_spend_update_transactions_none_token_fields():
     """Regression for #30307.
 
     Some providers (e.g. certain embedding backends) report usage with the token


### PR DESCRIPTION
## Relevant issues

Fixes #30307

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

The crash is in the in-memory aggregation, so it reproduces without a database or any provider call. Two same-key transactions whose token and request counts are None (as some embedding backends report) are aggregated:

```python
from litellm.proxy.db.db_transaction_queue.daily_spend_update_queue import DailySpendUpdateQueue

key = "user1_2023-01-01_key123_jina-embeddings-v4_openai"
none_txn = {"spend": 0.0, "prompt_tokens": None, "completion_tokens": None,
            "api_requests": None, "successful_requests": None, "failed_requests": None}
real_txn = {"spend": 1.0, "prompt_tokens": 100, "completion_tokens": 50,
            "api_requests": 1, "successful_requests": 1, "failed_requests": 0}

agg = DailySpendUpdateQueue.get_aggregated_daily_spend_update_transactions(
    [{key: none_txn}, {key: dict(none_txn)}, {key: real_txn}]
)
print(agg[key]["prompt_tokens"])
```

Before this change the call raises `TypeError: unsupported operand type(s) for +=: 'NoneType' and 'NoneType'`, so the whole flush tick is dropped. After this change it returns the aggregated transaction and prints `100`.

A regression test covering this exact scenario is added at `tests/test_litellm/proxy/db/db_transaction_queue/test_daily_spend_update_queue.py::test_get_aggregated_daily_spend_update_transactions_none_token_fields`; it raises on the old code and passes on the fix.

## Type

🐛 Bug Fix

## Changes

`get_aggregated_daily_spend_update_transactions` merged same-key transactions with a bare `+=` on `prompt_tokens`, `completion_tokens`, `api_requests`, `successful_requests` and `failed_requests`. When a provider reports usage without those counts they arrive as None, and the deepcopy of the first such payload stores None in the accumulator, so the next same-key merge does `None += None` and raises. The entire APScheduler flush tick is then lost, so spend for every queued transaction in that tick goes unrecorded.

Both operands are now coerced from None to 0, matching the null-guard the `cache_read_input_tokens` and `cache_creation_input_tokens` fields in the same method already use. `spend` is left as a bare `+=` because it is a computed float that is always populated on this write path
