### PR TITLE
fix: sort tiered cost thresholds numerically instead of lexicographically

### DIFF
--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -255,8 +255,15 @@ def _get_token_base_cost(
         )
 
     # Only sort the threshold keys (typically 1-2 keys instead of 66+)
+    # Sort by parsed numeric threshold, not lexicographic string order,
+    # so that e.g. 128000 sorts above 90000 (string "9" > "1" would be wrong).
     threshold: Optional[float] = None
-    for key in sorted(threshold_keys, reverse=True):
+
+    def _threshold_sort_key(k: str) -> float:
+        raw = k.split("_above_")[1].split("_tokens")[0]
+        return float(raw.replace("k", "")) * (1000 if "k" in raw else 1)
+
+    for key in sorted(threshold_keys, key=_threshold_sort_key, reverse=True):
         value = model_info.get(key)
         if value is not None:
             try:

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
@@ -35,6 +35,7 @@ sys.path.insert(
 from litellm.litellm_core_utils.llm_cost_calc.utils import (
     PromptTokensDetailsResult,
     _calculate_input_cost,
+    _get_token_base_cost,
     calculate_cache_writing_cost,
     generic_cost_per_token,
 )
@@ -1642,3 +1643,42 @@ def test_priority_service_tier_above_threshold_falls_back_to_standard_for_cache_
     expected_completion = 1_000 * 2.25e-5
     assert prompt_cost == pytest.approx(expected_prompt, rel=1e-9)
     assert completion_cost == pytest.approx(expected_completion, rel=1e-9)
+def test_tiered_pricing_sorts_by_numeric_threshold_not_lexicographic():
+    """
+    Regression test for #30345: _get_token_base_cost sorted threshold keys
+    lexicographically on the raw key string. When thresholds had different
+    digit lengths (e.g. 90000 vs 128000), string sort diverged from numeric
+    sort: "9" > "1" so "90000" sorted after "128000" in reverse, causing a
+    150k-token request to be billed at the 90k tier instead of 128k.
+    """
+    model_info: ModelInfo = {
+        "input_cost_per_token": 1e-6,
+        "output_cost_per_token": 2e-6,
+        "input_cost_per_token_above_90000_tokens": 5e-7,
+        "output_cost_per_token_above_90000_tokens": 1e-6,
+        "input_cost_per_token_above_128000_tokens": 2.5e-7,
+        "output_cost_per_token_above_128000_tokens": 5e-7,
+    }
+
+    usage = Usage(
+        prompt_tokens=150000,
+        completion_tokens=1000,
+        total_tokens=151000,
+    )
+
+    (
+        prompt_base_cost,
+        completion_base_cost,
+        _cache_creation,
+        _cache_creation_1hr,
+        _cache_read,
+    ) = _get_token_base_cost(model_info=model_info, usage=usage)
+
+    assert prompt_base_cost == 2.5e-7, (
+        f"Expected 128k tier input rate (2.5e-7), got {prompt_base_cost}. "
+        "Threshold sort may be lexicographic instead of numeric."
+    )
+    assert completion_base_cost == 5e-7, (
+        f"Expected 128k tier output rate (5e-7), got {completion_base_cost}. "
+        "Threshold sort may be lexicographic instead of numeric."
+    )


### PR DESCRIPTION
## Problem

`_get_token_base_cost` in `litellm/litellm_core_utils/llm_cost_calc/utils.py` sorts threshold keys with `sorted(threshold_keys, reverse=True)` — lexicographic on the raw key string. When thresholds have different digit lengths (e.g. `90000` vs `128000`), string sort diverges from numeric sort because `"9" > "1"`, so `"90000"` sorts after `"128000"` in reverse. A 150k-token request matches the 90k tier instead of the correct 128k tier.

This is latent on the bundled model map today (128k/200k/272k are all 3 digits and happen to sort correctly), but becomes reachable with custom-registered models or any future entry with tiers of differing digit lengths.

## Fix

Sort by parsed numeric threshold using a `_threshold_sort_key` helper that extracts and parses the numeric value from each key.

## How to Test

```python
# With tiers at 90000 and 128000, a 150k-token request should use the 128k tier rate
model_info = {
    "input_cost_per_token": 0.000001,  # base rate
    "input_cost_per_token_above_90000_tokens": 0.0000005,
    "input_cost_per_token_above_128000_tokens": 0.0000003,
}
cost = cost_per_token(model="custom/model", prompt_tokens=150000, completion_tokens=0, model_info=model_info)
# Should use 0.0000003 (128k tier), not 0.0000005 (90k tier)
```

Test added: `test_tiered_pricing_sorts_by_numeric_threshold_not_lexicographic` — all 48 tests in the file pass.

Fixes #30345