### PR TITLE
fix(advisor): route through proxy, render native blocks, and attribute per-model usage

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -1735,3 +1735,17 @@ ADVISOR_TOOL_DESCRIPTION: str = (
     "want to verify your reasoning, or face a complex decision. "
     "Describe your question or challenge clearly in the 'question' field."
 )
+# System prompt for the advisor sub-call. Anthropic frames the advisor server-side
+# natively; in our orchestration we hand it a plain request, so without an explicit
+# role it adopts the executor's persona from the forwarded conversation and refuses
+# or punts. This defines the advisor's role so it answers directly.
+ADVISOR_SYSTEM_PROMPT: str = (
+    "You are an expert advisor: a high-intelligence model consulted by another AI "
+    "assistant that is working on a task for a user. The messages are that "
+    "assistant's conversation so far, given to you purely as context. The final "
+    "message is the question the assistant is asking you. Answer that question "
+    "directly, concretely, and substantively as the advisor. Do not roleplay or "
+    "impersonate the other assistant, do not say you are unable to consult an "
+    "advisor or another model, and do not hand the task back; you are the advisor, "
+    "so give your own best answer."
+)

--- a/litellm/llms/anthropic/common_utils.py
+++ b/litellm/llms/anthropic/common_utils.py
@@ -786,6 +786,26 @@ class AnthropicModelInfo(BaseLLMModelInfo):
         return AnthropicTokenCounter()
 
 
+def _advisor_result_text(content: Any) -> str:
+    """Extract advice text from an advisor_tool_result's content, which Anthropic
+    emits as an {"type": "advisor_result", "text": ...} dict but which may also
+    arrive as a plain string or a list of content blocks."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, dict):
+        return content.get("text", "")
+    if isinstance(content, list):
+        return next(
+            (
+                b.get("text", "")
+                for b in content
+                if isinstance(b, dict) and b.get("text")
+            ),
+            "",
+        )
+    return ""
+
+
 def strip_advisor_blocks_from_messages(
     messages: List[Any], replace_with_text: bool = False
 ) -> List[Any]:
@@ -834,20 +854,9 @@ def strip_advisor_blocks_from_messages(
                     and block.get("type") == "advisor_tool_result"
                     and block.get("tool_use_id") in advisor_id_to_text
                 ):
-                    raw = block.get("content") or ""
-                    text = (
-                        raw
-                        if isinstance(raw, str)
-                        else next(
-                            (
-                                b.get("text", "")
-                                for b in raw
-                                if isinstance(b, dict) and b.get("type") == "text"
-                            ),
-                            "",
-                        )
+                    advisor_id_to_text[block["tool_use_id"]] = _advisor_result_text(
+                        block.get("content")
                     )
-                    advisor_id_to_text[block["tool_use_id"]] = text
 
         new_content = []
         for block in content:

--- a/litellm/llms/anthropic/experimental_pass_through/messages/fake_stream_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/fake_stream_iterator.py
@@ -152,12 +152,13 @@ def build_content_block_chunks(block_dict: Dict[str, Any], index: int) -> List[b
             )
         )
 
-    chunks.append(
-        _sse(
-            "content_block_stop",
-            {"type": "content_block_stop", "index": index},
+    if chunks:
+        chunks.append(
+            _sse(
+                "content_block_stop",
+                {"type": "content_block_stop", "index": index},
+            )
         )
-    )
     return chunks
 
 

--- a/litellm/llms/anthropic/experimental_pass_through/messages/fake_stream_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/fake_stream_iterator.py
@@ -16,6 +16,151 @@ from litellm.types.llms.anthropic_messages.anthropic_response import (
 )
 
 
+def _sse(event: str, data: Dict[str, Any]) -> bytes:
+    return f"event: {event}\ndata: {json.dumps(data)}\n\n".encode()
+
+
+def build_content_block_chunks(block_dict: Dict[str, Any], index: int) -> List[bytes]:
+    """Build the SSE chunks for a single content block (start, optional deltas,
+    stop). Shared by the fake iterator and the advisor streaming orchestrator."""
+    chunks: List[bytes] = []
+    block_type = block_dict.get("type")
+
+    if block_type == "text":
+        chunks.append(
+            _sse(
+                "content_block_start",
+                {
+                    "type": "content_block_start",
+                    "index": index,
+                    "content_block": {"type": "text", "text": ""},
+                },
+            )
+        )
+        chunks.append(
+            _sse(
+                "content_block_delta",
+                {
+                    "type": "content_block_delta",
+                    "index": index,
+                    "delta": {
+                        "type": "text_delta",
+                        "text": block_dict.get("text", ""),
+                    },
+                },
+            )
+        )
+
+    elif block_type == "thinking":
+        chunks.append(
+            _sse(
+                "content_block_start",
+                {
+                    "type": "content_block_start",
+                    "index": index,
+                    "content_block": {
+                        "type": "thinking",
+                        "thinking": "",
+                        "signature": "",
+                    },
+                },
+            )
+        )
+        thinking_text = block_dict.get("thinking", "")
+        if thinking_text:
+            chunks.append(
+                _sse(
+                    "content_block_delta",
+                    {
+                        "type": "content_block_delta",
+                        "index": index,
+                        "delta": {
+                            "type": "thinking_delta",
+                            "thinking": thinking_text,
+                        },
+                    },
+                )
+            )
+        signature = block_dict.get("signature", "")
+        if signature:
+            chunks.append(
+                _sse(
+                    "content_block_delta",
+                    {
+                        "type": "content_block_delta",
+                        "index": index,
+                        "delta": {"type": "signature_delta", "signature": signature},
+                    },
+                )
+            )
+
+    elif block_type == "redacted_thinking":
+        chunks.append(
+            _sse(
+                "content_block_start",
+                {
+                    "type": "content_block_start",
+                    "index": index,
+                    "content_block": {"type": "redacted_thinking"},
+                },
+            )
+        )
+
+    elif block_type in ("tool_use", "server_tool_use"):
+        chunks.append(
+            _sse(
+                "content_block_start",
+                {
+                    "type": "content_block_start",
+                    "index": index,
+                    "content_block": {
+                        "type": block_type,
+                        "id": block_dict.get("id"),
+                        "name": block_dict.get("name"),
+                        "input": {},
+                    },
+                },
+            )
+        )
+        chunks.append(
+            _sse(
+                "content_block_delta",
+                {
+                    "type": "content_block_delta",
+                    "index": index,
+                    "delta": {
+                        "type": "input_json_delta",
+                        "partial_json": json.dumps(block_dict.get("input", {})),
+                    },
+                },
+            )
+        )
+
+    elif block_type == "advisor_tool_result":
+        chunks.append(
+            _sse(
+                "content_block_start",
+                {
+                    "type": "content_block_start",
+                    "index": index,
+                    "content_block": {
+                        "type": "advisor_tool_result",
+                        "tool_use_id": block_dict.get("tool_use_id"),
+                        "content": block_dict.get("content"),
+                    },
+                },
+            )
+        )
+
+    chunks.append(
+        _sse(
+            "content_block_stop",
+            {"type": "content_block_stop", "index": index},
+        )
+    )
+    return chunks
+
+
 class FakeAnthropicMessagesStreamIterator:
     """
     Fake streaming iterator for Anthropic Messages responses.
@@ -41,101 +186,7 @@ class FakeAnthropicMessagesStreamIterator:
     def _create_content_block_chunks(
         self, block_dict: Dict[str, Any], index: int
     ) -> List[bytes]:
-        """Build SSE chunks for a single content block."""
-        chunks = []
-        block_type = block_dict.get("type")
-
-        if block_type == "text":
-            content_block_start = {
-                "type": "content_block_start",
-                "index": index,
-                "content_block": {"type": "text", "text": ""},
-            }
-            chunks.append(
-                f"event: content_block_start\ndata: {json.dumps(content_block_start)}\n\n".encode()
-            )
-            text = block_dict.get("text", "")
-            content_block_delta = {
-                "type": "content_block_delta",
-                "index": index,
-                "delta": {"type": "text_delta", "text": text},
-            }
-            chunks.append(
-                f"event: content_block_delta\ndata: {json.dumps(content_block_delta)}\n\n".encode()
-            )
-
-        elif block_type == "thinking":
-            content_block_start = {
-                "type": "content_block_start",
-                "index": index,
-                "content_block": {"type": "thinking", "thinking": "", "signature": ""},
-            }
-            chunks.append(
-                f"event: content_block_start\ndata: {json.dumps(content_block_start)}\n\n".encode()
-            )
-            thinking_text = block_dict.get("thinking", "")
-            if thinking_text:
-                content_block_delta = {
-                    "type": "content_block_delta",
-                    "index": index,
-                    "delta": {"type": "thinking_delta", "thinking": thinking_text},
-                }
-                chunks.append(
-                    f"event: content_block_delta\ndata: {json.dumps(content_block_delta)}\n\n".encode()
-                )
-            signature = block_dict.get("signature", "")
-            if signature:
-                signature_delta = {
-                    "type": "content_block_delta",
-                    "index": index,
-                    "delta": {"type": "signature_delta", "signature": signature},
-                }
-                chunks.append(
-                    f"event: content_block_delta\ndata: {json.dumps(signature_delta)}\n\n".encode()
-                )
-
-        elif block_type == "redacted_thinking":
-            content_block_start = {
-                "type": "content_block_start",
-                "index": index,
-                "content_block": {"type": "redacted_thinking"},
-            }
-            chunks.append(
-                f"event: content_block_start\ndata: {json.dumps(content_block_start)}\n\n".encode()
-            )
-
-        elif block_type == "tool_use":
-            content_block_start = {
-                "type": "content_block_start",
-                "index": index,
-                "content_block": {
-                    "type": "tool_use",
-                    "id": block_dict.get("id"),
-                    "name": block_dict.get("name"),
-                    "input": {},
-                },
-            }
-            chunks.append(
-                f"event: content_block_start\ndata: {json.dumps(content_block_start)}\n\n".encode()
-            )
-            input_data = block_dict.get("input", {})
-            content_block_delta = {
-                "type": "content_block_delta",
-                "index": index,
-                "delta": {
-                    "type": "input_json_delta",
-                    "partial_json": json.dumps(input_data),
-                },
-            }
-            chunks.append(
-                f"event: content_block_delta\ndata: {json.dumps(content_block_delta)}\n\n".encode()
-            )
-
-        content_block_stop = {"type": "content_block_stop", "index": index}
-        chunks.append(
-            f"event: content_block_stop\ndata: {json.dumps(content_block_stop)}\n\n".encode()
-        )
-        return chunks
+        return build_content_block_chunks(block_dict, index)
 
     def _create_streaming_chunks(self) -> List[bytes]:
         """Convert the non-streaming response to streaming chunks"""

--- a/litellm/llms/anthropic/experimental_pass_through/messages/interceptors/advisor.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/interceptors/advisor.py
@@ -17,7 +17,6 @@ How it works:
    in-progress, then resolves when the result arrives.
 """
 
-import json
 import uuid
 from typing import Any, AsyncIterator, Dict, List, Optional, Union, cast
 

--- a/litellm/llms/anthropic/experimental_pass_through/messages/interceptors/advisor.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/interceptors/advisor.py
@@ -269,6 +269,14 @@ class AdvisorOrchestrationHandler(MessagesInterceptor):
         """Emit the advisor exchanges as Anthropic SSE as the loop runs. The
         server_tool_use block is flushed before the advisor sub-call is awaited,
         so the client renders the advisor as running until its result arrives."""
+        loop_iter = loop.__aiter__()
+        first_event = await loop_iter.__anext__()
+        first_kind, first_a, first_b = first_event
+
+        first_usage = (
+            first_a.get("usage") if isinstance(first_a, dict) else None
+        ) or {}
+
         index = 0
         yield _sse(
             "message_start",
@@ -282,12 +290,20 @@ class AdvisorOrchestrationHandler(MessagesInterceptor):
                     "content": [],
                     "stop_reason": None,
                     "stop_sequence": None,
-                    "usage": {"input_tokens": 0, "output_tokens": 0},
+                    "usage": {
+                        "input_tokens": first_usage.get("input_tokens", 0),
+                        "output_tokens": 0,
+                    },
                 },
             },
         )
 
-        async for kind, a, b in loop:
+        async def _all_events():
+            yield first_event
+            async for event in loop_iter:
+                yield event
+
+        async for kind, a, b in _all_events():
             if kind == "advisor_call":
                 for block in _executor_text_blocks(a):
                     for chunk in build_content_block_chunks(block, index):

--- a/litellm/llms/anthropic/experimental_pass_through/messages/interceptors/advisor.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/interceptors/advisor.py
@@ -27,6 +27,7 @@ from litellm.types.llms.anthropic import ANTHROPIC_ADVISOR_TOOL_TYPE
 ADVISOR_MAX_USES: int = _c.ADVISOR_MAX_USES
 ADVISOR_NATIVE_PROVIDERS: frozenset = _c.ADVISOR_NATIVE_PROVIDERS
 ADVISOR_TOOL_DESCRIPTION: str = _c.ADVISOR_TOOL_DESCRIPTION
+ADVISOR_SYSTEM_PROMPT: str = _c.ADVISOR_SYSTEM_PROMPT
 
 from .base import MessagesInterceptor
 
@@ -171,6 +172,7 @@ class AdvisorOrchestrationHandler(MessagesInterceptor):
                 stream=False,
                 max_tokens=max_tokens,
                 custom_llm_provider=None,
+                system=ADVISOR_SYSTEM_PROMPT,
                 metadata={
                     **metadata_base,
                     "advisor_sub_call": True,

--- a/litellm/llms/anthropic/experimental_pass_through/messages/interceptors/advisor.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/interceptors/advisor.py
@@ -19,7 +19,7 @@ How it works:
 
 import json
 import uuid
-from typing import Any, AsyncIterator, Dict, List, Optional, Union
+from typing import Any, AsyncIterator, Dict, List, Optional, Union, cast
 
 import litellm.constants as _c
 from litellm.llms.anthropic.common_utils import strip_advisor_blocks_from_messages
@@ -28,6 +28,7 @@ from litellm.llms.anthropic.experimental_pass_through.messages.fake_stream_itera
 )
 from litellm.types.llms.anthropic_messages.anthropic_response import (
     AnthropicMessagesResponse,
+    AnthropicUsage,
 )
 from litellm.types.llms.anthropic import ANTHROPIC_ADVISOR_TOOL_TYPE
 
@@ -248,7 +249,7 @@ class AdvisorOrchestrationHandler(MessagesInterceptor):
                 return {
                     **a,
                     "content": output_content + list(a.get("content") or []),
-                    "usage": {**(a.get("usage") or {}), "iterations": b},
+                    "usage": cast(AnthropicUsage, {**(a.get("usage") or {}), "iterations": b}),
                 }
         raise AdvisorMaxIterationsError("Advisor loop ended without a final response")
 

--- a/litellm/llms/anthropic/experimental_pass_through/messages/interceptors/advisor.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/interceptors/advisor.py
@@ -415,7 +415,6 @@ def _advisor_result_block(advisor_use_block: Dict, advisor_text: str) -> Dict:
     }
 
 
-
 _USAGE_TOKEN_KEYS = (
     "input_tokens",
     "output_tokens",

--- a/litellm/llms/anthropic/experimental_pass_through/messages/interceptors/advisor.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/interceptors/advisor.py
@@ -11,14 +11,21 @@ How it works:
 4. If the executor makes a tool_use call named "advisor", runs the advisor model
    and injects the result as a tool_result before re-calling the executor.
 5. Repeats until the executor produces a final text response or max_uses is hit.
-6. Wraps in FakeAnthropicMessagesStreamIterator if the caller requested streaming.
+6. Surfaces each advisor exchange to the caller as native server_tool_use /
+   advisor_tool_result blocks so clients render the advisor activity; when
+   streaming, the call block is flushed before the advisor runs so it renders as
+   in-progress, then resolves when the result arrives.
 """
 
+import json
 import uuid
 from typing import Any, AsyncIterator, Dict, List, Optional, Union
 
 import litellm.constants as _c
 from litellm.llms.anthropic.common_utils import strip_advisor_blocks_from_messages
+from litellm.llms.anthropic.experimental_pass_through.messages.fake_stream_iterator import (
+    build_content_block_chunks,
+)
 from litellm.types.llms.anthropic_messages.anthropic_response import (
     AnthropicMessagesResponse,
 )
@@ -61,10 +68,6 @@ class AdvisorOrchestrationHandler(MessagesInterceptor):
         custom_llm_provider: Optional[str],
         **kwargs,
     ) -> Union[AnthropicMessagesResponse, AsyncIterator]:
-        from litellm.llms.anthropic.experimental_pass_through.messages.fake_stream_iterator import (
-            FakeAnthropicMessagesStreamIterator,
-        )
-
         # Extract advisor tool config.
         advisor_tool = next(
             (t for t in (tools or []) if t.get("type") == ANTHROPIC_ADVISOR_TOOL_TYPE),
@@ -108,11 +111,65 @@ class AdvisorOrchestrationHandler(MessagesInterceptor):
             kwargs.pop("litellm_call_id", None) or uuid.uuid4()
         )
         metadata_base: Dict = dict(kwargs.pop("metadata", None) or {})
-        iteration = 0
 
+        # Carry only the proxy's budget/auth/session context (litellm_metadata)
+        # into the advisor leg so its spend is attributed to the caller's key and
+        # groups under the same session. Deliberately do NOT inherit the executor's
+        # generation params (system, tool_choice, thinking, sampling): the advisor
+        # is a fresh consultation, and feeding it the executor's agent system prompt
+        # makes it mimic the executor and echo the advisor call instead of
+        # answering. api_key/api_base come from the advisor tool definition only —
+        # the executor's would be None under the router and override the advisor
+        # deployment's resolved credentials.
+        advisor_kwargs: Dict = {}
+        if "litellm_metadata" in kwargs:
+            advisor_kwargs["litellm_metadata"] = kwargs["litellm_metadata"]
+        if advisor_api_key is not None:
+            advisor_kwargs["api_key"] = advisor_api_key
+        if advisor_api_base is not None:
+            advisor_kwargs["api_base"] = advisor_api_base
+
+        loop = self._run_loop(
+            model=model,
+            current_messages=current_messages,
+            executor_tools=executor_tools,
+            advisor_model=advisor_model,
+            max_uses=max_uses,
+            max_tokens=max_tokens,
+            custom_llm_provider=custom_llm_provider,
+            parent_request_id=parent_request_id,
+            metadata_base=metadata_base,
+            advisor_kwargs=advisor_kwargs,
+            kwargs=kwargs,
+        )
+
+        if stream:
+            return self._stream(loop, model=model, request_id=parent_request_id)
+        return await self._collect(loop)
+
+    async def _run_loop(
+        self,
+        *,
+        model: str,
+        current_messages: List[Dict],
+        executor_tools: List[Dict],
+        advisor_model: str,
+        max_uses: int,
+        max_tokens: int,
+        custom_llm_provider: Optional[str],
+        parent_request_id: str,
+        metadata_base: Dict,
+        advisor_kwargs: Dict,
+        kwargs: Dict,
+    ) -> AsyncIterator[tuple]:
+        """Drive the executor/advisor loop, yielding semantic events so streaming
+        and non-streaming consumers share one orchestration path. The advisor
+        sub-call runs between the "advisor_call" and "advice" events, so a
+        streaming consumer that flushes "advisor_call" first surfaces the advisor
+        as in-progress for the duration of its real latency."""
+        iteration = 0
         while True:
-            # --- Executor call (always non-streaming) ---
-            executor_response: AnthropicMessagesResponse = await _call_messages_handler(
+            executor_response = await _call_messages_handler(
                 model=model,
                 messages=current_messages,
                 tools=executor_tools,
@@ -128,12 +185,9 @@ class AdvisorOrchestrationHandler(MessagesInterceptor):
             )
 
             advisor_use_block = _find_advisor_tool_use(executor_response)
-
             if advisor_use_block is None:
-                # No more advisor calls — this is the final response.
-                if stream:
-                    return FakeAnthropicMessagesStreamIterator(executor_response)
-                return executor_response
+                yield ("final", executor_response, None)
+                return
 
             iteration += 1
             if iteration > max_uses:
@@ -142,30 +196,12 @@ class AdvisorOrchestrationHandler(MessagesInterceptor):
                     "Increase max_uses in the advisor tool definition or cap the request."
                 )
 
-            # --- Build advisor context ---
+            yield ("advisor_call", executor_response, advisor_use_block)
+
             advisor_messages = _build_advisor_context(
                 current_messages, executor_response, advisor_use_block
             )
-
-            # --- Advisor sub-call (always non-streaming, no tools) ---
-            # Carry only the proxy's budget/auth/session context (litellm_metadata)
-            # so the advisor's spend is attributed to the caller's key and groups
-            # under the same session. Deliberately do NOT inherit the executor's
-            # generation params (system, tool_choice, thinking, sampling): the
-            # advisor is a fresh consultation, and feeding it the executor's agent
-            # system prompt makes it mimic the executor and echo the advisor call
-            # instead of answering. api_key/api_base come from the advisor tool
-            # definition only — the executor's would be None under the router and
-            # override the advisor deployment's resolved credentials.
-            advisor_kwargs: Dict = {}
-            if "litellm_metadata" in kwargs:
-                advisor_kwargs["litellm_metadata"] = kwargs["litellm_metadata"]
-            if advisor_api_key is not None:
-                advisor_kwargs["api_key"] = advisor_api_key
-            if advisor_api_base is not None:
-                advisor_kwargs["api_base"] = advisor_api_base
-
-            advisor_response: AnthropicMessagesResponse = await _call_messages_handler(
+            advisor_response = await _call_messages_handler(
                 model=advisor_model,
                 messages=advisor_messages,
                 tools=None,
@@ -180,16 +216,86 @@ class AdvisorOrchestrationHandler(MessagesInterceptor):
                 },
                 **advisor_kwargs,
             )
-
             advisor_text = _extract_response_text(advisor_response)
 
-            # --- Inject advisor result and continue loop ---
+            yield ("advice", advisor_use_block, advisor_text)
+
             current_messages = _inject_advisor_turn(
                 current_messages,
                 executor_response,
                 advisor_use_block,
                 advisor_text,
             )
+
+    async def _collect(self, loop: AsyncIterator[tuple]) -> AnthropicMessagesResponse:
+        """Accumulate the loop's advisor exchanges and executor text into a single
+        non-streaming response."""
+        output_content: List[Dict] = []
+        async for kind, a, b in loop:
+            if kind == "advisor_call":
+                output_content.extend(_executor_text_blocks(a))
+                output_content.append(_server_tool_use_block(b))
+            elif kind == "advice":
+                output_content.append(_advisor_result_block(a, b))
+            elif kind == "final":
+                return {
+                    **a,
+                    "content": output_content + list(a.get("content") or []),
+                }
+        raise AdvisorMaxIterationsError("Advisor loop ended without a final response")
+
+    async def _stream(
+        self,
+        loop: AsyncIterator[tuple],
+        *,
+        model: str,
+        request_id: str,
+    ) -> AsyncIterator[bytes]:
+        """Emit the advisor exchanges as Anthropic SSE as the loop runs. The
+        server_tool_use block is flushed before the advisor sub-call is awaited,
+        so the client renders the advisor as running until its result arrives."""
+        index = 0
+        yield _sse(
+            "message_start",
+            {
+                "type": "message_start",
+                "message": {
+                    "id": request_id,
+                    "type": "message",
+                    "role": "assistant",
+                    "model": model,
+                    "content": [],
+                    "stop_reason": None,
+                    "stop_sequence": None,
+                    "usage": {"input_tokens": 0, "output_tokens": 0},
+                },
+            },
+        )
+
+        async for kind, a, b in loop:
+            if kind == "advisor_call":
+                for block in _executor_text_blocks(a):
+                    for chunk in build_content_block_chunks(block, index):
+                        yield chunk
+                    index += 1
+                for chunk in build_content_block_chunks(
+                    _server_tool_use_block(b), index
+                ):
+                    yield chunk
+                index += 1
+            elif kind == "advice":
+                for chunk in build_content_block_chunks(
+                    _advisor_result_block(a, b), index
+                ):
+                    yield chunk
+                index += 1
+            elif kind == "final":
+                for block in a.get("content") or []:
+                    for chunk in build_content_block_chunks(block, index):
+                        yield chunk
+                    index += 1
+                for chunk in _final_message_events(a):
+                    yield chunk
 
 
 # ---------------------------------------------------------------------------
@@ -246,6 +352,71 @@ def _extract_response_text(response: Any) -> str:
 _PROVIDER_SPECIFIC_KEYS = frozenset({"provider_specific_fields"})
 
 
+def _executor_text_blocks(executor_response: Any) -> List[Dict]:
+    """Executor's text blocks, stripped of provider-specific fields."""
+    raw_content = (
+        executor_response.get("content") if isinstance(executor_response, dict) else []
+    ) or []
+    return [
+        {k: v for k, v in block.items() if k not in _PROVIDER_SPECIFIC_KEYS}
+        for block in raw_content
+        if isinstance(block, dict) and block.get("type") == "text"
+    ]
+
+
+def _server_tool_use_block(advisor_use_block: Dict) -> Dict:
+    """The advisor call, in Anthropic's native server-side advisor shape, so clients
+    render the advisor activity instead of seeing a flattened response."""
+    return {
+        "type": "server_tool_use",
+        "id": advisor_use_block.get("id", ""),
+        "name": "advisor",
+        "input": {},
+    }
+
+
+def _advisor_result_block(advisor_use_block: Dict, advisor_text: str) -> Dict:
+    """The advisor reply that resolves the matching server_tool_use call."""
+    return {
+        "type": "advisor_tool_result",
+        "tool_use_id": advisor_use_block.get("id", ""),
+        "content": {"type": "advisor_result", "text": advisor_text},
+    }
+
+
+def _sse(event: str, data: Dict) -> bytes:
+    return f"event: {event}\ndata: {json.dumps(data)}\n\n".encode()
+
+
+def _final_message_events(executor_response: Any) -> List[bytes]:
+    """The closing message_delta (stop reason + output usage) and message_stop."""
+    usage = (
+        executor_response.get("usage") if isinstance(executor_response, dict) else None
+    ) or {}
+    delta_usage: Dict[str, Any] = {"output_tokens": usage.get("output_tokens", 0)}
+    for key in (
+        "input_tokens",
+        "cache_creation_input_tokens",
+        "cache_read_input_tokens",
+    ):
+        if usage.get(key) is not None:
+            delta_usage[key] = usage[key]
+    return [
+        _sse(
+            "message_delta",
+            {
+                "type": "message_delta",
+                "delta": {
+                    "stop_reason": executor_response.get("stop_reason"),
+                    "stop_sequence": executor_response.get("stop_sequence"),
+                },
+                "usage": delta_usage,
+            },
+        ),
+        _sse("message_stop", {"type": "message_stop", "usage": usage}),
+    ]
+
+
 def _build_advisor_context(
     messages: List[Dict],
     executor_response: Any,
@@ -263,18 +434,10 @@ def _build_advisor_context(
     question = (advisor_use_block.get("input") or {}).get("question") or (
         "Please provide guidance on the current task."
     )
-    raw_content = (
-        executor_response.get("content") if isinstance(executor_response, dict) else []
-    ) or []
-    # Keep only text blocks — strip tool_use and provider-specific fields.
-    executor_text_blocks = [
-        {k: v for k, v in block.items() if k not in _PROVIDER_SPECIFIC_KEYS}
-        for block in raw_content
-        if isinstance(block, dict) and block.get("type") == "text"
-    ]
     result = list(messages)
-    if executor_text_blocks:
-        result.append({"role": "assistant", "content": executor_text_blocks})
+    executor_text = _executor_text_blocks(executor_response)
+    if executor_text:
+        result.append({"role": "assistant", "content": executor_text})
     result.append({"role": "user", "content": question})
     return result
 

--- a/litellm/llms/anthropic/experimental_pass_through/messages/interceptors/advisor.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/interceptors/advisor.py
@@ -82,8 +82,6 @@ class AdvisorOrchestrationHandler(MessagesInterceptor):
         max_uses: int = (
             ADVISOR_MAX_USES if _raw_max_uses is None else int(_raw_max_uses)
         )
-        # Optional routing overrides for the advisor sub-call (e.g. proxy routing).
-        # If not set in the tool definition, litellm resolves from env vars.
         advisor_api_key: Optional[str] = advisor_tool.get("api_key")
         advisor_api_base: Optional[str] = advisor_tool.get("api_base")
 
@@ -149,20 +147,28 @@ class AdvisorOrchestrationHandler(MessagesInterceptor):
             )
 
             # --- Advisor sub-call (always non-streaming, no tools) ---
+            # Only include api_key/api_base when explicitly set in the tool
+            # definition; passing None would override the router's deployment
+            # credentials during kwargs merging.
+            advisor_overrides: Dict = {}
+            if advisor_api_key is not None:
+                advisor_overrides["api_key"] = advisor_api_key
+            if advisor_api_base is not None:
+                advisor_overrides["api_base"] = advisor_api_base
+
             advisor_response: AnthropicMessagesResponse = await _call_messages_handler(
                 model=advisor_model,
                 messages=advisor_messages,
                 tools=None,
                 stream=False,
                 max_tokens=max_tokens,
-                custom_llm_provider=None,  # let litellm resolve from model name
+                custom_llm_provider=None,
                 metadata={
                     **metadata_base,
                     "advisor_sub_call": True,
                     "parent_request_id": parent_request_id,
                 },
-                api_key=advisor_api_key,
-                api_base=advisor_api_base,
+                **advisor_overrides,
             )
 
             advisor_text = _extract_response_text(advisor_response)
@@ -322,6 +328,15 @@ def _inject_max_uses_error(
     ]
 
 
+def _get_llm_router():
+    try:
+        from litellm.proxy.proxy_server import llm_router
+
+        return llm_router
+    except ImportError:
+        return None
+
+
 async def _call_messages_handler(
     model: str,
     messages: List[Dict],
@@ -331,13 +346,19 @@ async def _call_messages_handler(
     custom_llm_provider: Optional[str],
     **kwargs,
 ) -> Any:
-    """
-    Call anthropic_messages() — the public async /messages entry point — for
-    orchestration sub-calls (executor or advisor).
+    """Route through the proxy's llm_router when available; fall back to
+    direct anthropic_messages() for standalone SDK usage."""
+    router = _get_llm_router()
+    if router is not None:
+        return await router.anthropic_messages(
+            model=model,
+            messages=messages,
+            tools=tools,
+            stream=stream,
+            max_tokens=max_tokens,
+            **kwargs,
+        )
 
-    Using the public function (decorated with @client) ensures logging, retries,
-    and provider resolution all work correctly, identical to a direct user call.
-    """
     from litellm.llms.anthropic.experimental_pass_through.messages.handler import (
         anthropic_messages,
     )

--- a/litellm/llms/anthropic/experimental_pass_through/messages/interceptors/advisor.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/interceptors/advisor.py
@@ -166,8 +166,11 @@ class AdvisorOrchestrationHandler(MessagesInterceptor):
         and non-streaming consumers share one orchestration path. The advisor
         sub-call runs between the "advisor_call" and "advice" events, so a
         streaming consumer that flushes "advisor_call" first surfaces the advisor
-        as in-progress for the duration of its real latency."""
+        as in-progress for the duration of its real latency. The advisor legs are
+        accumulated into a usage.iterations[] list (carried on the "final" event)
+        so clients attribute the advisor model's tokens to its own cost line."""
         iteration = 0
+        iterations: List[Dict] = []
         while True:
             executor_response = await _call_messages_handler(
                 model=model,
@@ -186,7 +189,8 @@ class AdvisorOrchestrationHandler(MessagesInterceptor):
 
             advisor_use_block = _find_advisor_tool_use(executor_response)
             if advisor_use_block is None:
-                yield ("final", executor_response, None)
+                iterations.append(_iteration_entry("message", model, executor_response))
+                yield ("final", executor_response, iterations)
                 return
 
             iteration += 1
@@ -217,6 +221,9 @@ class AdvisorOrchestrationHandler(MessagesInterceptor):
                 **advisor_kwargs,
             )
             advisor_text = _extract_response_text(advisor_response)
+            iterations.append(
+                _iteration_entry("advisor_message", advisor_model, advisor_response)
+            )
 
             yield ("advice", advisor_use_block, advisor_text)
 
@@ -241,6 +248,7 @@ class AdvisorOrchestrationHandler(MessagesInterceptor):
                 return {
                     **a,
                     "content": output_content + list(a.get("content") or []),
+                    "usage": {**(a.get("usage") or {}), "iterations": b},
                 }
         raise AdvisorMaxIterationsError("Advisor loop ended without a final response")
 
@@ -294,7 +302,7 @@ class AdvisorOrchestrationHandler(MessagesInterceptor):
                     for chunk in build_content_block_chunks(block, index):
                         yield chunk
                     index += 1
-                for chunk in _final_message_events(a):
+                for chunk in _final_message_events(a, b):
                     yield chunk
 
 
@@ -388,8 +396,30 @@ def _sse(event: str, data: Dict) -> bytes:
     return f"event: {event}\ndata: {json.dumps(data)}\n\n".encode()
 
 
-def _final_message_events(executor_response: Any) -> List[bytes]:
-    """The closing message_delta (stop reason + output usage) and message_stop."""
+_USAGE_TOKEN_KEYS = (
+    "input_tokens",
+    "output_tokens",
+    "cache_creation_input_tokens",
+    "cache_read_input_tokens",
+)
+
+
+def _iteration_entry(entry_type: str, model: str, response: Any) -> Dict:
+    """A usage.iterations[] entry. Clients attribute an advisor_message entry's
+    tokens to its own model, so the advisor leg gets its own cost line instead of
+    folding into the executor's."""
+    usage = (response.get("usage") if isinstance(response, dict) else None) or {}
+    entry: Dict[str, Any] = {"type": entry_type, "model": model}
+    for key in _USAGE_TOKEN_KEYS:
+        entry[key] = usage.get(key, 0)
+    return entry
+
+
+def _final_message_events(
+    executor_response: Any, iterations: List[Dict]
+) -> List[bytes]:
+    """The closing message_delta (stop reason + usage, including the advisor
+    iterations) and message_stop."""
     usage = (
         executor_response.get("usage") if isinstance(executor_response, dict) else None
     ) or {}
@@ -401,6 +431,7 @@ def _final_message_events(executor_response: Any) -> List[bytes]:
     ):
         if usage.get(key) is not None:
             delta_usage[key] = usage[key]
+    delta_usage["iterations"] = iterations
     return [
         _sse(
             "message_delta",
@@ -413,7 +444,10 @@ def _final_message_events(executor_response: Any) -> List[bytes]:
                 "usage": delta_usage,
             },
         ),
-        _sse("message_stop", {"type": "message_stop", "usage": usage}),
+        _sse(
+            "message_stop",
+            {"type": "message_stop", "usage": {**usage, "iterations": iterations}},
+        ),
     ]
 
 

--- a/litellm/llms/anthropic/experimental_pass_through/messages/interceptors/advisor.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/interceptors/advisor.py
@@ -90,6 +90,8 @@ class AdvisorOrchestrationHandler(MessagesInterceptor):
         advisor_api_key: Optional[str] = advisor_tool.get("api_key")
         advisor_api_base: Optional[str] = advisor_tool.get("api_base")
 
+        await _check_advisor_model_access(advisor_model, kwargs)
+
         # Build the synthetic tool definition the provider will receive.
         synthetic_advisor_tool = _make_synthetic_advisor_tool()
 
@@ -546,6 +548,34 @@ def _get_llm_router():
         return llm_router
     except ImportError:
         return None
+
+
+async def _check_advisor_model_access(advisor_model: str, kwargs: Dict) -> None:
+    """Validate that the caller's API key is allowed to invoke the advisor model.
+
+    Only runs when a proxy router is available (i.e. inside the proxy); standalone
+    SDK usage has no auth layer and skips the check."""
+    router = _get_llm_router()
+    if router is None:
+        return
+
+    litellm_metadata = kwargs.get("litellm_metadata")
+    if not isinstance(litellm_metadata, dict):
+        return
+
+    user_api_key_auth = litellm_metadata.get("user_api_key_auth")
+    if user_api_key_auth is None:
+        return
+
+    import litellm
+    from litellm.proxy.auth.auth_checks import can_key_call_model
+
+    await can_key_call_model(
+        model=advisor_model,
+        llm_model_list=getattr(litellm, "model_list", None),
+        valid_token=user_api_key_auth,
+        llm_router=router,
+    )
 
 
 async def _call_messages_handler(

--- a/litellm/llms/anthropic/experimental_pass_through/messages/interceptors/advisor.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/interceptors/advisor.py
@@ -249,7 +249,10 @@ class AdvisorOrchestrationHandler(MessagesInterceptor):
                 return {
                     **a,
                     "content": output_content + list(a.get("content") or []),
-                    "usage": cast(AnthropicUsage, {**(a.get("usage") or {}), "iterations": b}),
+                    "usage": cast(
+                        AnthropicUsage,
+                        {**(a.get("usage") or {}), "iterations": b},
+                    ),
                 }
         raise AdvisorMaxIterationsError("Advisor loop ended without a final response")
 

--- a/litellm/llms/anthropic/experimental_pass_through/messages/interceptors/advisor.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/interceptors/advisor.py
@@ -147,14 +147,22 @@ class AdvisorOrchestrationHandler(MessagesInterceptor):
             )
 
             # --- Advisor sub-call (always non-streaming, no tools) ---
-            # Only include api_key/api_base when explicitly set in the tool
-            # definition; passing None would override the router's deployment
-            # credentials during kwargs merging.
-            advisor_overrides: Dict = {}
+            # Carry only the proxy's budget/auth/session context (litellm_metadata)
+            # so the advisor's spend is attributed to the caller's key and groups
+            # under the same session. Deliberately do NOT inherit the executor's
+            # generation params (system, tool_choice, thinking, sampling): the
+            # advisor is a fresh consultation, and feeding it the executor's agent
+            # system prompt makes it mimic the executor and echo the advisor call
+            # instead of answering. api_key/api_base come from the advisor tool
+            # definition only — the executor's would be None under the router and
+            # override the advisor deployment's resolved credentials.
+            advisor_kwargs: Dict = {}
+            if "litellm_metadata" in kwargs:
+                advisor_kwargs["litellm_metadata"] = kwargs["litellm_metadata"]
             if advisor_api_key is not None:
-                advisor_overrides["api_key"] = advisor_api_key
+                advisor_kwargs["api_key"] = advisor_api_key
             if advisor_api_base is not None:
-                advisor_overrides["api_base"] = advisor_api_base
+                advisor_kwargs["api_base"] = advisor_api_base
 
             advisor_response: AnthropicMessagesResponse = await _call_messages_handler(
                 model=advisor_model,
@@ -168,7 +176,7 @@ class AdvisorOrchestrationHandler(MessagesInterceptor):
                     "advisor_sub_call": True,
                     "parent_request_id": parent_request_id,
                 },
-                **advisor_overrides,
+                **advisor_kwargs,
             )
 
             advisor_text = _extract_response_text(advisor_response)

--- a/litellm/llms/anthropic/experimental_pass_through/messages/interceptors/advisor.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/interceptors/advisor.py
@@ -24,6 +24,7 @@ from typing import Any, AsyncIterator, Dict, List, Optional, Union, cast
 import litellm.constants as _c
 from litellm.llms.anthropic.common_utils import strip_advisor_blocks_from_messages
 from litellm.llms.anthropic.experimental_pass_through.messages.fake_stream_iterator import (
+    _sse,
     build_content_block_chunks,
 )
 from litellm.types.llms.anthropic_messages.anthropic_response import (
@@ -397,9 +398,6 @@ def _advisor_result_block(advisor_use_block: Dict, advisor_text: str) -> Dict:
         "content": {"type": "advisor_result", "text": advisor_text},
     }
 
-
-def _sse(event: str, data: Dict) -> bytes:
-    return f"event: {event}\ndata: {json.dumps(data)}\n\n".encode()
 
 
 _USAGE_TOKEN_KEYS = (

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -4106,6 +4106,37 @@ def test_strip_advisor_blocks_when_no_advisor_tool():
     assert len(assistant_content) == 2
 
 
+def test_strip_advisor_blocks_replace_with_text_extracts_advisor_result_dict():
+    """replace_with_text=True must recover the advice from the native
+    advisor_result content shape ({"type":"advisor_result","text":...}); a prior
+    bug only handled str/list content and silently dropped the dict's text."""
+    from litellm.llms.anthropic.common_utils import strip_advisor_blocks_from_messages
+
+    messages = [
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "server_tool_use",
+                    "id": "srvtoolu_abc123",
+                    "name": "advisor",
+                    "input": {},
+                },
+                {
+                    "type": "advisor_tool_result",
+                    "tool_use_id": "srvtoolu_abc123",
+                    "content": {"type": "advisor_result", "text": "Use channels."},
+                },
+            ],
+        }
+    ]
+    result = strip_advisor_blocks_from_messages(messages, replace_with_text=True)
+    blocks = result[0]["content"]
+    assert all(b["type"] == "text" for b in blocks)
+    assert "<advisor_feedback>" in blocks[0]["text"]
+    assert "Use channels." in blocks[0]["text"]
+
+
 def test_strip_advisor_blocks_no_op_when_no_advisor_blocks():
     """strip_advisor_blocks_from_messages is a no-op when no advisor blocks exist."""
     from litellm.llms.anthropic.common_utils import strip_advisor_blocks_from_messages

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_advisor_integration.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_advisor_integration.py
@@ -766,3 +766,112 @@ async def test_streaming_flushes_advisor_call_before_running_advisor():
     assert events.index("advisor_leg_invoked") < events.index(
         "emit:advisor_tool_result"
     ), "advisor result must be emitted after the advisor sub-call returns"
+
+
+# ---------------------------------------------------------------------------
+# 11. Advisor token usage is attributed to the advisor model via usage.iterations[]
+# ---------------------------------------------------------------------------
+
+
+def _advisor_iterations(usage):
+    return [
+        it
+        for it in (usage or {}).get("iterations", [])
+        if it.get("type") == "advisor_message"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_non_streaming_reports_advisor_usage_in_iterations():
+    """Without usage.iterations[], a client folds all spend into the executor
+    model and the advisor's cost disappears. The final response must carry an
+    advisor_message iteration tagged with the advisor model and its token counts,
+    and the last iteration must be the executor turn so the context-window readout
+    stays correct."""
+    from litellm.llms.anthropic.experimental_pass_through.messages.handler import (
+        anthropic_messages,
+    )
+
+    call_count = 0
+
+    async def mock_handler(model, messages, tools, stream, max_tokens, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return _advisor_call_resp()
+        if call_count == 2:
+            resp = _text_resp("Use a sieve.", model="claude-opus-4-6")
+            resp["usage"] = {"input_tokens": 1234, "output_tokens": 56}
+            return resp
+        return _text_resp("def is_prime(n): ...")
+
+    with patch(
+        "litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor._call_messages_handler",
+        side_effect=mock_handler,
+    ):
+        result = await anthropic_messages(
+            model="openai/gpt-4o-mini",
+            messages=MESSAGES,
+            tools=[ADVISOR_TOOL],
+            stream=False,
+            max_tokens=512,
+            custom_llm_provider="openai",
+        )
+
+    iterations = result["usage"]["iterations"]
+    advisor_iters = _advisor_iterations(result["usage"])
+    assert len(advisor_iters) == 1
+    entry = advisor_iters[0]
+    assert entry["model"] == "claude-opus-4-6"
+    assert entry["input_tokens"] == 1234
+    assert entry["output_tokens"] == 56
+    assert iterations[-1]["type"] != "advisor_message"
+
+
+@pytest.mark.asyncio
+async def test_streaming_reports_advisor_usage_in_message_delta():
+    """The streamed message_delta must carry usage.iterations[] with the advisor
+    leg, since clients read per-model usage from there."""
+    from litellm.llms.anthropic.experimental_pass_through.messages.handler import (
+        anthropic_messages,
+    )
+
+    call_count = 0
+
+    async def mock_handler(model, messages, tools, stream, max_tokens, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return _advisor_call_resp()
+        if call_count == 2:
+            resp = _text_resp("Use a sieve.", model="claude-opus-4-6")
+            resp["usage"] = {"input_tokens": 1234, "output_tokens": 56}
+            return resp
+        return _text_resp("Final answer.")
+
+    delta_usage = None
+    with patch(
+        "litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor._call_messages_handler",
+        side_effect=mock_handler,
+    ):
+        result = await anthropic_messages(
+            model="openai/gpt-4o-mini",
+            messages=MESSAGES,
+            tools=[ADVISOR_TOOL],
+            stream=True,
+            max_tokens=512,
+            custom_llm_provider="openai",
+        )
+        async for raw in result:
+            text = raw.decode()
+            if "event: message_delta" in text:
+                delta_usage = json.loads(
+                    text.split("data: ", 1)[1].split("\n\n", 1)[0]
+                )["usage"]
+
+    assert delta_usage is not None
+    advisor_iters = _advisor_iterations(delta_usage)
+    assert len(advisor_iters) == 1
+    assert advisor_iters[0]["model"] == "claude-opus-4-6"
+    assert advisor_iters[0]["input_tokens"] == 1234
+    assert advisor_iters[0]["output_tokens"] == 56

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_advisor_integration.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_advisor_integration.py
@@ -8,6 +8,7 @@ The only thing mocked is _call_messages_handler (the outbound LLM call), so the
 interceptor detection, loop logic, and message assembly all run for real.
 """
 
+import json
 from typing import Dict
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -113,7 +114,30 @@ async def test_full_dispatch_interceptor_fires_and_loop_completes():
     assert len(text_blocks) >= 1, "Final response must have text"
     assert (
         len(advisor_uses) == 0
-    ), "No advisor tool_use blocks must appear in final output"
+    ), "No raw tool_use advisor blocks must appear in final output"
+
+    # The advisor exchange must surface as native server-side advisor blocks so
+    # clients (e.g. Claude Code) render the advisor activity. Pre-fix the loop
+    # flattened these away and the final content had no advisor blocks at all.
+    server_tool_uses = [
+        b
+        for b in content
+        if b.get("type") == "server_tool_use" and b.get("name") == "advisor"
+    ]
+    advisor_results = [b for b in content if b.get("type") == "advisor_tool_result"]
+    assert len(server_tool_uses) == 1, "advisor call must surface as server_tool_use"
+    assert (
+        len(advisor_results) == 1
+    ), "advisor reply must surface as advisor_tool_result"
+
+    call_block, result_block = server_tool_uses[0], advisor_results[0]
+    assert call_block["id"] == "tid_01"
+    assert call_block["input"] == {}
+    assert result_block["tool_use_id"] == call_block["id"]
+    assert result_block["content"] == {
+        "type": "advisor_result",
+        "text": "Use trial division.",
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -615,3 +639,130 @@ async def test_advisor_subcall_forwards_litellm_metadata_but_not_executor_params
     assert captured_advisor_kwargs.get("system") == ADVISOR_SYSTEM_PROMPT
     assert captured_advisor_kwargs.get("system") != executor_system
     assert "tool_choice" not in captured_advisor_kwargs
+
+
+# ---------------------------------------------------------------------------
+# 9. Round-trip: the advisor blocks we emit are consumable on the next turn
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_emitted_advisor_blocks_round_trip_through_strip():
+    """The server_tool_use / advisor_tool_result blocks we surface must be the
+    exact shape strip_advisor_blocks_from_messages recognizes, so when the client
+    echoes them back in history the next turn folds them into an <advisor_feedback>
+    text block for the executor rather than 400-ing on a dangling advisor block."""
+    from litellm.llms.anthropic.common_utils import (
+        strip_advisor_blocks_from_messages,
+    )
+    from litellm.llms.anthropic.experimental_pass_through.messages.handler import (
+        anthropic_messages,
+    )
+
+    call_count = 0
+
+    async def mock_handler(model, messages, tools, stream, max_tokens, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return _advisor_call_resp()
+        if call_count == 2:
+            return _text_resp("Prefer a sieve.", model="claude-opus-4-6")
+        return _text_resp("Done.")
+
+    with patch(
+        "litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor._call_messages_handler",
+        side_effect=mock_handler,
+    ):
+        result = await anthropic_messages(
+            model="openai/gpt-4o-mini",
+            messages=MESSAGES,
+            tools=[ADVISOR_TOOL],
+            stream=False,
+            max_tokens=512,
+            custom_llm_provider="openai",
+        )
+
+    history = [{"role": "assistant", "content": result["content"]}]
+    stripped = strip_advisor_blocks_from_messages(history, replace_with_text=True)
+
+    blocks = stripped[0]["content"]
+    assert not any(b.get("type") == "server_tool_use" for b in blocks)
+    assert not any(b.get("type") == "advisor_tool_result" for b in blocks)
+    feedback = [
+        b
+        for b in blocks
+        if b.get("type") == "text" and "<advisor_feedback>" in b.get("text", "")
+    ]
+    assert len(feedback) == 1
+    assert "Prefer a sieve." in feedback[0]["text"]
+
+
+# ---------------------------------------------------------------------------
+# 10. Streaming surfaces the advisor as in-progress, then done
+# ---------------------------------------------------------------------------
+
+
+def _block_type_from_start_event(raw: bytes):
+    text = raw.decode()
+    if "event: content_block_start" not in text:
+        return None
+    payload = json.loads(text.split("data: ", 1)[1].split("\n\n", 1)[0])
+    return payload["content_block"]["type"]
+
+
+@pytest.mark.asyncio
+async def test_streaming_flushes_advisor_call_before_running_advisor():
+    """The live advisor UX (running -> done) depends on the server_tool_use block
+    reaching the client BEFORE the advisor sub-call runs, and the advisor_tool_result
+    reaching it AFTER. A burst-at-end implementation runs the whole loop first and
+    emits everything at once, so the advisor never renders as in-progress.
+
+    We interleave call markers and emitted-block markers in one list: the
+    server_tool_use must be emitted before the advisor leg is invoked, and the
+    result after."""
+    from litellm.llms.anthropic.experimental_pass_through.messages.handler import (
+        anthropic_messages,
+    )
+
+    events = []
+    call_count = 0
+
+    async def mock_handler(model, messages, tools, stream, max_tokens, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return _advisor_call_resp()
+        if call_count == 2:
+            events.append("advisor_leg_invoked")
+            return _text_resp("Advice text.", model="claude-opus-4-6")
+        return _text_resp("Final answer.")
+
+    with patch(
+        "litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor._call_messages_handler",
+        side_effect=mock_handler,
+    ):
+        result = await anthropic_messages(
+            model="openai/gpt-4o-mini",
+            messages=MESSAGES,
+            tools=[ADVISOR_TOOL],
+            stream=True,
+            max_tokens=512,
+            custom_llm_provider="openai",
+        )
+
+        assert hasattr(result, "__aiter__"), "streaming must return an async iterator"
+
+        async for raw in result:
+            block_type = _block_type_from_start_event(raw)
+            if block_type in ("server_tool_use", "advisor_tool_result"):
+                events.append(f"emit:{block_type}")
+
+    assert "emit:server_tool_use" in events
+    assert "emit:advisor_tool_result" in events
+    assert events.index("emit:server_tool_use") < events.index(
+        "advisor_leg_invoked"
+    ), "advisor call block must be flushed before the advisor sub-call runs"
+    assert events.index("advisor_leg_invoked") < events.index(
+        "emit:advisor_tool_result"
+    ), "advisor result must be emitted after the advisor sub-call returns"

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_advisor_integration.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_advisor_integration.py
@@ -593,8 +593,12 @@ async def test_advisor_subcall_forwards_litellm_metadata_but_not_executor_params
     assert captured_executor_kwargs.get("litellm_metadata") == sentinel_metadata
     assert captured_advisor_kwargs.get("litellm_metadata") == sentinel_metadata
 
-    # Executor keeps its system prompt; the advisor must not inherit it (nor
-    # tool_choice), or it mimics the executor and echoes the call.
+    # The executor keeps its own system prompt. The advisor gets the dedicated
+    # advisor role prompt — NOT the executor's leaked one — and never the
+    # executor's tool_choice; otherwise it mimics the executor and echoes the call.
+    from litellm.constants import ADVISOR_SYSTEM_PROMPT
+
     assert captured_executor_kwargs.get("system") == executor_system
-    assert "system" not in captured_advisor_kwargs
+    assert captured_advisor_kwargs.get("system") == ADVISOR_SYSTEM_PROMPT
+    assert captured_advisor_kwargs.get("system") != executor_system
     assert "tool_choice" not in captured_advisor_kwargs

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_advisor_integration.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_advisor_integration.py
@@ -875,3 +875,91 @@ async def test_streaming_reports_advisor_usage_in_message_delta():
     assert advisor_iters[0]["model"] == "claude-opus-4-6"
     assert advisor_iters[0]["input_tokens"] == 1234
     assert advisor_iters[0]["output_tokens"] == 56
+
+
+# ---------------------------------------------------------------------------
+# 12. Advisor model access is validated against the caller's API key
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_advisor_model_access_denied_raises():
+    """When the proxy router is available and can_key_call_model rejects the
+    advisor model, the exception must propagate before any sub-call runs."""
+    from litellm.proxy._types import ProxyException
+
+    mock_router = MagicMock()
+    mock_token = MagicMock()
+
+    with (
+        patch(
+            "litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor._get_llm_router",
+            return_value=mock_router,
+        ),
+        patch(
+            "litellm.proxy.auth.auth_checks.can_key_call_model",
+            side_effect=ProxyException(
+                message="key not allowed to call claude-opus-4-6",
+                type="key_model_access_denied",
+                param="model",
+                code=403,
+            ),
+        ),
+    ):
+        with pytest.raises(ProxyException, match="key not allowed"):
+            from litellm.llms.anthropic.experimental_pass_through.messages.handler import (
+                anthropic_messages,
+            )
+
+            await anthropic_messages(
+                model="openai/gpt-4o-mini",
+                messages=MESSAGES,
+                tools=[ADVISOR_TOOL],
+                stream=False,
+                max_tokens=512,
+                custom_llm_provider="openai",
+                litellm_metadata={"user_api_key_auth": mock_token},
+            )
+
+    mock_router.anthropic_messages.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_advisor_model_access_skipped_without_router():
+    """Without a proxy router (standalone SDK), the auth check is skipped and
+    the advisor loop runs normally."""
+    call_count = 0
+
+    async def mock_handler(model, messages, tools, stream, max_tokens, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return _advisor_call_resp()
+        if call_count == 2:
+            return _text_resp("Advice.", model="claude-opus-4-6")
+        return _text_resp("Done.")
+
+    with (
+        patch(
+            "litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor._get_llm_router",
+            return_value=None,
+        ),
+        patch(
+            "litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor._call_messages_handler",
+            side_effect=mock_handler,
+        ),
+    ):
+        from litellm.llms.anthropic.experimental_pass_through.messages.handler import (
+            anthropic_messages,
+        )
+
+        result = await anthropic_messages(
+            model="openai/gpt-4o-mini",
+            messages=MESSAGES,
+            tools=[ADVISOR_TOOL],
+            stream=False,
+            max_tokens=512,
+            custom_llm_provider="openai",
+        )
+
+    assert call_count == 3

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_advisor_integration.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_advisor_integration.py
@@ -224,6 +224,8 @@ async def test_named_params_forwarded_into_advisor_executor_subcall():
     async def mock_handler(
         model, messages, tools, stream, max_tokens, custom_llm_provider, **kwargs
     ):
+        # First call is the executor sub-call (returns advisor tool_use).
+        # Capture its kwargs so we can assert the forwarded params.
         if not captured_executor_kwargs:
             captured_executor_kwargs.update(
                 {
@@ -238,6 +240,7 @@ async def test_named_params_forwarded_into_advisor_executor_subcall():
                 }
             )
             return _advisor_call_resp()
+        # Subsequent calls — terminate the loop.
         if tools is None:
             return _text_resp("Some advice.", model="claude-opus-4-6")
         return _text_resp("Final answer.")
@@ -264,8 +267,11 @@ async def test_named_params_forwarded_into_advisor_executor_subcall():
         )
 
     assert captured_executor_kwargs["thinking"] == {"type": "adaptive"}, (
-        "thinking must be forwarded into executor sub-call"
+        "thinking must be forwarded into executor sub-call — see "
+        "anthropic_messages.handler interceptor invocation."
     )
+    # The advisor enriches metadata with `advisor_sub_call` / `parent_request_id`,
+    # but the original caller fields must survive into the executor sub-call.
     assert isinstance(captured_executor_kwargs["metadata"], dict)
     assert captured_executor_kwargs["metadata"].get("caller_field") == "preserve_me"
     assert captured_executor_kwargs["system"] == "You are a helpful assistant."
@@ -317,6 +323,11 @@ async def test_pre_request_hook_override_does_not_collide_with_explicit_kwargs()
     async def fake_pre_request_hooks(
         model, messages, tools, stream, custom_llm_provider, **hook_kwargs
     ):
+        # Simulate a CustomLogger.async_pre_request_hook that overrides several
+        # named params on its way through. Without the request_kwargs.pop()
+        # extraction in handler.py, these would collide with the explicit
+        # kwargs passed to interceptor.handle() (TypeError: got multiple
+        # values for keyword argument).
         return {
             "tools": tools,
             "stream": stream,
@@ -336,6 +347,7 @@ async def test_pre_request_hook_override_does_not_collide_with_explicit_kwargs()
             side_effect=mock_handler,
         ),
     ):
+        # Should not raise TypeError.
         await anthropic_messages(
             model="openai/gpt-4o-mini",
             messages=MESSAGES,
@@ -348,6 +360,7 @@ async def test_pre_request_hook_override_does_not_collide_with_explicit_kwargs()
             temperature=0.9,
         )
 
+    # Hook overrides win and reach the executor sub-call.
     assert captured["thinking"] == {"type": "enabled", "budget_tokens": 2048}
     assert captured["system"] == "Hook overrode the system prompt."
     assert captured["temperature"] == 0.1

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_advisor_integration.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_advisor_integration.py
@@ -9,7 +9,7 @@ interceptor detection, loop logic, and message assembly all run for real.
 """
 
 from typing import Dict
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -224,8 +224,6 @@ async def test_named_params_forwarded_into_advisor_executor_subcall():
     async def mock_handler(
         model, messages, tools, stream, max_tokens, custom_llm_provider, **kwargs
     ):
-        # First call is the executor sub-call (returns advisor tool_use).
-        # Capture its kwargs so we can assert the forwarded params.
         if not captured_executor_kwargs:
             captured_executor_kwargs.update(
                 {
@@ -240,7 +238,6 @@ async def test_named_params_forwarded_into_advisor_executor_subcall():
                 }
             )
             return _advisor_call_resp()
-        # Subsequent calls — terminate the loop.
         if tools is None:
             return _text_resp("Some advice.", model="claude-opus-4-6")
         return _text_resp("Final answer.")
@@ -267,11 +264,8 @@ async def test_named_params_forwarded_into_advisor_executor_subcall():
         )
 
     assert captured_executor_kwargs["thinking"] == {"type": "adaptive"}, (
-        "thinking must be forwarded into executor sub-call — see "
-        "anthropic_messages.handler interceptor invocation."
+        "thinking must be forwarded into executor sub-call"
     )
-    # The advisor enriches metadata with `advisor_sub_call` / `parent_request_id`,
-    # but the original caller fields must survive into the executor sub-call.
     assert isinstance(captured_executor_kwargs["metadata"], dict)
     assert captured_executor_kwargs["metadata"].get("caller_field") == "preserve_me"
     assert captured_executor_kwargs["system"] == "You are a helpful assistant."
@@ -323,11 +317,6 @@ async def test_pre_request_hook_override_does_not_collide_with_explicit_kwargs()
     async def fake_pre_request_hooks(
         model, messages, tools, stream, custom_llm_provider, **hook_kwargs
     ):
-        # Simulate a CustomLogger.async_pre_request_hook that overrides several
-        # named params on its way through. Without the request_kwargs.pop()
-        # extraction in handler.py, these would collide with the explicit
-        # kwargs passed to interceptor.handle() (TypeError: got multiple
-        # values for keyword argument).
         return {
             "tools": tools,
             "stream": stream,
@@ -347,7 +336,6 @@ async def test_pre_request_hook_override_does_not_collide_with_explicit_kwargs()
             side_effect=mock_handler,
         ),
     ):
-        # Should not raise TypeError.
         await anthropic_messages(
             model="openai/gpt-4o-mini",
             messages=MESSAGES,
@@ -360,7 +348,180 @@ async def test_pre_request_hook_override_does_not_collide_with_explicit_kwargs()
             temperature=0.9,
         )
 
-    # Hook overrides win and reach the executor sub-call.
     assert captured["thinking"] == {"type": "enabled", "budget_tokens": 2048}
     assert captured["system"] == "Hook overrode the system prompt."
     assert captured["temperature"] == 0.1
+
+
+# ---------------------------------------------------------------------------
+# 6. Router routing: sub-calls go through the proxy router when available
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_call_handler_routes_through_router():
+    from litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor import (
+        _call_messages_handler,
+    )
+
+    expected = _text_resp("Router response.")
+    mock_router = MagicMock()
+    mock_router.anthropic_messages = AsyncMock(return_value=expected)
+
+    with patch(
+        "litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor._get_llm_router",
+        return_value=mock_router,
+    ):
+        result = await _call_messages_handler(
+            model="claude-opus-4-7",
+            messages=MESSAGES,
+            tools=None,
+            stream=False,
+            max_tokens=512,
+            custom_llm_provider=None,
+        )
+
+    mock_router.anthropic_messages.assert_called_once_with(
+        model="claude-opus-4-7",
+        messages=MESSAGES,
+        tools=None,
+        stream=False,
+        max_tokens=512,
+    )
+    assert result == expected
+
+
+@pytest.mark.asyncio
+async def test_call_handler_falls_back_without_router():
+    from litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor import (
+        _call_messages_handler,
+    )
+
+    expected = _text_resp("Direct response.")
+
+    with (
+        patch(
+            "litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor._get_llm_router",
+            return_value=None,
+        ),
+        patch(
+            "litellm.llms.anthropic.experimental_pass_through.messages.handler.anthropic_messages",
+            new_callable=AsyncMock,
+            return_value=expected,
+        ) as mock_direct,
+    ):
+        result = await _call_messages_handler(
+            model="claude-opus-4-7",
+            messages=MESSAGES,
+            tools=None,
+            stream=False,
+            max_tokens=512,
+            custom_llm_provider="anthropic",
+        )
+
+    mock_direct.assert_called_once_with(
+        model="claude-opus-4-7",
+        messages=MESSAGES,
+        tools=None,
+        stream=False,
+        max_tokens=512,
+        custom_llm_provider="anthropic",
+    )
+    assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# 7. Advisor sub-call does not pass None api_key/api_base to the router
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_advisor_subcall_omits_none_credentials():
+    """When the advisor tool definition has no api_key/api_base, those keys
+    must not appear in the kwargs passed to _call_messages_handler. Otherwise
+    None would override the router's deployment credentials during merging."""
+    from litellm.llms.anthropic.experimental_pass_through.messages.handler import (
+        anthropic_messages,
+    )
+
+    captured_advisor_kwargs: Dict = {}
+    call_count = 0
+
+    mock_router = MagicMock()
+
+    async def mock_router_call(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return _advisor_call_resp()
+        if call_count == 2:
+            captured_advisor_kwargs.update(kwargs)
+            return _text_resp("Advice.", model="claude-opus-4-7")
+        return _text_resp("Final answer.")
+
+    mock_router.anthropic_messages = AsyncMock(side_effect=mock_router_call)
+
+    with patch(
+        "litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor._get_llm_router",
+        return_value=mock_router,
+    ):
+        await anthropic_messages(
+            model="openai/gpt-4o-mini",
+            messages=MESSAGES,
+            tools=[ADVISOR_TOOL],
+            stream=False,
+            max_tokens=512,
+            custom_llm_provider="openai",
+        )
+
+    assert "api_key" not in captured_advisor_kwargs
+    assert "api_base" not in captured_advisor_kwargs
+
+
+@pytest.mark.asyncio
+async def test_advisor_subcall_forwards_explicit_credentials():
+    """When the advisor tool definition includes api_key/api_base, those
+    values must be forwarded to the router call so they override deployment
+    credentials."""
+    from litellm.llms.anthropic.experimental_pass_through.messages.handler import (
+        anthropic_messages,
+    )
+
+    advisor_tool_with_creds = {
+        **ADVISOR_TOOL,
+        "api_key": "sk-explicit-override",
+        "api_base": "https://custom.endpoint.com",
+    }
+
+    captured_advisor_kwargs: Dict = {}
+    call_count = 0
+
+    mock_router = MagicMock()
+
+    async def mock_router_call(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return _advisor_call_resp()
+        if call_count == 2:
+            captured_advisor_kwargs.update(kwargs)
+            return _text_resp("Advice.", model="claude-opus-4-7")
+        return _text_resp("Final answer.")
+
+    mock_router.anthropic_messages = AsyncMock(side_effect=mock_router_call)
+
+    with patch(
+        "litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor._get_llm_router",
+        return_value=mock_router,
+    ):
+        await anthropic_messages(
+            model="openai/gpt-4o-mini",
+            messages=MESSAGES,
+            tools=[advisor_tool_with_creds],
+            stream=False,
+            max_tokens=512,
+            custom_llm_provider="openai",
+        )
+
+    assert captured_advisor_kwargs["api_key"] == "sk-explicit-override"
+    assert captured_advisor_kwargs["api_base"] == "https://custom.endpoint.com"

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_advisor_integration.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_advisor_integration.py
@@ -525,3 +525,76 @@ async def test_advisor_subcall_forwards_explicit_credentials():
 
     assert captured_advisor_kwargs["api_key"] == "sk-explicit-override"
     assert captured_advisor_kwargs["api_base"] == "https://custom.endpoint.com"
+
+
+# ---------------------------------------------------------------------------
+# 6. Advisor sub-call carries the caller's budget/auth context
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_advisor_subcall_forwards_litellm_metadata_but_not_executor_params():
+    """The advisor leg must carry the caller's litellm_metadata (the proxy's
+    user_api_key/team/budget/session context) so its spend is attributed to the
+    caller's key and grouped under the session. It must NOT inherit the executor's
+    generation params (system prompt, tool_choice, sampling): feeding the advisor
+    the executor's agent system prompt makes it mimic the executor and echo the
+    advisor call instead of answering.
+
+    Two regressions guarded: (1) dropping litellm_metadata left the advisor's cost
+    unattributed; (2) forwarding the whole executor kwargs leaked the system
+    prompt / tool_choice into the advisor and broke its answers."""
+    from litellm.llms.anthropic.experimental_pass_through.messages.handler import (
+        anthropic_messages,
+    )
+
+    sentinel_metadata = {
+        "user_api_key": "sk-caller-key",
+        "user_api_key_team_id": "team-42",
+        "litellm_session_id": "sess-abc",
+    }
+    executor_system = "You are the coding agent. Consult your advisor when stuck."
+    captured_executor_kwargs: Dict = {}
+    captured_advisor_kwargs: Dict = {}
+    call_count = 0
+
+    mock_router = MagicMock()
+
+    async def mock_router_call(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            captured_executor_kwargs.update(kwargs)
+            return _advisor_call_resp()
+        if call_count == 2:
+            captured_advisor_kwargs.update(kwargs)
+            return _text_resp("Advice.", model="claude-opus-4-6")
+        return _text_resp("Final answer.")
+
+    mock_router.anthropic_messages = AsyncMock(side_effect=mock_router_call)
+
+    with patch(
+        "litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor._get_llm_router",
+        return_value=mock_router,
+    ):
+        await anthropic_messages(
+            model="openai/gpt-4o-mini",
+            messages=MESSAGES,
+            tools=[ADVISOR_TOOL],
+            stream=False,
+            max_tokens=512,
+            custom_llm_provider="openai",
+            system=executor_system,
+            tool_choice={"type": "auto"},
+            litellm_metadata=sentinel_metadata,
+        )
+
+    # Budget context reaches both legs.
+    assert captured_executor_kwargs.get("litellm_metadata") == sentinel_metadata
+    assert captured_advisor_kwargs.get("litellm_metadata") == sentinel_metadata
+
+    # Executor keeps its system prompt; the advisor must not inherit it (nor
+    # tool_choice), or it mimics the executor and echoes the call.
+    assert captured_executor_kwargs.get("system") == executor_system
+    assert "system" not in captured_advisor_kwargs
+    assert "tool_choice" not in captured_advisor_kwargs

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_advisor_integration.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_advisor_integration.py
@@ -963,3 +963,55 @@ async def test_advisor_model_access_skipped_without_router():
         )
 
     assert call_count == 3
+
+
+# ---------------------------------------------------------------------------
+# 13. Streaming message_start carries real input_tokens
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_streaming_message_start_has_real_input_tokens():
+    """message_start must carry the executor's input_tokens, not a placeholder
+    zero. Clients that read usage from message_start (per the Anthropic SSE
+    protocol) would otherwise show incorrect billing data."""
+    from litellm.llms.anthropic.experimental_pass_through.messages.handler import (
+        anthropic_messages,
+    )
+
+    call_count = 0
+
+    async def mock_handler(model, messages, tools, stream, max_tokens, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            resp = _advisor_call_resp()
+            resp["usage"] = {"input_tokens": 777, "output_tokens": 15}
+            return resp
+        if call_count == 2:
+            return _text_resp("Advice.", model="claude-opus-4-6")
+        return _text_resp("Final.")
+
+    message_start_usage = None
+    with patch(
+        "litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor._call_messages_handler",
+        side_effect=mock_handler,
+    ):
+        result = await anthropic_messages(
+            model="openai/gpt-4o-mini",
+            messages=MESSAGES,
+            tools=[ADVISOR_TOOL],
+            stream=True,
+            max_tokens=512,
+            custom_llm_provider="openai",
+        )
+        async for raw in result:
+            text = raw.decode()
+            if "event: message_start" in text:
+                payload = json.loads(
+                    text.split("data: ", 1)[1].split("\n\n", 1)[0]
+                )
+                message_start_usage = payload["message"]["usage"]
+
+    assert message_start_usage is not None
+    assert message_start_usage["input_tokens"] == 777

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_fake_stream_iterator.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_fake_stream_iterator.py
@@ -1,0 +1,82 @@
+"""
+Tests for FakeAnthropicMessagesStreamIterator.
+
+Focus: the advisor blocks (server_tool_use + advisor_tool_result) must stream as
+content_block_start events so clients render the advisor activity. Before the fix
+these block types were silently dropped by the iterator.
+"""
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("../../../../.."))
+
+from litellm.llms.anthropic.experimental_pass_through.messages.fake_stream_iterator import (
+    FakeAnthropicMessagesStreamIterator,
+)
+
+
+def _parse_events(chunks):
+    events = []
+    for raw in chunks:
+        text = raw.decode()
+        for block in text.strip().split("\n\n"):
+            if not block.strip():
+                continue
+            data_line = next(
+                line for line in block.splitlines() if line.startswith("data: ")
+            )
+            events.append(json.loads(data_line[len("data: ") :]))
+    return events
+
+
+def _advisor_response():
+    return {
+        "id": "msg_x",
+        "type": "message",
+        "role": "assistant",
+        "model": "gpt-4o-mini",
+        "content": [
+            {"type": "server_tool_use", "id": "tid_01", "name": "advisor", "input": {}},
+            {
+                "type": "advisor_tool_result",
+                "tool_use_id": "tid_01",
+                "content": {"type": "advisor_result", "text": "Use a sieve."},
+            },
+            {"type": "text", "text": "Final answer."},
+        ],
+        "stop_reason": "end_turn",
+        "usage": {"input_tokens": 10, "output_tokens": 20},
+    }
+
+
+def test_advisor_blocks_emitted_as_content_block_start():
+    iterator = FakeAnthropicMessagesStreamIterator(_advisor_response())
+    events = _parse_events(list(iterator))
+
+    starts = [e for e in events if e["type"] == "content_block_start"]
+    by_type = {e["content_block"]["type"]: e["content_block"] for e in starts}
+
+    assert "server_tool_use" in by_type, "advisor call must stream"
+    assert by_type["server_tool_use"]["name"] == "advisor"
+
+    assert "advisor_tool_result" in by_type, "advisor reply must stream"
+    assert by_type["advisor_tool_result"]["tool_use_id"] == "tid_01"
+    assert by_type["advisor_tool_result"]["content"] == {
+        "type": "advisor_result",
+        "text": "Use a sieve.",
+    }
+
+
+def test_server_tool_use_emits_input_json_delta():
+    iterator = FakeAnthropicMessagesStreamIterator(_advisor_response())
+    events = _parse_events(list(iterator))
+
+    deltas = [
+        e
+        for e in events
+        if e["type"] == "content_block_delta"
+        and e["delta"].get("type") == "input_json_delta"
+    ]
+    assert any(d["delta"]["partial_json"] == "{}" for d in deltas)

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_fake_stream_iterator.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_fake_stream_iterator.py
@@ -80,3 +80,12 @@ def test_server_tool_use_emits_input_json_delta():
         and e["delta"].get("type") == "input_json_delta"
     ]
     assert any(d["delta"]["partial_json"] == "{}" for d in deltas)
+
+
+def test_unknown_block_type_produces_no_chunks():
+    from litellm.llms.anthropic.experimental_pass_through.messages.fake_stream_iterator import (
+        build_content_block_chunks,
+    )
+
+    chunks = build_content_block_chunks({"type": "unknown_future_type", "data": 42}, 0)
+    assert chunks == []

--- a/tests/test_litellm/llms/anthropic/messages/test_advisor_orchestration.py
+++ b/tests/test_litellm/llms/anthropic/messages/test_advisor_orchestration.py
@@ -255,16 +255,14 @@ async def test_loop_max_uses_raises():
 
 
 # ---------------------------------------------------------------------------
-# 6. Streaming: final response wrapped in FakeAnthropicMessagesStreamIterator
+# 6. Streaming: returns a valid Anthropic SSE stream
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_loop_streaming_wraps_response():
-    """stream=True: final response must be wrapped in FakeAnthropicMessagesStreamIterator."""
-    from litellm.llms.anthropic.experimental_pass_through.messages.fake_stream_iterator import (
-        FakeAnthropicMessagesStreamIterator,
-    )
+async def test_loop_streaming_returns_sse_stream():
+    """stream=True must return an async SSE stream that opens with message_start,
+    carries the executor's text, and closes with message_stop."""
     from litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor import (
         AdvisorOrchestrationHandler,
     )
@@ -286,15 +284,19 @@ async def test_loop_streaming_wraps_response():
             custom_llm_provider="openai",
         )
 
-    assert isinstance(result, FakeAnthropicMessagesStreamIterator)
+        assert hasattr(result, "__aiter__")
 
-    chunks = []
-    async for chunk in result:
-        chunks.append(chunk)
+        # Streaming is lazy: the executor call runs while the stream is consumed,
+        # so iterate inside the patch context.
+        chunks = []
+        async for chunk in result:
+            chunks.append(chunk.decode() if isinstance(chunk, bytes) else str(chunk))
 
     assert len(chunks) > 0
-    first = chunks[0].decode() if isinstance(chunks[0], bytes) else str(chunks[0])
-    assert "message_start" in first
+    assert "message_start" in chunks[0]
+    joined = "".join(chunks)
+    assert "Hello, world!" in joined
+    assert "message_stop" in joined
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Relevant issues

Upstream advisor rollout: BerriAI/litellm#25516. Ported from scaledata/litellm PRs #4, #7, #8

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code) (the touched/related suites pass; 32 tests across 4 test files)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## What and why

Three related fixes to the advisor orchestration loop for non-Anthropic executor providers, combined into a single PR since they form a coherent stack (each builds on the prior). Follow-up commits address all review findings from Greptile and Veria-AI.

**1. Route sub-calls through the proxy router** (scaledata/litellm#4)

Routes advisor and executor sub-calls through the proxy's `llm_router` in-process when available (falling back to direct `anthropic_messages()` for standalone SDK use), instead of requiring `ANTHROPIC_API_KEY` and `ANTHROPIC_BASE_URL` pointed at localhost with the master key. Stops passing `api_key=None`/`api_base=None` to the advisor sub-call, which would override the router's resolved deployment credentials during kwargs merging. Forwards the caller's `litellm_metadata` into the advisor sub-call so the advisor model's spend is attributed to the caller's key and budget. Gives the advisor sub-call its own role system prompt so it answers as the advisor rather than adopting the executor's persona.

**2. Render advisor activity in clients** (scaledata/litellm#7)

Through the proxy, a non-Anthropic executor with an `advisor_20260301` tool was orchestrated entirely in litellm: the executor/advisor loop ran in-process and only the final, flattened executor response was returned. Claude Code drives its advisor UI from `server_tool_use` (name `advisor`) and `advisor_tool_result` content blocks; when the executor is non-Anthropic the server cannot run that loop, so this change has our orchestrator synthesize the same blocks, making the proxy path render identically to the native one. For streaming, the `server_tool_use` block is flushed before the advisor sub-call is awaited, so the advisor renders as in-progress for its real latency and resolves when the result arrives.

Also fixes `strip_advisor_blocks_from_messages` to recover advice text from the native `{"type":"advisor_result","text":...}` content shape (previously handled only str/list content and silently dropped the dict's text, breaking the multi-turn round-trip).

Also extracts the shared `build_content_block_chunks` helper in `fake_stream_iterator.py` and teaches it the `server_tool_use` and `advisor_tool_result` block types (previously unknown types were silently dropped from the stream).

**3. Attribute advisor spend to its own model** (scaledata/litellm#8)

When an advisor consult ran through the proxy, Claude Code's `/usage` attributed all spend to the executor model and showed nothing for the advisor model. Claude Code computes per-model usage from `usage.iterations[]` entries of `type:"advisor_message"`. This change emits `usage.iterations[]` from the orchestrator: one `advisor_message` entry per advisor sub-call, carrying the advisor model and its token counts, on both the non-streaming response and the streaming `message_delta`.

**4. Review feedback fixes**

Addresses all automated review findings:
- **Model authorization bypass** (Veria-AI, High): validates `advisor_model` against the caller's `UserAPIKeyAuth` via `can_key_call_model` before entering the loop, following the same pattern as the MCP sampling handler. Skipped in standalone SDK mode (no auth layer)
- **Duplicated `_sse` helper** (Greptile): removed the copy from `advisor.py`, now imports from `fake_stream_iterator.py`
- **`message_start.usage` zero tokens** (Greptile): the streaming path now peeks the first loop event to extract the executor's real `input_tokens` before emitting `message_start`, matching the Anthropic SSE protocol and `FakeAnthropicMessagesStreamIterator`
- **Orphan `content_block_stop`** (Greptile): `build_content_block_chunks` now only emits `content_block_stop` when a `content_block_start` was emitted, so unknown block types produce no chunks instead of a protocol-violating orphan stop

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

Run a proxy with a non-Anthropic executor and an Anthropic advisor, then drive the advisor through the streaming `/v1/messages` passthrough hitting real providers:

```yaml
# dev_config.yaml
model_list:
  - model_name: gemini-flash
    litellm_params:
      model: gemini/gemini-2.5-flash
      api_key: os.environ/GEMINI_API_KEY
  - model_name: opus-advisor
    litellm_params:
      model: anthropic/claude-opus-4-8
      api_key: os.environ/ANTHROPIC_API_KEY
```

```bash
python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log

curl -N http://localhost:4000/v1/messages \
  -H "content-type: application/json" -H "x-api-key: $LITELLM_MASTER_KEY" \
  -H "anthropic-beta: advisor-tool-2026-03-01" \
  -d '{"model":"gemini-flash","max_tokens":1024,"stream":true,
       "tools":[{"type":"advisor_20260301","name":"advisor","model":"opus-advisor"}],
       "messages":[{"role":"user","content":"Before answering, consult your advisor: cleanest way to debounce in React? Then summarize."}]}'
```

Expected SSE order: `content_block_start` for `server_tool_use` (name advisor), a pause for the advisor latency, then `content_block_start` for `advisor_tool_result`, then the executor text. The `message_start` carries real `input_tokens` from the executor, and the `message_delta` carries `usage.iterations[]` with the advisor model's token counts. In Claude Code pointed at the proxy with `/advisor opus-advisor`, the advisor dot shows in-progress then resolves, and `/usage` shows a separate cost line for the advisor model

## Type

🐛 Bug Fix

## Changes

See the "What and why" section above