### PR TITLE
feat: add fastCRW search provider

### DIFF
--- a/litellm/llms/fastcrw/__init__.py
+++ b/litellm/llms/fastcrw/__init__.py
@@ -1,0 +1,7 @@
+"""
+fastCRW API integration module.
+"""
+
+from litellm.llms.fastcrw.search.transformation import FastCRWSearchConfig
+
+__all__ = ["FastCRWSearchConfig"]

--- a/litellm/llms/fastcrw/search/__init__.py
+++ b/litellm/llms/fastcrw/search/__init__.py
@@ -1,0 +1,7 @@
+"""
+fastCRW Search API module.
+"""
+
+from litellm.llms.fastcrw.search.transformation import FastCRWSearchConfig
+
+__all__ = ["FastCRWSearchConfig"]

--- a/litellm/llms/fastcrw/search/transformation.py
+++ b/litellm/llms/fastcrw/search/transformation.py
@@ -1,0 +1,182 @@
+"""
+Calls fastCRW's /v1/search endpoint to search the web.
+
+fastCRW is a Firecrawl-compatible web data engine (single Rust binary; self-host
+or cloud). The search response uses the Firecrawl-compatible envelope
+{ "success": true, "data": [ { "title", "url", "description", "markdown"? } ] }.
+
+fastCRW API Reference: https://fastcrw.com/docs/rest-api
+"""
+
+from typing import Dict, List, Optional, TypedDict, Union
+
+import httpx
+
+from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+from litellm.llms.base_llm.search.transformation import (
+    BaseSearchConfig,
+    SearchResponse,
+    SearchResult,
+)
+from litellm.secret_managers.main import get_secret_str
+
+
+class _FastCRWSearchRequestRequired(TypedDict):
+    """Required fields for fastCRW Search API request."""
+
+    query: str  # Required - search query
+
+
+class FastCRWSearchRequest(_FastCRWSearchRequestRequired, total=False):
+    """
+    fastCRW Search API request format.
+    Based on: https://fastcrw.com/docs/rest-api
+    """
+
+    limit: int  # Optional - maximum number of results to return
+    sources: List[
+        str
+    ]  # Optional - sources to search ('web', 'images'), default ['web']
+    scrapeOptions: Dict  # Optional - options for scraping search results
+
+
+class FastCRWSearchConfig(BaseSearchConfig):
+    FASTCRW_API_BASE = "https://fastcrw.com/api/v1"
+
+    @staticmethod
+    def ui_friendly_name() -> str:
+        return "fastCRW"
+
+    def validate_environment(
+        self,
+        headers: Dict,
+        api_key: Optional[str] = None,
+        api_base: Optional[str] = None,
+        **kwargs,
+    ) -> Dict:
+        """
+        Validate environment and return headers.
+        """
+        api_key = api_key or get_secret_str("CRW_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "CRW_API_KEY is not set. Set `CRW_API_KEY` environment variable."
+            )
+        headers["Authorization"] = f"Bearer {api_key}"
+        headers["Content-Type"] = "application/json"
+        return headers
+
+    def get_complete_url(
+        self,
+        api_base: Optional[str],
+        optional_params: dict,
+        data: Optional[Union[Dict, List[Dict]]] = None,
+        **kwargs,
+    ) -> str:
+        """
+        Get complete URL for Search endpoint.
+        """
+        api_base = api_base or get_secret_str("CRW_API_BASE") or self.FASTCRW_API_BASE
+
+        # Append "/search" to the api base if it's not already there
+        if not api_base.endswith("/search"):
+            api_base = f"{api_base}/search"
+
+        return api_base
+
+    def transform_search_request(
+        self,
+        query: Union[str, List[str]],
+        optional_params: dict,
+        **kwargs,
+    ) -> Dict:
+        """
+        Transform Search request to fastCRW API format.
+
+        Transforms Perplexity unified spec parameters:
+        - query -> query (same)
+        - max_results -> limit
+
+        All other fastCRW-specific parameters are passed through as-is.
+
+        Args:
+            query: Search query (string or list of strings). fastCRW only supports single string queries.
+            optional_params: Optional parameters for the request
+
+        Returns:
+            Dict with typed request data following FastCRWSearchRequest spec
+        """
+        if isinstance(query, list):
+            # fastCRW only supports single string queries, join with spaces
+            query = " ".join(query)
+
+        request_data: FastCRWSearchRequest = {
+            "query": query,
+        }
+
+        # Transform Perplexity unified spec parameters to fastCRW format
+        if "max_results" in optional_params:
+            request_data["limit"] = optional_params["max_results"]
+
+        # Convert to dict before dynamic key assignments
+        result_data = dict(request_data)
+
+        # pass through all other parameters as-is
+        for param, value in optional_params.items():
+            if (
+                param not in self.get_supported_perplexity_optional_params()
+                and param not in result_data
+            ):
+                result_data[param] = value
+
+        # By default, request markdown content if not explicitly specified
+        # fastCRW doesn't return content unless explicitly requested via scrapeOptions
+        if "scrapeOptions" not in result_data:
+            result_data["scrapeOptions"] = {
+                "formats": ["markdown"],
+                "onlyMainContent": True,
+            }
+
+        return result_data
+
+    def transform_search_response(
+        self,
+        raw_response: httpx.Response,
+        logging_obj: LiteLLMLoggingObj,
+        **kwargs,
+    ) -> SearchResponse:
+        """
+        Transform fastCRW API response to LiteLLM unified SearchResponse format.
+
+        fastCRW (Firecrawl-compatible) returns:
+            {"success": true, "data": [{"url": "...", "title": "...", "description": "...", "markdown"?: "..."}, ...]}
+
+        Args:
+            raw_response: Raw httpx response from fastCRW API
+            logging_obj: Logging object for tracking
+
+        Returns:
+            SearchResponse with standardized format
+        """
+        response_json = raw_response.json()
+
+        results = []
+
+        data = response_json.get("data", [])
+
+        if isinstance(data, list):
+            for result in data:
+                snippet = result.get("markdown") or result.get("description", "")
+                search_result = SearchResult(
+                    title=result.get("title", ""),
+                    url=result.get("url", ""),
+                    snippet=snippet,
+                    date=None,
+                    last_updated=None,
+                )
+                results.append(search_result)
+
+        return SearchResponse(
+            results=results,
+            object="search",
+        )

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3455,6 +3455,7 @@ class SearchProviders(str, Enum):
     GOOGLE_PSE = "google_pse"
     DATAFORSEO = "dataforseo"
     FIRECRAWL = "firecrawl"
+    FASTCRW = "fastcrw"
     SEARXNG = "searxng"
     LINKUP = "linkup"
     DUCKDUCKGO = "duckduckgo"

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -9647,6 +9647,7 @@ class ProviderConfigManager:
         from litellm.llms.dataforseo.search.transformation import DataForSEOSearchConfig
         from litellm.llms.duckduckgo.search.transformation import DuckDuckGoSearchConfig
         from litellm.llms.exa_ai.search.transformation import ExaAISearchConfig
+        from litellm.llms.fastcrw.search.transformation import FastCRWSearchConfig
         from litellm.llms.firecrawl.search.transformation import FirecrawlSearchConfig
         from litellm.llms.google_pse.search.transformation import GooglePSESearchConfig
         from litellm.llms.linkup.search.transformation import LinkupSearchConfig
@@ -9669,6 +9670,7 @@ class ProviderConfigManager:
             SearchProviders.GOOGLE_PSE: GooglePSESearchConfig,
             SearchProviders.DATAFORSEO: DataForSEOSearchConfig,
             SearchProviders.FIRECRAWL: FirecrawlSearchConfig,
+            SearchProviders.FASTCRW: FastCRWSearchConfig,
             SearchProviders.SEARXNG: SearXNGSearchConfig,
             SearchProviders.LINKUP: LinkupSearchConfig,
             SearchProviders.DUCKDUCKGO: DuckDuckGoSearchConfig,

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -972,6 +972,23 @@
         "search": true
       }
     },
+    "fastcrw": {
+      "display_name": "fastCRW (`fastcrw`)",
+      "url": "https://docs.litellm.ai/docs/search/fastcrw",
+      "endpoints": {
+        "chat_completions": false,
+        "messages": false,
+        "responses": false,
+        "embeddings": false,
+        "image_generations": false,
+        "audio_transcriptions": false,
+        "audio_speech": false,
+        "moderations": false,
+        "batches": false,
+        "rerank": false,
+        "search": true
+      }
+    },
     "linkup": {
       "display_name": "Linkup (`linkup`)",
       "url": "https://docs.litellm.ai/docs/search/linkup",

--- a/tests/code_coverage_tests/enforce_llms_folder_style.py
+++ b/tests/code_coverage_tests/enforce_llms_folder_style.py
@@ -14,6 +14,7 @@ SEARCH_PROVIDERS = [
     "exa_ai",
     "brave",
     "firecrawl",
+    "fastcrw",
     "searxng",
     "linkup",
     "duckduckgo",

--- a/tests/test_litellm/llms/fastcrw/search/test_transformation.py
+++ b/tests/test_litellm/llms/fastcrw/search/test_transformation.py
@@ -1,0 +1,182 @@
+import os
+from unittest.mock import Mock, patch
+
+import pytest
+
+import litellm
+from litellm.llms.fastcrw.search.transformation import FastCRWSearchConfig
+
+
+def _config() -> FastCRWSearchConfig:
+    return FastCRWSearchConfig()
+
+
+def test_fastcrw_search_request_body():
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "success": True,
+        "data": [
+            {
+                "title": "Test Title",
+                "url": "https://example.com",
+                "description": "Test description",
+                "markdown": "Test content",
+            }
+        ],
+    }
+
+    with (
+        patch.dict(os.environ, {"CRW_API_KEY": "test-api-key"}),
+        patch(
+            "litellm.llms.custom_httpx.http_handler.HTTPHandler.post",
+            return_value=mock_response,
+        ) as mock_post,
+    ):
+        response = litellm.search(
+            query="test query",
+            search_provider="fastcrw",
+            max_results=10,
+        )
+
+        assert mock_post.called
+        call_kwargs = mock_post.call_args.kwargs
+        assert call_kwargs.get("url", "").endswith("/search")
+
+        request_body = call_kwargs.get("json")
+        assert request_body is not None
+        assert request_body["query"] == "test query"
+        assert request_body["limit"] == 10
+
+        assert len(response.results) == 1
+        result = response.results[0]
+        assert result.title == "Test Title"
+        assert result.url == "https://example.com"
+        assert result.snippet == "Test content"
+
+
+def test_ui_friendly_name():
+    assert _config().ui_friendly_name() == "fastCRW"
+
+
+def test_validate_environment_with_explicit_key():
+    headers = _config().validate_environment({}, api_key="explicit-key")
+    assert headers["Authorization"] == "Bearer explicit-key"
+    assert headers["Content-Type"] == "application/json"
+
+
+def test_validate_environment_reads_env_key():
+    with patch.dict(os.environ, {"CRW_API_KEY": "env-key"}, clear=False):
+        headers = _config().validate_environment({})
+    assert headers["Authorization"] == "Bearer env-key"
+
+
+def test_validate_environment_missing_key_raises():
+    with patch.dict(os.environ, {}, clear=True):
+        with pytest.raises(ValueError, match="CRW_API_KEY"):
+            _config().validate_environment({})
+
+
+def test_get_complete_url_default_base():
+    with patch.dict(os.environ, {}, clear=True):
+        assert _config().get_complete_url(None, {}) == "https://fastcrw.com/api/v1/search"
+
+
+def test_get_complete_url_appends_search():
+    assert (
+        _config().get_complete_url("https://self-hosted.local/api/v1", {})
+        == "https://self-hosted.local/api/v1/search"
+    )
+
+
+def test_get_complete_url_does_not_double_append():
+    assert (
+        _config().get_complete_url("https://self-hosted.local/api/v1/search", {})
+        == "https://self-hosted.local/api/v1/search"
+    )
+
+
+def test_get_complete_url_reads_env_base():
+    with patch.dict(
+        os.environ, {"CRW_API_BASE": "https://env-base.local/v1"}, clear=True
+    ):
+        assert _config().get_complete_url(None, {}) == "https://env-base.local/v1/search"
+
+
+def test_transform_search_request_basic():
+    data = _config().transform_search_request("hello", {"max_results": 5})
+    assert data["query"] == "hello"
+    assert data["limit"] == 5
+    assert data["scrapeOptions"]["formats"] == ["markdown"]
+    assert data["scrapeOptions"]["onlyMainContent"] is True
+
+
+def test_transform_search_request_joins_list_query():
+    assert _config().transform_search_request(["foo", "bar"], {})["query"] == "foo bar"
+
+
+def test_transform_search_request_passes_through_extra_params():
+    data = _config().transform_search_request("q", {"sources": ["web", "images"]})
+    assert data["sources"] == ["web", "images"]
+
+
+def test_transform_search_request_preserves_explicit_scrape_options():
+    custom = {"formats": ["html"]}
+    data = _config().transform_search_request("q", {"scrapeOptions": custom})
+    assert data["scrapeOptions"] == custom
+
+
+def _resp(payload):
+    r = Mock()
+    r.json.return_value = payload
+    return r
+
+
+def test_transform_search_response_prefers_markdown():
+    resp = _config().transform_search_response(
+        _resp(
+            {
+                "success": True,
+                "data": [
+                    {
+                        "title": "T",
+                        "url": "https://e.com",
+                        "description": "d",
+                        "markdown": "md",
+                    }
+                ],
+            }
+        ),
+        logging_obj=Mock(),
+    )
+    assert len(resp.results) == 1
+    assert resp.results[0].snippet == "md"
+
+
+def test_transform_search_response_falls_back_to_description():
+    resp = _config().transform_search_response(
+        _resp(
+            {
+                "success": True,
+                "data": [
+                    {"title": "T", "url": "https://e.com", "description": "only-desc"}
+                ],
+            }
+        ),
+        logging_obj=Mock(),
+    )
+    assert resp.results[0].snippet == "only-desc"
+
+
+def test_transform_search_response_empty_data():
+    resp = _config().transform_search_response(
+        _resp({"success": True, "data": []}), logging_obj=Mock()
+    )
+    assert resp.results == []
+
+
+def test_transform_search_response_non_list_data():
+    resp = _config().transform_search_response(
+        _resp({"success": True, "data": {"unexpected": "shape"}}), logging_obj=Mock()
+    )
+    assert resp.results == []


### PR DESCRIPTION
## What
Adds **fastCRW** as a search provider, alongside the existing Firecrawl search provider.

New `litellm/llms/fastcrw/search/`, registered in the provider map.

## Why

[fastCRW](https://fastcrw.com) is a fully open-source (AGPL) web scraping and search engine — a single ~8 MB Rust binary, ~6 MB RAM at runtime, no additional services required.

**Runs 100% locally, including on protected/JS-heavy sites.** Anti-bot/stealth handling, BYO-proxy + rotation, and JS rendering (Cloudflare JS-challenge, SPA rendering, UA rotation, HTTP → headless → proxy fallback) all ship in the open core. Firecrawl's self-hosted build gates its `fire-engine` (anti-bot/stealth layer) behind a cloud-only flag, so its self-host cannot reach protected or JS-heavy pages; fastCRW's can.

**Faster and higher-quality on Firecrawl's own benchmark dataset.** On Firecrawl's published benchmark corpus: truth-recall 63.74% vs 56.04%, with faster median latency (p50 ~1.9 s vs ~2.3 s).

**Search is built on SearXNG, not just backed by it.** crw is not an alternative to SearXNG — it is built on top of it. SearXNG is the metasearch aggregator underneath; crw adds a quality layer: query expansion (multi-variant rewrite), content-aware reranking (re-scoring by fetched content instead of SearXNG's content-blind ordering), and category routing (research queries fan out to arxiv / semantic scholar / Google Scholar, code queries to GitHub). So you get SearXNG's breadth plus a measurable accuracy layer, all open-source (AGPL) and self-hostable.

**Flat pricing.** 1 credit = 1 page, no 4× stealth surcharge, no billed-on-failure.

The integration is a small additive diff (Firecrawl untouched) precisely because fastCRW implements the Firecrawl REST API — so the code surface is minimal.

Key via `CRW_API_KEY` (free tier at https://fastcrw.com/dashboard); self-host base URL supported. I maintain fastCRW and can provide free credits for testing. Happy to adjust to your conventions.
