### PR TITLE
fix(pricing): correct swapped input/output token costs for command-r7b-12-2024

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -10811,13 +10811,13 @@
         "supports_tool_choice": true
     },
     "command-r7b-12-2024": {
-        "input_cost_per_token": 1.5e-07,
+        "input_cost_per_token": 3.75e-08,
         "litellm_provider": "cohere_chat",
         "max_input_tokens": 128000,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
-        "output_cost_per_token": 3.75e-08,
+        "output_cost_per_token": 1.5e-07,
         "source": "https://docs.cohere.com/v2/docs/command-r7b",
         "supports_function_calling": true,
         "supports_tool_choice": true

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -10811,13 +10811,13 @@
         "supports_tool_choice": true
     },
     "command-r7b-12-2024": {
-        "input_cost_per_token": 1.5e-07,
+        "input_cost_per_token": 3.75e-08,
         "litellm_provider": "cohere_chat",
         "max_input_tokens": 128000,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
-        "output_cost_per_token": 3.75e-08,
+        "output_cost_per_token": 1.5e-07,
         "source": "https://docs.cohere.com/v2/docs/command-r7b",
         "supports_function_calling": true,
         "supports_tool_choice": true

--- a/tests/test_litellm/test_command_r7b_pricing.py
+++ b/tests/test_litellm/test_command_r7b_pricing.py
@@ -37,8 +37,14 @@ def _backup_path() -> str:
 
 
 def _main_path() -> str:
+    # This test lives at ``tests/test_litellm/``; the primary price map sits at
+    # the repo root, two directories up. Resolve it relative to this file so the
+    # test works regardless of where ``litellm`` itself is installed (e.g. a pip
+    # install into site-packages).
     return os.path.join(
-        os.path.dirname(os.path.dirname(litellm.__file__)),
+        os.path.dirname(__file__),
+        "..",
+        "..",
         "model_prices_and_context_window.json",
     )
 

--- a/tests/test_litellm/test_command_r7b_pricing.py
+++ b/tests/test_litellm/test_command_r7b_pricing.py
@@ -1,0 +1,70 @@
+"""
+Regression test: ``command-r7b-12-2024`` had its input/output per-token
+costs transposed in the model-cost maps (input=1.5e-07 / output=3.75e-08),
+even though Cohere publishes $0.0375/1M input and $0.15/1M output, i.e.
+output is ~4x input like every other ``command-r`` entry.
+
+These tests pin the corrected values in both the primary price map and the
+``litellm/`` backup, and verify ``get_model_info`` surfaces them, so the
+swap cannot silently regress.
+"""
+
+import json
+import os
+import sys
+
+sys.path.insert(
+    0, os.path.abspath("../..")
+)  # Adds the parent directory to the system path
+
+import litellm
+
+MODEL = "command-r7b-12-2024"
+EXPECTED_INPUT_COST = 3.75e-08
+EXPECTED_OUTPUT_COST = 1.5e-07
+
+
+def _load_json(path: str) -> dict:
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _backup_path() -> str:
+    return os.path.join(
+        os.path.dirname(litellm.__file__),
+        "model_prices_and_context_window_backup.json",
+    )
+
+
+def _main_path() -> str:
+    return os.path.join(
+        os.path.dirname(os.path.dirname(litellm.__file__)),
+        "model_prices_and_context_window.json",
+    )
+
+
+class TestCommandR7bPricingData:
+    """The JSON price maps must carry Cohere's published costs, with output
+    more expensive than input."""
+
+    def test_backup_costs_not_swapped(self):
+        entry = _load_json(_backup_path())[MODEL]
+        assert entry["input_cost_per_token"] == EXPECTED_INPUT_COST
+        assert entry["output_cost_per_token"] == EXPECTED_OUTPUT_COST
+        assert entry["output_cost_per_token"] > entry["input_cost_per_token"]
+
+    def test_main_costs_not_swapped(self):
+        entry = _load_json(_main_path())[MODEL]
+        assert entry["input_cost_per_token"] == EXPECTED_INPUT_COST
+        assert entry["output_cost_per_token"] == EXPECTED_OUTPUT_COST
+        assert entry["output_cost_per_token"] > entry["input_cost_per_token"]
+
+
+class TestCommandR7bPricingModelInfo:
+    """``get_model_info`` must report the corrected, un-swapped costs."""
+
+    def test_get_model_info_costs(self):
+        info = litellm.get_model_info(MODEL)
+        assert info["input_cost_per_token"] == EXPECTED_INPUT_COST
+        assert info["output_cost_per_token"] == EXPECTED_OUTPUT_COST
+        assert info["output_cost_per_token"] > info["input_cost_per_token"]


### PR DESCRIPTION
The `command-r7b-12-2024` entry has its input and output per-token costs transposed: it sets input=1.5e-07 / output=3.75e-08, but Cohere's published pricing is $0.0375/1M input and $0.15/1M output (output ~4x input, like every other `command-r` entry). The current values cause cost tracking to over-bill input and under-bill output by 4x. This swaps the two fields in both the primary and backup price maps and adds a regression test.