### PR TITLE
feat(proxy): add verification_uri_complete to CLI SSO device flow

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2152,6 +2152,10 @@ class ConfigGeneralSettings(LiteLLMPydanticObjectBase):
     master_key: Optional[str] = Field(
         None, description="require a key for all calls to proxy"
     )
+    allow_cli_sso_verification_uri_complete: bool | None = Field(
+        None,
+        description="opt-in to RFC 8628 verification_uri_complete for the CLI SSO device flow, pre-filling the user_code in the browser. Off by default; intended for same-host clients where the device that starts the flow and the browser run on the same machine",
+    )
     database_url: Optional[str] = Field(
         None,
         description="connect to a postgres db - needed for generating temporary keys + tracking spend / key",

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -185,7 +185,7 @@ def _is_valid_cli_sso_login_id(login_id: Optional[str]) -> bool:
     return isinstance(login_id, str) and bool(_CLI_SSO_LOGIN_ID_RE.fullmatch(login_id))
 
 
-def _is_valid_cli_sso_user_code(user_code: Optional[str]) -> bool:
+def _is_valid_cli_sso_user_code(user_code: str | None) -> bool:
     return isinstance(user_code, str) and bool(
         _CLI_SSO_USER_CODE_RE.fullmatch(user_code)
     )
@@ -489,7 +489,7 @@ def _cli_poll_attribution_metadata_from_session(
 def _render_cli_sso_verification_page(
     verify_url: str,
     browser_complete_token: str,
-    prefill_user_code: Optional[str] = None,
+    prefill_user_code: str | None = None,
 ) -> str:
     escaped_verify_url = escape(verify_url, quote=True)
     escaped_browser_complete_token = escape(browser_complete_token, quote=True)
@@ -861,7 +861,7 @@ async def google_login(
     key: Optional[str] = None,
     existing_key: Optional[str] = None,
     return_to: Optional[str] = None,
-    user_code: Optional[str] = None,
+    user_code: str | None = None,
 ):
     """
     Create Proxy API Keys using Google Workspace SSO. Requires setting PROXY_BASE_URL in .env
@@ -2044,7 +2044,7 @@ async def _complete_cli_sso_callback_session(
     prisma_client: PrismaClient,
     user_api_key_cache: UserApiKeyCache,
     proxy_logging_obj: ProxyLogging,
-    prefill_user_code: Optional[str] = None,
+    prefill_user_code: str | None = None,
 ):
     from fastapi.responses import HTMLResponse
 
@@ -2119,7 +2119,7 @@ async def cli_sso_callback(
     key: Optional[str] = None,
     result: Optional[Union[OpenID, dict]] = None,
     received_response: Optional[dict] = None,
-    prefill_user_code: Optional[str] = None,
+    prefill_user_code: str | None = None,
 ):
     """CLI SSO callback - stores session info for JWT generation on polling"""
     verbose_proxy_logger.info("CLI SSO callback")
@@ -3093,10 +3093,10 @@ class SSOAuthenticationHandler:
 
     @staticmethod
     def _get_cli_state(
-        source: Optional[str],
-        key: Optional[str],
-        existing_key: Optional[str] = None,
-        user_code: Optional[str] = None,
+        source: str | None,
+        key: str | None,
+        existing_key: str | None = None,
+        user_code: str | None = None,
     ) -> Optional[str]:
         """
         Checks the request 'source' if a cli state token was passed in

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -145,6 +145,9 @@ _CLI_SSO_START_RATE_LIMIT_WINDOW_SECONDS = 60
 _CLI_SSO_START_RATE_LIMIT_MAX_ATTEMPTS = 30
 _CLI_SSO_USER_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
 _CLI_SSO_LOGIN_ID_RE = re.compile(r"^cli-[A-Za-z0-9_-]{12,124}$")
+_CLI_SSO_USER_CODE_RE = re.compile(
+    rf"^[{_CLI_SSO_USER_CODE_ALPHABET}]{{4}}-[{_CLI_SSO_USER_CODE_ALPHABET}]{{4}}$"
+)
 _CLI_SSO_SCALAR_TYPES = (str, int, float, bool)
 _CLI_SSO_DEST_KEY_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
 _CLI_SSO_SECRET_KEY_FRAGMENTS = frozenset(
@@ -180,6 +183,12 @@ def _get_cli_sso_flow_cache_key(login_id: str) -> str:
 
 def _is_valid_cli_sso_login_id(login_id: Optional[str]) -> bool:
     return isinstance(login_id, str) and bool(_CLI_SSO_LOGIN_ID_RE.fullmatch(login_id))
+
+
+def _is_valid_cli_sso_user_code(user_code: Optional[str]) -> bool:
+    return isinstance(user_code, str) and bool(
+        _CLI_SSO_USER_CODE_RE.fullmatch(user_code)
+    )
 
 
 def _get_cli_sso_start_rate_limit_cache_key(
@@ -487,6 +496,11 @@ def _render_cli_sso_verification_page(
     user_code_value_attr = (
         f' value="{escape(prefill_user_code, quote=True)}"' if prefill_user_code else ""
     )
+    instructions = (
+        "Confirm the verification code below to finish this login."
+        if prefill_user_code
+        else "Enter the verification code shown in your terminal to finish this login."
+    )
     return f"""
     <!doctype html>
     <html>
@@ -540,7 +554,7 @@ def _render_cli_sso_verification_page(
       <body>
         <main>
           <h1>Complete CLI Login</h1>
-          <p>Enter the verification code shown in your terminal to finish this login.</p>
+          <p>{instructions}</p>
           <form method="post" action="{escaped_verify_url}">
             <input type="hidden" name="browser_complete_token" value="{escaped_browser_complete_token}" />
             <label for="user_code">Verification code</label>
@@ -3098,7 +3112,7 @@ class SSOAuthenticationHandler:
         )
 
         if source == LITELLM_CLI_SOURCE_IDENTIFIER and key:
-            if user_code:
+            if _is_valid_cli_sso_user_code(user_code):
                 return f"{LITELLM_CLI_SESSION_TOKEN_PREFIX}:{key}:{user_code}"
             return f"{LITELLM_CLI_SESSION_TOKEN_PREFIX}:{key}"
         else:

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -191,6 +191,39 @@ def _is_valid_cli_sso_user_code(user_code: str | None) -> bool:
     )
 
 
+def _cli_sso_verification_uri_complete_enabled() -> bool:
+    from litellm.proxy.proxy_server import general_settings
+
+    return bool(
+        general_settings.get(  # any-ok: operator opt-in read from the untyped general_settings dict
+            "allow_cli_sso_verification_uri_complete", False
+        )
+    )
+
+
+def _cli_sso_start_response_body(
+    *,
+    login_id: str,
+    poll_secret: str,
+    user_code: str,
+    verification_uri_complete: str | None,
+) -> dict[str, str | int]:
+    if verification_uri_complete is None:
+        return {
+            "login_id": login_id,
+            "poll_secret": poll_secret,
+            "user_code": user_code,
+            "expires_in": CLI_SSO_SESSION_TTL_SECONDS,
+        }
+    return {
+        "login_id": login_id,
+        "poll_secret": poll_secret,
+        "user_code": user_code,
+        "verification_uri_complete": verification_uri_complete,
+        "expires_in": CLI_SSO_SESSION_TTL_SECONDS,
+    }
+
+
 def _get_cli_sso_start_rate_limit_cache_key(
     request: Request, use_x_forwarded_for: Optional[bool] = False
 ) -> str:
@@ -592,25 +625,29 @@ async def cli_sso_start(request: Request):
     }
     _set_cli_sso_flow(login_id=login_id, cache=user_api_key_cache, flow=flow)
 
-    verification_uri_complete = (
-        get_custom_url(request_base_url=str(request.base_url), route="sso/key/generate")
-        + "?"
-        + urlencode(
-            {
-                "source": LITELLM_CLI_SOURCE_IDENTIFIER,
-                "key": login_id,
-                "user_code": user_code,
-            }
+    verification_uri_complete: str | None = (
+        (
+            get_custom_url(
+                request_base_url=str(request.base_url), route="sso/key/generate"
+            )
+            + "?"
+            + urlencode(
+                {
+                    "source": LITELLM_CLI_SOURCE_IDENTIFIER,
+                    "key": login_id,
+                    "user_code": user_code,
+                }
+            )
         )
+        if _cli_sso_verification_uri_complete_enabled()
+        else None
     )
-
-    return {
-        "login_id": login_id,
-        "poll_secret": poll_secret,
-        "user_code": user_code,
-        "verification_uri_complete": verification_uri_complete,
-        "expires_in": CLI_SSO_SESSION_TTL_SECONDS,
-    }
+    return _cli_sso_start_response_body(
+        login_id=login_id,
+        poll_secret=poll_secret,
+        user_code=user_code,
+        verification_uri_complete=verification_uri_complete,
+    )
 
 
 @router.post(
@@ -930,7 +967,7 @@ async def google_login(
     cli_state: Optional[str] = SSOAuthenticationHandler._get_cli_state(
         source=source,
         key=key,
-        user_code=user_code,
+        user_code=(user_code if _cli_sso_verification_uri_complete_enabled() else None),
     )
 
     # check if user defined a custom auth sso sign in handler, if yes, use it

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -478,10 +478,15 @@ def _cli_poll_attribution_metadata_from_session(
 
 
 def _render_cli_sso_verification_page(
-    verify_url: str, browser_complete_token: str
+    verify_url: str,
+    browser_complete_token: str,
+    prefill_user_code: Optional[str] = None,
 ) -> str:
     escaped_verify_url = escape(verify_url, quote=True)
     escaped_browser_complete_token = escape(browser_complete_token, quote=True)
+    user_code_value_attr = (
+        f' value="{escape(prefill_user_code, quote=True)}"' if prefill_user_code else ""
+    )
     return f"""
     <!doctype html>
     <html>
@@ -539,7 +544,7 @@ def _render_cli_sso_verification_page(
           <form method="post" action="{escaped_verify_url}">
             <input type="hidden" name="browser_complete_token" value="{escaped_browser_complete_token}" />
             <label for="user_code">Verification code</label>
-            <input id="user_code" name="user_code" autocomplete="one-time-code" required autofocus />
+            <input id="user_code" name="user_code" autocomplete="one-time-code"{user_code_value_attr} required autofocus />
             <button type="submit">Continue</button>
           </form>
         </main>
@@ -573,10 +578,23 @@ async def cli_sso_start(request: Request):
     }
     _set_cli_sso_flow(login_id=login_id, cache=user_api_key_cache, flow=flow)
 
+    verification_uri_complete = (
+        get_custom_url(request_base_url=str(request.base_url), route="sso/key/generate")
+        + "?"
+        + urlencode(
+            {
+                "source": LITELLM_CLI_SOURCE_IDENTIFIER,
+                "key": login_id,
+                "user_code": user_code,
+            }
+        )
+    )
+
     return {
         "login_id": login_id,
         "poll_secret": poll_secret,
         "user_code": user_code,
+        "verification_uri_complete": verification_uri_complete,
         "expires_in": CLI_SSO_SESSION_TTL_SECONDS,
     }
 
@@ -829,6 +847,7 @@ async def google_login(
     key: Optional[str] = None,
     existing_key: Optional[str] = None,
     return_to: Optional[str] = None,
+    user_code: Optional[str] = None,
 ):
     """
     Create Proxy API Keys using Google Workspace SSO. Requires setting PROXY_BASE_URL in .env
@@ -897,6 +916,7 @@ async def google_login(
     cli_state: Optional[str] = SSOAuthenticationHandler._get_cli_state(
         source=source,
         key=key,
+        user_code=user_code,
     )
 
     # check if user defined a custom auth sso sign in handler, if yes, use it
@@ -1921,14 +1941,16 @@ async def auth_callback(request: Request, state: Optional[str] = None):
         )
 
     if state and state.startswith(f"{LITELLM_CLI_SESSION_TOKEN_PREFIX}:"):
-        # State format: {PREFIX}:{login_id}
-        state_parts = state.split(":", 1)
+        # State format: {PREFIX}:{login_id}[:{user_code}]
+        state_parts = state.split(":", 2)
         key_id = state_parts[1] if len(state_parts) > 1 else None
+        prefill_user_code = state_parts[2] if len(state_parts) > 2 else None
 
         verbose_proxy_logger.info("CLI SSO callback detected")
         return await cli_sso_callback(
             request=request,
             key=key_id,
+            prefill_user_code=prefill_user_code,
             result=result,
             received_response=received_response,
         )
@@ -2008,6 +2030,7 @@ async def _complete_cli_sso_callback_session(
     prisma_client: PrismaClient,
     user_api_key_cache: UserApiKeyCache,
     proxy_logging_obj: ProxyLogging,
+    prefill_user_code: Optional[str] = None,
 ):
     from fastapi.responses import HTMLResponse
 
@@ -2071,6 +2094,7 @@ async def _complete_cli_sso_callback_session(
         content=_render_cli_sso_verification_page(
             verify_url=verify_url,
             browser_complete_token=browser_complete_token,
+            prefill_user_code=prefill_user_code,
         ),
         status_code=200,
     )
@@ -2081,6 +2105,7 @@ async def cli_sso_callback(
     key: Optional[str] = None,
     result: Optional[Union[OpenID, dict]] = None,
     received_response: Optional[dict] = None,
+    prefill_user_code: Optional[str] = None,
 ):
     """CLI SSO callback - stores session info for JWT generation on polling"""
     verbose_proxy_logger.info("CLI SSO callback")
@@ -2137,6 +2162,7 @@ async def cli_sso_callback(
             prisma_client=prisma_client,
             user_api_key_cache=user_api_key_cache,
             proxy_logging_obj=proxy_logging_obj,
+            prefill_user_code=prefill_user_code,
         )
     except ProxyException:
         raise
@@ -3053,21 +3079,27 @@ class SSOAuthenticationHandler:
 
     @staticmethod
     def _get_cli_state(
-        source: Optional[str], key: Optional[str], existing_key: Optional[str] = None
+        source: Optional[str],
+        key: Optional[str],
+        existing_key: Optional[str] = None,
+        user_code: Optional[str] = None,
     ) -> Optional[str]:
         """
         Checks the request 'source' if a cli state token was passed in
 
         This is used to authenticate through the CLI login flow.
 
-        The state parameter format is: {PREFIX}:{login_id}
+        The state parameter format is: {PREFIX}:{login_id}[:{user_code}]
         - The state parameter is used to pass data through the OAuth flow without changing the callback URL
+        - user_code is appended only for the opt-in verification_uri_complete flow so the verify page can pre-fill it
         """
         from litellm.constants import (
             LITELLM_CLI_SESSION_TOKEN_PREFIX,
         )
 
         if source == LITELLM_CLI_SOURCE_IDENTIFIER and key:
+            if user_code:
+                return f"{LITELLM_CLI_SESSION_TOKEN_PREFIX}:{key}:{user_code}"
             return f"{LITELLM_CLI_SESSION_TOKEN_PREFIX}:{key}"
         else:
             return None

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -2121,8 +2121,8 @@ class TestCLIKeyRegenerationFlow:
         mock_cache.set_cache.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_cli_sso_start_returns_verification_uri_complete(self):
-        """Test CLI SSO start returns a verification_uri_complete that round-trips the user_code through the browser SSO start route"""
+    async def test_cli_sso_start_returns_verification_uri_complete_when_enabled(self):
+        """Test CLI SSO start returns a verification_uri_complete that round-trips the user_code only when the operator opts in"""
         from urllib.parse import parse_qs, urlparse
 
         from litellm.constants import LITELLM_CLI_SOURCE_IDENTIFIER
@@ -2141,6 +2141,10 @@ class TestCLIKeyRegenerationFlow:
                 {"PROXY_BASE_URL": "https://proxy.example.com", "SERVER_ROOT_PATH": ""},
             ),
             patch("litellm.proxy.proxy_server.user_api_key_cache", mock_cache),
+            patch(
+                "litellm.proxy.proxy_server.general_settings",
+                {"allow_cli_sso_verification_uri_complete": True},
+            ),
         ):
             result = await cli_sso_start(request=mock_request)
 
@@ -2152,6 +2156,93 @@ class TestCLIKeyRegenerationFlow:
         assert query["source"] == [LITELLM_CLI_SOURCE_IDENTIFIER]
         assert query["key"] == [result["login_id"]]
         assert query["user_code"] == [result["user_code"]]
+
+    @pytest.mark.asyncio
+    async def test_cli_sso_start_omits_verification_uri_complete_by_default(self):
+        """Test CLI SSO start does NOT advertise verification_uri_complete unless the operator enables it (default off)"""
+        from litellm.proxy.management_endpoints.ui_sso import cli_sso_start
+
+        mock_request = MagicMock(spec=Request)
+        mock_request.client = SimpleNamespace(host="127.0.0.1")
+        mock_request.headers = {}
+        mock_request.base_url = "https://proxy.example.com/"
+        mock_cache = MagicMock()
+        mock_cache.increment_cache.return_value = 1
+
+        with (
+            patch("litellm.proxy.proxy_server.user_api_key_cache", mock_cache),
+            patch("litellm.proxy.proxy_server.general_settings", {}),
+        ):
+            result = await cli_sso_start(request=mock_request)
+
+        assert "verification_uri_complete" not in result
+        assert result["user_code"]
+        assert result["login_id"].startswith("cli-")
+
+    def test_cli_sso_verification_uri_complete_enabled_reads_general_settings(self):
+        """Test the operator opt-in flag is read from general_settings and defaults off"""
+        from litellm.proxy.management_endpoints.ui_sso import (
+            _cli_sso_verification_uri_complete_enabled,
+        )
+
+        with patch("litellm.proxy.proxy_server.general_settings", {}):
+            assert _cli_sso_verification_uri_complete_enabled() is False
+        with patch(
+            "litellm.proxy.proxy_server.general_settings",
+            {"allow_cli_sso_verification_uri_complete": True},
+        ):
+            assert _cli_sso_verification_uri_complete_enabled() is True
+
+    @pytest.mark.asyncio
+    async def test_google_login_only_threads_user_code_when_enabled(self):
+        """Test google_login forwards user_code into the OAuth state only when the operator opt-in is on, dropping it otherwise"""
+        from litellm.proxy.management_endpoints.ui_sso import google_login
+
+        mock_request = MagicMock(spec=Request)
+        mock_request.base_url = "https://proxy.example.com/"
+        mock_cache = MagicMock()
+        mock_cache.get_cache.return_value = {"poll_secret_hash": "h"}
+
+        async def drive(enabled: bool):
+            with (
+                patch.dict(os.environ, {}, clear=True),
+                patch("litellm.proxy.proxy_server.premium_user", True),
+                patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
+                patch("litellm.proxy.proxy_server.user_api_key_cache", mock_cache),
+                patch(
+                    "litellm.proxy.proxy_server.user_custom_ui_sso_sign_in_handler",
+                    None,
+                ),
+                patch(
+                    "litellm.proxy.proxy_server.general_settings",
+                    {"allow_cli_sso_verification_uri_complete": enabled},
+                ),
+                patch(
+                    "litellm.proxy.management_endpoints.ui_sso.show_missing_vars_in_env",
+                    return_value=None,
+                ),
+                patch(
+                    "litellm.proxy.management_endpoints.ui_sso.SSOAuthenticationHandler.get_redirect_url_for_sso",
+                    return_value="https://proxy.example.com/sso/callback",
+                ),
+                patch(
+                    "litellm.proxy.management_endpoints.ui_sso.SSOAuthenticationHandler._get_cli_state",
+                    return_value=None,
+                ) as mock_get_cli_state,
+            ):
+                try:
+                    await google_login(
+                        request=mock_request,
+                        source="litellm-cli",
+                        key="cli-validsessionkey123456",
+                        user_code="WXYZ-2345",
+                    )
+                except Exception:
+                    pass
+            return mock_get_cli_state.call_args.kwargs["user_code"]
+
+        assert await drive(enabled=True) == "WXYZ-2345"
+        assert await drive(enabled=False) is None
 
     def test_get_cli_state_appends_user_code_for_prefill(self):
         """Test the OAuth state carries the user_code only for the opt-in prefill flow"""

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -2121,6 +2121,164 @@ class TestCLIKeyRegenerationFlow:
         mock_cache.set_cache.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_cli_sso_start_returns_verification_uri_complete(self):
+        """Test CLI SSO start returns a verification_uri_complete that round-trips the user_code through the browser SSO start route"""
+        from urllib.parse import parse_qs, urlparse
+
+        from litellm.constants import LITELLM_CLI_SOURCE_IDENTIFIER
+        from litellm.proxy.management_endpoints.ui_sso import cli_sso_start
+
+        mock_request = MagicMock(spec=Request)
+        mock_request.client = SimpleNamespace(host="127.0.0.1")
+        mock_request.headers = {}
+        mock_request.base_url = "https://proxy.example.com/"
+        mock_cache = MagicMock()
+        mock_cache.increment_cache.return_value = 1
+
+        with (
+            patch.dict(
+                os.environ,
+                {"PROXY_BASE_URL": "https://proxy.example.com", "SERVER_ROOT_PATH": ""},
+            ),
+            patch("litellm.proxy.proxy_server.user_api_key_cache", mock_cache),
+        ):
+            result = await cli_sso_start(request=mock_request)
+
+        verification_uri_complete = result["verification_uri_complete"]
+        parsed = urlparse(verification_uri_complete)
+        query = parse_qs(parsed.query)
+
+        assert parsed.path.endswith("/sso/key/generate")
+        assert query["source"] == [LITELLM_CLI_SOURCE_IDENTIFIER]
+        assert query["key"] == [result["login_id"]]
+        assert query["user_code"] == [result["user_code"]]
+
+    def test_get_cli_state_appends_user_code_for_prefill(self):
+        """Test the OAuth state carries the user_code only for the opt-in prefill flow"""
+        from litellm.constants import (
+            LITELLM_CLI_SESSION_TOKEN_PREFIX,
+            LITELLM_CLI_SOURCE_IDENTIFIER,
+        )
+        from litellm.proxy.management_endpoints.ui_sso import SSOAuthenticationHandler
+
+        manual_state = SSOAuthenticationHandler._get_cli_state(
+            source=LITELLM_CLI_SOURCE_IDENTIFIER, key="cli-abc123"
+        )
+        prefill_state = SSOAuthenticationHandler._get_cli_state(
+            source=LITELLM_CLI_SOURCE_IDENTIFIER,
+            key="cli-abc123",
+            user_code="WXYZ-2345",
+        )
+
+        assert manual_state == f"{LITELLM_CLI_SESSION_TOKEN_PREFIX}:cli-abc123"
+        assert (
+            prefill_state == f"{LITELLM_CLI_SESSION_TOKEN_PREFIX}:cli-abc123:WXYZ-2345"
+        )
+        assert (
+            SSOAuthenticationHandler._get_cli_state(
+                source="not-cli", key="cli-abc123", user_code="WXYZ-2345"
+            )
+            is None
+        )
+
+    def test_cli_state_round_trips_user_code_to_callback_parser(self):
+        """Test the callback's state parser recovers login_id and user_code from the state _get_cli_state builds"""
+        from litellm.constants import LITELLM_CLI_SOURCE_IDENTIFIER
+        from litellm.proxy.management_endpoints.ui_sso import SSOAuthenticationHandler
+
+        state = SSOAuthenticationHandler._get_cli_state(
+            source=LITELLM_CLI_SOURCE_IDENTIFIER,
+            key="cli-abc123",
+            user_code="WXYZ-2345",
+        )
+
+        state_parts = state.split(":", 2)
+        key_id = state_parts[1] if len(state_parts) > 1 else None
+        prefill_user_code = state_parts[2] if len(state_parts) > 2 else None
+
+        assert key_id == "cli-abc123"
+        assert prefill_user_code == "WXYZ-2345"
+
+    def test_render_cli_sso_verification_page_prefills_user_code(self):
+        """Test the verify page pre-fills the user_code input (HTML-escaped) when provided"""
+        from litellm.proxy.management_endpoints.ui_sso import (
+            _render_cli_sso_verification_page,
+        )
+
+        html = _render_cli_sso_verification_page(
+            verify_url="https://proxy.example.com/sso/cli/complete/cli-abc123",
+            browser_complete_token="browser-token",
+            prefill_user_code='WXYZ-2345"><script>',
+        )
+
+        assert 'name="user_code"' in html
+        assert "WXYZ-2345&quot;&gt;&lt;script&gt;" in html
+        assert '"><script>' not in html
+
+    def test_render_cli_sso_verification_page_omits_value_without_prefill(self):
+        """Test the verify page renders the empty manual input when no prefill is provided (backward compatible)"""
+        from litellm.proxy.management_endpoints.ui_sso import (
+            _render_cli_sso_verification_page,
+        )
+
+        html = _render_cli_sso_verification_page(
+            verify_url="https://proxy.example.com/sso/cli/complete/cli-abc123",
+            browser_complete_token="browser-token",
+        )
+
+        input_line = next(
+            line for line in html.splitlines() if 'name="user_code"' in line
+        )
+        assert "value=" not in input_line
+
+    @pytest.mark.asyncio
+    async def test_cli_sso_callback_prefills_user_code_on_verify_page(self):
+        """Test the CLI SSO callback threads prefill_user_code into the rendered verify page"""
+        from litellm.proxy._types import LiteLLM_UserTable
+        from litellm.proxy.management_endpoints.ui_sso import cli_sso_callback
+
+        mock_request = MagicMock(spec=Request)
+        mock_request.base_url = "https://proxy.example.com/"
+
+        mock_user_info = LiteLLM_UserTable(
+            user_id="test-user-123",
+            user_role="internal_user",
+            teams=[],
+            models=[],
+        )
+        mock_sso_result = {"user_email": "test@example.com", "user_id": "test-user-123"}
+
+        mock_cache = MagicMock()
+        mock_cache.get_cache.return_value = {
+            "poll_secret_hash": "poll-secret-hash",
+            "user_code_hash": "user-code-hash",
+            "sso_complete": False,
+            "user_code_verified": False,
+            "session_data": None,
+        }
+        with (
+            patch.dict(
+                os.environ,
+                {"PROXY_BASE_URL": "https://proxy.example.com", "SERVER_ROOT_PATH": ""},
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.ui_sso.get_user_info_from_db",
+                return_value=mock_user_info,
+            ),
+            patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
+            patch("litellm.proxy.proxy_server.user_api_key_cache", mock_cache),
+        ):
+            result = await cli_sso_callback(
+                request=mock_request,
+                key="cli-session-4567890",
+                result=mock_sso_result,
+                prefill_user_code="WXYZ-2345",
+            )
+
+        assert result.status_code == 200
+        assert 'value="WXYZ-2345"' in result.body.decode()
+
+    @pytest.mark.asyncio
     async def test_cli_sso_complete_verifies_user_code(self):
         """Test CLI SSO complete marks a session as verified"""
         from litellm.proxy.management_endpoints.ui_sso import (
@@ -2454,6 +2612,46 @@ class TestCLIKeyRegenerationFlow:
             mock_cli_callback.assert_called_once_with(
                 request=mock_request,
                 key="cli-new-session-key-456",
+                prefill_user_code=None,
+                result=mock_result,
+                received_response=None,
+            )
+
+    @pytest.mark.asyncio
+    async def test_auth_callback_forwards_prefill_user_code_from_state(self):
+        """Test auth_callback recovers the user_code from the state and forwards it for prefill"""
+        from litellm.constants import LITELLM_CLI_SESSION_TOKEN_PREFIX
+        from litellm.proxy.management_endpoints.ui_sso import auth_callback
+
+        mock_request = MagicMock(spec=Request)
+        cli_state = (
+            f"{LITELLM_CLI_SESSION_TOKEN_PREFIX}:cli-new-session-key-456:WXYZ-2345"
+        )
+        mock_result = {"user_id": "test-user", "email": "test@example.com"}
+
+        with (
+            patch(
+                "litellm.proxy.management_endpoints.ui_sso.cli_sso_callback"
+            ) as mock_cli_callback,
+            patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
+            patch("litellm.proxy.proxy_server.master_key", "test-master-key"),
+            patch("litellm.proxy.proxy_server.general_settings", {}),
+            patch("litellm.proxy.proxy_server.jwt_handler", MagicMock()),
+            patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
+            patch.dict(os.environ, {"GOOGLE_CLIENT_ID": "test-google-id"}, clear=True),
+            patch(
+                "litellm.proxy.management_endpoints.ui_sso.GoogleSSOHandler.get_google_callback_response",
+                return_value=mock_result,
+            ),
+        ):
+            mock_cli_callback.return_value = MagicMock()
+
+            await auth_callback(request=mock_request, state=cli_state)
+
+            mock_cli_callback.assert_called_once_with(
+                request=mock_request,
+                key="cli-new-session-key-456",
+                prefill_user_code="WXYZ-2345",
                 result=mock_result,
                 received_response=None,
             )

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -2181,6 +2181,40 @@ class TestCLIKeyRegenerationFlow:
             is None
         )
 
+    def test_get_cli_state_drops_malformed_user_code(self):
+        """Test a user_code that is not a server-issued code is dropped before reaching the size-limited OAuth state"""
+        from litellm.constants import (
+            LITELLM_CLI_SESSION_TOKEN_PREFIX,
+            LITELLM_CLI_SOURCE_IDENTIFIER,
+        )
+        from litellm.proxy.management_endpoints.ui_sso import SSOAuthenticationHandler
+
+        manual_only = f"{LITELLM_CLI_SESSION_TOKEN_PREFIX}:cli-abc123"
+        for bad_user_code in ("A" * 4096, "not-a-code", "WXYZ2345", "WXYZ-234", ""):
+            assert (
+                SSOAuthenticationHandler._get_cli_state(
+                    source=LITELLM_CLI_SOURCE_IDENTIFIER,
+                    key="cli-abc123",
+                    user_code=bad_user_code,
+                )
+                == manual_only
+            )
+
+    def test_is_valid_cli_sso_user_code_matches_generated_format(self):
+        """Test the user_code validator accepts a freshly generated code and rejects malformed input"""
+        from litellm.proxy.management_endpoints.ui_sso import (
+            _generate_cli_sso_user_code,
+            _is_valid_cli_sso_user_code,
+        )
+
+        assert _is_valid_cli_sso_user_code(_generate_cli_sso_user_code())
+        assert _is_valid_cli_sso_user_code("WXYZ-2345")
+        assert not _is_valid_cli_sso_user_code("WXYZ-2340")  # 0 is not in the alphabet
+        assert not _is_valid_cli_sso_user_code("wxyz-2345")
+        assert not _is_valid_cli_sso_user_code("WXYZ2345")
+        assert not _is_valid_cli_sso_user_code("A" * 64)
+        assert not _is_valid_cli_sso_user_code(None)
+
     def test_cli_state_round_trips_user_code_to_callback_parser(self):
         """Test the callback's state parser recovers login_id and user_code from the state _get_cli_state builds"""
         from litellm.constants import LITELLM_CLI_SOURCE_IDENTIFIER
@@ -2214,6 +2248,8 @@ class TestCLIKeyRegenerationFlow:
         assert 'name="user_code"' in html
         assert "WXYZ-2345&quot;&gt;&lt;script&gt;" in html
         assert '"><script>' not in html
+        assert "Confirm the verification code below" in html
+        assert "shown in your terminal" not in html
 
     def test_render_cli_sso_verification_page_omits_value_without_prefill(self):
         """Test the verify page renders the empty manual input when no prefill is provided (backward compatible)"""
@@ -2230,6 +2266,7 @@ class TestCLIKeyRegenerationFlow:
             line for line in html.splitlines() if 'name="user_code"' in line
         )
         assert "value=" not in input_line
+        assert "shown in your terminal" in html
 
     @pytest.mark.asyncio
     async def test_cli_sso_callback_prefills_user_code_on_verify_page(self):

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -48141,6 +48141,7 @@ export interface operations {
                 key?: string | null;
                 existing_key?: string | null;
                 return_to?: string | null;
+                user_code?: string | null;
             };
             header?: never;
             path?: never;

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -22053,6 +22053,11 @@ export interface components {
              */
             alerting_threshold?: number | null;
             /**
+             * Allow Cli Sso Verification Uri Complete
+             * @description opt-in to RFC 8628 verification_uri_complete for the CLI SSO device flow, pre-filling the user_code in the browser. Off by default; intended for same-host clients where the device that starts the flow and the browser run on the same machine
+             */
+            allow_cli_sso_verification_uri_complete?: boolean | null;
+            /**
              * Allowed Routes
              * @description Proxy API Endpoints you want users to be able to access
              */


### PR DESCRIPTION
## Relevant issues

Resolves LIT-3693. Reported via Pylon #4797 (CLI SSO device flow verification_uri_complete request)

## Linear ticket

LIT-3693

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Changes

The CLI SSO device flow makes a same-host client read a user_code out of its terminal and type it into the browser to finish login. For daemon and background contexts where no terminal is visible, the code is effectively unreadable and login stalls. RFC 8628 §3.3.1 anticipates this with verification_uri_complete; a URL that embeds the user_code so the user confirms rather than transcribes.

This adds an opt-in verification_uri_complete to POST /sso/cli/start. The value is the same /sso/key/generate?source=litellm-cli&key=<login_id> browser-start URL the CLI already opens, with an added user_code query param. The user_code is carried across the SSO redirect through the OAuth state, the same channel that already carries login_id (state format is now {PREFIX}:{login_id}[:{user_code}]). After SSO completes and the browser_complete_token is minted, the verify page pre-fills the user_code input with the carried value, HTML-escaped, and the instruction text switches to "Confirm the verification code below" instead of pointing at a terminal.

The behavior is gated behind a new general_settings flag allow_cli_sso_verification_uri_complete, default false. When off, /sso/cli/start does not return verification_uri_complete and /sso/key/generate ignores the user_code query param, so the default deployment keeps the existing manual flow byte-for-byte. The flag is intended for same-host clients, where the device that starts the flow and the browser run on the same machine, and operators opt in explicitly. The submitted code is still hashed and compare_digest-checked, browser_complete_token is still required, and poll_secret handling, TTL, and single-use semantics are unchanged. The user_code query param is validated against the canonical server-issued format before it enters the OAuth state. There is no auto-submit.

The litellm CLI client is intentionally left unchanged; it is interactive and shows the code in the terminal already.

## Screenshots / Proof of Fix

Live proxy on localhost:4000 loaded from this worktree (verified `import litellm` resolves to the worktree before testing).

Default deployment, flag off - no verification_uri_complete (manual flow, unchanged):

```
$ curl -s -X POST http://localhost:4000/sso/cli/start | python3 -m json.tool
{
    "login_id": "cli-C9KbajezU3-Kv5zLHe_zkktYHgz0LHkd",
    "poll_secret": "v31zQRz9MjQyJ66QB1ZjlVnMiaEwhwaU2YNPnHPLZSA",
    "user_code": "A4KE-QECH",
    "expires_in": 600
}
```

Operator opted in, general_settings.allow_cli_sso_verification_uri_complete: true - verification_uri_complete present and round-tripping source/key/user_code through the browser SSO start route:

```
$ curl -s -X POST http://localhost:4000/sso/cli/start | python3 -m json.tool
{
    "login_id": "cli-4IIL3Xfm8NIr0etbiJm7TIb6HR_BPpOm",
    "poll_secret": "JN6KgHYpK4hVNrww5TWtnRsbukiJeXZOL7Zd8YMAxV4",
    "user_code": "3897-5KZN",
    "verification_uri_complete": "http://localhost:4000/sso/key/generate?source=litellm-cli&key=cli-4IIL3Xfm8NIr0etbiJm7TIb6HR_BPpOm&user_code=3897-5KZN",
    "expires_in": 600
}
```

The browser SSO round-trip that renders the pre-filled verify page needs a real IdP, so it cannot be reproduced with curl against a headless proxy. That behavior is locked down by unit tests asserting the exact rendered HTML (prefilled value, HTML-escaping of a `WXYZ-2345"><script>` payload, the conditional instruction text, and no value attribute when no prefill is carried), the auth_callback state-forwarding path, and that google_login only threads user_code into the state when the operator opt-in is on.

## Type

🆕 New Feature

## Changes

litellm/proxy/management_endpoints/ui_sso.py
- cli_sso_start returns verification_uri_complete only when the operator opt-in is enabled
- new _cli_sso_verification_uri_complete_enabled() reads the general_settings flag; _cli_sso_start_response_body() builds the typed response
- google_login accepts a user_code query param and threads it into the OAuth state only when enabled
- _is_valid_cli_sso_user_code guards the user_code format before it enters the state
- _get_cli_state appends user_code to the state only for the opt-in flow
- auth_callback recovers user_code from the state and forwards it
- cli_sso_callback / _complete_cli_sso_callback_session thread prefill_user_code to the renderer
- _render_cli_sso_verification_page pre-fills the input (HTML-escaped) and switches the instruction text when present

litellm/proxy/_types.py
- documents allow_cli_sso_verification_uri_complete on ConfigGeneralSettings

ui/litellm-dashboard/src/lib/http/schema.d.ts
- regenerated for the new query param and general setting
