### PR TITLE
fix(otel): emit gen_ai.input.messages and gen_ai.output.messages from the genai mapper

### DIFF
--- a/litellm/integrations/otel/mappers/genai.py
+++ b/litellm/integrations/otel/mappers/genai.py
@@ -7,7 +7,8 @@ Each span kind declares its schema as a flat ``attribute key -> extractor``
 table: one lambda per mapping operation, applied against the typed span data.
 """
 
-from typing import Callable
+import json
+from typing import Callable, Mapping
 
 from litellm.integrations.otel.mappers.base import AttributeMap, AttrValue, SpanData
 from litellm.integrations.otel.mappers.utils import collect, drop_none
@@ -80,6 +81,14 @@ class GenAIMapper:
         LiteLLM.REQUEST_STREAMING: lambda d: d.is_streaming,
     }
 
+    # Prompt/response content, serialized into the OTel GenAI message schema.
+    # Populated only when content capture is enabled — otherwise ``messages_in``
+    # and ``choices_out`` arrive empty and these resolve to ``None``.
+    _BLOB_ATTRS: dict[str, Callable[[LLMCallSpanData], AttrValue | None]] = {
+        GenAI.INPUT_MESSAGES: lambda d: _input_messages(d.messages_in),
+        GenAI.OUTPUT_MESSAGES: lambda d: _output_messages(d.choices_out),
+    }
+
     _TOOL_ATTRS: dict[str, Callable[[ToolDefinition], AttrValue | None]] = {
         "name": lambda t: t.name,
         "description": lambda t: t.description or None,
@@ -137,17 +146,21 @@ class GenAIMapper:
 
     @classmethod
     def _llm_call(cls, data: LLMCallSpanData) -> AttributeMap:
-        attrs = collect(cls._LLM_CALL_ATTRS, data)
-        attrs.update(
-            drop_none(
-                {
-                    f"gen_ai.tool.{idx}.{suffix}": extract(tool)
-                    for idx, tool in enumerate(data.tools)
-                    for suffix, extract in cls._TOOL_ATTRS.items()
-                }
-            )
+        return {
+            **collect(cls._LLM_CALL_ATTRS, data),
+            **collect(cls._BLOB_ATTRS, data),
+            **cls._tools(data),
+        }
+
+    @classmethod
+    def _tools(cls, data: LLMCallSpanData) -> AttributeMap:
+        return drop_none(
+            {
+                f"gen_ai.tool.{idx}.{suffix}": extract(tool)
+                for idx, tool in enumerate(data.tools)
+                for suffix, extract in cls._TOOL_ATTRS.items()
+            }
         )
-        return attrs
 
     @classmethod
     def _guardrail(cls, data: GuardrailSpanData) -> AttributeMap:
@@ -171,3 +184,108 @@ class GenAIMapper:
             }
         )
         return attrs
+
+
+# --- OTel GenAI message serialization ---------------------------------------- #
+#
+# ``gen_ai.input.messages`` / ``gen_ai.output.messages`` carry a list of
+# ``{"role", "parts": [...]}`` objects, where each part is a typed fragment
+# (``text``, ``tool_call``, ``tool_call_response``). Spans can't hold nested
+# structures, so the list is serialized to a JSON string (the convention's
+# documented fallback). Output messages add the choice's ``finish_reason``.
+
+
+def _input_messages(messages: tuple[Mapping[str, object], ...]) -> str | None:
+    return json.dumps([_input_message(m) for m in messages]) if messages else None
+
+
+def _output_messages(choices: tuple[Mapping[str, object], ...]) -> str | None:
+    return json.dumps([_output_message(c) for c in choices]) if choices else None
+
+
+def _input_message(message: Mapping[str, object]) -> Mapping[str, object]:
+    return _prune({"role": _as_str(message.get("role")), "parts": _parts(message)})
+
+
+def _output_message(choice: Mapping[str, object]) -> Mapping[str, object]:
+    message = _as_mapping(choice.get("message"))
+    return _prune(
+        {
+            "role": _as_str(message.get("role")) or "assistant",
+            "parts": _parts(message),
+            "finish_reason": _as_str(choice.get("finish_reason")),
+        }
+    )
+
+
+def _parts(message: Mapping[str, object]) -> list[Mapping[str, object]]:
+    if message.get("role") == "tool":
+        return [_tool_response_part(message)]
+    return [
+        *_text_parts(message.get("content")),
+        *_tool_call_parts(message.get("tool_calls")),
+    ]
+
+
+def _text_parts(content: object) -> list[Mapping[str, object]]:
+    if isinstance(content, str):
+        return [{"type": "text", "content": content}] if content else []
+    if not isinstance(content, list):
+        return []
+    texts = (
+        part.get("text")
+        for part in content
+        if isinstance(part, dict) and part.get("type") == "text"
+    )
+    return [{"type": "text", "content": t} for t in texts if isinstance(t, str) and t]
+
+
+def _tool_call_parts(tool_calls: object) -> list[Mapping[str, object]]:
+    if not isinstance(tool_calls, list):
+        return []
+    return [_tool_call_part(c) for c in tool_calls if isinstance(c, dict)]
+
+
+def _tool_call_part(call: Mapping[str, object]) -> Mapping[str, object]:
+    function = _as_mapping(call.get("function"))
+    return _prune(
+        {
+            "type": "tool_call",
+            "id": _as_str(call.get("id")),
+            "name": _as_str(function.get("name")),
+            "arguments": _maybe_json(function.get("arguments")),
+        }
+    )
+
+
+def _tool_response_part(message: Mapping[str, object]) -> Mapping[str, object]:
+    return _prune(
+        {
+            "type": "tool_call_response",
+            "id": _as_str(message.get("tool_call_id")),
+            "result": message.get("content"),
+        }
+    )
+
+
+def _maybe_json(value: object) -> object:
+    """Parse a JSON-string ``arguments`` blob into structured form; pass through
+    anything that isn't valid JSON so the raw value survives."""
+    if not isinstance(value, str):
+        return value
+    try:
+        return json.loads(value)
+    except ValueError:
+        return value
+
+
+def _as_str(value: object) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+def _as_mapping(value: object) -> Mapping[str, object]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _prune(values: Mapping[str, object]) -> Mapping[str, object]:
+    return {key: value for key, value in values.items() if value is not None}

--- a/litellm/integrations/otel/mappers/genai.py
+++ b/litellm/integrations/otel/mappers/genai.py
@@ -11,7 +11,7 @@ import json
 from typing import Callable, Mapping
 
 from litellm.integrations.otel.mappers.base import AttributeMap, AttrValue, SpanData
-from litellm.integrations.otel.mappers.utils import collect, drop_none
+from litellm.integrations.otel.mappers.utils import collect, drop_none, json_or_none
 from litellm.integrations.otel.model.payloads import (
     GuardrailSpanData,
     LLMCallSpanData,
@@ -196,11 +196,11 @@ class GenAIMapper:
 
 
 def _input_messages(messages: tuple[Mapping[str, object], ...]) -> str | None:
-    return json.dumps([_input_message(m) for m in messages]) if messages else None
+    return json_or_none([_input_message(m) for m in messages]) if messages else None
 
 
 def _output_messages(choices: tuple[Mapping[str, object], ...]) -> str | None:
-    return json.dumps([_output_message(c) for c in choices]) if choices else None
+    return json_or_none([_output_message(c) for c in choices]) if choices else None
 
 
 def _input_message(message: Mapping[str, object]) -> Mapping[str, object]:

--- a/litellm/integrations/otel/mappers/genai.py
+++ b/litellm/integrations/otel/mappers/genai.py
@@ -208,11 +208,13 @@ def _input_message(message: Mapping[str, object]) -> Mapping[str, object]:
 
 
 def _output_message(choice: Mapping[str, object]) -> Mapping[str, object]:
+    # Chat choices carry the completion under ``message``; legacy text-completion
+    # choices expose it as a top-level ``text`` string, so fall back to that.
     message = _as_mapping(choice.get("message"))
     return _prune(
         {
             "role": _as_str(message.get("role")) or "assistant",
-            "parts": _parts(message),
+            "parts": _parts(message) or _text_parts(choice.get("text")),
             "finish_reason": _as_str(choice.get("finish_reason")),
         }
     )

--- a/tests/test_litellm/integrations/otel/test_otel_v2_components.py
+++ b/tests/test_litellm/integrations/otel/test_otel_v2_components.py
@@ -2,6 +2,8 @@
 baggage helpers, metrics, the typed coercion helpers, mapper branches, span-name
 builders, and the registry validator's failure paths. Needs the OTel SDK."""
 
+import json
+
 import pytest
 
 pytest.importorskip("opentelemetry")
@@ -280,6 +282,128 @@ def test_genai_mapper_cost_breakdown_absent():
         k.startswith(LiteLLM.COST_PREFIX) and k != f"{LiteLLM.COST_PREFIX}total"
         for k in attrs
     )
+
+
+def _llm_call_with_content(**overrides):
+    base = dict(
+        operation=GenAIOperation.CHAT,
+        provider="openai",
+        request_model="gpt-4o",
+        response_model="gpt-4o-2024",
+        response_id="resp_1",
+        request_params=LLMRequestParams(),
+        usage=LLMUsage(input_tokens=10, output_tokens=5, total_tokens=15),
+        finish_reasons=("stop",),
+        error=None,
+        response_cost=None,
+        server=None,
+        identity=RequestIdentity(call_id="c1"),
+        messages_in=(
+            {"role": "system", "content": "Be concise."},
+            {"role": "user", "content": "Weather in Paris?"},
+        ),
+        choices_out=(
+            {
+                "finish_reason": "stop",
+                "message": {"role": "assistant", "content": "Sunny."},
+            },
+        ),
+    )
+    base.update(overrides)
+    return LLMCallSpanData(**base)
+
+
+def test_genai_mapper_input_messages_use_parts_schema():
+    attrs = GenAIMapper().map(_llm_call_with_content())
+    assert json.loads(attrs[GenAI.INPUT_MESSAGES]) == [
+        {"role": "system", "parts": [{"type": "text", "content": "Be concise."}]},
+        {"role": "user", "parts": [{"type": "text", "content": "Weather in Paris?"}]},
+    ]
+
+
+def test_genai_mapper_output_messages_carry_finish_reason():
+    attrs = GenAIMapper().map(_llm_call_with_content())
+    assert json.loads(attrs[GenAI.OUTPUT_MESSAGES]) == [
+        {
+            "role": "assistant",
+            "parts": [{"type": "text", "content": "Sunny."}],
+            "finish_reason": "stop",
+        }
+    ]
+
+
+def test_genai_mapper_omits_messages_when_content_not_captured():
+    # Capture off → payload builds empty tuples → no message attributes stamped.
+    attrs = GenAIMapper().map(_llm_call_with_content(messages_in=(), choices_out=()))
+    assert GenAI.INPUT_MESSAGES not in attrs
+    assert GenAI.OUTPUT_MESSAGES not in attrs
+
+
+def test_genai_mapper_multimodal_keeps_text_parts_only():
+    data = _llm_call_with_content(
+        messages_in=(
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "describe "},
+                    {"type": "image_url", "image_url": {"url": "data:..."}},
+                    {"type": "text", "text": "this"},
+                ],
+            },
+        )
+    )
+    (message,) = json.loads(GenAIMapper().map(data)[GenAI.INPUT_MESSAGES])
+    assert message["parts"] == [
+        {"type": "text", "content": "describe "},
+        {"type": "text", "content": "this"},
+    ]
+
+
+def test_genai_mapper_assistant_tool_call_becomes_tool_call_part():
+    data = _llm_call_with_content(
+        choices_out=(
+            {
+                "finish_reason": "tool_calls",
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_42",
+                            "function": {
+                                "name": "get_weather",
+                                "arguments": '{"city": "Paris"}',
+                            },
+                        }
+                    ],
+                },
+            },
+        )
+    )
+    (message,) = json.loads(GenAIMapper().map(data)[GenAI.OUTPUT_MESSAGES])
+    assert message["finish_reason"] == "tool_calls"
+    # ``arguments`` is parsed from the JSON-string blob into structured form.
+    assert message["parts"] == [
+        {
+            "type": "tool_call",
+            "id": "call_42",
+            "name": "get_weather",
+            "arguments": {"city": "Paris"},
+        }
+    ]
+
+
+def test_genai_mapper_tool_result_message_becomes_response_part():
+    data = _llm_call_with_content(
+        messages_in=(
+            {"role": "tool", "tool_call_id": "call_42", "content": "21C and sunny"},
+        )
+    )
+    (message,) = json.loads(GenAIMapper().map(data)[GenAI.INPUT_MESSAGES])
+    assert message["role"] == "tool"
+    assert message["parts"] == [
+        {"type": "tool_call_response", "id": "call_42", "result": "21C and sunny"}
+    ]
 
 
 def test_llm_cost_from_breakdown_maps_costbreakdown_keys():

--- a/tests/test_litellm/integrations/otel/test_otel_v2_components.py
+++ b/tests/test_litellm/integrations/otel/test_otel_v2_components.py
@@ -3,6 +3,7 @@ baggage helpers, metrics, the typed coercion helpers, mapper branches, span-name
 builders, and the registry validator's failure paths. Needs the OTel SDK."""
 
 import json
+from datetime import datetime
 
 import pytest
 
@@ -404,6 +405,46 @@ def test_genai_mapper_tool_result_message_becomes_response_part():
     assert message["parts"] == [
         {"type": "tool_call_response", "id": "call_42", "result": "21C and sunny"}
     ]
+
+
+def test_genai_mapper_tool_call_arguments_pass_through_when_not_json():
+    # A non-string blob is kept as-is; an unparseable string survives verbatim
+    # rather than letting the JSON parse error bubble up.
+    data = _llm_call_with_content(
+        choices_out=(
+            {
+                "finish_reason": "tool_calls",
+                "message": {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {"id": "a", "function": {"name": "f", "arguments": "not json"}},
+                        {"id": "b", "function": {"name": "g", "arguments": {"x": 1}}},
+                    ],
+                },
+            },
+        )
+    )
+    (message,) = json.loads(GenAIMapper().map(data)[GenAI.OUTPUT_MESSAGES])
+    assert [p["arguments"] for p in message["parts"]] == ["not json", {"x": 1}]
+
+
+def test_genai_mapper_output_choice_without_message_defaults_role():
+    data = _llm_call_with_content(choices_out=({"finish_reason": "stop"},))
+    (message,) = json.loads(GenAIMapper().map(data)[GenAI.OUTPUT_MESSAGES])
+    assert message == {"role": "assistant", "parts": [], "finish_reason": "stop"}
+
+
+def test_genai_mapper_non_serializable_content_does_not_crash_span():
+    # json_or_none guards the dump: a stray non-JSON value is stringified instead
+    # of raising through ``collect`` and dropping the whole span.
+    data = _llm_call_with_content(
+        messages_in=(
+            {"role": "tool", "tool_call_id": "c", "content": datetime(2026, 1, 1)},
+        )
+    )
+    (message,) = json.loads(GenAIMapper().map(data)[GenAI.INPUT_MESSAGES])
+    assert message["parts"][0]["type"] == "tool_call_response"
+    assert "2026" in message["parts"][0]["result"]
 
 
 def test_llm_cost_from_breakdown_maps_costbreakdown_keys():

--- a/tests/test_litellm/integrations/otel/test_otel_v2_components.py
+++ b/tests/test_litellm/integrations/otel/test_otel_v2_components.py
@@ -434,6 +434,20 @@ def test_genai_mapper_output_choice_without_message_defaults_role():
     assert message == {"role": "assistant", "parts": [], "finish_reason": "stop"}
 
 
+def test_genai_mapper_text_completion_choice_uses_text_field():
+    # Legacy /completions choices expose the completion as a top-level ``text``
+    # string with no ``message``; it still becomes a text part.
+    data = _llm_call_with_content(
+        choices_out=({"finish_reason": "stop", "text": "a cold beer"},)
+    )
+    (message,) = json.loads(GenAIMapper().map(data)[GenAI.OUTPUT_MESSAGES])
+    assert message == {
+        "role": "assistant",
+        "parts": [{"type": "text", "content": "a cold beer"}],
+        "finish_reason": "stop",
+    }
+
+
 def test_genai_mapper_non_serializable_content_does_not_crash_span():
     # json_or_none guards the dump: a stray non-JSON value is stringified instead
     # of raising through ``collect`` and dropping the whole span.


### PR DESCRIPTION
## Relevant issues

Reported by a user testing OpenTelemetry V2 on 1.88.1 with console export: with `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=span_and_event`, the canonical genai mapper never produced `gen_ai.input.messages` or `gen_ai.output.messages`, while other mappers such as `openinference` did

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## What was wrong

`GenAIMapper` is the always-active, canonical OTel GenAI vocabulary. It stamped request params, usage, cost, finish reasons, and tool definitions, but it never read `messages_in` or `choices_out`. So even with content capture explicitly enabled, the two semconv attributes that carry the actual prompt and completion bodies, `gen_ai.input.messages` and `gen_ai.output.messages`, were simply absent.

This was the only mapper missing message content. `openinference`, `langfuse`, `weave`, and `langtrace` all serialized `messages_in` / `choices_out`, which is why the user saw the content show up in those vocabularies but not in the canonical one. The keys themselves already existed in `semconv.py` (`GenAI.INPUT_MESSAGES` / `GenAI.OUTPUT_MESSAGES`); nothing ever populated them.

## The fix

`GenAIMapper._llm_call` now serializes both message lists into the OpenTelemetry GenAI message schema: each message is `{"role", "parts": [...]}`, where parts are typed fragments (`text`, `tool_call`, `tool_call_response`), and output messages carry the choice's `finish_reason`. Spans cannot hold nested structures, so the list is serialized to a JSON string, which is the convention's documented fallback for span attributes. Tool-call `arguments` blobs are parsed back from their JSON-string form into structured objects, falling back to the raw value if they are not valid JSON.

Serialization goes through the shared `json_or_none` helper (the same one the other mapper utilities use), so a stray non-serializable value in a message field is stringified rather than raising a `TypeError` up through `collect` and dropping the whole span.

Chat choices carry the completion under `message`, but legacy `/completions` choices expose it as a top-level `text` string with no `message`; output serialization falls back to that `text` so text-completion responses still produce a populated `parts` list instead of an empty one.

Content stays gated exactly as before: `messages_in` and `choices_out` are populated only when `capture_span_content` is on (`span_only` / `span_and_event`); otherwise they arrive as empty tuples and the new attributes resolve to nothing. An operator must still opt in before any prompt or completion body leaves the process.

Example `gen_ai.output.messages` value for a tool-calling turn:

```json
[{"role":"assistant","parts":[{"type":"tool_call","id":"call_42","name":"get_weather","arguments":{"city":"Paris"}}],"finish_reason":"tool_calls"}]
```

## Screenshots / Proof of Fix

Run a proxy with content capture on and console export, then send one chat request and read the printed span:

```bash
export LITELLM_OTEL_V2=true
export OTEL_EXPORTER=console
export OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=span_and_event
python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log
```

```bash
curl -s http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"gpt-4o","messages":[{"role":"user","content":"Reply with the single word: sunny"}]}'
```

In the console span output, confirm the two attributes are now present (they were absent before this change):

```bash
grep -E "gen_ai.input.messages|gen_ai.output.messages" litellm.log
```

You should see the request and response serialized under both keys, for example `gen_ai.input.messages` -> `[{"role":"user","parts":[{"type":"text","content":"Reply with the single word: sunny"}]}]` and `gen_ai.output.messages` -> `[{"role":"assistant","parts":[{"type":"text","content":"sunny"}],"finish_reason":"stop"}]`

## Type

🐛 Bug Fix

## Changes

`litellm/integrations/otel/mappers/genai.py`: add a `_BLOB_ATTRS` table that maps `gen_ai.input.messages` / `gen_ai.output.messages`, plus pure helper functions that convert OpenAI-format chat messages and response choices into the OTel GenAI `role`/`parts` schema, serialized through `json_or_none`. `_llm_call` is reshaped into a no-mutation dict merge (matching the sibling vendor mappers), with tool-definition stamping pulled into a small `_tools` helper. Output serialization falls back to a choice's top-level `text` field so legacy `/completions` responses, which have no nested `message`, still emit a populated `parts` list.

`tests/test_litellm/integrations/otel/test_otel_v2_components.py`: regression tests covering input/output message serialization, the parts schema, `finish_reason` on output, multimodal text-only extraction, assistant tool calls with parsed arguments, tool-result responses, the capture-off path where both attributes are omitted, non-string / unparseable tool-call arguments passthrough, the choice-without-message default role, text-completion output drawn from the `text` field, and a non-serializable tool result surviving serialization.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> When message content capture is enabled, prompts and completions are written to span attributes (PII exposure to observability backends); behavior is gated upstream and serialization is hardened with json_or_none.
> 
> **Overview**
> Fixes the canonical **GenAIMapper** so LLM spans include **`gen_ai.input.messages`** and **`gen_ai.output.messages`** when `messages_in` / `choices_out` are populated (content capture on). Previously those semconv keys existed but were never filled, unlike other vendor mappers.
> 
> The mapper now serializes chat input and completion choices into the OTel GenAI **`role` / `parts`** shape (text, tool calls, tool results), JSON-stringifies the lists via **`json_or_none`**, and adds **`finish_reason`** on outputs. It handles multimodal input (text parts only), parses tool **`arguments`** JSON when possible, falls back to legacy **`text`** completions, and omits both attributes when capture leaves empty tuples.
> 
> **`_llm_call`** is refactored to merge **`_BLOB_ATTRS`** with existing attrs and a new **`_tools`** helper. Regression tests cover the main serialization paths and failure modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 636a3f279876327289967cb4e9dc01508d6762ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

