### PR TITLE
fix: sort tiered token-cost thresholds numerically

### DIFF
--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -191,6 +191,11 @@ def _get_service_tier_cost_key(base_key: str, service_tier: Optional[str]) -> st
     return base_key
 
 
+def _parse_above_token_threshold(key: str) -> float:
+    threshold_str = key.split("_above_")[1].split("_tokens")[0]
+    return float(threshold_str.replace("k", "")) * (1000 if "k" in threshold_str else 1)
+
+
 def _get_token_base_cost(
     model_info: ModelInfo, usage: Usage, service_tier: Optional[str] = None
 ) -> Tuple[float, float, float, float, float]:
@@ -256,7 +261,7 @@ def _get_token_base_cost(
 
     # Only sort the threshold keys (typically 1-2 keys instead of 66+)
     threshold: Optional[float] = None
-    for key in sorted(threshold_keys, reverse=True):
+    for key in sorted(threshold_keys, key=_parse_above_token_threshold, reverse=True):
         value = model_info.get(key)
         if value is not None:
             try:

--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -267,9 +267,7 @@ def _get_token_base_cost(
             try:
                 # Handle both formats: _above_128k_tokens and _above_128_tokens
                 threshold_str = key.split("_above_")[1].split("_tokens")[0]
-                threshold = float(threshold_str.replace("k", "")) * (
-                    1000 if "k" in threshold_str else 1
-                )
+                threshold = _parse_above_token_threshold(key)
                 if usage.prompt_tokens > threshold:
                     # Prefer a service_tier-specific above-threshold key when available,
                     # e.g. input_cost_per_token_priority_above_200k_tokens for Gemini

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
@@ -35,6 +35,7 @@ sys.path.insert(
 from litellm.litellm_core_utils.llm_cost_calc.utils import (
     PromptTokensDetailsResult,
     _calculate_input_cost,
+    _get_token_base_cost,
     calculate_cache_writing_cost,
     generic_cost_per_token,
 )
@@ -296,6 +297,26 @@ def test_generic_cost_per_token_above_200k_tokens():
         * usage.completion_tokens,
         10,
     )
+
+
+def test_get_token_base_cost_picks_highest_crossed_tier():
+    """Regression test for #30345.
+
+    With graduated tiers at 90k and 128k whose keys have different digit lengths, a request
+    crossing both must be billed at the highest tier it crosses (128k), not the lower one that
+    happens to sort first lexicographically.
+    """
+    model_info = {
+        "input_cost_per_token": 1e-6,
+        "output_cost_per_token": 2e-6,
+        "input_cost_per_token_above_90k_tokens": 5e-6,
+        "input_cost_per_token_above_128k_tokens": 9e-6,
+    }
+    usage = Usage(prompt_tokens=150_000, completion_tokens=10, total_tokens=150_010)
+
+    prompt_base_cost = _get_token_base_cost(model_info, usage)[0]
+
+    assert prompt_base_cost == 9e-6
 
 
 def test_generic_cost_per_token_gpt54_above_272k_tokens():


### PR DESCRIPTION
## Relevant issues

Fixes #30345

## Pre-Submission checklist

- [x] I have added meaningful tests

## Changes

`_get_token_base_cost` in `litellm/litellm_core_utils/llm_cost_calc/utils.py` picks which `input_cost_per_token_above_<N>_tokens` tier to apply by iterating the tier keys with `sorted(threshold_keys, reverse=True)` and taking the first one the request is above. That sort is lexicographic on the raw key strings, not numeric on the parsed threshold, so when two tiers have different digit lengths the order diverges from the numeric order. For instance `..._above_90k_tokens` sorts after `..._above_128k_tokens` under `reverse=True` because the character `9` is greater than `1`, so a request crossing both boundaries gets billed at the 90k tier and breaks before the 128k tier is ever considered.

This is latent on the bundled model map today (the surviving thresholds are 128k/200k/272k, all three digits, which happen to sort correctly), but it becomes reachable through a custom-registered model or any future map entry with two tiers of differing digit length.

The fix sorts the tier keys by their parsed numeric threshold via a small `_parse_above_token_threshold` helper, so the highest tier the request actually crosses is applied. A regression test in the mapped test file covers a 90k/128k pair where a 150k-token request must bill at the 128k tier.

## Screenshots / Proof of Fix

No real model call is needed; the issue calls the tiered-cost helper directly so both tiers reach it. With the fix applied:

```
$ python repro.py
per-token cost: 9e-06 (expected 9e-06 = 128k tier)
```

Before the fix the same script printed `5e-06` (the 90k tier).

## Type

🐛 Bug Fix