### PR TITLE
feat: add missing UK PII entity types to Presidio guardrail

### DIFF
--- a/litellm/types/guardrails.py
+++ b/litellm/types/guardrails.py
@@ -373,13 +373,17 @@ class PresidioConfigModel(PresidioPresidioConfigModelUserInterface):
         default=None,
         description="Path to a JSON file containing ad-hoc recognizers for Presidio",
     )
-    mock_redacted_text: Optional[dict] = Field(default=None, description="Mock redacted text for testing")
+    mock_redacted_text: Optional[dict] = Field(
+        default=None, description="Mock redacted text for testing"
+    )
 
 
 class BedrockGuardrailConfigModel(BaseModel):
     """Configuration parameters for the AWS Bedrock guardrail"""
 
-    guardrailIdentifier: Optional[str] = Field(default=None, description="The ID of your guardrail on Bedrock")
+    guardrailIdentifier: Optional[str] = Field(
+        default=None, description="The ID of your guardrail on Bedrock"
+    )
     guardrailVersion: Optional[str] = Field(
         default=None,
         description="The version of your Bedrock guardrail (e.g., DRAFT or version number)",
@@ -388,29 +392,59 @@ class BedrockGuardrailConfigModel(BaseModel):
         default=False,
         description="If True, will not raise an exception when the guardrail is blocked. Useful for OpenWebUI where exceptions can end the chat flow.",
     )
-    aws_region_name: Optional[str] = Field(default=None, description="AWS region where your guardrail is deployed")
-    aws_access_key_id: Optional[str] = Field(default=None, description="AWS access key ID for authentication")
-    aws_secret_access_key: Optional[str] = Field(default=None, description="AWS secret access key for authentication")
-    aws_session_token: Optional[str] = Field(default=None, description="AWS session token for temporary credentials")
-    aws_session_name: Optional[str] = Field(default=None, description="Name of the AWS session")
-    aws_profile_name: Optional[str] = Field(default=None, description="AWS profile name for credential retrieval")
-    aws_role_name: Optional[str] = Field(default=None, description="AWS role name for assuming roles")
+    aws_region_name: Optional[str] = Field(
+        default=None, description="AWS region where your guardrail is deployed"
+    )
+    aws_access_key_id: Optional[str] = Field(
+        default=None, description="AWS access key ID for authentication"
+    )
+    aws_secret_access_key: Optional[str] = Field(
+        default=None, description="AWS secret access key for authentication"
+    )
+    aws_session_token: Optional[str] = Field(
+        default=None, description="AWS session token for temporary credentials"
+    )
+    aws_session_name: Optional[str] = Field(
+        default=None, description="Name of the AWS session"
+    )
+    aws_profile_name: Optional[str] = Field(
+        default=None, description="AWS profile name for credential retrieval"
+    )
+    aws_role_name: Optional[str] = Field(
+        default=None, description="AWS role name for assuming roles"
+    )
     aws_web_identity_token: Optional[str] = Field(
         default=None, description="Web identity token for AWS role assumption"
     )
-    aws_sts_endpoint: Optional[str] = Field(default=None, description="AWS STS endpoint URL")
-    aws_bedrock_runtime_endpoint: Optional[str] = Field(default=None, description="AWS Bedrock runtime endpoint URL")
+    aws_sts_endpoint: Optional[str] = Field(
+        default=None, description="AWS STS endpoint URL"
+    )
+    aws_bedrock_runtime_endpoint: Optional[str] = Field(
+        default=None, description="AWS Bedrock runtime endpoint URL"
+    )
 
 
 class LakeraV2GuardrailConfigModel(BaseModel):
     """Configuration parameters for the Lakera AI v2 guardrail"""
 
-    api_key: Optional[str] = Field(default=None, description="API key for the Lakera AI service")
-    api_base: Optional[str] = Field(default=None, description="Base URL for the Lakera AI API")
-    project_id: Optional[str] = Field(default=None, description="Project ID for the Lakera AI project")
-    payload: Optional[bool] = Field(default=True, description="Whether to include payload in the response")
-    breakdown: Optional[bool] = Field(default=True, description="Whether to include breakdown in the response")
-    metadata: Optional[Dict] = Field(default=None, description="Additional metadata to include in the request")
+    api_key: Optional[str] = Field(
+        default=None, description="API key for the Lakera AI service"
+    )
+    api_base: Optional[str] = Field(
+        default=None, description="Base URL for the Lakera AI API"
+    )
+    project_id: Optional[str] = Field(
+        default=None, description="Project ID for the Lakera AI project"
+    )
+    payload: Optional[bool] = Field(
+        default=True, description="Whether to include payload in the response"
+    )
+    breakdown: Optional[bool] = Field(
+        default=True, description="Whether to include breakdown in the response"
+    )
+    metadata: Optional[Dict] = Field(
+        default=None, description="Additional metadata to include in the request"
+    )
     dev_info: Optional[bool] = Field(
         default=True,
         description="Whether to include developer information in the response",
@@ -424,9 +458,15 @@ class LakeraV2GuardrailConfigModel(BaseModel):
 class LassoGuardrailConfigModel(BaseModel):
     """Configuration parameters for the Lasso guardrail"""
 
-    lasso_user_id: Optional[str] = Field(default=None, description="User ID for the Lasso guardrail")
-    lasso_conversation_id: Optional[str] = Field(default=None, description="Conversation ID for the Lasso guardrail")
-    mask: Optional[bool] = Field(default=False, description="Enable content masking using Lasso classifix API")
+    lasso_user_id: Optional[str] = Field(
+        default=None, description="User ID for the Lasso guardrail"
+    )
+    lasso_conversation_id: Optional[str] = Field(
+        default=None, description="Conversation ID for the Lasso guardrail"
+    )
+    mask: Optional[bool] = Field(
+        default=False, description="Enable content masking using Lasso classifix API"
+    )
 
 
 class PillarGuardrailConfigModel(BaseModel):
@@ -500,11 +540,21 @@ class ZscalerAIGuardConfigModel(BaseModel):
 class JavelinGuardrailConfigModel(BaseModel):
     """Configuration parameters for the Javelin guardrail"""
 
-    guard_name: Optional[str] = Field(default=None, description="Name of the Javelin guard to use")
-    api_version: Optional[str] = Field(default="v1", description="API version for Javelin service")
-    metadata: Optional[Dict] = Field(default=None, description="Additional metadata to send with requests")
-    application: Optional[str] = Field(default=None, description="Application name for Javelin service")
-    config: Optional[Dict] = Field(default=None, description="Additional configuration for the guardrail")
+    guard_name: Optional[str] = Field(
+        default=None, description="Name of the Javelin guard to use"
+    )
+    api_version: Optional[str] = Field(
+        default="v1", description="API version for Javelin service"
+    )
+    metadata: Optional[Dict] = Field(
+        default=None, description="Additional metadata to send with requests"
+    )
+    application: Optional[str] = Field(
+        default=None, description="Application name for Javelin service"
+    )
+    config: Optional[Dict] = Field(
+        default=None, description="Additional configuration for the guardrail"
+    )
 
 
 class ContentFilterAction(str, Enum):
@@ -518,7 +568,9 @@ class BlockedWord(BaseModel):
     """Represents a blocked word with its action and optional description"""
 
     keyword: str = Field(description="The keyword to block or mask")
-    action: ContentFilterAction = Field(description="Action to take when keyword is detected (BLOCK or MASK)")
+    action: ContentFilterAction = Field(
+        description="Action to take when keyword is detected (BLOCK or MASK)"
+    )
     description: Optional[str] = Field(
         default=None,
         description="Optional description explaining why this keyword is sensitive",
@@ -543,7 +595,9 @@ class ContentFilterPattern(BaseModel):
         default=None,
         description="Name for this pattern (used in logging and error messages)",
     )
-    action: ContentFilterAction = Field(description="Action to take when pattern matches (BLOCK or MASK)")
+    action: ContentFilterAction = Field(
+        description="Action to take when pattern matches (BLOCK or MASK)"
+    )
 
 
 class ContentFilterConfigModel(BaseModel):
@@ -577,9 +631,15 @@ class ContentFilterConfigModel(BaseModel):
     )
 
 
-class BaseLitellmParams(ContentFilterConfigModel):  # works for new and patch update guardrails
-    api_key: Optional[str] = Field(default=None, description="API key for the guardrail service")
-    api_base: Optional[str] = Field(default=None, description="Base URL for the guardrail service API")
+class BaseLitellmParams(
+    ContentFilterConfigModel
+):  # works for new and patch update guardrails
+    api_key: Optional[str] = Field(
+        default=None, description="API key for the guardrail service"
+    )
+    api_base: Optional[str] = Field(
+        default=None, description="Base URL for the guardrail service API"
+    )
 
     experimental_use_latest_role_message_only: Optional[bool] = Field(
         default=False,
@@ -618,8 +678,12 @@ class BaseLitellmParams(ContentFilterConfigModel):  # works for new and patch up
     )
 
     # guardrails ai params
-    guard_name: Optional[str] = Field(default=None, description="Name of the guardrail in guardrails.ai")
-    default_on: Optional[bool] = Field(default=None, description="Whether the guardrail is enabled by default")
+    guard_name: Optional[str] = Field(
+        default=None, description="Name of the guardrail in guardrails.ai"
+    )
+    default_on: Optional[bool] = Field(
+        default=None, description="Whether the guardrail is enabled by default"
+    )
 
     ################## PII control params #################
     ########################################################
@@ -633,9 +697,13 @@ class BaseLitellmParams(ContentFilterConfigModel):  # works for new and patch up
     )
 
     # pangea params
-    pangea_input_recipe: Optional[str] = Field(default=None, description="Recipe for input (LLM request)")
+    pangea_input_recipe: Optional[str] = Field(
+        default=None, description="Recipe for input (LLM request)"
+    )
 
-    pangea_output_recipe: Optional[str] = Field(default=None, description="Recipe for output (LLM response)")
+    pangea_output_recipe: Optional[str] = Field(
+        default=None, description="Recipe for output (LLM response)"
+    )
 
     model: Optional[str] = Field(
         default=None,
@@ -663,13 +731,19 @@ class BaseLitellmParams(ContentFilterConfigModel):  # works for new and patch up
     )
 
     # Model Armor params
-    template_id: Optional[str] = Field(default=None, description="The ID of your Model Armor template")
-    location: Optional[str] = Field(default=None, description="Google Cloud location/region (e.g., us-central1)")
+    template_id: Optional[str] = Field(
+        default=None, description="The ID of your Model Armor template"
+    )
+    location: Optional[str] = Field(
+        default=None, description="Google Cloud location/region (e.g., us-central1)"
+    )
     credentials: Optional[str] = Field(
         default=None,
         description="Path to Google Cloud credentials JSON file or JSON string",
     )
-    api_endpoint: Optional[str] = Field(default=None, description="Optional custom API endpoint for Model Armor")
+    api_endpoint: Optional[str] = Field(
+        default=None, description="Optional custom API endpoint for Model Armor"
+    )
     fail_on_error: Optional[bool] = Field(
         default=True,
         description="Whether to fail the request if Model Armor encounters an error",
@@ -760,15 +834,21 @@ class BaseLitellmParams(ContentFilterConfigModel):  # works for new and patch up
     @model_validator(mode="after")
     def validate_sensitive_data_routing(self) -> "BaseLitellmParams":
         if self.on_sensitive_data == "route" and not self.sensitive_data_route_to_model:
-            raise ValueError("sensitive_data_route_to_model must be set when on_sensitive_data='route'")
+            raise ValueError(
+                "sensitive_data_route_to_model must be set when on_sensitive_data='route'"
+            )
         return self
 
     model_config = ConfigDict(extra="allow", protected_namespaces=())
 
 
 class Mode(BaseModel):
-    tags: Dict[str, Union[str, List[str]]] = Field(description="Tags for the guardrail mode")
-    default: Optional[Union[str, List[str]]] = Field(default=None, description="Default mode when no tags match")
+    tags: Dict[str, Union[str, List[str]]] = Field(
+        description="Tags for the guardrail mode"
+    )
+    default: Optional[Union[str, List[str]]] = Field(
+        default=None, description="Default mode when no tags match"
+    )
 
 
 class LitellmParams(
@@ -875,7 +955,9 @@ class GuardrailInfoResponse(BaseModel):
     guardrail_info: Optional[Dict] = None
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
-    guardrail_definition_location: GUARDRAIL_DEFINITION_LOCATION = GUARDRAIL_DEFINITION_LOCATION.CONFIG
+    guardrail_definition_location: GUARDRAIL_DEFINITION_LOCATION = (
+        GUARDRAIL_DEFINITION_LOCATION.CONFIG
+    )
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/litellm/types/guardrails.py
+++ b/litellm/types/guardrails.py
@@ -211,6 +211,9 @@ class PiiEntityType(str, Enum):
     # UK
     UK_NHS = "UK_NHS"
     UK_NINO = "UK_NINO"
+    UK_PASSPORT = "UK_PASSPORT"
+    UK_POSTCODE = "UK_POSTCODE"
+    UK_VEHICLE_REGISTRATION = "UK_VEHICLE_REGISTRATION"
     # Spain
     ES_NIF = "ES_NIF"
     ES_NIE = "ES_NIE"
@@ -265,7 +268,13 @@ PII_ENTITY_CATEGORIES_MAP = {
         PiiEntityType.US_PASSPORT,
         PiiEntityType.US_SSN,
     ],
-    PiiEntityCategory.UK: [PiiEntityType.UK_NHS, PiiEntityType.UK_NINO],
+    PiiEntityCategory.UK: [
+        PiiEntityType.UK_NHS,
+        PiiEntityType.UK_NINO,
+        PiiEntityType.UK_PASSPORT,
+        PiiEntityType.UK_POSTCODE,
+        PiiEntityType.UK_VEHICLE_REGISTRATION,
+    ],
     PiiEntityCategory.SPAIN: [PiiEntityType.ES_NIF, PiiEntityType.ES_NIE],
     PiiEntityCategory.ITALY: [
         PiiEntityType.IT_FISCAL_CODE,
@@ -319,8 +328,7 @@ class PresidioPresidioConfigModelUserInterface(BaseModel):
     presidio_filter_scope: Optional[Literal["input", "output", "both"]] = Field(
         default=None,
         description=(
-            "Where to apply Presidio checks: 'input' (user -> model), "
-            "'output' (model -> user), or 'both' (default)."
+            "Where to apply Presidio checks: 'input' (user -> model), 'output' (model -> user), or 'both' (default)."
         ),
     )
     output_parse_pii: Optional[bool] = Field(
@@ -365,17 +373,13 @@ class PresidioConfigModel(PresidioPresidioConfigModelUserInterface):
         default=None,
         description="Path to a JSON file containing ad-hoc recognizers for Presidio",
     )
-    mock_redacted_text: Optional[dict] = Field(
-        default=None, description="Mock redacted text for testing"
-    )
+    mock_redacted_text: Optional[dict] = Field(default=None, description="Mock redacted text for testing")
 
 
 class BedrockGuardrailConfigModel(BaseModel):
     """Configuration parameters for the AWS Bedrock guardrail"""
 
-    guardrailIdentifier: Optional[str] = Field(
-        default=None, description="The ID of your guardrail on Bedrock"
-    )
+    guardrailIdentifier: Optional[str] = Field(default=None, description="The ID of your guardrail on Bedrock")
     guardrailVersion: Optional[str] = Field(
         default=None,
         description="The version of your Bedrock guardrail (e.g., DRAFT or version number)",
@@ -384,59 +388,29 @@ class BedrockGuardrailConfigModel(BaseModel):
         default=False,
         description="If True, will not raise an exception when the guardrail is blocked. Useful for OpenWebUI where exceptions can end the chat flow.",
     )
-    aws_region_name: Optional[str] = Field(
-        default=None, description="AWS region where your guardrail is deployed"
-    )
-    aws_access_key_id: Optional[str] = Field(
-        default=None, description="AWS access key ID for authentication"
-    )
-    aws_secret_access_key: Optional[str] = Field(
-        default=None, description="AWS secret access key for authentication"
-    )
-    aws_session_token: Optional[str] = Field(
-        default=None, description="AWS session token for temporary credentials"
-    )
-    aws_session_name: Optional[str] = Field(
-        default=None, description="Name of the AWS session"
-    )
-    aws_profile_name: Optional[str] = Field(
-        default=None, description="AWS profile name for credential retrieval"
-    )
-    aws_role_name: Optional[str] = Field(
-        default=None, description="AWS role name for assuming roles"
-    )
+    aws_region_name: Optional[str] = Field(default=None, description="AWS region where your guardrail is deployed")
+    aws_access_key_id: Optional[str] = Field(default=None, description="AWS access key ID for authentication")
+    aws_secret_access_key: Optional[str] = Field(default=None, description="AWS secret access key for authentication")
+    aws_session_token: Optional[str] = Field(default=None, description="AWS session token for temporary credentials")
+    aws_session_name: Optional[str] = Field(default=None, description="Name of the AWS session")
+    aws_profile_name: Optional[str] = Field(default=None, description="AWS profile name for credential retrieval")
+    aws_role_name: Optional[str] = Field(default=None, description="AWS role name for assuming roles")
     aws_web_identity_token: Optional[str] = Field(
         default=None, description="Web identity token for AWS role assumption"
     )
-    aws_sts_endpoint: Optional[str] = Field(
-        default=None, description="AWS STS endpoint URL"
-    )
-    aws_bedrock_runtime_endpoint: Optional[str] = Field(
-        default=None, description="AWS Bedrock runtime endpoint URL"
-    )
+    aws_sts_endpoint: Optional[str] = Field(default=None, description="AWS STS endpoint URL")
+    aws_bedrock_runtime_endpoint: Optional[str] = Field(default=None, description="AWS Bedrock runtime endpoint URL")
 
 
 class LakeraV2GuardrailConfigModel(BaseModel):
     """Configuration parameters for the Lakera AI v2 guardrail"""
 
-    api_key: Optional[str] = Field(
-        default=None, description="API key for the Lakera AI service"
-    )
-    api_base: Optional[str] = Field(
-        default=None, description="Base URL for the Lakera AI API"
-    )
-    project_id: Optional[str] = Field(
-        default=None, description="Project ID for the Lakera AI project"
-    )
-    payload: Optional[bool] = Field(
-        default=True, description="Whether to include payload in the response"
-    )
-    breakdown: Optional[bool] = Field(
-        default=True, description="Whether to include breakdown in the response"
-    )
-    metadata: Optional[Dict] = Field(
-        default=None, description="Additional metadata to include in the request"
-    )
+    api_key: Optional[str] = Field(default=None, description="API key for the Lakera AI service")
+    api_base: Optional[str] = Field(default=None, description="Base URL for the Lakera AI API")
+    project_id: Optional[str] = Field(default=None, description="Project ID for the Lakera AI project")
+    payload: Optional[bool] = Field(default=True, description="Whether to include payload in the response")
+    breakdown: Optional[bool] = Field(default=True, description="Whether to include breakdown in the response")
+    metadata: Optional[Dict] = Field(default=None, description="Additional metadata to include in the request")
     dev_info: Optional[bool] = Field(
         default=True,
         description="Whether to include developer information in the response",
@@ -450,15 +424,9 @@ class LakeraV2GuardrailConfigModel(BaseModel):
 class LassoGuardrailConfigModel(BaseModel):
     """Configuration parameters for the Lasso guardrail"""
 
-    lasso_user_id: Optional[str] = Field(
-        default=None, description="User ID for the Lasso guardrail"
-    )
-    lasso_conversation_id: Optional[str] = Field(
-        default=None, description="Conversation ID for the Lasso guardrail"
-    )
-    mask: Optional[bool] = Field(
-        default=False, description="Enable content masking using Lasso classifix API"
-    )
+    lasso_user_id: Optional[str] = Field(default=None, description="User ID for the Lasso guardrail")
+    lasso_conversation_id: Optional[str] = Field(default=None, description="Conversation ID for the Lasso guardrail")
+    mask: Optional[bool] = Field(default=False, description="Enable content masking using Lasso classifix API")
 
 
 class PillarGuardrailConfigModel(BaseModel):
@@ -532,21 +500,11 @@ class ZscalerAIGuardConfigModel(BaseModel):
 class JavelinGuardrailConfigModel(BaseModel):
     """Configuration parameters for the Javelin guardrail"""
 
-    guard_name: Optional[str] = Field(
-        default=None, description="Name of the Javelin guard to use"
-    )
-    api_version: Optional[str] = Field(
-        default="v1", description="API version for Javelin service"
-    )
-    metadata: Optional[Dict] = Field(
-        default=None, description="Additional metadata to send with requests"
-    )
-    application: Optional[str] = Field(
-        default=None, description="Application name for Javelin service"
-    )
-    config: Optional[Dict] = Field(
-        default=None, description="Additional configuration for the guardrail"
-    )
+    guard_name: Optional[str] = Field(default=None, description="Name of the Javelin guard to use")
+    api_version: Optional[str] = Field(default="v1", description="API version for Javelin service")
+    metadata: Optional[Dict] = Field(default=None, description="Additional metadata to send with requests")
+    application: Optional[str] = Field(default=None, description="Application name for Javelin service")
+    config: Optional[Dict] = Field(default=None, description="Additional configuration for the guardrail")
 
 
 class ContentFilterAction(str, Enum):
@@ -560,9 +518,7 @@ class BlockedWord(BaseModel):
     """Represents a blocked word with its action and optional description"""
 
     keyword: str = Field(description="The keyword to block or mask")
-    action: ContentFilterAction = Field(
-        description="Action to take when keyword is detected (BLOCK or MASK)"
-    )
+    action: ContentFilterAction = Field(description="Action to take when keyword is detected (BLOCK or MASK)")
     description: Optional[str] = Field(
         default=None,
         description="Optional description explaining why this keyword is sensitive",
@@ -587,9 +543,7 @@ class ContentFilterPattern(BaseModel):
         default=None,
         description="Name for this pattern (used in logging and error messages)",
     )
-    action: ContentFilterAction = Field(
-        description="Action to take when pattern matches (BLOCK or MASK)"
-    )
+    action: ContentFilterAction = Field(description="Action to take when pattern matches (BLOCK or MASK)")
 
 
 class ContentFilterConfigModel(BaseModel):
@@ -623,15 +577,9 @@ class ContentFilterConfigModel(BaseModel):
     )
 
 
-class BaseLitellmParams(
-    ContentFilterConfigModel
-):  # works for new and patch update guardrails
-    api_key: Optional[str] = Field(
-        default=None, description="API key for the guardrail service"
-    )
-    api_base: Optional[str] = Field(
-        default=None, description="Base URL for the guardrail service API"
-    )
+class BaseLitellmParams(ContentFilterConfigModel):  # works for new and patch update guardrails
+    api_key: Optional[str] = Field(default=None, description="API key for the guardrail service")
+    api_base: Optional[str] = Field(default=None, description="Base URL for the guardrail service API")
 
     experimental_use_latest_role_message_only: Optional[bool] = Field(
         default=False,
@@ -670,12 +618,8 @@ class BaseLitellmParams(
     )
 
     # guardrails ai params
-    guard_name: Optional[str] = Field(
-        default=None, description="Name of the guardrail in guardrails.ai"
-    )
-    default_on: Optional[bool] = Field(
-        default=None, description="Whether the guardrail is enabled by default"
-    )
+    guard_name: Optional[str] = Field(default=None, description="Name of the guardrail in guardrails.ai")
+    default_on: Optional[bool] = Field(default=None, description="Whether the guardrail is enabled by default")
 
     ################## PII control params #################
     ########################################################
@@ -689,13 +633,9 @@ class BaseLitellmParams(
     )
 
     # pangea params
-    pangea_input_recipe: Optional[str] = Field(
-        default=None, description="Recipe for input (LLM request)"
-    )
+    pangea_input_recipe: Optional[str] = Field(default=None, description="Recipe for input (LLM request)")
 
-    pangea_output_recipe: Optional[str] = Field(
-        default=None, description="Recipe for output (LLM response)"
-    )
+    pangea_output_recipe: Optional[str] = Field(default=None, description="Recipe for output (LLM response)")
 
     model: Optional[str] = Field(
         default=None,
@@ -723,19 +663,13 @@ class BaseLitellmParams(
     )
 
     # Model Armor params
-    template_id: Optional[str] = Field(
-        default=None, description="The ID of your Model Armor template"
-    )
-    location: Optional[str] = Field(
-        default=None, description="Google Cloud location/region (e.g., us-central1)"
-    )
+    template_id: Optional[str] = Field(default=None, description="The ID of your Model Armor template")
+    location: Optional[str] = Field(default=None, description="Google Cloud location/region (e.g., us-central1)")
     credentials: Optional[str] = Field(
         default=None,
         description="Path to Google Cloud credentials JSON file or JSON string",
     )
-    api_endpoint: Optional[str] = Field(
-        default=None, description="Optional custom API endpoint for Model Armor"
-    )
+    api_endpoint: Optional[str] = Field(default=None, description="Optional custom API endpoint for Model Armor")
     fail_on_error: Optional[bool] = Field(
         default=True,
         description="Whether to fail the request if Model Armor encounters an error",
@@ -826,21 +760,15 @@ class BaseLitellmParams(
     @model_validator(mode="after")
     def validate_sensitive_data_routing(self) -> "BaseLitellmParams":
         if self.on_sensitive_data == "route" and not self.sensitive_data_route_to_model:
-            raise ValueError(
-                "sensitive_data_route_to_model must be set when on_sensitive_data='route'"
-            )
+            raise ValueError("sensitive_data_route_to_model must be set when on_sensitive_data='route'")
         return self
 
     model_config = ConfigDict(extra="allow", protected_namespaces=())
 
 
 class Mode(BaseModel):
-    tags: Dict[str, Union[str, List[str]]] = Field(
-        description="Tags for the guardrail mode"
-    )
-    default: Optional[Union[str, List[str]]] = Field(
-        default=None, description="Default mode when no tags match"
-    )
+    tags: Dict[str, Union[str, List[str]]] = Field(description="Tags for the guardrail mode")
+    default: Optional[Union[str, List[str]]] = Field(default=None, description="Default mode when no tags match")
 
 
 class LitellmParams(
@@ -947,9 +875,7 @@ class GuardrailInfoResponse(BaseModel):
     guardrail_info: Optional[Dict] = None
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
-    guardrail_definition_location: GUARDRAIL_DEFINITION_LOCATION = (
-        GUARDRAIL_DEFINITION_LOCATION.CONFIG
-    )
+    guardrail_definition_location: GUARDRAIL_DEFINITION_LOCATION = GUARDRAIL_DEFINITION_LOCATION.CONFIG
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/tests/test_litellm/types/test_uk_pii_entities.py
+++ b/tests/test_litellm/types/test_uk_pii_entities.py
@@ -1,0 +1,59 @@
+"""
+Test UK PII entity types in guardrails module
+"""
+
+from litellm.types.guardrails import PiiEntityType, PiiEntityCategory, PII_ENTITY_CATEGORIES_MAP
+
+
+class TestUKPiiEntities:
+    """Test UK PII entity type definitions and mappings"""
+
+    def test_uk_pii_entity_types_exist(self):
+        """Test all UK PII entity types are defined"""
+        assert hasattr(PiiEntityType, "UK_NHS")
+        assert hasattr(PiiEntityType, "UK_NINO")
+        assert hasattr(PiiEntityType, "UK_PASSPORT")
+        assert hasattr(PiiEntityType, "UK_POSTCODE")
+        assert hasattr(PiiEntityType, "UK_VEHICLE_REGISTRATION")
+
+    def test_uk_pii_entity_values(self):
+        """Test UK PII entity types have correct string values"""
+        assert PiiEntityType.UK_NHS == "UK_NHS"
+        assert PiiEntityType.UK_NINO == "UK_NINO"
+        assert PiiEntityType.UK_PASSPORT == "UK_PASSPORT"
+        assert PiiEntityType.UK_POSTCODE == "UK_POSTCODE"
+        assert PiiEntityType.UK_VEHICLE_REGISTRATION == "UK_VEHICLE_REGISTRATION"
+
+    def test_uk_category_exists(self):
+        """Test UK category exists in PII_ENTITY_CATEGORIES_MAP"""
+        assert PiiEntityCategory.UK in PII_ENTITY_CATEGORIES_MAP
+
+    def test_uk_category_contains_all_entities(self):
+        """Test UK category contains all UK PII entity types"""
+        uk_entities = PII_ENTITY_CATEGORIES_MAP[PiiEntityCategory.UK]
+
+        assert PiiEntityType.UK_NHS in uk_entities
+        assert PiiEntityType.UK_NINO in uk_entities
+        assert PiiEntityType.UK_PASSPORT in uk_entities
+        assert PiiEntityType.UK_POSTCODE in uk_entities
+        assert PiiEntityType.UK_VEHICLE_REGISTRATION in uk_entities
+
+    def test_uk_category_entity_count(self):
+        """Test UK category has exactly 5 entity types"""
+        uk_entities = PII_ENTITY_CATEGORIES_MAP[PiiEntityCategory.UK]
+        assert len(uk_entities) == 5
+
+    def test_uk_entities_match_presidio_recognizers(self):
+        """Test UK entity type names match Presidio recognizer names"""
+        expected_entities = {
+            "UK_NHS",
+            "UK_NINO",
+            "UK_PASSPORT",
+            "UK_POSTCODE",
+            "UK_VEHICLE_REGISTRATION",
+        }
+
+        uk_entities = PII_ENTITY_CATEGORIES_MAP[PiiEntityCategory.UK]
+        actual_entities = {entity for entity in uk_entities}
+
+        assert actual_entities == expected_entities

--- a/tests/test_litellm/types/test_uk_pii_entities.py
+++ b/tests/test_litellm/types/test_uk_pii_entities.py
@@ -38,11 +38,6 @@ class TestUKPiiEntities:
         assert PiiEntityType.UK_POSTCODE in uk_entities
         assert PiiEntityType.UK_VEHICLE_REGISTRATION in uk_entities
 
-    def test_uk_category_entity_count(self):
-        """Test UK category has exactly 5 entity types"""
-        uk_entities = PII_ENTITY_CATEGORIES_MAP[PiiEntityCategory.UK]
-        assert len(uk_entities) == 5
-
     def test_uk_entities_match_presidio_recognizers(self):
         """Test UK entity type names match Presidio recognizer names"""
         expected_entities = {
@@ -54,6 +49,6 @@ class TestUKPiiEntities:
         }
 
         uk_entities = PII_ENTITY_CATEGORIES_MAP[PiiEntityCategory.UK]
-        actual_entities = {entity for entity in uk_entities}
+        actual_entities = set(uk_entities)
 
         assert actual_entities == expected_entities


### PR DESCRIPTION
## Relevant issues

Fixes #30511

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🆕 New Feature

## Changes

Added three missing UK PII entity types to the Presidio guardrail configuration:
- `UK_PASSPORT`
- `UK_POSTCODE` 
- `UK_VEHICLE_REGISTRATION`

These entity types are supported by Microsoft Presidio but were previously missing from litellm's `PiiEntityType` enum and `PII_ENTITY_CATEGORIES_MAP`, preventing users from configuring UK-specific PII detection.

### Modified Files

**litellm/types/guardrails.py**
- Added `UK_PASSPORT`, `UK_POSTCODE`, and `UK_VEHICLE_REGISTRATION` to `PiiEntityType` enum
- Updated `PII_ENTITY_CATEGORIES_MAP` to include all 5 UK entity types in the UK category

**tests/test_litellm/types/test_uk_pii_entities.py** (new file)
- Added 6 comprehensive unit tests verifying UK entity type definitions and mappings
- Tests confirm all 5 UK entities exist, have correct values, and are properly categorized

### Test Results

```bash
$ uv run python -m pytest tests/test_litellm/types/test_uk_pii_entities.py -v
============================== 6 passed in 0.07s ===============================

$ uv run python -m pytest tests/test_litellm/types/test_guardrails_case_normalization.py -v
============================== 15 passed in 0.08s ===============================
```

All new tests pass and no regressions in existing guardrail tests.

## Screenshots / Proof of Fix

The fix enables users to configure UK PII detection in their guardrails config:

```yaml
guardrails:
  - guardrail_name: "uk-pii-detection"
    litellm_params:
      guardrail: presidio
      mode: pre_call
      pii_entities:
        UK_NHS: MASK
        UK_NINO: MASK
        UK_PASSPORT: MASK          # Now supported
        UK_POSTCODE: MASK          # Now supported
        UK_VEHICLE_REGISTRATION: MASK  # Now supported
```

Verification script available at `verify_uk_pii_proxy.sh` for manual testing against a live proxy instance with real Presidio API calls.