### PR TITLE
fix(exception-mapping): map Gemini upstream-error body code 429 to RateLimitError

### DIFF
--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -1425,9 +1425,15 @@ def exception_type(  # type: ignore  # noqa: PLR0915
                             ),
                         ),
                     )
-                elif _get_body_error_code(error_str) == 429:
-                    # upstream gateway wraps a 429 inside a 500/503 body
-                    # e.g. {"error":{"code":429,"type":"upstream_error",...}}
+                elif (
+                    isinstance(getattr(original_exception, "status_code", None), int)
+                    and 500 <= original_exception.status_code < 600
+                    and _get_body_error_code(error_str) == 429
+                ):
+                    # upstream gateway wraps a 429 inside a 5xx envelope
+                    # e.g. HTTP 500/503 with {"error":{"code":429,...}}.
+                    # Scoped to 5xx so HTTP 400/401 with body code:429
+                    # still maps to BadRequestError / AuthenticationError.
                     exception_mapping_worked = True
                     raise RateLimitError(
                         message=f"litellm.RateLimitError: {custom_llm_provider}Exception - {error_str}",

--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -170,6 +170,16 @@ def get_error_message(error_obj) -> Optional[str]:
 
 
 ####### EXCEPTION MAPPING ################
+def _get_body_error_code(error_str: str) -> Optional[int]:
+    """Return error.code from a JSON error body, or None if not parseable."""
+    try:
+        body = json.loads(error_str)
+        code = body.get("error", {}).get("code")
+        return int(code) if code is not None else None
+    except Exception:
+        return None
+
+
 def _get_response_headers(original_exception: Exception) -> Optional[httpx.Headers]:
     """
     Extract and return the response headers from an exception, if present.
@@ -1401,6 +1411,23 @@ def exception_type(  # type: ignore  # noqa: PLR0915
                     or "429 Unable to submit request because the service is temporarily out of capacity."
                     in error_str
                 ):
+                    exception_mapping_worked = True
+                    raise RateLimitError(
+                        message=f"litellm.RateLimitError: {custom_llm_provider}Exception - {error_str}",
+                        model=model,
+                        llm_provider=custom_llm_provider,
+                        litellm_debug_info=extra_information,
+                        response=httpx.Response(
+                            status_code=429,
+                            request=httpx.Request(
+                                method="POST",
+                                url=" https://cloud.google.com/vertex-ai/",
+                            ),
+                        ),
+                    )
+                elif _get_body_error_code(error_str) == 429:
+                    # upstream gateway wraps a 429 inside a 500/503 body
+                    # e.g. {"error":{"code":429,"type":"upstream_error",...}}
                     exception_mapping_worked = True
                     raise RateLimitError(
                         message=f"litellm.RateLimitError: {custom_llm_provider}Exception - {error_str}",

--- a/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
@@ -385,42 +385,74 @@ class TestGetBodyErrorCode:
         assert _get_body_error_code('{"error":{"message":"x"}}') is None
 
 
-# Test cases for Gemini upstream-error body-code mapping
-# Body code 429 wrapped in HTTP 500/503 envelopes (e.g. new-api gateways)
-# must map to RateLimitError so Router retries kick in.
+# Test cases for Gemini upstream-error body-code mapping.
+#
+# Body code 429 wrapped in a 5xx HTTP envelope (e.g. new-api gateways)
+# must map to RateLimitError so Router retries kick in. A 4xx HTTP
+# envelope with body code:429 must NOT — it falls through to whatever
+# the HTTP status code maps to (BadRequestError, AuthenticationError,
+# etc.), matching upstream's existing semantics.
 gemini_body_code_429_test_cases = [
-    # (error_body, should_be_rate_limit, description)
+    # (status_code, error_body, expected_exception_type, description)
     (
+        500,
         '{"error":{"message":" This model is currently experiencing high demand.'
         " Spikes in demand are usually temporary. Please try again later."
         ' (request id: x)","type":"upstream_error","param":"","code":429}}',
-        True,
-        "new-api gateway wraps Gemini overload as code:429",
+        litellm.RateLimitError,
+        "HTTP 500 envelope with body code:429 -> RateLimitError",
     ),
     (
+        503,
+        '{"error":{"message":"upstream unavailable","type":"upstream_error",'
+        '"param":"","code":429}}',
+        litellm.RateLimitError,
+        "HTTP 503 envelope with body code:429 -> RateLimitError",
+    ),
+    (
+        502,
+        '{"error":{"message":"bad gateway","code":429}}',
+        litellm.RateLimitError,
+        "HTTP 502 envelope with body code:429 -> RateLimitError",
+    ),
+    (
+        500,
         '{"error":{"message":"server boom","code":500}}',
-        False,
-        "genuine 500 body stays InternalServerError",
+        litellm.InternalServerError,
+        "HTTP 500 with body code:500 stays InternalServerError",
     ),
     (
+        500,
         "plain text 500 error",
-        False,
-        "non-JSON body falls through to status_code mapping",
+        litellm.InternalServerError,
+        "HTTP 500 with non-JSON body falls through to status_code mapping",
+    ),
+    (
+        400,
+        '{"error":{"message":"malformed","code":429}}',
+        litellm.BadRequestError,
+        "HTTP 400 with body code:429 must NOT be promoted to RateLimitError",
+    ),
+    (
+        401,
+        '{"error":{"message":"bad key","code":429}}',
+        litellm.AuthenticationError,
+        "HTTP 401 with body code:429 must NOT be promoted to RateLimitError",
     ),
 ]
 
 
 @pytest.mark.parametrize(
-    "error_body, should_be_rate_limit, description",
+    "status_code, error_body, expected_exception, description",
     gemini_body_code_429_test_cases,
 )
 def test_gemini_upstream_error_body_code_429_maps_to_rate_limit(
-    error_body, should_be_rate_limit, description
+    status_code, error_body, expected_exception, description
 ):
     """
-    Some upstream gateways wrap a 429 rate-limit signal inside an HTTP 500
-    envelope (body still says code:429). LiteLLM must surface this as
-    RateLimitError, not InternalServerError, so Router fallbacks trigger.
+    Body code 429 inside a 5xx envelope -> RateLimitError so Router
+    retries kick in. Body code 429 inside a 4xx envelope must fall
+    through to the HTTP-status-code branch (P1 from greptile review).
     """
     model = "gemini/gemini-2.5-flash"
     custom_llm_provider = "gemini"
@@ -433,24 +465,15 @@ def test_gemini_upstream_error_body_code_429_maps_to_rate_limit(
             self.message = message
             super().__init__(message)
 
-    original_exception = _FakeGeminiError(status_code=500, message=error_body)
+    original_exception = _FakeGeminiError(status_code=status_code, message=error_body)
 
-    if should_be_rate_limit:
-        with pytest.raises(litellm.RateLimitError) as excinfo:
-            exception_type(
-                model=model,
-                original_exception=original_exception,
-                custom_llm_provider=custom_llm_provider,
-            )
-        assert isinstance(excinfo.value, litellm.RateLimitError), description
-    else:
-        with pytest.raises(litellm.InternalServerError) as excinfo:
-            exception_type(
-                model=model,
-                original_exception=original_exception,
-                custom_llm_provider=custom_llm_provider,
-            )
-        assert isinstance(excinfo.value, litellm.InternalServerError), description
+    with pytest.raises(expected_exception) as excinfo:
+        exception_type(
+            model=model,
+            original_exception=original_exception,
+            custom_llm_provider=custom_llm_provider,
+        )
+    assert isinstance(excinfo.value, expected_exception), description
 
 
 class TestExtractAndRaiseLitellmException:

--- a/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
@@ -11,6 +11,7 @@ sys.path.insert(
 
 from litellm.litellm_core_utils.exception_mapping_utils import (
     ExceptionCheckers,
+    _get_body_error_code,
     exception_type,
     extract_and_raise_litellm_exception,
 )
@@ -357,6 +358,99 @@ def test_vertex_ai_rate_limit_error_mapping(error_message, should_raise_rate_lim
                 original_exception=original_exception,
                 custom_llm_provider=custom_llm_provider,
             )
+
+
+class TestGetBodyErrorCode:
+    """Unit tests for _get_body_error_code helper."""
+
+    def test_parses_int_code(self):
+        body = (
+            '{"error":{"message":"high demand","type":"upstream_error",'
+            '"param":"","code":429}}'
+        )
+        assert _get_body_error_code(body) == 429
+
+    def test_parses_string_code(self):
+        # some gateways serialize code as a string
+        body = '{"error":{"message":"x","code":"503"}}'
+        assert _get_body_error_code(body) == 503
+
+    def test_returns_none_on_non_json(self):
+        assert _get_body_error_code("not json") is None
+
+    def test_returns_none_when_no_error_key(self):
+        assert _get_body_error_code('{"ok":true}') is None
+
+    def test_returns_none_when_no_code_key(self):
+        assert _get_body_error_code('{"error":{"message":"x"}}') is None
+
+
+# Test cases for Gemini upstream-error body-code mapping
+# Body code 429 wrapped in HTTP 500/503 envelopes (e.g. new-api gateways)
+# must map to RateLimitError so Router retries kick in.
+gemini_body_code_429_test_cases = [
+    # (error_body, should_be_rate_limit, description)
+    (
+        '{"error":{"message":" This model is currently experiencing high demand.'
+        " Spikes in demand are usually temporary. Please try again later."
+        ' (request id: x)","type":"upstream_error","param":"","code":429}}',
+        True,
+        "new-api gateway wraps Gemini overload as code:429",
+    ),
+    (
+        '{"error":{"message":"server boom","code":500}}',
+        False,
+        "genuine 500 body stays InternalServerError",
+    ),
+    (
+        "plain text 500 error",
+        False,
+        "non-JSON body falls through to status_code mapping",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "error_body, should_be_rate_limit, description",
+    gemini_body_code_429_test_cases,
+)
+def test_gemini_upstream_error_body_code_429_maps_to_rate_limit(
+    error_body, should_be_rate_limit, description
+):
+    """
+    Some upstream gateways wrap a 429 rate-limit signal inside an HTTP 500
+    envelope (body still says code:429). LiteLLM must surface this as
+    RateLimitError, not InternalServerError, so Router fallbacks trigger.
+    """
+    model = "gemini/gemini-2.5-flash"
+    custom_llm_provider = "gemini"
+
+    # Build an exception that looks like what _handle_error produces:
+    # a BaseLLMException-style object with .status_code and .message
+    class _FakeGeminiError(Exception):
+        def __init__(self, status_code, message):
+            self.status_code = status_code
+            self.message = message
+            super().__init__(message)
+
+    original_exception = _FakeGeminiError(status_code=500, message=error_body)
+
+    if should_be_rate_limit:
+        with pytest.raises(litellm.RateLimitError) as excinfo:
+            exception_type(
+                model=model,
+                original_exception=original_exception,
+                custom_llm_provider=custom_llm_provider,
+            )
+        assert isinstance(excinfo.value, litellm.RateLimitError), description
+    else:
+        with pytest.raises(litellm.InternalServerError) as excinfo:
+            exception_type(
+                model=model,
+                original_exception=original_exception,
+                custom_llm_provider=custom_llm_provider,
+            )
+        assert isinstance(excinfo.value, litellm.InternalServerError), description
 
 
 class TestExtractAndRaiseLitellmException:


### PR DESCRIPTION
## Relevant issues

No existing issue. Gemini-compatible gateways (e.g. new-api) sometimes wrap a 429 rate-limit signal inside an HTTP 500/503 envelope. LiteLLM currently maps this to `InternalServerError`, which Router treats as non-retryable for many configs — users get hard 500s instead of fallback/retry.

## Type

🐛 Bug Fix

## Pre-Submission checklist

- [x] I have added a test for my change
- [x] I have updated relevant documentation (N/A — internal exception mapping)
- [x] My change passes `make test` locally
- [x] My change adheres to the existing code style

## Description

Some Gemini-compatible gateways wrap a 429 rate-limit signal from upstream inside an HTTP 500/503 envelope, with the real code only surfaced in the JSON body:

```json
{
  "error": {
    "message": "...high demand...",
    "type": "upstream_error",
    "param": "",
    "code": 429
  }
}
```

Previously LiteLLM only looked at the HTTP status and mapped this to `InternalServerError`, which Router treats as non-retryable for many configs.

## Fix

The Gemini/Vertex exception mapper now parses `error.code` from the body and routes code `429` to `RateLimitError` before falling through to the HTTP-status branches. Other body codes fall through unchanged.

## Test plan

3 new parametrized cases in `tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py::test_gemini_upstream_error_body_code_429_maps_to_rate_limit`:

- new-api gateway's `code:429` payload → `RateLimitError`
- Genuine 500-body responses → still `InternalServerError`
- Non-JSON body strings → fall through to status-code mapping unchanged

All 8 Gemini tests in the file pass.