### PR TITLE
fix(bedrock): type invoke request params

### DIFF
--- a/litellm/llms/bedrock/chat/invoke_transformations/base_invoke_transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_transformations/base_invoke_transformation.py
@@ -2,7 +2,18 @@ import copy
 import json
 import time
 from functools import partial
-from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union, cast, get_args
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    FrozenSet,
+    List,
+    Optional,
+    Tuple,
+    Union,
+    cast,
+    get_args,
+)
 
 import httpx
 
@@ -24,6 +35,19 @@ from litellm.llms.custom_httpx.http_handler import (
     HTTPHandler,
     _get_httpx_client,
 )
+from litellm.types.llms.bedrock import (
+    BedrockInvokeAI21InferenceParams,
+    BedrockInvokeAI21Request,
+    BedrockInvokeCohereChatRequest,
+    BedrockInvokeCohereCompletionRequest,
+    BedrockInvokeCohereInferenceParams,
+    BedrockInvokeLlamaInferenceParams,
+    BedrockInvokeLlamaRequest,
+    BedrockInvokeMistralInferenceParams,
+    BedrockInvokeMistralRequest,
+    BedrockInvokeTitanInferenceParams,
+    BedrockInvokeTitanRequest,
+)
 from litellm.types.llms.openai import AllMessageValues
 from litellm.types.utils import ModelResponse, Usage
 from litellm.utils import CustomStreamWrapper
@@ -39,6 +63,22 @@ from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
 
 
 class AmazonInvokeConfig(BaseConfig, BaseAWSLLM):
+    BEDROCK_INVOKE_COHERE_ALLOWED_INFERENCE_FIELDS: FrozenSet[str] = frozenset(
+        BedrockInvokeCohereInferenceParams.__annotations__.keys()
+    )
+    BEDROCK_INVOKE_AI21_ALLOWED_INFERENCE_FIELDS: FrozenSet[str] = frozenset(
+        BedrockInvokeAI21InferenceParams.__annotations__.keys()
+    )
+    BEDROCK_INVOKE_MISTRAL_ALLOWED_INFERENCE_FIELDS: FrozenSet[str] = frozenset(
+        BedrockInvokeMistralInferenceParams.__annotations__.keys()
+    )
+    BEDROCK_INVOKE_TITAN_ALLOWED_INFERENCE_FIELDS: FrozenSet[str] = frozenset(
+        BedrockInvokeTitanInferenceParams.__annotations__.keys()
+    )
+    BEDROCK_INVOKE_LLAMA_ALLOWED_INFERENCE_FIELDS: FrozenSet[str] = frozenset(
+        BedrockInvokeLlamaInferenceParams.__annotations__.keys()
+    )
+
     def __init__(self, **kwargs):
         BaseConfig.__init__(self, **kwargs)
         BaseAWSLLM.__init__(self, **kwargs)
@@ -134,11 +174,144 @@ class AmazonInvokeConfig(BaseConfig, BaseAWSLLM):
             fake_stream=fake_stream,
         )
 
-    def _apply_config_to_params(self, config: dict, inference_params: dict) -> None:
-        """Apply config values to inference_params if not already set."""
-        for k, v in config.items():
-            if k not in inference_params:
-                inference_params[k] = v
+    def _get_filtered_inference_params(
+        self,
+        optional_params: dict,
+        config: dict,
+        allowed_fields: FrozenSet[str],
+    ) -> Dict[str, object]:
+        copied_params = copy.deepcopy(optional_params)
+        inference_params = {
+            k: v
+            for k, v in copied_params.items()
+            if k in allowed_fields and k not in self.aws_authentication_params
+        }
+        config_params = {
+            k: v
+            for k, v in config.items()
+            if k in allowed_fields
+            and k not in self.aws_authentication_params
+            and k not in inference_params
+        }
+        return {**config_params, **inference_params}
+
+    def _get_cohere_inference_params(
+        self, optional_params: dict, config: dict
+    ) -> BedrockInvokeCohereInferenceParams:
+        return cast(
+            BedrockInvokeCohereInferenceParams,
+            self._get_filtered_inference_params(
+                optional_params=optional_params,
+                config=config,
+                allowed_fields=self.BEDROCK_INVOKE_COHERE_ALLOWED_INFERENCE_FIELDS,
+            ),
+        )
+
+    def _get_ai21_inference_params(
+        self, optional_params: dict, config: dict
+    ) -> BedrockInvokeAI21InferenceParams:
+        return cast(
+            BedrockInvokeAI21InferenceParams,
+            self._get_filtered_inference_params(
+                optional_params=optional_params,
+                config=config,
+                allowed_fields=self.BEDROCK_INVOKE_AI21_ALLOWED_INFERENCE_FIELDS,
+            ),
+        )
+
+    def _get_mistral_inference_params(
+        self, optional_params: dict, config: dict
+    ) -> BedrockInvokeMistralInferenceParams:
+        return cast(
+            BedrockInvokeMistralInferenceParams,
+            self._get_filtered_inference_params(
+                optional_params=optional_params,
+                config=config,
+                allowed_fields=self.BEDROCK_INVOKE_MISTRAL_ALLOWED_INFERENCE_FIELDS,
+            ),
+        )
+
+    def _get_titan_inference_params(
+        self, optional_params: dict, config: dict
+    ) -> BedrockInvokeTitanInferenceParams:
+        return cast(
+            BedrockInvokeTitanInferenceParams,
+            self._get_filtered_inference_params(
+                optional_params=optional_params,
+                config=config,
+                allowed_fields=self.BEDROCK_INVOKE_TITAN_ALLOWED_INFERENCE_FIELDS,
+            ),
+        )
+
+    def _get_llama_inference_params(
+        self, optional_params: dict, config: dict
+    ) -> BedrockInvokeLlamaInferenceParams:
+        return cast(
+            BedrockInvokeLlamaInferenceParams,
+            self._get_filtered_inference_params(
+                optional_params=optional_params,
+                config=config,
+                allowed_fields=self.BEDROCK_INVOKE_LLAMA_ALLOWED_INFERENCE_FIELDS,
+            ),
+        )
+
+    @staticmethod
+    def _build_cohere_chat_request(
+        prompt: str,
+        inference_params: BedrockInvokeCohereInferenceParams,
+        chat_history: Optional[List[Dict[str, object]]],
+    ) -> BedrockInvokeCohereChatRequest:
+        request: Dict[str, object] = {"message": prompt, **inference_params}
+        if chat_history is not None:
+            request["chat_history"] = chat_history
+        return cast(BedrockInvokeCohereChatRequest, request)
+
+    @staticmethod
+    def _build_cohere_completion_request(
+        prompt: str,
+        inference_params: BedrockInvokeCohereInferenceParams,
+    ) -> BedrockInvokeCohereCompletionRequest:
+        return cast(
+            BedrockInvokeCohereCompletionRequest,
+            {"prompt": prompt, **inference_params},
+        )
+
+    @staticmethod
+    def _build_ai21_request(
+        prompt: str,
+        inference_params: BedrockInvokeAI21InferenceParams,
+    ) -> BedrockInvokeAI21Request:
+        return cast(BedrockInvokeAI21Request, {"prompt": prompt, **inference_params})
+
+    @staticmethod
+    def _build_mistral_request(
+        prompt: str,
+        inference_params: BedrockInvokeMistralInferenceParams,
+    ) -> BedrockInvokeMistralRequest:
+        return cast(
+            BedrockInvokeMistralRequest,
+            {"prompt": prompt, **inference_params},
+        )
+
+    @staticmethod
+    def _build_titan_request(
+        prompt: str,
+        inference_params: BedrockInvokeTitanInferenceParams,
+    ) -> BedrockInvokeTitanRequest:
+        return BedrockInvokeTitanRequest(
+            inputText=prompt,
+            textGenerationConfig=inference_params,
+        )
+
+    @staticmethod
+    def _build_llama_request(
+        prompt: str,
+        inference_params: BedrockInvokeLlamaInferenceParams,
+    ) -> BedrockInvokeLlamaRequest:
+        return cast(
+            BedrockInvokeLlamaRequest,
+            {"prompt": prompt, **inference_params},
+        )
 
     def transform_request(
         self,
@@ -162,31 +335,36 @@ class AmazonInvokeConfig(BaseConfig, BaseAWSLLM):
             provider=provider,
             custom_prompt_dict=custom_prompt_dict,
         )
-        inference_params = copy.deepcopy(optional_params)
-        inference_params = {
-            k: v
-            for k, v in inference_params.items()
-            if k not in self.aws_authentication_params
-        }
-        request_data: dict = {}
         if provider == "cohere":
             if model.startswith("cohere.command-r"):
-                ## LOAD CONFIG
                 config = litellm.AmazonCohereChatConfig().get_config()
-                self._apply_config_to_params(config, inference_params)
-                _data = {"message": prompt, **inference_params}
-                if chat_history is not None:
-                    _data["chat_history"] = chat_history
-                request_data = _data
+                cohere_inference_params = self._get_cohere_inference_params(
+                    optional_params=optional_params,
+                    config=config,
+                )
+                return cast(
+                    dict,
+                    self._build_cohere_chat_request(
+                        prompt=prompt,
+                        inference_params=cohere_inference_params,
+                        chat_history=chat_history,
+                    ),
+                )
             else:
-                ## LOAD CONFIG
                 config = litellm.AmazonCohereConfig.get_config()
-                self._apply_config_to_params(config, inference_params)
+                cohere_inference_params = self._get_cohere_inference_params(
+                    optional_params=optional_params,
+                    config=config,
+                )
                 if stream is True:
-                    inference_params["stream"] = (
-                        True  # cohere requires stream = True in inference params
-                    )
-                request_data = {"prompt": prompt, **inference_params}
+                    cohere_inference_params["stream"] = True
+                return cast(
+                    dict,
+                    self._build_cohere_completion_request(
+                        prompt=prompt,
+                        inference_params=cohere_inference_params,
+                    ),
+                )
         elif provider == "anthropic":
             transformed_request = (
                 litellm.AmazonAnthropicClaudeConfig().transform_request(
@@ -208,28 +386,57 @@ class AmazonInvokeConfig(BaseConfig, BaseAWSLLM):
                 headers=headers,
             )
         elif provider == "ai21":
-            ## LOAD CONFIG
             config = litellm.AmazonAI21Config.get_config()
-            self._apply_config_to_params(config, inference_params)
-            request_data = {"prompt": prompt, **inference_params}
+            ai21_inference_params = self._get_ai21_inference_params(
+                optional_params=optional_params,
+                config=config,
+            )
+            return cast(
+                dict,
+                self._build_ai21_request(
+                    prompt=prompt,
+                    inference_params=ai21_inference_params,
+                ),
+            )
         elif provider == "mistral":
-            ## LOAD CONFIG
             config = litellm.AmazonMistralConfig.get_config()
-            self._apply_config_to_params(config, inference_params)
-            request_data = {"prompt": prompt, **inference_params}
+            mistral_inference_params = self._get_mistral_inference_params(
+                optional_params=optional_params,
+                config=config,
+            )
+            return cast(
+                dict,
+                self._build_mistral_request(
+                    prompt=prompt,
+                    inference_params=mistral_inference_params,
+                ),
+            )
         elif provider == "amazon":  # amazon titan
-            ## LOAD CONFIG
             config = litellm.AmazonTitanConfig.get_config()
-            self._apply_config_to_params(config, inference_params)
-            request_data = {
-                "inputText": prompt,
-                "textGenerationConfig": inference_params,
-            }
+            titan_inference_params = self._get_titan_inference_params(
+                optional_params=optional_params,
+                config=config,
+            )
+            return cast(
+                dict,
+                self._build_titan_request(
+                    prompt=prompt,
+                    inference_params=titan_inference_params,
+                ),
+            )
         elif provider == "meta" or provider == "llama" or provider == "deepseek_r1":
-            ## LOAD CONFIG
             config = litellm.AmazonLlamaConfig.get_config()
-            self._apply_config_to_params(config, inference_params)
-            request_data = {"prompt": prompt, **inference_params}
+            llama_inference_params = self._get_llama_inference_params(
+                optional_params=optional_params,
+                config=config,
+            )
+            return cast(
+                dict,
+                self._build_llama_request(
+                    prompt=prompt,
+                    inference_params=llama_inference_params,
+                ),
+            )
         elif provider == "twelvelabs":
             return litellm.AmazonTwelveLabsPegasusConfig().transform_request(
                 model=model,
@@ -254,8 +461,6 @@ class AmazonInvokeConfig(BaseConfig, BaseAWSLLM):
                     provider, model
                 ),
             )
-
-        return request_data
 
     def transform_response(  # noqa: PLR0915
         self,

--- a/litellm/llms/bedrock/chat/invoke_transformations/base_invoke_transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_transformations/base_invoke_transformation.py
@@ -1,12 +1,12 @@
 import copy
 import json
 import time
+from dataclasses import dataclass, replace
 from functools import partial
 from typing import (
     TYPE_CHECKING,
     Any,
     Dict,
-    FrozenSet,
     List,
     Optional,
     Tuple,
@@ -36,14 +36,10 @@ from litellm.llms.custom_httpx.http_handler import (
     _get_httpx_client,
 )
 from litellm.types.llms.bedrock import (
-    BedrockInvokeAI21InferenceParams,
     BedrockInvokeAI21Request,
     BedrockInvokeCohereChatRequest,
     BedrockInvokeCohereCompletionRequest,
-    BedrockInvokeCohereInferenceParams,
-    BedrockInvokeLlamaInferenceParams,
     BedrockInvokeLlamaRequest,
-    BedrockInvokeMistralInferenceParams,
     BedrockInvokeMistralRequest,
     BedrockInvokeTitanInferenceParams,
     BedrockInvokeTitanRequest,
@@ -62,23 +58,63 @@ else:
 from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
 
 
-class AmazonInvokeConfig(BaseConfig, BaseAWSLLM):
-    BEDROCK_INVOKE_COHERE_ALLOWED_INFERENCE_FIELDS: FrozenSet[str] = frozenset(
-        BedrockInvokeCohereInferenceParams.__annotations__.keys()
-    )
-    BEDROCK_INVOKE_AI21_ALLOWED_INFERENCE_FIELDS: FrozenSet[str] = frozenset(
-        BedrockInvokeAI21InferenceParams.__annotations__.keys()
-    )
-    BEDROCK_INVOKE_MISTRAL_ALLOWED_INFERENCE_FIELDS: FrozenSet[str] = frozenset(
-        BedrockInvokeMistralInferenceParams.__annotations__.keys()
-    )
-    BEDROCK_INVOKE_TITAN_ALLOWED_INFERENCE_FIELDS: FrozenSet[str] = frozenset(
-        BedrockInvokeTitanInferenceParams.__annotations__.keys()
-    )
-    BEDROCK_INVOKE_LLAMA_ALLOWED_INFERENCE_FIELDS: FrozenSet[str] = frozenset(
-        BedrockInvokeLlamaInferenceParams.__annotations__.keys()
-    )
+@dataclass(frozen=True, slots=True)
+class BedrockInvokeCohereParams:
+    max_tokens: Optional[int] = None
+    temperature: Optional[float] = None
+    return_likelihood: Optional[str] = None
+    p: Optional[float] = None
+    k: Optional[int] = None
+    stop_sequences: Optional[List[str]] = None
+    num_generations: Optional[int] = None
+    frequency_penalty: Optional[float] = None
+    presence_penalty: Optional[float] = None
+    truncate: Optional[str] = None
+    stream: Optional[bool] = None
+    tools: Optional[List[Dict[str, object]]] = None
+    tool_results: Optional[List[Dict[str, object]]] = None
+    seed: Optional[int] = None
+    force_single_step: Optional[bool] = None
 
+
+@dataclass(frozen=True, slots=True)
+class BedrockInvokeAI21Params:
+    maxTokens: Optional[int] = None
+    temperature: Optional[float] = None
+    topP: Optional[float] = None
+    stopSequences: Optional[List[str]] = None
+    frequencyPenalty: Optional[Dict[str, object]] = None
+    frequencePenalty: Optional[Dict[str, object]] = None
+    presencePenalty: Optional[Dict[str, object]] = None
+    countPenalty: Optional[Dict[str, object]] = None
+
+
+@dataclass(frozen=True, slots=True)
+class BedrockInvokeMistralParams:
+    max_tokens: Optional[int] = None
+    temperature: Optional[float] = None
+    top_p: Optional[float] = None
+    top_k: Optional[float] = None
+    stop: Optional[List[str]] = None
+
+
+@dataclass(frozen=True, slots=True)
+class BedrockInvokeTitanParams:
+    maxTokenCount: Optional[int] = None
+    stopSequences: Optional[List[str]] = None
+    temperature: Optional[float] = None
+    topP: Optional[int] = None
+
+
+@dataclass(frozen=True, slots=True)
+class BedrockInvokeLlamaParams:
+    max_gen_len: Optional[int] = None
+    temperature: Optional[float] = None
+    top_p: Optional[float] = None
+    topP: Optional[float] = None
+
+
+class AmazonInvokeConfig(BaseConfig, BaseAWSLLM):
     def __init__(self, **kwargs):
         BaseConfig.__init__(self, **kwargs)
         BaseAWSLLM.__init__(self, **kwargs)
@@ -174,94 +210,200 @@ class AmazonInvokeConfig(BaseConfig, BaseAWSLLM):
             fake_stream=fake_stream,
         )
 
-    def _get_filtered_inference_params(
-        self,
-        optional_params: dict,
-        config: dict,
-        allowed_fields: FrozenSet[str],
-    ) -> Dict[str, object]:
-        copied_params = copy.deepcopy(optional_params)
-        inference_params = {
-            k: v
-            for k, v in copied_params.items()
-            if k in allowed_fields and k not in self.aws_authentication_params
-        }
-        config_params = {
-            k: v
-            for k, v in config.items()
-            if k in allowed_fields
-            and k not in self.aws_authentication_params
-            and k not in inference_params
-        }
-        return {**config_params, **inference_params}
+    @staticmethod
+    def _get_param_value(optional_params: dict, config: dict, key: str) -> object:
+        if key in optional_params:
+            return copy.deepcopy(optional_params[key])
+        return copy.deepcopy(config.get(key))
 
-    def _get_cohere_inference_params(
+    @staticmethod
+    def _drop_none(data: Dict[str, object]) -> Dict[str, object]:
+        return {key: value for key, value in data.items() if value is not None}
+
+    def _parse_cohere_params(
         self, optional_params: dict, config: dict
-    ) -> BedrockInvokeCohereInferenceParams:
-        return cast(
-            BedrockInvokeCohereInferenceParams,
-            self._get_filtered_inference_params(
-                optional_params=optional_params,
-                config=config,
-                allowed_fields=self.BEDROCK_INVOKE_COHERE_ALLOWED_INFERENCE_FIELDS,
+    ) -> BedrockInvokeCohereParams:
+        return BedrockInvokeCohereParams(
+            max_tokens=cast(
+                Optional[int],
+                self._get_param_value(optional_params, config, "max_tokens"),
+            ),
+            temperature=cast(
+                Optional[float],
+                self._get_param_value(optional_params, config, "temperature"),
+            ),
+            return_likelihood=cast(
+                Optional[str],
+                self._get_param_value(optional_params, config, "return_likelihood"),
+            ),
+            p=cast(
+                Optional[float],
+                self._get_param_value(optional_params, config, "p"),
+            ),
+            k=cast(
+                Optional[int],
+                self._get_param_value(optional_params, config, "k"),
+            ),
+            stop_sequences=cast(
+                Optional[List[str]],
+                self._get_param_value(optional_params, config, "stop_sequences"),
+            ),
+            num_generations=cast(
+                Optional[int],
+                self._get_param_value(optional_params, config, "num_generations"),
+            ),
+            frequency_penalty=cast(
+                Optional[float],
+                self._get_param_value(optional_params, config, "frequency_penalty"),
+            ),
+            presence_penalty=cast(
+                Optional[float],
+                self._get_param_value(optional_params, config, "presence_penalty"),
+            ),
+            truncate=cast(
+                Optional[str],
+                self._get_param_value(optional_params, config, "truncate"),
+            ),
+            stream=cast(
+                Optional[bool],
+                self._get_param_value(optional_params, config, "stream"),
+            ),
+            tools=cast(
+                Optional[List[Dict[str, object]]],
+                self._get_param_value(optional_params, config, "tools"),
+            ),
+            tool_results=cast(
+                Optional[List[Dict[str, object]]],
+                self._get_param_value(optional_params, config, "tool_results"),
+            ),
+            seed=cast(
+                Optional[int],
+                self._get_param_value(optional_params, config, "seed"),
+            ),
+            force_single_step=cast(
+                Optional[bool],
+                self._get_param_value(optional_params, config, "force_single_step"),
             ),
         )
 
-    def _get_ai21_inference_params(
+    def _parse_ai21_params(
         self, optional_params: dict, config: dict
-    ) -> BedrockInvokeAI21InferenceParams:
-        return cast(
-            BedrockInvokeAI21InferenceParams,
-            self._get_filtered_inference_params(
-                optional_params=optional_params,
-                config=config,
-                allowed_fields=self.BEDROCK_INVOKE_AI21_ALLOWED_INFERENCE_FIELDS,
+    ) -> BedrockInvokeAI21Params:
+        return BedrockInvokeAI21Params(
+            maxTokens=cast(
+                Optional[int],
+                self._get_param_value(optional_params, config, "maxTokens"),
+            ),
+            temperature=cast(
+                Optional[float],
+                self._get_param_value(optional_params, config, "temperature"),
+            ),
+            topP=cast(
+                Optional[float],
+                self._get_param_value(optional_params, config, "topP"),
+            ),
+            stopSequences=cast(
+                Optional[List[str]],
+                self._get_param_value(optional_params, config, "stopSequences"),
+            ),
+            frequencyPenalty=cast(
+                Optional[Dict[str, object]],
+                self._get_param_value(optional_params, config, "frequencyPenalty"),
+            ),
+            frequencePenalty=cast(
+                Optional[Dict[str, object]],
+                self._get_param_value(optional_params, config, "frequencePenalty"),
+            ),
+            presencePenalty=cast(
+                Optional[Dict[str, object]],
+                self._get_param_value(optional_params, config, "presencePenalty"),
+            ),
+            countPenalty=cast(
+                Optional[Dict[str, object]],
+                self._get_param_value(optional_params, config, "countPenalty"),
             ),
         )
 
-    def _get_mistral_inference_params(
+    def _parse_mistral_params(
         self, optional_params: dict, config: dict
-    ) -> BedrockInvokeMistralInferenceParams:
-        return cast(
-            BedrockInvokeMistralInferenceParams,
-            self._get_filtered_inference_params(
-                optional_params=optional_params,
-                config=config,
-                allowed_fields=self.BEDROCK_INVOKE_MISTRAL_ALLOWED_INFERENCE_FIELDS,
+    ) -> BedrockInvokeMistralParams:
+        return BedrockInvokeMistralParams(
+            max_tokens=cast(
+                Optional[int],
+                self._get_param_value(optional_params, config, "max_tokens"),
+            ),
+            temperature=cast(
+                Optional[float],
+                self._get_param_value(optional_params, config, "temperature"),
+            ),
+            top_p=cast(
+                Optional[float],
+                self._get_param_value(optional_params, config, "top_p"),
+            ),
+            top_k=cast(
+                Optional[float],
+                self._get_param_value(optional_params, config, "top_k"),
+            ),
+            stop=cast(
+                Optional[List[str]],
+                self._get_param_value(optional_params, config, "stop"),
             ),
         )
 
-    def _get_titan_inference_params(
+    def _parse_titan_params(
         self, optional_params: dict, config: dict
-    ) -> BedrockInvokeTitanInferenceParams:
-        return cast(
-            BedrockInvokeTitanInferenceParams,
-            self._get_filtered_inference_params(
-                optional_params=optional_params,
-                config=config,
-                allowed_fields=self.BEDROCK_INVOKE_TITAN_ALLOWED_INFERENCE_FIELDS,
+    ) -> BedrockInvokeTitanParams:
+        return BedrockInvokeTitanParams(
+            maxTokenCount=cast(
+                Optional[int],
+                self._get_param_value(optional_params, config, "maxTokenCount"),
+            ),
+            stopSequences=cast(
+                Optional[List[str]],
+                self._get_param_value(optional_params, config, "stopSequences"),
+            ),
+            temperature=cast(
+                Optional[float],
+                self._get_param_value(optional_params, config, "temperature"),
+            ),
+            topP=cast(
+                Optional[int],
+                self._get_param_value(optional_params, config, "topP"),
             ),
         )
 
-    def _get_llama_inference_params(
+    def _parse_llama_params(
         self, optional_params: dict, config: dict
-    ) -> BedrockInvokeLlamaInferenceParams:
-        return cast(
-            BedrockInvokeLlamaInferenceParams,
-            self._get_filtered_inference_params(
-                optional_params=optional_params,
-                config=config,
-                allowed_fields=self.BEDROCK_INVOKE_LLAMA_ALLOWED_INFERENCE_FIELDS,
+    ) -> BedrockInvokeLlamaParams:
+        return BedrockInvokeLlamaParams(
+            max_gen_len=cast(
+                Optional[int],
+                self._get_param_value(optional_params, config, "max_gen_len"),
+            ),
+            temperature=cast(
+                Optional[float],
+                self._get_param_value(optional_params, config, "temperature"),
+            ),
+            top_p=cast(
+                Optional[float],
+                self._get_param_value(optional_params, config, "top_p"),
+            ),
+            topP=cast(
+                Optional[float],
+                self._get_param_value(optional_params, config, "topP"),
             ),
         )
 
     @staticmethod
     def _build_cohere_chat_request(
         prompt: str,
-        inference_params: BedrockInvokeCohereInferenceParams,
+        inference_params: BedrockInvokeCohereParams,
         chat_history: Optional[List[Dict[str, object]]],
     ) -> BedrockInvokeCohereChatRequest:
-        request: Dict[str, object] = {"message": prompt, **inference_params}
+        request: Dict[str, object] = {
+            "message": prompt,
+            **AmazonInvokeConfig._cohere_params_to_wire_dict(inference_params),
+        }
         if chat_history is not None:
             request["chat_history"] = chat_history
         return cast(BedrockInvokeCohereChatRequest, request)
@@ -269,48 +411,123 @@ class AmazonInvokeConfig(BaseConfig, BaseAWSLLM):
     @staticmethod
     def _build_cohere_completion_request(
         prompt: str,
-        inference_params: BedrockInvokeCohereInferenceParams,
+        inference_params: BedrockInvokeCohereParams,
     ) -> BedrockInvokeCohereCompletionRequest:
         return cast(
             BedrockInvokeCohereCompletionRequest,
-            {"prompt": prompt, **inference_params},
+            {
+                "prompt": prompt,
+                **AmazonInvokeConfig._cohere_params_to_wire_dict(inference_params),
+            },
         )
 
     @staticmethod
     def _build_ai21_request(
         prompt: str,
-        inference_params: BedrockInvokeAI21InferenceParams,
+        inference_params: BedrockInvokeAI21Params,
     ) -> BedrockInvokeAI21Request:
-        return cast(BedrockInvokeAI21Request, {"prompt": prompt, **inference_params})
+        return cast(
+            BedrockInvokeAI21Request,
+            {
+                "prompt": prompt,
+                **AmazonInvokeConfig._drop_none(
+                    {
+                        "maxTokens": inference_params.maxTokens,
+                        "temperature": inference_params.temperature,
+                        "topP": inference_params.topP,
+                        "stopSequences": inference_params.stopSequences,
+                        "frequencyPenalty": inference_params.frequencyPenalty,
+                        "frequencePenalty": inference_params.frequencePenalty,
+                        "presencePenalty": inference_params.presencePenalty,
+                        "countPenalty": inference_params.countPenalty,
+                    }
+                ),
+            },
+        )
 
     @staticmethod
     def _build_mistral_request(
         prompt: str,
-        inference_params: BedrockInvokeMistralInferenceParams,
+        inference_params: BedrockInvokeMistralParams,
     ) -> BedrockInvokeMistralRequest:
         return cast(
             BedrockInvokeMistralRequest,
-            {"prompt": prompt, **inference_params},
+            {
+                "prompt": prompt,
+                **AmazonInvokeConfig._drop_none(
+                    {
+                        "max_tokens": inference_params.max_tokens,
+                        "temperature": inference_params.temperature,
+                        "top_p": inference_params.top_p,
+                        "top_k": inference_params.top_k,
+                        "stop": inference_params.stop,
+                    }
+                ),
+            },
         )
 
     @staticmethod
     def _build_titan_request(
         prompt: str,
-        inference_params: BedrockInvokeTitanInferenceParams,
+        inference_params: BedrockInvokeTitanParams,
     ) -> BedrockInvokeTitanRequest:
         return BedrockInvokeTitanRequest(
             inputText=prompt,
-            textGenerationConfig=inference_params,
+            textGenerationConfig=cast(
+                BedrockInvokeTitanInferenceParams,
+                AmazonInvokeConfig._drop_none(
+                    {
+                        "maxTokenCount": inference_params.maxTokenCount,
+                        "stopSequences": inference_params.stopSequences,
+                        "temperature": inference_params.temperature,
+                        "topP": inference_params.topP,
+                    }
+                ),
+            ),
         )
 
     @staticmethod
     def _build_llama_request(
         prompt: str,
-        inference_params: BedrockInvokeLlamaInferenceParams,
+        inference_params: BedrockInvokeLlamaParams,
     ) -> BedrockInvokeLlamaRequest:
         return cast(
             BedrockInvokeLlamaRequest,
-            {"prompt": prompt, **inference_params},
+            {
+                "prompt": prompt,
+                **AmazonInvokeConfig._drop_none(
+                    {
+                        "max_gen_len": inference_params.max_gen_len,
+                        "temperature": inference_params.temperature,
+                        "top_p": inference_params.top_p,
+                        "topP": inference_params.topP,
+                    }
+                ),
+            },
+        )
+
+    @staticmethod
+    def _cohere_params_to_wire_dict(
+        inference_params: BedrockInvokeCohereParams,
+    ) -> Dict[str, object]:
+        return AmazonInvokeConfig._drop_none(
+            {
+                "max_tokens": inference_params.max_tokens,
+                "temperature": inference_params.temperature,
+                "return_likelihood": inference_params.return_likelihood,
+                "p": inference_params.p,
+                "k": inference_params.k,
+                "stop_sequences": inference_params.stop_sequences,
+                "num_generations": inference_params.num_generations,
+                "frequency_penalty": inference_params.frequency_penalty,
+                "presence_penalty": inference_params.presence_penalty,
+                "truncate": inference_params.truncate,
+                "stream": inference_params.stream,
+                "tools": inference_params.tools,
+                "tool_results": inference_params.tool_results,
+                "seed": inference_params.seed,
+                "force_single_step": inference_params.force_single_step,
+            }
         )
 
     def transform_request(
@@ -338,7 +555,7 @@ class AmazonInvokeConfig(BaseConfig, BaseAWSLLM):
         if provider == "cohere":
             if model.startswith("cohere.command-r"):
                 config = litellm.AmazonCohereChatConfig().get_config()
-                cohere_inference_params = self._get_cohere_inference_params(
+                cohere_inference_params = self._parse_cohere_params(
                     optional_params=optional_params,
                     config=config,
                 )
@@ -352,12 +569,15 @@ class AmazonInvokeConfig(BaseConfig, BaseAWSLLM):
                 )
             else:
                 config = litellm.AmazonCohereConfig.get_config()
-                cohere_inference_params = self._get_cohere_inference_params(
+                cohere_inference_params = self._parse_cohere_params(
                     optional_params=optional_params,
                     config=config,
                 )
                 if stream is True:
-                    cohere_inference_params["stream"] = True
+                    cohere_inference_params = replace(
+                        cohere_inference_params,
+                        stream=True,
+                    )
                 return cast(
                     dict,
                     self._build_cohere_completion_request(
@@ -387,7 +607,7 @@ class AmazonInvokeConfig(BaseConfig, BaseAWSLLM):
             )
         elif provider == "ai21":
             config = litellm.AmazonAI21Config.get_config()
-            ai21_inference_params = self._get_ai21_inference_params(
+            ai21_inference_params = self._parse_ai21_params(
                 optional_params=optional_params,
                 config=config,
             )
@@ -400,7 +620,7 @@ class AmazonInvokeConfig(BaseConfig, BaseAWSLLM):
             )
         elif provider == "mistral":
             config = litellm.AmazonMistralConfig.get_config()
-            mistral_inference_params = self._get_mistral_inference_params(
+            mistral_inference_params = self._parse_mistral_params(
                 optional_params=optional_params,
                 config=config,
             )
@@ -413,7 +633,7 @@ class AmazonInvokeConfig(BaseConfig, BaseAWSLLM):
             )
         elif provider == "amazon":  # amazon titan
             config = litellm.AmazonTitanConfig.get_config()
-            titan_inference_params = self._get_titan_inference_params(
+            titan_inference_params = self._parse_titan_params(
                 optional_params=optional_params,
                 config=config,
             )
@@ -426,7 +646,7 @@ class AmazonInvokeConfig(BaseConfig, BaseAWSLLM):
             )
         elif provider == "meta" or provider == "llama" or provider == "deepseek_r1":
             config = litellm.AmazonLlamaConfig.get_config()
-            llama_inference_params = self._get_llama_inference_params(
+            llama_inference_params = self._parse_llama_params(
                 optional_params=optional_params,
                 config=config,
             )

--- a/litellm/types/llms/bedrock.py
+++ b/litellm/types/llms/bedrock.py
@@ -432,6 +432,85 @@ class BedrockInvokeNovaRequest(TypedDict, total=False):
     guardrailConfig: Optional[GuardrailConfigBlock]
 
 
+class BedrockInvokeCohereInferenceParams(TypedDict, total=False):
+    max_tokens: int
+    temperature: float
+    return_likelihood: str
+    p: float
+    k: int
+    stop_sequences: List[str]
+    num_generations: int
+    frequency_penalty: float
+    presence_penalty: float
+    truncate: str
+    stream: bool
+    tools: List[Dict[str, object]]
+    tool_results: List[Dict[str, object]]
+    seed: int
+    force_single_step: bool
+
+
+class BedrockInvokeCohereCompletionRequest(
+    BedrockInvokeCohereInferenceParams, total=False
+):
+    prompt: Required[str]
+
+
+class BedrockInvokeCohereChatRequest(BedrockInvokeCohereInferenceParams, total=False):
+    message: Required[str]
+    chat_history: List[Dict[str, object]]
+
+
+class BedrockInvokeAI21InferenceParams(TypedDict, total=False):
+    maxTokens: int
+    temperature: float
+    topP: float
+    stopSequences: List[str]
+    frequencyPenalty: Dict[str, object]
+    frequencePenalty: Dict[str, object]
+    presencePenalty: Dict[str, object]
+    countPenalty: Dict[str, object]
+
+
+class BedrockInvokeAI21Request(BedrockInvokeAI21InferenceParams, total=False):
+    prompt: Required[str]
+
+
+class BedrockInvokeMistralInferenceParams(TypedDict, total=False):
+    max_tokens: int
+    temperature: float
+    top_p: float
+    top_k: float
+    stop: List[str]
+
+
+class BedrockInvokeMistralRequest(BedrockInvokeMistralInferenceParams, total=False):
+    prompt: Required[str]
+
+
+class BedrockInvokeTitanInferenceParams(TypedDict, total=False):
+    maxTokenCount: int
+    stopSequences: List[str]
+    temperature: float
+    topP: int
+
+
+class BedrockInvokeTitanRequest(TypedDict):
+    inputText: str
+    textGenerationConfig: BedrockInvokeTitanInferenceParams
+
+
+class BedrockInvokeLlamaInferenceParams(TypedDict, total=False):
+    max_gen_len: int
+    temperature: float
+    top_p: float
+    topP: float
+
+
+class BedrockInvokeLlamaRequest(BedrockInvokeLlamaInferenceParams, total=False):
+    prompt: Required[str]
+
+
 class GenericStreamingChunk(TypedDict):
     text: Required[str]
     tool_use: Optional[ChatCompletionToolCallChunk]

--- a/litellm/types/llms/bedrock.py
+++ b/litellm/types/llms/bedrock.py
@@ -432,7 +432,8 @@ class BedrockInvokeNovaRequest(TypedDict, total=False):
     guardrailConfig: Optional[GuardrailConfigBlock]
 
 
-class BedrockInvokeCohereInferenceParams(TypedDict, total=False):
+class BedrockInvokeCohereCompletionRequest(TypedDict, total=False):
+    prompt: Required[str]
     max_tokens: int
     temperature: float
     return_likelihood: str
@@ -450,18 +451,28 @@ class BedrockInvokeCohereInferenceParams(TypedDict, total=False):
     force_single_step: bool
 
 
-class BedrockInvokeCohereCompletionRequest(
-    BedrockInvokeCohereInferenceParams, total=False
-):
-    prompt: Required[str]
-
-
-class BedrockInvokeCohereChatRequest(BedrockInvokeCohereInferenceParams, total=False):
+class BedrockInvokeCohereChatRequest(TypedDict, total=False):
     message: Required[str]
     chat_history: List[Dict[str, object]]
+    max_tokens: int
+    temperature: float
+    return_likelihood: str
+    p: float
+    k: int
+    stop_sequences: List[str]
+    num_generations: int
+    frequency_penalty: float
+    presence_penalty: float
+    truncate: str
+    stream: bool
+    tools: List[Dict[str, object]]
+    tool_results: List[Dict[str, object]]
+    seed: int
+    force_single_step: bool
 
 
-class BedrockInvokeAI21InferenceParams(TypedDict, total=False):
+class BedrockInvokeAI21Request(TypedDict, total=False):
+    prompt: Required[str]
     maxTokens: int
     temperature: float
     topP: float
@@ -472,20 +483,13 @@ class BedrockInvokeAI21InferenceParams(TypedDict, total=False):
     countPenalty: Dict[str, object]
 
 
-class BedrockInvokeAI21Request(BedrockInvokeAI21InferenceParams, total=False):
+class BedrockInvokeMistralRequest(TypedDict, total=False):
     prompt: Required[str]
-
-
-class BedrockInvokeMistralInferenceParams(TypedDict, total=False):
     max_tokens: int
     temperature: float
     top_p: float
     top_k: float
     stop: List[str]
-
-
-class BedrockInvokeMistralRequest(BedrockInvokeMistralInferenceParams, total=False):
-    prompt: Required[str]
 
 
 class BedrockInvokeTitanInferenceParams(TypedDict, total=False):
@@ -500,15 +504,12 @@ class BedrockInvokeTitanRequest(TypedDict):
     textGenerationConfig: BedrockInvokeTitanInferenceParams
 
 
-class BedrockInvokeLlamaInferenceParams(TypedDict, total=False):
+class BedrockInvokeLlamaRequest(TypedDict, total=False):
+    prompt: Required[str]
     max_gen_len: int
     temperature: float
     top_p: float
     topP: float
-
-
-class BedrockInvokeLlamaRequest(BedrockInvokeLlamaInferenceParams, total=False):
-    prompt: Required[str]
 
 
 class GenericStreamingChunk(TypedDict):

--- a/tests/test_litellm/llms/bedrock/chat/invoke_transformations/test_base_invoke_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/invoke_transformations/test_base_invoke_transformation.py
@@ -39,3 +39,52 @@ def test_transform_request_drops_stream_chunk_size(config, model):
     )
 
     assert "stream_chunk_size" not in json.dumps(request_body)
+
+
+@pytest.mark.parametrize(
+    "model,valid_param,valid_value,valid_param_path",
+    [
+        ("cohere.command-text-v14", "max_tokens", 10, ("max_tokens",)),
+        ("ai21.j2-ultra-v1", "maxTokens", 10, ("maxTokens",)),
+        ("mistral.mistral-7b-instruct-v0:2", "max_tokens", 10, ("max_tokens",)),
+        (
+            "amazon.titan-text-express-v1",
+            "maxTokenCount",
+            10,
+            ("textGenerationConfig", "maxTokenCount"),
+        ),
+        ("meta.llama2-13b-chat-v1", "max_gen_len", 10, ("max_gen_len",)),
+    ],
+)
+def test_transform_request_drops_internal_params_from_typed_invoke_body(
+    model, valid_param, valid_value, valid_param_path
+):
+    request_body = AmazonInvokeConfig().transform_request(
+        model=model,
+        messages=[{"role": "user", "content": "hi"}],
+        optional_params={
+            "skip_mcp_handler": True,
+            "_skip_mcp_handler": True,
+            "mcp_handler_context": {"request_id": "test"},
+            "stream_chunk_size": 2048,
+            "aws_region_name": "us-east-1",
+            valid_param: valid_value,
+        },
+        litellm_params={},
+        headers={},
+    )
+
+    serialized_request = json.dumps(request_body)
+    for internal_param in (
+        "skip_mcp_handler",
+        "_skip_mcp_handler",
+        "mcp_handler_context",
+        "stream_chunk_size",
+        "aws_region_name",
+    ):
+        assert internal_param not in serialized_request
+
+    value = request_body
+    for path_part in valid_param_path:
+        value = value[path_part]
+    assert value == valid_value


### PR DESCRIPTION
## Relevant issues

Fixes #30371

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Delays in PR merge?

N/A

## CI (LiteLLM team)

- [ ] Branch creation CI run
       Link:

- [ ] CI run for the last commit
       Link:

- [ ] Merge / cherry-pick CI run
       Links:

## Screenshots / Proof of Fix

No-network repro now strips the LiteLLM internal key while preserving the Bedrock inference param:

```bash
uv run python -c '
from litellm.llms.bedrock.chat.invoke_transformations.base_invoke_transformation import AmazonInvokeConfig
import json

body = AmazonInvokeConfig().transform_request(
    model="mistral.mistral-7b-instruct-v0:2",
    messages=[{"role": "user", "content": "hi"}],
    optional_params={"skip_mcp_handler": True, "max_tokens": 10},
    litellm_params={},
    headers={},
)
print(json.dumps(body, indent=2))
print("skip_mcp_handler in body:", "skip_mcp_handler" in body)
print("max_tokens in body:", "max_tokens" in body)
'
```

Output:

```text
{
  "prompt": "<s>[INST] hi [/INST]\n",
  "max_tokens": 10
}
skip_mcp_handler in body: False
max_tokens in body: True
```

## Type

Bug Fix
Refactoring
Test

## Changes

This adds provider-specific Bedrock invoke wire `TypedDict`s and parses base invoke params into provider-specific frozen dataclasses before request body construction. The wire builders now accept those frozen param objects instead of raw `optional_params` or dict-like inference params, so the type boundary prevents accidentally splatting LiteLLM-internal attrs into provider payloads after ingress

A regression test covers representative base invoke providers and asserts internal params are stripped while valid provider params survive

Targeted checks run locally:

```bash
uv run ruff check litellm/types/llms/bedrock.py litellm/llms/bedrock/chat/invoke_transformations/base_invoke_transformation.py tests/test_litellm/llms/bedrock/chat/invoke_transformations/test_base_invoke_transformation.py
uv run pytest tests/test_litellm/llms/bedrock/chat/invoke_transformations/test_base_invoke_transformation.py
uv run --no-sync mypy litellm/types/llms/bedrock.py litellm/llms/bedrock/chat/invoke_transformations/base_invoke_transformation.py --ignore-missing-imports
```