### PR TITLE
fix: guard check_and_fix_namespace against None key

### DIFF
--- a/litellm/caching/redis_cache.py
+++ b/litellm/caching/redis_cache.py
@@ -365,12 +365,13 @@ class RedisCache(BaseCache):
         self.redis_async_client = redis_async_client  # type: ignore
         return redis_async_client
 
-    def check_and_fix_namespace(self, key: str) -> str:
+    def check_and_fix_namespace(self, key: Optional[str]) -> Optional[str]:
         """
-        Make sure each key starts with the given namespace
+        Make sure each key starts with the given namespace.
+        Returns None if key is None (caller is responsible for guarding).
         """
         if key is None:
-            return key  # type: ignore[return-value]
+            return None
         if self.namespace is not None and not key.startswith(self.namespace):
             key = self.namespace + ":" + key
 
@@ -790,6 +791,8 @@ class RedisCache(BaseCache):
             raise e
 
         key = self.check_and_fix_namespace(key=key)
+        if key is None:
+            return
         print_verbose(f"Set ASYNC Redis Cache: key: {key}\nValue {value}\nttl={ttl}")
         try:
             await self._set_cache_sadd_helper(

--- a/litellm/caching/redis_cache.py
+++ b/litellm/caching/redis_cache.py
@@ -365,13 +365,12 @@ class RedisCache(BaseCache):
         self.redis_async_client = redis_async_client  # type: ignore
         return redis_async_client
 
-    def check_and_fix_namespace(self, key: Optional[str]) -> Optional[str]:
+    def check_and_fix_namespace(self, key: str) -> str:
         """
-        Make sure each key starts with the given namespace.
-        Returns None if key is None (caller is responsible for guarding).
+        Make sure each key starts with the given namespace
         """
         if key is None:
-            return None
+            return key  # type: ignore[return-value]
         if self.namespace is not None and not key.startswith(self.namespace):
             key = self.namespace + ":" + key
 
@@ -791,8 +790,6 @@ class RedisCache(BaseCache):
             raise e
 
         key = self.check_and_fix_namespace(key=key)
-        if key is None:
-            return
         print_verbose(f"Set ASYNC Redis Cache: key: {key}\nValue {value}\nttl={ttl}")
         try:
             await self._set_cache_sadd_helper(

--- a/litellm/caching/redis_cache.py
+++ b/litellm/caching/redis_cache.py
@@ -365,12 +365,12 @@ class RedisCache(BaseCache):
         self.redis_async_client = redis_async_client  # type: ignore
         return redis_async_client
 
-    def check_and_fix_namespace(self, key: Optional[str]) -> Optional[str]:
+    def check_and_fix_namespace(self, key: str) -> str:
         """
         Make sure each key starts with the given namespace
         """
         if key is None:
-            return key
+            return key  # type: ignore[return-value]
         if self.namespace is not None and not key.startswith(self.namespace):
             key = self.namespace + ":" + key
 

--- a/litellm/caching/redis_cache.py
+++ b/litellm/caching/redis_cache.py
@@ -369,6 +369,8 @@ class RedisCache(BaseCache):
         """
         Make sure each key starts with the given namespace
         """
+        if key is None:
+            return key
         if self.namespace is not None and not key.startswith(self.namespace):
             key = self.namespace + ":" + key
 

--- a/litellm/caching/redis_cache.py
+++ b/litellm/caching/redis_cache.py
@@ -365,7 +365,7 @@ class RedisCache(BaseCache):
         self.redis_async_client = redis_async_client  # type: ignore
         return redis_async_client
 
-    def check_and_fix_namespace(self, key: str) -> str:
+    def check_and_fix_namespace(self, key: Optional[str]) -> Optional[str]:
         """
         Make sure each key starts with the given namespace
         """

--- a/tests/test_litellm/caching/test_check_and_fix_namespace_none_guard.py
+++ b/tests/test_litellm/caching/test_check_and_fix_namespace_none_guard.py
@@ -1,0 +1,49 @@
+"""
+Test that check_and_fix_namespace handles None key gracefully.
+
+Regression test for https://github.com/BerriAI/litellm/issues/30424
+"""
+from unittest.mock import MagicMock
+
+from litellm.caching.redis_cache import RedisCache
+
+
+def test_check_and_fix_namespace_with_none_key():
+    """When key is None, check_and_fix_namespace should return None without raising."""
+    cache = MagicMock(spec=RedisCache)
+    cache.namespace = "litellm"
+    # Call the real method
+    result = RedisCache.check_and_fix_namespace(cache, key=None)
+    assert result is None
+
+
+def test_check_and_fix_namespace_with_none_key_no_namespace():
+    """When key is None and namespace is None, should return None without raising."""
+    cache = MagicMock(spec=RedisCache)
+    cache.namespace = None
+    result = RedisCache.check_and_fix_namespace(cache, key=None)
+    assert result is None
+
+
+def test_check_and_fix_namespace_with_valid_key():
+    """Normal behavior: prefix key with namespace if not already prefixed."""
+    cache = MagicMock(spec=RedisCache)
+    cache.namespace = "litellm"
+    result = RedisCache.check_and_fix_namespace(cache, key="my_key")
+    assert result == "litellm:my_key"
+
+
+def test_check_and_fix_namespace_with_already_prefixed_key():
+    """If key already starts with namespace, don't double-prefix."""
+    cache = MagicMock(spec=RedisCache)
+    cache.namespace = "litellm"
+    result = RedisCache.check_and_fix_namespace(cache, key="litellm:my_key")
+    assert result == "litellm:my_key"
+
+
+def test_check_and_fix_namespace_no_namespace():
+    """When namespace is None, return key as-is."""
+    cache = MagicMock(spec=RedisCache)
+    cache.namespace = None
+    result = RedisCache.check_and_fix_namespace(cache, key="my_key")
+    assert result == "my_key"


### PR DESCRIPTION
## Problem

When a request is made without a `user` field (i.e. `user_id=None`), the proxy's spend-tracking path calls `_update_user_db(user_id=None, ...)` which passes `None` as the Redis cache key. This reaches `check_and_fix_namespace(key=None)` where `None.startswith(...)` raises an `AttributeError`.

The error is caught by the `except Exception` in `dual_cache.async_get_cache` so requests are not affected, but an `ERROR`-level log is produced for every such request, causing log noise and masking real errors.

**Error log:**
```
File "redis_cache.py", line 358, in check_and_fix_namespace
    if self.namespace is not None and not key.startswith(self.namespace):
AttributeError: 'NoneType' object has no attribute 'startswith'
```

## Fix

Add an early return for `None` key in `check_and_fix_namespace`:

```python
def check_and_fix_namespace(self, key: str) -> str:
    if key is None:
        return key
    if self.namespace is not None and not key.startswith(self.namespace):
        key = self.namespace + ":" + key
    return key
```

## Testing

- Added 5 unit tests covering: None key with namespace, None key without namespace, valid key, already-prefixed key, no namespace
- All tests pass

Fixes #30424