### PR TITLE
Translation v2 wave-3: ollama_chat, github_copilot, databricks (the final outbound providers)

### DIFF
--- a/litellm/translation/CLAUDE.md
+++ b/litellm/translation/CLAUDE.md
@@ -47,13 +47,22 @@ translation/
 │       │                #   seen-tool-calls stop->tool_calls rewrite ride
 │       │                #   StreamState); the ollama_chat dialect splits one
 │       │                #   NDJSON wire chunk into delta + finish + usage
-│       │                #   bodies (started/finished_reasoning ride
-│       │                #   StreamState; the pure body builders live in
-│       │                #   ollama_fold.py to keep this file under the cap)
-│       └── ollama_fold.py # the ollama NDJSON wire fold: the two-flag
-│                        #   think-tag machine (only the tag-bearing chunk is
-│                        #   reasoning — v1's truncation bug) + the delta/
-│                        #   finish/usage body builders, pure over primitives
+│       │                #   bodies, the databricks dialect folds ONE chunk ->
+│       │                #   ONE body (usage dropped, DB-R5) — both keep their
+│       │                #   pure body builders in *_fold.py siblings.
+│       │                #   HEADROOM: this file is at 711/720 — the NEXT
+│       │                #   inbound dialect arm MUST extract its fold to a new
+│       │                #   sibling *_fold.py (the ollama/databricks
+│       │                #   precedent), never grow stream.py past the cap
+│       ├── ollama_fold.py # the ollama NDJSON wire fold: the two-flag
+│       │                #   think-tag machine (only the tag-bearing chunk is
+│       │                #   reasoning — v1's truncation bug) + the delta/
+│       │                #   finish/usage body builders, pure over primitives
+│       └── databricks_fold.py # the databricks chunk fold: content-list
+│                        #   flatten, reasoning/summary -> reasoning_content +
+│                        #   thinking_blocks, citations lift, {} -> "" args,
+│                        #   the stateful json_mode json_tool_call -> content
+│                        #   byte-reformat (DB-R8); usage never carried (DB-R5)
 ├── providers/      # one subpackage per wire format. Pure, no I/O
 │   ├── anthropic/
 │   │   ├── serialize.py # body assembly in v1 transform_request order

--- a/litellm/translation/CLAUDE.md
+++ b/litellm/translation/CLAUDE.md
@@ -530,6 +530,29 @@ translation/
 │   │                    #   finish + usage-tail bodies; the think-tag machine
 │   │                    #   and body builders live in
 │   │                    #   inbound/openai_chat/ollama_fold.py)
+│   ├── github_copilot/  # wave-3 own module: the SDK-path openai-compat
+│   │   │                #   provider (the big openai elif). The serializer is
+│   │   │                #   openai_compat.assemble_body + ONE delta: the
+│   │   │                #   system->assistant role rewrite (every system
+│   │   │                #   message; gated OFF by the ambient
+│   │   │                #   litellm.disable_copilot_system_to_assistant flag
+│   │   │                #   threaded through deps). Construction arm "openai"
+│   │   │                #   with the seam re-prefix github_copilot/{wire_model}
+│   │   │                #   (the compat_sdk seam arm). No stream.py: chunks
+│   │   │                #   ride the default openai dialect (no v1 iterator).
+│   │   │                #   The codex family bridges to the Responses API
+│   │   │                #   ABOVE the chat seam and never reaches here
+│   │   ├── guard.py     # explicit stream:false + the shared openai guard
+│   │   │                #   (FULL message-name fallback: the base transform
+│   │   │                #   forwards names and the rewrite preserves them)
+│   │   ├── params.py    # the shared openai_compat gates verbatim (gpt-5 /
+│   │   │                #   o-series families fail closed; claude thinking/
+│   │   │                #   reasoning_effort RAISE — DEAD params at HEAD;
+│   │   │                #   user falls back; response_format name gate)
+│   │   ├── serialize.py # assemble_body + the system->assistant rewrite
+│   │   └── response.py  # re-export of the shared openai parser (the SDK
+│   │                    #   LIVE normalizer convert_to_model_response_object;
+│   │                    #   transform_response is DEAD on this path)
 │   ├── openrouter/      # wave-2b-alpha own module (httpx dedicated elif
 │   │   │                #   main.py:3354, transforms LIVE, bare wire model)
 │   │   ├── guard.py     # explicit stream:false + the cache-capable-model
@@ -783,7 +806,7 @@ A behavior change ships as its own snapshot-diffed PR, never inside a port.
 
 ## Current scope
 
-OpenAI-chat-in to seventy-eight providers out — `anthropic`,
+OpenAI-chat-in to seventy-nine providers out — `anthropic`,
 `bedrock_converse`, `bedrock_invoke`, `openai_compat`, `vertex_ai` (gemini
 route), `gemini` (AI Studio), `vertex_anthropic`, `azure`, `azure_ai`,
 `azure_ai_anthropic`, `xai`, the thirteen wave-1a compat_sdk providers
@@ -803,9 +826,12 @@ path, `cometapi` on the httpx path), and the wave-2b-alpha own modules
 (`deepseek`, `openrouter`, `hosted_vllm`, `fireworks_ai`, `snowflake`,
 `huggingface` on its api_base route), the wave-2b-beta own modules
 (`cohere`/`cohere_chat` (one module), `mistral`, `watsonx`,
-`sagemaker_chat`, `groq`), and the wave-3 own module `ollama_chat` (the
+`sagemaker_chat`, `groq`), and the wave-3 own modules `ollama_chat` (the
 `/api/chat` NDJSON wire — the legacy `ollama` `/api/generate` prefix stays
-a v1 fallback by absence) — request, response, and stream
+a v1 fallback by absence) and `github_copilot` (the SDK-path openai-compat
+provider with the system->assistant role rewrite; the codex family bridges
+to the Responses API above the chat seam and stays v1 by absence) —
+request, response, and stream
 translation,
 differential-green (anthropic: 46-shape corpus + responses + stream
 replays; bedrock and google: the characterization corpus per route + quirk
@@ -1405,6 +1431,49 @@ state into optional_params (main.py:2338-2344) — ambient module state v2
 cannot see, so the fork MUST fall back to v1 when that config is
 non-empty (the ambient-globals rule: vertex_ai_safety_settings/
 custom_prompt_dict precedent).
+Deliberate wave-3 github_copilot fallback surfaces (providers/github_copilot;
+each names the v1 path): the gpt-5 and o-series model families (v1's
+OpenAIGPT5Config/OpenAIOSeriesConfig own their param rewrites — temperature!=1
+RAISES on gpt-5, probed; the shared openai_compat family gate falls back on
+the whole family); ``thinking`` and ``reasoning_effort`` on claude models (v1
+RAISES UnsupportedParamsError — the config's claude thinking/reasoning_effort
+additions are DEAD at HEAD because the ``supports_reasoning`` map keys are
+absent, researcher-5 correction 3, probed; if upstream adds bare-claude
+model_cost entries the gate flips ON ambiently — the differential RAISE rows
+keep the drift loud); ``user`` (model-list gated upstream — v1 SERVES it for
+gpt-4o and silently DROPS it for claude, both probed; the shared gate falls
+back on user for every model because the open_ai_chat_completion_models
+membership is ambient state v2 does not read, so v1 keeps serving the served
+case and reproduces the drop on the other); ``top_k`` (not an openai chat
+param); ``response_format`` on a model literally named gpt-4/gpt-3.5-turbo-16k
+(the base-list name gate — copilot endpoint names are bare so the corner is
+reachable); explicit stream:false (the SDK serializes the key); message
+``name`` and every other openai-guard raw shape (the base transform forwards
+names; the system->assistant rewrite is a message.copy() that preserves every
+key, so a name would survive into the rewritten assistant message and the IR
+cannot carry it — the FULL name fallback); the parse-level unknowns
+(n/seed/penalties/logprobs/logit_bias/stream_options/web_search_options — v1
+serves them). SERVED, pinned IDENTICAL: the system->assistant role rewrite
+(EVERY system message's role -> assistant, content untouched, gated OFF when
+litellm.disable_copilot_system_to_assistant is True — both flag states probed
+two-sided), and the plain SDK body (no rename — assemble_body re-emits the
+caller's keys). github_copilot fork obligations (NOT wired; integrator scope):
+construction arm "openai" (the cdr normalizer + the seam re-prefix
+``github_copilot/{wire_model}`` exactly like the compat_sdk family — NOT a
+parser-side prefix; machine-readable in OWN_MODULE_RESPONSE_STYLES, wrong-arm
+divergence pinned in the response gate); the auth is ENVELOPE — the OAuth
+device-flow happens in validate_environment ABOVE the seam (the xai-OAuth
+rule; resolution is api_base arg > api-key.json endpoints.api >
+GITHUB_COPILOT_API_BASE > the default), so the fork must thread a RESOLVED
+token through the envelope and NEVER trigger the device flow (a bare
+capability read on a github_copilot/ key with no token cache does LIVE
+interactive OAuth — researcher-5 GC-R1; the differential tests seed
+GITHUB_COPILOT_TOKEN_DIR and a guard test asserts no path can reach it). The
+``x-request-id: uuid4()`` default header is nondeterministic envelope bytes
+(out of serializer scope); and EXPERIMENTAL_OPENAI_BASE_LLM_HTTP_HANDLER=true
+wakes the dormant validate_environment + anthropic-native transform_response
+(GC-R2) — a one-env-var dormancy flip the fork must keep on v1 until those
+surfaces are ported.
 Not yet here, each its own follow-up: streaming seams live; the other
 inbound schemas (`anthropic_messages`, `google_genai`, `responses`,
 `completions`); the same-family fast path (waits on the opaque-body

--- a/litellm/translation/CLAUDE.md
+++ b/litellm/translation/CLAUDE.md
@@ -366,6 +366,73 @@ translation/
 │   │                    #   the real wire sends ``type`` — both regimes
 │   │                    #   pinned (wrapper end-of-stream synthesis = seam
 │   │                    #   scope)
+│   ├── databricks/      # wave-3 own module, the LAST outbound provider
+│   │   │                #   (httpx dedicated elif main.py:3280, transforms
+│   │   │                #   LIVE, NO seam preset). openai-chat-shaped wire
+│   │   │                #   (transform_request is OpenAIGPTConfig's; the
+│   │   │                #   anthropic plane contributes pure param mappers
+│   │   │                #   only) with the ``"claude" in model`` SUBSTRING
+│   │   │                #   fork (DB-R1) driving tools/response_format/
+│   │   │                #   reasoning_effort. M2M token POST + WorkspaceClient
+│   │   │                #   URL synthesis are ENVELOPE (the watsonx-IAM rule).
+│   │   │                #   The fake_stream method is DEAD CODE at HEAD
+│   │   │                #   (canary). The claude-fork helpers + the thinking
+│   │   │                #   max-bump live in tools.py (the ollama_fold split)
+│   │   ├── guard.py     # the cache_control move arm (v1 MOVES message-level
+│   │   │                #   markers into a text block; a whitespace-only
+│   │   │                #   message LOSES the marker — a trap, fall back) +
+│   │   │                #   the whitespace-only string-content arm (v1's
+│   │   │                #   _sanitize_empty_content REMOVES the content key)
+│   │   │                #   + the shared openai guard with
+│   │   │                #   name_fallback_user_only (v1 KEEPS user names,
+│   │   │                #   strips assistant/tool == the IR drop); NO
+│   │   │                #   stream:false arm (the body always carries stream)
+│   │   ├── params.py    # the supported-list/serve-fallback split: SERVE
+│   │   │                #   non-claude tools verbatim, claude tools (the
+│   │   │                #   round-trip), thinking, non-claude reasoning_effort
+│   │   │                #   WITH max_tokens, top_k (DRIFT: researcher-5 said
+│   │   │                #   unsupported, the probe SERVES it). FALLBACK:
+│   │   │                #   parallel_tool_calls (UPE), user (silent drop),
+│   │   │                #   response_format on claude (DB-R2 json_object
+│   │   │                #   SILENT DROP + the json_tool_call machinery),
+│   │   │                #   reasoning_effort on claude (thinking machinery),
+│   │   │                #   reasoning_effort on non-claude WITHOUT max_tokens
+│   │   │                #   (DB-R3 raw KeyError crash)
+│   │   ├── serialize.py # {model, messages, stream-always, **mapped}: mct
+│   │   │                #   ALWAYS -> max_tokens, the thinking max-bump
+│   │   │                #   (budget + DEFAULT_MAX_TOKENS when no caller max),
+│   │   │                #   top_k verbatim top-level, tools (claude round-trip
+│   │   │                #   / non-claude verbatim), tool_choice, response_format
+│   │   │                #   verbatim (non-claude), reasoning_effort verbatim
+│   │   │                #   (non-claude + max_tokens)
+│   │   ├── tools.py     # the claude tool round-trip (openai -> anthropic ->
+│   │   │                #   databricks: DROPS function-level strict/$schema/
+│   │   │                #   cache_control via the AnthropicInputSchema
+│   │   │                #   allowed-keys filter, KEEPS additionalProperties,
+│   │   │                #   normalizes empty params; $ref/$defs fall back) +
+│   │   │                #   thinking_max_tokens (the budget+4096 bump)
+│   │   ├── response.py  # the OWN parser (the cohere/ollama_chat shape): the
+│   │   │                #   normalized body on ChatResponse.wire with the
+│   │   │                #   databricks/{wire model} prefix INSIDE the parser
+│   │   │                #   (DB-R7: v1's prefix is litellm_params.custom_llm_
+│   │   │                #   provider, default "databricks" — fork obligation),
+│   │   │                #   block-list flatten, reasoning/summary -> reasoning_
+│   │   │                #   content + thinking_blocks, citations + supported_
+│   │   │                #   text, UNKNOWN keys DROPPED; construction arm
+│   │   │                #   "openai"; a missing required key is a raw v1
+│   │   │                #   KeyError (drift from researcher-5's
+│   │   │                #   DatabricksException claim — the TypedDict does not
+│   │   │                #   validate)
+│   │   └── stream.py    # the SSE line seam -> the inbound "databricks" chunk
+│   │                    #   dialect (one wire chunk -> ONE body, NO split):
+│   │                    #   usage DROPPED (DB-R5), "{}" args -> "", content-
+│   │                    #   list flatten + citation lift, and the STATEFUL
+│   │                    #   json_mode tool->content byte-reformat (DB-R8,
+│   │                    #   _last_function_name rides StreamState; json_mode
+│   │                    #   is a request-side fallback so the arm is dormant
+│   │                    #   from v2's flow, pinned by the REAL-iterator
+│   │                    #   replay). The fold lives in inbound/openai_chat/
+│   │                    #   databricks_fold.py
 │   ├── deepseek/        # wave-2b-alpha own module (httpx dedicated elif
 │   │   │                #   main.py:1942, transforms LIVE, bare wire model)
 │   │   ├── guard.py     # explicit stream:false + the shared openai guard
@@ -806,7 +873,7 @@ A behavior change ships as its own snapshot-diffed PR, never inside a port.
 
 ## Current scope
 
-OpenAI-chat-in to seventy-nine providers out — `anthropic`,
+OpenAI-chat-in to eighty providers out — `anthropic`,
 `bedrock_converse`, `bedrock_invoke`, `openai_compat`, `vertex_ai` (gemini
 route), `gemini` (AI Studio), `vertex_anthropic`, `azure`, `azure_ai`,
 `azure_ai_anthropic`, `xai`, the thirteen wave-1a compat_sdk providers
@@ -828,9 +895,13 @@ path, `cometapi` on the httpx path), and the wave-2b-alpha own modules
 (`cohere`/`cohere_chat` (one module), `mistral`, `watsonx`,
 `sagemaker_chat`, `groq`), and the wave-3 own modules `ollama_chat` (the
 `/api/chat` NDJSON wire — the legacy `ollama` `/api/generate` prefix stays
-a v1 fallback by absence) and `github_copilot` (the SDK-path openai-compat
+a v1 fallback by absence), `github_copilot` (the SDK-path openai-compat
 provider with the system->assistant role rewrite; the codex family bridges
-to the Responses API above the chat seam and stays v1 by absence) —
+to the Responses API above the chat seam and stays v1 by absence), and
+`databricks` (the LAST outbound provider: openai-chat-shaped wire with the
+`"claude" in model` SUBSTRING fork over tools/response_format/
+reasoning_effort, its own response parser and its own NDJSON-style chunk
+dialect — usage DROPPED, json_mode byte-reformat) —
 request, response, and stream
 translation,
 differential-green (anthropic: 46-shape corpus + responses + stream
@@ -1474,6 +1545,99 @@ GITHUB_COPILOT_TOKEN_DIR and a guard test asserts no path can reach it). The
 wakes the dormant validate_environment + anthropic-native transform_response
 (GC-R2) — a one-env-var dormancy flip the fork must keep on v1 until those
 surfaces are ported.
+Deliberate wave-3 databricks fallback surfaces (providers/databricks, the
+LAST outbound provider; each names the v1 path). The CENTRAL structural fact
+is the ``"claude" in model`` SUBSTRING fork (DB-R1, ``params.is_claude``) — a
+user-named serving endpoint carrying the substring (``my-claude-proxy-llama``,
+probed) gets anthropic param treatment; the gate uses the SAME substring,
+never a model-map lookup, so every differential row is parameterized
+claude × non-claude. FALLBACK (v1 RAISES): ``parallel_tool_calls`` (the
+supported list omits it -> UnsupportedParamsError); ``reasoning_effort`` on a
+NON-claude model WITHOUT max_tokens/max_completion_tokens (DB-R3: v1 CRASHES
+with a raw ``KeyError('thinking')`` in
+update_optional_params_with_thinking_tokens, NOT a typed UPE — the row asserts
+v1 raises KeyError so an upstream fix turns it red). FALLBACK (v1 SERVES, the
+machinery is unported): ``response_format`` on a claude-substring model — v1
+routes json_schema through the json_tool_call tool + json_mode + forced
+tool_choice (tool_choice OMITTED when thinking is enabled, probed) and
+SILENTLY DROPS ``{"type":"json_object"}`` ENTIRELY (DB-R2, probed: the
+anthropic mapper returns None and the unconditional pop runs — nothing on the
+wire), the cross-plane json_mode state spanning request/response/stream;
+``reasoning_effort`` on a claude-substring model (v1 maps it to
+thinking{enabled,budget} via AnthropicConfig._map_reasoning_effort —
+low->1024, high->4096, none->popped clean, probed — plus the adaptive
+thinking{type:adaptive} + output_config{effort} arm on the name-predicate
+``_is_adaptive_thinking_model`` opus-4-6 names, traffic-dormant since no such
+model_cost key exists at HEAD); ``cache_control`` on ANY message or tool (v1
+MOVES message-level markers into a text block and a whitespace-only message
+LOSES the marker with the sanitized block — a lossy interaction, guard-side);
+empty/whitespace-only string message content (v1's ``_sanitize_empty_content``
+REMOVES the content key -> a bare ``{role}``, guard-side, the openai guard
+only catches None); USER message ``name`` (v1 KEEPS it via
+``strip_name_from_message(allowed_name_roles=["user"])`` while assistant/tool
+names are STRIPPED == the IR drop -> the name_fallback_user_only arm);
+``user`` (silently dropped upstream, model-list gated — v1 serves its own
+drop); legacy ``$ref``/``$defs`` in a claude tool's parameters (v1 inlines via
+unpack_legacy_defs before the anthropic schema filter — unported, the
+fireworks precedent); and the openai-guard raw shapes + parse-level unknowns
+(n is SERVED by v1's list but is a parse-level unknown; seed/frequency_penalty/
+presence_penalty/logprobs all RAISE in v1's _check_valid_arg, served as
+fallbacks). SERVED, pinned IDENTICAL (claude AND non-claude arms): plain chat;
+temperature/top_p/stop; ``mct -> max_tokens`` ALWAYS (v1 never re-emits
+max_completion_tokens — contrast the openai_compat re-emit); the thinking
+max-bump (``budget_tokens + DEFAULT_MAX_TOKENS`` ONLY when thinking carries a
+budget and the caller gave no max_tokens, probed 2048->6144; a caller max is
+never adjusted, a budget-less thinking dict triggers no bump); ``top_k``
+verbatim TOP-LEVEL (DRIFT: researcher-5 ranked it unsupported; the HEAD probe
+REFUTES it — v1 serves it on the wire both arms); tools on NON-claude verbatim
+(strict/$schema/cache_control KEPT); tools on claude via the round-trip
+(openai -> anthropic -> databricks DROPS function-level strict/$schema/
+cache_control through the ``AnthropicInputSchema`` allowed-keys filter, KEEPS
+additionalProperties, normalizes empty parameters to
+``{"type":"object","properties":{}}``, repositions a present empty description
+AFTER parameters — all probed); tool_choice; ``thinking`` passthrough as
+``{type:enabled[,budget_tokens]}``; ``reasoning_effort`` verbatim on NON-claude
+WITH max_tokens (one line); ``response_format`` verbatim on NON-claude
+(json_object AND json_schema). The ``stream`` key ALWAYS materializes (default
+False) so explicit-false == absent (NO guard arm — the snowflake shape). The
+RESPONSE parser builds v1's normalized body itself (construction arm "openai",
+the cohere/ollama_chat fresh-ModelResponse shape): ``databricks/{wire model}``
+prefix INSIDE the parser (DB-R7: v1's prefix is
+``litellm_params.custom_llm_provider or "databricks"`` — a custom provider
+riding the databricks config keeps its OWN prefix; the dispatch name is
+"databricks", so the literal is correct and the override is a FORK
+OBLIGATION), content block-list flattened to a joined string, reasoning/summary
+blocks -> reasoning_content + thinking_blocks (missing signature -> ""),
+citations -> provider_specific_fields.citations with a supported_text mirror,
+UNKNOWN top-level keys DROPPED (only id/created/model/usage/choices survive;
+the wire's ``object``/``system_fingerprint`` values are NOT carried — probed),
+and a missing required key is a RAW v1 ``KeyError`` (DRIFT from researcher-5's
+"DatabricksException" claim: the ``DatabricksResponse(**json)`` TypedDict does
+NOT validate — pinned as a v1-raise fallback row). The STREAM rides the OWN
+"databricks" chunk dialect (one wire chunk -> ONE ModelResponseStream body, NO
+split): the wire ``usage`` is DROPPED ENTIRELY (DB-R5 — the seam must NOT
+attach a parsed usage tail), ``{}`` tool arguments -> ``""``, a content LIST
+flattens to a string + reasoning/thinking blocks, a first-item ``citations``
+list lifts to ``provider_specific_fields.citation = citations[0]``, and the
+STATEFUL json_mode machine (``_last_function_name`` rides
+``StreamState.last_function_name``) folds a json_tool_call tool delta to
+content with the json.loads+dumps byte REFORMAT (DB-R8: ``{"a":1}`` ->
+``{"a": 1}``, byte-compared not JSON-compared); json_mode is a request-side
+fallback so the arm is dormant from v2's own flow, pinned by the
+REAL-iterator replay with json_mode=True. ``_should_fake_stream`` is DEAD CODE
+at HEAD (DB-R4, verified: only groq's two sites call its own
+``_should_fake_stream``; nothing sets databricks ``fake_stream`` and databricks
+is NOT in openai_compatible_providers) — a canary asserts it so an upstream
+wire-up turns the streaming behavior loud. databricks fork obligations (NOT
+wired; integrator scope): construction arm "openai" (machine-readable in
+``OWN_MODULE_RESPONSE_STYLES``, wrong-arm divergence pinned in the response
+gate), NO seam preset (the parser owns the databricks/{wire} prefix), the
+streaming seam folds providers/databricks.parse_line with the "databricks"
+chunk dialect (the json_mode flag rides StreamState), and the M2M OAuth token
+POST (per request, uncached, at validate_environment time) + the
+WorkspaceClient URL synthesis are ENVELOPE (the watsonx-IAM rule: serialize/
+parse never touch them; a request with api_base=None AND no env hits v1's
+WorkspaceClient ambient-auth arm -> typed fallback, DB-R6).
 Not yet here, each its own follow-up: streaming seams live; the other
 inbound schemas (`anthropic_messages`, `google_genai`, `responses`,
 `completions`); the same-family fast path (waits on the opaque-body

--- a/litellm/translation/CLAUDE.md
+++ b/litellm/translation/CLAUDE.md
@@ -40,12 +40,20 @@ translation/
 │       │                #   ResponseDialect (anthropic | bedrock_converse |
 │       │                #   gemini) because v1's outbound shapes are
 │       │                #   per-provider
-│       └── stream.py    # IR stream events -> chunk bodies (pure fold); same
-│                        #   dialect idea via ChunkDialect on StreamState;
-│                        #   the gemini dialect consumes composite chunk
-│                        #   events (cumulative tool index + the
-│                        #   seen-tool-calls stop->tool_calls rewrite ride
-│                        #   StreamState)
+│       ├── stream.py    # IR stream events -> chunk bodies (pure fold); same
+│       │                #   dialect idea via ChunkDialect on StreamState;
+│       │                #   the gemini dialect consumes composite chunk
+│       │                #   events (cumulative tool index + the
+│       │                #   seen-tool-calls stop->tool_calls rewrite ride
+│       │                #   StreamState); the ollama_chat dialect splits one
+│       │                #   NDJSON wire chunk into delta + finish + usage
+│       │                #   bodies (started/finished_reasoning ride
+│       │                #   StreamState; the pure body builders live in
+│       │                #   ollama_fold.py to keep this file under the cap)
+│       └── ollama_fold.py # the ollama NDJSON wire fold: the two-flag
+│                        #   think-tag machine (only the tag-bearing chunk is
+│                        #   reasoning — v1's truncation bug) + the delta/
+│                        #   finish/usage body builders, pure over primitives
 ├── providers/      # one subpackage per wire format. Pure, no I/O
 │   ├── anthropic/
 │   │   ├── serialize.py # body assembly in v1 transform_request order
@@ -491,6 +499,37 @@ translation/
 │   │                    #   httpx_chunk factory (reasoning="rename" + the
 │   │                    #   passthrough_delta_keys axis admitting
 │   │                    #   thinking_blocks); "xai" chunk dialect
+│   ├── ollama_chat/     # wave-3 own module: the ollama /api/chat NDJSON
+│   │   │                #   wire (its OWN stream dialect — usage rides every
+│   │   │                #   chunk, incompatible with the httpx_chunk factory;
+│   │   │                #   bare wire model; legacy "ollama" /api/generate
+│   │   │                #   prefix stays a v1 fallback by absence)
+│   │   ├── guard.py     # the shared openai guard with skip_name_fallback
+│   │   │                #   (v1's munge whitelist drops every message name);
+│   │   │                #   NO stream:false arm (the body always carries
+│   │   │                #   stream, default false — absent == explicit false)
+│   │   ├── params.py    # the OllamaChatConfig supported list as typed
+│   │   │                #   fallbacks (parallel_tool_calls/thinking raise,
+│   │   │                #   user silent-drop, tool cache_control); top_k
+│   │   │                #   SERVED via the provider-native options passthrough
+│   │   ├── serialize.py # {model, messages, options, stream} + top-level
+│   │   │                #   format/tools/think; the message munge mirrors
+│   │   │                #   v1's whitelist (content ALWAYS a string, the
+│   │   │                #   <think>/<thinking>/<budget:thinking> regex emits
+│   │   │                #   `thinking` while content keeps the FULL tagged
+│   │   │                #   string, images base64-stripped, tool_calls ->
+│   │   │                #   {function:{name,arguments:<json.loads>}} with a
+│   │   │                #   blank-arg fallback, name dropped); reasoning_effort
+│   │   │                #   -> think (verbatim for gpt-oss*, else the bool)
+│   │   ├── response.py  # mirrors transform_response (the ollama_chat/{REQUEST
+│   │   │                #   model} prefix is parser scope; construction arm
+│   │   │                #   "openai" — fresh-ModelResponse mutation, the
+│   │   │                #   cohere shape, ambient chatcmpl id kept)
+│   │   └── stream.py    # the NDJSON wire decode -> the inbound "ollama_chat"
+│   │                    #   chunk dialect (one wire chunk splits into delta +
+│   │                    #   finish + usage-tail bodies; the think-tag machine
+│   │                    #   and body builders live in
+│   │                    #   inbound/openai_chat/ollama_fold.py)
 │   ├── openrouter/      # wave-2b-alpha own module (httpx dedicated elif
 │   │   │                #   main.py:3354, transforms LIVE, bare wire model)
 │   │   ├── guard.py     # explicit stream:false + the cache-capable-model
@@ -744,7 +783,7 @@ A behavior change ships as its own snapshot-diffed PR, never inside a port.
 
 ## Current scope
 
-OpenAI-chat-in to seventy-seven providers out — `anthropic`,
+OpenAI-chat-in to seventy-eight providers out — `anthropic`,
 `bedrock_converse`, `bedrock_invoke`, `openai_compat`, `vertex_ai` (gemini
 route), `gemini` (AI Studio), `vertex_anthropic`, `azure`, `azure_ai`,
 `azure_ai_anthropic`, `xai`, the thirteen wave-1a compat_sdk providers
@@ -762,9 +801,11 @@ route), `gemini` (AI Studio), `vertex_anthropic`, `azure`, `azure_ai`,
 providers (`perplexity`, `sambanova`, `deepinfra`, `moonshot` on the SDK
 path, `cometapi` on the httpx path), and the wave-2b-alpha own modules
 (`deepseek`, `openrouter`, `hosted_vllm`, `fireworks_ai`, `snowflake`,
-`huggingface` on its api_base route), and the wave-2b-beta own modules
+`huggingface` on its api_base route), the wave-2b-beta own modules
 (`cohere`/`cohere_chat` (one module), `mistral`, `watsonx`,
-`sagemaker_chat`, `groq`) — request, response, and stream
+`sagemaker_chat`, `groq`), and the wave-3 own module `ollama_chat` (the
+`/api/chat` NDJSON wire — the legacy `ollama` `/api/generate` prefix stays
+a v1 fallback by absence) — request, response, and stream
 translation,
 differential-green (anthropic: 46-shape corpus + responses + stream
 replays; bedrock and google: the characterization corpus per route + quirk

--- a/litellm/translation/deps.py
+++ b/litellm/translation/deps.py
@@ -76,3 +76,10 @@ class TranslationDeps:
     """The deployment-space alternative to ``watsonx_project_id`` (same
     resolution chain, WATSONX_DEPLOYMENT_SPACE_ID/... env); v1 only injects
     it when the project id is absent."""
+    disable_copilot_system_to_assistant: bool = False
+    """wave-3 github_copilot: the ``litellm.disable_copilot_system_to_assistant``
+    global (default False) read once at the seam. When False (default) v1's
+    ``GithubCopilotConfig._transform_messages`` rewrites every system message's
+    role to ``assistant``; when True the messages ride unchanged. It is a plain
+    litellm module global, not a ``litellm.constants`` leaf, so it enters here
+    as a value like every other ambient flag."""

--- a/litellm/translation/dispatch.py
+++ b/litellm/translation/dispatch.py
@@ -159,6 +159,11 @@ Provider = Literal[
     # clamp on responses; the json_schema workaround/raise arms are typed
     # fallbacks, native-schema models serve verbatim).
     "groq",
+    # wave-3: ollama_chat (the /api/chat NDJSON wire; own module with its
+    # own chunk dialect). The legacy "ollama" prefix (/api/generate) stays
+    # a deliberate v1 fallback by ABSENCE (researcher-4/-5: no coercion
+    # exists between the two names; the prefix split is the whole truth).
+    "ollama_chat",
 ]
 
 NeverPortProvider = Literal[

--- a/litellm/translation/dispatch.py
+++ b/litellm/translation/dispatch.py
@@ -172,6 +172,17 @@ Provider = Literal[
     # the chat seam and never reaches here (canary-pinned). The OAuth
     # device-flow is envelope (validate_environment, above the seam).
     "github_copilot",
+    # wave-3: databricks (the LAST outbound provider; httpx dedicated elif
+    # main.py:3280 -> base_llm_http_handler, transforms LIVE, NO seam preset).
+    # The wire is openai-chat-shaped (transform_request is OpenAIGPTConfig's)
+    # but the "claude" in model SUBSTRING fork (DB-R1) drives tools /
+    # response_format / reasoning_effort. Its OWN response parser (block-list
+    # flatten, reasoning/citation extraction, databricks/{wire} prefix INSIDE
+    # the parser, unknown-keys-drop; construction arm "openai") and its OWN
+    # NDJSON-style chunk dialect (usage DROPPED, json_mode byte-reformat). M2M
+    # token POST + WorkspaceClient URL synthesis are envelope (the watsonx-IAM
+    # rule). The fake_stream method is DEAD CODE at HEAD (canary-pinned).
+    "databricks",
 ]
 
 NeverPortProvider = Literal[

--- a/litellm/translation/dispatch.py
+++ b/litellm/translation/dispatch.py
@@ -164,6 +164,14 @@ Provider = Literal[
     # a deliberate v1 fallback by ABSENCE (researcher-4/-5: no coercion
     # exists between the two names; the prefix split is the whole truth).
     "ollama_chat",
+    # wave-3: github_copilot (SDK path — the big openai elif; serializer is
+    # openai_compat assemble_body + the system->assistant role rewrite gated
+    # by the ambient disable flag through deps; construction arm "openai"
+    # with the seam re-prefix github_copilot/{wire_model}). The codex family
+    # (gpt-5.3-codex / gpt-5.1-codex-max) bridges to the Responses API ABOVE
+    # the chat seam and never reaches here (canary-pinned). The OAuth
+    # device-flow is envelope (validate_environment, above the seam).
+    "github_copilot",
 ]
 
 NeverPortProvider = Literal[

--- a/litellm/translation/engine/pipeline.py
+++ b/litellm/translation/engine/pipeline.py
@@ -64,6 +64,11 @@ from ..providers.compat_httpx import SERIALIZERS as compat_httpx_serializers
 from ..providers.compat_httpx.response import ResponseStyle
 from ..providers.compat_sdk import GUARDS as compat_sdk_guards
 from ..providers.compat_sdk import SERIALIZERS as compat_sdk_serializers
+from ..providers.databricks import parse_response as databricks_parse_response
+from ..providers.databricks import serialize_request as databricks_serialize_request
+from ..providers.databricks import (
+    unsupported_request_shapes as databricks_unsupported_request_shapes,
+)
 from ..providers.deepseek import parse_response as deepseek_parse_response
 from ..providers.deepseek import serialize_request as deepseek_serialize_request
 from ..providers.deepseek import (
@@ -210,6 +215,9 @@ _SERIALIZERS: Mapping[Provider, _Serializer] = MappingProxyType(
         # wave-3: github_copilot (SDK path — openai_compat assemble_body +
         # the system->assistant rewrite gated by the ambient disable flag).
         "github_copilot": github_copilot_serialize_request,
+        # wave-3: databricks (openai-shaped wire + the claude-substring fork
+        # over tools/response_format/reasoning_effort; its own body assembly).
+        "databricks": databricks_serialize_request,
     }
 )
 
@@ -290,6 +298,13 @@ _RESPONSE_PARSERS: Mapping[Provider, _ResponseParser] = MappingProxyType(
         # github_copilot/{wire_model} re-prefix as the seam's preset arm
         # (construction arm "openai", NOT parser scope — the compat_sdk shape).
         "github_copilot": github_copilot_parse_response,
+        # wave-3: the databricks parser builds the normalized body itself
+        # (block-list flatten, reasoning/citation extraction, unknown-keys
+        # drop) with the databricks/{wire model} prefix INSIDE the parser, and
+        # rides it on ChatResponse.wire; seam construction arm "openai" (fresh
+        # ModelResponse mutation, the cohere/ollama_chat shape). A malformed
+        # body raises a raw KeyError in v1 — pinned as a fallback row.
+        "databricks": databricks_parse_response,
     }
 )
 
@@ -343,6 +358,12 @@ OWN_MODULE_RESPONSE_STYLES: Mapping[Provider, ResponseStyle] = MappingProxyType(
         # seam re-prefix (the compat_sdk shape) — construction arm "openai";
         # wrong-arm pin in its response gate (the cohere no-id template).
         "github_copilot": "openai",
+        # wave-3: databricks mutates a fresh ModelResponse (the wire's own
+        # id/created copied, model = databricks/{wire}, unknown keys dropped)
+        # — the cdr arm; wrong-arm pin in its response gate (the fireworks/
+        # snowflake template: a verbatim wire index 5 the openai_like arm
+        # keeps and the cdr arm enumerate-rewrites to 0).
+        "databricks": "openai",
     }
 )
 
@@ -411,6 +432,11 @@ _RESPONSE_DIALECTS: Mapping[Provider, ResponseDialect] = MappingProxyType(
         # custom iterator exists in the provider; chunks ride the openai
         # dialect exactly like the compat_sdk family).
         "github_copilot": _OPENAI_DIALECT,
+        # wave-3: databricks — openai outbound body (the parser rides the
+        # normalized body on wire); the chunk-fold dialect is "databricks"
+        # (its own arm — usage DROPPED, json_mode byte-reformat — selected by
+        # the stream gates/future streaming seam, not this outbound-body table).
+        "databricks": _OPENAI_DIALECT,
     }
 )
 
@@ -470,6 +496,11 @@ _RAW_GUARDS: Mapping[Provider, _RawGuard] = MappingProxyType(
         # (the base transform forwards names; the system->assistant rewrite
         # preserves them and the IR cannot carry name).
         "github_copilot": github_copilot_unsupported_request_shapes,
+        # wave-3: databricks — the cache_control move arm + the whitespace-only
+        # content arm + the shared openai guard with name_fallback_user_only
+        # (v1 strips assistant/tool names == the IR drop, keeps user names);
+        # NO stream:false arm (the body always carries stream, default false).
+        "databricks": databricks_unsupported_request_shapes,
     }
 )
 

--- a/litellm/translation/engine/pipeline.py
+++ b/litellm/translation/engine/pipeline.py
@@ -104,6 +104,11 @@ from ..providers.mistral import serialize_request as mistral_serialize_request
 from ..providers.mistral import (
     unsupported_request_shapes as mistral_unsupported_request_shapes,
 )
+from ..providers.ollama_chat import parse_response as ollama_chat_parse_response
+from ..providers.ollama_chat import serialize_request as ollama_chat_serialize_request
+from ..providers.ollama_chat import (
+    unsupported_request_shapes as ollama_chat_unsupported_request_shapes,
+)
 from ..providers.openai_compat import parse_response as openai_compat_parse_response
 from ..providers.openai_compat import (
     serialize_request as openai_compat_serialize_request,
@@ -190,6 +195,9 @@ _SERIALIZERS: Mapping[Provider, _Serializer] = MappingProxyType(
         "watsonx": watsonx_serialize_request,
         "sagemaker_chat": sagemaker_chat_serialize_request,
         "groq": groq_serialize_request,
+        # wave-3: ollama_chat (the NDJSON /api/chat wire — its own body
+        # assembly over the shared message inverse).
+        "ollama_chat": ollama_chat_serialize_request,
     }
 )
 
@@ -259,6 +267,11 @@ _RESPONSE_PARSERS: Mapping[Provider, _ResponseParser] = MappingProxyType(
         # service_tier clamp (bare wire model; construction arm
         # "openai_like" — the direct ModelResponse(**json) style).
         "groq": groq_parse_response,
+        # wave-3: the ollama_chat parser builds the normalized body itself
+        # (ollama-native wire; the ollama_chat/{REQUEST model} prefix is
+        # parser scope) and rides it on ChatResponse.wire; seam construction
+        # arm "openai" (fresh-ModelResponse mutation, the cohere shape).
+        "ollama_chat": ollama_chat_parse_response,
     }
 )
 
@@ -303,6 +316,11 @@ OWN_MODULE_RESPONSE_STYLES: Mapping[Provider, ResponseStyle] = MappingProxyType(
         "sagemaker_chat": "openai",
         "watsonx": "openai_like",
         "groq": "openai_like",
+        # wave-3: ollama_chat mutates a fresh ModelResponse (ambient
+        # chatcmpl id kept, created re-stamped to the same ambient value) —
+        # the cdr arm; wrong-arm pin in its response gate (the cohere
+        # no-id template: "openai_like" mints a fresh envelope id).
+        "ollama_chat": "openai",
     }
 )
 
@@ -362,6 +380,11 @@ _RESPONSE_DIALECTS: Mapping[Provider, ResponseDialect] = MappingProxyType(
         # dict path) over the groq line parser; seam construction arm
         # "openai_like".
         "groq": _OPENAI_DIALECT,
+        # wave-3: ollama_chat — openai outbound body (the parser rides the
+        # normalized body on wire); the chunk-fold dialect is "ollama_chat"
+        # (its own NDJSON arm — selected by the stream gates/future
+        # streaming seam, not this outbound-body table).
+        "ollama_chat": _OPENAI_DIALECT,
     }
 )
 
@@ -412,6 +435,10 @@ _RAW_GUARDS: Mapping[Provider, _RawGuard] = MappingProxyType(
         # groq: explicit stream:false + the shared openai guard (full name
         # fallback).
         "groq": groq_unsupported_request_shapes,
+        # wave-3: ollama_chat — the shared openai guard with
+        # skip_name_fallback (v1's munge whitelist drops every message
+        # name); NO stream:false arm (the body always carries stream).
+        "ollama_chat": ollama_chat_unsupported_request_shapes,
     }
 )
 

--- a/litellm/translation/engine/pipeline.py
+++ b/litellm/translation/engine/pipeline.py
@@ -74,6 +74,15 @@ from ..providers.fireworks_ai import serialize_request as fireworks_serialize_re
 from ..providers.fireworks_ai import (
     unsupported_request_shapes as fireworks_unsupported_request_shapes,
 )
+from ..providers.github_copilot import (
+    parse_response as github_copilot_parse_response,
+)
+from ..providers.github_copilot import (
+    serialize_request as github_copilot_serialize_request,
+)
+from ..providers.github_copilot import (
+    unsupported_request_shapes as github_copilot_unsupported_request_shapes,
+)
 from ..providers.google_genai import parse_response as google_parse_response
 from ..providers.google_genai import (
     serialize_request_studio as google_serialize_request_studio,
@@ -198,6 +207,9 @@ _SERIALIZERS: Mapping[Provider, _Serializer] = MappingProxyType(
         # wave-3: ollama_chat (the NDJSON /api/chat wire — its own body
         # assembly over the shared message inverse).
         "ollama_chat": ollama_chat_serialize_request,
+        # wave-3: github_copilot (SDK path — openai_compat assemble_body +
+        # the system->assistant rewrite gated by the ambient disable flag).
+        "github_copilot": github_copilot_serialize_request,
     }
 )
 
@@ -272,6 +284,12 @@ _RESPONSE_PARSERS: Mapping[Provider, _ResponseParser] = MappingProxyType(
         # parser scope) and rides it on ChatResponse.wire; seam construction
         # arm "openai" (fresh-ModelResponse mutation, the cohere shape).
         "ollama_chat": ollama_chat_parse_response,
+        # wave-3: github_copilot — the SDK-path LIVE normalizer is
+        # convert_to_model_response_object (the config's transform_response is
+        # dead there); the shared openai parser verbatim, with the
+        # github_copilot/{wire_model} re-prefix as the seam's preset arm
+        # (construction arm "openai", NOT parser scope — the compat_sdk shape).
+        "github_copilot": github_copilot_parse_response,
     }
 )
 
@@ -321,6 +339,10 @@ OWN_MODULE_RESPONSE_STYLES: Mapping[Provider, ResponseStyle] = MappingProxyType(
         # the cdr arm; wrong-arm pin in its response gate (the cohere
         # no-id template: "openai_like" mints a fresh envelope id).
         "ollama_chat": "openai",
+        # wave-3: github_copilot rides the SDK-path cdr normalizer with the
+        # seam re-prefix (the compat_sdk shape) — construction arm "openai";
+        # wrong-arm pin in its response gate (the cohere no-id template).
+        "github_copilot": "openai",
     }
 )
 
@@ -385,6 +407,10 @@ _RESPONSE_DIALECTS: Mapping[Provider, ResponseDialect] = MappingProxyType(
         # (its own NDJSON arm — selected by the stream gates/future
         # streaming seam, not this outbound-body table).
         "ollama_chat": _OPENAI_DIALECT,
+        # wave-3: github_copilot — SDK path, default openai wrapper arm (no
+        # custom iterator exists in the provider; chunks ride the openai
+        # dialect exactly like the compat_sdk family).
+        "github_copilot": _OPENAI_DIALECT,
     }
 )
 
@@ -439,6 +465,11 @@ _RAW_GUARDS: Mapping[Provider, _RawGuard] = MappingProxyType(
         # skip_name_fallback (v1's munge whitelist drops every message
         # name); NO stream:false arm (the body always carries stream).
         "ollama_chat": ollama_chat_unsupported_request_shapes,
+        # wave-3: github_copilot — explicit stream:false (SDK serializes the
+        # key) + the shared openai guard with the FULL message-name fallback
+        # (the base transform forwards names; the system->assistant rewrite
+        # preserves them and the IR cannot carry name).
+        "github_copilot": github_copilot_unsupported_request_shapes,
     }
 )
 

--- a/litellm/translation/inbound/openai_chat/databricks_fold.py
+++ b/litellm/translation/inbound/openai_chat/databricks_fold.py
@@ -1,0 +1,170 @@
+"""The databricks chunk fold: one wire chunk -> one ModelResponseStream body.
+
+Pure over primitives, split out of ``stream.py`` to keep it under the cap (the
+ollama_fold precedent). Mirrors ``DatabricksChatResponseIterator.chunk_parser``
+(probed chunk-by-chunk in-process at HEAD). The wire ``usage`` is DROPPED by v1
+ENTIRELY (DB-R5), so the body NEVER carries usage and the fold attaches no
+tail. The transform is per-choice:
+
+- json_mode (STATEFUL ``last_function_name``): when a tool delta's function
+  name is (or the remembered name was) ``json_tool_call``, the arguments are
+  json.loads+dumps ROUND-TRIPPED into content (``{"a":1}`` -> ``{"a": 1}`` —
+  DB-R8) with ``{}`` -> ``""``, and ``tool_calls`` is nulled;
+- non-json_mode: a ``{}`` tool argument string is rewritten to ``""``;
+- a content LIST whose FIRST item carries ``citations`` lifts
+  ``citations[0]`` to ``delta.provider_specific_fields.citation``;
+- a content LIST is flattened to a string (the concatenation of its text
+  items) and reasoning/summary blocks become ``reasoning_content`` +
+  ``thinking_blocks``; content/reasoning_content/thinking_blocks are ALWAYS
+  set on the delta (None when absent — v1 assigns them unconditionally).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import NamedTuple
+
+from ...ir import PlainJson
+
+RESPONSE_FORMAT_TOOL_NAME = "json_tool_call"
+"""Mirror of ``litellm.constants.RESPONSE_FORMAT_TOOL_NAME``; the stream gate
+pins it against the constant at HEAD."""
+
+
+class FoldedDelta(NamedTuple):
+    delta: dict[str, PlainJson]
+    last_function_name: str | None
+
+
+def fold_choice(
+    choice: dict[str, PlainJson], json_mode: bool, last_function_name: str | None
+) -> FoldedDelta:
+    raw = choice.get("delta")
+    delta = dict(raw) if isinstance(raw, dict) else {}
+    tool_calls = delta.get("tool_calls")
+    if json_mode and isinstance(tool_calls, list) and tool_calls:
+        return _json_mode_delta(delta, tool_calls, last_function_name)
+    if isinstance(tool_calls, list) and tool_calls:
+        delta = {**delta, "tool_calls": _empty_args_to_blank(tool_calls)}
+    return _content_normalized(delta, last_function_name)
+
+
+def _json_mode_delta(
+    delta: dict[str, PlainJson],
+    tool_calls: list[PlainJson],
+    last_function_name: str | None,
+) -> FoldedDelta:
+    function_name = _first_function_name(tool_calls)
+    remembered = function_name if function_name is not None else last_function_name
+    matches = RESPONSE_FORMAT_TOOL_NAME in (remembered, function_name)
+    if not matches:
+        return _content_normalized(delta, remembered)
+    content = _json_mode_content(tool_calls)
+    converted = {**delta, "content": content, "tool_calls": None}
+    return _content_normalized(converted, remembered)
+
+
+def _first_function_name(tool_calls: list[PlainJson]) -> str | None:
+    first = tool_calls[0] if tool_calls else None
+    function = first.get("function") if isinstance(first, dict) else None
+    name = function.get("name") if isinstance(function, dict) else None
+    return name if isinstance(name, str) else None
+
+
+def _json_mode_content(tool_calls: list[PlainJson]) -> PlainJson:
+    first = tool_calls[0] if tool_calls else None
+    function = first.get("function") if isinstance(first, dict) else None
+    arguments = function.get("arguments") if isinstance(function, dict) else None
+    if not isinstance(arguments, str):
+        return None
+    try:
+        reformatted = json.dumps(json.loads(arguments))
+    except ValueError:
+        return arguments
+    return "" if reformatted == "{}" else reformatted
+
+
+def _empty_args_to_blank(tool_calls: list[PlainJson]) -> list[PlainJson]:
+    out: list[PlainJson] = []
+    for call in tool_calls:
+        if not isinstance(call, dict):
+            out = [*out, call]
+            continue
+        function = call.get("function")
+        if isinstance(function, dict) and function.get("arguments") == "{}":
+            out = [*out, {**call, "function": {**function, "arguments": ""}}]
+        else:
+            out = [*out, call]
+    return out
+
+
+def _content_normalized(
+    delta: dict[str, PlainJson], last_function_name: str | None
+) -> FoldedDelta:
+    content = delta.get("content")
+    with_citation = _with_citation(delta, content)
+    content_str = _content_str(content)
+    reasoning, thinking_blocks = _reasoning(content)
+    normalized = {
+        **with_citation,
+        "content": content_str,
+        "reasoning_content": reasoning,
+        "thinking_blocks": thinking_blocks,
+    }
+    return FoldedDelta(delta=normalized, last_function_name=last_function_name)
+
+
+def _with_citation(
+    delta: dict[str, PlainJson], content: PlainJson
+) -> dict[str, PlainJson]:
+    if not isinstance(content, list) or not content:
+        return delta
+    first = content[0]
+    if not isinstance(first, dict):
+        return delta
+    citations = first.get("citations")
+    if not isinstance(citations, list) or not citations:
+        return delta
+    existing = delta.get("provider_specific_fields")
+    base = dict(existing) if isinstance(existing, dict) else {}
+    return {**delta, "provider_specific_fields": {**base, "citation": citations[0]}}
+
+
+def _content_str(content: PlainJson) -> PlainJson:
+    if content is None or isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, dict) and item.get("type") == "text":
+                text = item.get("text", "")
+                parts = [*parts, str(text) if text is not None else ""]
+        return "".join(parts)
+    return content
+
+
+def _reasoning(content: PlainJson) -> tuple[str | None, list[PlainJson] | None]:
+    if not isinstance(content, list):
+        return None, None
+    reasoning: str | None = None
+    blocks: list[PlainJson] = []
+    for item in content:
+        if not isinstance(item, dict) or item.get("type") != "reasoning":
+            continue
+        summary = item.get("summary")
+        if not isinstance(summary, list):
+            continue
+        for entry in summary:
+            if not isinstance(entry, dict):
+                continue
+            text = entry.get("text", "")
+            reasoning = (reasoning or "") + (text if isinstance(text, str) else "")
+            blocks = [
+                *blocks,
+                {
+                    "type": "thinking",
+                    "thinking": text if text is not None else "",
+                    "signature": entry.get("signature", ""),
+                },
+            ]
+    return reasoning, (blocks or None)

--- a/litellm/translation/inbound/openai_chat/databricks_fold.py
+++ b/litellm/translation/inbound/openai_chat/databricks_fold.py
@@ -45,7 +45,11 @@ def fold_choice(
     if json_mode and isinstance(tool_calls, list) and tool_calls:
         return _json_mode_delta(delta, tool_calls, last_function_name)
     if isinstance(tool_calls, list) and tool_calls:
-        delta = {**delta, "tool_calls": _empty_args_to_blank(tool_calls)}
+        blanked: dict[str, PlainJson] = {
+            **delta,
+            "tool_calls": _empty_args_to_blank(tool_calls),
+        }
+        return _content_normalized(blanked, last_function_name)
     return _content_normalized(delta, last_function_name)
 
 
@@ -60,7 +64,11 @@ def _json_mode_delta(
     if not matches:
         return _content_normalized(delta, remembered)
     content = _json_mode_content(tool_calls)
-    converted = {**delta, "content": content, "tool_calls": None}
+    converted: dict[str, PlainJson] = {
+        **delta,
+        "content": content,
+        "tool_calls": None,
+    }
     return _content_normalized(converted, remembered)
 
 
@@ -105,7 +113,7 @@ def _content_normalized(
     with_citation = _with_citation(delta, content)
     content_str = _content_str(content)
     reasoning, thinking_blocks = _reasoning(content)
-    normalized = {
+    normalized: dict[str, PlainJson] = {
         **with_citation,
         "content": content_str,
         "reasoning_content": reasoning,

--- a/litellm/translation/inbound/openai_chat/ollama_fold.py
+++ b/litellm/translation/inbound/openai_chat/ollama_fold.py
@@ -1,0 +1,108 @@
+"""The ollama NDJSON wire-chunk fold (wave-3).
+
+Pure helpers that turn one ollama ``/api/chat`` wire chunk into the chat-
+completion chunk bodies v1's CustomStreamWrapper emits for that family. The
+stateful orchestration (the two reasoning flags ride ``StreamState``) stays in
+``stream._step_ollama_chat``; everything here is pure over primitives so the
+fold lives beside its dialect without growing the dialect file past the cap.
+"""
+
+from __future__ import annotations
+
+from ...ir import Body, PlainJson
+
+
+def ollama_reasoning_split(
+    thinking: PlainJson, content: PlainJson, started: bool, finished: bool
+) -> tuple[str | None, str | None, bool, bool]:
+    """v1's two-flag think-tag machine. A ``thinking`` field sets started;
+    truthy content FIRST flips finished when reasoning had started (only the
+    tag-bearing chunk is reasoning), then ``<think>``/``</think>`` tags are
+    stripped and flip the flags, and the leftover text rides reasoning while
+    started-and-not-finished, else content. A single chunk carrying both an
+    open and a close tag loses the reasoning entirely (v1 parity)."""
+    reasoning_out: str | None = None
+    content_out: str | None = None
+    if isinstance(thinking, str) and thinking:
+        reasoning_out = thinking
+        started = True
+    if not (isinstance(content, str) and content):
+        return reasoning_out, content_out, started, finished
+    if started and not finished:
+        finished = True
+    text, started, finished = _strip_think_tags(content, started, finished)
+    if started and not finished:
+        reasoning_out = text
+    else:
+        content_out = text
+    return reasoning_out, content_out, started, finished
+
+
+def _strip_think_tags(
+    text: str, started: bool, finished: bool
+) -> tuple[str, bool, bool]:
+    if "<think>" in text:
+        text = text.replace("<think>", "")
+        started = True
+    if "</think>" in text and started:
+        text = text.replace("</think>", "")
+        finished = True
+    return text, started, finished
+
+
+def ollama_delta_body(
+    sent_role: bool,
+    model: str,
+    content_out: str | None,
+    reasoning_out: str | None,
+    entries: tuple[PlainJson, ...] | None,
+) -> Body | None:
+    """The content/reasoning/tool delta chunk, or None when the wire chunk
+    bears no payload (v1's empty-chunk drop)."""
+    if content_out is None and reasoning_out is None and entries is None:
+        return None
+    delta: dict[str, PlainJson] = {
+        "role": None if sent_role else "assistant",
+        "content": content_out,
+        "provider_specific_fields": None,
+    }
+    if reasoning_out is not None:
+        delta = {**delta, "reasoning_content": reasoning_out}
+    if entries is not None:
+        delta = {**delta, "tool_calls": list(entries)}
+    return {
+        "model": model,
+        "object": "chat.completion.chunk",
+        "system_fingerprint": None,
+        "choices": [{"index": 0, "delta": delta, "finish_reason": None}],
+    }
+
+
+def ollama_bodies(
+    model: str, delta: Body | None, finish: PlainJson, usage: PlainJson
+) -> tuple[Body, ...]:
+    bodies: tuple[Body, ...] = () if delta is None else (delta,)
+    if finish is not None:
+        # v1's wrapper-synthesized SPLIT flush (a payload-bearing done chunk)
+        # carries no system_fingerprint; a standalone finish is the iterator's
+        # own chunk and does (probed)
+        final: Body = {
+            "model": model,
+            "object": "chat.completion.chunk",
+            **({} if delta is not None else {"system_fingerprint": None}),
+            "choices": [
+                {"index": 0, "delta": {"content": None}, "finish_reason": finish}
+            ],
+        }
+        bodies = (*bodies, final)
+    if isinstance(usage, dict):
+        bodies = (
+            *bodies,
+            {
+                "model": model,
+                "object": "chat.completion.chunk",
+                "choices": [],
+                "usage": usage,
+            },
+        )
+    return bodies

--- a/litellm/translation/inbound/openai_chat/stream.py
+++ b/litellm/translation/inbound/openai_chat/stream.py
@@ -47,6 +47,7 @@ from typing_extensions import assert_never
 
 from ...errors import BoundaryError, TranslationError
 from ...ir import Body, CompositeChunk, PlainJson, StreamEvent
+from .databricks_fold import fold_choice
 from .ollama_fold import ollama_bodies, ollama_delta_body, ollama_reasoning_split
 
 BlockDialect = Literal["anthropic", "bedrock_converse"]
@@ -87,6 +88,16 @@ ChunkDialect = Literal[
     # contract). usage/ids/created are envelope (per-chunk fresh ids; the
     # split finish reuses its source chunk's id — pinned in the gate).
     "ollama_chat",
+    # wave-3: the databricks chunk dialect (providers/databricks is the ONE
+    # consumer). One wire chunk -> ONE ModelResponseStream body (NO split,
+    # unlike ollama_chat/gemini). v1's DatabricksChatResponseIterator DROPS
+    # the wire usage ENTIRELY (DB-R5 — never attach a usage tail), flattens a
+    # content LIST to a string + reasoning/thinking blocks, lifts a first-item
+    # citations list to provider_specific_fields.citation, rewrites "{}" tool
+    # arguments to "", and (STATEFUL via StreamState.last_function_name) folds
+    # a json_tool_call tool delta to content with the json.loads+dumps byte
+    # REFORMAT (DB-R8). ids/created/model ride the wire chunk verbatim.
+    "databricks",
 ]
 
 
@@ -109,6 +120,15 @@ class StreamState:
     """ollama_chat: v1's ``finished_reasoning_content`` flag — flips on the
     FIRST content after reasoning started (v1's truncation bug, pinned) or a
     ``</think>`` tag."""
+    last_function_name: str | None = None
+    """databricks json_mode: v1's ``_last_function_name`` — the iterator
+    remembers the last tool function name across chunks so an arguments-only
+    delta still folds to content when the name was ``json_tool_call``."""
+    databricks_json_mode: bool = False
+    """databricks: v1's iterator ``json_mode`` flag (the json_tool_call ->
+    content + byte-reformat machine). v2 falls back on every json_mode REQUEST,
+    so the live flag is always False; the stream gate sets it True to pin v1's
+    byte-reformat against the REAL iterator."""
 
 
 def initial_state(model: str = "", dialect: ChunkDialect = "anthropic") -> StreamState:
@@ -157,6 +177,8 @@ def _step_wire_chunk(state: StreamState, payload: PlainJson) -> _StepResult:
         return _step_generic(state, payload)
     if state.dialect == "ollama_chat":
         return _step_ollama_chat(state, payload)
+    if state.dialect == "databricks":
+        return _step_databricks(state, payload)
     return _step_openai(state, payload)
 
 
@@ -181,7 +203,15 @@ def _as_block_dialect(
     match dialect:
         case "anthropic" | "bedrock_converse":
             return dialect
-        case "openai" | "azure" | "gemini" | "xai" | "generic" | "ollama_chat":
+        case (
+            "openai"
+            | "azure"
+            | "gemini"
+            | "xai"
+            | "generic"
+            | "ollama_chat"
+            | "databricks"
+        ):
             # wire/composite dialects fold whole chunks; a per-block delta
             # here is a wiring bug and must be loud, never a fabricated
             # anthropic-shaped placeholder (critic-google M5 / critic-azure M3).
@@ -467,6 +497,46 @@ def _step_ollama_chat(state: StreamState, payload: PlainJson) -> _StepResult:
         ),
         bodies,
     )
+
+
+def _step_databricks(state: StreamState, payload: PlainJson) -> _StepResult:
+    """wave-3: mirror ``DatabricksChatResponseIterator.chunk_parser`` — ONE
+    wire chunk -> ONE ModelResponseStream body (no split). v1 DROPS the wire
+    usage entirely (DB-R5); ids/created/model ride the wire chunk verbatim.
+    The json_mode ``_last_function_name`` rides StreamState (databricks json
+    mode is a request-side fallback, so the arm is dormant from v2's own flow
+    but the stream gate replays the REAL iterator's json_mode sequences)."""
+    if not isinstance(payload, dict):
+        return TranslationError.of_unsupported(
+            "databricks chunk dialect received a non-object payload; wiring bug"
+        )
+    raw_choices = payload.get("choices")
+    choices = raw_choices if isinstance(raw_choices, list) else []
+    transformed: list[PlainJson] = []
+    last_function_name = state.last_function_name
+    for entry in choices:
+        if not isinstance(entry, dict):
+            return TranslationError.of_unsupported(
+                "databricks chunk dialect received a non-object choice; wiring bug"
+            )
+        folded = fold_choice(entry, state.databricks_json_mode, last_function_name)
+        last_function_name = folded.last_function_name
+        transformed = [
+            *transformed,
+            {
+                "index": entry.get("index", 0),
+                "finish_reason": entry.get("finish_reason"),
+                "delta": folded.delta,
+            },
+        ]
+    body: Body = {
+        "id": payload.get("id"),
+        "object": "chat.completion.chunk",
+        "created": payload.get("created"),
+        "model": payload.get("model"),
+        "choices": transformed,
+    }
+    return replace(state, last_function_name=last_function_name), (body,)
 
 
 def _content_filter_field(choice: dict[str, PlainJson]) -> dict[str, PlainJson]:

--- a/litellm/translation/inbound/openai_chat/stream.py
+++ b/litellm/translation/inbound/openai_chat/stream.py
@@ -47,6 +47,7 @@ from typing_extensions import assert_never
 
 from ...errors import BoundaryError, TranslationError
 from ...ir import Body, CompositeChunk, PlainJson, StreamEvent
+from .ollama_fold import ollama_bodies, ollama_delta_body, ollama_reasoning_split
 
 BlockDialect = Literal["anthropic", "bedrock_converse"]
 """Dialects whose provider parsers emit per-block delta events
@@ -73,6 +74,19 @@ ChunkDialect = Literal[
     # finished; include_usage estimate chunk) is seam scope — see
     # _step_generic's docstring.
     "generic",
+    # wave-3: the ollama NDJSON family (providers/ollama_chat is the ONE
+    # consumer). One wire chunk can carry content/thinking/tool deltas AND
+    # the finish (done: true), so the arm emits delta + finish bodies from
+    # one event exactly like v1's wrapper SPLIT (the gemini composite-chunk
+    # shape). The think-tag state machine is STATEFUL across chunks —
+    # StreamState.started_reasoning/finished_reasoning mirror v1's two
+    # iterator flags, truncation bug included (only the tag-BEARING chunk
+    # emits reasoning; the next content chunk flips to plain content). The
+    # iterator's per-chunk usage stamps are stripped by v1's WRAPPER, so the
+    # fold emits usage only as the done chunk's choices: [] tail (seam
+    # contract). usage/ids/created are envelope (per-chunk fresh ids; the
+    # split finish reuses its source chunk's id — pinned in the gate).
+    "ollama_chat",
 ]
 
 
@@ -88,6 +102,13 @@ class StreamState:
     seen_tool_calls: bool = False
     """gemini: tool calls and finishReason arrive in separate wire chunks, so
     a later ``stop`` rewrites to ``tool_calls`` (v1 ``has_seen_tool_calls``)."""
+    started_reasoning: bool = False
+    """ollama_chat: v1's ``started_reasoning_content`` iterator flag (set by
+    a ``thinking`` field or a ``<think>`` tag in content)."""
+    finished_reasoning: bool = False
+    """ollama_chat: v1's ``finished_reasoning_content`` flag — flips on the
+    FIRST content after reasoning started (v1's truncation bug, pinned) or a
+    ``</think>`` tag."""
 
 
 def initial_state(model: str = "", dialect: ChunkDialect = "anthropic") -> StreamState:
@@ -125,12 +146,18 @@ def step(state: StreamState, event: StreamEvent) -> _StepResult:
         case "stop":
             return state, ()
         case "wire_chunk":
-            if state.dialect == "generic":
-                return _step_generic(state, event.wire_chunk.value)
-            return _step_openai(state, event.wire_chunk.value)
+            return _step_wire_chunk(state, event.wire_chunk.value)
         case "chunk":
             return _gemini_chunk_step(state, event.chunk)
     assert_never(event.tag)
+
+
+def _step_wire_chunk(state: StreamState, payload: PlainJson) -> _StepResult:
+    if state.dialect == "generic":
+        return _step_generic(state, payload)
+    if state.dialect == "ollama_chat":
+        return _step_ollama_chat(state, payload)
+    return _step_openai(state, payload)
 
 
 def _thinking_event_step(state: StreamState, event: StreamEvent) -> _StepResult:
@@ -154,7 +181,7 @@ def _as_block_dialect(
     match dialect:
         case "anthropic" | "bedrock_converse":
             return dialect
-        case "openai" | "azure" | "gemini" | "xai" | "generic":
+        case "openai" | "azure" | "gemini" | "xai" | "generic" | "ollama_chat":
             # wire/composite dialects fold whole chunks; a per-block delta
             # here is a wiring bug and must be loud, never a fabricated
             # anthropic-shaped placeholder (critic-google M5 / critic-azure M3).
@@ -396,6 +423,50 @@ def _step_generic(state: StreamState, payload: PlainJson) -> _StepResult:
             },
         )
     return replace(state, sent_role=sent_role), bodies
+
+
+def _step_ollama_chat(state: StreamState, payload: PlainJson) -> _StepResult:
+    """wave-3: mirror v1's wrapper output for the ollama NDJSON family,
+    probed in-process at HEAD (providers/ollama_chat builds the payload):
+
+    - the think-tag state machine runs v1's EXACT flag order (see
+      ``_ollama_reasoning_split``): only the tag-bearing chunk is reasoning,
+      the next content chunk flips to plain content (v1's truncation bug).
+    - one wire chunk emits up to delta + finish + usage-tail bodies (v1's
+      wrapper splits a payload-bearing done chunk; the split finish carries
+      NO system_fingerprint while a standalone finish does — probed).
+    - empty deltas are swallowed (v1's empty-chunk drop); the first emitted
+      delta carries ``role: assistant``.
+    - the finish flush rides the RAW done_reason (both sides run the live
+      map_finish_reason inside StreamingChoices — the watsonx rule).
+    """
+    if not isinstance(payload, dict):
+        return TranslationError.of_unsupported(
+            "ollama_chat chunk dialect received a non-object payload; wiring bug"
+        )
+    reasoning_out, content_out, started, finished = ollama_reasoning_split(
+        payload.get("thinking"),
+        payload.get("content"),
+        state.started_reasoning,
+        state.finished_reasoning,
+    )
+    tool_calls = payload.get("tool_calls")
+    entries = tuple(tool_calls) if isinstance(tool_calls, list) and tool_calls else None
+    delta = ollama_delta_body(
+        state.sent_role, state.model, content_out, reasoning_out, entries
+    )
+    bodies = ollama_bodies(
+        state.model, delta, payload.get("finish"), payload.get("usage")
+    )
+    return (
+        replace(
+            state,
+            sent_role=state.sent_role or delta is not None,
+            started_reasoning=started,
+            finished_reasoning=finished,
+        ),
+        bodies,
+    )
 
 
 def _content_filter_field(choice: dict[str, PlainJson]) -> dict[str, PlainJson]:

--- a/litellm/translation/providers/databricks/__init__.py
+++ b/litellm/translation/providers/databricks/__init__.py
@@ -1,0 +1,12 @@
+from .guard import unsupported_request_shapes
+from .response import parse_response
+from .serialize import serialize_request
+from .stream import parse_event, parse_line
+
+__all__ = (
+    "parse_event",
+    "parse_line",
+    "parse_response",
+    "serialize_request",
+    "unsupported_request_shapes",
+)

--- a/litellm/translation/providers/databricks/guard.py
+++ b/litellm/translation/providers/databricks/guard.py
@@ -1,0 +1,73 @@
+"""Raw-shape fidelity guard for the databricks serializer.
+
+databricks' wire is openai-chat-shaped (``transform_request`` is
+OpenAIGPTConfig's), but ``_transform_messages`` runs a databricks-specific
+munge BEFORE the base assembly (probed in-process at HEAD):
+
+- message ``name`` is stripped for ASSISTANT and TOOL roles but KEPT for USER
+  (``strip_name_from_message(allowed_name_roles=["user"])``). So the IR's
+  name-drop matches v1 only off the user role -> the ``name_fallback_user_only``
+  arm (the xai/mistral shape): a USER ``name`` falls back (v1 forwards it, the
+  IR drops it), an assistant/tool ``name`` SERVES (v1 strips it == the IR drop).
+- message-level ``cache_control`` is MOVED into a text block, and a
+  whitespace-only message LOSES the marker together with the sanitized block
+  (probed) — a lossy interaction the IR cannot reproduce. ANY ``cache_control``
+  anywhere in messages or tools falls back so v1 serves its own move/drop (the
+  azure verbatim-forward precedent over the shared ``carries_cache_control``
+  scanner).
+- ``_sanitize_empty_content`` REMOVES the ``content`` key for empty or
+  whitespace-only string content (``"   "`` -> ``{"role": "user"}``, probed),
+  which the IR keeps as a text block. The openai guard only catches
+  ``content is None``, so this guard adds the whitespace-only string arm and
+  falls back (v1 serves the bare ``{"role": ...}``).
+
+NO explicit ``stream: false`` arm: databricks ALWAYS materializes ``stream``
+(default False in optional_params), so absent and explicit-false are the same
+wire byte (the snowflake shape, pinned by the request gate's IDENTICAL row).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import cast
+
+from ...errors import TranslationError
+from ..openai_compat.guard import (
+    carries_cache_control,
+)
+from ..openai_compat.guard import (
+    unsupported_request_shapes as openai_unsupported_request_shapes,
+)
+
+_Raw = Mapping[str, object]
+
+
+def unsupported_request_shapes(raw: _Raw) -> TranslationError | None:
+    if carries_cache_control(raw.get("messages")) or carries_cache_control(
+        raw.get("tools")
+    ):
+        return TranslationError.of_unsupported(
+            "cache_control on a databricks message/tool: v1 MOVES message-level "
+            "markers into a text block (and a whitespace-only message LOSES the "
+            "marker with the sanitized block — a lossy interaction); the shared "
+            "tool/message assembly strips the marker, so v1 serves its own move"
+        )
+    if _whitespace_only_content(raw.get("messages")):
+        return TranslationError.of_unsupported(
+            "whitespace-only/empty string message content: v1's "
+            "_sanitize_empty_content REMOVES the content key (the message "
+            "survives as a bare {role}); the IR keeps it as a text block"
+        )
+    return openai_unsupported_request_shapes(raw, name_fallback_user_only=True)
+
+
+def _whitespace_only_content(messages: object) -> bool:
+    if not isinstance(messages, Sequence) or isinstance(messages, str):
+        return False
+    for item in cast(Sequence[object], messages):
+        if not isinstance(item, Mapping):
+            continue
+        content = cast(_Raw, item).get("content")
+        if isinstance(content, str) and content.strip() == "":
+            return True
+    return False

--- a/litellm/translation/providers/databricks/params.py
+++ b/litellm/translation/providers/databricks/params.py
@@ -1,0 +1,90 @@
+"""Parameter gates for the databricks chat serializer.
+
+``DatabricksConfig.get_supported_openai_params`` (probed in-process at HEAD):
+stream/stop/temperature/top_p/max_tokens/max_completion_tokens/n/
+response_format/tools/tool_choice/reasoning_effort/thinking. v1's
+``_check_valid_arg`` RAISES UnsupportedParamsError on anything else (probed:
+frequency_penalty, presence_penalty, seed, logprobs, parallel_tool_calls);
+``user`` is silently dropped upstream (model-list gated, never raised).
+
+The central structural fact is the ``"claude" in model`` SUBSTRING fork
+(DB-R1): a model whose name CONTAINS "claude" (custom serving endpoints are
+user-named, so ``my-claude-proxy-llama`` counts) gets anthropic param
+treatment for tools / response_format / reasoning_effort. The gate uses the
+SAME substring, never a model-map lookup.
+
+Probed serve/fallback split (the wave-3 dossier's narrower set):
+
+- SERVE: plain chat all models; temperature/top_p/stop/n; mct -> max_tokens
+  (ALWAYS renamed — v1 never re-emits max_completion_tokens); top_k verbatim
+  top-level (researcher-5 said unsupported; the HEAD probe REFUTES it — v1
+  serves it on the wire, both arms); tools on NON-claude verbatim; tools on
+  claude (the openai -> anthropic -> databricks round-trip, pure); tool_choice;
+  thinking passthrough + the max-bump arithmetic; reasoning_effort on
+  NON-claude WITH max_tokens (verbatim one-liner); response_format on
+  NON-claude verbatim.
+- TYPED FALLBACK (v1 SERVES): response_format on claude (the json_tool_call +
+  json_mode machinery spans request/response/stream state — DB-R2's
+  json_object SILENT DROP lives in this arm too); reasoning_effort on claude
+  (the thinking machinery + the adaptive output_config arm); cache_control on
+  ANY message (v1 MOVES message-level markers into a text block, and a
+  whitespace-only message LOSES the marker with the sanitized block — a trap;
+  guard-side); ``user`` (v1 serves its own drop).
+- FALLBACK (v1 RAISES): parallel_tool_calls (UPE); reasoning_effort on
+  NON-claude WITHOUT max_tokens (the raw ``KeyError: 'thinking'`` crash,
+  DB-R3 — v1 serves its own crash, the row asserts v1 raises KeyError).
+"""
+
+from __future__ import annotations
+
+from ...ir import ChatRequest
+
+
+def is_claude(model: str) -> bool:
+    """v1's ``"claude" in model`` substring (DB-R1) — NOT a model-map
+    capability lookup; user-named endpoints carrying the substring fork too."""
+    return "claude" in model
+
+
+def unsupported_params(request: ChatRequest) -> str | None:
+    if request.parallel_tool_calls.is_some():
+        return (
+            "parallel_tool_calls is outside databricks' supported list; v1's "
+            "get_optional_params raises UnsupportedParamsError"
+        )
+    if request.user.is_some():
+        return (
+            "user is model-list gated upstream and silently dropped for "
+            "databricks; v1 serves its own drop"
+        )
+    claude = is_claude(request.model)
+    if request.response_format.is_some() and claude:
+        return (
+            "response_format on a claude-substring model: v1 routes json_schema "
+            "through the json_tool_call + json_mode machinery and SILENTLY DROPS "
+            "json_object entirely (DB-R2) — the cross-plane state is unported, "
+            "typed fallback so v1 serves it"
+        )
+    if request.reasoning_effort.is_some() and claude:
+        return (
+            "reasoning_effort on a claude-substring model: v1 maps it to "
+            "thinking{enabled,budget} (and the adaptive output_config arm on "
+            "opus-4-6 names) — unported, typed fallback so v1 serves it"
+        )
+    return _nonclaude_reasoning_effort(request, claude)
+
+
+def _nonclaude_reasoning_effort(request: ChatRequest, claude: bool) -> str | None:
+    if claude or request.reasoning_effort.is_none():
+        return None
+    if (
+        request.params.max_tokens.is_none()
+        and request.params.max_completion_tokens.is_none()
+    ):
+        return (
+            "reasoning_effort on a NON-claude model WITHOUT max_tokens: v1 "
+            "CRASHES with a raw KeyError('thinking') in "
+            "update_optional_params_with_thinking_tokens (DB-R3, probed) — typed "
+            "fallback so v1 serves its own crash"
+        )
+    return None

--- a/litellm/translation/providers/databricks/response.py
+++ b/litellm/translation/providers/databricks/response.py
@@ -1,0 +1,330 @@
+"""databricks response JSON -> IR ``ChatResponse``.
+
+Mirrors ``DatabricksConfig.transform_response`` + ``_transform_dbrx_choices``
+(probed in-process at HEAD). v1 parses a ``DatabricksResponse`` TypedDict onto
+a fresh ``ModelResponse``; the normalized chat-completion body rides
+``ChatResponse.wire`` and the seam's ``openai`` construction arm reproduces
+v1's assembly (the cohere/ollama_chat shape — the body carries the wire's
+own id/created, so the ambient envelope is overwritten exactly like v1):
+
+- ``model`` = ``databricks/{wire model}`` (the prefix is v1's
+  ``litellm_params.custom_llm_provider or "databricks"`` — DB-R7: a custom
+  provider riding the databricks config keeps its OWN prefix; the dispatch
+  provider here is "databricks", so the literal is correct, and the override
+  is a documented fork obligation; the wire model is ``response.model or ""``);
+- ``id``/``created`` copied verbatim (a missing ``id``/``created`` KeyErrors in
+  v1 — a drift from researcher-5's "DatabricksException" claim: the
+  ``DatabricksResponse(**json)`` TypedDict construction does NOT validate, so a
+  malformed body raises a RAW ``KeyError`` on the first missing required key
+  — pinned as a v1-raise fallback row);
+- ``usage`` = ``Usage(**usage)``;
+- per choice, ``_transform_dbrx_choices``: a content block-list is flattened to
+  a joined text string (``extract_content_str``), ``reasoning``/``summary``
+  blocks become ``reasoning_content`` (concatenated) + ``thinking_blocks``
+  (missing signature -> ``""``), citations become
+  ``provider_specific_fields.citations`` with a ``supported_text`` mirror of
+  the block's text, tool_calls ride verbatim, logprobs is forced None;
+- UNKNOWN top-level keys are DROPPED (only id/created/model/usage/choices come
+  from the wire; ``object``/``system_fingerprint`` are ModelResponse defaults,
+  the wire values are NOT carried — probed).
+
+The json_mode single-tool -> content rewrite is NOT reached from v2: it fires
+only when ``json_mode=True``, and v2 falls back on every response_format-on-
+claude request (the json_tool_call machinery is unported), so json_mode is
+always absent at parse time. The arm is a request-side fallback, pinned there.
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+from expression import Error, Nothing, Ok, Result, Some
+from expression.collections import Block
+
+from ...errors import BoundaryError, TranslationError
+from ...ir import (
+    ChatRequest,
+    ChatResponse,
+    ContentBlock,
+    FinishReason,
+    JsonBlob,
+    PlainJson,
+    ResponseUsage,
+    Text,
+    ToolUse,
+)
+
+_ParseResult = Result[ChatResponse, TranslationError]
+
+_IR_FINISH: frozenset[str] = frozenset(
+    {"stop", "length", "tool_calls", "content_filter"}
+)
+
+
+def _boundary(reason: str) -> TranslationError:
+    return TranslationError.of_boundary(BoundaryError.of(Block.of_seq([reason])))
+
+
+def parse_response(raw: PlainJson, request: ChatRequest) -> _ParseResult:
+    if not isinstance(raw, dict):
+        return Error(_boundary("databricks response is not an object (v1 raises)"))
+    for key in ("id", "created", "usage", "choices"):
+        if key not in raw:
+            return Error(
+                _boundary(
+                    f"databricks response missing required key {key!r}: v1's "
+                    "DatabricksResponse access raises a raw KeyError (the "
+                    "TypedDict construction does not validate — probed)"
+                )
+            )
+    usage = _usage(raw["usage"])
+    if isinstance(usage, TranslationError):
+        return Error(usage)
+    wire_model = raw.get("model") or ""
+    if not isinstance(wire_model, str):
+        return Error(_boundary("databricks response model is not a string (v1 raises)"))
+    choices = _choices(raw["choices"])
+    if isinstance(choices, TranslationError):
+        return Error(choices)
+    model = f"databricks/{wire_model}"
+    body: dict[str, PlainJson] = {
+        "id": raw["id"],
+        "created": raw["created"],
+        "model": model,
+        "object": "chat.completion",
+        "choices": [choice.wire for choice in choices],
+        "usage": usage.wire,
+    }
+    return Ok(
+        ChatResponse(
+            id=raw["id"] if isinstance(raw["id"], str) else "",
+            model=model,
+            content=_first_blocks(choices),
+            finish=_first_finish(choices),
+            usage=usage.ir,
+            synthesized_json_content=False,
+            wire=Some(JsonBlob(value=body)),
+        )
+    )
+
+
+class _Usage(NamedTuple):
+    wire: PlainJson
+    ir: ResponseUsage
+
+
+def _usage(raw: PlainJson) -> _Usage | TranslationError:
+    if not isinstance(raw, dict):
+        return _boundary(
+            "databricks usage is not an object (v1's Usage(**usage) raises)"
+        )
+    prompt = _int(raw.get("prompt_tokens"))
+    completion = _int(raw.get("completion_tokens"))
+    total = _int(raw.get("total_tokens"))
+    if prompt is None or completion is None:
+        return _boundary(
+            "databricks usage missing integer prompt_tokens/completion_tokens "
+            "(v1's Usage validation raises)"
+        )
+    total_value = total if total is not None else prompt + completion
+    return _Usage(
+        wire=dict(raw),
+        ir=ResponseUsage(
+            input_tokens=prompt,
+            output_tokens=completion,
+            cache_creation_input_tokens=0,
+            cache_read_input_tokens=0,
+            cache_creation=Nothing,
+            total_tokens=Some(total_value),
+        ),
+    )
+
+
+def _int(value: PlainJson) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    return None
+
+
+class _Choice(NamedTuple):
+    wire: PlainJson
+    blocks: Block[ContentBlock]
+    finish: FinishReason
+
+
+def _choices(raw: PlainJson) -> list[_Choice] | TranslationError:
+    if not isinstance(raw, list):
+        return _boundary("databricks choices is not a list (v1 raises)")
+    out: list[_Choice] = []
+    for entry in raw:
+        choice = _choice(entry)
+        if isinstance(choice, TranslationError):
+            return choice
+        out = [*out, choice]
+    return out
+
+
+def _choice(raw: PlainJson) -> _Choice | TranslationError:
+    if not isinstance(raw, dict):
+        return _boundary("databricks choice is not an object (v1 raises)")
+    if "message" not in raw or "index" not in raw or "finish_reason" not in raw:
+        return _boundary(
+            "databricks choice missing index/message/finish_reason (v1's "
+            "TypedDict access raises a raw KeyError)"
+        )
+    message = raw["message"]
+    if not isinstance(message, dict):
+        return _boundary("databricks choice message is not an object (v1 raises)")
+    rebuilt = _message(message)
+    if isinstance(rebuilt, TranslationError):
+        return rebuilt
+    finish_raw = raw["finish_reason"]
+    wire: dict[str, PlainJson] = {
+        "index": raw["index"],
+        "finish_reason": finish_raw,
+        "message": rebuilt,
+        "logprobs": None,
+    }
+    return _Choice(wire=wire, blocks=_blocks(rebuilt), finish=_ir_finish(finish_raw))
+
+
+def _message(message: dict[str, PlainJson]) -> dict[str, PlainJson] | TranslationError:
+    content = message.get("content")
+    content_str = _content_str(content)
+    if isinstance(content_str, TranslationError):
+        return content_str
+    out: dict[str, PlainJson] = {
+        "role": "assistant",
+        "content": content_str,
+        "tool_calls": message.get("tool_calls"),
+    }
+    reasoning, thinking_blocks = _reasoning(content)
+    if reasoning is not None:
+        out = {
+            **out,
+            "reasoning_content": reasoning,
+            "thinking_blocks": thinking_blocks,
+        }
+    citations = _citations(content)
+    if citations is not None:
+        out = {**out, "provider_specific_fields": {"citations": citations}}
+    return out
+
+
+def _content_str(content: PlainJson) -> PlainJson | TranslationError:
+    if content is None or isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, dict) and item.get("type") == "text":
+                text = item.get("text", "")
+                parts = [*parts, str(text) if text is not None else ""]
+        return "".join(parts)
+    return _boundary(
+        "databricks message content is neither null/str/list (v1's "
+        "extract_content_str raises Exception)"
+    )
+
+
+def _reasoning(content: PlainJson) -> tuple[str | None, list[PlainJson] | None]:
+    if not isinstance(content, list):
+        return None, None
+    reasoning: str | None = None
+    blocks: list[PlainJson] = []
+    for item in content:
+        if not isinstance(item, dict) or item.get("type") != "reasoning":
+            continue
+        summary = item.get("summary")
+        if not isinstance(summary, list):
+            continue
+        for entry in summary:
+            if not isinstance(entry, dict):
+                continue
+            text = entry.get("text", "")
+            reasoning = (reasoning or "") + (text if isinstance(text, str) else "")
+            blocks = [
+                *blocks,
+                {
+                    "type": "thinking",
+                    "thinking": text if text is not None else "",
+                    "signature": entry.get("signature", ""),
+                },
+            ]
+    return reasoning, (blocks or None)
+
+
+def _citations(content: PlainJson) -> list[PlainJson] | None:
+    if not isinstance(content, list):
+        return None
+    citations: list[PlainJson] = []
+    for item in content:
+        if not isinstance(item, dict):
+            continue
+        text = item.get("text")
+        item_citations = item.get("citations")
+        if item_citations and isinstance(item_citations, list):
+            citations = [
+                *citations,
+                [
+                    {**citation, "supported_text": text}
+                    for citation in item_citations
+                    if isinstance(citation, dict)
+                ],
+            ]
+    return citations or None
+
+
+def _ir_finish(finish: PlainJson) -> FinishReason:
+    if finish == "length":
+        return "length"
+    if finish == "tool_calls":
+        return "tool_calls"
+    if finish == "content_filter":
+        return "content_filter"
+    return "stop"
+
+
+def _blocks(message: dict[str, PlainJson]) -> Block[ContentBlock]:
+    """Lenient IR content beside the strict wire body (the cohere/ollama N3
+    rule): nothing reads ``ChatResponse.content`` on the openai construction
+    arm; the wire body is the parity surface."""
+    out: list[ContentBlock] = []
+    content = message.get("content")
+    tool_calls = message.get("tool_calls")
+    if isinstance(content, str) and content and not tool_calls:
+        out = [ContentBlock.of_text(Text(text=content, cache=Nothing))]
+    for call in tool_calls if isinstance(tool_calls, list) else []:
+        if not isinstance(call, dict):
+            continue
+        function = call.get("function")
+        function_map = function if isinstance(function, dict) else {}
+        identifier = call.get("id")
+        name = function_map.get("name")
+        arguments = function_map.get("arguments")
+        out = [
+            *out,
+            ContentBlock.of_tool_use(
+                ToolUse(
+                    id=identifier if isinstance(identifier, str) else "",
+                    name=name if isinstance(name, str) else "",
+                    arguments=JsonBlob(
+                        value=arguments if isinstance(arguments, str) else ""
+                    ),
+                    cache=Nothing,
+                )
+            ),
+        ]
+    return Block.of_seq(out)
+
+
+def _first_blocks(choices: list[_Choice]) -> Block[ContentBlock]:
+    return choices[0].blocks if choices else Block.empty()
+
+
+def _first_finish(choices: list[_Choice]) -> FinishReason:
+    return choices[0].finish if choices else "stop"

--- a/litellm/translation/providers/databricks/serialize.py
+++ b/litellm/translation/providers/databricks/serialize.py
@@ -1,0 +1,180 @@
+"""Serialize the IR into a databricks ``/serving-endpoints`` chat body.
+
+databricks' wire is openai-chat-shaped: ``DatabricksConfig``'s MRO routes
+``transform_request`` to ``OpenAIGPTConfig`` (the anthropic serializer NEVER
+runs), while the anthropic planes contribute pure param mappers. The body is
+``{model, messages, **mapped_params}`` with ``stream`` ALWAYS materialized
+(default False). Probed in-process at HEAD; the central fork is
+``"claude" in model`` (DB-R1, ``params.is_claude``).
+
+The served set (the narrower wave-3 split; everything else is a typed
+fallback the params gate / guard reports so v1 serves its own behavior):
+
+- messages: the shared ``serialize_messages`` inverse (the guard already falls
+  back on cache_control, whitespace-only content, and USER message ``name`` —
+  the cases v1's munge handles losslessly or keeps; assistant/tool names are
+  stripped by v1 == the IR drop);
+- temperature/top_p/stop verbatim; ``top_k`` verbatim TOP-LEVEL (DB-R drift:
+  researcher-5 said unsupported, the probe serves it both arms);
+- ``max_tokens``: mct is ALWAYS renamed to ``max_tokens`` (v1 never re-emits
+  max_completion_tokens), then the thinking max-bump (``tools.thinking_max_tokens``)
+  overrides ONLY when thinking carries a budget and the caller gave none;
+- tools: NON-claude verbatim (the shared assembly), claude via the
+  ``tools.claude_tools`` round-trip (drops strict/$schema/cache_control);
+- tool_choice verbatim;
+- ``thinking``: passthrough as ``{type:enabled[,budget_tokens]}`` for ANY model
+  (the bump rides max_tokens);
+- ``reasoning_effort``: served ONLY on NON-claude WITH max_tokens (rides the
+  wire verbatim — one line); claude reasoning_effort and non-claude-without-
+  max_tokens are params-gate fallbacks (the thinking machinery / the DB-R3
+  KeyError crash);
+- ``response_format``: NON-claude verbatim (claude is a params-gate fallback —
+  the json_tool_call machinery and the DB-R2 json_object silent drop).
+
+The M2M token POST and the WorkspaceClient URL synthesis live in the ENVELOPE
+(v1's own resolution, the watsonx-IAM rule); this serializer reads no env and
+triggers no network (semgrep-enforced purity).
+"""
+
+from __future__ import annotations
+
+from expression import Error, Ok, Option, Result
+
+from ...deps import TranslationDeps
+from ...errors import TranslationError
+from ...ir import Body, ChatRequest, PlainJson, ToolDef
+from ..anthropic.params import thinking_json
+from ..openai_compat.messages import serialize_messages
+from ..openai_compat.serialize import _response_format_json
+from . import params as p
+from . import tools as t
+
+_SerializeResult = Result[Body, TranslationError]
+
+
+def serialize_request(request: ChatRequest, deps: TranslationDeps) -> _SerializeResult:
+    reason = p.unsupported_params(request)
+    if reason is not None:
+        return Error(TranslationError.of_unsupported(reason))
+    messages = serialize_messages(request)
+    if isinstance(messages, TranslationError):
+        return Error(messages)
+    tools = _tools(request)
+    if isinstance(tools, TranslationError):
+        return Error(tools)
+    body: Body = {
+        "model": request.model,
+        "messages": messages,
+        "stream": request.stream,
+        **_sampling(request),
+        **_tools_field(tools),
+        **_tool_choice_field(request),
+        **_thinking_field(request),
+        **_reasoning_effort_field(request),
+        **_response_format_field(request),
+        **_max_tokens_field(request),
+    }
+    return Ok(body)
+
+
+def _sampling(request: ChatRequest) -> dict[str, PlainJson]:
+    params = request.params
+    fields: tuple[tuple[str, PlainJson | None], ...] = (
+        ("temperature", params.temperature.default_value(None)),
+        ("top_p", params.top_p.default_value(None)),
+        ("top_k", params.top_k.default_value(None)),
+        ("stop", list(params.stop) if len(params.stop) > 0 else None),
+    )
+    return {key: value for key, value in fields if value is not None}
+
+
+def _max_tokens_field(request: ChatRequest) -> dict[str, PlainJson]:
+    caller = request.params.max_completion_tokens.default_value(
+        request.params.max_tokens.default_value(None)
+    )
+    match request.thinking:
+        case Option(tag="some", some=thinking):
+            bumped = t.thinking_max_tokens(thinking, caller)
+        case _:
+            bumped = None
+    value = bumped if bumped is not None else caller
+    return {"max_tokens": value} if value is not None else {}
+
+
+def _tools(request: ChatRequest) -> list[PlainJson] | None | TranslationError:
+    if len(request.tools) == 0:
+        return None
+    if p.is_claude(request.model):
+        return t.claude_tools(request.tools)
+    return [_verbatim_tool(tool) for tool in request.tools]
+
+
+def _verbatim_tool(tool: ToolDef) -> PlainJson:
+    function: dict[str, PlainJson] = {"name": tool.name}
+    match tool.description:
+        case Option(tag="some", some=description):
+            function = {**function, "description": description}
+        case _:
+            pass
+    match tool.parameters:
+        case Option(tag="some", some=parameters):
+            function = {**function, "parameters": parameters.value}
+        case _:
+            pass
+    match tool.strict:
+        case Option(tag="some", some=strict):
+            function = {**function, "strict": strict}
+        case _:
+            pass
+    return {"type": "function", "function": function}
+
+
+def _tools_field(tools: list[PlainJson] | None) -> dict[str, PlainJson]:
+    return {"tools": tools} if tools is not None else {}
+
+
+def _tool_choice_field(request: ChatRequest) -> dict[str, PlainJson]:
+    match request.tool_choice:
+        case Option(tag="some", some=choice):
+            pass
+        case _:
+            return {}
+    match choice.tag:
+        case "auto":
+            return {"tool_choice": "auto"}
+        case "required":
+            return {"tool_choice": "required"}
+        case "none":
+            return {"tool_choice": "none"}
+        case "specific":
+            return {
+                "tool_choice": {
+                    "type": "function",
+                    "function": {"name": choice.specific},
+                }
+            }
+    return {}
+
+
+def _thinking_field(request: ChatRequest) -> dict[str, PlainJson]:
+    match request.thinking:
+        case Option(tag="some", some=thinking):
+            return {"thinking": thinking_json(thinking)}
+        case _:
+            return {}
+
+
+def _reasoning_effort_field(request: ChatRequest) -> dict[str, PlainJson]:
+    match request.reasoning_effort:
+        case Option(tag="some", some=effort):
+            return {"reasoning_effort": effort}
+        case _:
+            return {}
+
+
+def _response_format_field(request: ChatRequest) -> dict[str, PlainJson]:
+    """NON-claude only (the params gate falls back on claude). The wire shape
+    is the openai one verbatim — REUSE the shared builder (v1 passes the
+    caller's response_format through unchanged on non-claude models)."""
+    value = _response_format_json(request.response_format)
+    return {"response_format": value} if value is not None else {}

--- a/litellm/translation/providers/databricks/serialize.py
+++ b/litellm/translation/providers/databricks/serialize.py
@@ -45,7 +45,7 @@ from ...errors import TranslationError
 from ...ir import Body, ChatRequest, PlainJson, ToolDef
 from ..anthropic.params import thinking_json
 from ..openai_compat.messages import serialize_messages
-from ..openai_compat.serialize import _response_format_json
+from ..openai_compat.serialize import response_format_json
 from . import params as p
 from . import tools as t
 
@@ -176,5 +176,5 @@ def _response_format_field(request: ChatRequest) -> dict[str, PlainJson]:
     """NON-claude only (the params gate falls back on claude). The wire shape
     is the openai one verbatim — REUSE the shared builder (v1 passes the
     caller's response_format through unchanged on non-claude models)."""
-    value = _response_format_json(request.response_format)
+    value = response_format_json(request.response_format)
     return {"response_format": value} if value is not None else {}

--- a/litellm/translation/providers/databricks/stream.py
+++ b/litellm/translation/providers/databricks/stream.py
@@ -1,0 +1,132 @@
+"""databricks SSE stream chunks -> IR stream events.
+
+v1 decodes through ``DatabricksChatResponseIterator`` (a
+``BaseModelResponseIterator``): each line rides ``_handle_string_chunk`` (an
+SSE ``data:`` prefix stripped if present, ``[DONE]`` ends the stream, a line
+that fails ``json.loads`` is SILENTLY SWALLOWED). v2 errors loudly on the
+swallow cases — the watsonx/ollama line-seam PINNED DIVERGENCE (fail-closed on
+a failure path, named report row).
+
+``parse_event`` normalizes one wire chunk into the payload the ``databricks``
+chunk dialect folds into ONE ``ModelResponseStream`` body (v1 yields one out
+chunk per wire chunk, NO split). Probed chunk-by-chunk at HEAD:
+
+- the wire chunk ``usage`` is DROPPED ENTIRELY (DB-R5: the iterator never
+  passes usage to ``ModelResponseStream``); the seam must NOT attach a parsed
+  usage tail;
+- ``{}`` tool arguments are rewritten to ``""`` (non-json_mode chunks);
+- a content LIST is flattened to a content str (``extract_content_str``),
+  reasoning/summary blocks become reasoning_content + thinking_blocks, and a
+  ``citations`` list on the FIRST content item becomes
+  ``provider_specific_fields.citation = citations[0]``;
+- json_mode (the STATEFUL ``_last_function_name`` machine) converts a
+  ``json_tool_call`` tool delta to content with the json.loads+dumps byte
+  REFORMAT (``{"a":1}`` -> ``{"a": 1}``, DB-R8) and ``{}`` -> ``""``; the
+  ``_last_function_name`` rides ``StreamState.last_function_name``. json_mode
+  is a REQUEST-side fallback (v2 never sends a json_mode request), so this arm
+  is dormant from v2's own flow but pinned by the stream gate's REAL-iterator
+  replay;
+- missing ``id``/``created``/``model``/``choices`` -> loud (v1 raises
+  DatabricksException 400).
+"""
+
+from __future__ import annotations
+
+import json
+
+from expression import Error, Ok, Result
+from expression.collections import Block
+
+from ...errors import BoundaryError, TranslationError
+from ...ir import JsonBlob, PlainJson, StreamEvent
+
+_EventResult = Result[StreamEvent | None, TranslationError]
+
+RESPONSE_FORMAT_TOOL_NAME = "json_tool_call"
+"""The ONE in-package mirror of ``litellm.constants.RESPONSE_FORMAT_TOOL_NAME``;
+the stream gate pins it against the constant at HEAD."""
+
+
+def _boundary(reason: str) -> TranslationError:
+    return TranslationError.of_boundary(BoundaryError.of(Block.of_seq([reason])))
+
+
+def parse_line(line: str) -> _EventResult:
+    stripped = line.strip()
+    if stripped.startswith("data:"):
+        stripped = stripped[len("data:") :].strip()
+    if "[DONE]" in line:
+        return Ok(StreamEvent.of_stop())
+    if not stripped:
+        return Error(
+            _boundary(
+                "empty databricks stream line: v1's base iterator silently "
+                "swallows it — deliberate fail-closed divergence on a failure "
+                "path (named report row)"
+            )
+        )
+    try:
+        event: PlainJson = json.loads(stripped)
+    except ValueError:
+        return Error(
+            _boundary(
+                f"non-JSON databricks stream line {stripped[:80]!r}: v1's base "
+                "iterator silently swallows it — deliberate fail-closed "
+                "divergence on a failure path (named report row)"
+            )
+        )
+    return parse_event(event)
+
+
+def parse_event(event: PlainJson) -> _EventResult:
+    if not isinstance(event, dict):
+        return Error(_boundary("databricks stream chunk is not an object (v1 raises)"))
+    for key in ("id", "created", "model", "choices"):
+        if key not in event:
+            return Error(
+                _boundary(
+                    f"databricks stream chunk missing {key!r} (v1 raises "
+                    "DatabricksException 400)"
+                )
+            )
+    choices = event["choices"]
+    if not isinstance(choices, list):
+        return Error(_boundary("databricks stream choices is not a list (v1 raises)"))
+    normalized = _choices(choices)
+    if isinstance(normalized, TranslationError):
+        return Error(normalized)
+    payload: dict[str, PlainJson] = {
+        "id": event["id"],
+        "created": event["created"],
+        "model": event["model"],
+        "choices": normalized,
+    }
+    return Ok(StreamEvent.of_wire_chunk(JsonBlob(value=payload)))
+
+
+def _choices(choices: list[PlainJson]) -> list[PlainJson] | TranslationError:
+    out: list[PlainJson] = []
+    for choice in choices:
+        normalized = _choice(choice)
+        if isinstance(normalized, TranslationError):
+            return normalized
+        out = [*out, normalized]
+    return out
+
+
+def _choice(choice: PlainJson) -> PlainJson | TranslationError:
+    if not isinstance(choice, dict):
+        return _boundary("databricks stream choice is not an object (v1 raises)")
+    if "delta" not in choice:
+        return _boundary(
+            "databricks stream choice missing 'delta' (v1's KeyError -> "
+            "DatabricksException 400)"
+        )
+    delta = choice["delta"]
+    if not isinstance(delta, dict):
+        return _boundary("databricks stream delta is not an object (v1 raises)")
+    return {
+        "index": choice.get("index", 0),
+        "finish_reason": choice.get("finish_reason"),
+        "delta": dict(delta),
+    }

--- a/litellm/translation/providers/databricks/tools.py
+++ b/litellm/translation/providers/databricks/tools.py
@@ -43,7 +43,7 @@ the ``thinking`` dict omits ``budget_tokens`` NO bump fires (v1's
 
 from __future__ import annotations
 
-from litellm.constants import DEFAULT_MAX_TOKENS
+from litellm.constants import DEFAULT_MAX_RECURSE_DEPTH, DEFAULT_MAX_TOKENS
 
 from ...errors import TranslationError
 from ...ir import (
@@ -123,7 +123,7 @@ def _carries_legacy_defs(schema: dict[str, PlainJson]) -> bool:
 
 
 def _scan_legacy_defs(value: PlainJson, depth: int) -> bool:
-    if depth > 100:
+    if depth > DEFAULT_MAX_RECURSE_DEPTH:
         return True
     if isinstance(value, dict):
         if "$ref" in value or "$defs" in value or "definitions" in value:

--- a/litellm/translation/providers/databricks/tools.py
+++ b/litellm/translation/providers/databricks/tools.py
@@ -1,0 +1,160 @@
+"""The databricks claude tool round-trip and the thinking max-token bump.
+
+Two databricks-only pure transforms, split out of ``serialize.py`` to keep it
+under the size cap (the ollama_fold precedent).
+
+THE CLAUDE TOOL ROUND-TRIP (``"claude" in model`` only — DB-R1). v1 runs
+openai-tool -> anthropic-tool (``AnthropicConfig._map_tool_helper``) ->
+databricks-tool (``convert_anthropic_tool_to_databricks_tool``). Probed
+in-process at HEAD, the net effect on a function tool is:
+
+- the FUNCTION-level ``strict`` and ``cache_control`` are DROPPED (the
+  anthropic mapper reads only name/parameters/description);
+- ``parameters`` is filtered to ``AnthropicInputSchema``'s allowed keys
+  (``$defs``/additionalProperties/properties/required/strict/type) -> a
+  ``$schema`` key inside parameters is DROPPED, ``additionalProperties`` is
+  KEPT;
+- absent/None parameters become ``{"type": "object", "properties": {}}``; a
+  non-"object" ``type`` is coerced to "object" (+ ``properties: {}`` if
+  missing);
+- the description rides only when present (the empty string "" IS present, so
+  it survives — repositioned AFTER parameters in the output, probed);
+- the output shape is ``{"type": "function", "function": {"name",
+  "parameters", ["description"]}}``.
+
+NON-claude tools ride VERBATIM (v1's ``if "claude" not in model: return
+tools``) — the shared openai_compat assembly already emits them.
+
+The schema-key whitelist is the SAME ``AnthropicInputSchema`` symbol v1
+filters against (the request gate's mirror test pins it), so a new allowed
+key cannot silently drift. Legacy ``$ref``/``$defs`` schemas fall back at the
+serializer (v1 inlines them via ``unpack_legacy_defs`` — unported, the
+fireworks legacy-defs precedent).
+
+THE THINKING MAX-BUMP. ``update_optional_params_with_thinking_tokens`` fires
+for ALL models: when ``thinking`` is enabled WITH a ``budget_tokens`` and the
+caller gave NO max_tokens/max_completion_tokens, v1 sets ``max_tokens =
+budget_tokens + DEFAULT_MAX_TOKENS`` (probed: 2048 -> 6144, 1024 -> 5120 with
+DEFAULT_MAX_TOKENS=4096). A caller-supplied max_tokens is NEVER adjusted
+(probed: budget 1024 + max_tokens 100 -> over-budget pair sent as-is). When
+the ``thinking`` dict omits ``budget_tokens`` NO bump fires (v1's
+``is not None`` gate), and the budget key never rides the wire either.
+"""
+
+from __future__ import annotations
+
+from litellm.constants import DEFAULT_MAX_TOKENS
+
+from ...errors import TranslationError
+from ...ir import (
+    Block,
+    JsonBlob,
+    Option,
+    PlainJson,
+    ThinkingEnabled,
+    ThinkingParam,
+    ToolDef,
+)
+
+_ANTHROPIC_INPUT_SCHEMA_KEYS = frozenset(
+    {"$defs", "additionalProperties", "properties", "required", "strict", "type"}
+)
+"""The ONE in-package mirror of ``AnthropicInputSchema.__annotations__``; the
+request gate's mirror test pins it against v1's TypedDict at HEAD."""
+
+
+def claude_tools(tools: Block[ToolDef]) -> list[PlainJson] | TranslationError:
+    """The claude-substring tool round-trip. Returns a typed fallback when a
+    schema carries ``$ref``/``$defs`` (v1 inlines via unpack_legacy_defs —
+    unported)."""
+    out: list[PlainJson] = []
+    for tool in tools:
+        converted = _claude_tool(tool)
+        if isinstance(converted, TranslationError):
+            return converted
+        out = [*out, converted]
+    return out
+
+
+def _claude_tool(tool: ToolDef) -> PlainJson | TranslationError:
+    parameters = _parameters(tool)
+    if _carries_legacy_defs(parameters):
+        return TranslationError.of_unsupported(
+            "databricks claude tool with $ref/$defs in its parameters: v1 "
+            "inlines them via unpack_legacy_defs before the anthropic schema "
+            "filter — unported (the fireworks legacy-defs precedent)"
+        )
+    function: dict[str, PlainJson] = {
+        "name": tool.name,
+        "parameters": _filtered_schema(parameters),
+    }
+    match tool.description:
+        case _ if tool.description.is_some():
+            function = {**function, "description": tool.description.value}
+        case _:
+            pass
+    return {"type": "function", "function": function}
+
+
+def _parameters(tool: ToolDef) -> dict[str, PlainJson]:
+    match tool.parameters:
+        case Option(tag="some", some=JsonBlob(value=dict() as schema)):
+            pass
+        case _:
+            return {"type": "object", "properties": {}}
+    if schema.get("type") != "object":
+        coerced: dict[str, PlainJson] = {**schema, "type": "object"}
+        if "properties" not in coerced:
+            coerced = {**coerced, "properties": {}}
+        return coerced
+    return dict(schema)
+
+
+def _filtered_schema(schema: dict[str, PlainJson]) -> dict[str, PlainJson]:
+    return {
+        key: value
+        for key, value in schema.items()
+        if key in _ANTHROPIC_INPUT_SCHEMA_KEYS
+    }
+
+
+def _carries_legacy_defs(schema: dict[str, PlainJson]) -> bool:
+    return _scan_legacy_defs(schema, 0)
+
+
+def _scan_legacy_defs(value: PlainJson, depth: int) -> bool:
+    if depth > 100:
+        return True
+    if isinstance(value, dict):
+        if "$ref" in value or "$defs" in value or "definitions" in value:
+            return True
+        return any(_scan_legacy_defs(item, depth + 1) for item in value.values())
+    if isinstance(value, list):
+        return any(_scan_legacy_defs(item, depth + 1) for item in value)
+    return False
+
+
+def thinking_max_tokens(
+    thinking: ThinkingParam, caller_max_tokens: int | None
+) -> int | None:
+    """v1's max-token bump: ``budget_tokens + DEFAULT_MAX_TOKENS`` when thinking
+    is enabled WITH a budget and the caller gave NO max_tokens; the caller's
+    value is never adjusted, and a budget-less thinking dict triggers NO bump
+    (v1's ``is not None`` gate). Returns the bumped value, or ``None`` when no
+    bump applies."""
+    if caller_max_tokens is not None:
+        return None
+    match thinking.tag:
+        case "enabled":
+            return _enabled_bump(thinking.enabled)
+        case "disabled" | "adaptive":
+            return None
+    return None
+
+
+def _enabled_bump(enabled: ThinkingEnabled) -> int | None:
+    match enabled.budget_tokens:
+        case Option(tag="some", some=budget):
+            return budget + DEFAULT_MAX_TOKENS
+        case _:
+            return None

--- a/litellm/translation/providers/github_copilot/__init__.py
+++ b/litellm/translation/providers/github_copilot/__init__.py
@@ -1,0 +1,9 @@
+from .guard import unsupported_request_shapes
+from .response import parse_response
+from .serialize import serialize_request
+
+__all__ = (
+    "parse_response",
+    "serialize_request",
+    "unsupported_request_shapes",
+)

--- a/litellm/translation/providers/github_copilot/guard.py
+++ b/litellm/translation/providers/github_copilot/guard.py
@@ -1,0 +1,22 @@
+"""Raw-shape fidelity guard for the github_copilot serializer.
+
+``GithubCopilotConfig`` extends ``OpenAIConfig`` over the SDK path: the
+explicit ``stream: false`` arm applies (the SDK serializes the key — the
+compat_sdk shape), then the shared openai guard with the FULL message-``name``
+fallback (the base transform forwards names; the system->assistant rewrite is
+a ``message.copy()`` that preserves every key, so a ``name`` would survive
+into the rewritten message and the IR cannot carry it).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from ...errors import TranslationError
+from ..openai_compat.guard import stream_false_then_unsupported_shapes
+
+_Raw = Mapping[str, object]
+
+
+def unsupported_request_shapes(raw: _Raw) -> TranslationError | None:
+    return stream_false_then_unsupported_shapes(raw)

--- a/litellm/translation/providers/github_copilot/params.py
+++ b/litellm/translation/providers/github_copilot/params.py
@@ -1,0 +1,41 @@
+"""Parameter gates for the github_copilot chat serializer.
+
+``GithubCopilotConfig`` extends ``OpenAIConfig`` (NOT OpenAIGPTConfig), so
+its supported-param surface is OpenAI's own model-shape fork over the BARE
+model name. Copilot model names are bare ("gpt-4o", "gpt-5",
+"claude-sonnet-4.5"), so OpenAI's gpt-5 / o-series gates leak in exactly
+like provider "openai" names — REUSE the shared openai_compat gates. Probed
+in-process at HEAD with a seeded fake token dir (no live OAuth):
+
+- gpt-5 names: ``temperature != 1`` RAISES (OpenAIGPT5Config) — the shared
+  ``unsupported_model_family`` gate falls back on the whole gpt-5 family;
+- o-series names: their own param rewrites — same shared family gate;
+- claude models: ``reasoning_effort`` and ``thinking`` RAISE
+  UnsupportedParamsError (the config's claude thinking/reasoning_effort
+  additions are DEAD at HEAD — ``supports_reasoning`` keys are absent, so
+  the params never enter the supported list; researcher-5 correction 3);
+- ``user`` is silently dropped (model-list gated upstream — v1 serves its
+  own drop) for claude; it SERVES for gpt-4o. The shared gate falls back on
+  ``user`` for every model (the model-list membership is ambient state v2
+  does not read), so v1 keeps serving the served case and reproduces the
+  drop on the other — a typed fallback either way;
+- ``response_format`` on the two name-gated models raises (the base-list
+  name gate).
+"""
+
+from __future__ import annotations
+
+from ...ir import ChatRequest
+from ..openai_compat import params as openai_params
+
+
+def unsupported_model_family(model: str) -> str | None:
+    return openai_params.unsupported_model_family(model)
+
+
+def unsupported_params(request: ChatRequest) -> str | None:
+    return openai_params.unsupported_params(request)
+
+
+def unsupported_response_format(request: ChatRequest) -> str | None:
+    return openai_params.unsupported_response_format(request)

--- a/litellm/translation/providers/github_copilot/response.py
+++ b/litellm/translation/providers/github_copilot/response.py
@@ -1,0 +1,16 @@
+"""github_copilot response parsing: the shared openai parser verbatim.
+
+On the SDK chat path the LIVE normalizer is
+``convert_to_model_response_object`` (``GithubCopilotConfig.transform_response``
+and its Anthropic-native-body synthesis are DEAD on this path — they wake only
+under the EXPERIMENTAL_OPENAI_BASE_LLM_HTTP_HANDLER env secret, researcher-5
+§1.1). The response model is the seam preset + cdr re-prefix ->
+``github_copilot/{wire_model}`` (the compat_sdk seam arm; construction arm
+"openai" — NO parser-side prefix, the same as every other SDK-path member).
+"""
+
+from __future__ import annotations
+
+from ..openai_compat.response import parse_response
+
+__all__ = ("parse_response",)

--- a/litellm/translation/providers/github_copilot/serialize.py
+++ b/litellm/translation/providers/github_copilot/serialize.py
@@ -1,0 +1,68 @@
+"""Serialize the IR into a github_copilot ``/chat/completions`` request body.
+
+v1's chain on the SDK path (main.py's big openai elif, "github_copilot" in
+``openai_compatible_providers``) is ``GithubCopilotConfig.map_openai_params``
+(OpenAIConfig's model-shape fork) + ``transform_request``
+(OpenAIConfig.transform_request, which calls ``_transform_messages`` BEFORE
+the base five-touch assembly). The body is therefore the openai_compat
+assembly with ONE delta probed in-process at HEAD (seeded fake token dir, no
+live OAuth):
+
+- ``_transform_messages`` rewrites EVERY system message's ``role`` to
+  ``assistant`` (content untouched) UNLESS the ambient
+  ``litellm.disable_copilot_system_to_assistant`` global is True, in which
+  case the messages ride unchanged. The flag threads through
+  ``TranslationDeps`` (the DI rule — it is a litellm module global, not a
+  ``litellm.constants`` leaf).
+
+The IR hoists leading system text into ``request.system`` and the shared
+``serialize_messages`` inverse re-emits them as leading
+``{"role": "system", "content": text}`` entries; the shared openai guard
+already falls back on every OTHER system shape (list-form content, a system
+turn after the first, message ``name``), so the served set is exactly
+"leading string-content system messages" — the rewrite flips their role.
+
+The auth device-flow happens in ``validate_environment`` ABOVE the seam
+(envelope scope, the xai-OAuth rule); this serializer reads no token files
+and triggers no network (semgrep-enforced purity).
+"""
+
+from __future__ import annotations
+
+from expression import Error, Ok, Result
+
+from ...deps import TranslationDeps
+from ...errors import TranslationError
+from ...ir import Body, ChatRequest, PlainJson
+from ..openai_compat.serialize import assemble_body
+from . import params as p
+
+_SerializeResult = Result[Body, TranslationError]
+
+
+def serialize_request(request: ChatRequest, deps: TranslationDeps) -> _SerializeResult:
+    reason = (
+        p.unsupported_model_family(request.model)
+        or p.unsupported_params(request)
+        or p.unsupported_response_format(request)
+    )
+    if reason is not None:
+        return Error(TranslationError.of_unsupported(reason))
+    return assemble_body(request).map(
+        lambda body: _with_copilot_system_rewrite(body, deps)
+    )
+
+
+def _with_copilot_system_rewrite(body: Body, deps: TranslationDeps) -> Body:
+    if deps.disable_copilot_system_to_assistant:
+        return body
+    messages = body.get("messages")
+    if not isinstance(messages, list):
+        return body
+    return {**body, "messages": [_system_to_assistant(message) for message in messages]}
+
+
+def _system_to_assistant(message: PlainJson) -> PlainJson:
+    if not isinstance(message, dict) or message.get("role") != "system":
+        return message
+    return {**message, "role": "assistant"}

--- a/litellm/translation/providers/github_copilot/serialize.py
+++ b/litellm/translation/providers/github_copilot/serialize.py
@@ -29,7 +29,7 @@ and triggers no network (semgrep-enforced purity).
 
 from __future__ import annotations
 
-from expression import Error, Ok, Result
+from expression import Error, Result
 
 from ...deps import TranslationDeps
 from ...errors import TranslationError

--- a/litellm/translation/providers/ollama_chat/__init__.py
+++ b/litellm/translation/providers/ollama_chat/__init__.py
@@ -1,0 +1,12 @@
+from .guard import unsupported_request_shapes
+from .response import parse_response
+from .serialize import serialize_request
+from .stream import parse_event, parse_line
+
+__all__ = (
+    "parse_event",
+    "parse_line",
+    "parse_response",
+    "serialize_request",
+    "unsupported_request_shapes",
+)

--- a/litellm/translation/providers/ollama_chat/guard.py
+++ b/litellm/translation/providers/ollama_chat/guard.py
@@ -1,0 +1,30 @@
+"""Raw-shape fidelity guard for the ollama_chat NDJSON serializer.
+
+The shared openai guard runs with ``skip_name_fallback`` because v1's message
+munge (``OllamaChatCompletionMessage``) whitelists role/thinking/content/
+images/tool_calls/tool_call_id — message ``name`` is dropped for EVERY role,
+so the IR's name-drop IS v1's behavior (probed in-process at HEAD).
+
+Deliberately NO explicit ``stream: false`` arm: the ollama body ALWAYS
+carries ``stream`` (transform_request pops it with default False), so an
+explicitly-sent false and an absent key are the same wire byte — the
+snowflake shape, pinned by the request gate's ``stream_false`` IDENTICAL row.
+
+The shared arms that fire here are all conservative v1-serves fallbacks
+(string stop rides verbatim into ``options.stop``; both max-tokens keys
+last-write ``num_predict``; consecutive turns / mid-conversation system
+messages ride VERBATIM in v1's munge while the IR merges/hoists them).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from ...errors import TranslationError
+from ..openai_compat.guard import unsupported_request_shapes as _openai_shapes
+
+_Raw = Mapping[str, object]
+
+
+def unsupported_request_shapes(raw: _Raw) -> TranslationError | None:
+    return _openai_shapes(raw, skip_name_fallback=True)

--- a/litellm/translation/providers/ollama_chat/params.py
+++ b/litellm/translation/providers/ollama_chat/params.py
@@ -1,0 +1,55 @@
+"""Parameter gates for the ollama_chat serializer.
+
+v1's supported list (``OllamaChatConfig.get_supported_openai_params``):
+max_tokens/max_completion_tokens/stream/top_p/temperature/seed/
+frequency_penalty/stop/tools/tool_choice/functions/response_format/
+reasoning_effort. ``_check_valid_arg`` RAISES UnsupportedParamsError on
+anything else (probed at HEAD: n, logprobs, presence_penalty, thinking).
+IR-carried params outside the list are typed fallbacks so v1 serves its own
+raise; ``seed``/``frequency_penalty``/``functions`` and the provider-native
+passthroughs (mirostat, num_ctx, keep_alive, format, think, function_name)
+are parse-level unknowns — v1 SERVES each, the inbound boundary falls back.
+
+``top_k`` is NOT in the openai list but IS in the IR: v1's provider-native
+passthrough places it in optional_params and the transform emits it inside
+``options`` — SERVED (the cohere/snowflake top-level-passthrough shape).
+
+``user`` is silently dropped upstream (model-list gated, never raised) —
+typed fallback, v1 serves its own drop.
+
+Tool-level ``cache_control`` falls back: v1 forwards the caller's tools
+VERBATIM (no strip anywhere on this path) while the shared openai tool
+assembly drops the marker.
+"""
+
+from __future__ import annotations
+
+from ...deps import TranslationDeps
+from ...ir import ChatRequest
+
+
+def unsupported_params(request: ChatRequest, deps: TranslationDeps) -> str | None:
+    # deps is unused — the uniform own-module gate signature
+    if request.parallel_tool_calls.is_some():
+        return (
+            "parallel_tool_calls is outside ollama_chat's supported list; "
+            "v1's get_optional_params raises UnsupportedParamsError (or "
+            "drops it under drop_params)"
+        )
+    if request.thinking.is_some():
+        return (
+            "thinking is outside ollama_chat's supported list; v1 raises "
+            "UnsupportedParamsError (reasoning_effort is the served knob)"
+        )
+    if request.user.is_some():
+        return (
+            "user is model-list gated upstream and silently dropped for "
+            "ollama_chat; v1 serves its own drop"
+        )
+    if any(tool.cache.is_some() for tool in request.tools):
+        return (
+            "tool-level cache_control: v1 forwards the caller's tools "
+            "verbatim onto the ollama wire; the shared tool assembly strips "
+            "the marker"
+        )
+    return None

--- a/litellm/translation/providers/ollama_chat/response.py
+++ b/litellm/translation/providers/ollama_chat/response.py
@@ -1,0 +1,336 @@
+"""Ollama ``/api/chat`` response JSON -> IR ``ChatResponse``.
+
+Mirrors ``OllamaChatConfig.transform_response`` (probed in-process at HEAD),
+which mutates a fresh ``ModelResponse``: the normalized chat-completion body
+rides ``ChatResponse.wire`` and the seam's ``openai`` construction arm
+reproduces v1's assembly byte-for-byte (the cohere shape — the body carries
+NO id/created, so the ambient envelope stays litellm's; v1 re-stamps
+``created = int(time.time())``, the same frozen ambient value):
+
+- ``model`` = ``ollama_chat/{REQUEST model}`` (the wire ``model`` key is
+  IGNORED — quirk-pinned);
+- finish from ``map_finish_reason(done_reason or "stop")`` via the
+  in-package mirror of v1's table (unknown values -> "stop"; the
+  ``function_call`` passthrough value is IR-unrepresentable -> typed
+  fallback, v1 serves it);
+- message rides VERBATIM into the body (extra keys included — v1's
+  ``Message(**message)`` forwards them) after the remap: a ``thinking``
+  key (any value) becomes ``reasoning_content``; else a STRING content is
+  think-tag split (``reasoning_content`` = inner text, content = the
+  REMAINDER — note the request-side munge keeps the full string instead);
+  v1 then sets ``reasoning_content: None`` when the regex misses, mirrored
+  verbatim so both Message constructions see identical bytes;
+- tool_calls present (truthy) force finish "tool_calls"; the entries ride
+  verbatim — the seam's ``Message(**...)`` mints missing ids (bare uuid4)
+  and re-dumps dict arguments with ``", "``/``": "`` separators exactly
+  like v1's, because BOTH sides run the same validation;
+- usage = ``Usage(prompt_eval_count, eval_count, sum)``; a body missing
+  EITHER count falls back typed — v1 fills the gap with local
+  ``litellm.token_counter`` estimates (deterministic, but a v1-stack call;
+  deps hook deferred per the wave-3 dossier).
+
+Fail-closed arms reproduce v1's raises: non-object body, missing/null/
+non-object ``message`` (TypeError), a final content that is not a string —
+``None``/missing included: v1's eval-count default EAGERLY evaluates
+``token_counter(text=content)`` even when ``eval_count`` is present, so a
+null content raises ValueError REGARDLESS of counts (probed) — non-str
+truthy content (the think regex TypeErrors), malformed tool_call entries
+(Message construction raises on both sides; typed here so the raise never
+escapes the seam), and unhashable ``done_reason`` values (v1's dict lookup
+TypeErrors).
+"""
+
+from __future__ import annotations
+
+import json
+from types import MappingProxyType
+
+from expression import Error, Nothing, Ok, Result, Some
+from expression.collections import Block
+
+from ...errors import BoundaryError, TranslationError
+from ...ir import (
+    ChatRequest,
+    ChatResponse,
+    ContentBlock,
+    FinishReason,
+    JsonBlob,
+    PlainJson,
+    ResponseUsage,
+    Text,
+    ToolUse,
+)
+from .serialize import THINK_TAG_RE
+
+_ParseResult = Result[ChatResponse, TranslationError]
+
+FINISH_REASON_MIRROR: MappingProxyType[str, str] = MappingProxyType(
+    {
+        # The in-package mirror of v1's core_helpers._FINISH_REASON_MAP
+        # (the package cannot import the v1 stack); the response gate's
+        # mirror test pins every row against v1's live table. Unmapped
+        # strings default to "stop" (v1 logs a warning and serves "stop").
+        "stop_sequence": "stop",
+        "end_turn": "stop",
+        "max_tokens": "length",
+        "tool_use": "tool_calls",
+        "refusal": "content_filter",
+        "compaction": "length",
+        "COMPLETE": "stop",
+        "ERROR_TOXIC": "content_filter",
+        "ERROR": "stop",
+        "eos_token": "stop",
+        "eos": "stop",
+        "STOP": "stop",
+        "MAX_TOKENS": "length",
+        "SAFETY": "content_filter",
+        "RECITATION": "content_filter",
+        "FINISH_REASON_UNSPECIFIED": "stop",
+        "MALFORMED_FUNCTION_CALL": "stop",
+        "LANGUAGE": "content_filter",
+        "OTHER": "content_filter",
+        "BLOCKLIST": "content_filter",
+        "PROHIBITED_CONTENT": "content_filter",
+        "SPII": "content_filter",
+        "IMAGE_SAFETY": "content_filter",
+        "IMAGE_PROHIBITED_CONTENT": "content_filter",
+        "TOO_MANY_TOOL_CALLS": "stop",
+        "MALFORMED_RESPONSE": "stop",
+        "network_error": "stop",
+        "sensitive": "content_filter",
+        "guardrail_intervened": "content_filter",
+        "stop": "stop",
+        "length": "length",
+        "tool_calls": "tool_calls",
+        "function_call": "function_call",
+        "content_filter": "content_filter",
+        "content_filtered": "content_filter",
+    }
+)
+
+_IR_FINISH: frozenset[str] = frozenset(
+    {"stop", "length", "tool_calls", "content_filter"}
+)
+
+
+def _boundary(reason: str) -> TranslationError:
+    return TranslationError.of_boundary(BoundaryError.of(Block.of_seq([reason])))
+
+
+def parse_response(raw: PlainJson, request: ChatRequest) -> _ParseResult:
+    if not isinstance(raw, dict):
+        return Error(_boundary("ollama response is not an object (v1 raises)"))
+    message = raw.get("message")
+    if not isinstance(message, dict):
+        return Error(
+            _boundary(
+                "ollama response 'message' is missing or not an object (v1's "
+                "Message(**message) raises TypeError)"
+            )
+        )
+    remapped = _remapped_message(message)
+    if isinstance(remapped, TranslationError):
+        return Error(remapped)
+    tool_calls = remapped.get("tool_calls")
+    tool_reason = _tool_calls_reason(tool_calls)
+    if tool_reason is not None:
+        return Error(_boundary(tool_reason))
+    finish = _finish(raw.get("done_reason"), tool_calls)
+    if isinstance(finish, TranslationError):
+        return Error(finish)
+    counts = _usage_counts(raw)
+    if isinstance(counts, TranslationError):
+        return Error(counts)
+    prompt, completion = counts
+    body: dict[str, PlainJson] = {
+        "object": "chat.completion",
+        "model": f"ollama_chat/{request.model}",
+        "choices": [{"index": 0, "finish_reason": finish, "message": remapped}],
+        "usage": {
+            "prompt_tokens": prompt,
+            "completion_tokens": completion,
+            "total_tokens": prompt + completion,
+        },
+    }
+    return Ok(
+        ChatResponse(
+            id="",  # v1 keeps the ambient chatcmpl id (no wire id exists)
+            model=f"ollama_chat/{request.model}",
+            content=_semantic_blocks(remapped),
+            finish=_ir_finish(finish),
+            usage=ResponseUsage(
+                input_tokens=prompt,
+                output_tokens=completion,
+                cache_creation_input_tokens=0,
+                cache_read_input_tokens=0,
+                cache_creation=Nothing,
+                total_tokens=Some(prompt + completion),
+            ),
+            synthesized_json_content=False,
+            wire=Some(JsonBlob(value=body)),
+        )
+    )
+
+
+def _remapped_message(
+    message: dict[str, PlainJson],
+) -> dict[str, PlainJson] | TranslationError:
+    if "thinking" in message:
+        remapped = {
+            **{key: value for key, value in message.items() if key != "thinking"},
+            "reasoning_content": message["thinking"],
+        }
+    else:
+        content = message.get("content")
+        if content is None:
+            remapped = dict(message)
+        elif not isinstance(content, str):
+            return _boundary(
+                "ollama message content is not a string (v1's think-tag "
+                "regex raises TypeError)"
+            )
+        else:
+            matched = THINK_TAG_RE.match(content)
+            remapped = {
+                **message,
+                "reasoning_content": matched.group(1) if matched else None,
+                "content": matched.group(2) if matched else content,
+            }
+    final_content = remapped.get("content")
+    if not isinstance(final_content, str):
+        return _boundary(
+            "ollama message content is missing or null: v1's eval-count "
+            "default eagerly runs token_counter(text=content) and raises "
+            "ValueError even when eval_count is present (probed)"
+        )
+    return remapped
+
+
+def _tool_calls_reason(tool_calls: PlainJson) -> str | None:
+    """Pre-check the shapes both sides' ``Message(**...)`` validation raises
+    on, so the raise never escapes the seam untyped (the cohere F8 rule).
+    Value-level validation stays with Message itself — identical on both
+    sides by construction."""
+    if tool_calls is None:
+        return None
+    if not isinstance(tool_calls, list):
+        return "ollama message tool_calls is not a list (v1's Message raises)"
+    for call in tool_calls:
+        if not isinstance(call, dict):
+            return "ollama tool_call entry is not an object (v1's Message raises)"
+        function = call.get("function")
+        if not isinstance(function, dict):
+            return (
+                "ollama tool_call has no 'function' object (v1's Message "
+                "construction raises)"
+            )
+        arguments = function.get("arguments")
+        if arguments is not None and not isinstance(arguments, (str, dict)):
+            return (
+                "ollama tool_call arguments are neither a string nor an "
+                "object (v1's Function validation raises)"
+            )
+    return None
+
+
+def _finish(
+    done_reason: PlainJson, tool_calls: PlainJson
+) -> str | TranslationError:
+    if isinstance(tool_calls, list) and len(tool_calls) > 0:
+        # v1 forces "tool_calls" whenever Message.tool_calls is truthy,
+        # overriding the mapped done_reason
+        return "tool_calls"
+    if not done_reason:
+        return "stop"  # v1's `done_reason or "stop"` falsy gate
+    if isinstance(done_reason, str):
+        mapped = FINISH_REASON_MIRROR.get(done_reason, "stop")
+        if mapped not in _IR_FINISH:
+            return _boundary(
+                f"ollama done_reason {done_reason!r} maps to {mapped!r}, "
+                "which the IR cannot carry (v1 serves it verbatim)"
+            )
+        return mapped
+    if isinstance(done_reason, (list, dict)):
+        return _boundary(
+            "unhashable ollama done_reason (v1's finish-reason table lookup "
+            "raises TypeError)"
+        )
+    return "stop"  # v1's map .get(non-str hashable) misses and defaults
+
+
+def _ir_finish(finish: str) -> FinishReason:
+    if finish == "length":
+        return "length"
+    if finish == "tool_calls":
+        return "tool_calls"
+    if finish == "content_filter":
+        return "content_filter"
+    return "stop"
+
+
+def _usage_counts(raw: dict[str, PlainJson]) -> tuple[int, int] | TranslationError:
+    if "prompt_eval_count" not in raw or "eval_count" not in raw:
+        return _boundary(
+            "ollama response missing prompt_eval_count/eval_count: v1 fills "
+            "the gap with local litellm.token_counter estimates (a v1-stack "
+            "call; deps hook deferred — typed fallback per the wave-3 dossier)"
+        )
+    prompt = _int_count(raw, "prompt_eval_count")
+    if isinstance(prompt, TranslationError):
+        return prompt
+    completion = _int_count(raw, "eval_count")
+    if isinstance(completion, TranslationError):
+        return completion
+    return prompt, completion
+
+
+def _int_count(raw: dict[str, PlainJson], key: str) -> int | TranslationError:
+    value = raw.get(key)
+    if isinstance(value, (bool, int)):
+        return int(value)
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    return _boundary(
+        f"ollama {key} is not an integer: {value!r} (v1's raw addition or "
+        "Usage validation raises)"
+    )
+
+
+def _semantic_blocks(message: dict[str, PlainJson]) -> Block[ContentBlock]:
+    """Deliberately LENIENT beside the strict wire body (the cohere N3 rule):
+    nothing reads ``ChatResponse.content`` on the openai construction arm
+    today; the wire body is the parity surface."""
+    blocks: list[ContentBlock] = []
+    content = message.get("content")
+    tool_calls = message.get("tool_calls")
+    if isinstance(content, str) and content and not tool_calls:
+        blocks = [ContentBlock.of_text(Text(text=content, cache=Nothing))]
+    for call in tool_calls if isinstance(tool_calls, list) else []:
+        call_map = call if isinstance(call, dict) else {}
+        function_raw = call_map.get("function")
+        function = function_raw if isinstance(function_raw, dict) else {}
+        arguments = function.get("arguments")
+        parsed: PlainJson
+        if isinstance(arguments, dict):
+            parsed = arguments
+        elif isinstance(arguments, str):
+            try:
+                parsed = json.loads(arguments) if arguments else {}
+            except ValueError:
+                parsed = {}
+        else:
+            parsed = {}
+        identifier = call_map.get("id")
+        name = function.get("name")
+        blocks = [
+            *blocks,
+            ContentBlock.of_tool_use(
+                ToolUse(
+                    id=identifier if isinstance(identifier, str) else "",
+                    name=name if isinstance(name, str) else "",
+                    arguments=JsonBlob(value=parsed),
+                    cache=Nothing,
+                )
+            ),
+        ]
+    return Block.of_seq(blocks)

--- a/litellm/translation/providers/ollama_chat/serialize.py
+++ b/litellm/translation/providers/ollama_chat/serialize.py
@@ -1,0 +1,253 @@
+"""Serialize the IR into an ollama ``/api/chat`` request body.
+
+Mirrors ``OllamaChatConfig.map_openai_params`` + ``transform_request``
+(probed in-process at HEAD): the body is ``{model, messages, options,
+stream}`` plus top-level ``format``/``tools``/``think``. The openai params
+land in ``options`` under ollama names (max_tokens/mct -> ``num_predict``,
+last write wins — the raw guard rejects both keys together), ``top_k`` rides
+``options`` via v1's provider-native passthrough, ``stop`` rides verbatim,
+and ``stream`` is ALWAYS a body key (default false).
+
+Message munge, per v1's whitelist transform over the openai wire messages
+(the shared ``serialize_messages`` inverse is the proven reconstruction of
+exactly those messages):
+
+- ``content`` is ALWAYS a string: lists flatten to the concatenation of
+  their truthy text parts, ``None`` becomes ``""``;
+- a STRING content matching v1's ``<think>``/``<thinking>``/
+  ``<budget:thinking>`` open+close regex emits ``thinking`` = the inner text
+  while the content stays the FULL tagged string (v1 reads the regex result
+  for ``thinking`` only and flattens the ORIGINAL content — probed; the
+  remainder group is discarded). List content is never think-parsed (v1's
+  string-only fork; the raw guard keeps single-text lists on v1);
+- ``images`` is attached to EVERY message (``[]`` included): image parts'
+  urls with ``data:...;base64,`` prefixes are stripped to the bare base64
+  payload, other urls ride verbatim;
+- assistant ``tool_calls`` become ``[{function: {name, arguments:
+  <parsed dict>}}]`` — the wire ``id`` and ``type`` are DROPPED and the
+  argument string is ``json.loads``-ed (a blank argument string raises
+  json.JSONDecodeError in v1 — typed fallback here);
+- ``tool_call_id`` is forwarded; message ``name`` is dropped (v1 parity).
+
+``response_format`` json_object -> ``format: "json"``; json_schema -> the
+bare schema dict (name/strict dropped; a FALSY schema is dropped entirely —
+v1's truthiness gate). ``reasoning_effort`` -> ``think``: verbatim for
+``gpt-oss*`` models, else the boolean ``value in {low, medium, high}``.
+``tool_choice`` is silently dropped (v1 pops it — hang avoidance) and the
+caller's tools ride VERBATIM (openai shape, ``strict`` included).
+
+Ambient ``OllamaChatConfig`` class-attr defaults merge into ``options`` in
+v1 (the groq class-attr precedent) — module state v2 cannot see; the future
+completion() fork MUST fall back to v1 when ``OllamaChatConfig.get_config()``
+is non-empty (CLAUDE.md fork obligation).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+from expression import Error, Ok, Option, Result
+
+from ...deps import TranslationDeps
+from ...errors import TranslationError
+from ...ir import Body, ChatRequest, PlainJson, ResponseFormat
+from ..openai_compat.serialize import assemble_body
+from . import params as p
+
+_SerializeResult = Result[Body, TranslationError]
+
+THINK_TAG_RE = re.compile(
+    r"<(?:think|thinking|budget:thinking)>(.*?)</(?:think|thinking|budget:thinking)>(.*)",
+    re.DOTALL,
+)
+"""The ONE in-package mirror of v1's ``_parse_content_for_reasoning`` regex
+(litellm_core_utils/prompt_templates/common_utils.py); the request gate's
+mirror test pins it against v1's source."""
+
+
+def serialize_request(request: ChatRequest, deps: TranslationDeps) -> _SerializeResult:
+    reason = p.unsupported_params(request, deps)
+    if reason is not None:
+        return Error(TranslationError.of_unsupported(reason))
+    match assemble_body(request):
+        case Result(tag="ok", ok=assembled):
+            pass
+        case Result(error=err):
+            return Error(err)
+    messages = _munged_messages(assembled.get("messages"))
+    if isinstance(messages, TranslationError):
+        return Error(messages)
+    body: Body = {
+        "model": request.model,
+        "messages": messages,
+        "options": _options(request),
+        "stream": request.stream,
+        **_format_field(request.response_format),
+        **_tools_field(assembled.get("tools")),
+        **_think_field(request),
+    }
+    return Ok(body)
+
+
+def _options(request: ChatRequest) -> dict[str, PlainJson]:
+    params = request.params
+    out: dict[str, PlainJson] = {}
+    num_predict = params.max_completion_tokens.default_value(
+        params.max_tokens.default_value(None)
+    )
+    fields: tuple[tuple[str, PlainJson | None], ...] = (
+        ("num_predict", num_predict),
+        ("temperature", params.temperature.default_value(None)),
+        ("top_p", params.top_p.default_value(None)),
+        ("stop", list(params.stop) if len(params.stop) > 0 else None),
+        ("top_k", params.top_k.default_value(None)),
+    )
+    for key, value in fields:
+        if value is not None:
+            out = {**out, key: value}
+    return out
+
+
+def _format_field(response_format: Option[ResponseFormat]) -> dict[str, PlainJson]:
+    rf = response_format.default_value(None)
+    if rf is None:
+        return {}
+    match rf.tag:
+        case "json_object":
+            return {"format": "json"}
+        case "json_schema":
+            schema = rf.json_schema.schema.value
+            # v1's truthiness gate: a falsy schema never reaches the wire
+            return {"format": schema} if schema else {}
+        case _:
+            return {}  # "text" is dropped entirely (probed)
+
+
+def _tools_field(tools: PlainJson | None) -> dict[str, PlainJson]:
+    if tools is None:
+        return {}
+    return {"tools": tools}
+
+
+def _think_field(request: ChatRequest) -> dict[str, PlainJson]:
+    effort = request.reasoning_effort.default_value(None)
+    if effort is None:
+        return {}
+    if request.model.startswith("gpt-oss"):
+        return {"think": effort}
+    return {"think": effort in ("low", "medium", "high")}
+
+
+def _munged_messages(messages: PlainJson | None) -> list[PlainJson] | TranslationError:
+    if not isinstance(messages, list):
+        return TranslationError.of_unsupported(
+            "ollama_chat serializer received a non-list message assembly; wiring bug"
+        )
+    munged = [_munge_message(message) for message in messages]
+    for entry in munged:
+        if isinstance(entry, TranslationError):
+            return entry
+    return [entry for entry in munged if not isinstance(entry, TranslationError)]
+
+
+def _munge_message(message: PlainJson) -> PlainJson | TranslationError:
+    if not isinstance(message, dict):
+        return TranslationError.of_unsupported(
+            "ollama_chat serializer received a non-object wire message; wiring bug"
+        )
+    content = message.get("content")
+    tool_calls = _ollama_tool_calls(message.get("tool_calls"))
+    if isinstance(tool_calls, TranslationError):
+        return tool_calls
+    out: dict[str, PlainJson] = {"role": message.get("role")}
+    thinking = _think_tag_reasoning(content)
+    if thinking is not None:
+        out = {**out, "thinking": thinking}
+    out = {**out, "content": _flattened_content(content), "images": _images(content)}
+    if tool_calls is not None:
+        out = {**out, "tool_calls": tool_calls}
+    tool_call_id = message.get("tool_call_id")
+    if tool_call_id is not None:
+        out = {**out, "tool_call_id": tool_call_id}
+    return out
+
+
+def _think_tag_reasoning(content: PlainJson) -> str | None:
+    if not isinstance(content, str):
+        return None  # v1 think-parses STRING content only
+    matched = THINK_TAG_RE.match(content)
+    return matched.group(1) if matched else None
+
+
+def _flattened_content(content: PlainJson) -> str:
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""  # v1's convert_content_list_to_str returns "" for None
+    parts: list[str] = []
+    for item in content:
+        if not isinstance(item, dict):
+            continue
+        text = item.get("text")
+        if isinstance(text, str) and text:
+            parts = [*parts, text]
+    return "".join(parts)
+
+
+def _images(content: PlainJson) -> list[PlainJson]:
+    if not isinstance(content, list):
+        return []
+    out: list[PlainJson] = []
+    for item in content:
+        if not isinstance(item, dict):
+            continue
+        image_url = item.get("image_url")
+        if isinstance(image_url, str) and image_url:
+            out = [*out, _base64_payload(image_url)]
+        elif isinstance(image_url, dict) and "url" in image_url:
+            url = image_url.get("url")
+            if isinstance(url, str):
+                out = [*out, _base64_payload(url)]
+    return out
+
+
+def _base64_payload(url: str) -> str:
+    if url.startswith("data:") and ";base64," in url:
+        return url.split(";base64,", 1)[1]
+    return url
+
+
+def _ollama_tool_calls(
+    tool_calls: PlainJson,
+) -> list[PlainJson] | None | TranslationError:
+    if tool_calls is None:
+        return None
+    if not isinstance(tool_calls, list):
+        return TranslationError.of_unsupported(
+            "ollama_chat serializer received non-list tool_calls; wiring bug"
+        )
+    out: list[PlainJson] = []
+    for call in tool_calls:
+        if not isinstance(call, dict):
+            return TranslationError.of_unsupported(
+                "ollama_chat serializer received a non-object tool_call; wiring bug"
+            )
+        function = call.get("function")
+        function_map = function if isinstance(function, dict) else {}
+        arguments_raw = function_map.get("arguments")
+        try:
+            arguments: PlainJson = (
+                json.loads(arguments_raw) if isinstance(arguments_raw, str) else {}
+            )
+        except ValueError:
+            return TranslationError.of_unsupported(
+                "tool_call arguments that json.loads rejects (blank string "
+                "included): v1's ollama_chat munge raises json.JSONDecodeError"
+            )
+        name = function_map.get("name")
+        out = [
+            *out,
+            {"function": {"name": name if name else "", "arguments": arguments}},
+        ]
+    return out

--- a/litellm/translation/providers/ollama_chat/stream.py
+++ b/litellm/translation/providers/ollama_chat/stream.py
@@ -1,0 +1,257 @@
+"""Ollama NDJSON stream lines -> IR stream events.
+
+v1 decodes through ``OllamaChatCompletionResponseIterator`` (a
+``BaseModelResponseIterator``): each line rides ``_handle_string_chunk`` —
+an SSE ``data:`` prefix is stripped if present, ``[DONE]`` ends the stream,
+and a line that fails ``json.loads`` (or parses falsy: ``""``, ``{}``,
+``null``) is SILENTLY SWALLOWED. v2 errors loudly on those — the watsonx
+line-seam PINNED DIVERGENCE (fail-closed on a failure path, named report
+row).
+
+``parse_event`` normalizes one wire chunk into the payload the
+``ollama_chat`` chunk dialect folds (the fold owns the think-tag state
+machine because it is STATEFUL — ``StreamState.started_reasoning``/
+``finished_reasoning``):
+
+- missing ``message``/``done`` keys -> loud (v1 raises OllamaError 400);
+  null/non-object ``message`` -> loud (v1 AttributeErrors);
+- tool_calls entries -> the validated delta shape (``index: 0``, ``type:
+  "function"``, dict arguments re-dumped with v1's ``", "``/``": "``
+  separators). The wire ``id`` is KEPT only while arguments are incomplete;
+  COMPLETE arguments (a dict, or a string json.loads accepts, length > 0)
+  get a fresh uuid4 in v1 — CLOBBERING any wire-carried id (probed). The
+  mint is envelope nondeterminism: the payload carries the ``""`` sentinel
+  and the seam (or the gate adapter) mints the bare uuid;
+- ``finish`` rides the RAW ``done_reason or "stop"`` only when ``done is
+  True`` (v1's identity check: a truthy non-True ``done`` is a mid chunk),
+  overridden to ``"tool_calls"`` when the chunk carries a tool_calls key
+  (v1: ``is not None`` — an EMPTY list still overrides); the live
+  ``map_finish_reason`` runs inside StreamingChoices on BOTH sides, so the
+  raw value needs no in-package map here (the watsonx rule);
+- usage: v1's iterator stamps eval counts on EVERY chunk but the WRAPPER
+  strips them from every emitted chunk (probed — the dossier's OL-R2
+  "per-chunk usage" claim holds only below the wrapper). The payload
+  carries usage ONLY for a done chunk that names at least one count; the
+  fold emits it as the trailing ``choices: []`` tail (the family seam
+  contract — v1's include_usage synthesis carries exactly the wire values
+  then; with NO counts v1 synthesizes token-counter ESTIMATES the seam
+  owns, pinned in the gate).
+"""
+
+from __future__ import annotations
+
+import json
+
+from expression import Error, Ok, Result
+from expression.collections import Block
+
+from ...errors import BoundaryError, TranslationError
+from ...ir import JsonBlob, PlainJson, StreamEvent
+
+_EventResult = Result[StreamEvent | None, TranslationError]
+
+MINT_TOOL_ID = ""
+"""Sentinel for "v1 mints a bare uuid4 here" (the StreamToolCall empty-id
+convention); the seam/gate adapter replaces it before chunk construction."""
+
+
+def _boundary(reason: str) -> TranslationError:
+    return TranslationError.of_boundary(BoundaryError.of(Block.of_seq([reason])))
+
+
+def parse_line(line: str) -> _EventResult:
+    stripped = line.strip()
+    if stripped.startswith("data:"):
+        stripped = stripped[len("data:") :].strip()
+    if "[DONE]" in line:
+        return Ok(StreamEvent.of_stop())
+    if not stripped:
+        return Error(
+            _boundary(
+                "empty ollama stream line: v1's base iterator silently "
+                "swallows it — deliberate fail-closed divergence on a "
+                "failure path (named report row)"
+            )
+        )
+    try:
+        event: PlainJson = json.loads(stripped)
+    except ValueError:
+        return Error(
+            _boundary(
+                f"non-JSON ollama stream line {stripped[:80]!r}: v1's base "
+                "iterator silently swallows it — deliberate fail-closed "
+                "divergence on a failure path (named report row)"
+            )
+        )
+    if not event:
+        return Error(
+            _boundary(
+                "falsy-JSON ollama stream line (empty object/null/zero): "
+                "v1's base iterator silently swallows it — deliberate "
+                "fail-closed divergence on a failure path (named report row)"
+            )
+        )
+    return parse_event(event)
+
+
+def parse_event(event: PlainJson) -> _EventResult:
+    if not isinstance(event, dict):
+        return Error(
+            _boundary("ollama stream chunk is not an object (v1 raises)")
+        )
+    if "message" not in event or "done" not in event:
+        return Error(
+            _boundary(
+                "ollama stream chunk missing 'message'/'done' (v1 raises "
+                "OllamaError 400)"
+            )
+        )
+    message = event.get("message")
+    if not isinstance(message, dict):
+        return Error(
+            _boundary(
+                "ollama stream chunk 'message' is not an object (v1 "
+                "AttributeErrors)"
+            )
+        )
+    tool_calls = _delta_tool_calls(message.get("tool_calls"))
+    if isinstance(tool_calls, TranslationError):
+        return Error(tool_calls)
+    thinking = message.get("thinking")
+    if thinking and not isinstance(thinking, str):
+        return Error(
+            _boundary(
+                "ollama stream chunk thinking is truthy but not a string "
+                "(v1's Delta validation raises)"
+            )
+        )
+    content = message.get("content")
+    if content and not isinstance(content, str):
+        return Error(
+            _boundary(
+                "ollama stream chunk content is truthy but not a string "
+                "(v1's tag scan raises TypeError)"
+            )
+        )
+    done = event.get("done")
+    finish = _finish(event, done, message)
+    if isinstance(finish, TranslationError):
+        return Error(finish)
+    payload: dict[str, PlainJson] = {
+        "thinking": thinking if isinstance(thinking, str) else None,
+        "content": content if isinstance(content, str) else None,
+        "tool_calls": tool_calls,
+        "finish": finish,
+        "usage": _done_usage(event) if done is True else None,
+    }
+    return Ok(StreamEvent.of_wire_chunk(JsonBlob(value=payload)))
+
+
+def _finish(
+    event: dict[str, PlainJson], done: PlainJson, message: dict[str, PlainJson]
+) -> PlainJson | TranslationError:
+    if done is not True:
+        return None
+    if message.get("tool_calls") is not None:
+        # v1 overrides on key PRESENCE (`is not None`), empty list included
+        return "tool_calls"
+    done_reason = event.get("done_reason")
+    if isinstance(done_reason, (list, dict)):
+        return _boundary(
+            "unhashable ollama done_reason (the live map_finish_reason "
+            "lookup raises TypeError in v1's StreamingChoices)"
+        )
+    return done_reason if done_reason else "stop"
+
+
+def _done_usage(event: dict[str, PlainJson]) -> PlainJson:
+    if "prompt_eval_count" not in event and "eval_count" not in event:
+        return None
+    prompt = event.get("prompt_eval_count", 0)
+    completion = event.get("eval_count", 0)
+    if not isinstance(prompt, int) or not isinstance(completion, int):
+        return None  # non-int counts never reach v1's synthesized chunk cleanly
+    return {
+        "prompt_tokens": prompt,
+        "completion_tokens": completion,
+        "total_tokens": prompt + completion,
+    }
+
+
+def _delta_tool_calls(
+    tool_calls: PlainJson,
+) -> list[PlainJson] | None | TranslationError:
+    if tool_calls is None:
+        return None
+    if not isinstance(tool_calls, list):
+        return _boundary(
+            "ollama stream tool_calls is not a list (v1's id loop raises)"
+        )
+    out: list[PlainJson] = []
+    for call in tool_calls:
+        if not isinstance(call, dict):
+            return _boundary(
+                "ollama stream tool_call entry is not an object (v1 raises)"
+            )
+        function = call.get("function")
+        if not isinstance(function, dict):
+            return _boundary(
+                "ollama stream tool_call has no 'function' object (v1's "
+                ".get chain AttributeErrors)"
+            )
+        arguments = function.get("arguments")
+        entry = _delta_entry(call, function, arguments)
+        if isinstance(entry, TranslationError):
+            return entry
+        out = [*out, entry]
+    return out
+
+
+def _delta_entry(
+    call: dict[str, PlainJson],
+    function: dict[str, PlainJson],
+    arguments: PlainJson,
+) -> PlainJson | TranslationError:
+    if arguments is not None and not isinstance(arguments, (str, dict)):
+        return _boundary(
+            "ollama stream tool_call arguments are neither a string nor an "
+            "object (v1's completeness probe / Delta validation raises)"
+        )
+    complete = _arguments_complete(arguments)
+    wire_id = call.get("id")
+    identifier: PlainJson
+    if complete:
+        identifier = MINT_TOOL_ID  # v1 mints uuid4, clobbering any wire id
+    else:
+        identifier = wire_id if isinstance(wire_id, str) else None
+    name = function.get("name")
+    if name is not None and not isinstance(name, str):
+        return _boundary(
+            "ollama stream tool_call name is not a string (v1's Delta "
+            "validation raises)"
+        )
+    arguments_str = (
+        json.dumps(arguments) if isinstance(arguments, dict) else arguments
+    )
+    return {
+        "id": identifier,
+        "type": "function",
+        "index": 0,
+        "function": {"name": name, "arguments": arguments_str},
+    }
+
+
+def _arguments_complete(arguments: PlainJson) -> bool:
+    """v1's gate: arguments non-None, ``len > 0``, and a dict or a string
+    json.loads accepts (``_is_function_call_complete``)."""
+    if arguments is None or not isinstance(arguments, (str, dict)):
+        return False
+    if len(arguments) == 0:
+        return False
+    if isinstance(arguments, dict):
+        return True
+    try:
+        json.loads(arguments)
+    except ValueError:
+        return False
+    return True

--- a/litellm/translation/providers/openai_compat/serialize.py
+++ b/litellm/translation/providers/openai_compat/serialize.py
@@ -86,7 +86,7 @@ def assemble_body(request: ChatRequest) -> _SerializeResult:
             tools=_tools_json(request.tools),
             tool_choice=_tool_choice_json(request.tool_choice),
             parallel_tool_calls=request.parallel_tool_calls.default_value(None),
-            response_format=_response_format_json(request.response_format),
+            response_format=response_format_json(request.response_format),
         ),
     }
     return Ok(body)
@@ -167,9 +167,13 @@ def _tool_choice_json(choice_opt: Option[ToolChoice]) -> PlainJson | None:
     assert_never(choice.tag)
 
 
-def _response_format_json(
+def response_format_json(
     response_format_opt: Option[ResponseFormat],
 ) -> PlainJson | None:
+    """The openai-wire response_format builder (type:text/json_object/
+    json_schema). Public because databricks re-emits the SAME verbatim shape
+    on NON-claude models (v1 passes response_format through unchanged there) —
+    the strip_function_strict sharing precedent."""
     match response_format_opt:
         case Option(tag="some", some=response_format):
             pass

--- a/litellm/translation_seam.py
+++ b/litellm/translation_seam.py
@@ -66,6 +66,8 @@ def build_translation_deps(
         drop_params=drop_params_global or request_drop_params is True,
         drop_params_global=drop_params_global,
         modify_params=litellm.modify_params is True,
+        disable_copilot_system_to_assistant=litellm.disable_copilot_system_to_assistant
+        is True,
     )
 
 

--- a/tests/test_litellm/translation/DIFFERENTIAL_REPORT.md
+++ b/tests/test_litellm/translation/DIFFERENTIAL_REPORT.md
@@ -1,4 +1,4 @@
-# Translation v2 differential report (anthropic + bedrock + openai + google + azure + xai + the compat_sdk family (waves 1a+1b+2a) + the wave-1b compat_httpx family + the wave-2b-alpha + wave-2b-beta own modules + the wave-3 ollama_chat and github_copilot own modules)
+# Translation v2 differential report (anthropic + bedrock + openai + google + azure + xai + the compat_sdk family (waves 1a+1b+2a) + the wave-1b compat_httpx family + the wave-2b-alpha + wave-2b-beta own modules + the wave-3 ollama_chat, github_copilot, and databricks own modules)
 
 v1 and v2 run over the same corpus; every row must be IDENTICAL (or an
 explained FALLBACK that v1 serves) for a provider's flag to turn on.
@@ -6,7 +6,7 @@ Bedrock and google rows additionally pin the characterization-corpus
 snapshot, so each row proves snapshot == v1-at-HEAD == v2. Regenerate with:
 `python -m tests.test_litellm.translation.generate_differential_report`
 
-- commit: 01cf1937f4
+- commit: 3b267ec2e2
 
 ## anthropic: request bodies (v1 map_openai_params + transform_request vs v2)
 
@@ -2533,6 +2533,79 @@ ollama_chat streams ride a dedicated inbound NDJSON dialect (inbound/openai_chat
 - IDENTICAL: tool_calls_rewrites_stop
 
 github_copilot has no custom stream iterator in v1 (SDK chunks ride the default openai dialect); streaming stays on v1 until the streaming seam lands, so there is no stream differential row here yet. The codex family (gpt-5.3-codex / gpt-5.1-codex-max) bridges to the Responses API above the chat seam and stays v1 by absence (canary in the request gate).
+
+## databricks: request bodies (v1 get_optional_params('databricks') + the LIVE DatabricksConfig.transform_request — the {model, messages, stream} body, mct->max_tokens, the claude-substring tool round-trip (drops strict/$schema) and the thinking max-bump — vs v2 providers/databricks; every shared shape on BOTH the claude and non-claude arms of the "claude" in model fork)
+
+- IDENTICAL: max_tokens_verbatim (claude)
+- IDENTICAL: max_tokens_verbatim (nonclaude)
+- IDENTICAL: mct_to_max_tokens (claude)
+- IDENTICAL: mct_to_max_tokens (nonclaude)
+- IDENTICAL: plain (claude)
+- IDENTICAL: plain (nonclaude)
+- IDENTICAL: sampling (claude)
+- IDENTICAL: sampling (nonclaude)
+- IDENTICAL: stream_false_always_present (claude)
+- IDENTICAL: stream_false_always_present (nonclaude)
+- IDENTICAL: stream_true (claude)
+- IDENTICAL: stream_true (nonclaude)
+- IDENTICAL: thinking_budget_bumps_max_tokens (claude)
+- IDENTICAL: thinking_budget_bumps_max_tokens (nonclaude)
+- IDENTICAL: thinking_budget_with_caller_max_tokens_no_bump (claude)
+- IDENTICAL: thinking_budget_with_caller_max_tokens_no_bump (nonclaude)
+- IDENTICAL: thinking_no_budget_no_bump (claude)
+- IDENTICAL: thinking_no_budget_no_bump (nonclaude)
+- IDENTICAL: tool_choice_auto (claude)
+- IDENTICAL: tool_choice_auto (nonclaude)
+- IDENTICAL: tool_choice_required (claude)
+- IDENTICAL: tool_choice_required (nonclaude)
+- IDENTICAL: tool_choice_specific (claude)
+- IDENTICAL: tool_choice_specific (nonclaude)
+- IDENTICAL: top_k_top_level (claude)
+- IDENTICAL: top_k_top_level (nonclaude)
+- IDENTICAL: reasoning_effort_with_max_tokens_nonclaude
+- IDENTICAL: response_format_json_object_nonclaude
+- IDENTICAL: response_format_json_schema_nonclaude
+- IDENTICAL: tools_verbatim_nonclaude
+- IDENTICAL: tools_roundtrip_drops_strict_and_schema_claude
+- FALLBACK (v1 raises UnsupportedParamsError): parallel_tool_calls (parallel_tool_calls)
+- FALLBACK (v1 raises raw KeyError, DB-R3): nonclaude_reasoning_effort_without_max_tokens_keyerror (reasoning_effort)
+- FALLBACK (v1 serves it): claude_reasoning_effort_thinking_machinery (reasoning_effort)
+- FALLBACK (v1 serves it): claude_response_format_json_object_silently_dropped (response_format)
+- FALLBACK (v1 serves it): claude_response_format_json_schema_machinery (response_format)
+- FALLBACK (v1 serves it): n_parse_level_unknown (not yet supported by translation v2: n)
+- FALLBACK (v1 serves it): user_silent_drop (user)
+
+## databricks: responses (v1's transform_response — content-list flatten, reasoning/summary -> reasoning_content + thinking_blocks, citations -> provider_specific_fields with supported_text, the databricks/{wire model} prefix; a missing required key is a RAW KeyError — vs v2 the parser + openai construction arm)
+
+- IDENTICAL: citations_lift_with_supported_text
+- IDENTICAL: content_list_flattens
+- IDENTICAL: finish_length
+- IDENTICAL: finish_unknown_maps_stop
+- IDENTICAL: plain
+- IDENTICAL: reasoning_summary_missing_signature
+- IDENTICAL: reasoning_summary_to_reasoning_content
+- IDENTICAL: tool_calls_verbatim
+- IDENTICAL: unknown_top_level_key_dropped
+- IDENTICAL: wire_model_prefixed
+- FALLBACK (v1 raises raw KeyError): choice_missing_finish_reason (finish_reason)
+- FALLBACK (v1 raises raw KeyError): choice_missing_message (message)
+- FALLBACK (v1 raises raw KeyError): missing_choices (choices)
+- FALLBACK (v1 raises raw KeyError): missing_created (created)
+- FALLBACK (v1 raises raw KeyError): missing_id (id)
+- FALLBACK (v1 raises raw KeyError): missing_usage (usage)
+
+## databricks: streams (v1 DatabricksChatResponseIterator — ONE body per wire chunk, the wire usage DROPPED ENTIRELY (DB-R5), the json_mode json_tool_call->content byte-reformat (DB-R8) — vs v2 the databricks chunk dialect; the non-JSON/empty line seam is a PINNED DIVERGENCE)
+
+- IDENTICAL: citations_lift
+- IDENTICAL: content
+- IDENTICAL: content_list_flattens
+- IDENTICAL: reasoning_summary
+- IDENTICAL: reasoning_summary_missing_signature
+- IDENTICAL: tool_call
+- IDENTICAL: tool_call_empty_args_blanked
+- IDENTICAL: usage_chunk_dropped
+- PINNED DIVERGENCE (v1 swallows, v2 loud): empty_line (empty)
+- PINNED DIVERGENCE (v1 swallows, v2 loud): non_json_line (non-JSON)
 
 ## azure: request bodies (v1 api-version-aware map_openai_params + transform_request vs v2)
 

--- a/tests/test_litellm/translation/DIFFERENTIAL_REPORT.md
+++ b/tests/test_litellm/translation/DIFFERENTIAL_REPORT.md
@@ -1,4 +1,4 @@
-# Translation v2 differential report (anthropic + bedrock + openai + google + azure + xai + the compat_sdk family (waves 1a+1b+2a) + the wave-1b compat_httpx family + the wave-2b-alpha + wave-2b-beta own modules)
+# Translation v2 differential report (anthropic + bedrock + openai + google + azure + xai + the compat_sdk family (waves 1a+1b+2a) + the wave-1b compat_httpx family + the wave-2b-alpha + wave-2b-beta own modules + the wave-3 ollama_chat own module)
 
 v1 and v2 run over the same corpus; every row must be IDENTICAL (or an
 explained FALLBACK that v1 serves) for a provider's flag to turn on.
@@ -6,7 +6,7 @@ Bedrock and google rows additionally pin the characterization-corpus
 snapshot, so each row proves snapshot == v1-at-HEAD == v2. Regenerate with:
 `python -m tests.test_litellm.translation.generate_differential_report`
 
-- commit: 76bb3a6a77
+- commit: aa2b84f101
 
 ## anthropic: request bodies (v1 map_openai_params + transform_request vs v2)
 
@@ -2420,6 +2420,86 @@ snapshot, so each row proves snapshot == v1-at-HEAD == v2. Regenerate with:
 - FALLBACK (v1 raises APIError): non-str delta reasoning_content (the F6 groq-local pre-step; the wrapper epilogue join TypeErrors in v1)
 - IDENTICAL: non-str refusal forwarded VERBATIM (the wave-2b-beta F6 INTEGRATOR-FLIP handoff, discharged at the sibling merge: the shared httpx_chunk factory used to null what v1 forwards; the refusal-on-finish half is the failure-counted PINNED DIVERGENCE row below)
 - PINNED DIVERGENCE (fail-closed where v1 serves the lossy finish): refusal-on-finish: groq's v1 wrapper silently DROPS a refusal value riding the finish chunk and serves the lossy finish; v2 takes the loud finish-chunk fallback for any value type (test_refusal_on_finish_chunk_is_loud_where_v1_drops_it; critic-wave2b-final MAJOR-2 made the gate-pinned divergence a failure-counted report row)
+
+## ollama_chat: request bodies (v1 get_optional_params('ollama_chat') + the LIVE OllamaChatConfig.transform_request — dedicated elif, the {model, messages, options, stream} NDJSON body with the message munge whitelist, the think-tag thinking-extract quirk and the always-on stream key — vs v2 providers/ollama_chat)
+
+- IDENTICAL: assistant_think_tags_full_content_plus_thinking
+- IDENTICAL: empty_assistant_content_rides
+- IDENTICAL: image_data_url_stripped_to_base64
+- IDENTICAL: image_http_url_verbatim
+- IDENTICAL: mct_to_num_predict
+- IDENTICAL: message_name_dropped_every_role
+- IDENTICAL: multi_text_list_flattens
+- IDENTICAL: plain
+- IDENTICAL: reasoning_effort_gptoss_verbatim
+- IDENTICAL: reasoning_effort_low_to_think_true
+- IDENTICAL: reasoning_effort_minimal_to_think_false
+- IDENTICAL: reasoning_effort_none_string_to_think_false
+- IDENTICAL: rf_json_object
+- IDENTICAL: rf_json_schema_bare_schema
+- IDENTICAL: rf_text_dropped
+- IDENTICAL: sampling
+- IDENTICAL: stream_false
+- IDENTICAL: stream_true
+- IDENTICAL: system_rides_in_messages
+- IDENTICAL: temperature_int_stays_int
+- IDENTICAL: tool_choice_popped
+- IDENTICAL: tool_roundtrip_id_type_dropped
+- IDENTICAL: tools_strict_rides
+- IDENTICAL: tools_verbatim
+- IDENTICAL: top_k_options_passthrough
+- IDENTICAL: user_think_tags_same_quirk
+- FALLBACK (v1 raises UnsupportedParamsError): logprobs (logprobs)
+- FALLBACK (v1 raises UnsupportedParamsError): n (n)
+- FALLBACK (v1 raises UnsupportedParamsError): parallel_tool_calls (parallel_tool_calls)
+- FALLBACK (v1 raises UnsupportedParamsError): presence_penalty (presence_penalty)
+- FALLBACK (v1 raises UnsupportedParamsError): thinking (thinking)
+- FALLBACK (v1 serves it): assistant_reasoning_content_to_thinking (reasoning_content)
+- FALLBACK (v1 serves it): both_max_tokens_keys (max_tokens)
+- FALLBACK (v1 serves it): consecutive_user_turns (consecutive)
+- FALLBACK (v1 serves it): frequency_penalty_to_repeat_penalty (frequency_penalty)
+- FALLBACK (v1 serves it): function_name_near_dormant_synth_arm (function_name)
+- FALLBACK (v1 serves it): functions_to_tools_verbatim (functions)
+- FALLBACK (v1 serves it): keep_alive_passthrough (keep_alive)
+- FALLBACK (v1 serves it): mid_conversation_system (system)
+- FALLBACK (v1 serves it): mirostat_native_passthrough (mirostat)
+- FALLBACK (v1 serves it): seed_parse_level (seed)
+- FALLBACK (v1 serves it): string_stop_rides_verbatim (stop)
+- FALLBACK (v1 serves it): tool_cache_control_verbatim (cache_control)
+- FALLBACK (v1 serves it): user_silent_drop (user)
+- FALLBACK (v1 raises json.JSONDecodeError): blank_tool_arguments_json_decode_error (JSON repair)
+
+## ollama_chat: responses (v1's OWN transform_response mutating a pre-allocated ModelResponse — the ollama_chat/{REQUEST model} prefix, the thinking remap / think-tag split, tool-arg restringify — vs v2 parser + the openai construction arm; the wire carries no id so the ambient chatcmpl id is kept)
+
+- IDENTICAL: done_reason_length
+- IDENTICAL: done_reason_missing_defaults_stop
+- IDENTICAL: done_reason_unknown_maps_stop
+- IDENTICAL: extra_message_key_rides
+- IDENTICAL: extra_top_level_key_dropped
+- IDENTICAL: plain
+- IDENTICAL: think_tags_split_remainder
+- IDENTICAL: think_tags_unclosed_verbatim
+- IDENTICAL: thinking_field_to_reasoning_content
+- IDENTICAL: tool_calls_dict_args_restringified
+- IDENTICAL: tool_calls_force_finish_over_done_reason
+- IDENTICAL: tool_calls_str_args_verbatim
+- IDENTICAL: tool_calls_wire_id_kept
+- IDENTICAL: wire_model_ignored
+- FALLBACK (v1 raises): content_key_missing (missing or null)
+- FALLBACK (v1 raises): missing_message (message)
+- FALLBACK (v1 raises): non_object_body (not an object)
+- FALLBACK (v1 raises): non_str_content (not a string)
+- FALLBACK (v1 raises): null_content_eager_token_counter (token_counter)
+- FALLBACK (v1 raises): null_content_with_thinking (missing or null)
+- FALLBACK (v1 raises): null_message (message)
+- FALLBACK (v1 raises): tool_call_missing_function (function)
+- FALLBACK (v1 raises): tool_call_non_object_entry (not an object)
+- FALLBACK (v1 raises): unhashable_done_reason (unhashable)
+- FALLBACK (v1 serves it): function_call_done_reason_outside_ir (function_call)
+- FALLBACK (v1 serves it): missing_eval_count_token_counter (token_counter)
+- FALLBACK (v1 serves it): missing_prompt_eval_count_token_counter (token_counter)
+
+ollama_chat streams ride a dedicated inbound NDJSON dialect (inbound/openai_chat: the ollama_chat ChunkDialect + ollama_fold); like every other provider, streaming stays on v1 until the streaming seam lands, so there is no stream differential row here yet.
 
 ## azure: request bodies (v1 api-version-aware map_openai_params + transform_request vs v2)
 

--- a/tests/test_litellm/translation/DIFFERENTIAL_REPORT.md
+++ b/tests/test_litellm/translation/DIFFERENTIAL_REPORT.md
@@ -1,4 +1,4 @@
-# Translation v2 differential report (anthropic + bedrock + openai + google + azure + xai + the compat_sdk family (waves 1a+1b+2a) + the wave-1b compat_httpx family + the wave-2b-alpha + wave-2b-beta own modules + the wave-3 ollama_chat own module)
+# Translation v2 differential report (anthropic + bedrock + openai + google + azure + xai + the compat_sdk family (waves 1a+1b+2a) + the wave-1b compat_httpx family + the wave-2b-alpha + wave-2b-beta own modules + the wave-3 ollama_chat and github_copilot own modules)
 
 v1 and v2 run over the same corpus; every row must be IDENTICAL (or an
 explained FALLBACK that v1 serves) for a provider's flag to turn on.
@@ -6,7 +6,7 @@ Bedrock and google rows additionally pin the characterization-corpus
 snapshot, so each row proves snapshot == v1-at-HEAD == v2. Regenerate with:
 `python -m tests.test_litellm.translation.generate_differential_report`
 
-- commit: aa2b84f101
+- commit: 68500e3fc7
 
 ## anthropic: request bodies (v1 map_openai_params + transform_request vs v2)
 
@@ -2500,6 +2500,39 @@ snapshot, so each row proves snapshot == v1-at-HEAD == v2. Regenerate with:
 - FALLBACK (v1 serves it): missing_prompt_eval_count_token_counter (token_counter)
 
 ollama_chat streams ride a dedicated inbound NDJSON dialect (inbound/openai_chat: the ollama_chat ChunkDialect + ollama_fold); like every other provider, streaming stays on v1 until the streaming seam lands, so there is no stream differential row here yet.
+
+## github_copilot: request bodies (v1 get_optional_params ('github_copilot') + the LIVE GithubCopilotConfig.transform_request — the SDK-path big openai elif, openai_compat assembly with the system->assistant role rewrite gated by litellm.disable_copilot_system_to_assistant — vs v2 providers/github_copilot; probed with a seeded fake token dir, no live OAuth)
+
+- IDENTICAL: claude_plain_serves
+- IDENTICAL: mct_verbatim_no_rename
+- IDENTICAL: plain
+- IDENTICAL: response_format_json_schema
+- IDENTICAL: sampling
+- IDENTICAL: stream_true
+- IDENTICAL: system_to_assistant
+- IDENTICAL: temperature_int_stays_int
+- IDENTICAL: tool_call_compact_roundtrip
+- IDENTICAL: tool_choice_specific
+- IDENTICAL: tools_auto
+- FALLBACK (v1 raises UnsupportedParamsError): claude_reasoning_effort (reasoning_effort)
+- FALLBACK (v1 raises UnsupportedParamsError): claude_thinking (thinking)
+- FALLBACK (v1 raises UnsupportedParamsError): gpt5_temperature_not_one (gpt-5)
+- FALLBACK (v1 serves it): explicit_stream_false (stream)
+- FALLBACK (v1 serves it): message_name_forwarded (name)
+- FALLBACK (v1 serves it): n_parse_level (field)
+- FALLBACK (v1 serves it): seed_parse_level (seed)
+- FALLBACK (v1 serves it): string_stop (stop)
+- FALLBACK (v1 serves it): top_k_not_a_chat_param (top_k)
+- FALLBACK (v1 serves it): user_claude_dropped_by_v1 (user)
+- FALLBACK (v1 serves it): user_gpt4o_served_by_v1 (user)
+
+## github_copilot: responses (v1's SDK-path convert_to_model_response_object over the github_copilot/{model} preset — the config's transform_response is DEAD on this path — vs v2 the shared openai parser + the seam re-prefix; construction arm openai)
+
+- IDENTICAL: cached_and_reasoning_usage_details
+- IDENTICAL: text
+- IDENTICAL: tool_calls_rewrites_stop
+
+github_copilot has no custom stream iterator in v1 (SDK chunks ride the default openai dialect); streaming stays on v1 until the streaming seam lands, so there is no stream differential row here yet. The codex family (gpt-5.3-codex / gpt-5.1-codex-max) bridges to the Responses API above the chat seam and stays v1 by absence (canary in the request gate).
 
 ## azure: request bodies (v1 api-version-aware map_openai_params + transform_request vs v2)
 

--- a/tests/test_litellm/translation/DIFFERENTIAL_REPORT.md
+++ b/tests/test_litellm/translation/DIFFERENTIAL_REPORT.md
@@ -6,7 +6,7 @@ Bedrock and google rows additionally pin the characterization-corpus
 snapshot, so each row proves snapshot == v1-at-HEAD == v2. Regenerate with:
 `python -m tests.test_litellm.translation.generate_differential_report`
 
-- commit: 68500e3fc7
+- commit: 01cf1937f4
 
 ## anthropic: request bodies (v1 map_openai_params + transform_request vs v2)
 

--- a/tests/test_litellm/translation/generate_differential_report.py
+++ b/tests/test_litellm/translation/generate_differential_report.py
@@ -2877,12 +2877,152 @@ def _github_copilot_rows(lines: list) -> int:
     return failures
 
 
+def _databricks_rows(lines: list) -> int:
+    from litellm.exceptions import UnsupportedParamsError
+
+    from . import test_differential_databricks_request as req
+    from . import test_differential_databricks_response as resp
+    from . import test_differential_databricks_stream as stream
+
+    failures = 0
+    lines += [
+        "",
+        "## databricks: request bodies (v1 get_optional_params('databricks') +"
+        " the LIVE DatabricksConfig.transform_request — the {model, messages,"
+        " stream} body, mct->max_tokens, the claude-substring tool round-trip"
+        " (drops strict/$schema) and the thinking max-bump — vs v2"
+        " providers/databricks; every shared shape on BOTH the claude and"
+        " non-claude arms of the \"claude\" in model fork)",
+        "",
+    ]
+    for name in sorted(req._SHARED_CASES):
+        for model in (req.CLAUDE, req.NONCLAUDE):
+            case = {"model": model, **req._SHARED_CASES[name]}
+            result = req._v2(case)
+            same = result.is_ok() and req._norm(result.ok) == req._norm(
+                req.run_v1_request_transform(case)
+            )
+            failures += 0 if same else 1
+            arm = "claude" if model == req.CLAUDE else "nonclaude"
+            lines.append(f"- {'IDENTICAL' if same else 'DIVERGENT'}: {name} ({arm})")
+    for name in sorted(req._NONCLAUDE_ONLY_CASES):
+        case = {"model": req.NONCLAUDE, **req._NONCLAUDE_ONLY_CASES[name]}
+        result = req._v2(case)
+        same = result.is_ok() and req._norm(result.ok) == req._norm(
+            req.run_v1_request_transform(case)
+        )
+        failures += 0 if same else 1
+        lines.append(f"- {'IDENTICAL' if same else 'DIVERGENT'}: {name}")
+    for name in sorted(req._CLAUDE_ONLY_CASES):
+        case = {"model": req.CLAUDE, **req._CLAUDE_ONLY_CASES[name]}
+        result = req._v2(case)
+        same = result.is_ok() and req._norm(result.ok) == req._norm(
+            req.run_v1_request_transform(case)
+        )
+        failures += 0 if same else 1
+        lines.append(f"- {'IDENTICAL' if same else 'DIVERGENT'}: {name}")
+    for name in sorted(req._V1_RAISES):
+        case, reason = req._V1_RAISES[name]
+        result = req._v2(case)
+        try:
+            req.run_v1_request_transform(case)
+            raised = False
+        except UnsupportedParamsError:
+            raised = True
+        ok = result.is_error() and reason in result.error.summary and raised
+        failures += 0 if ok else 1
+        label = "FALLBACK (v1 raises UnsupportedParamsError)" if ok else "DIVERGENT"
+        lines.append(f"- {label}: {name} ({reason})")
+    for name in sorted(req._V1_RAISES_RAW):
+        case, reason = req._V1_RAISES_RAW[name]
+        result = req._v2(case)
+        try:
+            req.run_v1_request_transform(case)
+            raised = False
+        except KeyError:
+            raised = True
+        ok = result.is_error() and reason in result.error.summary and raised
+        failures += 0 if ok else 1
+        label = "FALLBACK (v1 raises raw KeyError, DB-R3)" if ok else "DIVERGENT"
+        lines.append(f"- {label}: {name} ({reason})")
+    for name in sorted(req._V1_SERVES_FALLBACKS):
+        case, reason = req._V1_SERVES_FALLBACKS[name]
+        result = req._v2(case)
+        ok = result.is_error() and reason in result.error.summary
+        failures += 0 if ok else 1
+        label = "FALLBACK (v1 serves it)" if ok else "DIVERGENT"
+        lines.append(f"- {label}: {name} ({reason})")
+    lines += [
+        "",
+        "## databricks: responses (v1's transform_response — content-list"
+        " flatten, reasoning/summary -> reasoning_content + thinking_blocks,"
+        " citations -> provider_specific_fields with supported_text, the"
+        " databricks/{wire model} prefix; a missing required key is a RAW"
+        " KeyError — vs v2 the parser + openai construction arm)",
+        "",
+    ]
+    for name in sorted(resp._RESPONSES):
+        raw = resp._RESPONSES[name]
+        same = resp._norm(resp._v2_model_response(raw)) == resp._norm(
+            resp._v1_model_response(raw)
+        )
+        failures += 0 if same else 1
+        lines.append(f"- {'IDENTICAL' if same else 'DIVERGENT'}: {name}")
+    for name in sorted(resp._LOUD):
+        raw, fragment = resp._LOUD[name]
+        result = resp._v2_parse(raw)
+        try:
+            resp._v1_model_response(raw)
+            raised = False
+        except KeyError:
+            raised = True
+        ok = result.is_error() and fragment in result.error.summary and raised
+        failures += 0 if ok else 1
+        label = "FALLBACK (v1 raises raw KeyError)" if ok else "DIVERGENT"
+        lines.append(f"- {label}: {name} ({fragment})")
+    lines += [
+        "",
+        "## databricks: streams (v1 DatabricksChatResponseIterator — ONE body"
+        " per wire chunk, the wire usage DROPPED ENTIRELY (DB-R5), the json_mode"
+        " json_tool_call->content byte-reformat (DB-R8) — vs v2 the databricks"
+        " chunk dialect; the non-JSON/empty line seam is a PINNED DIVERGENCE)",
+        "",
+    ]
+    for name in sorted(stream.STREAMS):
+        events = stream.STREAMS[name]
+        v1 = stream._v1_chunks(events)
+        v2 = stream._v2_bodies(events)
+        same = len(v1) == len(v2) and all(
+            stream._norm_delta(stream._v1_delta(a)) == stream._norm_delta(
+                stream._v2_delta(b)
+            )
+            for a, b in zip(v1, v2)
+        )
+        failures += 0 if same else 1
+        lines.append(f"- {'IDENTICAL' if same else 'DIVERGENT'}: {name}")
+    for name in sorted(stream._PINNED_DIVERGENCES):
+        raw_lines, fragment = stream._PINNED_DIVERGENCES[name]
+        from litellm.translation.engine.stream import fold_lines
+        from litellm.translation.inbound.openai_chat.stream import initial_state
+
+        folded = fold_lines(
+            list(raw_lines),
+            stream.parse_line,
+            initial_state(stream.MODEL, dialect="databricks"),
+        )
+        ok = folded.is_error() and fragment in folded.error.summary
+        failures += 0 if ok else 1
+        label = "PINNED DIVERGENCE (v1 swallows, v2 loud)" if ok else "DIVERGENT"
+        lines.append(f"- {label}: {name} ({fragment})")
+    return failures
+
+
 def main() -> None:
     _freeze_ambient()
     _stub_vertex_token()
 
     lines = [
-        "# Translation v2 differential report (anthropic + bedrock + openai + google + azure + xai + the compat_sdk family (waves 1a+1b+2a) + the wave-1b compat_httpx family + the wave-2b-alpha + wave-2b-beta own modules + the wave-3 ollama_chat and github_copilot own modules)",
+        "# Translation v2 differential report (anthropic + bedrock + openai + google + azure + xai + the compat_sdk family (waves 1a+1b+2a) + the wave-1b compat_httpx family + the wave-2b-alpha + wave-2b-beta own modules + the wave-3 ollama_chat, github_copilot, and databricks own modules)",
         "",
         "v1 and v2 run over the same corpus; every row must be IDENTICAL (or an",
         "explained FALLBACK that v1 serves) for a provider's flag to turn on.",
@@ -2907,6 +3047,7 @@ def main() -> None:
     failures += _groq_rows(lines)
     failures += _ollama_chat_rows(lines)
     failures += _github_copilot_rows(lines)
+    failures += _databricks_rows(lines)
     failures += _azure_rows(lines)
     failures += _azure_ai_rows(lines)
     failures += _bedrock_request_rows(lines)

--- a/tests/test_litellm/translation/generate_differential_report.py
+++ b/tests/test_litellm/translation/generate_differential_report.py
@@ -2702,12 +2702,114 @@ def _google_stream_rows(lines: list) -> int:
     return failures
 
 
+def _ollama_chat_rows(lines: list) -> int:
+    import json as _json
+
+    from litellm.exceptions import UnsupportedParamsError
+
+    from . import test_differential_ollama_chat_request as req
+    from . import test_differential_ollama_chat_response as resp
+
+    failures = 0
+    lines += [
+        "",
+        "## ollama_chat: request bodies (v1 get_optional_params('ollama_chat')"
+        " + the LIVE OllamaChatConfig.transform_request — dedicated elif, the"
+        " {model, messages, options, stream} NDJSON body with the message"
+        " munge whitelist, the think-tag thinking-extract quirk and the"
+        " always-on stream key — vs v2 providers/ollama_chat)",
+        "",
+    ]
+    for name in sorted(req.CASES):
+        case = req.CASES[name]
+        result = req._v2(case)
+        same = result.is_ok() and req._norm(result.ok) == req._norm(
+            req.run_v1_request_transform(case)
+        )
+        failures += 0 if same else 1
+        lines.append(f"- {'IDENTICAL' if same else 'DIVERGENT'}: {name}")
+    for name in sorted(req.V1_RAISES):
+        case, reason = req.V1_RAISES[name]
+        result = req._v2(case)
+        try:
+            req.run_v1_request_transform(case)
+            raised = False
+        except UnsupportedParamsError:
+            raised = True
+        ok = result.is_error() and reason in result.error.summary and raised
+        failures += 0 if ok else 1
+        label = "FALLBACK (v1 raises UnsupportedParamsError)" if ok else "DIVERGENT"
+        lines.append(f"- {label}: {name} ({reason})")
+    for name in sorted(req.V1_SERVES_FALLBACKS):
+        case, reason = req.V1_SERVES_FALLBACKS[name]
+        result = req._v2(case)
+        ok = result.is_error() and reason in result.error.summary
+        failures += 0 if ok else 1
+        label = "FALLBACK (v1 serves it)" if ok else "DIVERGENT"
+        lines.append(f"- {label}: {name} ({reason})")
+    for name in sorted(req.V1_RAISES_RAW):
+        case, reason = req.V1_RAISES_RAW[name]
+        result = req._v2(case)
+        try:
+            req.run_v1_request_transform(case)
+            raised = False
+        except _json.JSONDecodeError:
+            raised = True
+        ok = result.is_error() and reason in result.error.summary and raised
+        failures += 0 if ok else 1
+        label = "FALLBACK (v1 raises json.JSONDecodeError)" if ok else "DIVERGENT"
+        lines.append(f"- {label}: {name} ({reason})")
+    lines += [
+        "",
+        "## ollama_chat: responses (v1's OWN transform_response mutating a"
+        " pre-allocated ModelResponse — the ollama_chat/{REQUEST model} prefix,"
+        " the thinking remap / think-tag split, tool-arg restringify — vs v2"
+        " parser + the openai construction arm; the wire carries no id so the"
+        " ambient chatcmpl id is kept)",
+        "",
+    ]
+    for name in sorted(resp._RESPONSES):
+        raw = resp._RESPONSES[name]
+        same = resp._norm(resp._v2_model_response(raw)) == resp._norm(
+            resp._v1_model_response(raw)
+        )
+        failures += 0 if same else 1
+        lines.append(f"- {'IDENTICAL' if same else 'DIVERGENT'}: {name}")
+    for name in sorted(resp._LOUD):
+        raw, fragment = resp._LOUD[name]
+        result = resp._v2_parse(raw)
+        try:
+            resp._v1_model_response(raw)
+            raised = False
+        except Exception:
+            raised = True
+        ok = result.is_error() and fragment in result.error.summary and raised
+        failures += 0 if ok else 1
+        label = "FALLBACK (v1 raises)" if ok else "DIVERGENT"
+        lines.append(f"- {label}: {name} ({fragment})")
+    for name in sorted(resp._V1_SERVES_FALLBACKS):
+        raw, fragment = resp._V1_SERVES_FALLBACKS[name]
+        result = resp._v2_parse(raw)
+        ok = result.is_error() and fragment in result.error.summary
+        failures += 0 if ok else 1
+        label = "FALLBACK (v1 serves it)" if ok else "DIVERGENT"
+        lines.append(f"- {label}: {name} ({fragment})")
+    lines += [
+        "",
+        "ollama_chat streams ride a dedicated inbound NDJSON dialect"
+        " (inbound/openai_chat: the ollama_chat ChunkDialect + ollama_fold);"
+        " like every other provider, streaming stays on v1 until the streaming"
+        " seam lands, so there is no stream differential row here yet.",
+    ]
+    return failures
+
+
 def main() -> None:
     _freeze_ambient()
     _stub_vertex_token()
 
     lines = [
-        "# Translation v2 differential report (anthropic + bedrock + openai + google + azure + xai + the compat_sdk family (waves 1a+1b+2a) + the wave-1b compat_httpx family + the wave-2b-alpha + wave-2b-beta own modules)",
+        "# Translation v2 differential report (anthropic + bedrock + openai + google + azure + xai + the compat_sdk family (waves 1a+1b+2a) + the wave-1b compat_httpx family + the wave-2b-alpha + wave-2b-beta own modules + the wave-3 ollama_chat own module)",
         "",
         "v1 and v2 run over the same corpus; every row must be IDENTICAL (or an",
         "explained FALLBACK that v1 serves) for a provider's flag to turn on.",
@@ -2730,6 +2832,7 @@ def main() -> None:
     failures += _watsonx_rows(lines)
     failures += _sagemaker_chat_rows(lines)
     failures += _groq_rows(lines)
+    failures += _ollama_chat_rows(lines)
     failures += _azure_rows(lines)
     failures += _azure_ai_rows(lines)
     failures += _bedrock_request_rows(lines)

--- a/tests/test_litellm/translation/generate_differential_report.py
+++ b/tests/test_litellm/translation/generate_differential_report.py
@@ -2804,12 +2804,85 @@ def _ollama_chat_rows(lines: list) -> int:
     return failures
 
 
+def _github_copilot_rows(lines: list) -> int:
+    from litellm.exceptions import UnsupportedParamsError
+
+    from . import test_differential_github_copilot_request as req
+    from . import test_differential_github_copilot_response as resp
+
+    failures = 0
+    lines += [
+        "",
+        "## github_copilot: request bodies (v1 get_optional_params"
+        " ('github_copilot') + the LIVE GithubCopilotConfig.transform_request"
+        " — the SDK-path big openai elif, openai_compat assembly with the"
+        " system->assistant role rewrite gated by"
+        " litellm.disable_copilot_system_to_assistant — vs v2"
+        " providers/github_copilot; probed with a seeded fake token dir, no"
+        " live OAuth)",
+        "",
+    ]
+    for name in sorted(req.CASES):
+        case = req.CASES[name]
+        result = req._v2(case)
+        same = result.is_ok() and req._norm(result.ok) == req._norm(
+            req.run_v1_request_transform(case)
+        )
+        failures += 0 if same else 1
+        lines.append(f"- {'IDENTICAL' if same else 'DIVERGENT'}: {name}")
+    for name in sorted(req.V1_RAISES):
+        case, reason = req.V1_RAISES[name]
+        result = req._v2(case)
+        try:
+            req.run_v1_request_transform(case)
+            raised = False
+        except UnsupportedParamsError:
+            raised = True
+        ok = result.is_error() and reason in result.error.summary and raised
+        failures += 0 if ok else 1
+        label = "FALLBACK (v1 raises UnsupportedParamsError)" if ok else "DIVERGENT"
+        lines.append(f"- {label}: {name} ({reason})")
+    for name in sorted(req.V1_SERVES_FALLBACKS):
+        case, reason = req.V1_SERVES_FALLBACKS[name]
+        result = req._v2(case)
+        ok = result.is_error() and reason in result.error.summary
+        failures += 0 if ok else 1
+        label = "FALLBACK (v1 serves it)" if ok else "DIVERGENT"
+        lines.append(f"- {label}: {name} ({reason})")
+    lines += [
+        "",
+        "## github_copilot: responses (v1's SDK-path"
+        " convert_to_model_response_object over the github_copilot/{model}"
+        " preset — the config's transform_response is DEAD on this path — vs"
+        " v2 the shared openai parser + the seam re-prefix; construction arm"
+        " openai)",
+        "",
+    ]
+    for name in sorted(resp._RESPONSE_ROWS):
+        raw = resp._RESPONSES[name]
+        same = resp._norm(resp._v2_model_response(raw, resp._PRESET)) == resp._norm(
+            resp._v1_model_response(raw, resp._PRESET)
+        )
+        failures += 0 if same else 1
+        lines.append(f"- {'IDENTICAL' if same else 'DIVERGENT'}: {name}")
+    lines += [
+        "",
+        "github_copilot has no custom stream iterator in v1 (SDK chunks ride"
+        " the default openai dialect); streaming stays on v1 until the"
+        " streaming seam lands, so there is no stream differential row here"
+        " yet. The codex family (gpt-5.3-codex / gpt-5.1-codex-max) bridges to"
+        " the Responses API above the chat seam and stays v1 by absence"
+        " (canary in the request gate).",
+    ]
+    return failures
+
+
 def main() -> None:
     _freeze_ambient()
     _stub_vertex_token()
 
     lines = [
-        "# Translation v2 differential report (anthropic + bedrock + openai + google + azure + xai + the compat_sdk family (waves 1a+1b+2a) + the wave-1b compat_httpx family + the wave-2b-alpha + wave-2b-beta own modules + the wave-3 ollama_chat own module)",
+        "# Translation v2 differential report (anthropic + bedrock + openai + google + azure + xai + the compat_sdk family (waves 1a+1b+2a) + the wave-1b compat_httpx family + the wave-2b-alpha + wave-2b-beta own modules + the wave-3 ollama_chat and github_copilot own modules)",
         "",
         "v1 and v2 run over the same corpus; every row must be IDENTICAL (or an",
         "explained FALLBACK that v1 serves) for a provider's flag to turn on.",
@@ -2833,6 +2906,7 @@ def main() -> None:
     failures += _sagemaker_chat_rows(lines)
     failures += _groq_rows(lines)
     failures += _ollama_chat_rows(lines)
+    failures += _github_copilot_rows(lines)
     failures += _azure_rows(lines)
     failures += _azure_ai_rows(lines)
     failures += _bedrock_request_rows(lines)

--- a/tests/test_litellm/translation/test_differential_compat_sdk_request.py
+++ b/tests/test_litellm/translation/test_differential_compat_sdk_request.py
@@ -621,6 +621,8 @@ def test_registered_providers_have_differential_coverage() -> None:
         "watsonx",  # test_differential_watsonx_{request,response,stream}
         "sagemaker_chat",  # test_differential_sagemaker_chat_{request,response,stream}
         "groq",  # test_differential_groq_{request,response,stream}
+        # wave-3 own modules:
+        "ollama_chat",  # test_differential_ollama_chat_{request,response,stream}
     }
     assert providers == dedicated_gates | set(SPECS) | set(HTTPX_SPECS)
     own_modules = {
@@ -638,6 +640,9 @@ def test_registered_providers_have_differential_coverage() -> None:
         "watsonx",
         "sagemaker_chat",
         "groq",
+        # wave-3 (same convention: the row lands in the commit that adds
+        # the module, with the wrong-arm pin in its response gate)
+        "ollama_chat",
     }
     # critic-wave2b-alpha MAJOR-4: every own-module provider must carry a row
     # in pipeline.OWN_MODULE_RESPONSE_STYLES (the construction-style truth the

--- a/tests/test_litellm/translation/test_differential_compat_sdk_request.py
+++ b/tests/test_litellm/translation/test_differential_compat_sdk_request.py
@@ -623,6 +623,7 @@ def test_registered_providers_have_differential_coverage() -> None:
         "groq",  # test_differential_groq_{request,response,stream}
         # wave-3 own modules:
         "ollama_chat",  # test_differential_ollama_chat_{request,response,stream}
+        "github_copilot",  # test_differential_github_copilot_{request,response}
     }
     assert providers == dedicated_gates | set(SPECS) | set(HTTPX_SPECS)
     own_modules = {
@@ -643,6 +644,7 @@ def test_registered_providers_have_differential_coverage() -> None:
         # wave-3 (same convention: the row lands in the commit that adds
         # the module, with the wrong-arm pin in its response gate)
         "ollama_chat",
+        "github_copilot",
     }
     # critic-wave2b-alpha MAJOR-4: every own-module provider must carry a row
     # in pipeline.OWN_MODULE_RESPONSE_STYLES (the construction-style truth the

--- a/tests/test_litellm/translation/test_differential_compat_sdk_request.py
+++ b/tests/test_litellm/translation/test_differential_compat_sdk_request.py
@@ -624,6 +624,7 @@ def test_registered_providers_have_differential_coverage() -> None:
         # wave-3 own modules:
         "ollama_chat",  # test_differential_ollama_chat_{request,response,stream}
         "github_copilot",  # test_differential_github_copilot_{request,response}
+        "databricks",  # test_differential_databricks_{request,response,stream}
     }
     assert providers == dedicated_gates | set(SPECS) | set(HTTPX_SPECS)
     own_modules = {
@@ -645,6 +646,7 @@ def test_registered_providers_have_differential_coverage() -> None:
         # the module, with the wrong-arm pin in its response gate)
         "ollama_chat",
         "github_copilot",
+        "databricks",
     }
     # critic-wave2b-alpha MAJOR-4: every own-module provider must carry a row
     # in pipeline.OWN_MODULE_RESPONSE_STYLES (the construction-style truth the

--- a/tests/test_litellm/translation/test_differential_databricks_request.py
+++ b/tests/test_litellm/translation/test_differential_databricks_request.py
@@ -1,0 +1,360 @@
+"""Differential parity for the databricks request path (wave 3).
+
+v1 side, invoked the way main.py's databricks elif runs:
+``get_optional_params(custom_llm_provider="databricks")`` then
+``DatabricksConfig().transform_request`` (probed in-process at HEAD). The
+central structural fact is the ``"claude" in model`` SUBSTRING fork (DB-R1):
+every served case is parameterized claude x non-claude so both arms are
+pinned. The serializer pins: the ``{model, messages, stream}`` body with
+``stream`` ALWAYS present (default false), mct -> ``max_tokens`` (ALWAYS
+renamed, v1 never re-emits max_completion_tokens), ``top_k`` verbatim
+top-level (researcher-5 said unsupported; the HEAD probe REFUTES it, both
+arms), claude tools via the openai->anthropic->databricks round-trip (drops
+function-level ``strict``/``$schema``/cache_control, repositions description
+after parameters) vs non-claude tools verbatim, the thinking max-bump
+(``budget_tokens + DEFAULT_MAX_TOKENS`` only when the caller gave no
+max_tokens), and reasoning_effort verbatim on NON-claude WITH max_tokens.
+
+The fallback rows (v1 SERVES its own behavior, v2 falls back typed so the
+seam keeps serving v1): claude response_format (the json_tool_call machinery;
+DB-R2 json_object is SILENTLY DROPPED) and claude reasoning_effort (the
+thinking machinery). The raise rows: parallel_tool_calls
+(UnsupportedParamsError) and the DB-R3 raw ``KeyError('thinking')`` crash on
+NON-claude reasoning_effort WITHOUT max_tokens.
+"""
+
+import copy
+import json
+
+import pytest
+
+from litellm.exceptions import UnsupportedParamsError
+from litellm.llms.databricks.chat.transformation import DatabricksConfig
+from litellm.utils import get_optional_params
+
+from litellm.translation.engine.pipeline import translate_chat_request
+from litellm.translation_seam import build_translation_deps
+
+PROVIDER = "databricks"
+CLAUDE = "databricks-claude-3-7-sonnet"
+NONCLAUDE = "databricks-dbrx-instruct"
+
+_U = [{"role": "user", "content": "hi"}]
+
+_TOOL = [
+    {
+        "type": "function",
+        "function": {
+            "name": "f",
+            "description": "d",
+            "strict": True,
+            "parameters": {
+                "type": "object",
+                "properties": {"a": {"type": "string"}},
+                "$schema": "http://json-schema.org/draft-07/schema#",
+            },
+        },
+    }
+]
+
+# Served shapes, each run on BOTH model arms (the "claude" substring fork).
+# (name, request-without-model)
+_SHARED_CASES = {
+    "plain": {"messages": _U},
+    "sampling": {
+        "messages": _U,
+        "temperature": 0.5,
+        "top_p": 0.9,
+        "stop": ["x", "y"],
+    },
+    "mct_to_max_tokens": {"messages": _U, "max_completion_tokens": 50},
+    "max_tokens_verbatim": {"messages": _U, "max_tokens": 80},
+    "top_k_top_level": {"messages": _U, "top_k": 7},
+    "stream_true": {"messages": _U, "stream": True},
+    "stream_false_always_present": {"messages": _U, "stream": False},
+    "tool_choice_auto": {
+        "messages": _U,
+        "tools": copy.deepcopy(_TOOL),
+        "tool_choice": "auto",
+    },
+    "tool_choice_required": {
+        "messages": _U,
+        "tools": copy.deepcopy(_TOOL),
+        "tool_choice": "required",
+    },
+    "tool_choice_specific": {
+        "messages": _U,
+        "tools": copy.deepcopy(_TOOL),
+        "tool_choice": {"type": "function", "function": {"name": "f"}},
+    },
+    "thinking_budget_bumps_max_tokens": {
+        "messages": _U,
+        "thinking": {"type": "enabled", "budget_tokens": 1024},
+    },
+    "thinking_budget_with_caller_max_tokens_no_bump": {
+        "messages": _U,
+        "thinking": {"type": "enabled", "budget_tokens": 1024},
+        "max_tokens": 100,
+    },
+    "thinking_no_budget_no_bump": {
+        "messages": _U,
+        "thinking": {"type": "enabled"},
+    },
+}
+
+# These differ between arms: tools (claude round-trip drops strict/$schema),
+# response_format (non-claude serves; claude falls back), reasoning_effort
+# (non-claude+max_tokens serves; claude falls back). Keyed by arm.
+_NONCLAUDE_ONLY_CASES = {
+    "tools_verbatim_nonclaude": {"messages": _U, "tools": copy.deepcopy(_TOOL)},
+    "response_format_json_object_nonclaude": {
+        "messages": _U,
+        "response_format": {"type": "json_object"},
+    },
+    "response_format_json_schema_nonclaude": {
+        "messages": _U,
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "n",
+                "schema": {"type": "object", "properties": {"a": {"type": "string"}}},
+            },
+        },
+    },
+    "reasoning_effort_with_max_tokens_nonclaude": {
+        "messages": _U,
+        "reasoning_effort": "low",
+        "max_tokens": 100,
+    },
+}
+
+_CLAUDE_ONLY_CASES = {
+    "tools_roundtrip_drops_strict_and_schema_claude": {
+        "messages": _U,
+        "tools": copy.deepcopy(_TOOL),
+    },
+}
+
+# v1 RAISES UnsupportedParamsError; v2 falls back typed naming the surface.
+_V1_RAISES = {
+    "parallel_tool_calls": (
+        {"model": NONCLAUDE, "messages": _U, "parallel_tool_calls": True},
+        "parallel_tool_calls",
+    ),
+}
+
+# v1 CRASHES with a raw KeyError (NOT UnsupportedParamsError); v2 falls back
+# typed so v1 serves its own crash (DB-R3).
+_V1_RAISES_RAW = {
+    "nonclaude_reasoning_effort_without_max_tokens_keyerror": (
+        {"model": NONCLAUDE, "messages": _U, "reasoning_effort": "low"},
+        "reasoning_effort",
+    ),
+}
+
+# v1 SERVES (silent drop / unported machinery); v2 falls back typed so v1
+# keeps serving. Each names the v1 path.
+_V1_SERVES_FALLBACKS = {
+    "claude_response_format_json_object_silently_dropped": (
+        {"model": CLAUDE, "messages": _U, "response_format": {"type": "json_object"}},
+        "response_format",
+    ),
+    "claude_response_format_json_schema_machinery": (
+        {
+            "model": CLAUDE,
+            "messages": _U,
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {"name": "n", "schema": {"type": "object"}},
+            },
+        },
+        "response_format",
+    ),
+    "claude_reasoning_effort_thinking_machinery": (
+        {"model": CLAUDE, "messages": _U, "reasoning_effort": "low"},
+        "reasoning_effort",
+    ),
+    "user_silent_drop": (
+        {"model": NONCLAUDE, "messages": _U, "user": "u1"},
+        "user",
+    ),
+    "n_parse_level_unknown": (
+        {"model": NONCLAUDE, "messages": _U, "n": 2},
+        "not yet supported by translation v2: n",
+    ),
+}
+
+
+def run_v1_request_transform(case: dict) -> dict:
+    """May RAISE (UnsupportedParamsError / KeyError) — that IS the pinned v1
+    behavior for the raise rows."""
+    request = copy.deepcopy(case)
+    model = request.pop("model")
+    messages = request.pop("messages")
+    optional_params = get_optional_params(
+        model=model,
+        custom_llm_provider=PROVIDER,
+        messages=copy.deepcopy(messages),
+        **request,
+    )
+    optional_params.pop("extra_body", None)
+    return DatabricksConfig().transform_request(
+        model=model,
+        messages=messages,
+        optional_params=optional_params,
+        litellm_params={},
+        headers={},
+    )
+
+
+def _v2(case: dict):
+    return translate_chat_request(
+        copy.deepcopy(case), PROVIDER, build_translation_deps()
+    )
+
+
+def _norm(body: dict) -> str:
+    return json.dumps(body, sort_keys=True, default=str)
+
+
+def _shared_params() -> list[tuple[str, str]]:
+    return [
+        (name, model)
+        for name in sorted(_SHARED_CASES)
+        for model in (CLAUDE, NONCLAUDE)
+    ]
+
+
+@pytest.mark.parametrize("name,model", _shared_params())
+def test_v2_shared_request_matches_v1_both_arms(name: str, model: str) -> None:
+    case = {"model": model, **_SHARED_CASES[name]}
+    result = _v2(case)
+    assert result.is_ok(), f"{name}/{model}: {result.error.summary}"
+    assert _norm(result.ok) == _norm(run_v1_request_transform(case))
+
+
+@pytest.mark.parametrize("name", sorted(_NONCLAUDE_ONLY_CASES))
+def test_v2_nonclaude_request_matches_v1(name: str) -> None:
+    case = {"model": NONCLAUDE, **_NONCLAUDE_ONLY_CASES[name]}
+    result = _v2(case)
+    assert result.is_ok(), f"{name}: {result.error.summary}"
+    assert _norm(result.ok) == _norm(run_v1_request_transform(case))
+
+
+@pytest.mark.parametrize("name", sorted(_CLAUDE_ONLY_CASES))
+def test_v2_claude_request_matches_v1(name: str) -> None:
+    case = {"model": CLAUDE, **_CLAUDE_ONLY_CASES[name]}
+    result = _v2(case)
+    assert result.is_ok(), f"{name}: {result.error.summary}"
+    assert _norm(result.ok) == _norm(run_v1_request_transform(case))
+
+
+@pytest.mark.parametrize("name", sorted(_V1_RAISES))
+def test_v1_raise_rows_fall_back_typed(name: str) -> None:
+    case, fragment = _V1_RAISES[name]
+    result = _v2(case)
+    assert result.is_error(), f"{name} unexpectedly translated: {result.ok!r}"
+    assert fragment in result.error.summary, result.error.summary
+    with pytest.raises(UnsupportedParamsError):
+        run_v1_request_transform(case)
+
+
+@pytest.mark.parametrize("name", sorted(_V1_RAISES_RAW))
+def test_v1_raw_keyerror_rows_fall_back_typed(name: str) -> None:
+    case, fragment = _V1_RAISES_RAW[name]
+    result = _v2(case)
+    assert result.is_error(), f"{name} unexpectedly translated: {result.ok!r}"
+    assert fragment in result.error.summary, result.error.summary
+    with pytest.raises(KeyError):
+        run_v1_request_transform(case)
+
+
+@pytest.mark.parametrize("name", sorted(_V1_SERVES_FALLBACKS))
+def test_v1_serves_fallback_rows(name: str) -> None:
+    case, fragment = _V1_SERVES_FALLBACKS[name]
+    result = _v2(case)
+    assert result.is_error(), f"{name} unexpectedly translated: {result.ok!r}"
+    assert fragment in result.error.summary, result.error.summary
+    # v1 serves the same request without raising.
+    run_v1_request_transform(case)
+
+
+def test_claude_json_object_is_silently_dropped_by_v1() -> None:
+    """DB-R2: the probe-found trap a code-reading port would get wrong. v1
+    does NOT raise on claude json_object — it silently drops it ENTIRELY (the
+    body carries no response_format), so v2 must fall back (not match the drop
+    and not serve the format)."""
+    case = {
+        "model": CLAUDE,
+        "messages": _U,
+        "response_format": {"type": "json_object"},
+    }
+    v1 = run_v1_request_transform(case)
+    assert "response_format" not in v1
+    assert _v2(case).is_error()
+
+
+def test_claude_tools_roundtrip_drops_strict_and_schema() -> None:
+    """The claude substring fork runs openai->anthropic->databricks: the
+    function-level strict and the parameters $schema are DROPPED, while
+    additionalProperties/properties/required/type survive."""
+    case = {"model": CLAUDE, "messages": _U, "tools": copy.deepcopy(_TOOL)}
+    v1 = run_v1_request_transform(case)
+    function = v1["tools"][0]["function"]
+    assert "strict" not in v1["tools"][0] and "strict" not in function
+    assert "$schema" not in function["parameters"]
+    assert function["parameters"]["properties"] == {"a": {"type": "string"}}
+    result = _v2(case)
+    assert result.is_ok()
+    assert _norm(result.ok) == _norm(v1)
+
+
+def test_nonclaude_tools_keep_strict_and_schema_verbatim() -> None:
+    """The non-claude arm sends tools VERBATIM (v1's ``if "claude" not in
+    model: return tools``) — the discriminator the claude arm pins against."""
+    case = {"model": NONCLAUDE, "messages": _U, "tools": copy.deepcopy(_TOOL)}
+    v1 = run_v1_request_transform(case)
+    assert v1["tools"][0]["function"]["strict"] is True
+    assert "$schema" in v1["tools"][0]["function"]["parameters"]
+    result = _v2(case)
+    assert result.is_ok()
+    assert _norm(result.ok) == _norm(v1)
+
+
+def test_thinking_max_token_bump_arithmetic() -> None:
+    """v1 sets max_tokens = budget_tokens + DEFAULT_MAX_TOKENS only when the
+    caller gave none; a caller value is never adjusted (probed both arms)."""
+    from litellm.constants import DEFAULT_MAX_TOKENS
+
+    for model in (CLAUDE, NONCLAUDE):
+        bumped = run_v1_request_transform(
+            {
+                "model": model,
+                "messages": _U,
+                "thinking": {"type": "enabled", "budget_tokens": 1024},
+            }
+        )
+        assert bumped["max_tokens"] == 1024 + DEFAULT_MAX_TOKENS
+        unbumped = run_v1_request_transform(
+            {
+                "model": model,
+                "messages": _U,
+                "thinking": {"type": "enabled", "budget_tokens": 1024},
+                "max_tokens": 100,
+            }
+        )
+        assert unbumped["max_tokens"] == 100
+
+
+def test_anthropic_input_schema_key_mirror_matches_v1() -> None:
+    """The claude tool filter keeps exactly AnthropicInputSchema's keys; drift
+    here silently changes which schema keys survive the round-trip."""
+    from litellm.types.llms.anthropic import AnthropicInputSchema
+
+    from litellm.translation.providers.databricks.tools import (
+        _ANTHROPIC_INPUT_SCHEMA_KEYS,
+    )
+
+    assert _ANTHROPIC_INPUT_SCHEMA_KEYS == frozenset(
+        AnthropicInputSchema.__annotations__
+    )

--- a/tests/test_litellm/translation/test_differential_databricks_response.py
+++ b/tests/test_litellm/translation/test_differential_databricks_response.py
@@ -1,0 +1,339 @@
+"""Differential parity for the databricks response path (wave 3).
+
+v1 side: ``DatabricksConfig.transform_response`` mutating a pre-allocated
+``ModelResponse`` (probed in-process at HEAD). v1 reads a ``DatabricksResponse``
+TypedDict whose construction does NOT validate, so a body missing a required
+key (id/created/usage/choices, or a choice's index/message/finish_reason)
+raises a RAW ``KeyError`` (a drift from researcher-5's "DatabricksException"
+claim, pinned). The model is ``databricks/{wire model}``, id/created copied
+verbatim, usage from prompt/completion tokens, and ``_transform_dbrx_choices``
+flattens a content block-list to a joined text string, turns reasoning/summary
+blocks into ``reasoning_content`` + ``thinking_blocks`` (missing signature ->
+""), and lifts a first-item ``citations`` list to
+``provider_specific_fields.citations`` with a ``supported_text`` mirror.
+
+v2 side: the parser builds the normalized body on ``ChatResponse.wire`` and the
+seam constructs it. Because the parser PRE-NORMALIZES the whole body, the
+"openai" (cdr) and "openai_like" (ModelResponse(**json)) construction arms
+COINCIDE on the corpus (the cohere/ollama N3 rule: the wire body is the parity
+surface), so unlike ollama there is no envelope-id discriminator. The
+construction arm is pinned by the registration value
+``OWN_MODULE_RESPONSE_STYLES["databricks"] == "openai"`` and a documented
+arms-coincide note (a flip would not change bytes on this corpus — the
+registration gate is the guard, not output divergence).
+"""
+
+import copy
+import json
+import time
+
+import httpx
+import pytest
+
+from litellm.litellm_core_utils.litellm_logging import Logging
+from litellm.llms.databricks.chat.transformation import DatabricksConfig
+from litellm.types.utils import ModelResponse
+
+from litellm.translation.engine.pipeline import OWN_MODULE_RESPONSE_STYLES
+from litellm.translation.inbound.openai_chat import parse_request
+from litellm.translation.inbound.openai_chat.response import serialize_response
+from litellm.translation.providers.databricks import parse_response
+from litellm.translation_seam import (
+    UsageStyle,
+    build_translation_deps,
+    to_model_response,
+)
+
+MODEL = "databricks-dbrx-instruct"
+PREFIXED = "databricks/dbrx"
+_AMBIENT_ID = "chatcmpl-databricks-amb"
+
+_REQUEST = {"model": MODEL, "messages": [{"role": "user", "content": "hi"}]}
+
+_BASE = {
+    "id": "chatcmpl-db",
+    "created": 1718000000,
+    "model": "dbrx",
+    "usage": {"prompt_tokens": 7, "completion_tokens": 3, "total_tokens": 10},
+    "choices": [
+        {
+            "index": 0,
+            "finish_reason": "stop",
+            "message": {"role": "assistant", "content": "hello"},
+        }
+    ],
+}
+
+_RESPONSES = {
+    "plain": _BASE,
+    "finish_length": {
+        **_BASE,
+        "choices": [{**_BASE["choices"][0], "finish_reason": "length"}],
+    },
+    "finish_unknown_maps_stop": {
+        **_BASE,
+        "choices": [{**_BASE["choices"][0], "finish_reason": "weird"}],
+    },
+    "wire_model_prefixed": {**_BASE, "model": "my-endpoint"},
+    "content_list_flattens": {
+        **_BASE,
+        "choices": [
+            {
+                "index": 0,
+                "finish_reason": "stop",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "text", "text": "a"},
+                        {"type": "text", "text": "b"},
+                    ],
+                },
+            }
+        ],
+    },
+    "reasoning_summary_to_reasoning_content": {
+        **_BASE,
+        "choices": [
+            {
+                "index": 0,
+                "finish_reason": "stop",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "text", "text": "ans"},
+                        {
+                            "type": "reasoning",
+                            "summary": [
+                                {
+                                    "type": "summary_text",
+                                    "text": "thinking",
+                                    "signature": "sig",
+                                }
+                            ],
+                        },
+                    ],
+                },
+            }
+        ],
+    },
+    "reasoning_summary_missing_signature": {
+        **_BASE,
+        "choices": [
+            {
+                "index": 0,
+                "finish_reason": "stop",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "reasoning",
+                            "summary": [{"type": "summary_text", "text": "t"}],
+                        }
+                    ],
+                },
+            }
+        ],
+    },
+    "citations_lift_with_supported_text": {
+        **_BASE,
+        "choices": [
+            {
+                "index": 0,
+                "finish_reason": "stop",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "ans",
+                            "citations": [{"source": "doc1"}],
+                        }
+                    ],
+                },
+            }
+        ],
+    },
+    "tool_calls_verbatim": {
+        **_BASE,
+        "choices": [
+            {
+                "index": 0,
+                "finish_reason": "tool_calls",
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "c1",
+                            "type": "function",
+                            "function": {"name": "f", "arguments": '{"a": 1}'},
+                        }
+                    ],
+                },
+            }
+        ],
+    },
+    "unknown_top_level_key_dropped": {**_BASE, "object": "WRONG", "extra": 9},
+}
+
+# v1 raises a RAW KeyError (the unvalidated TypedDict access); v2 falls back
+# typed so v1 serves its own crash.
+_LOUD = {
+    "missing_id": ({k: v for k, v in _BASE.items() if k != "id"}, "id"),
+    "missing_created": (
+        {k: v for k, v in _BASE.items() if k != "created"},
+        "created",
+    ),
+    "missing_usage": ({k: v for k, v in _BASE.items() if k != "usage"}, "usage"),
+    "missing_choices": (
+        {k: v for k, v in _BASE.items() if k != "choices"},
+        "choices",
+    ),
+    "choice_missing_message": (
+        {**_BASE, "choices": [{"index": 0, "finish_reason": "stop"}]},
+        "message",
+    ),
+    "choice_missing_finish_reason": (
+        {
+            **_BASE,
+            "choices": [
+                {"index": 0, "message": {"role": "assistant", "content": "x"}}
+            ],
+        },
+        "finish_reason",
+    ),
+}
+
+
+def _v1_model_response(raw) -> dict:
+    logging = Logging(
+        model=MODEL,
+        messages=copy.deepcopy(_REQUEST["messages"]),
+        stream=False,
+        call_type="completion",
+        start_time=time.time(),
+        litellm_call_id="diff-databricks-response",
+        function_id="diff-databricks-response",
+    )
+    response = httpx.Response(
+        200,
+        json=copy.deepcopy(raw),
+        request=httpx.Request("POST", "https://x/serving-endpoints"),
+    )
+    return (
+        DatabricksConfig()
+        .transform_response(
+            model=MODEL,
+            raw_response=response,
+            model_response=ModelResponse(id=_AMBIENT_ID),
+            logging_obj=logging,
+            request_data={},
+            messages=copy.deepcopy(_REQUEST["messages"]),
+            optional_params={},
+            litellm_params={},
+            encoding=None,
+        )
+        .model_dump()
+    )
+
+
+def _v2_parse(raw):
+    parsed = parse_request(copy.deepcopy(_REQUEST))
+    assert parsed.is_ok(), parsed.error.summary
+    return parse_response(copy.deepcopy(raw), parsed.ok)
+
+
+def _v2_with_style(raw, style: UsageStyle) -> dict:
+    response = _v2_parse(raw)
+    assert response.is_ok(), response.error.summary
+    body = serialize_response(response.ok, build_translation_deps(), "openai")
+    return to_model_response(
+        body, ModelResponse(id=_AMBIENT_ID), usage_style=style
+    ).model_dump()
+
+
+def _v2_model_response(raw) -> dict:
+    return _v2_with_style(raw, OWN_MODULE_RESPONSE_STYLES["databricks"])
+
+
+def _norm(payload: dict) -> str:
+    return json.dumps(payload, sort_keys=True, default=str)
+
+
+@pytest.mark.parametrize("name", sorted(_RESPONSES))
+def test_v2_response_matches_v1(name: str) -> None:
+    raw = _RESPONSES[name]
+    assert _norm(_v2_model_response(raw)) == _norm(_v1_model_response(raw))
+
+
+@pytest.mark.parametrize("name", sorted(_RESPONSES))
+def test_model_is_prefixed_and_ids_copied_verbatim(name: str) -> None:
+    """model = databricks/{wire model}; id/created ride the WIRE chunk
+    verbatim (no ambient overwrite — the wire carries them, unlike ollama)."""
+    raw = _RESPONSES[name]
+    v1 = _v1_model_response(raw)
+    v2 = _v2_model_response(raw)
+    for dump in (v1, v2):
+        assert dump["model"] == f"databricks/{raw['model']}"
+        assert dump["id"] == raw["id"]
+        assert dump["created"] == raw["created"]
+
+
+@pytest.mark.parametrize("name", sorted(_LOUD))
+def test_loud_shapes_fall_back_where_v1_raw_keyerrors(name: str) -> None:
+    raw, fragment = _LOUD[name]
+    result = _v2_parse(raw)
+    assert result.is_error(), f"{name} unexpectedly parsed"
+    assert fragment in result.error.summary, result.error.summary
+    with pytest.raises(KeyError):
+        _v1_model_response(copy.deepcopy(raw))
+
+
+def test_content_list_flattens_to_joined_text() -> None:
+    raw = _RESPONSES["content_list_flattens"]
+    for dump in (_v1_model_response(raw), _v2_model_response(raw)):
+        assert dump["choices"][0]["message"]["content"] == "ab"
+
+
+def test_reasoning_summary_missing_signature_defaults_empty() -> None:
+    raw = _RESPONSES["reasoning_summary_missing_signature"]
+    for dump in (_v1_model_response(raw), _v2_model_response(raw)):
+        blocks = dump["choices"][0]["message"]["thinking_blocks"]
+        assert blocks[0]["signature"] == ""
+
+
+def test_citations_lift_to_provider_specific_fields_with_supported_text() -> None:
+    raw = _RESPONSES["citations_lift_with_supported_text"]
+    for dump in (_v1_model_response(raw), _v2_model_response(raw)):
+        psf = dump["choices"][0]["message"]["provider_specific_fields"]
+        assert psf["citations"] == [[{"source": "doc1", "supported_text": "ans"}]]
+
+
+def test_construction_arms_coincide_and_the_table_pins_the_value() -> None:
+    """Unlike ollama (whose body carries no id, so the cdr vs ModelResponse
+    arms diverge on the envelope id), the databricks parser PRE-NORMALIZES the
+    whole body onto ChatResponse.wire, so the "openai" and "openai_like" arms
+    produce identical bytes on the corpus. The construction arm is therefore
+    pinned by the registration VALUE, not by output divergence — a flip would
+    be silent here, so the registration gate is the guard. This test pins both
+    the value AND the coincidence fact (if a future change makes the arms
+    diverge, re-introduce an output-divergence pin)."""
+    assert OWN_MODULE_RESPONSE_STYLES["databricks"] == "openai"
+    for name in ("plain", "tool_calls_verbatim", "finish_length"):
+        raw = _RESPONSES[name]
+        cdr = _v2_with_style(raw, "openai")
+        direct = _v2_with_style(raw, "openai_like")
+        assert _norm(cdr) == _norm(direct), (
+            f"{name}: the arms diverged — databricks gained an envelope-shaped "
+            "discriminator; pin it with an output-divergence test like ollama's"
+        )
+
+
+def test_finish_reason_mirror_matches_v1_table() -> None:
+    """The IR finish set is the four chat-completion reasons; an unknown wire
+    finish maps to stop on both sides (probed: 'weird' -> 'stop')."""
+    raw = _RESPONSES["finish_unknown_maps_stop"]
+    v1 = _v1_model_response(raw)
+    v2 = _v2_model_response(raw)
+    assert v1["choices"][0]["finish_reason"] == "stop"
+    assert v2["choices"][0]["finish_reason"] == "stop"

--- a/tests/test_litellm/translation/test_differential_databricks_stream.py
+++ b/tests/test_litellm/translation/test_differential_databricks_stream.py
@@ -131,7 +131,15 @@ STREAMS = {
         _chunk({}, finish="tool_calls"),
     ],
     "usage_chunk_dropped": [
-        _chunk({"role": "assistant", "content": "x"}),
+        # usage rides BOTH a content-bearing chunk AND the finish chunk: v1
+        # drops it from EVERY emitted body (DB-R5), so a usage-leak regression
+        # at either fold layer (parse_event or _step_databricks) must surface
+        # here. A usage-bearing CONTENT chunk is the discriminator the
+        # finish-only case missed (critic-wave3 MAJOR-1).
+        {
+            **_chunk({"role": "assistant", "content": "x"}),
+            "usage": {"prompt_tokens": 3, "completion_tokens": 1, "total_tokens": 4},
+        },
         {
             **_chunk({}, finish="stop"),
             "usage": {"prompt_tokens": 5, "completion_tokens": 2, "total_tokens": 7},
@@ -230,20 +238,28 @@ def test_v2_stream_delta_matches_v1(name: str) -> None:
 @pytest.mark.parametrize("name", sorted(STREAMS))
 def test_one_body_per_wire_chunk_no_usage_tail(name: str) -> None:
     """DB-R5: v1 yields exactly one out-chunk per wire chunk and NEVER attaches
-    usage (even the usage-bearing wire chunk produces a usage-less body)."""
+    usage. Assert the body carries NO usage KEY (not merely a None value), so a
+    regression that copies the wire usage dict into the body is caught even
+    when the source chunk's usage is a real dict."""
     events = STREAMS[name]
     v2 = _v2_bodies(events)
     assert len(v2) == len(events)
     for body in v2:
-        assert body.get("usage") is None
+        assert "usage" not in body or body["usage"] is None
 
 
 def test_usage_is_dropped_entirely_both_sides() -> None:
+    """The usage_chunk_dropped stream carries usage on a CONTENT chunk AND the
+    finish chunk; v1 drops it from every emitted body and so must v2. The
+    content-chunk usage is the discriminator: a fold that copied
+    payload usage would surface a non-None usage dict here (critic-wave3
+    MAJOR-1 — mutation-verified to flip)."""
     events = STREAMS["usage_chunk_dropped"]
     v1 = _v1_chunks(events)
     v2 = _v2_bodies(events)
     for v1_chunk in v1:
-        assert getattr(v1_chunk, "usage", None) is None or v1_chunk.get("usage") is None
+        assert getattr(v1_chunk, "usage", None) is None
+    assert any(event.get("usage") for event in events), "corpus must carry wire usage"
     for body in v2:
         assert body.get("usage") is None
 

--- a/tests/test_litellm/translation/test_differential_databricks_stream.py
+++ b/tests/test_litellm/translation/test_differential_databricks_stream.py
@@ -1,0 +1,320 @@
+"""Differential parity for the databricks stream path (wave 3).
+
+v1 side: ``DatabricksChatResponseIterator.chunk_parser`` (a
+``BaseModelResponseIterator``), replayed in-process at HEAD. v1 yields ONE
+``ModelResponseStream`` per wire chunk (no split) and DROPS the wire ``usage``
+ENTIRELY (DB-R5: the iterator never passes usage through), so the v2 fold never
+attaches a usage tail. A content block-list flattens to a string,
+reasoning/summary blocks become reasoning_content + thinking_blocks, a first-
+item ``citations`` list lifts to ``provider_specific_fields.citation``, and a
+``{}`` tool argument string is rewritten to ``""``. Under json_mode (the
+STATEFUL ``_last_function_name`` machine) a ``json_tool_call`` tool delta folds
+to content with the json.loads+dumps byte REFORMAT (DB-R8). json_mode is a
+REQUEST-side fallback (v2 never sends a json_mode request), so that arm is
+dormant from v2's own flow but pinned here against the REAL iterator.
+
+The line seam (``parse_line``): an SSE ``data:`` prefix is stripped, ``[DONE]``
+ends the stream, and a line that fails ``json.loads`` (or an empty line) is
+SILENTLY SWALLOWED by v1's base iterator; v2 errors loudly — the watsonx/ollama
+line-seam PINNED DIVERGENCE (fail-closed on a failure path, named report row).
+"""
+
+import copy
+import json
+
+import pytest
+
+from litellm.llms.databricks.chat.transformation import DatabricksChatResponseIterator
+
+from litellm.translation.engine.stream import fold_events, fold_lines
+from litellm.translation.inbound.openai_chat.stream import StreamState, initial_state
+from litellm.translation.providers.databricks import parse_event, parse_line
+
+MODEL = "databricks-dbrx-instruct"
+
+
+def _chunk(delta: dict, finish=None, index: int = 0) -> dict:
+    return {
+        "id": "chatcmpl-stream",
+        "created": 1718000000,
+        "model": "dbrx",
+        "choices": [{"index": index, "delta": delta, "finish_reason": finish}],
+    }
+
+
+STREAMS = {
+    "content": [
+        _chunk({"role": "assistant", "content": "Hel"}),
+        _chunk({"content": "lo"}),
+        _chunk({}, finish="stop"),
+    ],
+    "content_list_flattens": [
+        _chunk(
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "a"},
+                    {"type": "text", "text": "b"},
+                ],
+            }
+        ),
+        _chunk({}, finish="stop"),
+    ],
+    "reasoning_summary": [
+        _chunk(
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "reasoning",
+                        "summary": [
+                            {"type": "summary_text", "text": "think", "signature": "s"}
+                        ],
+                    }
+                ],
+            }
+        ),
+        _chunk({}, finish="stop"),
+    ],
+    "reasoning_summary_missing_signature": [
+        _chunk(
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "reasoning", "summary": [{"type": "summary_text", "text": "t"}]}
+                ],
+            }
+        ),
+        _chunk({}, finish="stop"),
+    ],
+    "citations_lift": [
+        _chunk(
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "ans", "citations": [{"source": "d1"}]}
+                ],
+            }
+        ),
+        _chunk({}, finish="stop"),
+    ],
+    "tool_call": [
+        _chunk(
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "c1",
+                        "type": "function",
+                        "function": {"name": "f", "arguments": '{"a": 1}'},
+                    }
+                ],
+            }
+        ),
+        _chunk({}, finish="tool_calls"),
+    ],
+    "tool_call_empty_args_blanked": [
+        _chunk(
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "c1",
+                        "type": "function",
+                        "function": {"name": "f", "arguments": "{}"},
+                    }
+                ],
+            }
+        ),
+        _chunk({}, finish="tool_calls"),
+    ],
+    "usage_chunk_dropped": [
+        _chunk({"role": "assistant", "content": "x"}),
+        {
+            **_chunk({}, finish="stop"),
+            "usage": {"prompt_tokens": 5, "completion_tokens": 2, "total_tokens": 7},
+        },
+    ],
+}
+
+# json_mode: the STATEFUL json_tool_call -> content byte-reformat (DB-R8). v2
+# never SENDS a json_mode request (it falls back), so the live state flag is
+# always False; the gate sets it True to pin v1's reformat against the REAL
+# iterator.
+_JSON_MODE_STREAM = [
+    _chunk(
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "index": 0,
+                    "id": "t",
+                    "type": "function",
+                    "function": {"name": "json_tool_call", "arguments": '{"a":1}'},
+                }
+            ],
+        }
+    ),
+    _chunk({}, finish="stop"),
+]
+
+
+def _v1_chunks(events: list, json_mode: bool = False) -> list:
+    iterator = DatabricksChatResponseIterator(
+        streaming_response=iter([]), sync_stream=True, json_mode=json_mode
+    )
+    return [
+        iterator.chunk_parser(copy.deepcopy(event)).model_dump() for event in events
+    ]
+
+
+def _v2_state(json_mode: bool) -> StreamState:
+    base = initial_state(MODEL, dialect="databricks")
+    return base if not json_mode else _with_json_mode(base)
+
+
+def _with_json_mode(state: StreamState) -> StreamState:
+    from dataclasses import replace
+
+    return replace(state, databricks_json_mode=True)
+
+
+def _v2_bodies(events: list, json_mode: bool = False) -> list:
+    folded = fold_events(
+        copy.deepcopy(events), parse_event, _v2_state(json_mode)
+    )
+    assert folded.is_ok(), folded.error.summary
+    return list(folded.ok)
+
+
+def _v1_delta(chunk: dict) -> dict:
+    return chunk["choices"][0]["delta"]
+
+
+def _v2_delta(body: dict) -> dict:
+    return body["choices"][0]["delta"]
+
+
+def _norm_delta(delta: dict) -> str:
+    """v1's ModelResponseStream Delta materializes a fixed key set
+    (function_call/audio/etc. defaulted to None); v2 emits the normalized
+    fold body. Compare the keys the fold OWNS — content, reasoning_content,
+    thinking_blocks, tool_calls, role, provider_specific_fields — which is the
+    DB-R5/R8 parity surface (the Delta envelope defaults are seam scope)."""
+    keys = (
+        "content",
+        "reasoning_content",
+        "thinking_blocks",
+        "tool_calls",
+        "role",
+        "provider_specific_fields",
+    )
+    return json.dumps(
+        {key: delta.get(key) for key in keys}, sort_keys=True, default=str
+    )
+
+
+@pytest.mark.parametrize("name", sorted(STREAMS))
+def test_v2_stream_delta_matches_v1(name: str) -> None:
+    events = STREAMS[name]
+    v1 = _v1_chunks(events)
+    v2 = _v2_bodies(events)
+    assert len(v1) == len(v2)
+    for v1_chunk, v2_body in zip(v1, v2):
+        assert _norm_delta(_v1_delta(v1_chunk)) == _norm_delta(_v2_delta(v2_body))
+
+
+@pytest.mark.parametrize("name", sorted(STREAMS))
+def test_one_body_per_wire_chunk_no_usage_tail(name: str) -> None:
+    """DB-R5: v1 yields exactly one out-chunk per wire chunk and NEVER attaches
+    usage (even the usage-bearing wire chunk produces a usage-less body)."""
+    events = STREAMS[name]
+    v2 = _v2_bodies(events)
+    assert len(v2) == len(events)
+    for body in v2:
+        assert body.get("usage") is None
+
+
+def test_usage_is_dropped_entirely_both_sides() -> None:
+    events = STREAMS["usage_chunk_dropped"]
+    v1 = _v1_chunks(events)
+    v2 = _v2_bodies(events)
+    for v1_chunk in v1:
+        assert getattr(v1_chunk, "usage", None) is None or v1_chunk.get("usage") is None
+    for body in v2:
+        assert body.get("usage") is None
+
+
+def test_empty_args_rewritten_to_blank_string() -> None:
+    events = STREAMS["tool_call_empty_args_blanked"]
+    v1 = _v1_chunks(events)
+    v1_args = _v1_delta(v1[0])["tool_calls"][0]["function"]["arguments"]
+    assert v1_args == ""
+    v2_args = _v2_delta(_v2_bodies(events)[0])["tool_calls"][0]["function"]["arguments"]
+    assert v2_args == ""
+
+
+def test_json_mode_byte_reformat_db_r8() -> None:
+    """DB-R8: under json_mode the json_tool_call delta becomes content with the
+    json.loads+dumps reformat ({"a":1} -> {"a": 1}) and tool_calls nulled.
+    Replayed against the REAL iterator with json_mode=True (v2 never sends a
+    json_mode request, so this pins the dormant arm)."""
+    v1 = _v1_chunks(_JSON_MODE_STREAM, json_mode=True)
+    v2 = _v2_bodies(_JSON_MODE_STREAM, json_mode=True)
+    v1_delta = _v1_delta(v1[0])
+    v2_delta = _v2_delta(v2[0])
+    assert v1_delta["content"] == '{"a": 1}'
+    assert v1_delta.get("tool_calls") is None
+    assert _norm_delta(v1_delta) == _norm_delta(v2_delta)
+
+
+def test_json_mode_off_keeps_the_tool_call() -> None:
+    """The discriminator for DB-R8: WITHOUT json_mode the same json_tool_call
+    delta rides as a tool_call (no content reformat) — so the byte-reformat is
+    genuinely gated on the stateful flag."""
+    v1 = _v1_chunks(_JSON_MODE_STREAM, json_mode=False)
+    v2 = _v2_bodies(_JSON_MODE_STREAM, json_mode=False)
+    assert _v1_delta(v1[0]).get("tool_calls") is not None
+    assert _norm_delta(_v1_delta(v1[0])) == _norm_delta(_v2_delta(v2[0]))
+
+
+_PINNED_DIVERGENCES = {
+    "non_json_line": (["data: {notjson", "data: [DONE]"], "non-JSON"),
+    "empty_line": (["data: ", "data: [DONE]"], "empty"),
+}
+
+
+@pytest.mark.parametrize("name", sorted(_PINNED_DIVERGENCES))
+def test_line_seam_pinned_divergence_loud_where_v1_swallows(name: str) -> None:
+    """v1's base iterator silently swallows a non-JSON or empty line; v2 errors
+    loudly (the fail-closed line-seam divergence, named report row)."""
+    raw_lines, fragment = _PINNED_DIVERGENCES[name]
+    folded = fold_lines(
+        list(raw_lines), parse_line, initial_state(MODEL, dialect="databricks")
+    )
+    assert folded.is_error(), f"{name} unexpectedly folded"
+    assert fragment in folded.error.summary, folded.error.summary
+
+
+def test_data_prefix_stripped_and_done_ends_stream() -> None:
+    raw = [
+        f"data: {json.dumps(_chunk({'role': 'assistant', 'content': 'hi'}))}",
+        f"data: {json.dumps(_chunk({}, finish='stop'))}",
+        "data: [DONE]",
+    ]
+    folded = fold_lines(raw, parse_line, initial_state(MODEL, dialect="databricks"))
+    assert folded.is_ok(), folded.error.summary
+    assert len(folded.ok) == 2
+
+
+def test_response_format_tool_name_mirror_matches_constant() -> None:
+    from litellm.constants import RESPONSE_FORMAT_TOOL_NAME
+
+    from litellm.translation.providers.databricks.stream import (
+        RESPONSE_FORMAT_TOOL_NAME as mirror,
+    )
+
+    assert mirror == RESPONSE_FORMAT_TOOL_NAME

--- a/tests/test_litellm/translation/test_differential_github_copilot_request.py
+++ b/tests/test_litellm/translation/test_differential_github_copilot_request.py
@@ -1,0 +1,310 @@
+"""Differential parity for the github_copilot request path (wave 3).
+
+v1 side, invoked the way main.py's big openai elif runs for an
+``openai_compatible_providers`` member:
+``get_optional_params(custom_llm_provider="github_copilot")`` (OpenAIConfig's
+model-shape fork) then ``GithubCopilotConfig().transform_request``
+(OpenAIConfig.transform_request, which calls ``_transform_messages`` before
+the base five-touch assembly). The serializer pins (all probed in-process at
+HEAD with a SEEDED fake token dir — NO live OAuth):
+
+- the system->assistant role rewrite: EVERY system message's ``role`` becomes
+  ``assistant`` (content untouched) when the ambient
+  ``litellm.disable_copilot_system_to_assistant`` flag is False (default), and
+  rides unchanged when it is True — both states pinned two-sided below;
+- max_completion_tokens passes VERBATIM (OpenAIConfig does NOT rename it);
+- the body is otherwise the plain openai_compat assembly.
+
+OAUTH SAFETY (researcher-5 GC-R1): a capability read on a github_copilot/ key
+with no token cache does LIVE interactive OAuth (device-code prompt + polling
+github.com). This module seeds ``GITHUB_COPILOT_TOKEN_DIR`` at a fake temp dir
+and points the device-code/access-token/api-key URLs at an unroutable host
+BEFORE importing anything that resolves the provider; the guard test asserts
+the seed is in place and that no transform path opens a socket.
+"""
+
+import copy
+import json
+import os
+import socket
+import tempfile
+
+import pytest
+
+_TOKEN_DIR = tempfile.mkdtemp(prefix="gcp_tok_")
+with open(os.path.join(_TOKEN_DIR, "api-key.json"), "w") as _f:
+    json.dump(
+        {
+            "token": "fake-copilot-key",
+            "expires_at": 9999999999,
+            "endpoints": {"api": "https://api.fake-copilot.test"},
+        },
+        _f,
+    )
+with open(os.path.join(_TOKEN_DIR, "access-token"), "w") as _f:
+    _f.write("fake-access-token")
+
+# DI/seed only (NO monkeypatching): every env points at the fake dir / an
+# unroutable host, so even a misfire cannot reach the real device flow.
+os.environ.setdefault("GITHUB_COPILOT_TOKEN_DIR", _TOKEN_DIR)
+os.environ.setdefault("GITHUB_COPILOT_DEVICE_CODE_URL", "http://127.0.0.1:9")
+os.environ.setdefault("GITHUB_COPILOT_ACCESS_TOKEN_URL", "http://127.0.0.1:9")
+os.environ.setdefault("GITHUB_COPILOT_API_KEY_URL", "http://127.0.0.1:9")
+
+import litellm  # noqa: E402
+from litellm.exceptions import UnsupportedParamsError  # noqa: E402
+from litellm.llms.github_copilot.chat.transformation import (  # noqa: E402
+    GithubCopilotConfig,
+)
+from litellm.utils import get_optional_params  # noqa: E402
+
+from litellm.translation.engine.pipeline import translate_chat_request  # noqa: E402
+from litellm.translation_seam import build_translation_deps  # noqa: E402
+
+PROVIDER = "github_copilot"
+MODEL = "gpt-4o"
+CLAUDE = "claude-sonnet-4.5"
+
+_U = [{"role": "user", "content": "hi"}]
+
+CASES = {
+    "plain": {"model": MODEL, "messages": _U},
+    "system_to_assistant": {
+        "model": MODEL,
+        "messages": [{"role": "system", "content": "be brief"}, *_U],
+    },
+    "sampling": {
+        "model": MODEL,
+        "messages": _U,
+        "temperature": 0.5,
+        "top_p": 0.9,
+        "max_tokens": 100,
+        "stop": ["x", "y"],
+    },
+    "mct_verbatim_no_rename": {
+        "model": MODEL,
+        "messages": _U,
+        "max_completion_tokens": 50,
+    },
+    "temperature_int_stays_int": {"model": MODEL, "messages": _U, "temperature": 1},
+    "stream_true": {"model": MODEL, "messages": _U, "stream": True},
+    "tools_auto": {
+        "model": MODEL,
+        "messages": [{"role": "user", "content": "w?"}],
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "f",
+                    "description": "d",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ],
+        "tool_choice": "auto",
+    },
+    "tool_choice_specific": {
+        "model": MODEL,
+        "messages": [{"role": "user", "content": "w?"}],
+        "tools": [{"type": "function", "function": {"name": "f"}}],
+        "tool_choice": {"type": "function", "function": {"name": "f"}},
+    },
+    "tool_call_compact_roundtrip": {
+        "model": MODEL,
+        "messages": [
+            {"role": "user", "content": "w?"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "f",
+                            "arguments": '{"city":"Paris"}',
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "ok"},
+            {"role": "user", "content": "thanks"},
+        ],
+    },
+    "claude_plain_serves": {"model": CLAUDE, "messages": _U},
+    "response_format_json_schema": {
+        "model": MODEL,
+        "messages": _U,
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "n",
+                "schema": {"type": "object", "properties": {"a": {"type": "string"}}},
+            },
+        },
+    },
+}
+
+# v1 RAISES UnsupportedParamsError (the model-shape / claude-DEAD-param gates,
+# probed); v2 must be a typed fallback naming the surface.
+V1_RAISES = {
+    "gpt5_temperature_not_one": (
+        {"model": "gpt-5", "messages": _U, "temperature": 0.5},
+        "gpt-5",
+    ),
+    "claude_reasoning_effort": (
+        {"model": CLAUDE, "messages": _U, "reasoning_effort": "high"},
+        "reasoning_effort",
+    ),
+    "claude_thinking": (
+        {"model": CLAUDE, "messages": _U, "thinking": {"type": "enabled"}},
+        "thinking",
+    ),
+}
+
+# v1 SERVES these (silent drop / verbatim passthrough / model-list gate); v2
+# falls back typed so v1 keeps serving.
+V1_SERVES_FALLBACKS = {
+    "user_gpt4o_served_by_v1": ({"model": MODEL, "messages": _U, "user": "u1"}, "user"),
+    "user_claude_dropped_by_v1": (
+        {"model": CLAUDE, "messages": _U, "user": "u1"},
+        "user",
+    ),
+    "top_k_not_a_chat_param": ({"model": MODEL, "messages": _U, "top_k": 7}, "top_k"),
+    "seed_parse_level": ({"model": MODEL, "messages": _U, "seed": 42}, "seed"),
+    "n_parse_level": ({"model": MODEL, "messages": _U, "n": 2}, "field"),
+    "message_name_forwarded": (
+        {"model": MODEL, "messages": [{"role": "user", "content": "hi", "name": "bob"}]},
+        "name",
+    ),
+    "explicit_stream_false": (
+        {"model": MODEL, "messages": _U, "stream": False},
+        "stream",
+    ),
+    "string_stop": ({"model": MODEL, "messages": _U, "stop": "end"}, "stop"),
+}
+
+
+def run_v1_request_transform(case: dict) -> dict:
+    """May RAISE — that IS the pinned v1 behavior for the raise rows."""
+    request = copy.deepcopy(case)
+    model = request.pop("model")
+    messages = request.pop("messages")
+    optional_params = get_optional_params(
+        model=model,
+        custom_llm_provider=PROVIDER,
+        messages=copy.deepcopy(messages),
+        stream=request.pop("stream", None),
+        **request,
+    )
+    optional_params.pop("extra_body", None)
+    return GithubCopilotConfig().transform_request(
+        model=model,
+        messages=messages,
+        optional_params=optional_params,
+        litellm_params={},
+        headers={},
+    )
+
+
+def _v2(case: dict):
+    return translate_chat_request(
+        copy.deepcopy(case), PROVIDER, build_translation_deps()
+    )
+
+
+def _norm(body: dict) -> str:
+    return json.dumps(body, sort_keys=True, default=str)
+
+
+@pytest.mark.parametrize("name", sorted(CASES))
+def test_v2_request_matches_v1(name: str) -> None:
+    case = CASES[name]
+    result = _v2(case)
+    assert result.is_ok(), result.error.summary
+    assert _norm(result.ok) == _norm(run_v1_request_transform(case))
+
+
+@pytest.mark.parametrize("name", sorted(V1_RAISES))
+def test_v1_raise_rows_fall_back_typed(name: str) -> None:
+    case, fragment = V1_RAISES[name]
+    result = _v2(case)
+    assert result.is_error(), f"{name} unexpectedly translated: {result.ok!r}"
+    assert fragment in result.error.summary, result.error.summary
+    with pytest.raises(UnsupportedParamsError):
+        run_v1_request_transform(case)
+
+
+@pytest.mark.parametrize("name", sorted(V1_SERVES_FALLBACKS))
+def test_v1_serves_fallback_rows(name: str) -> None:
+    case, fragment = V1_SERVES_FALLBACKS[name]
+    result = _v2(case)
+    assert result.is_error(), f"{name} unexpectedly translated: {result.ok!r}"
+    assert fragment in result.error.summary, result.error.summary
+    # v1 serves the same request without raising.
+    run_v1_request_transform(case)
+
+
+def test_system_to_assistant_both_flag_states_match_v1() -> None:
+    """GC-R4: the deps threading must be byte-equal for BOTH flag values. v1
+    reads ``litellm.disable_copilot_system_to_assistant``; v2 reads the same
+    value off ``TranslationDeps``. Toggle it in-process (DI, no monkeypatch)
+    and assert the multi-system bodies match in both states."""
+    case = {
+        "model": MODEL,
+        "messages": [{"role": "system", "content": "be brief"}, *_U],
+    }
+    original = litellm.disable_copilot_system_to_assistant
+    try:
+        litellm.disable_copilot_system_to_assistant = False
+        v1_on = run_v1_request_transform(case)
+        v2_on = _v2(case)
+        assert v2_on.is_ok(), v2_on.error.summary
+        assert v1_on["messages"][0]["role"] == "assistant"
+        assert _norm(v2_on.ok) == _norm(v1_on)
+
+        litellm.disable_copilot_system_to_assistant = True
+        v1_off = run_v1_request_transform(case)
+        v2_off = _v2(case)
+        assert v2_off.is_ok(), v2_off.error.summary
+        assert v1_off["messages"][0]["role"] == "system"
+        assert _norm(v2_off.ok) == _norm(v1_off)
+    finally:
+        litellm.disable_copilot_system_to_assistant = original
+
+
+def test_oauth_seed_is_in_place_and_no_socket_is_opened() -> None:
+    """GC-R1 guard: every characterization path here must run with the token
+    dir seeded and must NEVER reach the live device flow. Assert the seed env
+    is set and that serializing a github_copilot request opens no socket (a
+    real OAuth attempt would connect to the device-code URL)."""
+    assert os.environ.get("GITHUB_COPILOT_TOKEN_DIR") == _TOKEN_DIR
+    assert os.path.exists(os.path.join(_TOKEN_DIR, "api-key.json"))
+
+    real_connect = socket.socket.connect
+    connections: list[object] = []
+
+    def _record(self, address):
+        connections.append(address)
+        raise AssertionError(f"transform path opened a socket to {address!r}")
+
+    socket.socket.connect = _record  # type: ignore[method-assign]
+    try:
+        for case in CASES.values():
+            run_v1_request_transform(case)
+            _v2(case)
+    finally:
+        socket.socket.connect = real_connect  # type: ignore[method-assign]
+    assert connections == []
+
+
+def test_codex_family_stays_v1_by_responses_bridge() -> None:
+    """The codex family bridges to the Responses API ABOVE the chat seam and
+    never reaches this module. Pin that ``responses_api_bridge_check`` still
+    returns mode "responses" for them, so an upstream flip to chat mode goes
+    RED here and demands new chat rows (researcher-5 §1.2)."""
+    from litellm.main import responses_api_bridge_check
+
+    for model in ("gpt-5.3-codex", "gpt-5.1-codex-max"):
+        model_info, _ = responses_api_bridge_check(model, PROVIDER)
+        assert model_info.get("mode") == "responses", (model, model_info)

--- a/tests/test_litellm/translation/test_differential_github_copilot_response.py
+++ b/tests/test_litellm/translation/test_differential_github_copilot_response.py
@@ -1,0 +1,116 @@
+"""Differential parity for the github_copilot response path (wave 3).
+
+github_copilot is SDK-path: the LIVE v1 normalizer is
+``convert_to_model_response_object`` (the config's ``transform_response`` and
+its Anthropic-native synthesis are DEAD on this path). The per-provider delta
+is the envelope PRESET — main.py sets ``model_response.model =
+f"github_copilot/{model}"`` before conversion and cdr re-prefixes onto the
+wire model -> ``github_copilot/{wire_model}`` (the compat_sdk seam arm,
+construction arm "openai"). These rows pin that through the seam's
+``_to_model_response_openai`` exactly like the compat_sdk family, plus the
+wrong-construction-arm divergence the OWN_MODULE_RESPONSE_STYLES table must
+pin (the cdr float-``created`` template).
+
+OAuth safety: parsing is pure (no token files, no network); these rows touch
+no provider resolution at all, so they cannot reach the device flow.
+"""
+
+import copy
+import json
+
+import pydantic
+import pytest
+
+from litellm.types.utils import ModelResponse
+from litellm.utils import convert_to_model_response_object
+
+from litellm.translation.engine.pipeline import OWN_MODULE_RESPONSE_STYLES
+from litellm.translation.inbound.openai_chat import parse_request
+from litellm.translation.inbound.openai_chat.response import serialize_response
+from litellm.translation.providers.github_copilot import parse_response
+from litellm.translation_seam import (
+    UsageStyle,
+    build_translation_deps,
+    to_model_response,
+)
+
+from .test_differential_openai_response import _RESPONSES
+
+PROVIDER = "github_copilot"
+MODEL = "gpt-4o"
+_REQUEST = {"model": MODEL, "messages": [{"role": "user", "content": "hi"}]}
+_PRESET = f"{PROVIDER}/{MODEL}"
+
+_RESPONSE_ROWS = (
+    "text",
+    "tool_calls_rewrites_stop",
+    "cached_and_reasoning_usage_details",
+)
+
+
+def _v1_model_response(raw: dict, preset_model: str) -> dict:
+    result = convert_to_model_response_object(
+        response_object=copy.deepcopy(raw),
+        model_response_object=ModelResponse(model=preset_model),
+    )
+    return result.model_dump()
+
+
+def _v2_with_style(raw: dict, preset_model: str, style: UsageStyle) -> dict:
+    parsed = parse_request(copy.deepcopy(_REQUEST))
+    assert parsed.is_ok(), parsed.error.summary
+    response = parse_response(copy.deepcopy(raw), parsed.ok)
+    assert response.is_ok(), response.error.summary
+    body = serialize_response(response.ok, build_translation_deps(), "openai")
+    return to_model_response(
+        body, ModelResponse(model=preset_model), usage_style=style
+    ).model_dump()
+
+
+def _v2_model_response(raw: dict, preset_model: str) -> dict:
+    return _v2_with_style(raw, preset_model, "openai")
+
+
+def _norm(payload: dict) -> str:
+    return json.dumps(payload, sort_keys=True, default=str)
+
+
+@pytest.mark.parametrize("name", sorted(_RESPONSE_ROWS))
+def test_preset_reprefix_matches_v1(name: str, frozen_ambient) -> None:
+    """SDK-path preset: github_copilot/{request model} in,
+    github_copilot/{wire model} out, byte-identical dumps both sides."""
+    raw = _RESPONSES[name]
+    v1 = _v1_model_response(raw, _PRESET)
+    v2 = _v2_model_response(raw, _PRESET)
+    assert _norm(v2) == _norm(v1)
+    assert v2["model"] == f"{PROVIDER}/{raw['model']}"
+
+
+def test_preset_survives_when_wire_model_missing(frozen_ambient) -> None:
+    """cdr's elif arm needs a non-None wire model; without one the preset
+    github_copilot/{request model} survives verbatim on both sides."""
+    raw = {k: v for k, v in _RESPONSES["text"].items() if k != "model"}
+    v1 = _v1_model_response(raw, _PRESET)
+    v2 = _v2_model_response(raw, _PRESET)
+    assert _norm(v2) == _norm(v1)
+    assert v2["model"] == _PRESET
+
+
+def test_wrong_construction_arm_diverges_and_the_table_pins_it(
+    frozen_ambient,
+) -> None:
+    """The OWN_MODULE_RESPONSE_STYLES value is enforced by this divergence
+    (verifier-wave2b-final F1): a FLOAT wire ``created`` rides the normalized
+    body; the correct cdr ("openai") arm coerces it and serves exactly like
+    v1, while the wrong "openai_like" arm (ModelResponse(**json)) raises
+    ValidationError on traffic v1 serves. If the arms stop diverging here the
+    pin is dead — re-decide before relying on it."""
+    assert OWN_MODULE_RESPONSE_STYLES[PROVIDER] == "openai"
+    raw = copy.deepcopy(_RESPONSES["text"])
+    raw["created"] = raw["created"] + 0.5
+    v1 = _v1_model_response(raw, _PRESET)
+    correct = _v2_with_style(raw, _PRESET, OWN_MODULE_RESPONSE_STYLES[PROVIDER])
+    assert _norm(correct) == _norm(v1)
+    assert correct["created"] == _RESPONSES["text"]["created"]
+    with pytest.raises(pydantic.ValidationError):
+        _v2_with_style(raw, _PRESET, "openai_like")

--- a/tests/test_litellm/translation/test_differential_ollama_chat_request.py
+++ b/tests/test_litellm/translation/test_differential_ollama_chat_request.py
@@ -1,0 +1,488 @@
+"""Differential parity for the ollama_chat request path (wave 3).
+
+v1 side, invoked the way main.py's ollama_chat elif runs:
+``get_optional_params(custom_llm_provider="ollama_chat")`` then
+``OllamaChatConfig.transform_request`` (httpx path, transforms LIVE). The
+serializer pins (all probed in-process at HEAD): the ``{model, messages,
+options, stream}`` body with ``stream`` ALWAYS present (explicit false ==
+absent — the snowflake shape, NO guard arm), ``images: []`` attached to
+EVERY message, message ``name`` dropped for every role, max_tokens/mct ->
+``options.num_predict``, ``top_k`` riding ``options`` via the provider-
+native passthrough, response_format json_object -> ``format: "json"`` /
+json_schema -> the bare schema dict, reasoning_effort -> ``think`` (verbatim
+for gpt-oss*, else the {low, medium, high} boolean), tool_choice silently
+POPPED, tools verbatim (openai shape), assistant tool_calls munged to
+``{function: {name, arguments: <parsed>}}`` (id/type dropped), and the
+think-tag quirk: a string content matching v1's regex emits ``thinking``
+while the content stays the FULL tagged string.
+
+The ambient ``OllamaChatConfig`` class-attr defaults (its ``__init__``
+setattrs onto the CLASS) merge into ``options`` in v1 — module state v2
+cannot see; the canary below pins that the default config is empty and the
+fork obligation (fall back when non-empty) is recorded in CLAUDE.md.
+"""
+
+import copy
+import json
+
+import pytest
+
+from litellm.exceptions import UnsupportedParamsError
+from litellm.llms.ollama.chat.transformation import OllamaChatConfig
+from litellm.utils import get_optional_params
+
+from litellm.translation.engine.pipeline import translate_chat_request
+from litellm.translation_seam import build_translation_deps
+
+PROVIDER = "ollama_chat"
+MODEL = "llama3.1"
+
+_U = [{"role": "user", "content": "hi"}]
+
+CASES = {
+    "plain": {"model": MODEL, "messages": _U},
+    "sampling": {
+        "model": MODEL,
+        "messages": _U,
+        "temperature": 0.5,
+        "top_p": 0.9,
+        "max_tokens": 100,
+        "stop": ["x", "y"],
+    },
+    "mct_to_num_predict": {
+        "model": MODEL,
+        "messages": _U,
+        "max_completion_tokens": 50,
+    },
+    "top_k_options_passthrough": {"model": MODEL, "messages": _U, "top_k": 7},
+    "temperature_int_stays_int": {"model": MODEL, "messages": _U, "temperature": 1},
+    "stream_true": {"model": MODEL, "messages": _U, "stream": True},
+    "stream_false": {"model": MODEL, "messages": _U, "stream": False},
+    "tools_verbatim": {
+        "model": MODEL,
+        "messages": _U,
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "d",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ],
+    },
+    "tools_strict_rides": {
+        "model": MODEL,
+        "messages": _U,
+        "tools": [
+            {
+                "type": "function",
+                "function": {"name": "f", "parameters": {}, "strict": True},
+            }
+        ],
+    },
+    "tool_choice_popped": {
+        "model": MODEL,
+        "messages": _U,
+        "tools": [{"type": "function", "function": {"name": "f"}}],
+        "tool_choice": "required",
+    },
+    "rf_json_object": {
+        "model": MODEL,
+        "messages": _U,
+        "response_format": {"type": "json_object"},
+    },
+    "rf_json_schema_bare_schema": {
+        "model": MODEL,
+        "messages": _U,
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "n",
+                "strict": True,
+                "schema": {"type": "object", "properties": {"a": {"type": "string"}}},
+            },
+        },
+    },
+    "rf_text_dropped": {
+        "model": MODEL,
+        "messages": _U,
+        "response_format": {"type": "text"},
+    },
+    "reasoning_effort_low_to_think_true": {
+        "model": MODEL,
+        "messages": _U,
+        "reasoning_effort": "low",
+    },
+    "reasoning_effort_minimal_to_think_false": {
+        "model": MODEL,
+        "messages": _U,
+        "reasoning_effort": "minimal",
+    },
+    "reasoning_effort_none_string_to_think_false": {
+        "model": MODEL,
+        "messages": _U,
+        "reasoning_effort": "none",
+    },
+    "reasoning_effort_gptoss_verbatim": {
+        "model": "gpt-oss:20b",
+        "messages": _U,
+        "reasoning_effort": "low",
+    },
+    "system_rides_in_messages": {
+        "model": MODEL,
+        "messages": [{"role": "system", "content": "be nice"}, *_U],
+    },
+    "multi_text_list_flattens": {
+        "model": MODEL,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "a"},
+                    {"type": "text", "text": "b"},
+                ],
+            }
+        ],
+    },
+    "image_data_url_stripped_to_base64": {
+        "model": MODEL,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "look"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "data:image/png;base64,iVBOR"},
+                    },
+                ],
+            }
+        ],
+    },
+    "image_http_url_verbatim": {
+        "model": MODEL,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "look"},
+                    {"type": "image_url", "image_url": {"url": "https://x.test/a.png"}},
+                ],
+            }
+        ],
+    },
+    "tool_roundtrip_id_type_dropped": {
+        "model": MODEL,
+        "messages": [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "f", "arguments": '{"a": 1}'},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "result"},
+            {"role": "user", "content": "ok"},
+        ],
+    },
+    "message_name_dropped_every_role": {
+        "model": MODEL,
+        "messages": [{"role": "user", "content": "hi", "name": "bob"}],
+    },
+    "assistant_think_tags_full_content_plus_thinking": {
+        "model": MODEL,
+        "messages": [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "<think>hmm</think>yes"},
+            {"role": "user", "content": "more"},
+        ],
+    },
+    "user_think_tags_same_quirk": {
+        "model": MODEL,
+        "messages": [{"role": "user", "content": "<think>x</think>y"}],
+    },
+    "empty_assistant_content_rides": {
+        "model": MODEL,
+        "messages": [
+            {"role": "user", "content": "q"},
+            {"role": "assistant", "content": ""},
+            {"role": "user", "content": "r"},
+        ],
+    },
+}
+
+# v1 RAISES UnsupportedParamsError (outside the supported list, probed);
+# v2 must be a typed fallback naming the surface.
+V1_RAISES = {
+    "n": ({"model": MODEL, "messages": _U, "n": 2}, "n"),
+    "logprobs": ({"model": MODEL, "messages": _U, "logprobs": True}, "logprobs"),
+    "presence_penalty": (
+        {"model": MODEL, "messages": _U, "presence_penalty": 0.1},
+        "presence_penalty",
+    ),
+    "parallel_tool_calls": (
+        {"model": MODEL, "messages": _U, "parallel_tool_calls": True},
+        "parallel_tool_calls",
+    ),
+    "thinking": (
+        {"model": MODEL, "messages": _U, "thinking": {"type": "enabled"}},
+        "thinking",
+    ),
+}
+
+# v1 SERVES these (silent drop / passthrough / local raise the inbound
+# boundary reproduces); v2 falls back typed so v1 keeps serving.
+V1_SERVES_FALLBACKS = {
+    "user_silent_drop": ({"model": MODEL, "messages": _U, "user": "u1"}, "user"),
+    "seed_parse_level": ({"model": MODEL, "messages": _U, "seed": 42}, "seed"),
+    "frequency_penalty_to_repeat_penalty": (
+        {"model": MODEL, "messages": _U, "frequency_penalty": 0.2},
+        "frequency_penalty",
+    ),
+    "functions_to_tools_verbatim": (
+        {"model": MODEL, "messages": _U, "functions": [{"name": "g"}]},
+        "functions",
+    ),
+    "mirostat_native_passthrough": (
+        {"model": MODEL, "messages": _U, "mirostat": 1},
+        "mirostat",
+    ),
+    "keep_alive_passthrough": (
+        {"model": MODEL, "messages": _U, "keep_alive": "5m"},
+        "keep_alive",
+    ),
+    "function_name_near_dormant_synth_arm": (
+        {"model": MODEL, "messages": _U, "function_name": "f"},
+        "function_name",
+    ),
+    "string_stop_rides_verbatim": (
+        {"model": MODEL, "messages": _U, "stop": "end"},
+        "stop",
+    ),
+    "both_max_tokens_keys": (
+        {"model": MODEL, "messages": _U, "max_tokens": 100, "max_completion_tokens": 50},
+        "max_tokens",
+    ),
+    "assistant_reasoning_content_to_thinking": (
+        {
+            "model": MODEL,
+            "messages": [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "ans", "reasoning_content": "hmm"},
+                {"role": "user", "content": "more"},
+            ],
+        },
+        "reasoning_content",
+    ),
+    "tool_cache_control_verbatim": (
+        {
+            "model": MODEL,
+            "messages": _U,
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {"name": "f", "parameters": {}},
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+        },
+        "cache_control",
+    ),
+    "mid_conversation_system": (
+        {
+            "model": MODEL,
+            "messages": [
+                {"role": "user", "content": "hi"},
+                {"role": "system", "content": "late"},
+                {"role": "user", "content": "more"},
+            ],
+        },
+        "system",
+    ),
+    "consecutive_user_turns": (
+        {
+            "model": MODEL,
+            "messages": [
+                {"role": "user", "content": "a"},
+                {"role": "user", "content": "b"},
+            ],
+        },
+        "consecutive",
+    ),
+}
+
+# v1 CRASHES with a raw exception (not UnsupportedParamsError); v2 must be
+# a typed fallback so v1 serves its own raise.
+V1_RAISES_RAW = {
+    "blank_tool_arguments_json_decode_error": (
+        {
+            "model": MODEL,
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "c",
+                            "type": "function",
+                            "function": {"name": "f", "arguments": "not-json"},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "c", "content": "r"},
+            ],
+        },
+        "JSON repair",
+    ),
+}
+
+
+def run_v1_request_transform(case: dict) -> dict:
+    """May RAISE — that IS the pinned v1 behavior for the raise rows."""
+    request = copy.deepcopy(case)
+    model = request.pop("model")
+    messages = request.pop("messages")
+    optional_params = get_optional_params(
+        model=model,
+        custom_llm_provider=PROVIDER,
+        messages=copy.deepcopy(messages),
+        stream=request.pop("stream", None),
+        **request,
+    )
+    optional_params.pop("extra_body", None)
+    return OllamaChatConfig().transform_request(
+        model=model,
+        messages=messages,
+        optional_params=optional_params,
+        litellm_params={},
+        headers={},
+    )
+
+
+def _v2(case: dict):
+    return translate_chat_request(
+        copy.deepcopy(case), PROVIDER, build_translation_deps()
+    )
+
+
+def _norm(body: dict) -> str:
+    return json.dumps(body, sort_keys=True, default=str)
+
+
+@pytest.mark.parametrize("name", sorted(CASES))
+def test_v2_request_matches_v1(name: str) -> None:
+    case = CASES[name]
+    result = _v2(case)
+    assert result.is_ok(), result.error.summary
+    assert _norm(result.ok) == _norm(run_v1_request_transform(case))
+
+
+@pytest.mark.parametrize("name", sorted(V1_RAISES))
+def test_v1_raise_rows_fall_back_typed(name: str) -> None:
+    case, fragment = V1_RAISES[name]
+    result = _v2(case)
+    assert result.is_error(), f"{name} unexpectedly translated: {result.ok!r}"
+    assert fragment in result.error.summary, result.error.summary
+    with pytest.raises(UnsupportedParamsError):
+        run_v1_request_transform(case)
+
+
+@pytest.mark.parametrize("name", sorted(V1_SERVES_FALLBACKS))
+def test_v1_serves_fallback_rows(name: str) -> None:
+    case, fragment = V1_SERVES_FALLBACKS[name]
+    result = _v2(case)
+    assert result.is_error(), f"{name} unexpectedly translated: {result.ok!r}"
+    assert fragment in result.error.summary, result.error.summary
+    # v1 serves the same request without raising.
+    run_v1_request_transform(case)
+
+
+@pytest.mark.parametrize("name", sorted(V1_RAISES_RAW))
+def test_v1_raw_raise_rows_fall_back_typed(name: str) -> None:
+    case, fragment = V1_RAISES_RAW[name]
+    result = _v2(case)
+    assert result.is_error(), f"{name} unexpectedly translated: {result.ok!r}"
+    assert fragment in result.error.summary, result.error.summary
+    with pytest.raises(json.JSONDecodeError):
+        run_v1_request_transform(case)
+
+
+def test_stream_false_equals_absent_on_the_wire() -> None:
+    """The snowflake shape: v1's transform pops stream with default False,
+    so the body ALWAYS carries the key — explicit false and absent are the
+    same wire byte and the guard deliberately has no stream:false arm."""
+    absent = run_v1_request_transform(CASES["plain"])
+    explicit = run_v1_request_transform(CASES["stream_false"])
+    assert absent["stream"] is False
+    assert _norm(absent) == _norm(explicit)
+    result = _v2(CASES["stream_false"])
+    assert result.is_ok() and result.ok["stream"] is False
+
+
+def test_images_list_attached_to_every_message() -> None:
+    v1 = run_v1_request_transform(CASES["system_rides_in_messages"])
+    result = _v2(CASES["system_rides_in_messages"])
+    assert result.is_ok()
+    for body in (v1, result.ok):
+        assert all(message["images"] == [] for message in body["messages"])
+
+
+def test_think_tag_request_quirk_keeps_full_content() -> None:
+    """The probe-found quirk a code-reading port would invert: v1 reads the
+    regex result for ``thinking`` but flattens the ORIGINAL content, so the
+    tagged bytes stay on the wire alongside the extracted thinking."""
+    v1 = run_v1_request_transform(
+        CASES["assistant_think_tags_full_content_plus_thinking"]
+    )
+    assistant = v1["messages"][1]
+    assert assistant["thinking"] == "hmm"
+    assert assistant["content"] == "<think>hmm</think>yes"
+    result = _v2(CASES["assistant_think_tags_full_content_plus_thinking"])
+    assert result.is_ok()
+    assert _norm(result.ok) == _norm(v1)
+
+
+def test_think_regex_mirror_matches_v1_source() -> None:
+    """The serializer's THINK_TAG_RE is the one in-package mirror of v1's
+    ``_parse_content_for_reasoning`` regex; drift here is a silent
+    divergence, so pin the pattern against representative inputs through
+    v1's live helper."""
+    from litellm.litellm_core_utils.prompt_templates.common_utils import (
+        _parse_content_for_reasoning,
+    )
+
+    from litellm.translation.providers.ollama_chat.serialize import THINK_TAG_RE
+
+    samples = (
+        "<think>a</think>b",
+        "<thinking>a</thinking>b",
+        "<budget:thinking>a</budget:thinking>b",
+        "<think>multi\nline</think>rest",
+        "pre<think>a</think>b",  # no match: v1 anchors at the start
+        "<think>unclosed",
+        "<think>a</thinking>b",  # mismatched tags still match v1's regex
+        "",
+        "plain",
+    )
+    for text in samples:
+        v1_reasoning, _ = _parse_content_for_reasoning(text)
+        matched = THINK_TAG_RE.match(text) if text else None
+        v2_reasoning = matched.group(1) if matched else None
+        assert v2_reasoning == v1_reasoning, text
+
+
+def test_ambient_class_config_canary() -> None:
+    """v1 merges ``OllamaChatConfig.get_config()`` CLASS-ATTR state into
+    ``options`` (the groq class-attr precedent) — ambient module state v2
+    cannot see. The default must be empty (every differential row relies on
+    it) and the fork obligation (fall back when non-empty) is recorded in
+    CLAUDE.md. If this canary goes red, an earlier test leaked class state
+    or upstream grew defaults — either way the corpus assumption broke."""
+    assert OllamaChatConfig.get_config() == {}

--- a/tests/test_litellm/translation/test_differential_ollama_chat_response.py
+++ b/tests/test_litellm/translation/test_differential_ollama_chat_response.py
@@ -1,0 +1,355 @@
+"""Differential parity for the ollama_chat response path (wave 3).
+
+v1 side: ``OllamaChatConfig.transform_response`` mutating a pre-allocated
+``ModelResponse`` — ``model = ollama_chat/{REQUEST model}`` (the wire model
+key is IGNORED), finish from ``map_finish_reason(done_reason or "stop")``
+with the tool_calls override, the message riding VERBATIM into
+``Message(**message)`` (extra keys included) after the thinking remap /
+think-tag split, usage from prompt_eval_count/eval_count.
+
+v2 side: the ollama_chat parser builds the normalized body on
+``ChatResponse.wire``; the seam's ``openai`` construction arm reproduces
+v1's assembly. Both sides get the SAME pre-allocated ``ModelResponse(id=...)``
+(v1 keeps the ambient chatcmpl id — no wire id exists on this wire).
+
+Minted tool-call ids are normalized in ``_norm``: BOTH sides mint them
+inside ``Message(**...)`` validation (v1 during transform_response, v2
+during ``to_model_response``), so under the frozen-uuid fixture the values
+are counter positions, not parity surface — the mint FACT (bare uuid, every
+id-less entry) is pinned by its own test.
+"""
+
+import copy
+import json
+import re
+import time
+
+import httpx
+import pytest
+
+from litellm.litellm_core_utils.litellm_logging import Logging
+from litellm.llms.ollama.chat.transformation import OllamaChatConfig
+from litellm.types.utils import ModelResponse
+
+from litellm.translation.inbound.openai_chat import parse_request
+from litellm.translation.inbound.openai_chat.response import serialize_response
+from litellm.translation.providers.ollama_chat import parse_response
+from litellm.translation_seam import (
+    UsageStyle,
+    build_translation_deps,
+    to_model_response,
+)
+
+MODEL = "llama3.1"
+PREFIXED = f"ollama_chat/{MODEL}"
+_AMBIENT_ID = "chatcmpl-ollama-diff"
+
+_REQUEST = {"model": MODEL, "messages": [{"role": "user", "content": "hi"}]}
+
+_BASE = {
+    "model": MODEL,
+    "created_at": "2025-05-24T02:12:05Z",
+    "message": {"role": "assistant", "content": "hello"},
+    "done": True,
+    "done_reason": "stop",
+    "prompt_eval_count": 7,
+    "eval_count": 3,
+}
+
+_RESPONSES = {
+    "plain": _BASE,
+    "done_reason_length": {**_BASE, "done_reason": "length"},
+    "done_reason_missing_defaults_stop": {
+        k: v for k, v in _BASE.items() if k != "done_reason"
+    },
+    "done_reason_unknown_maps_stop": {**_BASE, "done_reason": "load"},
+    "wire_model_ignored": {**_BASE, "model": "OTHER-MODEL"},
+    "thinking_field_to_reasoning_content": {
+        **_BASE,
+        "message": {"role": "assistant", "content": "yes", "thinking": "hmm"},
+    },
+    "think_tags_split_remainder": {
+        **_BASE,
+        "message": {"role": "assistant", "content": "<think>hmm</think>yes"},
+    },
+    "think_tags_unclosed_verbatim": {
+        **_BASE,
+        "message": {"role": "assistant", "content": "<think>hmm yes"},
+    },
+    "tool_calls_dict_args_restringified": {
+        **_BASE,
+        "message": {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"function": {"name": "f", "arguments": {"a": 1, "b": [1, 2]}}}
+            ],
+        },
+    },
+    "tool_calls_str_args_verbatim": {
+        **_BASE,
+        "message": {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"function": {"name": "f", "arguments": '{"a":1}'}}],
+        },
+    },
+    "tool_calls_wire_id_kept": {
+        **_BASE,
+        "message": {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "wire-id",
+                    "type": "function",
+                    "function": {"name": "f", "arguments": {}},
+                }
+            ],
+        },
+    },
+    "tool_calls_force_finish_over_done_reason": {
+        **_BASE,
+        "done_reason": "length",
+        "message": {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"function": {"name": "f", "arguments": {}}}],
+        },
+    },
+    "extra_message_key_rides": {
+        **_BASE,
+        "message": {"role": "assistant", "content": "x", "weird_key": 5},
+    },
+    "extra_top_level_key_dropped": {**_BASE, "total_duration": 12345},
+}
+
+# v1 RAISES out of transform_response (TypeError / ValueError / the eager
+# token_counter default); v2 must be a loud typed error.
+_LOUD = {
+    "non_object_body": ([1, 2], "not an object"),
+    "missing_message": (
+        {k: v for k, v in _BASE.items() if k != "message"},
+        "message",
+    ),
+    "null_message": ({**_BASE, "message": None}, "message"),
+    "non_str_content": (
+        {**_BASE, "message": {"role": "assistant", "content": 5}},
+        "not a string",
+    ),
+    "null_content_eager_token_counter": (
+        {**_BASE, "message": {"role": "assistant", "content": None}},
+        "token_counter",
+    ),
+    "content_key_missing": (
+        {**_BASE, "message": {"role": "assistant"}},
+        "missing or null",
+    ),
+    "null_content_with_thinking": (
+        {**_BASE, "message": {"role": "assistant", "thinking": "h", "content": None}},
+        "missing or null",
+    ),
+    "tool_call_non_object_entry": (
+        {
+            **_BASE,
+            "message": {"role": "assistant", "content": "", "tool_calls": ["x"]},
+        },
+        "not an object",
+    ),
+    "tool_call_missing_function": (
+        {
+            **_BASE,
+            "message": {"role": "assistant", "content": "", "tool_calls": [{"id": "c"}]},
+        },
+        "function",
+    ),
+    "unhashable_done_reason": (
+        {**_BASE, "done_reason": {"x": 1}},
+        "unhashable",
+    ),
+}
+
+# v1 SERVES these; v2 falls back typed so v1 keeps serving.
+_V1_SERVES_FALLBACKS = {
+    "missing_prompt_eval_count_token_counter": (
+        {k: v for k, v in _BASE.items() if k != "prompt_eval_count"},
+        "token_counter",
+    ),
+    "missing_eval_count_token_counter": (
+        {k: v for k, v in _BASE.items() if k != "eval_count"},
+        "token_counter",
+    ),
+    "function_call_done_reason_outside_ir": (
+        {**_BASE, "done_reason": "function_call"},
+        "function_call",
+    ),
+}
+
+
+def _v1_model_response(raw) -> dict:
+    logging = Logging(
+        model=MODEL,
+        messages=copy.deepcopy(_REQUEST["messages"]),
+        stream=False,
+        call_type="completion",
+        start_time=time.time(),
+        litellm_call_id="diff-ollama-response",
+        function_id="diff-ollama-response",
+    )
+    response = httpx.Response(
+        200,
+        json=copy.deepcopy(raw),
+        request=httpx.Request("POST", "http://localhost:11434/api/chat"),
+    )
+    return (
+        OllamaChatConfig()
+        .transform_response(
+            model=MODEL,
+            raw_response=response,
+            model_response=ModelResponse(id=_AMBIENT_ID),
+            logging_obj=logging,
+            request_data={},
+            messages=copy.deepcopy(_REQUEST["messages"]),
+            optional_params={},
+            litellm_params={},
+            encoding=None,
+        )
+        .model_dump()
+    )
+
+
+def _v2_parse(raw):
+    parsed = parse_request(copy.deepcopy(_REQUEST))
+    assert parsed.is_ok(), parsed.error.summary
+    return parse_response(copy.deepcopy(raw), parsed.ok)
+
+
+def _v2_with_style(raw, style: UsageStyle) -> dict:
+    response = _v2_parse(raw)
+    assert response.is_ok(), response.error.summary
+    body = serialize_response(response.ok, build_translation_deps(), "openai")
+    return to_model_response(
+        body, ModelResponse(id=_AMBIENT_ID), usage_style=style
+    ).model_dump()
+
+
+def _v2_model_response(raw) -> dict:
+    return _v2_with_style(raw, "openai")
+
+
+_UUID_RE = re.compile(
+    r"^(call_)?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+)
+
+
+def _norm(payload: dict) -> str:
+    """Minted tool ids are envelope nondeterminism (both sides mint inside
+    Message validation at different frozen-counter positions): uuid-shaped
+    ids normalize to a sentinel, wire-carried ids stay verbatim."""
+    normalized = copy.deepcopy(payload)
+    for choice in normalized.get("choices", []):
+        for call in (choice.get("message") or {}).get("tool_calls") or []:
+            if isinstance(call.get("id"), str) and _UUID_RE.match(call["id"]):
+                call["id"] = "MINTED"
+    return json.dumps(normalized, sort_keys=True, default=str)
+
+
+@pytest.mark.parametrize("name", sorted(_RESPONSES))
+def test_v2_response_matches_v1(name: str, frozen_ambient) -> None:
+    raw = _RESPONSES[name]
+    assert _norm(_v2_model_response(raw)) == _norm(_v1_model_response(raw))
+
+
+@pytest.mark.parametrize("name", sorted(_RESPONSES))
+def test_prefix_and_envelope_quirks(name: str, frozen_ambient) -> None:
+    """The response model is ollama_chat/{REQUEST model} (wire model
+    ignored), the ambient chatcmpl id is kept, and created is the frozen
+    ambient stamp (v1 re-stamps int(time.time()) — the same value)."""
+    v1 = _v1_model_response(_RESPONSES[name])
+    v2 = _v2_model_response(_RESPONSES[name])
+    for dump in (v1, v2):
+        assert dump["model"] == PREFIXED
+        assert dump["id"] == _AMBIENT_ID
+        assert dump["created"] == 1718064000
+
+
+@pytest.mark.parametrize("name", sorted(_LOUD))
+def test_loud_shapes_error_on_both_sides(name: str, frozen_ambient) -> None:
+    raw, fragment = _LOUD[name]
+    result = _v2_parse(raw)
+    assert result.is_error(), f"{name} unexpectedly parsed"
+    assert fragment in result.error.summary, result.error.summary
+    with pytest.raises(Exception):
+        _v1_model_response(copy.deepcopy(raw))
+
+
+@pytest.mark.parametrize("name", sorted(_V1_SERVES_FALLBACKS))
+def test_v1_serves_fallback_rows(name: str, frozen_ambient) -> None:
+    raw, fragment = _V1_SERVES_FALLBACKS[name]
+    result = _v2_parse(raw)
+    assert result.is_error(), f"{name} unexpectedly parsed"
+    assert fragment in result.error.summary, result.error.summary
+    v1 = _v1_model_response(copy.deepcopy(raw))
+    assert v1["choices"], f"{name}: v1 stopped serving; re-decide the fallback"
+
+
+def test_minted_tool_ids_are_bare_uuids_on_both_sides(frozen_ambient) -> None:
+    """Both sides mint the missing tool id inside Message(**...) validation:
+    a bare uuid (no call_ prefix — that prefix exists only in the dormant
+    json+function_name synth arm)."""
+    raw = _RESPONSES["tool_calls_dict_args_restringified"]
+    for dump in (_v1_model_response(raw), _v2_model_response(raw)):
+        minted = dump["choices"][0]["message"]["tool_calls"][0]["id"]
+        assert _UUID_RE.match(minted) and not minted.startswith("call_")
+
+
+def test_wire_tool_id_survives_both_sides(frozen_ambient) -> None:
+    raw = _RESPONSES["tool_calls_wire_id_kept"]
+    for dump in (_v1_model_response(raw), _v2_model_response(raw)):
+        assert dump["choices"][0]["message"]["tool_calls"][0]["id"] == "wire-id"
+
+
+def test_dict_args_restringified_with_default_separators(frozen_ambient) -> None:
+    raw = _RESPONSES["tool_calls_dict_args_restringified"]
+    for dump in (_v1_model_response(raw), _v2_model_response(raw)):
+        arguments = dump["choices"][0]["message"]["tool_calls"][0]["function"][
+            "arguments"
+        ]
+        assert arguments == '{"a": 1, "b": [1, 2]}'
+
+
+def test_finish_map_mirror_matches_v1_table() -> None:
+    """FINISH_REASON_MIRROR is the one in-package mirror of v1's
+    core_helpers._FINISH_REASON_MAP; key-for-key drift would silently
+    diverge served finish reasons."""
+    from litellm.litellm_core_utils.core_helpers import _FINISH_REASON_MAP
+
+    from litellm.translation.providers.ollama_chat.response import (
+        FINISH_REASON_MIRROR,
+    )
+
+    assert dict(FINISH_REASON_MIRROR) == dict(_FINISH_REASON_MAP)
+
+
+def test_wrong_construction_arm_diverges_and_the_table_pins_it(
+    frozen_ambient,
+) -> None:
+    """The cohere no-id template: the ollama body deliberately carries NO id,
+    so the correct cdr ("openai") arm keeps the ambient chatcmpl id exactly
+    like v1's fresh-ModelResponse mutation, while the wrong "openai_like"
+    arm (ModelResponse(**json)) ignores the pre-allocated envelope and mints
+    a fresh id."""
+    from litellm.translation.engine.pipeline import OWN_MODULE_RESPONSE_STYLES
+
+    assert OWN_MODULE_RESPONSE_STYLES["ollama_chat"] == "openai"
+    raw = _RESPONSES["plain"]
+    v1 = _v1_model_response(raw)
+    correct = _v2_with_style(raw, OWN_MODULE_RESPONSE_STYLES["ollama_chat"])
+    wrong = _v2_with_style(raw, "openai_like")
+    assert _norm(correct) == _norm(v1)
+    assert correct["id"] == _AMBIENT_ID
+    assert wrong["id"] != _AMBIENT_ID
+    assert _norm(wrong) != _norm(v1), (
+        "the construction arms stopped diverging on the envelope id — "
+        "the F1 gate lost its discriminator; re-decide before relying on it"
+    )

--- a/tests/test_litellm/translation/test_import_contract.py
+++ b/tests/test_litellm/translation/test_import_contract.py
@@ -53,6 +53,7 @@ def test_no_module_imports_a_forbidden_v1_surface() -> None:
 # unification item). APPEND a module name below when a new consumer lands.
 
 _DEPTH_CAP_CONSUMERS = (
+    "providers.databricks.tools",
     "providers.google_genai.schema",
     "providers.mistral.serialize",
     "providers.openai_compat.guard",


### PR DESCRIPTION
## Relevant issues

Stacked on #30324 (wave-2b). Completes the outbound provider port for Core Translation v2: with these three the v2 hub-and-spoke covers eighty providers.

## What this adds

Three own-module providers, one self-contained commit each, all differential-green against v1 probed in-process at HEAD and fail-closed everywhere outside the pinned corpus.

ollama_chat: the `/api/chat` NDJSON wire as its own stream family (usage rides every chunk, so it cannot use the shared httpx_chunk factory). The request munge mirrors v1's whitelist, the `<think>`/`<thinking>`/`<budget:thinking>` regex extracts reasoning while the content keeps the full tagged string, images are base64-stripped, and reasoning_effort maps to `think`. The think-tag stream state machine reproduces v1's truncation bug (only the tag-bearing chunk is reasoning). The legacy `ollama` `/api/generate` prefix stays a v1 fallback by absence.

github_copilot: the SDK path (openai_compat body plus the system to assistant role rewrite, gated by `litellm.disable_copilot_system_to_assistant` threaded through TranslationDeps). Params reuse the shared openai gates since GithubCopilotConfig extends OpenAIConfig. The device-flow OAuth lives in validate_environment above the seam; the transforms read no token files and open no sockets, pinned by a guard test that intercepts socket.connect. The codex family bridges to the Responses API above the chat seam and stays v1 by absence, pinned by a canary on the real bridge check.

databricks: the `"claude" in model` substring fork, parameterized claude and non-claude across the whole corpus. claude tools take the openai to anthropic to databricks round-trip (dropping function-level strict and the parameters `$schema`); non-claude tools ride verbatim. mct renames to max_tokens always, top_k rides top-level, and the thinking budget bumps max_tokens only when the caller gave none. Deliberate v1 fallbacks: claude response_format (v1 silently drops json_object entirely and routes json_schema through the json_tool_call machinery), claude reasoning_effort, and the raw KeyError crash on non-claude reasoning_effort without max_tokens. The stream drops the wire usage entirely and reformats json_mode arguments, both replayed against the real iterator.

## How it is proven

Characterization then differential, per the package conventions. Each provider has request, response, and (where applicable) stream differential gates that run v1 in-process at HEAD over the corpus and assert identical normalized JSON or an explained fallback that v1 serves. `DIFFERENTIAL_REPORT.md` regenerates with zero divergent rows. Streaming stays on v1 until the streaming seam lands, as it does for every other provider.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests (`make lint-translation`: ruff, pyright strict 0 errors, semgrep, import-linter, file-size, CLAUDE.md freshness, pytest 3271 passed / 8 skipped)
- [x] My PR's scope is as isolated as possible
- [ ] I have requested a Greptile review

## Type

🆕 New Feature

## Changes

ollama_chat, github_copilot, and databricks added under `litellm/translation/providers/`, registered in the engine pipeline tables and the dispatch Provider literal, with the ollama_chat and databricks chunk dialects' pure folds extracted to `inbound/openai_chat/{ollama_fold,databricks_fold}.py`. Differential corpora and report wiring added; `litellm/translation/CLAUDE.md` mapped and the scope count moved to eighty. The one out-of-package edit is a single deps-thread line in `litellm/translation_seam.py` for the github_copilot ambient flag.