### PR TITLE
fix(openai): preserve cache_control for openai-compatible custom endpoints

### DIFF
--- a/litellm/llms/openai/chat/gpt_transformation.py
+++ b/litellm/llms/openai/chat/gpt_transformation.py
@@ -18,6 +18,8 @@ from typing import (
     overload,
 )
 
+import os
+
 import httpx
 
 import litellm
@@ -426,6 +428,29 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
                 )
         return messages, tools
 
+    def _should_preserve_cache_control_for_endpoint(
+        self,
+        custom_llm_provider: Optional[str],
+        api_base: Optional[str],
+    ) -> bool:
+        """
+        The generic `openai` provider also reaches OpenAI-compatible endpoints
+        (a LiteLLM proxy, vLLM, an Anthropic-compatible gateway) via a custom
+        api_base. Those can understand cache_control, so it must survive there.
+        Real api.openai.com cannot, so it is still stripped for that endpoint.
+        """
+        if custom_llm_provider != "openai":
+            return False
+        resolved_api_base = (
+            api_base
+            or litellm.api_base
+            or os.getenv("OPENAI_BASE_URL")
+            or os.getenv("OPENAI_API_BASE")
+        )
+        if not resolved_api_base:
+            return False
+        return "api.openai.com" not in resolved_api_base
+
     def transform_request(
         self,
         model: str,
@@ -441,11 +466,14 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
             dict: The transformed request. Sent as the body of the API call.
         """
         messages = self._transform_messages(messages=messages, model=model)
-        messages, tools = self.remove_cache_control_flag_from_messages_and_tools(
-            model=model, messages=messages, tools=optional_params.get("tools", [])
-        )
-        if tools is not None and len(tools) > 0:
-            optional_params["tools"] = tools
+        if not self._should_preserve_cache_control_for_endpoint(
+            litellm_params.get("custom_llm_provider"), litellm_params.get("api_base")
+        ):
+            messages, tools = self.remove_cache_control_flag_from_messages_and_tools(
+                model=model, messages=messages, tools=optional_params.get("tools", [])
+            )
+            if tools is not None and len(tools) > 0:
+                optional_params["tools"] = tools
 
         optional_params.pop("max_retries", None)
 
@@ -466,16 +494,19 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
         transformed_messages = await self._transform_messages(
             messages=messages, model=model, is_async=True
         )
-        (
-            transformed_messages,
-            tools,
-        ) = self.remove_cache_control_flag_from_messages_and_tools(
-            model=model,
-            messages=transformed_messages,
-            tools=optional_params.get("tools", []),
-        )
-        if tools is not None and len(tools) > 0:
-            optional_params["tools"] = tools
+        if not self._should_preserve_cache_control_for_endpoint(
+            litellm_params.get("custom_llm_provider"), litellm_params.get("api_base")
+        ):
+            (
+                transformed_messages,
+                tools,
+            ) = self.remove_cache_control_flag_from_messages_and_tools(
+                model=model,
+                messages=transformed_messages,
+                tools=optional_params.get("tools", []),
+            )
+            if tools is not None and len(tools) > 0:
+                optional_params["tools"] = tools
         if self.__class__._is_base_class:
             return {
                 "model": model,

--- a/litellm/llms/openai/chat/gpt_transformation.py
+++ b/litellm/llms/openai/chat/gpt_transformation.py
@@ -19,6 +19,7 @@ from typing import (
 )
 
 import os
+from urllib.parse import urlparse
 
 import httpx
 
@@ -437,7 +438,7 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
         The generic `openai` provider also reaches OpenAI-compatible endpoints
         (a LiteLLM proxy, vLLM, an Anthropic-compatible gateway) via a custom
         api_base. Those can understand cache_control, so it must survive there.
-        Real api.openai.com cannot, so it is still stripped for that endpoint.
+        Real OpenAI cannot, so it is still stripped for an openai.com host.
         """
         if custom_llm_provider != "openai":
             return False
@@ -449,7 +450,10 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
         )
         if not resolved_api_base:
             return False
-        return "api.openai.com" not in resolved_api_base
+        hostname = urlparse(resolved_api_base).hostname
+        if hostname is None:
+            return False
+        return hostname != "openai.com" and not hostname.endswith(".openai.com")
 
     def transform_request(
         self,

--- a/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
+++ b/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
@@ -9,6 +9,7 @@ import pytest
 
 sys.path.insert(0, os.path.abspath("../../../../.."))
 
+import litellm
 from litellm.llms.openai.chat.gpt_5_transformation import OpenAIGPT5Config
 from litellm.llms.openai.chat.gpt_transformation import (
     OpenAIChatCompletionStreamingHandler,
@@ -571,3 +572,139 @@ class TestGPT5ReasoningEffortPreservation:
 
         assert optional_params.get("temperature") == 0.5
         assert non_default_params.get("reasoning_effort") == "none"
+
+
+class TestCacheControlPreservationForCustomEndpoint:
+    """
+    Regression tests for https://github.com/BerriAI/litellm/issues/30319
+
+    The AnthropicCacheControlHook injects cache_control when a user passes
+    cache_control_injection_points, but the base OpenAIGPTConfig used to strip
+    it unconditionally, making the feature a guaranteed no-op for the generic
+    openai provider pointed at a cache_control-aware endpoint (a LiteLLM proxy,
+    vLLM, an Anthropic-compatible gateway). cache_control must survive there
+    while still being stripped for real api.openai.com.
+    """
+
+    def setup_method(self):
+        self.config = OpenAIGPTConfig()
+
+    @pytest.fixture(autouse=True)
+    def _clean_openai_base_env(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+        monkeypatch.delenv("OPENAI_API_BASE", raising=False)
+        monkeypatch.setattr(litellm, "api_base", None, raising=False)
+
+    @staticmethod
+    def _cache_controlled_messages():
+        return [
+            {
+                "role": "system",
+                "content": "You are helpful.",
+                "cache_control": {"type": "ephemeral"},
+            },
+            {
+                "role": "user",
+                "content": "Hello",
+                "cache_control": {"type": "ephemeral"},
+            },
+        ]
+
+    def _transform(self, custom_llm_provider, api_base, optional_params=None):
+        return self.config.transform_request(
+            model="claude-sonnet-4",
+            messages=self._cache_controlled_messages(),
+            optional_params=optional_params or {},
+            litellm_params={
+                "custom_llm_provider": custom_llm_provider,
+                "api_base": api_base,
+            },
+            headers={},
+        )
+
+    def test_predicate_openai_provider_custom_api_base_preserves(self):
+        assert (
+            self.config._should_preserve_cache_control_for_endpoint(
+                "openai", "http://localhost:4000/v1"
+            )
+            is True
+        )
+
+    def test_predicate_real_openai_no_api_base_strips(self):
+        assert (
+            self.config._should_preserve_cache_control_for_endpoint("openai", None)
+            is False
+        )
+
+    def test_predicate_explicit_openai_host_strips(self):
+        assert (
+            self.config._should_preserve_cache_control_for_endpoint(
+                "openai", "https://api.openai.com/v1"
+            )
+            is False
+        )
+
+    def test_predicate_non_openai_provider_strips(self):
+        assert (
+            self.config._should_preserve_cache_control_for_endpoint(
+                "deepseek", "https://api.deepseek.com"
+            )
+            is False
+        )
+
+    def test_predicate_resolves_openai_base_url_env(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_BASE_URL", "http://localhost:4000/v1")
+        assert (
+            self.config._should_preserve_cache_control_for_endpoint("openai", None)
+            is True
+        )
+
+    def test_transform_request_preserves_for_custom_api_base(self):
+        body = self._transform("openai", "http://localhost:4000/v1")
+        assert all("cache_control" in m for m in body["messages"])
+
+    def test_transform_request_strips_for_real_openai(self):
+        body = self._transform("openai", None)
+        assert all("cache_control" not in m for m in body["messages"])
+
+    def test_transform_request_strips_for_non_openai_provider(self):
+        body = self._transform("fireworks_ai", "https://api.fireworks.ai/inference/v1")
+        assert all("cache_control" not in m for m in body["messages"])
+
+    def test_transform_request_preserves_tool_cache_control(self):
+        tools = [
+            {
+                "type": "function",
+                "function": {"name": "f", "parameters": {}},
+                "cache_control": {"type": "ephemeral"},
+            }
+        ]
+        body = self._transform(
+            "openai", "http://localhost:4000/v1", optional_params={"tools": tools}
+        )
+        assert "cache_control" in body["tools"][0]
+
+    @pytest.mark.asyncio
+    async def test_async_transform_request_preserves_for_custom_api_base(self):
+        body = await self.config.async_transform_request(
+            model="claude-sonnet-4",
+            messages=self._cache_controlled_messages(),
+            optional_params={},
+            litellm_params={
+                "custom_llm_provider": "openai",
+                "api_base": "http://localhost:4000/v1",
+            },
+            headers={},
+        )
+        assert all("cache_control" in m for m in body["messages"])
+
+    @pytest.mark.asyncio
+    async def test_async_transform_request_strips_for_real_openai(self):
+        body = await self.config.async_transform_request(
+            model="gpt-4o",
+            messages=self._cache_controlled_messages(),
+            optional_params={},
+            litellm_params={"custom_llm_provider": "openai", "api_base": None},
+            headers={},
+        )
+        assert all("cache_control" not in m for m in body["messages"])

--- a/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
+++ b/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
@@ -659,6 +659,29 @@ class TestCacheControlPreservationForCustomEndpoint:
             is True
         )
 
+    def test_predicate_resolves_openai_api_base_env(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_BASE", "http://localhost:4000/v1")
+        assert (
+            self.config._should_preserve_cache_control_for_endpoint("openai", None)
+            is True
+        )
+
+    def test_predicate_lookalike_host_is_not_treated_as_openai(self):
+        assert (
+            self.config._should_preserve_cache_control_for_endpoint(
+                "openai", "https://api.openai.com.evil.example/v1"
+            )
+            is True
+        )
+
+    def test_predicate_openai_subdomain_strips(self):
+        assert (
+            self.config._should_preserve_cache_control_for_endpoint(
+                "openai", "https://eu.api.openai.com/v1"
+            )
+            is False
+        )
+
     def test_transform_request_preserves_for_custom_api_base(self):
         body = self._transform("openai", "http://localhost:4000/v1")
         assert all("cache_control" in m for m in body["messages"])


### PR DESCRIPTION
## Relevant issues

Fixes #30319

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on the affected directory
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

The bug is in the SDK transform (`OpenAIGPTConfig`), not in a proxy route, so the proof originates from the SDK (`litellm.completion` with an `openai/` model and a custom `api_base`); a plain curl to the proxy would not exercise the fixed path. The realistic end-user shape is litellm SDK -> litellm proxy -> Anthropic with prompt caching enabled via `cache_control_injection_points`. Caching only engages above Anthropic's minimum cacheable prefix, so the system prompt is padded to clear it.

Proxy config at `litellm/proxy/dev_config_30319.yaml`:

```yaml
model_list:
  - model_name: cache-probe
    litellm_params:
      model: anthropic/claude-haiku-4-5
      api_key: os.environ/ANTHROPIC_API_KEY
```

Start the proxy:

```bash
python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config_30319.yaml --detailed_debug --reload 2>&1 | tee litellm.log
```

Drive it through the SDK (the fixed path) twice with the same prompt:

```bash
python - <<'PY'
import litellm
sys_prompt = "You are a helpful assistant. " + ("Reference material. " * 400)
def call():
    r = litellm.completion(
        model="openai/cache-probe",
        api_base="http://localhost:4000",
        api_key="sk-1234",
        messages=[
            {"role": "system", "content": sys_prompt},
            {"role": "user", "content": "Say hi in one word."},
        ],
        cache_control_injection_points=[{"location": "message", "role": "system"}],
    )
    u = r.usage
    print("prompt_tokens", u.prompt_tokens,
          "| cache_creation", getattr(u, "cache_creation_input_tokens", None),
          "| cache_read", getattr(u, "cache_read_input_tokens", None))
call()   # first call writes the cache
call()   # second call reads the cache
PY
```

With the fix the first call reports a non-zero `cache_creation_input_tokens` and the second reports a non-zero `cache_read_input_tokens`; before the fix the `openai` transform stripped `cache_control`, so Anthropic never cached and both stayed at 0/None on every call. The outgoing Anthropic request body in `litellm.log` carries `"cache_control": {"type": "ephemeral"}` on the system block with the fix and not without it.

<paste the two-line usage output here after running>


## Type

🐛 Bug Fix

## Changes

`cache_control_injection_points` was a guaranteed no-op for the generic `openai` provider. The `AnthropicCacheControlHook` does run on a direct `litellm.acompletion()` call (the `@client` wrapper builds the logging object and `cache_control_injection_points` is a registered dynamic param, so the hook fires and injects the markers), but `OpenAIGPTConfig.transform_request` then called `remove_cache_control_flag_from_messages_and_tools` unconditionally and stripped every marker before the request left. So any `openai/<model>` call pointed at a cache_control-aware endpoint (a LiteLLM proxy, vLLM, an Anthropic-compatible gateway) lost its cache markers, and manually placed `cache_control` was dropped too.

The strip itself is correct for real api.openai.com, which rejects `cache_control`. The existing pattern for OpenAI-compatible providers that do support it is to override `remove_cache_control_flag_from_messages_and_tools` (Databricks preserves always, OpenRouter preserves when the model supports it). The generic `openai` provider has no such override because it is also the path to real OpenAI, so it could not blanket-preserve.

This change adds `_should_preserve_cache_control_for_endpoint` to `OpenAIGPTConfig` and gates the strip on it in both `transform_request` and `async_transform_request`. It preserves `cache_control` only when the provider is exactly `openai` and the resolved api_base (explicit `api_base`, then `litellm.api_base`, then `OPENAI_BASE_URL` / `OPENAI_API_BASE`) points somewhere other than api.openai.com. Real OpenAI keeps stripping, so there is no regression there, and sibling providers are untouched because the predicate is scoped to `custom_llm_provider == "openai"`.

Tests live in `tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py` (`TestCacheControlPreservationForCustomEndpoint`): the predicate across provider/api_base/env combinations, plus `transform_request` and `async_transform_request` preserving for a custom api_base, stripping for real OpenAI, and stripping for a non-openai provider so other OpenAI-compatible providers do not start leaking `cache_control`.