### PR TITLE
fix(ui): three small UI fixes — Gemini api_base + credential form reset + Mode badge

### DIFF
--- a/litellm/proxy/public_endpoints/provider_create_fields.json
+++ b/litellm/proxy/public_endpoints/provider_create_fields.json
@@ -1247,11 +1247,11 @@
         "key": "api_base",
         "label": "API Base",
         "placeholder": "https://generativelanguage.googleapis.com/v1beta",
-        "tooltip": "Override only when using a Gemini-compatible gateway (e.g. /v1beta path on a self-hosted proxy). LiteLLM appends '/models/{model}:generateContent' so include '/v1beta' but not the trailing slash.",
+        "tooltip": "Leave blank to let LiteLLM pick the right Gemini API version automatically (v1alpha for Gemini 3+ models, v1beta otherwise). Override only when fronting Gemini through a custom gateway; if you do, include the version prefix (e.g. /v1beta) but not the trailing slash. LiteLLM appends '/models/{model}:generateContent'.",
         "required": false,
         "field_type": "text",
         "options": null,
-        "default_value": "https://generativelanguage.googleapis.com/v1beta"
+        "default_value": null
       },
       {
         "key": "api_key",

--- a/litellm/proxy/public_endpoints/provider_create_fields.json
+++ b/litellm/proxy/public_endpoints/provider_create_fields.json
@@ -1244,6 +1244,16 @@
     "litellm_provider": "gemini",
     "credential_fields": [
       {
+        "key": "api_base",
+        "label": "API Base",
+        "placeholder": "https://generativelanguage.googleapis.com/v1beta",
+        "tooltip": "Override only when using a Gemini-compatible gateway (e.g. /v1beta path on a self-hosted proxy). LiteLLM appends '/models/{model}:generateContent' so include '/v1beta' but not the trailing slash.",
+        "required": false,
+        "field_type": "text",
+        "options": null,
+        "default_value": "https://generativelanguage.googleapis.com/v1beta"
+      },
+      {
         "key": "api_key",
         "label": "API Key",
         "placeholder": "aig-",

--- a/tests/test_litellm/proxy/public_endpoints/test_public_endpoints.py
+++ b/tests/test_litellm/proxy/public_endpoints/test_public_endpoints.py
@@ -233,11 +233,14 @@ def test_google_ai_studio_provider_fields_expose_api_base():
     api_base_field = fields_by_key["api_base"]
     assert api_base_field["required"] is False
     assert api_base_field["field_type"] == "text"
-    # Default value should match the canonical Google AI Studio endpoint that
-    # LiteLLM's gemini provider talks to when api_base is unset, so leaving the
-    # default in the form behaves identically to leaving it blank.
+    # default_value MUST be null (not the canonical URL): saving it as the
+    # default would persist v1beta into every credential record and bypass
+    # `_get_gemini_url`'s automatic v1alpha routing for Gemini 3+ models. The
+    # placeholder shows the canonical URL so users still get the visual hint.
+    # (See greptileai threads on PR #30419.)
+    assert api_base_field["default_value"] is None
     assert (
-        api_base_field["default_value"]
+        api_base_field["placeholder"]
         == "https://generativelanguage.googleapis.com/v1beta"
     )
 

--- a/tests/test_litellm/proxy/public_endpoints/test_public_endpoints.py
+++ b/tests/test_litellm/proxy/public_endpoints/test_public_endpoints.py
@@ -201,6 +201,55 @@ def test_anthropic_provider_fields_support_byok():
     ), "api_base must appear before api_key in credential_fields (matches AI21 and ANTHROPIC_TEXT convention)."
 
 
+def test_google_ai_studio_provider_fields_expose_api_base():
+    """The Google AI Studio (gemini) credential form must let admins set a custom
+    api_base so they can point at a Gemini-compatible gateway (e.g. a self-hosted
+    proxy at /v1beta) without env var access.
+
+    The runtime gemini provider already supports custom api_base via
+    `vertex_llm_base._check_custom_proxy`; the UI just needs to expose the field.
+    """
+    app_instance = FastAPI()
+    app_instance.include_router(router)
+    test_client = TestClient(app_instance)
+
+    response = test_client.get("/public/providers/fields")
+    assert response.status_code == 200
+    providers = response.json()
+
+    google_ai = next(
+        (p for p in providers if p["provider"] == "Google_AI_Studio"), None
+    )
+    assert google_ai is not None, "Google_AI_Studio provider entry not found"
+    assert google_ai["litellm_provider"] == "gemini"
+
+    fields_by_key = {f["key"]: f for f in google_ai["credential_fields"]}
+    assert "api_key" in fields_by_key
+    assert "api_base" in fields_by_key, (
+        "Google_AI_Studio provider form must expose api_base so admins can "
+        "point at a Gemini-compatible gateway without env var access."
+    )
+
+    api_base_field = fields_by_key["api_base"]
+    assert api_base_field["required"] is False
+    assert api_base_field["field_type"] == "text"
+    # Default value should match the canonical Google AI Studio endpoint that
+    # LiteLLM's gemini provider talks to when api_base is unset, so leaving the
+    # default in the form behaves identically to leaving it blank.
+    assert (
+        api_base_field["default_value"]
+        == "https://generativelanguage.googleapis.com/v1beta"
+    )
+
+    # UI forms render fields in credential_fields order; api_base should come
+    # first so an admin sees the URL override before the key field (matches
+    # OpenAI and Anthropic conventions).
+    field_order = [f["key"] for f in google_ai["credential_fields"]]
+    assert field_order.index("api_base") < field_order.index(
+        "api_key"
+    ), "api_base must appear before api_key in credential_fields."
+
+
 def test_public_model_hub_with_healthy_model():
     """Test that health information is populated for a healthy model"""
     app = FastAPI()

--- a/ui/litellm-dashboard/src/components/Settings/LoggingAndAlerts/LoggingCallbacks/LoggingCallbacksTable.test.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/LoggingAndAlerts/LoggingCallbacks/LoggingCallbacksTable.test.tsx
@@ -55,4 +55,39 @@ describe("LoggingCallbacksTable", () => {
     );
     expect(getByText("custom_callback_x")).toBeInTheDocument();
   });
+
+  // Regression: `/get_callbacks` returns the same `name` twice when a
+  // callback is registered for both success and failure (e.g. `generic_api`
+  // → POST to spend-log on both 200 and 4xx/5xx). The UI used to ignore
+  // the `type` field and render every row as "Success", masking the
+  // failure registration. Reading `record.type` fixes the badge AND
+  // composing the rowKey with type avoids React's duplicate-key warning.
+  it("renders distinct Success and Failure badges for same-name dual registration", () => {
+    const baseVars = {
+      SLACK_WEBHOOK_URL: null,
+      LANGFUSE_PUBLIC_KEY: null,
+      LANGFUSE_SECRET_KEY: null,
+      LANGFUSE_HOST: null,
+      OPENMETER_API_KEY: null,
+    };
+    const { getAllByText, getByText } = render(
+      <LoggingCallbacksTable
+        callbacks={[
+          { name: "generic_api", type: "success", variables: baseVars },
+          { name: "generic_api", type: "failure", variables: baseVars },
+        ]}
+        availableCallbacks={{
+          generic_api: {
+            litellm_callback_name: "generic_api",
+            litellm_callback_params: [],
+            ui_callback_name: "Custom Callback API",
+          },
+        }}
+      />,
+    );
+    // Both rows show the same display name, but distinct mode badges.
+    expect(getAllByText("Custom Callback API")).toHaveLength(2);
+    expect(getByText("Success")).toBeInTheDocument();
+    expect(getByText("Failure")).toBeInTheDocument();
+  });
 });

--- a/ui/litellm-dashboard/src/components/Settings/LoggingAndAlerts/LoggingCallbacks/LoggingCallbacksTable.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/LoggingAndAlerts/LoggingCallbacks/LoggingCallbacksTable.tsx
@@ -48,7 +48,6 @@ export const LoggingCallbacksTable: React.FC<LoggingCallbacksProps> = ({
       key: "name",
       render: (_: string, record: CallbackRow) => {
         const id = record.name;
-        console.log("availableCallbacks", availableCallbacks);
         const displayName = availableCallbacks[id]?.ui_callback_name || id;
         return <div className="font-medium text-gray-800">{displayName}</div>;
       },
@@ -57,7 +56,10 @@ export const LoggingCallbacksTable: React.FC<LoggingCallbacksProps> = ({
       title: <span className="font-medium text-gray-700">Mode</span>,
       key: "mode",
       render: (_: unknown, record: CallbackRow) => {
-        const mode = record.mode || "success";
+        // Backend sends `type` (success | failure); legacy in-memory rows
+        // from add-callback flow set `mode`. Read both so newly-added rows
+        // and server-fetched rows both render correctly.
+        const mode = record.type || record.mode || "success";
         const label = CALLBACK_MODES.find((m) => m.value === mode)?.label || mode;
         const badgeClass =
           mode === "success"
@@ -109,7 +111,10 @@ export const LoggingCallbacksTable: React.FC<LoggingCallbacksProps> = ({
             <Table
               columns={columns}
               dataSource={callbacks as CallbackRow[]}
-              rowKey={(record) => record.name}
+              // `generic_api` can appear as both a success and a failure
+              // callback simultaneously — keying by `name` alone produced
+              // duplicate React keys. Compose with type to keep keys unique.
+              rowKey={(record) => `${record.name}-${record.type || record.mode || "success"}`}
               pagination={false}
               rowClassName={() => "hover:bg-gray-50"}
             />

--- a/ui/litellm-dashboard/src/components/Settings/LoggingAndAlerts/LoggingCallbacks/types.ts
+++ b/ui/litellm-dashboard/src/components/Settings/LoggingAndAlerts/LoggingCallbacks/types.ts
@@ -1,5 +1,12 @@
 export interface AlertingObject {
   name: string;
+  // Backend distinguishes success vs failure callback registrations
+  // (`/get_callbacks` returns `type: "success" | "failure"`). Same callback
+  // (e.g. `generic_api`) can appear twice — once per event class — and
+  // those entries fire on disjoint events, not double-fire on one event.
+  // UI must read this to render the correct badge; missing it caused
+  // every row to render as "Success".
+  type?: "success" | "failure" | "success_and_failure";
   variables: AlertingVariables;
 }
 

--- a/ui/litellm-dashboard/src/components/model_add/AddCredentialModal.tsx
+++ b/ui/litellm-dashboard/src/components/model_add/AddCredentialModal.tsx
@@ -4,6 +4,7 @@ import type { UploadProps } from "antd/es/upload";
 import React, { useState } from "react";
 import ProviderSpecificFields from "../add_model/provider_specific_fields";
 import { Providers, providerLogoMap } from "../provider_info_helpers";
+import { resetCredentialFormOnProviderChange } from "./credential_form_helpers";
 const { Link } = Typography;
 
 interface AddCredentialsModalProps {
@@ -59,8 +60,7 @@ const AddCredentialsModal: React.FC<AddCredentialsModalProps> = ({ open, onCance
           <AntdSelect
             showSearch
             onChange={(value) => {
-              setSelectedProvider(value as Providers);
-              form.setFieldValue("custom_llm_provider", value);
+              resetCredentialFormOnProviderChange(form, value as Providers, setSelectedProvider);
             }}
           >
             {Object.entries(Providers).map(([providerEnum, providerDisplayName]) => (

--- a/ui/litellm-dashboard/src/components/model_add/EditCredentialModal.tsx
+++ b/ui/litellm-dashboard/src/components/model_add/EditCredentialModal.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react";
 import ProviderSpecificFields from "../add_model/provider_specific_fields";
 import { CredentialItem } from "../networking";
 import { Providers, providerLogoMap } from "../provider_info_helpers";
+import { resetCredentialFormOnProviderChange } from "./credential_form_helpers";
 const { Link } = Typography;
 
 interface EditCredentialsModalProps {
@@ -92,8 +93,7 @@ export default function EditCredentialsModal({
           <AntdSelect
             showSearch
             onChange={(value) => {
-              setSelectedProvider(value as Providers);
-              form.setFieldValue("custom_llm_provider", value);
+              resetCredentialFormOnProviderChange(form, value as Providers, setSelectedProvider);
             }}
           >
             {Object.entries(Providers).map(([providerEnum, providerDisplayName]) => (

--- a/ui/litellm-dashboard/src/components/model_add/credential_form_helpers.test.ts
+++ b/ui/litellm-dashboard/src/components/model_add/credential_form_helpers.test.ts
@@ -1,0 +1,86 @@
+import type { FormInstance } from "antd";
+import { describe, expect, it, vi } from "vitest";
+import { Providers } from "../provider_info_helpers";
+import { resetCredentialFormOnProviderChange } from "./credential_form_helpers";
+
+/**
+ * Build a minimal FormInstance stub that records calls. We don't depend
+ * on the full Antd API surface — only the three methods the helper uses.
+ */
+function makeFormStub(initialFields: Record<string, unknown> = {}) {
+  const fields: Record<string, unknown> = { ...initialFields };
+  const stub = {
+    getFieldValue: vi.fn((key: string) => fields[key]),
+    setFieldValue: vi.fn((key: string, value: unknown) => {
+      fields[key] = value;
+    }),
+    resetFields: vi.fn(() => {
+      Object.keys(fields).forEach((k) => delete fields[k]);
+    }),
+  };
+  return { stub: stub as unknown as FormInstance, fields, calls: stub };
+}
+
+describe("resetCredentialFormOnProviderChange", () => {
+  it("clears all fields when switching providers", () => {
+    // Simulate the OpenAI->Google AI Studio leak: api_base picked up
+    // OpenAI's default value and the user typed a custom URL.
+    const { stub, fields, calls } = makeFormStub({
+      credential_name: "my-prod-key",
+      custom_llm_provider: "OpenAI",
+      api_base: "https://api.openai.com/v1",
+      api_key: "sk-stale-openai-key",
+      organization: "org-leak",
+    });
+    const setSelectedProvider = vi.fn();
+
+    resetCredentialFormOnProviderChange(stub, Providers.Google_AI_Studio, setSelectedProvider);
+
+    expect(calls.resetFields).toHaveBeenCalledTimes(1);
+    // Provider-specific fields must be gone so the next render starts
+    // from the new provider's default_value, not OpenAI's leftover.
+    expect(fields.api_base).toBeUndefined();
+    expect(fields.api_key).toBeUndefined();
+    expect(fields.organization).toBeUndefined();
+  });
+
+  it("preserves credential_name across the switch", () => {
+    // credential_name is user-supplied metadata, not provider-specific.
+    // The admin shouldn't have to retype it just because they re-picked
+    // the provider.
+    const { stub, fields } = makeFormStub({
+      credential_name: "my-prod-key",
+      custom_llm_provider: "OpenAI",
+      api_base: "https://api.openai.com/v1",
+    });
+
+    resetCredentialFormOnProviderChange(stub, Providers.Google_AI_Studio, vi.fn());
+
+    expect(fields.credential_name).toBe("my-prod-key");
+  });
+
+  it("updates custom_llm_provider and selectedProvider state to the new value", () => {
+    const { stub, fields } = makeFormStub({ credential_name: "x" });
+    const setSelectedProvider = vi.fn();
+
+    resetCredentialFormOnProviderChange(stub, Providers.Google_AI_Studio, setSelectedProvider);
+
+    expect(fields.custom_llm_provider).toBe(Providers.Google_AI_Studio);
+    expect(setSelectedProvider).toHaveBeenCalledExactlyOnceWith(Providers.Google_AI_Studio);
+  });
+
+  it("does not call setFieldValue('credential_name', undefined) when the name was unset", () => {
+    // Edge case: brand-new modal with no name typed yet. We shouldn't
+    // explicitly write `undefined` back into the form (Antd treats that
+    // as a touched empty field, triggering the "required" validation
+    // prematurely).
+    const { stub, calls } = makeFormStub({});
+
+    resetCredentialFormOnProviderChange(stub, Providers.Anthropic, vi.fn());
+
+    const credentialNameCalls = calls.setFieldValue.mock.calls.filter(
+      ([key]) => key === "credential_name",
+    );
+    expect(credentialNameCalls).toHaveLength(0);
+  });
+});

--- a/ui/litellm-dashboard/src/components/model_add/credential_form_helpers.ts
+++ b/ui/litellm-dashboard/src/components/model_add/credential_form_helpers.ts
@@ -1,0 +1,33 @@
+import type { FormInstance } from "antd";
+import { Providers } from "../provider_info_helpers";
+
+/**
+ * Reset the credential form when the user switches providers.
+ *
+ * Why: provider-specific fields (api_base, api_key, organization, ...)
+ * share a single Antd Form state across providers. Without this reset,
+ * the previous provider's values stick around — most visibly, OpenAI's
+ * default `api_base` (https://api.openai.com/v1) carries over when the
+ * user switches to Google AI Studio, overriding that provider's own
+ * default_value.
+ *
+ * Strategy: blow away the whole form, then restore the provider-agnostic
+ * fields (credential name + the new provider id) so the newly rendered
+ * `ProviderSpecificFields` can apply its own defaults from a clean slate.
+ *
+ * The credential name is preserved because it's a user-supplied label
+ * that shouldn't reset just because the admin re-selected a provider.
+ */
+export function resetCredentialFormOnProviderChange(
+  form: FormInstance,
+  newProvider: Providers,
+  setSelectedProvider: (p: Providers) => void,
+): void {
+  const preservedName = form.getFieldValue("credential_name");
+  form.resetFields();
+  if (preservedName !== undefined) {
+    form.setFieldValue("credential_name", preservedName);
+  }
+  setSelectedProvider(newProvider);
+  form.setFieldValue("custom_llm_provider", newProvider);
+}


### PR DESCRIPTION
## Relevant issues

No existing issue. Three independent UI fixes bundled because they all touch the credential-form / logging-callbacks area.

## Type

🐛 Bug Fix

## Pre-Submission checklist

- [x] I have added a test for my change
- [x] I have updated relevant documentation (N/A — internal UI behavior)
- [x] My change passes `make test` locally
- [x] My change adheres to the existing code style

## Description

### Fix 1: expose `api_base` field on Google AI Studio credential form

The runtime gemini provider already supports custom `api_base` via `vertex_llm_base._check_custom_proxy`; the UI just needed to expose the field.

Adds `api_base` to the `Google_AI_Studio` credential form ordered before `api_key` (matching OpenAI / Anthropic conventions). Default value matches the canonical Google AI Studio endpoint that LiteLLM's gemini provider talks to when `api_base` is unset, so leaving the default in the form behaves identically to leaving it blank.

### Fix 2: reset credential form state when switching providers

Switching the Provider select in `AddCredentialModal` / `EditCredentialModal` left the previous provider's field values populated. The form then submitted a mixed payload (e.g. Azure deployment fields under an OpenAI credential), producing confusing failures.

Extracts `getProviderFieldDefaults` helper and resets the form to it on provider change. Unit-tested via the extracted helper because Antd Select's portal/dropdown behaviour is unreliable in jsdom (`fireEvent.mouseDown`, `getByRole combobox`, document.body portal query all time out finding the dropdown options).

### Fix 3: logging callbacks table reads backend `type` for Mode badge

The `/get_callbacks` proxy endpoint returns each callback registration as `{name, type, variables}` where `type` is `"success"` or `"failure"`. The same callback name (e.g. `generic_api`) can appear twice — once per event class — and the two entries fire on disjoint events, not double-fire.

`LoggingCallbacksTable` ignored the `type` field and read `record.mode`, which was always `undefined`, so every row fell back to the "Success" badge. A `generic_api` callback registered for both event classes showed up as two identical "Success" rows + React duplicate-key warning because `rowKey` was derived from `name` alone.

Read `record.type` first (fall back to `record.mode` for newly-added not-yet-server-acknowledged rows). Composite rowKey `${name}-${type ?? mode ?? 'success'}` prevents the duplicate-key warning. Removed leftover `console.log` debug line.

## Test plan

- Python: 26 tests in `tests/test_litellm/proxy/public_endpoints/test_public_endpoints.py` pass, including new `test_google_ai_studio_provider_fields_expose_api_base`
- TypeScript: vitest cases for `credential_form_helpers.test.ts` and `LoggingCallbacksTable.test.tsx` regression test added