### PR TITLE
fix(guardrails): return 400 not 500 when AIM blocks a request

### DIFF
--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -2295,6 +2295,13 @@ class ProxyBaseLLMRequestProcessing:
 
         self._apply_router_cooldown_retry_after(headers, e)
 
+        if isinstance(e, ProxyException):
+            e.headers = {
+                **e.headers,
+                **{k: v if isinstance(v, str) else str(v) for k, v in headers.items()},
+            }
+            raise e
+
         if isinstance(e, HTTPException):
             raw_detail = getattr(e, "detail", str(e))
             message, structured_fields = _serialize_http_exception_detail(raw_detail)

--- a/litellm/proxy/guardrails/guardrail_hooks/aim/aim.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/aim/aim.py
@@ -129,9 +129,7 @@ class AimGuardrail(CustomGuardrail):
         return data
 
     @staticmethod
-    def _rejection(
-        message: str, *, openai_code: str | None = None
-    ) -> ProxyException:
+    def _rejection(message: str, *, openai_code: str | None = None) -> ProxyException:
         return ProxyException(
             message=message,
             type="invalid_request_error",

--- a/litellm/proxy/guardrails/guardrail_hooks/aim/aim.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/aim/aim.py
@@ -130,7 +130,7 @@ class AimGuardrail(CustomGuardrail):
 
     @staticmethod
     def _rejection(
-        message: str, *, openai_code: Optional[str] = None
+        message: str, *, openai_code: str | None = None
     ) -> ProxyException:
         return ProxyException(
             message=message,

--- a/litellm/proxy/guardrails/guardrail_hooks/aim/aim.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/aim/aim.py
@@ -9,7 +9,6 @@ import json
 import os
 from typing import TYPE_CHECKING, Any, AsyncGenerator, Optional, Type, Union
 
-from fastapi import HTTPException
 from pydantic import BaseModel
 from websockets.asyncio.client import ClientConnection, connect
 
@@ -129,6 +128,18 @@ class AimGuardrail(CustomGuardrail):
             verbose_proxy_logger.error(f"Aim: {action_type} action")
         return data
 
+    @staticmethod
+    def _rejection(
+        message: str, *, openai_code: Optional[str] = None
+    ) -> ProxyException:
+        return ProxyException(
+            message=message,
+            type="invalid_request_error",
+            param=None,
+            code=400,
+            openai_code=openai_code,
+        )
+
     def _handle_block_action(self, analysis_result: Any, required_action: Any) -> None:
         detection_message = required_action.get("detection_message", None)
         verbose_proxy_logger.info(
@@ -136,13 +147,7 @@ class AimGuardrail(CustomGuardrail):
                 policies=list(analysis_result["policy_drill_down"].keys()),
             ),
         )
-        raise ProxyException(
-            message=detection_message,
-            type="invalid_request_error",
-            param=None,
-            code=400,
-            openai_code="content_policy_violation",
-        )
+        raise self._rejection(detection_message, openai_code="content_policy_violation")
 
     def _anonymize_request(self, res: Any, data: dict) -> dict:
         verbose_proxy_logger.info("Aim: anonymize action")
@@ -154,14 +159,11 @@ class AimGuardrail(CustomGuardrail):
         # parts from a multimodal request — degrade to block so the
         # multimodal payload is never silently rewritten.
         if has_non_string_content(data):
-            raise HTTPException(
-                status_code=400,
-                detail=(
-                    "Aim: anonymize action requested for multimodal input "
-                    "but mask-in-place would drop non-text parts. Send the "
-                    "request with plain string content to use anonymize, "
-                    "or rely on block-mode policies."
-                ),
+            raise self._rejection(
+                "Aim: anonymize action requested for multimodal input "
+                "but mask-in-place would drop non-text parts. Send the "
+                "request with plain string content to use anonymize, "
+                "or rely on block-mode policies."
             )
         redacted_messages = [
             {
@@ -293,9 +295,9 @@ class AimGuardrail(CustomGuardrail):
             if aim_output_guardrail_result and aim_output_guardrail_result.get(
                 "detection_message"
             ):
-                raise HTTPException(
-                    status_code=400,
-                    detail=aim_output_guardrail_result.get("detection_message"),
+                raise self._rejection(
+                    aim_output_guardrail_result.get("detection_message"),
+                    openai_code="content_policy_violation",
                 )
             if aim_output_guardrail_result and aim_output_guardrail_result.get(
                 "redacted_output"

--- a/litellm/proxy/guardrails/guardrail_hooks/aim/aim.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/aim/aim.py
@@ -21,7 +21,7 @@ from litellm.llms.custom_httpx.http_handler import (
     get_async_httpx_client,
     httpxSpecialProvider,
 )
-from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy._types import ProxyException, UserAPIKeyAuth
 from litellm.proxy.guardrails._content_utils import (
     apply_redacted_messages_back,
     build_inspection_messages,
@@ -136,7 +136,13 @@ class AimGuardrail(CustomGuardrail):
                 policies=list(analysis_result["policy_drill_down"].keys()),
             ),
         )
-        raise HTTPException(status_code=400, detail=detection_message)
+        raise ProxyException(
+            message=detection_message,
+            type="invalid_request_error",
+            param=None,
+            code=400,
+            openai_code="content_policy_violation",
+        )
 
     def _anonymize_request(self, res: Any, data: dict) -> dict:
         verbose_proxy_logger.info("Aim: anonymize action")

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -2088,7 +2088,7 @@ class ProxyLogging:
             litellm_call_id=request_data.get("litellm_call_id", ""), status="fail"
         )
         if AlertType.llm_exceptions in self.alert_types and not isinstance(
-            original_exception, HTTPException
+            original_exception, (HTTPException, ProxyException)
         ):
             """
             Just alert on LLM API exceptions. Do not alert on user errors

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -2192,6 +2192,7 @@ class ProxyLogging:
         e.g should only return True for:
             - Authentication Errors from user_api_key_auth
             - HTTP HTTPException (rate limit errors)
+            - ProxyException (guardrail blocks, budget / rate-limit errors)
         """
 
         #########################################################
@@ -2208,7 +2209,7 @@ class ProxyLogging:
         ):
             return False
 
-        return isinstance(original_exception, HTTPException) or (
+        return isinstance(original_exception, (HTTPException, ProxyException)) or (
             error_type == ProxyErrorTypes.auth_error
         )
 

--- a/tests/local_testing/test_aim_guardrails.py
+++ b/tests/local_testing/test_aim_guardrails.py
@@ -10,6 +10,7 @@ from fastapi.exceptions import HTTPException
 from httpx import Request, Response
 
 from litellm import DualCache
+from litellm.proxy._types import ProxyException
 from litellm.proxy.guardrails.guardrail_hooks.aim.aim import (
     AimGuardrail,
     AimGuardrailMissingSecrets,
@@ -101,7 +102,7 @@ async def test_block_callback(mode: str):
         ],
     }
 
-    with pytest.raises(HTTPException, match="Jailbreak detected"):
+    with pytest.raises(ProxyException, match="Jailbreak detected") as exc_info:
         with patch(
             "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
             return_value=Response(
@@ -134,6 +135,12 @@ async def test_block_callback(mode: str):
                     user_api_key_dict=UserAPIKeyAuth(),
                     call_type="completion",
                 )
+
+    exc = exc_info.value
+    assert exc.code == "400"
+    assert exc.type == "invalid_request_error"
+    assert exc.param is None
+    assert exc.openai_code == "content_policy_violation"
 
 
 @pytest.mark.asyncio

--- a/tests/local_testing/test_aim_guardrails.py
+++ b/tests/local_testing/test_aim_guardrails.py
@@ -6,7 +6,6 @@ import sys
 from unittest.mock import AsyncMock, patch, call
 
 import pytest
-from fastapi.exceptions import HTTPException
 from httpx import Request, Response
 
 from litellm import DualCache
@@ -141,6 +140,131 @@ async def test_block_callback(mode: str):
     assert exc.type == "invalid_request_error"
     assert exc.param is None
     assert exc.openai_code == "content_policy_violation"
+
+
+@pytest.mark.asyncio
+async def test_output_block_raises_proxy_exception():
+    """An output-side block is a content-policy violation, like the input block:
+    it must surface a conformant ProxyException, not a bare HTTPException whose
+    type/param serialize as the literal string "None". Regression for LIT-3751."""
+    init_guardrails_v2(
+        all_guardrails=[
+            {
+                "guardrail_name": "gibberish-guard",
+                "litellm_params": {
+                    "guardrail": "aim",
+                    "mode": "post_call",
+                    "api_key": "hs-aim-key",
+                },
+            },
+        ],
+        config_file_path="",
+    )
+    aim_guardrails = [
+        callback for callback in litellm.callbacks if isinstance(callback, AimGuardrail)
+    ]
+    assert len(aim_guardrails) == 1
+    aim_guardrail = aim_guardrails[0]
+
+    block_on_output = Response(
+        json={
+            "analysis_result": {"policy_drill_down": {"PII": {}}},
+            "required_action": {
+                "action_type": "block_action",
+                "detection_message": "Output blocked: leaked secret",
+                "policy_name": "blocking policy",
+            },
+        },
+        status_code=200,
+        request=Request(method="POST", url="http://aim"),
+    )
+    response = ModelResponse(
+        choices=[
+            {
+                "finish_reason": "stop",
+                "index": 0,
+                "message": {"content": "here is the secret", "role": "assistant"},
+            }
+        ]
+    )
+
+    with patch(
+        "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+        return_value=block_on_output,
+    ):
+        with pytest.raises(ProxyException, match="Output blocked") as exc_info:
+            await aim_guardrail.async_post_call_success_hook(
+                data={"messages": [{"role": "user", "content": "tell me a secret"}]},
+                response=response,
+                user_api_key_dict=UserAPIKeyAuth(),
+            )
+
+    exc = exc_info.value
+    assert exc.code == "400"
+    assert exc.type == "invalid_request_error"
+    assert exc.param is None
+    assert exc.openai_code == "content_policy_violation"
+
+
+@pytest.mark.asyncio
+async def test_anonymize_multimodal_rejection_raises_proxy_exception():
+    """Anonymize on multimodal input degrades to a 400 because mask-in-place would
+    drop non-text parts. That is a usage error, not a content-policy violation, so
+    it must raise a conformant ProxyException WITHOUT the content_policy_violation
+    code. Regression for LIT-3751."""
+    init_guardrails_v2(
+        all_guardrails=[
+            {
+                "guardrail_name": "gibberish-guard",
+                "litellm_params": {
+                    "guardrail": "aim",
+                    "mode": "pre_call",
+                    "api_key": "hs-aim-key",
+                },
+            },
+        ],
+        config_file_path="",
+    )
+    aim_guardrails = [
+        callback for callback in litellm.callbacks if isinstance(callback, AimGuardrail)
+    ]
+    assert len(aim_guardrails) == 1
+    aim_guardrail = aim_guardrails[0]
+
+    data = {
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Hi my name is Brian"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "data:image/png;base64,iVBORw0KGgo="},
+                    },
+                ],
+            },
+        ],
+    }
+
+    with patch(
+        "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+        return_value=response_with_detections,
+    ):
+        with pytest.raises(
+            ProxyException, match="anonymize action requested for multimodal"
+        ) as exc_info:
+            await aim_guardrail.async_pre_call_hook(
+                data=data,
+                cache=DualCache(),
+                user_api_key_dict=UserAPIKeyAuth(),
+                call_type="completion",
+            )
+
+    exc = exc_info.value
+    assert exc.code == "400"
+    assert exc.type == "invalid_request_error"
+    assert exc.param is None
+    assert exc.openai_code != "content_policy_violation"
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -2415,6 +2415,41 @@ class TestHandleLLMApiExceptionDictDetail:
         proxy_exc = await self._invoke(exc)
         assert proxy_exc.code == "500"
 
+    async def test_already_normalized_proxy_exception_is_honored(self):
+        """A ProxyException raised mid-request (e.g. a guardrail block) is already
+        the OpenAI wire format. The funnel must re-raise it untouched instead of
+        re-deriving the status from a (nonexistent) status_code attribute and
+        defaulting to 500. Regression for LIT-3751."""
+        from litellm.proxy._types import ProxyException
+
+        exc = ProxyException(
+            message='"Leroy Jenkins" detected as name',
+            type="invalid_request_error",
+            param=None,
+            code=400,
+            openai_code="content_policy_violation",
+        )
+        proxy_exc = await self._invoke(exc)
+        assert proxy_exc is exc
+        assert proxy_exc.code == "400"
+        assert proxy_exc.type == "invalid_request_error"
+        assert proxy_exc.param is None
+        assert proxy_exc.openai_code == "content_policy_violation"
+        assert proxy_exc.message == '"Leroy Jenkins" detected as name'
+
+        # The body the OpenAI-SDK client actually receives. The HTTP status line
+        # comes from int(exc.code) == 400; the wire ``code`` stays the status
+        # string. ``openai_code`` ("content_policy_violation") is intentionally
+        # NOT serialized here - to_dict() emits only ``code`` - so this asserts
+        # the real contract rather than the write-only attribute.
+        assert int(proxy_exc.code) == 400
+        assert proxy_exc.to_dict() == {
+            "message": '"Leroy Jenkins" detected as name',
+            "type": "invalid_request_error",
+            "param": None,
+            "code": "400",
+        }
+
 
 class TestStreamCloseOnDisconnect:
     """

--- a/tests/test_litellm/proxy/test_proxy_utils.py
+++ b/tests/test_litellm/proxy/test_proxy_utils.py
@@ -427,6 +427,59 @@ class TestPostCallFailureHookLiftsFirstApiCallStartTime:
         assert "litellm_logging_obj" not in request_data
 
 
+class TestPostCallFailureHookLLMExceptionAlerting:
+    """The llm_exceptions alert is for infra / LLM-API failures, not user
+    errors (https://github.com/BerriAI/litellm/issues/3395). Already-normalized
+    client errors must be excluded so a guardrail content-policy block never
+    pages on-call. ProxyException is such an error; before LIT-3751 only
+    HTTPException was excluded, so AIM blocks paged as if the LLM API failed."""
+
+    async def _alerted(self, exc) -> bool:
+        import asyncio
+        from unittest.mock import AsyncMock
+
+        from litellm.proxy._types import AlertType, UserAPIKeyAuth
+
+        proxy_logging_obj = ProxyLogging(user_api_key_cache=DualCache())
+        proxy_logging_obj.alert_types = [AlertType.llm_exceptions]
+        alerting_handler = AsyncMock()
+        with (
+            patch.object(proxy_logging_obj, "update_request_status", new=AsyncMock()),
+            patch.object(proxy_logging_obj, "alerting_handler", new=alerting_handler),
+        ):
+            await proxy_logging_obj.post_call_failure_hook(
+                request_data={},
+                original_exception=exc,
+                user_api_key_dict=UserAPIKeyAuth(),
+            )
+        await asyncio.sleep(0)  # let the fire-and-forget alert task run
+        return alerting_handler.called
+
+    @pytest.mark.asyncio
+    async def test_proxy_exception_does_not_alert(self):
+        from litellm.proxy._types import ProxyException
+
+        exc = ProxyException(
+            message="content blocked",
+            type="invalid_request_error",
+            param=None,
+            code=400,
+            openai_code="content_policy_violation",
+        )
+        assert await self._alerted(exc) is False
+
+    @pytest.mark.asyncio
+    async def test_http_exception_does_not_alert(self):
+        assert (
+            await self._alerted(HTTPException(status_code=400, detail="blocked"))
+            is False
+        )
+
+    @pytest.mark.asyncio
+    async def test_genuine_llm_api_error_still_alerts(self):
+        assert await self._alerted(Exception("upstream 503")) is True
+
+
 class TestShouldUseSmtpSsl:
     def test_port_465_uses_ssl(self, monkeypatch):
         from litellm.proxy.utils import _should_use_smtp_ssl

--- a/tests/test_litellm/proxy/test_proxy_utils.py
+++ b/tests/test_litellm/proxy/test_proxy_utils.py
@@ -480,6 +480,67 @@ class TestPostCallFailureHookLLMExceptionAlerting:
         assert await self._alerted(Exception("upstream 503")) is True
 
 
+class TestPostCallFailureHookProxyExceptionLogging:
+    """A guardrail block raises a ProxyException; on an LLM route it must still
+    drive proxy-only failure logging (_handle_logging_proxy_only_error) so the
+    blocked request is recorded, exactly as the old HTTPException did. Before
+    LIT-3751 the classifier only matched HTTPException, so switching AIM to
+    ProxyException silently dropped the rejected prompt from failure logs."""
+
+    async def _logged(self, exc, *, request_route) -> bool:
+        from unittest.mock import AsyncMock
+
+        from litellm.proxy._types import UserAPIKeyAuth
+
+        proxy_logging_obj = ProxyLogging(user_api_key_cache=DualCache())
+        proxy_logging_obj.alert_types = []
+        handle_mock = AsyncMock()
+        with (
+            patch.object(proxy_logging_obj, "update_request_status", new=AsyncMock()),
+            patch.object(
+                proxy_logging_obj,
+                "_handle_logging_proxy_only_error",
+                new=handle_mock,
+            ),
+        ):
+            await proxy_logging_obj.post_call_failure_hook(
+                request_data={},
+                original_exception=exc,
+                user_api_key_dict=UserAPIKeyAuth(
+                    api_key="sk-test", request_route=request_route
+                ),
+            )
+        return handle_mock.await_count > 0
+
+    def _block(self):
+        from litellm.proxy._types import ProxyException
+
+        return ProxyException(
+            message="content blocked",
+            type="invalid_request_error",
+            param=None,
+            code=400,
+            openai_code="content_policy_violation",
+        )
+
+    @pytest.mark.asyncio
+    async def test_proxy_exception_on_llm_route_is_logged(self):
+        assert (
+            await self._logged(self._block(), request_route="/v1/chat/completions")
+            is True
+        )
+
+    @pytest.mark.asyncio
+    async def test_generic_exception_on_llm_route_is_not_logged(self):
+        # A raw provider/unknown exception is logged by the LLM call path, not here.
+        assert (
+            await self._logged(
+                Exception("upstream 503"), request_route="/v1/chat/completions"
+            )
+            is False
+        )
+
+
 class TestShouldUseSmtpSsl:
     def test_port_465_uses_ssl(self, monkeypatch):
         from litellm.proxy.utils import _should_use_smtp_ssl


### PR DESCRIPTION
## Linear ticket

Resolves LIT-3751

## Summary

AIM guardrail rejections now return HTTP 400 with a well-formed OpenAI error body. Previously a block raised a bare `HTTPException` whose `type` and `param` serialized as the literal string `"None"`, which broke OpenAI-SDK error parsing for downstream consumers (e.g. Google ADK). Making AIM raise a `ProxyException` fixed the body but exposed a second bug: the shared error funnel (`_handle_llm_api_exception`) re-derived the HTTP status from a nonexistent `status_code` attribute (`ProxyException` carries its status in `.code`) and downgraded the 400 to a 500. The funnel now honors an already-normalized `ProxyException` instead of rebuilding it, every AIM rejection path returns a conformant body, and the error-classification helpers in `post_call_failure_hook` treat `ProxyException` correctly: excluded from `llm_exceptions` paging (a policy block is not an infra failure) but still recorded by proxy-only failure logging.

## Type

🐛 Bug Fix

## Changes

- `litellm/proxy/guardrails/guardrail_hooks/aim/aim.py`: all three AIM rejection paths (input block, output block, and the multimodal anonymize rejection) raise a `ProxyException` via a shared `_rejection` helper instead of a bare `HTTPException`, so `type`/`param` are no longer the literal string `"None"`. The two real blocks carry `openai_code="content_policy_violation"`; the multimodal rejection stays a plain `invalid_request_error` because it is a usage error, not a policy violation
- `litellm/proxy/common_request_processing.py`: `_handle_llm_api_exception` re-raises an already-normalized `ProxyException` (merging response headers) instead of re-deriving its status from `status_code` and clobbering it to 500. This honors the deliberate status for every hook that raises a `ProxyException`, not just AIM
- `litellm/proxy/utils.py`: in `post_call_failure_hook`, `ProxyException` is excluded from the High-severity `llm_exceptions` alert alongside `HTTPException` (user-facing errors, not infra failures), and `_is_proxy_only_llm_api_error` now classifies `ProxyException` as a proxy-only error so guardrail blocks are still recorded by the configured failure loggers (restoring the pre-change `HTTPException` behavior). These two checks are independent

Deferred on purpose: serializing `openai_code` onto the wire so `error.code` reads `content_policy_violation` instead of `400`. `openai_code` is currently write-only, and changing `ProxyException.to_dict()` would shift provider error codes at the re-wrap sites and desync the hand-built streaming error frame, with no consumer reading it today. Worth its own change if a client needs to branch on the semantic code.

## Proof of Fix

Local proxy with the AIM guardrail pointed at a mock Aim `analyze` endpoint (real Aim is enterprise-gated); the clean request hits real groq.

Blocked request (prompt contains the configured trigger), now HTTP 400 with a conformant body:

\`\`\`
$ curl -s -w "\nHTTP %{http_code}\n" -X POST http://localhost:4000/v1/chat/completions \
    -H "Authorization: Bearer \$LITELLM_MASTER_KEY" -H "content-type: application/json" \
    -d '{"model":"groq-llama","messages":[{"role":"user","content":"My name is Leroy Jenkins"}]}'

{"error":{"message":"\"Leroy Jenkins\" detected as name","type":"invalid_request_error","param":null,"code":"400"}}
HTTP 400
\`\`\`

Clean request still succeeds against the real upstream:

\`\`\`
$ curl -s -w "\nHTTP %{http_code}\n" -X POST http://localhost:4000/v1/chat/completions \
    -H "Authorization: Bearer \$LITELLM_MASTER_KEY" -H "content-type: application/json" \
    -d '{"model":"groq-llama","messages":[{"role":"user","content":"Say hi in 3 words"}]}'

{"id":"chatcmpl-...","model":"groq-llama","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"Hello to you","role":"assistant"}}],...}
HTTP 200
\`\`\`

Before this change the same blocked request returned `HTTP 500` (status downgraded by the funnel), and on `main` the body carried `"type":"None","param":"None"`.

## Test plan

- [x] \`tests/test_litellm/proxy/test_common_request_processing.py::TestHandleLLMApiExceptionDictDetail::test_already_normalized_proxy_exception_is_honored\` - funnel re-raises a `ProxyException` with its 400 intact and asserts the wire body via `to_dict()`; fails (500) without the funnel fix
- [x] \`tests/test_litellm/proxy/test_proxy_utils.py::TestPostCallFailureHookLLMExceptionAlerting\` - `ProxyException` and `HTTPException` do not page; a genuine `Exception` still does
- [x] \`tests/test_litellm/proxy/test_proxy_utils.py::TestPostCallFailureHookProxyExceptionLogging\` - a `ProxyException` on an LLM route still drives proxy-only failure logging; a raw `Exception` does not; fails without the classifier fix
- [x] \`tests/local_testing/test_aim_guardrails.py::test_block_callback\` - input block raises a `ProxyException` with the correct `type`/`param`/`code`/`openai_code`
- [x] \`tests/local_testing/test_aim_guardrails.py::test_output_block_raises_proxy_exception\` - output-side block raises a conformant `ProxyException` with `content_policy_violation`
- [x] \`tests/local_testing/test_aim_guardrails.py::test_anonymize_multimodal_rejection_raises_proxy_exception\` - multimodal anonymize rejection raises `invalid_request_error` (400) and is NOT labeled a policy violation