### PR TITLE
fix(containers): let teams opt into team-visible code-interpreter containers

### DIFF
--- a/litellm/proxy/common_utils/resource_ownership.py
+++ b/litellm/proxy/common_utils/resource_ownership.py
@@ -93,9 +93,9 @@ def user_can_access_resource_owner(
 
 
 def user_can_access_resource_owner_or_team(
-    owner: Optional[str],
-    resource_team_id: Optional[str],
-    user_api_key_dict: Optional[UserAPIKeyAuth],
+    owner: str | None,
+    resource_team_id: str | None,
+    user_api_key_dict: UserAPIKeyAuth | None,
 ) -> bool:
     """Owner-scope access, widened to members of a team the resource is
     shared with. ``resource_team_id`` is only set when the creator opted the

--- a/litellm/proxy/common_utils/resource_ownership.py
+++ b/litellm/proxy/common_utils/resource_ownership.py
@@ -90,3 +90,21 @@ def user_can_access_resource_owner(
     if owner is None:
         return False
     return owner in get_resource_owner_scopes(user_api_key_dict)
+
+
+def user_can_access_resource_owner_or_team(
+    owner: Optional[str],
+    resource_team_id: Optional[str],
+    user_api_key_dict: Optional[UserAPIKeyAuth],
+) -> bool:
+    """Owner-scope access, widened to members of a team the resource is
+    shared with. ``resource_team_id`` is only set when the creator opted the
+    resource into team visibility, so a private resource (``resource_team_id``
+    None) falls back to owner-only access and the team branch never widens it.
+    This is what lets a team's service account (whose only scope is
+    ``team:<id>``) read a container a teammate created."""
+    if user_can_access_resource_owner(owner, user_api_key_dict):
+        return True
+    if user_api_key_dict is None or not resource_team_id:
+        return False
+    return f"team:{resource_team_id}" in get_resource_owner_scopes(user_api_key_dict)

--- a/litellm/proxy/container_endpoints/ownership.py
+++ b/litellm/proxy/container_endpoints/ownership.py
@@ -176,7 +176,7 @@ async def record_container_owners_from_responses_response(
             )
 
 
-def _resolve_container_team_id(user_api_key_dict: UserAPIKeyAuth) -> Optional[str]:
+def _resolve_container_team_id(user_api_key_dict: UserAPIKeyAuth) -> str | None:
     """Return the team to share a newly-created container with, or ``None`` to
     keep it private to its creator. A container is team-visible only when the
     creator belongs to a team whose metadata opts in
@@ -295,7 +295,7 @@ async def record_container_owner(
 
 async def _get_container_owner_and_team(
     original_container_id: str, custom_llm_provider: str
-) -> Tuple[Optional[str], Optional[str]]:
+) -> tuple[str | None, str | None]:
     """Return ``(created_by, team_id)`` for a container in a single DB read.
 
     Both values live on the same row, so the access check fetches them together
@@ -347,7 +347,7 @@ async def _get_container_owner_and_team(
 
 async def _get_container_owner(
     original_container_id: str, custom_llm_provider: str
-) -> Optional[str]:
+) -> str | None:
     owner, _ = await _get_container_owner_and_team(
         original_container_id, custom_llm_provider
     )
@@ -477,7 +477,7 @@ async def _get_allowed_container_ids(
     # A caller sees containers they own (created_by in their scopes) plus any
     # team-visible container shared with their team. ``owner_scopes`` already
     # varies by team, so the cache key stays correct.
-    where_filter: Dict[str, Any] = {"file_purpose": CONTAINER_OBJECT_PURPOSE}
+    where_filter: dict[str, Any] = {"file_purpose": CONTAINER_OBJECT_PURPOSE}
     caller_team_id = getattr(user_api_key_dict, "team_id", None)
     if caller_team_id:
         where_filter["OR"] = [

--- a/litellm/proxy/container_endpoints/ownership.py
+++ b/litellm/proxy/container_endpoints/ownership.py
@@ -10,7 +10,7 @@ from litellm.proxy.common_utils.resource_ownership import (
     get_primary_resource_owner_scope,
     get_resource_owner_scopes,
     is_proxy_admin,
-    user_can_access_resource_owner,
+    user_can_access_resource_owner_or_team,
 )
 from litellm.repositories.table_repositories import ManagedObjectRepository
 from litellm.responses.utils import ResponsesAPIRequestUtils
@@ -30,6 +30,13 @@ _CONTAINER_OWNER_CACHE = InMemoryCache(max_size_in_memory=10000, default_ttl=60)
 # re-hitting Prisma on every retrieve/delete.
 _NEGATIVE_STORED_ID_SENTINEL = "__litellm_container_no_stored_id__"
 _CONTAINER_STORED_ID_CACHE = InMemoryCache(max_size_in_memory=10000, default_ttl=60)
+
+# Caches the team a container is shared with (its ``team_id``), populated from
+# the same row fetch as the owner cache. A negative sentinel marks a private
+# container (no team), so the access check can distinguish "private" from a
+# cache miss.
+_NEGATIVE_TEAM_SENTINEL = "__litellm_container_no_team__"
+_CONTAINER_TEAM_CACHE = InMemoryCache(max_size_in_memory=10000, default_ttl=60)
 
 # Per-caller-scope cache for ``GET /v1/containers`` list filtering. Without
 # this, every list call issues a fresh ``find_many`` against
@@ -163,11 +170,25 @@ async def record_container_owners_from_responses_response(
             # batch — other containers in the same response should still
             # get recorded so their follow-up file API calls don't 403.
             verbose_proxy_logger.exception(
-                "Failed to record container ownership from responses output "
-                "for container_id=%s: %s",
+                "Failed to record container ownership from responses output for container_id=%s: %s",
                 container_id,
                 e,
             )
+
+
+def _resolve_container_team_id(user_api_key_dict: UserAPIKeyAuth) -> Optional[str]:
+    """Return the team to share a newly-created container with, or ``None`` to
+    keep it private to its creator. A container is team-visible only when the
+    creator belongs to a team whose metadata opts in
+    (``container_visibility == "team"``); this preserves the private-by-default
+    behaviour and makes team sharing an explicit team-level switch."""
+    team_id = getattr(user_api_key_dict, "team_id", None)
+    if not team_id:
+        return None
+    team_metadata = getattr(user_api_key_dict, "team_metadata", None) or {}
+    if team_metadata.get("container_visibility") == "team":
+        return team_id
+    return None
 
 
 async def record_container_owner(
@@ -214,15 +235,22 @@ async def record_container_owner(
         )
         return response
 
+    container_team_id = _resolve_container_team_id(user_api_key_dict)
     table = ManagedObjectRepository(prisma_client).table
     existing = await table.find_unique(where={"model_object_id": model_object_id})
     if existing is not None:
         if getattr(existing, "file_purpose", None) != CONTAINER_OBJECT_PURPOSE:
             raise HTTPException(status_code=500, detail="Unable to track container")
-        if not user_can_access_resource_owner(
-            getattr(existing, "created_by", None), user_api_key_dict
+        if not user_can_access_resource_owner_or_team(
+            getattr(existing, "created_by", None),
+            getattr(existing, "team_id", None),
+            user_api_key_dict,
         ):
             raise HTTPException(status_code=403, detail="Forbidden")
+        # Visibility is fixed at create time; a re-record (e.g. a colliding
+        # container id) refreshes the encoded id/object but must not silently
+        # flip an existing container's visibility, so ``team_id`` is left as-is.
+        effective_team_id = getattr(existing, "team_id", None)
         await table.update(
             where={"model_object_id": model_object_id},
             data={
@@ -232,6 +260,7 @@ async def record_container_owner(
             },
         )
     else:
+        effective_team_id = container_team_id
         await table.create(
             data={
                 "unified_object_id": container_id,
@@ -239,12 +268,16 @@ async def record_container_owner(
                 "file_object": file_object_json,
                 "file_purpose": CONTAINER_OBJECT_PURPOSE,
                 "created_by": owner,
+                "team_id": container_team_id,
                 "updated_by": owner,
             }
         )
 
     _CONTAINER_OWNER_CACHE.set_cache(model_object_id, owner)
     _CONTAINER_STORED_ID_CACHE.set_cache(model_object_id, container_id)
+    _CONTAINER_TEAM_CACHE.set_cache(
+        model_object_id, effective_team_id or _NEGATIVE_TEAM_SENTINEL
+    )
     # Drop the caller's own list-cache entry so the just-created container
     # shows up on their next ``GET /v1/containers``. Other callers with
     # disjoint scope tuples have their own entries; intersecting-scope
@@ -293,6 +326,11 @@ async def _get_container_owner(
             else _NEGATIVE_STORED_ID_SENTINEL
         ),
     )
+    team_id = getattr(row, "team_id", None) if row is not None else None
+    _CONTAINER_TEAM_CACHE.set_cache(
+        model_object_id,
+        team_id if isinstance(team_id, str) and team_id else _NEGATIVE_TEAM_SENTINEL,
+    )
     return owner
 
 
@@ -338,6 +376,40 @@ async def _get_stored_container_id(
     return stored_id if isinstance(stored_id, str) and stored_id else None
 
 
+async def _get_container_team_id(
+    original_container_id: str, custom_llm_provider: str
+) -> Optional[str]:
+    """Return the team a container is shared with, or ``None`` if it is
+    private to its creator. ``_get_container_owner`` populates this cache from
+    the same row, so calling it right after an owner lookup is a cache hit."""
+    model_object_id = _container_model_object_id(
+        original_container_id, custom_llm_provider
+    )
+
+    cached = _CONTAINER_TEAM_CACHE.get_cache(model_object_id)
+    if cached == _NEGATIVE_TEAM_SENTINEL:
+        return None
+    if isinstance(cached, str) and cached:
+        return cached
+
+    prisma_client = await _get_prisma_client()
+    if prisma_client is None:
+        return None
+
+    row = await ManagedObjectRepository(prisma_client).table.find_first(
+        where={
+            "model_object_id": model_object_id,
+            "file_purpose": CONTAINER_OBJECT_PURPOSE,
+        }
+    )
+    team_id = getattr(row, "team_id", None) if row is not None else None
+    _CONTAINER_TEAM_CACHE.set_cache(
+        model_object_id,
+        team_id if isinstance(team_id, str) and team_id else _NEGATIVE_TEAM_SENTINEL,
+    )
+    return team_id if isinstance(team_id, str) and team_id else None
+
+
 async def assert_user_can_access_container(
     container_id: str,
     user_api_key_dict: UserAPIKeyAuth,
@@ -354,7 +426,12 @@ async def assert_user_can_access_container(
     # that pre-date this enforcement need an admin to either re-create
     # via the now-tracked flow or assign ``created_by`` on the row.
     owner = await _get_container_owner(original_container_id, resolved_provider)
-    if not user_can_access_resource_owner(owner, user_api_key_dict):
+    resource_team_id = await _get_container_team_id(
+        original_container_id, resolved_provider
+    )
+    if not user_can_access_resource_owner_or_team(
+        owner, resource_team_id, user_api_key_dict
+    ):
         raise HTTPException(status_code=403, detail="Forbidden")
 
     return original_container_id, resolved_provider
@@ -412,11 +489,20 @@ async def _get_allowed_container_ids(
     if prisma_client is None:
         return set()
 
+    # A caller sees containers they own (created_by in their scopes) plus any
+    # team-visible container shared with their team. ``owner_scopes`` already
+    # varies by team, so the cache key stays correct.
+    where_filter: Dict[str, Any] = {"file_purpose": CONTAINER_OBJECT_PURPOSE}
+    caller_team_id = getattr(user_api_key_dict, "team_id", None)
+    if caller_team_id:
+        where_filter["OR"] = [
+            {"created_by": {"in": owner_scopes}},
+            {"team_id": caller_team_id},
+        ]
+    else:
+        where_filter["created_by"] = {"in": owner_scopes}
     rows = await ManagedObjectRepository(prisma_client).table.find_many(
-        where={
-            "file_purpose": CONTAINER_OBJECT_PURPOSE,
-            "created_by": {"in": owner_scopes},
-        }
+        where=where_filter
     )
     allowed_ids = {
         row.model_object_id

--- a/litellm/proxy/container_endpoints/ownership.py
+++ b/litellm/proxy/container_endpoints/ownership.py
@@ -279,9 +279,12 @@ async def record_container_owner(
         model_object_id, effective_team_id or _NEGATIVE_TEAM_SENTINEL
     )
     # Drop the caller's own list-cache entry so the just-created container
-    # shows up on their next ``GET /v1/containers``. Other callers with
-    # disjoint scope tuples have their own entries; intersecting-scope
-    # tuples self-correct on the 60s TTL.
+    # shows up on their next ``GET /v1/containers``. Teammates who can also see
+    # a team-visible container hold their own (disjoint) scope-tuple entries;
+    # those are not eagerly invalidated, so a teammate's list view can lag by up
+    # to the 60s TTL. This is a list-view freshness tradeoff only — the access
+    # check reads the per-container owner/team caches directly and is never
+    # stale in the same way.
     caller_scopes = get_resource_owner_scopes(user_api_key_dict)
     if caller_scopes:
         _ALLOWED_CONTAINER_IDS_CACHE.delete_cache(
@@ -290,22 +293,30 @@ async def record_container_owner(
     return response
 
 
-async def _get_container_owner(
+async def _get_container_owner_and_team(
     original_container_id: str, custom_llm_provider: str
-) -> Optional[str]:
+) -> Tuple[Optional[str], Optional[str]]:
+    """Return ``(created_by, team_id)`` for a container in a single DB read.
+
+    Both values live on the same row, so the access check fetches them together
+    rather than calling two helpers and relying on the second being a cache hit
+    off the first. An independent eviction of either cache entry would otherwise
+    cost a second, uncorrelated query; here a miss on either triggers exactly
+    one refetch that repopulates both (plus the stored-id cache)."""
     model_object_id = _container_model_object_id(
         original_container_id, custom_llm_provider
     )
 
-    cached = _CONTAINER_OWNER_CACHE.get_cache(model_object_id)
-    if cached == _NEGATIVE_OWNER_SENTINEL:
-        return None
-    if cached is not None:
-        return cached
+    owner_cached = _CONTAINER_OWNER_CACHE.get_cache(model_object_id)
+    team_cached = _CONTAINER_TEAM_CACHE.get_cache(model_object_id)
+    if owner_cached is not None and team_cached is not None:
+        owner = None if owner_cached == _NEGATIVE_OWNER_SENTINEL else owner_cached
+        team = None if team_cached == _NEGATIVE_TEAM_SENTINEL else team_cached
+        return owner, team
 
     prisma_client = await _get_prisma_client()
     if prisma_client is None:
-        return None
+        return None, None
 
     row = await ManagedObjectRepository(prisma_client).table.find_first(
         where={
@@ -314,10 +325,15 @@ async def _get_container_owner(
         }
     )
     owner = getattr(row, "created_by", None) if row is not None else None
+    team_id = getattr(row, "team_id", None) if row is not None else None
+    stored_id = getattr(row, "unified_object_id", None) if row is not None else None
     _CONTAINER_OWNER_CACHE.set_cache(
         model_object_id, owner if owner is not None else _NEGATIVE_OWNER_SENTINEL
     )
-    stored_id = getattr(row, "unified_object_id", None) if row is not None else None
+    _CONTAINER_TEAM_CACHE.set_cache(
+        model_object_id,
+        team_id if isinstance(team_id, str) and team_id else _NEGATIVE_TEAM_SENTINEL,
+    )
     _CONTAINER_STORED_ID_CACHE.set_cache(
         model_object_id,
         (
@@ -326,10 +342,14 @@ async def _get_container_owner(
             else _NEGATIVE_STORED_ID_SENTINEL
         ),
     )
-    team_id = getattr(row, "team_id", None) if row is not None else None
-    _CONTAINER_TEAM_CACHE.set_cache(
-        model_object_id,
-        team_id if isinstance(team_id, str) and team_id else _NEGATIVE_TEAM_SENTINEL,
+    return owner, (team_id if isinstance(team_id, str) and team_id else None)
+
+
+async def _get_container_owner(
+    original_container_id: str, custom_llm_provider: str
+) -> Optional[str]:
+    owner, _ = await _get_container_owner_and_team(
+        original_container_id, custom_llm_provider
     )
     return owner
 
@@ -376,40 +396,6 @@ async def _get_stored_container_id(
     return stored_id if isinstance(stored_id, str) and stored_id else None
 
 
-async def _get_container_team_id(
-    original_container_id: str, custom_llm_provider: str
-) -> Optional[str]:
-    """Return the team a container is shared with, or ``None`` if it is
-    private to its creator. ``_get_container_owner`` populates this cache from
-    the same row, so calling it right after an owner lookup is a cache hit."""
-    model_object_id = _container_model_object_id(
-        original_container_id, custom_llm_provider
-    )
-
-    cached = _CONTAINER_TEAM_CACHE.get_cache(model_object_id)
-    if cached == _NEGATIVE_TEAM_SENTINEL:
-        return None
-    if isinstance(cached, str) and cached:
-        return cached
-
-    prisma_client = await _get_prisma_client()
-    if prisma_client is None:
-        return None
-
-    row = await ManagedObjectRepository(prisma_client).table.find_first(
-        where={
-            "model_object_id": model_object_id,
-            "file_purpose": CONTAINER_OBJECT_PURPOSE,
-        }
-    )
-    team_id = getattr(row, "team_id", None) if row is not None else None
-    _CONTAINER_TEAM_CACHE.set_cache(
-        model_object_id,
-        team_id if isinstance(team_id, str) and team_id else _NEGATIVE_TEAM_SENTINEL,
-    )
-    return team_id if isinstance(team_id, str) and team_id else None
-
-
 async def assert_user_can_access_container(
     container_id: str,
     user_api_key_dict: UserAPIKeyAuth,
@@ -425,8 +411,7 @@ async def assert_user_can_access_container(
     # Untracked rows (no ownership) are admin-only. Pre-isolation rows
     # that pre-date this enforcement need an admin to either re-create
     # via the now-tracked flow or assign ``created_by`` on the row.
-    owner = await _get_container_owner(original_container_id, resolved_provider)
-    resource_team_id = await _get_container_team_id(
+    owner, resource_team_id = await _get_container_owner_and_team(
         original_container_id, resolved_provider
     )
     if not user_can_access_resource_owner_or_team(

--- a/tests/test_litellm/containers/test_container_proxy_ownership.py
+++ b/tests/test_litellm/containers/test_container_proxy_ownership.py
@@ -14,17 +14,17 @@ from litellm.types.containers.main import ContainerListResponse, ContainerObject
 
 @pytest.fixture(autouse=True)
 def clear_container_owner_cache():
-    for cache in (
+    caches = (
         ownership._CONTAINER_OWNER_CACHE,
+        ownership._CONTAINER_STORED_ID_CACHE,
+        ownership._CONTAINER_TEAM_CACHE,
         ownership._ALLOWED_CONTAINER_IDS_CACHE,
-    ):
+    )
+    for cache in caches:
         cache.cache_dict.clear()
         cache.ttl_dict.clear()
     yield
-    for cache in (
-        ownership._CONTAINER_OWNER_CACHE,
-        ownership._ALLOWED_CONTAINER_IDS_CACHE,
-    ):
+    for cache in caches:
         cache.cache_dict.clear()
         cache.ttl_dict.clear()
 
@@ -932,10 +932,7 @@ async def test_should_record_containers_from_responses_output_for_service_accoun
         AsyncMock(return_value=prisma_client),
     )
     auth = UserAPIKeyAuth(team_id="team-1")
-    encoded_container_id = (
-        "cntr_bGl0ZWxsbTpjdXN0b21fbGxtX3Byb3ZpZGVyOmF6dXJlO21vZGVsX2lkOmR"
-        "lZi0xMjM7Y29udGFpbmVyX2lkOmNudHJfbmF0aXZl"
-    )
+    encoded_container_id = "cntr_bGl0ZWxsbTpjdXN0b21fbGxtX3Byb3ZpZGVyOmF6dXJlO21vZGVsX2lkOmRlZi0xMjM7Y29udGFpbmVyX2lkOmNudHJfbmF0aXZl"
     responses_payload = {
         "output": [
             {
@@ -972,10 +969,7 @@ async def test_should_record_containers_from_responses_output_for_service_accoun
 async def test_service_account_can_access_container_after_responses_tracking(
     monkeypatch,
 ):
-    encoded_container_id = (
-        "cntr_bGl0ZWxsbTpjdXN0b21fbGxtX3Byb3ZpZGVyOmF6dXJlO21vZGVsX2lkOmR"
-        "lZi0xMjM7Y29udGFpbmVyX2lkOmNudHJfbmF0aXZl"
-    )
+    encoded_container_id = "cntr_bGl0ZWxsbTpjdXN0b21fbGxtX3Byb3ZpZGVyOmF6dXJlO21vZGVsX2lkOmRlZi0xMjM7Y29udGFpbmVyX2lkOmNudHJfbmF0aXZl"
     table = AsyncMock()
     table.find_unique.return_value = None
     prisma_client = SimpleNamespace(
@@ -1024,10 +1018,7 @@ async def test_should_record_container_ownership_after_streaming_responses_finis
     """
     from litellm.proxy.common_request_processing import ProxyBaseLLMRequestProcessing
 
-    encoded_container_id = (
-        "cntr_bGl0ZWxsbTpjdXN0b21fbGxtX3Byb3ZpZGVyOmF6dXJlO21vZGVsX2lkOmR"
-        "lZi0xMjM7Y29udGFpbmVyX2lkOmNudHJfbmF0aXZl"
-    )
+    encoded_container_id = "cntr_bGl0ZWxsbTpjdXN0b21fbGxtX3Byb3ZpZGVyOmF6dXJlO21vZGVsX2lkOmRlZi0xMjM7Y29udGFpbmVyX2lkOmNudHJfbmF0aXZl"
     response_body = SimpleNamespace(
         output=[
             SimpleNamespace(
@@ -1107,3 +1098,127 @@ async def test_streaming_ownership_wrap_no_op_when_stream_did_not_complete(
 
     assert chunks == ["data: chunk-1\n\n"]
     record.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Team-visibility opt-in (cross-principal access).
+#
+# Regression coverage for the Disney case: a container created by a user key
+# (owner = user_id) was unreachable by the team's service account (scope only
+# ``team:<id>``). The fix lets a creator's team opt into team visibility, which
+# stamps the container's ``team_id`` so any same-team principal can read it,
+# while keeping private-to-creator the default and preserving cross-team
+# isolation.
+# ---------------------------------------------------------------------------
+
+
+def _row(created_by, team_id, container_id="cntr_x"):
+    return SimpleNamespace(
+        created_by=created_by,
+        team_id=team_id,
+        unified_object_id=container_id,
+        file_object="{}",
+        file_purpose="container",
+    )
+
+
+def _prisma(monkeypatch, *, find_unique=None, find_first=None):
+    table = AsyncMock()
+    table.find_unique.return_value = find_unique
+    table.find_first.return_value = find_first
+    prisma_client = SimpleNamespace(
+        db=SimpleNamespace(litellm_managedobjecttable=table)
+    )
+    monkeypatch.setattr(
+        ownership, "_get_prisma_client", AsyncMock(return_value=prisma_client)
+    )
+    return table
+
+
+@pytest.mark.asyncio
+async def test_user_created_container_is_private_by_default(monkeypatch):
+    """A user whose team has NOT opted in creates a private container:
+    team_id is left unset so no teammate (or service account) inherits access."""
+    table = _prisma(monkeypatch, find_unique=None)
+    creator = UserAPIKeyAuth(user_id="alice", team_id="team-1", team_metadata={})
+
+    await ownership.record_container_owner(
+        response=_container("cntr_priv"),
+        user_api_key_dict=creator,
+        custom_llm_provider="openai",
+    )
+
+    data = table.create.call_args.kwargs["data"]
+    assert data["created_by"] == "alice"
+    assert data["team_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_team_opt_in_stamps_team_id_but_keeps_creator(monkeypatch):
+    """With the team opted in, the container is stamped with the team while
+    still recording the individual creator in created_by."""
+    table = _prisma(monkeypatch, find_unique=None)
+    creator = UserAPIKeyAuth(
+        user_id="alice",
+        team_id="team-1",
+        team_metadata={"container_visibility": "team"},
+    )
+
+    await ownership.record_container_owner(
+        response=_container("cntr_shared"),
+        user_api_key_dict=creator,
+        custom_llm_provider="openai",
+    )
+
+    data = table.create.call_args.kwargs["data"]
+    assert data["created_by"] == "alice"
+    assert data["team_id"] == "team-1"
+
+
+@pytest.mark.asyncio
+async def test_same_team_service_account_can_access_team_visible_container(monkeypatch):
+    """The Disney case, fixed: a user-created, team-visible container is
+    reachable by the team's service account (user_id=None, scope team:team-1)."""
+    _prisma(monkeypatch, find_first=_row("alice", "team-1", "cntr_shared"))
+    service_account = UserAPIKeyAuth(team_id="team-1")
+
+    original_id, provider = await ownership.assert_user_can_access_container(
+        container_id="cntr_shared",
+        user_api_key_dict=service_account,
+        custom_llm_provider="openai",
+    )
+
+    assert original_id == "cntr_shared"
+    assert provider == "openai"
+
+
+@pytest.mark.asyncio
+async def test_service_account_denied_on_private_user_container(monkeypatch):
+    """Regression guard: when the team has NOT opted in (team_id None), a
+    same-team service account is still forbidden from a user's container."""
+    _prisma(monkeypatch, find_first=_row("alice", None, "cntr_priv"))
+    service_account = UserAPIKeyAuth(team_id="team-1")
+
+    with pytest.raises(HTTPException) as exc:
+        await ownership.assert_user_can_access_container(
+            container_id="cntr_priv",
+            user_api_key_dict=service_account,
+            custom_llm_provider="openai",
+        )
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_other_team_cannot_access_team_visible_container(monkeypatch):
+    """Cross-team isolation is preserved: a service account from a different
+    team cannot read a team-visible container."""
+    _prisma(monkeypatch, find_first=_row("alice", "team-1", "cntr_shared"))
+    other_team = UserAPIKeyAuth(team_id="team-2")
+
+    with pytest.raises(HTTPException) as exc:
+        await ownership.assert_user_can_access_container(
+            container_id="cntr_shared",
+            user_api_key_dict=other_team,
+            custom_llm_provider="openai",
+        )
+    assert exc.value.status_code == 403

--- a/tests/test_litellm/containers/test_container_proxy_ownership.py
+++ b/tests/test_litellm/containers/test_container_proxy_ownership.py
@@ -1222,3 +1222,21 @@ async def test_other_team_cannot_access_team_visible_container(monkeypatch):
             custom_llm_provider="openai",
         )
     assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_access_check_reads_owner_and_team_in_one_query(monkeypatch):
+    """created_by and team_id live on one row, so a cold-cache access check
+    must issue a single query, not one per field. Guards against the owner and
+    team lookups drifting back into two independent (and separately evictable)
+    DB reads."""
+    table = _prisma(monkeypatch, find_first=_row("alice", "team-1", "cntr_one"))
+    service_account = UserAPIKeyAuth(team_id="team-1")
+
+    await ownership.assert_user_can_access_container(
+        container_id="cntr_one",
+        user_api_key_dict=service_account,
+        custom_llm_provider="openai",
+    )
+
+    assert table.find_first.await_count == 1

--- a/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
@@ -531,6 +531,7 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
           opted_out_global_guardrails: optedOutGlobalGuardrails,
           ...(values.logging_settings?.length > 0 ? { logging: values.logging_settings } : {}),
           disable_global_guardrails: killSwitchOnAtSave,
+          container_visibility: values.container_visibility ? "team" : "private",
           soft_budget_alerting_emails:
             typeof values.soft_budget_alerting_emails === "string"
               ? values.soft_budget_alerting_emails
@@ -955,6 +956,7 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
                       guardrails: effectiveGuardrails,
                       policies: info.policies || [],
                       disable_global_guardrails: info.metadata?.disable_global_guardrails || false,
+                      container_visibility: info.metadata?.container_visibility === "team",
                       soft_budget_alerting_emails: Array.isArray(info.metadata?.soft_budget_alerting_emails)
                         ? info.metadata.soft_budget_alerting_emails.join(", ")
                         : "",
@@ -967,6 +969,7 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
                               model_tpm_limit,
                               model_rpm_limit,
                               allowed_passthrough_routes,
+                              container_visibility,
                               ...rest
                             }) => rest)(info.metadata),
                             null,
@@ -1461,6 +1464,21 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
                         placeholder='{"namespace": "admin", "mount": "secret", "path_prefix": "litellm"}'
                         disabled={!premiumUser}
                       />
+                    </Form.Item>
+
+                    <Form.Item
+                      label={
+                        <span>
+                          Team-visible code interpreter containers{" "}
+                          <Tooltip title="When on, code-interpreter containers created by any team member are accessible to the whole team, including the team's service-account keys. When off, each container stays private to its creator.">
+                            <InfoCircleOutlined style={{ marginLeft: "4px" }} />
+                          </Tooltip>
+                        </span>
+                      }
+                      name="container_visibility"
+                      valuePropName="checked"
+                    >
+                      <Switch checkedChildren="Team" unCheckedChildren="Private" />
                     </Form.Item>
 
                     <Form.Item label="Metadata" name="metadata">


### PR DESCRIPTION
## Relevant issues
- User-created containers aren't accessible by team-level service accounts (virtual keys tied to team_id but not user_id)
- A container created by a person is marked private to that person, while a container created by a service account is marked as belonging to the team

Root Cause:
- code-interpreter container is owned by creator's user_id
- A service account has no user_id and only team_id, so can never match user-created container's owner

Fix:
- Add an opt-in: a team sets container_visibility: "team" (via the toggle in the team settings UI, or directly in the team's metadata)
- Write side: at container-create time, if the creator's team has opted in, the container records its team_id alongside the creator's created_by; with no opt-in, team_id is left unset
- Read side: widen the access check to grant access when the caller matches either the container's created_by or its team_id (previously it checked created_by only)
- This lets a same-team principal with no user_id (the service account, whose only scope is team:<id>) match on team_id and be granted access
- Private-by-default is unchanged (no opt-in means no team_id, so containers stay creator-only), and cross-team isolation holds because team_id is only ever the creator's real team

## Linear ticket
Resolves LIT-3769

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Root cause

Container ownership is recorded with a single owner string chosen by `get_primary_resource_owner_scope`, which prefers `user_id`. A container created by a normal user key is therefore stamped `created_by=<user_id>` and is private to that user. A service-account key has no `user_id`; its only scope is `team:<team_id>`, so the access check `user_can_access_resource_owner` can never match a user-owned container and returns 403. The reverse direction works (a service-account-created container is owned by `team:<team_id>`, which a same-team user does carry), so the behavior was inconsistent depending on who created the container. Sibling managed resources (files, batches, vector stores) already store `created_by` and `team_id` separately and OR them, so containers were the outlier.

## Changes

Adds an explicit, opt-in team-visibility switch for containers, defaulting to today's private-to-creator behavior so nothing changes for existing setups.

When the creator's team sets metadata `container_visibility=team`, `record_container_owner` stamps the container's existing (previously unused) `team_id` column at create time while still recording the individual creator in `created_by`. The access path (`assert_user_can_access_container`) and the list filter (`_get_allowed_container_ids`) are widened to grant any same-team principal, including a service account whose only scope is `team:<id>`, via a new `user_can_access_resource_owner_or_team` helper. Private containers (no `team_id`) keep owner-only access, and cross-tenant isolation is unchanged because a team scope is only ever stamped when the creator genuinely belongs to that team.

No database migration is required; the `team_id` column already exists on `LiteLLM_ManagedObjectTable` and is indexed. The team setting is read from `UserAPIKeyAuth.team_metadata`, which is already populated during auth, so no extra lookup is added on the hot path.

## Type

🐛 Bug Fix

## Proof of Fix

Built the PR images and chart and deployed the full chart to a Kubernetes cluster (gateway data plane, backend management API, one-shot migration job) behind an nginx ingress, with a bundled Postgres, no Redis, and virtual-key auth. Then drove the create-with-a-user, fetch-with-a-service-account flow through the ingress against the live proxy

```bash
BASE=https://<proxy>      # nginx ingress in front of the gateway data plane
MASTER=sk-...             # LITELLM_MASTER_KEY

# Two teams: one opted into team-visible containers, one left at the private default
TON=$(curl -s -X POST $BASE/team/new -H "Authorization: Bearer $MASTER" -H 'Content-Type: application/json' \
  -d '{"team_alias":"shared-on","metadata":{"container_visibility":"team"}}' | jq -r .team_id)
TOFF=$(curl -s -X POST $BASE/team/new -H "Authorization: Bearer $MASTER" -H 'Content-Type: application/json' \
  -d '{"team_alias":"private-default"}' | jq -r .team_id)

# In each team, a user key (has user_id) and a service-account key (no user_id)
mkkey(){ # $1 team_id, $2 user_id (empty -> service account)
  [ -n "$2" ] && id=",\"user_id\":\"$2\"" || id=",\"metadata\":{\"service_account_id\":\"svc\"}"
  curl -s -X POST $BASE/key/generate -H "Authorization: Bearer $MASTER" -H 'Content-Type: application/json' \
    -d "{\"team_id\":\"$1\",\"allowed_routes\":[\"llm_api_routes\"]$id}" | jq -r .key; }
A_USER=$(mkkey $TON alice); A_SA=$(mkkey $TON "")
B_USER=$(mkkey $TOFF bob);  B_SA=$(mkkey $TOFF "")

# Create a container as one key, then fetch its file as another.
# Parse with Python (strict=False): a real code-interpreter response carries the
# generated source in the `code` field with literal newlines, which is invalid
# per the JSON spec and rejected by strict parsers such as jq, so extract leniently.
create(){ curl -s -X POST $BASE/responses -H "Authorization: Bearer $1" -H 'Content-Type: application/json' \
  -d '{"model":"gpt-5.4","input":"make a chart","tools":[{"type":"code_interpreter","container":{"type":"auto"}}]}'; }
cid(){ python3 -c 'import json,sys; d=json.load(sys.stdin,strict=False); print(next((o["container_id"] for o in d.get("output",[]) if o.get("container_id")), ""))'; }
fid(){ python3 -c 'import json,sys; d=json.load(sys.stdin,strict=False); print(next((a["file_id"] for o in d.get("output",[]) for c in (o.get("content") or []) for a in (c.get("annotations") or []) if a.get("type")=="container_file_citation"), ""))'; }
fetch(){ curl -s -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer $1" "$BASE/v1/containers/$2/files/$3/content"; }

R=$(create $A_USER); fetch $A_SA   "$(echo "$R"|cid)" "$(echo "$R"|fid)"   # team visibility ON,  user creates, service account fetches
R=$(create $B_USER); fetch $B_SA   "$(echo "$R"|cid)" "$(echo "$R"|fid)"   # default (private),    user creates, service account fetches
R=$(create $A_SA);   fetch $A_USER "$(echo "$R"|cid)" "$(echo "$R"|fid)"   # team visibility ON,  service account creates, user fetches
R=$(create $A_USER); fetch $B_SA   "$(echo "$R"|cid)" "$(echo "$R"|fid)"   # team-visible container fetched by a DIFFERENT team's service account
```

Output from the live proxy:

| create -> fetch | container_visibility | HTTP |
| --- | --- | --- |
| user -> same-team service account | team | 200 |
| user -> same-team service account | unset (default) | 403 |
| service account -> same-team user | team | 200 |
| user -> different-team service account | team | 403 |

The first row is the case that returned 403 before this change and now returns 200. It held 200 across five consecutive requests with three gateway replicas, so it does not depend on which pod serves the follow-up call. The second and fourth rows confirm private-by-default and cross-tenant isolation are unchanged

Regression coverage lives in `tests/test_litellm/containers/test_container_proxy_ownership.py`: private-by-default still denies the same-team service account, the team opt-in grants it while preserving the creator in `created_by`, and a different team is still refused
