### PR TITLE
fix(otel): accept UPPER_SNAKE_CASE OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT in v2

### DIFF
--- a/litellm/integrations/otel/model/config.py
+++ b/litellm/integrations/otel/model/config.py
@@ -184,6 +184,20 @@ class OpenTelemetryV2Config(BaseSettings):
         ),
     )
 
+    @field_validator("capture_message_content", mode="before")
+    @classmethod
+    def _normalize_capture_message_content(cls, value: object) -> object:
+        """Fold the capture mode to its canonical lower_snake_case form.
+
+        V1 read this env var case-insensitively, so operators set the
+        UPPER_SNAKE_CASE form (e.g. ``SPAN_AND_EVENT``). The canonical values
+        here are lower_snake_case; normalizing at the boundary keeps both
+        spellings working and lets every downstream comparison stay exact.
+        """
+        if isinstance(value, str):
+            return value.lower()
+        return value
+
     @field_validator(
         "baggage_promoted_keys",
         "baggage_metadata_keys",

--- a/tests/test_litellm/integrations/otel/test_otel_v2_sources_of_truth.py
+++ b/tests/test_litellm/integrations/otel/test_otel_v2_sources_of_truth.py
@@ -528,6 +528,22 @@ def test_capture_span_content_resolves_modes():
         ).capture_span_content
         is False
     )
+    # V1 accepted UPPER_SNAKE_CASE; the env value is case-insensitive so an
+    # operator carrying ``SPAN_AND_EVENT`` forward still enables capture.
+    assert (
+        OpenTelemetryV2Config(
+            capture_message_content="SPAN_AND_EVENT"
+        ).capture_span_content
+        is True
+    )
+    assert (
+        OpenTelemetryV2Config(capture_message_content="SPAN_ONLY").capture_span_content
+        is True
+    )
+    assert (
+        OpenTelemetryV2Config(capture_message_content="NO_CONTENT").capture_span_content
+        is False
+    )
 
 
 def test_v2_flag_is_off_by_default(monkeypatch):

--- a/tests/test_litellm/integrations/otel/test_otel_v2_sources_of_truth.py
+++ b/tests/test_litellm/integrations/otel/test_otel_v2_sources_of_truth.py
@@ -546,6 +546,19 @@ def test_capture_span_content_resolves_modes():
     )
 
 
+def test_capture_message_content_normalizer_only_touches_strings():
+    """The casing normalizer lower-cases strings and leaves anything else
+    untouched, so a non-string value still fails the field's ``str`` validation
+    instead of being silently coerced into a bogus capture mode."""
+    import pytest
+    from pydantic import ValidationError
+
+    from litellm.integrations.otel.model.config import OpenTelemetryV2Config
+
+    with pytest.raises(ValidationError):
+        OpenTelemetryV2Config(capture_message_content=123)
+
+
 def test_v2_flag_is_off_by_default(monkeypatch):
     monkeypatch.delenv("LITELLM_OTEL_V2", raising=False)
     assert is_otel_v2_enabled() is False


### PR DESCRIPTION
## Relevant issues

Follow-up to the OTel V2 content-capture work in #30548. Once the genai mapper learned to stamp `gen_ai.input.messages` / `gen_ai.output.messages`, a second regression became visible: the capture mode env var is case-sensitive in V2.

## Linear ticket

Resolves LIT-3791

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile returned 5/5)

## What's the bug

`OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` used to be case-insensitive. V1 (`litellm/integrations/opentelemetry.py`) normalizes the value with `.upper()` before matching, so an operator could set the documented UPPER_SNAKE_CASE form `SPAN_AND_EVENT` and content capture turned on.

In V2 (`litellm/integrations/otel/model/config.py`), `OpenTelemetryV2Config.capture_span_content` compares `self.capture_message_content` directly against the lower_snake_case canonical constants (`span_only`, `span_and_event`) with no normalization. An operator who carries their V1 setting `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=SPAN_AND_EVENT` forward gets `capture_span_content == False`, `messages_in` stays empty, and `gen_ai.input.messages` / `gen_ai.output.messages` never land on the span. No error is raised; capture just silently stays off. Only the lowercase `span_and_event` worked.

## The fix

Normalize the value to lower case once at the config boundary with a `field_validator` on `capture_message_content`, so the stored value is always canonical and every downstream comparison stays exact. This restores V1's case-insensitive behavior; `SPAN_AND_EVENT` and `span_and_event` both enable capture now.

## Screenshots / Proof of Fix

Live proxy against the real OpenAI API with the OTel V2 console exporter, using the uppercase `SPAN_AND_EVENT` value an operator would carry over from V1. The only thing that changes between the two runs is this one-line fix.

Launch (console exporter forced so spans print to the log; only `OPENAI_API_KEY` is taken from `.env`):

```bash
export OPENAI_API_KEY=...                       # real key
export LITELLM_OTEL_V2=1
export OTEL_EXPORTER=console
export OTEL_ENDPOINT=""                          # keep the console exporter (no OTLP)
export OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=SPAN_AND_EVENT
python litellm/proxy/proxy_cli.py --config config.yaml --port 4000 > proxy.log 2>&1 &
```

```yaml
# config.yaml
model_list:
  - model_name: gpt-4o-mini
    litellm_params:
      model: openai/gpt-4o-mini
      api_key: os.environ/OPENAI_API_KEY
litellm_settings:
  callbacks: ["otel"]
general_settings:
  master_key: sk-1234
```

Send one real chat completion, then read the gen_ai attribute keys off the exported span:

```bash
curl -s http://localhost:4000/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -H 'Authorization: Bearer sk-1234' \
  -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hello there reply with the single word ok"}]}'

grep -oE '"gen_ai\.[a-z_.]+":' proxy.log | sort -u
```

The curl returns a real completion (`"content":"ok"`) in both runs, so the upstream call is healthy in both; the difference is purely whether the prompt/response are captured.

Before the fix, the span is exported but carries no message content:

```
"gen_ai.operation.name":
"gen_ai.provider.name":
"gen_ai.request.model":
"gen_ai.response.finish_reasons":
"gen_ai.response.id":
"gen_ai.response.model":
"gen_ai.system":
"gen_ai.usage.completion_tokens":
"gen_ai.usage.input_tokens":
"gen_ai.usage.output_tokens":
"gen_ai.usage.prompt_tokens":
"gen_ai.usage.total_tokens":
```

After the fix, the same uppercase `SPAN_AND_EVENT` now captures the content:

```
"gen_ai.input.messages":          <-- new
"gen_ai.operation.name":
"gen_ai.output.messages":         <-- new
"gen_ai.provider.name":
"gen_ai.request.model":
"gen_ai.response.finish_reasons":
"gen_ai.response.id":
"gen_ai.response.model":
"gen_ai.system":
"gen_ai.usage.completion_tokens":
"gen_ai.usage.input_tokens":
"gen_ai.usage.output_tokens":
"gen_ai.usage.prompt_tokens":
"gen_ai.usage.total_tokens":
```

and the stamped attribute holds the actual prompt:

```
"gen_ai.input.messages": "[{\"role\": \"user\", \"content\": \"hello there reply with the single word ok\"...
```

The regression test `test_capture_span_content_resolves_modes` asserts `OpenTelemetryV2Config(capture_message_content="SPAN_AND_EVENT").capture_span_content is True`; it fails on the unfixed config (the casing makes it `False`) and passes with the fix.

## Type

🐛 Bug Fix

## Changes

`litellm/integrations/otel/model/config.py` gains a `mode="before"` `field_validator` on `capture_message_content` that lower-cases the incoming value, so the canonical lower_snake_case constants match regardless of the casing an operator supplies. The mapped test `tests/test_litellm/integrations/otel/test_otel_v2_sources_of_truth.py` is extended to cover the UPPER_SNAKE_CASE inputs `SPAN_AND_EVENT`, `SPAN_ONLY`, and `NO_CONTENT`
