### PR TITLE
fix: don't stack provider prefix on wildcard models with a custom prefix

### DIFF
--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -311,7 +311,15 @@ def get_known_models_from_wildcard(
     suffix_appended_wildcard_models = []
     for model in wildcard_models:
         if not model.startswith(wildcard_provider_prefix):
-            model = f"{wildcard_provider_prefix}/{model}"
+            # `get_provider_models` returns provider-prefixed ids (e.g. "ollama/gemma3:1b").
+            # When the wildcard uses a custom prefix (e.g. "ollama_server1/*" to distinguish
+            # multiple instances), replace that existing provider prefix instead of stacking
+            # both, which would otherwise yield an uncallable "ollama_server1/ollama/gemma3:1b".
+            _, sep, model_suffix = model.partition("/")
+            if sep:
+                model = f"{wildcard_provider_prefix}/{model_suffix}"
+            else:
+                model = f"{wildcard_provider_prefix}/{model}"
         suffix_appended_wildcard_models.append(model)
     return suffix_appended_wildcard_models or []
 

--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -10,6 +10,7 @@ from litellm.repositories.object_permission_repository import ObjectPermissionRe
 from litellm.router import Router
 from litellm.router_utils.fallback_event_handlers import get_fallback_model_group
 from litellm.types.router import CredentialLiteLLMParams, LiteLLM_Params
+from litellm.types.utils import LlmProviders
 from litellm.utils import get_valid_models
 
 _CREDENTIAL_LITELLM_PARAM_FIELDS = set(CredentialLiteLLMParams.model_fields)
@@ -308,6 +309,7 @@ def get_known_models_from_wildcard(
             # add model prefix to wildcard models
             wildcard_models = [f"{model_prefix}{model}" for model in wildcard_models]
 
+    known_providers = {provider.value for provider in LlmProviders}
     suffix_appended_wildcard_models = []
     for model in wildcard_models:
         if not model.startswith(wildcard_provider_prefix):
@@ -315,8 +317,10 @@ def get_known_models_from_wildcard(
             # When the wildcard uses a custom prefix (e.g. "ollama_server1/*" to distinguish
             # multiple instances), replace that existing provider prefix instead of stacking
             # both, which would otherwise yield an uncallable "ollama_server1/ollama/gemma3:1b".
-            _, sep, model_suffix = model.partition("/")
-            if sep:
+            # Only strip the leading segment when it is a known provider, so ids whose first
+            # segment is an org rather than a provider (e.g. "meta-llama/Llama-3-8B") keep it.
+            leading, sep, model_suffix = model.partition("/")
+            if sep and leading in known_providers:
                 model = f"{wildcard_provider_prefix}/{model_suffix}"
             else:
                 model = f"{wildcard_provider_prefix}/{model}"

--- a/tests/test_litellm/proxy/auth/test_model_checks.py
+++ b/tests/test_litellm/proxy/auth/test_model_checks.py
@@ -415,6 +415,33 @@ def test_wildcard_custom_prefix_does_not_stack_provider_prefix(monkeypatch):
     assert result == ["ollama_server1/gemma3:1b", "ollama_server1/llama3:8b"]
 
 
+def test_wildcard_custom_prefix_keeps_org_segment_for_non_provider_first_segment(
+    monkeypatch,
+):
+    """Only a known provider prefix should be stripped before re-prefixing.
+
+    If ``get_provider_models`` returns ids whose first segment is an org rather than a litellm
+    provider (e.g. ``meta-llama/Llama-3-8B``), stripping the first slash segment would drop the
+    org and produce an uncallable id. The org segment must be preserved.
+    """
+    from litellm.proxy.auth import model_checks
+    from litellm.proxy.auth.model_checks import get_known_models_from_wildcard
+    from litellm.types.router import LiteLLM_Params
+
+    monkeypatch.setattr(
+        model_checks,
+        "get_provider_models",
+        lambda provider, litellm_params=None: ["meta-llama/Llama-3-8B"],
+    )
+
+    result = get_known_models_from_wildcard(
+        wildcard_model="my_hf/*",
+        litellm_params=LiteLLM_Params(model="huggingface/*", custom_llm_provider="huggingface"),
+    )
+
+    assert result == ["my_hf/meta-llama/Llama-3-8B"]
+
+
 def test_wildcard_credential_hydration_preserves_missing_credential_name(
     monkeypatch,
 ):

--- a/tests/test_litellm/proxy/auth/test_model_checks.py
+++ b/tests/test_litellm/proxy/auth/test_model_checks.py
@@ -388,6 +388,33 @@ def test_wildcard_credential_hydration_preserves_deployment_params(
     }
 
 
+def test_wildcard_custom_prefix_does_not_stack_provider_prefix(monkeypatch):
+    """Regression test for #30358.
+
+    A wildcard with a custom prefix (e.g. ``ollama_server1/*`` to distinguish multiple Ollama
+    instances) must not stack the provider's own prefix onto the expanded model ids. The expanded
+    ids should be ``ollama_server1/gemma3:1b`` rather than ``ollama_server1/ollama/gemma3:1b``.
+    """
+    from litellm.proxy.auth import model_checks
+    from litellm.proxy.auth.model_checks import get_known_models_from_wildcard
+    from litellm.types.router import LiteLLM_Params
+
+    monkeypatch.setattr(
+        model_checks,
+        "get_provider_models",
+        lambda provider, litellm_params=None: ["ollama/gemma3:1b", "ollama/llama3:8b"],
+    )
+
+    result = get_known_models_from_wildcard(
+        wildcard_model="ollama_server1/*",
+        litellm_params=LiteLLM_Params(
+            model="ollama_chat/*", custom_llm_provider="ollama_chat"
+        ),
+    )
+
+    assert result == ["ollama_server1/gemma3:1b", "ollama_server1/llama3:8b"]
+
+
 def test_wildcard_credential_hydration_preserves_missing_credential_name(
     monkeypatch,
 ):


### PR DESCRIPTION
## Relevant issues

Fixes #30358

## Type

🐛 Bug Fix

## Changes

When an `ollama_chat` (or any provider) wildcard is configured with a custom `model_name` prefix to distinguish multiple instances, for example:

```yaml
model_name: "ollama_server1/*"
litellm_params:
  model: "ollama_chat/*"
  custom_llm_provider: "ollama_chat"
```

`/v1/models` returned `ollama_server1/ollama/gemma3:1b` instead of `ollama_server1/gemma3:1b`, and every such model id was uncallable (`model 'ollama/gemma3:1b' not found`).

`get_known_models_from_wildcard` builds ids from `get_provider_models`, which already returns provider-prefixed ids (e.g. `ollama/gemma3:1b`). The final step prepended the wildcard's prefix whenever an id did not already start with it, so a custom prefix stacked on top of the provider prefix.

The fix replaces an existing provider prefix with the wildcard's prefix instead of stacking both. The matching-prefix case (`ollama/*` -> `ollama/gemma3:1b`) and the bare-model case (`openai/*` -> `openai/gpt-4o`) are unchanged.

Added `test_wildcard_custom_prefix_does_not_stack_provider_prefix`, which fails on the current code and passes with this change. The rest of `tests/test_litellm/proxy/auth/test_model_checks.py` is unaffected.

## Screenshots / Proof of Fix

Unit-level expansion of `get_known_models_from_wildcard`, mocking `get_provider_models` to return the provider-prefixed ids ollama yields:

```
ollama_server1/* (custom prefix) -> ['ollama_server1/gemma3:1b', 'ollama_server1/llama3:8b']   # was ['ollama_server1/ollama/gemma3:1b', ...]
ollama/*         (matching)      -> ['ollama/gemma3:1b', 'ollama/llama3:8b']                    # unchanged
openai/*         (bare model)    -> ['openai/gpt-4o']                                           # unchanged
```