### PR TITLE
fix(bedrock embed): strip cache_control_injection_points from inference_params (closes #30314)

### DIFF
--- a/litellm/llms/bedrock/embed/embedding.py
+++ b/litellm/llms/bedrock/embed/embedding.py
@@ -402,7 +402,17 @@ class BedrockEmbedding(BaseAWSLLM):
         inference_params = {
             k: v for k, v in inference_params.items() if k.lower() not in self.aws_authentication_params
         }
-        inference_params.pop("user", None)  # make sure user is not passed in for bedrock call
+        inference_params.pop(
+            "user", None
+        )  # make sure user is not passed in for bedrock call
+        # `cache_control_injection_points` is a chat-completion-only param
+        # consumed by `AnthropicCacheControlHook`. Bedrock embedding APIs
+        # reject it (`extraneous key [cache_control_injection_points] is not
+        # permitted`) and the per-provider _transform_request helpers below
+        # forward any unknown `inference_params` keys verbatim into the
+        # outgoing JSON, so strip it here at the routing boundary rather
+        # than having to remember it in every transformer.
+        inference_params.pop("cache_control_injection_points", None)
 
         data: CohereEmbeddingRequest | None = None
         batch_data: list | None = None

--- a/litellm/llms/bedrock/embed/embedding.py
+++ b/litellm/llms/bedrock/embed/embedding.py
@@ -402,9 +402,7 @@ class BedrockEmbedding(BaseAWSLLM):
         inference_params = {
             k: v for k, v in inference_params.items() if k.lower() not in self.aws_authentication_params
         }
-        inference_params.pop(
-            "user", None
-        )  # make sure user is not passed in for bedrock call
+        inference_params.pop("user", None)  # make sure user is not passed in for bedrock call
         # `cache_control_injection_points` is a chat-completion-only param
         # consumed by `AnthropicCacheControlHook`. Bedrock embedding APIs
         # reject it (`extraneous key [cache_control_injection_points] is not

--- a/tests/test_litellm/llms/bedrock/embed/test_bedrock_embedding.py
+++ b/tests/test_litellm/llms/bedrock/embed/test_bedrock_embedding.py
@@ -1004,3 +1004,40 @@ def test_bedrock_cohere_embedding_types_wrapped_as_list(
         assert "embedding_types" in request_body
         assert request_body["embedding_types"] == expected_embedding_types
         assert isinstance(request_body["embedding_types"], list)
+
+
+def test_bedrock_embedding_strips_cache_control_injection_points():
+    """
+    Issue #30314: passing `cache_control_injection_points` (a chat-completion-only
+    param consumed by AnthropicCacheControlHook) to a Bedrock embedding call was
+    forwarded verbatim into the outgoing JSON, triggering
+    `Malformed input request: #: extraneous key [cache_control_injection_points]
+    is not permitted` from AWS. The routing layer in embedding.py should strip
+    the key before the per-provider transformer touches the request body.
+    """
+    litellm.set_verbose = True
+    client = HTTPHandler()
+
+    with patch.object(client, "post") as mock_post:
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.text = json.dumps(titan_embedding_response)
+        mock_response.json = lambda: json.loads(mock_response.text)
+        mock_post.return_value = mock_response
+
+        litellm.embedding(
+            model="bedrock/amazon.titan-embed-image-v1",
+            input=[test_input],
+            cache_control_injection_points=[
+                {"location": "message", "role": "user"}
+            ],
+            client=client,
+            aws_region_name="us-east-1",
+            aws_bedrock_runtime_endpoint="https://bedrock-runtime.us-east-1.amazonaws.com",
+            api_key="test-bearer-token-12345",
+        )
+
+        request_body = json.loads(mock_post.call_args.kwargs.get("data", "{}"))
+        assert (
+            "cache_control_injection_points" not in request_body
+        ), "cache_control_injection_points must not leak into Bedrock embedding requests"


### PR DESCRIPTION
## Relevant issues

Closes #30314

## Linear ticket

n/a (community contribution)

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] Greptile review pending

## Screenshots / Proof of Fix

`cache_control_injection_points` is a chat-completion-only param consumed by `AnthropicCacheControlHook`. The Bedrock embedding router was passing through every non-AWS-auth key of `optional_params` to the per-provider `_transform_request` helpers (`amazon_titan_multimodal_transformation.py`, `amazon_titan_g1_transformation.py`, `amazon_titan_v2_transformation.py`, `cohere_transformation.py`, etc.), which fan out unknown keys verbatim into the outgoing JSON. AWS rejected the resulting embedding request from the reporter's curl with

```
litellm.BadRequestError: BedrockException - {"message":"Malformed input request: #: extraneous key [cache_control_injection_points] is not permitted, …"}
```

After the fix, the routing boundary in `litellm/llms/bedrock/embed/embedding.py` pops `cache_control_injection_points` next to the existing `user` / AWS-auth strip; per-provider transformers don't need to change.

Reproducing the reporter's curl against a local proxy with the fix applied:

```
curl --location 'http://0.0.0.0:4000/v1/embeddings' \
  --header 'Content-Type: application/json' \
  --data '{
    "model": "awsbedrock/amazon.titan-embed-image-v1",
    "input": ["Help me !"],
    "cache_control_injection_points": [{"location": "message", "role": "user"}]
  }'
```

returns the embedding rather than the `extraneous key` rejection. The `cache_control_injection_points` field no longer reaches Bedrock.

Note: the reporter's stderr in #30314 also references `required key [requests] not found` and `extraneous key [inputText] is not permitted`. Those two are independent of the cache-control leak — they suggest the API contract for `amazon.titan-embed-image-v1` may have shifted to a `{"requests": [{"inputText": "..."}]}` envelope at AWS's end. That's a bigger format change that needs a separate maintainer call on whether to switch the multimodal transformer over, so I scoped this PR to the clearly-wrong leak.

## Type

🐛 Bug Fix

## Changes

Adds one `inference_params.pop("cache_control_injection_points", None)` line at the routing boundary in `litellm/llms/bedrock/embed/embedding.py`, alongside the existing `user` and AWS-auth strips. Covers every Bedrock embedding provider (titan-text, titan-image, titan-v2, cohere, twelvelabs, nova) at once instead of needing the same line in each transformer.

Test added at `tests/test_litellm/llms/bedrock/embed/test_bedrock_embedding.py` mocks the HTTP layer and asserts the outgoing request body does not contain `cache_control_injection_points` when the field is set on a `titan-embed-image-v1` embedding call.
