### PR TITLE
fix(otel): export v2 gen_ai client metrics to the configured meter provider

### DIFF
--- a/litellm/integrations/otel/README.md
+++ b/litellm/integrations/otel/README.md
@@ -216,7 +216,13 @@ lives in [`plumbing/`](./plumbing):
   `TracerProvider` so one logger serves many tenants. The cache is a bounded LRU
   that flushes + shuts down evicted providers, since the key derives from
   request-supplied credentials and must not grow (or leak threads) without limit.
-- [`metrics.py`](./plumbing/metrics.py) — GenAI client metric instruments.
+- [`metrics.py`](./plumbing/metrics.py) — GenAI client metric instruments. The
+  six `gen_ai.client.*` histograms are recorded through the meter resolved by
+  `providers.resolve_meter_provider`: an injected provider wins (tests/DI),
+  otherwise the operator's globally configured `MeterProvider` is reused so its
+  readers/exporters receive them alongside the server metrics, and one is built
+  and registered as the global only when none is set (mirroring how V2 owns trace
+  export).
 
 ### Adapter
 

--- a/litellm/integrations/otel/logger.py
+++ b/litellm/integrations/otel/logger.py
@@ -42,9 +42,10 @@ from litellm.integrations.otel.plumbing.metrics import (
     create_genai_metrics,
 )
 from litellm.integrations.otel.plumbing.providers import (
-    build_meter_provider,
     build_tracer_provider,
+    get_meter,
     get_tracer,
+    resolve_meter_provider,
 )
 from litellm.integrations.otel.plumbing.routing import TenantTracerCache
 from litellm.integrations.otel.model.spans import SpanRole, span_role_for_service
@@ -127,17 +128,15 @@ class OpenTelemetryV2(CustomLogger):
     def _init_metrics(self, meter_provider: Any | None) -> "GenAIMetricRecorder | None":
         """Create the six GenAI histograms when metrics are enabled, else ``None``.
 
-        ``meter_provider`` is an explicit override (tests inject one); otherwise a
-        provider is built from the config's exporter selection.
+        ``meter_provider`` is an explicit override (tests inject one); otherwise the
+        provider is resolved from the OTel global so the operator's configured
+        readers/exporters receive the metrics, building and registering one only
+        when no global provider is set.
         """
         if not self.config.enable_metrics:
             return None
-        provider = (
-            meter_provider
-            if meter_provider is not None
-            else build_meter_provider(self.config)
-        )
-        meter = provider.get_meter(LITELLM_TRACER_NAME)
+        provider = resolve_meter_provider(self.config, meter_provider)
+        meter = get_meter(provider, LITELLM_TRACER_NAME)
         return GenAIMetricRecorder(create_genai_metrics(meter), self.callback_name)
 
     # ====================================================================== #

--- a/litellm/integrations/otel/plumbing/providers.py
+++ b/litellm/integrations/otel/plumbing/providers.py
@@ -26,6 +26,7 @@ from litellm.integrations.otel.model.spans import LiteLLMSpanKind
 from litellm.integrations.otel.model.utils import parse_headers as parse_headers
 
 if TYPE_CHECKING:
+    from opentelemetry.metrics import Meter
     from opentelemetry.sdk.metrics import MeterProvider
     from opentelemetry.sdk.metrics.export import MetricReader
 
@@ -244,6 +245,38 @@ def build_meter_provider(
 
     reader = metric_reader if metric_reader is not None else build_metric_reader(config)
     return MeterProvider(metric_readers=[reader], resource=build_resource(config))
+
+
+def resolve_meter_provider(
+    config: OpenTelemetryV2Config,
+    meter_provider: "MeterProvider | None" = None,
+) -> "MeterProvider":
+    """Resolve the :class:`MeterProvider` GenAI metrics record through.
+
+    An injected provider wins (DI/tests). Otherwise reuse the operator's globally
+    configured ``MeterProvider`` when one is set, so its readers/exporters receive
+    the GenAI histograms alongside the server metrics. When none is set, build one
+    from the config and publish it as the OTel global so V2 owns metrics export
+    (mirroring how V2 owns trace export) and the server-metric instrumentation
+    shares it.
+    """
+    from opentelemetry import metrics
+    from opentelemetry.sdk.metrics import MeterProvider
+
+    if meter_provider is not None:
+        return meter_provider
+
+    existing = metrics.get_meter_provider()
+    if isinstance(existing, MeterProvider):
+        return existing
+
+    provider = build_meter_provider(config)
+    metrics.set_meter_provider(provider)
+    return provider
+
+
+def get_meter(provider: "MeterProvider", name: str = "litellm") -> "Meter":
+    return provider.get_meter(name, litellm_version)
 
 
 def build_resource(config: OpenTelemetryV2Config) -> Resource:

--- a/litellm/integrations/otel/plumbing/providers.py
+++ b/litellm/integrations/otel/plumbing/providers.py
@@ -4,8 +4,8 @@ from typing import TYPE_CHECKING, Any, Callable, Iterable
 
 from opentelemetry import baggage, metrics
 from opentelemetry.context import Context
-from opentelemetry.metrics import NoOpMeterProvider
-from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.metrics import MeterProvider, NoOpMeterProvider
+from opentelemetry.sdk.metrics import MeterProvider as SDKMeterProvider
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor, TracerProvider
 from opentelemetry.sdk.trace.export import (
@@ -235,7 +235,7 @@ def build_metric_reader(config: OpenTelemetryV2Config) -> "MetricReader":
 def build_meter_provider(
     config: OpenTelemetryV2Config,
     metric_reader: "MetricReader | None" = None,
-) -> MeterProvider:
+) -> SDKMeterProvider:
     """Build the :class:`MeterProvider` for GenAI metrics.
 
     ``metric_reader`` is an explicit override (tests inject an
@@ -243,7 +243,7 @@ def build_meter_provider(
     exporter kind via :func:`build_metric_reader`.
     """
     reader = metric_reader if metric_reader is not None else build_metric_reader(config)
-    return MeterProvider(metric_readers=[reader], resource=build_resource(config))
+    return SDKMeterProvider(metric_readers=[reader], resource=build_resource(config))
 
 
 def resolve_meter_provider(
@@ -265,7 +265,7 @@ def resolve_meter_provider(
         return meter_provider
 
     existing = metrics.get_meter_provider()
-    if isinstance(existing, (MeterProvider, NoOpMeterProvider)):
+    if isinstance(existing, (SDKMeterProvider, NoOpMeterProvider)):
         return existing
 
     provider = build_meter_provider(config)

--- a/litellm/integrations/otel/plumbing/providers.py
+++ b/litellm/integrations/otel/plumbing/providers.py
@@ -2,8 +2,10 @@
 
 from typing import TYPE_CHECKING, Any, Callable, Iterable
 
-from opentelemetry import baggage
+from opentelemetry import baggage, metrics
 from opentelemetry.context import Context
+from opentelemetry.metrics import NoOpMeterProvider
+from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor, TracerProvider
 from opentelemetry.sdk.trace.export import (
@@ -27,7 +29,6 @@ from litellm.integrations.otel.model.utils import parse_headers as parse_headers
 
 if TYPE_CHECKING:
     from opentelemetry.metrics import Meter
-    from opentelemetry.sdk.metrics import MeterProvider
     from opentelemetry.sdk.metrics.export import MetricReader
 
 _SPAN_KIND_BY_ROLE_KIND: dict[LiteLLMSpanKind, SpanKind] = {
@@ -234,40 +235,37 @@ def build_metric_reader(config: OpenTelemetryV2Config) -> "MetricReader":
 def build_meter_provider(
     config: OpenTelemetryV2Config,
     metric_reader: "MetricReader | None" = None,
-) -> "MeterProvider":
+) -> MeterProvider:
     """Build the :class:`MeterProvider` for GenAI metrics.
 
     ``metric_reader`` is an explicit override (tests inject an
     ``InMemoryMetricReader``); otherwise the reader is selected from the config's
     exporter kind via :func:`build_metric_reader`.
     """
-    from opentelemetry.sdk.metrics import MeterProvider
-
     reader = metric_reader if metric_reader is not None else build_metric_reader(config)
     return MeterProvider(metric_readers=[reader], resource=build_resource(config))
 
 
 def resolve_meter_provider(
     config: OpenTelemetryV2Config,
-    meter_provider: "MeterProvider | None" = None,
-) -> "MeterProvider":
+    meter_provider: MeterProvider | None = None,
+) -> MeterProvider:
     """Resolve the :class:`MeterProvider` GenAI metrics record through.
 
-    An injected provider wins (DI/tests). Otherwise reuse the operator's globally
-    configured ``MeterProvider`` when one is set, so its readers/exporters receive
-    the GenAI histograms alongside the server metrics. When none is set, build one
-    from the config and publish it as the OTel global so V2 owns metrics export
-    (mirroring how V2 owns trace export) and the server-metric instrumentation
-    shares it.
+    An injected provider wins (DI/tests). Otherwise reuse whatever the operator has
+    configured as the global, whether a real SDK provider or an explicit
+    ``NoOpMeterProvider``, so the GenAI histograms ride the operator's
+    readers/exporters and an explicit opt-out is honored. Only when the global is
+    still the default proxy placeholder does V2 build one from the config and
+    publish it as the global, mirroring how V2 owns trace export. The built
+    provider is the one returned, so its reader thread is always live, never
+    orphaned.
     """
-    from opentelemetry import metrics
-    from opentelemetry.sdk.metrics import MeterProvider
-
     if meter_provider is not None:
         return meter_provider
 
     existing = metrics.get_meter_provider()
-    if isinstance(existing, MeterProvider):
+    if isinstance(existing, (MeterProvider, NoOpMeterProvider)):
         return existing
 
     provider = build_meter_provider(config)
@@ -275,7 +273,7 @@ def resolve_meter_provider(
     return provider
 
 
-def get_meter(provider: "MeterProvider", name: str = "litellm") -> "Meter":
+def get_meter(provider: MeterProvider, name: str = "litellm") -> "Meter":
     return provider.get_meter(name, litellm_version)
 
 

--- a/tests/test_litellm/integrations/otel/test_otel_v2_metrics.py
+++ b/tests/test_litellm/integrations/otel/test_otel_v2_metrics.py
@@ -250,6 +250,50 @@ def test_no_filter_keeps_high_cardinality_keys():
             assert expected.issubset(set(dp.attributes.keys()))
 
 
+@pytest.fixture
+def operator_global_meter_provider():
+    """Install an operator-configured global ``MeterProvider`` (the way an app
+    wires its own metric exporter) and restore the previous global afterwards.
+
+    The operator owns the meter provider here -- the logger is given no provider
+    of its own -- so the GenAI histograms have to be recorded through the global
+    for the operator's reader to see them. Writes the global slot directly (the
+    same one ``metrics.set_meter_provider``/``get_meter_provider`` use) because
+    the public setter is set-once and can't be undone between tests."""
+    from opentelemetry import metrics
+    from opentelemetry.metrics import _internal as metrics_internal
+
+    reader = InMemoryMetricReader()
+    provider = MeterProvider(metric_readers=[reader])
+    saved_provider = metrics_internal._METER_PROVIDER
+    saved_once = metrics_internal._METER_PROVIDER_SET_ONCE
+    metrics_internal._METER_PROVIDER = provider
+    assert metrics.get_meter_provider() is provider
+    try:
+        yield reader
+    finally:
+        metrics_internal._METER_PROVIDER = saved_provider
+        metrics_internal._METER_PROVIDER_SET_ONCE = saved_once
+        provider.shutdown()
+
+
+def test_metrics_reach_operator_configured_global_provider(
+    operator_global_meter_provider,
+):
+    """Regression: with no meter provider injected, the six gen_ai.client.*
+    histograms must record through the operator's globally configured
+    MeterProvider so its readers/exporters receive them. Before the fix the logger
+    built an isolated provider and the operator's reader saw nothing."""
+    reader = operator_global_meter_provider
+    logger = OpenTelemetryV2(
+        config=OpenTelemetryV2Config(exporter="in_memory", enable_metrics=True),
+    )
+    kwargs, response_obj, start, end = _build_call()
+    asyncio.run(logger.async_log_success_event(kwargs, response_obj, start, end))
+
+    assert set(_metrics_by_name(reader).keys()) == set(ALL_METRICS)
+
+
 def _recorder(monkeypatch, attributes):
     """A recorder wired to a fresh in-memory meter, with callback_settings carrying
     `attributes`. record() resolves the filter lazily from there, so a misconfig

--- a/tests/test_litellm/integrations/otel/test_otel_v2_metrics.py
+++ b/tests/test_litellm/integrations/otel/test_otel_v2_metrics.py
@@ -33,6 +33,9 @@ from litellm.integrations.otel.plumbing.metrics import (  # noqa: E402
     GenAIMetricRecorder,
     create_genai_metrics,
 )
+from litellm.integrations.otel.plumbing.providers import (  # noqa: E402
+    resolve_meter_provider,
+)
 
 OPERATION_DURATION = "gen_ai.client.operation.duration"
 TOKEN_USAGE = "gen_ai.client.token.usage"
@@ -250,41 +253,17 @@ def test_no_filter_keeps_high_cardinality_keys():
             assert expected.issubset(set(dp.attributes.keys()))
 
 
-@pytest.fixture
-def operator_global_meter_provider():
-    """Install an operator-configured global ``MeterProvider`` (the way an app
-    wires its own metric exporter) and restore the previous global afterwards.
-
-    The operator owns the meter provider here -- the logger is given no provider
-    of its own -- so the GenAI histograms have to be recorded through the global
-    for the operator's reader to see them. Writes the global slot directly (the
-    same one ``metrics.set_meter_provider``/``get_meter_provider`` use) because
-    the public setter is set-once and can't be undone between tests."""
-    from opentelemetry import metrics
-    from opentelemetry.metrics import _internal as metrics_internal
-
-    reader = InMemoryMetricReader()
-    provider = MeterProvider(metric_readers=[reader])
-    saved_provider = metrics_internal._METER_PROVIDER
-    saved_once = metrics_internal._METER_PROVIDER_SET_ONCE
-    metrics_internal._METER_PROVIDER = provider
-    assert metrics.get_meter_provider() is provider
-    try:
-        yield reader
-    finally:
-        metrics_internal._METER_PROVIDER = saved_provider
-        metrics_internal._METER_PROVIDER_SET_ONCE = saved_once
-        provider.shutdown()
-
-
-def test_metrics_reach_operator_configured_global_provider(
-    operator_global_meter_provider,
-):
+def test_metrics_reach_operator_configured_global_provider(monkeypatch):
     """Regression: with no meter provider injected, the six gen_ai.client.*
     histograms must record through the operator's globally configured
     MeterProvider so its readers/exporters receive them. Before the fix the logger
     built an isolated provider and the operator's reader saw nothing."""
-    reader = operator_global_meter_provider
+    from opentelemetry import metrics
+
+    reader = InMemoryMetricReader()
+    operator_provider = MeterProvider(metric_readers=[reader])
+    monkeypatch.setattr(metrics, "get_meter_provider", lambda: operator_provider)
+
     logger = OpenTelemetryV2(
         config=OpenTelemetryV2Config(exporter="in_memory", enable_metrics=True),
     )
@@ -292,6 +271,30 @@ def test_metrics_reach_operator_configured_global_provider(
     asyncio.run(logger.async_log_success_event(kwargs, response_obj, start, end))
 
     assert set(_metrics_by_name(reader).keys()) == set(ALL_METRICS)
+    operator_provider.shutdown()
+
+
+def test_resolve_meter_provider_prefers_injected():
+    """An injected provider is used verbatim, never replaced by the global."""
+    injected = MeterProvider(metric_readers=[InMemoryMetricReader()])
+    resolved = resolve_meter_provider(
+        OpenTelemetryV2Config(exporter="in_memory"), injected
+    )
+    assert resolved is injected
+    injected.shutdown()
+
+
+def test_resolve_meter_provider_honors_operator_noop(monkeypatch):
+    """An operator that disabled metrics with a NoOpMeterProvider is not silently
+    overridden by a freshly built provider."""
+    from opentelemetry import metrics
+    from opentelemetry.metrics import NoOpMeterProvider
+
+    noop = NoOpMeterProvider()
+    monkeypatch.setattr(metrics, "get_meter_provider", lambda: noop)
+
+    resolved = resolve_meter_provider(OpenTelemetryV2Config(exporter="in_memory"))
+    assert resolved is noop
 
 
 def _recorder(monkeypatch, attributes):


### PR DESCRIPTION
## Relevant issues

Resolves LIT-3789

## Linear ticket

Resolves LIT-3789

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Root cause

With `LITELLM_OTEL_V2=true` and `LITELLM_OTEL_INTEGRATION_ENABLE_METRICS=true`, the V2 OpenTelemetry integration records the six `gen_ai.client.*` histograms but they never reach an operator's metric exporter. An earlier read of this suspected `plumbing/metrics.py` was dead code and the meter provider was never referenced; that is inaccurate. `logger.py` imports `create_genai_metrics`/`GenAIMetricRecorder`/`build_meter_provider`, calls `_init_metrics` in `__init__`, and records via `_record_metrics` in the success path, so the recording code does run.

The real defect is that `_init_metrics` built a brand-new `MeterProvider` locally via `build_meter_provider` and recorded the histograms into it without ever publishing it. That provider is disconnected from the global meter pipeline the operator configures, so the GenAI histograms land somewhere the operator cannot see while the FastAPI server metrics, which bind to the global meter provider, show up fine. This contrasts with the trace side, where the proxy publishes the V2 `TracerProvider` as the OTel global so server spans and gen-ai spans share one provider.

This builds directly on #30326 (merged), which introduced the six `gen_ai.client.*` histograms and the private `MeterProvider`. That PR made the metrics record; this one makes them reach the operator's exporter

## Fix

Resolve the meter provider the OTel-idiomatic way in `providers.resolve_meter_provider`. An injected `meter_provider` still wins for DI and tests. Otherwise the operator's globally configured `MeterProvider` is reused when one is set, so its readers and exporters receive the GenAI histograms alongside the server metrics; when none is set, V2 builds one from the config and registers it as the global so it owns metrics export, mirroring how V2 owns trace export today. The logger now obtains its meter from that resolved provider with the LiteLLM scope version stamped, consistent with `get_tracer`.

## Changes

- `plumbing/providers.py`: add `resolve_meter_provider` (reuse global, else build and register) and a `get_meter` helper that stamps the LiteLLM scope version
- `logger.py`: `_init_metrics` resolves the provider through `resolve_meter_provider` instead of always building a private one
- `tests/test_litellm/integrations/otel/test_otel_v2_metrics.py`: regression test proving the histograms reach an operator-configured global `MeterProvider` when no provider is injected
- `integrations/otel/README.md`: document the metric provider resolution

## Screenshots / Proof of Fix

Live proxy on port 4001 with V2 OTel and GenAI metrics on. An operator-owned global `MeterProvider` with a `ConsoleMetricExporter` is installed at interpreter startup via a `sitecustomize.py` (the way an application owns metrics), and a real OpenAI `gpt-4o-mini` chat completion is driven through `/v1/chat/completions`.

Launch (identical before and after):

```bash
export PYTHONPATH=/tmp/otel_bootstrap:$PWD
export OPERATOR_CONSOLE_METRICS=1          # sitecustomize sets a global console MeterProvider
export LITELLM_OTEL_V2=true
export LITELLM_OTEL_INTEGRATION_ENABLE_METRICS=true
export OTEL_EXPORTER=otlp_http
export OTEL_ENDPOINT=http://127.0.0.1:9999  # keep the pre-fix isolated provider off the operator console
python litellm/proxy/proxy_cli.py --config proof.yaml --port 4001 --num_workers 1
```

```bash
curl -s http://localhost:4001/v1/chat/completions \
  -H "Content-Type: application/json" -H "Authorization: Bearer sk-1234" \
  -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Say hello in 3 words"}]}'
# -> {"id":"chatcmpl-...","model":"gpt-4o-mini","choices":[{"message":{"content":"Hello, how are you?"...
```

Metric names seen in the operator's console export before the fix; the FastAPI server metrics arrive but no `gen_ai.client.*`:

```
   3 "name": "http.server.active_requests"
   3 "name": "http.server.duration"
   3 "name": "http.server.request.size"
   3 "name": "http.server.response.size"
   3 "name": "opentelemetry.instrumentation.fastapi"
gen_ai.client count: 0
```

Same operator console after the fix; the `gen_ai.client.*` histograms now arrive under the `litellm` scope alongside the server metrics:

```
   1 "name": "gen_ai.client.operation.duration"
   1 "name": "gen_ai.client.response.duration"
   1 "name": "gen_ai.client.token.cost"
   1 "name": "gen_ai.client.token.usage"
   2 "name": "http.server.active_requests"
   1 "name": "http.server.duration"
   1 "name": "http.server.request.size"
   1 "name": "http.server.response.size"
   1 "name": "litellm"
   2 "name": "opentelemetry.instrumentation.fastapi"
gen_ai.client count: 10
```

One exported `gen_ai.client.operation.duration` data point from the operator console after the fix:

```json
{
  "scope": "litellm",
  "metric": {
    "name": "gen_ai.client.operation.duration",
    "description": "GenAI operation duration",
    "unit": "s",
    "data": {
      "data_points": [
        {
          "attributes": {
            "gen_ai.operation.name": "chat",
            "gen_ai.system": "openai",
            "gen_ai.request.model": "gpt-4o-mini",
            "gen_ai.framework": "litellm"
          }
        }
      ]
    }
  }
}
```

## Type

🐛 Bug Fix

