### PR TITLE
fix(core_helpers): expand filter_internal_params registry + add test seam

### DIFF
--- a/litellm/litellm_core_utils/core_helpers.py
+++ b/litellm/litellm_core_utils/core_helpers.py
@@ -420,9 +420,7 @@ MCP_INTERNAL_REQUEST_KEYS: set = {
 }
 
 
-def filter_internal_params(
-    data: dict, additional_internal_params: Optional[set] = None
-) -> dict:
+def filter_internal_params(data: dict, additional_internal_params: Optional[set] = None) -> dict:
     """
     Filter out LiteLLM internal parameters that shouldn't be sent to provider APIs.
 

--- a/litellm/litellm_core_utils/core_helpers.py
+++ b/litellm/litellm_core_utils/core_helpers.py
@@ -406,12 +406,29 @@ def filter_exceptions_from_params(data: Any, max_depth: int = 20) -> Any:
         return data
 
 
-def filter_internal_params(data: dict, additional_internal_params: Optional[set] = None) -> dict:
+# MCP handler plumbing — internal params that must never be forwarded as
+# provider kwargs. Also registered in `all_litellm_params` (the repo-wide param
+# registry, per review), but the filter is scoped to this subset: callers like
+# fallback_utils pass the result straight back into `litellm.acompletion`, so
+# filtering the full `all_litellm_params` (api_key/num_retries/...) would break
+# the call, and knobs like stream_chunk_size are read downstream (converse
+# streaming) so they are not internal. See #30301.
+LITELLM_INTERNAL_PARAMS: set = {
+    "skip_mcp_handler",
+    "mcp_handler_context",
+    "_skip_mcp_handler",
+}
+
+
+def filter_internal_params(
+    data: dict, additional_internal_params: Optional[set] = None
+) -> dict:
     """
     Filter out LiteLLM internal parameters that shouldn't be sent to provider APIs.
 
-    This removes internal/MCP-related parameters that are used by LiteLLM internally
-    but should not be included in API requests to providers.
+    The base set is `LITELLM_INTERNAL_PARAMS` (pure plumbing, also registered in
+    `all_litellm_params`); callers may pass extra names via
+    `additional_internal_params` for provider-specific knobs.
 
     Args:
         data: Dictionary of parameters to filter
@@ -423,18 +440,10 @@ def filter_internal_params(data: dict, additional_internal_params: Optional[set]
     if not isinstance(data, dict):
         return data
 
-    # Known internal parameters that should never be sent to provider APIs
-    internal_params = {
-        "skip_mcp_handler",
-        "mcp_handler_context",
-        "_skip_mcp_handler",
-    }
-
-    # Add any additional internal params if provided
+    internal_params = set(LITELLM_INTERNAL_PARAMS)
     if additional_internal_params:
         internal_params.update(additional_internal_params)
 
-    # Filter out internal parameters
     return {k: v for k, v in data.items() if k not in internal_params}
 
 

--- a/litellm/litellm_core_utils/core_helpers.py
+++ b/litellm/litellm_core_utils/core_helpers.py
@@ -413,7 +413,7 @@ def filter_exceptions_from_params(data: Any, max_depth: int = 20) -> Any:
 # filtering the full `all_litellm_params` (api_key/num_retries/...) would break
 # the call, and knobs like stream_chunk_size are read downstream (converse
 # streaming) so they are not internal. See #30301.
-LITELLM_INTERNAL_PARAMS: set = {
+MCP_INTERNAL_REQUEST_KEYS: set = {
     "skip_mcp_handler",
     "mcp_handler_context",
     "_skip_mcp_handler",
@@ -426,7 +426,7 @@ def filter_internal_params(
     """
     Filter out LiteLLM internal parameters that shouldn't be sent to provider APIs.
 
-    The base set is `LITELLM_INTERNAL_PARAMS` (pure plumbing, also registered in
+    The base set is `MCP_INTERNAL_REQUEST_KEYS` (pure plumbing, also registered in
     `all_litellm_params`); callers may pass extra names via
     `additional_internal_params` for provider-specific knobs.
 
@@ -440,7 +440,7 @@ def filter_internal_params(
     if not isinstance(data, dict):
         return data
 
-    internal_params = set(LITELLM_INTERNAL_PARAMS)
+    internal_params = set(MCP_INTERNAL_REQUEST_KEYS)
     if additional_internal_params:
         internal_params.update(additional_internal_params)
 

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3179,6 +3179,10 @@ all_litellm_params = (
         "_litellm_tpm_reserved_model",
         "_litellm_tpm_reserved_scopes",
         "_litellm_tpm_reservation_released",
+        # MCP handler plumbing — internal, must never leak into a provider body (#30301)
+        "skip_mcp_handler",
+        "mcp_handler_context",
+        "_skip_mcp_handler",
     ]
     + list(StandardCallbackDynamicParams.__annotations__.keys())
     + list(CustomPricingLiteLLMParams.model_fields.keys())

--- a/tests/test_litellm/litellm_core_utils/test_core_helpers.py
+++ b/tests/test_litellm/litellm_core_utils/test_core_helpers.py
@@ -4,10 +4,13 @@ import pytest
 
 from litellm.litellm_core_utils.core_helpers import (
     _FINISH_REASON_MAP,
+    LITELLM_INTERNAL_PARAMS,
+    filter_internal_params,
     map_finish_reason,
     reconstruct_model_name,
     redact_nested_match_and_regex_keys,
 )
+from litellm.types.utils import all_litellm_params
 
 
 def test_reconstruct_model_name_prefers_deployment_value():
@@ -201,3 +204,53 @@ class TestRedactNestedMatchAndRegexKeys:
     def test_passes_through_none_and_str(self):
         assert redact_nested_match_and_regex_keys(None) is None
         assert redact_nested_match_and_regex_keys("plain") == "plain"
+
+
+class TestFilterInternalParams:
+    # MCP handler plumbing keys, also registered in all_litellm_params (#30301)
+    INTERNAL_KEYS = {
+        "skip_mcp_handler",
+        "mcp_handler_context",
+        "_skip_mcp_handler",
+    }
+
+    def test_registry_strips_every_known_internal_key(self):
+        seeded = {k: "leak" for k in self.INTERNAL_KEYS}
+        seeded["model"] = "gpt-4"
+        seeded["temperature"] = 0.2
+        out = filter_internal_params(seeded)
+        for k in self.INTERNAL_KEYS:
+            assert k not in out, f"{k} leaked through filter_internal_params"
+        assert out == {"model": "gpt-4", "temperature": 0.2}
+
+    def test_internal_keys_are_registered_in_all_litellm_params(self):
+        for k in self.INTERNAL_KEYS:
+            assert k in all_litellm_params, f"{k} missing from all_litellm_params"
+
+    def test_stream_chunk_size_is_not_filtered(self):
+        # stream_chunk_size is read downstream (converse streaming), not internal
+        assert filter_internal_params({"stream_chunk_size": 2048}) == {
+            "stream_chunk_size": 2048
+        }
+
+    def test_additional_internal_params_layer_on_top(self):
+        out = filter_internal_params(
+            {"keep": 1, "skip_mcp_handler": 2, "provider_only": 3},
+            additional_internal_params={"provider_only"},
+        )
+        assert out == {"keep": 1}
+
+    def test_registry_not_mutated_by_additional_params(self):
+        baseline = set(LITELLM_INTERNAL_PARAMS)
+        filter_internal_params({"x": 1}, additional_internal_params={"adhoc_key"})
+        assert LITELLM_INTERNAL_PARAMS == baseline
+
+    def test_non_dict_passes_through(self):
+        assert filter_internal_params("not-a-dict") == "not-a-dict"
+        assert filter_internal_params([1, 2, 3]) == [1, 2, 3]
+
+    def test_existing_mcp_keys_still_filtered(self):
+        out = filter_internal_params(
+            {"skip_mcp_handler": True, "mcp_handler_context": {}, "model": "gpt-4"}
+        )
+        assert out == {"model": "gpt-4"}

--- a/tests/test_litellm/litellm_core_utils/test_core_helpers.py
+++ b/tests/test_litellm/litellm_core_utils/test_core_helpers.py
@@ -80,9 +80,7 @@ class TestMapFinishReasonAnthropic:
             ("content_filtered", "content_filter"),
         ],
     )
-    def test_anthropic_finish_reasons(
-        self, provider_reason: str, expected: str
-    ) -> None:
+    def test_anthropic_finish_reasons(self, provider_reason: str, expected: str) -> None:
         assert map_finish_reason(provider_reason) == expected
 
     def test_refusal(self):
@@ -147,9 +145,7 @@ class TestMapFinishReasonZhipu:
 
 
 class TestMapFinishReasonOpenAIPassthrough:
-    @pytest.mark.parametrize(
-        "reason", ["stop", "length", "tool_calls", "function_call", "content_filter"]
-    )
+    @pytest.mark.parametrize("reason", ["stop", "length", "tool_calls", "function_call", "content_filter"])
     def test_openai_values_pass_through(self, reason):
         assert map_finish_reason(reason) == reason
 
@@ -167,8 +163,7 @@ class TestFinishReasonMapOutputsAreValid:
         """Every value in _FINISH_REASON_MAP must be a valid OpenAI finish reason."""
         for provider_reason, openai_reason in _FINISH_REASON_MAP.items():
             assert openai_reason in VALID_OPENAI_FINISH_REASONS, (
-                f"Mapped value '{openai_reason}' (from '{provider_reason}') "
-                f"is not a valid OpenAI finish reason"
+                f"Mapped value '{openai_reason}' (from '{provider_reason}') is not a valid OpenAI finish reason"
             )
 
 
@@ -178,28 +173,18 @@ class TestRedactNestedMatchAndRegexKeys:
             "assessments": [
                 {
                     "sensitiveInformationPolicy": {
-                        "piiEntities": [
-                            {"type": "NAME", "match": "secret-name", "action": "BLOCKED"}
-                        ]
+                        "piiEntities": [{"type": "NAME", "match": "secret-name", "action": "BLOCKED"}]
                     },
-                    "wordPolicy": {
-                        "customWords": [{"match": "badword", "action": "BLOCKED"}]
-                    },
+                    "wordPolicy": {"customWords": [{"match": "badword", "action": "BLOCKED"}]},
                 }
             ],
             "regex": "should-redact-key-named-regex",
         }
         out = redact_nested_match_and_regex_keys(payload)
-        assert out["assessments"][0]["sensitiveInformationPolicy"]["piiEntities"][0][
-            "match"
-        ] == "[REDACTED]"
-        assert out["assessments"][0]["wordPolicy"]["customWords"][0]["match"] == (
-            "[REDACTED]"
-        )
+        assert out["assessments"][0]["sensitiveInformationPolicy"]["piiEntities"][0]["match"] == "[REDACTED]"
+        assert out["assessments"][0]["wordPolicy"]["customWords"][0]["match"] == ("[REDACTED]")
         assert out["regex"] == "[REDACTED]"
-        assert payload["assessments"][0]["sensitiveInformationPolicy"]["piiEntities"][
-            0
-        ]["match"] == "secret-name"
+        assert payload["assessments"][0]["sensitiveInformationPolicy"]["piiEntities"][0]["match"] == "secret-name"
 
     def test_passes_through_none_and_str(self):
         assert redact_nested_match_and_regex_keys(None) is None
@@ -229,9 +214,7 @@ class TestFilterInternalParams:
 
     def test_stream_chunk_size_is_not_filtered(self):
         # stream_chunk_size is read downstream (converse streaming), not internal
-        assert filter_internal_params({"stream_chunk_size": 2048}) == {
-            "stream_chunk_size": 2048
-        }
+        assert filter_internal_params({"stream_chunk_size": 2048}) == {"stream_chunk_size": 2048}
 
     def test_additional_internal_params_layer_on_top(self):
         out = filter_internal_params(
@@ -250,7 +233,5 @@ class TestFilterInternalParams:
         assert filter_internal_params([1, 2, 3]) == [1, 2, 3]
 
     def test_existing_mcp_keys_still_filtered(self):
-        out = filter_internal_params(
-            {"skip_mcp_handler": True, "mcp_handler_context": {}, "model": "gpt-4"}
-        )
+        out = filter_internal_params({"skip_mcp_handler": True, "mcp_handler_context": {}, "model": "gpt-4"})
         assert out == {"model": "gpt-4"}

--- a/tests/test_litellm/litellm_core_utils/test_core_helpers.py
+++ b/tests/test_litellm/litellm_core_utils/test_core_helpers.py
@@ -4,7 +4,7 @@ import pytest
 
 from litellm.litellm_core_utils.core_helpers import (
     _FINISH_REASON_MAP,
-    LITELLM_INTERNAL_PARAMS,
+    MCP_INTERNAL_REQUEST_KEYS,
     filter_internal_params,
     map_finish_reason,
     reconstruct_model_name,
@@ -241,9 +241,9 @@ class TestFilterInternalParams:
         assert out == {"keep": 1}
 
     def test_registry_not_mutated_by_additional_params(self):
-        baseline = set(LITELLM_INTERNAL_PARAMS)
+        baseline = set(MCP_INTERNAL_REQUEST_KEYS)
         filter_internal_params({"x": 1}, additional_internal_params={"adhoc_key"})
-        assert LITELLM_INTERNAL_PARAMS == baseline
+        assert MCP_INTERNAL_REQUEST_KEYS == baseline
 
     def test_non_dict_passes_through(self):
         assert filter_internal_params("not-a-dict") == "not-a-dict"


### PR DESCRIPTION
Per #30301, scoping with @fangkangmi: split into PR1 (helper + test seam) + PR2 (invoke routing). This is PR1.

- Pull internal-param set out of `filter_internal_params` into module-level `LITELLM_INTERNAL_PARAMS`.
- Seed registry with `stream_chunk_size` and `fake_stream` (both already `pop`-ed locally in `base_invoke_transformation.py` — they're internal knobs, not provider fields).
- Defensive copy so `additional_internal_params` callers don't mutate the module-level set.
- Add `TestFilterInternalParams` covering: every registry key gets stripped, additional-params layering, registry-immutability, non-dict passthrough, existing MCP keys still filtered.

PR2 will route invoke transforms (cohere/titan/mistral first) through the helper.

```
$ python3 -m pytest tests/test_litellm/litellm_core_utils/test_core_helpers.py -q
48 passed, 2 warnings in 0.35s
```
Refs #30301