### PR TITLE
fix(proxy): apply default_team_params.models on team creation

### DIFF
--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -1043,6 +1043,14 @@ async def new_team(  # noqa: PLR0915
                 if default_value is not None:
                     setattr(data, field, default_value)
 
+        # `models` defaults to an empty list rather than None on the request, so it
+        # needs its own check: apply the configured default when the request did not
+        # specify any models (matches SSO-provisioned team behavior).
+        if not getattr(data, "models", None):
+            default_models = _get_default_team_param("models")
+            if default_models is not None:
+                data.models = default_models
+
         # Legacy fallback: apply max_budget from default_team_settings (YAML config)
         # if still not set after checking default_team_params.
         if data.max_budget is None:

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -1010,6 +1010,31 @@ async def new_team(  # noqa: PLR0915
                     },
                 )
 
+        # Apply defaults from litellm.default_team_params for any fields
+        # not explicitly provided in the request. This runs before the org
+        # limit checks below so inherited defaults (e.g. models) are validated
+        # against the organization's allowlist like explicit values.
+        for field in (
+            "max_budget",
+            "budget_duration",
+            "tpm_limit",
+            "rpm_limit",
+            "team_member_permissions",
+        ):
+            if getattr(data, field, None) is None:
+                default_value = _get_default_team_param(field)
+                if default_value is not None:
+                    setattr(data, field, default_value)
+
+        # `models` defaults to an empty list rather than None on the request, so
+        # use model_fields_set to distinguish "field omitted" (apply the default,
+        # matching SSO-provisioned team behavior) from an explicit `models: []`
+        # (meaning unrestricted access, which must be preserved).
+        if "models" not in data.model_fields_set:
+            default_models = _get_default_team_param("models")
+            if default_models is not None:
+                data.models = default_models
+
         # check org key limits - done here to handle inheriting org id from team
         if data.organization_id is not None and prisma_client is not None:
             org_table = await get_org_object(
@@ -1028,28 +1053,6 @@ async def new_team(  # noqa: PLR0915
                 data=data,
                 prisma_client=prisma_client,
             )
-
-        # Apply defaults from litellm.default_team_params for any fields
-        # not explicitly provided in the request.
-        for field in (
-            "max_budget",
-            "budget_duration",
-            "tpm_limit",
-            "rpm_limit",
-            "team_member_permissions",
-        ):
-            if getattr(data, field, None) is None:
-                default_value = _get_default_team_param(field)
-                if default_value is not None:
-                    setattr(data, field, default_value)
-
-        # `models` defaults to an empty list rather than None on the request, so it
-        # needs its own check: apply the configured default when the request did not
-        # specify any models (matches SSO-provisioned team behavior).
-        if not getattr(data, "models", None):
-            default_models = _get_default_team_param("models")
-            if default_models is not None:
-                data.models = default_models
 
         # Legacy fallback: apply max_budget from default_team_settings (YAML config)
         # if still not set after checking default_team_params.

--- a/tests/test_litellm/proxy/management_endpoints/test_team_default_params.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_default_params.py
@@ -343,6 +343,32 @@ class TestNewTeamDefaultParamsApplied:
         assert data.models == ["claude-3-5-sonnet"]
 
     @pytest.mark.asyncio
+    async def test_models_explicit_empty_list_not_overridden(self, monkeypatch):
+        """An explicit `models: []` means unrestricted access and must be preserved,
+        distinguished from an omitted field via model_fields_set."""
+        from litellm.proxy.management_endpoints.team_endpoints import new_team
+
+        monkeypatch.setattr(
+            litellm,
+            "default_team_params",
+            {"models": ["gpt-4"]},
+        )
+
+        data = NewTeamRequest(team_alias="my-team", models=[])
+        auth = self._make_admin_auth()
+
+        try:
+            await new_team(
+                data=data,
+                user_api_key_dict=auth,
+                http_request=MagicMock(),
+            )
+        except Exception:
+            pass
+
+        assert data.models == []
+
+    @pytest.mark.asyncio
     async def test_no_defaults_when_config_is_none(self, monkeypatch):
         """When default_team_params is None, no defaults applied."""
         from litellm.proxy.management_endpoints.team_endpoints import new_team

--- a/tests/test_litellm/proxy/management_endpoints/test_team_default_params.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_default_params.py
@@ -289,6 +289,60 @@ class TestNewTeamDefaultParamsApplied:
         assert data.rpm_limit == 500  # default applied
 
     @pytest.mark.asyncio
+    async def test_models_default_applied_when_not_provided(self, monkeypatch):
+        """default_team_params.models applies to teams created without models (#30478).
+
+        `models` defaults to an empty list rather than None, so it is not covered
+        by the None-guard loop and needs its own handling.
+        """
+        from litellm.proxy.management_endpoints.team_endpoints import new_team
+
+        monkeypatch.setattr(
+            litellm,
+            "default_team_params",
+            {"models": ["gpt-4", "gpt-3.5-turbo"]},
+        )
+
+        data = NewTeamRequest(team_alias="my-team")  # models defaults to []
+        auth = self._make_admin_auth()
+
+        try:
+            await new_team(
+                data=data,
+                user_api_key_dict=auth,
+                http_request=MagicMock(),
+            )
+        except Exception:
+            pass
+
+        assert data.models == ["gpt-4", "gpt-3.5-turbo"]
+
+    @pytest.mark.asyncio
+    async def test_models_explicit_not_overridden(self, monkeypatch):
+        """Explicit models on the request are not overridden by the default."""
+        from litellm.proxy.management_endpoints.team_endpoints import new_team
+
+        monkeypatch.setattr(
+            litellm,
+            "default_team_params",
+            {"models": ["gpt-4"]},
+        )
+
+        data = NewTeamRequest(team_alias="my-team", models=["claude-3-5-sonnet"])
+        auth = self._make_admin_auth()
+
+        try:
+            await new_team(
+                data=data,
+                user_api_key_dict=auth,
+                http_request=MagicMock(),
+            )
+        except Exception:
+            pass
+
+        assert data.models == ["claude-3-5-sonnet"]
+
+    @pytest.mark.asyncio
     async def test_no_defaults_when_config_is_none(self, monkeypatch):
         """When default_team_params is None, no defaults applied."""
         from litellm.proxy.management_endpoints.team_endpoints import new_team


### PR DESCRIPTION
`new_team` applies `default_team_params` only for fields whose request default is `None` (`max_budget`, `tpm_limit`, etc.). The `models` field on `NewTeamRequest` defaults to an empty list rather than `None`, so it was never covered by the None-guard loop and `default_team_params.models` was silently dropped for teams created via API / SCIM / UI — it only took effect on the SSO path.

This adds a dedicated check that applies the configured default when the request specifies no models, leaving explicit values untouched. Adds unit tests for the default-applied and explicit-not-overridden cases. Fixes #30478.