### PR TITLE
fix(openrouter): move usage accounting to extra_body for compatibility

### DIFF
--- a/litellm/llms/openrouter/chat/transformation.py
+++ b/litellm/llms/openrouter/chat/transformation.py
@@ -163,17 +163,19 @@ class OpenrouterConfig(OpenAIGPTConfig):
             messages = self._move_cache_control_to_content(messages)
 
         extra_body = optional_params.pop("extra_body", {})
-        response = super().transform_request(
+        request = super().transform_request(
             model, messages, optional_params, litellm_params, headers
         )
-        response.update(extra_body)
+        request.update(extra_body)
 
-        # ALWAYS add usage parameter to get cost data from OpenRouter
-        # This ensures cost tracking works for all OpenRouter models
-        if "usage" not in response:
-            response["usage"] = {"include": True}
+        # Usage accounting is an OpenRouter-specific flag, not a valid top-level
+        # OpenAI chat param. Sending it at the top level makes OpenAI-compatible
+        # clients reject the request ("unexpected keyword argument 'usage'"), so
+        # it must travel inside `extra_body` instead.
+        extra_body = request.setdefault("extra_body", {})
+        extra_body.setdefault("usage", {"include": True})
 
-        return response
+        return request
 
     def transform_response(
         self,

--- a/tests/test_litellm/llms/openrouter/chat/test_openrouter_chat_transformation.py
+++ b/tests/test_litellm/llms/openrouter/chat/test_openrouter_chat_transformation.py
@@ -372,7 +372,7 @@ def test_openrouter_cost_tracking_non_streaming():
     Test OpenRouter cost tracking for non-streaming completions.
 
     Verifies:
-    1. Request includes usage.include=true to get cost data
+    1. Request asks for usage accounting via extra_body, not a top-level usage field
     2. Response extracts cost from usage.cost and stores in _hidden_params
     """
     from unittest.mock import Mock, patch
@@ -380,7 +380,6 @@ def test_openrouter_cost_tracking_non_streaming():
 
     config = OpenrouterConfig()
 
-    # Test request adds usage parameter
     transformed_request = config.transform_request(
         model="openrouter/anthropic/claude-sonnet-4.5",
         messages=[{"role": "user", "content": "Hello"}],
@@ -388,8 +387,8 @@ def test_openrouter_cost_tracking_non_streaming():
         litellm_params={},
         headers={},
     )
-    assert "usage" in transformed_request
-    assert transformed_request["usage"] == {"include": True}
+    assert "usage" not in transformed_request
+    assert transformed_request["extra_body"]["usage"] == {"include": True}
 
     # Test response extracts cost
     mock_response = Mock(spec=httpx.Response)
@@ -460,13 +459,12 @@ def test_openrouter_cost_tracking_streaming():
     Test OpenRouter cost tracking for streaming completions.
 
     Verifies:
-    1. Request includes usage.include=true (same as non-streaming)
+    1. Request asks for usage accounting via extra_body (same as non-streaming)
     2. Streaming chunks preserve usage/cost data in the final chunk
     3. Cost field is accessible in the usage object
     """
     config = OpenrouterConfig()
 
-    # Test request adds usage parameter for streaming
     transformed_request = config.transform_request(
         model="openrouter/anthropic/claude-sonnet-4.5",
         messages=[{"role": "user", "content": "Hello"}],
@@ -474,8 +472,8 @@ def test_openrouter_cost_tracking_streaming():
         litellm_params={},
         headers={},
     )
-    assert "usage" in transformed_request
-    assert transformed_request["usage"] == {"include": True}
+    assert "usage" not in transformed_request
+    assert transformed_request["extra_body"]["usage"] == {"include": True}
 
     # Test streaming chunks preserve cost data
     handler = OpenRouterChatCompletionStreamingHandler(
@@ -526,6 +524,43 @@ def test_openrouter_cost_tracking_streaming():
     # Verify cost field is preserved in the Usage object - this is the key data for cost tracking
     # The chunk_parser converts the dict to a Usage Pydantic model which includes the cost field
     assert result2.usage.cost == 0.0001
+
+
+def test_openrouter_usage_accounting_not_top_level():
+    """
+    Regression: usage accounting must be requested via extra_body, never as a
+    top-level field. A top-level `usage` is rejected by OpenAI-compatible clients
+    with "unexpected keyword argument 'usage'" (e.g. for OpenAI models served
+    through OpenRouter).
+    """
+    transformed_request = OpenrouterConfig().transform_request(
+        model="openrouter/openai/gpt-4o",
+        messages=[{"role": "user", "content": "Hello"}],
+        optional_params={},
+        litellm_params={},
+        headers={},
+    )
+
+    assert "usage" not in transformed_request
+    assert transformed_request["extra_body"]["usage"] == {"include": True}
+
+
+def test_openrouter_usage_accounting_preserves_user_extra_body():
+    """
+    User-provided OpenRouter params still flatten to the top level (issue #8425)
+    while usage accounting is added under extra_body without clobbering them.
+    """
+    transformed_request = OpenrouterConfig().transform_request(
+        model="openrouter/openai/gpt-4o",
+        messages=[{"role": "user", "content": "Hello"}],
+        optional_params={"extra_body": {"provider": {"order": ["OpenAI"]}}},
+        litellm_params={},
+        headers={},
+    )
+
+    assert "usage" not in transformed_request
+    assert transformed_request["provider"]["order"] == ["OpenAI"]
+    assert transformed_request["extra_body"]["usage"] == {"include": True}
 
 
 def test_openrouter_reasoning_models_allow_reasoning_effort_param():


### PR DESCRIPTION
## Relevant issues

Fixes the OpenRouter request assembly bug where every chat request was given a top-level `usage` field, which OpenAI-compatible clients reject with `AsyncCompletions.create() got an unexpected keyword argument 'usage'` (hit when calling OpenAI-backed models through OpenRouter)

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Run a local proxy and hit an OpenAI-backed model through OpenRouter, which previously failed with the `usage` keyword error:

```bash
python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log

curl -s http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d '{
        "model": "openrouter/openai/gpt-4o",
        "messages": [{"role": "user", "content": "say hello in one word"}]
      }'

```

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes
