### PR TITLE
fix(anthropic): drop orphaned server_tool_use on multi-turn replay from generic OpenAI clients

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -1967,27 +1967,35 @@ def convert_to_anthropic_tool_invoke(
         # Check if this is a server-side tool (web_search, tool_search, etc.)
         # Server tool IDs start with "srvtoolu_"
         if tool_id.startswith("srvtoolu_"):
-            # Create server_tool_use block instead of tool_use
-            _anthropic_server_tool_use: Dict[str, Any] = {
-                "type": "server_tool_use",
-                "id": tool_id,
-                "name": tool_name,
-                "input": tool_input,
-            }
-            anthropic_tool_invoke.append(_anthropic_server_tool_use)
-
-            # Add corresponding tool result if available.
-            # Check both web_search_results (web_search_tool_result / web_fetch_tool_result)
-            # and tool_results (bash_code_execution_tool_result, etc.)
+            # A server_tool_use block MUST be immediately followed by its matching
+            # *_tool_result block, or Anthropic rejects the request. The result is
+            # carried in provider_specific_fields (web_search_results / tool_results)
+            # — see PRs #17746 / #17798. A generic OpenAI client that does NOT
+            # round-trip provider_specific_fields (e.g. Open WebUI) drops it on
+            # replay, leaving no result to pair. In that case emit neither a bare
+            # server_tool_use here nor a user tool_result for the same id (see the
+            # tool/function handling in anthropic_messages_pt) — the server-side
+            # search already shaped the assistant's text answer, and replaying an
+            # unpaired server tool turn is exactly what triggers the 400
+            # ("unexpected tool_use_id ... in tool_result blocks").
             _all_tool_results: List[Any] = []
             if web_search_results:
                 _all_tool_results.extend(web_search_results)
             if tool_results:
                 _all_tool_results.extend(tool_results)
-            for result in _all_tool_results:
-                if result.get("tool_use_id") == tool_id:
-                    anthropic_tool_invoke.append(result)
-                    break
+            _matching_tool_result = next(
+                (r for r in _all_tool_results if r.get("tool_use_id") == tool_id),
+                None,
+            )
+            if _matching_tool_result is not None:
+                _anthropic_server_tool_use: Dict[str, Any] = {
+                    "type": "server_tool_use",
+                    "id": tool_id,
+                    "name": tool_name,
+                    "input": tool_input,
+                }
+                anthropic_tool_invoke.append(_anthropic_server_tool_use)
+                anthropic_tool_invoke.append(_matching_tool_result)
         else:
             # Regular tool_use
             sanitized_tool_id = _sanitize_anthropic_tool_use_id(tool_id)
@@ -2673,12 +2681,24 @@ def anthropic_messages_pt(  # noqa: PLR0915
                 user_message_types_block["role"] == "tool"
                 or user_message_types_block["role"] == "function"
             ):
-                # OpenAI's tool message content will always be a string
-                user_content.append(
-                    convert_to_anthropic_tool_result(
-                        user_message_types_block, force_base64=force_base64
+                # A generic OpenAI client (e.g. Open WebUI) emits a `tool` message
+                # for a server-side tool call (id starts with "srvtoolu_") to
+                # satisfy OpenAI's "every tool_call needs a tool result" rule.
+                # Anthropic rejects a user tool_result whose id maps to a
+                # server_tool_use (it is not a client tool_use), and the unpaired
+                # server_tool_use is already dropped in
+                # convert_to_anthropic_tool_invoke when its result didn't survive
+                # the round-trip — so skip the orphaned server-tool result here too.
+                _tc_id = user_message_types_block.get("tool_call_id")
+                if isinstance(_tc_id, str) and _tc_id.startswith("srvtoolu_"):
+                    pass
+                else:
+                    # OpenAI's tool message content will always be a string
+                    user_content.append(
+                        convert_to_anthropic_tool_result(
+                            user_message_types_block, force_base64=force_base64
+                        )
                     )
-                )
 
             msg_i += 1
 

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -2690,9 +2690,7 @@ def anthropic_messages_pt(  # noqa: PLR0915
                 # convert_to_anthropic_tool_invoke when its result didn't survive
                 # the round-trip — so skip the orphaned server-tool result here too.
                 _tc_id = user_message_types_block.get("tool_call_id")
-                if isinstance(_tc_id, str) and _tc_id.startswith("srvtoolu_"):
-                    pass
-                else:
+                if not (isinstance(_tc_id, str) and _tc_id.startswith("srvtoolu_")):
                     # OpenAI's tool message content will always be a string
                     user_content.append(
                         convert_to_anthropic_tool_result(

--- a/tests/llm_translation/test_prompt_factory.py
+++ b/tests/llm_translation/test_prompt_factory.py
@@ -1419,9 +1419,13 @@ def test_convert_to_anthropic_tool_invoke_sanitizes_invalid_ids():
     assert valid_result[0]["id"] == "toolu_01ABC-xyz_123"
 
 
-def test_convert_to_anthropic_tool_invoke_server_tool():
+def test_convert_to_anthropic_tool_invoke_server_tool_without_result_is_dropped():
     """
-    Test that server_tool_use (srvtoolu_) is reconstructed as server_tool_use.
+    A server_tool_use (srvtoolu_) whose matching *_tool_result is NOT available
+    (e.g. a generic OpenAI client dropped provider_specific_fields on replay) is
+    omitted entirely. A bare server_tool_use with no following tool_result is
+    rejected by Anthropic ("unexpected tool_use_id ... in tool_result blocks"),
+    so it must not be emitted.
 
     Fixes: https://github.com/BerriAI/litellm/issues/17737
     """
@@ -1438,11 +1442,72 @@ def test_convert_to_anthropic_tool_invoke_server_tool():
 
     result = convert_to_anthropic_tool_invoke(tool_calls)
 
-    assert len(result) == 1
-    assert result[0]["type"] == "server_tool_use"  # NOT tool_use
-    assert result[0]["id"] == "srvtoolu_01ABC123"
-    assert result[0]["name"] == "web_search"
-    assert result[0]["input"] == {"query": "elephant weight"}
+    # No web_search_results / tool_results to pair with -> drop the orphan
+    # rather than emit an invalid bare server_tool_use.
+    assert result == []
+
+
+def test_anthropic_messages_pt_generic_client_drops_orphan_server_tool():
+    """
+    A generic OpenAI client (e.g. Open WebUI) replays a prior web-search turn as
+    an assistant tool_call + a `tool` message keyed to the same srvtoolu_ id, and
+    does NOT round-trip provider_specific_fields. The transformed Anthropic
+    messages must contain neither a bare server_tool_use nor a user tool_result
+    for that id — either is rejected with "unexpected tool_use_id ... in
+    tool_result blocks". The assistant's own text answer is preserved.
+
+    Fixes: https://github.com/BerriAI/litellm/issues/17737
+    """
+    messages = [
+        {"role": "user", "content": "what's the latest news on elephants?"},
+        {
+            "role": "assistant",
+            "content": "Here's what I found about elephants...",
+            "tool_calls": [
+                {
+                    "id": "srvtoolu_01ABC123",
+                    "type": "function",
+                    "function": {
+                        "name": "web_search",
+                        "arguments": '{"query": "latest elephant news"}',
+                    },
+                }
+            ],
+            # NOTE: no provider_specific_fields — a generic OpenAI client drops it.
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "srvtoolu_01ABC123",
+            "content": "...search results...",
+        },
+        {"role": "user", "content": "tell me more"},
+    ]
+
+    result = anthropic_messages_pt(
+        messages, model="claude-sonnet-4-5", llm_provider="anthropic"
+    )
+
+    for msg in result:
+        content = msg.get("content")
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            assert block.get("type") != "server_tool_use", result
+            if block.get("type") == "tool_result":
+                assert not str(block.get("tool_use_id", "")).startswith(
+                    "srvtoolu_"
+                ), result
+
+    assistant_text = " ".join(
+        b.get("text", "")
+        for m in result
+        if m.get("role") == "assistant"
+        for b in (m.get("content") or [])
+        if isinstance(b, dict) and b.get("type") == "text"
+    )
+    assert "elephants" in assistant_text
 
 
 def test_convert_to_anthropic_tool_invoke_with_web_search_results():

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -1803,6 +1803,91 @@ def test_anthropic_messages_pt_server_tool_use_passthrough():
     assert text_block["text"] == "I found the time tool. How can I help you?"
 
 
+def test_convert_to_anthropic_tool_invoke_server_tool_dropped_without_result():
+    """
+    A server_tool_use (srvtoolu_) whose matching *_tool_result is not available
+    (a generic OpenAI client dropped provider_specific_fields on replay) must be
+    omitted: a bare server_tool_use with no following tool_result is rejected by
+    Anthropic. See https://github.com/BerriAI/litellm/issues/17737
+    """
+    from litellm.litellm_core_utils.prompt_templates.factory import (
+        convert_to_anthropic_tool_invoke,
+    )
+
+    tool_calls = [
+        {
+            "id": "srvtoolu_01ABC123",
+            "type": "function",
+            "function": {"name": "web_search", "arguments": '{"query": "x"}'},
+        }
+    ]
+
+    # No web_search_results / tool_results -> drop the orphan rather than emit a
+    # bare server_tool_use.
+    assert convert_to_anthropic_tool_invoke(tool_calls) == []
+
+
+def test_anthropic_messages_pt_drops_orphan_server_tool_from_generic_client():
+    """
+    A generic OpenAI client (e.g. Open WebUI) replays a prior web-search turn as
+    an assistant tool_call + a `tool` message both keyed to the same srvtoolu_ id,
+    without round-tripping provider_specific_fields. The transformed Anthropic
+    messages must contain neither a bare server_tool_use nor a user tool_result
+    for that id (either is rejected with "unexpected tool_use_id ... in
+    tool_result blocks"). See https://github.com/BerriAI/litellm/issues/17737
+    """
+    from litellm.litellm_core_utils.prompt_templates.factory import (
+        anthropic_messages_pt,
+    )
+
+    messages = [
+        {"role": "user", "content": "latest news on elephants?"},
+        {
+            "role": "assistant",
+            "content": "Here's what I found about elephants...",
+            "tool_calls": [
+                {
+                    "id": "srvtoolu_01ABC123",
+                    "type": "function",
+                    "function": {
+                        "name": "web_search",
+                        "arguments": '{"query": "latest elephant news"}',
+                    },
+                }
+            ],
+            # no provider_specific_fields — a generic OpenAI client drops it
+        },
+        {"role": "tool", "tool_call_id": "srvtoolu_01ABC123", "content": "...results..."},
+        {"role": "user", "content": "tell me more"},
+    ]
+
+    result = anthropic_messages_pt(
+        messages, model="claude-sonnet-4-5", llm_provider="anthropic"
+    )
+
+    for msg in result:
+        content = msg.get("content")
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            assert block.get("type") != "server_tool_use", result
+            if block.get("type") == "tool_result":
+                assert not str(block.get("tool_use_id", "")).startswith(
+                    "srvtoolu_"
+                ), result
+
+    assistant_text = " ".join(
+        b.get("text", "")
+        for m in result
+        if m.get("role") == "assistant"
+        for b in (m.get("content") or [])
+        if isinstance(b, dict) and b.get("type") == "text"
+    )
+    assert "elephants" in assistant_text
+
+
 def test_bedrock_tools_unpack_defs_no_oom_with_nested_refs():
     """
     Regression test for issue #19098: unpack_defs() causes OOM with nested tool schemas.

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -1827,6 +1827,45 @@ def test_convert_to_anthropic_tool_invoke_server_tool_dropped_without_result():
     assert convert_to_anthropic_tool_invoke(tool_calls) == []
 
 
+def test_convert_to_anthropic_tool_invoke_server_tool_paired_with_result():
+    """
+    When the matching *_tool_result IS available (provider_specific_fields was
+    preserved, e.g. the litellm SDK round-trip), the server_tool_use is emitted
+    immediately followed by its web_search_tool_result — the existing valid-pair
+    behavior is unchanged. See https://github.com/BerriAI/litellm/issues/17737
+    """
+    from litellm.litellm_core_utils.prompt_templates.factory import (
+        convert_to_anthropic_tool_invoke,
+    )
+
+    tool_calls = [
+        {
+            "id": "srvtoolu_01ABC123",
+            "type": "function",
+            "function": {"name": "web_search", "arguments": '{"query": "x"}'},
+        }
+    ]
+    web_search_results = [
+        {
+            "type": "web_search_tool_result",
+            "tool_use_id": "srvtoolu_01ABC123",
+            "content": [
+                {"type": "web_search_result", "url": "https://example.com", "title": "t"}
+            ],
+        }
+    ]
+
+    result = convert_to_anthropic_tool_invoke(
+        tool_calls, web_search_results=web_search_results
+    )
+
+    assert len(result) == 2
+    assert result[0]["type"] == "server_tool_use"
+    assert result[0]["id"] == "srvtoolu_01ABC123"
+    assert result[1]["type"] == "web_search_tool_result"
+    assert result[1]["tool_use_id"] == "srvtoolu_01ABC123"
+
+
 def test_anthropic_messages_pt_drops_orphan_server_tool_from_generic_client():
     """
     A generic OpenAI client (e.g. Open WebUI) replays a prior web-search turn as


### PR DESCRIPTION
## Relevant issues

Follow-up to #17746 / #17798 — addresses the **generic OpenAI client** (no `provider_specific_fields` round-trip) case of #17737.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

When an Anthropic server-side tool (web search, id `srvtoolu_…`) is used, its result is carried in `provider_specific_fields.web_search_results`. #17746/#17798 restore it for callers that round-trip `provider_specific_fields` (e.g. the litellm SDK).

A **generic OpenAI client that does not preserve `provider_specific_fields`** — e.g. Open WebUI talking to a Vertex/Anthropic model over `/chat/completions` — drops it on replay, and instead sends back an assistant `tool_call` **plus** a `tool` message both keyed to the `srvtoolu_` id (to satisfy OpenAI's "every tool_call needs a tool result" rule). The transform then produced:

- a **bare `server_tool_use`** with no following `*_tool_result` (the result wasn't available to pair), and
- a **user `tool_result`** for the same `srvtoolu_` id,

both of which Anthropic rejects on the next turn:

```
messages.N.content.0: unexpected `tool_use_id` found in `tool_result` blocks:
srvtoolu_vrtx_... Each `tool_result` block must have a corresponding `tool_use`
block in the previous message.
```

This is the commonly-reported `vertex_ai` symptom where **Gemini works but Claude 400s on the second turn** of a web-search chat (Gemini grounding is surfaced as OpenAI `annotations`, never a replayable `tool_call`).

### Fix — `litellm/litellm_core_utils/prompt_templates/factory.py`

- **`convert_to_anthropic_tool_invoke`**: only emit a `server_tool_use` block when its matching `*_tool_result` is available to pair with it; otherwise skip it. A bare `server_tool_use` is itself invalid, and the server-side search already shaped the assistant's text answer.
- **`anthropic_messages_pt`**: drop a replayed `tool`/`function` message whose `tool_call_id` starts with `srvtoolu_` — a server-executed tool produces no client result, so a user `tool_result` for it is invalid.

The existing reconstruction path (when `provider_specific_fields.web_search_results` **is** present, e.g. the litellm SDK) is **unchanged**, as is ordinary client `tool_use`/`tool_result` handling. The fix is provider-agnostic and lives entirely in the OpenAI `/chat/completions` → Anthropic message transform; the native `/v1/messages` passthrough is not touched.

### Tests — `tests/llm_translation/test_prompt_factory.py`

- Updated `test_convert_to_anthropic_tool_invoke_server_tool` → `test_convert_to_anthropic_tool_invoke_server_tool_without_result_is_dropped` (a `srvtoolu_` call with no available result is now dropped, not emitted bare).
- Added `test_anthropic_messages_pt_generic_client_drops_orphan_server_tool` (end-to-end: assistant `srvtoolu_` `tool_call` + a `tool` message, **no** `provider_specific_fields` → no bare `server_tool_use`, no orphaned `tool_result`, assistant text preserved).

## Screenshots / Proof of Fix

Targeted prompt-factory tests (server-tool / web-search / generic-client) pass against this branch:

```
$ pytest tests/llm_translation/test_prompt_factory.py \
    -k "server_tool or web_search_results or generic_client or tool_results or mixed_tools or with_server_tool_use" -q
9 passed, 65 deselected
```
