### PR TITLE
chore(codecov): add Batches, Videos, and Realtime components

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -35,6 +35,22 @@ component_management:
     - component_id: "Enterprise"
       paths:
         - "enterprise/**"
+    - component_id: "Batches"
+      paths:
+        - "litellm/proxy/batches_endpoints/**"
+        - "litellm/batches/**"
+        - "*/llms/*/batches/**"
+    - component_id: "Videos"
+      paths:
+        - "litellm/videos/**"
+        - "*/proxy/video_endpoints/**"
+        - "*/llms/*/videos/**"
+    - component_id: "Realtime"
+      paths:
+        - "litellm/realtime_api/**"
+        - "*/proxy/realtime_endpoints/**"
+        - "*/llms/*/realtime/**"
+        - "litellm/litellm_core_utils/realtime_streaming.py"
 comment:
   layout: "header, diff, flags, components"  # show component info in the PR comment
 

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -37,7 +37,7 @@ component_management:
         - "enterprise/**"
     - component_id: "Batches"
       paths:
-        - "litellm/proxy/batches_endpoints/**"
+        - "*/proxy/batches_endpoints/**"
         - "litellm/batches/**"
         - "*/llms/*/batches/**"
     - component_id: "Videos"


### PR DESCRIPTION
## Summary
- Add Codecov components for Batches, Videos, and Realtime so PR comments report per-feature coverage
- Batches: proxy batch endpoints, `litellm/batches/`, provider `*/batches/**` (excludes `batch_completion` and shared `common_utils`)
- Videos: `litellm/videos/`, proxy video endpoints, provider `*/videos/**`
- Realtime: `realtime_api/`, proxy realtime endpoints, provider `*/realtime/**`, and `realtime_streaming.py`

## Test plan
- [x] Verified glob patterns match intended files and exclude `batch_completion`, `types/*`, and shared utils
- [ ] After merge, confirm Codecov PR comment shows Batches / Videos / Realtime component rows on the next upload

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change to coverage reporting paths; no application or CI test behavior is modified.
> 
> **Overview**
> Extends **Codecov component management** with three new `component_id` entries—**Batches**, **Videos**, and **Realtime**—each mapped to path globs for core packages, proxy endpoints, and provider-specific `llms` subtrees (Realtime also includes `realtime_streaming.py`).
> 
> PR comments already use `layout: "header, diff, flags, components"`, so after the next coverage upload reviewers should see per-feature component rows alongside existing components like Router and LLMs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53164cabf6e615169344a741c3fe6fdb8c660e1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->