### PR TITLE
fix(mcp): default Linear MCP registry entry to streamable HTTP

### DIFF
--- a/litellm/proxy/mcp_registry.json
+++ b/litellm/proxy/mcp_registry.json
@@ -44,8 +44,8 @@
       "icon_url": "https://cdn.simpleicons.org/linear",
       "category": "Developer Tools",
       "registry_url": "https://registry.modelcontextprotocol.io/servers/app.linear%2Flinear",
-      "transport": "sse",
-      "url": "https://mcp.linear.app/sse",
+      "transport": "http",
+      "url": "https://mcp.linear.app/mcp",
       "env_vars": []
     },
     {

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_discovery.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_discovery.py
@@ -85,6 +85,15 @@ class TestMCPRegistryFile:
                     "url" in server and server["url"]
                 ), f"HTTP/SSE server {server['name']} missing 'url'"
 
+    def test_linear_uses_streamable_http(self, registry_path):
+        """Linear's MCP server should default to streamable HTTP at /mcp, not SSE at /sse."""
+        with open(registry_path, "r") as f:
+            data = json.load(f)
+        linear = next(s for s in data["servers"] if s["name"] == "linear")
+        assert linear["transport"] == "http"
+        assert linear["url"] == "https://mcp.linear.app/mcp"
+        assert "/sse" not in linear["url"]
+
     def test_well_known_servers_present(self, registry_path):
         """Ensure key well-known MCPs are in the registry."""
         with open(registry_path, "r") as f:


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

The curated MCP discovery registry (`litellm/proxy/mcp_registry.json`, served by `GET /v1/mcp/server/discover` and shown in the "add MCP server" picker) listed Linear with the SSE transport and the `/sse` URL. Linear is deprecating that endpoint in favor of streamable HTTP at `https://mcp.linear.app/mcp` (see https://linear.app/docs/mcp), so the preset now lands users on a transport that is going away.

This flips the Linear entry to `transport: http` and `url: https://mcp.linear.app/mcp`, matching how the other streamable-HTTP presets (github, gitlab, atlassian, exa, stripe) are already configured.

You can confirm the served registry against a running proxy:

```
curl -s http://localhost:4000/v1/mcp/server/discover \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
  | jq '.servers[] | select(.name == "linear") | {transport, url}'
```

Expected:

```
{
  "transport": "http",
  "url": "https://mcp.linear.app/mcp"
}
```

## Type

🐛 Bug Fix

## Changes

Updated the Linear entry in the curated MCP discovery registry to default to streamable HTTP (`transport: http`) at `https://mcp.linear.app/mcp` instead of SSE at `https://mcp.linear.app/sse`. Added a regression test in `test_mcp_discovery.py` pinning Linear to the `http` transport and the `/mcp` URL so it can't silently regress back to `/sse`.

Note for a separate follow-up: the unused root-level `mcp_servers.json` sample still lists Linear's `sse_url` as `https://mcp.linear.app/sse`. It is not referenced anywhere in the codebase, so I left it out of this PR to keep the scope isolated.
