### PR TITLE
fix(cost): apply service_tier suffix to above-threshold cache rates and expose priority+threshold keys in ModelInfo

### DIFF
--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -327,33 +327,30 @@ def _get_token_base_cost(
                         else f"cache_read_input_token_cost_above_{threshold_str}_tokens"
                     )
 
-                    if cache_creation_tiered_key in model_info:
-                        cache_creation_cost = cast(
-                            float,
-                            _get_cost_per_unit(
-                                model_info,
-                                cache_creation_tiered_key,
-                                cache_creation_cost,
-                            ),
-                        )
+                    cache_creation_cost = cast(
+                        float,
+                        _get_cost_per_unit(
+                            model_info,
+                            cache_creation_tiered_key,
+                            cache_creation_cost,
+                        ),
+                    )
 
-                    if cache_creation_1hr_tiered_key in model_info:
-                        cache_creation_cost_above_1hr = cast(
-                            float,
-                            _get_cost_per_unit(
-                                model_info,
-                                cache_creation_1hr_tiered_key,
-                                cache_creation_cost_above_1hr,
-                            ),
-                        )
+                    cache_creation_cost_above_1hr = cast(
+                        float,
+                        _get_cost_per_unit(
+                            model_info,
+                            cache_creation_1hr_tiered_key,
+                            cache_creation_cost_above_1hr,
+                        ),
+                    )
 
-                    if cache_read_tiered_key in model_info:
-                        cache_read_cost = cast(
-                            float,
-                            _get_cost_per_unit(
-                                model_info, cache_read_tiered_key, cache_read_cost
-                            ),
-                        )
+                    cache_read_cost = cast(
+                        float,
+                        _get_cost_per_unit(
+                            model_info, cache_read_tiered_key, cache_read_cost
+                        ),
+                    )
 
                     break
             except (IndexError, ValueError):

--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -303,11 +303,28 @@ def _get_token_base_cost(
 
                     # Apply tiered pricing to cache costs
                     cache_creation_tiered_key = (
-                        f"cache_creation_input_token_cost_above_{threshold_str}_tokens"
+                        _get_service_tier_cost_key(
+                            f"cache_creation_input_token_cost_above_{threshold_str}_tokens",
+                            service_tier,
+                        )
+                        if service_tier
+                        else f"cache_creation_input_token_cost_above_{threshold_str}_tokens"
                     )
-                    cache_creation_1hr_tiered_key = f"cache_creation_input_token_cost_above_1hr_above_{threshold_str}_tokens"
+                    cache_creation_1hr_tiered_key = (
+                        _get_service_tier_cost_key(
+                            f"cache_creation_input_token_cost_above_1hr_above_{threshold_str}_tokens",
+                            service_tier,
+                        )
+                        if service_tier
+                        else f"cache_creation_input_token_cost_above_1hr_above_{threshold_str}_tokens"
+                    )
                     cache_read_tiered_key = (
-                        f"cache_read_input_token_cost_above_{threshold_str}_tokens"
+                        _get_service_tier_cost_key(
+                            f"cache_read_input_token_cost_above_{threshold_str}_tokens",
+                            service_tier,
+                        )
+                        if service_tier
+                        else f"cache_read_input_token_cost_above_{threshold_str}_tokens"
                     )
 
                     if cache_creation_tiered_key in model_info:

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -196,7 +196,9 @@ class ModelInfoBase(ProviderSpecificModelInfo, total=False):
         float
     ]  # OpenAI priority service tier pricing
     cache_read_input_token_cost_above_200k_tokens: Optional[float]
+    cache_read_input_token_cost_above_200k_tokens_priority: Optional[float]
     cache_read_input_token_cost_above_272k_tokens: Optional[float]
+    cache_read_input_token_cost_above_272k_tokens_priority: Optional[float]
     cache_read_input_token_cost_above_512k_tokens: Optional[float]
     input_cost_per_character: Optional[float]  # only for vertex ai models
     input_cost_per_audio_token: Optional[float]
@@ -204,9 +206,11 @@ class ModelInfoBase(ProviderSpecificModelInfo, total=False):
     input_cost_per_token_above_200k_tokens: Optional[
         float
     ]  # only for vertex ai gemini-2.5-pro models
+    input_cost_per_token_above_200k_tokens_priority: Optional[float]
     input_cost_per_token_above_272k_tokens: Optional[
         float
     ]  # GPT-5.4/5.4-pro: prompts >272K priced at 2x input
+    input_cost_per_token_above_272k_tokens_priority: Optional[float]
     input_cost_per_token_above_512k_tokens: Optional[
         float
     ]  # MiniMax-M3: prompts >512K priced at 2x input
@@ -240,9 +244,11 @@ class ModelInfoBase(ProviderSpecificModelInfo, total=False):
     output_cost_per_token_above_200k_tokens: Optional[
         float
     ]  # only for vertex ai gemini-2.5-pro models
+    output_cost_per_token_above_200k_tokens_priority: Optional[float]
     output_cost_per_token_above_272k_tokens: Optional[
         float
     ]  # GPT-5.4/5.4-pro: prompts >272K priced at 1.5x output
+    output_cost_per_token_above_272k_tokens_priority: Optional[float]
     output_cost_per_token_above_512k_tokens: Optional[
         float
     ]  # MiniMax-M3: prompts >512K priced at 2x output
@@ -3093,6 +3099,8 @@ class CustomPricingLiteLLMParams(BaseModel):
     cache_read_input_token_cost_flex: Optional[float] = None
     cache_read_input_token_cost_priority: Optional[float] = None
     cache_read_input_token_cost_above_200k_tokens: Optional[float] = None
+    cache_read_input_token_cost_above_200k_tokens_priority: Optional[float] = None
+    cache_read_input_token_cost_above_272k_tokens_priority: Optional[float] = None
     cache_read_input_audio_token_cost: Optional[float] = None
     input_cost_per_character: Optional[float] = None
     input_cost_per_character_above_128k_tokens: Optional[float] = None
@@ -3100,6 +3108,8 @@ class CustomPricingLiteLLMParams(BaseModel):
     input_cost_per_token_cache_hit: Optional[float] = None
     input_cost_per_token_above_128k_tokens: Optional[float] = None
     input_cost_per_token_above_200k_tokens: Optional[float] = None
+    input_cost_per_token_above_200k_tokens_priority: Optional[float] = None
+    input_cost_per_token_above_272k_tokens_priority: Optional[float] = None
     input_cost_per_query: Optional[float] = None
     input_cost_per_image: Optional[float] = None
     input_cost_per_image_above_128k_tokens: Optional[float] = None
@@ -3117,6 +3127,8 @@ class CustomPricingLiteLLMParams(BaseModel):
     output_cost_per_audio_token: Optional[float] = None
     output_cost_per_token_above_128k_tokens: Optional[float] = None
     output_cost_per_token_above_200k_tokens: Optional[float] = None
+    output_cost_per_token_above_200k_tokens_priority: Optional[float] = None
+    output_cost_per_token_above_272k_tokens_priority: Optional[float] = None
     output_cost_per_character_above_128k_tokens: Optional[float] = None
     output_cost_per_image: Optional[float] = None
     output_cost_per_image_token: Optional[float] = None

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -6028,8 +6028,14 @@ def _get_model_info_helper(  # noqa: PLR0915
                 cache_read_input_token_cost_above_200k_tokens=_model_info.get(
                     "cache_read_input_token_cost_above_200k_tokens", None
                 ),
+                cache_read_input_token_cost_above_200k_tokens_priority=_model_info.get(
+                    "cache_read_input_token_cost_above_200k_tokens_priority", None
+                ),
                 cache_read_input_token_cost_above_272k_tokens=_model_info.get(
                     "cache_read_input_token_cost_above_272k_tokens", None
+                ),
+                cache_read_input_token_cost_above_272k_tokens_priority=_model_info.get(
+                    "cache_read_input_token_cost_above_272k_tokens_priority", None
                 ),
                 cache_read_input_token_cost_above_512k_tokens=_model_info.get(
                     "cache_read_input_token_cost_above_512k_tokens", None
@@ -6052,8 +6058,14 @@ def _get_model_info_helper(  # noqa: PLR0915
                 input_cost_per_token_above_200k_tokens=_model_info.get(
                     "input_cost_per_token_above_200k_tokens", None
                 ),
+                input_cost_per_token_above_200k_tokens_priority=_model_info.get(
+                    "input_cost_per_token_above_200k_tokens_priority", None
+                ),
                 input_cost_per_token_above_272k_tokens=_model_info.get(
                     "input_cost_per_token_above_272k_tokens", None
+                ),
+                input_cost_per_token_above_272k_tokens_priority=_model_info.get(
+                    "input_cost_per_token_above_272k_tokens_priority", None
                 ),
                 input_cost_per_token_above_512k_tokens=_model_info.get(
                     "input_cost_per_token_above_512k_tokens", None
@@ -6110,8 +6122,14 @@ def _get_model_info_helper(  # noqa: PLR0915
                 output_cost_per_token_above_200k_tokens=_model_info.get(
                     "output_cost_per_token_above_200k_tokens", None
                 ),
+                output_cost_per_token_above_200k_tokens_priority=_model_info.get(
+                    "output_cost_per_token_above_200k_tokens_priority", None
+                ),
                 output_cost_per_token_above_272k_tokens=_model_info.get(
                     "output_cost_per_token_above_272k_tokens", None
+                ),
+                output_cost_per_token_above_272k_tokens_priority=_model_info.get(
+                    "output_cost_per_token_above_272k_tokens_priority", None
                 ),
                 output_cost_per_token_above_512k_tokens=_model_info.get(
                     "output_cost_per_token_above_512k_tokens", None

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
@@ -1573,3 +1573,35 @@ def test_data_residency_composes_with_service_tier(_local_model_cost_map):
 
     assert priority_base_total > 0
     assert priority_eu_total == pytest.approx(priority_base_total * 1.10, rel=1e-9)
+
+
+def test_priority_service_tier_above_threshold_uses_priority_tier_rates_for_cached_tokens(
+    _local_model_cost_map,
+):
+    """Regression: for a model that publishes both service_tier and above_threshold rate
+    variants, a priority request over the threshold must bill cached tokens at
+    cache_read_input_token_cost_above_200k_tokens_priority (and analogously for
+    input/output above-threshold), not the standard above-threshold rate."""
+    usage = Usage(
+        prompt_tokens=250_000,
+        completion_tokens=1_000,
+        total_tokens=251_000,
+        prompt_tokens_details=PromptTokensDetailsWrapper(
+            cached_tokens=200_000, text_tokens=50_000
+        ),
+        completion_tokens_details=CompletionTokensDetailsWrapper(text_tokens=1_000),
+    )
+
+    prompt_cost, completion_cost = generic_cost_per_token(
+        model="gemini-3-pro-preview",
+        usage=usage,
+        custom_llm_provider="gemini",
+        service_tier="priority",
+    )
+
+    # gemini-3-pro-preview priority + above_200k rates from the pricing JSON:
+    #   input  7.2e-6, output 3.24e-5, cache_read 7.2e-7
+    expected_prompt = 50_000 * 7.2e-6 + 200_000 * 7.2e-7
+    expected_completion = 1_000 * 3.24e-5
+    assert prompt_cost == pytest.approx(expected_prompt, rel=1e-9)
+    assert completion_cost == pytest.approx(expected_completion, rel=1e-9)

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
@@ -1605,3 +1605,40 @@ def test_priority_service_tier_above_threshold_uses_priority_tier_rates_for_cach
     expected_completion = 1_000 * 3.24e-5
     assert prompt_cost == pytest.approx(expected_prompt, rel=1e-9)
     assert completion_cost == pytest.approx(expected_completion, rel=1e-9)
+
+
+def test_priority_service_tier_above_threshold_falls_back_to_standard_for_cache_creation(
+    _local_model_cost_map,
+):
+    """Regression: priority requests against models that publish standard above-threshold
+    cache_creation rates but no priority variant must fall back to the standard
+    above-threshold rate, not the priority-base rate. vertex_ai/claude-sonnet-4-5
+    has cache_creation_input_token_cost_above_200k_tokens but no _priority sibling."""
+    usage = Usage(
+        prompt_tokens=350_000,
+        completion_tokens=1_000,
+        total_tokens=351_000,
+        prompt_tokens_details=PromptTokensDetailsWrapper(
+            cached_tokens=200_000,
+            cache_creation_tokens=100_000,
+            text_tokens=50_000,
+        ),
+        completion_tokens_details=CompletionTokensDetailsWrapper(text_tokens=1_000),
+    )
+
+    prompt_cost, completion_cost = generic_cost_per_token(
+        model="vertex_ai/claude-sonnet-4-5",
+        usage=usage,
+        custom_llm_provider="vertex_ai",
+        service_tier="priority",
+    )
+
+    # vertex_ai/claude-sonnet-4-5 above_200k (no _priority variants):
+    #   input 6e-6, output 2.25e-5, cache_read 6e-7, cache_creation 7.5e-6
+    # text                  50_000  * 6e-6   = 0.30
+    # cache_read           200_000  * 6e-7   = 0.12
+    # cache_creation       100_000  * 7.5e-6 = 0.75
+    expected_prompt = 50_000 * 6e-6 + 200_000 * 6e-7 + 100_000 * 7.5e-6
+    expected_completion = 1_000 * 2.25e-5
+    assert prompt_cost == pytest.approx(expected_prompt, rel=1e-9)
+    assert completion_cost == pytest.approx(expected_completion, rel=1e-9)


### PR DESCRIPTION
## Relevant issues

None filed; surfacing the bug and the fix together.

## Linear ticket

n/a (external contributor)

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes the affected unit tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Delays in PR merge?

Will ping `#pr-review` on Slack if review takes more than a few days.

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link: pending
- [ ] **CI run for the last commit**
       Link: pending
- [ ] **Merge / cherry-pick CI run**
       Links: pending

## Screenshots / Proof of Fix

The end-user-visible symptom is a wrong dollar number in cost reports. The cleanest way to show the before/after without burning real Gemini priority credits is to run `generic_cost_per_token` directly with the live pricing JSON loaded; that is the exact function the proxy and the SDK both call to populate spend logs. Same number that would show up under a curl of `/v1/chat/completions` against a real provider.

Commands; copy-paste reproducible against `litellm_internal_staging`:

```bash
git checkout litellm_internal_staging
python -c "
from litellm.types.utils import Usage, PromptTokensDetailsWrapper, CompletionTokensDetailsWrapper
from litellm.litellm_core_utils.llm_cost_calc.utils import generic_cost_per_token
usage = Usage(
    prompt_tokens=250000, completion_tokens=1000, total_tokens=251000,
    prompt_tokens_details=PromptTokensDetailsWrapper(cached_tokens=200000, text_tokens=50000),
    completion_tokens_details=CompletionTokensDetailsWrapper(text_tokens=1000),
)
p, c = generic_cost_per_token('gemini-3-pro-preview', usage, 'gemini', service_tier='priority')
print(f'prompt={p:.6f} completion={c:.6f} total={p+c:.6f}')
"
```

Before the fix:

```
prompt=0.280000 completion=0.018000 total=0.298000
```

After applying this branch:

```
prompt=0.504000 completion=0.032400 total=0.536400
```

Expected per the pricing JSON (`gemini-3-pro-preview` priority + `_above_200k_tokens` rates: input `7.2e-6`, output `3.24e-5`, cache_read `7.2e-7`):

```
50_000 * 7.2e-6 + 200_000 * 7.2e-7  = 0.504000  (prompt)
 1_000 * 3.24e-5                    = 0.032400  (completion)
                                      0.536400  (total)
```

The before-fix total under-charges the priority request by 44 percent. Happy to also run this through a live proxy + real Gemini key on request; flagging only because cost calc is locally deterministic from the usage block.

## Type

🐛 Bug Fix

## Changes

Two stacked defects cause priority+above-threshold requests to bill cached tokens at the standard above-threshold rate instead of the priority above-threshold rate. Affected entries in the live pricing JSON include `gemini-3-pro-preview`, `gemini-3.1-pro-preview` and their `vertex_ai/` and `gemini/` variants, plus `azure/gpt-5.4` and `azure_ai/gpt-5.4`.

**Defect 1 (`ModelInfoBase` + `get_model_info`).** `ModelInfoBase` in `litellm/types/utils.py`, the `ModelInfo` pydantic class in the same file and the `get_model_info` construction in `litellm/utils.py` enumerate `_above_200k_tokens`, `_above_272k_tokens` and `_priority` cost keys separately, but no `_above_*_tokens_priority` keys. So the priority+above-threshold rates never reach `model_info` and the cost calculator cannot see them. This PR adds the six keys that the live pricing JSON actually publishes today: `input_cost_per_token_above_200k_tokens_priority`, `input_cost_per_token_above_272k_tokens_priority`, `output_cost_per_token_above_200k_tokens_priority`, `output_cost_per_token_above_272k_tokens_priority`, `cache_read_input_token_cost_above_200k_tokens_priority`, `cache_read_input_token_cost_above_272k_tokens_priority`.

**Defect 2 (`_get_token_base_cost`).** In `litellm/litellm_core_utils/llm_cost_calc/utils.py`, the cache_creation, cache_creation_1hr and cache_read tiered keys are built as plain `f"...above_{threshold_str}_tokens"`. The sibling input and output tiered keys above and below them are already wrapped with `_get_service_tier_cost_key` when `service_tier` is set. The change here applies that same wrapping to the three cache keys, so a priority request reads the priority above-threshold cache rate when present and falls back to the standard above-threshold rate (via `_get_cost_per_unit`'s existing service_tier fallback) when not.

## Regression test

`tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py::test_priority_service_tier_above_threshold_uses_priority_tier_rates_for_cached_tokens` drives the real `generic_cost_per_token` path against the live pricing JSON entry for `gemini-3-pro-preview` and asserts the priority above_200k rates are picked. Confirmed to fail on `litellm_internal_staging` before the source changes and pass after, so it would catch a regression of either defect in isolation.
