### PR TITLE
fix(mcp): send configured auth when fetching the OpenAPI spec for MCP servers

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -847,6 +847,7 @@ class MCPServerManager:
             get_base_url as get_openapi_base_url,
         )
         from litellm.proxy._experimental.mcp_server.openapi_to_mcp_generator import (
+            build_openapi_auth_headers,
             load_openapi_spec_async,
             resolve_operation_params,
         )
@@ -855,44 +856,19 @@ class MCPServerManager:
         )
 
         try:
-            # Load OpenAPI spec (async to avoid "called from within a running event loop")
-            spec = await load_openapi_spec_async(spec_path)
-
-            # Use base_url from config if provided, otherwise extract from spec
-            if not base_url:
-                base_url = get_openapi_base_url(spec, spec_path)
-            verbose_logger.info(
-                f"Registering OpenAPI tools for server {server.name} with base URL: {base_url}"
-            )
-
-            # Get server prefix for tool naming
-            server_prefix = get_server_prefix(server)
-
-            # Build headers from server configuration
-            headers: Dict[str, str] = {}
-
-            # Add authentication headers if configured
-            if server.authentication_token:
-                from litellm.types.mcp import MCPAuth
-
-                if server.auth_type == MCPAuth.bearer_token:
-                    headers["Authorization"] = f"Bearer {server.authentication_token}"
-                elif server.auth_type == MCPAuth.api_key:
-                    headers["Authorization"] = f"ApiKey {server.authentication_token}"
-                elif server.auth_type == MCPAuth.basic:
-                    headers["Authorization"] = f"Basic {server.authentication_token}"
-                elif server.auth_type == MCPAuth.token:
-                    headers["Authorization"] = f"token {server.authentication_token}"
-
-            # Add any static headers from server config.
+            # Build headers from server configuration first so a spec hosted
+            # behind the same credential as its endpoints downloads with auth
+            # instead of returning 401.
             #
             # Note: `extra_headers` on MCPServer is a List[str] of header names to forward
             # from each client MCP request; values are applied at call time via
             # `_request_extra_headers` in server.py (not baked in here).
             # `static_headers` is a dict of concrete headers to always send.
-            headers = (
+            headers: Dict[str, str] = (
                 merge_mcp_headers(
-                    extra_headers=headers,
+                    extra_headers=build_openapi_auth_headers(
+                        server.auth_type, server.authentication_token
+                    ),
                     static_headers=server.static_headers,
                 )
                 or {}
@@ -901,6 +877,24 @@ class MCPServerManager:
             verbose_logger.debug(
                 f"Using headers for OpenAPI tools (excluding sensitive values): {list(headers.keys())}"
             )
+
+            # Load OpenAPI spec (async to avoid "called from within a running event loop")
+            spec = await load_openapi_spec_async(  # any-ok: OpenAPI spec is arbitrary external JSON
+                spec_path, headers=headers
+            )
+
+            # Use base_url from config if provided, otherwise extract from spec
+            if not base_url:
+                base_url = get_openapi_base_url(
+                    spec,  # any-ok: OpenAPI spec is arbitrary external JSON
+                    spec_path,
+                )
+            verbose_logger.info(
+                f"Registering OpenAPI tools for server {server.name} with base URL: {base_url}"
+            )
+
+            # Get server prefix for tool naming
+            server_prefix = get_server_prefix(server)
 
             # Extract and register tools from OpenAPI paths
             paths = spec.get("paths", {})

--- a/litellm/proxy/_experimental/mcp_server/openapi_to_mcp_generator.py
+++ b/litellm/proxy/_experimental/mcp_server/openapi_to_mcp_generator.py
@@ -86,6 +86,29 @@ def _sanitize_path_parameter_value(param_value: Any, param_name: str) -> str:
     return quote(value_str, safe="")
 
 
+def build_openapi_auth_headers(
+    auth_type: Optional[str], auth_value: Optional[str]
+) -> Dict[str, str]:
+    """Map a configured MCP auth_type + token to upstream Authorization headers.
+
+    Shared by the spec fetch and the per-tool request builder so a protected
+    OpenAPI spec (one that requires the same credential as its endpoints) is
+    downloaded with auth instead of returning 401. ``auth_type`` is compared by
+    string value to avoid importing the ``MCPAuth`` enum into this module.
+    """
+    if not auth_value or not auth_type:
+        return {}
+    scheme = {
+        "bearer_token": "Bearer",
+        "api_key": "ApiKey",
+        "basic": "Basic",
+        "token": "token",
+    }.get(auth_type)
+    if scheme is None:
+        return {}
+    return {"Authorization": f"{scheme} {auth_value}"}
+
+
 def load_openapi_spec(filepath: str) -> Dict[str, Any]:
     """
     Sync wrapper. For URL specs, use the shared/custom MCP httpx client.
@@ -104,10 +127,14 @@ def load_openapi_spec(filepath: str) -> Dict[str, Any]:
     return asyncio.run(load_openapi_spec_async(filepath))
 
 
-async def load_openapi_spec_async(filepath: str) -> Dict[str, Any]:
+async def load_openapi_spec_async(
+    filepath: str, headers: Optional[Dict[str, str]] = None
+) -> Dict[str, Any]:
     if filepath.startswith("http://") or filepath.startswith("https://"):
         client = get_async_httpx_client(llm_provider=httpxSpecialProvider.MCP)
-        r = await async_safe_get(client, filepath)
+        r = await async_safe_get(  # any-ok: async_safe_get is an untyped (-> Any) shared helper
+            client, filepath, headers=headers or {}
+        )
         r.raise_for_status()
         return r.json()
 

--- a/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
@@ -1045,7 +1045,9 @@ if MCP_AVAILABLE:
                 "message": _connection_error_message(e),
             }
 
-    async def _preview_openapi_tools(spec_path: str) -> dict:
+    async def _preview_openapi_tools(
+        spec_path: str, headers: Optional[Dict[str, str]] = None
+    ) -> dict:
         """Generate tool previews from an OpenAPI spec without creating a server."""
         from litellm.proxy._experimental.mcp_server.openapi_to_mcp_generator import (
             _OPENAPI_TOOL_NAME_MAX_LEN,
@@ -1056,7 +1058,9 @@ if MCP_AVAILABLE:
         )
 
         try:
-            spec = await load_openapi_spec_async(spec_path)
+            spec = await load_openapi_spec_async(  # any-ok: OpenAPI spec is arbitrary external JSON
+                spec_path, headers=headers
+            )
             paths = spec.get("paths", {})
             components = spec.get("components", {})
             tools: List[dict] = []
@@ -1164,9 +1168,25 @@ if MCP_AVAILABLE:
             new_mcp_server_request
         )
 
-        # For OpenAPI spec servers, generate tools from the spec directly
+        # For OpenAPI spec servers, generate tools from the spec directly.
+        # Send the configured credential so a spec hosted behind the same auth
+        # as its endpoints can be fetched instead of returning 401.
         if new_mcp_server_request.spec_path:
-            return await _preview_openapi_tools(new_mcp_server_request.spec_path)
+            from litellm.proxy._experimental.mcp_server.openapi_to_mcp_generator import (
+                build_openapi_auth_headers,
+            )
+
+            credentials = new_mcp_server_request.credentials or {}
+            spec_headers = {
+                **build_openapi_auth_headers(
+                    new_mcp_server_request.auth_type,
+                    credentials.get("auth_value"),
+                ),
+                **(new_mcp_server_request.static_headers or {}),
+            }
+            return await _preview_openapi_tools(  # any-ok: preview returns a loose tool-list payload
+                new_mcp_server_request.spec_path, headers=spec_headers
+            )
 
         from litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp import (
             MCPRequestHandler,

--- a/tests/mcp_tests/test_openapi_spec_path_url.py
+++ b/tests/mcp_tests/test_openapi_spec_path_url.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from typing import Any, Dict
 
 import httpx
@@ -98,3 +99,55 @@ def test_load_openapi_spec_supports_local_file_path(
 
     spec = gen.load_openapi_spec(str(p))
     assert spec == expected
+
+
+@pytest.mark.parametrize(
+    "auth_type, auth_value, expected",
+    [
+        ("bearer_token", "tok", {"Authorization": "Bearer tok"}),
+        ("api_key", "tok", {"Authorization": "ApiKey tok"}),
+        ("basic", "tok", {"Authorization": "Basic tok"}),
+        ("token", "tok", {"Authorization": "token tok"}),
+        ("oauth2", "tok", {}),
+        ("bearer_token", None, {}),
+        (None, "tok", {}),
+    ],
+)
+def test_build_openapi_auth_headers(auth_type, auth_value, expected) -> None:
+    assert gen.build_openapi_auth_headers(auth_type, auth_value) == expected
+
+
+def test_load_openapi_spec_forwards_auth_headers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: a spec hosted behind the same Bearer credential as its
+    endpoints must be fetched WITH the Authorization header, otherwise the
+    upstream returns 401 before the server can be added."""
+    url = "http://example.local/openapi.json"
+    expected: Dict[str, Any] = {
+        "openapi": "3.0.0",
+        "info": {"title": "Protected API", "version": "1.0.0"},
+        "paths": {},
+    }
+    req = httpx.Request("GET", url)
+    resp = httpx.Response(status_code=200, json=expected, request=req)
+
+    monkeypatch.setattr(
+        gen,
+        "get_async_httpx_client",
+        lambda *a, **k: _FakeAsyncHTTPHandler(resp, expected_url=url),
+    )
+
+    seen: Dict[str, Any] = {}
+
+    async def fake_async_safe_get(client, request_url, **kw):
+        seen["headers"] = kw.get("headers")
+        return await client.get(request_url)
+
+    monkeypatch.setattr(gen, "async_safe_get", fake_async_safe_get)
+
+    auth_headers = gen.build_openapi_auth_headers("bearer_token", "secret-token")
+    spec = asyncio.run(gen.load_openapi_spec_async(url, headers=auth_headers))
+
+    assert spec == expected
+    assert seen["headers"] == {"Authorization": "Bearer secret-token"}

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
@@ -1610,7 +1610,7 @@ class TestPreviewOpenAPITools:
     async def test_preview_sanitizes_slash_in_operation_id(self, monkeypatch):
         import re
 
-        async def fake_load_spec(spec_path):  # noqa: ANN001
+        async def fake_load_spec(spec_path, headers=None):  # noqa: ANN001
             return {
                 "paths": {
                     "/repos/{owner}/{repo}/actions/jobs/{job_id}/logs": {
@@ -1691,7 +1691,7 @@ class TestPreviewOpenAPITools:
             }
         }
 
-        async def fake_load_spec(spec_path):  # noqa: ANN001
+        async def fake_load_spec(spec_path, headers=None):  # noqa: ANN001
             return spec
 
         monkeypatch.setattr(
@@ -1755,6 +1755,48 @@ class TestPreviewOpenAPITools:
             "order is out of sync, so collision suffixes (_2, _3, ...) "
             "land on different operations"
         )
+
+    async def test_preview_sends_bearer_token_to_protected_spec(self, monkeypatch):
+        """Regression: when the operator configures a Bearer token, the preview
+        must fetch the OpenAPI spec WITH that Authorization header. A spec
+        hosted behind the same credential as its endpoints otherwise returns
+        401 and the user can never add the server."""
+        seen: dict = {}
+
+        async def fake_load_spec(spec_path, headers=None):  # noqa: ANN001
+            seen["headers"] = headers
+            return {"paths": {}}
+
+        from litellm.proxy._experimental.mcp_server import (
+            openapi_to_mcp_generator,
+        )
+
+        monkeypatch.setattr(
+            openapi_to_mcp_generator,
+            "load_openapi_spec_async",
+            fake_load_spec,
+            raising=False,
+        )
+
+        payload = NewMCPServerRequest(
+            server_name="protected_openapi_mcp",
+            spec_path="https://example.invalid/openapi.json",
+            transport="http",
+            auth_type="bearer_token",
+            credentials={"auth_value": "secret-token"},
+        )
+        request = _build_request()
+
+        from litellm.proxy._types import LitellmUserRoles
+
+        result = await rest_endpoints.test_tools_list(
+            request,
+            payload,
+            user_api_key_dict=UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN),
+        )
+
+        assert result.get("error") is None, result
+        assert seen["headers"] == {"Authorization": "Bearer secret-token"}
 
 
 class TestConnectionErrorMessage:


### PR DESCRIPTION
## Relevant issues

Fixes #30560

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Serve an OpenAPI spec behind a Bearer token, then drive the dashboard the same way the bug reporter does. The steps below assume a proxy running on `localhost:4000` and a spec at `https://your-host/openapi.json` that requires `Authorization: Bearer <token>`.

1. Open http://localhost:4000/ui and sign in as an admin
2. Go to MCP Servers and click Add New MCP Server
3. Pick the OpenAPI spec option and paste the protected spec URL
4. Set Authentication to Bearer Token and paste a valid token
5. Click the button that previews the tools

Before this change the preview returns a 401 and no tools, while the same URL with the token returns the spec from Postman. After this change the preview lists the tools from the spec.

The same path can be exercised without the UI by calling the preview endpoint directly:

```bash
curl -s http://localhost:4000/v1/mcp/server/test/tools/list \
  -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d '{
        "server_name": "protected_openapi_mcp",
        "transport": "http",
        "spec_path": "https://your-host/openapi.json",
        "auth_type": "bearer_token",
        "credentials": {"auth_value": "<your-upstream-token>"}
      }'
```

Before the fix this returns `{"tools": [], "error": true, "message": "Failed to load OpenAPI spec: ... 401 ..."}`. After the fix it returns the tools parsed from the spec.

## Type

🐛 Bug Fix

## Changes

OpenAPI-backed MCP servers downloaded the spec document (`spec_path`) without sending the configured credential. `load_openapi_spec_async` issued a plain GET with no Authorization header in both the dashboard tools preview (`/v1/mcp/server/test/tools/list`) and the registration path in `mcp_server_manager._register_openapi_tools`. A spec hosted behind the same credential as its endpoints, which is the common case, replied 401 and the server could never be added, even though the token was correct and Postman loaded the same URL fine.

This adds `build_openapi_auth_headers`, a small shared helper that maps the configured `auth_type` and token to the upstream Authorization header for the supported schemes (bearer_token, api_key, basic, token). `load_openapi_spec_async` now accepts an optional `headers` argument and forwards it on the GET. The registration path builds the credential before downloading the spec and reuses it for both the spec fetch and the generated tool calls, replacing the previous inline auth branching. The dashboard preview sends the credential from the submitted request, including the static headers.

This is distinct from the request-time `extra_headers` forwarding in #27383 and #26864, which only covers headers sent while executing a tool; the spec fetch itself was still unauthenticated, which is the gap closed here.

Tests cover the credential mapping for each scheme, that `load_openapi_spec_async` forwards the Authorization header on the fetch, and that the dashboard preview sends the Bearer token through to the spec download.
