### PR TITLE
fix: download and base64-encode remote image URLs for ollama_chat

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -1567,7 +1567,10 @@ def _extract_ollama_image_data(image_url: str) -> str:
             convert_url_to_base64,
         )
 
-        image_url = convert_url_to_base64(image_url)
+        try:
+            return _extract_base64_data(convert_url_to_base64(image_url))
+        except litellm.ImageFetchError:
+            return image_url
     return _extract_base64_data(image_url)
 
 

--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -1555,13 +1555,29 @@ def _extract_base64_data(image_url: str) -> str:
     return image_url
 
 
+def _extract_ollama_image_data(image_url: str) -> str:
+    """
+    Return pure base64 image data for providers like Ollama that do not accept URLs.
+
+    Remote http(s) URLs are downloaded and base64-encoded; data URLs have their base64
+    payload extracted; anything else is returned unchanged.
+    """
+    if image_url.startswith(("http://", "https://")):
+        from litellm.litellm_core_utils.prompt_templates.image_handling import (
+            convert_url_to_base64,
+        )
+
+        image_url = convert_url_to_base64(image_url)
+    return _extract_base64_data(image_url)
+
+
 def extract_images_from_message(message: AllMessageValues) -> List[str]:
     """
     Extract images from a message.
 
-    For data URLs (e.g., "data:image/png;base64,iVBOR..."), only the base64
-    data portion is extracted. This is required for providers like Ollama
-    that expect pure base64 data rather than full data URLs.
+    For data URLs (e.g., "data:image/png;base64,iVBOR..."), only the base64 data portion is
+    extracted, and remote http(s) URLs are downloaded and base64-encoded. This is required for
+    providers like Ollama that expect pure base64 data rather than URLs or full data URLs.
     """
     images = []
     message_content = message.get("content")
@@ -1570,9 +1586,9 @@ def extract_images_from_message(message: AllMessageValues) -> List[str]:
             image_url = m.get("image_url")
             if image_url:
                 if isinstance(image_url, str):
-                    images.append(_extract_base64_data(image_url))
+                    images.append(_extract_ollama_image_data(image_url))
                 elif isinstance(image_url, dict) and "url" in image_url:
-                    images.append(_extract_base64_data(image_url["url"]))
+                    images.append(_extract_ollama_image_data(image_url["url"]))
     return images
 
 

--- a/tests/test_litellm/litellm_core_utils/test_extract_base64_image.py
+++ b/tests/test_litellm/litellm_core_utils/test_extract_base64_image.py
@@ -117,6 +117,34 @@ class TestExtractImagesFromMessage:
         mock_convert.assert_called_once_with("https://example.com/image.png")
         assert result == ["ZmV0Y2hlZA=="]
 
+    def test_extract_from_message_falls_back_to_url_when_download_fails(self):
+        """If the remote download is disabled or fails, fall back to the URL.
+
+        This preserves the prior behavior (forwarding the URL) instead of introducing a new
+        hard failure for users who set ``MAX_IMAGE_URL_DOWNLOAD_SIZE_MB=0`` or whose image is
+        unreachable.
+        """
+        import litellm
+
+        message = {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "https://example.com/image.png"},
+                }
+            ],
+        }
+        with patch(
+            "litellm.litellm_core_utils.prompt_templates.image_handling.convert_url_to_base64",
+            side_effect=litellm.ImageFetchError(
+                message="boom", model="ollama", llm_provider="ollama"
+            ),
+        ):
+            result = extract_images_from_message(message)
+
+        assert result == ["https://example.com/image.png"]
+
     def test_extract_multiple_images(self):
         """Test extracting multiple images from a single message"""
         message = {

--- a/tests/test_litellm/litellm_core_utils/test_extract_base64_image.py
+++ b/tests/test_litellm/litellm_core_utils/test_extract_base64_image.py
@@ -7,6 +7,8 @@ which fixes the Ollama error "illegal base64 data at input byte 4".
 Related issue: https://github.com/BerriAI/litellm/issues/18338
 """
 
+from unittest.mock import patch
+
 import pytest
 
 from litellm.litellm_core_utils.prompt_templates.common_utils import (
@@ -91,8 +93,12 @@ class TestExtractImagesFromMessage:
         result = extract_images_from_message(message)
         assert result == ["iVBORw0KGgo"]
 
-    def test_extract_from_message_with_regular_url(self):
-        """Test that regular URLs are preserved"""
+    def test_extract_from_message_with_remote_url_downloads_and_encodes(self):
+        """Remote http(s) URLs must be downloaded and base64-encoded (issue #30313).
+
+        Ollama does not accept URLs, so forwarding one verbatim made it fail with
+        "illegal base64 data at input byte 5".
+        """
         message = {
             "role": "user",
             "content": [
@@ -102,8 +108,14 @@ class TestExtractImagesFromMessage:
                 }
             ],
         }
-        result = extract_images_from_message(message)
-        assert result == ["https://example.com/image.png"]
+        with patch(
+            "litellm.litellm_core_utils.prompt_templates.image_handling.convert_url_to_base64",
+            return_value="data:image/png;base64,ZmV0Y2hlZA==",
+        ) as mock_convert:
+            result = extract_images_from_message(message)
+
+        mock_convert.assert_called_once_with("https://example.com/image.png")
+        assert result == ["ZmV0Y2hlZA=="]
 
     def test_extract_multiple_images(self):
         """Test extracting multiple images from a single message"""
@@ -124,11 +136,15 @@ class TestExtractImagesFromMessage:
                 },
             ],
         }
-        result = extract_images_from_message(message)
+        with patch(
+            "litellm.litellm_core_utils.prompt_templates.image_handling.convert_url_to_base64",
+            return_value="data:image/png;base64,image3base64",
+        ):
+            result = extract_images_from_message(message)
         assert result == [
             "image1base64",
             "image2base64",
-            "https://example.com/image3.png",
+            "image3base64",
         ]
 
     def test_empty_content(self):

--- a/tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py
+++ b/tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py
@@ -2,6 +2,7 @@ import inspect
 import os
 import sys
 from typing import cast
+from unittest.mock import patch
 
 import pytest
 from pydantic import BaseModel
@@ -276,7 +277,7 @@ class TestOllamaChatConfigResponseFormat:
         assert result["messages"][0]["images"][1] == "image2data..."
 
     def test_transform_request_image_url_as_string(self):
-        """Test handling of image_url as direct string (edge case)"""
+        """Remote image_url strings are downloaded and base64-encoded for Ollama (#30313)."""
         config = OllamaChatConfig()
 
         # Test message with image_url as string (edge case from extract_images_from_message)
@@ -296,18 +297,22 @@ class TestOllamaChatConfigResponseFormat:
             ],
         )
 
-        result = config.transform_request(
-            model="llama2",
-            messages=messages,
-            optional_params={},
-            litellm_params={},
-            headers={},
-        )
+        with patch(
+            "litellm.litellm_core_utils.prompt_templates.image_handling.convert_url_to_base64",
+            return_value="data:image/jpeg;base64,ZmV0Y2hlZA==",
+        ):
+            result = config.transform_request(
+                model="llama2",
+                messages=messages,
+                optional_params={},
+                litellm_params={},
+                headers={},
+            )
 
-        # Verify image URL was extracted
+        # Verify the remote image URL was fetched and encoded to pure base64
         assert "images" in result["messages"][0]
         assert len(result["messages"][0]["images"]) == 1
-        assert result["messages"][0]["images"][0] == "https://example.com/image.jpg"
+        assert result["messages"][0]["images"][0] == "ZmV0Y2hlZA=="
 
     def test_transform_request_no_images_no_images_key(self):
         """Test that messages without images don't have images key"""


### PR DESCRIPTION
## Relevant issues

Fixes #30313

## Pre-Submission checklist

- [x] I have added meaningful tests

## Changes

When a chat request to an `ollama_chat/*` model carries an `image_url` content block whose `url` is a remote `http(s)` URL, `extract_images_from_message` forwarded the URL string to Ollama's `images` field verbatim. Ollama expects pure base64 and does not accept URLs, so it failed with `illegal base64 data at input byte 5` (byte 5 is the `:` in `https:`).

The data:-URL prefix-stripping case was already handled (see #18465, which closed #18338, failing at byte 4 = the `:` in `data:`); this is the adjacent remote-URL case. The fix downloads remote http(s) URLs and base64-encodes them via the existing `convert_url_to_base64` helper, then extracts the base64 payload, so Ollama receives pure base64 as documented in the image handling docs. data: URLs and already-base64 values keep their previous behavior.

The download helper is imported lazily inside the new `_extract_ollama_image_data` helper to avoid a circular import between `common_utils` and `image_handling`.

## Screenshots / Proof of Fix

`extract_images_from_message` is the function Ollama uses to build its `images` field. The regression tests in `tests/test_litellm/litellm_core_utils/test_extract_base64_image.py` patch the network download and assert that a remote `https://...` image_url is converted to base64 (rather than passed through verbatim), while data: URLs still have their base64 payload extracted.

## Type

🐛 Bug Fix