### PR TITLE
docs(mcp): document long-running tool calls and Tasks roadmap

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/README.md
+++ b/litellm/proxy/_experimental/mcp_server/README.md
@@ -1,0 +1,44 @@
+# MCP server: long-running tool calls
+
+How the gateway streams progress for tools that take a while to finish, and what
+the path forward looks like once the MCP Tasks extension lands.
+
+## Today: progress notifications over the stateful transport
+
+A host that wants progress updates includes a `progressToken` in the `_meta` of
+its `tools/call` request. The gateway captures that token from the host request
+context and registers a `host_progress_callback` (`forward_progress` in
+`server.py`). As the upstream MCP server emits progress notifications during the
+call, the callback relays each one back to the host session with
+`send_progress_notification`, so the host sees progress in real time while the
+call is still running.
+
+This relies on the stateful StreamableHTTP transport. Request routing picks the
+stateful session manager whenever the request carries an `mcp-session-id` header
+or is an `initialize` (see the routing block in `server.py`); stateless callers
+(curl, Inspector) fall through to the stateless manager and do not get a
+streamed progress channel. The stateful path was restored in #26857 (LIT-2196).
+
+The practical bound is the connection and its TTL window. Progress streams for as
+long as the host keeps the connection open and the server honors it; if the
+connection drops, the stream stops with it. For work that needs to outlive a
+single connection, progress notifications are not the right tool, which is what
+the Tasks extension is meant to solve.
+
+## Not yet: the MCP Tasks extension
+
+The MCP Tasks lifecycle (`tasks/get`, `tasks/update`, `tasks/cancel`, with a
+`resultType: "task"` handle returned from `tools/call`) is the stateless
+successor for long-running work. The gateway does not implement it yet. Tasks
+was experimental in the `2025-11-25` spec and was reshaped into an extension
+(SEP-2663) in the `2026-07-28` release candidate, which also removes
+protocol-level sessions. Support is gated on the `mcp` Python SDK v2 line
+(LiteLLM currently pins `mcp>=1.26.0,<2.0`) and on the spec finalizing. The
+migration is tracked in LIT-3784.
+
+## Code pointers
+
+- `server.py`: `forward_progress` / `host_progress_callback` capture and relay
+- `server.py`: session-id routing that selects the stateful vs stateless manager
+- `call_mcp_tool` in this package threads `host_progress_callback` down to the
+  upstream client call


### PR DESCRIPTION
## Relevant issues

Came out of a LANL support thread asking whether the MCP gateway supports the new Tasks extension and, if not, what the recommended path is for long-running tool calls

## Linear ticket

LIT-3784 (Align MCP server with the 2026-07-28 stateless spec: Tasks extension + session removal)

## Pre-Submission checklist

- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have added meaningful tests
- [ ] My PR passes all unit tests on `make test-unit`
- [ ] I have requested a Greptile review

## Screenshots / Proof of Fix

Docs-only change, so there is no runtime behavior to exercise against a live proxy. The artifact is the rendered README at `litellm/proxy/_experimental/mcp_server/README.md`

## Type

📖 Documentation

## Changes

Adds a developer reference next to the MCP server that captures how the gateway handles long-running tool calls today and where the work is headed. The knowledge currently only lives in the `server.py` progress-forwarding path and in the support thread, so this writes it down

What it documents:
- Progress notifications: a host passes a `progressToken` in the `tools/call` `_meta`; the gateway captures it and relays upstream progress back to the host session via `host_progress_callback` / `forward_progress`. This needs the stateful StreamableHTTP transport that #26857 restored, and it is bounded by the connection/TTL window
- Tasks extension: not implemented yet. It is the stateless successor for long-running work (`tasks/get` / `tasks/update` / `tasks/cancel`), reshaped into an extension in the `2026-07-28` spec RC and gated on the `mcp` Python SDK v2 line; tracked in LIT-3784

The site docs tree is not present in this branch, so this lands as a code-adjacent README rather than a Docusaurus page; the customer-facing docs page should be added wherever that site builds from

https://claude.ai/code/session_01KDdQ8YqNVM3Hh4a92QBhfq

---
_Generated by [Claude Code](https://claude.ai/code/session_01KDdQ8YqNVM3Hh4a92QBhfq)_