### PR TITLE
fix: forward any input_cost_per_token_above_<N>_tokens in get_model_info

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -6184,7 +6184,7 @@ def _get_model_info_helper(  # noqa: PLR0915
         # without a corresponding code change.
         for _k, _v in _model_info.items():
             if "_above_" in _k and _k not in result:
-                dict.__setitem__(result, _k, _v)  # type: ignore[literal-required]
+                dict.__setitem__(result, _k, _v)  # type: ignore[literal-required,index]
 
         return result
     except Exception as e:

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -6184,7 +6184,7 @@ def _get_model_info_helper(  # noqa: PLR0915
         # without a corresponding code change.
         for _k, _v in _model_info.items():
             if "_above_" in _k and _k not in result:
-                result[_k] = _v
+                dict.__setitem__(result, _k, _v)  # type: ignore[literal-required]
 
         return result
     except Exception as e:

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -6004,7 +6004,7 @@ def _get_model_info_helper(  # noqa: PLR0915
                 )
                 _output_cost_per_token = 0
 
-            return ModelInfoBase(
+            result = ModelInfoBase(
                 key=key,
                 max_tokens=_model_info.get("max_tokens", None),
                 max_input_tokens=_model_info.get("max_input_tokens", None),
@@ -6045,18 +6045,6 @@ def _get_model_info_helper(  # noqa: PLR0915
                 ),
                 input_cost_per_character=_model_info.get(
                     "input_cost_per_character", None
-                ),
-                input_cost_per_token_above_128k_tokens=_model_info.get(
-                    "input_cost_per_token_above_128k_tokens", None
-                ),
-                input_cost_per_token_above_200k_tokens=_model_info.get(
-                    "input_cost_per_token_above_200k_tokens", None
-                ),
-                input_cost_per_token_above_272k_tokens=_model_info.get(
-                    "input_cost_per_token_above_272k_tokens", None
-                ),
-                input_cost_per_token_above_512k_tokens=_model_info.get(
-                    "input_cost_per_token_above_512k_tokens", None
                 ),
                 input_cost_per_query=_model_info.get("input_cost_per_query", None),
                 input_cost_per_second=_model_info.get("input_cost_per_second", None),
@@ -6100,21 +6088,6 @@ def _get_model_info_helper(  # noqa: PLR0915
                 ),
                 output_cost_per_reasoning_token=_model_info.get(
                     "output_cost_per_reasoning_token", None
-                ),
-                output_cost_per_token_above_128k_tokens=_model_info.get(
-                    "output_cost_per_token_above_128k_tokens", None
-                ),
-                output_cost_per_character_above_128k_tokens=_model_info.get(
-                    "output_cost_per_character_above_128k_tokens", None
-                ),
-                output_cost_per_token_above_200k_tokens=_model_info.get(
-                    "output_cost_per_token_above_200k_tokens", None
-                ),
-                output_cost_per_token_above_272k_tokens=_model_info.get(
-                    "output_cost_per_token_above_272k_tokens", None
-                ),
-                output_cost_per_token_above_512k_tokens=_model_info.get(
-                    "output_cost_per_token_above_512k_tokens", None
                 ),
                 output_cost_per_second=_model_info.get("output_cost_per_second", None),
                 output_cost_per_second_1080p=_model_info.get(
@@ -6203,6 +6176,17 @@ def _get_model_info_helper(  # noqa: PLR0915
                 uses_embed_content=_model_info.get("uses_embed_content", None),
                 supports_image_size=_model_info.get("supports_image_size", None),
             )
+        # Forward any `_above_` tier key the caller configured
+        # but wasn't in the fixed list above.  This makes every
+        # threshold the parser supports actually reachable instead of
+        # being silently dropped when N is not one of the hard-coded
+        # values, and also catches keys added to model_prices_and_context_window.json
+        # without a corresponding code change.
+        for _k, _v in _model_info.items():
+            if "_above_" in _k and _k not in result:
+                result[_k] = _v
+
+        return result
     except Exception as e:
         verbose_logger.debug(f"Error getting model info: {e}")
         raise Exception(

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -1305,7 +1305,7 @@ def test_get_model_info_forward_custom_tier_thresholds():
     must survive get_model_info instead of being silently dropped when N
     is not one of the hard-coded values (128k/200k/272k/512k).
 
-    See: https://github.com/ylcnymn/litellm/issues/30344
+    See: https://github.com/BerriAI/litellm/issues/30344
     """
     import litellm
     from litellm.utils import _get_model_info_helper
@@ -1325,13 +1325,18 @@ def test_get_model_info_forward_custom_tier_thresholds():
         }
     })
 
-    info = litellm.get_model_info(model=model_name, custom_llm_provider="openai")
+    try:
+        info = litellm.get_model_info(model=model_name, custom_llm_provider="openai")
 
-    # The custom tier must survive round-trip through get_model_info
-    assert info.get(custom_tier_key) == 9e-6, (
-        f"Custom tier '{custom_tier_key}' was dropped by get_model_info; "
-        f"got {info.get(custom_tier_key)}"
-    )
+        # The custom tier must survive round-trip through get_model_info
+        assert info.get(custom_tier_key) == 9e-6, (
+            f"Custom tier '{custom_tier_key}' was dropped by get_model_info; "
+            f"got {info.get(custom_tier_key)}"
+        )
+    finally:
+        # Teardown: remove the test model from global state
+        if hasattr(litellm, "model_cost"):
+            litellm.model_cost.pop(model_name, None)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -1299,6 +1299,41 @@ def test_get_model_info_shows_supports_computer_use():
     )  # Expecting None due to the default in ModelInfoBase
 
 
+def test_get_model_info_forward_custom_tier_thresholds():
+    """
+    Regression test: custom input_cost_per_token_above_<N>_tokens tiers
+    must survive get_model_info instead of being silently dropped when N
+    is not one of the hard-coded values (128k/200k/272k/512k).
+
+    See: https://github.com/ylcnymn/litellm/issues/30344
+    """
+    import litellm
+    from litellm.utils import _get_model_info_helper
+
+    model_name = "test-custom-tier-model-30344"
+    custom_tier_key = "input_cost_per_token_above_500k_tokens"
+
+    # Register via the standard public API path
+    litellm.register_model({
+        model_name: {
+            "litellm_provider": "openai",
+            "mode": "chat",
+            "input_cost_per_token": 1e-6,
+            "output_cost_per_token": 2e-6,
+            "max_tokens": 1000,
+            custom_tier_key: 9e-6,
+        }
+    })
+
+    info = litellm.get_model_info(model=model_name, custom_llm_provider="openai")
+
+    # The custom tier must survive round-trip through get_model_info
+    assert info.get(custom_tier_key) == 9e-6, (
+        f"Custom tier '{custom_tier_key}' was dropped by get_model_info; "
+        f"got {info.get(custom_tier_key)}"
+    )
+
+
 @pytest.mark.parametrize(
     "model, custom_llm_provider",
     [


### PR DESCRIPTION
Closes https://github.com/BerriAI/litellm/issues/30344

## Root cause

`get_model_info` in `litellm/utils.py` builds `ModelInfoBase` by explicitly copying only 4 known context-size tier boundaries: `input_cost_per_token_above_128k_tokens`, `200k`, `272k`, and `512k` (and the output equivalents). Any other threshold a user configures (e.g. `input_cost_per_token_above_500k_tokens`) is silently dropped even though the downstream parser in `_get_token_base_cost` has always supported arbitrary thresholds.

## Fix

Instead of listing each allowed key name, build the known fields as before and then iterate the source `_model_info` for any key containing `_above_` that isn't already in the result. This makes every threshold the parser understands reachable without requiring a code change when a new boundary appears, and also catches keys added to `model_prices_and_context_window.json` automatically.

## Type

Bug Fix