### PR TITLE
fix(otel): stamp gen_ai.input/output.messages on v2 spans

### DIFF
--- a/litellm/integrations/otel/mappers/genai.py
+++ b/litellm/integrations/otel/mappers/genai.py
@@ -10,7 +10,12 @@ table: one lambda per mapping operation, applied against the typed span data.
 from typing import Callable
 
 from litellm.integrations.otel.mappers.base import AttributeMap, AttrValue, SpanData
-from litellm.integrations.otel.mappers.utils import collect, drop_none
+from litellm.integrations.otel.mappers.utils import (
+    collect,
+    drop_none,
+    output_messages,
+    serialize_messages,
+)
 from litellm.integrations.otel.model.payloads import (
     GuardrailSpanData,
     LLMCallSpanData,
@@ -47,6 +52,8 @@ class GenAIMapper:
             else None
         ),
         GenAI.REQUEST_SEED: lambda d: d.request_params.seed,
+        GenAI.INPUT_MESSAGES: lambda d: serialize_messages(d.messages_in),
+        GenAI.OUTPUT_MESSAGES: lambda d: serialize_messages(output_messages(d)),
         GenAI.RESPONSE_MODEL: lambda d: d.response_model,
         GenAI.RESPONSE_ID: lambda d: d.response_id,
         GenAI.RESPONSE_FINISH_REASONS: lambda d: (

--- a/tests/test_litellm/integrations/otel/test_otel_v2_components.py
+++ b/tests/test_litellm/integrations/otel/test_otel_v2_components.py
@@ -2,6 +2,8 @@
 baggage helpers, metrics, the typed coercion helpers, mapper branches, span-name
 builders, and the registry validator's failure paths. Needs the OTel SDK."""
 
+import json
+
 import pytest
 
 pytest.importorskip("opentelemetry")
@@ -223,6 +225,47 @@ def test_genai_mapper_all_request_params():
     assert attrs[GenAI.REQUEST_STOP_SEQUENCES] == ["STOP"]
     assert attrs[GenAI.REQUEST_SEED] == 42
     assert attrs["server.port"] == 443
+
+
+def test_genai_mapper_stamps_input_output_messages():
+    data = LLMCallSpanData(
+        operation=GenAIOperation.CHAT,
+        provider="openai",
+        request_model="gpt-4o",
+        response_model="gpt-4o-2024",
+        response_id="resp_1",
+        request_params=LLMRequestParams(),
+        usage=LLMUsage(),
+        finish_reasons=("stop",),
+        error=None,
+        response_cost=None,
+        server=None,
+        identity=RequestIdentity(call_id="c1"),
+        messages_in=(
+            {"role": "system", "content": "Be concise."},
+            {"role": "user", "content": "What's the weather?"},
+        ),
+        choices_out=(
+            {
+                "finish_reason": "stop",
+                "message": {"role": "assistant", "content": "Sunny."},
+            },
+        ),
+    )
+    attrs = GenAIMapper().map(data)
+    assert json.loads(attrs[GenAI.INPUT_MESSAGES]) == [
+        {"role": "system", "content": "Be concise."},
+        {"role": "user", "content": "What's the weather?"},
+    ]
+    assert json.loads(attrs[GenAI.OUTPUT_MESSAGES]) == [
+        {"role": "assistant", "content": "Sunny."}
+    ]
+
+
+def test_genai_mapper_omits_messages_when_content_not_captured():
+    attrs = GenAIMapper().map(_full_llm_call())
+    assert GenAI.INPUT_MESSAGES not in attrs
+    assert GenAI.OUTPUT_MESSAGES not in attrs
 
 
 def test_genai_mapper_cost_breakdown():


### PR DESCRIPTION
## Relevant issues

Resolves LIT-3788

## Linear ticket

LIT-3788

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Live proxy from this branch with the V2 OTel console span exporter, message capture on, hitting the real Anthropic API.

Config (`otel_proof_config.yaml`):

```yaml
model_list:
  - model_name: claude-haiku-4-5
    litellm_params:
      model: anthropic/claude-haiku-4-5
      api_key: os.environ/ANTHROPIC_API_KEY

litellm_settings:
  callbacks: ["otel"]

general_settings:
  master_key: sk-otel-proof-1234
```

Env and launch:

```bash
export LITELLM_OTEL_V2=true
export OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=span_and_event
export OTEL_EXPORTER=console
export OTEL_ENDPOINT=""   # console exporter, no OTLP endpoint
python litellm/proxy/proxy_cli.py --config otel_proof_config.yaml --port 4000
```

Request:

```bash
curl -sS http://localhost:4000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer sk-otel-proof-1234" \
  -d '{
    "model": "claude-haiku-4-5",
    "messages": [
      {"role": "system", "content": "You are a concise assistant."},
      {"role": "user", "content": "Say hello in exactly three words."}
    ]
  }'
```

Response content: `Hello world friend.`

Exported console span (gen_ai attributes shown); both `gen_ai.input.messages` and `gen_ai.output.messages` now appear with content:

```json
{
  "name": "chat claude-haiku-4-5",
  "kind": "SpanKind.CLIENT",
  "attributes": {
    "gen_ai.operation.name": "chat",
    "gen_ai.provider.name": "anthropic",
    "gen_ai.request.model": "claude-haiku-4-5",
    "gen_ai.response.model": "claude-haiku-4-5",
    "gen_ai.input.messages": "[{\"role\": \"system\", \"content\": \"You are a concise assistant.\"}, {\"role\": \"user\", \"content\": \"Say hello in exactly three words.\"}]",
    "gen_ai.output.messages": "[{\"content\": \"Hello world friend.\", \"role\": \"assistant\", \"tool_calls\": null, \"function_call\": null, \"provider_specific_fields\": {\"citations\": null, \"thinking_blocks\": null}}]",
    "gen_ai.usage.input_tokens": 21,
    "gen_ai.usage.output_tokens": 7
  }
}
```

## Type

🐛 Bug Fix

## Changes

The canonical GenAI mapper (`litellm/integrations/otel/mappers/genai.py`) declares the V2 span schema as an `attribute key -> extractor` table; the LLM-call table had no entries for `gen_ai.input.messages` or `gen_ai.output.messages`. The request and response bodies were already captured onto `LLMCallSpanData.messages_in` and `choices_out` (gated by `capture_span_content`, which `SPAN_AND_EVENT` turns on), but nothing read them back, so the canonical V2 spans never carried prompt or completion content. The OpenInference vendor mapper does emit them, which is why other vocabularies looked fine while the canonical one did not

This adds the two missing extractors, serializing `messages_in` and `output_messages(d)` through the existing `serialize_messages` helper. `serialize_messages` returns `None` for an empty sequence, so `collect`/`drop_none` omit the keys entirely when content capture is off; the spans stay sparse rather than carrying empty arrays

The regression test in `tests/test_litellm/integrations/otel/test_otel_v2_components.py` builds an `LLMCallSpanData` with non-empty `messages_in`/`choices_out`, runs `GenAIMapper().map(...)`, and asserts both keys round-trip the messages; a second test asserts the keys are absent when the bodies are empty. The first test fails on the pre-fix mapper with `KeyError: 'gen_ai.input.messages'`
