### PR TITLE
fix(proxy): allow internal roles to access vector store CRUD routes

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -373,6 +373,8 @@ class LiteLLMRoutes(enum.Enum):
         # vector stores
         "/vector_stores",
         "/v1/vector_stores",
+        "/vector_stores/{vector_store_id}",
+        "/v1/vector_stores/{vector_store_id}",
         "/vector_stores/{vector_store_id}/search",
         "/v1/vector_stores/{vector_store_id}/search",
         "/vector_stores/{vector_store_id}/files",

--- a/tests/test_litellm/proxy/auth/test_route_checks.py
+++ b/tests/test_litellm/proxy/auth/test_route_checks.py
@@ -1400,6 +1400,65 @@ def test_rag_routes_accessible_to_internal_user_viewer():
         )
 
 
+@pytest.mark.parametrize(
+    "route",
+    [
+        "/vector_stores/vs_123",
+        "/v1/vector_stores/vs_123",
+        "/vector_stores/vs_123/search",
+        "/v1/vector_stores/vs_123/search",
+        "/vector_stores/vs_123/files",
+        "/v1/vector_stores/vs_123/files",
+    ],
+)
+def test_vector_store_routes_are_llm_api_routes(route):
+    """Retrieve/update/delete on a single vector store must classify as LLM API routes.
+
+    Regression for the missing bare `/v1/vector_stores/{vector_store_id}` entry in
+    `openai_routes` that left retrieve/update/delete blocked for internal roles
+    while `/search` and `/files` sub-routes worked.
+    """
+
+    assert RouteChecks.is_llm_api_route(route) is True
+
+
+@pytest.mark.parametrize(
+    "user_role",
+    [
+        LitellmUserRoles.INTERNAL_USER.value,
+        LitellmUserRoles.INTERNAL_USER_VIEW_ONLY.value,
+    ],
+)
+@pytest.mark.parametrize(
+    "method, route",
+    [
+        ("GET", "/v1/vector_stores/vs_123"),
+        ("POST", "/v1/vector_stores/vs_123"),
+        ("DELETE", "/v1/vector_stores/vs_123"),
+    ],
+)
+def test_vector_store_crud_accessible_to_internal_roles(user_role, method, route):
+    """Internal user and internal viewer must reach vector store retrieve/update/delete.
+
+    Object-level access is still gated by `assert_user_can_access_vector_store`;
+    this only verifies the route gate no longer 403s these roles.
+    """
+
+    valid_token = UserAPIKeyAuth(user_id="test_user", user_role=user_role)
+    request = MagicMock(spec=Request)
+    request.method = method
+    request.query_params = {}
+
+    RouteChecks.non_proxy_admin_allowed_routes_check(
+        user_obj=LiteLLM_UserTable(user_id="test_user", user_role=user_role),
+        _user_role=user_role,
+        route=route,
+        request=request,
+        valid_token=valid_token,
+        request_data={},
+    )
+
+
 def test_videos_route_accessible_to_internal_users():
     """
     Test that internal users can access the videos routes.


### PR DESCRIPTION
Description
Internal user and internal viewer keys could call vector store list, create, search, and file endpoints, but GET/POST/DELETE on /v1/vector_stores/{vector_store_id} returned 403 because the bare resource path was missing from openai_routes. This adds that route pattern and regression tests so retrieve, update, and delete pass the LLM API route gate for those roles. Object-level vector store access checks are unchanged.

Cause
LiteLLMRoutes.openai_routes included /v1/vector_stores and sub-routes like /v1/vector_stores/{vector_store_id}/search and .../files, but not /v1/vector_stores/{vector_store_id} itself. RouteChecks.is_llm_api_route() returned False for retrieve/update/delete URLs, so non_proxy_admin_allowed_routes_check() did not treat them as LLM API routes and internal roles hit the admin-only fallback.

Fix
Add /vector_stores/{vector_store_id} and /v1/vector_stores/{vector_store_id} to openai_routes in litellm/proxy/_types.py. Add regression tests in tests/test_litellm/proxy/auth/test_route_checks.py covering route classification and internal user / internal viewer access for GET, POST, and DELETE on the bare path.

<img width="1203" height="496" alt="Screenshot 2026-06-15 at 8 34 36 PM" src="https://github.com/user-attachments/assets/1eab11cb-38ae-427e-a55b-7e23b0095739" />
<img width="1184" height="637" alt="Screenshot 2026-06-15 at 8 35 23 PM" src="https://github.com/user-attachments/assets/c5693ed8-049d-4079-b6e5-3b302bce01a0" />
<img width="1203" height="698" alt="Screenshot 2026-06-15 at 8 35 48 PM" src="https://github.com/user-attachments/assets/4ec62650-73a5-45a3-ac8d-62da49b65292" />

