### PR TITLE
fix: harden 7 Veria security findings (param smuggling/SSRF, JWT escalation, secret redaction)

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/messages/interceptors/advisor.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/interceptors/advisor.py
@@ -84,8 +84,19 @@ class AdvisorOrchestrationHandler(MessagesInterceptor):
         )
         # Optional routing overrides for the advisor sub-call (e.g. proxy routing).
         # If not set in the tool definition, litellm resolves from env vars.
-        advisor_api_key: Optional[str] = advisor_tool.get("api_key")
-        advisor_api_base: Optional[str] = advisor_tool.get("api_base")
+        #
+        # SEC: the advisor tool is fully caller-controlled. Honoring a
+        # client-supplied api_base/api_key here would let a request redirect
+        # the advisor sub-call to an attacker endpoint (and, with api_key
+        # omitted, fall back to the server's ANTHROPIC_API_KEY and ship it
+        # there). Only trust these when the proxy admin has explicitly enabled
+        # clientside credentials; otherwise drop them and let litellm resolve
+        # from server config / env based on the advisor model name (Veria #7).
+        advisor_api_key: Optional[str] = None
+        advisor_api_base: Optional[str] = None
+        if _allow_client_side_advisor_credentials():
+            advisor_api_key = advisor_tool.get("api_key")
+            advisor_api_base = advisor_tool.get("api_base")
 
         # Build the synthetic tool definition the provider will receive.
         synthetic_advisor_tool = _make_synthetic_advisor_tool()
@@ -179,6 +190,20 @@ class AdvisorOrchestrationHandler(MessagesInterceptor):
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _allow_client_side_advisor_credentials() -> bool:
+    """Whether a caller-supplied advisor api_base/api_key may be honored.
+
+    Gated on the proxy's ``allow_client_side_credentials`` opt-in. When the
+    interceptor runs outside the proxy (SDK use), there is no admin boundary
+    to protect, so client-supplied routing is allowed.
+    """
+    try:
+        from litellm.proxy.proxy_server import general_settings
+    except Exception:
+        return True
+    return general_settings.get("allow_client_side_credentials") is True
 
 
 def _make_synthetic_advisor_tool() -> Dict:

--- a/litellm/llms/bedrock/base_aws_llm.py
+++ b/litellm/llms/bedrock/base_aws_llm.py
@@ -256,7 +256,9 @@ class BaseAWSLLM:
             "aws_session_token=[set=%s]\n"
             "aws_region_name=%s\n"
             "aws_session_name=%s\n"
-            "aws_profile_name=%s\n"
+            # SEC: Issue 4 (Veria #4) — aws_profile_name may resolve from an
+            # os.environ/ secret; log only whether it is set, never the value.
+            "aws_profile_name=[set=%s]\n"
             "aws_role_name=%s\n"
             "aws_web_identity_token=[set=%s]\n"
             "aws_sts_endpoint=%s\n"
@@ -266,7 +268,7 @@ class BaseAWSLLM:
             aws_session_token is not None,
             aws_region_name,
             aws_session_name,
-            aws_profile_name,
+            aws_profile_name is not None,
             aws_role_name,
             aws_web_identity_token is not None,
             aws_sts_endpoint,
@@ -1234,9 +1236,19 @@ class BaseAWSLLM:
         import boto3
 
         # uses auth values from AWS profile usually stored in ~/.aws/credentials
-        with tracer.trace("boto3.Session(profile_name=aws_profile_name)"):
-            client = boto3.Session(profile_name=aws_profile_name)
-            return client.get_credentials(), None
+        # SEC: Issue 4 (Veria #4) — boto3 raises ProfileNotFound carrying the resolved
+        # profile name (which may be an os.environ/ secret) in its message; an unhandled
+        # raise leaks it into the server traceback. Map to a generic error that never
+        # reflects the user-supplied/resolved value.
+        try:
+            with tracer.trace("boto3.Session(profile_name=aws_profile_name)"):
+                client = boto3.Session(profile_name=aws_profile_name)
+                return client.get_credentials(), None
+        except Exception:
+            raise AwsAuthError(
+                message="The specified AWS profile could not be found.",
+                status_code=400,
+            )
 
     @tracer.wrap()
     def _auth_with_aws_session_token(

--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -258,6 +258,34 @@ _BANNED_REQUEST_BODY_PARAMS: Tuple[str, ...] = (
     "aws_web_identity_token",
     "aws_role_name",
     "vertex_credentials",
+    # SEC: alias the Vertex provider also accepts for the same credential
+    # blob (litellm/main.py pops ``vertex_ai_credentials`` out of
+    # optional_params), so banning only ``vertex_credentials`` left this
+    # synonym as an open exfil path (Veria #6a).
+    "vertex_ai_credentials",
+    # SEC: project/region targeting + remaining Bedrock/OCI credential
+    # fields. ``vertex_project`` re-routes the request to any GCP project
+    # reachable with the deployment's service account; the ``aws_*`` keys
+    # are raw AWS credentials; the ``oci_*`` fields are the OCI signing
+    # identity; ``base_model`` forges cost tracking and slips a
+    # client-chosen base model into provider routing (Veria #3).
+    "vertex_project",
+    "vertex_location",
+    "aws_access_key_id",
+    "aws_secret_access_key",
+    "aws_session_token",
+    "base_model",
+    "oci_signer",
+    "oci_user",
+    "oci_fingerprint",
+    "oci_tenancy",
+    "oci_key",
+    "oci_key_file",
+    # SEC: ``model_list`` is an SDK-only construct. main.py reads
+    # api_base/api_key out of its nested ``litellm_params`` and runs
+    # batch_completion_models with server creds, so it is also rejected
+    # outright in ``is_request_body_safe`` regardless of opt-in (Veria #1).
+    "model_list",
     # Azure managed-identity / federated-auth token. The Azure provider
     # transformer reads ``azure_ad_token`` (top-level or via
     # ``extra_body``) and resolves it through ``get_secret`` before
@@ -364,6 +392,19 @@ def is_request_body_safe(
     ``litellm_embedding_config.api_base`` (VERIA-6) without exposing a
     recursion-depth DoS surface.
     """
+    # SEC: ``model_list`` is an SDK-only feature with no proxy API meaning.
+    # main.py extracts api_base/api_key from each entry's ``litellm_params``
+    # and dispatches batch_completion_models with server credentials, so the
+    # whole field is rejected unconditionally — the opt-ins don't apply, since
+    # there is no legitimate proxy use of caller-supplied deployments (Veria #1).
+    if "model_list" in request_body:
+        raise ValueError(
+            "Rejected Request: model_list is not allowed in request body. "
+            "It is an SDK-only feature and lets a caller smuggle deployment "
+            "credentials/endpoints into the proxy. "
+            "Relevant Issue: https://huntr.com/bounties/4001e1a2-7b7a-4776-a3ae-e6692ec3d997",
+        )
+
     _check_banned_params(request_body, general_settings, llm_router, model)
     for nested_key in _NESTED_CONFIG_KEYS:
         nested = _coerce_metadata_to_dict(request_body.get(nested_key))
@@ -373,7 +414,30 @@ def is_request_body_safe(
         metadata = _coerce_metadata_to_dict(request_body.get(metadata_key))
         if metadata is not None:
             _check_banned_params(metadata, general_settings, llm_router, model)
+    # SEC: scan caller-supplied tool definitions. Provider interceptors read
+    # api_base/api_key out of a tool entry (e.g. the Anthropic
+    # advisor_20260301 tool) and fall back to server credentials, so the same
+    # banned-param check has to descend into each tool dict and its nested
+    # ``function`` object (Veria #6b, #7).
+    for tool in _iter_request_tools(request_body.get("tools")):
+        _check_banned_params(tool, general_settings, llm_router, model)
+        function = tool.get("function")
+        if isinstance(function, dict):
+            _check_banned_params(function, general_settings, llm_router, model)
     return True
+
+
+def _iter_request_tools(tools: Any) -> Tuple[Dict[str, Any], ...]:
+    """Return the dict entries of a request ``tools`` array.
+
+    The OpenAI ``tools`` field is a list of objects; provider-specific tools
+    (advisor, web search, etc.) carry routing fields at the top level of each
+    entry. Non-dict entries are skipped rather than raising so a malformed
+    array still reaches the normal request validation downstream.
+    """
+    if not isinstance(tools, (list, tuple)):
+        return ()
+    return tuple(tool for tool in tools if isinstance(tool, dict))
 
 
 def _coerce_metadata_to_dict(value: Any) -> Optional[Dict[str, Any]]:

--- a/litellm/proxy/auth/handle_jwt.py
+++ b/litellm/proxy/auth/handle_jwt.py
@@ -113,6 +113,12 @@ class JWTHandler:
         LITELLM_ORG_ID_CLAIM,
         LITELLM_END_USER_ID_CLAIM,
     )
+    # Registered JWT claims (RFC 7519) that are safe to carry through issuer
+    # normalization regardless of mapping config: they identify/scope the token
+    # itself and are never trusted for authorization by LiteLLM.
+    STANDARD_JWT_CLAIMS = frozenset(
+        ("iss", "sub", "aud", "exp", "nbf", "iat", "jti")
+    )
 
     def __init__(
         self,
@@ -941,8 +947,12 @@ class JWTHandler:
     def _apply_issuer_claim_mappings(
         self, token: dict, issuer_config: JWTIssuerConfig
     ) -> dict:
+        # SEC: allowlist JWT claims to prevent cross-issuer injection (Veria #2)
+        # Authorization-bearing claims (scope, roles, ...) survive only when THIS
+        # issuer's config maps them below; everything unmapped is dropped so a
+        # low-trust issuer can't smuggle "scope": "litellm_proxy_admin" through.
         normalized: dict = {
-            k: v for k, v in token.items() if k not in self.LITELLM_INTERNAL_CLAIMS
+            k: v for k, v in token.items() if k in self.STANDARD_JWT_CLAIMS
         }
         normalized[self.LITELLM_JWT_ISSUER_CLAIM] = issuer_config.issuer
         claim_mappings = [

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -1016,15 +1016,13 @@ if MCP_AVAILABLE:
         if is_restricted_virtual_key:
             return _sanitize_mcp_server_list_for_virtual_key(redacted_mcp_servers)
 
-        # Non-admin authenticated users may see the server inventory but
-        # not credential-bearing fields like `url` (often contains bearer
-        # tokens) or headers/env (often contain Authorization).
-        if not _user_has_admin_view(user_api_key_dict):
-            return _sanitize_mcp_server_list_for_non_admin(redacted_mcp_servers)
-
+        # SEC: Issue 5 (Veria #5) — only a FULL PROXY_ADMIN may see credential-bearing
+        # fields. PROXY_ADMIN_VIEW_ONLY (covered by _user_has_admin_view) previously
+        # skipped this sanitizer and only had global env var values blanked, leaking
+        # secrets embedded in url/headers/env. Gate on _user_is_full_admin so view-only
+        # admins get the same redacted inventory as any other non-managing caller.
         if not _user_is_full_admin(user_api_key_dict):
-            for server in redacted_mcp_servers:
-                _redact_global_env_var_values(server)
+            return _sanitize_mcp_server_list_for_non_admin(redacted_mcp_servers)
 
         return redacted_mcp_servers
 
@@ -1415,10 +1413,12 @@ if MCP_AVAILABLE:
         redacted = _redact_mcp_credentials(mcp_server)
         if is_restricted_virtual_key:
             return _sanitize_mcp_server_for_virtual_key(redacted)
-        if not _user_has_admin_view(user_api_key_dict):
-            return _sanitize_mcp_server_for_non_admin(redacted)
+        # SEC: Issue 5 (Veria #5) — gate credential exposure on FULL PROXY_ADMIN, not
+        # _user_has_admin_view (which also grants PROXY_ADMIN_VIEW_ONLY). A view-only
+        # admin must go through the non-admin sanitizer so secrets embedded in
+        # url/headers/env are stripped, not merely have global env values blanked.
         if not _user_is_full_admin(user_api_key_dict):
-            _redact_global_env_var_values(redacted)
+            return _sanitize_mcp_server_for_non_admin(redacted)
         return redacted
 
     @router.post(

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -14644,6 +14644,20 @@ async def update_config_general_settings(
     return response
 
 
+# SEC: Issue 5 (Veria #5) — general_settings fields whose value must never reach a
+# non-full-admin. The masker catches *_key/*_password/*token/etc. by segment; these
+# are the secret-bearing names it does not segment-match (database_url embeds the DB
+# password but splits into "database"/"url").
+_EXTRA_SECRET_GENERAL_SETTINGS_FIELDS = frozenset({"database_url"})
+
+
+def _is_secret_general_setting_field(field_name: str) -> bool:
+    return (
+        field_name in _EXTRA_SECRET_GENERAL_SETTINGS_FIELDS
+        or SENSITIVE_DATA_MASKER.is_sensitive_key(field_name)
+    )
+
+
 @router.get(
     "/config/field/info",
     tags=["config.yaml"],
@@ -14696,9 +14710,17 @@ async def get_config_general_settings(
         general_settings = dict(db_general_settings.param_value)
 
         if field_name in general_settings:
-            return ConfigFieldInfo(
-                field_name=field_name, field_value=general_settings[field_name]
-            )
+            # SEC: Issue 5 (Veria #5) — _user_has_admin_view also grants
+            # PROXY_ADMIN_VIEW_ONLY. Returning the raw value let a view-only admin
+            # read secrets like master_key/database_url (== full admin). Only a FULL
+            # PROXY_ADMIN sees raw secret-bearing fields; others get them redacted.
+            field_value = general_settings[field_name]
+            if (
+                user_api_key_dict.user_role != LitellmUserRoles.PROXY_ADMIN
+                and _is_secret_general_setting_field(field_name)
+            ):
+                field_value = "REDACTED"
+            return ConfigFieldInfo(field_name=field_name, field_value=field_value)
         else:
             raise HTTPException(
                 status_code=400,

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -26,6 +26,7 @@ from typing import (
     AsyncGenerator,
     Callable,
     Dict,
+    FrozenSet,
     Generator,
     List,
     Literal,
@@ -230,6 +231,60 @@ else:
 
 class RoutingArgs(enum.Enum):
     ttl = 60  # 1min (RPM/TPM expire key)
+
+
+# SEC: credential / endpoint / project-targeting fields a deployment pins
+# from server-side config. The `_completion`/`_acompletion` merges put
+# request-derived `**kwargs` AFTER `**litellm_params` (deployment config),
+# so a caller could shadow these with their own values and exfiltrate via
+# an attacker endpoint or borrow the deployment's credentials. Stripping
+# them from request kwargs before the merge keeps deployment config
+# authoritative. The sanctioned clientside keys (api_key/api_base/base_url)
+# are intentionally absent: those flow through the explicit
+# `allow_client_side_credentials` / `configurable_clientside_auth_params`
+# opt-in in `_update_kwargs_with_deployment`, not this merge (Veria #3).
+_DEPLOYMENT_OWNED_CREDENTIAL_KWARGS: FrozenSet[str] = frozenset(
+    {
+        "api_version",
+        "vertex_project",
+        "vertex_location",
+        "vertex_credentials",
+        "vertex_ai_credentials",
+        "region_name",
+        "aws_access_key_id",
+        "aws_secret_access_key",
+        "aws_session_token",
+        "aws_region_name",
+        "aws_bedrock_runtime_endpoint",
+        "aws_bedrock_project_id",
+        "aws_sts_endpoint",
+        "aws_web_identity_token",
+        "aws_role_name",
+        "watsonx_region_name",
+        "azure_ad_token",
+        "azure_ad_token_provider",
+        "base_model",
+        "s3_endpoint_url",
+        "sagemaker_base_url",
+        "deployment_url",
+        "oci_signer",
+        "oci_user",
+        "oci_fingerprint",
+        "oci_tenancy",
+        "oci_key",
+        "oci_key_file",
+    }
+)
+
+
+def _strip_deployment_owned_credential_kwargs(kwargs: dict) -> None:
+    """Drop caller-supplied credential/endpoint/project kwargs in place.
+
+    Run before merging request ``kwargs`` over deployment ``litellm_params``
+    so user input cannot override the server-pinned credential fields.
+    """
+    for key in _DEPLOYMENT_OWNED_CREDENTIAL_KWARGS:
+        kwargs.pop(key, None)
 
 
 class Router:
@@ -1925,6 +1980,10 @@ class Router:
             if not self.has_model_id(model):
                 self.routing_strategy_pre_call_checks(deployment=deployment)
 
+            # SEC: drop caller-supplied credential/endpoint/project kwargs so
+            # they can't shadow the deployment's server-pinned values in the
+            # `**litellm_params, ..., **kwargs` merge below (Veria #3).
+            _strip_deployment_owned_credential_kwargs(kwargs)
             input_kwargs = {
                 **litellm_params,
                 "messages": messages,
@@ -2964,6 +3023,10 @@ class Router:
             )
             self.total_calls[model_name] += 1
 
+            # SEC: drop caller-supplied credential/endpoint/project kwargs so
+            # they can't shadow the deployment's server-pinned values in the
+            # `**litellm_params, ..., **kwargs` merge below (Veria #3).
+            _strip_deployment_owned_credential_kwargs(kwargs)
             input_kwargs = {
                 **litellm_params,
                 "messages": messages,

--- a/litellm/router_utils/clientside_credential_handler.py
+++ b/litellm/router_utils/clientside_credential_handler.py
@@ -96,7 +96,13 @@ def get_dynamic_litellm_params(litellm_params: dict, request_kwargs: dict) -> di
     # admin's value in ``litellm_params`` and have it forwarded to the
     # redirected upstream.
     if "api_base" in request_kwargs or "base_url" in request_kwargs:
-        for field in _ADMIN_CONFIG_FIELDS_TO_CLEAR_ON_BASE_OVERRIDE:
+        # SEC: ``api_key`` must be dropped alongside the other admin config
+        # fields. It lives in ``clientside_credential_keys`` (so it isn't in
+        # the cleared-fields list), which left the deployment key in
+        # ``litellm_params`` whenever the caller redirected api_base without
+        # resupplying a key — leaking the proxy's own credential to the
+        # attacker-controlled upstream (Veria #6c).
+        for field in (*_ADMIN_CONFIG_FIELDS_TO_CLEAR_ON_BASE_OVERRIDE, "api_key"):
             litellm_params.pop(field, None)
             if field in request_kwargs:
                 litellm_params[field] = request_kwargs[field]

--- a/tests/test_litellm/llms/anthropic/messages/test_advisor_orchestration.py
+++ b/tests/test_litellm/llms/anthropic/messages/test_advisor_orchestration.py
@@ -101,9 +101,7 @@ async def test_anthropic_native_interceptor_skipped():
     )
 
     h = AdvisorOrchestrationHandler()
-    assert not h.can_handle(
-        [ADVISOR_TOOL], "anthropic"
-    ), "Interceptor must NOT trigger for anthropic provider"
+    assert not h.can_handle([ADVISOR_TOOL], "anthropic"), "Interceptor must NOT trigger for anthropic provider"
 
 
 # ---------------------------------------------------------------------------
@@ -204,9 +202,7 @@ async def test_loop_one_advisor_call():
     assert "is_prime" in texts[0]["text"]
 
     # No advisor tool_use blocks in final response
-    advisor_uses = [
-        b for b in content if b.get("type") == "tool_use" and b.get("name") == "advisor"
-    ]
+    advisor_uses = [b for b in content if b.get("type") == "tool_use" and b.get("name") == "advisor"]
     assert len(advisor_uses) == 0
 
 
@@ -366,9 +362,7 @@ async def test_prior_advisor_blocks_replaced_in_history():
 
     # Text block with advisor feedback must be present
     text_blocks = [b for b in content if b.get("type") == "text"]
-    feedback_blocks = [
-        b for b in text_blocks if "advisor_feedback" in b.get("text", "")
-    ]
+    feedback_blocks = [b for b in text_blocks if "advisor_feedback" in b.get("text", "")]
     assert len(feedback_blocks) >= 1
     assert "trial division" in feedback_blocks[0]["text"]
 
@@ -516,3 +510,84 @@ async def test_max_uses_none_falls_back_to_default():
             )
 
     assert str(_c.ADVISOR_MAX_USES) in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# 12. Defense-in-depth: client-supplied advisor api_base/api_key are dropped
+#     unless the proxy admin opted into clientside credentials (Veria #7)
+# ---------------------------------------------------------------------------
+
+
+ADVISOR_TOOL_WITH_CREDS = {
+    "type": "advisor_20260301",
+    "name": "advisor",
+    "model": "claude-opus-4-6",
+    "api_base": "https://attacker.example",
+    "api_key": "sk-attacker",
+}
+
+
+async def _run_advisor_and_capture_subcall_kwargs():
+    """Run one advisor turn and return the kwargs of the advisor sub-call."""
+    from litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor import (
+        AdvisorOrchestrationHandler,
+    )
+
+    advisor_tool_use_resp = _make_advisor_tool_use_response(tool_id="toolu_01")
+    advisor_advice_resp = _make_text_response("advice", model="claude-opus-4-6")
+    final_resp = _make_text_response("final answer")
+
+    captured = {}
+    call_count = 0
+
+    async def mock_call(model, messages, tools, stream, max_tokens, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return advisor_tool_use_resp
+        if call_count == 2:
+            # The advisor sub-call — capture its routing kwargs.
+            captured["api_key"] = kwargs.get("api_key")
+            captured["api_base"] = kwargs.get("api_base")
+            return advisor_advice_resp
+        return final_resp
+
+    with patch(
+        "litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor._call_messages_handler",
+        side_effect=mock_call,
+    ):
+        h = AdvisorOrchestrationHandler()
+        await h.handle(
+            model="openai/gpt-4o-mini",
+            messages=MESSAGES,
+            tools=[ADVISOR_TOOL_WITH_CREDS],
+            stream=False,
+            max_tokens=512,
+            custom_llm_provider="openai",
+        )
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_advisor_creds_dropped_when_proxy_opt_in_disabled():
+    """On the proxy without opt-in, the caller's advisor api_base/api_key must
+    NOT reach the sub-call (would redirect it / leak the server key)."""
+    with patch(
+        "litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor._allow_client_side_advisor_credentials",
+        return_value=False,
+    ):
+        captured = await _run_advisor_and_capture_subcall_kwargs()
+    assert captured["api_key"] is None
+    assert captured["api_base"] is None
+
+
+@pytest.mark.asyncio
+async def test_advisor_creds_honored_when_proxy_opt_in_enabled():
+    """With the admin opt-in, the documented clientside routing still works."""
+    with patch(
+        "litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor._allow_client_side_advisor_credentials",
+        return_value=True,
+    ):
+        captured = await _run_advisor_and_capture_subcall_kwargs()
+    assert captured["api_key"] == "sk-attacker"
+    assert captured["api_base"] == "https://attacker.example"

--- a/tests/test_litellm/llms/bedrock/test_base_aws_llm.py
+++ b/tests/test_litellm/llms/bedrock/test_base_aws_llm.py
@@ -163,6 +163,28 @@ def test_aws_profile_path_not_cached_in_iam_cache():
         assert mock_profile.call_count == 2
 
 
+def test_aws_profile_not_found_raises_generic_error_without_leaking_value():
+    """SEC Veria #4: boto3 ProfileNotFound carries the resolved profile name (which may
+    be an os.environ/ secret). _auth_with_aws_profile must map it to a generic error that
+    never reflects the user-supplied/resolved value into logs or tracebacks."""
+    from botocore.exceptions import ProfileNotFound
+
+    secret_profile_value = "super-secret-resolved-profile-name"
+
+    fake_boto3 = MagicMock()
+    fake_boto3.Session.side_effect = ProfileNotFound(profile=secret_profile_value)
+
+    base = BaseAWSLLM()
+    with patch.dict("sys.modules", {"boto3": fake_boto3}):
+        with pytest.raises(AwsAuthError) as exc_info:
+            base._auth_with_aws_profile(secret_profile_value)
+
+    err = exc_info.value
+    assert secret_profile_value not in err.message
+    assert secret_profile_value not in str(err)
+    assert err.message == "The specified AWS profile could not be found."
+
+
 def test_web_identity_path_not_cached_in_iam_cache():
     base = BaseAWSLLM()
     with patch.object(

--- a/tests/test_litellm/proxy/auth/test_auth_utils.py
+++ b/tests/test_litellm/proxy/auth/test_auth_utils.py
@@ -42,9 +42,7 @@ class TestGetKeyModelRpmLimit:
         """Should fall back to team metadata when key metadata exists but has no model_rpm_limit."""
         user_api_key_dict = UserAPIKeyAuth(
             api_key="sk-123",
-            metadata={
-                "some_other_key": "value"
-            },  # Has metadata, but not model_rpm_limit
+            metadata={"some_other_key": "value"},  # Has metadata, but not model_rpm_limit
             team_metadata={"model_rpm_limit": {"gpt-4": 50}},
         )
         result = get_key_model_rpm_limit(user_api_key_dict)
@@ -126,9 +124,7 @@ class TestGetKeyModelTpmLimit:
         """Should fall back to team metadata when key metadata exists but has no model_tpm_limit."""
         user_api_key_dict = UserAPIKeyAuth(
             api_key="sk-123",
-            metadata={
-                "some_other_key": "value"
-            },  # Has metadata, but not model_tpm_limit
+            metadata={"some_other_key": "value"},  # Has metadata, but not model_tpm_limit
             team_metadata={"model_tpm_limit": {"gpt-4": 5000}},
         )
         result = get_key_model_tpm_limit(user_api_key_dict)
@@ -239,9 +235,7 @@ class TestGetEndUserIdFromRequestBodyWithStandardHeaders:
         request_body = {"user": "body-user"}
 
         with patch("litellm.proxy.proxy_server.general_settings", {}):
-            result = get_end_user_id_from_request_body(
-                request_body=request_body, request_headers=headers
-            )
+            result = get_end_user_id_from_request_body(request_body=request_body, request_headers=headers)
         assert result == "header-customer"
 
     def test_should_fall_back_to_body_when_no_standard_header(self):
@@ -250,9 +244,7 @@ class TestGetEndUserIdFromRequestBodyWithStandardHeaders:
         request_body = {"user": "body-user"}
 
         with patch("litellm.proxy.proxy_server.general_settings", {}):
-            result = get_end_user_id_from_request_body(
-                request_body=request_body, request_headers=headers
-            )
+            result = get_end_user_id_from_request_body(request_body=request_body, request_headers=headers)
         assert result == "body-user"
 
 
@@ -350,9 +342,7 @@ def test_get_model_from_request_extracts_unified_file_id_models():
         "litellm_proxy:application/octet-stream;unified_id,test-id;"
         "target_model_names,model-a,model-b;llm_output_file_id,file-provider-id"
     )
-    encoded_unified_file_id = (
-        base64.urlsafe_b64encode(raw_unified_file_id.encode()).decode().rstrip("=")
-    )
+    encoded_unified_file_id = base64.urlsafe_b64encode(raw_unified_file_id.encode()).decode().rstrip("=")
 
     assert get_model_from_request(
         request_data={"file_id": encoded_unified_file_id},
@@ -412,9 +402,7 @@ def test_get_model_from_request_resolves_video_id_model_with_router():
         model_id="veo-3.1-generate-001",
     )
     llm_router = MagicMock()
-    llm_router.resolve_model_name_from_model_id.return_value = (
-        "gcp/google/veo-3.1-generate-001"
-    )
+    llm_router.resolve_model_name_from_model_id.return_value = "gcp/google/veo-3.1-generate-001"
 
     assert (
         get_model_from_request(
@@ -424,9 +412,7 @@ def test_get_model_from_request_resolves_video_id_model_with_router():
         )
         == "gcp/google/veo-3.1-generate-001"
     )
-    llm_router.resolve_model_name_from_model_id.assert_called_once_with(
-        "veo-3.1-generate-001"
-    )
+    llm_router.resolve_model_name_from_model_id.assert_called_once_with("veo-3.1-generate-001")
 
 
 def test_get_model_from_request_resolves_character_id_model_with_router():
@@ -438,9 +424,7 @@ def test_get_model_from_request_resolves_character_id_model_with_router():
         model_id="veo-3.1-generate-001",
     )
     llm_router = MagicMock()
-    llm_router.resolve_model_name_from_model_id.return_value = (
-        "gcp/google/veo-3.1-generate-001"
-    )
+    llm_router.resolve_model_name_from_model_id.return_value = "gcp/google/veo-3.1-generate-001"
 
     assert (
         get_model_from_request(
@@ -450,9 +434,7 @@ def test_get_model_from_request_resolves_character_id_model_with_router():
         )
         == "gcp/google/veo-3.1-generate-001"
     )
-    llm_router.resolve_model_name_from_model_id.assert_called_once_with(
-        "veo-3.1-generate-001"
-    )
+    llm_router.resolve_model_name_from_model_id.assert_called_once_with("veo-3.1-generate-001")
 
 
 def test_get_model_from_request_only_runs_media_decoders_for_matching_fields():
@@ -537,9 +519,7 @@ def test_abbreviate_api_key():
 def test_get_customer_user_header_returns_none_when_no_customer_role():
     from litellm.proxy.auth.auth_utils import get_customer_user_header_from_mapping
 
-    mappings = [
-        {"header_name": "X-OpenWebUI-User-Id", "litellm_user_role": "internal_user"}
-    ]
+    mappings = [{"header_name": "X-OpenWebUI-User-Id", "litellm_user_role": "internal_user"}]
     result = get_customer_user_header_from_mapping(mappings)
     assert result is None
 
@@ -592,9 +572,7 @@ def test_get_end_user_id_returns_id_from_user_header_mappings():
         ),
         patch("litellm.proxy.proxy_server.general_settings", general_settings),
     ):
-        result = get_end_user_id_from_request_body(
-            request_body={}, request_headers=headers
-        )
+        result = get_end_user_id_from_request_body(request_body={}, request_headers=headers)
 
     assert result == "1234"
 
@@ -620,9 +598,7 @@ def test_get_end_user_id_returns_first_customer_header_when_multiple_mappings_ex
         ),
         patch("litellm.proxy.proxy_server.general_settings", general_settings),
     ):
-        result = get_end_user_id_from_request_body(
-            request_body={}, request_headers=headers
-        )
+        result = get_end_user_id_from_request_body(request_body={}, request_headers=headers)
 
     assert result == "user-456"
 
@@ -643,9 +619,7 @@ def test_get_end_user_id_returns_none_when_no_customer_role_in_mappings():
         ),
         patch("litellm.proxy.proxy_server.general_settings", general_settings),
     ):
-        result = get_end_user_id_from_request_body(
-            request_body={}, request_headers=headers
-        )
+        result = get_end_user_id_from_request_body(request_body={}, request_headers=headers)
 
     assert result is None
 
@@ -663,9 +637,7 @@ def test_get_end_user_id_falls_back_to_deprecated_user_header_name():
         ),
         patch("litellm.proxy.proxy_server.general_settings", general_settings),
     ):
-        result = get_end_user_id_from_request_body(
-            request_body={}, request_headers=headers
-        )
+        result = get_end_user_id_from_request_body(request_body={}, request_headers=headers)
 
     assert result == "user-legacy"
 
@@ -809,9 +781,7 @@ class TestGetEndUserIdDropsMalformedBodyValues:
         }
 
         with patch("litellm.proxy.proxy_server.general_settings", {}):
-            result = get_end_user_id_from_request_body(
-                request_body=request_body, request_headers={}
-            )
+            result = get_end_user_id_from_request_body(request_body=request_body, request_headers={})
 
         assert result == "alice@example.com"
 
@@ -821,9 +791,7 @@ class TestGetEndUserIdDropsMalformedBodyValues:
         }
 
         with patch("litellm.proxy.proxy_server.general_settings", {}):
-            result = get_end_user_id_from_request_body(
-                request_body=request_body, request_headers={}
-            )
+            result = get_end_user_id_from_request_body(request_body=request_body, request_headers={})
 
         assert result is None
 
@@ -836,19 +804,14 @@ class TestGetEndUserIdDropsMalformedBodyValues:
         """
         import litellm
 
-        blob = (
-            '{"device_id":"d5abe9199ee7759a","account_uuid":"",'
-            '"session_id":"c284b8cb-a050-4278-8599-cc4e016a10ab"}'
-        )
+        blob = '{"device_id":"d5abe9199ee7759a","account_uuid":"","session_id":"c284b8cb-a050-4278-8599-cc4e016a10ab"}'
         request_body = {"user": blob}
 
         original = litellm.validate_end_user_id_in_db
         litellm.validate_end_user_id_in_db = False
         try:
             with patch("litellm.proxy.proxy_server.general_settings", {}):
-                result = get_end_user_id_from_request_body(
-                    request_body=request_body, request_headers={}
-                )
+                result = get_end_user_id_from_request_body(request_body=request_body, request_headers={})
         finally:
             litellm.validate_end_user_id_in_db = original
 
@@ -859,8 +822,7 @@ class TestGetEndUserIdDropsMalformedBodyValues:
 
         request_body = {
             "user": (
-                '{"device_id":"d5abe9199ee7759a","account_uuid":"",'
-                '"session_id":"c284b8cb-a050-4278-8599-cc4e016a10ab"}'
+                '{"device_id":"d5abe9199ee7759a","account_uuid":"","session_id":"c284b8cb-a050-4278-8599-cc4e016a10ab"}'
             ),
         }
 
@@ -868,9 +830,7 @@ class TestGetEndUserIdDropsMalformedBodyValues:
         litellm.validate_end_user_id_in_db = True
         try:
             with patch("litellm.proxy.proxy_server.general_settings", {}):
-                result = get_end_user_id_from_request_body(
-                    request_body=request_body, request_headers={}
-                )
+                result = get_end_user_id_from_request_body(request_body=request_body, request_headers={})
         finally:
             litellm.validate_end_user_id_in_db = original
 
@@ -880,9 +840,7 @@ class TestGetEndUserIdDropsMalformedBodyValues:
         request_body = {"user": "alice@example.com"}
 
         with patch("litellm.proxy.proxy_server.general_settings", {}):
-            result = get_end_user_id_from_request_body(
-                request_body=request_body, request_headers={}
-            )
+            result = get_end_user_id_from_request_body(request_body=request_body, request_headers={})
 
         assert result == "alice@example.com"
 
@@ -894,9 +852,7 @@ class TestGetEndUserIdDropsMalformedBodyValues:
         request_body = {"user": codex_id}
 
         with patch("litellm.proxy.proxy_server.general_settings", {}):
-            result = get_end_user_id_from_request_body(
-                request_body=request_body, request_headers={}
-            )
+            result = get_end_user_id_from_request_body(request_body=request_body, request_headers={})
 
         assert result == codex_id
 
@@ -904,9 +860,7 @@ class TestGetEndUserIdDropsMalformedBodyValues:
         request_body = {"user": 12345}
 
         with patch("litellm.proxy.proxy_server.general_settings", {}):
-            result = get_end_user_id_from_request_body(
-                request_body=request_body, request_headers={}
-            )
+            result = get_end_user_id_from_request_body(request_body=request_body, request_headers={})
 
         assert result == "12345"
 
@@ -917,9 +871,7 @@ class TestGetEndUserIdDropsMalformedBodyValues:
         }
 
         with patch("litellm.proxy.proxy_server.general_settings", {}):
-            result = get_end_user_id_from_request_body(
-                request_body=request_body, request_headers={}
-            )
+            result = get_end_user_id_from_request_body(request_body=request_body, request_headers={})
 
         assert result == "alice@example.com"
 
@@ -929,9 +881,7 @@ class TestGetEndUserIdDropsMalformedBodyValues:
         }
 
         with patch("litellm.proxy.proxy_server.general_settings", {}):
-            result = get_end_user_id_from_request_body(
-                request_body=request_body, request_headers={}
-            )
+            result = get_end_user_id_from_request_body(request_body=request_body, request_headers={})
 
         assert result is None
 
@@ -941,9 +891,7 @@ class TestGetEndUserIdDropsMalformedBodyValues:
         }
 
         with patch("litellm.proxy.proxy_server.general_settings", {}):
-            result = get_end_user_id_from_request_body(
-                request_body=request_body, request_headers={}
-            )
+            result = get_end_user_id_from_request_body(request_body=request_body, request_headers={})
 
         assert result is None
 
@@ -951,9 +899,7 @@ class TestGetEndUserIdDropsMalformedBodyValues:
         request_body = {"user": "   ", "safety_identifier": "alice@example.com"}
 
         with patch("litellm.proxy.proxy_server.general_settings", {}):
-            result = get_end_user_id_from_request_body(
-                request_body=request_body, request_headers={}
-            )
+            result = get_end_user_id_from_request_body(request_body=request_body, request_headers={})
 
         assert result == "alice@example.com"
 
@@ -972,16 +918,12 @@ class TestGetEndUserIdDropsMalformedBodyValues:
             ),
             patch("litellm.proxy.proxy_server.general_settings", general_settings),
         ):
-            result = get_end_user_id_from_request_body(
-                request_body=request_body, request_headers=headers
-            )
+            result = get_end_user_id_from_request_body(request_body=request_body, request_headers=headers)
 
         assert result == "alice@example.com"
 
 
-def _make_deployment_dict(
-    model_name: str, tpm: Optional[int] = None, rpm: Optional[int] = None
-) -> dict:
+def _make_deployment_dict(model_name: str, tpm: Optional[int] = None, rpm: Optional[int] = None) -> dict:
     """Helper to build a minimal deployment dict as returned by router.get_model_list."""
     litellm_params: dict = {"model": model_name}
     if tpm is not None:
@@ -1001,9 +943,7 @@ class TestDeploymentDefaultRpmLimit:
         """Case 2 from spec: key has no model-specific limits, falls back to deployment default."""
         user_api_key_dict = UserAPIKeyAuth(api_key="sk-123")
         mock_router = MagicMock()
-        mock_router.get_model_list.return_value = [
-            _make_deployment_dict("model1", rpm=200)
-        ]
+        mock_router.get_model_list.return_value = [_make_deployment_dict("model1", rpm=200)]
         with patch(_ROUTER_PATCH, mock_router):
             result = get_key_model_rpm_limit(user_api_key_dict, model_name="model1")
         assert result == {"model1": 200}
@@ -1015,9 +955,7 @@ class TestDeploymentDefaultRpmLimit:
             metadata={"model_rpm_limit": {"model1": 10}},
         )
         mock_router = MagicMock()
-        mock_router.get_model_list.return_value = [
-            _make_deployment_dict("model1", rpm=200)
-        ]
+        mock_router.get_model_list.return_value = [_make_deployment_dict("model1", rpm=200)]
         with patch(_ROUTER_PATCH, mock_router):
             result = get_key_model_rpm_limit(user_api_key_dict, model_name="model1")
         assert result == {"model1": 10}
@@ -1037,9 +975,7 @@ class TestDeploymentDefaultRpmLimit:
         """No model_name means deployment fallback is skipped."""
         user_api_key_dict = UserAPIKeyAuth(api_key="sk-123")
         mock_router = MagicMock()
-        mock_router.get_model_list.return_value = [
-            _make_deployment_dict("model1", rpm=200)
-        ]
+        mock_router.get_model_list.return_value = [_make_deployment_dict("model1", rpm=200)]
         with patch(_ROUTER_PATCH, mock_router):
             result = get_key_model_rpm_limit(user_api_key_dict)
         assert result is None
@@ -1100,9 +1036,7 @@ class TestDeploymentDefaultTpmLimit:
         """Case 2 from spec: key has no model-specific limits, falls back to deployment default."""
         user_api_key_dict = UserAPIKeyAuth(api_key="sk-123")
         mock_router = MagicMock()
-        mock_router.get_model_list.return_value = [
-            _make_deployment_dict("model1", tpm=100)
-        ]
+        mock_router.get_model_list.return_value = [_make_deployment_dict("model1", tpm=100)]
         with patch(_ROUTER_PATCH, mock_router):
             result = get_key_model_tpm_limit(user_api_key_dict, model_name="model1")
         assert result == {"model1": 100}
@@ -1114,9 +1048,7 @@ class TestDeploymentDefaultTpmLimit:
             metadata={"model_tpm_limit": {"model1": 20}},
         )
         mock_router = MagicMock()
-        mock_router.get_model_list.return_value = [
-            _make_deployment_dict("model1", tpm=100)
-        ]
+        mock_router.get_model_list.return_value = [_make_deployment_dict("model1", tpm=100)]
         with patch(_ROUTER_PATCH, mock_router):
             result = get_key_model_tpm_limit(user_api_key_dict, model_name="model1")
         assert result == {"model1": 20}
@@ -1136,9 +1068,7 @@ class TestDeploymentDefaultTpmLimit:
         """No model_name means deployment fallback is skipped."""
         user_api_key_dict = UserAPIKeyAuth(api_key="sk-123")
         mock_router = MagicMock()
-        mock_router.get_model_list.return_value = [
-            _make_deployment_dict("model1", tpm=100)
-        ]
+        mock_router.get_model_list.return_value = [_make_deployment_dict("model1", tpm=100)]
         with patch(_ROUTER_PATCH, mock_router):
             result = get_key_model_tpm_limit(user_api_key_dict)
         assert result is None
@@ -1627,11 +1557,7 @@ class TestIsRequestBodySafeNestedConfig:
         when nested."""
         with pytest.raises(ValueError, match="langfuse_host"):
             is_request_body_safe(
-                request_body={
-                    "litellm_embedding_config": {
-                        "langfuse_host": "https://attacker.example.com"
-                    }
-                },
+                request_body={"litellm_embedding_config": {"langfuse_host": "https://attacker.example.com"}},
                 general_settings={},
                 llm_router=None,
                 model="milvus-store",
@@ -1642,11 +1568,7 @@ class TestIsRequestBodySafeNestedConfig:
         keep the existing escape hatch — same UX as for root-level."""
         assert (
             is_request_body_safe(
-                request_body={
-                    "litellm_embedding_config": {
-                        "api_base": "https://my-azure.example.com"
-                    }
-                },
+                request_body={"litellm_embedding_config": {"api_base": "https://my-azure.example.com"}},
                 general_settings={"allow_client_side_credentials": True},
                 llm_router=None,
                 model="milvus-store",
@@ -1786,9 +1708,7 @@ class TestObservabilityCallbackBans:
             "phoenix_project_name_override",
         ],
     )
-    def test_observability_field_in_metadata_dict_is_rejected(
-        self, metadata_key, field
-    ):
+    def test_observability_field_in_metadata_dict_is_rejected(self, metadata_key, field):
         # Verifies the metadata walk: a value smuggled inside ``metadata``
         # or ``litellm_metadata`` is just as dangerous as the same field
         # at the body root, and must hit the same gate.
@@ -1808,9 +1728,7 @@ class TestObservabilityCallbackBans:
         "metadata_key",
         ["metadata", "litellm_metadata"],
     )
-    def test_observability_field_in_json_string_metadata_is_rejected(
-        self, metadata_key
-    ):
+    def test_observability_field_in_json_string_metadata_is_rejected(self, metadata_key):
         # Multipart/form-data and ``extra_body`` callers send metadata as a
         # JSON-encoded string. The bouncer parses it before applying the
         # banned-params check so the JSON-string path can't smuggle past
@@ -1821,9 +1739,7 @@ class TestObservabilityCallbackBans:
             is_request_body_safe(
                 request_body={
                     "model": "gpt-4",
-                    metadata_key: json.dumps(
-                        {"langfuse_host": "https://attacker.example"}
-                    ),
+                    metadata_key: json.dumps({"langfuse_host": "https://attacker.example"}),
                 },
                 general_settings={},
                 llm_router=None,
@@ -1930,8 +1846,7 @@ def test_observability_ban_covers_canonical_supported_callback_params():
         )
     for param in _request_blocked_callback_params:
         assert param in banned, (
-            f"{param} is in _request_blocked_callback_params but is not banned "
-            "at the proxy request-body boundary."
+            f"{param} is in _request_blocked_callback_params but is not banned at the proxy request-body boundary."
         )
 
 
@@ -2029,7 +1944,231 @@ class TestGetRequestRouteTemplate:
 
     def test_exception_returns_none(self):
         req = MagicMock()
-        type(req).scope = property(
-            lambda self: (_ for _ in ()).throw(RuntimeError("boom"))
-        )
+        type(req).scope = property(lambda self: (_ for _ in ()).throw(RuntimeError("boom")))
         assert get_request_route_template(req) is None
+
+
+class TestIsRequestBodySafeBlocksModelList:
+    """``model_list`` is an SDK-only construct. main.py reads api_base/api_key
+    out of each entry's ``litellm_params`` and runs batch_completion_models
+    with server credentials, so the field is rejected outright regardless of
+    any clientside opt-in (Veria #1)."""
+
+    def test_model_list_in_request_body_is_rejected(self):
+        with pytest.raises(ValueError, match="model_list"):
+            is_request_body_safe(
+                request_body={
+                    "model": "gpt-4",
+                    "model_list": [
+                        {
+                            "model_name": "gpt-4",
+                            "litellm_params": {
+                                "model": "gpt-4",
+                                "api_base": "https://attacker.example",
+                                "api_key": "sk-leak",
+                            },
+                        }
+                    ],
+                },
+                general_settings={},
+                llm_router=None,
+                model="gpt-4",
+            )
+
+    def test_model_list_rejected_even_with_proxy_wide_opt_in(self):
+        # Unlike the other banned params, model_list has no legitimate proxy
+        # use, so even the proxy-wide opt-in must not let it through.
+        with pytest.raises(ValueError, match="model_list"):
+            is_request_body_safe(
+                request_body={
+                    "model": "gpt-4",
+                    "model_list": [
+                        {
+                            "model_name": "gpt-4",
+                            "litellm_params": {
+                                "model": "gpt-4",
+                                "api_base": "https://attacker.example",
+                            },
+                        }
+                    ],
+                },
+                general_settings={"allow_client_side_credentials": True},
+                llm_router=None,
+                model="gpt-4",
+            )
+
+    def test_empty_model_list_still_rejected(self):
+        # Membership, not truthiness — an empty list is still the SDK-only
+        # field and must be blocked.
+        with pytest.raises(ValueError, match="model_list"):
+            is_request_body_safe(
+                request_body={"model": "gpt-4", "model_list": []},
+                general_settings={},
+                llm_router=None,
+                model="gpt-4",
+            )
+
+
+class TestIsRequestBodySafeBlocksVertexAndCredentialAliases:
+    """Aliases and project/credential fields that reach the provider layer
+    and were missing from the ban list (Veria #3, #6a)."""
+
+    @pytest.mark.parametrize(
+        "field,value",
+        [
+            ("vertex_ai_credentials", '{"private_key":"-----BEGIN..."}'),
+            ("vertex_project", "attacker-gcp-project"),
+            ("vertex_location", "us-central1"),
+            ("aws_access_key_id", "AKIA-EXAMPLE"),
+            ("aws_secret_access_key", "secret-example"),
+            ("aws_session_token", "session-example"),
+            ("base_model", "azure/gpt-4"),
+            ("oci_key", "-----BEGIN PRIVATE KEY-----"),
+            ("oci_tenancy", "ocid1.tenancy.oc1..attacker"),
+        ],
+    )
+    def test_credential_field_in_request_body_is_rejected(self, field, value):
+        with pytest.raises(ValueError, match=field):
+            is_request_body_safe(
+                request_body={"model": "gpt-4", field: value},
+                general_settings={},
+                llm_router=None,
+                model="gpt-4",
+            )
+
+    def test_vertex_ai_credentials_alias_not_bypassed_by_api_key(self):
+        # The historical api_key bypass must not reopen the alias path.
+        with pytest.raises(ValueError, match="vertex_ai_credentials"):
+            is_request_body_safe(
+                request_body={
+                    "model": "vertex_ai/gemini-2.0-flash",
+                    "api_key": "sk-anything",
+                    "vertex_ai_credentials": '{"private_key":"x"}',
+                },
+                general_settings={},
+                llm_router=None,
+                model="vertex_ai/gemini-2.0-flash",
+            )
+
+
+class TestIsRequestBodySafeScansTools:
+    """Provider interceptors (e.g. the Anthropic advisor tool) read
+    api_base/api_key out of a caller-supplied tool entry and fall back to
+    server credentials. The banned-param check must descend into each tool
+    dict and its nested ``function`` object (Veria #6b, #7)."""
+
+    def test_banned_param_in_tool_entry_is_rejected(self):
+        with pytest.raises(ValueError, match="api_base"):
+            is_request_body_safe(
+                request_body={
+                    "model": "gpt-4",
+                    "tools": [
+                        {
+                            "type": "advisor_20260301",
+                            "model": "claude-opus-4-8",
+                            "api_base": "https://attacker.example",
+                            "api_key": "sk-leak",
+                        }
+                    ],
+                },
+                general_settings={},
+                llm_router=None,
+                model="gpt-4",
+            )
+
+    def test_banned_param_in_nested_function_is_rejected(self):
+        with pytest.raises(ValueError, match="api_base"):
+            is_request_body_safe(
+                request_body={
+                    "model": "gpt-4",
+                    "tools": [
+                        {
+                            "type": "function",
+                            "function": {
+                                "name": "x",
+                                "api_base": "https://attacker.example",
+                            },
+                        }
+                    ],
+                },
+                general_settings={},
+                llm_router=None,
+                model="gpt-4",
+            )
+
+    def test_safe_tools_array_accepted(self):
+        assert (
+            is_request_body_safe(
+                request_body={
+                    "model": "gpt-4",
+                    "tools": [
+                        {
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "parameters": {"type": "object"},
+                            },
+                        }
+                    ],
+                },
+                general_settings={},
+                llm_router=None,
+                model="gpt-4",
+            )
+            is True
+        )
+
+    def test_malformed_tools_entries_do_not_raise(self):
+        # Non-dict entries are skipped so a malformed array still reaches
+        # normal downstream validation rather than erroring in the auth gate.
+        assert (
+            is_request_body_safe(
+                request_body={"model": "gpt-4", "tools": ["not-a-dict", 123, None]},
+                general_settings={},
+                llm_router=None,
+                model="gpt-4",
+            )
+            is True
+        )
+
+
+class TestGetDynamicLitellmParamsClearsApiKeyOnBaseOverride:
+    """When the caller redirects ``api_base``/``base_url`` without resupplying
+    a key, the admin's deployment ``api_key`` must be dropped so the proxy
+    doesn't forward its own credential to the attacker upstream (Veria #6c)."""
+
+    def test_admin_api_key_cleared_when_base_overridden_without_key(self):
+        from litellm.router_utils.clientside_credential_handler import (
+            get_dynamic_litellm_params,
+        )
+
+        out = get_dynamic_litellm_params(
+            litellm_params={
+                "model": "gpt-4",
+                "api_key": "sk-admin-secret",
+                "api_base": "https://admin.upstream/v1",
+            },
+            request_kwargs={"api_base": "https://attacker.example"},
+        )
+        assert out["api_base"] == "https://attacker.example"
+        assert "api_key" not in out
+        assert "sk-admin-secret" not in str(out)
+
+    def test_caller_supplied_api_key_still_wins_on_base_override(self):
+        from litellm.router_utils.clientside_credential_handler import (
+            get_dynamic_litellm_params,
+        )
+
+        out = get_dynamic_litellm_params(
+            litellm_params={
+                "model": "gpt-4",
+                "api_key": "sk-admin-secret",
+                "api_base": "https://admin.upstream/v1",
+            },
+            request_kwargs={
+                "api_base": "https://attacker.example",
+                "api_key": "sk-byok",
+            },
+        )
+        assert out["api_key"] == "sk-byok"
+        assert "sk-admin-secret" not in str(out)

--- a/tests/test_litellm/proxy/auth/test_handle_jwt.py
+++ b/tests/test_litellm/proxy/auth/test_handle_jwt.py
@@ -4274,6 +4274,91 @@ async def test_multi_issuer_jwt_strips_unmapped_internal_claims(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_multi_issuer_jwt_drops_unmapped_scope_blocks_admin_escalation(
+    monkeypatch,
+):
+    """A token from a configured-but-low-trust issuer that carries a raw
+    ``scope`` claim must NOT escalate to proxy admin. The issuer config below
+    maps only an identity field, so ``scope`` is unmapped and dropped during
+    normalization; ``get_scopes``/``is_admin`` then see nothing.
+    """
+    monkeypatch.delenv("JWT_AUDIENCE", raising=False)
+    monkeypatch.delenv("JWT_PUBLIC_KEY_URL", raising=False)
+
+    issuer = "https://low-trust-issuer.example.com"
+    jwks_url = f"{issuer}/keys"
+    private_key, jwk = _get_rsa_key_and_jwk(kid="issuer-key")
+    jwt_handler = _get_jwt_handler_with_issuer_keys(
+        issuers=[
+            {
+                "issuer": issuer,
+                "jwks_url": jwks_url,
+                "audience": "expected-audience",
+                "user_id_jwt_field": "sub",
+            }
+        ],
+        keys_by_url={jwks_url: [jwk]},
+    )
+    token = _encode_rsa_jwt(
+        private_key=private_key,
+        issuer=issuer,
+        audience="expected-audience",
+        kid="issuer-key",
+        extra_claims={
+            "scope": "litellm_proxy_admin",
+            "roles": ["litellm_proxy_admin"],
+        },
+    )
+
+    claims = await jwt_handler.auth_jwt(token=token)
+
+    assert "scope" not in claims
+    assert "roles" not in claims
+    assert jwt_handler.get_scopes(token=claims) == []
+    assert jwt_handler.is_admin(scopes=jwt_handler.get_scopes(token=claims)) is False
+
+
+@pytest.mark.asyncio
+async def test_global_jwt_path_still_trusts_scope_for_admin(monkeypatch):
+    """The legacy single-issuer / global path (no ``issuers`` configured) must
+    keep honoring the ``scope`` claim as the admin field. The cross-issuer
+    allowlist only applies to issuer-scoped normalization, so this path is
+    unchanged and a token carrying the configured admin scope still maps to
+    proxy admin.
+    """
+    from litellm.caching.dual_cache import DualCache
+
+    monkeypatch.delenv("JWT_AUDIENCE", raising=False)
+    monkeypatch.delenv("JWT_ISSUER", raising=False)
+
+    jwks_url = "https://global-issuer.example.com/keys"
+    monkeypatch.setenv("JWT_PUBLIC_KEY_URL", jwks_url)
+
+    private_key, jwk = _get_rsa_key_and_jwk(kid="global-key")
+    cache = DualCache()
+    cache.set_cache(key=f"litellm_jwt_auth_keys_{jwks_url}", value=[jwk])
+
+    jwt_handler = JWTHandler()
+    jwt_handler.update_environment(
+        prisma_client=None,
+        user_api_key_cache=cache,
+        litellm_jwtauth=LiteLLM_JWTAuth(),
+    )
+    token = _encode_rsa_jwt(
+        private_key=private_key,
+        issuer="https://global-issuer.example.com",
+        audience="any-audience",
+        kid="global-key",
+        extra_claims={"scope": "litellm_proxy_admin"},
+    )
+
+    claims = await jwt_handler.auth_jwt(token=token)
+
+    assert jwt_handler.get_scopes(token=claims) == ["litellm_proxy_admin"]
+    assert jwt_handler.is_admin(scopes=jwt_handler.get_scopes(token=claims)) is True
+
+
+@pytest.mark.asyncio
 async def test_multi_issuer_jwt_does_not_emit_unscoped_global_warning(
     monkeypatch, caplog
 ):

--- a/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
@@ -1197,6 +1197,136 @@ class TestListMCPServers:
         # Non-admin viewers get no env var config at all (not even names).
         assert result.env_vars is None
 
+    @pytest.mark.asyncio
+    async def test_fetch_single_mcp_server_sanitizes_for_view_only_admin(self):
+        """SEC Veria #5: PROXY_ADMIN_VIEW_ONLY must NOT see credential-bearing fields.
+
+        It previously passed the _user_has_admin_view gate (which also grants view-only
+        admins) and only had the explicit `credentials` field cleared, leaking secrets
+        embedded in url/static_headers/env_vars. Only a FULL PROXY_ADMIN may see those.
+        This test exercises the real role helpers (no patching of the gate)."""
+        mock_server = LiteLLM_MCPServerTable.model_construct(
+            server_id="leaky-server",
+            server_name="Leaky Server",
+            alias="Leaky Server",
+            transport=MCPTransport.http,
+            url="https://leaky.example.com/mcp?api_key=sk-embedded-in-url",
+            static_headers={"Authorization": "Bearer sk-secret-header"},
+            env={"UPSTREAM_TOKEN": "sk-secret-env"},
+            env_vars=[
+                {"name": "GLOBAL_KEY", "value": "super-secret", "scope": "global"},
+            ],
+            credentials={"auth_value": "sk-explicit-credential"},
+        )
+
+        mock_prisma_client = MagicMock()
+
+        mock_health_result = generate_mock_mcp_server_db_record(
+            server_id="leaky-server", alias="Leaky Server"
+        )
+        mock_health_result.status = "healthy"
+        mock_health_result.last_health_check = datetime.now()
+        mock_health_result.health_check_error = None
+
+        mock_manager = MagicMock()
+        mock_manager.add_server = AsyncMock()
+        mock_manager.health_check_server = AsyncMock(return_value=mock_health_result)
+
+        mock_user_auth = generate_mock_user_api_key_auth(
+            user_role=LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY
+        )
+
+        with (
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.get_prisma_client_or_throw",
+                return_value=mock_prisma_client,
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.get_mcp_server",
+                AsyncMock(return_value=mock_server),
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.global_mcp_server_manager",
+                mock_manager,
+            ),
+        ):
+            from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+                fetch_mcp_server,
+            )
+
+            result = await fetch_mcp_server(
+                request=_make_mock_request(),
+                server_id="leaky-server",
+                user_api_key_dict=mock_user_auth,
+            )
+
+        assert result.server_id == "leaky-server"
+        assert result.credentials is None
+        assert result.url is None
+        assert result.static_headers is None
+        assert result.env == {}
+        assert result.env_vars is None
+
+    @pytest.mark.asyncio
+    async def test_fetch_single_mcp_server_full_admin_still_sees_secrets(self):
+        """SEC Veria #5 guardrail: the fix must not over-redact for FULL PROXY_ADMIN,
+        who needs url/static_headers/env to populate the edit form."""
+        mock_server = LiteLLM_MCPServerTable.model_construct(
+            server_id="admin-server",
+            server_name="Admin Server",
+            alias="Admin Server",
+            transport=MCPTransport.http,
+            url="https://admin.example.com/mcp",
+            static_headers={"Authorization": "Bearer sk-secret-header"},
+            credentials={"auth_value": "sk-explicit-credential"},
+        )
+
+        mock_prisma_client = MagicMock()
+
+        mock_health_result = generate_mock_mcp_server_db_record(
+            server_id="admin-server", alias="Admin Server"
+        )
+        mock_health_result.status = "healthy"
+        mock_health_result.last_health_check = datetime.now()
+        mock_health_result.health_check_error = None
+
+        mock_manager = MagicMock()
+        mock_manager.add_server = AsyncMock()
+        mock_manager.health_check_server = AsyncMock(return_value=mock_health_result)
+
+        mock_user_auth = generate_mock_user_api_key_auth(
+            user_role=LitellmUserRoles.PROXY_ADMIN
+        )
+
+        with (
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.get_prisma_client_or_throw",
+                return_value=mock_prisma_client,
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.get_mcp_server",
+                AsyncMock(return_value=mock_server),
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.global_mcp_server_manager",
+                mock_manager,
+            ),
+        ):
+            from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+                fetch_mcp_server,
+            )
+
+            result = await fetch_mcp_server(
+                request=_make_mock_request(),
+                server_id="admin-server",
+                user_api_key_dict=mock_user_auth,
+            )
+
+        # credentials field is always redacted; the rest must survive for full admin.
+        assert result.credentials is None
+        assert result.url == "https://admin.example.com/mcp"
+        assert result.static_headers == {"Authorization": "Bearer sk-secret-header"}
+
 
 class TestTeamScopedMCPServerAccess:
     """Tests for cross-team information disclosure and restricted key bypass fixes."""
@@ -3693,18 +3823,12 @@ def _server_with_env_vars(server_id: str = "srv-env"):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "user_role, expected_global_value",
-    [
-        (LitellmUserRoles.PROXY_ADMIN, "super-secret"),
-        (LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY, ""),
-    ],
-)
-async def test_fetch_single_mcp_server_redacts_global_env_for_view_only_admin(
-    user_role, expected_global_value
-):
-    """Read-only admins must not receive admin-supplied global env var secrets;
-    full admins still see them so the edit form can pre-fill."""
+async def test_fetch_single_mcp_server_env_vars_full_admin_vs_view_only():
+    """SEC Veria #5: full admins see admin-supplied global env var secrets so the edit
+    form can pre-fill; read-only admins now go through the non-admin sanitizer, which
+    drops env_vars entirely (the names alone, e.g. ADMIN_API_KEY, leak what secrets the
+    admin configured). Previously the view-only case merely blanked the global value
+    while keeping the names, which still leaked configuration metadata."""
     server = _server_with_env_vars()
 
     health_result = generate_mock_mcp_server_db_record(server_id=server.server_id)
@@ -3712,34 +3836,39 @@ async def test_fetch_single_mcp_server_redacts_global_env_for_view_only_admin(
     health_result.last_health_check = datetime.now()
     health_result.health_check_error = None
 
-    with (
-        patch(
-            "litellm.proxy.management_endpoints.mcp_management_endpoints.get_prisma_client_or_throw",
-            return_value=MagicMock(),
-        ),
-        patch(
-            "litellm.proxy.management_endpoints.mcp_management_endpoints.get_mcp_server",
-            AsyncMock(return_value=server),
-        ),
-        patch(
-            "litellm.proxy.management_endpoints.mcp_management_endpoints.global_mcp_server_manager.add_server",
-            AsyncMock(return_value=None),
-        ),
-        patch(
-            "litellm.proxy.management_endpoints.mcp_management_endpoints.global_mcp_server_manager.health_check_server",
-            AsyncMock(return_value=health_result),
-        ),
-    ):
-        result = await mgmt_endpoints.fetch_mcp_server(
-            request=_make_mock_request(),
-            server_id=server.server_id,
-            user_api_key_dict=generate_mock_user_api_key_auth(user_role=user_role),
-        )
+    async def _fetch(user_role):
+        with (
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.get_prisma_client_or_throw",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.get_mcp_server",
+                AsyncMock(return_value=server),
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.global_mcp_server_manager.add_server",
+                AsyncMock(return_value=None),
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.global_mcp_server_manager.health_check_server",
+                AsyncMock(return_value=health_result),
+            ),
+        ):
+            return await mgmt_endpoints.fetch_mcp_server(
+                request=_make_mock_request(),
+                server_id=server.server_id,
+                user_api_key_dict=generate_mock_user_api_key_auth(user_role=user_role),
+            )
 
-    by_name = {ev.name: ev for ev in result.env_vars}
-    assert by_name["ADMIN_API_KEY"].value == expected_global_value
-    # Per-user placeholders are always preserved.
+    full_admin = await _fetch(LitellmUserRoles.PROXY_ADMIN)
+    by_name = {ev.name: ev for ev in full_admin.env_vars}
+    assert by_name["ADMIN_API_KEY"].value == "super-secret"
     assert by_name["USER_TOKEN"].value == "placeholder-hint"
+
+    view_only = await _fetch(LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY)
+    assert view_only.env_vars is None
+
     # The source record must never be mutated.
     assert {ev.name: ev.value for ev in server.env_vars}[
         "ADMIN_API_KEY"
@@ -3747,39 +3876,39 @@ async def test_fetch_single_mcp_server_redacts_global_env_for_view_only_admin(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "user_role, expected_global_value",
-    [
-        (LitellmUserRoles.PROXY_ADMIN, "super-secret"),
-        (LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY, ""),
-    ],
-)
-async def test_fetch_all_mcp_servers_redacts_global_env_for_view_only_admin(
-    user_role, expected_global_value
-):
+async def test_fetch_all_mcp_servers_env_vars_full_admin_vs_view_only():
+    """SEC Veria #5 (list endpoint): same posture as the single-server fetch. Full admins
+    keep the env var values; view-only admins get env_vars dropped via the non-admin
+    sanitizer rather than only having the global value blanked."""
     server = _server_with_env_vars()
 
-    with (
-        patch(
-            "litellm.proxy.management_endpoints.mcp_management_endpoints._get_user_mcp_management_mode",
-            return_value="view_all",
-        ),
-        patch(
-            "litellm.proxy.management_endpoints.mcp_management_endpoints.global_mcp_server_manager.get_all_mcp_servers_unfiltered",
-            AsyncMock(return_value=[server]),
-        ),
-        patch(
-            "litellm.proxy.proxy_server.prisma_client",
-            None,
-        ),
-    ):
-        result = await mgmt_endpoints.fetch_all_mcp_servers(
-            user_api_key_dict=generate_mock_user_api_key_auth(user_role=user_role),
-        )
+    async def _fetch_all(user_role):
+        with (
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints._get_user_mcp_management_mode",
+                return_value="view_all",
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.global_mcp_server_manager.get_all_mcp_servers_unfiltered",
+                AsyncMock(return_value=[server]),
+            ),
+            patch(
+                "litellm.proxy.proxy_server.prisma_client",
+                None,
+            ),
+        ):
+            return await mgmt_endpoints.fetch_all_mcp_servers(
+                user_api_key_dict=generate_mock_user_api_key_auth(user_role=user_role),
+            )
 
-    by_name = {ev.name: ev for ev in result[0].env_vars}
-    assert by_name["ADMIN_API_KEY"].value == expected_global_value
+    full_admin = await _fetch_all(LitellmUserRoles.PROXY_ADMIN)
+    by_name = {ev.name: ev for ev in full_admin[0].env_vars}
+    assert by_name["ADMIN_API_KEY"].value == "super-secret"
     assert by_name["USER_TOKEN"].value == "placeholder-hint"
+
+    view_only = await _fetch_all(LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY)
+    assert view_only[0].env_vars is None
+
     assert {ev.name: ev.value for ev in server.env_vars}[
         "ADMIN_API_KEY"
     ] == "super-secret"

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -8044,3 +8044,73 @@ def test_get_config_list_includes_cancel_on_disconnect(monkeypatch):
         assert fields["cancel_on_disconnect"]["field_type"] == "Boolean"
     finally:
         app.dependency_overrides.clear()
+
+
+def _config_field_info_client(monkeypatch, user_role):
+    import types
+    from unittest.mock import AsyncMock, MagicMock
+
+    from fastapi.testclient import TestClient
+
+    import litellm.proxy.proxy_server as ps
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.proxy.proxy_server import app
+
+    db_record = types.SimpleNamespace(
+        param_value={
+            "master_key": "sk-super-secret-master",
+            "database_url": "postgresql://user:p4ssw0rd@db:5432/litellm",
+            "max_parallel_requests": 100,
+        }
+    )
+    mock_config_table = MagicMock()
+    mock_config_table.find_first = AsyncMock(return_value=db_record)
+    mock_prisma = MagicMock()
+    mock_prisma.db = types.SimpleNamespace(litellm_config=mock_config_table)
+    monkeypatch.setattr(ps, "prisma_client", mock_prisma)
+    app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_id="u", user_role=user_role
+    )
+    return TestClient(app)
+
+
+def test_config_field_info_redacts_secrets_for_view_only_admin(monkeypatch):
+    """SEC Veria #5: /config/field/info gates on _user_has_admin_view, which also grants
+    PROXY_ADMIN_VIEW_ONLY. A view-only admin reading master_key/database_url verbatim is
+    effectively a full admin. Secret-bearing fields must come back REDACTED for anyone who
+    is not a FULL PROXY_ADMIN, while non-secret fields stay readable."""
+    from litellm.proxy._types import LitellmUserRoles
+
+    client = _config_field_info_client(
+        monkeypatch, LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY
+    )
+    try:
+        for secret_field in ("master_key", "database_url"):
+            resp = client.get("/config/field/info", params={"field_name": secret_field})
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["field_value"] == "REDACTED"
+            assert "secret" not in str(body["field_value"])
+            assert "p4ssw0rd" not in str(body["field_value"])
+
+        resp = client.get(
+            "/config/field/info", params={"field_name": "max_parallel_requests"}
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["field_value"] == 100
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_config_field_info_returns_raw_secrets_for_full_admin(monkeypatch):
+    """SEC Veria #5 guardrail: the redaction must not over-apply. A FULL PROXY_ADMIN still
+    needs the real master_key value to populate the admin edit form."""
+    from litellm.proxy._types import LitellmUserRoles
+
+    client = _config_field_info_client(monkeypatch, LitellmUserRoles.PROXY_ADMIN)
+    try:
+        resp = client.get("/config/field/info", params={"field_name": "master_key"})
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["field_value"] == "sk-super-secret-master"
+    finally:
+        app.dependency_overrides.clear()

--- a/tests/test_litellm/test_router_credential_kwarg_override.py
+++ b/tests/test_litellm/test_router_credential_kwarg_override.py
@@ -1,0 +1,90 @@
+"""
+Regression tests for Veria #3: caller-supplied credential/endpoint/project
+kwargs must not override the deployment's server-pinned values in the Router's
+``{**litellm_params, ..., **kwargs}`` merge.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import litellm
+from litellm import Router
+from litellm.router import (
+    _DEPLOYMENT_OWNED_CREDENTIAL_KWARGS,
+    _strip_deployment_owned_credential_kwargs,
+)
+
+
+def test_strip_helper_removes_credential_kwargs_in_place():
+    kwargs = {
+        "temperature": 0.2,
+        "vertex_project": "attacker-project",
+        "aws_access_key_id": "AKIA-ATTACKER",
+        "api_version": "attacker-version",
+        "base_model": "azure/forged",
+    }
+    _strip_deployment_owned_credential_kwargs(kwargs)
+    assert kwargs == {"temperature": 0.2}
+
+
+def test_strip_helper_leaves_sanctioned_clientside_keys():
+    # api_key / api_base / base_url go through the explicit opt-in path, not
+    # this merge, so they must NOT be in the stripped set.
+    for key in ("api_key", "api_base", "base_url"):
+        assert key not in _DEPLOYMENT_OWNED_CREDENTIAL_KWARGS
+
+
+def _router() -> Router:
+    return Router(
+        model_list=[
+            {
+                "model_name": "primary",
+                "litellm_params": {
+                    "model": "vertex_ai/gemini-2.0-flash",
+                    "vertex_project": "admin-project",
+                    "vertex_credentials": '{"private_key":"admin"}',
+                    "api_key": "sk-admin",
+                },
+            }
+        ]
+    )
+
+
+def test_sync_completion_ignores_caller_credential_kwargs():
+    router = _router()
+    mock_response = litellm.ModelResponse(choices=[{"message": {"content": "ok"}}])
+    mock_completion = MagicMock(return_value=mock_response)
+
+    with patch.object(litellm, "completion", mock_completion):
+        router.completion(
+            model="primary",
+            messages=[{"role": "user", "content": "hi"}],
+            vertex_project="attacker-project",
+            vertex_credentials='{"private_key":"attacker"}',
+        )
+
+    assert mock_completion.call_count == 1
+    _, kwargs = mock_completion.call_args
+    assert kwargs["vertex_project"] == "admin-project"
+    assert kwargs["vertex_credentials"] == '{"private_key":"admin"}'
+    assert "attacker" not in str(kwargs["vertex_credentials"])
+
+
+@pytest.mark.asyncio
+async def test_async_completion_ignores_caller_credential_kwargs():
+    router = _router()
+    mock_response = litellm.ModelResponse(choices=[{"message": {"content": "ok"}}])
+    mock_acompletion = AsyncMock(return_value=mock_response)
+
+    with patch.object(litellm, "acompletion", mock_acompletion):
+        await router.acompletion(
+            model="primary",
+            messages=[{"role": "user", "content": "hi"}],
+            vertex_project="attacker-project",
+            aws_access_key_id="AKIA-ATTACKER",
+        )
+
+    assert mock_acompletion.call_count == 1
+    _, kwargs = mock_acompletion.call_args
+    assert kwargs["vertex_project"] == "admin-project"
+    assert kwargs.get("aws_access_key_id") is None


### PR DESCRIPTION
## Security hardening — 7 findings (Veria scan)

> ⚠️ Security-sensitive. These harden 7 vulnerabilities (6 Critical, 1 High) surfaced by the Veria scan and verified against the code. AI-assisted patches — **please review carefully before merge**, and consider whether this should be handled via a private security advisory rather than a public PR.

Based off `litellm_internal_staging`. Grouped into three themes; each commit is self-contained with regression tests.

### Theme 1 — Parameter smuggling / SSRF / downstream key theft (Veria #1, #3, #6, #7)
- **#1 model_list SSRF:** `is_request_body_safe()` now rejects `model_list` outright (SDK-only field; `main.py` reads `api_base`/`api_key` from its nested `litellm_params` and runs with server creds).
- **#3 kwargs override (Vertex/Bedrock/OCI):** request `kwargs` were merged *after* deployment `litellm_params`, letting callers shadow credential/endpoint/project fields. New `_strip_deployment_owned_credential_kwargs()` runs before the merge in `_completion`/`_acompletion`; banned-params list extended (`vertex_project/location`, `aws_*`, `oci_*`, `base_model`).
- **#6a:** banned the `vertex_ai_credentials` alias (only `vertex_credentials` was blocked).
- **#6b/#7:** `tools[]` (and `tool.function`) are now scanned for banned params, closing the Anthropic advisor-tool `api_base`/`api_key` injection; defense-in-depth gate added in the advisor interceptor.
- **#6c:** deployment `api_key` is now cleared when a caller overrides `api_base`/`base_url` (was forwarding the proxy's own key to the redirected upstream).

### Theme 2 — Cross-issuer JWT claim injection → PROXY_ADMIN (Veria #2)
- `_apply_issuer_claim_mappings()` switched from a denylist to a strict **allowlist**: normalized token = standard RFC 7519 claims + only the claims *this* issuer explicitly maps. Unmapped `scope`/`roles` are dropped, so a low-trust issuer can no longer inject `scope: litellm_proxy_admin`. Legacy single-issuer path unchanged (backward-compat note in commit body).

### Theme 3 — Access control / secret redaction (Veria #4, #5)
- **#4 AWS profile env leak:** `_auth_with_aws_profile` wraps `boto3.Session(profile_name=...)` and raises a generic error; `aws_profile_name` redacted in the debug log. (Leak surface was **server logs/traceback**, not the HTTP response — corrected from the original finding.)
- **#5 view-only secret reads:** `/config/field/info` now redacts secret-bearing fields (`master_key`, `database_url`) for any non-full-`PROXY_ADMIN`; MCP server endpoints gated on `_user_is_full_admin` so `PROXY_ADMIN_VIEW_ONLY` goes through the non-admin sanitizer.

### Testing
- New / expanded regression tests for every finding (auth_utils, handle_jwt, advisor orchestration, router credential-kwarg override, base_aws_llm, proxy_server config-field, mcp management endpoints). Each was confirmed to fail pre-fix and pass post-fix.
- `black` / `ruff` / `mypy` clean on touched source; all 8 changed source files byte-compile on py3.13.

Co-authored with Claude Code.
