### PR TITLE
fix: route volcengine (Doubao) tiered-pricing models to the tiered cost handler

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -655,6 +655,15 @@ def cost_per_token(
         )
 
         return dashscope_cost_per_token(model=model, usage=usage_block)
+    elif custom_llm_provider == "volcengine":
+        # Volcengine (Doubao) models share Dashscope's tiered-pricing structure
+        from litellm.llms.dashscope.cost_calculator import (
+            cost_per_token as tiered_cost_per_token,
+        )
+
+        return tiered_cost_per_token(
+            model=model, usage=usage_block, custom_llm_provider="volcengine"
+        )
     elif custom_llm_provider == "azure_ai":
         return azure_ai_cost_per_token(
             model=model,

--- a/litellm/llms/dashscope/cost_calculator.py
+++ b/litellm/llms/dashscope/cost_calculator.py
@@ -186,20 +186,25 @@ def _calculate_completion_cost(
     )
 
 
-def cost_per_token(model: str, usage: Usage) -> Tuple[float, float]:
+def cost_per_token(
+    model: str, usage: Usage, custom_llm_provider: str = "dashscope"
+) -> Tuple[float, float]:
     """
-    Calculate cost per token for Dashscope models.
+    Calculate cost per token for tiered-pricing models.
 
-    Supports both tiered and flat pricing with cached and reasoning tokens.
+    Supports both tiered and flat pricing with cached and reasoning tokens. The logic reads
+    `tiered_pricing` from the model map, so it is provider-agnostic and shared by other providers
+    with the same tiered structure (e.g. Volcengine/Doubao) via the `custom_llm_provider` argument.
 
     Args:
         model: Model name without provider prefix
         usage: LiteLLM Usage block
+        custom_llm_provider: Provider to resolve the model under (defaults to "dashscope")
 
     Returns:
         Tuple[float, float] - (prompt_cost_in_usd, completion_cost_in_usd)
     """
-    model_info = get_model_info(model=model, custom_llm_provider="dashscope")
+    model_info = get_model_info(model=model, custom_llm_provider=custom_llm_provider)
     breakdown = _extract_token_breakdown(usage)
     tiered_pricing = (
         model_info.get("tiered_pricing")

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -2733,3 +2733,44 @@ def test_openrouter_gemini_3_1_flash_lite_stable_pricing():
     assert model_info["cache_read_input_token_cost"] == 2.5e-08
     assert model_info["max_input_tokens"] == 1048576
     assert model_info["max_output_tokens"] == 65536
+
+
+def test_volcengine_tiered_pricing_graduated_cost(monkeypatch):
+    """Regression test for #30346.
+
+    Volcengine (Doubao) models define `tiered_pricing` but no flat per-token cost, so the cost
+    calculator billed them at $0. They must route to the shared tiered-pricing handler and produce
+    the correct graduated cost across tiers.
+    """
+    monkeypatch.setattr(litellm, "model_cost", litellm.get_model_cost_map(url=""))
+    model = "doubao-seed-2-0-pro-260215"
+    model_info = litellm.get_model_info(f"volcengine/{model}")
+    tier_0, tier_1 = model_info["tiered_pricing"][0], model_info["tiered_pricing"][1]
+    boundary = int(tier_0["range"][1])
+
+    prompt_tokens = boundary + 10000
+    completion_tokens = boundary + 5000
+    usage = Usage(
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=prompt_tokens + completion_tokens,
+    )
+
+    prompt_cost, completion_cost = cost_per_token(
+        model=model,
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        custom_llm_provider="volcengine",
+        usage_object=usage,
+    )
+
+    expected_prompt_cost = (boundary * tier_0["input_cost_per_token"]) + (
+        10000 * tier_1["input_cost_per_token"]
+    )
+    expected_completion_cost = (boundary * tier_0["output_cost_per_token"]) + (
+        5000 * tier_1["output_cost_per_token"]
+    )
+
+    assert prompt_cost > 0 and completion_cost > 0
+    assert prompt_cost == pytest.approx(expected_prompt_cost, rel=1e-10)
+    assert completion_cost == pytest.approx(expected_completion_cost, rel=1e-10)


### PR DESCRIPTION
## Relevant issues

Fixes #30346

## Type

🐛 Bug Fix

## Changes

Volcengine doubao models (for example `volcengine/doubao-seed-2-0-pro-260215`) define `tiered_pricing` in the model map but carry no flat `input_cost_per_token`/`output_cost_per_token`. The `cost_per_token` dispatcher had no `volcengine` branch, so these models fell through to `generic_cost_per_token`, which only reads flat per-token costs. The result was that every volcengine doubao request was tracked as $0

The dashscope cost calculator already implements graduated tiered pricing and reads `tiered_pricing` generically from the model map; the only provider-specific part was the hardcoded provider passed to `get_model_info`. This change makes that provider an argument (defaulting to `dashscope`, so existing behavior is unchanged) and routes `volcengine` to the same handler, mirroring how `dashscope` is dispatched

Added a regression test that asserts the graduated cost across two tiers for a doubao model; it fails on the current code (cost is $0) and passes with the fix

## Screenshots / Proof of Fix

This path is network-free: cost is computed from the bundled `model_prices_and_context_window_backup.json`, so it does not require a live volcengine key. Reproduction on the local model map:

Before (current behavior):

```
volcengine/doubao-seed-2-0-pro-260215, prompt_tokens=10000, completion_tokens=2000
-> prompt_cost=$0.000000, completion_cost=$0.000000  (tracked as $0)
```

After this change:

```
volcengine/doubao-seed-2-0-pro-260215, prompt_tokens=10000, completion_tokens=2000
-> prompt_cost > 0, completion_cost > 0, matching the graduated tiered_pricing in the model map
```

The regression test `test_volcengine_tiered_pricing_graduated_cost` in `tests/test_litellm/test_cost_calculator.py` encodes the expected graduated cost across the first two tiers and verifies it end to end through `cost_per_token(..., custom_llm_provider="volcengine")`