### PR TITLE
fix(otel): record full error message on standard exception event in otel v2

### DIFF
--- a/litellm/integrations/otel/emitter.py
+++ b/litellm/integrations/otel/emitter.py
@@ -17,7 +17,7 @@ from litellm.integrations.otel.model.payloads import (
     ServiceSpanData,
 )
 from litellm.integrations.otel.plumbing.providers import to_otel_span_kind
-from litellm.integrations.otel.model.semconv import Error
+from litellm.integrations.otel.model.semconv import Error, ExceptionEvent
 from litellm.integrations.otel.model.spans import (
     SPAN_REGISTRY,
     SpanRole,
@@ -179,9 +179,17 @@ class SpanEmitter:
             else None
         )
         if error and (error.error_type or error.message):
-            span.set_attribute(Error.TYPE, error.error_type or "error")
-            span.set_status(
-                Status(StatusCode.ERROR, error.message or error.error_type or "error")
+            error_type = error.error_type or "error"
+            message = error.message or error.error_type or "error"
+            span.set_attribute(Error.TYPE, error_type)
+            span.set_status(Status(StatusCode.ERROR, message))
+            # Carry the full message on the standard ``exception`` event so backends
+            # map it as full text under ``exception.message``. Setting it as a bare
+            # string attribute instead lets backends like Elasticsearch dynamic-map
+            # it to a ``keyword`` capped at 1024 chars, truncating the message.
+            span.add_event(
+                ExceptionEvent.NAME,
+                {ExceptionEvent.TYPE: error_type, ExceptionEvent.MESSAGE: message},
             )
         # On success leave the status UNSET (the semconv default) rather than
         # forcing OK — that matches the FastAPI server span and avoids implying a

--- a/litellm/integrations/otel/model/semconv.py
+++ b/litellm/integrations/otel/model/semconv.py
@@ -146,6 +146,21 @@ class Error:
     TYPE: Final = "error.type"
 
 
+class ExceptionEvent:
+    """OTel exception-event name and attribute keys (semconv ``exception.*``).
+
+    The full error message rides ``exception.message`` on a span event rather than
+    a custom string attribute. Backends recognise these semantic-convention names
+    and map them as full text; an unrecognised key (e.g. ``error_message``) falls
+    into the default dynamic template, which truncates strings to a 1024-char
+    ``keyword``.
+    """
+
+    NAME: Final = "exception"
+    TYPE: Final = "exception.type"
+    MESSAGE: Final = "exception.message"
+
+
 class Server:
     ADDRESS: Final = "server.address"
     PORT: Final = "server.port"

--- a/tests/test_litellm/integrations/otel/test_otel_v2_components.py
+++ b/tests/test_litellm/integrations/otel/test_otel_v2_components.py
@@ -502,6 +502,90 @@ def test_emitter_without_call_id_is_not_deduped():
     assert len(exporter.get_finished_spans()) == 2
 
 
+def _emit_error_span(message, error_type="litellm.APIError"):
+    from litellm.integrations.otel.emitter import SpanEmitter
+
+    cfg = OpenTelemetryV2Config(exporter="in_memory")
+    provider, exporter = providers.in_memory_provider(cfg)
+    engine = SpanEmitter(providers.get_tracer(provider, "t"), cfg)
+    data = LLMCallSpanData(
+        operation=GenAIOperation.CHAT,
+        provider="openai",
+        request_model="gpt-4o",
+        response_model=None,
+        response_id=None,
+        request_params=LLMRequestParams(),
+        usage=LLMUsage(),
+        finish_reasons=(),
+        error=SpanError(error_type=error_type, message=message),
+        response_cost=None,
+        server=None,
+        identity=RequestIdentity(call_id=None),
+    )
+    engine.emit(SpanRole.LLM_CALL, data)
+    (span,) = exporter.get_finished_spans()
+    return span
+
+
+def _exception_event(span):
+    from litellm.integrations.otel.model.semconv import ExceptionEvent
+
+    events = [e for e in span.events if e.name == ExceptionEvent.NAME]
+    assert len(events) == 1, "expected exactly one exception event"
+    return events[0]
+
+
+def test_error_message_recorded_as_full_exception_event_untruncated():
+    """Regression for the Elasticsearch keyword/ignore_above:1024 truncation.
+
+    A long error message must survive intact on the standard ``exception``
+    event under ``exception.message`` — not get dropped onto a bare string
+    attribute that backends dynamic-map to a 1024-char ``keyword``. The SDK
+    must not truncate it either, so a 5000-char message stays 5000 chars.
+    """
+    from litellm.integrations.otel.model.semconv import Error, ExceptionEvent
+
+    long_message = "boom: " + "x" * 5000
+    span = _emit_error_span(long_message, error_type="litellm.APIError")
+
+    event = _exception_event(span)
+    assert event.attributes[ExceptionEvent.MESSAGE] == long_message
+    assert len(event.attributes[ExceptionEvent.MESSAGE]) == len(long_message) > 1024
+    assert event.attributes[ExceptionEvent.TYPE] == "litellm.APIError"
+
+    # error.type stays a low-cardinality attribute; the message does NOT become a
+    # bare string attribute (which is what got truncated).
+    assert span.attributes[Error.TYPE] == "litellm.APIError"
+    assert ExceptionEvent.MESSAGE not in span.attributes
+    assert span.status.description == long_message
+
+
+def test_success_span_records_no_exception_event():
+    from litellm.integrations.otel.emitter import SpanEmitter
+    from litellm.integrations.otel.model.semconv import ExceptionEvent
+
+    cfg = OpenTelemetryV2Config(exporter="in_memory")
+    provider, exporter = providers.in_memory_provider(cfg)
+    engine = SpanEmitter(providers.get_tracer(provider, "t"), cfg)
+    data = LLMCallSpanData(
+        operation=GenAIOperation.CHAT,
+        provider="openai",
+        request_model="gpt-4o",
+        response_model="gpt-4o",
+        response_id="resp-1",
+        request_params=LLMRequestParams(),
+        usage=LLMUsage(),
+        finish_reasons=("stop",),
+        error=None,
+        response_cost=None,
+        server=None,
+        identity=RequestIdentity(call_id=None),
+    )
+    engine.emit(SpanRole.LLM_CALL, data)
+    (span,) = exporter.get_finished_spans()
+    assert all(e.name != ExceptionEvent.NAME for e in span.events)
+
+
 # --- service taxonomy: which calls become spans, and of what kind ----------- #
 
 


### PR DESCRIPTION
## Relevant issues

Error messages emitted by the OpenTelemetry v2 integration are truncated downstream. Reported via EAIP-2334; the root cause analysis there is that the backend (Elasticsearch) applies a dynamic index field-type mapping that converts the error message field from `string` to `keyword`, and `keyword` defaults to `ignore_above: 1024`, so anything past 1024 chars is dropped

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Ran the proxy with otel v2 + the console exporter (`LITELLM_OTEL_V2=true OTEL_EXPORTER=console`), pointing a model at a dead endpoint so the call fails and the v2 failure path emits the LLM-call span.

Config used:

```yaml
model_list:
  - model_name: broken-model
    litellm_params:
      model: openai/gpt-4o-mini
      api_key: sk-fake-key
      api_base: http://127.0.0.1:9/v1
litellm_settings:
  callbacks: ["otel"]
general_settings:
  master_key: sk-1234
```

Request:

```bash
curl -s http://127.0.0.1:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"broken-model","messages":[{"role":"user","content":"hi"}]}'
```

Before the fix, the emitted `chat broken-model` span carried the message only in the status description; its event list was empty, so the only place the message lived was a field a backend dynamic-maps to a truncating keyword:

```
"status": {
    "status_code": "ERROR",
    "description": "litellm.InternalServerError: InternalServerError: OpenAIException - Connection error."
},
"error.type": "InternalServerError"
"events": []
```

After the fix, the same span carries the full message on the standard `exception` event under `exception.message` (recognized semconv field, mapped as full text), while `error.type` stays a low-cardinality attribute:

```
"error.type": "InternalServerError"
"events": [
    {
        "name": "exception",
        "attributes": {
            "exception.type": "InternalServerError",
            "exception.message": "litellm.InternalServerError: InternalServerError: OpenAIException - Connection error."
        }
    }
]
```

## Type

🐛 Bug Fix

## Changes

The v2 span engine (`emitter.py`) previously stamped only `error.type` and put the message into the span status description; it never recorded the standard OTel exception event that v1 emits via `record_exception`. A non-semconv field name (e.g. `error_message`) falls into the backend's default dynamic template, which maps strings to a `keyword` capped at `ignore_above: 1024` and truncates them.

`finish_span` now also records the standard `exception` span event carrying `exception.type` and the full `exception.message`, so the message rides a recognized semantic-convention field that backends map as full text rather than a truncated keyword. Added `ExceptionEvent` semconv constants and a regression test asserting a 5000-char message survives intact on the event (and that success spans record no exception event)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJRWw5cz2dETrW7ZFKN85M)_