### PR TITLE
fix(mcp): stop phantom 401 trace on OAuth2 passthrough success

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
+++ b/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
@@ -15,7 +15,7 @@ from litellm.proxy._types import (
     UserAPIKeyAuth,
 )
 from litellm.proxy.auth.ip_address_utils import IPAddressUtils
-from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+from litellm.proxy.auth.user_api_key_auth import _get_bearer_token, user_api_key_auth
 from litellm.repositories.table_repositories import (
     AgentsRepository,
     MCPServerRepository,
@@ -240,77 +240,86 @@ class MCPRequestHandler:
                 api_key=litellm_api_key, request=request
             )
         elif oauth2_headers:
-            # No x-litellm-api-key, but Authorization header present.
-            # Could be a LiteLLM key (backward compat) OR an opaque OAuth2 token
-            # the operator wants forwarded to an upstream OAuth2-mode MCP server.
-            # Try LiteLLM auth first; on auth failure, only fall back to anonymous
-            # passthrough when the request actually targets a server whose operator
-            # configured ``auth_type=oauth2``. For any other server (api_key,
-            # bearer_token, basic, etc.), a failed LiteLLM auth is a real failure
-            # and must propagate — otherwise an attacker can exchange any garbage
-            # bearer for an anonymous session.
-            try:
-                validated_user_api_key_auth = await user_api_key_auth(
-                    api_key=litellm_api_key, request=request
+            # Authorization without x-litellm-api-key: the bearer is either a
+            # LiteLLM key (backward compat) or an opaque OAuth2 token to forward
+            # upstream. Virtual keys start with "sk-" (enforced in
+            # user_api_key_auth), so a non-"sk-" bearer on an OAuth2-mode target is
+            # passed through without validation: validating it could only fail, and
+            # that 401 gets logged as an auth span on calls that actually succeed.
+            # Other bearers are validated so failures on non-OAuth2 servers still
+            # propagate instead of granting an anonymous session.
+            client_ip = IPAddressUtils.get_mcp_client_ip(request)
+            targets_oauth2 = MCPRequestHandler._target_servers_use_oauth2(
+                path=request_route,
+                mcp_servers=mcp_servers,
+                client_ip=client_ip,
+            )
+            bearer_token = _get_bearer_token(litellm_api_key)
+            if targets_oauth2 and not bearer_token.startswith("sk-"):
+                verbose_logger.debug(
+                    "MCP OAuth2 passthrough: forwarding non-LiteLLM bearer upstream"
                 )
-            except (HTTPException, ProxyException) as e:
-                # HTTPException.status_code is int; ProxyException.code is
-                # normalized to str in its __init__ but can be ``"None"`` or any
-                # non-numeric string when the caller didn't supply a numeric
-                # code, so we compare against both int and str forms rather
-                # than coercing (``int("None")`` would raise ValueError and
-                # rewrite the auth error as a 500).
-                status = e.status_code if isinstance(e, HTTPException) else e.code
-                is_auth_error = status in (401, 403, "401", "403")
-                is_unauthenticated = status in (401, "401")
-                client_ip = IPAddressUtils.get_mcp_client_ip(request)
-                if is_auth_error and MCPRequestHandler._target_servers_use_oauth2(
-                    path=request_route,
-                    mcp_servers=mcp_servers,
-                    client_ip=client_ip,
-                ):
-                    verbose_logger.debug(
-                        "MCP OAuth2: target server is OAuth2-mode, treating "
-                        "Authorization as upstream OAuth2 token passthrough"
+                validated_user_api_key_auth = UserAPIKeyAuth()
+            else:
+                try:
+                    validated_user_api_key_auth = await user_api_key_auth(
+                        api_key=litellm_api_key, request=request
                     )
-                    validated_user_api_key_auth = UserAPIKeyAuth()
-                elif is_unauthenticated:
-                    # Pass-through cold-start return: per RFC 9728 / MCP
-                    # Authorization spec the client completes upstream OAuth
-                    # discovery and returns with ``Authorization: Bearer
-                    # <upstream-token>``. For ``auth_type=none`` passthrough
-                    # servers that bearer is not a LiteLLM key (auth above
-                    # failed) but is meant to be forwarded upstream
-                    # unchanged. Fall back to anonymous admission so the
-                    # caller is not rejected for following the discovery
-                    # flow without also setting ``x-litellm-api-key``.
-                    # Only trigger on 401 (token unrecognized); a 403 means
-                    # the key WAS recognized but is forbidden (e.g. over
-                    # budget / rate limited) and must propagate so those
-                    # controls are not bypassed via anonymous admission.
-                    mcp_servers_from_path = _parse_mcp_server_names_from_path(
-                        request_route, mcp_servers
-                    )
-                    if (
-                        mcp_servers_from_path is not None
-                        and not _has_client_supplied_mcp_auth(
-                            mcp_auth_header,
-                            mcp_server_auth_headers,
-                        )
-                        and _is_mcp_passthrough_cold_start(
-                            mcp_servers_from_path, client_ip=client_ip
-                        )
-                    ):
+                except (HTTPException, ProxyException) as e:
+                    # HTTPException.status_code is int; ProxyException.code is
+                    # normalized to str in its __init__ but can be ``"None"`` or
+                    # any non-numeric string when the caller didn't supply a
+                    # numeric code, so we compare against both int and str forms
+                    # rather than coercing (``int("None")`` would raise
+                    # ValueError and rewrite the auth error as a 500).
+                    status = e.status_code if isinstance(e, HTTPException) else e.code
+                    is_auth_error = status in (401, 403, "401", "403")
+                    is_unauthenticated = status in (401, "401")
+                    if is_auth_error and targets_oauth2:
+                        # "sk-"-shaped bearer that isn't a valid key: forward it to
+                        # the OAuth2 target as a token.
                         verbose_logger.debug(
-                            "MCP pass-through return: target server is "
-                            "passthrough, treating Authorization as "
-                            "upstream OAuth token for delegated auth"
+                            "MCP OAuth2: target server is OAuth2-mode, treating "
+                            "Authorization as upstream OAuth2 token passthrough"
                         )
                         validated_user_api_key_auth = UserAPIKeyAuth()
+                    elif is_unauthenticated:
+                        # Pass-through cold-start return: per RFC 9728 / MCP
+                        # Authorization spec the client completes upstream OAuth
+                        # discovery and returns with ``Authorization: Bearer
+                        # <upstream-token>``. For ``auth_type=none`` passthrough
+                        # servers that bearer is not a LiteLLM key (auth above
+                        # failed) but is meant to be forwarded upstream
+                        # unchanged. Fall back to anonymous admission so the
+                        # caller is not rejected for following the discovery
+                        # flow without also setting ``x-litellm-api-key``.
+                        # Only trigger on 401 (token unrecognized); a 403 means
+                        # the key WAS recognized but is forbidden (e.g. over
+                        # budget / rate limited) and must propagate so those
+                        # controls are not bypassed via anonymous admission.
+                        mcp_servers_from_path = _parse_mcp_server_names_from_path(
+                            request_route, mcp_servers
+                        )
+                        if (
+                            mcp_servers_from_path is not None
+                            and not _has_client_supplied_mcp_auth(
+                                mcp_auth_header,
+                                mcp_server_auth_headers,
+                            )
+                            and _is_mcp_passthrough_cold_start(
+                                mcp_servers_from_path, client_ip=client_ip
+                            )
+                        ):
+                            verbose_logger.debug(
+                                "MCP pass-through return: target server is "
+                                "passthrough, treating Authorization as "
+                                "upstream OAuth token for delegated auth"
+                            )
+                            validated_user_api_key_auth = UserAPIKeyAuth()
+                        else:
+                            raise
                     else:
                         raise
-                else:
-                    raise
         else:
             try:
                 validated_user_api_key_auth = await user_api_key_auth(

--- a/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
@@ -709,6 +709,101 @@ class TestMCPOAuth2AuthFlow:
                 == "Bearer atlassian-oauth2-access-token-xyz"
             )
 
+    async def test_oauth2_token_skips_litellm_validation_no_phantom_401(self):
+        """
+        Regression: an opaque OAuth2 token (non-LiteLLM bearer) on an OAuth2-mode
+        target must be passed through WITHOUT attempting LiteLLM-key validation.
+        That validation can only fail (virtual keys always start with 'sk-') and
+        its failure is emitted to observability as a 401 auth span, which surfaced
+        on tool calls that actually succeeded. Asserting ``user_api_key_auth`` is
+        never called pins that the doomed validation — and the phantom 401 — is
+        gone.
+        """
+        from litellm.types.mcp import MCPAuth
+
+        scope = {
+            "type": "http",
+            "method": "POST",
+            "path": "/mcp/atlassian_mcp",
+            "headers": [
+                (b"authorization", b"Bearer eyJraWQ-opaque-oauth2-token"),
+            ],
+        }
+
+        async def fail_if_called(api_key, request):
+            raise AssertionError(
+                "user_api_key_auth must not be called for a non-sk bearer on an "
+                "OAuth2 target"
+            )
+
+        oauth2_server = MagicMock()
+        oauth2_server.auth_type = MCPAuth.oauth2
+
+        with (
+            patch(
+                "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.user_api_key_auth",
+                side_effect=fail_if_called,
+            ) as mock_auth,
+            patch(
+                "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager"
+            ) as mock_mgr,
+        ):
+            mock_mgr.get_mcp_server_by_name.return_value = oauth2_server
+            (
+                auth_result,
+                _mcp_auth_header,
+                _mcp_servers,
+                _mcp_server_auth_headers,
+                oauth2_headers,
+                _raw_headers,
+            ) = await MCPRequestHandler.process_mcp_request(scope)
+
+        mock_auth.assert_not_called()
+        assert isinstance(auth_result, UserAPIKeyAuth)
+        # The opaque token is preserved for upstream forwarding.
+        assert (
+            oauth2_headers.get("Authorization") == "Bearer eyJraWQ-opaque-oauth2-token"
+        )
+
+    async def test_sk_bearer_on_oauth2_target_still_validates(self):
+        """
+        Backward compat: an 'sk-'-shaped bearer on an OAuth2 target is still
+        validated as a LiteLLM key (so it resolves the user for spend / rate
+        limits and stored-token injection) rather than being blindly passed
+        through. The passthrough-first shortcut only applies to non-'sk-' bearers.
+        """
+        from litellm.types.mcp import MCPAuth
+
+        scope = {
+            "type": "http",
+            "method": "POST",
+            "path": "/mcp/atlassian_mcp",
+            "headers": [
+                (b"authorization", b"Bearer sk-litellm-valid-key"),
+            ],
+        }
+
+        async def mock_user_api_key_auth(api_key, request):
+            return UserAPIKeyAuth(api_key=api_key, user_id="test-user")
+
+        oauth2_server = MagicMock()
+        oauth2_server.auth_type = MCPAuth.oauth2
+
+        with (
+            patch(
+                "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.user_api_key_auth",
+                side_effect=mock_user_api_key_auth,
+            ) as mock_auth,
+            patch(
+                "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager"
+            ) as mock_mgr,
+        ):
+            mock_mgr.get_mcp_server_by_name.return_value = oauth2_server
+            auth_result, *_rest = await MCPRequestHandler.process_mcp_request(scope)
+
+        mock_auth.assert_called_once()
+        assert auth_result.user_id == "test-user"
+
     async def test_explicit_litellm_key_with_oauth2_authorization(self):
         """
         When both x-litellm-api-key AND Authorization header are present,


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist
- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Proof of Fix

For an OAuth2-mode MCP server such as Atlassian, an MCP client authenticates by sending its upstream OAuth token as `Authorization: Bearer <token>`. Before this change `process_mcp_request` validated that bearer as a LiteLLM key first; that always fails for an opaque OAuth token, and the auth exception handler logged the failure to the observability callbacks as a 401 error span before the OAuth2 passthrough recovered. Every successful OAuth2 tool call therefore carried a phantom 401 in its traces

Repro against a live proxy that has an OAuth2 MCP server configured and `callbacks: ["otel"]`:

```bash
curl -sL -N http://localhost:4000/<server>/mcp \
  -H "Content-Type: application/json" \
  -H "Accept: application/json, text/event-stream" \
  -H "Authorization: Bearer <upstream-oauth-token>" \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"<tool>","arguments":{}}}'
```

Before: the proxy logs `401: LiteLLM Virtual Key expected. Received=...` and emits a 401 OTel span for the request even though the tool returns a result

After: no `Virtual Key expected` line is logged and no 401 span is emitted; the opaque bearer takes the passthrough path and the tool result is unchanged

## Type

Bug Fix

## Changes

`process_mcp_request` forwards an opaque upstream OAuth2 token straight to an OAuth2-mode target instead of validating it as a LiteLLM key first. A bearer that LiteLLM can actually authenticate still validates normally so the user is resolved: an `sk-` key always, and a JWT-shaped bearer when `enable_jwt_auth` is on. A failed validation on a non-OAuth2 server still propagates instead of granting an anonymous session. The branch is factored into `_resolve_oauth2_header_auth` with early returns

Tests added in `test_user_api_key_auth_mcp.py`: opaque token skips validation (no phantom 401), `sk-` and JWT (when enabled) still validate, a JWT-shaped token passes through when JWT auth is off, and a non-`sk-` bearer on a non-OAuth2 target still raises