### PR TITLE
feat(proxy): read cold-storage prompts back in the logs detail view

### DIFF
--- a/litellm/proxy/spend_tracking/cold_storage_handler.py
+++ b/litellm/proxy/spend_tracking/cold_storage_handler.py
@@ -16,7 +16,13 @@ class ColdStorageHandler:
     This class is responsible for handling Getting/Setting the proxy server request from cold storage.
 
     It allows fetching a dict of the proxy server request from s3 or GCS bucket.
+
+    The cold storage logger can be injected for testing; when omitted it is
+    resolved from the configured ``litellm.cold_storage_custom_logger``.
     """
+
+    def __init__(self, cold_storage_logger: Optional[CustomLogger] = None):
+        self._injected_cold_storage_logger = cold_storage_logger
 
     async def get_proxy_server_request_from_cold_storage_with_object_key(
         self,
@@ -31,32 +37,25 @@ class ColdStorageHandler:
         Returns:
             Optional[dict]: The proxy server request dict or None if not found
         """
-
-        # select the custom logger to use for cold storage
-        custom_logger_name: Optional[_custom_logger_compatible_callbacks_literal] = (
-            self._select_custom_logger_for_cold_storage()
+        custom_logger = (
+            self._injected_cold_storage_logger or self._resolve_cold_storage_logger()
         )
-
-        # if no custom logger name is configured, return None
-        if custom_logger_name is None:
+        if custom_logger is None:
             return None
 
-        # get the active/initialized custom logger
-        custom_logger: Optional[CustomLogger] = (
+        return await custom_logger.get_proxy_server_request_from_cold_storage_with_object_key(
+            object_key=object_key,
+        )
+
+    def _resolve_cold_storage_logger(self) -> Optional[CustomLogger]:
+        custom_logger_name = self._select_custom_logger_for_cold_storage()
+        if custom_logger_name is None:
+            return None
+        return (
             litellm.logging_callback_manager.get_active_custom_logger_for_callback_name(
                 custom_logger_name
             )
         )
-
-        # if no custom logger is found, return None
-        if custom_logger is None:
-            return None
-
-        proxy_server_request = await custom_logger.get_proxy_server_request_from_cold_storage_with_object_key(
-            object_key=object_key,
-        )
-
-        return proxy_server_request
 
     def _select_custom_logger_for_cold_storage(
         self,

--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -3,7 +3,17 @@ import collections
 import json
 import os
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    List,
+    Literal,
+    Mapping,
+    NamedTuple,
+    Optional,
+    Union,
+)
 
 import fastapi
 from fastapi import APIRouter, Depends, HTTPException, Request, status
@@ -29,6 +39,7 @@ from litellm.repositories.verification_token_repository import (
 
 if TYPE_CHECKING:
     from litellm.proxy.proxy_server import PrismaClient
+    from litellm.proxy.spend_tracking.cold_storage_handler import ColdStorageHandler
 else:
     PrismaClient = Any
 
@@ -2175,6 +2186,81 @@ async def ui_view_spend_logs(  # noqa: PLR0915
         raise handle_exception_on_proxy(e)
 
 
+class RequestResponsePayload(NamedTuple):
+    messages: Optional[Union[str, list, dict]]
+    response: Optional[Union[str, list, dict]]
+    proxy_server_request: Optional[Union[str, dict]]
+
+
+_EMPTY_SPEND_LOG_VALUES = frozenset({"", "{}", "[]", "null"})
+
+
+def _spend_log_field_has_content(value: Optional[Union[str, list, dict]]) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return value.strip() not in _EMPTY_SPEND_LOG_VALUES
+    if isinstance(value, (list, dict)):
+        return len(value) > 0
+    return True
+
+
+def _cold_storage_object_key_from_metadata(
+    metadata: Optional[Union[str, dict]],
+) -> Optional[str]:
+    if isinstance(metadata, str):
+        try:
+            metadata = json.loads(metadata)
+        except (json.JSONDecodeError, TypeError):
+            return None
+    if not isinstance(metadata, dict):
+        return None
+    object_key = metadata.get("cold_storage_object_key")
+    return object_key if isinstance(object_key, str) and object_key else None
+
+
+async def _resolve_request_response_payload(
+    row: Mapping[str, Any],
+    cold_storage_handler: "ColdStorageHandler",
+) -> RequestResponsePayload:
+    """
+    Decide where the prompt/response come from for a single spend-log row.
+
+    PG holds the content when ``store_prompts_in_spend_logs`` is on; otherwise it
+    holds ``"{}"`` placeholders and the real payload lives in cold storage keyed
+    by ``metadata.cold_storage_object_key``. The choice is made on actual row
+    content, not config flags, so historical and mixed-storage rows both resolve
+    correctly.
+    """
+    messages = row.get("messages")
+    response = row.get("response")
+    proxy_server_request = row.get("proxy_server_request")
+
+    pg_payload = RequestResponsePayload(messages, response, proxy_server_request)
+    if (
+        _spend_log_field_has_content(messages)
+        or _spend_log_field_has_content(response)
+        or _spend_log_field_has_content(proxy_server_request)
+    ):
+        return pg_payload
+
+    object_key = _cold_storage_object_key_from_metadata(row.get("metadata"))
+    if object_key is None:
+        return pg_payload
+
+    payload = await cold_storage_handler.get_proxy_server_request_from_cold_storage_with_object_key(
+        object_key=object_key
+    )
+    if payload is None:
+        return pg_payload
+
+    return RequestResponsePayload(
+        messages=payload.get("messages"),
+        response=payload.get("response"),
+        proxy_server_request=payload.get("proxy_server_request"),
+    )
+
+
 @router.get(
     "/spend/logs/ui/{request_id}",
     tags=["Budget & Spend Tracking"],
@@ -2241,26 +2327,27 @@ async def ui_view_request_response_for_request_id(
         if payload is not None:
             return payload
 
-    # Fallback: fetch heavy columns directly from the database.
-    # The list endpoint (/spend/logs/ui) intentionally excludes messages,
-    # response, and proxy_server_request for performance. When no custom
-    # logger (S3, GCS, etc.) is configured, we still need to serve these
-    # fields from the DB for the detail/drawer view.
+    # Fallback: the list endpoint omits the heavy columns for performance, so
+    # serve them here. When prompts were offloaded to cold storage the DB holds
+    # only placeholders, so _resolve_request_response_payload fetches the real
+    # payload from the configured cold storage backend by object key.
     if prisma_client is not None:
+        from litellm.proxy.spend_tracking.cold_storage_handler import (
+            ColdStorageHandler,
+        )
+
         sql_query = """
-            SELECT messages, response, proxy_server_request
+            SELECT messages, response, proxy_server_request, metadata
             FROM "LiteLLM_SpendLogs"
             WHERE request_id = $1
             LIMIT 1
         """
         db_result = await prisma_client.db.query_raw(sql_query, request_id)
         if db_result and len(db_result) > 0:
-            row = db_result[0]
-            return {
-                "messages": row.get("messages"),
-                "response": row.get("response"),
-                "proxy_server_request": row.get("proxy_server_request"),
-            }
+            resolved = await _resolve_request_response_payload(
+                db_result[0], cold_storage_handler=ColdStorageHandler()
+            )
+            return resolved._asdict()
 
     return None
 

--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -2248,9 +2248,17 @@ async def _resolve_request_response_payload(
     if object_key is None:
         return pg_payload
 
-    payload = await cold_storage_handler.get_proxy_server_request_from_cold_storage_with_object_key(
-        object_key=object_key
-    )
+    try:
+        payload = await cold_storage_handler.get_proxy_server_request_from_cold_storage_with_object_key(
+            object_key=object_key
+        )
+    except Exception:
+        verbose_proxy_logger.warning(
+            "Failed to fetch cold storage payload for key %s; falling back to DB values",
+            object_key,
+            exc_info=True,
+        )
+        return pg_payload
     if payload is None:
         return pg_payload
 

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
@@ -3784,3 +3784,164 @@ async def test_ui_view_spend_logs_metadata_invalid_json_falls_back_to_empty_dict
         assert body["data"][0]["metadata"] == {}
     finally:
         app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+
+class _FakeColdStorageLogger:
+    """Injectable cold storage logger that records the object key it was asked for."""
+
+    def __init__(self, payload):
+        self._payload = payload
+        self.requested_object_keys = []
+
+    async def get_proxy_server_request_from_cold_storage_with_object_key(
+        self, object_key
+    ):
+        self.requested_object_keys.append(object_key)
+        return self._payload
+
+
+def _cold_storage_handler(payload):
+    from litellm.proxy.spend_tracking.cold_storage_handler import ColdStorageHandler
+
+    logger = _FakeColdStorageLogger(payload)
+    return ColdStorageHandler(cold_storage_logger=logger), logger
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (None, False),
+        ("", False),
+        ("   ", False),
+        ("{}", False),
+        ("[]", False),
+        ("null", False),
+        ('{"a": 1}', True),
+        ({}, False),
+        ({"a": 1}, True),
+        ([], False),
+        ([1], True),
+    ],
+)
+def test_spend_log_field_has_content(value, expected):
+    assert spend_management_endpoints._spend_log_field_has_content(value) is expected
+
+
+@pytest.mark.parametrize(
+    "metadata, expected",
+    [
+        (None, None),
+        ("{}", None),
+        ("not-json", None),
+        ({"cold_storage_object_key": ""}, None),
+        ({"cold_storage_object_key": "k/req-1.json"}, "k/req-1.json"),
+        ('{"cold_storage_object_key": "k/req-2.json"}', "k/req-2.json"),
+    ],
+)
+def test_cold_storage_object_key_from_metadata(metadata, expected):
+    assert (
+        spend_management_endpoints._cold_storage_object_key_from_metadata(metadata)
+        == expected
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_payload_prefers_pg_and_skips_cold_storage():
+    handler, logger = _cold_storage_handler({"messages": "X", "response": "Y"})
+    row = {
+        "messages": "{}",
+        "response": '{"choices": [{"message": {"content": "hi"}}]}',
+        "proxy_server_request": "{}",
+        "metadata": {"cold_storage_object_key": "k/req.json"},
+    }
+
+    resolved = await spend_management_endpoints._resolve_request_response_payload(
+        row, cold_storage_handler=handler
+    )
+
+    assert resolved.response == '{"choices": [{"message": {"content": "hi"}}]}'
+    assert logger.requested_object_keys == []
+
+
+@pytest.mark.asyncio
+async def test_resolve_payload_fetches_from_cold_storage_when_pg_empty():
+    cold_payload = {
+        "messages": [{"role": "user", "content": "what is 2+2"}],
+        "response": {"choices": [{"message": {"content": "4"}}]},
+        "proxy_server_request": {"body": {"model": "gpt-4o-mini"}},
+    }
+    handler, logger = _cold_storage_handler(cold_payload)
+    row = {
+        "messages": "{}",
+        "response": "{}",
+        "proxy_server_request": "{}",
+        "metadata": {"cold_storage_object_key": "llm-gateway/prod/req-42.json"},
+    }
+
+    resolved = await spend_management_endpoints._resolve_request_response_payload(
+        row, cold_storage_handler=handler
+    )
+
+    assert logger.requested_object_keys == ["llm-gateway/prod/req-42.json"]
+    assert resolved.messages == cold_payload["messages"]
+    assert resolved.response == cold_payload["response"]
+    assert resolved.proxy_server_request == cold_payload["proxy_server_request"]
+
+
+@pytest.mark.asyncio
+async def test_resolve_payload_metadata_as_json_string():
+    cold_payload = {"messages": "in", "response": "out", "proxy_server_request": None}
+    handler, logger = _cold_storage_handler(cold_payload)
+    row = {
+        "messages": "{}",
+        "response": "{}",
+        "proxy_server_request": "{}",
+        "metadata": json.dumps({"cold_storage_object_key": "k/str-meta.json"}),
+    }
+
+    resolved = await spend_management_endpoints._resolve_request_response_payload(
+        row, cold_storage_handler=handler
+    )
+
+    assert logger.requested_object_keys == ["k/str-meta.json"]
+    assert resolved.response == "out"
+
+
+@pytest.mark.asyncio
+async def test_resolve_payload_no_object_key_returns_empty_without_fetch():
+    handler, logger = _cold_storage_handler({"messages": "should-not-be-used"})
+    row = {
+        "messages": "{}",
+        "response": "{}",
+        "proxy_server_request": "{}",
+        "metadata": {},
+    }
+
+    resolved = await spend_management_endpoints._resolve_request_response_payload(
+        row, cold_storage_handler=handler
+    )
+
+    assert logger.requested_object_keys == []
+    assert resolved == spend_management_endpoints.RequestResponsePayload(
+        "{}", "{}", "{}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_payload_cold_storage_miss_falls_back_to_pg_values():
+    handler, logger = _cold_storage_handler(None)
+    row = {
+        "messages": "{}",
+        "response": "{}",
+        "proxy_server_request": "{}",
+        "metadata": {"cold_storage_object_key": "k/missing.json"},
+    }
+
+    resolved = await spend_management_endpoints._resolve_request_response_payload(
+        row, cold_storage_handler=handler
+    )
+
+    assert logger.requested_object_keys == ["k/missing.json"]
+    assert resolved == spend_management_endpoints.RequestResponsePayload(
+        "{}", "{}", "{}"
+    )

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
@@ -3821,6 +3821,7 @@ def _cold_storage_handler(payload):
         ({"a": 1}, True),
         ([], False),
         ([1], True),
+        (5, True),
     ],
 )
 def test_spend_log_field_has_content(value, expected):
@@ -3945,3 +3946,136 @@ async def test_resolve_payload_cold_storage_miss_falls_back_to_pg_values():
     assert resolved == spend_management_endpoints.RequestResponsePayload(
         "{}", "{}", "{}"
     )
+
+
+@pytest.mark.asyncio
+async def test_resolve_payload_cold_storage_exception_falls_back_to_pg_values():
+    """A backend error during fetch degrades to PG values instead of bubbling a 500."""
+
+    class _RaisingLogger:
+        async def get_proxy_server_request_from_cold_storage_with_object_key(
+            self, object_key
+        ):
+            raise RuntimeError("cold storage backend unavailable")
+
+    from litellm.proxy.spend_tracking.cold_storage_handler import ColdStorageHandler
+
+    handler = ColdStorageHandler(cold_storage_logger=_RaisingLogger())
+    row = {
+        "messages": "{}",
+        "response": "{}",
+        "proxy_server_request": "{}",
+        "metadata": {"cold_storage_object_key": "k/boom.json"},
+    }
+
+    resolved = await spend_management_endpoints._resolve_request_response_payload(
+        row, cold_storage_handler=handler
+    )
+
+    assert resolved == spend_management_endpoints.RequestResponsePayload(
+        "{}", "{}", "{}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_cold_storage_handler_uses_injected_logger():
+    from litellm.proxy.spend_tracking.cold_storage_handler import ColdStorageHandler
+
+    logger = _FakeColdStorageLogger({"messages": "in", "response": "out"})
+    handler = ColdStorageHandler(cold_storage_logger=logger)
+
+    result = await handler.get_proxy_server_request_from_cold_storage_with_object_key(
+        object_key="k/req.json"
+    )
+
+    assert result == {"messages": "in", "response": "out"}
+    assert logger.requested_object_keys == ["k/req.json"]
+
+
+@pytest.mark.asyncio
+async def test_cold_storage_handler_returns_none_when_no_logger_configured(monkeypatch):
+    from litellm.proxy.spend_tracking.cold_storage_handler import ColdStorageHandler
+
+    monkeypatch.setattr(litellm, "cold_storage_custom_logger", None, raising=False)
+    handler = ColdStorageHandler()
+
+    result = await handler.get_proxy_server_request_from_cold_storage_with_object_key(
+        object_key="k/req.json"
+    )
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_cold_storage_handler_resolves_configured_logger_from_registry(monkeypatch):
+    from litellm.proxy.spend_tracking.cold_storage_handler import ColdStorageHandler
+
+    logger = _FakeColdStorageLogger({"messages": "from-registry"})
+    monkeypatch.setattr(litellm, "cold_storage_custom_logger", "s3_v2", raising=False)
+    monkeypatch.setattr(
+        litellm.logging_callback_manager,
+        "get_active_custom_logger_for_callback_name",
+        lambda name: logger if name == "s3_v2" else None,
+    )
+    handler = ColdStorageHandler()
+
+    result = await handler.get_proxy_server_request_from_cold_storage_with_object_key(
+        object_key="k/req.json"
+    )
+
+    assert result == {"messages": "from-registry"}
+    assert logger.requested_object_keys == ["k/req.json"]
+
+
+def test_ui_view_request_response_reads_from_cold_storage(client, monkeypatch):
+    """End-to-end: a placeholder row with a cold_storage_object_key is served from
+    cold storage through the detail endpoint."""
+    from types import SimpleNamespace
+
+    placeholder_row = {
+        "messages": "{}",
+        "response": "{}",
+        "proxy_server_request": "{}",
+        "metadata": {"cold_storage_object_key": "k/cold.json"},
+    }
+
+    async def _query_raw(_sql, *_args):
+        return [placeholder_row]
+
+    fake_prisma = SimpleNamespace(db=SimpleNamespace(query_raw=_query_raw))
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", fake_prisma)
+
+    cold_logger = _FakeColdStorageLogger(
+        {
+            "messages": [{"role": "user", "content": "hi"}],
+            "response": {"choices": [{"message": {"content": "hello"}}]},
+            "proxy_server_request": None,
+        }
+    )
+    monkeypatch.setattr(litellm, "cold_storage_custom_logger", "s3_v2", raising=False)
+    monkeypatch.setattr(
+        litellm.logging_callback_manager,
+        "get_active_additional_logging_utils_from_custom_logger",
+        lambda: [],
+    )
+    monkeypatch.setattr(
+        litellm.logging_callback_manager,
+        "get_active_custom_logger_for_callback_name",
+        lambda name: cold_logger if name == "s3_v2" else None,
+    )
+
+    app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin_1"
+    )
+    try:
+        response = client.get(
+            "/spend/logs/ui/req-cold",
+            headers={"Authorization": "Bearer sk-test"},
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["messages"] == [{"role": "user", "content": "hi"}]
+        assert body["response"] == {"choices": [{"message": {"content": "hello"}}]}
+        assert cold_logger.requested_object_keys == ["k/cold.json"]
+    finally:
+        app.dependency_overrides.pop(ps.user_api_key_auth, None)

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/PrettyMessagesView.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/PrettyMessagesView.test.tsx
@@ -27,6 +27,17 @@ describe("PrettyMessagesView", () => {
     expect(screen.getByText("Hi there!")).toBeInTheDocument();
   });
 
+  it("renders input when request is a bare messages array (cold storage payload)", () => {
+    const request = [{ role: "user", content: "Write me a poem" }];
+    const response = {
+      choices: [{ message: { role: "assistant", content: "A quiet moment." } }],
+    };
+
+    render(<PrettyMessagesView request={request} response={response} />);
+    expect(screen.getByText("Write me a poem")).toBeInTheDocument();
+    expect(screen.getByText("A quiet moment.")).toBeInTheDocument();
+  });
+
   it("should render the realtime pretty view for realtime API responses", () => {
     const request = {};
     const response = {

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/prettyMessagesUtils.ts
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/prettyMessagesUtils.ts
@@ -39,18 +39,24 @@ export const ROLE_STYLES: Record<string, RoleStyle> = {
  * Parse request messages and response message from log data
  */
 export const parseMessages = (request: any, response: any): ParsedMessages => {
-  // Parse request messages
+  // Parse request messages. `request` is either the raw request body
+  // ({ messages: [...] }) or, when prompts come from cold storage, the bare
+  // messages array itself.
   const requestMessages: ParsedMessage[] = [];
 
-  if (request?.messages && Array.isArray(request.messages)) {
-    request.messages.forEach((msg: any) => {
-      requestMessages.push({
-        role: msg.role || "user",
-        content: parseMessageContent(msg.content),
-        toolCallId: msg.tool_call_id,
-      });
+  const requestMessageList = Array.isArray(request)
+    ? request
+    : Array.isArray(request?.messages)
+      ? request.messages
+      : [];
+
+  requestMessageList.forEach((msg: any) => {
+    requestMessages.push({
+      role: msg.role || "user",
+      content: parseMessageContent(msg.content),
+      toolCallId: msg.tool_call_id,
     });
-  }
+  });
 
   // Parse response message
   let responseMessage: ParsedMessage | null = null;


### PR DESCRIPTION
# PR: feat(proxy): read spend-log prompts/responses back from cold storage in the UI detail view

> **Branch**: `Bytechoreographer:litellm_cold_storage_ui_readback`
> **Target**: `BerriAI:litellm_internal_staging`  (do not target main)
> **PR link**: https://github.com/Bytechoreographer/litellm/pull/new/litellm_cold_storage_ui_readback

---

## Relevant issues

<!-- none; visibility gap found and reproduced locally -->

## Linear ticket

<!-- fill in -->

## Pre-Submission checklist

- [x] I have added meaningful tests (helper unit tests, mutation-oriented; injected fake logger, no monkeypatch)
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Type

🆕 New Feature

## Changes

### Problem

When a deployment offloads prompts and responses to cold storage instead of
Postgres (the spend-logs `messages`, `response`, and `proxy_server_request`
columns are written as empty `"{}"` placeholders, with the real payload kept in
an object store and only a pointer `metadata.cold_storage_object_key` left in
the row), the UI logs detail drawer shows nothing. The data is written to cold
storage but never read back, so from the UI it is effectively write-only.

The detail endpoint `GET /spend/logs/ui/{request_id}` already loops over loggers
that implement `AdditionalLoggingUtils.get_request_response_payload` (GCS,
Datadog), which look the object up by `request_id` plus a guessed date prefix.
The S3 logger is not an `AdditionalLoggingUtils`, so it is skipped by that loop,
and its content is never surfaced. The endpoint's database fallback only
returned the three placeholder columns.

### Approach

Resolve where the payload comes from based on the row's actual content, not on a
config flag. If any of `messages` / `response` / `proxy_server_request` has real
content, return the Postgres values. Otherwise, read the exact
`cold_storage_object_key` stored on the row and fetch the object by key from the
configured cold storage backend.

Reading the stored key is deliberate. The key embeds a microsecond-precision
timestamp captured at write time and is persisted verbatim as a string, so the
read is a single direct object GET. Reconstructing the key from the row's
`startTime` is not possible because that column is stored at millisecond
precision and is not the same instant the key was generated from, so the
microseconds do not line up. Listing the day's prefix and matching on
`request_id` would work for a one-off offline backfill but is far too expensive
for a per-open hot path, so it is intentionally not used here.

Routing goes through `ColdStorageHandler` rather than calling the S3 logger
directly, so any backend that later implements
`get_proxy_server_request_from_cold_storage_with_object_key` is picked up with
no endpoint change. When no backend implements it, the base class returns
`None`, the handler returns `None`, and the drawer stays empty; graceful
degradation, no crash.

Per-user isolation is unchanged. `_assert_user_can_view_request_id` runs before
any fetch, so the cold storage read inherits the existing authorization.

Why the decision is on row content rather than a config flag: the flag can
change over time. A deployment that uses cold storage today and turns on
Postgres storage tomorrow ends up with historical rows in cold storage and new
rows in Postgres; deciding per row routes both correctly, and the endpoint never
has to know the configuration.

Note on detecting empty content: a plain completion never writes the prompt to
the `messages` column (only realtime calls do), so the input lives in
`proxy_server_request` and the output in `response`. The emptiness check looks
at all three columns; checking only `messages` would misfire and trigger an
unnecessary object fetch on every plain completion.

One UI change is needed for the input to actually render. The cold storage
payload carries the prompt as a bare messages array (the stored
`StandardLoggingPayload` has no `proxy_server_request`), and the detail drawer's
pretty view fell back to that array but only knew how to read input from an
object shaped like `{ messages: [...] }`. So the output rendered while the input
stayed blank. The pretty-view parser now accepts both a bare messages array and
the request-body object. This gap exists independently of cold storage (it would
also affect any row whose input arrives as a bare array), it was just surfaced
by this feature.

### Implementation

`litellm/proxy/spend_tracking/spend_management_endpoints.py`
- Add `_resolve_request_response_payload(row, cold_storage_handler)` returning a
  typed `RequestResponsePayload` (NamedTuple), with helpers
  `_spend_log_field_has_content` (treats `""`, `"{}"`, `"[]"`, `"null"`,
  whitespace, and empty containers as empty) and
  `_cold_storage_object_key_from_metadata` (accepts metadata as dict or JSON
  string).
- The DB fallback in `ui_view_request_response_for_request_id` now also selects
  `metadata` and runs the row through the resolver.

`litellm/proxy/spend_tracking/cold_storage_handler.py`
- `ColdStorageHandler.__init__` accepts an optional injected
  `cold_storage_logger` for testability (no monkeypatch); when omitted it
  resolves from `litellm.cold_storage_custom_logger` as before. Logger
  resolution is extracted to `_resolve_cold_storage_logger`.

`ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/prettyMessagesUtils.ts`
- `parseMessages` now reads request input from either a bare messages array or a
  request-body object, so the input card renders when the prompt comes from cold
  storage.

### Files changed

| File | Change |
|------|--------|
| `litellm/proxy/spend_tracking/spend_management_endpoints.py` | Resolver + helpers; DB fallback selects `metadata` and merges cold storage |
| `litellm/proxy/spend_tracking/cold_storage_handler.py` | Constructor dependency injection; extract `_resolve_cold_storage_logger` |
| `tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py` | Unit tests for the resolver and helpers |
| `ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/prettyMessagesUtils.ts` | `parseMessages` accepts a bare messages array so cold-storage input renders |
| `ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/PrettyMessagesView.test.tsx` | Regression test: input renders from a bare messages array |

### Tests

Targeted at `_resolve_request_response_payload` with an injected fake logger
(dependency injection, no monkeypatch):

- cold storage hit: all three columns are `"{}"`, metadata has the key, fake
  logger returns a payload; the resolver returns the cold storage input/output
  and requests the exact object key.
- Postgres fast path: `response` has real content; the resolver returns the
  Postgres value and the logger is never called.
- cold storage miss: key present but the logger returns `None`; falls back to the
  Postgres placeholders without raising.
- metadata as a JSON string still yields the key.
- `_spend_log_field_has_content` boundaries: `None`, `""`, whitespace, `"{}"`,
  `"[]"`, `"null"`, real string, empty/non-empty dict and list.
- `_cold_storage_object_key_from_metadata`: `None`, `"{}"`, non-JSON string,
  empty key, valid dict, valid JSON string.

Run: `python -m pytest tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py -k "resolve_payload or spend_log_field_has_content or cold_storage_object_key_from_metadata"`

Frontend, in `PrettyMessagesView.test.tsx`: a regression test rendering the
pretty view with `request` as a bare messages array and asserting the input
message renders (it stayed blank before the parser change).

Run: `cd ui/litellm-dashboard && npx vitest run src/components/view_logs/LogDetailsDrawer/PrettyMessagesView.test.tsx`

### Out of scope / follow-ups

- This PR only adds readback to the detail endpoint. It does not change the S3
  logger (download already supports a custom endpoint), the list endpoint, or
  the write path.
- `proxy_server_request` is passed through; it is not deep-resolved from cold
  storage in this PR. The cold storage payload has no `proxy_server_request`, so
  the input renders from the payload's `messages` (handled by the pretty-view
  parser change above).
- `_generate_cold_storage_object_key` hardcodes the S3 key layout, which blocks
  using GCS/Azure as a readable cold storage source. The correct fix is to have
  each logger generate and persist its own key in its own format. That is a
  separate change.

## Proof of Fix

Against a live proxy configured with a cold storage logger
(`cold_storage_custom_logger` set under `litellm_settings`, plus the matching
callback params), so new rows carry a real `cold_storage_object_key`:

1. Send a real completion through the proxy and note its `id` (request_id):
   ```
   curl -s http://localhost:4000/v1/chat/completions \
     -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
     -d '{"model":"<a-model>","messages":[{"role":"user","content":"write one short sentence"}],"max_tokens":60}'
   ```
2. Open the detail endpoint for that request_id and confirm the input and output
   come back (before this PR the same call returns `messages: {}` and
   `response: {}`):
   ```
   curl -s "http://localhost:4000/spend/logs/ui/<request_id>" \
     -H "Authorization: Bearer $KEY"
   ```
3. Isolation regression: with a non-admin internal-user key, request another
   user's request_id and confirm `403`.

In the UI: open http://localhost:4000/ui/?page=logs, click the row for that
request, and confirm the drawer shows the prompt and response.
