### PR TITLE
fix(streaming): guard raise_on_model_repetition against empty choices

### DIFF
--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -295,6 +295,12 @@ class CustomStreamWrapper:
         if len(self.chunks) < 2:
             return
 
+        # Providers like Vertex Gemini (Flash / Flash Lite with web search) emit
+        # metadata-only / usage-only chunks with no choices. These get stored in
+        # self.chunks but carry no comparable content, so skip repetition detection.
+        if not self.chunks[-1].choices or not self.chunks[-2].choices:
+            return
+
         last_content = self.chunks[-1].choices[0].delta.content
 
         if (

--- a/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
@@ -1509,6 +1509,44 @@ def test_raise_on_model_repetition(
             wrapper.raise_on_model_repetition()
 
 
+@pytest.mark.parametrize(
+    "empty_chunk_index",
+    [-1, -2],
+    ids=["last_chunk_empty", "second_to_last_chunk_empty"],
+)
+def test_raise_on_model_repetition_tolerates_empty_choices(
+    initialized_custom_stream_wrapper: CustomStreamWrapper,
+    empty_chunk_index: int,
+):
+    """
+    Regression test for https://github.com/BerriAI/litellm/issues/28884
+
+    Vertex Gemini Flash / Flash Lite with web search streaming emits
+    metadata-only and usage-only chunks that carry no choices. These are
+    appended to self.chunks, and raise_on_model_repetition() previously
+    accessed choices[0] unconditionally, raising IndexError mid-stream
+    (surfaced to users as MidStreamFallbackError -> APIConnectionError).
+    """
+    wrapper = initialized_custom_stream_wrapper
+
+    chunks = [
+        _make_chunk("hello world"),
+        ModelResponseStream(
+            id="usage-only",
+            created=1741037890,
+            model="vertex_ai/gemini-3.1-flash-lite",
+            choices=[],
+            usage=Usage(prompt_tokens=10, completion_tokens=0, total_tokens=10),
+        ),
+    ]
+    if empty_chunk_index == -2:
+        chunks.append(_make_chunk("hello world again"))
+
+    for chunk in chunks:
+        wrapper.chunks.append(chunk)
+        wrapper.raise_on_model_repetition()
+
+
 def test_usage_chunk_after_finish_reason_updates_hidden_params(logging_obj):
     """
     Test that provider-reported usage from a post-finish_reason chunk


### PR DESCRIPTION
Resolves LIT-3776

Relevant issues
Fixes mid-stream IndexError: list index out of range for Vertex Gemini Flash / Flash Lite streaming with web_search_options (related: #28884)

Type
Bug Fix

Cause
Vertex Gemini Flash and Flash Lite with web_search_options={} + stream=True emit metadata-only and usage-only SSE chunks that have no streamable delta. With stream_options={"include_usage": True}, those chunks are stored in CustomStreamWrapper.chunks with choices=[].

Later, when a real content chunk arrives, return_processed_chunk_logic() calls raise_on_model_repetition(), which unconditionally reads self.chunks[-1].choices[0] and self.chunks[-2].choices[0]. If either historical chunk has empty choices, LiteLLM raises IndexError, which surfaces to callers as APIConnectionError / MidStreamFallbackError.

Gemini Pro is less affected because its streaming shape rarely inserts these empty-choice chunks before content arrives.

Fix
Add an early return in raise_on_model_repetition() when either of the last two stored chunks has empty choices. Repetition detection only needs comparable text content; metadata/usage chunks should be skipped. This matches the existing empty-choices guard already used in _has_special_delta_content().

Changes
litellm/litellm_core_utils/streaming_handler.py: guard before accessing choices[0] on historical chunks
tests/test_litellm/litellm_core_utils/test_streaming_handler.py: regression test test_raise_on_model_repetition_tolerates_empty_choices (parametrized for empty chunk at -1 and -2)

Run this e2e test:

```
import asyncio
import os
from litellm import acompletion, completion
MODELS = [
    "vertex_ai/gemini-3.1-flash-lite-preview",
    "vertex_ai/gemini-3.1-flash-lite",
    "vertex_ai/gemini-3-flash-preview",
]
PROMPT = "Search the web and summarize the latest news about OpenAI."
COMMON = dict(
    messages=[{"role": "user", "content": PROMPT}],
    stream=True,
    web_search_options={},
    stream_options={"include_usage": True},
    vertex_project=os.environ.get("VERTEXAI_PROJECT"),
    vertex_location=os.environ.get("VERTEXAI_LOCATION", "global"),
    vertex_credentials=os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"),
)
async def repro_async() -> None:
    for model in MODELS:
        print(f"\n=== {model} (async) ===")
        try:
            response = await acompletion(model=model, **COMMON)
            async for chunk in response:
                print(chunk)
            print("OK")
        except Exception as e:
            print(f"FAILED: {type(e).__name__}: {e}")
def repro_sync() -> None:
    model = MODELS[0]
    print(f"\n=== {model} (sync) ===")
    response = completion(model=model, **COMMON)
    for chunk in response:
        print(chunk)
if __name__ == "__main__":
    asyncio.run(repro_async())
```

Before: list index out of range
<img width="553" height="383" alt="Screenshot 2026-06-15 at 2 46 58 PM" src="https://github.com/user-attachments/assets/f4e2805f-3b42-40b2-a2a4-edeafa5060db" />

After: Streaming finishes
<img width="561" height="348" alt="Screenshot 2026-06-15 at 2 45 50 PM" src="https://github.com/user-attachments/assets/58f2a955-c7a5-4df1-aa8e-0c32310f928d" />
