### PR TITLE
fix(realtime): relax logging object results type to accept unknown GA event types

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -3,7 +3,7 @@
 import logging
 import time
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, List, Literal, Optional, Tuple, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union, cast
 
 from httpx import Response
 from pydantic import BaseModel
@@ -81,7 +81,6 @@ from litellm.types.llms.openai import (
     HttpxBinaryResponseContent,
     ImageGenerationRequestQuality,
     OpenAIModerationResponse,
-    OpenAIRealtimeStreamList,
     OpenAIRealtimeStreamResponseBaseObject,
     OpenAIRealtimeStreamSessionEvents,
     ResponseAPIUsage,
@@ -316,9 +315,7 @@ def cost_per_token(  # noqa: PLR0915
     ### SERVICE TIER ###
     service_tier: Optional[str] = None,  # for OpenAI service tier pricing
     ### DATA RESIDENCY ###
-    data_residency: Optional[
-        str
-    ] = None,  # for OpenAI regional-processing uplift (e.g. "eu", "us")
+    data_residency: Optional[str] = None,  # for OpenAI regional-processing uplift (e.g. "eu", "us")
     response: Optional[Any] = None,
     ### REQUEST MODEL ###
     request_model: Optional[str] = None,  # original request model for router detection
@@ -375,9 +372,7 @@ def cost_per_token(  # noqa: PLR0915
             # either `cache_write_tokens` (kimi-k2) or `cache_creation_tokens`.
             # Mirror db_spend_update_writer to stay symmetric.
             _cache_creation_tokens = float(
-                getattr(_pt_details, "cache_write_tokens", 0)
-                or getattr(_pt_details, "cache_creation_tokens", 0)
-                or 0
+                getattr(_pt_details, "cache_write_tokens", 0) or getattr(_pt_details, "cache_creation_tokens", 0) or 0
             )
 
         _anthropic_read = getattr(usage_object, "cache_read_input_tokens", None)
@@ -450,12 +445,8 @@ def cost_per_token(  # noqa: PLR0915
         else:
             model_with_provider = f"{custom_llm_provider}/{model}"
         if region_name is not None:
-            model_with_provider_and_region = (
-                f"{custom_llm_provider}/{region_name}/{model}"
-            )
-            if (
-                model_with_provider_and_region in model_cost_ref
-            ):  # use region based pricing, if it's available
+            model_with_provider_and_region = f"{custom_llm_provider}/{region_name}/{model}"
+            if model_with_provider_and_region in model_cost_ref:  # use region based pricing, if it's available
                 model_with_provider = model_with_provider_and_region
     else:
         _, custom_llm_provider, _, _ = litellm.get_llm_provider(model=model)
@@ -474,9 +465,7 @@ def cost_per_token(  # noqa: PLR0915
     Option2. model = "openai/gpt-4"       - model = provider/model
     Option3. model = "anthropic.claude-3" - model = model
     """
-    if (
-        model_with_provider in model_cost_ref
-    ):  # Option 2. use model with provider, model = "openai/gpt-4"
+    if model_with_provider in model_cost_ref:  # Option 2. use model with provider, model = "openai/gpt-4"
         model = model_with_provider
     elif model in model_cost_ref:  # Option 1. use model passed, model="gpt-4"
         model = model
@@ -487,9 +476,7 @@ def cost_per_token(  # noqa: PLR0915
 
     # see this https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
     if call_type == "speech" or call_type == "aspeech":
-        speech_model_info = litellm.get_model_info(
-            model=model_without_prefix, custom_llm_provider=custom_llm_provider
-        )
+        speech_model_info = litellm.get_model_info(model=model_without_prefix, custom_llm_provider=custom_llm_provider)
         cost_metric = select_cost_metric_for_model(speech_model_info)
         prompt_cost: float = 0.0
         completion_cost: float = 0.0
@@ -586,11 +573,7 @@ def cost_per_token(  # noqa: PLR0915
             model=model,
             custom_llm_provider=custom_llm_provider,
             number_of_queries=number_of_queries or 1,
-            optional_params=(
-                response._hidden_params
-                if response and hasattr(response, "_hidden_params")
-                else None
-            ),
+            optional_params=(response._hidden_params if response and hasattr(response, "_hidden_params") else None),
         )
     elif custom_llm_provider == "vertex_ai":
         cost_router = google_cost_router(
@@ -616,9 +599,7 @@ def cost_per_token(  # noqa: PLR0915
     elif custom_llm_provider == "anthropic":
         return anthropic_cost_per_token(model=model, usage=usage_block)
     elif custom_llm_provider == "bedrock":
-        return bedrock_cost_per_token(
-            model=model, usage=usage_block, service_tier=service_tier
-        )
+        return bedrock_cost_per_token(model=model, usage=usage_block, service_tier=service_tier)
     elif custom_llm_provider == "openai":
         return openai_cost_per_token(
             model=model,
@@ -638,9 +619,7 @@ def cost_per_token(  # noqa: PLR0915
             service_tier=service_tier,
         )
     elif custom_llm_provider == "gemini":
-        return gemini_cost_per_token(
-            model=model, usage=usage_block, service_tier=service_tier
-        )
+        return gemini_cost_per_token(model=model, usage=usage_block, service_tier=service_tier)
     elif custom_llm_provider == "deepseek":
         return deepseek_cost_per_token(model=model, usage=usage_block)
     elif custom_llm_provider == "perplexity":
@@ -664,13 +643,9 @@ def cost_per_token(  # noqa: PLR0915
             service_tier=service_tier,
         )
     else:
-        model_info = _cached_get_model_info_helper(
-            model=model, custom_llm_provider=custom_llm_provider
-        )
+        model_info = _cached_get_model_info_helper(model=model, custom_llm_provider=custom_llm_provider)
 
-        if (model_info.get("input_cost_per_token") or 0.0) > 0 or (
-            model_info.get("output_cost_per_token") or 0.0
-        ) > 0:
+        if (model_info.get("input_cost_per_token") or 0.0) > 0 or (model_info.get("output_cost_per_token") or 0.0) > 0:
             return generic_cost_per_token(
                 model=model,
                 usage=usage_block,
@@ -679,10 +654,7 @@ def cost_per_token(  # noqa: PLR0915
                 data_residency=data_residency,
             )
 
-        if (
-            model_info.get("input_cost_per_second", None) is not None
-            and response_time_ms is not None
-        ):
+        if model_info.get("input_cost_per_second", None) is not None and response_time_ms is not None:
             verbose_logger.debug(
                 "For model=%s - input_cost_per_second: %s; response time: %s",
                 model,
@@ -694,10 +666,7 @@ def cost_per_token(  # noqa: PLR0915
                 model_info["input_cost_per_second"] * response_time_ms / 1000  # type: ignore
             )
 
-        if (
-            model_info.get("output_cost_per_second", None) is not None
-            and response_time_ms is not None
-        ):
+        if model_info.get("output_cost_per_second", None) is not None and response_time_ms is not None:
             verbose_logger.debug(
                 "For model=%s - output_cost_per_second: %s; response time: %s",
                 model,
@@ -721,7 +690,9 @@ def cost_per_token(  # noqa: PLR0915
 def get_replicate_completion_pricing(completion_response: dict, total_time=0.0):
     # see https://replicate.com/pricing
     # for all litellm currently supported LLMs, almost all requests go to a100_80gb
-    a100_80gb_price_per_second_public = DEFAULT_REPLICATE_GPU_PRICE_PER_SECOND  # assume all calls sent to A100 80GB for now
+    a100_80gb_price_per_second_public = (
+        DEFAULT_REPLICATE_GPU_PRICE_PER_SECOND  # assume all calls sent to A100 80GB for now
+    )
     if total_time == 0.0:  # total time is in ms
         start_time = completion_response.get("created", time.time())
         end_time = getattr(completion_response, "ended", time.time())
@@ -770,9 +741,7 @@ def _select_model_name_for_cost_calc(
 
     return_model: Optional[str] = None
     region_name: Optional[str] = None
-    custom_llm_provider = _get_provider_for_cost_calc(
-        model=model, custom_llm_provider=custom_llm_provider
-    )
+    custom_llm_provider = _get_provider_for_cost_calc(model=model, custom_llm_provider=custom_llm_provider)
 
     completion_response_model: Optional[str] = None
     if completion_response is not None:
@@ -785,10 +754,7 @@ def _select_model_name_for_cost_calc(
     if custom_pricing is True:
         if router_model_id is not None and router_model_id in litellm.model_cost:
             entry = litellm.model_cost[router_model_id]
-            if (
-                entry.get("input_cost_per_token") is not None
-                or entry.get("input_cost_per_second") is not None
-            ):
+            if entry.get("input_cost_per_token") is not None or entry.get("input_cost_per_second") is not None:
                 return_model = router_model_id
             else:
                 return_model = model
@@ -799,14 +765,9 @@ def _select_model_name_for_cost_calc(
         return_model = base_model
 
     elif completion_response_model is None and hidden_params is not None:
-        if (
-            hidden_params.get("model", None) is not None
-            and len(hidden_params["model"]) > 0
-        ):
+        if hidden_params.get("model", None) is not None and len(hidden_params["model"]) > 0:
             return_model = hidden_params.get("model", model)
-    elif (
-        hidden_params is not None and hidden_params.get("region_name", None) is not None
-    ):
+    elif hidden_params is not None and hidden_params.get("region_name", None) is not None:
         region_name = hidden_params.get("region_name", None)
 
     if return_model is None and completion_response_model is not None:
@@ -906,20 +867,12 @@ def _get_usage_object(
         and (isinstance(usage_obj, dict) or isinstance(usage_obj, ResponseAPIUsage))
         and ResponseAPILoggingUtils._is_response_api_usage(usage_obj)
     ):
-        return ResponseAPILoggingUtils._transform_response_api_usage_to_chat_usage(
-            usage_obj
-        )
-    elif TranscriptionUsageObjectTransformation.is_transcription_usage_object(
-        usage_obj
-    ):
-        return (
-            TranscriptionUsageObjectTransformation.transform_transcription_usage_object(
-                cast(
-                    Union[
-                        TranscriptionUsageDurationObject, TranscriptionUsageTokensObject
-                    ],
-                    usage_obj,
-                )
+        return ResponseAPILoggingUtils._transform_response_api_usage_to_chat_usage(usage_obj)
+    elif TranscriptionUsageObjectTransformation.is_transcription_usage_object(usage_obj):
+        return TranscriptionUsageObjectTransformation.transform_transcription_usage_object(
+            cast(
+                Union[TranscriptionUsageDurationObject, TranscriptionUsageTokensObject],
+                usage_obj,
             )
         )
     elif isinstance(usage_obj, dict):
@@ -927,9 +880,7 @@ def _get_usage_object(
     elif isinstance(usage_obj, BaseModel):
         return Usage(**usage_obj.model_dump())
     else:
-        verbose_logger.debug(
-            f"Unknown usage object type: {type(usage_obj)}, usage_obj: {usage_obj}"
-        )
+        verbose_logger.debug(f"Unknown usage object type: {type(usage_obj)}, usage_obj: {usage_obj}")
         return None
 
 
@@ -938,24 +889,18 @@ def _is_known_usage_objects(usage_obj):
     return (
         isinstance(usage_obj, litellm.Usage)
         or isinstance(usage_obj, ResponseAPIUsage)
-        or TranscriptionUsageObjectTransformation.is_transcription_usage_object(
-            usage_obj
-        )
+        or TranscriptionUsageObjectTransformation.is_transcription_usage_object(usage_obj)
     )
 
 
-def _infer_call_type(
-    call_type: Optional[CallTypesLiteral], completion_response: Any
-) -> Optional[CallTypesLiteral]:
+def _infer_call_type(call_type: Optional[CallTypesLiteral], completion_response: Any) -> Optional[CallTypesLiteral]:
     if call_type is not None:
         return call_type
 
     if completion_response is None:
         return None
 
-    if isinstance(completion_response, ModelResponse) or isinstance(
-        completion_response, ModelResponseStream
-    ):
+    if isinstance(completion_response, ModelResponse) or isinstance(completion_response, ModelResponseStream):
         return "completion"
     elif isinstance(completion_response, EmbeddingResponse):
         return "embedding"
@@ -1000,7 +945,7 @@ def _apply_cost_discount(
 
         if verbose_logger.isEnabledFor(logging.DEBUG):
             verbose_logger.debug(
-                f"Applied {discount_percent*100}% discount to {custom_llm_provider}: "
+                f"Applied {discount_percent * 100}% discount to {custom_llm_provider}: "
                 f"${original_cost:.6f} -> ${final_cost:.6f} (saved ${discount_amount:.6f})"
             )
 
@@ -1033,9 +978,7 @@ def _apply_cost_margin(
     if custom_llm_provider and custom_llm_provider in litellm.cost_margin_config:
         margin_config = litellm.cost_margin_config[custom_llm_provider]
         if verbose_logger.isEnabledFor(logging.DEBUG):
-            verbose_logger.debug(
-                f"Found provider-specific margin config for {custom_llm_provider}: {margin_config}"
-            )
+            verbose_logger.debug(f"Found provider-specific margin config for {custom_llm_provider}: {margin_config}")
     elif "global" in litellm.cost_margin_config:
         margin_config = litellm.cost_margin_config["global"]
         if verbose_logger.isEnabledFor(logging.DEBUG):
@@ -1068,7 +1011,7 @@ def _apply_cost_margin(
             verbose_logger.debug(
                 f"Applied margin to {custom_llm_provider or 'global'}: "
                 f"${original_cost:.6f} -> ${final_cost:.6f} "
-                f"(margin: {margin_percent*100 if margin_percent > 0 else 0}% + ${margin_fixed_amount:.6f} = ${margin_total_amount:.6f})"
+                f"(margin: {margin_percent * 100 if margin_percent > 0 else 0}% + ${margin_fixed_amount:.6f} = ${margin_total_amount:.6f})"
             )
 
         return final_cost, margin_percent, margin_fixed_amount, margin_total_amount
@@ -1164,9 +1107,7 @@ def completion_cost(  # noqa: PLR0915
     ### SERVICE TIER ###
     service_tier: Optional[str] = None,  # for OpenAI service tier pricing
     ### DATA RESIDENCY ###
-    data_residency: Optional[
-        str
-    ] = None,  # for OpenAI regional-processing uplift (e.g. "eu", "us")
+    data_residency: Optional[str] = None,  # for OpenAI regional-processing uplift (e.g. "eu", "us")
 ) -> float:
     """
     Calculate the cost of a given completion call fot GPT-3.5-turbo, llama2, any litellm supported llm.
@@ -1215,9 +1156,7 @@ def completion_cost(  # noqa: PLR0915
         cache_creation_input_tokens: Optional[int] = None
         cache_read_input_tokens: Optional[int] = None
         audio_transcription_file_duration: float = 0.0
-        cost_per_token_usage_object: Optional[Usage] = _get_usage_object(
-            completion_response=completion_response
-        )
+        cost_per_token_usage_object: Optional[Usage] = _get_usage_object(completion_response=completion_response)
         rerank_billed_units: Optional[RerankBilledUnits] = None
 
         # Extract service_tier from optional_params if not provided directly
@@ -1234,9 +1173,7 @@ def completion_cost(  # noqa: PLR0915
         # Extract service_tier from usage object if not provided
         if service_tier is None and cost_per_token_usage_object is not None:
             if isinstance(cost_per_token_usage_object, BaseModel):
-                service_tier = getattr(
-                    cost_per_token_usage_object, "service_tier", None
-                )
+                service_tier = getattr(cost_per_token_usage_object, "service_tier", None)
             elif isinstance(cost_per_token_usage_object, dict):
                 service_tier = cost_per_token_usage_object.get("service_tier")
 
@@ -1259,23 +1196,16 @@ def completion_cost(  # noqa: PLR0915
         for idx, model in enumerate(potential_model_names):
             try:
                 if verbose_logger.isEnabledFor(logging.DEBUG):
-                    verbose_logger.debug(
-                        f"selected model name for cost calculation: {model}"
-                    )
+                    verbose_logger.debug(f"selected model name for cost calculation: {model}")
 
                 if completion_response is not None and (
-                    isinstance(completion_response, BaseModel)
-                    or isinstance(completion_response, dict)
+                    isinstance(completion_response, BaseModel) or isinstance(completion_response, dict)
                 ):  # tts returns a custom class
                     if isinstance(completion_response, dict):
-                        usage_obj: Optional[Union[dict, Usage]] = (
-                            completion_response.get("usage", {})
-                        )
+                        usage_obj: Optional[Union[dict, Usage]] = completion_response.get("usage", {})
                     else:
                         usage_obj = getattr(completion_response, "usage", {})
-                    if isinstance(usage_obj, BaseModel) and not _is_known_usage_objects(
-                        usage_obj=usage_obj
-                    ):
+                    if isinstance(usage_obj, BaseModel) and not _is_known_usage_objects(usage_obj=usage_obj):
                         _usage_for_dump = cast(BaseModel, usage_obj)
                         setattr(
                             completion_response,
@@ -1293,9 +1223,7 @@ def completion_cost(  # noqa: PLR0915
                         _usage = ResponseAPILoggingUtils._transform_response_api_usage_to_chat_usage(
                             _usage
                         ).model_dump()
-                    elif TranscriptionUsageObjectTransformation.is_transcription_usage_object(
-                        _usage
-                    ):
+                    elif TranscriptionUsageObjectTransformation.is_transcription_usage_object(_usage):
                         tr_usage = TranscriptionUsageObjectTransformation.transform_transcription_usage_object(
                             cast(
                                 Union[
@@ -1313,29 +1241,21 @@ def completion_cost(  # noqa: PLR0915
                     # get input/output tokens from completion_response
                     prompt_tokens = _usage.get("prompt_tokens", 0)
                     completion_tokens = _usage.get("completion_tokens", 0)
-                    cache_creation_input_tokens = _usage.get(
-                        "cache_creation_input_tokens", 0
-                    )
+                    cache_creation_input_tokens = _usage.get("cache_creation_input_tokens", 0)
                     cache_read_input_tokens = _usage.get("cache_read_input_tokens", 0)
                     if (
                         "prompt_tokens_details" in _usage
                         and _usage["prompt_tokens_details"] != {}
                         and _usage["prompt_tokens_details"]
                     ):
-                        prompt_tokens_details = (
-                            _usage.get("prompt_tokens_details") or {}
-                        )
-                        cache_read_input_tokens = prompt_tokens_details.get(
-                            "cached_tokens", 0
-                        )
+                        prompt_tokens_details = _usage.get("prompt_tokens_details") or {}
+                        cache_read_input_tokens = prompt_tokens_details.get("cached_tokens", 0)
 
                     total_time = getattr(completion_response, "_response_ms", 0)
 
                     hidden_params = getattr(completion_response, "_hidden_params", None)
                     if hidden_params is not None:
-                        custom_llm_provider = hidden_params.get(
-                            "custom_llm_provider", custom_llm_provider or None
-                        )
+                        custom_llm_provider = hidden_params.get("custom_llm_provider", custom_llm_provider or None)
                         region_name = hidden_params.get("region_name", region_name)
 
                         # For Gemini/Vertex AI responses, trafficType is stored in
@@ -1343,14 +1263,10 @@ def completion_cost(  # noqa: PLR0915
                         # by the cost key lookup (_priority / _flex suffixes) so that
                         # ON_DEMAND_PRIORITY requests are billed at priority prices.
                         if service_tier is None:
-                            provider_specific = (
-                                hidden_params.get("provider_specific_fields") or {}
-                            )
+                            provider_specific = hidden_params.get("provider_specific_fields") or {}
                             raw_traffic_type = provider_specific.get("traffic_type")
                             if raw_traffic_type:
-                                service_tier = _map_traffic_type_to_service_tier(
-                                    raw_traffic_type
-                                )
+                                service_tier = _map_traffic_type_to_service_tier(raw_traffic_type)
                 else:
                     if model is None:
                         raise ValueError(
@@ -1366,9 +1282,7 @@ def completion_cost(  # noqa: PLR0915
                 if call_type in _A2A_CALL_TYPES:
                     from litellm.a2a_protocol.cost_calculator import A2ACostCalculator
 
-                    return A2ACostCalculator.calculate_a2a_cost(
-                        litellm_logging_obj=litellm_logging_obj
-                    )
+                    return A2ACostCalculator.calculate_a2a_cost(litellm_logging_obj=litellm_logging_obj)
 
                 if model is None:
                     raise ValueError(
@@ -1385,9 +1299,9 @@ def completion_cost(  # noqa: PLR0915
                                 str(e)
                             )
                         )
-                if CostCalculatorUtils._call_type_has_image_response(
-                    call_type
-                ) and isinstance(completion_response, ImageResponse):
+                if CostCalculatorUtils._call_type_has_image_response(call_type) and isinstance(
+                    completion_response, ImageResponse
+                ):
                     ### IMAGE GENERATION COST CALCULATION ###
                     return CostCalculatorUtils.route_image_generation_cost_calculator(
                         model=model,
@@ -1404,9 +1318,7 @@ def completion_cost(  # noqa: PLR0915
                     # Extract custom model_info for deployment-specific pricing
                     _video_model_info: Optional[ModelInfo] = None
                     if custom_pricing and litellm_logging_obj is not None:
-                        _litellm_params = getattr(
-                            litellm_logging_obj, "litellm_params", None
-                        )
+                        _litellm_params = getattr(litellm_logging_obj, "litellm_params", None)
                         if _litellm_params is not None:
                             _metadata = _litellm_params.get("metadata", {}) or {}
                             _video_model_info = _metadata.get("model_info", None)
@@ -1420,9 +1332,7 @@ def completion_cost(  # noqa: PLR0915
                             duration_seconds = usage_obj.get("duration_seconds", None)
                             _vr = usage_obj.get("video_resolution", None)
                         else:
-                            duration_seconds = getattr(
-                                usage_obj, "duration_seconds", None
-                            )
+                            duration_seconds = getattr(usage_obj, "duration_seconds", None)
                             _vr = getattr(usage_obj, "video_resolution", None)
                         if _vr is not None:
                             video_resolution = str(_vr).strip().lower()
@@ -1461,9 +1371,7 @@ def completion_cost(  # noqa: PLR0915
                         getattr(completion_response, "duration", 0.0),
                     )
                 elif call_type in _RERANK_CALL_TYPES:
-                    if completion_response is not None and isinstance(
-                        completion_response, RerankResponse
-                    ):
+                    if completion_response is not None and isinstance(completion_response, RerankResponse):
                         meta_obj = completion_response.meta
                         if meta_obj is not None:
                             billed_units = meta_obj.get("billed_units", {}) or {}
@@ -1475,9 +1383,7 @@ def completion_cost(  # noqa: PLR0915
                             total_tokens=billed_units.get("total_tokens"),
                         )
 
-                        search_units = (
-                            billed_units.get("search_units") or 1
-                        )  # cohere charges per request by default.
+                        search_units = billed_units.get("search_units") or 1  # cohere charges per request by default.
                         completion_tokens = search_units
                 elif call_type in _SEARCH_CALL_TYPES:
                     from litellm.search import search_provider_cost_per_query
@@ -1551,10 +1457,7 @@ def completion_cost(  # noqa: PLR0915
                 elif call_type == _AREALTIME_CALL_TYPE and isinstance(
                     completion_response, LiteLLMRealtimeStreamLoggingObject
                 ):
-                    if (
-                        cost_per_token_usage_object is None
-                        or custom_llm_provider is None
-                    ):
+                    if cost_per_token_usage_object is None or custom_llm_provider is None:
                         raise ValueError(
                             "usage object and custom_llm_provider must be provided for realtime stream cost calculation. Got cost_per_token_usage_object={}, custom_llm_provider={}".format(
                                 cost_per_token_usage_object,
@@ -1573,27 +1476,17 @@ def completion_cost(  # noqa: PLR0915
                         MCPCostCalculator,
                     )
 
-                    return MCPCostCalculator.calculate_mcp_tool_call_cost(
-                        litellm_logging_obj=litellm_logging_obj
-                    )
+                    return MCPCostCalculator.calculate_mcp_tool_call_cost(litellm_logging_obj=litellm_logging_obj)
                 # Calculate cost based on prompt_tokens, completion_tokens
-                if (
-                    "togethercomputer" in model
-                    or "together_ai" in model
-                    or custom_llm_provider == "together_ai"
-                ):
+                if "togethercomputer" in model or "together_ai" in model or custom_llm_provider == "together_ai":
                     # together ai prices based on size of llm
                     # get_model_params_and_category takes a model name and returns the category of LLM size it is in model_prices_and_context_window.json
 
-                    model = get_model_params_and_category(
-                        model, call_type=CallTypes(call_type)
-                    )
+                    model = get_model_params_and_category(model, call_type=CallTypes(call_type))
 
                 # replicate llms are calculate based on time for request running
                 # see https://replicate.com/pricing
-                elif (
-                    model in litellm.replicate_models or "replicate" in model
-                ) and model not in litellm.model_cost:
+                elif (model in litellm.replicate_models or "replicate" in model) and model not in litellm.model_cost:
                     # for unmapped replicate model, default to replicate's time tracking logic
                     return get_replicate_completion_pricing(completion_response, total_time)  # type: ignore
 
@@ -1602,28 +1495,17 @@ def completion_cost(  # noqa: PLR0915
                         f"Model is None and does not exist in passed completion_response. Passed completion_response={completion_response}, model={model}"
                     )
 
-                if (
-                    custom_llm_provider is not None
-                    and custom_llm_provider == "vertex_ai"
-                ):
+                if custom_llm_provider is not None and custom_llm_provider == "vertex_ai":
                     # Calculate the prompt characters + response characters
                     if len(messages) > 0:
                         prompt_string = litellm.utils.get_formatted_prompt(
                             data={"messages": messages}, call_type="completion"
                         )
 
-                        prompt_characters = litellm.utils._count_characters(
-                            text=prompt_string
-                        )
-                    if completion_response is not None and isinstance(
-                        completion_response, ModelResponse
-                    ):
-                        completion_string = litellm.utils.get_response_string(
-                            response_obj=completion_response
-                        )
-                        completion_characters = litellm.utils._count_characters(
-                            text=completion_string
-                        )
+                        prompt_characters = litellm.utils._count_characters(text=prompt_string)
+                    if completion_response is not None and isinstance(completion_response, ModelResponse):
+                        completion_string = litellm.utils.get_response_string(response_obj=completion_response)
+                        completion_characters = litellm.utils._count_characters(text=completion_string)
 
                 # Get the original request model for router detection
                 request_model_for_cost = None
@@ -1660,12 +1542,8 @@ def completion_cost(  # noqa: PLR0915
                 if custom_llm_provider == "azure_ai":
                     model_for_additional_costs = request_model_for_cost
                     if completion_response is not None:
-                        hidden_params = (
-                            getattr(completion_response, "_hidden_params", None) or {}
-                        )
-                        hidden_model = hidden_params.get("model") or hidden_params.get(
-                            "litellm_model_name"
-                        )
+                        hidden_params = getattr(completion_response, "_hidden_params", None) or {}
+                        hidden_model = hidden_params.get("model") or hidden_params.get("litellm_model_name")
                         if hidden_model and (
                             "model_router" in (hidden_model or "").lower()
                             or "model-router" in (hidden_model or "").lower()
@@ -1684,17 +1562,13 @@ def completion_cost(  # noqa: PLR0915
                 else:
                     additional_costs = None
 
-                _final_cost = (
-                    prompt_tokens_cost_usd_dollar + completion_tokens_cost_usd_dollar
-                )
-                cost_for_built_in_tools = (
-                    StandardBuiltInToolCostTracking.get_cost_for_built_in_tools(
-                        model=model,
-                        response_object=completion_response,
-                        usage=cost_per_token_usage_object,
-                        standard_built_in_tools_params=standard_built_in_tools_params,
-                        custom_llm_provider=custom_llm_provider,
-                    )
+                _final_cost = prompt_tokens_cost_usd_dollar + completion_tokens_cost_usd_dollar
+                cost_for_built_in_tools = StandardBuiltInToolCostTracking.get_cost_for_built_in_tools(
+                    model=model,
+                    response_object=completion_response,
+                    usage=cost_per_token_usage_object,
+                    standard_built_in_tools_params=standard_built_in_tools_params,
+                    custom_llm_provider=custom_llm_provider,
                 )
                 _final_cost += cost_for_built_in_tools
                 if additional_costs:
@@ -1735,23 +1609,17 @@ def completion_cost(  # noqa: PLR0915
                     _cache_read_cost: Optional[float] = None
                     _cache_creation_cost: Optional[float] = None
                     if cost_per_token_usage_object is not None:
-                        _cr = getattr(
-                            cost_per_token_usage_object, "cache_read_input_tokens", None
-                        ) or (cost_per_token_usage_object.model_extra or {}).get(
-                            "cache_read_input_tokens"
-                        )
+                        _cr = getattr(cost_per_token_usage_object, "cache_read_input_tokens", None) or (
+                            cost_per_token_usage_object.model_extra or {}
+                        ).get("cache_read_input_tokens")
                         _cc = getattr(
                             cost_per_token_usage_object,
                             "cache_creation_input_tokens",
                             None,
-                        ) or (cost_per_token_usage_object.model_extra or {}).get(
-                            "cache_creation_input_tokens"
-                        )
+                        ) or (cost_per_token_usage_object.model_extra or {}).get("cache_creation_input_tokens")
                         if (_cr or _cc) and model:
                             try:
-                                _mi = litellm.get_model_info(
-                                    model=model, custom_llm_provider=custom_llm_provider
-                                )
+                                _mi = litellm.get_model_info(model=model, custom_llm_provider=custom_llm_provider)
                                 _cr_rate = _mi.get("cache_read_input_token_cost")
                                 if _cr and _cr_rate is not None:
                                     _cache_read_cost = float(_cr) * float(_cr_rate)
@@ -1786,11 +1654,7 @@ def completion_cost(  # noqa: PLR0915
                 )
                 if idx == len(potential_model_names) - 1:
                     raise e
-        raise Exception(
-            "Unable to calculat cost for received potential model names - {}".format(
-                potential_model_names
-            )
-        )
+        raise Exception("Unable to calculat cost for received potential model names - {}".format(potential_model_names))
     except Exception as e:
         raise e
 
@@ -1804,10 +1668,7 @@ def get_response_cost_from_hidden_params(
         _hidden_params_dict = hidden_params
 
     additional_headers = _hidden_params_dict.get("additional_headers", {})
-    if (
-        additional_headers
-        and "llm_provider-x-litellm-response-cost" in additional_headers
-    ):
+    if additional_headers and "llm_provider-x-litellm-response-cost" in additional_headers:
         response_cost = additional_headers["llm_provider-x-litellm-response-cost"]
         if response_cost is None:
             return None
@@ -1864,9 +1725,7 @@ def response_cost_calculator(
     ### SERVICE TIER ###
     service_tier: Optional[str] = None,  # for OpenAI service tier pricing
     ### DATA RESIDENCY ###
-    data_residency: Optional[
-        str
-    ] = None,  # for OpenAI regional-processing uplift (e.g. "eu", "us")
+    data_residency: Optional[str] = None,  # for OpenAI regional-processing uplift (e.g. "eu", "us")
 ) -> float:
     """
     Returns
@@ -1880,9 +1739,7 @@ def response_cost_calculator(
             if isinstance(response_object, BaseModel):
                 if hasattr(response_object, "_hidden_params"):
                     response_object._hidden_params["optional_params"] = optional_params
-                    provider_response_cost = get_response_cost_from_hidden_params(
-                        response_object._hidden_params
-                    )
+                    provider_response_cost = get_response_cost_from_hidden_params(response_object._hidden_params)
                     if provider_response_cost is not None:
                         return provider_response_cost
 
@@ -1929,17 +1786,13 @@ def ocr_cost(
     # validate it's an OCR response
     #########################################################
     if response is None or not isinstance(response, OCRResponse):
-        raise ValueError(
-            f"response must be of type OCRResponse got type={type(response)}"
-        )
+        raise ValueError(f"response must be of type OCRResponse got type={type(response)}")
 
     if response.usage_info is None:
         raise ValueError("OCR response usage_info is None")
 
     try:
-        model_info: Optional[ModelInfo] = litellm.get_model_info(
-            model=model, custom_llm_provider=custom_llm_provider
-        )
+        model_info: Optional[ModelInfo] = litellm.get_model_info(model=model, custom_llm_provider=custom_llm_provider)
     except Exception:
         model_info = None
 
@@ -2015,9 +1868,7 @@ def vector_store_search_cost(
     )
 
     if config is None:
-        verbose_logger.debug(
-            f"Vector store search is not supported for {custom_llm_provider}"
-        )
+        verbose_logger.debug(f"Vector store search is not supported for {custom_llm_provider}")
         return 0.0, 0.0
 
     return config.calculate_vector_store_cost(
@@ -2034,9 +1885,7 @@ def rerank_cost(
     Returns
     - float or None: cost of response OR none if error.
     """
-    _, custom_llm_provider, _, _ = litellm.get_llm_provider(
-        model=model, custom_llm_provider=custom_llm_provider
-    )
+    _, custom_llm_provider, _, _ = litellm.get_llm_provider(model=model, custom_llm_provider=custom_llm_provider)
 
     try:
         config = ProviderConfigManager.get_provider_rerank_config(
@@ -2063,12 +1912,8 @@ def rerank_cost(
         raise e
 
 
-def transcription_cost(
-    model: str, custom_llm_provider: Optional[str], duration: float
-) -> Tuple[float, float]:
-    return openai_cost_per_second(
-        model=model, custom_llm_provider=custom_llm_provider, duration=duration
-    )
+def transcription_cost(model: str, custom_llm_provider: Optional[str], duration: float) -> Tuple[float, float]:
+    return openai_cost_per_second(model=model, custom_llm_provider=custom_llm_provider, duration=duration)
 
 
 def default_image_cost_calculator(
@@ -2097,11 +1942,7 @@ def default_image_cost_calculator(
     """
     # Standardize size format to use "-x-"
     size_str: str = size or "1024-x-1024"
-    size_str = (
-        size_str.replace("x", "-x-")
-        if "x" in size_str and "-x-" not in size_str
-        else size_str
-    )
+    size_str = size_str.replace("x", "-x-") if "x" in size_str and "-x-" not in size_str else size_str
 
     # Parse dimensions
     height, width = map(int, size_str.split("-x-"))
@@ -2110,29 +1951,17 @@ def default_image_cost_calculator(
     base_model_name = f"{size_str}/{model}"
     model_name_without_custom_llm_provider: Optional[str] = None
     if custom_llm_provider and model.startswith(f"{custom_llm_provider}/"):
-        model_name_without_custom_llm_provider = model.replace(
-            f"{custom_llm_provider}/", ""
-        )
-        base_model_name = (
-            f"{custom_llm_provider}/{size_str}/{model_name_without_custom_llm_provider}"
-        )
-    model_name_with_quality = (
-        f"{quality}/{base_model_name}" if quality else base_model_name
-    )
+        model_name_without_custom_llm_provider = model.replace(f"{custom_llm_provider}/", "")
+        base_model_name = f"{custom_llm_provider}/{size_str}/{model_name_without_custom_llm_provider}"
+    model_name_with_quality = f"{quality}/{base_model_name}" if quality else base_model_name
 
     # gpt-image-1 models use low, medium, high quality. If user did not specify quality, use medium fot gpt-image-1 model family
-    model_name_with_v2_quality = (
-        f"{ImageGenerationRequestQuality.HIGH.value}/{base_model_name}"
-    )
+    model_name_with_v2_quality = f"{ImageGenerationRequestQuality.HIGH.value}/{base_model_name}"
 
-    verbose_logger.debug(
-        f"Looking up cost for models: {model_name_with_quality}, {base_model_name}"
-    )
+    verbose_logger.debug(f"Looking up cost for models: {model_name_with_quality}, {base_model_name}")
 
     model_without_provider = f"{size_str}/{model.split('/')[-1]}"
-    model_with_quality_without_provider = (
-        f"{quality}/{model_without_provider}" if quality else model_without_provider
-    )
+    model_with_quality_without_provider = f"{quality}/{model_without_provider}" if quality else model_without_provider
 
     # Try model with quality first, fall back to base model name
     cost_info: Optional[dict] = None
@@ -2150,26 +1979,16 @@ def default_image_cost_calculator(
             cost_info = litellm.model_cost[_model]
             break
     if cost_info is None:
-        raise Exception(
-            f"Model not found in cost map. Tried checking {models_to_check}"
-        )
+        raise Exception(f"Model not found in cost map. Tried checking {models_to_check}")
 
     # Priority 1: Use per-image pricing if available (for gpt-image-1 and similar models)
-    if (
-        "input_cost_per_image" in cost_info
-        and cost_info["input_cost_per_image"] is not None
-    ):
+    if "input_cost_per_image" in cost_info and cost_info["input_cost_per_image"] is not None:
         return cost_info["input_cost_per_image"] * n
     # Priority 2: Fall back to per-pixel pricing for backward compatibility
-    elif (
-        "input_cost_per_pixel" in cost_info
-        and cost_info["input_cost_per_pixel"] is not None
-    ):
+    elif "input_cost_per_pixel" in cost_info and cost_info["input_cost_per_pixel"] is not None:
         return cost_info["input_cost_per_pixel"] * height * width * n
     else:
-        raise Exception(
-            f"No pricing information found for model {model}. Tried checking {models_to_check}"
-        )
+        raise Exception(f"No pricing information found for model {model}. Tried checking {models_to_check}")
 
 
 def default_video_cost_calculator(
@@ -2206,12 +2025,8 @@ def default_video_cost_calculator(
         base_model_name = model
         model_name_without_custom_llm_provider: Optional[str] = None
         if custom_llm_provider and model.startswith(f"{custom_llm_provider}/"):
-            model_name_without_custom_llm_provider = model.replace(
-                f"{custom_llm_provider}/", ""
-            )
-            base_model_name = (
-                f"{custom_llm_provider}/{model_name_without_custom_llm_provider}"
-            )
+            model_name_without_custom_llm_provider = model.replace(f"{custom_llm_provider}/", "")
+            base_model_name = f"{custom_llm_provider}/{model_name_without_custom_llm_provider}"
 
         verbose_logger.debug(f"Looking up cost for video model: {base_model_name}")
 
@@ -2271,9 +2086,7 @@ def batch_cost_calculator(
             deployment-specific pricing is used.
     """
 
-    _, custom_llm_provider, _, _ = litellm.get_llm_provider(
-        model=model, custom_llm_provider=custom_llm_provider
-    )
+    _, custom_llm_provider, _, _ = litellm.get_llm_provider(model=model, custom_llm_provider=custom_llm_provider)
 
     verbose_logger.debug(
         "Calculating batch cost per token. model=%s, custom_llm_provider=%s",
@@ -2283,9 +2096,7 @@ def batch_cost_calculator(
 
     if model_info is None:
         try:
-            model_info = litellm.get_model_info(
-                model=model, custom_llm_provider=custom_llm_provider
-            )
+            model_info = litellm.get_model_info(model=model, custom_llm_provider=custom_llm_provider)
         except Exception:
             model_info = None
     elif not any(
@@ -2301,9 +2112,7 @@ def batch_cost_calculator(
         # but carries no pricing fields. Fall back to the global pricing table so
         # that standard model pricing is used instead of silently returning $0.
         try:
-            global_info = litellm.get_model_info(
-                model=model, custom_llm_provider=custom_llm_provider
-            )
+            global_info = litellm.get_model_info(model=model, custom_llm_provider=custom_llm_provider)
             if global_info:
                 model_info = global_info
         except Exception:
@@ -2330,13 +2139,8 @@ def batch_cost_calculator(
         # Add cache read cost if applicable
         details = _parse_prompt_tokens_details(usage)
         cache_read_tokens = details["cache_hit_tokens"]
-        cache_read_cost_key = _get_service_tier_cost_key(
-            "cache_read_input_token_cost", None
-        )
-        total_prompt_cost += (
-            calculate_cost_component(model_info, cache_read_cost_key, cache_read_tokens)
-            / 2
-        )
+        cache_read_cost_key = _get_service_tier_cost_key("cache_read_input_token_cost", None)
+        total_prompt_cost += calculate_cost_component(model_info, cache_read_cost_key, cache_read_tokens) / 2
     if output_cost_per_token_batches:
         total_completion_cost = usage.completion_tokens * output_cost_per_token_batches
     elif output_cost_per_token:
@@ -2381,10 +2185,7 @@ class BaseTokenUsageProcessor:
                         setattr(combined, attr, current_val + new_val)
             # Handle nested prompt_tokens_details
             if hasattr(usage, "prompt_tokens_details") and usage.prompt_tokens_details:
-                if (
-                    not hasattr(combined, "prompt_tokens_details")
-                    or not combined.prompt_tokens_details
-                ):
+                if not hasattr(combined, "prompt_tokens_details") or not combined.prompt_tokens_details:
                     combined.prompt_tokens_details = PromptTokensDetailsWrapper()
 
                 # Check what keys exist in the model's prompt_tokens_details
@@ -2395,9 +2196,7 @@ class BaseTokenUsageProcessor:
                         and not attr.startswith("_")
                         and not callable(getattr(usage.prompt_tokens_details, attr))
                     ):
-                        current_val = (
-                            getattr(combined.prompt_tokens_details, attr, 0) or 0
-                        )
+                        current_val = getattr(combined.prompt_tokens_details, attr, 0) or 0
                         new_val = getattr(usage.prompt_tokens_details, attr, 0) or 0
                         if new_val is not None and isinstance(new_val, (int, float)):
                             setattr(
@@ -2407,27 +2206,15 @@ class BaseTokenUsageProcessor:
                             )
 
             # Handle nested completion_tokens_details
-            if (
-                hasattr(usage, "completion_tokens_details")
-                and usage.completion_tokens_details
-            ):
-                if (
-                    not hasattr(combined, "completion_tokens_details")
-                    or not combined.completion_tokens_details
-                ):
-                    combined.completion_tokens_details = (
-                        CompletionTokensDetailsWrapper()
-                    )
+            if hasattr(usage, "completion_tokens_details") and usage.completion_tokens_details:
+                if not hasattr(combined, "completion_tokens_details") or not combined.completion_tokens_details:
+                    combined.completion_tokens_details = CompletionTokensDetailsWrapper()
 
                 # Check what keys exist in the model's completion_tokens_details
                 # Access model_fields on the class, not the instance, to avoid Pydantic 2.11+ deprecation warnings
                 for attr in type(usage.completion_tokens_details).model_fields:
-                    if not attr.startswith("_") and not callable(
-                        getattr(usage.completion_tokens_details, attr)
-                    ):
-                        current_val = (
-                            getattr(combined.completion_tokens_details, attr, 0) or 0
-                        )
+                    if not attr.startswith("_") and not callable(getattr(usage.completion_tokens_details, attr)):
+                        current_val = getattr(combined.completion_tokens_details, attr, 0) or 0
                         new_val = getattr(usage.completion_tokens_details, attr, 0) or 0
                         if isinstance(new_val, (int, float)):
                             setattr(
@@ -2442,7 +2229,7 @@ class BaseTokenUsageProcessor:
 class RealtimeAPITokenUsageProcessor(BaseTokenUsageProcessor):
     @staticmethod
     def collect_usage_from_realtime_stream_results(
-        results: OpenAIRealtimeStreamList,
+        results: List[Dict[str, Any]],  # any-ok: open-ended realtime event dicts
     ) -> List[Usage]:
         """
         Collect usage from realtime stream results
@@ -2453,34 +2240,27 @@ class RealtimeAPITokenUsageProcessor(BaseTokenUsageProcessor):
         )
         usage_objects: List[Usage] = []
         for result in response_done_events:
-            usage_object = (
-                ResponseAPILoggingUtils._transform_response_api_usage_to_chat_usage(
-                    result["response"].get("usage", {})
-                )
+            usage_object = ResponseAPILoggingUtils._transform_response_api_usage_to_chat_usage(
+                result["response"].get("usage", {})
             )
             usage_objects.append(usage_object)
         return usage_objects
 
     @staticmethod
     def collect_and_combine_usage_from_realtime_stream_results(
-        results: OpenAIRealtimeStreamList,
+        results: List[Dict[str, Any]],  # any-ok: open-ended realtime event dicts
     ) -> Usage:
         """
         Collect and combine usage from realtime stream results
         """
-        collected_usage_objects = (
-            RealtimeAPITokenUsageProcessor.collect_usage_from_realtime_stream_results(
-                results
-            )
-        )
-        combined_usage_object = RealtimeAPITokenUsageProcessor.combine_usage_objects(
-            collected_usage_objects
-        )
+        collected_usage_objects = RealtimeAPITokenUsageProcessor.collect_usage_from_realtime_stream_results(results)
+        combined_usage_object = RealtimeAPITokenUsageProcessor.combine_usage_objects(collected_usage_objects)
         return combined_usage_object
 
     @staticmethod
     def create_logging_realtime_object(
-        usage: Usage, results: OpenAIRealtimeStreamList
+        usage: Usage,
+        results: List[Dict[str, Any]],  # any-ok: open-ended realtime event dicts
     ) -> LiteLLMRealtimeStreamLoggingObject:
         return LiteLLMRealtimeStreamLoggingObject(
             usage=usage,
@@ -2488,13 +2268,11 @@ class RealtimeAPITokenUsageProcessor(BaseTokenUsageProcessor):
         )
 
 
-_TRANSCRIPTION_COMPLETED_EVENT_TYPE = (
-    "conversation.item.input_audio_transcription.completed"
-)
+_TRANSCRIPTION_COMPLETED_EVENT_TYPE = "conversation.item.input_audio_transcription.completed"
 
 
 def handle_realtime_stream_cost_calculation(
-    results: OpenAIRealtimeStreamList,
+    results: List[Dict[str, Any]],
     combined_usage_object: Usage,
     custom_llm_provider: str,
     litellm_model_name: str,
@@ -2512,9 +2290,7 @@ def handle_realtime_stream_cost_calculation(
     potential_model_names = []
     for result in results:
         if result["type"] == "session.created":
-            received_model = cast(OpenAIRealtimeStreamSessionEvents, result)[
-                "session"
-            ].get("model", None)
+            received_model = cast(OpenAIRealtimeStreamSessionEvents, result)["session"].get("model", None)
             potential_model_names.append(received_model)
 
     potential_model_names.append(litellm_model_name)
@@ -2549,7 +2325,7 @@ def handle_realtime_stream_cost_calculation(
 
 
 def handle_realtime_transcription_cost_calculation(
-    results: OpenAIRealtimeStreamList,
+    results: List[Dict[str, Any]],
     custom_llm_provider: str,
     litellm_model_name: str,
 ) -> float:
@@ -2563,20 +2339,14 @@ def handle_realtime_transcription_cost_calculation(
       - {"type": "tokens", "input_tokens": ...}    → priced via input/audio token cost
     """
     completed_events = [
-        cast(dict, result)
-        for result in results
-        if result.get("type") == _TRANSCRIPTION_COMPLETED_EVENT_TYPE
+        cast(dict, result) for result in results if result.get("type") == _TRANSCRIPTION_COMPLETED_EVENT_TYPE
     ]
     if not completed_events:
         return 0.0
 
-    model_name = (
-        _get_transcription_model_name_from_results(results) or litellm_model_name
-    )
+    model_name = _get_transcription_model_name_from_results(results) or litellm_model_name
     try:
-        model_info = litellm.get_model_info(
-            model=model_name, custom_llm_provider=custom_llm_provider
-        )
+        model_info = litellm.get_model_info(model=model_name, custom_llm_provider=custom_llm_provider)
     except Exception:
         model_info = None
 
@@ -2588,7 +2358,7 @@ def handle_realtime_transcription_cost_calculation(
 
 
 def _get_transcription_model_name_from_results(
-    results: OpenAIRealtimeStreamList,
+    results: List[Dict[str, Any]],
 ) -> Optional[str]:
     """Resolve the ASR model from a transcription_session.* / session.* event."""
     for result in results:
@@ -2599,9 +2369,9 @@ def _get_transcription_model_name_from_results(
             "session.updated",
         ):
             session = cast(dict, result).get("session", {}) or {}
-            transcription = (
-                (session.get("audio", {}) or {}).get("input", {}) or {}
-            ).get("transcription", {}) or session.get("input_audio_transcription", {})
+            transcription = ((session.get("audio", {}) or {}).get("input", {}) or {}).get(
+                "transcription", {}
+            ) or session.get("input_audio_transcription", {})
             model = (transcription or {}).get("model") or session.get("model")
             if model:
                 return model
@@ -2622,15 +2392,9 @@ def _transcription_usage_cost(usage: dict, model_info: Optional[ModelInfo]) -> f
         text_tokens = input_token_details.get("text_tokens") or 0
         output_tokens = usage.get("output_tokens") or 0
         audio_cost = float(audio_tokens) * float(
-            model_info.get("input_cost_per_audio_token")
-            or model_info.get("input_cost_per_token")
-            or 0.0
+            model_info.get("input_cost_per_audio_token") or model_info.get("input_cost_per_token") or 0.0
         )
-        text_cost = float(text_tokens) * float(
-            model_info.get("input_cost_per_token") or 0.0
-        )
-        output_cost = float(output_tokens) * float(
-            model_info.get("output_cost_per_token") or 0.0
-        )
+        text_cost = float(text_tokens) * float(model_info.get("input_cost_per_token") or 0.0)
+        output_cost = float(output_tokens) * float(model_info.get("output_cost_per_token") or 0.0)
         return audio_cost + text_cost + output_cost
     return 0.0

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -69,7 +69,6 @@ from .llms.openai import (
     OpenAIChatCompletionChunk,
     OpenAIChatCompletionFinishReason,
     OpenAIFileObject,
-    OpenAIRealtimeStreamList,
     ResponsesAPIResponse,
     WebSearchOptions,
 )
@@ -148,9 +147,7 @@ class ProviderSpecificModelInfo(TypedDict, total=False):
     supports_max_reasoning_effort: Optional[bool]
     supports_output_config: Optional[bool]
     supports_image_size: Optional[bool]
-    bedrock_output_config_effort_ceiling: Optional[
-        Literal["low", "medium", "high", "max", "xhigh"]
-    ]
+    bedrock_output_config_effort_ceiling: Optional[Literal["low", "medium", "high", "max", "xhigh"]]
 
 
 class SearchContextCostPerQuery(TypedDict, total=False):
@@ -182,37 +179,23 @@ class ModelInfoBase(ProviderSpecificModelInfo, total=False):
     max_output_tokens: Required[Optional[int]]
     input_cost_per_token: Required[Optional[float]]
     input_cost_per_token_flex: Optional[float]  # OpenAI flex service tier pricing
-    input_cost_per_token_priority: Optional[
-        float
-    ]  # OpenAI priority service tier pricing
+    input_cost_per_token_priority: Optional[float]  # OpenAI priority service tier pricing
     cache_creation_input_token_cost: Optional[float]
     cache_creation_input_token_cost_above_200k_tokens: Optional[float]
     cache_creation_input_token_cost_above_1hr: Optional[float]
     cache_read_input_token_cost: Optional[float]
-    cache_read_input_token_cost_flex: Optional[
-        float
-    ]  # OpenAI flex service tier pricing
-    cache_read_input_token_cost_priority: Optional[
-        float
-    ]  # OpenAI priority service tier pricing
+    cache_read_input_token_cost_flex: Optional[float]  # OpenAI flex service tier pricing
+    cache_read_input_token_cost_priority: Optional[float]  # OpenAI priority service tier pricing
     cache_read_input_token_cost_above_200k_tokens: Optional[float]
     cache_read_input_token_cost_above_272k_tokens: Optional[float]
     cache_read_input_token_cost_above_512k_tokens: Optional[float]
     input_cost_per_character: Optional[float]  # only for vertex ai models
     input_cost_per_audio_token: Optional[float]
     input_cost_per_token_above_128k_tokens: Optional[float]  # only for vertex ai models
-    input_cost_per_token_above_200k_tokens: Optional[
-        float
-    ]  # only for vertex ai gemini-2.5-pro models
-    input_cost_per_token_above_272k_tokens: Optional[
-        float
-    ]  # GPT-5.4/5.4-pro: prompts >272K priced at 2x input
-    input_cost_per_token_above_512k_tokens: Optional[
-        float
-    ]  # MiniMax-M3: prompts >512K priced at 2x input
-    input_cost_per_character_above_128k_tokens: Optional[
-        float
-    ]  # only for vertex ai models
+    input_cost_per_token_above_200k_tokens: Optional[float]  # only for vertex ai gemini-2.5-pro models
+    input_cost_per_token_above_272k_tokens: Optional[float]  # GPT-5.4/5.4-pro: prompts >272K priced at 2x input
+    input_cost_per_token_above_512k_tokens: Optional[float]  # MiniMax-M3: prompts >512K priced at 2x input
+    input_cost_per_character_above_128k_tokens: Optional[float]  # only for vertex ai models
     input_cost_per_query: Optional[float]  # only for rerank models
     input_cost_per_image: Optional[float]  # only for vertex ai models
     input_cost_per_image_token: Optional[float]  # for gpt-image-1 and similar models
@@ -223,9 +206,7 @@ class ModelInfoBase(ProviderSpecificModelInfo, total=False):
     output_cost_per_token_batches: Optional[float]
     output_cost_per_token: Required[Optional[float]]
     output_cost_per_token_flex: Optional[float]  # OpenAI flex service tier pricing
-    output_cost_per_token_priority: Optional[
-        float
-    ]  # OpenAI priority service tier pricing
+    output_cost_per_token_priority: Optional[float]  # OpenAI priority service tier pricing
     regional_processing_uplift_multiplier_eu: Optional[
         float
     ]  # OpenAI EU data-residency uplift multiplier applied to all token costs (e.g. 1.10 = +10%)
@@ -234,21 +215,11 @@ class ModelInfoBase(ProviderSpecificModelInfo, total=False):
     ]  # OpenAI US data-residency uplift multiplier applied to all token costs (e.g. 1.10 = +10%)
     output_cost_per_character: Optional[float]  # only for vertex ai models
     output_cost_per_audio_token: Optional[float]
-    output_cost_per_token_above_128k_tokens: Optional[
-        float
-    ]  # only for vertex ai models
-    output_cost_per_token_above_200k_tokens: Optional[
-        float
-    ]  # only for vertex ai gemini-2.5-pro models
-    output_cost_per_token_above_272k_tokens: Optional[
-        float
-    ]  # GPT-5.4/5.4-pro: prompts >272K priced at 1.5x output
-    output_cost_per_token_above_512k_tokens: Optional[
-        float
-    ]  # MiniMax-M3: prompts >512K priced at 2x output
-    output_cost_per_character_above_128k_tokens: Optional[
-        float
-    ]  # only for vertex ai models
+    output_cost_per_token_above_128k_tokens: Optional[float]  # only for vertex ai models
+    output_cost_per_token_above_200k_tokens: Optional[float]  # only for vertex ai gemini-2.5-pro models
+    output_cost_per_token_above_272k_tokens: Optional[float]  # GPT-5.4/5.4-pro: prompts >272K priced at 1.5x output
+    output_cost_per_token_above_512k_tokens: Optional[float]  # MiniMax-M3: prompts >512K priced at 2x output
+    output_cost_per_character_above_128k_tokens: Optional[float]  # only for vertex ai models
     output_cost_per_image: Optional[float]
     output_cost_per_image_token: Optional[float]
     output_vector_size: Optional[int]
@@ -262,13 +233,9 @@ class ModelInfoBase(ProviderSpecificModelInfo, total=False):
     ocr_cost_per_page: Optional[float]  # for OCR models
     ocr_cost_per_credit: Optional[float]  # for OCR models priced by credit
     annotation_cost_per_page: Optional[float]  # for OCR models
-    search_context_cost_per_query: Optional[
-        SearchContextCostPerQuery
-    ]  # Cost for using web search tool
+    search_context_cost_per_query: Optional[SearchContextCostPerQuery]  # Cost for using web search tool
     citation_cost_per_token: Optional[float]  # Cost per citation token for Perplexity
-    tiered_pricing: Optional[
-        List[Dict[str, Any]]
-    ]  # Tiered pricing structure for models like Dashscope
+    tiered_pricing: Optional[List[Dict[str, Any]]]  # Tiered pricing structure for models like Dashscope
     litellm_provider: Required[str]
     mode: Required[
         Literal[
@@ -993,9 +960,7 @@ class FunctionCall(OpenAIObject):
 
 class Function(OpenAIObject):
     arguments: str
-    name: Optional[
-        str
-    ]  # can be None - openai e.g.: ChoiceDeltaToolCallFunction(arguments='{"', name=None), type=None)
+    name: Optional[str]  # can be None - openai e.g.: ChoiceDeltaToolCallFunction(arguments='{"', name=None), type=None)
 
     def __init__(
         self,
@@ -1004,9 +969,7 @@ class Function(OpenAIObject):
         **params,
     ):
         if arguments is None:
-            if params.get("parameters", None) is not None and isinstance(
-                params["parameters"], dict
-            ):
+            if params.get("parameters", None) is not None and isinstance(params["parameters"], dict):
                 arguments = json.dumps(params["parameters"])
                 params.pop("parameters")
             else:
@@ -1147,9 +1110,7 @@ ChatCompletionMessage(content='This is a test', role='assistant', function_call=
 """
 
 
-def add_provider_specific_fields(
-    object: BaseModel, provider_specific_fields: Optional[Dict[str, Any]]
-):
+def add_provider_specific_fields(object: BaseModel, provider_specific_fields: Optional[Dict[str, Any]]):
     if not provider_specific_fields:  # set if provider_specific_fields is not empty
         return
     setattr(object, "provider_specific_fields", provider_specific_fields)
@@ -1163,9 +1124,7 @@ class Message(SafeAttributeModel, OpenAIObject):
     audio: Optional[ChatCompletionAudioResponse] = None
     images: Optional[List[ImageURLListItem]] = None
     reasoning_content: Optional[str] = None
-    thinking_blocks: Optional[
-        List[Union[ChatCompletionThinkingBlock, ChatCompletionRedactedThinkingBlock]]
-    ] = None
+    thinking_blocks: Optional[List[Union[ChatCompletionThinkingBlock, ChatCompletionRedactedThinkingBlock]]] = None
     reasoning_items: Optional[List[ChatCompletionReasoningItem]] = None
     provider_specific_fields: Optional[Dict[str, Any]] = Field(default=None)
     annotations: Optional[List[ChatCompletionAnnotation]] = None
@@ -1180,11 +1139,7 @@ class Message(SafeAttributeModel, OpenAIObject):
         images: Optional[List[ImageURLListItem]] = None,
         provider_specific_fields: Optional[Dict[str, Any]] = None,
         reasoning_content: Optional[str] = None,
-        thinking_blocks: Optional[
-            List[
-                Union[ChatCompletionThinkingBlock, ChatCompletionRedactedThinkingBlock]
-            ]
-        ] = None,
+        thinking_blocks: Optional[List[Union[ChatCompletionThinkingBlock, ChatCompletionRedactedThinkingBlock]]] = None,
         reasoning_items: Optional[List[ChatCompletionReasoningItem]] = None,
         annotations: Optional[List[ChatCompletionAnnotation]] = None,
         **params,
@@ -1192,16 +1147,10 @@ class Message(SafeAttributeModel, OpenAIObject):
         init_values: Dict[str, Any] = {
             "content": content,
             "role": role or "assistant",  # handle null input
-            "function_call": (
-                FunctionCall(**function_call) if function_call is not None else None
-            ),
+            "function_call": (FunctionCall(**function_call) if function_call is not None else None),
             "tool_calls": (
                 [
-                    (
-                        ChatCompletionMessageToolCall(**tool_call)
-                        if isinstance(tool_call, dict)
-                        else tool_call
-                    )
+                    (ChatCompletionMessageToolCall(**tool_call) if isinstance(tool_call, dict) else tool_call)
                     for tool_call in tool_calls
                 ]
                 if tool_calls is not None and len(tool_calls) > 0
@@ -1287,9 +1236,7 @@ class Message(SafeAttributeModel, OpenAIObject):
 
 class Delta(SafeAttributeModel, OpenAIObject):
     reasoning_content: Optional[str] = None
-    thinking_blocks: Optional[
-        List[Union[ChatCompletionThinkingBlock, ChatCompletionRedactedThinkingBlock]]
-    ] = None
+    thinking_blocks: Optional[List[Union[ChatCompletionThinkingBlock, ChatCompletionRedactedThinkingBlock]]] = None
     reasoning_items: Optional[List[ChatCompletionReasoningItem]] = None
     provider_specific_fields: Optional[Dict[str, Any]] = Field(default=None)
 
@@ -1302,11 +1249,7 @@ class Delta(SafeAttributeModel, OpenAIObject):
         audio: Optional[ChatCompletionAudioResponse] = None,
         images: Optional[List[ImageURLListItem]] = None,
         reasoning_content: Optional[str] = None,
-        thinking_blocks: Optional[
-            List[
-                Union[ChatCompletionThinkingBlock, ChatCompletionRedactedThinkingBlock]
-            ]
-        ] = None,
+        thinking_blocks: Optional[List[Union[ChatCompletionThinkingBlock, ChatCompletionRedactedThinkingBlock]]] = None,
         reasoning_items: Optional[List[ChatCompletionReasoningItem]] = None,
         annotations: Optional[List[ChatCompletionAnnotation]] = None,
         **params,
@@ -1420,9 +1363,7 @@ class Choices(SafeAttributeModel, OpenAIObject):
             mapped = map_finish_reason(finish_reason)
             params["finish_reason"] = mapped
             if finish_reason != mapped:
-                provider_specific_fields = (
-                    dict(provider_specific_fields) if provider_specific_fields else {}
-                )
+                provider_specific_fields = dict(provider_specific_fields) if provider_specific_fields else {}
                 provider_specific_fields["native_finish_reason"] = finish_reason
         else:
             params["finish_reason"] = "stop"
@@ -1439,11 +1380,7 @@ class Choices(SafeAttributeModel, OpenAIObject):
                 params["message"] = Message(**message)
             elif isinstance(message, BaseModel):
                 # Normalize provider/OpenAI SDK message models into LiteLLM's Message type.
-                dump = (
-                    message.model_dump()
-                    if hasattr(message, "model_dump")
-                    else message.dict()
-                )
+                dump = message.model_dump() if hasattr(message, "model_dump") else message.dict()
                 params["message"] = Message(**dump)
         if logprobs is not None:
             if isinstance(logprobs, dict):
@@ -1481,9 +1418,7 @@ class Choices(SafeAttributeModel, OpenAIObject):
         setattr(self, key, value)
 
 
-class CompletionTokensDetailsWrapper(
-    CompletionTokensDetails
-):  # wrapper for older openai versions
+class CompletionTokensDetailsWrapper(CompletionTokensDetails):  # wrapper for older openai versions
     text_tokens: Optional[int] = None
     """Text tokens generated by the model."""
 
@@ -1578,12 +1513,8 @@ class Usage(SafeAttributeModel, CompletionUsage):
         completion_tokens: Optional[int] = None,
         total_tokens: Optional[int] = None,
         reasoning_tokens: Optional[int] = None,
-        prompt_tokens_details: Optional[
-            Union[PromptTokensDetailsWrapper, PromptTokensDetails, dict]
-        ] = None,
-        completion_tokens_details: Optional[
-            Union[CompletionTokensDetailsWrapper, dict]
-        ] = None,
+        prompt_tokens_details: Optional[Union[PromptTokensDetailsWrapper, PromptTokensDetails, dict]] = None,
+        completion_tokens_details: Optional[Union[CompletionTokensDetailsWrapper, dict]] = None,
         server_tool_use: Optional[Union[ServerToolUse, dict]] = None,
         cost: Optional[float] = None,
         **params,
@@ -1594,9 +1525,7 @@ class Usage(SafeAttributeModel, CompletionUsage):
         # First, handle existing completion_tokens_details
         if completion_tokens_details:
             if isinstance(completion_tokens_details, dict):
-                _completion_tokens_details = CompletionTokensDetailsWrapper(
-                    **completion_tokens_details
-                )
+                _completion_tokens_details = CompletionTokensDetailsWrapper(**completion_tokens_details)
             elif isinstance(completion_tokens_details, CompletionTokensDetails):
                 _completion_tokens_details = completion_tokens_details
 
@@ -1612,10 +1541,7 @@ class Usage(SafeAttributeModel, CompletionUsage):
 
             # Auto-calculate text_tokens only if provider didn't set it explicitly
             # Formula: text_tokens = completion_tokens - reasoning_tokens - image_tokens - audio_tokens
-            if (
-                _completion_tokens_details.text_tokens is None
-                and completion_tokens is not None
-            ):
+            if _completion_tokens_details.text_tokens is None and completion_tokens is not None:
                 calculated_text_tokens = completion_tokens - reasoning_tokens
 
                 # Subtract other modality tokens if present
@@ -1633,49 +1559,33 @@ class Usage(SafeAttributeModel, CompletionUsage):
         # guarantee prompt_token_details is always a PromptTokensDetailsWrapper
         if prompt_tokens_details:
             if isinstance(prompt_tokens_details, dict):
-                _prompt_tokens_details = PromptTokensDetailsWrapper(
-                    **prompt_tokens_details
-                )
+                _prompt_tokens_details = PromptTokensDetailsWrapper(**prompt_tokens_details)
             elif isinstance(prompt_tokens_details, PromptTokensDetails):
-                _prompt_tokens_details = PromptTokensDetailsWrapper(
-                    **prompt_tokens_details.model_dump()
-                )
+                _prompt_tokens_details = PromptTokensDetailsWrapper(**prompt_tokens_details.model_dump())
             elif isinstance(prompt_tokens_details, PromptTokensDetailsWrapper):
                 _prompt_tokens_details = prompt_tokens_details
 
         ## DEEPSEEK MAPPING ##
-        if "prompt_cache_hit_tokens" in params and isinstance(
-            params["prompt_cache_hit_tokens"], int
-        ):
+        if "prompt_cache_hit_tokens" in params and isinstance(params["prompt_cache_hit_tokens"], int):
             if _prompt_tokens_details is None:
-                _prompt_tokens_details = PromptTokensDetailsWrapper(
-                    cached_tokens=params["prompt_cache_hit_tokens"]
-                )
+                _prompt_tokens_details = PromptTokensDetailsWrapper(cached_tokens=params["prompt_cache_hit_tokens"])
             else:
                 _prompt_tokens_details.cached_tokens = params["prompt_cache_hit_tokens"]
 
         ## ANTHROPIC MAPPING ##
-        if "cache_read_input_tokens" in params and isinstance(
-            params["cache_read_input_tokens"], int
-        ):
+        if "cache_read_input_tokens" in params and isinstance(params["cache_read_input_tokens"], int):
             if _prompt_tokens_details is None:
-                _prompt_tokens_details = PromptTokensDetailsWrapper(
-                    cached_tokens=params["cache_read_input_tokens"]
-                )
+                _prompt_tokens_details = PromptTokensDetailsWrapper(cached_tokens=params["cache_read_input_tokens"])
             else:
                 _prompt_tokens_details.cached_tokens = params["cache_read_input_tokens"]
 
-        if "cache_creation_input_tokens" in params and isinstance(
-            params["cache_creation_input_tokens"], int
-        ):
+        if "cache_creation_input_tokens" in params and isinstance(params["cache_creation_input_tokens"], int):
             if _prompt_tokens_details is None:
                 _prompt_tokens_details = PromptTokensDetailsWrapper(
                     cache_creation_tokens=params["cache_creation_input_tokens"]
                 )
             else:
-                _prompt_tokens_details.cache_creation_tokens = params[
-                    "cache_creation_input_tokens"
-                ]
+                _prompt_tokens_details.cache_creation_tokens = params["cache_creation_input_tokens"]
 
         super().__init__(
             prompt_tokens=prompt_tokens or 0,
@@ -1699,20 +1609,14 @@ class Usage(SafeAttributeModel, CompletionUsage):
             del self.cost
 
         ## ANTHROPIC MAPPING ##
-        if "cache_creation_input_tokens" in params and isinstance(
-            params["cache_creation_input_tokens"], int
-        ):
+        if "cache_creation_input_tokens" in params and isinstance(params["cache_creation_input_tokens"], int):
             self._cache_creation_input_tokens = params["cache_creation_input_tokens"]
 
-        if "cache_read_input_tokens" in params and isinstance(
-            params["cache_read_input_tokens"], int
-        ):
+        if "cache_read_input_tokens" in params and isinstance(params["cache_read_input_tokens"], int):
             self._cache_read_input_tokens = params["cache_read_input_tokens"]
 
         ## DEEPSEEK MAPPING ##
-        if "prompt_cache_hit_tokens" in params and isinstance(
-            params["prompt_cache_hit_tokens"], int
-        ):
+        if "prompt_cache_hit_tokens" in params and isinstance(params["prompt_cache_hit_tokens"], int):
             self._cache_read_input_tokens = params["prompt_cache_hit_tokens"]
 
         for k, v in params.items():
@@ -1834,9 +1738,7 @@ class ModelResponseStream(ModelResponseBase):
 
     def __init__(
         self,
-        choices: Optional[
-            Union[List[StreamingChoices], Union[StreamingChoices, dict, BaseModel]]
-        ] = None,
+        choices: Optional[Union[List[StreamingChoices], Union[StreamingChoices, dict, BaseModel]]] = None,
         id: Optional[str] = None,
         created: Optional[int] = None,
         provider_specific_fields: Optional[Dict[str, Any]] = None,
@@ -1871,9 +1773,7 @@ class ModelResponseStream(ModelResponseBase):
                 kwargs["usage"] = Usage(**kwargs["usage"])
             elif isinstance(kwargs["usage"], BaseModel):
                 dump = (
-                    kwargs["usage"].model_dump()
-                    if hasattr(kwargs["usage"], "model_dump")
-                    else kwargs["usage"].dict()
+                    kwargs["usage"].model_dump() if hasattr(kwargs["usage"], "model_dump") else kwargs["usage"].dict()
                 )
                 kwargs["usage"] = Usage(**dump)
 
@@ -1933,11 +1833,7 @@ class ModelResponse(ModelResponseBase):
                 elif isinstance(choice, dict):
                     _new_choice = Choices(**choice)  # type: ignore
                 elif isinstance(choice, BaseModel):
-                    dump = (
-                        choice.model_dump()
-                        if hasattr(choice, "model_dump")
-                        else choice.dict()
-                    )
+                    dump = choice.model_dump() if hasattr(choice, "model_dump") else choice.dict()
                     _new_choice = Choices(**dump)  # type: ignore
                 else:
                     _new_choice = choice
@@ -1958,9 +1854,7 @@ class ModelResponse(ModelResponseBase):
             if isinstance(usage, dict):
                 usage = Usage(**usage)
             elif isinstance(usage, BaseModel):
-                dump = (
-                    usage.model_dump() if hasattr(usage, "model_dump") else usage.dict()
-                )
+                dump = usage.model_dump() if hasattr(usage, "model_dump") else usage.dict()
                 usage = Usage(**dump)
             else:
                 usage = usage
@@ -2443,9 +2337,7 @@ class TranscriptionUsageTokensObject(BaseModel):
 
 class TranscriptionResponse(OpenAIObject):
     text: Optional[str] = None
-    usage: Optional[
-        Union[TranscriptionUsageDurationObject, TranscriptionUsageTokensObject]
-    ] = None
+    usage: Optional[Union[TranscriptionUsageDurationObject, TranscriptionUsageTokensObject]] = None
 
     _hidden_params: dict = {}
     _response_headers: Optional[dict] = None
@@ -2665,23 +2557,17 @@ class StandardLoggingMetadata(StandardLoggingUserAPIKeyMetadata):
     Specific metadata k,v pairs logged to integration for easier cost tracking and prompt management
     """
 
-    spend_logs_metadata: Optional[
-        dict
-    ]  # special param to log k,v pairs to spendlogs for a call
+    spend_logs_metadata: Optional[dict]  # special param to log k,v pairs to spendlogs for a call
     requester_ip_address: Optional[str]
     user_agent: Optional[str]
     requester_metadata: Optional[dict]
-    requester_custom_headers: Optional[
-        Dict[str, str]
-    ]  # Log any custom (`x-`) headers sent by the client to the proxy.
+    requester_custom_headers: Optional[Dict[str, str]]  # Log any custom (`x-`) headers sent by the client to the proxy.
     prompt_management_metadata: Optional[StandardLoggingPromptManagementMetadata]
     mcp_tool_call_metadata: Optional[StandardLoggingMCPToolCall]
     vector_store_request_metadata: Optional[List[StandardLoggingVectorStoreRequest]]
     applied_guardrails: Optional[List[str]]
     usage_object: Optional[dict]
-    cold_storage_object_key: Optional[
-        str
-    ]  # S3/GCS object key for cold storage retrieval
+    cold_storage_object_key: Optional[str]  # S3/GCS object key for cold storage retrieval
     team_alias: Optional[str]
     team_id: Optional[str]
 
@@ -2761,17 +2647,13 @@ class GuardrailMode(TypedDict, total=False):
     default: Optional[Union[str, List[str]]]
 
 
-GuardrailStatus = Literal[
-    "success", "guardrail_intervened", "guardrail_failed_to_respond", "not_run"
-]
+GuardrailStatus = Literal["success", "guardrail_intervened", "guardrail_failed_to_respond", "not_run"]
 
 
 class StandardLoggingGuardrailInformation(TypedDict, total=False):
     guardrail_name: Optional[str]
     guardrail_provider: Optional[str]
-    guardrail_mode: Optional[
-        Union[GuardrailEventHooks, List[GuardrailEventHooks], GuardrailMode]
-    ]
+    guardrail_mode: Optional[Union[GuardrailEventHooks, List[GuardrailEventHooks], GuardrailMode]]
     guardrail_request: Optional[dict]
     guardrail_response: Optional[Union[dict, str, List[dict]]]
     guardrail_status: GuardrailStatus
@@ -2903,14 +2785,10 @@ class CostBreakdown(TypedDict, total=False):
     input_cost: float  # Cost of raw (non-cached) input tokens only
     cache_read_cost: float  # Cost of cache-read tokens (discounted rate)
     cache_creation_cost: float  # Cost of cache-write tokens (premium rate)
-    output_cost: (
-        float  # Cost of output/completion tokens (includes reasoning if applicable)
-    )
+    output_cost: float  # Cost of output/completion tokens (includes reasoning if applicable)
     total_cost: float  # Total cost (input + output + tool usage)
     tool_usage_cost: float  # Cost of usage of built-in tools
-    additional_costs: Dict[
-        str, float
-    ]  # Free-form additional costs (e.g., {"azure_model_router_flat_cost": 0.00014})
+    additional_costs: Dict[str, float]  # Free-form additional costs (e.g., {"azure_model_router_flat_cost": 0.00014})
     original_cost: float  # Cost before discount (optional)
     discount_percent: float  # Discount percentage applied (e.g., 0.05 = 5%) (optional)
     discount_amount: float  # Discount amount in USD (optional)
@@ -2956,9 +2834,7 @@ class StandardLoggingPayload(TypedDict):
     stream: Optional[bool]
     response_cost: float
     cost_breakdown: Optional[CostBreakdown]  # Detailed cost breakdown
-    response_cost_failure_debug_info: Optional[
-        StandardLoggingModelCostFailureDebugInformation
-    ]
+    response_cost_failure_debug_info: Optional[StandardLoggingModelCostFailureDebugInformation]
     status: StandardLoggingPayloadStatus
     status_fields: StandardLoggingPayloadStatusFields
     custom_llm_provider: Optional[str]
@@ -2998,9 +2874,7 @@ from typing import AsyncIterator, Iterator
 class CustomStreamingDecoder:
     async def aiter_bytes(
         self, iterator: AsyncIterator[bytes]
-    ) -> AsyncIterator[
-        Optional[Union[GenericStreamingChunk, StreamingChatCompletionChunk]]
-    ]:
+    ) -> AsyncIterator[Optional[Union[GenericStreamingChunk, StreamingChatCompletionChunk]]]:
         raise NotImplementedError
 
     def iter_bytes(
@@ -3241,9 +3115,7 @@ all_litellm_params = (
 
 
 class KeyGenerationConfig(TypedDict, total=False):
-    required_params: List[
-        str
-    ]  # specify params that must be present in the key generation request
+    required_params: List[str]  # specify params that must be present in the key generation request
 
 
 class TeamUIKeyGenerationConfig(KeyGenerationConfig):
@@ -3438,9 +3310,7 @@ OPENAI_COMPATIBLE_BATCH_AND_FILES_PROVIDERS: set[str] = {
 
 ListBatchesSupportedProvider = Literal["openai", "azure", "hosted_vllm", "vertex_ai"]
 
-LIST_BATCHES_SUPPORTED_PROVIDERS: frozenset[str] = frozenset(
-    get_args(ListBatchesSupportedProvider)
-)
+LIST_BATCHES_SUPPORTED_PROVIDERS: frozenset[str] = frozenset(get_args(ListBatchesSupportedProvider))
 
 
 class SearchProviders(str, Enum):
@@ -3481,9 +3351,7 @@ class LiteLLMLoggingBaseClass:
     def pre_call(self, input, api_key, model=None, additional_args={}):
         pass
 
-    def post_call(
-        self, original_response, input=None, api_key=None, additional_args={}
-    ):
+    def post_call(self, original_response, input=None, api_key=None, additional_args={}):
         pass
 
 
@@ -3574,7 +3442,9 @@ class LiteLLMBatch(Batch):
 
 
 class LiteLLMRealtimeStreamLoggingObject(LiteLLMPydanticObjectBase):
-    results: OpenAIRealtimeStreamList
+    results: List[
+        Dict[str, Any]
+    ]  # any-ok: OpenAI realtime event dicts are open-ended; strict union validation caused prod crashes on unknown GA event types (rate_limits.updated, response.function_call_arguments.delta)
     usage: Usage
     _hidden_params: dict = {}
 
@@ -3631,11 +3501,11 @@ class ExtractedFileData(TypedDict):
 
 class SpecialEnums(Enum):
     LITELM_MANAGED_FILE_ID_PREFIX = "litellm_proxy"
-    LITELLM_MANAGED_FILE_COMPLETE_STR = "litellm_proxy:{};unified_id,{};target_model_names,{};llm_output_file_id,{};llm_output_file_model_id,{}"
-
-    LITELLM_MANAGED_RESPONSE_COMPLETE_STR = (
-        "litellm:custom_llm_provider:{};model_id:{};response_id:{}"
+    LITELLM_MANAGED_FILE_COMPLETE_STR = (
+        "litellm_proxy:{};unified_id,{};target_model_names,{};llm_output_file_id,{};llm_output_file_model_id,{}"
     )
+
+    LITELLM_MANAGED_RESPONSE_COMPLETE_STR = "litellm:custom_llm_provider:{};model_id:{};response_id:{}"
 
     LITELLM_MANAGED_BATCH_COMPLETE_STR = "litellm_proxy;model_id:{};llm_batch_id:{}"
 
@@ -3645,13 +3515,9 @@ class SpecialEnums(Enum):
 
     LITELLM_MANAGED_GENERIC_RESPONSE_COMPLETE_STR = "litellm_proxy;model_id:{};generic_response_id:{}"  # generic implementation of 'managed batches' - used for finetuning and any future work.
 
-    LITELLM_MANAGED_VIDEO_COMPLETE_STR = (
-        "litellm:custom_llm_provider:{};model_id:{};video_id:{}"
-    )
+    LITELLM_MANAGED_VIDEO_COMPLETE_STR = "litellm:custom_llm_provider:{};model_id:{};video_id:{}"
 
-    LITELLM_PASSTHROUGH_MANAGED_ID_COMPLETE_STR = (
-        "litellm_proxy:passthrough;provider:{};unified_id,{};raw_id,{}"
-    )
+    LITELLM_PASSTHROUGH_MANAGED_ID_COMPLETE_STR = "litellm_proxy:passthrough;provider:{};unified_id,{};raw_id,{}"
 
 
 class ServiceTier(Enum):

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -3,9 +3,7 @@ import sys
 
 import pytest
 
-sys.path.insert(
-    0, os.path.abspath("../..")
-)  # Adds the parent directory to the system path
+sys.path.insert(0, os.path.abspath("../.."))  # Adds the parent directory to the system path
 
 
 from pydantic import BaseModel
@@ -101,9 +99,7 @@ def test_completion_cost_uses_response_model_for_dynamic_routing():
 
 def test_cost_calculator_with_response_cost_in_additional_headers():
     class MockResponse(BaseModel):
-        _hidden_params = {
-            "additional_headers": {"llm_provider-x-litellm-response-cost": 1000}
-        }
+        _hidden_params = {"additional_headers": {"llm_provider-x-litellm-response-cost": 1000}}
 
     result = response_cost_calculator(
         response_object=MockResponse(),
@@ -246,13 +242,12 @@ def test_cost_calculator_with_usage(monkeypatch):
 
     # Step 1: Test a model where input_cost_per_image_token is not set.
     # In this case the calculation should use input_cost_per_token as fallback.
-    assert (
-        model_info.get("input_cost_per_image_token") is None
-    ), "Test case expects that input_cost_per_image_token is not set"
+    assert model_info.get("input_cost_per_image_token") is None, (
+        "Test case expects that input_cost_per_image_token is not set"
+    )
 
     expected_cost = (
-        usage.prompt_tokens_details.audio_tokens
-        * model_info["input_cost_per_audio_token"]
+        usage.prompt_tokens_details.audio_tokens * model_info["input_cost_per_audio_token"]
         + usage.prompt_tokens_details.text_tokens * model_info["input_cost_per_token"]
         + usage.prompt_tokens_details.image_tokens * model_info["input_cost_per_token"]
         + usage.completion_tokens * model_info["output_cost_per_token"]
@@ -287,12 +282,9 @@ def test_cost_calculator_with_usage(monkeypatch):
     )
 
     expected_cost = (
-        usage.prompt_tokens_details.audio_tokens
-        * temp_model_info_object["input_cost_per_audio_token"]
-        + usage.prompt_tokens_details.text_tokens
-        * temp_model_info_object["input_cost_per_token"]
-        + usage.prompt_tokens_details.image_tokens
-        * temp_model_info_object["input_cost_per_image_token"]
+        usage.prompt_tokens_details.audio_tokens * temp_model_info_object["input_cost_per_audio_token"]
+        + usage.prompt_tokens_details.text_tokens * temp_model_info_object["input_cost_per_token"]
+        + usage.prompt_tokens_details.image_tokens * temp_model_info_object["input_cost_per_image_token"]
         + usage.completion_tokens * temp_model_info_object["output_cost_per_token"]
     )
 
@@ -309,9 +301,7 @@ def test_transcription_cost_uses_token_pricing():
         prompt_tokens=14,
         completion_tokens=45,
         total_tokens=59,
-        prompt_tokens_details=PromptTokensDetailsWrapper(
-            text_tokens=0, audio_tokens=14
-        ),
+        prompt_tokens_details=PromptTokensDetailsWrapper(text_tokens=0, audio_tokens=14),
     )
     response = TranscriptionResponse(text="demo text")
     response.usage = usage
@@ -355,9 +345,7 @@ def test_handle_realtime_stream_cost_calculation():
         {"type": "session.created", "session": {"model": "gpt-3.5-turbo"}},
         {
             "type": "response.done",
-            "response": {
-                "usage": {"input_tokens": 100, "output_tokens": 50, "total_tokens": 150}
-            },
+            "response": {"usage": {"input_tokens": 100, "output_tokens": 50, "total_tokens": 150}},
         },
         {
             "type": "response.done",
@@ -388,9 +376,7 @@ def test_handle_realtime_stream_cost_calculation():
     expected_cost = (300 * 0.0015 / 1000) + (  # input tokens (100 + 200)
         150 * 0.002 / 1000
     )  # output tokens (50 + 100)
-    assert (
-        abs(cost - expected_cost) <= 0.00075
-    )  # Allow small floating point differences
+    assert abs(cost - expected_cost) <= 0.00075  # Allow small floating point differences
 
     # Test with different model name in session
     results[0]["session"]["model"] = "gpt-4"
@@ -493,9 +479,7 @@ def test_realtime_logging_object_allows_null_transcript_in_conversation_item_add
         },
     ]
 
-    usage = RealtimeAPITokenUsageProcessor.collect_and_combine_usage_from_realtime_stream_results(
-        results=results
-    )
+    usage = RealtimeAPITokenUsageProcessor.collect_and_combine_usage_from_realtime_stream_results(results=results)
     logging_result = RealtimeAPITokenUsageProcessor.create_logging_realtime_object(
         usage=usage,
         results=results,
@@ -521,9 +505,7 @@ def test_realtime_transcription_duration_cost(monkeypatch):
             "type": "session.created",
             "session": {
                 "type": "transcription",
-                "audio": {
-                    "input": {"transcription": {"model": "gpt-realtime-whisper"}}
-                },
+                "audio": {"input": {"transcription": {"model": "gpt-realtime-whisper"}}},
             },
         },
         {
@@ -538,9 +520,7 @@ def test_realtime_transcription_duration_cost(monkeypatch):
         },
     ]
 
-    combined = RealtimeAPITokenUsageProcessor.collect_and_combine_usage_from_realtime_stream_results(
-        results=results
-    )
+    combined = RealtimeAPITokenUsageProcessor.collect_and_combine_usage_from_realtime_stream_results(results=results)
     cost = handle_realtime_stream_cost_calculation(
         results=results,
         combined_usage_object=combined,
@@ -609,9 +589,7 @@ def test_realtime_transcription_token_billed_fallback(monkeypatch):
 
     # gpt-4o-transcribe: input_cost_per_audio_token = 2.5e-06, input_cost_per_token = 2.5e-06,
     # output_cost_per_token = 1e-05
-    model_info = litellm.get_model_info(
-        model="gpt-4o-transcribe", custom_llm_provider="openai"
-    )
+    model_info = litellm.get_model_info(model="gpt-4o-transcribe", custom_llm_provider="openai")
     usage = {
         "type": "tokens",
         "input_tokens": 40,
@@ -648,6 +626,57 @@ def test_get_transcription_model_falls_back_to_session_model(monkeypatch):
     ]
     assert _get_transcription_model_name_from_results(results) == "gpt-realtime-whisper"
 
+
+def test_realtime_logging_object_tolerates_unknown_ga_event_types():
+    """Regression: gpt-realtime-2 emits GA-only event types (rate_limits.updated,
+    response.function_call_arguments.delta) that are not in the OpenAIRealtimeEvents
+    union. LiteLLMRealtimeStreamLoggingObject must not raise ValidationError on them."""
+    from litellm.cost_calculator import RealtimeAPITokenUsageProcessor
+
+    results = [
+        {
+            "type": "session.created",
+            "event_id": "event_session",
+            "session": {"id": "sess_abc", "model": "gpt-realtime-2"},
+        },
+        {
+            "type": "rate_limits.updated",
+            "event_id": "event_rl",
+            "rate_limits": [{"name": "requests", "limit": 1000, "remaining": 999, "reset_seconds": 0.009}],
+        },
+        {
+            "type": "response.function_call_arguments.delta",
+            "event_id": "event_fca_delta",
+            "response_id": "resp_xyz",
+            "item_id": "item_xyz",
+            "output_index": 0,
+            "call_id": "call_xyz",
+            "delta": '{"key":',
+        },
+        {
+            "type": "response.done",
+            "event_id": "event_done",
+            "response": {
+                "id": "resp_xyz",
+                "object": "realtime.response",
+                "status": "completed",
+                "usage": {"input_tokens": 5, "output_tokens": 3, "total_tokens": 8},
+            },
+        },
+    ]
+
+    usage = RealtimeAPITokenUsageProcessor.collect_and_combine_usage_from_realtime_stream_results(results=results)
+    logging_result = RealtimeAPITokenUsageProcessor.create_logging_realtime_object(
+        usage=usage,
+        results=results,
+    )
+
+    assert logging_result.usage.total_tokens == 8
+    assert logging_result.results[1]["type"] == "rate_limits.updated"
+    assert logging_result.results[2]["type"] == "response.function_call_arguments.delta"
+
+
+def test_custom_pricing_with_router_model_id():
     from litellm import Router
 
     router = Router(
@@ -692,10 +721,7 @@ def test_get_transcription_model_falls_back_to_session_model(monkeypatch):
         mock_response=True,
     )
 
-    assert (
-        result._hidden_params["response_cost"]
-        > result_2._hidden_params["response_cost"]
-    )
+    assert result._hidden_params["response_cost"] > result_2._hidden_params["response_cost"]
 
     model_info = router.get_deployment_model_info(
         model_id="my-unique-model-id", model_name="anthropic/claude-sonnet-4-5-20250929"
@@ -836,9 +862,7 @@ def test_azure_realtime_cost_calculator():
         combined_usage_object=Usage(
             prompt_tokens=100,
             completion_tokens=100,
-            prompt_tokens_details=PromptTokensDetailsWrapper(
-                text_tokens=10, audio_tokens=90
-            ),
+            prompt_tokens_details=PromptTokensDetailsWrapper(text_tokens=10, audio_tokens=90),
         ),
         custom_llm_provider="azure",
         litellm_model_name="my-custom-azure-deployment",
@@ -915,14 +939,10 @@ def test_azure_audio_output_cost_calculation():
     wrong_total_cost = expected_input_cost + wrong_output_cost
 
     # Verify audio tokens are NOT charged at text rate (the bug)
-    assert (
-        abs(cost - wrong_total_cost) > 0.001
-    ), "Bug: Audio tokens are being charged at text token rate"
+    assert abs(cost - wrong_total_cost) > 0.001, "Bug: Audio tokens are being charged at text token rate"
 
     # Verify cost matches
-    assert (
-        abs(cost - expected_total_cost) < 0.0000001
-    ), f"Expected cost {expected_total_cost}, got {cost}"
+    assert abs(cost - expected_total_cost) < 0.0000001, f"Expected cost {expected_total_cost}, got {cost}"
 
 
 def test_default_image_cost_calculator(monkeypatch):
@@ -936,9 +956,7 @@ def test_default_image_cost_calculator(monkeypatch):
     monkeypatch.setattr(
         litellm,
         "model_cost",
-        {
-            "azure/bf9001cd7209f5734ecb4ab937a5a0e2ba5f119708bd68f184db362930f9dc7b": temp_object
-        },
+        {"azure/bf9001cd7209f5734ecb4ab937a5a0e2ba5f119708bd68f184db362930f9dc7b": temp_object},
     )
 
     args = {
@@ -1154,9 +1172,7 @@ def test_gemini_25_implicit_caching_cost():
     expected_cost = 0.00068708
 
     # Allow for small floating point differences
-    assert (
-        abs(result - expected_cost) < 1e-8
-    ), f"Expected cost {expected_cost}, but got {result}"
+    assert abs(result - expected_cost) < 1e-8, f"Expected cost {expected_cost}, but got {result}"
 
     print(f"✓ Gemini 2.5 implicit caching cost calculation is correct: ${result:.8f}")
 
@@ -1227,9 +1243,7 @@ def test_log_context_cost_calculation():
     # Get model info to understand the pricing
     from litellm import get_model_info
 
-    model_info = get_model_info(
-        model="claude-4-sonnet-20250514", custom_llm_provider="anthropic"
-    )
+    model_info = get_model_info(model="claude-4-sonnet-20250514", custom_llm_provider="anthropic")
 
     # Calculate expected cost based on actual model pricing
     input_cost_per_token = model_info.get("input_cost_per_token", 0)
@@ -1237,12 +1251,8 @@ def test_log_context_cost_calculation():
     cache_creation_cost_per_token = model_info.get("cache_creation_input_token_cost", 0)
 
     # Check if tiered pricing is applied
-    input_cost_above_200k = model_info.get(
-        "input_cost_per_token_above_200k_tokens", input_cost_per_token
-    )
-    output_cost_above_200k = model_info.get(
-        "output_cost_per_token_above_200k_tokens", output_cost_per_token
-    )
+    input_cost_above_200k = model_info.get("input_cost_per_token_above_200k_tokens", input_cost_per_token)
+    output_cost_above_200k = model_info.get("output_cost_per_token_above_200k_tokens", output_cost_per_token)
     cache_creation_above_200k = model_info.get(
         "cache_creation_input_token_cost_above_200k_tokens",
         cache_creation_cost_per_token,
@@ -1250,31 +1260,23 @@ def test_log_context_cost_calculation():
 
     print(f"DEBUG: Base input cost per token: ${input_cost_per_token:.2e}")
     print(f"DEBUG: Base output cost per token: ${output_cost_per_token:.2e}")
-    print(
-        f"DEBUG: Base cache creation cost per token: ${cache_creation_cost_per_token:.2e}"
-    )
+    print(f"DEBUG: Base cache creation cost per token: ${cache_creation_cost_per_token:.2e}")
 
     # Handle tiered pricing - if not available, use base pricing
     if input_cost_above_200k is not None:
-        print(
-            f"DEBUG: Tiered input cost per token (>200k): ${input_cost_above_200k:.2e}"
-        )
+        print(f"DEBUG: Tiered input cost per token (>200k): ${input_cost_above_200k:.2e}")
     else:
         print("DEBUG: No tiered input pricing available, using base pricing")
         input_cost_above_200k = input_cost_per_token
 
     if output_cost_above_200k is not None:
-        print(
-            f"DEBUG: Tiered output cost per token (>200k): ${output_cost_above_200k:.2e}"
-        )
+        print(f"DEBUG: Tiered output cost per token (>200k): ${output_cost_above_200k:.2e}")
     else:
         print("DEBUG: No tiered output pricing available, using base pricing")
         output_cost_above_200k = output_cost_per_token
 
     if cache_creation_above_200k is not None:
-        print(
-            f"DEBUG: Tiered cache creation cost per token (>200k): ${cache_creation_above_200k:.2e}"
-        )
+        print(f"DEBUG: Tiered cache creation cost per token (>200k): ${cache_creation_above_200k:.2e}")
     else:
         print("DEBUG: No tiered cache creation pricing available, using base pricing")
         cache_creation_above_200k = cache_creation_cost_per_token
@@ -1288,13 +1290,9 @@ def test_log_context_cost_calculation():
     print(f"DEBUG: Expected total: ${expected_total:.6f}")
 
     # Allow for small floating point differences
-    assert (
-        abs(result - expected_total) < 1e-6
-    ), f"Expected cost ${expected_total:.6f}, but got ${result:.6f}"
+    assert abs(result - expected_total) < 1e-6, f"Expected cost ${expected_total:.6f}, but got ${result:.6f}"
 
-    print(
-        f"✓ Log context cost calculation with tiered pricing is correct: ${result:.6f}"
-    )
+    print(f"✓ Log context cost calculation with tiered pricing is correct: ${result:.6f}")
     print(f"  - Input tokens (300k): ${expected_input_cost:.6f}")
     print(f"  - Output tokens (50k): ${expected_output_cost:.6f}")
     print(f"  - Cache creation (1k): ${expected_cache_cost:.6f}")
@@ -1353,8 +1351,7 @@ def test_gemini_25_explicit_caching_cost_direct_usage():
 
     expected_actual_cost = (
         model_info["input_cost_per_token"] * usage.prompt_tokens_details.text_tokens
-        + model_info["cache_read_input_token_cost"]
-        * usage.prompt_tokens_details.cached_tokens
+        + model_info["cache_read_input_token_cost"] * usage.prompt_tokens_details.cached_tokens
         + model_info["output_cost_per_token"] * usage.completion_tokens
     )
 
@@ -1429,12 +1426,12 @@ def test_azure_ai_cache_cost_calculation():
     print(f"Output cost: {output_cost}, Expected: {expected_output_cost}")
     print(f"Total cost: {total_cost}")
 
-    assert (
-        abs(input_cost - expected_input_cost) < 1e-10
-    ), f"Input cost mismatch: got {input_cost}, expected {expected_input_cost}"
-    assert (
-        abs(output_cost - expected_output_cost) < 1e-10
-    ), f"Output cost mismatch: got {output_cost}, expected {expected_output_cost}"
+    assert abs(input_cost - expected_input_cost) < 1e-10, (
+        f"Input cost mismatch: got {input_cost}, expected {expected_input_cost}"
+    )
+    assert abs(output_cost - expected_output_cost) < 1e-10, (
+        f"Output cost mismatch: got {output_cost}, expected {expected_output_cost}"
+    )
 
 
 def test_cost_discount_vertex_ai():
@@ -1668,9 +1665,7 @@ def test_cost_margin_combined():
     )
 
     # Set 8% margin + $0.0005 fixed for openai
-    litellm.cost_margin_config = {
-        "openai": {"percentage": 0.08, "fixed_amount": 0.0005}
-    }
+    litellm.cost_margin_config = {"openai": {"percentage": 0.08, "fixed_amount": 0.0005}}
 
     # Calculate cost with margin
     cost_with_margin = completion_cost(
@@ -1790,9 +1785,7 @@ def test_cost_margin_provider_overrides_global():
 
     print("✓ Cost margin provider override test passed:")
     print(f"  - Original cost: ${cost_without_margin:.6f}")
-    print(
-        f"  - Cost with provider margin (10%, overrides 5% global): ${cost_with_provider_margin:.6f}"
-    )
+    print(f"  - Cost with provider margin (10%, overrides 5% global): ${cost_with_provider_margin:.6f}")
     print(f"  - Margin added: ${cost_with_provider_margin - cost_without_margin:.6f}")
 
 
@@ -1878,9 +1871,7 @@ def test_azure_image_generation_cost_calculator():
             size=None,
             usage=ImageUsage(
                 input_tokens=0,
-                input_tokens_details=ImageUsageInputTokensDetails(
-                    image_tokens=0, text_tokens=0
-                ),
+                input_tokens_details=ImageUsageInputTokensDetails(image_tokens=0, text_tokens=0),
                 output_tokens=0,
                 total_tokens=0,
             ),
@@ -1953,9 +1944,7 @@ def test_completion_cost_extracts_service_tier_from_response():
     assert flex_cost < standard_cost, "Flex cost should be less than standard cost"
 
     flex_ratio = flex_cost / standard_cost
-    assert (
-        0.45 <= flex_ratio <= 0.55
-    ), f"Flex pricing should be ~50% of standard, got {flex_ratio:.2f}"
+    assert 0.45 <= flex_ratio <= 0.55, f"Flex pricing should be ~50% of standard, got {flex_ratio:.2f}"
 
 
 def test_completion_cost_extracts_service_tier_from_usage():
@@ -1969,9 +1958,7 @@ def test_completion_cost_extracts_service_tier_from_usage():
     model = "gpt-5-nano"
 
     # Create usage object with service_tier
-    usage_with_service_tier = Usage(
-        prompt_tokens=1000, completion_tokens=500, total_tokens=1500
-    )
+    usage_with_service_tier = Usage(prompt_tokens=1000, completion_tokens=500, total_tokens=1500)
     # Set service_tier as an attribute on the usage object
     setattr(usage_with_service_tier, "service_tier", "flex")
 
@@ -1989,9 +1976,7 @@ def test_completion_cost_extracts_service_tier_from_usage():
     )
 
     # Create usage object without service_tier
-    usage_without_service_tier = Usage(
-        prompt_tokens=1000, completion_tokens=500, total_tokens=1500
-    )
+    usage_without_service_tier = Usage(prompt_tokens=1000, completion_tokens=500, total_tokens=1500)
 
     # Create ModelResponse with usage without service_tier
     response_standard = ModelResponse(
@@ -2012,9 +1997,7 @@ def test_completion_cost_extracts_service_tier_from_usage():
     assert flex_cost < standard_cost, "Flex cost should be less than standard cost"
 
     flex_ratio = flex_cost / standard_cost
-    assert (
-        0.45 <= flex_ratio <= 0.55
-    ), f"Flex pricing should be ~50% of standard, got {flex_ratio:.2f}"
+    assert 0.45 <= flex_ratio <= 0.55, f"Flex pricing should be ~50% of standard, got {flex_ratio:.2f}"
 
 
 def test_completion_cost_service_tier_priority():
@@ -2072,9 +2055,7 @@ def test_completion_cost_service_tier_priority():
     assert cost_from_usage > 0, "Cost from usage should be greater than 0"
 
     # Costs should be similar (all using flex)
-    assert (
-        abs(cost_from_params - cost_from_usage) < 1e-6
-    ), "Costs from params and usage should be similar (both flex)"
+    assert abs(cost_from_params - cost_from_usage) < 1e-6, "Costs from params and usage should be similar (both flex)"
 
 
 def test_completion_cost_service_tier_for_bedrock():
@@ -2164,28 +2145,26 @@ def test_gemini_cache_tokens_details_no_negative_values():
     usage = VertexGeminiConfig._calculate_usage(completion_response)
 
     # Text tokens should be non-cached text only: 9402 - 9393 = 9
-    assert (
-        usage.prompt_tokens_details.text_tokens == 9
-    ), f"Expected text_tokens=9, got {usage.prompt_tokens_details.text_tokens}"
+    assert usage.prompt_tokens_details.text_tokens == 9, (
+        f"Expected text_tokens=9, got {usage.prompt_tokens_details.text_tokens}"
+    )
 
     # Image tokens should be non-cached image only: 258 - 258 = 0
-    assert (
-        usage.prompt_tokens_details.image_tokens == 0
-    ), f"Expected image_tokens=0, got {usage.prompt_tokens_details.image_tokens}"
+    assert usage.prompt_tokens_details.image_tokens == 0, (
+        f"Expected image_tokens=0, got {usage.prompt_tokens_details.image_tokens}"
+    )
 
     # Total cached should match
-    assert (
-        usage.prompt_tokens_details.cached_tokens == 9651
-    ), f"Expected cached_tokens=9651, got {usage.prompt_tokens_details.cached_tokens}"
+    assert usage.prompt_tokens_details.cached_tokens == 9651, (
+        f"Expected cached_tokens=9651, got {usage.prompt_tokens_details.cached_tokens}"
+    )
 
     # MOST IMPORTANT: text_tokens should NEVER be negative
-    assert (
-        usage.prompt_tokens_details.text_tokens >= 0
-    ), f"BUG: text_tokens is negative ({usage.prompt_tokens_details.text_tokens})! This was the issue in #18750"
-
-    print(
-        "✅ Issue #18750 fix verified: text_tokens is correctly calculated and non-negative"
+    assert usage.prompt_tokens_details.text_tokens >= 0, (
+        f"BUG: text_tokens is negative ({usage.prompt_tokens_details.text_tokens})! This was the issue in #18750"
     )
+
+    print("✅ Issue #18750 fix verified: text_tokens is correctly calculated and non-negative")
 
 
 def test_gemini_without_cache_tokens_details():
@@ -2253,18 +2232,18 @@ def test_gemini_implicit_caching_cost_calculation():
     usage = VertexGeminiConfig._calculate_usage(completion_response)
 
     # Verify parsing
-    assert (
-        usage.cache_read_input_tokens == 8000
-    ), f"cache_read_input_tokens should be 8000, got {usage.cache_read_input_tokens}"
-    assert (
-        usage.prompt_tokens_details.cached_tokens == 8000
-    ), f"cached_tokens should be 8000, got {usage.prompt_tokens_details.cached_tokens}"
+    assert usage.cache_read_input_tokens == 8000, (
+        f"cache_read_input_tokens should be 8000, got {usage.cache_read_input_tokens}"
+    )
+    assert usage.prompt_tokens_details.cached_tokens == 8000, (
+        f"cached_tokens should be 8000, got {usage.prompt_tokens_details.cached_tokens}"
+    )
 
     # CRITICAL: text_tokens should be (10000 - 8000) = 2000, NOT 10000
     # This is the fix for issue #16341
-    assert (
-        usage.prompt_tokens_details.text_tokens == 2000
-    ), f"text_tokens should be 2000 (10000 - 8000), got {usage.prompt_tokens_details.text_tokens}"
+    assert usage.prompt_tokens_details.text_tokens == 2000, (
+        f"text_tokens should be 2000 (10000 - 8000), got {usage.prompt_tokens_details.text_tokens}"
+    )
 
     # Verify cost calculation uses cached token pricing
     response = ModelResponse(
@@ -2302,9 +2281,7 @@ def test_gemini_implicit_caching_cost_calculation():
         f"Cached tokens may not be using reduced pricing."
     )
 
-    print(
-        "✅ Issue #16341 fix verified: Gemini implicit caching cost calculated correctly"
-    )
+    print("✅ Issue #16341 fix verified: Gemini implicit caching cost calculated correctly")
 
 
 def test_additional_costs_only_for_azure_ai():
@@ -2467,12 +2444,7 @@ def test_custom_pricing_applies_cache_creation_input_cost_via_prompt_details():
         },
     )
 
-    expected = (
-        (4000 - 1000 - 500) * 0.0000025
-        + 1000 * 0.00000025
-        + 500 * 0.000003125
-        + 100 * 0.000015
-    )
+    expected = (4000 - 1000 - 500) * 0.0000025 + 1000 * 0.00000025 + 500 * 0.000003125 + 100 * 0.000015
 
     assert cost == pytest.approx(expected)
 
@@ -2517,9 +2489,7 @@ def test_custom_pricing_applies_cache_creation_input_cost_via_cache_write_tokens
         },
     )
 
-    expected_prompt = (
-        (4000 - 1000 - 500) * 0.0000025 + 1000 * 0.00000025 + 500 * 0.000003125
-    )
+    expected_prompt = (4000 - 1000 - 500) * 0.0000025 + 1000 * 0.00000025 + 500 * 0.000003125
     expected_completion = 100 * 0.000015
 
     assert prompt_cost == pytest.approx(expected_prompt)
@@ -2559,10 +2529,7 @@ def test_extract_cache_read_tokens_zero_when_missing():
 
     assert _extract_cache_read_tokens({}) == 0
     assert _extract_cache_read_tokens({"cache_read_input_tokens": None}) == 0
-    assert (
-        _extract_cache_read_tokens({"prompt_tokens_details": {"cached_tokens": None}})
-        == 0
-    )
+    assert _extract_cache_read_tokens({"prompt_tokens_details": {"cached_tokens": None}}) == 0
 
 
 def test_extract_cache_creation_tokens_anthropic_top_level():
@@ -2612,12 +2579,7 @@ def test_extract_cache_creation_tokens_zero_when_missing():
 
     assert _extract_cache_creation_tokens({}) == 0
     assert _extract_cache_creation_tokens({"cache_creation_input_tokens": None}) == 0
-    assert (
-        _extract_cache_creation_tokens(
-            {"prompt_tokens_details": {"cache_write_tokens": None}}
-        )
-        == 0
-    )
+    assert _extract_cache_creation_tokens({"prompt_tokens_details": {"cache_write_tokens": None}}) == 0
 
 
 def test_custom_pricing_anthropic_style_cache_tokens_not_double_counted():


### PR DESCRIPTION
## Relevant issues

Closes #30581

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting \`@greptileai\` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Run a proxy with a \`gpt-realtime-2\` deployment configured, then connect a WebSocket client and complete a session that includes tool calls. Before this fix, each session would emit hundreds-to-thousands of Pydantic \`ValidationError\` lines in the logs (visible with \`--detailed_debug\`), blocking the event loop and causing readiness probe timeouts. After this fix the session closes cleanly with no validation errors.

\`\`\`bash
python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload 2>&1 | tee litellm.log

grep "ValidationError.*LiteLLMRealtimeStreamLoggingObject" litellm.log
# should produce no output after the fix
\`\`\`

## Type

Bug Fix

## Changes

\`LiteLLMRealtimeStreamLoggingObject.results\` was typed as \`List[OpenAIRealtimeEvents]\`, a discriminated union of known event types. The \`gpt-realtime-2\` model (and other GA realtime models) emit event types not present in this union: \`rate_limits.updated\`, \`response.function_call_arguments.delta\`, and others. On every session close, Pydantic attempted to validate each unknown event against all ~15 union members, producing 1300-1910 \`ValidationError\`s per session. The volume of validation work blocked the asyncio event loop, causing readiness and liveness probe timeouts across all pods.

The fix relaxes the field to \`List[Dict[str, Any]]\`. The cost calculator and logging paths only read \`result["type"]\` and \`result.get("usage")\` from these dicts at runtime, so the strict union provided no practical type safety while being the direct cause of the production incident.