### PR TITLE
fix(presidio): don't mask the live request when guardrail is logging_only

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -741,6 +741,17 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
 
         For multiple messages in /chat/completions, we'll need to call them in parallel.
         """
+        # Respect the configured event hook. In `logging_only` mode (and any config that
+        # excludes pre_call) the live request must not be masked - masking is applied to a
+        # copy at logging time via `async_logging_hook`. Without this gate the request sent
+        # to the model would carry anonymization tokens and the response would echo them.
+        if (
+            self.should_run_guardrail(
+                data=data, event_type=GuardrailEventHooks.pre_call
+            )
+            is not True
+        ):
+            return data
 
         try:
             content_safety = data.get("content_safety", None)

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
@@ -585,6 +585,50 @@ async def test_logging_hook_multiple_content_items(presidio_guardrail):
 
 
 @pytest.mark.asyncio
+async def test_logging_only_does_not_mask_pre_call_request(
+    mock_user_api_key, mock_cache
+):
+    """
+    A guardrail configured with `logging_only` must only mask PII for logs/traces,
+    never for the request sent to the model. `async_pre_call_hook` should leave the
+    request untouched so the model receives (and replies based on) the real input.
+
+    Regression test for the case where the pre-call hook masked the live request,
+    causing the model's response to contain anonymization tokens (e.g. <PERSON>)
+    instead of the real output.
+    """
+    presidio_guardrail = _OPTIONAL_PresidioPIIMasking(
+        mock_testing=True,
+        logging_only=True,
+        pii_entities_config={PiiEntityType.PHONE_NUMBER: PiiAction.MASK},
+    )
+
+    async def mock_check_pii(text, output_parse_pii, presidio_config, request_data):
+        return text.replace("555-123-4567", "[PHONE]")
+
+    presidio_guardrail.check_pii = mock_check_pii
+
+    original_text = "My phone is 555-123-4567"
+    test_data = {
+        "messages": [{"role": "user", "content": original_text}],
+        "model": "gpt-4",
+    }
+
+    result = await presidio_guardrail.async_pre_call_hook(
+        user_api_key_dict=mock_user_api_key,
+        cache=mock_cache,
+        data=test_data,
+        call_type="completion",
+    )
+
+    # The live request must be unchanged: PII reaches the model intact.
+    assert result["messages"][0]["content"] == original_text
+    assert "[PHONE]" not in result["messages"][0]["content"]
+
+    print("✓ logging_only leaves the pre-call request unmasked")
+
+
+@pytest.mark.asyncio
 async def test_presidio_sets_guardrail_information_in_request_data():
     """
     Test that Presidio populates guardrail information into request_data metadata.


### PR DESCRIPTION
## Relevant issues

Closes #30447

## Type

🐛 Bug Fix

## Changes

A Presidio guardrail configured with `mode: logging_only` was masking the live request, not just the logged copy. `async_pre_call_hook` ran the anonymizer on `data["messages"]` unconditionally, so the model received masked input and its reply came back full of tokens like `<PERSON>` / `<DATE_TIME>` instead of the real text.

The hook now gates on `should_run_guardrail(data, GuardrailEventHooks.pre_call)`, the same guard every other guardrail (bedrock, aporia, lakera, noma, …) already uses. In `logging_only` mode the event hook is `logging_only`, so the gate returns early and the request is left untouched. PII masking for observability still runs via `async_logging_hook`. Default masking guardrails (`event_hook=None`) and `output_parse_pii` / `apply_to_output` are unaffected — the gate returns `True` for them.

## Testing

Added `test_logging_only_does_not_mask_pre_call_request` asserting the pre-call request is unchanged in `logging_only` mode. Full `test_presidio.py` suite (64 tests) and `test_presidio_union_fix.py` pass; `mypy` clean on the changed file.
