### PR TITLE
fix(bedrock): recognize Claude Opus 4.8 in claude_4_5 cache TTL predicate

### DIFF
--- a/litellm/llms/bedrock/common_utils.py
+++ b/litellm/llms/bedrock/common_utils.py
@@ -681,6 +681,10 @@ def is_claude_4_5_on_bedrock(model: str) -> bool:
         "opus_4.7",
         "opus-4-7",
         "opus_4_7",
+        "opus-4.8",
+        "opus_4.8",
+        "opus-4-8",
+        "opus_4_8",
     ]
     return any(pattern in model_lower for pattern in claude_4_5_patterns)
 

--- a/tests/test_litellm/llms/bedrock/test_bedrock_common_utils.py
+++ b/tests/test_litellm/llms/bedrock/test_bedrock_common_utils.py
@@ -263,3 +263,42 @@ def test_bundled_bedrock_opus_model_info_declares_output_config_effort_ceiling(
     model_info = GetModelCostMap.load_local_model_cost_map()[model]
 
     assert model_info["bedrock_output_config_effort_ceiling"] == expected_ceiling
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "anthropic.claude-opus-4-8",
+        "anthropic.claude-opus-4-8-v1:0",
+        "us.anthropic.claude-opus-4-8",
+        "us.anthropic.claude-opus-4-8-v1:0",
+        "eu.anthropic.claude-opus-4-8",
+        "global.anthropic.claude-opus-4-8",
+        "bedrock/converse/us.anthropic.claude-opus-4-8",
+        "bedrock/invoke/us.anthropic.claude-opus-4-8",
+        "claude-opus-4.8",
+        "claude_opus_4_8",
+        "CLAUDE-OPUS-4-8",
+    ],
+)
+def test_is_claude_4_5_on_bedrock_recognises_opus_4_8(model):
+    from litellm.llms.bedrock.common_utils import is_claude_4_5_on_bedrock
+
+    assert is_claude_4_5_on_bedrock(model) is True
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "anthropic.claude-3-sonnet",
+        "anthropic.claude-opus-4",
+        "us.anthropic.claude-opus-4-4",
+        "us.anthropic.claude-opus-4-9",
+        "anthropic.claude-haiku-4-8",
+        "anthropic.claude-sonnet-4-8",
+    ],
+)
+def test_is_claude_4_5_on_bedrock_does_not_overmatch(model):
+    from litellm.llms.bedrock.common_utils import is_claude_4_5_on_bedrock
+
+    assert is_claude_4_5_on_bedrock(model) is False


### PR DESCRIPTION
## Relevant issues

None filed; surfaces a gap left by #29204, which registered Opus 4.8 across providers but did not extend the Bedrock cache TTL predicate.

## Linear ticket

N/A (external contributor)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code) — see note in Screenshots / Proof of Fix
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run** — Link:
- [ ] **CI run for the last commit** — Link:
- [ ] **Merge / cherry-pick CI run** — Links:

## Screenshots / Proof of Fix

The fix is exercised against a local proxy hitting real AWS Bedrock with the `us.anthropic.claude-opus-4-8` cross-region inference profile. The system block requests a 1h ephemeral cache; the response usage block reveals which TTL bucket Bedrock actually used.

Start the proxy (single Bedrock model entry pointing at the inference profile, plus an Anthropic master key for auth):

```bash
litellm --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log
```

First request after the proxy starts (cold cache; >2048 input tokens to satisfy Bedrock's Opus prompt-caching minimum):

```bash
curl -s http://localhost:4000/v1/messages \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer sk-1234" \
  -H "anthropic-version: 2023-06-01" \
  -d '{
    "model": "bedrock/invoke/us.anthropic.claude-opus-4-8",
    "max_tokens": 16,
    "system": [
      {"type":"text","text":"<<2048+ tokens of stable preamble>>","cache_control":{"type":"ephemeral","ttl":"1h"}}
    ],
    "messages": [{"role":"user","content":"ping"}]
  }' | jq .usage
```

**Before this PR:** the response shows `cache_creation.ephemeral_5m_input_tokens` taking the full block and `ephemeral_1h_input_tokens: 0`, because `_sanitize_cache_control` drops the `ttl` key when `is_claude_4_5_on_bedrock(model)` returns `False`.

**After this PR:** the same request returns `ephemeral_1h_input_tokens: <full block>` and `ephemeral_5m_input_tokens: 0`, confirming the 1h bucket is used. A second identical request within the hour returns `cache_read_input_tokens: <full block>` with both creation buckets at 0, confirming the 1h cached entry is read back.

### Note on `make test-unit` and `make lint`

Both fail on the current `litellm_internal_staging` HEAD **before** this PR is applied, on issues unrelated to this change:

- **`make test-unit`** aborts during pytest collection because `tests/test_litellm/models/test_models.py` and `tests/test_litellm/proxy/client/test_models.py` share the basename `test_models` and neither directory has an `__init__.py`, so xdist's import-mode trips an "import file mismatch" error.
- **`make lint`** fails because thirteen files under `enterprise/litellm_enterprise/` are not Black-clean against the version pinned in this repo's environment.

Both failures reproduce on the parent commit `2655d1dd5e` with no PR changes applied, so they are tracked as pre-existing repo state, not regressions from this fix.

The test added in this PR was run directly with:

```bash
uv run pytest tests/test_litellm/llms/bedrock/test_bedrock_common_utils.py -v
```

All 34 tests pass; `black --check`, `ruff check`, and `mypy --ignore-missing-imports` are clean on both files touched by this PR.

## Type

🐛 Bug Fix

## Changes

`is_claude_4_5_on_bedrock` in `litellm/llms/bedrock/common_utils.py` decides whether `cache_control.ttl` (`"5m"` / `"1h"`) is preserved on Bedrock requests. It is consumed by:

- The Converse path in `converse_transformation.py` for system and message cache points and `parallel_tool_use_config` merging
- The Invoke `/v1/messages` path in `anthropic_claude3_transformation.py` for system-block TTL gating
- `add_cache_point_tool_block` in `factory.py` for tool-block caching

Its pattern list ended at opus-4-7, so Opus 4.8 traffic silently fell back to the default 5m bucket even after PR #29204 registered the model in `BEDROCK_CONVERSE_MODELS`, the cost map, and the setup wizard.

This PR appends `opus-4.8`, `opus_4.8`, `opus-4-8`, `opus_4_8` to `claude_4_5_patterns`, mirroring the four-variant style already used for 4.5, 4.6, and 4.7. No call sites change; the closure in `is_claude_4_5_on_bedrock` references the local list, so every consumer picks up the addition without further edits.

## Tests

Tests live in `tests/test_litellm/llms/bedrock/test_bedrock_common_utils.py` (the parallel-path mirror of `litellm/llms/bedrock/common_utils.py`, per the repo's `tests/test_litellm/readme.md` convention). Two parametrized test functions are added:

- **Positive set** — all four written forms, the bare and `-v1:0`-suffixed Bedrock IDs, the `us.` / `eu.` / `global.` cross-region inference prefixes, the `bedrock/converse/` and `bedrock/invoke/` route prefixes, and an uppercase variant to guard the `model.lower()` normalization
- **Negative set** — predicate stays narrow against adjacent versions (`opus-4-4`, `opus-4-9`) and same-version-different-family IDs (`haiku-4-8`, `sonnet-4-8`)

All eleven positive cases were verified to fail before this fix, so the regression set fails on any future revert of the pattern addition.