### PR TITLE
feat: add TokenMix as an OpenAI-compatible provider

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -809,6 +809,7 @@ openai_compatible_endpoints: List = [
     "https://nano-gpt.com/api/v1",
     "https://api.poe.com/v1",
     "https://llm.chutes.ai/v1/",
+    "https://api.tokenmix.ai/v1",
     "https://api.v0.dev/v1",
     "https://api.morphllm.com/v1",
     "https://api.lambda.ai/v1",
@@ -862,6 +863,7 @@ openai_compatible_providers: List = [
     "nano-gpt",  # Nano-GPT - JSON-configured provider
     "poe",  # Poe - JSON-configured provider
     "chutes",  # Chutes - JSON-configured provider
+    "tokenmix",  # TokenMix - JSON-configured provider
     "parasail",  # Parasail - JSON-configured provider
     "libertai",  # LibertAI - JSON-configured provider
     "featherless_ai",

--- a/litellm/litellm_core_utils/get_llm_provider_logic.py
+++ b/litellm/litellm_core_utils/get_llm_provider_logic.py
@@ -370,6 +370,9 @@ def get_llm_provider(
                     elif endpoint == "https://llm.chutes.ai/v1/":
                         custom_llm_provider = "chutes"
                         dynamic_api_key = get_secret_str("CHUTES_API_KEY")
+                    elif endpoint == "https://api.tokenmix.ai/v1":
+                        custom_llm_provider = "tokenmix"
+                        dynamic_api_key = get_secret_str("TOKENMIX_API_KEY")
                     elif endpoint == "https://api.v0.dev/v1":
                         custom_llm_provider = "v0"
                         dynamic_api_key = get_secret_str("V0_API_KEY")

--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -65,6 +65,13 @@
       "max_completion_tokens": "max_tokens"
     }
   },
+  "tokenmix": {
+    "base_url": "https://api.tokenmix.ai/v1",
+    "api_key_env": "TOKENMIX_API_KEY",
+    "param_mappings": {
+      "max_completion_tokens": "max_tokens"
+    }
+  },
   "abliteration": {
     "base_url": "https://api.abliteration.ai/v1",
     "api_key_env": "ABLITERATION_API_KEY"

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3483,6 +3483,7 @@ class LlmProviders(str, Enum):
     NANOGPT = "nano-gpt"
     POE = "poe"
     CHUTES = "chutes"
+    TOKENMIX = "tokenmix"
     NEOSANTARA = "neosantara"
     PARASAIL = "parasail"
     XIAOMI_MIMO = "xiaomi_mimo"

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -509,6 +509,22 @@
         "a2a": false
       }
     },
+    "tokenmix": {
+      "display_name": "TokenMix (`tokenmix`)",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": false,
+        "responses": false,
+        "embeddings": false,
+        "image_generations": false,
+        "audio_transcriptions": false,
+        "audio_speech": false,
+        "moderations": false,
+        "batches": false,
+        "rerank": false,
+        "a2a": false
+      }
+    },
     "clarifai": {
       "display_name": "Clarifai (`clarifai`)",
       "url": "https://docs.litellm.ai/docs/providers/clarifai",


### PR DESCRIPTION
## What this does

Adds **TokenMix** as a JSON-configured OpenAI-compatible provider, following the exact pattern used by the existing gateway providers in `litellm/llms/openai_like/providers.json` (e.g. `chutes`, `nano-gpt`, `poe`).

[TokenMix](https://tokenmix.ai) is an OpenAI-compatible API gateway that exposes DeepSeek, Qwen, Kimi, GLM, MiniMax and other models through a single endpoint (`https://api.tokenmix.ai/v1`) and one API key.

## Changes (4 files, +13 lines)

- `litellm/llms/openai_like/providers.json` �� add the `tokenmix` JSON entry (base_url + `TOKENMIX_API_KEY` + standard `max_completion_tokens -> max_tokens` mapping)
- `litellm/constants.py` �� add the endpoint to `openai_compatible_endpoints` and the slug to `openai_compatible_providers`
- `litellm/litellm_core_utils/get_llm_provider_logic.py` �� add base-URL auto-detection routing
- `litellm/types/utils.py` �� add `TOKENMIX` to the `LlmProviders` enum

No new dependencies, no new imports.

## Usage

```python
import litellm

resp = litellm.completion(
    model="tokenmix/deepseek/deepseek-v4-pro",
    messages=[{"role": "user", "content": "hello"}],
    api_key="...",  # or set TOKENMIX_API_KEY
)
```

## Notes

- Targeted at `litellm_oss_branch` per the contributor guidance in `guard-main-branch.yml`.
- Verified locally: `black --check` clean, `ruff check` (v0.15.3) clean, `providers.json` valid.