### PR TITLE
fix(proxy): enforce budget ceiling when non-admin users generate keys

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -735,13 +735,10 @@ async def _common_key_generation_helper(  # noqa: PLR0915
     # check if user set upperbound key/generate params on config.yaml
     _enforce_upperbound_key_params(data, fill_defaults=True)
 
-    # Delegated-authority ceiling (GHSA-q775-qw9r-2r4g): a non-admin caller
-    # with an explicit budget cannot grant a key a higher budget than their own.
-    # Callers with max_budget=None (unlimited) can delegate any budget.
-    # A UI/CLI session token's max_budget is a per-session chat spend cap
-    # (max_ui_session_budget), not a delegation authority, so it is exempt only
-    # when creating a team key - that key's spend is bounded by the team budget
-    # at request time. Personal keys keep the ceiling; nothing else bounds them.
+    # Delegated-authority ceiling: a non-admin caller cannot grant a key a
+    # higher budget than their own. A UI/CLI session token's max_budget is a
+    # per-session chat spend cap, not a delegation authority, so it is exempt
+    # when creating a team key - that key's spend is bounded by the team budget.
     is_ui_session_team_key = (
         user_api_key_dict.team_id == UI_SESSION_TOKEN_TEAM_ID
         and _requested_team_id is not None
@@ -749,19 +746,10 @@ async def _common_key_generation_helper(  # noqa: PLR0915
     if (
         user_api_key_dict.user_role != LitellmUserRoles.PROXY_ADMIN.value
         and not is_ui_session_team_key
-        and _requested_max_budget is not None
         and user_api_key_dict.max_budget is not None
-        and _requested_max_budget > user_api_key_dict.max_budget
     ):
-        raise HTTPException(
-            status_code=400,
-            detail={
-                "error": (
-                    f"max_budget ({_requested_max_budget}) cannot exceed the caller's "
-                    f"own max_budget ({user_api_key_dict.max_budget})."
-                )
-            },
-        )
+        if data.max_budget is None or data.max_budget > user_api_key_dict.max_budget:
+            data.max_budget = user_api_key_dict.max_budget
 
     # APPLY ENTERPRISE KEY MANAGEMENT PARAMS
     try:


### PR DESCRIPTION
## What

Cap new API key budgets at the creator's own max_budget for non-admin users.

## Why

When a non-admin user with a `max_budget` set generates a new API key without specifying `max_budget`, the new key currently gets no budget limit. This allows budget-constrained users to effectively bypass their spending limits by creating uncapped keys.

## How

Instead of raising an error when budget exceeds the caller's limit, silently cap the new key's budget at the creator's own `max_budget`:

```python
if (
    user_api_key_dict.user_role != LitellmUserRoles.PROXY_ADMIN.value
    and not is_ui_session_team_key
    and user_api_key_dict.max_budget is not None
):
    if data.max_budget is None or data.max_budget > user_api_key_dict.max_budget:
        data.max_budget = user_api_key_dict.max_budget
```

- Admin users remain unrestricted
- UI session team keys remain exempt (bounded by team budget)
- Non-admin users get their key budget capped rather than an error

## Testing

- Admin can still create unlimited keys
- Non-admin with budget=100 creating key with no budget → key gets budget=100
- Non-admin with budget=100 creating key with budget=50 → key gets budget=50

## Breaking changes

Non-admin users who previously created keys with higher budgets than their own will now have those keys silently capped. This provides defense in depth for budget enforcement.