### PR TITLE
feat(ui): add Integrations tab to MCP server view with Claude Cowork connect URL

### DIFF
--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_view.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_view.tsx
@@ -9,6 +9,7 @@ import MCPServerEdit, { EDIT_OAUTH_UI_STATE_KEY } from "./mcp_server_edit";
 import { getSecureItem } from "@/utils/secureStorage";
 import MCPServerCostDisplay from "./mcp_server_cost_display";
 import { getMaskedAndFullUrl } from "./utils";
+import { getProxyBaseUrl } from "@/components/networking";
 import { copyToClipboard as utilCopyToClipboard } from "@/utils/dataUtils";
 import { CheckIcon, CopyIcon } from "lucide-react";
 import { Button as AntdButton } from "antd";
@@ -55,12 +56,12 @@ export const MCPServerView: React.FC<MCPServerViewProps> = ({
   initialTabIndex = 0,
 }) => {
   // Open the editing Settings tab on first render when returning from the edit OAuth
-  // redirect, so the "token fetched" feedback shows where the user left off (Settings=2).
+  // redirect, so the "token fetched" feedback shows where the user left off (Settings=3).
   const returningFromEditOAuth = isReturningFromEditOAuth(isProxyAdmin, mcpServer.server_id);
   const [editing, setEditing] = useState(isEditing || returningFromEditOAuth);
   const [showFullUrl, setShowFullUrl] = useState(false);
   const [copiedStates, setCopiedStates] = useState<Record<string, boolean>>({});
-  const [selectedTabIndex, setSelectedTabIndex] = useState(returningFromEditOAuth ? 2 : initialTabIndex);
+  const [selectedTabIndex, setSelectedTabIndex] = useState(returningFromEditOAuth ? 3 : initialTabIndex);
 
   const handleSuccess = (updated: MCPServer) => {
     setEditing(false);
@@ -69,6 +70,10 @@ export const MCPServerView: React.FC<MCPServerViewProps> = ({
 
   const urlValue = mcpServer.url ?? "";
   const { maskedUrl, hasToken } = urlValue ? getMaskedAndFullUrl(urlValue) : { maskedUrl: "—", hasToken: false };
+
+  const coworkServerIdentifier = mcpServer.alias || mcpServer.server_name || mcpServer.server_id;
+  const coworkUrl = `${getProxyBaseUrl()}/${coworkServerIdentifier}/mcp`;
+  const isUpstreamDelegated = mcpServer.delegate_auth_to_upstream === true;
 
   const renderUrlWithToggle = (url: string | null | undefined, showFull: boolean) => {
     if (!url) return "—";
@@ -151,6 +156,7 @@ export const MCPServerView: React.FC<MCPServerViewProps> = ({
           {[
             <Tab key="overview">Overview</Tab>,
             <Tab key="tools">MCP Tools</Tab>,
+            <Tab key="integrations">Integrations</Tab>,
             ...(isProxyAdmin ? [<Tab key="settings">Settings</Tab>] : []),
           ]}
         </TabList>
@@ -217,6 +223,45 @@ export const MCPServerView: React.FC<MCPServerViewProps> = ({
               serverAlias={mcpServer.alias}
               extraHeaders={mcpServer.extra_headers}
             />
+          </TabPanel>
+
+          {/* Integrations Panel */}
+          <TabPanel>
+            <Card className="p-6">
+              <Title>Claude Cowork</Title>
+              <Text className="text-gray-500 mt-1">
+                Add this MCP server to Claude Cowork by pasting the URL below into the connector setup.
+              </Text>
+
+              <div className="mt-5">
+                <Text className="text-xs font-medium text-gray-500 uppercase tracking-wide">Server URL</Text>
+                <div className="mt-2 flex items-center gap-2 rounded border border-gray-200 bg-gray-50 px-3 py-2">
+                  <Text className="flex-1 break-all font-mono text-sm text-gray-900">{coworkUrl}</Text>
+                  <AntdButton
+                    type="text"
+                    size="small"
+                    icon={copiedStates["mcp-cowork-url"] ? <CheckIcon size={12} /> : <CopyIcon size={12} />}
+                    onClick={() => copyToClipboard(coworkUrl, "mcp-cowork-url")}
+                    className={`transition-all duration-200 ${
+                      copiedStates["mcp-cowork-url"]
+                        ? "text-green-600 bg-green-50 border-green-200"
+                        : "text-gray-400 hover:text-gray-600 hover:bg-gray-100"
+                    }`}
+                  />
+                </div>
+              </div>
+
+              {isUpstreamDelegated && (
+                <div className="mt-5 rounded border border-blue-200 bg-blue-50 p-4">
+                  <Text className="text-sm font-semibold text-blue-900">OAuth: Dynamic Client Registration</Text>
+                  <Text className="mt-1 text-sm text-blue-800">
+                    This server delegates authentication upstream, so Claude Cowork completes the OAuth flow directly
+                    with the provider through Dynamic Client Registration. Leave the auth fields empty; no LiteLLM key
+                    header is needed.
+                  </Text>
+                </div>
+              )}
+            </Card>
           </TabPanel>
 
           {/* Settings Panel */}

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_view.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_view.tsx
@@ -72,7 +72,7 @@ export const MCPServerView: React.FC<MCPServerViewProps> = ({
   const { maskedUrl, hasToken } = urlValue ? getMaskedAndFullUrl(urlValue) : { maskedUrl: "—", hasToken: false };
 
   const coworkServerIdentifier = mcpServer.alias || mcpServer.server_name || mcpServer.server_id;
-  const coworkUrl = `${getProxyBaseUrl()}/${coworkServerIdentifier}/mcp`;
+  const coworkUrl = `${getProxyBaseUrl()}/${encodeURIComponent(coworkServerIdentifier ?? "")}/mcp`;
   const isUpstreamDelegated = mcpServer.delegate_auth_to_upstream === true;
 
   const renderUrlWithToggle = (url: string | null | undefined, showFull: boolean) => {


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

Note: this is a UI-only presentational change (a new tab rendering a copyable URL and a conditional note), so no test was added

## Screenshots / Proof of Fix

UI-only change, so the proof is the new tab rendering correctly for both a passthrough and a non-passthrough server. To reproduce locally, run a proxy with two MCP servers, one with `auth_type: oauth2` and `delegate_auth_to_upstream: true` and one with `auth_type: none`, then

1. open `http://localhost:4000/ui/` and log in as admin
2. go to MCP Servers in the sidebar and open the oauth2 passthrough server
3. click the new Integrations tab; it shows the copyable Claude Cowork URL plus the "OAuth: Dynamic Client Registration" note
4. open the non-passthrough server and click Integrations; it shows the copyable URL only, no OAuth note

Screenshots to follow

## Type

🆕 New Feature

## Changes

Adds an Integrations tab between MCP Tools and Settings on the MCP server detail page, visible to all users. The tab has a Claude Cowork section with a copyable connect URL built from `getProxyBaseUrl()` and the server's alias (falling back to server name), matching the gateway's `/{server}/mcp` routing where alias is resolved first.

The only auth-dependent behavior is for upstream-delegated servers; when `delegate_auth_to_upstream` is true the tab adds a Dynamic Client Registration note telling the user to leave the auth fields empty since Claude Cowork completes OAuth directly with the provider. Everything else just shows the URL. Both `auth_type` and `delegate_auth_to_upstream` already flow to the UI on every server object, so no backend change was needed.

Inserting the tab at index 2 shifts Settings to index 3, so the post-OAuth-edit redirect index was bumped from 2 to 3 to keep landing on Settings