### PR TITLE
fix(redis): don't pass db to Sentinel connections (fixes SELECT error with redis_db + sentinel)

### DIFF
--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -488,6 +488,13 @@ def _get_redis_sentinel_connection_kwargs(redis_kwargs: dict) -> dict:
         if arg in args:
             connection_kwargs[arg] = redis_kwargs[arg]
 
+    # `db` (the Redis logical database / SELECT index) is not always reported by
+    # `inspect.getfullargspec(redis.Redis)` across redis-py versions (newer
+    # redis-py uses **kwargs), so it can be dropped by the loop above. Forward it
+    # explicitly so the master/replica connection honors the configured db index.
+    if "db" in redis_kwargs and redis_kwargs["db"] is not None:
+        connection_kwargs["db"] = redis_kwargs["db"]
+
     return connection_kwargs
 
 
@@ -498,6 +505,10 @@ def _init_redis_sentinel(redis_kwargs) -> redis.Redis:
     connection_kwargs = _get_redis_sentinel_connection_kwargs(redis_kwargs)
     connection_kwargs.setdefault("socket_timeout", REDIS_SOCKET_TIMEOUT)
     sentinel_kwargs = dict(connection_kwargs)
+    # The `db` index applies to the master/replica connection only. Sentinel
+    # nodes don't support `SELECT`, so leaking `db` into the sentinel
+    # connections causes `unknown command 'SELECT'` when redis_db is non-zero.
+    sentinel_kwargs.pop("db", None)
     sentinel_kwargs["password"] = sentinel_password
 
     if not sentinel_nodes or not service_name:
@@ -525,6 +536,10 @@ def _init_async_redis_sentinel(redis_kwargs) -> async_redis.Redis:
     connection_kwargs = _get_redis_sentinel_connection_kwargs(redis_kwargs)
     connection_kwargs.setdefault("socket_timeout", REDIS_SOCKET_TIMEOUT)
     sentinel_kwargs = dict(connection_kwargs)
+    # The `db` index applies to the master/replica connection only. Sentinel
+    # nodes don't support `SELECT`, so leaking `db` into the sentinel
+    # connections causes `unknown command 'SELECT'` when redis_db is non-zero.
+    sentinel_kwargs.pop("db", None)
     sentinel_kwargs["password"] = sentinel_password
 
     if not sentinel_nodes or not service_name:

--- a/tests/test_litellm/test_redis.py
+++ b/tests/test_litellm/test_redis.py
@@ -546,6 +546,55 @@ def test_async_sentinel_uses_sentinel_password_and_master_password(
     )
 
 
+@patch("litellm._redis.redis.Sentinel")
+def test_sync_sentinel_does_not_pass_db_to_sentinel_connections(mock_sentinel_cls):
+    """
+    A non-zero `db` must NOT be forwarded to the Sentinel connections.
+
+    Sentinel nodes don't support `SELECT`, so passing `db` into
+    `sentinel_kwargs` produces `unknown command 'SELECT'` and breaks Sentinel
+    when a non-zero redis_db is configured (see GitHub issue #10276). The `db`
+    index belongs only on the master/replica connection via `master_for()`.
+    """
+    mock_sentinel = MagicMock()
+    mock_sentinel_cls.return_value = mock_sentinel
+
+    get_redis_client(
+        sentinel_nodes=[("sentinel-1", 26379)],
+        sentinel_password="sentinel-secret",
+        service_name="mymaster",
+        db=3,
+    )
+
+    mock_sentinel_cls.assert_called_once()
+    sentinel_call_kwargs = mock_sentinel_cls.call_args[1]
+    # db must be stripped from the sentinel connection kwargs
+    assert "db" not in sentinel_call_kwargs["sentinel_kwargs"]
+    # ...but it must still reach the master/replica connection
+    master_call_kwargs = mock_sentinel.master_for.call_args[1]
+    assert master_call_kwargs["db"] == 3
+
+
+@patch("litellm._redis.async_redis.Sentinel")
+def test_async_sentinel_does_not_pass_db_to_sentinel_connections(mock_sentinel_cls):
+    """Async sentinel must also strip `db` from the sentinel connections."""
+    mock_sentinel = MagicMock()
+    mock_sentinel_cls.return_value = mock_sentinel
+
+    get_redis_async_client(
+        sentinel_nodes=[("sentinel-1", 26379)],
+        sentinel_password="sentinel-secret",
+        service_name="mymaster",
+        db=3,
+    )
+
+    mock_sentinel_cls.assert_called_once()
+    sentinel_call_kwargs = mock_sentinel_cls.call_args[1]
+    assert "db" not in sentinel_call_kwargs["sentinel_kwargs"]
+    master_call_kwargs = mock_sentinel.master_for.call_args[1]
+    assert master_call_kwargs["db"] == 3
+
+
 @patch("litellm._redis.init_redis_cluster")
 def test_sync_client_preserves_password_for_cluster_when_url_also_set(
     mock_init_cluster, monkeypatch


### PR DESCRIPTION
## Relevant issues

Related: #10276 (DB index selection for Redis Sentinel), #21198 (Sentinel SSL/password support — adjacent area, does not target this bug).

## The bug

Redis Sentinel nodes do **not** support the `SELECT` command. However, both `_init_redis_sentinel` and `_init_async_redis_sentinel` in `litellm/_redis.py` copy the full connection kwargs — including `db` — into `sentinel_kwargs`:

```python
connection_kwargs = _get_redis_sentinel_connection_kwargs(redis_kwargs)  # includes `db`
connection_kwargs.setdefault("socket_timeout", REDIS_SOCKET_TIMEOUT)
sentinel_kwargs = dict(connection_kwargs)   # <-- db leaks into sentinel_kwargs
sentinel_kwargs["password"] = sentinel_password
...
sentinel = redis.Sentinel(sentinel_nodes, sentinel_kwargs=sentinel_kwargs)  # sentinel conns get db
return sentinel.master_for(service_name, **connection_kwargs)              # master correctly gets db
```

When a non-zero `redis_db` is configured, the Sentinel discovery connections then issue `SELECT <db>` and the server responds with `unknown command 'SELECT'`, breaking caching / routing on any Sentinel deployment that uses DB separation.

### Minimal repro

```yaml
litellm_settings:
  cache: true
  cache_params:
    type: redis
    sentinel_nodes: [["sentinel-1", 26379]]
    service_name: mymaster
    redis_db: 1        # any non-zero db
```

Result on startup: `redis.exceptions.ResponseError: unknown command 'SELECT'` from the Sentinel connection.

## The fix

`db` belongs **only** on the master/replica connection (created via `sentinel.master_for(...)`), never on the Sentinel discovery connections.

- Strip `db` from `sentinel_kwargs` in both the sync and async sentinel initializers.
- Explicitly forward `db` from `redis_kwargs` to the master connection kwargs. On newer redis-py, `inspect.getfullargspec(redis.Redis)` does not expose `db` (it uses `**kwargs`), so `db` was previously dropped from the sentinel path entirely there — meaning DB index selection with Sentinel never worked. This makes it work, addressing the use case raised in #10276.

The change is isolated to the two sentinel initializers plus the shared kwargs helper.

## Tests

Added two focused unit tests in `tests/test_litellm/test_redis.py`:

- `test_sync_sentinel_does_not_pass_db_to_sentinel_connections`
- `test_async_sentinel_does_not_pass_db_to_sentinel_connections`

Each asserts that with `db` set, `sentinel_kwargs` does **not** contain `db`, while `master_for(...)` still receives it.

Verified locally against redis-py `5.3.1` (the version pinned in `uv.lock`):

- Without the fix, `sentinel_kwargs` = `{'db': 3, 'password': ..., 'socket_timeout': 0.1}` and the new tests fail (reproducing the bug).
- With the fix, all sentinel tests pass; full `tests/test_litellm/test_redis.py` passes (28 passed).

## Type

🐛 Bug Fix
✅ Test

## Changes

- `litellm/_redis.py` — `_get_redis_sentinel_connection_kwargs` forwards `db` to the master connection explicitly; `_init_redis_sentinel` and `_init_async_redis_sentinel` strip `db` from `sentinel_kwargs`.
- `tests/test_litellm/test_redis.py` — sync + async regression tests.
