### PR TITLE
feat(search): add TinyFish as search provider

### DIFF
--- a/litellm/llms/tinyfish/search/__init__.py
+++ b/litellm/llms/tinyfish/search/__init__.py
@@ -1,0 +1,3 @@
+from litellm.llms.tinyfish.search.transformation import TinyfishSearchConfig
+
+__all__ = ["TinyfishSearchConfig"]

--- a/litellm/llms/tinyfish/search/transformation.py
+++ b/litellm/llms/tinyfish/search/transformation.py
@@ -88,7 +88,9 @@ class TinyfishSearchConfig(BaseSearchConfig):
             request_data["location"] = optional_params["country"]
 
         if "max_results" in optional_params:
-            request_data["max_results"] = min(int(optional_params["max_results"]), 20)
+            request_data["max_results"] = max(
+                1, min(int(optional_params["max_results"]), 20)
+            )
 
         if "search_domain_filter" in optional_params:
             domains = optional_params["search_domain_filter"]

--- a/litellm/llms/tinyfish/search/transformation.py
+++ b/litellm/llms/tinyfish/search/transformation.py
@@ -1,0 +1,130 @@
+"""
+TinyFish Search API.
+Endpoint: GET https://api.search.tinyfish.ai
+Docs: https://docs.tinyfish.ai/search-api
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Literal, Optional, TypedDict, Union
+from urllib.parse import urlencode
+
+import httpx
+
+from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+from litellm.llms.base_llm.search.transformation import (
+    BaseSearchConfig,
+    SearchResponse,
+    SearchResult,
+)
+from litellm.secret_managers.main import get_secret_str
+
+
+class _TinyfishSearchRequestRequired(TypedDict):
+    query: str
+
+
+class TinyfishSearchRequest(_TinyfishSearchRequestRequired, total=False):
+    location: str
+    language: str
+    page: int
+    include_thumbnail: str
+
+
+class TinyfishSearchConfig(BaseSearchConfig):
+    TINYFISH_API_BASE = "https://api.search.tinyfish.ai"
+
+    @staticmethod
+    def ui_friendly_name() -> str:
+        return "TinyFish"
+
+    def get_http_method(self) -> Literal["GET", "POST"]:
+        return "GET"
+
+    def validate_environment(
+        self,
+        headers: Dict,
+        api_key: Optional[str] = None,
+        api_base: Optional[str] = None,
+        **kwargs,
+    ) -> Dict:
+        api_key = api_key or get_secret_str("TINYFISH_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "TINYFISH_API_KEY is not set. Set `TINYFISH_API_KEY` environment variable."
+            )
+        headers["X-API-Key"] = api_key
+        headers["Accept"] = "application/json"
+        return headers
+
+    def get_complete_url(
+        self,
+        api_base: Optional[str],
+        optional_params: dict,
+        data: Optional[Union[Dict, List[Dict]]] = None,
+        **kwargs,
+    ) -> str:
+        api_base = (
+            api_base or get_secret_str("TINYFISH_API_BASE") or self.TINYFISH_API_BASE
+        )
+        if data and isinstance(data, dict) and "_tinyfish_params" in data:
+            query_string = urlencode(data["_tinyfish_params"], doseq=True)
+            return f"{api_base}?{query_string}"
+        return api_base
+
+    def transform_search_request(
+        self,
+        query: Union[str, List[str]],
+        optional_params: dict,
+        **kwargs,
+    ) -> Dict:
+        if isinstance(query, list):
+            query = " ".join(query)
+
+        request_data: TinyfishSearchRequest = {"query": query}
+
+        if "country" in optional_params:
+            request_data["location"] = optional_params["country"]
+
+        if "search_domain_filter" in optional_params:
+            domains = optional_params["search_domain_filter"]
+            if isinstance(domains, list) and len(domains) > 0:
+                request_data["query"] = self._append_domain_filters(
+                    request_data["query"], domains
+                )
+
+        result_data = dict(request_data)
+
+        for param, value in optional_params.items():
+            if (
+                param not in self.get_supported_perplexity_optional_params()
+                and param not in result_data
+            ):
+                result_data[param] = value
+
+        return {"_tinyfish_params": result_data}
+
+    @staticmethod
+    def _append_domain_filters(query: str, domains: List[str]) -> str:
+        domain_clauses = " OR ".join(f"site:{d}" for d in domains)
+        return f"({query}) ({domain_clauses})"
+
+    def transform_search_response(
+        self,
+        raw_response: httpx.Response,
+        logging_obj: Optional[LiteLLMLoggingObj],
+        **kwargs,
+    ) -> SearchResponse:
+        response_json = raw_response.json()
+
+        results: List[SearchResult] = []
+        for item in response_json.get("results", []):
+            results.append(
+                SearchResult(
+                    title=item.get("title", ""),
+                    url=item.get("url", ""),
+                    snippet=item.get("snippet", ""),
+                )
+            )
+
+        return SearchResponse(results=results, object="search")

--- a/litellm/llms/tinyfish/search/transformation.py
+++ b/litellm/llms/tinyfish/search/transformation.py
@@ -28,7 +28,8 @@ class TinyfishSearchRequest(_TinyfishSearchRequestRequired, total=False):
     location: str
     language: str
     page: int
-    include_thumbnail: str
+    include_thumbnail: bool
+    max_results: int
 
 
 class TinyfishSearchConfig(BaseSearchConfig):
@@ -86,6 +87,9 @@ class TinyfishSearchConfig(BaseSearchConfig):
         if "country" in optional_params:
             request_data["location"] = optional_params["country"]
 
+        if "max_results" in optional_params:
+            request_data["max_results"] = min(int(optional_params["max_results"]), 20)
+
         if "search_domain_filter" in optional_params:
             domains = optional_params["search_domain_filter"]
             if isinstance(domains, list) and len(domains) > 0:
@@ -117,8 +121,13 @@ class TinyfishSearchConfig(BaseSearchConfig):
     ) -> SearchResponse:
         response_json = raw_response.json()
 
+        query_params = raw_response.request.url.params if raw_response.request else {}
+        max_results = max(1, min(int(query_params.get("max_results", 20)), 20))
+
         results: List[SearchResult] = []
         for item in response_json.get("results", []):
+            if len(results) >= max_results:
+                break
             results.append(
                 SearchResult(
                     title=item.get("title", ""),

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3465,6 +3465,7 @@ class SearchProviders(str, Enum):
     SERPER = "serper"
     YOU_COM = "you_com"
     APISERPENT = "apiserpent"
+    TINYFISH = "tinyfish"
 
 
 # Create a set of all search provider values for quick lookup

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -9687,6 +9687,7 @@ class ProviderConfigManager:
         from litellm.llms.serper.search.transformation import SerperSearchConfig
         from litellm.llms.tavily.search.transformation import TavilySearchConfig
         from litellm.llms.you_com.search.transformation import YouComSearchConfig
+        from litellm.llms.tinyfish.search.transformation import TinyfishSearchConfig
 
         PROVIDER_TO_CONFIG_MAP = {
             SearchProviders.PERPLEXITY: PerplexitySearchConfig,
@@ -9705,6 +9706,7 @@ class ProviderConfigManager:
             SearchProviders.SERPER: SerperSearchConfig,
             SearchProviders.YOU_COM: YouComSearchConfig,
             SearchProviders.APISERPENT: APISerpentSearchConfig,
+            SearchProviders.TINYFISH: TinyfishSearchConfig,
         }
         config_class = PROVIDER_TO_CONFIG_MAP.get(provider, None)
         if config_class is None:

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -13775,6 +13775,14 @@
             "notes": "APISerpent deep search (/api/search), multi-engine (Google, Bing, Yahoo, DuckDuckGo). Pricing: $0.60/1k searches."
         }
     },
+    "tinyfish/search": {
+        "input_cost_per_query": 0.0,
+        "litellm_provider": "tinyfish",
+        "mode": "search",
+        "metadata": {
+            "notes": "TinyFish Search API. Search is included with subscription, no per-query cost."
+        }
+    },
     "elevenlabs/scribe_v1": {
         "input_cost_per_second": 6.11e-05,
         "litellm_provider": "elevenlabs",

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -2303,6 +2303,13 @@
         "search": true
       }
     },
+    "tinyfish": {
+      "display_name": "TinyFish (`tinyfish`)",
+      "url": "https://docs.litellm.ai/docs/search/tinyfish",
+      "endpoints": {
+        "search": true
+      }
+    },
     "triton": {
       "display_name": "Triton (`triton`)",
       "url": "https://docs.litellm.ai/docs/providers/triton-inference-server",

--- a/tests/code_coverage_tests/enforce_llms_folder_style.py
+++ b/tests/code_coverage_tests/enforce_llms_folder_style.py
@@ -21,6 +21,7 @@ SEARCH_PROVIDERS = [
     "searchapi",
     "serper",
     "apiserpent",
+    "tinyfish",
 ]
 
 ALLOWED_FILES_IN_LLMS_FOLDER = [

--- a/tests/search_tests/test_tinyfish_search.py
+++ b/tests/search_tests/test_tinyfish_search.py
@@ -1,0 +1,189 @@
+"""
+Tests for TinyFish Search API integration.
+"""
+
+import os
+import pytest
+from urllib.parse import urlparse, parse_qs
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import litellm
+
+
+MOCK_TINYFISH_RESPONSE = {
+    "query": "web automation tools",
+    "results": [
+        {
+            "position": 1,
+            "site_name": "tinyfish.ai",
+            "title": "TinyFish — AI Web Automation",
+            "snippet": "Automate any website with natural language.",
+            "url": "https://tinyfish.ai",
+        },
+        {
+            "position": 2,
+            "site_name": "github.com",
+            "title": "Top Web Automation Tools",
+            "snippet": "A curated list of browser automation frameworks.",
+            "url": "https://github.com/example/web-automation",
+        },
+    ],
+    "total_results": 2,
+    "page": 0,
+}
+
+
+def _make_mock_response(json_data: dict, status_code: int = 200) -> MagicMock:
+    mock = MagicMock()
+    mock.status_code = status_code
+    mock.json.return_value = json_data
+    return mock
+
+
+class TestTinyfishSearch:
+    @pytest.mark.asyncio
+    async def test_basic_search(self):
+        os.environ["TINYFISH_API_KEY"] = "sk-tinyfish-test"
+
+        mock_response = _make_mock_response(MOCK_TINYFISH_RESPONSE)
+
+        with patch(
+            "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.get",
+            new_callable=AsyncMock,
+        ) as mock_get:
+            mock_get.return_value = mock_response
+
+            response = await litellm.asearch(
+                query="web automation tools",
+                search_provider="tinyfish",
+            )
+
+            assert mock_get.call_count == 1
+
+            call_args = mock_get.call_args
+            parsed_url = urlparse(call_args.kwargs["url"])
+            assert parsed_url.scheme == "https"
+            assert parsed_url.netloc == "api.search.tinyfish.ai"
+            assert parsed_url.path == ""
+
+            query_params = parse_qs(parsed_url.query)
+            assert query_params["query"] == ["web automation tools"]
+
+            headers = call_args.kwargs.get("headers", {})
+            assert headers["X-API-Key"] == "sk-tinyfish-test"
+
+            assert hasattr(response, "results")
+            assert response.object == "search"
+            assert len(response.results) == 2
+
+            first = response.results[0]
+            assert first.title == "TinyFish — AI Web Automation"
+            assert first.url == "https://tinyfish.ai"
+            assert first.snippet == "Automate any website with natural language."
+
+    @pytest.mark.asyncio
+    async def test_country_maps_to_location(self):
+        os.environ["TINYFISH_API_KEY"] = "sk-tinyfish-test"
+
+        mock_response = _make_mock_response(MOCK_TINYFISH_RESPONSE)
+
+        with patch(
+            "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.get",
+            new_callable=AsyncMock,
+        ) as mock_get:
+            mock_get.return_value = mock_response
+
+            await litellm.asearch(
+                query="test",
+                search_provider="tinyfish",
+                country="US",
+            )
+
+            call_args = mock_get.call_args
+            parsed_url = urlparse(call_args.kwargs["url"])
+            query_params = parse_qs(parsed_url.query)
+            assert query_params["location"] == ["US"]
+
+    @pytest.mark.asyncio
+    async def test_domain_filter_injection(self):
+        os.environ["TINYFISH_API_KEY"] = "sk-tinyfish-test"
+
+        mock_response = _make_mock_response(MOCK_TINYFISH_RESPONSE)
+
+        with patch(
+            "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.get",
+            new_callable=AsyncMock,
+        ) as mock_get:
+            mock_get.return_value = mock_response
+
+            await litellm.asearch(
+                query="python tutorials",
+                search_provider="tinyfish",
+                search_domain_filter=["arxiv.org", "github.com"],
+            )
+
+            call_args = mock_get.call_args
+            parsed_url = urlparse(call_args.kwargs["url"])
+            query_params = parse_qs(parsed_url.query)
+            query_value = query_params["query"][0]
+            assert "site:arxiv.org" in query_value
+            assert "site:github.com" in query_value
+            assert "python tutorials" in query_value
+
+    @pytest.mark.asyncio
+    async def test_language_passthrough(self):
+        os.environ["TINYFISH_API_KEY"] = "sk-tinyfish-test"
+
+        mock_response = _make_mock_response(MOCK_TINYFISH_RESPONSE)
+
+        with patch(
+            "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.get",
+            new_callable=AsyncMock,
+        ) as mock_get:
+            mock_get.return_value = mock_response
+
+            await litellm.asearch(
+                query="test",
+                search_provider="tinyfish",
+                language="en",
+            )
+
+            call_args = mock_get.call_args
+            parsed_url = urlparse(call_args.kwargs["url"])
+            query_params = parse_qs(parsed_url.query)
+            assert query_params["language"] == ["en"]
+
+    @pytest.mark.asyncio
+    async def test_empty_results(self):
+        os.environ["TINYFISH_API_KEY"] = "sk-tinyfish-test"
+
+        empty_response = {
+            "query": "xyznonexistent",
+            "results": [],
+            "total_results": 0,
+            "page": 0,
+        }
+        mock_response = _make_mock_response(empty_response)
+
+        with patch(
+            "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.get",
+            new_callable=AsyncMock,
+        ) as mock_get:
+            mock_get.return_value = mock_response
+
+            response = await litellm.asearch(
+                query="xyznonexistent",
+                search_provider="tinyfish",
+            )
+
+            assert response.object == "search"
+            assert len(response.results) == 0
+
+    def test_missing_api_key(self):
+        os.environ.pop("TINYFISH_API_KEY", None)
+
+        from litellm.llms.tinyfish.search.transformation import TinyfishSearchConfig
+
+        config = TinyfishSearchConfig()
+        with pytest.raises(ValueError, match="TINYFISH_API_KEY"):
+            config.validate_environment(headers={})

--- a/tests/search_tests/test_tinyfish_search.py
+++ b/tests/search_tests/test_tinyfish_search.py
@@ -7,6 +7,8 @@ import pytest
 from urllib.parse import urlparse, parse_qs
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
+
 import litellm
 
 
@@ -33,10 +35,17 @@ MOCK_TINYFISH_RESPONSE = {
 }
 
 
-def _make_mock_response(json_data: dict, status_code: int = 200) -> MagicMock:
+def _make_mock_response(
+    json_data: dict, status_code: int = 200, request_url: str | None = None
+) -> MagicMock:
     mock = MagicMock()
     mock.status_code = status_code
     mock.json.return_value = json_data
+    if request_url:
+        mock.request = MagicMock()
+        mock.request.url = httpx.URL(request_url)
+    else:
+        mock.request = None
     return mock
 
 
@@ -152,6 +161,34 @@ class TestTinyfishSearch:
             parsed_url = urlparse(call_args.kwargs["url"])
             query_params = parse_qs(parsed_url.query)
             assert query_params["language"] == ["en"]
+
+    def test_max_results_truncates_response(self):
+        """max_results is sent as a query param and used to truncate results client-side."""
+        from litellm.llms.tinyfish.search.transformation import TinyfishSearchConfig
+
+        config = TinyfishSearchConfig()
+        many_results = {
+            "results": [
+                {
+                    "title": f"Result {i}",
+                    "url": f"https://example.com/{i}",
+                    "snippet": f"Snippet {i}",
+                }
+                for i in range(10)
+            ]
+        }
+        mock_response = _make_mock_response(
+            many_results,
+            request_url="https://api.search.tinyfish.ai?query=test&max_results=3",
+        )
+
+        result = config.transform_search_response(
+            raw_response=mock_response,
+            logging_obj=None,
+        )
+        assert len(result.results) == 3
+        assert result.results[0].title == "Result 0"
+        assert result.results[2].title == "Result 2"
 
     @pytest.mark.asyncio
     async def test_empty_results(self):


### PR DESCRIPTION
Re-opening from #30158 which was approved (LGTM from @Sameerlite) but closed due to merge conflicts when the base branch moved. Rebased onto today's staging branch with conflicts resolved; the TinyFish code itself is unchanged.

## What this does

Adds TinyFish (https://tinyfish.ai) as a search provider, following the same GET-based pattern as Brave and Serper. The implementation is self-contained in `litellm/llms/tinyfish/` with standard registration hooks.

- `TinyfishSearchConfig` extends `BaseSearchConfig` with GET method, `X-API-Key` header auth, and the `_tinyfish_params` wrapper dict pattern for URL query encoding
- Unified param mappings: `country` -> `location`, `search_domain_filter` -> `site:` query injection, `max_results` -> clamped (1-20) and enforced client-side in `transform_search_response`
- 7 unit tests (all mocked, no real API calls in CI)
- Live integration test transcript with real API calls posted in #30158

## Files changed (8)

| File | Change |
|------|--------|
| `litellm/llms/tinyfish/search/__init__.py` | New module export |
| `litellm/llms/tinyfish/search/transformation.py` | Core TinyfishSearchConfig implementation |
| `litellm/types/utils.py` | Add `TINYFISH` to `SearchProviders` enum |
| `litellm/utils.py` | Register config in `get_provider_search_config()` |
| `model_prices_and_context_window.json` | Add `tinyfish/search` pricing entry |
| `provider_endpoints_support.json` | Add tinyfish endpoint metadata |
| `tests/code_coverage_tests/enforce_llms_folder_style.py` | Add tinyfish to `SEARCH_PROVIDERS` |
| `tests/search_tests/test_tinyfish_search.py` | 7 unit tests |

## Proof of testing

Live integration test output against real TinyFish API (full transcript in #30158):

```
Test 1: Basic search ("what is litellm proxy") -> 9 results, top hit: github.com/BerriAI/litellm
Test 2: Domain filter (arxiv.org) -> 10 results, all from arxiv.org (Attention Is All You Need, etc.)
Test 3: max_results=2 -> exactly 2 results returned
Test 4: Country="US" -> 10 US-localized results
```

## Prior review history

- #28385: Greptile 5/5, closed by bot (base branch deleted)
- #30158: Greptile 4/5, approved by @Sameerlite ("LGTM"), closed due to merge conflicts with new providers (`you_com`, `apiserpent`) landing on the same files
- Both Greptile inline findings were addressed: `max_results` lower-bound clamping added in `transform_search_request`, and `get_complete_url` fallback kept intentionally (matches Brave's pattern; framework calls it with `data=None` during setup)