### PR TITLE
fix(types): prevent internal parallel_request_limiter fields from leaking to upstream providers

### DIFF
--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3234,6 +3234,11 @@ all_litellm_params = (
         "order",
         "enable_json_schema_validation",
         "use_xai_oauth",
+        "_litellm_rate_limit_descriptors",
+        "_litellm_tpm_reserved_tokens",
+        "_litellm_tpm_reserved_model",
+        "_litellm_tpm_reserved_scopes",
+        "_litellm_tpm_reservation_released",
     ]
     + list(StandardCallbackDynamicParams.__annotations__.keys())
     + list(CustomPricingLiteLLMParams.model_fields.keys())

--- a/tests/test_litellm/types/test_types_utils.py
+++ b/tests/test_litellm/types/test_types_utils.py
@@ -321,6 +321,29 @@ class TestNativeFinishReason:
         assert choice.provider_specific_fields["native_finish_reason"] == "MAX_TOKENS"
 
 
+def test_parallel_request_limiter_internal_fields_in_all_litellm_params():
+    """
+    Regression test: internal fields written by parallel_request_limiter_v3 must
+    be in all_litellm_params so they are stripped before forwarding to upstream
+    providers.  If missing, they are sent as extra body parameters and providers
+    like OpenAI reject the request with a 400 invalid_request_error.
+    """
+    from litellm.types.utils import all_litellm_params
+
+    internal_fields = [
+        "_litellm_rate_limit_descriptors",
+        "_litellm_tpm_reserved_tokens",
+        "_litellm_tpm_reserved_model",
+        "_litellm_tpm_reserved_scopes",
+        "_litellm_tpm_reservation_released",
+    ]
+    for field in internal_fields:
+        assert field in all_litellm_params, (
+            f"{field!r} is not in all_litellm_params. "
+            "It will be forwarded to upstream providers and cause 400 errors."
+        )
+
+
 def test_delta_maps_reasoning_to_reasoning_content():
     """
     Test that Delta maps 'reasoning' field to 'reasoning_content'.


### PR DESCRIPTION
## Relevant issues

Fixes #30544

## Summary

Registers five internal `parallel_request_limiter_v3` fields in `all_litellm_params` so they are stripped before a request is forwarded to an upstream provider.

## Background

`parallel_request_limiter_v3.py` writes internal bookkeeping fields directly onto the top-level request data dict during `async_pre_call_hook`:

- `_litellm_rate_limit_descriptors`
- `_litellm_tpm_reserved_tokens`
- `_litellm_tpm_reserved_model`
- `_litellm_tpm_reserved_scopes`
- `_litellm_tpm_reservation_released`

These fields are intended to be consumed by post-call callbacks to reconcile actual vs. reserved token counts, but they were never registered in `all_litellm_params`. Without that registration, LiteLLM does not strip them before forwarding the request to an upstream provider, causing providers like OpenAI to reject the request with `400 invalid_request_error: Unrecognized request arguments supplied`.


## Screenshots / Proof of Fix

**Before the fix**

`litellm.RateLimitError: RateLimitError: OpenAIException - Unrecognized request arguments supplied: _litellm_rate_limit_descriptors, _litellm_tpm_reserved_model, _litellm_tpm_reserved_scopes, _litellm_tpm_reserved_tokens`

**After the fix**
```
tests/test_litellm/types/test_types_utils.py ...................                                                             [100%]

======================================================== 19 passed in 0.09s ========================================================
```
<!-- Include screenshots, screen recordings, or log output demonstrating that your changes work as expected.
     For bug fixes: show reproduction before the fix and passing behavior after.
     For new features: show the feature working end-to-end.
     For UI changes: include before/after screenshots. -->

## Type

🐛 Bug Fix
✅ Test

## Changes

- **`litellm/types/utils.py`** — added the five fields to `all_litellm_params`
- **`tests/test_litellm/types/test_types_utils.py`** — added a regression test asserting all five fields are present in the blocklist