### PR TITLE
fix(ui): render usage chart tooltips in a portal to prevent clipping

### DIFF
--- a/ui/litellm-dashboard/src/components/UsagePage/components/ChartTooltipPortal.test.tsx
+++ b/ui/litellm-dashboard/src/components/UsagePage/components/ChartTooltipPortal.test.tsx
@@ -1,0 +1,90 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { ChartTooltipPortal, useCursorPosition } from "./ChartTooltipPortal";
+
+describe("ChartTooltipPortal", () => {
+  beforeEach(() => {
+    window.innerWidth = 1024;
+    window.innerHeight = 768;
+  });
+
+  it("renders the tooltip on document.body so an overflow ancestor cannot clip it", () => {
+    render(
+      <div data-testid="clipping-container" style={{ overflow: "auto", maxHeight: 80 }}>
+        <ChartTooltipPortal active position={{ x: 100, y: 100 }}>
+          <span>Successful: 42</span>
+        </ChartTooltipPortal>
+      </div>,
+    );
+
+    const tooltip = screen.getByText("Successful: 42");
+    expect(screen.getByTestId("clipping-container")).not.toContainElement(tooltip);
+    expect(document.body).toContainElement(tooltip);
+  });
+
+  it("renders nothing when inactive", () => {
+    render(
+      <ChartTooltipPortal active={false} position={{ x: 0, y: 0 }}>
+        <span>Successful: 42</span>
+      </ChartTooltipPortal>,
+    );
+
+    expect(screen.queryByText("Successful: 42")).toBeNull();
+  });
+
+  it("pins the tooltip at the cursor with fixed positioning above other layers and ignores pointer events", () => {
+    render(
+      <ChartTooltipPortal active position={{ x: 120, y: 140 }}>
+        <span>tip</span>
+      </ChartTooltipPortal>,
+    );
+
+    const portal = screen.getByTestId("chart-tooltip-portal");
+    expect(portal).toHaveStyle({ position: "fixed", pointerEvents: "none" });
+    expect(portal.style.zIndex).toBe("9999");
+    expect(portal.style.left).toBe("134px");
+    expect(portal.style.top).toBe("154px");
+    expect(portal.style.transform).toBe("translate(0, 0)");
+  });
+
+  it("flips toward the cursor near the right and bottom edges to stay on screen", () => {
+    render(
+      <ChartTooltipPortal active position={{ x: 1000, y: 700 }}>
+        <span>tip</span>
+      </ChartTooltipPortal>,
+    );
+
+    const portal = screen.getByTestId("chart-tooltip-portal");
+    expect(portal.style.transform).toBe("translate(-100%, -100%)");
+    expect(portal.style.left).toBe("986px");
+    expect(portal.style.top).toBe("686px");
+  });
+
+  it("useCursorPosition records the latest cursor coordinates from mouse move", () => {
+    function Harness() {
+      const { positionRef, handleMouseMove } = useCursorPosition();
+      const [, force] = useState(0);
+      return (
+        <div
+          data-testid="area"
+          onMouseMove={(event) => {
+            handleMouseMove(event);
+            force((tick) => tick + 1);
+          }}
+        >
+          <ChartTooltipPortal active position={positionRef.current}>
+            <span>tip</span>
+          </ChartTooltipPortal>
+        </div>
+      );
+    }
+
+    render(<Harness />);
+    fireEvent.mouseMove(screen.getByTestId("area"), { clientX: 220, clientY: 330 });
+
+    const portal = screen.getByTestId("chart-tooltip-portal");
+    expect(portal.style.left).toBe("234px");
+    expect(portal.style.top).toBe("344px");
+  });
+});

--- a/ui/litellm-dashboard/src/components/UsagePage/components/ChartTooltipPortal.tsx
+++ b/ui/litellm-dashboard/src/components/UsagePage/components/ChartTooltipPortal.tsx
@@ -1,0 +1,50 @@
+import { useCallback, useRef, type MouseEvent, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+
+const CURSOR_OFFSET_PX = 14;
+const EDGE_FLIP_RATIO = 0.6;
+
+export interface CursorPosition {
+  x: number;
+  y: number;
+}
+
+export function useCursorPosition() {
+  const positionRef = useRef<CursorPosition>({ x: 0, y: 0 });
+  const handleMouseMove = useCallback((event: MouseEvent<HTMLElement>): void => {
+    positionRef.current = { x: event.clientX, y: event.clientY };
+  }, []);
+  return { positionRef, handleMouseMove };
+}
+
+interface ChartTooltipPortalProps {
+  active: boolean;
+  position: CursorPosition;
+  children: ReactNode;
+}
+
+export function ChartTooltipPortal({ active, position, children }: ChartTooltipPortalProps): ReactNode {
+  if (!active || typeof document === "undefined") {
+    return null;
+  }
+
+  const flipX = position.x > window.innerWidth * EDGE_FLIP_RATIO;
+  const flipY = position.y > window.innerHeight * EDGE_FLIP_RATIO;
+
+  return createPortal(
+    <div
+      data-testid="chart-tooltip-portal"
+      style={{
+        position: "fixed",
+        left: position.x + (flipX ? -CURSOR_OFFSET_PX : CURSOR_OFFSET_PX),
+        top: position.y + (flipY ? -CURSOR_OFFSET_PX : CURSOR_OFFSET_PX),
+        transform: `translate(${flipX ? "-100%" : "0"}, ${flipY ? "-100%" : "0"})`,
+        zIndex: 9999,
+        pointerEvents: "none",
+      }}
+    >
+      {children}
+    </div>,
+    document.body,
+  );
+}

--- a/ui/litellm-dashboard/src/components/UsagePage/components/EntityUsage/TopKeyView.tsx
+++ b/ui/litellm-dashboard/src/components/UsagePage/components/EntityUsage/TopKeyView.tsx
@@ -9,6 +9,7 @@ import { keyInfoV1Call } from "../../../networking";
 import KeyInfoView from "../../../templates/key_info_view";
 import { DataTable } from "../../../view_logs/table";
 import { TagUsage } from "../../types";
+import { ChartTooltipPortal, useCursorPosition } from "../ChartTooltipPortal";
 
 interface TopKeyViewProps {
   topKeys: any[];
@@ -25,6 +26,7 @@ const TopKeyView: React.FC<TopKeyViewProps> = ({ topKeys, teams, showTags = fals
   const [keyData, setKeyData] = useState<any | undefined>(undefined);
   const [viewMode, setViewMode] = useState<"chart" | "table">("table");
   const [expandedTags, setExpandedTags] = useState<Set<string>>(new Set());
+  const { positionRef: keysCursor, handleMouseMove: handleKeysMouseMove } = useCursorPosition();
 
   const toggleTagsExpansion = (apiKey: string) => {
     setExpandedTags((prev) => {
@@ -207,7 +209,7 @@ const TopKeyView: React.FC<TopKeyViewProps> = ({ topKeys, teams, showTags = fals
       </div>
 
       {viewMode === "chart" ? (
-        <div className="relative max-h-[600px] overflow-y-auto">
+        <div className="relative max-h-[600px] overflow-y-auto" onMouseMove={handleKeysMouseMove}>
           <BarChart
             className="mt-4 cursor-pointer hover:opacity-90"
             style={{ height: Math.min(processedTopKeys.length, topKeysLimit) * 52 }}
@@ -222,25 +224,27 @@ const TopKeyView: React.FC<TopKeyViewProps> = ({ topKeys, teams, showTags = fals
             valueFormatter={(value) => `$${formatNumberWithCommas(value, 2)}`}
             onValueChange={(item) => handleKeyClick(item)}
             showTooltip={true}
-            customTooltip={(props) => {
-              const item = props.payload?.[0]?.payload;
+            customTooltip={({ payload, active }) => {
+              const item = payload?.[0]?.payload;
               return (
-                <div className="relative z-50 p-3 bg-black/90 shadow-lg rounded-lg text-white max-w-xs">
-                  <div className="space-y-1.5">
-                    <div className="text-sm">
-                      <span className="text-gray-300">Key Alias: </span>
-                      <span className="font-mono text-gray-100 break-all">{item?.key_alias}</span>
-                    </div>
-                    <div className="text-sm">
-                      <span className="text-gray-300">Key ID: </span>
-                      <span className="font-mono text-gray-100 break-all">{item?.api_key}</span>
-                    </div>
-                    <div className="text-sm">
-                      <span className="text-gray-300">Spend: </span>
-                      <span className="text-white font-medium">${formatNumberWithCommas(item?.spend, 2)}</span>
+                <ChartTooltipPortal active={!!active && !!item} position={keysCursor.current}>
+                  <div className="p-3 bg-black/90 shadow-lg rounded-lg text-white max-w-xs">
+                    <div className="space-y-1.5">
+                      <div className="text-sm">
+                        <span className="text-gray-300">Key Alias: </span>
+                        <span className="font-mono text-gray-100 break-all">{item?.key_alias}</span>
+                      </div>
+                      <div className="text-sm">
+                        <span className="text-gray-300">Key ID: </span>
+                        <span className="font-mono text-gray-100 break-all">{item?.api_key}</span>
+                      </div>
+                      <div className="text-sm">
+                        <span className="text-gray-300">Spend: </span>
+                        <span className="text-white font-medium">${formatNumberWithCommas(item?.spend, 2)}</span>
+                      </div>
                     </div>
                   </div>
-                </div>
+                </ChartTooltipPortal>
               );
             }}
           />

--- a/ui/litellm-dashboard/src/components/UsagePage/components/EntityUsage/TopModelView.tsx
+++ b/ui/litellm-dashboard/src/components/UsagePage/components/EntityUsage/TopModelView.tsx
@@ -3,6 +3,7 @@ import { Segmented } from "antd";
 import { useState } from "react";
 import { formatNumberWithCommas } from "../../../../utils/dataUtils";
 import { DataTable } from "../../../view_logs/table";
+import { ChartTooltipPortal, useCursorPosition } from "../ChartTooltipPortal";
 
 interface TopModel {
   key: string;
@@ -20,6 +21,7 @@ interface TopModelViewProps {
 
 export default function TopModelView({ topModels, topModelsLimit, setTopModelsLimit }: TopModelViewProps) {
   const [modelViewMode, setModelViewMode] = useState<"chart" | "table">("table");
+  const { positionRef: modelsCursor, handleMouseMove: handleModelsMouseMove } = useCursorPosition();
 
   const columns = [
     {
@@ -82,7 +84,7 @@ export default function TopModelView({ topModels, topModelsLimit, setTopModelsLi
         </div>
       </div>
       {modelViewMode === "chart" ? (
-        <div className="relative max-h-[600px] overflow-y-auto">
+        <div className="relative max-h-[600px] overflow-y-auto" onMouseMove={handleModelsMouseMove}>
           <BarChart
             className="mt-4 cursor-pointer hover:opacity-90"
             style={{ height: Math.min(processedTopModels.length, topModelsLimit) * 52 }}
@@ -95,6 +97,20 @@ export default function TopModelView({ topModels, topModelsLimit, setTopModelsLi
             yAxisWidth={200}
             tickGap={5}
             showLegend={false}
+            customTooltip={({ payload, active }) => {
+              const item = payload?.[0]?.payload as TopModel | undefined;
+              return (
+                <ChartTooltipPortal active={!!active && !!item} position={modelsCursor.current}>
+                  <div className="bg-white p-4 shadow-lg rounded-lg border">
+                    <p className="font-bold">{item?.key}</p>
+                    <p className="text-cyan-500">Spend: ${formatNumberWithCommas(item?.spend, 2)}</p>
+                    <p className="text-green-600">Successful: {item?.successful_requests.toLocaleString()}</p>
+                    <p className="text-red-600">Failed: {item?.failed_requests.toLocaleString()}</p>
+                    <p className="text-gray-600">Tokens: {item?.tokens.toLocaleString()}</p>
+                  </div>
+                </ChartTooltipPortal>
+              );
+            }}
           />
         </div>
       ) : (

--- a/ui/litellm-dashboard/src/components/UsagePage/components/UsagePageView.tsx
+++ b/ui/litellm-dashboard/src/components/UsagePage/components/UsagePageView.tsx
@@ -45,6 +45,7 @@ import ViewUserSpend from "../../view_user_spend";
 import { usePaginatedDailyActivity } from "../hooks/usePaginatedDailyActivity";
 import { DailyData, KeyMetricWithMetadata, MetricWithMetadata } from "../types";
 import { valueFormatterSpend } from "../utils/value_formatters";
+import { ChartTooltipPortal, useCursorPosition } from "./ChartTooltipPortal";
 import EndpointUsage from "./EndpointUsage/EndpointUsage";
 import EntityUsage, { EntityList } from "./EntityUsage/EntityUsage";
 import SpendByProvider from "./EntityUsage/SpendByProvider";
@@ -146,6 +147,7 @@ const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
   const [topKeysLimit, setTopKeysLimit] = useState<number>(5);
   const [topModelsLimit, setTopModelsLimit] = useState<number>(5);
   const [showTokenBreakdown, setShowTokenBreakdown] = useState(false);
+  const { positionRef: topModelsCursor, handleMouseMove: handleTopModelsMouseMove } = useCursorPosition();
   // Sync selectedUserId when auth state settles (isAdmin/userID may be null on initial render)
   useEffect(() => {
     if (!isAdmin && userID) {
@@ -769,7 +771,10 @@ const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
                           {loading ? (
                             <ChartLoader isDateChanging={isDateChanging} />
                           ) : (
-                            <div className="relative max-h-[600px] overflow-y-auto">
+                            <div
+                              className="relative max-h-[600px] overflow-y-auto"
+                              onMouseMove={handleTopModelsMouseMove}
+                            >
                               {(() => {
                                 const modelData = modelViewType === "groups" ? topModelGroups : topModels;
                                 return (
@@ -785,25 +790,29 @@ const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
                                     yAxisWidth={200}
                                     showLegend={false}
                                     customTooltip={({ payload, active }) => {
-                                      if (!active || !payload?.[0]) return null;
-                                      const data = payload[0].payload;
+                                      const data = payload?.[0]?.payload;
                                       return (
-                                        <div className="bg-white p-4 shadow-lg rounded-lg border">
-                                          <p className="font-bold">{data.key}</p>
-                                          <p className="text-cyan-500">
-                                            Spend: ${formatNumberWithCommas(data.spend, 2)}
-                                          </p>
-                                          <p className="text-gray-600">
-                                            Total Requests: {data.requests.toLocaleString()}
-                                          </p>
-                                          <p className="text-green-600">
-                                            Successful: {data.successful_requests.toLocaleString()}
-                                          </p>
-                                          <p className="text-red-600">
-                                            Failed: {data.failed_requests.toLocaleString()}
-                                          </p>
-                                          <p className="text-gray-600">Tokens: {data.tokens.toLocaleString()}</p>
-                                        </div>
+                                        <ChartTooltipPortal
+                                          active={!!active && !!data}
+                                          position={topModelsCursor.current}
+                                        >
+                                          <div className="bg-white p-4 shadow-lg rounded-lg border">
+                                            <p className="font-bold">{data?.key}</p>
+                                            <p className="text-cyan-500">
+                                              Spend: ${formatNumberWithCommas(data?.spend, 2)}
+                                            </p>
+                                            <p className="text-gray-600">
+                                              Total Requests: {data?.requests.toLocaleString()}
+                                            </p>
+                                            <p className="text-green-600">
+                                              Successful: {data?.successful_requests.toLocaleString()}
+                                            </p>
+                                            <p className="text-red-600">
+                                              Failed: {data?.failed_requests.toLocaleString()}
+                                            </p>
+                                            <p className="text-gray-600">Tokens: {data?.tokens.toLocaleString()}</p>
+                                          </div>
+                                        </ChartTooltipPortal>
                                       );
                                     }}
                                   />


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

On the Usage dashboard, hovering a bar under "Top Public Model Names" used to show a tooltip whose bottom rows were cut off by the chart's scroll container. The tooltip now renders fully, follows the cursor, and stays on screen.

Steps to reproduce and confirm against a live proxy with real spend data:

1. Run the proxy on `:4000` with logs that have spend, then start the dashboard with `cd ui/litellm-dashboard && npm run dev` and open http://localhost:3000
2. Go to the Usage page, set the row count to "5" so the chart is short (the worst case for clipping)
3. Hover a bar under "Top Public Model Names"; the full tooltip (Spend, Total Requests, Successful, Failed, Tokens) is visible instead of being truncated
4. Switch "Top Virtual Keys" and "Top Models" to "Chart View" and hover; same behavior

Screenshots to follow.

<img width="846" height="427" alt="image" src="https://github.com/user-attachments/assets/4567b91e-23a0-4a78-bc01-22073da66418" />

## Type

🐛 Bug Fix

## Changes

The three "Top ..." bar charts on the Usage dashboard ("Top Public Model Names" in `UsagePageView`, "Top Virtual Keys" in `TopKeyView`, and "Top Models" in `TopModelView`) wrap their Tremor `BarChart` in a `max-h-[600px] overflow-y-auto` scroll container so a 25 or 50 row list scrolls instead of stretching the card. Recharts renders its tooltip as a DOM node inside that same container, so the container's overflow clips it. When only a few bars are present the chart's drawn height is `rows * 52`, which is shorter than the tooltip itself, so the bottom of the tooltip is always cut off. This is overflow clipping by an ancestor, not a stacking issue, so the `z-50` that `TopKeyView` already carried did nothing.

This adds a small reusable helper, `ChartTooltipPortal` plus a `useCursorPosition` hook, that renders the tooltip through a portal to `document.body` with `position: fixed` at the cursor, so it escapes the overflow ancestor entirely. It follows the cursor and flips toward it near the right and bottom edges to stay within the viewport, and uses `pointer-events: none` so it never intercepts hover or clicks (the keys chart is clickable). The helper is applied to all three charts that share the clipping container; `TopModelView` previously relied on Tremor's default tooltip, which was clipped the same way, and now uses the portal too. The dead `relative z-50` on the keys tooltip is removed.

Tests live in `ChartTooltipPortal.test.tsx`. The core regression test renders the tooltip inside an `overflow: auto` container and asserts the content mounts on `document.body` rather than inside the container, which is exactly the clipping scenario; the rest cover the inactive case, fixed positioning above other layers, edge flipping, and cursor tracking. The dashboard vitest suites for the touched components pass
