### PR TITLE
fix(budget): recompute budget_reset_at when budget_duration changes on /budget/update

### DIFF
--- a/litellm/proxy/common_utils/timezone_utils.py
+++ b/litellm/proxy/common_utils/timezone_utils.py
@@ -15,7 +15,7 @@ def get_budget_reset_timezone():
     return getattr(litellm, "timezone", None) or "UTC"
 
 
-def get_budget_reset_time(budget_duration: str):
+def get_budget_reset_time(budget_duration: str) -> datetime:
     """
     Get the budget reset time based on the configured timezone.
     Falls back to UTC if not specified.

--- a/litellm/proxy/management_endpoints/budget_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/budget_management_endpoints.py
@@ -183,10 +183,23 @@ async def update_budget(
         except ValueError as e:
             raise HTTPException(status_code=400, detail={"error": str(e)})
 
+    # recompute budget_reset_at when the duration changes, unless the caller pinned a reset time explicitly
+    recomputed_reset_at = (
+        {
+            "budget_reset_at": get_budget_reset_time(
+                budget_duration=budget_obj.budget_duration
+            )
+        }
+        if budget_obj.budget_duration is not None
+        and "budget_reset_at" not in budget_obj.model_fields_set
+        else {}
+    )
+
     response = await BudgetRepository(prisma_client).table.update(
         where={"budget_id": budget_obj.budget_id},
         data={
             **budget_obj.model_dump(exclude_unset=True),  # type: ignore
+            **recomputed_reset_at,
             "updated_by": user_api_key_dict.user_id or litellm_proxy_admin_name,
         },  # type: ignore
     )

--- a/tests/test_litellm/proxy/management_endpoints/test_budget_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_budget_endpoints.py
@@ -3,6 +3,7 @@
 import os
 import sys
 import types
+from datetime import datetime, timedelta, timezone
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 from fastapi.testclient import TestClient
@@ -10,7 +11,6 @@ from fastapi.testclient import TestClient
 import litellm.proxy.proxy_server as ps
 from litellm.proxy.proxy_server import app
 from litellm.proxy._types import UserAPIKeyAuth, LitellmUserRoles, CommonProxyErrors
-
 
 sys.path.insert(
     0, os.path.abspath("../../../")
@@ -265,3 +265,98 @@ async def test_new_budget_invalid_model_max_budget(client_and_mocks, monkeypatch
     assert resp.status_code in (400, 422), resp.text
     detail = resp.json()["detail"]
     assert "model_max_budget" in str(detail) or "dictionary" in str(detail).lower()
+
+
+def _capture_update_data(mock_table):
+    captured = {}
+
+    async def capture(*, where, data):
+        captured.update(data)
+        return {**where, **data}
+
+    mock_table.update = AsyncMock(side_effect=capture)
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_update_budget_recomputes_reset_at_when_duration_changes(
+    client_and_mocks,
+):
+    """
+    Regression for LIT-3362: shortening budget_duration without an explicit
+    budget_reset_at must bring the reset forward instead of leaving it pinned
+    to the previous (longer) schedule.
+    """
+    client, _, mock_table = client_and_mocks
+    captured = _capture_update_data(mock_table)
+
+    before = datetime.now(timezone.utc)
+    resp = client.post(
+        "/budget/update",
+        json={"budget_id": "budget_reset_recompute", "budget_duration": "1d"},
+    )
+    assert resp.status_code == 200, resp.text
+
+    assert (
+        "budget_reset_at" in captured
+    ), "duration change must recompute budget_reset_at"
+    reset_at = captured["budget_reset_at"]
+    assert isinstance(reset_at, datetime)
+    assert reset_at > before, "recomputed reset must be in the future"
+    # "1d" resets at the next standardized day boundary, always within ~24h
+    assert reset_at <= before + timedelta(days=1, hours=1), reset_at
+    # and it must be far closer than a stale 30d schedule would have left it
+    assert reset_at < before + timedelta(days=29)
+
+
+@pytest.mark.asyncio
+async def test_update_budget_preserves_explicit_reset_at(client_and_mocks):
+    """An explicit budget_reset_at from the caller always wins over recompute."""
+    client, _, mock_table = client_and_mocks
+    captured = _capture_update_data(mock_table)
+
+    explicit = datetime(2027, 1, 1, tzinfo=timezone.utc)
+    resp = client.post(
+        "/budget/update",
+        json={
+            "budget_id": "budget_explicit_reset",
+            "budget_duration": "1d",
+            "budget_reset_at": explicit.isoformat(),
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+    assert captured["budget_reset_at"] == explicit
+
+
+@pytest.mark.asyncio
+async def test_update_budget_without_duration_leaves_reset_at_untouched(
+    client_and_mocks,
+):
+    """Updates that do not touch budget_duration must not introduce budget_reset_at."""
+    client, _, mock_table = client_and_mocks
+    captured = _capture_update_data(mock_table)
+
+    resp = client.post(
+        "/budget/update",
+        json={"budget_id": "budget_other_field", "max_budget": 200.0},
+    )
+    assert resp.status_code == 200, resp.text
+
+    assert "budget_reset_at" not in captured
+
+
+@pytest.mark.asyncio
+async def test_update_budget_duration_none_does_not_recompute(client_and_mocks):
+    """Clearing budget_duration (explicit null) must not recompute against a None duration."""
+    client, _, mock_table = client_and_mocks
+    captured = _capture_update_data(mock_table)
+
+    resp = client.post(
+        "/budget/update",
+        json={"budget_id": "budget_clear_duration", "budget_duration": None},
+    )
+    assert resp.status_code == 200, resp.text
+
+    assert "budget_duration" in captured and captured["budget_duration"] is None
+    assert "budget_reset_at" not in captured


### PR DESCRIPTION
## Relevant issues

Resolves LIT-3362

## Linear ticket

LIT-3362

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of 5/5** (no files require attention)

## Summary

`POST /budget/update` did not recompute `budget_reset_at` when `budget_duration` changed and no explicit `budget_reset_at` was supplied. Shortening a budget therefore did not bring its reset forward; the row stayed pinned to the prior, longer schedule and would not reset until that old timestamp fired. The same defect reached `POST /team/update` through `team_member_budget_duration`, since that path delegates to `update_budget` via `TeamMemberBudgetHandler.upsert_team_member_budget_table`. In the reported case a team had daily resets silently blocked for about 7 days after a duration was shortened from `1mo` to `1d`.

## Fix

In `update_budget` (`litellm/proxy/management_endpoints/budget_management_endpoints.py`), when the caller sets `budget_duration` without pinning `budget_reset_at`, recompute `budget_reset_at = get_budget_reset_time(budget_duration)` before the write. This mirrors what `/budget/new` already does. The guard keys off `budget_obj.model_fields_set`, so a caller-supplied `budget_reset_at` always wins and updates that do not touch `budget_duration` leave the reset alone. Clearing the duration (`budget_duration: null`) does not recompute against a `None` duration, which keeps the team member budget clear path correct.

```python
recomputed_reset_at = (
    {"budget_reset_at": get_budget_reset_time(budget_duration=budget_obj.budget_duration)}
    if budget_obj.budget_duration is not None and "budget_reset_at" not in budget_obj.model_fields_set
    else {}
)
```

Fixing `update_budget` fixes the team path for free; no separate change to `team_endpoints.py` is needed.

## Type

🐛 Bug Fix

## Changes

- `litellm/proxy/management_endpoints/budget_management_endpoints.py`: recompute `budget_reset_at` in `update_budget` when the duration changes and the caller did not pin a reset time
- `litellm/proxy/common_utils/timezone_utils.py`: declare the `datetime` return type on `get_budget_reset_time` so the recomputed value stays concretely typed (keeps the Any-discipline gate green)
- `tests/test_litellm/proxy/management_endpoints/test_budget_endpoints.py`: 4 regression tests added to the existing mapped test file

## Screenshots / Proof of Fix

Real proxy backed by a Postgres container, hitting the live `/budget/*` management endpoints. The proxy was launched against the worktree via `PYTHONPATH`, with the fix stashed for the BEFORE run and restored for the AFTER run; same proxy config, fresh process per run. `/health/readiness` returned `{"status":"healthy","db":"connected"}` before each capture.

Launch (per run):

```
docker run -d --name lit3362-pg -e POSTGRES_PASSWORD=litellm -e POSTGRES_USER=litellm \
  -e POSTGRES_DB=litellm -p 5433:5432 postgres:16
DATABASE_URL=postgresql://litellm:litellm@127.0.0.1:5433/litellm \
PYTHONPATH=$PWD python litellm/proxy/proxy_cli.py --config config.yaml --port 4000 --use_v2_migration_resolver
```

### Before fix (duration change ignored)

```
### now=2026-06-16T19:27:01Z
-- POST /budget/new   {"budget_id":"lit3362-b2","max_budget":100,"budget_duration":"30d"}
   duration: 30d   reset_at: 2026-07-01T00:00:00Z
-- POST /budget/update {"budget_id":"lit3362-b2","budget_duration":"1d"}   (no budget_reset_at)
   duration: 1d    reset_at: 2026-07-01T00:00:00Z
-- POST /budget/info  read-back
   duration: 1d    reset_at: 2026-07-01T00:00:00Z   <-- BUG: still pinned to the 30d schedule
```

### After fix (duration change recomputes)

```
### now=2026-06-16T19:27:30Z   (1d -> next UTC midnight 2026-06-17)
-- POST /budget/new   {"budget_id":"lit3362-a2","max_budget":100,"budget_duration":"30d"}
   duration: 30d   reset_at: 2026-07-01T00:00:00Z
-- POST /budget/update {"budget_id":"lit3362-a2","budget_duration":"1d"}   (no budget_reset_at)
   duration: 1d    reset_at: 2026-06-17T00:00:00Z   <-- FIXED: recomputed to the 1d schedule
-- POST /budget/info  read-back
   duration: 1d    reset_at: 2026-06-17T00:00:00Z

### Edge 1: explicit budget_reset_at is preserved (not recomputed)
-- POST /budget/update {"budget_id":"lit3362-a2","budget_duration":"7d","budget_reset_at":"2027-01-01T00:00:00Z"}
   duration: 7d    reset_at: 2027-01-01T00:00:00Z

### Edge 2: update other field only (no budget_duration) leaves reset_at untouched
-- POST /budget/update {"budget_id":"lit3362-a2","max_budget":250}
   max_budget: 250.0   reset_at: 2027-01-01T00:00:00Z
```

## Tests

Four regression tests were added to the existing mapped file `tests/test_litellm/proxy/management_endpoints/test_budget_endpoints.py` (per the convention of extending the mapped test file for bug fixes):

- `test_update_budget_recomputes_reset_at_when_duration_changes` - a duration-only update recomputes `budget_reset_at` to a future time within the new (shorter) window. This is the direct regression guard; it fails against the unfixed handler.
- `test_update_budget_preserves_explicit_reset_at` - an explicit `budget_reset_at` from the caller is preserved even when `budget_duration` is also present.
- `test_update_budget_without_duration_leaves_reset_at_untouched` - an update that does not include `budget_duration` does not introduce `budget_reset_at`.
- `test_update_budget_duration_none_does_not_recompute` - clearing the duration (`budget_duration: null`) does not recompute against a `None` duration.

```
tests/test_litellm/proxy/management_endpoints/test_budget_endpoints.py ............... [100%]
15 passed
```

Mutation check: with the production change reverted, `test_update_budget_recomputes_reset_at_when_duration_changes` fails ("duration change must recompute budget_reset_at"); it passes only with the fix in place. The 11 pre-existing tests in the file continue to pass.


## CI status

CI run for the latest commit: https://github.com/BerriAI/litellm/actions/runs/27643359968 — 120/121 checks green. The single red check is `lint`, which fails on the repo-wide basedpyright budget gate (main has drifted above its committed ceilings; identical failure on all open PRs). This PR adds zero basedpyright errors; `budgets / Run tests`, `any-discipline`, MyPy, Black, and the ruff strict-rule budget are all green.

Greptile: Confidence Score 5/5 (no files require attention).