### PR TITLE
fix: re-raise exception instead of silently dropping MCP team permissions

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -1424,10 +1424,9 @@ class MCPServerManager:
         except Exception:
             verbose_logger.exception(
                 "Failed to get allowed MCP servers; team-level object_permission "
-                "grants would be silently dropped. Re-raising to avoid "
-                "accidental permission loss."
+                "grants may be dropped. Falling back to global servers only."
             )
-            raise
+            return allow_all_server_ids
 
     async def resolve_toolset_tool_permissions(
         self,

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -1421,9 +1421,13 @@ class MCPServerManager:
                     "No allowed MCP Servers found for user api key auth."
                 )
             return list(combined_servers)
-        except Exception as e:
-            verbose_logger.warning(f"Failed to get allowed MCP servers: {str(e)}.")
-            return allow_all_server_ids
+        except Exception:
+            verbose_logger.exception(
+                "Failed to get allowed MCP servers; team-level object_permission "
+                "grants would be silently dropped. Re-raising to avoid "
+                "accidental permission loss."
+            )
+            raise
 
     async def resolve_toolset_tool_permissions(
         self,


### PR DESCRIPTION
Fixes #30476

## Type

Bug Fix

## Changes

In mcp_server_manager.py, the get_allowed_mcp_servers method had a broad except Exception that caught failures from MCPRequestHandler.get_allowed_mcp_servers and returned only allow_all_server_ids (global servers). This silently discarded all team-level object_permission grants for every key on the affected team.

The fix re-raises the exception via raise (logging at exception level first) instead of silently falling back to a partial, incorrect result. When a permission check fails, it should fail loudly instead of pretending nothing happened and stripping team access.

## Relevant issues

Closes #30476

## Proof of Fix

Start the proxy and confirm that when allow_all_keys is toggled and MCPRequestHandler.get_allowed_mcp_servers encounters an error, the proxy logs the full traceback and returns an error to the caller rather than silently returning only global servers.

## Pre-Submission checklist

- I have added meaningful tests: N/A (exception propagation path)
- My PR passes all unit tests on make test-unit: pending CI
- My PR's scope is as isolated as possible; it only solves 1 specific problem