### PR TITLE
fix: strip existing provider prefix in get_known_models_from_wildcard

### DIFF
--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -311,7 +311,11 @@ def get_known_models_from_wildcard(
     suffix_appended_wildcard_models = []
     for model in wildcard_models:
         if not model.startswith(wildcard_provider_prefix):
-            model = f"{wildcard_provider_prefix}/{model}"
+            # Strip any existing provider prefix (e.g. "ollama/gemma3:1b" -> "gemma3:1b")
+            # before prepending the user-defined wildcard prefix.
+            # This prevents double prefixes like "ollama_server1/ollama/gemma3:1b"
+            _model = model.split("/", 1)[-1] if "/" in model else model
+            model = f"{wildcard_provider_prefix}/{_model}"
         suffix_appended_wildcard_models.append(model)
     return suffix_appended_wildcard_models or []
 

--- a/tests/test_litellm/proxy/auth/test_model_checks.py
+++ b/tests/test_litellm/proxy/auth/test_model_checks.py
@@ -487,3 +487,69 @@ async def test_get_available_models_for_user_expands_query_team_wildcard(
     )
 
     assert "openai/gpt-4o-mini" in result
+
+
+def test_wildcard_expansion_handles_prefixed_provider_models(monkeypatch):
+    """
+    Regression test: when get_provider_models returns names with a provider prefix
+    (e.g. "ollama/gemma3:1b"), the wildcard expansion must NOT double-prefix them.
+    See: https://github.com/ylcnymn/litellm/issues/30358
+    """
+    from litellm.proxy.auth import model_checks
+    from litellm.proxy.auth.model_checks import get_known_models_from_wildcard
+    from litellm.types.router import LiteLLM_Params
+
+    # Case 1: provider models come back with a prefix (e.g. "ollama/gemma3:1b")
+    # and the user-defined model_name is different (e.g. "ollama_server1/*")
+    def fake_provider_with_prefix(provider, litellm_params=None):
+        return ["ollama/gemma3:1b"]
+
+    monkeypatch.setattr(model_checks, "get_provider_models", fake_provider_with_prefix)
+
+    result = get_known_models_from_wildcard(
+        wildcard_model="ollama_server1/*",
+        litellm_params=LiteLLM_Params(
+            model="ollama_chat/*",
+            custom_llm_provider="ollama_chat",
+        ),
+    )
+
+    assert result == [
+        "ollama_server1/gemma3:1b"
+    ], f"Expected single prefix, got {result}"
+
+    # Case 2: provider models return raw names (no prefix) - existing behavior preserved
+    def fake_provider_raw(provider, litellm_params=None):
+        return ["gemma3:1b"]
+
+    monkeypatch.setattr(model_checks, "get_provider_models", fake_provider_raw)
+
+    result = get_known_models_from_wildcard(
+        wildcard_model="ollama_server1/*",
+        litellm_params=LiteLLM_Params(
+            model="ollama_chat/*",
+            custom_llm_provider="ollama_chat",
+        ),
+    )
+
+    assert result == [
+        "ollama_server1/gemma3:1b"
+    ], f"Expected raw model prefixed, got {result}"
+
+    # Case 3: wildcard prefix matches the provider prefix - no double prefix
+    def fake_provider_matching(provider, litellm_params=None):
+        return ["ollama/gemma3:1b"]
+
+    monkeypatch.setattr(model_checks, "get_provider_models", fake_provider_matching)
+
+    result = get_known_models_from_wildcard(
+        wildcard_model="ollama/*",
+        litellm_params=LiteLLM_Params(
+            model="ollama_chat/*",
+            custom_llm_provider="ollama_chat",
+        ),
+    )
+
+    assert result == [
+        "ollama/gemma3:1b"
+    ], f"Expected matching prefix preserved, got {result}"


### PR DESCRIPTION
Closes https://github.com/BerriAI/litellm/issues/30358

## Root cause

`get_known_models_from_wildcard` receives model names from `get_provider_models` that may already carry a provider prefix (e.g. `ollama/gemma3:1b` from `OllamaModelInfo`). When the user-defined `model_name` prefix differs from that provider (e.g. `ollama_server1/*`), the code unconditionally prepends the user prefix, producing a double prefix like `ollama_server1/ollama/gemma3:1b`.

## Fix

Before adding the user-defined prefix, strip the existing provider prefix when it does not match the user-defined one. Raw (unprefixed) model names are unaffected. When the wildcard prefix happens to match the provider prefix, the existing `startswith` guard still applies.

## Test

Added a regression test with three cases:
1. Prefixed provider model + different user prefix (the exact bug scenario)
2. Raw (unprefixed) model name (existing behavior preserved)
3. Matching prefix (existing behavior preserved)

## Type

Bug Fix