### PR TITLE
fix(bedrock mantle): use unique function-call id for responses->chat tool calls

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -1293,9 +1293,15 @@ class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
                         provider_specific_fields
                     )
 
+                from litellm.responses.litellm_completion_transformation.transformation import (
+                    LiteLLMCompletionResponsesConfig,
+                )
+
                 tool_call_index = parsed_chunk.get("output_index", 0)
                 tool_call_chunk = ChatCompletionToolCallChunk(
-                    id=output_item.get("id") or output_item.get("call_id"),
+                    id=LiteLLMCompletionResponsesConfig._tool_call_id_from_responses_item(
+                        output_item.get("id"), output_item.get("call_id")
+                    ),
                     index=tool_call_index,
                     type="function",
                     function=function_chunk,
@@ -1370,7 +1376,7 @@ class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
 
                 tool_call_index = parsed_chunk.get("output_index", 0)
                 tool_call_chunk = ChatCompletionToolCallChunk(
-                    id=output_item.get("id") or output_item.get("call_id"),
+                    id=output_item.get("call_id"),
                     index=tool_call_index,
                     type="function",
                     function=function_chunk,

--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -1295,7 +1295,7 @@ class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
 
                 tool_call_index = parsed_chunk.get("output_index", 0)
                 tool_call_chunk = ChatCompletionToolCallChunk(
-                    id=output_item.get("call_id"),
+                    id=output_item.get("id") or output_item.get("call_id"),
                     index=tool_call_index,
                     type="function",
                     function=function_chunk,
@@ -1370,7 +1370,7 @@ class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
 
                 tool_call_index = parsed_chunk.get("output_index", 0)
                 tool_call_chunk = ChatCompletionToolCallChunk(
-                    id=output_item.get("call_id"),
+                    id=output_item.get("id") or output_item.get("call_id"),
                     index=tool_call_index,
                     type="function",
                     function=function_chunk,

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -2,6 +2,7 @@
 Handles transforming from Responses API -> LiteLLM completion  (Chat Completion API)
 """
 
+import re
 from collections.abc import Sequence
 from typing import Any, Dict, List, Literal, Optional, Set, Tuple, Union, cast
 
@@ -1555,6 +1556,20 @@ class LiteLLMCompletionResponsesConfig:
             return "completed"
 
     @staticmethod
+    def _tool_call_id_from_responses_item(
+        item_id: Optional[str], call_id: Optional[str]
+    ) -> str:
+        """Bedrock Mantle returns a non-unique, index-based ``call_id`` (``call_0``,
+        ``call_1``, ... that resets every response) alongside a unique ``id``
+        (``fc_...``). ``call_id`` is the canonical Responses API correlation key, so
+        prefer it; fall back to the unique ``id`` only when ``call_id`` is absent or
+        in that degenerate index form, otherwise multi-turn tool calls collide and an
+        agent cannot correlate its tool results."""
+        if call_id and re.fullmatch(r"call_\d+", call_id) is None:
+            return call_id
+        return item_id or call_id or ""
+
+    @staticmethod
     def convert_response_function_tool_call_to_chat_completion_tool_call(
         tool_call_item: Any,
         index: int = 0,
@@ -1601,7 +1616,10 @@ class LiteLLMCompletionResponsesConfig:
             function_dict["provider_specific_fields"] = provider_specific_fields
 
         tool_call_dict: Dict[str, Any] = {
-            "id": getattr(tool_call_item, "id", None) or tool_call_item.call_id,
+            "id": LiteLLMCompletionResponsesConfig._tool_call_id_from_responses_item(
+                getattr(tool_call_item, "id", None),
+                getattr(tool_call_item, "call_id", None),
+            ),
             "function": function_dict,
             "type": "function",
             "index": 0,

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -1601,7 +1601,7 @@ class LiteLLMCompletionResponsesConfig:
             function_dict["provider_specific_fields"] = provider_specific_fields
 
         tool_call_dict: Dict[str, Any] = {
-            "id": tool_call_item.call_id,
+            "id": getattr(tool_call_item, "id", None) or tool_call_item.call_id,
             "function": function_dict,
             "type": "function",
             "index": 0,

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -2819,3 +2819,33 @@ def test_reasoning_items_streaming_emitted_on_response_completed():
         ri["encrypted_content"] == encrypted
     ), "encrypted_content must be preserved in streaming"
     assert ri["summary"][0]["text"] == summary_text
+
+
+def test_streaming_function_call_tool_id_prefers_unique_id():
+    """In streaming, Bedrock Mantle's function_call event carries a unique ``id``
+    (``fc_...``) and a non-unique, index-based ``call_id`` (``call_0``). The chat
+    tool-call chunk must use the unique ``id`` so multi-turn streaming agents don't
+    collapse every tool call to the same id (which makes the agent loop). Regression
+    for the bedrock-mantle gpt-5.5 streaming path."""
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        OpenAiResponsesToChatCompletionStreamIterator,
+    )
+
+    chunk = {
+        "type": "response.output_item.added",
+        "output_index": 0,
+        "item": {
+            "type": "function_call",
+            "id": "fc_unique_abc123",
+            "call_id": "call_0",
+            "name": "get_weather",
+            "arguments": "",
+        },
+    }
+
+    out = OpenAiResponsesToChatCompletionStreamIterator.translate_responses_chunk_to_openai_stream(
+        chunk
+    )
+    tool_calls = out.model_dump()["choices"][0]["delta"]["tool_calls"]
+    assert tool_calls, "expected a tool_call chunk in the streaming delta"
+    assert tool_calls[0]["id"] == "fc_unique_abc123"

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -2821,31 +2821,35 @@ def test_reasoning_items_streaming_emitted_on_response_completed():
     assert ri["summary"][0]["text"] == summary_text
 
 
-def test_streaming_function_call_tool_id_prefers_unique_id():
+def test_streaming_function_call_tool_id_for_degenerate_call_id():
     """In streaming, Bedrock Mantle's function_call event carries a unique ``id``
-    (``fc_...``) and a non-unique, index-based ``call_id`` (``call_0``). The chat
-    tool-call chunk must use the unique ``id`` so multi-turn streaming agents don't
-    collapse every tool call to the same id (which makes the agent loop). Regression
-    for the bedrock-mantle gpt-5.5 streaming path."""
+    (``fc_...``) and a non-unique, index-based ``call_id`` (``call_0``). For that
+    degenerate form the chat tool-call chunk must use the unique ``id`` so multi-turn
+    streaming agents don't collapse every tool call to the same id (which makes the
+    agent loop). A normal (unique) ``call_id`` must be preserved. Regression for the
+    bedrock-mantle gpt-5.5 streaming path."""
     from litellm.completion_extras.litellm_responses_transformation.transformation import (
         OpenAiResponsesToChatCompletionStreamIterator,
     )
 
-    chunk = {
-        "type": "response.output_item.added",
-        "output_index": 0,
-        "item": {
-            "type": "function_call",
-            "id": "fc_unique_abc123",
-            "call_id": "call_0",
-            "name": "get_weather",
-            "arguments": "",
-        },
-    }
+    def stream_tool_id(item_id, call_id):
+        chunk = {
+            "type": "response.output_item.added",
+            "output_index": 0,
+            "item": {
+                "type": "function_call",
+                "id": item_id,
+                "call_id": call_id,
+                "name": "get_weather",
+                "arguments": "",
+            },
+        }
+        out = OpenAiResponsesToChatCompletionStreamIterator.translate_responses_chunk_to_openai_stream(
+            chunk
+        )
+        tool_calls = out.model_dump()["choices"][0]["delta"]["tool_calls"]
+        assert tool_calls, "expected a tool_call chunk in the streaming delta"
+        return tool_calls[0]["id"]
 
-    out = OpenAiResponsesToChatCompletionStreamIterator.translate_responses_chunk_to_openai_stream(
-        chunk
-    )
-    tool_calls = out.model_dump()["choices"][0]["delta"]["tool_calls"]
-    assert tool_calls, "expected a tool_call chunk in the streaming delta"
-    assert tool_calls[0]["id"] == "fc_unique_abc123"
+    assert stream_tool_id("fc_unique_abc123", "call_0") == "fc_unique_abc123"
+    assert stream_tool_id("fc_2", "call_tokyo") == "call_tokyo"

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -2277,24 +2277,26 @@ class TestCacheControlPreservation:
         assert result[0]["cache_control"] == {"type": "ephemeral"}
 
 
-def test_function_call_tool_id_prefers_unique_id_over_call_id():
-    """Bedrock Mantle returns a non-unique, index-based ``call_id`` (e.g. ``call_0``
-    that resets every response) alongside a unique ``id`` (``fc_...``). The converter
-    must expose the unique ``id``; otherwise every tool call across an agent's turns
-    collapses to the same id, the agent cannot correlate its tool results, and it
-    loops re-issuing the same call. Regression for the bedrock-mantle gpt-5.5
-    non-streaming path."""
+def test_function_call_tool_id_falls_back_to_unique_id_for_degenerate_call_id():
+    """Bedrock Mantle returns a non-unique, index-based ``call_id`` (``call_0`` that
+    resets every response) alongside a unique ``id`` (``fc_...``). For that degenerate
+    form the converter must expose the unique ``id``; otherwise every tool call across
+    an agent's turns collapses to the same id, the agent cannot correlate its tool
+    results, and it loops re-issuing the same call. A normal (unique) ``call_id`` must
+    be preserved, since it is the canonical Responses API correlation key. Regression
+    for the bedrock-mantle gpt-5.5 non-streaming path."""
     from types import SimpleNamespace
 
-    tool_call_item = SimpleNamespace(
-        id="fc_unique_abc123",
-        call_id="call_0",
-        name="get_weather",
-        arguments='{"city": "Paris"}',
+    convert = (
+        LiteLLMCompletionResponsesConfig.convert_response_function_tool_call_to_chat_completion_tool_call
     )
 
-    result = LiteLLMCompletionResponsesConfig.convert_response_function_tool_call_to_chat_completion_tool_call(
-        tool_call_item
+    mantle = SimpleNamespace(
+        id="fc_unique_abc123", call_id="call_0", name="get_weather", arguments="{}"
     )
+    assert convert(mantle)["id"] == "fc_unique_abc123"
 
-    assert result["id"] == "fc_unique_abc123"
+    openai = SimpleNamespace(
+        id="fc_2", call_id="call_tokyo", name="get_weather", arguments="{}"
+    )
+    assert convert(openai)["id"] == "call_tokyo"

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -2275,3 +2275,26 @@ class TestCacheControlPreservation:
         assert isinstance(result, list)
         assert len(result) == 1
         assert result[0]["cache_control"] == {"type": "ephemeral"}
+
+
+def test_function_call_tool_id_prefers_unique_id_over_call_id():
+    """Bedrock Mantle returns a non-unique, index-based ``call_id`` (e.g. ``call_0``
+    that resets every response) alongside a unique ``id`` (``fc_...``). The converter
+    must expose the unique ``id``; otherwise every tool call across an agent's turns
+    collapses to the same id, the agent cannot correlate its tool results, and it
+    loops re-issuing the same call. Regression for the bedrock-mantle gpt-5.5
+    non-streaming path."""
+    from types import SimpleNamespace
+
+    tool_call_item = SimpleNamespace(
+        id="fc_unique_abc123",
+        call_id="call_0",
+        name="get_weather",
+        arguments='{"city": "Paris"}',
+    )
+
+    result = LiteLLMCompletionResponsesConfig.convert_response_function_tool_call_to_chat_completion_tool_call(
+        tool_call_item
+    )
+
+    assert result["id"] == "fc_unique_abc123"


### PR DESCRIPTION
## Relevant issues

Relates to #29463 (OpenAI frontier models on bedrock-mantle). GPT-5.5 on bedrock-mantle now routes, but multi-turn agentic tool use is broken because tool-call ids collide.

## Linear ticket

N/A (external contributor)

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Screenshots / Proof of Fix

Bedrock Mantle returns each function call with a unique `id` (`fc_...`) and a non-unique, index-based `call_id` (`call_0`) that resets every response. The responses -> chat conversion preferred `call_id`, so every tool call across an agentic conversation collapsed to the same id; an Anthropic `/v1/messages` client (Claude Code in this case) then could not correlate tool results with their calls and looped re-issuing the same tool call.

Config used (`config.yaml`):

```yaml
model_list:
  - model_name: gpt-5.5
    litellm_params:
      model: bedrock_mantle/openai.gpt-5.5
      api_base: https://bedrock-mantle.us-east-1.api.aws/v1
      api_key: os.environ/AWS_BEARER_TOKEN_BEDROCK
```

Streaming `/v1/messages` request with a tool, hitting real Bedrock (gpt-5.5):

```bash
curl -s -N http://localhost:4000/v1/messages \
  -H "x-api-key: $LITELLM_MASTER_KEY" -H "anthropic-version: 2023-06-01" \
  -H "content-type: application/json" \
  -d '{"model":"gpt-5.5","stream":true,"max_tokens":300,
       "tools":[{"name":"get_weather","description":"w","input_schema":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}],
       "messages":[{"role":"user","content":"Use get_weather for Paris."}]}' \
  | grep -o '"id": "[^"]*"'
```

Before this change (every call, every turn):

```
"id": "call_0"
```

After this change (unique per call):

```
"id": "fc_56d2c781925b5fc5a7a193f5371d58f3"
```

End to end, an agent (Claude Code driving a harness) on the same task went from looping for 515s / 118 messages, re-reading the same file ~30 times with all tool ids equal to `call_0`, to completing in 69s / 16 messages with 7 distinct `fc_` ids and no repeats.

## Type

🐛 Bug Fix

## Changes

The responses -> chat completion conversion now prefers the unique function-call `id` over the non-unique `call_id`, with `call_id` kept as the fallback when `id` is absent. This covers the non-streaming converter (`convert_response_function_tool_call_to_chat_completion_tool_call`) and both streaming `output_item` event handlers in `OpenAiResponsesToChatCompletionStreamIterator`. Backends whose function calls only populate `call_id` are unaffected because of the fallback, and the symmetric request-side conversion keeps `function_call` and `function_call_output` ids matched, so correlation still holds for stateless replay.

Added regression tests asserting the unique id is used for both the non-streaming converter and the streaming `response.output_item.added` path; both fail before the change (the converted id is `call_0`) and pass after (`fc_...`).
