### PR TITLE
test(bedrock): lock in cache token billing for converse (#29145)

### DIFF
--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -14,6 +14,9 @@ from unittest.mock import MagicMock, patch
 import litellm
 from litellm import ModelResponse, RateLimitError, completion
 from litellm.llms.bedrock.chat.converse_transformation import AmazonConverseConfig
+from litellm.llms.bedrock.cost_calculation import (
+    cost_per_token as bedrock_cost_per_token,
+)
 from litellm.types.llms.bedrock import ConverseTokenUsageBlock
 
 
@@ -49,6 +52,45 @@ def test_transform_usage():
     assert openai_usage.completion_tokens_details is not None
     assert openai_usage.completion_tokens_details.reasoning_tokens == 0
     assert openai_usage.completion_tokens_details.text_tokens == usage["outputTokens"]
+
+
+def test_converse_cache_tokens_are_billed():
+    """
+    Regression test for https://github.com/BerriAI/litellm/issues/29145
+
+    Cache creation and cache read tokens on bedrock_converse responses must be
+    billed at their respective rates, not silently dropped to $0. The token
+    counts from the converse usage block have to survive into prompt_tokens_details
+    so the cost calculator can price them.
+    """
+    usage = ConverseTokenUsageBlock(
+        **{
+            "inputTokens": 1,
+            "cacheReadInputTokens": 32634,
+            "cacheWriteInputTokens": 1190,
+            "outputTokens": 672,
+            "totalTokens": 1 + 32634 + 1190 + 672,
+        }
+    )
+    model = "eu.anthropic.claude-sonnet-4-6"
+    transformed_usage = AmazonConverseConfig()._transform_usage(usage)
+
+    model_info = litellm.get_model_info(model=model, custom_llm_provider="bedrock")
+    expected_cache_creation_cost = 1190 * model_info["cache_creation_input_token_cost"]
+    expected_cache_read_cost = 32634 * model_info["cache_read_input_token_cost"]
+    expected_text_cost = 1 * model_info["input_cost_per_token"]
+    expected_completion_cost = 672 * model_info["output_cost_per_token"]
+
+    prompt_cost, completion_cost = bedrock_cost_per_token(
+        model=model, usage=transformed_usage
+    )
+
+    assert expected_cache_creation_cost > 0
+    assert expected_cache_read_cost > 0
+    assert prompt_cost == pytest.approx(
+        expected_text_cost + expected_cache_creation_cost + expected_cache_read_cost
+    )
+    assert completion_cost == pytest.approx(expected_completion_cost)
 
 
 def test_transform_usage_with_reasoning_content():


### PR DESCRIPTION
## Relevant issues

Closes #29145

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Issue #29145 reports that `bedrock_converse` prompt-caching responses silently bill `cache_creation_input_token_cost` and `cache_read_input_token_cost` at $0, under-billing cache-heavy workloads by a large margin (the reporter is on v1.86.2). Tracing the current pipeline shows the under-billing is already resolved on the current head: the converse `_transform_usage` populates `prompt_tokens_details` with `cached_tokens` / `cache_creation_tokens`, the streaming aggregator preserves them, and `generic_cost_per_token` prices them. What was missing is a test that locks the billing in end to end, so a future change that drops the cache token counts before cost calc would silently reintroduce the same $0 bug.

This PR adds that regression test. It feeds the exact token counts from the issue (1 text, 32,634 cache read, 1,190 cache write, 672 output) through the converse usage transform and then through the bedrock cost calculator, and asserts the cache contributions are billed at the model's configured rates rather than zero. Under the original bug `prompt_cost` would collapse to the text-only cost and the assertion fails.

Running the exact issue scenario against the calculator on this branch:

```
$ python -c "
from litellm.llms.bedrock.chat.converse_transformation import AmazonConverseConfig
from litellm.types.llms.bedrock import ConverseTokenUsageBlock
from litellm.llms.bedrock.cost_calculation import cost_per_token
usage = ConverseTokenUsageBlock(**{'inputTokens':1,'cacheReadInputTokens':32634,'cacheWriteInputTokens':1190,'outputTokens':672,'totalTokens':1+32634+1190+672})
u = AmazonConverseConfig()._transform_usage(usage)
p, c = cost_per_token(model='eu.anthropic.claude-sonnet-4-6', usage=u)
print('prompt_cost', round(p,8), 'completion', round(c,8), 'total', round(p+c,8))
"
prompt_cost 0.01568127 completion 0.011088 total 0.02676927
```

That matches the issue's expected total of ~$0.026769, versus the buggy text-only $0.0000033.

## Type

✅ Test

## Changes

Adds `test_converse_cache_tokens_are_billed` to `tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py`, a regression test that asserts cache creation and cache read tokens on a bedrock_converse response are billed at their configured rates instead of being dropped to $0.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M7puVswhCWNazLsNcHHPsN)_