### PR TITLE
fix(pricing): add GitHub Copilot MAI Code Flash pricing

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -18822,6 +18822,38 @@
         "supports_response_schema": true,
         "supports_vision": true
     },
+    "github_copilot/mai-code-1-flash": {
+        "cache_read_input_token_cost": 7.5e-08,
+        "input_cost_per_token": 7.5e-07,
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "output_cost_per_token": 4.5e-06,
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true
+    },
+    "github_copilot/mai-code-1-flash-internal": {
+        "cache_read_input_token_cost": 7.5e-08,
+        "input_cost_per_token": 7.5e-07,
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "output_cost_per_token": 4.5e-06,
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true
+    },
     "github_copilot/text-embedding-3-small": {
         "litellm_provider": "github_copilot",
         "max_input_tokens": 8191,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -18822,6 +18822,38 @@
         "supports_response_schema": true,
         "supports_vision": true
     },
+    "github_copilot/mai-code-1-flash": {
+        "cache_read_input_token_cost": 7.5e-08,
+        "input_cost_per_token": 7.5e-07,
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "output_cost_per_token": 4.5e-06,
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true
+    },
+    "github_copilot/mai-code-1-flash-internal": {
+        "cache_read_input_token_cost": 7.5e-08,
+        "input_cost_per_token": 7.5e-07,
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "output_cost_per_token": 4.5e-06,
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true
+    },
     "github_copilot/text-embedding-3-small": {
         "litellm_provider": "github_copilot",
         "max_input_tokens": 8191,

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -180,6 +180,43 @@ def test_openrouter_qwen36_plus_model_info():
     assert model_info["supports_vision"] is True
 
 
+@pytest.mark.parametrize(
+    "model",
+    [
+        "github_copilot/mai-code-1-flash",
+        "github_copilot/mai-code-1-flash-internal",
+    ],
+)
+def test_github_copilot_mai_code_1_flash_pricing(model):
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+
+    model_info = litellm.model_cost.get(model)
+
+    assert model_info is not None, f"Missing model pricing entry: {model}"
+    assert model_info["litellm_provider"] == "github_copilot"
+    assert model_info["mode"] == "chat"
+    assert model_info["input_cost_per_token"] == 7.5e-07
+    assert model_info["cache_read_input_token_cost"] == 7.5e-08
+    assert model_info["output_cost_per_token"] == 4.5e-06
+    assert model_info["supported_endpoints"] == ["/v1/chat/completions"]
+
+    prompt_usd, completion_usd = cost_per_token(
+        model=model,
+        prompt_tokens=1000,
+        completion_tokens=500,
+        custom_llm_provider="github_copilot",
+        usage_object=Usage(
+            prompt_tokens=1000,
+            completion_tokens=500,
+            prompt_tokens_details=PromptTokensDetailsWrapper(cached_tokens=200),
+        ),
+    )
+
+    assert prompt_usd == pytest.approx((800 * 7.5e-07) + (200 * 7.5e-08))
+    assert completion_usd == pytest.approx(500 * 4.5e-06)
+
+
 def test_cost_calculator_with_usage(monkeypatch):
     os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
     litellm.model_cost = litellm.get_model_cost_map(url="")
@@ -385,7 +422,7 @@ def test_handle_realtime_stream_cost_calculation():
     )
     assert cost == 0.0  # No usage, no cost
 
-    
+
 def test_realtime_stream_combines_text_and_audio_token_details():
     """Realtime response.done usage with input_token_details / output_token_details."""
     from litellm.cost_calculator import RealtimeAPITokenUsageProcessor


### PR DESCRIPTION
## Relevant issues

None. I could not find an existing LiteLLM issue or PR for MAI-Code-1-Flash pricing

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code) — see "Local test status" below
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

GitHub Copilot's official models and pricing table lists MAI-Code-1-Flash under Microsoft at $0.75 per 1M input tokens, $0.075 per 1M cached input tokens, and $4.50 per 1M output tokens: https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing. Encoded per-token: input `7.5e-07`, cached input `7.5e-08`, output `4.5e-06`

This is a static model cost map update; it does not change provider request handling, so there is no live proxy request to show. The added unit test drives `cost_per_token()` for both model names and asserts the cached vs non-cached arithmetic

**Local test status (honest note for the `make test-unit` checkbox):** the new pricing test passes (`uv run pytest tests/test_litellm/test_cost_calculator.py -k github_copilot` -> `2 passed`). The full `make test-unit` command (`pytest tests/test_litellm -x -vv -n 4`) does not exit cleanly on a local checkout, but for reasons unrelated to this change: pytest hits a duplicate-basename collection error between the pre-existing `tests/test_litellm/models/test_models.py` and `tests/test_litellm/proxy/client/test_models.py`, and separately `tests/test_litellm/proxy/test_component_allowlists.py::test_gateway_plus_backend_covers_full_app` fails on an unrelated route allowlist. Neither of those files is touched by this PR, and both reproduce on the base branch. CI shards the suite, so it does not hit the local-only collection collision

**Metadata note:** the entries intentionally omit `supports_vision`. Microsoft's MAI-Code-1-Flash model card describes it as a text-to-text coding model (text input, text output), and GitHub's supported-models page does not list vision for it, so a vision capability flag would be inaccurate

## Type

Bug Fix
Test

## Changes

Adds `github_copilot/mai-code-1-flash` and `github_copilot/mai-code-1-flash-internal` pricing to both model cost maps using GitHub Copilot's published MAI-Code-1-Flash rates. The internal name is the identifier surfaced in GitHub Copilot CLI logs. Both entries explicitly declare `supported_endpoints: ["/v1/chat/completions"]` because they are `mode: "chat"` entries and should not be routed through `/v1/responses`

Adds a parametrized regression test that verifies both model names include input, cached input, output pricing, and the chat-completions endpoint, and are priced correctly by `cost_per_token`
