### PR TITLE
fix(ui): stop Virtual Keys page from infinite render loop

### DIFF
--- a/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.tsx
+++ b/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.tsx
@@ -96,6 +96,8 @@ export function VirtualKeysTable({ teams, organizations, onSortChange, currentSo
 
   // Use the filter logic hook
 
+  const keyList = useMemo(() => keys?.keys ?? [], [keys]);
+
   const {
     filters,
     filteredKeys,
@@ -105,7 +107,7 @@ export function VirtualKeysTable({ teams, organizations, onSortChange, currentSo
     handleFilterChange,
     handleFilterReset,
   } = useFilterLogic({
-    keys: keys?.keys || [],
+    keys: keyList,
     teams,
     organizations,
   });

--- a/ui/litellm-dashboard/src/components/key_team_helpers/filter_logic.test.tsx
+++ b/ui/litellm-dashboard/src/components/key_team_helpers/filter_logic.test.tsx
@@ -149,6 +149,23 @@ describe("useFilterLogic – filteredTotalCount", () => {
     expect(result.current.filteredTotalCount).toBeNull();
   });
 
+  it("should not enter an infinite update loop when keys is a fresh array reference on every render", () => {
+    const sourceKeys = [mockKey];
+    let renderCount = 0;
+
+    const { result } = renderHook(() => {
+      renderCount += 1;
+      const value = useFilterLogic({ keys: [...sourceKeys], teams: [], organizations: [] });
+      if (renderCount > 25) {
+        throw new Error(`useFilterLogic re-rendered ${renderCount} times; setFilteredKeys is looping`);
+      }
+      return value;
+    });
+
+    expect(result.current.filteredKeys).toEqual([mockKey]);
+    expect(renderCount).toBeLessThanOrEqual(25);
+  });
+
   it("should not trigger a debounced search when skipDebounce is true", async () => {
     const { result } = renderHook(() => useFilterLogic(defaultProps));
 

--- a/ui/litellm-dashboard/src/components/key_team_helpers/filter_logic.tsx
+++ b/ui/litellm-dashboard/src/components/key_team_helpers/filter_logic.tsx
@@ -99,7 +99,9 @@ export function useFilterLogic({
       result = result.filter((key) => (key.organization_id ?? key.org_id) === filters["Organization ID"]);
     }
 
-    setFilteredKeys(result);
+    setFilteredKeys((prev) =>
+      prev.length === result.length && prev.every((key, index) => key === result[index]) ? prev : result,
+    );
   }, [keys, filters]);
 
   // Fetch all data for filters when component mounts


### PR DESCRIPTION
## Summary

The Virtual Keys page could lock into an infinite render loop, spamming "Maximum update depth exceeded" and pinning the browser. The keys-filter effect in `useFilterLogic` called `setFilteredKeys` with a freshly built array on every `[keys, filters]` change, while the caller passed `keys?.keys || []`, which mints a new array identity on every render whenever the keys list is empty or still loading. That unstable reference re-fired the effect each render, looping until React bailed at max update depth. This is most visible right after a fresh DB / migration when there are no keys yet.

The fix makes `setFilteredKeys` bail out when the filtered result is element-for-element unchanged, matching the prev-bailout pattern the sibling teams/organizations effects in the same file already use, so the hook is loop-proof regardless of caller. The caller also memoizes the array it passes in so the hook stops receiving a churned reference.

## Test plan
- [x] `filter_logic.test.tsx` — new regression test renders the hook with a fresh array reference on every render; it fails fast without the guard (throws "re-rendered 26 times; setFilteredKeys is looping") and passes with it
- [x] `filter_logic.test.tsx` — all 8 tests pass
- [x] `VirtualKeysTable.test.tsx` — all 28 tests pass (caller memoization change)
- [x] Local dev server recompiled cleanly and the `Maximum update depth exceeded` spam no longer appears in the UI log when viewing the Virtual Keys page