### PR TITLE
feat: aws secret manager cross region replication

### DIFF
--- a/litellm/secret_managers/aws_secret_manager_v2.py
+++ b/litellm/secret_managers/aws_secret_manager_v2.py
@@ -16,7 +16,7 @@ Requires:
 
 import json
 import os
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 import httpx
 
@@ -43,6 +43,7 @@ class AWSSecretsManagerV2(BaseAWSLLM, BaseSecretManager):
         aws_profile_name: Optional[str] = None,
         aws_web_identity_token: Optional[str] = None,
         aws_sts_endpoint: Optional[str] = None,
+        replica_regions: Optional[List[str]] = None,
         **kwargs,
     ):
         BaseSecretManager.__init__(self, **kwargs)
@@ -56,6 +57,7 @@ class AWSSecretsManagerV2(BaseAWSLLM, BaseSecretManager):
         self.aws_profile_name = aws_profile_name
         self.aws_web_identity_token = aws_web_identity_token
         self.aws_sts_endpoint = aws_sts_endpoint
+        self.replica_regions: List[str] = replica_regions or []
 
     @classmethod
     def validate_environment(cls):
@@ -109,6 +111,9 @@ class AWSSecretsManagerV2(BaseAWSLLM, BaseSecretManager):
                     ),
                     "aws_sts_endpoint": getattr(
                         key_management_settings, "aws_sts_endpoint", None
+                    ),
+                    "replica_regions": getattr(
+                        key_management_settings, "replica_regions", None
                     ),
                 }
                 # Remove None values
@@ -307,6 +312,82 @@ class AWSSecretsManagerV2(BaseAWSLLM, BaseSecretManager):
             action="CreateSecret",
             secret_name=secret_name,
             secret_value=secret_value,
+            optional_params=optional_params,
+            request_data=data,
+        )
+
+        async_client = get_async_httpx_client(
+            llm_provider=httpxSpecialProvider.SecretManager,
+            params={"timeout": timeout},
+        )
+
+        try:
+            response = await async_client.post(
+                url=endpoint_url, headers=headers, data=body.decode("utf-8")
+            )
+            response.raise_for_status()
+            create_response = response.json()
+        except httpx.HTTPStatusError as err:
+            raise ValueError(f"HTTP error occurred: {err.response.text}")
+        except httpx.TimeoutException:
+            raise ValueError("Timeout error occurred")
+
+        if self.replica_regions:
+            try:
+                await self.async_replicate_secret(
+                    secret_name=secret_name,
+                    replica_regions=self.replica_regions,
+                    optional_params=optional_params,
+                    timeout=timeout,
+                )
+                verbose_logger.debug(
+                    "Replicated secret '%s' to regions: %s",
+                    secret_name,
+                    self.replica_regions,
+                )
+            except Exception as replication_err:
+                verbose_logger.warning(
+                    "Failed to replicate secret '%s' to regions %s: %s — key was created successfully.",
+                    secret_name,
+                    self.replica_regions,
+                    str(replication_err),
+                )
+
+        return create_response
+
+    async def async_replicate_secret(
+        self,
+        secret_name: str,
+        replica_regions: List[str],
+        optional_params: Optional[dict] = None,
+        timeout: Optional[Union[float, httpx.Timeout]] = None,
+    ) -> dict:
+        """
+        Replicate a secret to additional AWS regions using ReplicateSecretToRegions.
+
+        Called after a successful CreateSecret when replica_regions is configured.
+        Replication is best-effort — callers should not depend on this for correctness.
+
+        Args:
+            secret_name: Name or ARN of the secret to replicate
+            replica_regions: List of target AWS region names, e.g. ["us-west-2"]
+            optional_params: Additional AWS parameters
+            timeout: Request timeout
+
+        Returns:
+            dict: AWS response, or {} if replica_regions is empty
+        """
+        if not replica_regions:
+            return {}
+
+        data: Dict[str, Any] = {
+            "SecretId": secret_name,
+            "AddReplicaRegions": [{"Region": r} for r in replica_regions],
+        }
+
+        endpoint_url, headers, body = self._prepare_request(
+            action="ReplicateSecretToRegions",
+            secret_name=secret_name,
             optional_params=optional_params,
             request_data=data,
         )

--- a/litellm/secret_managers/aws_secret_manager_v2.py
+++ b/litellm/secret_managers/aws_secret_manager_v2.py
@@ -380,6 +380,12 @@ class AWSSecretsManagerV2(BaseAWSLLM, BaseSecretManager):
         if not replica_regions:
             return {}
 
+        verbose_logger.info(
+            "ReplicateSecretToRegions called for secret '%s' in regions %s",
+            secret_name,
+            replica_regions,
+        )
+
         data: Dict[str, Any] = {
             "SecretId": secret_name,
             "AddReplicaRegions": [{"Region": r} for r in replica_regions],

--- a/litellm/types/secret_managers/main.py
+++ b/litellm/types/secret_managers/main.py
@@ -72,3 +72,12 @@ class KeyManagementSettings(LiteLLMPydanticObjectBase):
 
     aws_sts_endpoint: Optional[str] = None
     """Custom STS endpoint URL (useful for VPC endpoints or testing)"""
+
+    replica_regions: Optional[List[str]] = None
+    """
+    Optional list of additional AWS regions to replicate secrets to after CreateSecret.
+    Uses the AWS Secrets Manager ReplicateSecretToRegions API. Replication is
+    best-effort — failure to replicate does not fail key creation.
+    Example: ["us-west-2", "eu-west-1"]
+    Only applies when key_management_system is "aws_secret_manager".
+    """

--- a/tests/test_litellm/secret_managers/test_aws_secret_manager_replication.py
+++ b/tests/test_litellm/secret_managers/test_aws_secret_manager_replication.py
@@ -1,0 +1,228 @@
+"""
+Unit tests for AWSSecretsManagerV2 cross-region replication via ReplicateSecretToRegions.
+
+All tests are mocked — no real AWS credentials required.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from litellm.secret_managers.aws_secret_manager_v2 import AWSSecretsManagerV2
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+_CREATE_RESPONSE = {
+    "ARN": "arn:aws:secretsmanager:us-east-1:123456789012:secret:litellm/test-key",
+    "Name": "litellm/test-key",
+    "VersionId": "mock-version-id",
+}
+
+_REPLICATE_RESPONSE = {
+    "ARN": "arn:aws:secretsmanager:us-east-1:123456789012:secret:litellm/test-key",
+    "ReplicationStatus": [
+        {"Region": "us-west-2", "Status": "InProgress"},
+    ],
+}
+
+
+def _mock_http_client(json_response: dict) -> MagicMock:
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json.return_value = json_response
+    mock_async_client = AsyncMock()
+    mock_async_client.post.return_value = mock_response
+    return mock_async_client
+
+
+# ---------------------------------------------------------------------------
+# Tests: async_write_secret + replication
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_write_secret_replicates_when_configured():
+    """async_replicate_secret is called after a successful CreateSecret when replica_regions is set."""
+    manager = AWSSecretsManagerV2(replica_regions=["us-west-2"])
+
+    with patch.object(
+        AWSSecretsManagerV2,
+        "_prepare_request",
+        return_value=(
+            "https://secretsmanager.us-east-1.amazonaws.com",
+            {"Content-Type": "application/x-amz-json-1.1"},
+            b'{"Name":"litellm/test-key"}',
+        ),
+    ):
+        with patch(
+            "litellm.secret_managers.aws_secret_manager_v2.get_async_httpx_client",
+            return_value=_mock_http_client(_CREATE_RESPONSE),
+        ):
+            with patch.object(
+                AWSSecretsManagerV2,
+                "async_replicate_secret",
+                new_callable=AsyncMock,
+                return_value=_REPLICATE_RESPONSE,
+            ) as mock_replicate:
+                result = await manager.async_write_secret(
+                    secret_name="litellm/test-key",
+                    secret_value="sk-test-value",
+                )
+
+    assert result == _CREATE_RESPONSE
+    mock_replicate.assert_called_once_with(
+        secret_name="litellm/test-key",
+        replica_regions=["us-west-2"],
+        optional_params=None,
+        timeout=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_write_secret_no_replication_when_not_configured():
+    """async_replicate_secret is NOT called when replica_regions is None."""
+    manager = AWSSecretsManagerV2(replica_regions=None)
+
+    with patch.object(
+        AWSSecretsManagerV2,
+        "_prepare_request",
+        return_value=(
+            "https://secretsmanager.us-east-1.amazonaws.com",
+            {"Content-Type": "application/x-amz-json-1.1"},
+            b'{"Name":"litellm/test-key"}',
+        ),
+    ):
+        with patch(
+            "litellm.secret_managers.aws_secret_manager_v2.get_async_httpx_client",
+            return_value=_mock_http_client(_CREATE_RESPONSE),
+        ):
+            with patch.object(
+                AWSSecretsManagerV2,
+                "async_replicate_secret",
+                new_callable=AsyncMock,
+            ) as mock_replicate:
+                result = await manager.async_write_secret(
+                    secret_name="litellm/test-key",
+                    secret_value="sk-test-value",
+                )
+
+    assert result == _CREATE_RESPONSE
+    mock_replicate.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_replication_failure_does_not_fail_write():
+    """If async_replicate_secret raises, async_write_secret still returns the CreateSecret response."""
+    manager = AWSSecretsManagerV2(replica_regions=["us-west-2"])
+
+    with patch.object(
+        AWSSecretsManagerV2,
+        "_prepare_request",
+        return_value=(
+            "https://secretsmanager.us-east-1.amazonaws.com",
+            {"Content-Type": "application/x-amz-json-1.1"},
+            b'{"Name":"litellm/test-key"}',
+        ),
+    ):
+        with patch(
+            "litellm.secret_managers.aws_secret_manager_v2.get_async_httpx_client",
+            return_value=_mock_http_client(_CREATE_RESPONSE),
+        ):
+            with patch.object(
+                AWSSecretsManagerV2,
+                "async_replicate_secret",
+                new_callable=AsyncMock,
+                side_effect=ValueError("AccessDenied: not authorized"),
+            ):
+                result = await manager.async_write_secret(
+                    secret_name="litellm/test-key",
+                    secret_value="sk-test-value",
+                )
+
+    assert result == _CREATE_RESPONSE
+
+
+# ---------------------------------------------------------------------------
+# Tests: async_replicate_secret directly
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_replicate_secret_empty_regions_returns_empty():
+    """async_replicate_secret returns {} immediately for an empty list — no HTTP call."""
+    manager = AWSSecretsManagerV2()
+
+    with patch(
+        "litellm.secret_managers.aws_secret_manager_v2.get_async_httpx_client"
+    ) as mock_get_client:
+        result = await manager.async_replicate_secret(
+            secret_name="litellm/test-key",
+            replica_regions=[],
+        )
+
+    assert result == {}
+    mock_get_client.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_async_replicate_secret_correct_payload():
+    """async_replicate_secret sends the correct AddReplicaRegions payload."""
+    manager = AWSSecretsManagerV2()
+    captured: dict = {}
+
+    def capture_prepare(action, secret_name, optional_params=None, request_data=None):
+        captured.update(request_data or {})
+        captured["_action"] = action
+        return (
+            "https://secretsmanager.us-east-1.amazonaws.com",
+            {"Content-Type": "application/x-amz-json-1.1"},
+            b"{}",
+        )
+
+    with patch.object(AWSSecretsManagerV2, "_prepare_request", side_effect=capture_prepare):
+        with patch(
+            "litellm.secret_managers.aws_secret_manager_v2.get_async_httpx_client",
+            return_value=_mock_http_client(_REPLICATE_RESPONSE),
+        ):
+            result = await manager.async_replicate_secret(
+                secret_name="litellm/test-key",
+                replica_regions=["us-west-2", "eu-west-1"],
+            )
+
+    assert result == _REPLICATE_RESPONSE
+    assert captured["_action"] == "ReplicateSecretToRegions"
+    assert captured["SecretId"] == "litellm/test-key"
+    assert captured["AddReplicaRegions"] == [
+        {"Region": "us-west-2"},
+        {"Region": "eu-west-1"},
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Tests: load_aws_secret_manager forwards replica_regions
+# ---------------------------------------------------------------------------
+
+
+def test_load_aws_secret_manager_passes_replica_regions():
+    """load_aws_secret_manager must forward replica_regions from key_management_settings."""
+    import litellm
+
+    settings = MagicMock()
+    settings.aws_region_name = "us-east-1"
+    settings.aws_role_name = None
+    settings.aws_session_name = None
+    settings.aws_external_id = None
+    settings.aws_profile_name = None
+    settings.aws_web_identity_token = None
+    settings.aws_sts_endpoint = None
+    settings.replica_regions = ["us-west-2", "eu-west-1"]
+
+    AWSSecretsManagerV2.load_aws_secret_manager(
+        use_aws_secret_manager=True,
+        key_management_settings=settings,
+    )
+
+    assert isinstance(litellm.secret_manager_client, AWSSecretsManagerV2)
+    assert litellm.secret_manager_client.replica_regions == ["us-west-2", "eu-west-1"]

--- a/tests/test_litellm/secret_managers/test_aws_secret_manager_replication.py
+++ b/tests/test_litellm/secret_managers/test_aws_secret_manager_replication.py
@@ -209,6 +209,7 @@ def test_load_aws_secret_manager_passes_replica_regions():
     """load_aws_secret_manager must forward replica_regions from key_management_settings."""
     import litellm
 
+    original = litellm.secret_manager_client
     settings = MagicMock()
     settings.aws_region_name = "us-east-1"
     settings.aws_role_name = None
@@ -219,10 +220,13 @@ def test_load_aws_secret_manager_passes_replica_regions():
     settings.aws_sts_endpoint = None
     settings.replica_regions = ["us-west-2", "eu-west-1"]
 
-    AWSSecretsManagerV2.load_aws_secret_manager(
-        use_aws_secret_manager=True,
-        key_management_settings=settings,
-    )
+    try:
+        AWSSecretsManagerV2.load_aws_secret_manager(
+            use_aws_secret_manager=True,
+            key_management_settings=settings,
+        )
 
-    assert isinstance(litellm.secret_manager_client, AWSSecretsManagerV2)
-    assert litellm.secret_manager_client.replica_regions == ["us-west-2", "eu-west-1"]
+        assert isinstance(litellm.secret_manager_client, AWSSecretsManagerV2)
+        assert litellm.secret_manager_client.replica_regions == ["us-west-2", "eu-west-1"]
+    finally:
+        litellm.secret_manager_client = original

--- a/tests/test_litellm/secret_managers/test_aws_secret_manager_replication.py
+++ b/tests/test_litellm/secret_managers/test_aws_secret_manager_replication.py
@@ -6,6 +6,7 @@ All tests are mocked — no real AWS credentials required.
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 
 from litellm.secret_managers.aws_secret_manager_v2 import AWSSecretsManagerV2
@@ -230,3 +231,135 @@ def test_load_aws_secret_manager_passes_replica_regions():
         assert litellm.secret_manager_client.replica_regions == ["us-west-2", "eu-west-1"]
     finally:
         litellm.secret_manager_client = original
+
+
+def _http_status_error(status_code: int, body: str) -> httpx.HTTPStatusError:
+    request = httpx.Request("POST", "https://secretsmanager.us-east-1.amazonaws.com")
+    response = httpx.Response(status_code=status_code, text=body, request=request)
+    return httpx.HTTPStatusError(message=body, request=request, response=response)
+
+
+def _mock_http_client_raising(exc: Exception) -> MagicMock:
+    mock_response = MagicMock()
+    mock_response.raise_for_status.side_effect = exc
+    mock_async_client = AsyncMock()
+    mock_async_client.post.return_value = mock_response
+    return mock_async_client
+
+
+# ---------------------------------------------------------------------------
+# Tests: error paths in async_write_secret
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_write_secret_http_error_raises():
+    """async_write_secret raises ValueError when CreateSecret returns a non-2xx HTTP status."""
+    manager = AWSSecretsManagerV2()
+
+    with patch.object(
+        AWSSecretsManagerV2,
+        "_prepare_request",
+        return_value=(
+            "https://secretsmanager.us-east-1.amazonaws.com",
+            {"Content-Type": "application/x-amz-json-1.1"},
+            b'{"Name":"litellm/test-key"}',
+        ),
+    ):
+        with patch(
+            "litellm.secret_managers.aws_secret_manager_v2.get_async_httpx_client",
+            return_value=_mock_http_client_raising(
+                _http_status_error(400, "ResourceExistsException")
+            ),
+        ):
+            with pytest.raises(ValueError, match="HTTP error occurred"):
+                await manager.async_write_secret(
+                    secret_name="litellm/test-key",
+                    secret_value="sk-test-value",
+                )
+
+
+@pytest.mark.asyncio
+async def test_write_secret_timeout_raises():
+    """async_write_secret raises ValueError when the CreateSecret call times out."""
+    manager = AWSSecretsManagerV2()
+
+    with patch.object(
+        AWSSecretsManagerV2,
+        "_prepare_request",
+        return_value=(
+            "https://secretsmanager.us-east-1.amazonaws.com",
+            {"Content-Type": "application/x-amz-json-1.1"},
+            b'{"Name":"litellm/test-key"}',
+        ),
+    ):
+        with patch(
+            "litellm.secret_managers.aws_secret_manager_v2.get_async_httpx_client",
+            return_value=_mock_http_client_raising(
+                httpx.ReadTimeout("timed out", request=None)
+            ),
+        ):
+            with pytest.raises(ValueError, match="Timeout error occurred"):
+                await manager.async_write_secret(
+                    secret_name="litellm/test-key",
+                    secret_value="sk-test-value",
+                )
+
+
+# ---------------------------------------------------------------------------
+# Tests: error paths in async_replicate_secret
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_replicate_secret_http_error_raises():
+    """async_replicate_secret raises ValueError when ReplicateSecretToRegions returns a non-2xx status."""
+    manager = AWSSecretsManagerV2()
+
+    with patch.object(
+        AWSSecretsManagerV2,
+        "_prepare_request",
+        return_value=(
+            "https://secretsmanager.us-east-1.amazonaws.com",
+            {"Content-Type": "application/x-amz-json-1.1"},
+            b"{}",
+        ),
+    ):
+        with patch(
+            "litellm.secret_managers.aws_secret_manager_v2.get_async_httpx_client",
+            return_value=_mock_http_client_raising(
+                _http_status_error(403, "AccessDeniedException")
+            ),
+        ):
+            with pytest.raises(ValueError, match="HTTP error occurred"):
+                await manager.async_replicate_secret(
+                    secret_name="litellm/test-key",
+                    replica_regions=["us-west-2"],
+                )
+
+
+@pytest.mark.asyncio
+async def test_replicate_secret_timeout_raises():
+    """async_replicate_secret raises ValueError when the ReplicateSecretToRegions call times out."""
+    manager = AWSSecretsManagerV2()
+
+    with patch.object(
+        AWSSecretsManagerV2,
+        "_prepare_request",
+        return_value=(
+            "https://secretsmanager.us-east-1.amazonaws.com",
+            {"Content-Type": "application/x-amz-json-1.1"},
+            b"{}",
+        ),
+    ):
+        with patch(
+            "litellm.secret_managers.aws_secret_manager_v2.get_async_httpx_client",
+            return_value=_mock_http_client_raising(
+                httpx.ReadTimeout("timed out", request=None)
+            ),
+        ):
+            with pytest.raises(ValueError, match="Timeout error occurred"):
+                await manager.async_replicate_secret(
+                    secret_name="litellm/test-key",
+                    replica_regions=["us-west-2"],
+                )

--- a/tests/test_litellm/secret_managers/test_aws_secret_manager_replication.py
+++ b/tests/test_litellm/secret_managers/test_aws_secret_manager_replication.py
@@ -182,7 +182,9 @@ async def test_async_replicate_secret_correct_payload():
             b"{}",
         )
 
-    with patch.object(AWSSecretsManagerV2, "_prepare_request", side_effect=capture_prepare):
+    with patch.object(
+        AWSSecretsManagerV2, "_prepare_request", side_effect=capture_prepare
+    ):
         with patch(
             "litellm.secret_managers.aws_secret_manager_v2.get_async_httpx_client",
             return_value=_mock_http_client(_REPLICATE_RESPONSE),
@@ -199,6 +201,35 @@ async def test_async_replicate_secret_correct_payload():
         {"Region": "us-west-2"},
         {"Region": "eu-west-1"},
     ]
+
+
+@pytest.mark.asyncio
+async def test_replication_fires_on_create(caplog):
+    """async_replicate_secret emits an INFO log line mentioning ReplicateSecretToRegions."""
+    import logging
+
+    manager = AWSSecretsManagerV2()
+
+    with patch.object(
+        AWSSecretsManagerV2,
+        "_prepare_request",
+        return_value=(
+            "https://secretsmanager.us-east-1.amazonaws.com",
+            {"Content-Type": "application/x-amz-json-1.1"},
+            b"{}",
+        ),
+    ):
+        with patch(
+            "litellm.secret_managers.aws_secret_manager_v2.get_async_httpx_client",
+            return_value=_mock_http_client(_REPLICATE_RESPONSE),
+        ):
+            with caplog.at_level(logging.INFO, logger="LiteLLM"):
+                await manager.async_replicate_secret(
+                    secret_name="litellm/test-key",
+                    replica_regions=["us-west-2"],
+                )
+
+    assert "ReplicateSecretToRegions" in caplog.text
 
 
 # ---------------------------------------------------------------------------
@@ -228,7 +259,10 @@ def test_load_aws_secret_manager_passes_replica_regions():
         )
 
         assert isinstance(litellm.secret_manager_client, AWSSecretsManagerV2)
-        assert litellm.secret_manager_client.replica_regions == ["us-west-2", "eu-west-1"]
+        assert litellm.secret_manager_client.replica_regions == [
+            "us-west-2",
+            "eu-west-1",
+        ]
     finally:
         litellm.secret_manager_client = original
 


### PR DESCRIPTION
## What does this PR do?

When LiteLLM is configured to store virtual keys in AWS Secrets Manager (`store_virtual_keys: true`), secrets are written only to the primary region. Users running multi-region active-passive setups (e.g. us-east-1 primary, us-west-2 DR) need the secrets to be available in the secondary region so that workloads there can authenticate during a regional failover.

This PR adds an optional `replica_regions` field to `KeyManagementSettings`. When set, `AWSSecretsManagerV2` calls the AWS Secrets Manager `ReplicateSecretToRegions` API immediately after each `CreateSecret` call. Replication is best-effort — a failure to replicate is logged as a warning and does not fail key creation.

## Type

- [x] 🆕 New Feature
- [ ] 🐛 Bug Fix
- [ ] 🔨 Refactoring
- [ ] 📝 Documentation
- [ ] ✅ Test
- [ ] 🏗️ Infrastructure

## Changes

- `litellm/types/secret_managers/main.py`: Added `replica_regions: Optional[List[str]] = None` field to `KeyManagementSettings` with docstring
- `litellm/secret_managers/aws_secret_manager_v2.py`:
  - Added `replica_regions` parameter to `__init__`
  - Added `async_replicate_secret()` method that calls `ReplicateSecretToRegions`
  - Modified `async_write_secret()` to call `async_replicate_secret()` after a successful `CreateSecret`
  - Updated `load_aws_secret_manager()` to forward `replica_regions` from settings
- `tests/test_litellm/secret_managers/test_aws_secret_manager_replication.py`: 6 new unit tests (all mocked, no real AWS credentials required)

## Usage

```yaml
general_settings:
  key_management_system: aws_secret_manager
  key_management_settings:
    store_virtual_keys: true
    aws_region_name: us-east-1
    replica_regions:
      - us-west-2
```

## Relevant issues

None

## Screenshots / Proof of Fix

`ReplicateSecretToRegions` is idempotent — calling it on a secret that already has a replica returns success. Replication failures are logged at WARNING level and do not propagate errors to the caller.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
