### PR TITLE
test(fireworks): mock whisper transcription tests instead of live calls

### DIFF
--- a/tests/llm_translation/test_fireworks_ai_translation.py
+++ b/tests/llm_translation/test_fireworks_ai_translation.py
@@ -70,6 +70,11 @@ def test_map_response_format():
     assert result == {"response_format": response_format}
 
 
+_AUDIO_FILE_PATH = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)), "gettysburg.wav"
+)
+
+
 class TestFireworksAIAudioTranscription(BaseLLMAudioTranscriptionTest):
     def get_base_audio_transcription_call_args(self) -> dict:
         return {
@@ -79,6 +84,60 @@ class TestFireworksAIAudioTranscription(BaseLLMAudioTranscriptionTest):
 
     def get_custom_llm_provider(self) -> litellm.LlmProviders:
         return litellm.LlmProviders.FIREWORKS_AI
+
+    def test_audio_transcription(self):
+        from unittest.mock import MagicMock
+
+        from openai.types.audio import Transcription
+
+        audio_file = open(_AUDIO_FILE_PATH, "rb")
+        mock_client = MagicMock()
+        mock_client.audio.transcriptions.create.return_value = Transcription(
+            text="four score and seven years ago"
+        )
+
+        transcript = transcription(
+            **self.get_base_audio_transcription_call_args(),
+            file=audio_file,
+            api_key="fw-test-key",
+            client=mock_client,
+        )
+
+        assert transcript.text == "four score and seven years ago"
+        sent = mock_client.audio.transcriptions.create.call_args.kwargs
+        assert sent["model"] == "whisper-v3"
+        assert sent["file"] is audio_file
+
+    @pytest.mark.asyncio
+    async def test_audio_transcription_async(self):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from openai.types.audio import Transcription
+
+        audio_file = open(_AUDIO_FILE_PATH, "rb")
+        raw_response = MagicMock()
+        raw_response.headers = {}
+        raw_response.parse.return_value = Transcription(
+            text="four score and seven years ago"
+        )
+        mock_client = MagicMock()
+        mock_client.audio.transcriptions.with_raw_response.create = AsyncMock(
+            return_value=raw_response
+        )
+
+        transcript = await litellm.atranscription(
+            **self.get_base_audio_transcription_call_args(),
+            file=audio_file,
+            api_key="fw-test-key",
+            client=mock_client,
+        )
+
+        assert transcript.text == "four score and seven years ago"
+        sent = (
+            mock_client.audio.transcriptions.with_raw_response.create.call_args.kwargs
+        )
+        assert sent["model"] == "whisper-v3"
+        assert sent["file"] is audio_file
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Relevant issues

`TestFireworksAIAudioTranscription::test_audio_transcription` and `::test_audio_transcription_async` were failing in CI with a 401 from Fireworks:

```
FAILED tests/llm_translation/test_fireworks_ai_translation.py::TestFireworksAIAudioTranscription::test_audio_transcription - openai.AuthenticationError: Error code: 401 - {'error': {'object': 'error', 'type': 'unauthorized', 'message': 'Unauthorized'}}
FAILED tests/llm_translation/test_fireworks_ai_translation.py::TestFireworksAIAudioTranscription::test_audio_transcription_async - litellm.exceptions.AuthenticationError: AuthenticationError: Fireworks_aiException - Unauthorized
```

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

This change is entirely within test code and has no runtime or proxy surface, so the usual live-proxy curl does not apply; the proof is that the two tests now pass without any network call. Before, they hit `audio-prod.api.fireworks.ai` and returned 401 in CI.

```
$ python -m pytest test_fireworks_ai_translation.py::TestFireworksAIAudioTranscription -q
....                                                                     [100%]
4 passed in 0.15s
```

The assertions are not vacuous; `sent["model"] == "whisper-v3"` only holds because the real routing strips the `fireworks_ai/` prefix, and `transcript.text` only matches because the mocked response is parsed through litellm's real transcription path.

## Type

✅ Test

## Changes

The two failing tests are inherited from `BaseLLMAudioTranscriptionTest`, which makes real calls to Fireworks' audio host `audio-prod.api.fireworks.ai`. That host is a separately-entitled product and the CI Fireworks key is rejected there with a 401, so the tests fail without telling us anything about litellm; they only ever proved the network worked.

This overrides both tests in the subclass with a dependency-injected mock OpenAI client. Fireworks audio routes through litellm's openai-compatible path, which uses the openai SDK (hence the original `openai.AuthenticationError`), and that handler accepts a `client=` and uses it as-is, so the real routing, model-prefix stripping, and response parsing all still run; only the network call is replaced. The sync path mocks `audio.transcriptions.create` and the async path mocks `audio.transcriptions.with_raw_response.create`.

This continues the existing direction in this file, where the document-inlining and global-disable tests were already moved off live Fireworks calls because the serverless catalog and endpoints rotate and break CI.