### PR TITLE
fix(proxy): improve prisma db startup guidance

### DIFF
--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -160,6 +160,24 @@ def _with_query_value(url: str, key: str, value: str) -> str:
     return urlparse.urlunparse(parsed._replace(query=urlparse.urlencode(pairs)))
 
 
+def _clear_prisma_module_cache() -> None:
+    for module_name in tuple(sys.modules):
+        if module_name == "prisma" or module_name.startswith("prisma."):
+            sys.modules.pop(module_name, None)
+
+
+def _is_prisma_client_generated() -> bool:
+    try:
+        prisma_module = importlib.import_module("prisma")
+    except Exception:
+        _clear_prisma_module_cache()
+        return False
+    if hasattr(prisma_module, "Prisma"):
+        return True
+    _clear_prisma_module_cache()
+    return False
+
+
 def append_query_params(url: str | None, params: dict) -> str:
     from litellm._logging import verbose_proxy_logger
 
@@ -1237,6 +1255,12 @@ def run_server(
                         flush=True,
                     )
                     sys.exit(1)
+            prisma_not_runnable_message = (
+                "Unable to connect to DB. DATABASE_URL found in environment, "
+                "but the prisma package was not found. Install database "
+                "dependencies with `pip install 'litellm[extra_proxy]'` or "
+                "`uv tool install 'litellm[proxy,extra_proxy]'`."
+            )
             try:
                 from litellm.secret_managers.main import get_secret
 
@@ -1271,9 +1295,25 @@ def run_server(
                     modified_url = append_query_params(database_url, connection_url_params)
                     os.environ["DIRECT_URL"] = modified_url
                 subprocess.run(["prisma"], capture_output=True)
+                if not _is_prisma_client_generated():
+                    prisma_schema_path = Path(__file__).parent / "schema.prisma"
+                    subprocess.run(
+                        ("prisma", "generate", "--schema", str(prisma_schema_path)),
+                        capture_output=True,
+                        check=True,
+                    )
+                    _clear_prisma_module_cache()
                 is_prisma_runnable = True
             except FileNotFoundError:
                 is_prisma_runnable = False
+            except subprocess.CalledProcessError:
+                is_prisma_runnable = False
+                prisma_not_runnable_message = (
+                    "Unable to connect to DB. DATABASE_URL found in environment, "
+                    "but `prisma generate` failed. Please run "
+                    "`prisma generate --schema litellm/proxy/schema.prisma` "
+                    "and check the Prisma CLI output before starting the proxy."
+                )
 
             if is_prisma_runnable:
                 from litellm.proxy.db.check_migration import check_prisma_schema_diff
@@ -1321,9 +1361,7 @@ def run_server(
                                 "Set --enforce_prisma_migration_check or ENFORCE_PRISMA_MIGRATION_CHECK=true to exit on failure.\033[0m"
                             )
             else:
-                print(
-                    f"Unable to connect to DB. DATABASE_URL found in environment, but prisma package not found."  # noqa: F541
-                )
+                print(prisma_not_runnable_message)
         if port == 4000 and ProxyInitializationHelpers._is_port_in_use(port):
             port = random.randint(1024, 49152)
 

--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -168,7 +168,7 @@ def _clear_prisma_module_cache() -> None:
 
 def _is_prisma_client_generated() -> bool:
     try:
-        prisma_module = importlib.import_module("prisma")
+        prisma_module: Final = importlib.import_module("prisma")
     except Exception:
         _clear_prisma_module_cache()
         return False
@@ -1255,7 +1255,7 @@ def run_server(
                         flush=True,
                     )
                     sys.exit(1)
-            prisma_not_runnable_message = (
+            prisma_not_runnable_message = (  # rebind-ok: generation failures replace the default install guidance
                 "Unable to connect to DB. DATABASE_URL found in environment, "
                 "but the prisma package was not found. Install database "
                 "dependencies with `pip install 'litellm[extra_proxy]'` or "
@@ -1296,7 +1296,7 @@ def run_server(
                     os.environ["DIRECT_URL"] = modified_url
                 subprocess.run(["prisma"], capture_output=True)
                 if not _is_prisma_client_generated():
-                    prisma_schema_path = Path(__file__).parent / "schema.prisma"
+                    prisma_schema_path: Final = Path(__file__).parent / "schema.prisma"
                     subprocess.run(
                         ("prisma", "generate", "--schema", str(prisma_schema_path)),
                         capture_output=True,
@@ -1307,8 +1307,8 @@ def run_server(
             except FileNotFoundError:
                 is_prisma_runnable = False
             except subprocess.CalledProcessError:
-                is_prisma_runnable = False
-                prisma_not_runnable_message = (
+                is_prisma_runnable = False  # rebind-ok: generation failure makes the existing availability flag false
+                prisma_not_runnable_message = (  # rebind-ok: show generation guidance instead of install guidance
                     "Unable to connect to DB. DATABASE_URL found in environment, "
                     "but `prisma generate` failed. Please run "
                     "`prisma generate --schema litellm/proxy/schema.prisma` "

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -3020,11 +3020,22 @@ class PrismaClient:
         verbose_proxy_logger.debug("Creating Prisma Client..")
         try:
             from prisma import Prisma
+        except ModuleNotFoundError as e:
+            if e.name == "prisma":
+                verbose_proxy_logger.error("Failed to import Prisma client: %s", e)
+                verbose_proxy_logger.error("DATABASE_URL requires LiteLLM's Prisma database dependencies.")
+                raise RuntimeError(
+                    "Prisma package is not installed. For database-backed proxy "
+                    "deployments, install LiteLLM with `pip install "
+                    "'litellm[extra_proxy]'` or `uv tool install "
+                    "'litellm[proxy,extra_proxy]'`."
+                ) from e
+            raise
         except Exception as e:
             verbose_proxy_logger.error("Failed to import Prisma client: %s", e)
             verbose_proxy_logger.error("This usually means 'prisma generate' hasn't been run yet.")
             verbose_proxy_logger.error("Please run 'prisma generate' to generate the Prisma client.")
-            raise Exception("Unable to find Prisma binaries. Please run 'prisma generate' first.")
+            raise Exception("Unable to find Prisma binaries. Please run 'prisma generate' first.") from e
         iam_flag: Final = self.iam_token_db_auth if self.iam_token_db_auth is not None else False
         # When read-replica routing is on, tag log lines with [writer]/[reader]
         # so the two wrappers' interleaved IAM refresh logs can be told apart.

--- a/tests/test_litellm/proxy/test_proxy_cli.py
+++ b/tests/test_litellm/proxy/test_proxy_cli.py
@@ -1,19 +1,18 @@
 import inspect
 import os
+import subprocess
 import sys
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import click
-import fastapi
 import pytest
 
 sys.path.insert(
     0, os.path.abspath("../../..")
 )  # Adds the parent directory to the system-path
 
-import builtins
 import types
 import urllib.parse as urlparse
 
@@ -1553,8 +1552,6 @@ class TestProxyInitializationHelpers:
     @patch("builtins.print")
     def test_run_server_no_config_passed(self, mock_print, mock_uvicorn_run):
         """Test that run_server properly handles the case when no config is passed"""
-        import asyncio
-
         from click.testing import CliRunner
 
         from litellm.proxy.proxy_cli import run_server
@@ -1725,6 +1722,239 @@ class TestQueryEngineReaperWiring:
 
 class TestRunServerDbSetup:
     """Tests for run_server's prisma setup_database behavior."""
+
+    def test_is_prisma_client_generated_returns_true_when_importable(self):
+        """Prisma generation check returns true when the client import works."""
+        from litellm.proxy import proxy_cli
+
+        prisma_module = types.ModuleType("prisma")
+        prisma_module.Prisma = object
+
+        with patch.dict(sys.modules, {"prisma": prisma_module}):
+            assert proxy_cli._is_prisma_client_generated() is True
+
+    def test_is_prisma_client_generated_returns_false_when_import_fails(self):
+        """Prisma generation check returns false for missing/generated errors."""
+        from litellm.proxy import proxy_cli
+
+        prisma_module = types.ModuleType("prisma")
+
+        with patch.dict(sys.modules, {"prisma": prisma_module}):
+            assert proxy_cli._is_prisma_client_generated() is False
+            assert "prisma" not in sys.modules
+
+    @patch("subprocess.run")
+    @patch("atexit.register")
+    @patch("litellm.proxy.db.prisma_client.PrismaManager.setup_database")
+    @patch("litellm.proxy.db.check_migration.check_prisma_schema_diff")
+    @patch("litellm.proxy.db.prisma_client.should_update_prisma_schema")
+    def test_database_startup_generates_prisma_client(
+        self,
+        mock_should_update_schema,
+        mock_check_schema_diff,
+        mock_setup_database,
+        mock_atexit_register,
+        mock_subprocess_run,
+    ):
+        """DATABASE_URL startup generates the Prisma client before setup."""
+        from litellm.proxy import proxy_cli
+        from litellm.proxy.proxy_cli import run_server
+
+        mock_subprocess_run.return_value = MagicMock(returncode=0)
+        mock_should_update_schema.return_value = True
+        mock_setup_database.return_value = True
+
+        mock_proxy_module = MagicMock(
+            app=MagicMock(),
+            ProxyConfig=MagicMock(),
+            KeyManagementSettings=MagicMock(),
+            save_worker_config=MagicMock(),
+        )
+
+        clean_env = {
+            k: v
+            for k, v in os.environ.items()
+            if k not in ("DATABASE_URL", "DIRECT_URL")
+        }
+        clean_env["DATABASE_URL"] = "postgresql://test:test@localhost:5432/test"
+
+        with (
+            patch(
+                "litellm.proxy.proxy_cli._is_prisma_client_generated",
+                return_value=False,
+            ),
+            patch.dict(os.environ, clean_env, clear=True),
+            patch.dict(
+                "sys.modules",
+                {
+                    "proxy_server": mock_proxy_module,
+                    "litellm.proxy.proxy_server": mock_proxy_module,
+                    "prisma": types.ModuleType("prisma"),
+                    "prisma.client": types.ModuleType("prisma.client"),
+                },
+            ),
+            patch(
+                "litellm.proxy.proxy_cli.ProxyInitializationHelpers._get_default_unvicorn_init_args"
+            ) as mock_get_args,
+        ):
+            mock_get_args.return_value = {
+                "app": "litellm.proxy.proxy_server:app",
+                "host": "localhost",
+                "port": 8000,
+            }
+
+            run_server.main(["--local", "--skip_server_startup"], standalone_mode=False)
+            assert "prisma" not in sys.modules
+            assert "prisma.client" not in sys.modules
+
+        schema_path = str(Path(proxy_cli.__file__).parent / "schema.prisma")
+        mock_subprocess_run.assert_any_call(
+            ("prisma", "generate", "--schema", schema_path),
+            capture_output=True,
+            check=True,
+        )
+
+    @patch("subprocess.run")
+    @patch("atexit.register")
+    @patch("litellm.proxy.db.prisma_client.PrismaManager.setup_database")
+    @patch("litellm.proxy.db.check_migration.check_prisma_schema_diff")
+    @patch("litellm.proxy.db.prisma_client.should_update_prisma_schema")
+    def test_database_startup_handles_prisma_generate_failure(
+        self,
+        mock_should_update_schema,
+        mock_check_schema_diff,
+        mock_setup_database,
+        mock_atexit_register,
+        mock_subprocess_run,
+        capsys,
+    ):
+        """DATABASE_URL startup does not crash when Prisma generation fails."""
+        from litellm.proxy import proxy_cli
+        from litellm.proxy.proxy_cli import run_server
+
+        def subprocess_run_side_effect(args, *_, **__):
+            if args[:2] == ("prisma", "generate"):
+                raise subprocess.CalledProcessError(returncode=1, cmd=args)
+            return MagicMock(returncode=0)
+
+        mock_subprocess_run.side_effect = subprocess_run_side_effect
+        mock_should_update_schema.return_value = True
+
+        mock_proxy_module = MagicMock(
+            app=MagicMock(),
+            ProxyConfig=MagicMock(),
+            KeyManagementSettings=MagicMock(),
+            save_worker_config=MagicMock(),
+        )
+
+        clean_env = {
+            k: v
+            for k, v in os.environ.items()
+            if k not in ("DATABASE_URL", "DIRECT_URL")
+        }
+        clean_env["DATABASE_URL"] = "postgresql://test:test@localhost:5432/test"
+
+        with (
+            patch(
+                "litellm.proxy.proxy_cli._is_prisma_client_generated",
+                return_value=False,
+            ),
+            patch.dict(os.environ, clean_env, clear=True),
+            patch.dict(
+                "sys.modules",
+                {
+                    "proxy_server": mock_proxy_module,
+                    "litellm.proxy.proxy_server": mock_proxy_module,
+                },
+            ),
+            patch(
+                "litellm.proxy.proxy_cli.ProxyInitializationHelpers._get_default_unvicorn_init_args"
+            ) as mock_get_args,
+        ):
+            mock_get_args.return_value = {
+                "app": "litellm.proxy.proxy_server:app",
+                "host": "localhost",
+                "port": 8000,
+            }
+
+            run_server.main(["--local", "--skip_server_startup"], standalone_mode=False)
+
+        output = capsys.readouterr().out
+        assert "`prisma generate` failed" in output
+        assert "prisma package was not found" not in output
+
+        schema_path = str(Path(proxy_cli.__file__).parent / "schema.prisma")
+        mock_subprocess_run.assert_any_call(
+            ("prisma", "generate", "--schema", schema_path),
+            capture_output=True,
+            check=True,
+        )
+        mock_setup_database.assert_not_called()
+
+    @patch("subprocess.run")
+    @patch("atexit.register")
+    @patch("litellm.proxy.db.prisma_client.PrismaManager.setup_database")
+    @patch("litellm.proxy.db.check_migration.check_prisma_schema_diff")
+    @patch("litellm.proxy.db.prisma_client.should_update_prisma_schema")
+    def test_database_startup_skips_prisma_generate_when_client_exists(
+        self,
+        mock_should_update_schema,
+        mock_check_schema_diff,
+        mock_setup_database,
+        mock_atexit_register,
+        mock_subprocess_run,
+    ):
+        """DATABASE_URL startup avoids runtime writes when Prisma is generated."""
+        from litellm.proxy.proxy_cli import run_server
+
+        mock_subprocess_run.return_value = MagicMock(returncode=0)
+        mock_should_update_schema.return_value = True
+        mock_setup_database.return_value = True
+
+        mock_proxy_module = MagicMock(
+            app=MagicMock(),
+            ProxyConfig=MagicMock(),
+            KeyManagementSettings=MagicMock(),
+            save_worker_config=MagicMock(),
+        )
+
+        clean_env = {
+            k: v
+            for k, v in os.environ.items()
+            if k not in ("DATABASE_URL", "DIRECT_URL")
+        }
+        clean_env["DATABASE_URL"] = "postgresql://test:test@localhost:5432/test"
+
+        with (
+            patch(
+                "litellm.proxy.proxy_cli._is_prisma_client_generated", return_value=True
+            ),
+            patch.dict(os.environ, clean_env, clear=True),
+            patch.dict(
+                "sys.modules",
+                {
+                    "proxy_server": mock_proxy_module,
+                    "litellm.proxy.proxy_server": mock_proxy_module,
+                },
+            ),
+            patch(
+                "litellm.proxy.proxy_cli.ProxyInitializationHelpers._get_default_unvicorn_init_args"
+            ) as mock_get_args,
+        ):
+            mock_get_args.return_value = {
+                "app": "litellm.proxy.proxy_server:app",
+                "host": "localhost",
+                "port": 8000,
+            }
+
+            run_server.main(["--local", "--skip_server_startup"], standalone_mode=False)
+
+        generate_calls = [
+            call
+            for call in mock_subprocess_run.call_args_list
+            if call.args and call.args[0][:2] == ["prisma", "generate"]
+        ]
+        assert generate_calls == []
 
     @patch("subprocess.run")
     @patch("atexit.register")

--- a/tests/test_litellm/proxy/test_proxy_cli.py
+++ b/tests/test_litellm/proxy/test_proxy_cli.py
@@ -1952,7 +1952,7 @@ class TestRunServerDbSetup:
         generate_calls = [
             call
             for call in mock_subprocess_run.call_args_list
-            if call.args and call.args[0][:2] == ["prisma", "generate"]
+            if call.args and call.args[0][:2] == ("prisma", "generate")
         ]
         assert generate_calls == []
 

--- a/tests/test_litellm/proxy/utils/prisma_and_spend/test_prisma_client_lifecycle.py
+++ b/tests/test_litellm/proxy/utils/prisma_and_spend/test_prisma_client_lifecycle.py
@@ -10,6 +10,7 @@ Symbols pinned here:
 from __future__ import annotations
 
 import asyncio
+import builtins
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -109,6 +110,48 @@ def test_prismaclient_init_raises_when_prisma_not_generated() -> None:
     finally:
         if had_prisma_attr:
             _prisma_pkg.Prisma = previous_prisma_attr  # type: ignore[attr-defined]
+
+
+def test_prismaclient_init_raises_when_prisma_package_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing prisma package gets install guidance instead of generate guidance."""
+    real_import = builtins.__import__
+
+    def fake_import(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == "prisma":
+            raise ModuleNotFoundError("No module named 'prisma'", name="prisma")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(Exception, match="litellm\\[proxy,extra_proxy\\]"):
+        PrismaClient(
+            database_url="postgres://x:y@h:5432/db",
+            proxy_logging_obj=MagicMock(),
+        )
+
+
+def test_prismaclient_init_reraises_other_module_not_found(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A transitive missing module should keep its original import error."""
+    real_import = builtins.__import__
+
+    def fake_import(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == "prisma":
+            raise ModuleNotFoundError("No module named 'other'", name="other")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(ModuleNotFoundError) as exc_info:
+        PrismaClient(
+            database_url="postgres://x:y@h:5432/db",
+            proxy_logging_obj=MagicMock(),
+        )
+
+    assert exc_info.value.name == "other"
 
 
 def test_writer_db_returns_db_when_no_routing(prisma_client: PrismaClient) -> None:


### PR DESCRIPTION
## Relevant issues

Fixes #30425

## Linear ticket

None

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Reproduced the confusing failure mode with the documented proxy install surface:

```bash
$ uv sync --frozen --extra proxy
$ uv run --no-sync python -c "import importlib.util; print(importlib.util.find_spec('prisma'))"
None

$ uv run --no-sync python -c "from litellm.proxy.utils import PrismaClient; from unittest.mock import MagicMock; PrismaClient(database_url='postgres://x:y@h:5432/db', proxy_logging_obj=MagicMock())"
ModuleNotFoundError: No module named 'prisma'
Exception: Unable to find Prisma binaries. Please run 'prisma generate' first.
```

This PR does not modify dependency metadata or `uv.lock`, because fork PRs are blocked from lockfile changes. Instead, it makes the DB-backed proxy startup path handle Prisma setup failures more explicitly:

- Missing `prisma` package errors now tell users to install `litellm[extra_proxy]` or `litellm[proxy,extra_proxy]`.
- If `prisma` is installed but the generated client is missing, startup runs `prisma generate --schema <proxy schema>` before DB setup.
- If `prisma generate` fails, startup no longer raises an unhandled `CalledProcessError`; it stays on the graceful fallback path and prints generation-failure guidance to run `prisma generate --schema litellm/proxy/schema.prisma` and inspect the CLI output.
- If the generated Prisma client already exists, startup skips generation to avoid unnecessary runtime writes in Docker/non-root deployments.
- Stale cached `prisma` modules are cleared after failed generated-client probes and after generation, so later imports see the generated files.

Validation run:

```bash
$ uv run --no-sync python -m pytest tests/test_litellm/proxy/test_proxy_cli.py::TestRunServerDbSetup tests/test_litellm/proxy/utils/prisma_and_spend/test_prisma_client_lifecycle.py::test_prismaclient_init_raises_when_prisma_not_generated tests/test_litellm/proxy/utils/prisma_and_spend/test_prisma_client_lifecycle.py::test_prismaclient_init_raises_when_prisma_package_missing tests/test_litellm/proxy/utils/prisma_and_spend/test_prisma_client_lifecycle.py::test_prismaclient_init_reraises_other_module_not_found -q
..........                                                               [100%]
10 passed in 64.67s (0:01:04)

$ uv run --no-sync black --check litellm/proxy/proxy_cli.py litellm/proxy/utils.py tests/test_litellm/proxy/test_proxy_cli.py tests/test_litellm/proxy/utils/prisma_and_spend/test_prisma_client_lifecycle.py
All done! 4 files would be left unchanged.

$ uv run --no-sync ruff check litellm/proxy/proxy_cli.py litellm/proxy/utils.py tests/test_litellm/proxy/test_proxy_cli.py tests/test_litellm/proxy/utils/prisma_and_spend/test_prisma_client_lifecycle.py
All checks passed!

$ uv run --no-sync mypy litellm/proxy/proxy_cli.py --ignore-missing-imports
Success: no issues found in 1 source file

$ uv run --no-sync mypy litellm/proxy/utils.py --ignore-missing-imports
Success: no issues found in 1 source file

$ git diff --check
```

I also tried `make lint`; it fails before reaching these changes because the current branch has unrelated enterprise files that Black would reformat.

## Type

Bug Fix

Test

## Changes

The proxy DB startup path now separates Prisma setup problems:

- `prisma` package missing: tell the user to install the database extras.
- generated Prisma client missing: generate it from LiteLLM's proxy schema before DB setup.
- generation failure: keep startup on the existing graceful fallback path and show generation-specific recovery guidance instead of raising an unhandled subprocess exception.
