### PR TITLE
fix(bedrock-invoke): filter internal params from request body

### DIFF
--- a/litellm/llms/bedrock/chat/invoke_transformations/base_invoke_transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_transformations/base_invoke_transformation.py
@@ -8,7 +8,10 @@ import httpx
 
 import litellm
 from litellm._logging import verbose_logger
-from litellm.litellm_core_utils.core_helpers import map_finish_reason
+from litellm.litellm_core_utils.core_helpers import (
+    filter_internal_params,
+    map_finish_reason,
+)
 from litellm.litellm_core_utils.logging_utils import track_llm_api_timing
 from litellm.litellm_core_utils.prompt_templates.factory import (
     cohere_message_pt,
@@ -168,6 +171,7 @@ class AmazonInvokeConfig(BaseConfig, BaseAWSLLM):
             for k, v in inference_params.items()
             if k not in self.aws_authentication_params
         }
+        inference_params = filter_internal_params(inference_params)
         request_data: dict = {}
         if provider == "cohere":
             if model.startswith("cohere.command-r"):

--- a/tests/llm_translation/test_unit_test_bedrock_invoke.py
+++ b/tests/llm_translation/test_unit_test_bedrock_invoke.py
@@ -281,3 +281,43 @@ def test_filter_headers_for_aws_signature():
     }
     filtered_non_aws = aws_llm._filter_headers_for_aws_signature(non_aws_headers)
     assert filtered_non_aws == {}
+
+
+def test_transform_request_filters_internal_params(bedrock_transformer):
+    """Test that LiteLLM internal params (e.g. MCP handler keys) are not leaked into the provider request body."""
+    messages = [{"role": "user", "content": "Hello"}]
+
+    # Cohere provider path — internal params should be stripped
+    result = bedrock_transformer.transform_request(
+        model="cohere.command-r",
+        messages=messages,
+        optional_params={
+            "max_tokens": 2048,
+            "skip_mcp_handler": True,
+            "_skip_mcp_handler": True,
+            "mcp_handler_context": {"some": "data"},
+        },
+        litellm_params={},
+        headers={},
+    )
+
+    assert "skip_mcp_handler" not in result, "skip_mcp_handler leaked into request body"
+    assert "_skip_mcp_handler" not in result, "_skip_mcp_handler leaked into request body"
+    assert "mcp_handler_context" not in result, "mcp_handler_context leaked into request body"
+    # Legit params should still be present
+    assert "max_tokens" in result
+
+    # AI21 provider path — same filter should apply
+    result_ai21 = bedrock_transformer.transform_request(
+        model="ai21.j2-ultra",
+        messages=messages,
+        optional_params={
+            "max_tokens": 2048,
+            "skip_mcp_handler": True,
+        },
+        litellm_params={},
+        headers={},
+    )
+
+    assert "skip_mcp_handler" not in result_ai21
+    assert "max_tokens" in result_ai21


### PR DESCRIPTION
## Problem

The Bedrock **invoke** transform leaks LiteLLM-internal `optional_params` into the provider request body. After filtering out AWS-auth keys, the remaining `inference_params` are splatted directly into the request:

```python
inference_params = {k: v for k, v in inference_params.items()
                    if k not in self.aws_authentication_params}
...
request_data = {"prompt": prompt, **inference_params}   # internal knobs leak through
```

Internal control flags like `skip_mcp_handler`, `_skip_mcp_handler`, and `mcp_handler_context` are not valid Bedrock inference parameters. Leaking them into the body can cause Bedrock to reject the request.

## Why this is a gap in an existing pattern

The sibling **Converse** path already guards against exactly this:

```python
# litellm/llms/bedrock/chat/converse_transformation.py
additional_request_params = filter_internal_params(additional_request_params)
```

The invoke path never calls `filter_internal_params` — it relies on `pop()`-ing each internal key one at a time (which is how `stream_chunk_size` leaked in #30240). Routing the invoke path through the same shared helper closes this class of bugs in one place.

## Fix

Added `filter_internal_params(inference_params)` after the `aws_authentication_params` exclusion in `transform_request`. This is the same one-line pattern the Converse path already uses.

Also added a regression test covering both Cohere and AI21 provider paths, verifying that internal params are stripped while legitimate params like `max_tokens` are preserved.

## Testing

```
tests/llm_translation/test_unit_test_bedrock_invoke.py — 11/11 passed
```

Closes #30371