### PR TITLE
fix(init): add bool type annotation to suppress_debug_info

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -412,7 +412,7 @@ anthropic_beta_headers_url: str = os.getenv(
     "LITELLM_ANTHROPIC_BETA_HEADERS_URL",
     "https://raw.githubusercontent.com/BerriAI/litellm/main/litellm/anthropic_beta_headers_config.json",
 )
-suppress_debug_info = False
+suppress_debug_info: bool = False
 dynamodb_table_name: Optional[str] = None
 s3_callback_params: Optional[Dict] = None
 s3_audit_callback_params: Optional[Dict] = None


### PR DESCRIPTION
## Title

fix(init): add `bool` type annotation to `suppress_debug_info`

## Relevant issues

Closes #30523

## What's happening

`suppress_debug_info` is declared at module level in `litellm/__init__.py` as a bare
`suppress_debug_info = False`, with no type annotation. Strict type checkers (the issue
reports `ty`) then infer its type as `Literal[False]`, so any reassignment to `True`
fails:

```
Object of type `Literal[True]` is not assignable to attribute
`suppress_debug_info` of type `Literal[False]`
```

That reassignment is a supported, intentional knob — the codebase itself does it in
`litellm/proxy/proxy_server.py` and `litellm/router.py`. Every other flag around it in
`__init__.py` is already annotated (`bool`, `Optional[...]`, etc.); this one was just
missed.

## Change

```diff
-suppress_debug_info = False
+suppress_debug_info: bool = False
```

One line, no runtime behavior change — it only widens the inferred type so the
documented `litellm.suppress_debug_info = True` usage type-checks.

## Testing

- Reproduced the reported `ty` error on a 2-line probe (`import litellm; litellm.suppress_debug_info = True`) before the change; error is gone after it.
- `black --check` clean, `ruff check .` + strict-rule gate clean (`litellm/__init__.py` is in the ruff `exclude` list; the strict gate reports no delta vs base).

## Type

- [x] Bug Fix
