### PR TITLE
fix(proxy): require admin role for credential management endpoints

### DIFF
--- a/litellm/proxy/credential_endpoints/endpoints.py
+++ b/litellm/proxy/credential_endpoints/endpoints.py
@@ -10,7 +10,7 @@ import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.litellm_core_utils.credential_accessor import CredentialAccessor
 from litellm.litellm_core_utils.litellm_logging import _get_masked_values
-from litellm.proxy._types import CommonProxyErrors, UserAPIKeyAuth
+from litellm.proxy._types import CommonProxyErrors, LitellmUserRoles, UserAPIKeyAuth
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 from litellm.proxy.common_utils.encrypt_decrypt_utils import encrypt_value_helper
 from litellm.proxy.utils import handle_exception_on_proxy, jsonify_object
@@ -60,6 +60,11 @@ async def create_credential(
     from litellm.proxy.proxy_server import llm_router, prisma_client
 
     try:
+        if user_api_key_dict.user_role != LitellmUserRoles.PROXY_ADMIN:
+            raise HTTPException(
+                status_code=403,
+                detail={"error": "Only proxy admins can manage credentials"},
+            )
         if prisma_client is None:
             raise HTTPException(
                 status_code=500,
@@ -241,6 +246,11 @@ async def delete_credential(
     from litellm.proxy.proxy_server import prisma_client
 
     try:
+        if user_api_key_dict.user_role != LitellmUserRoles.PROXY_ADMIN:
+            raise HTTPException(
+                status_code=403,
+                detail={"error": "Only proxy admins can manage credentials"},
+            )
         if prisma_client is None:
             raise HTTPException(
                 status_code=500,
@@ -320,6 +330,11 @@ async def update_credential(
     from litellm.proxy.proxy_server import prisma_client
 
     try:
+        if user_api_key_dict.user_role != LitellmUserRoles.PROXY_ADMIN:
+            raise HTTPException(
+                status_code=403,
+                detail={"error": "Only proxy admins can manage credentials"},
+            )
         if prisma_client is None:
             raise HTTPException(
                 status_code=500,


### PR DESCRIPTION
## What

Add role-based authorization to credential CRUD endpoints.

## Why

The credential management endpoints (`POST /credentials`, `DELETE /credentials/{name}`, `PATCH /credentials/{name}`) currently verify authentication (valid API key) but do not check the caller's role. This means any authenticated user can manage credentials, which should be an admin-only operation.

This aligns the credential endpoints with the authorization pattern used by other admin-only endpoints (model management, config, MCP).

## How

Added `PROXY_ADMIN` role check at the top of each credential endpoint handler:

```python
if user_api_key_dict.user_role != LitellmUserRoles.PROXY_ADMIN:
    raise HTTPException(
        status_code=403,
        detail={"error": "Only proxy admins can manage credentials"},
    )
```

Applied to all three mutating endpoints (create, delete, update). The GET endpoint remains accessible to authenticated users for credential listing.

## Testing

- Admin users can create/delete/update credentials as before
- Non-admin users receive 403 Forbidden

## Breaking changes

Users who previously relied on non-admin API keys to manage credentials will need to use admin keys. This is a security hardening change.