### PR TITLE
fix(guardrails): run pre_call hook once for model-level guardrails

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -190,6 +190,10 @@ DEFAULT_REASONING_EFFORT_MINIMAL_THINKING_BUDGET_GEMINI_2_5_FLASH_LITE = int(
 # Override with LITELLM_MAX_CALLBACKS env var for large deployments (e.g., many teams with guardrails)
 MAX_CALLBACKS = get_env_int("LITELLM_MAX_CALLBACKS", 100)
 
+# Metadata key recording which pre_call guardrails the proxy loop already ran,
+# so the deployment-level hook does not re-run them for the same request
+PRE_CALL_EXECUTED_GUARDRAILS_KEY = "_pre_call_executed_guardrails"
+
 # Generic fallback for unknown models
 DEFAULT_REASONING_EFFORT_MINIMAL_THINKING_BUDGET = int(
     os.getenv("DEFAULT_REASONING_EFFORT_MINIMAL_THINKING_BUDGET", 128)

--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -1,3 +1,4 @@
+import secrets
 from datetime import datetime
 from typing import (
     TYPE_CHECKING,
@@ -43,6 +44,7 @@ if TYPE_CHECKING:
 dc = DualCache()
 
 
+from litellm.constants import PRE_CALL_EXECUTED_GUARDRAILS_KEY
 from litellm.exceptions import (
     BlockedPiiEntityError,
     GuardrailRaisedException,
@@ -50,7 +52,11 @@ from litellm.exceptions import (
     SensitiveDataRouteException,
 )
 
-PRE_CALL_EXECUTED_GUARDRAILS_KEY = "_pre_call_executed_guardrails"
+# Per-process secret tagging each recorded marker. The deployment hook only
+# honors markers carrying this token, so a caller cannot forge the metadata
+# field to suppress a guardrail on the direct-SDK path that never reaches the
+# proxy's metadata sanitizer.
+_PRE_CALL_EXECUTED_TOKEN = secrets.token_hex(16)
 
 
 def get_session_id_from_request_data(request_data: Dict[str, Any]) -> Optional[str]:
@@ -460,6 +466,12 @@ class CustomGuardrail(CustomLogger):
 
         return False
 
+    def _pre_call_marker(self) -> Optional[str]:
+        name = self.guardrail_name
+        if not name:
+            return None
+        return f"{_PRE_CALL_EXECUTED_TOKEN}:{name}"
+
     def mark_pre_call_hook_ran(self, data: Dict[str, Any]) -> None:
         """
         Record that this guardrail's ``async_pre_call_hook`` already ran for this
@@ -470,30 +482,30 @@ class CustomGuardrail(CustomLogger):
         top-level request kwargs, which would otherwise re-trigger the same hook
         from ``async_pre_call_deployment_hook``.
         """
-        name = self.guardrail_name
-        if not name:
+        marker = self._pre_call_marker()
+        if marker is None:
             return
         for meta_key in ("metadata", "litellm_metadata"):
             meta = data.get(meta_key)
             if isinstance(meta, dict):
                 executed = meta.get(PRE_CALL_EXECUTED_GUARDRAILS_KEY)
                 if isinstance(executed, list):
-                    if name not in executed:
-                        executed.append(name)
+                    if marker not in executed:
+                        executed.append(marker)
                 else:
-                    meta[PRE_CALL_EXECUTED_GUARDRAILS_KEY] = [name]
+                    meta[PRE_CALL_EXECUTED_GUARDRAILS_KEY] = [marker]
                 return
-        data["metadata"] = {PRE_CALL_EXECUTED_GUARDRAILS_KEY: [name]}
+        data["metadata"] = {PRE_CALL_EXECUTED_GUARDRAILS_KEY: [marker]}
 
     def _pre_call_hook_already_ran(self, data: Dict[str, Any]) -> bool:
-        name = self.guardrail_name
-        if not name:
+        marker = self._pre_call_marker()
+        if marker is None:
             return False
         for meta_key in ("metadata", "litellm_metadata"):
             meta = data.get(meta_key)
             if isinstance(meta, dict):
                 executed = meta.get(PRE_CALL_EXECUTED_GUARDRAILS_KEY)
-                if isinstance(executed, list) and name in executed:
+                if isinstance(executed, list) and marker in executed:
                     return True
         return False
 

--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -50,6 +50,8 @@ from litellm.exceptions import (
     SensitiveDataRouteException,
 )
 
+PRE_CALL_EXECUTED_GUARDRAILS_KEY = "_pre_call_executed_guardrails"
+
 
 def get_session_id_from_request_data(request_data: Dict[str, Any]) -> Optional[str]:
     """Extract session_id from request data (litellm_session_id or metadata)."""
@@ -458,6 +460,43 @@ class CustomGuardrail(CustomLogger):
 
         return False
 
+    def mark_pre_call_hook_ran(self, data: Dict[str, Any]) -> None:
+        """
+        Record that this guardrail's ``async_pre_call_hook`` already ran for this
+        request, so the deployment-level hook does not run it a second time.
+
+        The proxy runs pre-call guardrails in ``ProxyLogging.pre_call_hook``. The
+        router later spreads a deployment's model-level ``guardrails`` into the
+        top-level request kwargs, which would otherwise re-trigger the same hook
+        from ``async_pre_call_deployment_hook``.
+        """
+        name = self.guardrail_name
+        if not name:
+            return
+        for meta_key in ("metadata", "litellm_metadata"):
+            meta = data.get(meta_key)
+            if isinstance(meta, dict):
+                executed = meta.get(PRE_CALL_EXECUTED_GUARDRAILS_KEY)
+                if isinstance(executed, list):
+                    if name not in executed:
+                        executed.append(name)
+                else:
+                    meta[PRE_CALL_EXECUTED_GUARDRAILS_KEY] = [name]
+                return
+        data["metadata"] = {PRE_CALL_EXECUTED_GUARDRAILS_KEY: [name]}
+
+    def _pre_call_hook_already_ran(self, data: Dict[str, Any]) -> bool:
+        name = self.guardrail_name
+        if not name:
+            return False
+        for meta_key in ("metadata", "litellm_metadata"):
+            meta = data.get(meta_key)
+            if isinstance(meta, dict):
+                executed = meta.get(PRE_CALL_EXECUTED_GUARDRAILS_KEY)
+                if isinstance(executed, list) and name in executed:
+                    return True
+        return False
+
     async def async_pre_call_deployment_hook(
         self, kwargs: Dict[str, Any], call_type: Optional[CallTypes]
     ) -> Optional[dict]:
@@ -466,6 +505,9 @@ class CustomGuardrail(CustomLogger):
         # should run guardrail
         litellm_guardrails = kwargs.get("guardrails")
         if litellm_guardrails is None or not isinstance(litellm_guardrails, list):
+            return kwargs
+
+        if self._pre_call_hook_already_ran(kwargs):
             return kwargs
 
         if (

--- a/litellm/proxy/common_utils/callback_utils.py
+++ b/litellm/proxy/common_utils/callback_utils.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Literal, 
 import litellm
 from litellm import get_secret
 from litellm._logging import verbose_proxy_logger
+from litellm.constants import PRE_CALL_EXECUTED_GUARDRAILS_KEY
 from litellm.integrations.custom_logger import CustomLogger
 from litellm.litellm_core_utils.sensitive_data_masker import SensitiveDataMasker
 from litellm.proxy._types import CommonProxyErrors, LiteLLMPromptInjectionParams
@@ -497,7 +498,7 @@ LITELLM_PROXY_INTERNAL_METADATA_KEYS = frozenset(
         "guardrail_config",
         "_guardrail_pipelines",
         "_pipeline_managed_guardrails",
-        "_pre_call_executed_guardrails",
+        PRE_CALL_EXECUTED_GUARDRAILS_KEY,
         "disable_global_guardrails",
         "disable_global_guardrail",
         "opted_out_global_guardrails",

--- a/litellm/proxy/common_utils/callback_utils.py
+++ b/litellm/proxy/common_utils/callback_utils.py
@@ -497,6 +497,7 @@ LITELLM_PROXY_INTERNAL_METADATA_KEYS = frozenset(
         "guardrail_config",
         "_guardrail_pipelines",
         "_pipeline_managed_guardrails",
+        "_pre_call_executed_guardrails",
         "disable_global_guardrails",
         "disable_global_guardrail",
         "opted_out_global_guardrails",

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -13,6 +13,7 @@ from starlette.datastructures import Headers
 import litellm
 from litellm._logging import verbose_logger, verbose_proxy_logger
 from litellm._service_logger import ServiceLogging
+from litellm.constants import PRE_CALL_EXECUTED_GUARDRAILS_KEY
 from litellm.litellm_core_utils.credential_accessor import CredentialAccessor
 from litellm.litellm_core_utils.safe_json_loads import safe_json_loads
 from litellm.litellm_core_utils.url_utils import is_url_destination_allowed_by_host
@@ -161,7 +162,7 @@ _UNTRUSTED_METADATA_CONTROL_FIELDS = (
     "secret_fields",
     "_guardrail_pipelines",
     "_pipeline_managed_guardrails",
-    "_pre_call_executed_guardrails",
+    PRE_CALL_EXECUTED_GUARDRAILS_KEY,
 )
 
 _UNTRUSTED_REQUEST_HEADER_CONTROL_FIELDS = frozenset(

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -161,6 +161,7 @@ _UNTRUSTED_METADATA_CONTROL_FIELDS = (
     "secret_fields",
     "_guardrail_pipelines",
     "_pipeline_managed_guardrails",
+    "_pre_call_executed_guardrails",
 )
 
 _UNTRUSTED_REQUEST_HEADER_CONTROL_FIELDS = frozenset(

--- a/litellm/proxy/policy_engine/pipeline_executor.py
+++ b/litellm/proxy/policy_engine/pipeline_executor.py
@@ -165,14 +165,16 @@ class PipelineExecutor:
                 target = UnifiedLLMGuardrails()
 
             if mode == "pre_call":
-                if isinstance(callback, CustomGuardrail):
-                    callback.mark_pre_call_hook_ran(data)
                 response = await target.async_pre_call_hook(
                     user_api_key_dict=user_api_key_dict,
                     cache=None,  # type: ignore
                     data=data,
                     call_type=call_type,  # type: ignore
                 )
+                if isinstance(callback, CustomGuardrail):
+                    callback.mark_pre_call_hook_ran(data)
+                    if isinstance(response, dict):
+                        callback.mark_pre_call_hook_ran(response)
             elif mode == "post_call":
                 response = await target.async_post_call_success_hook(
                     user_api_key_dict=user_api_key_dict,

--- a/litellm/proxy/policy_engine/pipeline_executor.py
+++ b/litellm/proxy/policy_engine/pipeline_executor.py
@@ -165,6 +165,8 @@ class PipelineExecutor:
                 target = UnifiedLLMGuardrails()
 
             if mode == "pre_call":
+                if isinstance(callback, CustomGuardrail):
+                    callback.mark_pre_call_hook_ran(data)
                 response = await target.async_pre_call_hook(
                     user_api_key_dict=user_api_key_dict,
                     cache=None,  # type: ignore

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -1135,6 +1135,8 @@ class ProxyLogging:
         if callback.should_run_guardrail(data=data, event_type=event_type) is not True:
             return None
 
+        callback.mark_pre_call_hook_ran(data)
+
         guardrail_name = callback.guardrail_name
 
         # Track timing and errors for prometheus metrics

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -1135,8 +1135,6 @@ class ProxyLogging:
         if callback.should_run_guardrail(data=data, event_type=event_type) is not True:
             return None
 
-        callback.mark_pre_call_hook_ran(data)
-
         guardrail_name = callback.guardrail_name
 
         # Track timing and errors for prometheus metrics
@@ -1172,6 +1170,8 @@ class ProxyLogging:
                 data = await self.process_pre_call_hook_response(
                     response=response, data=data, call_type=call_type
                 )
+
+            callback.mark_pre_call_hook_ran(data)
 
         except SensitiveDataRouteException:
             status = "intervened"

--- a/tests/test_litellm/integrations/test_custom_guardrail.py
+++ b/tests/test_litellm/integrations/test_custom_guardrail.py
@@ -84,6 +84,78 @@ class TestCustomGuardrailDeploymentHook:
         assert result["messages"] == mock_result["messages"]
         assert result["messages"] != original_messages
 
+    @pytest.mark.asyncio
+    async def test_deployment_hook_skips_when_pre_call_already_ran(self):
+        """The deployment hook must not re-run async_pre_call_hook once the proxy
+        pre-call loop has already run it for this request."""
+
+        class CountingGuardrail(CustomGuardrail):
+            def __init__(self):
+                super().__init__(guardrail_name="g1", default_on=True)
+                self.pre_call_count = 0
+
+            async def async_pre_call_hook(
+                self, user_api_key_dict, cache, data, call_type
+            ):
+                self.pre_call_count += 1
+                return data
+
+        guardrail = CountingGuardrail()
+        kwargs = {
+            "messages": [{"role": "user", "content": "hi"}],
+            "model": "gpt-3.5-turbo",
+            "guardrails": ["g1"],
+            "metadata": {},
+        }
+
+        guardrail.mark_pre_call_hook_ran(kwargs)
+        await guardrail.async_pre_call_deployment_hook(
+            kwargs=kwargs, call_type=CallTypes.completion
+        )
+
+        assert guardrail.pre_call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_deployment_hook_runs_when_not_marked(self):
+        """Without the proxy marker (direct-SDK usage) the deployment hook is the
+        only execution path and must still run the guardrail exactly once."""
+
+        class CountingGuardrail(CustomGuardrail):
+            def __init__(self):
+                super().__init__(guardrail_name="g1", default_on=True)
+                self.pre_call_count = 0
+
+            async def async_pre_call_hook(
+                self, user_api_key_dict, cache, data, call_type
+            ):
+                self.pre_call_count += 1
+                return data
+
+        guardrail = CountingGuardrail()
+        kwargs = {
+            "messages": [{"role": "user", "content": "hi"}],
+            "model": "gpt-3.5-turbo",
+            "guardrails": ["g1"],
+            "metadata": {},
+        }
+
+        await guardrail.async_pre_call_deployment_hook(
+            kwargs=kwargs, call_type=CallTypes.completion
+        )
+
+        assert guardrail.pre_call_count == 1
+
+    def test_mark_pre_call_hook_ran_uses_litellm_metadata(self):
+        """The marker is recorded in litellm_metadata when that is the metadata
+        bucket in use, and is then visible to the skip check."""
+        guardrail = CustomGuardrail(guardrail_name="g1")
+        kwargs = {"litellm_metadata": {}}
+
+        guardrail.mark_pre_call_hook_ran(kwargs)
+
+        assert "g1" in kwargs["litellm_metadata"]["_pre_call_executed_guardrails"]
+        assert guardrail._pre_call_hook_already_ran(kwargs) is True
+
 
 class TestCustomGuardrailShouldRunGuardrail:
 

--- a/tests/test_litellm/integrations/test_custom_guardrail.py
+++ b/tests/test_litellm/integrations/test_custom_guardrail.py
@@ -148,13 +148,47 @@ class TestCustomGuardrailDeploymentHook:
     def test_mark_pre_call_hook_ran_uses_litellm_metadata(self):
         """The marker is recorded in litellm_metadata when that is the metadata
         bucket in use, and is then visible to the skip check."""
+        from litellm.constants import PRE_CALL_EXECUTED_GUARDRAILS_KEY
+
         guardrail = CustomGuardrail(guardrail_name="g1")
         kwargs = {"litellm_metadata": {}}
 
         guardrail.mark_pre_call_hook_ran(kwargs)
 
-        assert "g1" in kwargs["litellm_metadata"]["_pre_call_executed_guardrails"]
+        assert kwargs["litellm_metadata"][PRE_CALL_EXECUTED_GUARDRAILS_KEY]
         assert guardrail._pre_call_hook_already_ran(kwargs) is True
+
+    @pytest.mark.asyncio
+    async def test_deployment_hook_ignores_forged_caller_marker(self):
+        """A direct-SDK caller controls request metadata but cannot know the
+        per-process token, so a hand-crafted marker must not suppress a
+        requested guardrail in async_pre_call_deployment_hook."""
+        from litellm.constants import PRE_CALL_EXECUTED_GUARDRAILS_KEY
+
+        class CountingGuardrail(CustomGuardrail):
+            def __init__(self):
+                super().__init__(guardrail_name="g1", default_on=True)
+                self.pre_call_count = 0
+
+            async def async_pre_call_hook(
+                self, user_api_key_dict, cache, data, call_type
+            ):
+                self.pre_call_count += 1
+                return data
+
+        guardrail = CountingGuardrail()
+        kwargs = {
+            "messages": [{"role": "user", "content": "hi"}],
+            "model": "gpt-3.5-turbo",
+            "guardrails": ["g1"],
+            "metadata": {PRE_CALL_EXECUTED_GUARDRAILS_KEY: ["g1"]},
+        }
+
+        await guardrail.async_pre_call_deployment_hook(
+            kwargs=kwargs, call_type=CallTypes.completion
+        )
+
+        assert guardrail.pre_call_count == 1
 
 
 class TestCustomGuardrailShouldRunGuardrail:

--- a/tests/test_litellm/proxy/test_model_level_guardrails.py
+++ b/tests/test_litellm/proxy/test_model_level_guardrails.py
@@ -220,6 +220,58 @@ async def test_pre_call_hook_runs_once_with_model_level_guardrails():
 
 
 @pytest.mark.asyncio
+async def test_pre_call_hook_runs_once_when_hook_returns_fresh_dict():
+    """
+    async_pre_call_hook may return a brand-new request dict instead of mutating
+    or spreading the one it received. The exactly-once marker must live on the
+    data that flows downstream, so the deployment hook still skips the guardrail
+    even when the proxy loop swapped in a fresh dict that never carried it.
+    """
+    from litellm.caching.caching import DualCache
+    from litellm.integrations.custom_guardrail import CustomGuardrail
+    from litellm.proxy._types import CallTypes, UserAPIKeyAuth
+    from litellm.proxy.utils import ProxyLogging
+    from litellm.types.guardrails import GuardrailEventHooks
+
+    class FreshDictGuardrail(CustomGuardrail):
+        def __init__(self):
+            super().__init__(
+                guardrail_name="counting-guardrail",
+                event_hook=GuardrailEventHooks.pre_call,
+                default_on=True,
+            )
+            self.pre_call_count = 0
+
+        async def async_pre_call_hook(self, user_api_key_dict, cache, data, call_type):
+            self.pre_call_count += 1
+            return {"model": data["model"], "messages": data["messages"]}
+
+    guardrail = FreshDictGuardrail()
+
+    with patch("litellm.callbacks", [guardrail]):
+        ProxyLogging._callback_capabilities_cache.clear()
+        proxy_logging = ProxyLogging(user_api_key_cache=DualCache())
+        user_api_key_dict = UserAPIKeyAuth(api_key="test-key")
+
+        data = {
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "hello"}],
+            "metadata": {},
+        }
+
+        data = await proxy_logging.pre_call_hook(
+            user_api_key_dict=user_api_key_dict,
+            data=data,
+            call_type="acompletion",
+        )
+
+        data["guardrails"] = ["counting-guardrail"]
+        await guardrail.async_pre_call_deployment_hook(data, CallTypes.acompletion)
+
+    assert guardrail.pre_call_count == 1
+
+
+@pytest.mark.asyncio
 async def test_deployment_hook_runs_pre_call_without_proxy_loop():
     """
     Direct-SDK usage (litellm.acompletion(..., guardrails=[...]) without the

--- a/tests/test_litellm/proxy/test_model_level_guardrails.py
+++ b/tests/test_litellm/proxy/test_model_level_guardrails.py
@@ -19,7 +19,6 @@ from litellm.proxy.utils import (
     _merge_guardrails_with_existing,
 )
 
-
 # ---------------------------------------------------------------------------
 # Unit tests for _check_and_merge_model_level_guardrails
 # ---------------------------------------------------------------------------
@@ -157,6 +156,105 @@ class TestCheckAndMergeModelLevelGuardrails:
         # Result should have the merged guardrail
         assert "new-guardrail" in result["metadata"]["guardrails"]
         assert "existing" in result["metadata"]["guardrails"]
+
+
+# ---------------------------------------------------------------------------
+# Regression test: pre_call hook must run exactly once with model-level guardrails
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pre_call_hook_runs_once_with_model_level_guardrails():
+    """
+    A guardrail attached at the model level (litellm_params.guardrails) is
+    spread into the top-level request kwargs by the router. The proxy pre-call
+    loop (async_pre_call_hook) and the deployment-level hook
+    (async_pre_call_deployment_hook) must together invoke async_pre_call_hook
+    exactly once, not twice.
+    """
+    from litellm.caching.caching import DualCache
+    from litellm.integrations.custom_guardrail import CustomGuardrail
+    from litellm.proxy._types import CallTypes, UserAPIKeyAuth
+    from litellm.proxy.utils import ProxyLogging
+    from litellm.types.guardrails import GuardrailEventHooks
+
+    class CountingGuardrail(CustomGuardrail):
+        def __init__(self):
+            super().__init__(
+                guardrail_name="counting-guardrail",
+                event_hook=GuardrailEventHooks.pre_call,
+                default_on=True,
+            )
+            self.pre_call_count = 0
+
+        async def async_pre_call_hook(self, user_api_key_dict, cache, data, call_type):
+            self.pre_call_count += 1
+            return data
+
+    guardrail = CountingGuardrail()
+
+    with patch("litellm.callbacks", [guardrail]):
+        ProxyLogging._callback_capabilities_cache.clear()
+        proxy_logging = ProxyLogging(user_api_key_cache=DualCache())
+        user_api_key_dict = UserAPIKeyAuth(api_key="test-key")
+
+        data = {
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "hello"}],
+            "metadata": {},
+        }
+
+        # Path A: proxy pre-call loop runs the guardrail and records that it ran
+        data = await proxy_logging.pre_call_hook(
+            user_api_key_dict=user_api_key_dict,
+            data=data,
+            call_type="acompletion",
+        )
+
+        # Path B: the router spreads the deployment's model-level guardrails into
+        # the top-level kwargs, then litellm.acompletion fires the deployment hook
+        data["guardrails"] = ["counting-guardrail"]
+        await guardrail.async_pre_call_deployment_hook(data, CallTypes.acompletion)
+
+    assert guardrail.pre_call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_deployment_hook_runs_pre_call_without_proxy_loop():
+    """
+    Direct-SDK usage (litellm.acompletion(..., guardrails=[...]) without the
+    proxy) never runs the proxy pre-call loop, so the deployment hook is the
+    only place the guardrail executes and it must still run exactly once.
+    """
+    from litellm.integrations.custom_guardrail import CustomGuardrail
+    from litellm.proxy._types import CallTypes
+    from litellm.types.guardrails import GuardrailEventHooks
+
+    class CountingGuardrail(CustomGuardrail):
+        def __init__(self):
+            super().__init__(
+                guardrail_name="counting-guardrail",
+                event_hook=GuardrailEventHooks.pre_call,
+                default_on=True,
+            )
+            self.pre_call_count = 0
+
+        async def async_pre_call_hook(self, user_api_key_dict, cache, data, call_type):
+            self.pre_call_count += 1
+            return data
+
+    guardrail = CountingGuardrail()
+
+    data = {
+        "model": "gpt-4",
+        "messages": [{"role": "user", "content": "hello"}],
+        "guardrails": ["counting-guardrail"],
+        "metadata": {},
+    }
+
+    await guardrail.async_pre_call_deployment_hook(data, CallTypes.acompletion)
+
+    assert guardrail.pre_call_count == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-3770

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review (5/5 on bd2fa5d)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

A `CustomGuardrail` attached to a deployment through `litellm_params.guardrails` had its `async_pre_call_hook` invoked twice for a single request. The proxy pre-call loop in `ProxyLogging.pre_call_hook` runs the guardrail once (Path A). The router then spreads the deployment's model-level `guardrails` into the top-level request kwargs, and `litellm.acompletion` fires `async_pre_call_deployment_hook`, which ran the same hook a second time (Path B). The result was duplicated scanning, doubled latency and cost for external guardrail providers, and double-counted side effects.

Reproduced against a live proxy backed by Postgres (Docker), hitting the real OpenAI API. The guardrail is a small `CustomGuardrail` subclass that increments a counter and prints which path invoked it. Config attaches it at the model level:

```yaml
model_list:
  - model_name: gpt-with-model-guardrail
    litellm_params:
      model: openai/gpt-4o-mini
      api_key: os.environ/OPENAI_API_KEY
      guardrails: ["counting-guardrail"]

guardrails:
  - guardrail_name: "counting-guardrail"
    litellm_params:
      guardrail: counting_guardrail.CountingGuardrail
      mode: "pre_call"
      default_on: true
```

Same request in both runs:

```bash
curl -s -X POST http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d '{"model":"gpt-with-model-guardrail","messages":[{"role":"user","content":"Say hello in 3 words"}]}'
```

Before the fix (two invocations for one request):

```
INFO:     Application startup complete.
>>> COUNTING_GUARDRAIL FIRED path=A(proxy_pre_call) guardrail=counting-guardrail top_level_guardrails=None total_invocations=1
>>> COUNTING_GUARDRAIL FIRED path=B(deployment_hook) guardrail=counting-guardrail top_level_guardrails=['counting-guardrail'] total_invocations=2
INFO:     127.0.0.1 - "POST /v1/chat/completions HTTP/1.1" 200 OK
```

After the fix (one invocation, Path B skipped):

```
INFO:     Application startup complete.
>>> COUNTING_GUARDRAIL FIRED path=A(proxy_pre_call) guardrail=counting-guardrail top_level_guardrails=None total_invocations=1
INFO:     127.0.0.1 - "POST /v1/chat/completions HTTP/1.1" 200 OK
```

Both runs returned a real OpenAI completion ("Hello, how are you?") with the proxy connected to the Postgres datasource at `localhost:5433`.

Direct-SDK usage (`litellm.acompletion(..., guardrails=[...])` with no proxy) never runs the proxy pre-call loop, so the deployment hook remains the sole invocation there and still fires exactly once; the regression test `test_deployment_hook_runs_pre_call_without_proxy_loop` locks that in.

## Type

🐛 Bug Fix

## Changes

The proxy pre-call loop now records, in request metadata, which guardrails it has already executed, and the deployment-level hook skips any guardrail that has been marked. The marker travels through the same metadata the router already forwards, so it reaches `async_pre_call_deployment_hook` reliably; when the proxy loop did not run (direct SDK), no marker exists and the deployment hook still runs once.

The marker is written after `async_pre_call_hook` returns, on the data object that flows downstream, not before it runs. A guardrail whose hook returns a brand-new request dict rather than mutating or spreading the one it received would otherwise drop the marker and let the deployment hook fire a second time; `test_pre_call_hook_runs_once_when_hook_returns_fresh_dict` covers that path.

`mark_pre_call_hook_ran` / `_pre_call_hook_already_ran` live on `CustomGuardrail` and key off `guardrail_name`, so distinct guardrails are tracked independently. The pipeline executor marks before it invokes a pre-call guardrail too, keeping policy-engine pipelines from re-triggering the deployment hook.

The marker key is added to `_UNTRUSTED_METADATA_CONTROL_FIELDS`, so a caller cannot pre-seed it in the request body to suppress a model-only guardrail, and to `LITELLM_PROXY_INTERNAL_METADATA_KEYS` so it is treated as internal and not leaked downstream.

The marker is tagged with a per-process secret token (`secrets.token_hex(16)`) so the deployment hook only honors a marker the proxy itself produced. A direct-SDK caller (`litellm.acompletion(..., guardrails=[...])`) controls request metadata but cannot reproduce the token, so a hand-crafted `_pre_call_executed_guardrails` entry will not suppress a requested guardrail; `test_deployment_hook_ignores_forged_caller_marker` locks that in. The metadata key name lives in `constants.py` as `PRE_CALL_EXECUTED_GUARDRAILS_KEY` and is imported where it is registered as an untrusted and an internal metadata field. The pipeline executor marks after the hook returns, matching the proxy pre-call loop.



