### PR TITLE
fix(proxy): release budget reservation when a request is cancelled mid-flight

### DIFF
--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -2531,6 +2531,7 @@ class ProxyBaseLLMRequestProcessing:
         debug_enabled = verbose_proxy_logger.isEnabledFor(logging.DEBUG)
         stream_completed = False
         client_disconnected = False
+        delivered_chunk = False
         try:
             str_so_far = ""
             async for (
@@ -2547,36 +2548,38 @@ class ProxyBaseLLMRequestProcessing:
                         "async_data_generator: received streaming chunk - %s", chunk
                     )
 
-                if fast_path:
-                    yield serialize_chunk(chunk)
-                    continue
+                if not fast_path:
+                    chunk = await proxy_logging_obj.async_post_call_streaming_hook(
+                        user_api_key_dict=user_api_key_dict,
+                        response=chunk,
+                        data=request_data,
+                        str_so_far=str_so_far,
+                    )
 
-                chunk = await proxy_logging_obj.async_post_call_streaming_hook(
-                    user_api_key_dict=user_api_key_dict,
-                    response=chunk,
-                    data=request_data,
-                    str_so_far=str_so_far,
-                )
+                    if isinstance(chunk, (ModelResponse, ModelResponseStream)):
+                        response_str = litellm.get_response_string(response_obj=chunk)
+                        str_so_far += response_str
+                    elif hasattr(chunk, "model_dump"):
+                        try:
+                            d = chunk.model_dump(mode="json", exclude_none=True)
+                            if isinstance(d, dict):
+                                str_so_far += str(d.get("content", ""))
+                        except Exception:
+                            pass
+                    elif isinstance(chunk, dict):
+                        str_so_far += str(chunk.get("content", ""))
 
-                if isinstance(chunk, (ModelResponse, ModelResponseStream)):
-                    response_str = litellm.get_response_string(response_obj=chunk)
-                    str_so_far += response_str
-                elif hasattr(chunk, "model_dump"):
-                    try:
-                        d = chunk.model_dump(mode="json", exclude_none=True)
-                        if isinstance(d, dict):
-                            str_so_far += str(d.get("content", ""))
-                    except Exception:
-                        pass
-                elif isinstance(chunk, dict):
-                    str_so_far += str(chunk.get("content", ""))
-
-                model_name = request_data.get("model", "")
-                chunk = (
-                    ProxyBaseLLMRequestProcessing._process_chunk_with_cost_injection(
+                    model_name = request_data.get("model", "")
+                    chunk = ProxyBaseLLMRequestProcessing._process_chunk_with_cost_injection(
                         chunk, model_name
                     )
-                )
+
+                # Set before the yield: an async generator suspends at the yield,
+                # so a GeneratorExit on client disconnect is raised there and any
+                # statement after the yield never runs. The slow-path hook is
+                # awaited above, so a cancellation during it still leaves this
+                # False and refunds.
+                delivered_chunk = True
                 yield serialize_chunk(chunk)
             stream_completed = True
         except (asyncio.CancelledError, GeneratorExit):
@@ -2591,6 +2594,14 @@ class ProxyBaseLLMRequestProcessing:
                     user_api_key_dict
                 )
                 client_disconnected = True
+            if not delivered_chunk:
+                from litellm.proxy.spend_tracking.budget_reservation import (
+                    release_budget_reservation_on_cancel,
+                )
+
+                await release_budget_reservation_on_cancel(
+                    getattr(user_api_key_dict, "budget_reservation", None)
+                )
             raise
         except Exception as e:
             verbose_proxy_logger.exception(

--- a/litellm/proxy/spend_tracking/budget_reservation.py
+++ b/litellm/proxy/spend_tracking/budget_reservation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -193,6 +194,32 @@ async def release_budget_reservation(budget_reservation: Optional[dict]) -> None
         budget_reservation=budget_reservation,
         actual_cost=0.0,
     )
+
+
+async def release_budget_reservation_on_cancel(
+    budget_reservation: Optional[dict],
+) -> None:
+    """Release a still-open reservation when the request is cancelled mid-flight.
+
+    A client disconnect or timeout cancels the request task, which surfaces as
+    CancelledError / GeneratorExit rather than a normal exception, so neither the
+    success cost callback nor the failure hook runs and the pre-call reservation
+    is never given back. Left alone it pins the spend counter above real spend
+    and 429s subsequent requests until the counter's TTL expires.
+
+    asyncio.shield keeps the release running to completion even though the
+    surrounding task is being cancelled. The `finalized` guard makes this a no-op
+    when success/failure handling already reconciled, so calling it on every
+    cancellation path is safe.
+    """
+    if not budget_reservation or budget_reservation.get("finalized") is True:
+        return
+    try:
+        await asyncio.shield(
+            release_budget_reservation(budget_reservation=budget_reservation)
+        )
+    except (asyncio.CancelledError, Exception):
+        pass
 
 
 async def invalidate_budget_reservation_counters(

--- a/litellm/proxy/spend_tracking/budget_reservation.py
+++ b/litellm/proxy/spend_tracking/budget_reservation.py
@@ -163,10 +163,14 @@ async def reserve_budget_for_request(
     if not applied_entries:
         return None
 
+    input_cost = estimate_request_input_cost(
+        request_body=request_body, route=route, llm_router=llm_router
+    )
     return {
         "reserved_cost": reservation_cost,
         "entries": applied_entries,
         "finalized": False,
+        "input_cost": min(float(input_cost or 0.0), reservation_cost),
     }
 
 
@@ -197,26 +201,35 @@ async def release_budget_reservation(budget_reservation: Optional[dict]) -> None
 
 
 async def release_budget_reservation_on_cancel(
-    budget_reservation: Optional[dict],
+    budget_reservation: dict | None,
 ) -> None:
-    """Release a still-open reservation when the request is cancelled mid-flight.
+    """Reconcile a still-open reservation when the request is cancelled mid-flight.
 
     A client disconnect or timeout cancels the request task, which surfaces as
     CancelledError / GeneratorExit rather than a normal exception, so neither the
     success cost callback nor the failure hook runs and the pre-call reservation
-    is never given back. Left alone it pins the spend counter above real spend
+    is never reconciled. Left alone it pins the spend counter above real spend
     and 429s subsequent requests until the counter's TTL expires.
 
-    asyncio.shield keeps the release running to completion even though the
+    Reconcile to the request's input-token cost rather than refunding to zero:
+    by the time a request is cancelled in-flight the provider call was already
+    dispatched, so the input tokens were billed even if no chunk reached the
+    client. Refunding to zero would let a caller abort pre-token to dodge that
+    charge; the worst-case output portion of the reservation is still released.
+
+    asyncio.shield keeps the reconcile running to completion even though the
     surrounding task is being cancelled. The `finalized` guard makes this a no-op
     when success/failure handling already reconciled, so calling it on every
     cancellation path is safe.
     """
     if not budget_reservation or budget_reservation.get("finalized") is True:
         return
+    incurred_cost = float(budget_reservation.get("input_cost") or 0.0)
     try:
         await asyncio.shield(
-            release_budget_reservation(budget_reservation=budget_reservation)
+            reconcile_budget_reservation(
+                budget_reservation=budget_reservation, actual_cost=incurred_cost
+            )
         )
     except (asyncio.CancelledError, Exception):
         pass
@@ -842,6 +855,61 @@ def estimate_request_max_cost(
     if not estimates:
         return None
     return max(cast(List[float], estimates))
+
+
+def estimate_request_input_cost(
+    request_body: dict,
+    route: str,
+    llm_router: Router | None,
+) -> float | None:
+    """Cost of the request's input tokens alone.
+
+    Once the provider request is dispatched the input tokens are billed even if
+    the client disconnects before the first chunk, so this is the cost floor a
+    cancelled in-flight request has already incurred. A cancelled reservation is
+    reconciled to this instead of being refunded to zero.
+    """
+    model = get_model_from_request(request_body, route, llm_router=llm_router)
+    if model is None:
+        return None
+
+    models = [model] if isinstance(model, str) else model
+    estimates = [
+        _estimate_request_input_cost_for_model(
+            request_body=request_body,
+            route=route,
+            model=model_name,
+            llm_router=llm_router,
+        )
+        for model_name in models
+    ]
+    estimates = [estimate for estimate in estimates if estimate is not None]
+    if not estimates:
+        return None
+    return max(cast("list[float]", estimates))
+
+
+def _estimate_request_input_cost_for_model(
+    request_body: dict,
+    route: str,
+    model: str,
+    llm_router: Router | None,
+) -> float | None:
+    model_info = _get_model_cost_info(model=model, llm_router=llm_router)
+    if model_info is None:
+        return None
+    input_cost_per_token = _to_float(model_info.get("input_cost_per_token"))
+    if input_cost_per_token is None:
+        return None
+    input_tokens = _estimate_input_tokens(
+        request_body=request_body,
+        route=route,
+        model=model,
+        model_info=model_info,
+    )
+    if input_tokens is None:
+        return None
+    return input_tokens * input_cost_per_token
 
 
 def _estimate_request_max_cost_for_model(

--- a/tests/test_litellm/proxy/test_budget_reservation.py
+++ b/tests/test_litellm/proxy/test_budget_reservation.py
@@ -1711,9 +1711,15 @@ async def test_release_budget_reservation_on_cancel_gives_back_counter(
         token="key-cancel-give-back", spend=0.0, max_budget=10.0
     )
 
-    with patch(
-        "litellm.proxy.spend_tracking.budget_reservation.estimate_request_max_cost",
-        return_value=3.0,
+    with (
+        patch(
+            "litellm.proxy.spend_tracking.budget_reservation.estimate_request_max_cost",
+            return_value=3.0,
+        ),
+        patch(
+            "litellm.proxy.spend_tracking.budget_reservation.estimate_request_input_cost",
+            return_value=0.5,
+        ),
     ):
         reservation = await reserve_budget_for_request(
             request_body=_request_body(),
@@ -1733,16 +1739,19 @@ async def test_release_budget_reservation_on_cancel_gives_back_counter(
 
     await release_budget_reservation_on_cancel(reservation)
 
+    # the provider already received the input, so the reservation is reconciled
+    # to the input cost (0.5), not refunded to zero; the worst-case output
+    # reservation (3.0 -> 0.5) is released
     assert counter_cache.in_memory_cache.get_cache(
         key="spend:key:key-cancel-give-back"
-    ) == pytest.approx(0.0)
+    ) == pytest.approx(0.5)
     assert reservation["finalized"] is True
 
-    # idempotent: a second cancel release must not double-subtract
+    # idempotent: a second cancel reconcile must not change the counter again
     await release_budget_reservation_on_cancel(reservation)
     assert counter_cache.in_memory_cache.get_cache(
         key="spend:key:key-cancel-give-back"
-    ) == pytest.approx(0.0)
+    ) == pytest.approx(0.5)
 
 
 @pytest.mark.asyncio
@@ -1783,9 +1792,15 @@ async def test_release_budget_reservation_on_cancel_noop_when_finalized(
 
 async def _reserve_for_stream(counter_cache, key_cache, proxy_logging_obj, token: str):
     valid_token = UserAPIKeyAuth(token=token, spend=0.0, max_budget=10.0)
-    with patch(
-        "litellm.proxy.spend_tracking.budget_reservation.estimate_request_max_cost",
-        return_value=2.0,
+    with (
+        patch(
+            "litellm.proxy.spend_tracking.budget_reservation.estimate_request_max_cost",
+            return_value=2.0,
+        ),
+        patch(
+            "litellm.proxy.spend_tracking.budget_reservation.estimate_request_input_cost",
+            return_value=0.5,
+        ),
     ):
         reservation = await reserve_budget_for_request(
             request_body=_request_body(),
@@ -1820,7 +1835,7 @@ def _drive_streaming_cancel(valid_token, iterator_hook):
 
 
 @pytest.mark.asyncio
-async def test_streaming_cancel_before_any_chunk_refunds_reservation(
+async def test_streaming_cancel_before_any_chunk_reconciles_to_input_cost(
     spend_counter_state,
 ):
     counter_cache, key_cache = spend_counter_state
@@ -1842,10 +1857,11 @@ async def test_streaming_cancel_before_any_chunk_refunds_reservation(
             received.append(chunk)
 
     assert received == []
-    # nothing was delivered, so the hold is refunded
+    # no chunk delivered, but the provider already received the input, so the
+    # reservation is reconciled to the input cost (0.5), not refunded to zero
     assert counter_cache.in_memory_cache.get_cache(
         key="spend:key:key-cancel-no-chunk"
-    ) == pytest.approx(0.0)
+    ) == pytest.approx(0.5)
     assert reservation["finalized"] is True
 
 
@@ -1888,9 +1904,10 @@ async def test_release_budget_reservation_on_cancel_swallows_release_errors():
         "reserved_cost": 3.0,
         "entries": [{"counter_key": "spend:key:key-cancel-error"}],
         "finalized": False,
+        "input_cost": 0.5,
     }
     with patch(
-        "litellm.proxy.spend_tracking.budget_reservation.release_budget_reservation",
+        "litellm.proxy.spend_tracking.budget_reservation.reconcile_budget_reservation",
         new=AsyncMock(side_effect=RuntimeError("redis down")),
     ):
         # must return without raising
@@ -1933,10 +1950,11 @@ async def test_streaming_cancel_in_slow_path_before_yield_refunds(spend_counter_
                 received.append(chunk)
 
     assert received == []
-    # cancellation happened before any chunk reached the client -> refund
+    # cancellation happened before any chunk reached the client, but the
+    # provider already received the input -> reconcile to the input cost (0.5)
     assert counter_cache.in_memory_cache.get_cache(
         key="spend:key:key-cancel-slowpath"
-    ) == pytest.approx(0.0)
+    ) == pytest.approx(0.5)
     assert reservation["finalized"] is True
 
 

--- a/tests/test_litellm/proxy/test_budget_reservation.py
+++ b/tests/test_litellm/proxy/test_budget_reservation.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -15,11 +16,13 @@ from litellm.proxy._types import (
     LiteLLM_UserTable,
     UserAPIKeyAuth,
 )
+from litellm.proxy.common_request_processing import ProxyBaseLLMRequestProcessing
 from litellm.proxy.spend_tracking.budget_reservation import (
     estimate_request_max_cost,
     get_budget_window_start,
     invalidate_budget_reservation_counters,
     release_budget_reservation,
+    release_budget_reservation_on_cancel,
     reserve_budget_for_request,
 )
 from litellm.proxy.utils import ProxyLogging
@@ -1696,3 +1699,308 @@ async def test_should_not_block_concurrent_team_request_when_first_request_lacks
         await release_budget_reservation(first_reservation)
     if second_reservation is not None:
         await release_budget_reservation(second_reservation)
+
+
+@pytest.mark.asyncio
+async def test_release_budget_reservation_on_cancel_gives_back_counter(
+    spend_counter_state,
+):
+    counter_cache, key_cache = spend_counter_state
+    proxy_logging_obj = ProxyLogging(user_api_key_cache=key_cache)
+    valid_token = UserAPIKeyAuth(
+        token="key-cancel-give-back", spend=0.0, max_budget=10.0
+    )
+
+    with patch(
+        "litellm.proxy.spend_tracking.budget_reservation.estimate_request_max_cost",
+        return_value=3.0,
+    ):
+        reservation = await reserve_budget_for_request(
+            request_body=_request_body(),
+            route="/chat/completions",
+            llm_router=None,
+            valid_token=valid_token,
+            team_object=None,
+            user_object=None,
+            prisma_client=None,
+            user_api_key_cache=key_cache,
+            proxy_logging_obj=proxy_logging_obj,
+        )
+    assert reservation is not None
+    assert counter_cache.in_memory_cache.get_cache(
+        key="spend:key:key-cancel-give-back"
+    ) == pytest.approx(3.0)
+
+    await release_budget_reservation_on_cancel(reservation)
+
+    assert counter_cache.in_memory_cache.get_cache(
+        key="spend:key:key-cancel-give-back"
+    ) == pytest.approx(0.0)
+    assert reservation["finalized"] is True
+
+    # idempotent: a second cancel release must not double-subtract
+    await release_budget_reservation_on_cancel(reservation)
+    assert counter_cache.in_memory_cache.get_cache(
+        key="spend:key:key-cancel-give-back"
+    ) == pytest.approx(0.0)
+
+
+@pytest.mark.asyncio
+async def test_release_budget_reservation_on_cancel_noop_when_finalized(
+    spend_counter_state,
+):
+    counter_cache, key_cache = spend_counter_state
+    proxy_logging_obj = ProxyLogging(user_api_key_cache=key_cache)
+    valid_token = UserAPIKeyAuth(
+        token="key-cancel-finalized", spend=0.0, max_budget=10.0
+    )
+
+    with patch(
+        "litellm.proxy.spend_tracking.budget_reservation.estimate_request_max_cost",
+        return_value=3.0,
+    ):
+        reservation = await reserve_budget_for_request(
+            request_body=_request_body(),
+            route="/chat/completions",
+            llm_router=None,
+            valid_token=valid_token,
+            team_object=None,
+            user_object=None,
+            prisma_client=None,
+            user_api_key_cache=key_cache,
+            proxy_logging_obj=proxy_logging_obj,
+        )
+    assert reservation is not None
+    reservation["finalized"] = True
+
+    await release_budget_reservation_on_cancel(reservation)
+
+    # already reconciled by the success/failure path -> must stay untouched
+    assert counter_cache.in_memory_cache.get_cache(
+        key="spend:key:key-cancel-finalized"
+    ) == pytest.approx(3.0)
+
+
+async def _reserve_for_stream(counter_cache, key_cache, proxy_logging_obj, token: str):
+    valid_token = UserAPIKeyAuth(token=token, spend=0.0, max_budget=10.0)
+    with patch(
+        "litellm.proxy.spend_tracking.budget_reservation.estimate_request_max_cost",
+        return_value=2.0,
+    ):
+        reservation = await reserve_budget_for_request(
+            request_body=_request_body(),
+            route="/chat/completions",
+            llm_router=None,
+            valid_token=valid_token,
+            team_object=None,
+            user_object=None,
+            prisma_client=None,
+            user_api_key_cache=key_cache,
+            proxy_logging_obj=proxy_logging_obj,
+        )
+    assert reservation is not None
+    assert counter_cache.in_memory_cache.get_cache(
+        key=f"spend:key:{token}"
+    ) == pytest.approx(2.0)
+    valid_token.budget_reservation = reservation
+    return valid_token, reservation
+
+
+def _drive_streaming_cancel(valid_token, iterator_hook):
+    streaming_logging_obj = MagicMock()
+    streaming_logging_obj.async_post_call_streaming_iterator_hook = iterator_hook
+    return ProxyBaseLLMRequestProcessing.async_streaming_data_generator(
+        response=MagicMock(),
+        user_api_key_dict=valid_token,
+        request_data=_request_body(),
+        proxy_logging_obj=streaming_logging_obj,
+        serialize_chunk=lambda chunk: chunk,
+        serialize_error=lambda exc: str(exc),
+    )
+
+
+@pytest.mark.asyncio
+async def test_streaming_cancel_before_any_chunk_refunds_reservation(
+    spend_counter_state,
+):
+    counter_cache, key_cache = spend_counter_state
+    proxy_logging_obj = ProxyLogging(user_api_key_cache=key_cache)
+    valid_token, reservation = await _reserve_for_stream(
+        counter_cache, key_cache, proxy_logging_obj, "key-cancel-no-chunk"
+    )
+
+    # Client disconnects before the upstream produced any output.
+    async def cancel_before_chunk(user_api_key_dict, response, request_data):
+        if False:
+            yield ""  # make this an async generator
+        raise asyncio.CancelledError()
+
+    generator = _drive_streaming_cancel(valid_token, cancel_before_chunk)
+    received = []
+    with pytest.raises(asyncio.CancelledError):
+        async for chunk in generator:
+            received.append(chunk)
+
+    assert received == []
+    # nothing was delivered, so the hold is refunded
+    assert counter_cache.in_memory_cache.get_cache(
+        key="spend:key:key-cancel-no-chunk"
+    ) == pytest.approx(0.0)
+    assert reservation["finalized"] is True
+
+
+@pytest.mark.asyncio
+async def test_streaming_cancel_after_chunk_keeps_reservation(
+    spend_counter_state,
+):
+    counter_cache, key_cache = spend_counter_state
+    proxy_logging_obj = ProxyLogging(user_api_key_cache=key_cache)
+    valid_token, reservation = await _reserve_for_stream(
+        counter_cache, key_cache, proxy_logging_obj, "key-cancel-after-chunk"
+    )
+
+    # Client consumes a chunk, then disconnects. Cancellation logs no cost, so
+    # refunding here would let the caller read partial output for free.
+    async def cancel_after_chunk(user_api_key_dict, response, request_data):
+        yield "data: chunk\n\n"
+        raise asyncio.CancelledError()
+
+    generator = _drive_streaming_cancel(valid_token, cancel_after_chunk)
+    received = []
+    with pytest.raises(asyncio.CancelledError):
+        async for chunk in generator:
+            received.append(chunk)
+
+    assert received == ["data: chunk\n\n"]
+    # a consumed stream must NOT be refunded
+    assert counter_cache.in_memory_cache.get_cache(
+        key="spend:key:key-cancel-after-chunk"
+    ) == pytest.approx(2.0)
+    assert reservation.get("finalized") is not True
+
+
+@pytest.mark.asyncio
+async def test_release_budget_reservation_on_cancel_swallows_release_errors():
+    # If the release itself fails (e.g. Redis unavailable) it must not escape
+    # the helper: doing so would replace the in-flight CancelledError /
+    # GeneratorExit at the call site and disrupt the disconnect teardown.
+    reservation = {
+        "reserved_cost": 3.0,
+        "entries": [{"counter_key": "spend:key:key-cancel-error"}],
+        "finalized": False,
+    }
+    with patch(
+        "litellm.proxy.spend_tracking.budget_reservation.release_budget_reservation",
+        new=AsyncMock(side_effect=RuntimeError("redis down")),
+    ):
+        # must return without raising
+        await release_budget_reservation_on_cancel(reservation)
+
+
+@pytest.mark.asyncio
+async def test_streaming_cancel_in_slow_path_before_yield_refunds(spend_counter_state):
+    counter_cache, key_cache = spend_counter_state
+    proxy_logging_obj = ProxyLogging(user_api_key_cache=key_cache)
+    valid_token, reservation = await _reserve_for_stream(
+        counter_cache, key_cache, proxy_logging_obj, "key-cancel-slowpath"
+    )
+
+    async def one_chunk(user_api_key_dict, response, request_data):
+        yield "data: chunk\n\n"
+
+    streaming_logging_obj = MagicMock()
+    streaming_logging_obj.async_post_call_streaming_iterator_hook = one_chunk
+    # On the slow path the per-chunk hook is awaited before the chunk is yielded
+    # to the client; cancel there. Nothing has reached the client yet.
+    streaming_logging_obj.async_post_call_streaming_hook = AsyncMock(
+        side_effect=asyncio.CancelledError()
+    )
+
+    generator = ProxyBaseLLMRequestProcessing.async_streaming_data_generator(
+        response=MagicMock(),
+        user_api_key_dict=valid_token,
+        request_data=_request_body(),
+        proxy_logging_obj=streaming_logging_obj,
+        serialize_chunk=lambda chunk: chunk,
+        serialize_error=lambda exc: str(exc),
+    )
+
+    received = []
+    # include_cost_in_streaming_usage forces fast_path off, so the hook above runs
+    with patch.object(litellm, "include_cost_in_streaming_usage", True, create=True):
+        with pytest.raises(asyncio.CancelledError):
+            async for chunk in generator:
+                received.append(chunk)
+
+    assert received == []
+    # cancellation happened before any chunk reached the client -> refund
+    assert counter_cache.in_memory_cache.get_cache(
+        key="spend:key:key-cancel-slowpath"
+    ) == pytest.approx(0.0)
+    assert reservation["finalized"] is True
+
+
+@pytest.mark.asyncio
+async def test_streaming_disconnect_after_consuming_chunk_keeps_reservation(
+    spend_counter_state,
+):
+    counter_cache, key_cache = spend_counter_state
+    proxy_logging_obj = ProxyLogging(user_api_key_cache=key_cache)
+    valid_token, reservation = await _reserve_for_stream(
+        counter_cache, key_cache, proxy_logging_obj, "key-disconnect-after-chunk"
+    )
+
+    async def two_chunks(user_api_key_dict, response, request_data):
+        yield "data: a\n\n"
+        yield "data: b\n\n"
+
+    generator = _drive_streaming_cancel(valid_token, two_chunks)
+
+    # Client consumes one chunk, then disconnects. aclose() raises GeneratorExit
+    # at the suspended yield, after the chunk already reached the client.
+    first = await generator.__anext__()
+    assert first == "data: a\n\n"
+    await generator.aclose()
+
+    # output was delivered, so the reservation must NOT be refunded
+    assert counter_cache.in_memory_cache.get_cache(
+        key="spend:key:key-disconnect-after-chunk"
+    ) == pytest.approx(2.0)
+    assert reservation.get("finalized") is not True
+
+
+@pytest.mark.asyncio
+async def test_streaming_slow_path_processes_and_yields_chunk(spend_counter_state):
+    counter_cache, key_cache = spend_counter_state
+    proxy_logging_obj = ProxyLogging(user_api_key_cache=key_cache)
+    valid_token, _ = await _reserve_for_stream(
+        counter_cache, key_cache, proxy_logging_obj, "key-slowpath-ok"
+    )
+
+    async def one_chunk(user_api_key_dict, response, request_data):
+        yield {"content": "hi"}
+
+    streaming_logging_obj = MagicMock()
+    streaming_logging_obj.async_post_call_streaming_iterator_hook = one_chunk
+    streaming_logging_obj.async_post_call_streaming_hook = AsyncMock(
+        side_effect=lambda **kwargs: kwargs["response"]
+    )
+
+    generator = ProxyBaseLLMRequestProcessing.async_streaming_data_generator(
+        response=MagicMock(),
+        user_api_key_dict=valid_token,
+        request_data=_request_body(),
+        proxy_logging_obj=streaming_logging_obj,
+        serialize_chunk=lambda chunk: chunk,
+        serialize_error=lambda exc: str(exc),
+    )
+
+    received = []
+    # include_cost_in_streaming_usage forces the slow path so the per-chunk hook,
+    # content accumulation, and cost-injection branch all run to a successful yield
+    with patch.object(litellm, "include_cost_in_streaming_usage", True, create=True):
+        async for chunk in generator:
+            received.append(chunk)
+
+    assert received == [{"content": "hi"}]
+    streaming_logging_obj.async_post_call_streaming_hook.assert_awaited_once()


### PR DESCRIPTION
## Relevant issues

Intermittent `429 Budget has been exceeded! Key=... Current cost: 805.8, Max budget: 800.0` on keys whose real spend is far below budget (~$280 of an $800 budget), self-healing after a pause and recurring under load.

## Pre-Submission checklist

- [x] I have added meaningful tests (mutation-verified)
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

The pre-call budget reservation (`reserve_budget_for_request`) increments the cross-pod spend counter by a request's worst-case cost up front, then reconciles it to the actual cost on success (cost callback) or on error (`async_post_call_failure_hook`). Neither runs when a streaming request is cancelled mid-flight: a client disconnect or timeout surfaces as `asyncio.CancelledError` (a `BaseException`, so `except Exception` misses it) or `GeneratorExit` in the streaming generator, so the reservation leaks. Under an agent retry storm the leaked reservations accumulate, pin the counter above the key's real spend, and 429 subsequent requests; the counter only recovers when its TTL lapses, which is why it is intermittent and self-healing.

The fix releases the reservation in `async_streaming_data_generator` (which `async_sse_data_generator` delegates to, so it covers OpenAI-style chat, Anthropic `/v1/messages`, and Google streaming) on the `(CancelledError, GeneratorExit)` path. `release_budget_reservation_on_cancel` wraps `release_budget_reservation` in `asyncio.shield` so it finishes despite the in-progress cancellation, short-circuits on the reservation's `finalized` flag, and is best-effort (a failing release is swallowed rather than replacing the in-flight cancellation).

Refund is gated on whether any chunk reached the client. On cancellation the stream wrapper logs no cost (`CancelledError` / `GeneratorExit` skip both the success and failure handlers in `CustomStreamWrapper.__anext__`), so a partial stream is never billed to the DB or the counter; refunding a stream the caller already consumed would let them read partial output then disconnect to dodge the charge. The reservation is therefore released only when no chunk was produced.

Non-streaming cancellation is intentionally not special-cased. A completed non-streaming response is reconciled to its real cost by the success cost callback, which fires independently of the client connection, so the reservation is charged correctly without any release on cancel. Reducing how aggressive the reservation estimate is (worst-case `max_tokens`) is a separate policy question and is left unchanged.

Tests in `tests/test_litellm/proxy/test_budget_reservation.py`: cancel-release gives the counter back and is idempotent; a finalized reservation is left untouched; a failing release is swallowed; a stream cancelled before any chunk is refunded while a stream cancelled after a chunk keeps its hold (removing the gate flips that test red).

## Screenshots / Proof of Fix

Live proxy run to be added.
