### PR TITLE
ci(lint): add blanket-noqa, dataclass-default, and unused-noqa Ruff rules

### DIFF
--- a/litellm/_logging.py
+++ b/litellm/_logging.py
@@ -419,7 +419,7 @@ def _enable_debugging():
 def print_verbose(print_statement):
     try:
         if set_verbose:
-            print(redact_secrets(str(print_statement)))  # noqa
+            print(redact_secrets(str(print_statement)))  # noqa: T201
     except Exception:
         pass
 

--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -567,7 +567,7 @@ def get_redis_client(**env_overrides):
     return redis.Redis(**redis_kwargs)
 
 
-def get_redis_async_client(  # noqa: PLR0915
+def get_redis_async_client(
     connection_pool: Optional[async_redis.BlockingConnectionPool] = None,
     **env_overrides,
 ) -> Union[async_redis.Redis, async_redis.RedisCluster]:

--- a/litellm/caching/caching.py
+++ b/litellm/caching/caching.py
@@ -27,7 +27,7 @@ from litellm.types.utils import EmbeddingResponse, all_litellm_params
 from .azure_blob_cache import AzureBlobCache
 from .base_cache import BaseCache
 from .disk_cache import DiskCache
-from .dual_cache import DualCache  # noqa
+from .dual_cache import DualCache  # noqa: F401
 from .gcs_cache import GCSCache
 from .in_memory_cache import InMemoryCache
 from .qdrant_semantic_cache import QdrantSemanticCache
@@ -41,7 +41,7 @@ def print_verbose(print_statement):
     try:
         verbose_logger.debug(print_statement)
         if litellm.set_verbose:
-            print(print_statement)  # noqa
+            print(print_statement)  # noqa: T201
     except Exception:
         pass
 

--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -693,7 +693,7 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
         original_response = model_call_details.get("original_response")
         return cls._recover_output_items_from_raw_sse(original_response)
 
-    def transform_response(  # noqa: PLR0915
+    def transform_response(
         self,
         model: str,
         raw_response: "BaseModel",

--- a/litellm/integrations/SlackAlerting/slack_alerting.py
+++ b/litellm/integrations/SlackAlerting/slack_alerting.py
@@ -1179,7 +1179,7 @@ Model Info:
         if response.status_code == 200:
             return True
         else:
-            print("Error sending webhook alert. Error=", response.text)  # noqa
+            print("Error sending webhook alert. Error=", response.text)  # noqa: T201
 
         return False
 

--- a/litellm/integrations/lunary.py
+++ b/litellm/integrations/lunary.py
@@ -75,16 +75,16 @@ class LunaryLogger:
             version = importlib.metadata.version("lunary")  # type: ignore
             # if version < 0.1.43 then raise ImportError
             if packaging.version.Version(version) < packaging.version.Version("0.1.43"):  # type: ignore
-                print(  # noqa
+                print(  # noqa: T201
                     "Lunary version outdated. Required: >= 0.1.43. Upgrade via 'pip install lunary --upgrade'"
                 )
                 raise ImportError
 
             self.lunary_client = lunary
         except ImportError:
-            print(  # noqa
+            print(  # noqa: T201
                 "Lunary not installed. Please install it using 'pip install lunary'"
-            )  # noqa
+            )
             raise ImportError
 
     def log_event(

--- a/litellm/integrations/websearch_interception/handler.py
+++ b/litellm/integrations/websearch_interception/handler.py
@@ -1128,7 +1128,7 @@ class WebSearchInterceptionLogger(CustomLogger):
             )
             raise
 
-    async def _execute_chat_completion_agentic_loop(  # noqa: PLR0915
+    async def _execute_chat_completion_agentic_loop(
         self,
         model: str,
         messages: List[Dict],
@@ -1159,7 +1159,7 @@ class WebSearchInterceptionLogger(CustomLogger):
             **request_patch.kwargs,
         )
 
-    async def _build_chat_completion_request_patch(  # noqa: PLR0915
+    async def _build_chat_completion_request_patch(
         self,
         model: str,
         messages: List[Dict],

--- a/litellm/integrations/weights_biases.py
+++ b/litellm/integrations/weights_biases.py
@@ -21,10 +21,11 @@ try:
         # contains a (known) object attribute
         object: Literal["chat.completion", "edit", "text_completion"]
 
-        def __getitem__(self, key: K) -> V: ...  # noqa
+        def __getitem__(self, key: K) -> V: ...
 
-        def get(self, key: K, default: Optional[V] = None) -> Optional[V]:  # noqa
-            ...  # pragma: no cover
+        def get(
+            self, key: K, default: Optional[V] = None
+        ) -> Optional[V]: ...  # pragma: no cover
 
     class OpenAIRequestResponseResolver:
         def __call__(

--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -250,14 +250,14 @@ def exception_type(  # type: ignore  # noqa: PLR0915
     exception_mapping_worked = False
     exception_provider = custom_llm_provider
     if litellm.suppress_debug_info is False:
-        print()  # noqa
-        print(  # noqa
-            "\033[1;31mGive Feedback / Get Help: https://github.com/BerriAI/litellm/issues/new\033[0m"  # noqa
-        )  # noqa
-        print(  # noqa
-            "LiteLLM.Info: If you need to debug this error, use `litellm._turn_on_debug()'."  # noqa
-        )  # noqa
-        print()  # noqa
+        print()  # noqa: T201
+        print(  # noqa: T201
+            "\033[1;31mGive Feedback / Get Help: https://github.com/BerriAI/litellm/issues/new\033[0m"
+        )
+        print(  # noqa: T201
+            "LiteLLM.Info: If you need to debug this error, use `litellm._turn_on_debug()'."
+        )
+        print()  # noqa: T201
 
     litellm_response_headers = _get_response_headers(
         original_exception=original_exception

--- a/litellm/litellm_core_utils/get_llm_provider_logic.py
+++ b/litellm/litellm_core_utils/get_llm_provider_logic.py
@@ -526,11 +526,11 @@ def get_llm_provider(  # noqa: PLR0915
             custom_llm_provider = "sap"
         if not custom_llm_provider:
             if litellm.suppress_debug_info is False:
-                print()  # noqa
-                print(  # noqa
-                    "\033[1;31mProvider List: https://docs.litellm.ai/docs/providers\033[0m"  # noqa
-                )  # noqa
-                print()  # noqa
+                print()  # noqa: T201
+                print(  # noqa: T201
+                    "\033[1;31mProvider List: https://docs.litellm.ai/docs/providers\033[0m"
+                )
+                print()  # noqa: T201
             error_str = f"LLM Provider NOT provided. Pass in the LLM provider you are trying to call. You passed model={model}\n Pass model as E.g. For 'Huggingface' inference endpoints pass in `completion(model='huggingface/starcoder',..)` Learn more: https://docs.litellm.ai/docs/providers"
             # maps to openai.NotFoundError, this is raised when openai does not recognize the llm
             raise litellm.exceptions.BadRequestError(  # type: ignore

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -5893,7 +5893,7 @@ def get_standard_logging_object_payload(
 
 def emit_standard_logging_payload(payload: StandardLoggingPayload):
     if os.getenv("LITELLM_PRINT_STANDARD_LOGGING_PAYLOAD"):
-        print(json.dumps(payload, indent=4))  # noqa
+        print(json.dumps(payload, indent=4))  # noqa: T201
 
 
 def get_standard_logging_metadata(

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -92,7 +92,7 @@ def is_async_iterable(obj: Any) -> bool:
 def print_verbose(print_statement):
     try:
         if litellm.set_verbose:
-            print(print_statement)  # noqa
+            print(print_statement)  # noqa: T201
     except Exception:
         pass
 
@@ -967,7 +967,7 @@ class CustomStreamWrapper:
                     delta, model_response.choices[0].delta, attribute
                 )
 
-    def return_processed_chunk_logic(  # noqa
+    def return_processed_chunk_logic(  # noqa: PLR0915, C901
         self,
         completion_obj: Dict[str, Any],
         model_response: ModelResponseStream,

--- a/litellm/llms/azure/azure.py
+++ b/litellm/llms/azure/azure.py
@@ -189,7 +189,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
         except Exception as e:
             raise e
 
-    def completion(  # noqa: PLR0915
+    def completion(
         self,
         model: str,
         messages: list,

--- a/litellm/llms/azure/completion/handler.py
+++ b/litellm/llms/azure/completion/handler.py
@@ -25,7 +25,7 @@ class AzureTextCompletion(BaseAzureLLM):
             headers["Authorization"] = f"Bearer {azure_ad_token}"
         return headers
 
-    def completion(  # noqa: PLR0915
+    def completion(
         self,
         model: str,
         messages: list,

--- a/litellm/llms/bedrock/chat/invoke_transformations/base_invoke_transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_transformations/base_invoke_transformation.py
@@ -257,7 +257,7 @@ class AmazonInvokeConfig(BaseConfig, BaseAWSLLM):
 
         return request_data
 
-    def transform_response(  # noqa: PLR0915
+    def transform_response(
         self,
         model: str,
         raw_response: httpx.Response,

--- a/litellm/llms/bytez/chat/transformation.py
+++ b/litellm/llms/bytez/chat/transformation.py
@@ -191,7 +191,7 @@ class BytezChatConfig(BaseConfig):
         api_key: Optional[str] = None,
         json_mode: Optional[bool] = None,
     ) -> ModelResponse:
-        json = raw_response.json()  # noqa: F811
+        json = raw_response.json()
 
         error = json.get("error")
 

--- a/litellm/llms/sagemaker/completion/handler.py
+++ b/litellm/llms/sagemaker/completion/handler.py
@@ -138,7 +138,7 @@ class SagemakerLLM(BaseAWSLLM):
 
         return prepped_request
 
-    def completion(  # noqa: PLR0915
+    def completion(
         self,
         model: str,
         messages: list,

--- a/litellm/llms/vertex_ai/vertex_ai_non_gemini.py
+++ b/litellm/llms/vertex_ai/vertex_ai_non_gemini.py
@@ -650,7 +650,7 @@ async def async_completion(  # noqa: PLR0915
         raise VertexAIError(status_code=500, message=str(e))
 
 
-async def async_streaming(  # noqa: PLR0915
+async def async_streaming(
     llm_model,
     mode: str,
     prompt: str,

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -392,7 +392,7 @@ class AsyncCompletions:
 
 @tracer.wrap()
 @client
-async def acompletion(  # noqa: PLR0915
+async def acompletion(
     model: str,
     # Optional OpenAI params: see https://platform.openai.com/docs/api-reference/chat/create
     messages: List = [],
@@ -7572,7 +7572,7 @@ def print_verbose(print_statement):
     try:
         verbose_logger.debug(print_statement)
         if litellm.set_verbose:
-            print(print_statement)  # noqa
+            print(print_statement)  # noqa: T201
     except Exception:
         pass
 

--- a/litellm/proxy/anthropic_endpoints/endpoints.py
+++ b/litellm/proxy/anthropic_endpoints/endpoints.py
@@ -28,7 +28,7 @@ router = APIRouter()
     tags=["[beta] Anthropic `/v1/messages`"],
     dependencies=[Depends(user_api_key_auth)],
 )
-async def anthropic_response(  # noqa: PLR0915
+async def anthropic_response(
     fastapi_response: Response,
     request: Request,
     user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),

--- a/litellm/proxy/auth/login_utils.py
+++ b/litellm/proxy/auth/login_utils.py
@@ -103,7 +103,7 @@ class LoginResult:
         self.login_method = login_method
 
 
-async def authenticate_user(  # noqa: PLR0915
+async def authenticate_user(
     username: str,
     password: str,
     master_key: Optional[str],

--- a/litellm/proxy/common_utils/debug_utils.py
+++ b/litellm/proxy/common_utils/debug_utils.py
@@ -92,12 +92,12 @@ if os.environ.get("LITELLM_PROFILE", "false").lower() == "true":
     try:
         import objgraph  # type: ignore
 
-        print("growth of objects")  # noqa
+        print("growth of objects")  # noqa: T201
         objgraph.show_growth()
-        print("\n\nMost common types")  # noqa
+        print("\n\nMost common types")  # noqa: T201
         objgraph.show_most_common_types()
         roots = objgraph.get_leaking_objects()
-        print("\n\nLeaking objects")  # noqa
+        print("\n\nLeaking objects")  # noqa: T201
         objgraph.show_most_common_types(objects=roots)
     except ImportError:
         raise ImportError(
@@ -739,7 +739,7 @@ async def get_otel_spans():
     else:
         recorded_spans = []
 
-    print("Spans: ", recorded_spans)  # noqa
+    print("Spans: ", recorded_spans)  # noqa: T201
 
     most_recent_parent = None
     most_recent_start_time = 1000000

--- a/litellm/proxy/db/check_migration.py
+++ b/litellm/proxy/db/check_migration.py
@@ -54,7 +54,7 @@ def check_prisma_schema_diff_helper(db_url: str) -> Tuple[bool, List[str]]:
         subprocess.CalledProcessError: If the Prisma command fails.
         Exception: For any other errors during execution.
     """
-    verbose_logger.debug("Checking for Prisma schema diff...")  # noqa: T201
+    verbose_logger.debug("Checking for Prisma schema diff...")
     try:
         result = subprocess.run(
             [

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -28,7 +28,7 @@ from typing import (
 
 import aiohttp
 
-import litellm  # noqa: E401
+import litellm
 from litellm import get_secret
 from litellm._logging import verbose_proxy_logger
 from litellm.types.utils import GenericGuardrailAPIInputs
@@ -1432,7 +1432,7 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         try:
             verbose_proxy_logger.debug(print_statement)
             if litellm.set_verbose:
-                print(print_statement)  # noqa
+                print(print_statement)  # noqa: T201
         except Exception:
             pass
 

--- a/litellm/proxy/hooks/batch_redis_get.py
+++ b/litellm/proxy/hooks/batch_redis_get.py
@@ -33,7 +33,7 @@ class _PROXY_BatchRedisRequests(CustomLogger):
         elif debug_level == "INFO":
             verbose_proxy_logger.debug(print_statement)
         if litellm.set_verbose is True:
-            print(print_statement)  # noqa
+            print(print_statement)  # noqa: T201
 
     async def async_pre_call_hook(
         self,

--- a/litellm/proxy/hooks/parallel_request_limiter.py
+++ b/litellm/proxy/hooks/parallel_request_limiter.py
@@ -50,7 +50,7 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
         try:
             verbose_proxy_logger.debug(print_statement)
             if litellm.set_verbose:
-                print(print_statement)  # noqa
+                print(print_statement)  # noqa: T201
         except Exception:
             pass
 
@@ -769,7 +769,7 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
                 litellm_parent_otel_span=litellm_parent_otel_span,
             )
         except Exception as e:
-            self.print_verbose(e)  # noqa
+            self.print_verbose(e)
 
     async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
         try:

--- a/litellm/proxy/hooks/prompt_injection_detection.py
+++ b/litellm/proxy/hooks/prompt_injection_detection.py
@@ -72,7 +72,7 @@ class _OPTIONAL_PromptInjectionDetection(CustomLogger):
             verbose_proxy_logger.debug(print_statement)
 
         if litellm.set_verbose is True:
-            print(print_statement)  # noqa
+            print(print_statement)  # noqa: T201
 
     def update_environment(self, router: Optional[Router] = None):
         self.llm_router = router

--- a/litellm/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/proxy/management_endpoints/internal_user_endpoints.py
@@ -755,7 +755,7 @@ def _build_user_info_response(
     response_model=UserInfoResponse,
 )
 @management_endpoint_wrapper
-async def user_info(  # noqa: PLR0915
+async def user_info(
     request: Request,
     user_id: Optional[str] = fastapi.Query(
         default=None, description="User ID in the request parameters"
@@ -1082,7 +1082,7 @@ def _process_keys_for_user_info(
                 continue
 
             try:
-                _key: dict = key.model_dump()  # noqa
+                _key: dict = key.model_dump()
             except Exception:
                 # if using pydantic v1
                 _key = key.dict()

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -2428,7 +2428,7 @@ async def _validate_update_key_data(
     "/key/update", tags=["key management"], dependencies=[Depends(user_api_key_auth)]
 )
 @management_endpoint_wrapper
-async def update_key_fn(  # noqa: PLR0915
+async def update_key_fn(
     request: Request,
     data: UpdateKeyRequest,
     user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
@@ -3377,7 +3377,7 @@ async def info_key_fn(
             )
         ## REMOVE HASHED TOKEN INFO BEFORE RETURNING ##
         try:
-            key_info = key_info.model_dump()  # noqa
+            key_info = key_info.model_dump()
         except Exception:
             # if using pydantic v1
             key_info = key_info.dict()
@@ -4412,7 +4412,7 @@ async def _execute_virtual_key_regeneration(
     dependencies=[Depends(user_api_key_auth)],
 )
 @management_endpoint_wrapper
-async def regenerate_key_fn(  # noqa: PLR0915
+async def regenerate_key_fn(
     key: Optional[str] = None,
     data: Optional[RegenerateKeyRequest] = None,
     user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),

--- a/litellm/proxy/management_endpoints/policy_endpoints/__init__.py
+++ b/litellm/proxy/management_endpoints/policy_endpoints/__init__.py
@@ -7,7 +7,7 @@ continue to work. Patch targets also resolve correctly since names
 are imported directly into this namespace.
 """
 
-from litellm.proxy.management_endpoints.policy_endpoints.endpoints import *  # noqa: F401, F403
+from litellm.proxy.management_endpoints.policy_endpoints.endpoints import *  # noqa: F403
 from litellm.proxy.management_endpoints.policy_endpoints.endpoints import (  # noqa: F401
     _build_all_names_per_competitor,
     _build_comparison_blocked_words,

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -3647,7 +3647,7 @@ async def team_info(
         ## REMOVE HASHED TOKEN INFO before returning ##
         for key in keys:
             try:
-                key = key.model_dump()  # noqa
+                key = key.model_dump()
             except Exception:
                 # if using pydantic v1
                 key = key.dict()

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -114,7 +114,7 @@ from litellm.repositories.table_repositories import SSOConfigRepository
 from litellm.repositories.team_repository import TeamRepository
 from litellm.repositories.user_repository import UserRepository
 from litellm.secret_managers.main import get_secret_bool, str_to_bool
-from litellm.types.proxy.management_endpoints.ui_sso import *  # noqa: F403, F401
+from litellm.types.proxy.management_endpoints.ui_sso import *  # noqa: F403
 from litellm.types.proxy.management_endpoints.ui_sso import (
     DefaultTeamSSOParams,
     MicrosoftGraphAPIUserGroupDirectoryObject,
@@ -829,7 +829,7 @@ async def google_login(
     key: Optional[str] = None,
     existing_key: Optional[str] = None,
     return_to: Optional[str] = None,
-):  # noqa: PLR0915
+):
     """
     Create Proxy API Keys using Google Workspace SSO. Requires setting PROXY_BASE_URL in .env
     PROXY_BASE_URL should be the your deployed proxy endpoint, e.g. PROXY_BASE_URL="https://litellm-production-7002.up.railway.app/"
@@ -1833,7 +1833,7 @@ async def check_and_update_if_proxy_admin_id(
 
 
 @router.get("/sso/callback", tags=["experimental"], include_in_schema=False)
-async def auth_callback(request: Request, state: Optional[str] = None):  # noqa: PLR0915
+async def auth_callback(request: Request, state: Optional[str] = None):
     """Verify login"""
     verbose_proxy_logger.info(f"Starting SSO callback with state: {state}")
 

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/cohere_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/cohere_passthrough_logging_handler.py
@@ -71,7 +71,7 @@ class CoherePassthroughLoggingHandler(BasePassthroughLoggingHandler):
         complete_streaming_response = stream_chunk_builder(chunks=all_openai_chunks)
         return complete_streaming_response
 
-    def cohere_passthrough_handler(  # noqa: PLR0915
+    def cohere_passthrough_handler(
         self,
         httpx_response: httpx.Response,
         response_body: dict,

--- a/litellm/proxy/post_call_rules.py
+++ b/litellm/proxy/post_call_rules.py
@@ -1,5 +1,5 @@
 def post_response_rule(input):  # receives the model response
-    print(f"post_response_rule:input={input}")  # noqa
+    print(f"post_response_rule:input={input}")  # noqa: T201
     if len(input) < 200:
         return {
             "decision": False,

--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -102,9 +102,9 @@ class ProxyInitializationHelpers:
 
     @staticmethod
     def _run_health_check(host, port):
-        print("\nLiteLLM: Health Testing models in config")  # noqa
+        print("\nLiteLLM: Health Testing models in config")
         response = httpx.get(url=f"http://{host}:{port}/health")
-        print(json.dumps(response.json(), indent=4))  # noqa
+        print(json.dumps(response.json(), indent=4))
 
     @staticmethod
     def _run_test_chat_completion(
@@ -138,7 +138,7 @@ class ProxyInitializationHelpers:
         )
         click.echo(f"\nLiteLLM: response from proxy {response}")
 
-        print(  # noqa
+        print(
             f"\n LiteLLM: Making a test ChatCompletions + streaming r equest to proxy. Model={request_model}"
         )
 
@@ -154,11 +154,11 @@ class ProxyInitializationHelpers:
         )
         for chunk in stream_response:
             click.echo(f"LiteLLM: streaming response from proxy {chunk}")
-        print("\n making completion request to proxy")  # noqa
+        print("\n making completion request to proxy")
         completion_response = client.completions.create(
             model=request_model, prompt="this is a test request, write a short poem"
         )
-        print(completion_response)  # noqa
+        print(completion_response)
 
     @staticmethod
     def _get_default_unvicorn_init_args(
@@ -184,7 +184,7 @@ class ProxyInitializationHelpers:
             "port": port,
         }
         if log_config is not None:
-            print(f"Using log_config: {log_config}")  # noqa
+            print(f"Using log_config: {log_config}")
             uvicorn_args["log_config"] = log_config
         elif litellm.json_logs:
             # Use JSON log config for uvicorn to ensure all logs (including exceptions) are JSON
@@ -198,7 +198,7 @@ class ProxyInitializationHelpers:
             ):
                 uvicorn_args["timeout_worker_healthcheck"] = timeout_worker_healthcheck
             else:
-                print(  # noqa
+                print(
                     f"\033[1;33mLiteLLM Proxy: --timeout_worker_healthcheck "
                     f"requires uvicorn>=0.37.0, but installed uvicorn=={uvicorn.__version__}. "
                     f"Ignoring the flag.\033[0m"
@@ -304,15 +304,15 @@ class ProxyInitializationHelpers:
         from hypercorn.asyncio import serve
         from hypercorn.config import Config
 
-        print(  # noqa
-            f"\033[1;32mLiteLLM Proxy: Starting server on {host}:{port} using Hypercorn\033[0m\n"  # noqa
-        )  # noqa
+        print(
+            f"\033[1;32mLiteLLM Proxy: Starting server on {host}:{port} using Hypercorn\033[0m\n"
+        )
         config = Config()
         config.bind = [f"{host}:{port}"]
 
         if ssl_certfile_path is not None and ssl_keyfile_path is not None:
-            print(  # noqa
-                f"\033[1;32mLiteLLM Proxy: Using SSL with certfile: {ssl_certfile_path} and keyfile: {ssl_keyfile_path}\033[0m\n"  # noqa
+            print(
+                f"\033[1;32mLiteLLM Proxy: Using SSL with certfile: {ssl_certfile_path} and keyfile: {ssl_keyfile_path}\033[0m\n"
             )
             config.certfile = ssl_certfile_path
             config.keyfile = ssl_keyfile_path
@@ -342,16 +342,16 @@ class ProxyInitializationHelpers:
         from granian import Granian
         from granian.constants import Interfaces
 
-        print(  # noqa
+        print(
             f"\033[1;32mLiteLLM Proxy: Starting server on {host}:{port} using Granian\033[0m\n"
         )
         if max_requests_before_restart is not None:
-            print(  # noqa
+            print(
                 "\033[1;33mLiteLLM: --max_requests_before_restart is not supported by Granian "
                 "(Granian uses workers_lifetime in seconds, not a per-request limit).\033[0m\n"
             )
         if ciphers is not None:
-            print(  # noqa
+            print(
                 "\033[1;33mLiteLLM: --ciphers is not applied when using --run_granian.\033[0m\n"
             )
 
@@ -366,7 +366,7 @@ class ProxyInitializationHelpers:
         if granian_runtime_threads is not None:
             kwargs["runtime_threads"] = granian_runtime_threads
         if ssl_certfile_path is not None and ssl_keyfile_path is not None:
-            print(  # noqa
+            print(
                 f"\033[1;32mLiteLLM Proxy: Using SSL with certfile: {ssl_certfile_path} and keyfile: {ssl_keyfile_path}\033[0m\n"
             )
             kwargs["ssl_cert"] = Path(ssl_certfile_path)
@@ -419,19 +419,19 @@ class ProxyInitializationHelpers:
                 }'
                 \n
                 """
-                print()  # noqa
-                print(  # noqa
+                print()
+                print(
                     '\033[1;34mLiteLLM: Test your local proxy with: "litellm --test" This runs an openai.ChatCompletion request to your proxy [In a new terminal tab]\033[0m\n'
                 )
-                print(  # noqa
+                print(
                     f"\033[1;34mLiteLLM: Curl Command Test for your local proxy\n {curl_command} \033[0m\n"
                 )
-                print(  # noqa
+                print(
                     "\033[1;34mDocs: https://docs.litellm.ai/docs/simple_proxy\033[0m\n"
-                )  # noqa
-                print(  # noqa
+                )
+                print(
                     f"\033[1;34mSee all Router/Swagger docs on http://0.0.0.0:{port} \033[0m\n"
-                )  # noqa
+                )
 
             def load_config(self):
                 # note: This Loads the gunicorn config - has nothing to do with LiteLLM Proxy config
@@ -451,8 +451,8 @@ class ProxyInitializationHelpers:
                 # gunicorn app function
                 return self.application
 
-        print(  # noqa
-            f"\033[1;32mLiteLLM Proxy: Starting server on {host}:{port} with {num_workers} workers\033[0m\n"  # noqa
+        print(
+            f"\033[1;32mLiteLLM Proxy: Starting server on {host}:{port} with {num_workers} workers\033[0m\n"
         )
         gunicorn_options = {
             "bind": f"{host}:{port}",
@@ -478,8 +478,8 @@ class ProxyInitializationHelpers:
             gunicorn_options["child_exit"] = child_exit
 
         if ssl_certfile_path is not None and ssl_keyfile_path is not None:
-            print(  # noqa
-                f"\033[1;32mLiteLLM Proxy: Using SSL with certfile: {ssl_certfile_path} and keyfile: {ssl_keyfile_path}\033[0m\n"  # noqa
+            print(
+                f"\033[1;32mLiteLLM Proxy: Using SSL with certfile: {ssl_certfile_path} and keyfile: {ssl_keyfile_path}\033[0m\n"
             )
             gunicorn_options["certfile"] = ssl_certfile_path
             gunicorn_options["keyfile"] = ssl_keyfile_path
@@ -496,7 +496,7 @@ class ProxyInitializationHelpers:
         except Exception as e:
             print(f"""
                 LiteLLM Warning: proxy started with `ollama` model\n`ollama serve` failed with Exception{e}. \nEnsure you run `ollama serve`
-            """)  # noqa  # noqa
+            """)
 
     @staticmethod
     def _is_port_in_use(port):
@@ -557,7 +557,7 @@ class ProxyInitializationHelpers:
         os.makedirs(multiproc_dir, exist_ok=True)
         wipe_directory(multiproc_dir)
         action = "Auto-created" if auto_created else "Using existing"
-        print(f"LiteLLM: {action} PROMETHEUS_MULTIPROC_DIR={multiproc_dir}")  # noqa
+        print(f"LiteLLM: {action} PROMETHEUS_MULTIPROC_DIR={multiproc_dir}")
 
 
 @click.command()
@@ -1185,7 +1185,7 @@ def run_server(  # noqa: PLR0915
                     check_prisma_schema_diff(db_url=None)
                 else:
                     if not use_v2_migration_resolver:
-                        print(  # noqa
+                        print(
                             "\033[1;33mLiteLLM Proxy: Using default (v1) migration resolver. "
                             "If your deployment has seen schema thrashing during rolling "
                             "deploys, try --use_v2_migration_resolver (safer: avoids the "
@@ -1201,7 +1201,7 @@ def run_server(  # noqa: PLR0915
                         # (e.g. non-idempotent failures, permission issues).
                         # v1 never raises here, so this only fires when the
                         # operator opted into v2.
-                        print(  # noqa
+                        print(
                             "\033[1;31mLiteLLM Proxy: Database migration cannot proceed. "
                             f"{e}\033[0m",
                             file=sys.stderr,
@@ -1210,19 +1210,19 @@ def run_server(  # noqa: PLR0915
                         sys.exit(2)
                     if not setup_ok:
                         if enforce_prisma_migration_check:
-                            print(  # noqa
+                            print(
                                 "\033[1;31mLiteLLM Proxy: Database setup failed after multiple retries. "
                                 "The proxy cannot start safely. Please check your database connection and migration status.\033[0m"
                             )
                             sys.exit(1)
                         else:
-                            print(  # noqa
+                            print(
                                 "\033[1;33mLiteLLM Proxy: Database migration failed but continuing startup. "
                                 "Set --enforce_prisma_migration_check or ENFORCE_PRISMA_MIGRATION_CHECK=true to exit on failure.\033[0m"
                             )
             else:
-                print(  # noqa
-                    f"Unable to connect to DB. DATABASE_URL found in environment, but prisma package not found."  # noqa
+                print(
+                    f"Unable to connect to DB. DATABASE_URL found in environment, but prisma package not found."  # noqa: F541
                 )
         if port == 4000 and ProxyInitializationHelpers._is_port_in_use(port):
             port = random.randint(1024, 49152)
@@ -1233,7 +1233,7 @@ def run_server(  # noqa: PLR0915
             litellm._turn_on_debug()
 
         # DO NOT DELETE - enables global variables to work across files
-        from litellm.proxy.proxy_server import app  # noqa
+        from litellm.proxy.proxy_server import app
 
         # Auto-create PROMETHEUS_MULTIPROC_DIR for multi-worker setups
         ProxyInitializationHelpers._maybe_setup_prometheus_multiproc_dir(
@@ -1243,9 +1243,7 @@ def run_server(  # noqa: PLR0915
 
         # Skip server startup if requested (after all setup is done)
         if skip_server_startup:
-            print(  # noqa
-                "LiteLLM: Setup complete. Skipping server startup as requested."
-            )
+            print("LiteLLM: Setup complete. Skipping server startup as requested.")
             return
 
         running_uvicorn = run_gunicorn is False and run_hypercorn is False
@@ -1263,8 +1261,8 @@ def run_server(  # noqa: PLR0915
             uvicorn_args["limit_max_requests"] = max_requests_before_restart
         if run_gunicorn is False and run_hypercorn is False and run_granian is False:
             if ssl_certfile_path is not None and ssl_keyfile_path is not None:
-                print(  # noqa
-                    f"\033[1;32mLiteLLM Proxy: Using SSL with certfile: {ssl_certfile_path} and keyfile: {ssl_keyfile_path}\033[0m\n"  # noqa
+                print(
+                    f"\033[1;32mLiteLLM Proxy: Using SSL with certfile: {ssl_certfile_path} and keyfile: {ssl_keyfile_path}\033[0m\n"
                 )
                 uvicorn_args["ssl_keyfile"] = ssl_keyfile_path
                 uvicorn_args["ssl_certfile"] = ssl_certfile_path

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -180,26 +180,26 @@ def generate_feedback_box():
     # Select a random message
     message = random.choice(list_of_messages)
 
-    print()  # noqa
-    print("\033[1;37m" + "#" + "-" * box_width + "#\033[0m")  # noqa
-    print("\033[1;37m" + "#" + " " * box_width + "#\033[0m")  # noqa
-    print("\033[1;37m" + "# {:^59} #\033[0m".format(message))  # noqa
-    print(  # noqa
+    print()  # noqa: T201
+    print("\033[1;37m" + "#" + "-" * box_width + "#\033[0m")  # noqa: T201
+    print("\033[1;37m" + "#" + " " * box_width + "#\033[0m")  # noqa: T201
+    print("\033[1;37m" + "# {:^59} #\033[0m".format(message))  # noqa: T201
+    print(  # noqa: T201
         "\033[1;37m"
         + "# {:^59} #\033[0m".format("https://github.com/BerriAI/litellm/issues/new")
-    )  # noqa
-    print("\033[1;37m" + "#" + " " * box_width + "#\033[0m")  # noqa
-    print("\033[1;37m" + "#" + "-" * box_width + "#\033[0m")  # noqa
-    print()  # noqa
-    print(" Thank you for using LiteLLM! - Krrish & Ishaan")  # noqa
-    print()  # noqa
-    print()  # noqa
-    print()  # noqa
-    print(  # noqa
+    )
+    print("\033[1;37m" + "#" + " " * box_width + "#\033[0m")  # noqa: T201
+    print("\033[1;37m" + "#" + "-" * box_width + "#\033[0m")  # noqa: T201
+    print()  # noqa: T201
+    print(" Thank you for using LiteLLM! - Krrish & Ishaan")  # noqa: T201
+    print()  # noqa: T201
+    print()  # noqa: T201
+    print()  # noqa: T201
+    print(  # noqa: T201
         "\033[1;31mGive Feedback / Get Help: https://github.com/BerriAI/litellm/issues/new\033[0m"
-    )  # noqa
-    print()  # noqa
-    print()  # noqa
+    )
+    print()  # noqa: T201
+    print()  # noqa: T201
 
 
 import contextlib
@@ -3805,9 +3805,9 @@ class ProxyConfig:
 
         search_tools_parsed: List[SearchToolTypedDict] = []
 
-        print(  # noqa
+        print(  # noqa: T201
             "\033[32mLiteLLM: Proxy initialized with Search Tools:\033[0m"
-        )  # noqa
+        )
 
         for search_tool in search_tools_raw:
             # Display loaded search tool
@@ -3815,7 +3815,9 @@ class ProxyConfig:
             search_provider = search_tool.get("litellm_params", {}).get(
                 "search_provider", ""
             )
-            print(f"\033[32m    {search_tool_name} ({search_provider})\033[0m")  # noqa
+            print(  # noqa: T201
+                f"\033[32m    {search_tool_name} ({search_provider})\033[0m"
+            )
 
             # Handle os.environ/ variables in litellm_params
             litellm_params = search_tool.get("litellm_params", {})
@@ -3925,7 +3927,7 @@ class ProxyConfig:
             reset_color_code = "\033[0m"
             for key, value in litellm_settings.items():
                 if key == "cache" and value is True:
-                    print(f"{blue_color_code}\nSetting Cache on Proxy")  # noqa
+                    print(f"{blue_color_code}\nSetting Cache on Proxy")  # noqa: T201
                     from litellm.caching.caching import Cache
 
                     cache_params = {}
@@ -4120,9 +4122,9 @@ class ProxyConfig:
                                         "mounting metrics endpoint"
                                     )
                                     PrometheusLogger._mount_metrics_endpoint()
-                    print(  # noqa
+                    print(  # noqa: T201
                         f"{blue_color_code} Initialized Success Callbacks - {litellm.success_callback} {reset_color_code}"
-                    )  # noqa
+                    )
                 elif key == "failure_callback":
                     litellm.failure_callback = []
 
@@ -4141,9 +4143,9 @@ class ProxyConfig:
                             litellm.logging_callback_manager.add_litellm_failure_callback(
                                 callback
                             )
-                    print(  # noqa
+                    print(  # noqa: T201
                         f"{blue_color_code} Initialized Failure Callbacks - {litellm.failure_callback} {reset_color_code}"
-                    )  # noqa
+                    )
                 elif key == "audit_log_callbacks":
                     from litellm.proxy.management_helpers.audit_logs import (
                         reset_audit_log_callback_cache,
@@ -4167,9 +4169,9 @@ class ProxyConfig:
                         "store_audit_logs", litellm.store_audit_logs
                     )
                     if _store_audit_logs:
-                        print(  # noqa
+                        print(  # noqa: T201
                             f"{blue_color_code} Initialized Audit Log Callbacks - {litellm.audit_log_callbacks} {reset_color_code}"
-                        )  # noqa
+                        )
                     else:
                         verbose_proxy_logger.warning(
                             "'audit_log_callbacks' is configured but 'store_audit_logs' is not enabled. "
@@ -4516,15 +4518,15 @@ class ProxyConfig:
         model_list = config.get("model_list", None)
         if model_list:
             router_params["model_list"] = model_list
-            print(  # noqa
+            print(  # noqa: T201
                 "\033[32mLiteLLM: Proxy initialized with Config, Set models:\033[0m"
-            )  # noqa
+            )
             for model in model_list:
                 ### LOAD FROM os.environ/ ###
                 for k, v in model["litellm_params"].items():
                     if isinstance(v, str) and v.startswith("os.environ/"):
                         model["litellm_params"][k] = get_secret(v)
-                print(f"\033[32m    {model.get('model_name', '')}\033[0m")  # noqa
+                print(f"\033[32m    {model.get('model_name', '')}\033[0m")  # noqa: T201
                 litellm_model_name = model["litellm_params"]["model"]
                 litellm_model_api_base = model["litellm_params"].get("api_base", None)
                 if "ollama" in litellm_model_name and litellm_model_api_base is None:
@@ -7996,7 +7998,7 @@ class ProxyStartupEvent:
             and proxy_logging_obj.slack_alerting_instance.alerting is not None
             and prisma_client is not None
         ):
-            print("Alerting: Initializing Weekly/Monthly Spend Reports")  # noqa
+            print("Alerting: Initializing Weekly/Monthly Spend Reports")  # noqa: T201
             spend_report_frequency: str = (
                 general_settings.get("spend_report_frequency", "7d") or "7d"
             )
@@ -8490,7 +8492,7 @@ async def model_info(
     tags=["chat/completions"],
     responses={200: {"description": "Successful response"}, **ERROR_RESPONSES},
 )  # azure compatible endpoint
-async def chat_completion(  # noqa: PLR0915
+async def chat_completion(
     request: Request,
     fastapi_response: Response,
     model: Optional[str] = None,
@@ -8894,7 +8896,7 @@ async def completion(  # noqa: PLR0915
     response_class=ORJSONResponse,
     tags=["embeddings"],
 )  # azure compatible endpoint
-async def embeddings(  # noqa: PLR0915
+async def embeddings(
     request: Request,
     fastapi_response: Response,
     model: Optional[str] = None,
@@ -12640,7 +12642,7 @@ def _get_proxy_model_info(model: dict) -> dict:
     tags=["model management"],
     dependencies=[Depends(user_api_key_auth)],
 )
-async def model_info_v1(  # noqa: PLR0915
+async def model_info_v1(
     user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
     litellm_model_id: Optional[str] = None,
     include_team_models: Optional[bool] = fastapi.Query(
@@ -13370,7 +13372,7 @@ async def fallback_login(request: Request):
 @router.post(
     "/login", include_in_schema=False
 )  # hidden since this is a helper for UI sso login
-async def login(request: Request):  # noqa: PLR0915
+async def login(request: Request):
     global premium_user, general_settings, master_key
     from litellm.proxy.auth.login_utils import authenticate_user, create_ui_token_object
     from litellm.proxy.utils import get_custom_url
@@ -13420,7 +13422,7 @@ async def login(request: Request):  # noqa: PLR0915
 @router.post(
     "/v2/login", include_in_schema=False
 )  # hidden helper for UI logins via API
-async def login_v2(request: Request):  # noqa: PLR0915
+async def login_v2(request: Request):
     global premium_user, general_settings, master_key
     from litellm.proxy.auth.login_utils import authenticate_user, create_ui_token_object
     from litellm.proxy.utils import get_custom_url
@@ -13495,7 +13497,7 @@ async def login_v2(request: Request):  # noqa: PLR0915
 @router.post(
     "/v3/login", include_in_schema=False
 )  # control-plane login — always returns token in body for cross-origin use
-async def login_v3(request: Request):  # noqa: PLR0915
+async def login_v3(request: Request):
     global premium_user, general_settings, master_key
     from litellm.proxy.auth.login_utils import authenticate_user, create_ui_token_object
     from litellm.proxy.utils import get_custom_url

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -191,7 +191,7 @@ def print_verbose(print_statement):
 
     verbose_proxy_logger.debug("{}\n{}".format(print_statement, traceback.format_exc()))
     if litellm.set_verbose:
-        print(f"LiteLLM Proxy: {_redact_string(str(print_statement))}")  # noqa
+        print(f"LiteLLM Proxy: {_redact_string(str(print_statement))}")  # noqa: T201
 
 
 def _get_email_logger_class():
@@ -3345,7 +3345,7 @@ class PrismaClient:
         on_backoff=on_backoff,  # specifying the function to call on backoff
     )
     @log_db_metrics
-    async def get_data(  # noqa: PLR0915
+    async def get_data(
         self,
         token: Optional[Union[str, list]] = None,
         user_id: Optional[str] = None,
@@ -3788,7 +3788,7 @@ class PrismaClient:
         max_time=10,  # maximum total time to retry for
         on_backoff=on_backoff,  # specifying the function to call on backoff
     )
-    async def insert_data(  # noqa: PLR0915
+    async def insert_data(
         self,
         data: dict,
         table_name: Literal[
@@ -3938,7 +3938,7 @@ class PrismaClient:
         max_time=10,  # maximum total time to retry for
         on_backoff=on_backoff,  # specifying the function to call on backoff
     )
-    async def update_data(  # noqa: PLR0915
+    async def update_data(
         self,
         token: Optional[str] = None,
         data: dict = {},
@@ -5514,7 +5514,7 @@ class ProxyUpdateSpend:
         return False
 
 
-async def update_spend(  # noqa: PLR0915
+async def update_spend(
     prisma_client: PrismaClient,
     db_writer_client: Optional[AsyncHTTPHandler],
     proxy_logging_obj: ProxyLogging,

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -2691,7 +2691,7 @@ class Router:
 
         return FallbackResponsesStreamWrapper(stream_with_fallbacks())
 
-    def _completion_streaming_iterator(  # noqa: PLR0915
+    def _completion_streaming_iterator(
         self,
         model_response: CustomStreamWrapper,
         messages: List[Dict[str, str]],

--- a/litellm/router_strategy/complexity_router/evals/eval_complexity_router.py
+++ b/litellm/router_strategy/complexity_router/evals/eval_complexity_router.py
@@ -250,10 +250,10 @@ def run_eval() -> Tuple[int, int, List[dict]]:
     total = len(EVAL_CASES)
     failures = []
 
-    print("=" * 70)  # noqa: T201
-    print("COMPLEXITY ROUTER EVALUATION")  # noqa: T201
-    print("=" * 70)  # noqa: T201
-    print()  # noqa: T201
+    print("=" * 70)
+    print("COMPLEXITY ROUTER EVALUATION")
+    print("=" * 70)
+    print()
 
     for i, case in enumerate(EVAL_CASES, 1):
         tier, score, signals = router.classify(case.prompt, case.system_prompt)
@@ -292,33 +292,33 @@ def run_eval() -> Tuple[int, int, List[dict]]:
             )
 
         # Print result
-        print(f"[{i:2d}] {status} | {case.description}")  # noqa: T201
+        print(f"[{i:2d}] {status} | {case.description}")
         print(
             f"     Expected: {case.expected_tier.value:10s} | Got: {tier.value:10s} | Score: {score:+.3f}"
-        )  # noqa: T201
+        )
         if signals:
-            print(f"     Signals: {', '.join(signals)}")  # noqa: T201
+            print(f"     Signals: {', '.join(signals)}")
         if not is_pass:
-            print(f"     Prompt: {case.prompt[:60]}...")  # noqa: T201
-        print()  # noqa: T201
+            print(f"     Prompt: {case.prompt[:60]}...")
+        print()
 
     # Summary
-    print("=" * 70)  # noqa: T201
-    print(f"RESULTS: {passed}/{total} passed ({100*passed/total:.1f}%)")  # noqa: T201
-    print("=" * 70)  # noqa: T201
+    print("=" * 70)
+    print(f"RESULTS: {passed}/{total} passed ({100*passed/total:.1f}%)")
+    print("=" * 70)
 
     if failures:
-        print("\nFAILURES:")  # noqa: T201
-        print("-" * 70)  # noqa: T201
+        print("\nFAILURES:")
+        print("-" * 70)
         for f in failures:
-            print(f"Case {f['case']}: {f['description']}")  # noqa: T201
+            print(f"Case {f['case']}: {f['description']}")
             print(
                 f"  Expected: {f['expected']}, Got: {f['actual']} (score: {f['score']})"
-            )  # noqa: T201
-            print(f"  Signals: {f['signals']}")  # noqa: T201
+            )
+            print(f"  Signals: {f['signals']}")
             if f["acceptable"]:
-                print(f"  Acceptable: {f['acceptable']}")  # noqa: T201
-            print()  # noqa: T201
+                print(f"  Acceptable: {f['acceptable']}")
+            print()
 
     return passed, total, failures
 
@@ -330,17 +330,13 @@ def main():
     # Exit with error code if too many failures
     pass_rate = passed / total
     if pass_rate < 0.80:
-        print(
-            f"\n❌ EVAL FAILED: Pass rate {pass_rate:.1%} is below 80% threshold"
-        )  # noqa: T201
+        print(f"\n❌ EVAL FAILED: Pass rate {pass_rate:.1%} is below 80% threshold")
         sys.exit(1)
     elif pass_rate < 0.90:
-        print(
-            f"\n⚠️  EVAL WARNING: Pass rate {pass_rate:.1%} is below 90%"
-        )  # noqa: T201
+        print(f"\n⚠️  EVAL WARNING: Pass rate {pass_rate:.1%} is below 90%")
         sys.exit(0)
     else:
-        print(f"\n✅ EVAL PASSED: Pass rate {pass_rate:.1%}")  # noqa: T201
+        print(f"\n✅ EVAL PASSED: Pass rate {pass_rate:.1%}")
         sys.exit(0)
 
 

--- a/litellm/router_strategy/lowest_tpm_rpm_v2.py
+++ b/litellm/router_strategy/lowest_tpm_rpm_v2.py
@@ -380,7 +380,7 @@ class LowestTPMLoggingHandler_v2(BaseRoutingStrategy, CustomLogger):
                 potential_deployments = [_deployment]
         return potential_deployments
 
-    def _common_checks_available_deployment(  # noqa: PLR0915
+    def _common_checks_available_deployment(
         self,
         model_group: str,
         healthy_deployments: list,

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -488,7 +488,7 @@ def print_verbose(
         elif log_level == "ERROR":
             verbose_logger.error(print_statement)
         if litellm.set_verbose is True and logger_only is False:
-            print(print_statement)  # noqa
+            print(print_statement)  # noqa: T201
     except Exception:
         pass
 
@@ -8609,7 +8609,7 @@ class ProviderConfigManager:
         return LangFlowConfig()
 
     @staticmethod
-    def get_provider_chat_config(  # noqa: PLR0915
+    def get_provider_chat_config(
         model: str,
         provider: LlmProviders,
         base_model: Optional[str] = None,

--- a/litellm/videos/main.py
+++ b/litellm/videos/main.py
@@ -159,7 +159,7 @@ def video_generation(
 
 
 @client
-def video_generation(  # noqa: PLR0915
+def video_generation(
     prompt: str,
     model: Optional[str] = None,
     input_reference: Optional[FileTypes] = None,
@@ -569,7 +569,7 @@ def video_remix(
 
 
 @client
-def video_remix(  # noqa: PLR0915
+def video_remix(
     video_id: str,
     prompt: str,
     timeout=600,  # default to 10 minutes
@@ -790,7 +790,7 @@ def video_list(
 
 
 @client
-def video_list(  # noqa: PLR0915
+def video_list(
     after: Optional[str] = None,
     limit: Optional[int] = None,
     order: Optional[str] = None,
@@ -993,7 +993,7 @@ def video_status(
 
 
 @client
-def video_status(  # noqa: PLR0915
+def video_status(
     video_id: str,
     timeout=600,  # default to 10 minutes
     custom_llm_provider=None,

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,5 +1,16 @@
 lint.ignore = ["F405", "E402", "E501", "F403"]
-lint.extend-select = ["E501", "PLR0915", "T20"]
+lint.extend-select = ["E501", "PLR0915", "T20", "PGH004", "RUF008", "RUF009", "RUF100"]
+# RUF100 (unused-noqa) only knows the rules enabled in THIS config, so it would strip
+# `# noqa` directives that protect rules enforced elsewhere. List those codes as external
+# so RUF100 leaves their directives alone: the strict gate (ruff-strict.toml) and upstream
+# litellm's own ruff config both rely on suppressions this config can't see.
+lint.external = [
+    # Enforced by the strict-rule gate (scripts/ruff_strict_gate.py + ruff-strict.toml)
+    "ANN001", "ANN002", "ANN003", "ANN401", "B006", "C901",
+    "PLR0913", "PLW0603", "RUF012", "TID251",
+    # Enforced by upstream litellm's ruff config, but not run in this repo's CI
+    "PLC0415", "E402", "BLE001", "ARG002", "S102", "S324", "S606", "D401", "F403", "F405",
+]
 line-length = 120
 exclude = ["litellm/types/*", "litellm/__init__.py", "litellm/proxy/example_config_yaml/*", "tests/*"]
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -6,8 +6,7 @@ lint.extend-select = ["E501", "PLR0915", "T20", "PGH004", "RUF008", "RUF009", "R
 # litellm's own ruff config both rely on suppressions this config can't see.
 lint.external = [
     # Enforced by the strict-rule gate (scripts/ruff_strict_gate.py + ruff-strict.toml)
-    "ANN001", "ANN002", "ANN003", "ANN401", "B006", "C901",
-    "PLR0913", "PLW0603", "RUF012", "TID251",
+    "C901",
     # Enforced by upstream litellm's ruff config, but not run in this repo's CI
     "PLC0415", "E402", "BLE001", "ARG002", "S102", "S324", "S606", "D401", "F403", "F405",
 ]


### PR DESCRIPTION
## Summary

Adds four Ruff rules to the main gating config (`ruff.toml`) and cleans up every resulting violation so they enforce at **zero** going forward:

| Rule | Name | Pre-existing violations |
|------|------|------------------------|
| `PGH004` | blanket-noqa (use specific codes) | 111 |
| `RUF008` | mutable-dataclass-default | 0 |
| `RUF009` | function-call-in-dataclass-default-argument | 0 |
| `RUF100` | unused-noqa | 224 |

`RUF008`/`RUF009` were already clean — pure forward-looking enforcement. `PGH004`/`RUF100` required cleaning up ~335 stale or overly-broad `# noqa` directives.

## How the noqas were cleaned up

- **Blanket `# noqa` → specific code.** Each bare `# noqa` is now scoped to the rule it actually suppresses (mostly `T201` print statements, plus a few `F401`/`F541`/`PLR0915`). One def (`return_processed_chunk_logic`) was hiding both `PLR0915` *and* the strict-gate rule `C901` via a blanket noqa, so it became `# noqa: PLR0915, C901` to preserve exact prior behavior.
- **Dead directives removed.** Stale `# noqa: PLR0915` on functions that are no longer long enough, redundant per-line `# noqa` in files with a file-level `# ruff: noqa: T201`, and blanket noqas that suppressed nothing.
- **Inapplicable codes trimmed.** e.g. `# noqa: F401, F403` on `import *` → `# noqa: F403` (`F401` never applies to star imports).
- **Black reformat.** Removing comments from a handful of stub/multi-line statements changed Black's line-collapsing, so 4 files were reformatted to stay Black-clean.

## `lint.external` — why RUF100 doesn't strip everything

`RUF100` only knows the rules enabled in *this* config, so it would flag `# noqa` directives for rules enforced elsewhere as "unused" and strip protection this config can't see. To prevent that, `lint.external` lists:

- **Strict-rule gate codes** (`scripts/ruff_strict_gate.py` via `ruff-strict.toml`): `ANN001-003`, `ANN401`, `B006`, `C901`, `PLR0913`, `PLW0603`, `RUF012`, `TID251`. Removing these noqas would silently inflate the strict-gate counts.
- **Upstream-litellm codes** not run in this repo's CI but meaningful on OSS merges: `PLC0415`, `E402`, `BLE001`, `ARG002`, `S102`, `S324`, `S606`, `D401`, `F403`, `F405`.

## Test plan

- [x] `cd litellm && ruff check .` → **All checks passed!**
- [x] `black --check --exclude '/enterprise/' .` → clean
- [x] `python scripts/ruff_strict_gate.py` → within ceiling (no strict-gate regression)
- [ ] CI green on this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-only changes to Ruff config and `# noqa` comments; no functional code paths altered.
> 
> **Overview**
> Extends **`ruff.toml`** with **`PGH004`**, **`RUF008`**, **`RUF009`**, and **`RUF100`**, and adds **`lint.external`** so unused-noqa checks do not strip **`# noqa`** for rules enforced only by the strict gate (**`C901`**, etc.) or upstream LiteLLM configs.
> 
> Across the codebase, **`# noqa`** comments are narrowed to the codes they actually suppress (mostly **`T201`** on debug **`print`** paths), stale **`PLR0915`** markers on functions that no longer need them are removed, and a few incorrect codes (**`F811`**, redundant **`F401`**) are fixed. **`return_processed_chunk_logic`** keeps both **`PLR0915`** and **`C901`** explicitly. **`proxy_cli`** drops redundant per-line **`T201`** suppressions where the file already ignores **`T201`** globally.
> 
> No runtime behavior changes—only lint configuration and comment/format cleanup (including minor Black-driven reflows).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb0adb4f2a6f87d0c40064cb6f6b7f583ec1dd1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->