### PR TITLE
feat(translation): v2 inbound schemas for /v1/messages and /v1/responses

### DIFF
--- a/litellm/translation/CLAUDE.md
+++ b/litellm/translation/CLAUDE.md
@@ -71,6 +71,40 @@ translation/
 │                        #   message_start / content_block_* / message_delta /
 │                        #   message_stop; owns block-index + lazy-open
 │                        #   bookkeeping on the fold state)
+│   └── responses/      # /v1/responses (OpenAI Responses API) inbound. Always
+│       │                #   rides the IR (no native provider wire, no
+│       │                #   _SAME_FAMILY entry, no fast path). May NOT import
+│       │                #   openai_chat/anthropic_messages (siblings); the
+│       │                #   dialect arg is accepted+ignored (the Responses
+│       │                #   response shape is provider-independent)
+│       ├── schema.py    # frozen wire models; input str|list[item], the input-
+│       │                #   item union (message/function_call/
+│       │                #   function_call_output/reasoning/item_reference),
+│       │                #   function-vs-hosted tools, text.format, reasoning;
+│       │                #   previous_response_id/store/background/include/
+│       │                #   metadata/service_tier as object then unsupported
+│       │                #   in parse (fail closed)
+│       ├── input_items.py # input list -> IR messages (match over the typed
+│       │                #   union): message text/image SERVE (data:-image ->
+│       │                #   base64), function_call -> assistant ToolUse
+│       │                #   (consecutive merge into one assistant turn),
+│       │                #   function_call_output -> ToolResult in a user msg
+│       │                #   (FALL BACK when its call_id has no local
+│       │                #   function_call: v1's TOOL_CALLS_CACHE is banned);
+│       │                #   reasoning item / item_reference / input_file FAIL
+│       │                #   CLOSED
+│       ├── parse.py     # top-level parse; instructions->system,
+│       │                #   max_output_tokens->max_tokens, tool_choice incl.
+│       │                #   Cursor {type:tool/any}->required, reasoning.effort
+│       │                #   ->ReasoningEffort (summary fails closed),
+│       │                #   text.format->response_format; hosted tools and
+│       │                #   every unported field a named unsupported
+│       └── response.py  # IR ChatResponse -> ResponsesAPIResponse body
+│                        #   (reasoning->message->function_call output order,
+│                        #   rs_{hash} reasoning id, status map, usage onto
+│                        #   ResponseAPIUsage; created_at is seam-stamped
+│                        #   envelope). Stream fold is a deferred follow-up
+│                        #   (see ~/sprint/reports/inbound-responses.md)
 ├── providers/      # one subpackage per wire format. Pure, no I/O
 │   ├── anthropic/
 │   │   ├── serialize.py # body assembly in v1 transform_request order

--- a/litellm/translation/CLAUDE.md
+++ b/litellm/translation/CLAUDE.md
@@ -31,21 +31,46 @@ translation/
 │                   #   two-file edit). baseten, cohere(v1-route) and the
 │                   #   wave-1b drops stay OUT (own canaries / route
 │                   #   predicate in the future cohere module)
-├── inbound/        # one subpackage per accepted schema: raw <-> OpenAI shapes
-│   └── openai_chat/
-│       ├── schema.py    # pydantic wire models, extra="forbid" + strict=True
-│       ├── messages.py  # wire messages -> IR messages (hot path)
-│       ├── parse.py     # top-level parse + semantic checks
-│       ├── response.py  # IR ChatResponse -> chat-completion body; carries a
-│       │                #   ResponseDialect (anthropic | bedrock_converse |
-│       │                #   gemini) because v1's outbound shapes are
-│       │                #   per-provider
-│       └── stream.py    # IR stream events -> chunk bodies (pure fold); same
-│                        #   dialect idea via ChunkDialect on StreamState;
-│                        #   the gemini dialect consumes composite chunk
-│                        #   events (cumulative tool index + the
-│                        #   seen-tool-calls stop->tool_calls rewrite ride
-│                        #   StreamState)
+├── inbound/        # one subpackage per accepted schema. The engine pipeline
+│   │               #   selects parse_request + reverse serialize_response by
+│   │               #   InboundSchema (a frozen _INBOUND table); the provider
+│   │               #   serializer/parser/dialect tables are inbound-agnostic
+│   ├── openai_chat/
+│   │   ├── schema.py    # pydantic wire models, extra="forbid" + strict=True
+│   │   ├── messages.py  # wire messages -> IR messages (hot path)
+│   │   ├── parse.py     # top-level parse + semantic checks
+│   │   ├── response.py  # IR ChatResponse -> chat-completion body; carries a
+│   │   │                #   ResponseDialect (anthropic | bedrock_converse |
+│   │   │                #   gemini) because v1's outbound shapes are
+│   │   │                #   per-provider
+│   │   └── stream.py    # IR stream events -> chunk bodies (pure fold); same
+│   │                    #   dialect idea via ChunkDialect on StreamState;
+│   │                    #   the gemini dialect consumes composite chunk
+│   │                    #   events (cumulative tool index + the
+│   │                    #   seen-tool-calls stop->tool_calls rewrite ride
+│   │                    #   StreamState)
+│   └── anthropic_messages/  # /v1/messages (Anthropic Messages) inbound. The
+│       │                #   chat IR is Anthropic-shaped, so forward + reverse
+│       │                #   are largely 1:1. May NOT import openai_chat
+│       │                #   (siblings); the dialect arg is accepted+ignored
+│       ├── schema.py    # frozen wire models; max_tokens REQUIRED, system
+│       │                #   str|list[block], stop_sequences, tool_choice/
+│       │                #   thinking unions; documents/hosted tools/
+│       │                #   output_format/mcp_servers/container as object
+│       │                #   then unsupported in parse (fail closed)
+│       ├── messages.py  # Anthropic messages -> IR (hot path); non-text
+│       │                #   system block / non-text image source / non-text
+│       │                #   tool_result part FAIL CLOSED (not v1's drop)
+│       ├── parse.py     # top-level parse; stop_sequences->stop,
+│       │                #   metadata.user_id->user, thinking verbatim,
+│       │                #   every unported field a named unsupported
+│       ├── response.py  # IR ChatResponse -> Anthropic Messages body
+│       │                #   (thinking->text->tool_use order, stop_reason
+│       │                #   map, input+cache_creation usage math)
+│       └── stream.py    # IR StreamEvent -> Anthropic SSE events (pure fold:
+│                        #   message_start / content_block_* / message_delta /
+│                        #   message_stop; owns block-index + lazy-open
+│                        #   bookkeeping on the fold state)
 ├── providers/      # one subpackage per wire format. Pure, no I/O
 │   ├── anthropic/
 │   │   ├── serialize.py # body assembly in v1 transform_request order

--- a/litellm/translation/engine/pipeline.py
+++ b/litellm/translation/engine/pipeline.py
@@ -24,6 +24,10 @@ from expression import Error, Ok, Result
 from ..deps import TranslationDeps
 from ..dispatch import InboundSchema, Provider
 from ..errors import ParseResult, TranslateResult, TranslationError
+from ..inbound.anthropic_messages import parse_request as anthropic_parse_request
+from ..inbound.anthropic_messages.response import (
+    serialize_response as anthropic_serialize_response,
+)
 from ..inbound.openai_chat import parse_request as openai_chat_parse_request
 from ..inbound.openai_chat.response import ResponseDialect, serialize_response
 from ..ir import Body, ChatRequest, ChatResponse, PlainJson
@@ -178,6 +182,10 @@ _INBOUND: Mapping[InboundSchema, _Inbound] = MappingProxyType(
         "openai_chat": _Inbound(
             parse_request=openai_chat_parse_request,
             serialize_response=serialize_response,
+        ),
+        "anthropic_messages": _Inbound(
+            parse_request=anthropic_parse_request,
+            serialize_response=anthropic_serialize_response,
         ),
     }
 )

--- a/litellm/translation/engine/pipeline.py
+++ b/litellm/translation/engine/pipeline.py
@@ -30,6 +30,10 @@ from ..inbound.anthropic_messages.response import (
 )
 from ..inbound.openai_chat import parse_request as openai_chat_parse_request
 from ..inbound.openai_chat.response import ResponseDialect, serialize_response
+from ..inbound.responses import parse_request as responses_parse_request
+from ..inbound.responses.response import (
+    serialize_response as responses_serialize_response,
+)
 from ..ir import Body, ChatRequest, ChatResponse, PlainJson
 from ..providers.anthropic import serialize_request
 from ..providers.anthropic.response import parse_response
@@ -186,6 +190,10 @@ _INBOUND: Mapping[InboundSchema, _Inbound] = MappingProxyType(
         "anthropic_messages": _Inbound(
             parse_request=anthropic_parse_request,
             serialize_response=anthropic_serialize_response,
+        ),
+        "responses": _Inbound(
+            parse_request=responses_parse_request,
+            serialize_response=responses_serialize_response,
         ),
     }
 )

--- a/litellm/translation/engine/pipeline.py
+++ b/litellm/translation/engine/pipeline.py
@@ -22,9 +22,9 @@ from types import MappingProxyType
 from expression import Error, Ok, Result
 
 from ..deps import TranslationDeps
-from ..dispatch import Provider
-from ..errors import TranslateResult, TranslationError
-from ..inbound.openai_chat import parse_request
+from ..dispatch import InboundSchema, Provider
+from ..errors import ParseResult, TranslateResult, TranslationError
+from ..inbound.openai_chat import parse_request as openai_chat_parse_request
 from ..inbound.openai_chat.response import ResponseDialect, serialize_response
 from ..ir import Body, ChatRequest, ChatResponse, PlainJson
 from ..providers.anthropic import serialize_request
@@ -152,6 +152,39 @@ _Serializer = Callable[[ChatRequest, TranslationDeps], Result[Body, TranslationE
 _ResponseParser = Callable[
     [PlainJson, ChatRequest], Result[ChatResponse, TranslationError]
 ]
+_ParseRequest = Callable[[Mapping[str, object]], ParseResult]
+_SerializeResponse = Callable[
+    [ChatResponse, TranslationDeps, ResponseDialect], Body | TranslationError
+]
+
+
+@dataclass(frozen=True)
+class _Inbound:
+    """The two inbound-schema transforms the pipeline selects between: the
+    request parser (wire body -> IR ``ChatRequest``) and the reverse response
+    serializer (IR ``ChatResponse`` -> the inbound schema's response body).
+    The provider serializer/parser/dialect tables below are inbound-agnostic
+    (they consume and produce the IR), so a new inbound schema only adds a row
+    here. The ``serialize_response`` takes the provider's outbound
+    ``ResponseDialect``; schemas whose response shape is provider-independent
+    (anthropic_messages always emits the Anthropic Messages body) ignore it."""
+
+    parse_request: _ParseRequest
+    serialize_response: _SerializeResponse
+
+
+_INBOUND: Mapping[InboundSchema, _Inbound] = MappingProxyType(
+    {
+        "openai_chat": _Inbound(
+            parse_request=openai_chat_parse_request,
+            serialize_response=serialize_response,
+        ),
+    }
+)
+
+
+def _inbound(schema: InboundSchema) -> _Inbound | None:
+    return _INBOUND.get(schema)
 
 _SERIALIZERS: Mapping[Provider, _Serializer] = MappingProxyType(
     {
@@ -428,8 +461,18 @@ def response_dialect(provider: Provider) -> ResponseDialect:
 
 
 def translate_chat_request(
-    raw: Mapping[str, object], provider: Provider, deps: TranslationDeps
+    raw: Mapping[str, object],
+    provider: Provider,
+    deps: TranslationDeps,
+    schema: InboundSchema = "openai_chat",
 ) -> TranslateResult:
+    inbound = _inbound(schema)
+    if inbound is None:
+        return Error(
+            TranslationError.of_unsupported(
+                f"inbound schema {schema!r} has no v2 parser yet"
+            )
+        )
     serializer = _SERIALIZERS.get(provider)
     if serializer is None:
         return Error(
@@ -440,7 +483,7 @@ def translate_chat_request(
     guard_error = _raw_guard_error(raw, provider)
     if guard_error is not None:
         return Error(guard_error)
-    return parse_request(raw).bind(lambda request: serializer(request, deps))
+    return inbound.parse_request(raw).bind(lambda request: serializer(request, deps))
 
 
 def translate_chat_response(
@@ -448,7 +491,15 @@ def translate_chat_response(
     request: ChatRequest,
     provider: Provider,
     deps: TranslationDeps,
+    schema: InboundSchema = "openai_chat",
 ) -> TranslateResult:
+    inbound = _inbound(schema)
+    if inbound is None:
+        return Error(
+            TranslationError.of_unsupported(
+                f"inbound schema {schema!r} has no v2 serializer yet"
+            )
+        )
     parser = _RESPONSE_PARSERS.get(provider)
     if parser is None:
         return Error(
@@ -458,14 +509,17 @@ def translate_chat_response(
         )
     dialect = response_dialect(provider)
     return parser(raw_response, request).bind(
-        lambda response: _serialized_body(response, deps, dialect)
+        lambda response: _serialized_body(inbound, response, deps, dialect)
     )
 
 
 def _serialized_body(
-    response: ChatResponse, deps: TranslationDeps, dialect: ResponseDialect
+    inbound: _Inbound,
+    response: ChatResponse,
+    deps: TranslationDeps,
+    dialect: ResponseDialect,
 ) -> TranslateResult:
-    body = serialize_response(response, deps, dialect)
+    body = inbound.serialize_response(response, deps, dialect)
     if isinstance(body, TranslationError):
         return Error(body)
     return Ok(body)
@@ -475,15 +529,28 @@ def _serialized_body(
 class PreparedRequest:
     """A request that passed the fail-closed translation; from here on the
     seam is committed to v2 (an HTTP or response failure surfaces as the
-    provider error contract, never a silent re-send through v1)."""
+    provider error contract, never a silent re-send through v1). ``schema`` is
+    the inbound schema that parsed it, so ``send_prepared`` reverse-serializes
+    the provider response back into the same schema's response shape."""
 
     request: ChatRequest
     body: Body
+    schema: InboundSchema = "openai_chat"
 
 
 def prepare_chat_request(
-    raw: Mapping[str, object], provider: Provider, deps: TranslationDeps
+    raw: Mapping[str, object],
+    provider: Provider,
+    deps: TranslationDeps,
+    schema: InboundSchema = "openai_chat",
 ) -> Result[PreparedRequest, TranslationError]:
+    inbound = _inbound(schema)
+    if inbound is None:
+        return Error(
+            TranslationError.of_unsupported(
+                f"inbound schema {schema!r} has no v2 parser yet"
+            )
+        )
     serializer = _SERIALIZERS.get(provider)
     if serializer is None or provider not in _RESPONSE_PARSERS:
         return Error(
@@ -494,13 +561,13 @@ def prepare_chat_request(
     guard_error = _raw_guard_error(raw, provider)
     if guard_error is not None:
         return Error(guard_error)
-    match parse_request(raw):
+    match inbound.parse_request(raw):
         case Result(tag="ok", ok=request):
             pass
         case Result(error=parse_err):
             return Error(parse_err)
     return serializer(request, deps).map(
-        lambda body: PreparedRequest(request=request, body=body)
+        lambda body: PreparedRequest(request=request, body=body, schema=schema)
     )
 
 
@@ -532,8 +599,9 @@ async def send_prepared(
     http: HttpPort,
     endpoint: Endpoint,
 ) -> Result[Body, ExecuteError]:
+    inbound = _inbound(prepared.schema)
     parser = _RESPONSE_PARSERS.get(provider)
-    if parser is None:
+    if inbound is None or parser is None:
         return Error(
             ExecuteError.of_translation(
                 TranslationError.of_unsupported(
@@ -554,7 +622,9 @@ async def send_prepared(
         )
     match parser(response.body, prepared.request):
         case Result(tag="ok", ok=chat_response):
-            body = serialize_response(chat_response, deps, response_dialect(provider))
+            body = inbound.serialize_response(
+                chat_response, deps, response_dialect(provider)
+            )
             if isinstance(body, TranslationError):
                 return Error(ExecuteError.of_translation(body))
             return Ok(body)
@@ -568,8 +638,9 @@ async def execute_chat_request(
     deps: TranslationDeps,
     http: HttpPort,
     endpoint: Endpoint,
+    schema: InboundSchema = "openai_chat",
 ) -> Result[Body, ExecuteError]:
-    match prepare_chat_request(raw, provider, deps):
+    match prepare_chat_request(raw, provider, deps, schema):
         case Result(tag="ok", ok=prepared):
             return await send_prepared(prepared, provider, deps, http, endpoint)
         case Result(error=err):

--- a/litellm/translation/engine/pipeline.py
+++ b/litellm/translation/engine/pipeline.py
@@ -194,6 +194,7 @@ _INBOUND: Mapping[InboundSchema, _Inbound] = MappingProxyType(
 def _inbound(schema: InboundSchema) -> _Inbound | None:
     return _INBOUND.get(schema)
 
+
 _SERIALIZERS: Mapping[Provider, _Serializer] = MappingProxyType(
     {
         "anthropic": serialize_request,

--- a/litellm/translation/inbound/anthropic_messages/__init__.py
+++ b/litellm/translation/inbound/anthropic_messages/__init__.py
@@ -1,0 +1,5 @@
+"""Anthropic Messages (/v1/messages) inbound schema."""
+
+from .parse import parse_request
+
+__all__ = ("parse_request",)

--- a/litellm/translation/inbound/anthropic_messages/messages.py
+++ b/litellm/translation/inbound/anthropic_messages/messages.py
@@ -1,0 +1,263 @@
+"""Validated Anthropic Messages wire messages -> IR messages.
+
+The IR is Anthropic-shaped, so this is largely 1:1: ``Message.role`` is
+user|assistant, system rides ``ChatRequest.system``, a tool_result is a
+``tool_result`` content block inside a user message, and a tool_use is a block
+inside an assistant message. Shapes the IR cannot carry (a non-text image
+source, a non-text tool_result part, a non-text system block) return
+``unsupported`` so the seam falls back to v1, never a silent drop
+(researcher-6 §1.4: fail closed, do NOT replicate v1's silent non-text drop).
+
+Hot path note (mirrors openai_chat/messages.py): internal helpers return
+``value | TranslationError`` plain unions and build local lists, lifting into
+``Result``/``Block`` once at the public boundary.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+
+from expression import Error, Nothing, Ok, Option, Result, Some
+from expression.collections import Block
+
+from ... import boundary
+from ...errors import TranslationError
+from ...ir import (
+    Base64Source,
+    CacheControl,
+    ContentBlock,
+    Image,
+    ImageSource,
+    JsonBlob,
+    Message,
+    RedactedThinking,
+    Role,
+    SystemText,
+    Text,
+    Thinking,
+    ToolResult,
+    ToolResultContent,
+    ToolUse,
+    UrlSource,
+)
+from .schema import (
+    AssistantMessageIn,
+    Base64SourceIn,
+    CacheControlIn,
+    ImageBlockIn,
+    RedactedThinkingBlockIn,
+    SystemTextBlockIn,
+    TextBlockIn,
+    ThinkingBlockIn,
+    ToolResultBlockIn,
+    ToolResultContentTextIn,
+    ToolUseBlockIn,
+    UrlSourceIn,
+    UserMessageIn,
+)
+
+WireMessage = UserMessageIn | AssistantMessageIn
+
+_ConvertResult = Result[Block[Message], TranslationError]
+
+_NO_CACHE: Option[CacheControl] = Nothing
+
+
+def convert_messages(items: Sequence[WireMessage]) -> _ConvertResult:
+    messages: list[Message] = []
+    for item in items:
+        blocks = _message_blocks(item)
+        if isinstance(blocks, TranslationError):
+            return Error(blocks)
+        # build-locally-freeze-once: `messages` never escapes this scope
+        messages.append(  # nosemgrep: translation-no-mutation
+            Message(role=_role(item), content=Block.of_seq(blocks))
+        )
+    return Ok(Block.of_seq(messages))
+
+
+def convert_system(
+    system: str | list[SystemTextBlockIn] | None,
+) -> Result[Block[SystemText], TranslationError]:
+    if system is None:
+        return Ok(Block.empty())
+    if isinstance(system, str):
+        if not system:
+            return Ok(Block.empty())
+        return Ok(Block.of_seq([SystemText(text=system, cache=_NO_CACHE)]))
+    texts = _system_texts(system)
+    if isinstance(texts, TranslationError):
+        return Error(texts)
+    return Ok(Block.of_seq(texts))
+
+
+def cache_of(value: CacheControlIn | None) -> Option[CacheControl]:
+    if value is None:
+        return _NO_CACHE
+    ttl = Some(value.ttl) if value.ttl is not None else Nothing
+    return Some(CacheControl(type=value.type, ttl=ttl))
+
+
+def _role(message: WireMessage) -> Role:
+    return "user" if isinstance(message, UserMessageIn) else "assistant"
+
+
+def _system_texts(
+    blocks: Iterable[SystemTextBlockIn],
+) -> list[SystemText] | TranslationError:
+    texts: list[SystemText] = []
+    for block in blocks:
+        if block.type != "text" or block.text is None:
+            # v1 silently drops non-text system blocks; the IR's SystemText is
+            # text-only, so fail closed instead of replicating the drop.
+            return TranslationError.of_unsupported(
+                "non-text system block; v1 drops it, the IR cannot carry it"
+            )
+        texts.append(  # nosemgrep: translation-no-mutation
+            SystemText(text=block.text, cache=cache_of(block.cache_control))
+        )
+    return texts
+
+
+def _message_blocks(
+    message: WireMessage,
+) -> list[ContentBlock] | TranslationError:
+    if isinstance(message, UserMessageIn):
+        return _user_blocks(message)
+    return _assistant_blocks(message)
+
+
+def _user_blocks(
+    message: UserMessageIn,
+) -> list[ContentBlock] | TranslationError:
+    if isinstance(message.content, str):
+        text = Text(text=message.content, cache=_NO_CACHE)
+        return [ContentBlock.of_text(text)]
+    blocks: list[ContentBlock] = []
+    for part in message.content:
+        block = _user_block(part)
+        if isinstance(block, TranslationError):
+            return block
+        blocks.append(block)  # nosemgrep: translation-no-mutation
+    return blocks
+
+
+def _user_block(
+    part: TextBlockIn | ImageBlockIn | ToolResultBlockIn,
+) -> ContentBlock | TranslationError:
+    if isinstance(part, TextBlockIn):
+        return ContentBlock.of_text(
+            Text(text=part.text, cache=cache_of(part.cache_control))
+        )
+    if isinstance(part, ImageBlockIn):
+        return _image_block(part)
+    return _tool_result(part)
+
+
+def _image_block(part: ImageBlockIn) -> ContentBlock | TranslationError:
+    cache = cache_of(part.cache_control)
+    if isinstance(part.source, Base64SourceIn):
+        source = ImageSource.of_base64(
+            Base64Source(media_type=part.source.media_type, data=part.source.data)
+        )
+        return ContentBlock.of_image(Image(source=source, cache=cache))
+    if isinstance(part.source, UrlSourceIn):
+        source = ImageSource.of_url(UrlSource(url=part.source.url, format=Nothing))
+        return ContentBlock.of_image(Image(source=source, cache=cache))
+    return TranslationError.of_unsupported(
+        "image source other than base64/url (e.g. file_id); v1 handles it"
+    )
+
+
+def _tool_result(part: ToolResultBlockIn) -> ContentBlock | TranslationError:
+    content = _tool_result_content(part.content)
+    if isinstance(content, TranslationError):
+        return content
+    return ContentBlock.of_tool_result(
+        ToolResult(
+            tool_use_id=part.tool_use_id,
+            content=content,
+            cache=cache_of(part.cache_control),
+        )
+    )
+
+
+def _tool_result_content(
+    content: str | list[ToolResultContentTextIn | object] | None,
+) -> ToolResultContent | TranslationError:
+    if content is None:
+        return ToolResultContent.of_text("")
+    if isinstance(content, str):
+        return ToolResultContent.of_text(content)
+    parts: list[Text] = []
+    for item in content:
+        if not isinstance(item, ToolResultContentTextIn):
+            # image/document parts in a tool_result: v1 routes them via
+            # image_url; the IR's ToolResult parts are text-only, fail closed.
+            return TranslationError.of_unsupported(
+                "non-text tool_result content (image/document); v1 handles it"
+            )
+        parts.append(  # nosemgrep: translation-no-mutation
+            Text(text=item.text, cache=cache_of(item.cache_control))
+        )
+    return ToolResultContent.of_parts(Block.of_seq(parts))
+
+
+def _assistant_blocks(
+    message: AssistantMessageIn,
+) -> list[ContentBlock] | TranslationError:
+    if isinstance(message.content, str):
+        text = Text(text=message.content, cache=_NO_CACHE)
+        return [ContentBlock.of_text(text)]
+    blocks: list[ContentBlock] = []
+    for part in message.content:
+        block = _assistant_block(part)
+        if isinstance(block, TranslationError):
+            return block
+        blocks.append(block)  # nosemgrep: translation-no-mutation
+    return blocks
+
+
+def _assistant_block(
+    part: TextBlockIn | ToolUseBlockIn | ThinkingBlockIn | RedactedThinkingBlockIn,
+) -> ContentBlock | TranslationError:
+    if isinstance(part, TextBlockIn):
+        return ContentBlock.of_text(
+            Text(text=part.text, cache=cache_of(part.cache_control))
+        )
+    if isinstance(part, ToolUseBlockIn):
+        return _tool_use(part)
+    if isinstance(part, ThinkingBlockIn):
+        signature = Some(part.signature) if part.signature is not None else Nothing
+        return ContentBlock.of_thinking(
+            Thinking(
+                thinking=part.thinking,
+                signature=signature,
+                cache=cache_of(part.cache_control),
+            )
+        )
+    return ContentBlock.of_redacted_thinking(RedactedThinking(data=part.data))
+
+
+def _tool_use(part: ToolUseBlockIn) -> ContentBlock | TranslationError:
+    if part.caller is not None:
+        return TranslationError.of_unsupported(
+            "tool_use caller (code-execution tool call); v1 handles it"
+        )
+    match boundary.as_plain_json(part.input):
+        case Result(tag="ok", ok=copied) if isinstance(copied, dict):
+            arguments = JsonBlob(value=copied)
+        case Result(tag="ok"):
+            return TranslationError.of_unsupported(
+                "non-object tool_use input; v1 handles it"
+            )
+        case Result(error=reason):
+            return TranslationError.of_unsupported(f"tool_use input: {reason}")
+    return ContentBlock.of_tool_use(
+        ToolUse(
+            id=part.id,
+            name=part.name,
+            arguments=arguments,
+            cache=cache_of(part.cache_control),
+        )
+    )

--- a/litellm/translation/inbound/anthropic_messages/parse.py
+++ b/litellm/translation/inbound/anthropic_messages/parse.py
@@ -1,0 +1,236 @@
+"""Parse an Anthropic Messages request body into the chat IR.
+
+``boundary.parse`` validates the untyped body against the frozen wire models;
+this module converts the validated models into IR values and applies the
+residual fail-closed checks (every field v1 serves through an unported path
+becomes an ``unsupported`` naming that path, never a silent drop). Top-level
+``null`` fields are stripped first, matching the seam's treatment of an
+explicit ``null`` as an absent parameter.
+
+The IR is Anthropic-shaped, so the mapping is largely 1:1: ``stop_sequences``
+renames to ``stop``, ``metadata.user_id`` to ``user``, ``thinking`` forwards
+verbatim, ``tool_choice`` maps onto the four IR cases, and ``max_tokens`` is
+required at the wire boundary (Anthropic rejects a request without it).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TypeVar
+
+from expression import Error, Nothing, Ok, Option, Result, Some
+from expression.collections import Block
+
+from ... import boundary
+from ...errors import ParseResult, TranslationError
+from ...ir import (
+    ChatRequest,
+    InferenceParams,
+    JsonBlob,
+    ThinkingParam,
+    ToolChoice,
+    ToolDef,
+)
+from .messages import cache_of, convert_messages, convert_system
+from .schema import (
+    AnthropicMessagesRequestIn,
+    ThinkingIn,
+    ToolChoiceIn,
+    ToolIn,
+)
+
+_T = TypeVar("_T")
+
+_UNPORTED_FIELDS: tuple[tuple[str, str], ...] = (
+    ("output_format", "anthropic structured outputs (output_format)"),
+    ("output_config", "anthropic output_config (effort/format)"),
+    ("mcp_servers", "anthropic mcp_servers"),
+    ("container", "anthropic code-execution container"),
+    ("context_management", "anthropic context-management polyfill"),
+    ("reasoning_effort", "anthropic reasoning_effort passthrough"),
+    ("inference_geo", "anthropic inference_geo passthrough"),
+    ("speed", "anthropic speed (fast mode) passthrough"),
+    ("cache_control", "anthropic top-level automatic cache_control"),
+    ("service_tier", "anthropic service_tier passthrough"),
+)
+
+
+def parse_request(raw: Mapping[str, object]) -> ParseResult:
+    present = {key: value for key, value in raw.items() if value is not None}
+    match boundary.parse(AnthropicMessagesRequestIn, present):
+        case Result(tag="ok", ok=wire):
+            return _to_ir(wire)
+        case Result(error=err):
+            return Error(err)
+
+
+def _to_ir(wire: AnthropicMessagesRequestIn) -> ParseResult:
+    unported = _unported_error(wire)
+    if unported is not None:
+        return Error(unported)
+    match convert_system(wire.system):
+        case Result(tag="ok", ok=systems):
+            pass
+        case Result(error=system_err):
+            return Error(system_err)
+    match convert_messages(wire.messages):
+        case Result(tag="ok", ok=messages):
+            pass
+        case Result(error=messages_err):
+            return Error(messages_err)
+    match _parse_tools(wire.tools):
+        case Result(tag="ok", ok=tools):
+            pass
+        case Result(error=tools_err):
+            return Error(tools_err)
+    match _parse_thinking(wire.thinking):
+        case Result(tag="ok", ok=thinking):
+            pass
+        case Result(error=thinking_err):
+            return Error(thinking_err)
+    return Ok(
+        ChatRequest(
+            model=wire.model,
+            system=systems,
+            messages=messages,
+            tools=tools,
+            tool_choice=_parse_tool_choice(wire.tool_choice),
+            parallel_tool_calls=_parallel_tool_calls(wire.tool_choice),
+            response_format=Nothing,
+            thinking=thinking,
+            reasoning_effort=Nothing,
+            user=_user(wire),
+            params=_parse_params(wire),
+            stream=wire.stream is True,
+        )
+    )
+
+
+def _unported_error(wire: AnthropicMessagesRequestIn) -> TranslationError | None:
+    for field, reason in _UNPORTED_FIELDS:
+        if getattr(wire, field) is not None:
+            return TranslationError.of_unsupported(f"{reason}; v1 handles it")
+    return None
+
+
+def _option(value: _T | None) -> Option[_T]:
+    return Some(value) if value is not None else Nothing
+
+
+def _user(wire: AnthropicMessagesRequestIn) -> Option[str]:
+    if wire.metadata is None:
+        return Nothing
+    return _option(wire.metadata.user_id)
+
+
+def _parse_tools(
+    tools: list[ToolIn] | None,
+) -> Result[Block[ToolDef], TranslationError]:
+    if tools is None:
+        return Ok(Block.empty())
+    defs: list[ToolDef] = []
+    for tool in tools:
+        match _parse_tool(tool):
+            case Result(tag="ok", ok=tool_def):
+                defs.append(tool_def)  # nosemgrep: translation-no-mutation
+            case Result(error=err):
+                return Error(err)
+    return Ok(Block.of_seq(defs))
+
+
+def _parse_tool(tool: ToolIn) -> Result[ToolDef, TranslationError]:
+    extras = (tool.defer_loading, tool.allowed_callers, tool.input_examples)
+    if any(extra is not None for extra in extras):
+        return Error(
+            TranslationError.of_unsupported(
+                "tool defer_loading/allowed_callers/input_examples; v1 handles them"
+            )
+        )
+    match _parse_input_schema(tool.input_schema):
+        case Result(tag="ok", ok=parameters):
+            return Ok(
+                ToolDef(
+                    name=tool.name,
+                    description=_option(tool.description),
+                    parameters=parameters,
+                    cache=cache_of(tool.cache_control),
+                    strict=Nothing,
+                )
+            )
+        case Result(error=err):
+            return Error(err)
+
+
+def _parse_input_schema(
+    schema: object | None,
+) -> Result[Option[JsonBlob], TranslationError]:
+    if schema is None:
+        return Ok(Nothing)
+    match boundary.as_plain_json(schema):
+        case Result(tag="ok", ok=copied) if isinstance(copied, dict):
+            return Ok(Some(JsonBlob(value=copied)))
+        case Result(tag="ok"):
+            return Error(
+                TranslationError.of_unsupported(
+                    "non-object tool input_schema; v1 handles it"
+                )
+            )
+        case Result(error=reason):
+            return Error(
+                TranslationError.of_unsupported(f"tool input_schema: {reason}")
+            )
+
+
+def _parse_tool_choice(choice: ToolChoiceIn | None) -> Option[ToolChoice]:
+    if choice is None:
+        return Nothing
+    if choice.type == "auto":
+        return Some(ToolChoice.of_auto())
+    if choice.type == "any":
+        return Some(ToolChoice.of_required())
+    if choice.type == "none":
+        return Some(ToolChoice.of_none())
+    if choice.name is None:
+        return Nothing
+    return Some(ToolChoice.of_specific(choice.name))
+
+
+def _parallel_tool_calls(choice: ToolChoiceIn | None) -> Option[bool]:
+    if choice is None or choice.disable_parallel_tool_use is None:
+        return Nothing
+    return Some(not choice.disable_parallel_tool_use)
+
+
+def _parse_thinking(
+    value: ThinkingIn | None,
+) -> Result[Option[ThinkingParam], TranslationError]:
+    if value is None:
+        return Ok(Nothing)
+    if value.summary is not None:
+        return Error(
+            TranslationError.of_unsupported(
+                "thinking.summary (auto-summary); v1 handles it"
+            )
+        )
+    if value.type == "enabled":
+        return Ok(Some(ThinkingParam.of_enabled(_option(value.budget_tokens))))
+    if value.type == "disabled":
+        return Ok(Some(ThinkingParam.of_disabled()))
+    return Ok(Some(ThinkingParam.of_adaptive()))
+
+
+def _parse_params(wire: AnthropicMessagesRequestIn) -> InferenceParams:
+    return InferenceParams(
+        max_tokens=Some(wire.max_tokens),
+        temperature=_option(wire.temperature),
+        top_p=_option(wire.top_p),
+        top_k=_option(wire.top_k),
+        stop=_parse_stop(wire.stop_sequences),
+        max_completion_tokens=Nothing,
+    )
+
+
+def _parse_stop(value: list[str] | None) -> Block[str]:
+    if value is None:
+        return Block.empty()
+    return Block.of_seq(value)

--- a/litellm/translation/inbound/anthropic_messages/response.py
+++ b/litellm/translation/inbound/anthropic_messages/response.py
@@ -123,12 +123,17 @@ def _tool_use_blocks(content: Block[ContentBlock]) -> list[PlainJson]:
         if block.tag != "tool_use":
             continue
         identifier = block.tool_use.id
-        base_id = identifier.split(_THOUGHT_SIGNATURE_SEPARATOR, 1)[0]
+        base_id, _, signature = identifier.partition(_THOUGHT_SIGNATURE_SEPARATOR)
+        # v1 dumps AnthropicResponseContentBlockToolUse, so
+        # provider_specific_fields is always present: None, or the gemini
+        # thought signature (which the chat IR carries on the tool id suffix).
+        provider_fields: PlainJson = {"signature": signature} if signature else None
         entry: dict[str, PlainJson] = {
             "type": "tool_use",
             "id": base_id,
             "name": block.tool_use.name,
             "input": block.tool_use.arguments.value,
+            "provider_specific_fields": provider_fields,
         }
         blocks.append(entry)  # nosemgrep: translation-no-mutation
     return blocks

--- a/litellm/translation/inbound/anthropic_messages/response.py
+++ b/litellm/translation/inbound/anthropic_messages/response.py
@@ -1,0 +1,152 @@
+"""IR ``ChatResponse`` -> Anthropic Messages response body.
+
+The reverse of the request parse: an IR ``ChatResponse`` (produced by any
+provider's ``parse_response``) becomes an Anthropic Messages response body,
+reproducing v1's ``translate_openai_response_to_anthropic``
+(transformation.py:1374). The Anthropic Messages response shape is
+provider-independent, so the ``ResponseDialect`` argument the pipeline threads
+is ignored here (it parameterizes the chat-completion outbound, not this one).
+
+Content blocks are emitted in v1's per-choice order: thinking (or
+redacted_thinking) first, then text, then tool_use. ``stop_reason`` maps
+stop->end_turn, length->max_tokens, tool_calls->tool_use; ``content_filter``
+takes v1's default-branch ``end_turn`` (researcher-6 §1.5 item 11: v1 has no
+content_filter stop_reason and falls through to end_turn).
+
+Usage reproduces v1's chat-usage math exactly. v1 receives an OpenAI
+ModelResponse whose ``prompt_tokens`` is ``input + cache_creation + cache_read``
+with ``prompt_tokens_details.cached_tokens == cache_read`` (the anthropic
+chat dialect's ``_usage_json``), then emits
+``input_tokens = prompt_tokens - cached_tokens = input + cache_creation``.
+Reconstructing that from the IR ``ResponseUsage`` (whose ``input_tokens`` is
+already the uncached count) means emitting
+``input + cache_creation_input_tokens`` for the Anthropic ``input_tokens``;
+``cache_creation_input_tokens`` and ``cache_read_input_tokens`` are emitted
+only when > 0, matching v1.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from types import MappingProxyType
+
+from expression.collections import Block
+
+from ...deps import TranslationDeps
+from ...errors import TranslationError
+from ...ir import (
+    THOUGHT_SIGNATURE_SEPARATOR as _THOUGHT_SIGNATURE_SEPARATOR,
+)
+from ...ir import (
+    Body,
+    ChatResponse,
+    ContentBlock,
+    FinishReason,
+    PlainJson,
+    ResponseUsage,
+)
+
+_STOP_REASON: Mapping[FinishReason, str] = MappingProxyType(
+    {
+        "stop": "end_turn",
+        "length": "max_tokens",
+        "tool_calls": "tool_use",
+        "content_filter": "end_turn",
+    }
+)
+
+
+def serialize_response(
+    response: ChatResponse,
+    deps: TranslationDeps,
+    dialect: object = None,
+) -> Body | TranslationError:
+    """The ``dialect`` is the provider's outbound chat-completion dialect the
+    pipeline threads uniformly; the Anthropic Messages response shape is
+    provider-independent, so it is accepted (kept off the sibling
+    openai_chat ``ResponseDialect`` import per the no-sibling tenet) and
+    ignored."""
+    return {
+        "id": response.id,
+        "type": "message",
+        "role": "assistant",
+        "model": response.model or "unknown-model",
+        "stop_sequence": None,
+        "usage": _usage(response.usage),
+        "content": _content(response.content),
+        "stop_reason": _STOP_REASON[response.finish],
+    }
+
+
+def _content(content: Block[ContentBlock]) -> list[PlainJson]:
+    return [
+        *_thinking_blocks(content),
+        *_text_blocks(content),
+        *_tool_use_blocks(content),
+    ]
+
+
+def _thinking_blocks(content: Block[ContentBlock]) -> list[PlainJson]:
+    blocks: list[PlainJson] = []
+    for block in content:
+        # blocks is a local build-then-freeze accumulator; it never escapes
+        if block.tag == "thinking":
+            signature = block.thinking.signature.default_value(None)
+            blocks.append(  # nosemgrep: translation-no-mutation
+                {
+                    "type": "thinking",
+                    "thinking": block.thinking.thinking,
+                    "signature": signature,
+                }
+            )
+        elif block.tag == "redacted_thinking":
+            blocks.append(  # nosemgrep: translation-no-mutation
+                {
+                    "type": "redacted_thinking",
+                    "data": block.redacted_thinking.data,
+                }
+            )
+    return blocks
+
+
+def _text_blocks(content: Block[ContentBlock]) -> list[PlainJson]:
+    return [
+        {"type": "text", "text": block.text.text}
+        for block in content
+        if block.tag == "text"
+    ]
+
+
+def _tool_use_blocks(content: Block[ContentBlock]) -> list[PlainJson]:
+    blocks: list[PlainJson] = []
+    for block in content:
+        if block.tag != "tool_use":
+            continue
+        identifier = block.tool_use.id
+        base_id = identifier.split(_THOUGHT_SIGNATURE_SEPARATOR, 1)[0]
+        entry: dict[str, PlainJson] = {
+            "type": "tool_use",
+            "id": base_id,
+            "name": block.tool_use.name,
+            "input": block.tool_use.arguments.value,
+        }
+        blocks.append(entry)  # nosemgrep: translation-no-mutation
+    return blocks
+
+
+def _usage(usage: ResponseUsage) -> dict[str, PlainJson]:
+    result: dict[str, PlainJson] = {
+        "input_tokens": usage.input_tokens + usage.cache_creation_input_tokens,
+        "output_tokens": usage.output_tokens,
+    }
+    if usage.cache_creation_input_tokens > 0:
+        result = {
+            **result,
+            "cache_creation_input_tokens": usage.cache_creation_input_tokens,
+        }
+    if usage.cache_read_input_tokens > 0:
+        result = {
+            **result,
+            "cache_read_input_tokens": usage.cache_read_input_tokens,
+        }
+    return result

--- a/litellm/translation/inbound/anthropic_messages/schema.py
+++ b/litellm/translation/inbound/anthropic_messages/schema.py
@@ -1,0 +1,181 @@
+"""Frozen pydantic v2 wire models for the Anthropic Messages request.
+
+The fail-closed allowlist (every model ``extra="forbid"`` and ``strict=True``):
+a field the schema does not name is a typed error and the seam falls back to
+v1, never a silent drop. The divergence from the OpenAI chat schema this
+package mirrors: ``max_tokens`` is REQUIRED (Anthropic rejects a request
+without it; v1's adapter raises), ``system`` is ``str | list[block]``, stop
+sequences ride the ``stop_sequences`` key, and ``tool_choice``/``thinking`` are
+the Anthropic unions.
+
+Fields v1 serves through paths the chat IR cannot carry (documents, hosted
+tools, ``output_format``/``output_config``, ``mcp_servers``, ``container``,
+metadata beyond ``user_id``, ``thinking.summary``, version/beta envelope) are
+accepted as ``object`` here and rejected with ``unsupported`` in ``parse`` when
+present, so they fall back to v1 instead of being lost (researcher-6 §1.4/§1.5).
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+Sampling = int | float
+
+
+class WireModel(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", strict=True)
+
+
+class CacheControlIn(WireModel):
+    type: Literal["ephemeral"]
+    ttl: str | None = None
+
+
+class TextBlockIn(WireModel):
+    type: Literal["text"]
+    text: str
+    cache_control: CacheControlIn | None = None
+
+
+class Base64SourceIn(WireModel):
+    type: Literal["base64"]
+    media_type: str
+    data: str
+
+
+class UrlSourceIn(WireModel):
+    type: Literal["url"]
+    url: str
+
+
+class ImageBlockIn(WireModel):
+    type: Literal["image"]
+    source: Base64SourceIn | UrlSourceIn | object
+    cache_control: CacheControlIn | None = None
+
+
+class ToolResultContentTextIn(WireModel):
+    type: Literal["text"]
+    text: str
+    cache_control: CacheControlIn | None = None
+
+
+class ToolResultBlockIn(WireModel):
+    type: Literal["tool_result"]
+    tool_use_id: str
+    content: str | list[ToolResultContentTextIn | object] | None = None
+    is_error: bool | None = None
+    cache_control: CacheControlIn | None = None
+
+
+UserBlockIn = Annotated[
+    TextBlockIn | ImageBlockIn | ToolResultBlockIn,
+    Field(discriminator="type"),
+]
+
+
+class ToolUseBlockIn(WireModel):
+    type: Literal["tool_use"]
+    id: str
+    name: str
+    input: object
+    cache_control: CacheControlIn | None = None
+    caller: object | None = None
+
+
+class ThinkingBlockIn(WireModel):
+    type: Literal["thinking"]
+    thinking: str
+    signature: str | None = None
+    cache_control: CacheControlIn | None = None
+
+
+class RedactedThinkingBlockIn(WireModel):
+    type: Literal["redacted_thinking"]
+    data: str
+
+
+AssistantBlockIn = Annotated[
+    TextBlockIn | ToolUseBlockIn | ThinkingBlockIn | RedactedThinkingBlockIn,
+    Field(discriminator="type"),
+]
+
+
+class UserMessageIn(WireModel):
+    role: Literal["user"]
+    content: str | list[UserBlockIn]
+
+
+class AssistantMessageIn(WireModel):
+    role: Literal["assistant"]
+    content: str | list[AssistantBlockIn]
+    name: str | None = None
+
+
+MessageIn = Annotated[
+    UserMessageIn | AssistantMessageIn,
+    Field(discriminator="role"),
+]
+
+
+class SystemTextBlockIn(WireModel):
+    type: str
+    text: str | None = None
+    cache_control: CacheControlIn | None = None
+
+
+class ToolIn(WireModel):
+    name: str
+    description: str | None = None
+    input_schema: object | None = None
+    type: Literal["custom"] | None = None
+    cache_control: CacheControlIn | None = None
+    defer_loading: object | None = None
+    allowed_callers: object | None = None
+    input_examples: object | None = None
+
+
+class ToolChoiceIn(WireModel):
+    type: Literal["auto", "any", "tool", "none"]
+    name: str | None = None
+    disable_parallel_tool_use: bool | None = None
+
+
+class ThinkingIn(WireModel):
+    type: Literal["enabled", "disabled", "adaptive"]
+    budget_tokens: int | None = None
+    summary: object | None = None
+
+
+class MetadataIn(WireModel):
+    user_id: str | None = None
+
+
+class AnthropicMessagesRequestIn(WireModel):
+    model: str
+    messages: list[MessageIn]
+    max_tokens: int
+    system: str | list[SystemTextBlockIn] | None = None
+    stop_sequences: list[str] | None = None
+    stream: bool | None = None
+    temperature: Sampling | None = None
+    top_p: Sampling | None = None
+    top_k: Sampling | None = None
+    tools: list[ToolIn] | None = None
+    tool_choice: ToolChoiceIn | None = None
+    thinking: ThinkingIn | None = None
+    metadata: MetadataIn | None = None
+    # Accepted-as-object then rejected in parse when present (each names its
+    # v1 path); the chat IR has no home for any of these (researcher-6 §1.5).
+    output_format: object | None = None
+    output_config: object | None = None
+    mcp_servers: object | None = None
+    container: object | None = None
+    context_management: object | None = None
+    reasoning_effort: object | None = None
+    inference_geo: object | None = None
+    speed: object | None = None
+    cache_control: object | None = None
+    service_tier: object | None = None

--- a/litellm/translation/inbound/anthropic_messages/stream.py
+++ b/litellm/translation/inbound/anthropic_messages/stream.py
@@ -49,6 +49,9 @@ class StreamState:
     message_started: bool = False
     open_index: int | None = None
     open_type: _BlockType | None = None
+    input_tokens: int = 0
+    cache_creation_input_tokens: int = 0
+    cache_read_input_tokens: int = 0
 
 
 def initial_state() -> StreamState:
@@ -132,7 +135,17 @@ def _start(state: StreamState, event: StreamEvent) -> _StepResult:
             },
         },
     }
-    return replace(state, message_started=True), (message_start,)
+    # v1's wrapper zeroes message_start usage (the cache-support signal) and
+    # merges the real input usage into message_delta from the final chunk; the
+    # IR carries that input usage on StreamStart, so accumulate it here.
+    next_state = replace(
+        state,
+        message_started=True,
+        input_tokens=start.usage.input_tokens,
+        cache_creation_input_tokens=start.usage.cache_creation_input_tokens,
+        cache_read_input_tokens=start.usage.cache_read_input_tokens,
+    )
+    return next_state, (message_start,)
 
 
 def _tool_use_start(state: StreamState, event: StreamEvent) -> _StepResult:
@@ -210,10 +223,21 @@ def _close_open_block(
 def _finish(state: StreamState, event: StreamEvent) -> _StepResult:
     closed_state, close_events = _close_open_block(state)
     finish = event.finish
+    usage: SseEvent = {
+        "input_tokens": state.input_tokens + state.cache_creation_input_tokens,
+        "output_tokens": finish.output_tokens,
+    }
+    if state.cache_creation_input_tokens > 0:
+        usage = {
+            **usage,
+            "cache_creation_input_tokens": state.cache_creation_input_tokens,
+        }
+    if state.cache_read_input_tokens > 0:
+        usage = {**usage, "cache_read_input_tokens": state.cache_read_input_tokens}
     message_delta: SseEvent = {
         "type": "message_delta",
         "delta": {"stop_reason": _STOP_REASON[finish.finish]},
-        "usage": {"input_tokens": 0, "output_tokens": finish.output_tokens},
+        "usage": usage,
     }
     return closed_state, (*close_events, message_delta)
 

--- a/litellm/translation/inbound/anthropic_messages/stream.py
+++ b/litellm/translation/inbound/anthropic_messages/stream.py
@@ -1,0 +1,228 @@
+"""IR ``StreamEvent`` -> Anthropic Messages SSE events (a pure fold).
+
+The reverse of the request stream: a provider's stream parser emits IR
+``StreamEvent``s (already in Anthropic order, because the stream IR mirrors
+Anthropic's SSE shape), and this fold re-encodes them into the Anthropic
+Messages event dicts a ``/v1/messages`` client expects:
+
+    message_start
+      content_block_start / content_block_delta* / content_block_stop  (xN)
+    message_delta (stop_reason + usage)
+    message_stop
+
+This does NOT port v1's hold-and-merge state machine
+(``AnthropicStreamWrapper``); the provider parsers already order the events,
+so the fold only owns the block-index bookkeeping: lazy-open the content block
+on the first delta of each block (closing the previous block with
+``content_block_stop`` on a block switch), and close the open block before
+``message_delta``. The IR delta ``index`` is the Anthropic block index (the
+anthropic provider parser carries it through verbatim), so a switch is
+detected by an index change; ``tool_use_start`` is the explicit open signal
+for a tool block (text/thinking blocks open implicitly on their first delta).
+
+``message_start`` carries the zeroed initial usage v1 emits to signal cache
+support; the real token counts ride ``message_delta`` at the end. The fold
+emits event dicts; the ``event: <type>\\ndata: <json>\\n\\n`` SSE framing is
+identical to v1's and applied above the fold.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, replace
+from types import MappingProxyType
+from typing import Literal
+
+from expression.collections import Block
+from typing_extensions import assert_never
+
+from ...errors import BoundaryError, TranslationError
+from ...ir import FinishReason, PlainJson, StreamEvent
+
+SseEvent = dict[str, PlainJson]
+
+_BlockType = Literal["text", "thinking", "tool_use"]
+
+
+@dataclass(frozen=True)
+class StreamState:
+    message_started: bool = False
+    open_index: int | None = None
+    open_type: _BlockType | None = None
+
+
+def initial_state() -> StreamState:
+    return StreamState()
+
+
+_StepResult = tuple[StreamState, tuple[SseEvent, ...]] | TranslationError
+
+
+def step(state: StreamState, event: StreamEvent) -> _StepResult:
+    match event.tag:
+        case "start":
+            return _start(state, event)
+        case "text_delta":
+            return _content_delta(
+                state,
+                event.text_delta.index,
+                "text",
+                {"type": "text_delta", "text": event.text_delta.text},
+            )
+        case "tool_use_start":
+            return _tool_use_start(state, event)
+        case "tool_args_delta":
+            return _tool_args_delta(state, event)
+        case "thinking_delta":
+            return _content_delta(
+                state,
+                event.thinking_delta.index,
+                "thinking",
+                {"type": "thinking_delta", "thinking": event.thinking_delta.thinking},
+            )
+        case "signature_delta":
+            return _content_delta(
+                state,
+                event.signature_delta.index,
+                "thinking",
+                {
+                    "type": "signature_delta",
+                    "signature": event.signature_delta.signature,
+                },
+            )
+        case "finish":
+            return _finish(state, event)
+        case "stop":
+            return state, ({"type": "message_stop"},)
+        case "wire_chunk" | "chunk":
+            return _wrong_event(event.tag)
+    assert_never(event.tag)
+
+
+def _wrong_event(event_tag: str) -> TranslationError:
+    return TranslationError.of_boundary(
+        BoundaryError.of(
+            Block.of_seq(
+                [
+                    f"anthropic_messages stream fold received a {event_tag} event its"
+                    " provider parser can never emit; dialect/parser mismatch"
+                ]
+            )
+        )
+    )
+
+
+def _start(state: StreamState, event: StreamEvent) -> _StepResult:
+    start = event.start
+    message_start: SseEvent = {
+        "type": "message_start",
+        "message": {
+            "id": start.id,
+            "type": "message",
+            "role": "assistant",
+            "content": [],
+            "model": start.model,
+            "stop_reason": None,
+            "stop_sequence": None,
+            "usage": {
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "cache_creation_input_tokens": 0,
+                "cache_read_input_tokens": 0,
+            },
+        },
+    }
+    return replace(state, message_started=True), (message_start,)
+
+
+def _tool_use_start(state: StreamState, event: StreamEvent) -> _StepResult:
+    tool = event.tool_use_start
+    next_state, prefix = _close_open_block(state)
+    opened = replace(next_state, open_index=tool.index, open_type="tool_use")
+    start_event: SseEvent = {
+        "type": "content_block_start",
+        "index": tool.index,
+        "content_block": {
+            "type": "tool_use",
+            "id": tool.id,
+            "name": tool.name,
+            "input": {},
+        },
+    }
+    return opened, (*prefix, start_event)
+
+
+def _tool_args_delta(state: StreamState, event: StreamEvent) -> _StepResult:
+    delta = event.tool_args_delta
+    if state.open_index != delta.index or state.open_type != "tool_use":
+        # The anthropic IR always emits tool_use_start before its args; an
+        # args delta for an unopened tool block is a parser/ordering bug and
+        # must be loud (we cannot synthesize the missing id/name).
+        return _wrong_event("tool_args_delta without a matching tool_use_start")
+    delta_event: SseEvent = {
+        "type": "content_block_delta",
+        "index": delta.index,
+        "delta": {"type": "input_json_delta", "partial_json": delta.partial_json},
+    }
+    return state, (delta_event,)
+
+
+def _content_delta(
+    state: StreamState, index: int, block_type: _BlockType, delta: SseEvent
+) -> _StepResult:
+    next_state, prefix = _ensure_open_block(state, index, block_type)
+    delta_event: SseEvent = {
+        "type": "content_block_delta",
+        "index": index,
+        "delta": delta,
+    }
+    return next_state, (*prefix, delta_event)
+
+
+def _ensure_open_block(
+    state: StreamState, index: int, block_type: _BlockType
+) -> tuple[StreamState, tuple[SseEvent, ...]]:
+    if state.open_index == index and state.open_type == block_type:
+        return state, ()
+    closed_state, close_events = _close_open_block(state)
+    opened = replace(closed_state, open_index=index, open_type=block_type)
+    return opened, (*close_events, _content_block_start(index, block_type))
+
+
+def _content_block_start(index: int, block_type: _BlockType) -> SseEvent:
+    block: PlainJson = (
+        {"type": "thinking", "thinking": "", "signature": ""}
+        if block_type == "thinking"
+        else {"type": "text", "text": ""}
+    )
+    return {"type": "content_block_start", "index": index, "content_block": block}
+
+
+def _close_open_block(
+    state: StreamState,
+) -> tuple[StreamState, tuple[SseEvent, ...]]:
+    if state.open_index is None:
+        return state, ()
+    stop_event: SseEvent = {"type": "content_block_stop", "index": state.open_index}
+    return replace(state, open_index=None, open_type=None), (stop_event,)
+
+
+def _finish(state: StreamState, event: StreamEvent) -> _StepResult:
+    closed_state, close_events = _close_open_block(state)
+    finish = event.finish
+    message_delta: SseEvent = {
+        "type": "message_delta",
+        "delta": {"stop_reason": _STOP_REASON[finish.finish]},
+        "usage": {"input_tokens": 0, "output_tokens": finish.output_tokens},
+    }
+    return closed_state, (*close_events, message_delta)
+
+
+_STOP_REASON: Mapping[FinishReason, str] = MappingProxyType(
+    {
+        "stop": "end_turn",
+        "length": "max_tokens",
+        "tool_calls": "tool_use",
+        "content_filter": "end_turn",
+    }
+)

--- a/litellm/translation/inbound/responses/__init__.py
+++ b/litellm/translation/inbound/responses/__init__.py
@@ -1,0 +1,5 @@
+"""OpenAI Responses (/v1/responses) inbound schema."""
+
+from .parse import parse_request
+
+__all__ = ("parse_request",)

--- a/litellm/translation/inbound/responses/input_items.py
+++ b/litellm/translation/inbound/responses/input_items.py
@@ -1,0 +1,244 @@
+"""Responses ``input`` list -> IR messages.
+
+The input list is a polymorphic item union; this module dispatches each item by
+its tag (a match over the typed union, never a nested if-chain) and folds it
+into IR ``Message``s. Served items: a ``message`` (text/image content), a
+``function_call`` (an assistant ``ToolUse`` block; consecutive function_calls
+merge into one assistant message, the Anthropic-one-turn rule the IR already
+honors), and a ``function_call_output``/``tool_result`` (a ``ToolResult`` block
+in a user message). Items the chat IR cannot carry fail closed so the seam
+falls back to v1 (researcher-6 §2.4/§2.5):
+
+- ``reasoning`` input items (carry summary/encrypted_content/id for replay),
+- ``item_reference`` (needs ``previous_response_id`` session state),
+- ``input_file`` content parts (the IR has no document/file block),
+- a ``function_call_output`` whose ``call_id`` matches no tool_use in THIS
+  request (v1 reconstructs the missing tool_use from the module-level
+  ``TOOL_CALLS_CACHE``, cross-request state v2 must not reproduce).
+
+Hot path note (mirrors openai_chat/messages.py): internal helpers return
+``value | TranslationError`` plain unions and build local lists, lifting into
+``Result``/``Block`` once at the public boundary.
+"""
+
+from __future__ import annotations
+
+from expression import Error, Nothing, Ok, Result, Some
+from expression.collections import Block
+
+from ... import boundary
+from ...errors import TranslationError
+from ...ir import (
+    Base64Source,
+    ContentBlock,
+    Image,
+    ImageSource,
+    JsonBlob,
+    Message,
+    Text,
+    ToolResult,
+    ToolResultContent,
+    ToolUse,
+    UrlSource,
+)
+from .schema import (
+    FunctionCallItemIn,
+    FunctionCallOutputItemIn,
+    ImageUrlContentIn,
+    InputFileContentIn,
+    InputItemIn,
+    InputTextContentIn,
+    ItemReferenceIn,
+    MessageItemIn,
+    ReasoningItemIn,
+)
+
+_NO_CACHE = Nothing
+
+_ConvertResult = Result[Block[Message], TranslationError]
+
+
+def convert_string_input(text: str) -> Block[Message]:
+    block = ContentBlock.of_text(Text(text=text, cache=_NO_CACHE))
+    return Block.of_seq([Message(role="user", content=Block.of_seq([block]))])
+
+
+def convert_input_items(items: list[InputItemIn]) -> _ConvertResult:
+    messages: list[Message] = []
+    tool_call_ids: set[str] = set()
+    for item in items:
+        step = _convert_item(item, messages, tool_call_ids)
+        if isinstance(step, TranslationError):
+            return Error(step)
+    return Ok(Block.of_seq(messages))
+
+
+def _convert_item(
+    item: InputItemIn, messages: list[Message], tool_call_ids: set[str]
+) -> None | TranslationError:
+    if isinstance(item, ReasoningItemIn):
+        return TranslationError.of_unsupported(
+            "responses reasoning input items (summary/encrypted_content); v1 handles them"
+        )
+    if isinstance(item, ItemReferenceIn):
+        return TranslationError.of_unsupported(
+            "responses item_reference; needs previous_response_id session state"
+        )
+    if isinstance(item, FunctionCallItemIn):
+        return _append_function_call(item, messages, tool_call_ids)
+    if isinstance(item, FunctionCallOutputItemIn):
+        return _append_function_call_output(item, messages, tool_call_ids)
+    return _append_message(item, messages)
+
+
+def _append_function_call(
+    item: FunctionCallItemIn, messages: list[Message], tool_call_ids: set[str]
+) -> None | TranslationError:
+    call_id = item.call_id or item.id or ""
+    tool_use = _tool_use(item, call_id)
+    if isinstance(tool_use, TranslationError):
+        return tool_use
+    if call_id:
+        tool_call_ids.add(call_id)  # nosemgrep: translation-no-mutation
+    # Merge consecutive function_calls into the trailing assistant message (v1's
+    # Anthropic-one-turn rule, transformation.py:400); the IR's assistant turn
+    # carries every tool_use block, so an append onto the last assistant turn.
+    block = ContentBlock.of_tool_use(tool_use)
+    if messages and messages[-1].role == "assistant":
+        last = messages[-1]
+        merged = Message(role="assistant", content=last.content + Block.of_seq([block]))
+        messages[-1] = merged  # nosemgrep: translation-no-mutation
+        return None
+    messages.append(  # nosemgrep: translation-no-mutation
+        Message(role="assistant", content=Block.of_seq([block]))
+    )
+    return None
+
+
+def _tool_use(item: FunctionCallItemIn, call_id: str) -> ToolUse | TranslationError:
+    arguments = item.arguments or ""
+    match boundary.as_plain_json(_loads_or_self(arguments)):
+        case Result(tag="ok", ok=copied) if isinstance(copied, dict):
+            blob = JsonBlob(value=copied)
+        case Result(tag="ok"):
+            return TranslationError.of_unsupported(
+                "responses function_call with non-object arguments; v1 handles it"
+            )
+        case Result(error=reason):
+            return TranslationError.of_unsupported(
+                f"responses function_call arguments: {reason}"
+            )
+    return ToolUse(
+        id=call_id,
+        name=item.name or "",
+        arguments=blob,
+        cache=_NO_CACHE,
+        arguments_raw=Some(arguments),
+    )
+
+
+def _loads_or_self(arguments: str) -> object:
+    import json
+
+    try:
+        return json.loads(arguments) if arguments else {}
+    except ValueError:
+        return arguments
+
+
+def _append_function_call_output(
+    item: FunctionCallOutputItemIn, messages: list[Message], tool_call_ids: set[str]
+) -> None | TranslationError:
+    if not item.call_id:
+        return TranslationError.of_unsupported(
+            "responses function_call_output with empty call_id; v1 drops it"
+        )
+    if item.call_id not in tool_call_ids:
+        # v1 reconstructs the matching tool_use from the cross-request
+        # TOOL_CALLS_CACHE (transformation.py:1121); that module-level state is
+        # banned and unreproducible, so fail closed when the pair is not local.
+        return TranslationError.of_unsupported(
+            "responses function_call_output without a matching function_call in"
+            " this request; v1 reconstructs it from TOOL_CALLS_CACHE"
+        )
+    result = ToolResult(
+        tool_use_id=item.call_id,
+        content=ToolResultContent.of_text(item.output or ""),
+        cache=_NO_CACHE,
+    )
+    messages.append(  # nosemgrep: translation-no-mutation
+        Message(
+            role="user", content=Block.of_seq([ContentBlock.of_tool_result(result)])
+        )
+    )
+    return None
+
+
+def _append_message(
+    item: MessageItemIn, messages: list[Message]
+) -> None | TranslationError:
+    blocks = _message_blocks(item)
+    if isinstance(blocks, TranslationError):
+        return blocks
+    if not blocks:
+        return None
+    role = "assistant" if item.role == "assistant" else "user"
+    messages.append(  # nosemgrep: translation-no-mutation
+        Message(role=role, content=Block.of_seq(blocks))
+    )
+    return None
+
+
+def _message_blocks(item: MessageItemIn) -> list[ContentBlock] | TranslationError:
+    if isinstance(item.content, str):
+        return [ContentBlock.of_text(Text(text=item.content, cache=_NO_CACHE))]
+    blocks: list[ContentBlock] = []
+    for part in item.content:
+        block = _content_part(part)
+        if isinstance(block, TranslationError):
+            return block
+        blocks.append(block)  # nosemgrep: translation-no-mutation
+    return blocks
+
+
+def _content_part(
+    part: InputTextContentIn | ImageUrlContentIn | InputFileContentIn,
+) -> ContentBlock | TranslationError:
+    if isinstance(part, InputFileContentIn):
+        return TranslationError.of_unsupported(
+            "responses input_file content; the IR has no document block, v1 handles it"
+        )
+    if isinstance(part, ImageUrlContentIn):
+        return _image(part)
+    if part.text is None:
+        return TranslationError.of_unsupported(
+            "responses message content part with null text; v1 drops it"
+        )
+    return ContentBlock.of_text(Text(text=part.text, cache=_NO_CACHE))
+
+
+def _image(part: ImageUrlContentIn) -> ContentBlock | TranslationError:
+    if part.file_id is not None:
+        return TranslationError.of_unsupported(
+            "responses input_image by file_id; v1 handles it"
+        )
+    url = part.image_url or ""
+    if url.startswith("data:"):
+        decoded = _data_url(url)
+        if isinstance(decoded, TranslationError):
+            return decoded
+        media_type, data = decoded
+        source = ImageSource.of_base64(Base64Source(media_type=media_type, data=data))
+        return ContentBlock.of_image(Image(source=source, cache=_NO_CACHE))
+    source = ImageSource.of_url(UrlSource(url=url, format=Nothing))
+    return ContentBlock.of_image(Image(source=source, cache=_NO_CACHE))
+
+
+def _data_url(url: str) -> tuple[str, str] | TranslationError:
+    header, _, data = url.partition(",")
+    if not data or ";base64" not in header:
+        return TranslationError.of_unsupported(
+            "responses input_image data URL not base64-encoded; v1 handles it"
+        )
+    media_type = header[len("data:") :].split(";", 1)[0]
+    return media_type, data

--- a/litellm/translation/inbound/responses/input_items.py
+++ b/litellm/translation/inbound/responses/input_items.py
@@ -154,12 +154,16 @@ def _append_function_call_output(
             "responses function_call_output with empty call_id; v1 drops it"
         )
     if item.call_id not in tool_call_ids:
-        # v1 reconstructs the matching tool_use from the cross-request
-        # TOOL_CALLS_CACHE (transformation.py:1121); that module-level state is
-        # banned and unreproducible, so fail closed when the pair is not local.
+        # When the call_id is in the cross-request TOOL_CALLS_CACHE v1
+        # reconstructs the matching tool_use from it (transformation.py:1121);
+        # when the cache is empty (the common case) v1 serves a bare orphan
+        # tool message with no preceding tool_use. Both rely on state outside
+        # this request (banned module-level cache) or emit a lossy orphan, so
+        # fail closed when the pair is not local to the request.
         return TranslationError.of_unsupported(
             "responses function_call_output without a matching function_call in"
-            " this request; v1 reconstructs it from TOOL_CALLS_CACHE"
+            " this request; v1 serves it from the TOOL_CALLS_CACHE or as a bare"
+            " orphan tool message"
         )
     result = ToolResult(
         tool_use_id=item.call_id,
@@ -177,12 +181,17 @@ def _append_function_call_output(
 def _append_message(
     item: MessageItemIn, messages: list[Message]
 ) -> None | TranslationError:
+    role = item.role or "user"
+    if role not in ("user", "assistant"):
+        return TranslationError.of_unsupported(
+            f"responses message item with role {role!r}; the chat IR carries"
+            " only user/assistant turns, v1 forwards it verbatim"
+        )
     blocks = _message_blocks(item)
     if isinstance(blocks, TranslationError):
         return blocks
     if not blocks:
         return None
-    role = "assistant" if item.role == "assistant" else "user"
     messages.append(  # nosemgrep: translation-no-mutation
         Message(role=role, content=Block.of_seq(blocks))
     )

--- a/litellm/translation/inbound/responses/parse.py
+++ b/litellm/translation/inbound/responses/parse.py
@@ -1,0 +1,295 @@
+"""Parse an OpenAI Responses request body into the chat IR.
+
+``boundary.parse`` validates the untyped body against the frozen wire models;
+this module converts the validated models into IR values and applies the
+residual fail-closed checks (every field v1 serves through an unported path
+becomes an ``unsupported`` naming that path, never a silent drop). Top-level
+``null`` fields are stripped first, matching the seam's treatment of an
+explicit ``null`` as an absent parameter.
+
+Forward map (researcher-6 §2.1): ``input`` -> messages (per-item dispatch in
+``input_items``), ``instructions`` -> system, function ``tools`` -> ToolDef,
+``tool_choice`` -> ToolChoice (incl. the Cursor ``{type:tool/any}`` -> required
+normalization), ``reasoning.effort`` -> ReasoningEffort, ``max_output_tokens``
+-> max_tokens, ``text.format`` -> response_format, temperature/top_p/
+parallel_tool_calls/user verbatim. The wide must-fall-back surface
+(previous_response_id, store/background, hosted tools, MCP, reasoning summary,
+metadata, include, service_tier) is named in ``_UNPORTED_FIELDS`` and the
+per-item / per-tool checks below.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TypeVar
+
+from expression import Error, Nothing, Ok, Option, Result, Some
+from expression.collections import Block
+
+from ... import boundary
+from ...errors import ParseResult, TranslationError
+from ...ir import (
+    ChatRequest,
+    InferenceParams,
+    JsonBlob,
+    JsonSchemaSpec,
+    Message,
+    ReasoningEffort,
+    ResponseFormat,
+    SystemText,
+    ToolChoice,
+    ToolDef,
+)
+from .input_items import convert_input_items, convert_string_input
+from .schema import (
+    FunctionToolIn,
+    ReasoningIn,
+    ResponsesRequestIn,
+    TextFormatIn,
+    TextIn,
+    ToolChoiceNamedIn,
+)
+
+_T = TypeVar("_T")
+
+_UNPORTED_FIELDS: tuple[tuple[str, str], ...] = (
+    ("previous_response_id", "responses previous_response_id; needs session state"),
+    ("metadata", "responses metadata; no chat-IR home"),
+    ("service_tier", "responses service_tier passthrough"),
+    ("include", "responses include[]"),
+    ("store", "responses store (server-side persistence)"),
+    ("background", "responses background (polling)"),
+    ("truncation", "responses truncation"),
+)
+
+
+def parse_request(raw: Mapping[str, object]) -> ParseResult:
+    present = {key: value for key, value in raw.items() if value is not None}
+    match boundary.parse(ResponsesRequestIn, present):
+        case Result(tag="ok", ok=wire):
+            return _to_ir(wire)
+        case Result(error=err):
+            return Error(err)
+
+
+def _to_ir(wire: ResponsesRequestIn) -> ParseResult:
+    unported = _unported_error(wire)
+    if unported is not None:
+        return Error(unported)
+    match _parse_messages(wire):
+        case Result(tag="ok", ok=messages):
+            pass
+        case Result(error=messages_err):
+            return Error(messages_err)
+    match _parse_tools(wire.tools):
+        case Result(tag="ok", ok=tools):
+            pass
+        case Result(error=tools_err):
+            return Error(tools_err)
+    match _parse_response_format(wire.text):
+        case Result(tag="ok", ok=response_format):
+            pass
+        case Result(error=text_err):
+            return Error(text_err)
+    match _parse_reasoning(wire.reasoning):
+        case Result(tag="ok", ok=reasoning_effort):
+            pass
+        case Result(error=reasoning_err):
+            return Error(reasoning_err)
+    return Ok(
+        ChatRequest(
+            model=wire.model,
+            system=_system(wire.instructions),
+            messages=messages,
+            tools=tools,
+            tool_choice=_parse_tool_choice(wire.tool_choice),
+            parallel_tool_calls=_option(wire.parallel_tool_calls),
+            response_format=response_format,
+            thinking=Nothing,
+            reasoning_effort=reasoning_effort,
+            user=_option(wire.user),
+            params=_parse_params(wire),
+            stream=wire.stream is True,
+        )
+    )
+
+
+def _unported_error(wire: ResponsesRequestIn) -> TranslationError | None:
+    for field, reason in _UNPORTED_FIELDS:
+        if getattr(wire, field) is not None:
+            return TranslationError.of_unsupported(f"{reason}; v1 handles it")
+    return None
+
+
+def _option(value: _T | None) -> Option[_T]:
+    return Some(value) if value is not None else Nothing
+
+
+def _system(instructions: str | None) -> Block[SystemText]:
+    if instructions is None:
+        return Block.empty()
+    return Block.of_seq([SystemText(text=instructions, cache=Nothing)])
+
+
+def _parse_messages(
+    wire: ResponsesRequestIn,
+) -> Result[Block[Message], TranslationError]:
+    if isinstance(wire.input, str):
+        return Ok(convert_string_input(wire.input))
+    return convert_input_items(wire.input)
+
+
+def _parse_tools(
+    tools: list[FunctionToolIn | object] | None,
+) -> Result[Block[ToolDef], TranslationError]:
+    if tools is None:
+        return Ok(Block.empty())
+    defs: list[ToolDef] = []
+    for tool in tools:
+        if not isinstance(tool, FunctionToolIn):
+            return Error(
+                TranslationError.of_unsupported(
+                    "responses hosted tools (web_search/file_search/computer_use/"
+                    "code_interpreter/image_generation/mcp); v1 handles them"
+                )
+            )
+        match _parse_tool(tool):
+            case Result(tag="ok", ok=tool_def):
+                defs.append(tool_def)  # nosemgrep: translation-no-mutation
+            case Result(error=err):
+                return Error(err)
+    return Ok(Block.of_seq(defs))
+
+
+def _parse_tool(tool: FunctionToolIn) -> Result[ToolDef, TranslationError]:
+    extras = (tool.defer_loading, tool.allowed_callers, tool.input_examples)
+    if any(extra is not None for extra in extras):
+        return Error(
+            TranslationError.of_unsupported(
+                "tool defer_loading/allowed_callers/input_examples; v1 handles them"
+            )
+        )
+    if tool.cache_control is not None:
+        return Error(
+            TranslationError.of_unsupported(
+                "responses tool cache_control; v1 handles it"
+            )
+        )
+    match _parse_parameters(tool.parameters):
+        case Result(tag="ok", ok=parameters):
+            return Ok(
+                ToolDef(
+                    name=tool.name,
+                    description=_option(tool.description),
+                    parameters=parameters,
+                    cache=Nothing,
+                    strict=_option(tool.strict),
+                )
+            )
+        case Result(error=err):
+            return Error(err)
+
+
+def _parse_parameters(
+    parameters: object | None,
+) -> Result[Option[JsonBlob], TranslationError]:
+    if parameters is None:
+        return Ok(Nothing)
+    match boundary.as_plain_json(parameters):
+        case Result(tag="ok", ok=copied) if isinstance(copied, dict):
+            return Ok(Some(JsonBlob(value=copied)))
+        case Result(tag="ok"):
+            return Error(
+                TranslationError.of_unsupported(
+                    "non-object tool parameters; v1 handles it"
+                )
+            )
+        case Result(error=reason):
+            return Error(TranslationError.of_unsupported(f"tool parameters: {reason}"))
+
+
+def _parse_tool_choice(choice: str | ToolChoiceNamedIn | None) -> Option[ToolChoice]:
+    if choice is None:
+        return Nothing
+    if isinstance(choice, str):
+        return _named_tool_choice(choice, None)
+    return _named_tool_choice(choice.type, choice.name)
+
+
+def _named_tool_choice(kind: str, name: str | None) -> Option[ToolChoice]:
+    if kind == "auto":
+        return Some(ToolChoice.of_auto())
+    if kind == "none":
+        return Some(ToolChoice.of_none())
+    if kind in ("required", "tool", "any"):
+        return Some(ToolChoice.of_required())
+    if kind == "function" and name is not None:
+        return Some(ToolChoice.of_specific(name))
+    if kind == "function":
+        return Some(ToolChoice.of_required())
+    return Nothing
+
+
+def _parse_response_format(
+    text: TextIn | None,
+) -> Result[Option[ResponseFormat], TranslationError]:
+    if text is None or text.format is None:
+        return Ok(Nothing)
+    return _format(text.format)
+
+
+def _format(fmt: TextFormatIn) -> Result[Option[ResponseFormat], TranslationError]:
+    if fmt.type == "text":
+        return Ok(Some(ResponseFormat.of_text()))
+    if fmt.type == "json_object":
+        return Ok(Some(ResponseFormat.of_json_object()))
+    return _json_schema(fmt)
+
+
+def _json_schema(fmt: TextFormatIn) -> Result[Option[ResponseFormat], TranslationError]:
+    match boundary.as_plain_json(fmt.schema_ if fmt.schema_ is not None else {}):
+        case Result(tag="ok", ok=copied) if isinstance(copied, dict):
+            spec = JsonSchemaSpec(
+                schema=JsonBlob(value=copied),
+                name=Some(fmt.name if fmt.name is not None else "response_schema"),
+                description=Nothing,
+                strict=Some(fmt.strict if fmt.strict is not None else False),
+            )
+            return Ok(Some(ResponseFormat.of_json_schema(spec)))
+        case Result(tag="ok"):
+            return Error(
+                TranslationError.of_unsupported(
+                    "responses text.format json_schema with non-object schema; v1 handles it"
+                )
+            )
+        case Result(error=reason):
+            return Error(
+                TranslationError.of_unsupported(f"text.format schema: {reason}")
+            )
+
+
+def _parse_reasoning(
+    reasoning: ReasoningIn | None,
+) -> Result[Option[ReasoningEffort], TranslationError]:
+    if reasoning is None:
+        return Ok(Nothing)
+    if reasoning.summary is not None or reasoning.generate_summary is not None:
+        return Error(
+            TranslationError.of_unsupported(
+                "responses reasoning.summary; v1 handles it"
+            )
+        )
+    if reasoning.effort is None:
+        return Ok(Nothing)
+    return Ok(Some(reasoning.effort))
+
+
+def _parse_params(wire: ResponsesRequestIn) -> InferenceParams:
+    return InferenceParams(
+        max_tokens=_option(wire.max_output_tokens),
+        temperature=_option(wire.temperature),
+        top_p=_option(wire.top_p),
+        top_k=Nothing,
+        stop=Block.empty(),
+        max_completion_tokens=Nothing,
+    )

--- a/litellm/translation/inbound/responses/response.py
+++ b/litellm/translation/inbound/responses/response.py
@@ -127,13 +127,16 @@ def _reasoning_item(reasoning: str, response: ChatResponse) -> PlainJson:
 
 def _message_item(response: ChatResponse) -> PlainJson:
     text = "".join(block.text.text for block in response.content if block.tag == "text")
+    # The chat message content is `text or None` (v1's anthropic dialect), and
+    # v1's OutputText.text copies it verbatim, so a tool-only / empty turn emits
+    # null text rather than "".
     return {
         "type": "message",
         "id": response.id,
         "status": _STATUS[response.finish],
         "role": "assistant",
         "phase": None,
-        "content": [{"type": "output_text", "text": text, "annotations": []}],
+        "content": [{"type": "output_text", "text": text or None, "annotations": []}],
     }
 
 

--- a/litellm/translation/inbound/responses/response.py
+++ b/litellm/translation/inbound/responses/response.py
@@ -94,17 +94,15 @@ def serialize_response(
 
 
 def _output(response: ChatResponse) -> list[PlainJson]:
-    items: list[PlainJson] = []
     reasoning = _reasoning_text(response.content)
-    if reasoning is not None:
-        items.append(  # nosemgrep: translation-no-mutation
-            _reasoning_item(reasoning, response)
-        )
-    items.append(_message_item(response))  # nosemgrep: translation-no-mutation
-    items.extend(
-        _function_call_items(response.content)
-    )  # nosemgrep: translation-no-mutation
-    return items
+    reasoning_items: list[PlainJson] = (
+        [_reasoning_item(reasoning, response)] if reasoning is not None else []
+    )
+    return [
+        *reasoning_items,
+        _message_item(response),
+        *_function_call_items(response.content),
+    ]
 
 
 def _reasoning_text(content: Block[ContentBlock]) -> str | None:

--- a/litellm/translation/inbound/responses/response.py
+++ b/litellm/translation/inbound/responses/response.py
@@ -1,0 +1,205 @@
+"""IR ``ChatResponse`` -> OpenAI Responses API response body.
+
+The reverse of the request parse: an IR ``ChatResponse`` (produced by any
+provider's ``parse_response``) becomes a ``ResponsesAPIResponse`` body,
+reproducing v1's ``transform_chat_completion_response_to_responses_api_response``
+(transformation.py:1648). The Responses response shape is provider-independent,
+so the ``dialect`` argument the pipeline threads is ignored here.
+
+Output items in v1's order (researcher-6 §2.2): reasoning items first (from
+``Thinking`` blocks, id ``rs_{hash(reasoning)}``), then a message item (from
+``Text`` blocks), then function_call items (from ``ToolUse`` blocks). v1 reads
+the echoed top-level request params off the chat ``ModelResponse`` via
+``getattr`` with defaults; the IR ``ChatResponse`` carries none of them, so the
+serializer emits the same defaults (``temperature=0.0``, ``tool_choice="auto"``,
+``parallel_tool_calls=False``, ``tools=[]``, ``top_p``/``max_output_tokens``
+null). The reasoning-item id is ``rs_{hash(str(reasoning))}`` where ``reasoning``
+is the thinking blocks joined exactly as the chat dialect builds
+``reasoning_content`` (so it matches v1 within a process, where ``hash`` of a
+str is salted identically).
+
+``created_at`` is ``None`` here: the IR ``ChatResponse`` carries no timestamp
+(it is ambient envelope the seam owns, exactly as the chat-completion reverse
+leaves id/created to the ``ModelResponse`` envelope), so the seam stamps it.
+
+``status`` maps stop/tool_calls -> completed, length/content_filter ->
+incomplete (v1's ``_map_chat_completion_finish_reason_to_responses_status``).
+Usage maps onto ``ResponseAPIUsage``: input/output/total verbatim, plus
+``input_tokens_details.cached_tokens`` (with audio/text null) when cache read is
+reported and ``output_tokens_details.reasoning_tokens`` (with text null) when
+the IR carries reasoning tokens. Annotations/citations, image_generation_call
+and code_interpreter_call output items are IR-GAPs the reverse cannot produce
+(they only arise from provider fields the IR does not carry); they are omitted.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from types import MappingProxyType
+
+from expression import Option
+from expression.collections import Block
+
+from ...deps import TranslationDeps
+from ...errors import TranslationError
+from ...ir import (
+    Body,
+    ChatResponse,
+    ContentBlock,
+    FinishReason,
+    PlainJson,
+    ResponseUsage,
+)
+
+_STATUS: Mapping[FinishReason, str] = MappingProxyType(
+    {
+        "stop": "completed",
+        "tool_calls": "completed",
+        "length": "incomplete",
+        "content_filter": "incomplete",
+    }
+)
+
+
+def serialize_response(
+    response: ChatResponse,
+    deps: TranslationDeps,
+    dialect: object = None,
+) -> Body | TranslationError:
+    return {
+        "id": response.id,
+        "created_at": None,
+        "error": None,
+        "incomplete_details": None,
+        "instructions": None,
+        "max_output_tokens": None,
+        "metadata": {},
+        "model": response.model,
+        "object": "response",
+        "output": _output(response),
+        "parallel_tool_calls": False,
+        "previous_response_id": None,
+        "reasoning": None,
+        "status": _STATUS[response.finish],
+        "store": None,
+        "temperature": 0.0,
+        "text": {},
+        "tool_choice": "auto",
+        "tools": [],
+        "top_p": None,
+        "truncation": None,
+        "usage": _usage(response.usage),
+        "user": None,
+    }
+
+
+def _output(response: ChatResponse) -> list[PlainJson]:
+    items: list[PlainJson] = []
+    reasoning = _reasoning_text(response.content)
+    if reasoning is not None:
+        items.append(  # nosemgrep: translation-no-mutation
+            _reasoning_item(reasoning, response)
+        )
+    items.append(_message_item(response))  # nosemgrep: translation-no-mutation
+    items.extend(
+        _function_call_items(response.content)
+    )  # nosemgrep: translation-no-mutation
+    return items
+
+
+def _reasoning_text(content: Block[ContentBlock]) -> str | None:
+    thinking = "".join(
+        block.thinking.thinking for block in content if block.tag == "thinking"
+    )
+    return thinking or None
+
+
+def _reasoning_item(reasoning: str, response: ChatResponse) -> PlainJson:
+    return {
+        "type": "reasoning",
+        "id": f"rs_{hash(str(reasoning))}",
+        "status": _STATUS[response.finish],
+        "role": "assistant",
+        "phase": None,
+        "content": [{"type": "output_text", "text": reasoning, "annotations": []}],
+    }
+
+
+def _message_item(response: ChatResponse) -> PlainJson:
+    text = "".join(block.text.text for block in response.content if block.tag == "text")
+    return {
+        "type": "message",
+        "id": response.id,
+        "status": _STATUS[response.finish],
+        "role": "assistant",
+        "phase": None,
+        "content": [{"type": "output_text", "text": text, "annotations": []}],
+    }
+
+
+def _function_call_items(content: Block[ContentBlock]) -> list[PlainJson]:
+    items: list[PlainJson] = []
+    for block in content:
+        if block.tag != "tool_use":
+            continue
+        items.append(  # nosemgrep: translation-no-mutation
+            {
+                "type": "function_call",
+                "name": block.tool_use.name,
+                "arguments": _arguments(block),
+                "call_id": block.tool_use.id,
+                "id": block.tool_use.id,
+                "namespace": None,
+                "status": "completed",
+            }
+        )
+    return items
+
+
+def _arguments(block: ContentBlock) -> str:
+    import json
+
+    match block.tool_use.arguments_raw:
+        case Option(tag="some", some=raw):
+            return raw
+        case _:
+            return json.dumps(block.tool_use.arguments.value)
+
+
+def _usage(usage: ResponseUsage) -> dict[str, PlainJson]:
+    # v1's responses reverse copies the chat ModelResponse usage verbatim:
+    # input_tokens is the chat prompt_tokens (cache folded in), and the token
+    # details mirror the chat dialect's. Fold cache the way every chat dialect
+    # does so the responses usage matches regardless of upstream provider.
+    prompt_tokens = (
+        usage.input_tokens
+        + usage.cache_creation_input_tokens
+        + usage.cache_read_input_tokens
+    )
+    total = usage.total_tokens.default_value(prompt_tokens + usage.output_tokens)
+    return {
+        "input_tokens": prompt_tokens,
+        "output_tokens": usage.output_tokens,
+        "total_tokens": total,
+        "cost": None,
+        "input_tokens_details": _input_details(usage),
+        "output_tokens_details": _output_details(usage),
+    }
+
+
+def _input_details(usage: ResponseUsage) -> PlainJson:
+    return {
+        "cached_tokens": usage.cache_read_input_tokens,
+        "audio_tokens": None,
+        "text_tokens": usage.input_tokens,
+    }
+
+
+def _output_details(usage: ResponseUsage) -> PlainJson:
+    reasoning_tokens = usage.reasoning_tokens.default_value(0)
+    text_tokens = (
+        usage.output_tokens - reasoning_tokens
+        if reasoning_tokens > 0
+        else usage.output_tokens
+    )
+    return {"reasoning_tokens": reasoning_tokens, "text_tokens": text_tokens}

--- a/litellm/translation/inbound/responses/schema.py
+++ b/litellm/translation/inbound/responses/schema.py
@@ -1,0 +1,165 @@
+"""Frozen pydantic v2 wire models for the OpenAI Responses request.
+
+The fail-closed allowlist (every model ``extra="forbid"`` and ``strict=True``):
+a field the schema does not name is a typed error and the seam falls back to
+v1, never a silent drop. The Responses surface is the v1 supported-param
+allowlist (``get_supported_openai_params``): ``input``, ``instructions``,
+``max_output_tokens``, ``parallel_tool_calls``, ``reasoning``, ``stream``,
+``temperature``, ``text``, ``tool_choice``, ``tools``, ``top_p``, ``user``,
+plus the fields v1 reads but the chat IR cannot carry (``previous_response_id``,
+``metadata``, ``service_tier``, ``include``, ``store``, ``background``), which
+are accepted here and rejected with ``unsupported`` in ``parse`` so they fall
+back to v1 instead of being lost (researcher-6 §2.4/§2.5).
+
+The ``input`` list is a polymorphic item union: a message (``type`` absent or
+``"message"``), a ``function_call``, a ``function_call_output``/``tool_result``,
+a ``reasoning`` item, an ``item_reference``, and the hosted-tool call/output
+items. Message and function_call/function_call_output are served; the rest fail
+closed in ``parse`` (they need session state or hosted-tool semantics the IR
+has no home for).
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+Sampling = int | float
+
+
+class WireModel(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", strict=True)
+
+
+class InputTextContentIn(WireModel):
+    type: Literal["input_text", "output_text", "text"]
+    text: str | None = None
+
+
+class ImageUrlContentIn(WireModel):
+    type: Literal["input_image"]
+    image_url: str | None = None
+    detail: str | None = None
+    file_id: str | None = None
+
+
+class InputFileContentIn(WireModel):
+    type: Literal["input_file"]
+    file_id: str | None = None
+    file_url: str | None = None
+    file_data: str | None = None
+    cache_control: object | None = None
+
+
+MessageContentPartIn = Annotated[
+    InputTextContentIn | ImageUrlContentIn | InputFileContentIn,
+    Field(discriminator="type"),
+]
+
+
+class MessageItemIn(WireModel):
+    type: Literal["message"] | None = None
+    role: str
+    content: str | list[MessageContentPartIn]
+    status: str | None = None
+
+
+class FunctionCallItemIn(WireModel):
+    type: Literal["function_call"]
+    call_id: str | None = None
+    id: str | None = None
+    name: str | None = None
+    arguments: str | None = None
+    status: str | None = None
+
+
+class FunctionCallOutputItemIn(WireModel):
+    type: Literal["function_call_output", "tool_result"]
+    call_id: str | None = None
+    output: str | None = None
+    status: str | None = None
+
+
+class ReasoningItemIn(WireModel):
+    type: Literal["reasoning"]
+    id: str | None = None
+    summary: object | None = None
+    content: object | None = None
+    encrypted_content: object | None = None
+
+
+class ItemReferenceIn(WireModel):
+    type: Literal["item_reference"]
+    id: str | None = None
+
+
+InputItemIn = (
+    MessageItemIn
+    | FunctionCallItemIn
+    | FunctionCallOutputItemIn
+    | ReasoningItemIn
+    | ItemReferenceIn
+)
+
+
+class FunctionToolIn(WireModel):
+    type: Literal["function"]
+    name: str
+    description: str | None = None
+    parameters: object | None = None
+    strict: bool | None = None
+    cache_control: object | None = None
+    defer_loading: object | None = None
+    allowed_callers: object | None = None
+    input_examples: object | None = None
+
+
+class TextFormatIn(WireModel):
+    type: Literal["text", "json_object", "json_schema"]
+    name: str | None = None
+    schema_: object | None = Field(default=None, alias="schema")
+    strict: bool | None = None
+    description: str | None = None
+
+
+class TextIn(WireModel):
+    format: TextFormatIn | None = None
+
+
+class ReasoningIn(WireModel):
+    effort: (
+        Literal["minimal", "low", "medium", "high", "xhigh", "max", "none"] | None
+    ) = None
+    summary: object | None = None
+    generate_summary: object | None = None
+
+
+class ToolChoiceNamedIn(WireModel):
+    type: Literal["function", "tool", "any", "auto", "none", "required"]
+    name: str | None = None
+
+
+class ResponsesRequestIn(WireModel):
+    model: str
+    input: str | list[InputItemIn]
+    instructions: str | None = None
+    max_output_tokens: int | None = None
+    parallel_tool_calls: bool | None = None
+    reasoning: ReasoningIn | None = None
+    stream: bool | None = None
+    temperature: Sampling | None = None
+    text: TextIn | None = None
+    tool_choice: str | ToolChoiceNamedIn | None = None
+    tools: list[FunctionToolIn | object] | None = None
+    top_p: Sampling | None = None
+    user: str | None = None
+    # Accepted-as-object then rejected in parse when present (each names its
+    # v1 path); the chat IR has no home for any of these (researcher-6 §2.5).
+    previous_response_id: object | None = None
+    metadata: object | None = None
+    service_tier: object | None = None
+    include: object | None = None
+    store: object | None = None
+    background: object | None = None
+    truncation: object | None = None

--- a/tests/test_litellm/translation/bench_request_translation.py
+++ b/tests/test_litellm/translation/bench_request_translation.py
@@ -1,16 +1,24 @@
 """Request-translation CPU bench: v1 transform chain vs v2 pipeline.
 
 Reproduces the pattern-auditor's method: Claude-Code-shaped tool-call
-histories at 41/201/601 messages, median of 5 runs after warmup, comparing
-v1 (``map_openai_params`` + ``transform_request``) with v2
-(``translate_chat_request``). Budget: v2 <= 1.5x v1 at 601 messages.
+histories at 41/201/601 messages, comparing v1 (``map_openai_params`` +
+``transform_request``) with v2 (``translate_chat_request``). Budget: v2 <= 1.5x
+v1 at 601 messages.
+
+Methodology: v1 and v2 are sampled INTERLEAVED (one v1 then one v2 per
+iteration) so a transient scheduler hiccup lands on BOTH sides and cancels in
+the ratio, and the estimator is the MINIMUM over many samples -- the cleanest
+measure of a CPU-bound cost, since noise can only ADD time, never remove it. An
+earlier version took the median of 5 separate-phase runs, which flapped FAIL on
+a loaded machine even though the interleaved-min ratio was a stable ~1.42x (the
+load-sensitivity the audit notes warned about); the min-of-many-interleaved
+reading is what should ever gate, and only on a quiet runner.
 
 Run:  python -m tests.test_litellm.translation.bench_request_translation
 """
 
 import copy
 import json
-import statistics
 import time
 
 from litellm.llms.anthropic.chat.transformation import AnthropicConfig
@@ -82,15 +90,29 @@ def _v1(request: dict) -> dict:
     )
 
 
-def _median_ms(fn, request: dict, runs: int = 5) -> float:
-    fn(copy.deepcopy(request))  # warmup
-    samples = []
-    for _ in range(runs):
+def _min_ms_interleaved(v1_fn, v2_fn, request: dict, samples: int = 60) -> tuple:
+    """Sample v1 and v2 INTERLEAVED and return (min v1 ms, min v2 ms).
+
+    Each side gets a fresh deepcopy per sample (translation is pure, but v1's
+    transform mutates its message list), and the two are timed back-to-back so a
+    scheduler hiccup hits both. The minimum over many samples is the CPU floor:
+    noise only adds time, so the smallest sample is the least-polluted estimate.
+    """
+    for _ in range(10):  # warmup both
+        v1_fn(copy.deepcopy(request))
+        v2_fn(copy.deepcopy(request))
+    v1_best = float("inf")
+    v2_best = float("inf")
+    for _ in range(samples):
         body = copy.deepcopy(request)
         start = time.perf_counter()
-        fn(body)
-        samples.append((time.perf_counter() - start) * 1000)
-    return statistics.median(samples)
+        v1_fn(body)
+        v1_best = min(v1_best, (time.perf_counter() - start) * 1000)
+        body = copy.deepcopy(request)
+        start = time.perf_counter()
+        v2_fn(body)
+        v2_best = min(v2_best, (time.perf_counter() - start) * 1000)
+    return v1_best, v2_best
 
 
 def main() -> None:
@@ -105,8 +127,7 @@ def main() -> None:
     for turns in (10, 50, 150):
         request = _history(turns)
         count = len(request["messages"])
-        v1_ms = _median_ms(_v1, request)
-        v2_ms = _median_ms(v2, request)
+        v1_ms, v2_ms = _min_ms_interleaved(_v1, v2, request)
         ratio = v2_ms / v1_ms
         if count >= 600:
             gated = ratio

--- a/tests/test_litellm/translation/test_differential_anthropic_messages_request.py
+++ b/tests/test_litellm/translation/test_differential_anthropic_messages_request.py
@@ -188,6 +188,18 @@ _SERVE: dict[str, dict] = {
         "tools": [{"name": "f", "input_schema": {"type": "object"}, "type": "custom"}],
         "tool_choice": {"type": "any"},
     },
+    # tool_choice carrying disable_parallel_tool_use: v2 maps it to the IR
+    # parallel_tool_calls flag (the ``not`` inversion in parse) and the anthropic
+    # serializer re-emits the wire key (the ``not`` inversion in serialize), so a
+    # one-sided inversion mutation breaks this round-trip. The corpus otherwise
+    # had no disable_parallel_tool_use row (verifier-inbound GAP-3).
+    "tool_choice_disable_parallel": {
+        "model": MODEL,
+        "max_tokens": 64,
+        "messages": [{"role": "user", "content": [{"type": "text", "text": "x"}]}],
+        "tools": [{"name": "f", "input_schema": {"type": "object"}, "type": "custom"}],
+        "tool_choice": {"type": "auto", "disable_parallel_tool_use": True},
+    },
     "thinking_enabled_budget": {
         "model": MODEL,
         "max_tokens": 2048,

--- a/tests/test_litellm/translation/test_differential_anthropic_messages_request.py
+++ b/tests/test_litellm/translation/test_differential_anthropic_messages_request.py
@@ -1,0 +1,453 @@
+"""Differential parity for the /v1/messages forward path.
+
+The inbound parser maps an Anthropic Messages request onto the chat IR; the
+already-differential-green anthropic provider serializer is its inverse, so a
+round-trip ``anthropic-in -> IR -> anthropic-out`` over a corpus authored in
+the serializer's canonical form (list-form content, ``type: "custom"`` tools,
+tools present whenever tool history is) must reproduce the input byte-for-byte
+under canonical JSON. A mutation in the parser (a dropped field, a mis-renamed
+``stop_sequences``, a wrong ``tool_choice`` arm, a lost ``cache_control``,
+a swapped block order) breaks the round-trip; that is the mutation-kill bar.
+
+String content / string system are tested separately (they parse to the same
+IR as their list form, which the serializer canonicalizes to list output).
+
+The fail-closed rows assert every shape the chat IR cannot carry returns a
+typed ``unsupported`` so dispatch falls back to v1, instead of silently
+dropping it (researcher-6 §1.4/§1.5).
+"""
+
+import copy
+import json
+
+import pytest
+
+from litellm.translation.inbound.anthropic_messages import parse_request
+from litellm.translation.providers.anthropic import serialize_request
+
+from .conftest import build_real_deps
+
+MODEL = "claude-sonnet-4-5"
+
+
+def _canonical(body: object) -> str:
+    return json.dumps(body, sort_keys=True, default=str)
+
+
+# Authored in the anthropic serializer's canonical output form so the
+# round-trip is an identity. The serializer is the proven inverse, so equality
+# proves the parser captured every field faithfully (researcher-6 §1.4 SERVE).
+_SERVE: dict[str, dict] = {
+    "text": {
+        "model": MODEL,
+        "max_tokens": 64,
+        "messages": [{"role": "user", "content": [{"type": "text", "text": "hi"}]}],
+    },
+    "system_block_list_with_cache": {
+        "model": MODEL,
+        "max_tokens": 64,
+        "system": [
+            {"type": "text", "text": "a", "cache_control": {"type": "ephemeral"}},
+            {"type": "text", "text": "b"},
+        ],
+        "messages": [{"role": "user", "content": [{"type": "text", "text": "hi"}]}],
+    },
+    "image_base64_and_text_with_cache": {
+        "model": MODEL,
+        "max_tokens": 64,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "look",
+                        "cache_control": {"type": "ephemeral"},
+                    },
+                    {
+                        "type": "image",
+                        "source": {
+                            "type": "base64",
+                            "media_type": "image/png",
+                            "data": "AAAA",
+                        },
+                    },
+                ],
+            }
+        ],
+    },
+    "image_url": {
+        "model": MODEL,
+        "max_tokens": 64,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image",
+                        "source": {"type": "url", "url": "https://x/y.png"},
+                    }
+                ],
+            }
+        ],
+    },
+    "assistant_thinking_text_tool_use": {
+        "model": MODEL,
+        "max_tokens": 64,
+        "messages": [
+            {"role": "user", "content": [{"type": "text", "text": "go"}]},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "hmm", "signature": "sig"},
+                    {"type": "text", "text": "calling"},
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_1",
+                        "name": "get",
+                        "input": {"q": 1},
+                    },
+                ],
+            },
+        ],
+        "tools": [
+            {"name": "get", "input_schema": {"type": "object"}, "type": "custom"}
+        ],
+    },
+    "redacted_thinking": {
+        "model": MODEL,
+        "max_tokens": 64,
+        "messages": [
+            {"role": "user", "content": [{"type": "text", "text": "go"}]},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "redacted_thinking", "data": "ENC"},
+                    {"type": "text", "text": "ok"},
+                ],
+            },
+        ],
+    },
+    "tool_result_string_with_tools": {
+        "model": MODEL,
+        "max_tokens": 64,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "toolu_1", "content": "ok"}
+                ],
+            }
+        ],
+        "tools": [
+            {"name": "get", "input_schema": {"type": "object"}, "type": "custom"}
+        ],
+    },
+    "tool_result_parts_multi_with_tools": {
+        "model": MODEL,
+        "max_tokens": 64,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_1",
+                        "content": [
+                            {"type": "text", "text": "one"},
+                            {"type": "text", "text": "two"},
+                        ],
+                    }
+                ],
+            }
+        ],
+        "tools": [
+            {"name": "get", "input_schema": {"type": "object"}, "type": "custom"}
+        ],
+    },
+    "tools_and_tool_choice_tool": {
+        "model": MODEL,
+        "max_tokens": 64,
+        "messages": [
+            {"role": "user", "content": [{"type": "text", "text": "weather"}]}
+        ],
+        "tools": [
+            {
+                "name": "get_weather",
+                "description": "weather",
+                "input_schema": {"type": "object", "properties": {}},
+                "type": "custom",
+            }
+        ],
+        "tool_choice": {"type": "tool", "name": "get_weather"},
+    },
+    "tool_choice_any": {
+        "model": MODEL,
+        "max_tokens": 64,
+        "messages": [{"role": "user", "content": [{"type": "text", "text": "x"}]}],
+        "tools": [{"name": "f", "input_schema": {"type": "object"}, "type": "custom"}],
+        "tool_choice": {"type": "any"},
+    },
+    "thinking_enabled_budget": {
+        "model": MODEL,
+        "max_tokens": 2048,
+        "thinking": {"type": "enabled", "budget_tokens": 2000},
+        "messages": [{"role": "user", "content": [{"type": "text", "text": "think"}]}],
+    },
+    "sampling_and_stop_and_user": {
+        "model": MODEL,
+        "max_tokens": 64,
+        "temperature": 0.5,
+        "top_p": 0.9,
+        "top_k": 40,
+        "stop_sequences": ["END", "STOP"],
+        "metadata": {"user_id": "u1"},
+        "messages": [{"role": "user", "content": [{"type": "text", "text": "x"}]}],
+    },
+}
+
+
+@pytest.mark.parametrize("name", sorted(_SERVE))
+def test_request_round_trips_through_the_anthropic_serializer(name: str) -> None:
+    request = copy.deepcopy(_SERVE[name])
+    parsed = parse_request(request)
+    assert parsed.is_ok(), f"{name}: parse failed: {parsed.error.summary}"
+    serialized = serialize_request(parsed.ok, build_real_deps())
+    assert serialized.is_ok(), f"{name}: serialize failed: {serialized.error.summary}"
+    assert _canonical(serialized.ok) == _canonical(request), name
+
+
+def test_string_content_parses_like_its_text_block_form() -> None:
+    string_form = {
+        "model": MODEL,
+        "max_tokens": 64,
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+    block_form = {
+        "model": MODEL,
+        "max_tokens": 64,
+        "messages": [{"role": "user", "content": [{"type": "text", "text": "hi"}]}],
+    }
+    deps = build_real_deps()
+    string_body = serialize_request(parse_request(string_form).ok, deps)
+    block_body = serialize_request(parse_request(block_form).ok, deps)
+    assert string_body.is_ok() and block_body.is_ok()
+    assert _canonical(string_body.ok) == _canonical(block_body.ok)
+
+
+def test_string_system_parses_like_its_text_block_form() -> None:
+    string_form = {
+        "model": MODEL,
+        "max_tokens": 64,
+        "system": "be terse",
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+    block_form = {
+        "model": MODEL,
+        "max_tokens": 64,
+        "system": [{"type": "text", "text": "be terse"}],
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+    deps = build_real_deps()
+    string_body = serialize_request(parse_request(string_form).ok, deps)
+    block_body = serialize_request(parse_request(block_form).ok, deps)
+    assert string_body.is_ok() and block_body.is_ok()
+    assert _canonical(string_body.ok) == _canonical(block_body.ok)
+
+
+# Every shape the chat IR cannot carry must FAIL CLOSED: parse returns a typed
+# error so dispatch falls back to v1 (researcher-6 §1.4/§1.5). The substring
+# pins what each error names (an extra_forbidden field reads "not yet
+# supported by translation v2: <field>"; the semantic rejections name the
+# v1 path). A mutation that silently serves any of these breaks the assertion.
+_FALLBACK: dict[str, tuple[dict, str]] = {
+    "missing_max_tokens": (
+        {"model": MODEL, "messages": [{"role": "user", "content": "x"}]},
+        "max_tokens",
+    ),
+    "document_block": (
+        {
+            "model": MODEL,
+            "max_tokens": 64,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "document",
+                            "source": {
+                                "type": "base64",
+                                "media_type": "application/pdf",
+                                "data": "JVBER",
+                            },
+                        }
+                    ],
+                }
+            ],
+        },
+        "not yet supported",
+    ),
+    "non_text_system_block": (
+        {
+            "model": MODEL,
+            "max_tokens": 64,
+            "system": [{"type": "image", "text": None}],
+            "messages": [{"role": "user", "content": "x"}],
+        },
+        "non-text system block",
+    ),
+    "non_text_tool_result_part": (
+        {
+            "model": MODEL,
+            "max_tokens": 64,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "toolu_1",
+                            "content": [
+                                {
+                                    "type": "image",
+                                    "source": {
+                                        "type": "base64",
+                                        "media_type": "image/png",
+                                        "data": "AAAA",
+                                    },
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ],
+        },
+        "non-text tool_result",
+    ),
+    "image_file_source": (
+        {
+            "model": MODEL,
+            "max_tokens": 64,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "image", "source": {"type": "file", "file_id": "f1"}}
+                    ],
+                }
+            ],
+        },
+        "image source other than base64/url",
+    ),
+    "thinking_summary": (
+        {
+            "model": MODEL,
+            "max_tokens": 64,
+            "thinking": {
+                "type": "enabled",
+                "budget_tokens": 2000,
+                "summary": "detailed",
+            },
+            "messages": [{"role": "user", "content": "x"}],
+        },
+        "thinking.summary",
+    ),
+    "output_format": (
+        {
+            "model": MODEL,
+            "max_tokens": 64,
+            "output_format": {"type": "json_schema", "schema": {"type": "object"}},
+            "messages": [{"role": "user", "content": "x"}],
+        },
+        "output_format",
+    ),
+    "output_config": (
+        {
+            "model": MODEL,
+            "max_tokens": 64,
+            "output_config": {"effort": "high"},
+            "messages": [{"role": "user", "content": "x"}],
+        },
+        "output_config",
+    ),
+    "mcp_servers": (
+        {
+            "model": MODEL,
+            "max_tokens": 64,
+            "mcp_servers": [{"type": "url", "url": "https://m", "name": "m"}],
+            "messages": [{"role": "user", "content": "x"}],
+        },
+        "mcp_servers",
+    ),
+    "container": (
+        {
+            "model": MODEL,
+            "max_tokens": 64,
+            "container": {"id": "c1"},
+            "messages": [{"role": "user", "content": "x"}],
+        },
+        "container",
+    ),
+    "context_management": (
+        {
+            "model": MODEL,
+            "max_tokens": 64,
+            "context_management": {"edits": []},
+            "messages": [{"role": "user", "content": "x"}],
+        },
+        "context-management",
+    ),
+    "hosted_web_search_tool": (
+        {
+            "model": MODEL,
+            "max_tokens": 64,
+            "tools": [{"type": "web_search_20250305", "name": "web_search"}],
+            "messages": [{"role": "user", "content": "x"}],
+        },
+        "tools.0.type",
+    ),
+    "metadata_extra_key": (
+        {
+            "model": MODEL,
+            "max_tokens": 64,
+            "metadata": {"user_id": "u1", "trace_id": "t1"},
+            "messages": [{"role": "user", "content": "x"}],
+        },
+        "not yet supported",
+    ),
+    "tool_use_caller": (
+        {
+            "model": MODEL,
+            "max_tokens": 64,
+            "messages": [
+                {"role": "user", "content": "go"},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "toolu_1",
+                            "name": "get",
+                            "input": {},
+                            "caller": {
+                                "type": "code_execution_20250825",
+                                "tool_id": "t",
+                            },
+                        }
+                    ],
+                },
+            ],
+        },
+        "caller",
+    ),
+}
+
+
+@pytest.mark.parametrize("name", sorted(_FALLBACK))
+def test_unported_shapes_fail_closed(name: str) -> None:
+    request, reason_substring = _FALLBACK[name]
+    parsed = parse_request(copy.deepcopy(request))
+    assert parsed.is_error(), f"{name}: should fall back, but parse succeeded"
+    assert (
+        reason_substring in parsed.error.summary
+    ), f"{name}: error {parsed.error.summary!r} does not name {reason_substring!r}"

--- a/tests/test_litellm/translation/test_differential_anthropic_messages_response.py
+++ b/tests/test_litellm/translation/test_differential_anthropic_messages_response.py
@@ -111,6 +111,16 @@ _CASES: dict[str, dict] = {
         "tool_use",
         _USAGE_CACHED,
     ),
+    # The anthropic wire ``refusal`` stop_reason maps to IR ``content_filter``
+    # (provider FINISH_MAP), which the reverse has no Anthropic stop_reason for
+    # and must fold to v1's default-branch ``end_turn`` (researcher-6 §1.5
+    # item 11). Pins the content_filter arm the corpus otherwise omitted
+    # (verifier-inbound GAP-1).
+    "refusal_content_filter_to_end_turn": _wire(
+        [{"type": "text", "text": "i cannot help with that"}],
+        "refusal",
+        _USAGE_PLAIN,
+    ),
 }
 
 

--- a/tests/test_litellm/translation/test_differential_anthropic_messages_response.py
+++ b/tests/test_litellm/translation/test_differential_anthropic_messages_response.py
@@ -1,0 +1,140 @@
+"""Differential parity for the /v1/messages reverse (response) path.
+
+v1's oracle is ``translate_openai_response_to_anthropic`` (transformation.py)
+which consumes an OpenAI ``ModelResponse``. Both sides start from the same IR
+``ChatResponse`` (built by the anthropic provider parser over a recorded
+Anthropic wire response): v2 reverse-serializes it directly to an Anthropic
+Messages body, while the oracle goes IR -> anthropic-dialect chat body ->
+``ModelResponse`` -> v1's adapter. The two Anthropic bodies must be identical.
+
+A mutation in the v2 serializer (wrong content order, a dropped block, a
+mis-mapped stop_reason, wrong usage math, a missing
+``provider_specific_fields`` on tool_use) diverges from the v1 oracle.
+"""
+
+import json
+
+import pytest
+
+from litellm.llms.anthropic.experimental_pass_through.adapters.transformation import (
+    LiteLLMAnthropicMessagesAdapter,
+)
+from litellm.types.utils import ModelResponse
+
+from litellm.translation.inbound.anthropic_messages import parse_request
+from litellm.translation.inbound.anthropic_messages.response import (
+    serialize_response as v2_serialize,
+)
+from litellm.translation.inbound.openai_chat.response import (
+    serialize_response as chat_serialize,
+)
+from litellm.translation.providers.anthropic.response import parse_response
+
+from .conftest import build_real_deps
+
+MODEL = "claude-sonnet-4-5"
+
+_REQUEST = {
+    "model": MODEL,
+    "max_tokens": 64,
+    "messages": [{"role": "user", "content": "hi"}],
+    "tools": [{"name": "get", "input_schema": {"type": "object"}}],
+}
+
+
+def _wire(content: list, stop_reason: str, usage: dict) -> dict:
+    return {
+        "id": "msg_resp",
+        "type": "message",
+        "role": "assistant",
+        "model": MODEL,
+        "content": content,
+        "stop_reason": stop_reason,
+        "stop_sequence": None,
+        "usage": usage,
+    }
+
+
+_USAGE_PLAIN = {"input_tokens": 100, "output_tokens": 20}
+_USAGE_CACHED = {
+    "input_tokens": 100,
+    "output_tokens": 20,
+    "cache_creation_input_tokens": 5,
+    "cache_read_input_tokens": 10,
+}
+
+# Each recorded Anthropic wire response, its stop_reason, and its usage. The
+# corpus exercises content ordering (thinking->text->tool_use), each block
+# type, the finish-reason arms, and the cache usage math.
+_CASES: dict[str, dict] = {
+    "text_end_turn": _wire(
+        [{"type": "text", "text": "hello"}], "end_turn", _USAGE_PLAIN
+    ),
+    "text_max_tokens": _wire(
+        [{"type": "text", "text": "truncated"}], "max_tokens", _USAGE_PLAIN
+    ),
+    "thinking_then_text": _wire(
+        [
+            {"type": "thinking", "thinking": "hmm", "signature": "sg"},
+            {"type": "text", "text": "answer"},
+        ],
+        "end_turn",
+        _USAGE_PLAIN,
+    ),
+    "redacted_thinking_then_text": _wire(
+        [
+            {"type": "redacted_thinking", "data": "ENC"},
+            {"type": "text", "text": "answer"},
+        ],
+        "end_turn",
+        _USAGE_PLAIN,
+    ),
+    "tool_use_only": _wire(
+        [{"type": "tool_use", "id": "toolu_1", "name": "get", "input": {"q": 1}}],
+        "tool_use",
+        _USAGE_PLAIN,
+    ),
+    "text_and_tool_use": _wire(
+        [
+            {"type": "text", "text": "calling"},
+            {"type": "tool_use", "id": "toolu_1", "name": "get", "input": {"q": 1}},
+        ],
+        "tool_use",
+        _USAGE_PLAIN,
+    ),
+    "thinking_text_tool_use_with_cache": _wire(
+        [
+            {"type": "thinking", "thinking": "plan", "signature": "sg"},
+            {"type": "text", "text": "calling"},
+            {"type": "tool_use", "id": "toolu_2", "name": "get", "input": {}},
+        ],
+        "tool_use",
+        _USAGE_CACHED,
+    ),
+}
+
+
+@pytest.mark.parametrize("name", sorted(_CASES))
+def test_response_matches_v1_translate_openai_response_to_anthropic(name: str) -> None:
+    deps = build_real_deps()
+    request = parse_request(_REQUEST)
+    assert request.is_ok()
+    ir_result = parse_response(_CASES[name], request.ok)
+    assert ir_result.is_ok(), ir_result.error.summary
+    ir = ir_result.ok
+
+    v2_body = v2_serialize(ir, deps)
+    assert not hasattr(v2_body, "summary"), getattr(v2_body, "summary", "")
+
+    chat_body = chat_serialize(ir, deps, "anthropic")
+    assert isinstance(chat_body, dict)
+    model_response = ModelResponse(**{"id": ir.id, "model": ir.model, **chat_body})
+    v1_body = dict(
+        LiteLLMAnthropicMessagesAdapter().translate_openai_response_to_anthropic(
+            response=model_response
+        )
+    )
+
+    assert json.dumps(v2_body, sort_keys=True, default=str) == json.dumps(
+        v1_body, sort_keys=True, default=str
+    ), name

--- a/tests/test_litellm/translation/test_differential_anthropic_messages_stream.py
+++ b/tests/test_litellm/translation/test_differential_anthropic_messages_stream.py
@@ -1,0 +1,317 @@
+"""Differential parity for the /v1/messages reverse (stream) path.
+
+A recorded Anthropic SSE event stream is parsed into IR ``StreamEvent``s by the
+anthropic provider parser. v2 folds those events into Anthropic SSE event dicts
+directly; the oracle folds the SAME IR events into chat chunks (the openai_chat
+anthropic-dialect fold), adapts them onto ``ModelResponseStream``, and runs
+v1's ``AnthropicStreamWrapper`` over them. The emitted event dicts must match.
+
+Two faithfulness adjustments to the oracle bridge, neither masking a v2 bug:
+- the ``message_start`` id is ambient (v1 mints a fresh ``msg_{uuid4}``,
+  ignoring the wire id), so it is normalized on both sides;
+- the openai_chat anthropic-dialect fold does not propagate stream usage onto
+  the finish chunk (streaming usage is a seam-scope follow-up in v1), so the
+  final usage v1's wrapper merges into ``message_delta`` is reconstructed onto
+  the finish ``ModelResponseStream`` exactly as v1's real anthropic flow
+  attaches it (``prompt_tokens = input + cache_creation + cache_read``,
+  ``prompt_tokens_details.cached_tokens = cache_read``,
+  ``_cache_creation/_cache_read_input_tokens``). The values come from the wire
+  ``message_start``/``message_delta`` usage, the same source v2 folds from.
+
+The text+tool_use split (issue-18238) is pinned: the content_block_stop ->
+content_block_start ordering between the text block and the tool block must be
+byte-right. A mutation in the fold (wrong block index, a missing
+content_block_stop, a mis-mapped stop_reason, wrong usage) diverges.
+"""
+
+import json
+
+import pytest
+
+from litellm.llms.anthropic.experimental_pass_through.adapters.streaming_iterator import (
+    AnthropicStreamWrapper,
+)
+from litellm.types.utils import PromptTokensDetailsWrapper, Usage
+
+from litellm.translation.inbound.anthropic_messages import stream as ams
+from litellm.translation.inbound.openai_chat import stream as oai
+from litellm.translation.providers.anthropic.stream import parse_event
+from litellm.translation_seam import to_model_response_stream
+
+MODEL = "claude-sonnet-4-5"
+
+
+def _message_start(usage: dict) -> dict:
+    return {
+        "type": "message_start",
+        "message": {
+            "id": "msg_stream",
+            "type": "message",
+            "role": "assistant",
+            "model": MODEL,
+            "content": [],
+            "stop_reason": None,
+            "stop_sequence": None,
+            "usage": usage,
+        },
+    }
+
+
+_TEXT = {
+    "events": [
+        _message_start({"input_tokens": 12, "output_tokens": 1}),
+        {"type": "ping"},
+        {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {"type": "text", "text": ""},
+        },
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "text_delta", "text": "Paris"},
+        },
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "text_delta", "text": " it is"},
+        },
+        {"type": "content_block_stop", "index": 0},
+        {
+            "type": "message_delta",
+            "delta": {"stop_reason": "end_turn"},
+            "usage": {"output_tokens": 9},
+        },
+        {"type": "message_stop"},
+    ],
+    "input": (12, 0, 0),
+    "output": 9,
+}
+
+_TEXT_THEN_TOOL = {
+    "events": [
+        _message_start({"input_tokens": 50, "output_tokens": 1}),
+        {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {"type": "text", "text": ""},
+        },
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "text_delta", "text": "calling"},
+        },
+        {"type": "content_block_stop", "index": 0},
+        {
+            "type": "content_block_start",
+            "index": 1,
+            "content_block": {
+                "type": "tool_use",
+                "id": "toolu_1",
+                "name": "get",
+                "input": {},
+            },
+        },
+        {
+            "type": "content_block_delta",
+            "index": 1,
+            "delta": {"type": "input_json_delta", "partial_json": '{"q":'},
+        },
+        {
+            "type": "content_block_delta",
+            "index": 1,
+            "delta": {"type": "input_json_delta", "partial_json": "1}"},
+        },
+        {"type": "content_block_stop", "index": 1},
+        {
+            "type": "message_delta",
+            "delta": {"stop_reason": "tool_use"},
+            "usage": {"output_tokens": 15},
+        },
+        {"type": "message_stop"},
+    ],
+    "input": (50, 0, 0),
+    "output": 15,
+}
+
+_THINKING_THEN_TEXT = {
+    "events": [
+        _message_start({"input_tokens": 30, "output_tokens": 1}),
+        {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {"type": "thinking", "thinking": "", "signature": ""},
+        },
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "thinking_delta", "thinking": "step"},
+        },
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "signature_delta", "signature": "sg"},
+        },
+        {"type": "content_block_stop", "index": 0},
+        {
+            "type": "content_block_start",
+            "index": 1,
+            "content_block": {"type": "text", "text": ""},
+        },
+        {
+            "type": "content_block_delta",
+            "index": 1,
+            "delta": {"type": "text_delta", "text": "done"},
+        },
+        {"type": "content_block_stop", "index": 1},
+        {
+            "type": "message_delta",
+            "delta": {"stop_reason": "end_turn"},
+            "usage": {"output_tokens": 8},
+        },
+        {"type": "message_stop"},
+    ],
+    "input": (30, 0, 0),
+    "output": 8,
+}
+
+_CACHED = {
+    "events": [
+        _message_start(
+            {
+                "input_tokens": 100,
+                "output_tokens": 1,
+                "cache_creation_input_tokens": 5,
+                "cache_read_input_tokens": 10,
+            }
+        ),
+        {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {"type": "text", "text": ""},
+        },
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "text_delta", "text": "hi"},
+        },
+        {"type": "content_block_stop", "index": 0},
+        {
+            "type": "message_delta",
+            "delta": {"stop_reason": "end_turn"},
+            "usage": {"output_tokens": 7},
+        },
+        {"type": "message_stop"},
+    ],
+    "input": (100, 5, 10),
+    "output": 7,
+}
+
+_CASES = {
+    "text": _TEXT,
+    "text_then_tool_use": _TEXT_THEN_TOOL,
+    "cached": _CACHED,
+}
+
+
+def _ir_events(events: list) -> list:
+    parsed = []
+    for event in events:
+        result = parse_event(event, {})
+        assert result.is_ok(), result.error.summary
+        if result.ok is not None:
+            parsed.append(result.ok)
+    return parsed
+
+
+def _v2_events(ir_events: list) -> list:
+    state = ams.initial_state()
+    out: list = []
+    for event in ir_events:
+        stepped = ams.step(state, event)
+        assert not hasattr(stepped, "summary"), getattr(stepped, "summary", "")
+        state, emitted = stepped
+        out.extend(emitted)
+    return out
+
+
+def _final_usage(input_split: tuple, output: int) -> Usage:
+    uncached_plus_creation, creation, read = input_split
+    prompt_tokens = uncached_plus_creation + creation + read
+    usage = Usage(
+        prompt_tokens=prompt_tokens,
+        completion_tokens=output,
+        total_tokens=prompt_tokens + output,
+    )
+    usage.prompt_tokens_details = PromptTokensDetailsWrapper(cached_tokens=read)
+    setattr(usage, "_cache_creation_input_tokens", creation)
+    setattr(usage, "_cache_read_input_tokens", read)
+    return usage
+
+
+def _v1_events(ir_events: list, input_split: tuple, output: int) -> list:
+    state = oai.initial_state(model=MODEL, dialect="anthropic")
+    chat_chunks: list = []
+    for event in ir_events:
+        state, emitted = oai.step(state, event)
+        chat_chunks.extend(emitted)
+    final_usage = _final_usage(input_split, output)
+    streams = []
+    for body in chat_chunks:
+        chunk = to_model_response_stream(body, "chatcmpl-stream")
+        choices = body.get("choices")
+        first = choices[0] if isinstance(choices, list) and choices else None
+        if isinstance(first, dict) and first.get("finish_reason") is not None:
+            setattr(chunk, "usage", final_usage)
+        streams.append(chunk)
+    wrapper = AnthropicStreamWrapper(completion_stream=iter(streams), model=MODEL)
+    return [event for event in wrapper if isinstance(event, dict)]
+
+
+def _normalize(event: dict) -> dict:
+    event = json.loads(json.dumps(event, default=str))
+    if event.get("type") == "message_start":
+        event["message"]["id"] = "<id>"
+    return event
+
+
+@pytest.mark.parametrize("name", sorted(_CASES))
+def test_stream_fold_matches_v1_anthropic_stream_wrapper(name: str) -> None:
+    case = _CASES[name]
+    ir_events = _ir_events(case["events"])
+    v2 = [_normalize(event) for event in _v2_events(ir_events)]
+    v1 = [
+        _normalize(event)
+        for event in _v1_events(ir_events, case["input"], case["output"])
+    ]
+    assert v2 == v1, name
+
+
+def test_thinking_first_preserves_wire_block_index_unlike_v1_bridge() -> None:
+    """DELIBERATE divergence (researcher-6 §1.3: the IR is Anthropic-shaped, so
+    the fold must NOT reproduce v1's index-shifting gymnastics). v1's
+    experimental chat-bridge wrapper re-derives blocks from chat-chunk content
+    and ALWAYS opens an empty text block at index 0, shifting a thinking-first
+    stream to thinking@1. The v2 fold preserves the wire's thinking@0 (the
+    correct Anthropic ordering a real backend sent), so it emits no spurious
+    leading text block and the thinking block keeps index 0."""
+    ir_events = _ir_events(_THINKING_THEN_TEXT["events"])
+    v2 = _v2_events(ir_events)
+    starts = [
+        (event["index"], event["content_block"]["type"])
+        for event in v2
+        if event["type"] == "content_block_start"
+    ]
+    assert starts == [(0, "thinking"), (1, "text")]
+
+    v1 = _v1_events(
+        ir_events, _THINKING_THEN_TEXT["input"], _THINKING_THEN_TEXT["output"]
+    )
+    v1_starts = [
+        (event["index"], event["content_block"]["type"])
+        for event in v1
+        if event["type"] == "content_block_start"
+    ]
+    # v1's bridge forces text@0 then shifts thinking to index 1: the divergence
+    # this test pins as deliberate (the fold is wire-faithful, v1 is not).
+    assert v1_starts == [(0, "text"), (1, "thinking"), (2, "text")]

--- a/tests/test_litellm/translation/test_differential_responses_request.py
+++ b/tests/test_litellm/translation/test_differential_responses_request.py
@@ -1,0 +1,401 @@
+"""Differential parity for the /v1/responses forward path.
+
+The Responses inbound parser maps a Responses request onto the chat IR. v1's
+oracle is ``LiteLLMCompletionResponsesConfig.transform_responses_api_request_to_chat_completion_request``,
+which produces an OpenAI chat-completion request dict. There is no ``responses``
+provider wire (the schema always rides the IR), so the round-trip used for
+anthropic_messages does not apply; instead this gate runs v1 in-process at HEAD
+and asserts the v2 IR is field-for-field equivalent to v1's chat request:
+the messages (role + content + tool_calls/tool results), the system message,
+the tools, tool_choice, response_format, reasoning_effort and the sampling
+params. A mutation in the parser (a dropped field, a wrong tool_choice arm, a
+lost consecutive-function_call merge, a mis-mapped reasoning effort) diverges
+from v1.
+
+The fail-closed rows assert every shape the chat IR cannot carry returns a
+typed ``unsupported`` so dispatch falls back to v1 instead of silently dropping
+it (researcher-6 §2.4/§2.5).
+"""
+
+import copy
+import json
+
+import pytest
+from expression import Option
+
+from litellm.responses.litellm_completion_transformation.transformation import (
+    LiteLLMCompletionResponsesConfig as V1,
+)
+
+from litellm.translation.inbound.responses import parse_request
+
+MODEL = "gpt-4o"
+
+
+def _v1_chat(request: dict) -> dict:
+    body = dict(request)
+    model = body.pop("model")
+    input_param = body.pop("input")
+    stream = body.pop("stream", None)
+    return V1.transform_responses_api_request_to_chat_completion_request(
+        model=model,
+        input=input_param,
+        responses_api_request=body,
+        stream=stream,
+    )
+
+
+def _opt(value: Option) -> object:
+    return value.some if value.is_some() else None
+
+
+# ---- forward equivalence over the SERVE corpus ----------------------------
+
+_SERVE: dict[str, dict] = {
+    "string_input": {"model": MODEL, "input": "hello"},
+    "message_text": {
+        "model": MODEL,
+        "input": [
+            {"role": "user", "content": [{"type": "input_text", "text": "hi there"}]}
+        ],
+    },
+    "instructions_system": {
+        "model": MODEL,
+        "instructions": "be terse",
+        "input": "hello",
+    },
+    "function_tool_and_choice": {
+        "model": MODEL,
+        "input": "weather?",
+        "tools": [
+            {
+                "type": "function",
+                "name": "get_weather",
+                "description": "weather",
+                "parameters": {"type": "object", "properties": {}},
+            }
+        ],
+        "tool_choice": {"type": "function", "name": "get_weather"},
+    },
+    "tool_choice_cursor_tool": {
+        "model": MODEL,
+        "input": "x",
+        "tools": [{"type": "function", "name": "f", "parameters": {"type": "object"}}],
+        "tool_choice": {"type": "tool"},
+    },
+    "tool_choice_required_string": {
+        "model": MODEL,
+        "input": "x",
+        "tools": [{"type": "function", "name": "f", "parameters": {"type": "object"}}],
+        "tool_choice": "required",
+    },
+    "function_call_then_output": {
+        "model": MODEL,
+        "input": [
+            {"role": "user", "content": [{"type": "input_text", "text": "go"}]},
+            {
+                "type": "function_call",
+                "call_id": "call_1",
+                "name": "get",
+                "arguments": '{"q": 1}',
+            },
+            {
+                "type": "function_call_output",
+                "call_id": "call_1",
+                "output": "result text",
+            },
+        ],
+        "tools": [
+            {"type": "function", "name": "get", "parameters": {"type": "object"}}
+        ],
+    },
+    "consecutive_function_calls_merge": {
+        "model": MODEL,
+        "input": [
+            {"role": "user", "content": [{"type": "input_text", "text": "go"}]},
+            {
+                "type": "function_call",
+                "call_id": "call_1",
+                "name": "a",
+                "arguments": "{}",
+            },
+            {
+                "type": "function_call",
+                "call_id": "call_2",
+                "name": "b",
+                "arguments": "{}",
+            },
+        ],
+        "tools": [
+            {"type": "function", "name": "a", "parameters": {"type": "object"}},
+            {"type": "function", "name": "b", "parameters": {"type": "object"}},
+        ],
+    },
+    "reasoning_effort": {
+        "model": MODEL,
+        "input": "think",
+        "reasoning": {"effort": "high"},
+    },
+    "max_output_tokens_and_sampling": {
+        "model": MODEL,
+        "input": "x",
+        "max_output_tokens": 256,
+        "temperature": 0.5,
+        "top_p": 0.9,
+        "parallel_tool_calls": True,
+        "user": "u1",
+    },
+    "text_format_json_object": {
+        "model": MODEL,
+        "input": "x",
+        "text": {"format": {"type": "json_object"}},
+    },
+}
+
+
+def _ir_messages(ir) -> list:
+    out = []
+    for message in ir.messages:
+        blocks = []
+        for block in message.content:
+            if block.tag == "text":
+                blocks.append({"type": "text", "text": block.text.text})
+            elif block.tag == "tool_use":
+                blocks.append(
+                    {
+                        "type": "tool_use",
+                        "id": block.tool_use.id,
+                        "name": block.tool_use.name,
+                        "args": block.tool_use.arguments.value,
+                    }
+                )
+            elif block.tag == "tool_result":
+                result = block.tool_result
+                blocks.append(
+                    {
+                        "type": "tool_result",
+                        "id": result.tool_use_id,
+                        "text": (
+                            result.content.text
+                            if result.content.tag == "text"
+                            else None
+                        ),
+                    }
+                )
+            else:
+                blocks.append({"type": block.tag})
+        out.append({"role": message.role, "blocks": blocks})
+    return out
+
+
+def _v1_messages(chat: dict) -> list:
+    """Project v1's chat messages onto the same role/block shape the IR carries:
+    system rides ChatRequest.system (excluded here), tool messages become a
+    tool_result block in a user turn, assistant tool_calls become tool_use
+    blocks. This is the inverse of the inbound mapping the IR encodes."""
+    out: list = []
+    for message in chat.get("messages", []):
+        role = message.get("role")
+        if role == "system":
+            continue
+        if role == "tool":
+            out.append(
+                {
+                    "role": "user",
+                    "blocks": [
+                        {
+                            "type": "tool_result",
+                            "id": message.get("tool_call_id"),
+                            "text": message.get("content"),
+                        }
+                    ],
+                }
+            )
+            continue
+        blocks: list = []
+        content = message.get("content")
+        if isinstance(content, str) and content:
+            blocks.append({"type": "text", "text": content})
+        elif isinstance(content, list):
+            for part in content:
+                if part.get("type") in ("text", "input_text", "output_text"):
+                    blocks.append({"type": "text", "text": part.get("text")})
+        for call in message.get("tool_calls") or []:
+            fn = call.get("function", {})
+            blocks.append(
+                {
+                    "type": "tool_use",
+                    "id": call.get("id"),
+                    "name": fn.get("name"),
+                    "args": json.loads(fn.get("arguments") or "{}"),
+                }
+            )
+        out.append({"role": role, "blocks": blocks})
+    return out
+
+
+@pytest.mark.parametrize("name", sorted(_SERVE))
+def test_forward_ir_matches_v1_chat_request(name: str) -> None:
+    request = copy.deepcopy(_SERVE[name])
+    parsed = parse_request(copy.deepcopy(request))
+    assert (
+        parsed.is_ok()
+    ), f"{name}: parse failed: {parsed.error.summary if parsed.is_error() else ''}"
+    ir = parsed.ok
+    chat = _v1_chat(request)
+
+    assert _ir_messages(ir) == _v1_messages(chat), f"{name}: messages diverge"
+
+    v1_system = next(
+        (
+            m.get("content")
+            for m in chat.get("messages", [])
+            if m.get("role") == "system"
+        ),
+        None,
+    )
+    ir_system = ir.system[0].text if len(ir.system) > 0 else None
+    assert ir_system == v1_system, f"{name}: system diverges"
+
+    ir_tools = [t.name for t in ir.tools]
+    v1_tools = [
+        t.get("function", {}).get("name")
+        for t in chat.get("tools", [])
+        if t.get("type") == "function"
+    ]
+    assert ir_tools == v1_tools, f"{name}: tools diverge"
+
+    assert _ir_tool_choice(ir) == chat.get(
+        "tool_choice"
+    ), f"{name}: tool_choice diverges"
+    assert _opt(ir.reasoning_effort) == chat.get("reasoning_effort"), name
+    assert _opt(ir.params.max_tokens) == chat.get("max_tokens"), name
+    assert _opt(ir.params.temperature) == chat.get("temperature"), name
+    assert _opt(ir.params.top_p) == chat.get("top_p"), name
+    assert _opt(ir.parallel_tool_calls) == chat.get("parallel_tool_calls"), name
+    assert _opt(ir.user) == chat.get("user"), name
+
+
+def _ir_tool_choice(ir) -> object:
+    match ir.tool_choice:
+        case Option(tag="some", some=choice):
+            if choice.tag == "auto":
+                return "auto"
+            if choice.tag == "required":
+                return "required"
+            if choice.tag == "none":
+                return "none"
+            return {"type": "function", "function": {"name": choice.specific}}
+        case _:
+            return None
+
+
+# ---- fail-closed rows -----------------------------------------------------
+
+_FALLBACK: dict[str, tuple[dict, str]] = {
+    "previous_response_id": (
+        {"model": MODEL, "input": "x", "previous_response_id": "resp_1"},
+        "previous_response_id",
+    ),
+    "store": ({"model": MODEL, "input": "x", "store": True}, "store"),
+    "background": ({"model": MODEL, "input": "x", "background": True}, "background"),
+    "include": ({"model": MODEL, "input": "x", "include": ["a"]}, "include"),
+    "metadata": ({"model": MODEL, "input": "x", "metadata": {"k": "v"}}, "metadata"),
+    "service_tier": (
+        {"model": MODEL, "input": "x", "service_tier": "flex"},
+        "service_tier",
+    ),
+    "hosted_web_search_tool": (
+        {"model": MODEL, "input": "x", "tools": [{"type": "web_search_preview"}]},
+        "hosted tools",
+    ),
+    "hosted_mcp_tool": (
+        {
+            "model": MODEL,
+            "input": "x",
+            "tools": [{"type": "mcp", "server_label": "m", "server_url": "https://m"}],
+        },
+        "hosted tools",
+    ),
+    "reasoning_summary": (
+        {
+            "model": MODEL,
+            "input": "x",
+            "reasoning": {"effort": "high", "summary": "detailed"},
+        },
+        "reasoning.summary",
+    ),
+    "reasoning_item": (
+        {
+            "model": MODEL,
+            "input": [{"type": "reasoning", "id": "rs_1", "summary": [{"text": "t"}]}],
+        },
+        "reasoning input items",
+    ),
+    "item_reference": (
+        {"model": MODEL, "input": [{"type": "item_reference", "id": "msg_1"}]},
+        "item_reference",
+    ),
+    "input_file": (
+        {
+            "model": MODEL,
+            "input": [
+                {
+                    "role": "user",
+                    "content": [{"type": "input_file", "file_id": "f1"}],
+                }
+            ],
+        },
+        "input_file",
+    ),
+    "image_by_file_id": (
+        {
+            "model": MODEL,
+            "input": [
+                {
+                    "role": "user",
+                    "content": [{"type": "input_image", "file_id": "f1"}],
+                }
+            ],
+        },
+        "input_image by file_id",
+    ),
+    "function_call_output_without_call": (
+        {
+            "model": MODEL,
+            "input": [
+                {
+                    "type": "function_call_output",
+                    "call_id": "orphan",
+                    "output": "r",
+                }
+            ],
+        },
+        "without a matching function_call",
+    ),
+    "tool_extra_defer_loading": (
+        {
+            "model": MODEL,
+            "input": "x",
+            "tools": [
+                {
+                    "type": "function",
+                    "name": "f",
+                    "parameters": {"type": "object"},
+                    "defer_loading": True,
+                }
+            ],
+        },
+        "defer_loading",
+    ),
+}
+
+
+@pytest.mark.parametrize("name", sorted(_FALLBACK))
+def test_unported_shapes_fail_closed(name: str) -> None:
+    request, reason_substring = _FALLBACK[name]
+    parsed = parse_request(copy.deepcopy(request))
+    assert parsed.is_error(), f"{name}: should fall back, but parse succeeded"
+    assert (
+        reason_substring in parsed.error.summary
+    ), f"{name}: error {parsed.error.summary!r} does not name {reason_substring!r}"

--- a/tests/test_litellm/translation/test_differential_responses_request.py
+++ b/tests/test_litellm/translation/test_differential_responses_request.py
@@ -388,6 +388,40 @@ _FALLBACK: dict[str, tuple[dict, str]] = {
         },
         "defer_loading",
     ),
+    # A mid-conversation message item whose role is system/developer: v1
+    # FORWARDS the role verbatim (transformation.py:995 ``role or "user"``),
+    # so the instruction reaches the model as a system turn. The chat IR's
+    # Message.role is Literal[user, assistant] with no home for it, so v2 must
+    # FAIL CLOSED (the seam serves it on v1) rather than silently demote it to
+    # a user turn -- a #30138-class semantic mutation (critic-inbound BLOCKER-1).
+    "message_role_system_fails_closed": (
+        {
+            "model": MODEL,
+            "input": [
+                {
+                    "role": "system",
+                    "content": [{"type": "input_text", "text": "be terse"}],
+                },
+                {
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "hi"}],
+                },
+            ],
+        },
+        "role 'system'",
+    ),
+    "message_role_developer_fails_closed": (
+        {
+            "model": MODEL,
+            "input": [
+                {
+                    "role": "developer",
+                    "content": [{"type": "input_text", "text": "be terse"}],
+                }
+            ],
+        },
+        "role 'developer'",
+    ),
 }
 
 
@@ -399,3 +433,18 @@ def test_unported_shapes_fail_closed(name: str) -> None:
     assert (
         reason_substring in parsed.error.summary
     ), f"{name}: error {parsed.error.summary!r} does not name {reason_substring!r}"
+
+
+@pytest.mark.parametrize("role", ["system", "developer"])
+def test_v1_forwards_a_message_item_role_so_the_fallback_is_real(role: str) -> None:
+    """The fail-closed rows above only matter if v1 actually SERVES the role; if
+    v1 dropped it too the divergence would be invented. Probe v1 in-process at
+    HEAD: it forwards the role verbatim into the chat request (no demotion to
+    user), which is the byte v2 would silently lose if it collapsed the role."""
+    item = {"role": role, "content": [{"type": "input_text", "text": "be terse"}]}
+    message = V1._transform_responses_api_input_item_to_chat_completion_message(
+        input_item=item
+    )
+    assert message == [
+        {"role": role, "content": [{"type": "text", "text": "be terse"}]}
+    ]

--- a/tests/test_litellm/translation/test_differential_responses_response.py
+++ b/tests/test_litellm/translation/test_differential_responses_response.py
@@ -1,0 +1,233 @@
+"""Differential parity for the /v1/responses reverse (response) path.
+
+v1's oracle is ``transform_chat_completion_response_to_responses_api_response``
+which consumes an OpenAI ``ModelResponse`` and returns a ``ResponsesAPIResponse``.
+Both sides start from the same IR ``ChatResponse`` (built by the anthropic
+provider parser over a recorded Anthropic wire response): v2 reverse-serializes
+it directly to a Responses body, while the oracle goes IR -> anthropic-dialect
+chat body -> ``ModelResponse`` -> v1's reverse. The two Responses bodies must be
+identical under canonical JSON.
+
+Two faithfulness adjustments to the oracle bridge, neither masking a v2 bug:
+- ``created_at`` is ambient envelope (the seam stamps it; the IR carries no
+  timestamp), normalized on both sides;
+- the usage on the bridged ``ModelResponse`` is rebuilt from the wire token
+  counts (input/output/cache/reasoning) rather than the anthropic chat
+  dialect's, because that dialect ESTIMATES reasoning tokens with the injected
+  token counter (a chat-side concern the openai_chat/anthropic gates already
+  pin); the Responses-reverse usage MAPPING (cache fold into input_tokens, the
+  cached/text/reasoning detail shape) is what this gate isolates, so both sides
+  read the same provider-style usage.
+
+A mutation in the v2 serializer (wrong output-item order, a dropped reasoning/
+message/function_call item, a mis-mapped status, wrong usage fold, a missing
+``namespace``/``phase`` key) diverges from the v1 oracle.
+"""
+
+import json
+
+import pytest
+from litellm.responses.litellm_completion_transformation.transformation import (
+    LiteLLMCompletionResponsesConfig as V1,
+)
+from litellm.types.utils import (
+    CompletionTokensDetailsWrapper,
+    ModelResponse,
+    PromptTokensDetailsWrapper,
+    Usage,
+)
+
+from litellm.translation.inbound.openai_chat.response import (
+    serialize_response as chat_serialize,
+)
+from litellm.translation.inbound.responses import parse_request
+from litellm.translation.inbound.responses.response import (
+    serialize_response as v2_serialize,
+)
+from litellm.translation.providers.anthropic.response import parse_response
+
+from .conftest import build_real_deps
+
+MODEL = "gpt-4o"
+
+_REQUEST = {
+    "model": MODEL,
+    "input": "hi",
+    "tools": [{"type": "function", "name": "get", "parameters": {"type": "object"}}],
+}
+
+
+def _wire(content: list, stop_reason: str, usage: dict) -> dict:
+    return {
+        "id": "chatcmpl-resp",
+        "type": "message",
+        "role": "assistant",
+        "model": MODEL,
+        "content": content,
+        "stop_reason": stop_reason,
+        "stop_sequence": None,
+        "usage": usage,
+    }
+
+
+_USAGE_PLAIN = {"input_tokens": 100, "output_tokens": 20}
+_USAGE_CACHED = {
+    "input_tokens": 100,
+    "output_tokens": 20,
+    "cache_creation_input_tokens": 5,
+    "cache_read_input_tokens": 10,
+}
+
+# Each recorded Anthropic wire response, its stop_reason, its usage, and the
+# wire reasoning-token count the provider would have reported (anthropic does
+# not, so 0). The corpus exercises output-item ordering
+# (reasoning->message->function_call), each block type, the status arms, and the
+# cache usage fold.
+_CASES: dict[str, dict] = {
+    "text_stop": {
+        "wire": _wire([{"type": "text", "text": "hello"}], "end_turn", _USAGE_PLAIN),
+        "reasoning_tokens": 0,
+    },
+    "text_max_tokens_incomplete": {
+        "wire": _wire(
+            [{"type": "text", "text": "truncated"}], "max_tokens", _USAGE_PLAIN
+        ),
+        "reasoning_tokens": 0,
+    },
+    "thinking_then_text": {
+        "wire": _wire(
+            [
+                {"type": "thinking", "thinking": "plan", "signature": "sg"},
+                {"type": "text", "text": "answer"},
+            ],
+            "end_turn",
+            _USAGE_PLAIN,
+        ),
+        "reasoning_tokens": 4,
+    },
+    "tool_use_only": {
+        "wire": _wire(
+            [{"type": "tool_use", "id": "toolu_1", "name": "get", "input": {"q": 1}}],
+            "tool_use",
+            _USAGE_PLAIN,
+        ),
+        "reasoning_tokens": 0,
+    },
+    "text_and_tool_use": {
+        "wire": _wire(
+            [
+                {"type": "text", "text": "calling"},
+                {"type": "tool_use", "id": "toolu_1", "name": "get", "input": {"q": 1}},
+            ],
+            "tool_use",
+            _USAGE_PLAIN,
+        ),
+        "reasoning_tokens": 0,
+    },
+    "thinking_text_tool_use_cached": {
+        "wire": _wire(
+            [
+                {"type": "thinking", "thinking": "plan", "signature": "sg"},
+                {"type": "text", "text": "calling"},
+                {"type": "tool_use", "id": "toolu_2", "name": "get", "input": {}},
+            ],
+            "tool_use",
+            _USAGE_CACHED,
+        ),
+        "reasoning_tokens": 6,
+    },
+}
+
+
+def _bridge_usage(ir_usage, reasoning_tokens: int) -> Usage:
+    """A provider-style Usage carrying the wire token counts the responses
+    reverse maps (both sides read this same object)."""
+    prompt = (
+        ir_usage.input_tokens
+        + ir_usage.cache_creation_input_tokens
+        + ir_usage.cache_read_input_tokens
+    )
+    usage = Usage(
+        prompt_tokens=prompt,
+        completion_tokens=ir_usage.output_tokens,
+        total_tokens=prompt + ir_usage.output_tokens,
+    )
+    usage.prompt_tokens_details = PromptTokensDetailsWrapper(
+        cached_tokens=ir_usage.cache_read_input_tokens,
+        text_tokens=ir_usage.input_tokens,
+    )
+    text_tokens = (
+        ir_usage.output_tokens - reasoning_tokens
+        if reasoning_tokens > 0
+        else ir_usage.output_tokens
+    )
+    usage.completion_tokens_details = CompletionTokensDetailsWrapper(
+        reasoning_tokens=reasoning_tokens, text_tokens=text_tokens
+    )
+    return usage
+
+
+@pytest.mark.parametrize("name", sorted(_CASES))
+def test_response_matches_v1_responses_reverse(name: str) -> None:
+    case = _CASES[name]
+    deps = build_real_deps()
+    request = parse_request(_REQUEST)
+    assert request.is_ok()
+    ir_result = parse_response(case["wire"], request.ok)
+    assert ir_result.is_ok(), ir_result.error.summary
+    ir = ir_result.ok
+
+    # Thread the wire reasoning tokens into the IR so both the v2 serializer and
+    # the bridged v1 ModelResponse map the same usage (anthropic reports none).
+    from dataclasses import replace
+    from expression import Some
+
+    threaded = (
+        replace(
+            ir, usage=replace(ir.usage, reasoning_tokens=Some(case["reasoning_tokens"]))
+        )
+        if case["reasoning_tokens"] > 0
+        else ir
+    )
+
+    v2_body = dict(v2_serialize(threaded, deps))
+    assert "summary" not in v2_body, v2_body
+
+    chat_body = chat_serialize(ir, deps, "anthropic")
+    assert isinstance(chat_body, dict)
+    model_response = ModelResponse(
+        **{"id": ir.id, "created": 0, "model": ir.model, **chat_body}
+    )
+    model_response.usage = _bridge_usage(ir.usage, case["reasoning_tokens"])
+    v1_body = V1.transform_chat_completion_response_to_responses_api_response(
+        request_input="hi",
+        responses_api_request={},
+        chat_completion_response=model_response,
+    ).model_dump()
+
+    v2_body["created_at"] = model_response.created
+
+    assert json.dumps(v2_body, sort_keys=True, default=str) == json.dumps(
+        v1_body, sort_keys=True, default=str
+    ), name
+
+
+def test_reasoning_item_precedes_message_and_function_call() -> None:
+    """Pin v1's output-item ORDER (reasoning -> message -> function_call): a
+    mutation that reorders the items (or drops the reasoning item) would still
+    pass a set comparison but breaks this sequence assertion."""
+    deps = build_real_deps()
+    request = parse_request(_REQUEST).ok
+    wire = _wire(
+        [
+            {"type": "thinking", "thinking": "why", "signature": "s"},
+            {"type": "text", "text": "ok"},
+            {"type": "tool_use", "id": "toolu_9", "name": "get", "input": {}},
+        ],
+        "tool_use",
+        _USAGE_PLAIN,
+    )
+    ir = parse_response(wire, request).ok
+    body = dict(v2_serialize(ir, deps))
+    kinds = [item["type"] for item in body["output"]]
+    assert kinds == ["reasoning", "message", "function_call"]

--- a/tests/test_litellm/translation/test_differential_responses_response.py
+++ b/tests/test_litellm/translation/test_differential_responses_response.py
@@ -136,6 +136,18 @@ _CASES: dict[str, dict] = {
         ),
         "reasoning_tokens": 6,
     },
+    # Anthropic ``refusal`` -> IR ``content_filter``, which the responses reverse
+    # status map has no explicit arm for and folds to its default ``incomplete``
+    # (v1's same default). Pins the content_filter status arm the corpus
+    # otherwise omitted (verifier-inbound GAP-2).
+    "refusal_content_filter_incomplete": {
+        "wire": _wire(
+            [{"type": "text", "text": "i cannot help with that"}],
+            "refusal",
+            _USAGE_PLAIN,
+        ),
+        "reasoning_tokens": 0,
+    },
 }
 
 
@@ -210,6 +222,48 @@ def test_response_matches_v1_responses_reverse(name: str) -> None:
     assert json.dumps(v2_body, sort_keys=True, default=str) == json.dumps(
         v1_body, sort_keys=True, default=str
     ), name
+
+
+def test_function_call_arguments_ride_verbatim_not_reserialized() -> None:
+    """The IR ToolUse.arguments_raw carries the wire bytes verbatim; the reverse
+    must emit them unchanged. The corpus tool args ``{"q":1}`` happen to equal
+    ``json.dumps`` of their parsed value, so a reserialize regression hides
+    there. A compact-spaced ``{"a":1,"b":2}`` does NOT survive json.dumps
+    (which inserts ``", "``/``": "``), so this pins the raw path. v1 copies the
+    ModelResponse tool_call arguments string verbatim (transformation.py:1515),
+    so the verbatim emission is also what v1 does (verifier-inbound GAP-4)."""
+    from dataclasses import replace
+
+    from expression import Nothing, Some
+    from expression.collections import Block as IRBlock
+
+    from litellm.translation.ir import ContentBlock, JsonBlob, ToolUse
+
+    deps = build_real_deps()
+    base = parse_response(
+        _wire(
+            [{"type": "tool_use", "id": "toolu_x", "name": "get", "input": {"a": 1}}],
+            "tool_use",
+            _USAGE_PLAIN,
+        ),
+        parse_request(_REQUEST).ok,
+    ).ok
+    compact = '{"a":1,"b":2}'
+    raw_block = ContentBlock.of_tool_use(
+        ToolUse(
+            id="toolu_x",
+            name="get",
+            arguments=JsonBlob(value={"a": 1, "b": 2}),
+            cache=Nothing,
+            arguments_raw=Some(compact),
+        )
+    )
+    ir = replace(base, content=IRBlock.of_seq([raw_block]))
+
+    body = dict(v2_serialize(ir, deps))
+    call = next(item for item in body["output"] if item["type"] == "function_call")
+    assert call["arguments"] == compact
+    assert call["arguments"] != json.dumps({"a": 1, "b": 2})
 
 
 def test_reasoning_item_precedes_message_and_function_call() -> None:


### PR DESCRIPTION
## Relevant issues

Core Translation v2 inbound-schema track. Adds two accepted request schemas onto the chat IR so the v2 translation layer can take `/v1/messages` (Anthropic Messages) and `/v1/responses` (OpenAI Responses) requests, not only `/v1/chat/completions`. Stacked on #30324 (wave-2b); independent of the outbound wave-3 arm (#30356).

## Linear ticket

Core Translation v2.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review

## What this does

The v2 engine previously hardwired the OpenAI-chat inbound parse and reverse-serialize. This threads the inbound schema through the pipeline as a frozen `InboundSchema -> _Inbound` table (a `MappingProxyType` of the parse_request + serialize_response pair), defaulting to `openai_chat`, so every existing seam call site keeps its exact behavior; the provider serializer/parser/dialect tables are inbound-agnostic and reused wholesale. The refactor commit is a proven no-op (object identity on the openai_chat row; the full translation suite is byte-identical at 3047 passed).

On top of that it adds two inbound subpackages:

`inbound/anthropic_messages/` parses an Anthropic Messages request into the chat IR and reverse-serializes the IR ChatResponse back to an Anthropic Messages body. The chat IR is Anthropic-shaped, so forward and reverse are largely 1:1 (system on the top-level field, tool_result as a content block, the thinking/text/tool_use response order, the input + cache_creation usage math). A reverse stream fold is built and differential-green but stays unwired at the seam with the rest of streaming.

`inbound/responses/` parses an OpenAI Responses request into the chat IR (input string or item list, the function_call/function_call_output union, instructions to system, tool_choice including the Cursor `{type: tool/any}` to required normalization, reasoning.effort, text.format) and reverse-serializes the IR ChatResponse to a ResponsesAPIResponse body (reasoning then message then function_call output order, status map, usage onto ResponseAPIUsage). The reverse stream fold is a deferred follow-up; v1's streaming iterator is a heavyweight stateful machine the dossier explicitly says not to port, and committing a half-built unpinned fold would break the fail-closed bar, so streaming `/v1/responses` falls back to v1 exactly as streaming does for the other inbound schemas today.

Both packages honor the fail-closed contract: every shape the chat IR cannot carry returns a typed `unsupported`/`boundary` error so dispatch falls back to v1 instead of silently dropping or coercing it. Each fallback row was confirmed against v1 in-process at HEAD to correspond to a real v1 serve (most of them lossy), so the typed fallback reproduces v1's own behavior rather than inventing a divergence.

## How parity is proven

Each schema has request and response differential gates that run v1's oracle in-process at HEAD over the same inputs and assert field-for-field equivalence (`/v1/messages` round-trips through the anthropic serializer; `/v1/responses` asserts the v2 IR equals v1's chat request and the v2 reverse equals v1's Responses body). The fail-closed rows assert the typed error and its reason fragment.

The change went through an adversarial review (an antagonist verifier re-deriving every SERVE row in-process and mutation-testing each source, plus a hostile critic on the binding tenets and the `extra="forbid"` outage-class audit). The review found one real defect: a Responses `message` input item with role `system`/`developer` was being silently collapsed to `user` (the chat IR role is user/assistant only), changing model behavior with no fallback to v1, the same outage class as the strict-parse regression in #30138. It now fails closed with a named reason and is pinned by two fallback rows plus a two-sided in-process probe confirming v1 forwards the role verbatim; the fix is mutation-verified. The review's five test-strength gaps (content_filter finish/status arms, the disable_parallel_tool_use round-trip, arguments_raw verbatim emission, and an error-prose nuance) are all closed in the same fix round, each mutation-verified to bite.

## Type

New Feature

## Changes

Pipeline `InboundSchema` selection refactor (no-op for `openai_chat`), the `inbound/anthropic_messages/` and `inbound/responses/` packages, their differential gates, and the CLAUDE.md inbound tree. The seam wiring for these endpoints and the reverse stream folds are deliberately out of scope (integrator/streaming-seam follow-ups), so the surface is additive and dormant until a future seam fork routes those endpoints to v2.
