### PR TITLE
fix(cost): sort tier thresholds numerically

### DIFF
--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -191,6 +191,16 @@ def _get_service_tier_cost_key(base_key: str, service_tier: Optional[str]) -> st
     return base_key
 
 
+def _get_token_cost_threshold(key: str) -> Optional[float]:
+    try:
+        threshold_str = key.split("_above_")[1].split("_tokens")[0]
+        return float(threshold_str.replace("k", "")) * (
+            1000 if "k" in threshold_str else 1
+        )
+    except (IndexError, ValueError):
+        return None
+
+
 def _get_token_base_cost(
     model_info: ModelInfo, usage: Usage, service_tier: Optional[str] = None
 ) -> Tuple[float, float, float, float, float]:
@@ -256,15 +266,19 @@ def _get_token_base_cost(
 
     # Only sort the threshold keys (typically 1-2 keys instead of 66+)
     threshold: Optional[float] = None
-    for key in sorted(threshold_keys, reverse=True):
+    for key in sorted(
+        threshold_keys,
+        key=lambda k: _get_token_cost_threshold(k) or -1,
+        reverse=True,
+    ):
         value = model_info.get(key)
         if value is not None:
             try:
                 # Handle both formats: _above_128k_tokens and _above_128_tokens
                 threshold_str = key.split("_above_")[1].split("_tokens")[0]
-                threshold = float(threshold_str.replace("k", "")) * (
-                    1000 if "k" in threshold_str else 1
-                )
+                threshold = _get_token_cost_threshold(key)
+                if threshold is None:
+                    continue
                 if usage.prompt_tokens > threshold:
                     # Prefer a service_tier-specific above-threshold key when available,
                     # e.g. input_cost_per_token_priority_above_200k_tokens for Gemini

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -1301,6 +1301,29 @@ def test_log_context_cost_calculation():
     print(f"  - Total: ${result:.6f}")
 
 
+def test_token_tier_thresholds_sort_by_numeric_value():
+    from litellm.litellm_core_utils.llm_cost_calc.utils import _get_token_base_cost
+
+    model_info = {
+        "input_cost_per_token": 1e-6,
+        "output_cost_per_token": 2e-6,
+        "input_cost_per_token_above_90k_tokens": 5e-6,
+        "input_cost_per_token_above_128k_tokens": 9e-6,
+        "output_cost_per_token_above_90k_tokens": 7e-6,
+        "output_cost_per_token_above_128k_tokens": 11e-6,
+    }
+    usage = Usage(
+        prompt_tokens=150_000,
+        completion_tokens=10,
+        total_tokens=150_010,
+    )
+
+    prompt_cost, completion_cost, *_ = _get_token_base_cost(model_info, usage)
+
+    assert prompt_cost == 9e-6
+    assert completion_cost == 11e-6
+
+
 def test_gemini_25_explicit_caching_cost_direct_usage():
     """
     Test that Gemini 2.5 models correctly calculate costs with explicit caching.

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -1324,6 +1324,20 @@ def test_token_tier_thresholds_sort_by_numeric_value():
     assert completion_cost == 11e-6
 
 
+def test_token_cost_threshold_parses_supported_formats():
+    from litellm.litellm_core_utils.llm_cost_calc.utils import (
+        _get_token_cost_threshold,
+    )
+
+    assert (
+        _get_token_cost_threshold("input_cost_per_token_above_128k_tokens")
+        == 128_000
+    )
+    assert _get_token_cost_threshold("input_cost_per_token_above_128_tokens") == 128
+    assert _get_token_cost_threshold("input_cost_per_token_above_many_tokens") is None
+    assert _get_token_cost_threshold("input_cost_per_token") is None
+
+
 def test_gemini_25_explicit_caching_cost_direct_usage():
     """
     Test that Gemini 2.5 models correctly calculate costs with explicit caching.


### PR DESCRIPTION
## Problem

Tiered token-cost keys are currently sorted as raw strings before selecting the highest crossed threshold. With mixed-width thresholds like `90k` and `128k`, string ordering visits the 90k key first, so a 150k-token request can use the lower tier and stop before the 128k tier is considered.

Fixes #30345.

## Fix

Parse the threshold value from each tier key and sort threshold keys by that numeric value before applying the first crossed tier. Malformed tier keys still fall through without changing the existing fallback behavior.

## Test

- `uvx --from uv==0.10.9 uv run pytest tests/test_litellm/test_cost_calculator.py -k token_tier_thresholds_sort_by_numeric_value -q`
- `git diff --check`

## Risk

Low. This only changes the ordering used when multiple above-threshold token pricing keys are present. Single-threshold models and models without tiered pricing keep the same path.