### PR TITLE
fix(responses): omit empty tools array in completion bridge

### DIFF
--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -259,6 +259,14 @@ class LiteLLMCompletionResponsesConfig:
             if litellm_logging_obj:
                 litellm_logging_obj.stream_options = stream_options
 
+        # An empty tools list is invalid for strict OpenAI-compatible backends
+        # (e.g. vLLM 422s with "`tools` must not be an empty array. Either
+        # provide at least one tool or omit the field entirely."). Drop the
+        # field (and the now-meaningless tool_choice) when there are no tools.
+        if not litellm_completion_request.get("tools"):
+            litellm_completion_request.pop("tools", None)
+            litellm_completion_request.pop("tool_choice", None)
+
         # only pass non-None values
         litellm_completion_request = {k: v for k, v in litellm_completion_request.items() if v is not None}
         return litellm_completion_request

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -930,6 +930,58 @@ class TestFunctionCallTransformation:
         assert function.get("arguments") == '{"query": "attribute objects"}'
 
 
+class TestEmptyToolsTransformation:
+    """Empty tools must be omitted, not forwarded as `tools: []`.
+
+    Strict OpenAI-compatible backends (e.g. vLLM) reject an empty tools array
+    with a 422 ("`tools` must not be an empty array. Either provide at least
+    one tool or omit the field entirely.").
+    """
+
+    def test_absent_tools_omits_tools_field(self):
+        result = LiteLLMCompletionResponsesConfig.transform_responses_api_request_to_chat_completion_request(
+            model="hosted_vllm/some-model",
+            input="hi",
+            responses_api_request={"temperature": 0.7},
+        )
+
+        assert "tools" not in result
+        # tool_choice is meaningless without tools and must not leak either.
+        assert "tool_choice" not in result
+
+    def test_empty_tools_list_omits_tools_field(self):
+        result = LiteLLMCompletionResponsesConfig.transform_responses_api_request_to_chat_completion_request(
+            model="hosted_vllm/some-model",
+            input="hi",
+            responses_api_request={"tools": []},
+        )
+
+        assert "tools" not in result
+
+    def test_non_empty_tools_are_preserved(self):
+        tools = [
+            {
+                "type": "function",
+                "name": "get_weather",
+                "description": "Get current temperature for a given location.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"location": {"type": "string"}},
+                    "required": ["location"],
+                },
+            }
+        ]
+
+        result = LiteLLMCompletionResponsesConfig.transform_responses_api_request_to_chat_completion_request(
+            model="hosted_vllm/some-model",
+            input="hi",
+            responses_api_request={"tools": tools},
+        )
+
+        assert "tools" in result
+        assert len(result["tools"]) == 1
+
+
 class TestToolChoiceTransformation:
     """Test the tool_choice transformation fix for Cursor IDE bug"""
 


### PR DESCRIPTION
## Relevant issues

Fixes #30539

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

The Responses → Chat Completions bridge (`LiteLLMCompletionResponsesConfig.transform_responses_api_request_to_chat_completion_request`) built the chat-completion request with:

```python
responses_api_request.get("tools") or []   # None / absent / [] all become []
```

and then only stripped `None` values:

```python
{k: v for k, v in litellm_completion_request.items() if v is not None}
```

Since `[] is not None`, a tool-less `/responses` request was forwarded upstream as `tools: []`. Strict OpenAI-compatible backends (e.g. **vLLM**) reject that with a 422:

```
`tools` must not be an empty array. Either provide at least one tool or omit the field entirely.
```

This affected requests that send **no** tools at all — the bridge manufactured the empty list itself.

**Fix:** drop `tools` (and the now-meaningless `tool_choice`) when there are no tools, so the field is omitted entirely per the OpenAI spec. Populated tools are unaffected.

### Before / after

```python
from litellm.responses.litellm_completion_transformation.transformation import (
    LiteLLMCompletionResponsesConfig as C,
)
req = C.transform_responses_api_request_to_chat_completion_request(
    model="hosted_vllm/some-model",
    input="hi",
    responses_api_request={"temperature": 0.7},  # no tools
)
# before: "tools" in req -> True, req["tools"] == []
# after:  "tools" in req -> False
```

### Tests

Added `TestEmptyToolsTransformation` in
`tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py`:
- absent tools → `tools`/`tool_choice` omitted
- explicit `tools: []` → omitted
- non-empty tools → preserved
