### PR TITLE
fix: filter internal params in Bedrock invoke path

### DIFF
--- a/litellm/llms/bedrock/chat/invoke_transformations/base_invoke_transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_transformations/base_invoke_transformation.py
@@ -8,7 +8,7 @@ import httpx
 
 import litellm
 from litellm._logging import verbose_logger
-from litellm.litellm_core_utils.core_helpers import map_finish_reason
+from litellm.litellm_core_utils.core_helpers import filter_internal_params, map_finish_reason
 from litellm.litellm_core_utils.logging_utils import track_llm_api_timing
 from litellm.litellm_core_utils.prompt_templates.factory import (
     cohere_message_pt,
@@ -19,7 +19,6 @@ from litellm.litellm_core_utils.prompt_templates.factory import (
 from litellm.llms.base_llm.chat.transformation import BaseConfig, BaseLLMException
 from litellm.llms.bedrock.chat.invoke_handler import make_call, make_sync_call
 from litellm.llms.bedrock.common_utils import BedrockError
-from litellm.litellm_core_utils.core_helpers import filter_internal_params
 from litellm.llms.custom_httpx.http_handler import (
     AsyncHTTPHandler,
     HTTPHandler,
@@ -152,6 +151,7 @@ class AmazonInvokeConfig(BaseConfig, BaseAWSLLM):
         ## SETUP ##
         stream = optional_params.pop("stream", None)
         optional_params.pop("stream_chunk_size", None)
+        optional_params = filter_internal_params(optional_params)
         custom_prompt_dict: dict = litellm_params.pop("custom_prompt_dict", None) or {}
         hf_model_name = litellm_params.get("hf_model_name", None)
 

--- a/litellm/llms/bedrock/chat/invoke_transformations/base_invoke_transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_transformations/base_invoke_transformation.py
@@ -19,6 +19,7 @@ from litellm.litellm_core_utils.prompt_templates.factory import (
 from litellm.llms.base_llm.chat.transformation import BaseConfig, BaseLLMException
 from litellm.llms.bedrock.chat.invoke_handler import make_call, make_sync_call
 from litellm.llms.bedrock.common_utils import BedrockError
+from litellm.litellm_core_utils.core_helpers import filter_internal_params
 from litellm.llms.custom_httpx.http_handler import (
     AsyncHTTPHandler,
     HTTPHandler,
@@ -168,6 +169,7 @@ class AmazonInvokeConfig(BaseConfig, BaseAWSLLM):
             for k, v in inference_params.items()
             if k not in self.aws_authentication_params
         }
+        inference_params = filter_internal_params(inference_params)
         request_data: dict = {}
         if provider == "cohere":
             if model.startswith("cohere.command-r"):

--- a/tests/test_litellm/llms/bedrock/chat/invoke_transformations/test_base_invoke_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/invoke_transformations/test_base_invoke_transformation.py
@@ -39,3 +39,23 @@ def test_transform_request_drops_stream_chunk_size(config, model):
     )
 
     assert "stream_chunk_size" not in json.dumps(request_body)
+
+
+def test_transform_request_filters_internal_params():
+    """Internal params like skip_mcp_handler must not leak into the Bedrock
+    invoke request body. Regression for issue #30371."""
+    request_body = AmazonInvokeConfig().transform_request(
+        model="mistral.mistral-7b-instruct-v0:2",
+        messages=[{"role": "user", "content": "hi"}],
+        optional_params={"skip_mcp_handler": True, "max_tokens": 10},
+        litellm_params={},
+        headers={},
+    )
+
+    body_str = json.dumps(request_body)
+
+    # The internal param must not appear in the request body sent to Bedrock
+    assert "skip_mcp_handler" not in body_str
+
+    # Legitimate params must still be forwarded
+    assert "max_tokens" in body_str

--- a/tests/test_litellm/llms/bedrock/chat/invoke_transformations/test_base_invoke_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/invoke_transformations/test_base_invoke_transformation.py
@@ -59,3 +59,23 @@ def test_transform_request_filters_internal_params():
 
     # Legitimate params must still be forwarded
     assert "max_tokens" in body_str
+
+
+def test_transform_request_filters_internal_params_anthropic():
+    """Anthropic provider early-returns via its own transform_request.
+    Internal params must still be filtered. Regression for issue #30371."""
+    request_body = AmazonAnthropicClaudeConfig().transform_request(
+        model="anthropic.claude-3-sonnet-20240229-v1:0",
+        messages=[{"role": "user", "content": "hi"}],
+        optional_params={"skip_mcp_handler": True, "max_tokens": 10},
+        litellm_params={},
+        headers={},
+    )
+
+    body_str = json.dumps(request_body)
+
+    # The internal param must not appear in the request body sent to Bedrock
+    assert "skip_mcp_handler" not in body_str
+
+    # Legitimate params must still be forwarded
+    assert "max_tokens" in body_str


### PR DESCRIPTION
Closes https://github.com/BerriAI/litellm/issues/30371

The Converse path already strips LiteLLM-internal control flags (e.g. skip_mcp_handler) from the request body via `filter_internal_params`. The Invoke path never called this helper, so internal knobs leaked into the Bedrock Invoke API request body, potentially causing validation failures.

## Changes

1. `base_invoke_transformation.py`: imported `filter_internal_params` from `litellm_core_utils.core_helpers` and added a call after the existing `aws_authentication_params` filter, mirroring the Converse path.

2. `test_base_invoke_transformation.py`: added a regression test that verifies `skip_mcp_handler` does not appear in the serialised request body while legitimate params (e.g. `max_tokens`) are still forwarded.

## Type

Bug Fix