### PR TITLE
fix(ui): use dynamic proxy base URL in MCP usage examples

### DIFF
--- a/ui/litellm-dashboard/src/components/public_model_hub.tsx
+++ b/ui/litellm-dashboard/src/components/public_model_hub.tsx
@@ -11,6 +11,7 @@ import Navbar from "./navbar";
 import {
   agentHubPublicModelsCall,
   skillHubPublicCall,
+  getProxyBaseUrl,
   getPublicModelHubInfo,
   getUiConfig,
   mcpHubPublicServersCall,
@@ -1929,7 +1930,7 @@ import asyncio
 config = {
     "mcpServers": {
         "${selectedMcpServer.server_name}": {
-            "url": "http://localhost:4000/${selectedMcpServer.server_name}/mcp",
+            "url": "${getProxyBaseUrl()}/${selectedMcpServer.server_name}/mcp",
             "headers": {
                 "x-litellm-api-key": "Bearer sk-1234"
             }
@@ -1969,7 +1970,7 @@ import asyncio
 config = {
     "mcpServers": {
         "${selectedMcpServer.server_name}": {
-            "url": "http://localhost:4000/${selectedMcpServer.server_name}/mcp",
+            "url": "${getProxyBaseUrl()}/${selectedMcpServer.server_name}/mcp",
             "headers": {
                 "x-litellm-api-key": "Bearer sk-1234"
             }


### PR DESCRIPTION
## Relevant issues

Fixes #30466

## Pre-Submission checklist

- [ ] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

This is a UI change. To verify:

1. Start the proxy with `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload`
2. Open http://localhost:4000/ui -> Model Hub -> MCP Hub tab
3. Click any MCP server to open the details modal
4. Check the "Usage Example" code snippet and click "Copy to clipboard"
5. Before this fix, the URL was always hardcoded to `http://localhost:4000/...` regardless of where the proxy is hosted
6. After this fix, the URL dynamically reflects the actual proxy base URL

## Type

Bug Fix

## Changes

The MCP server usage example in `public_model_hub.tsx` hardcodes `http://localhost:4000` as the base URL for the MCP server configuration snippet. This breaks for any non-local deployment (containers, remote servers, production).

Replaced the hardcoded URL with `getProxyBaseUrl()` (already exported from `networking.tsx` and used throughout the dashboard) in both the display snippet and the copy-to-clipboard snippet