### PR TITLE
fix(lint): anchor LIT001 to the mutable name's own line in multi-line annotations

### DIFF
--- a/scripts/check_type_discipline.py
+++ b/scripts/check_type_discipline.py
@@ -206,18 +206,26 @@ def scan_comments(path: Path, source: str) -> tuple[Comments, tuple[Violation, .
 # --------------------------------------------------------------------------- #
  
  
-def mutable_names_in(annotation: ast.expr) -> Iterator[str]:
-    """Yield mutable-collection names anywhere inside an annotation expression.
+class MutableRef(NamedTuple):
+    name: str
+    line: int
+
+
+def mutable_names_in(annotation: ast.expr) -> Iterator[MutableRef]:
+    """Yield each mutable-collection name inside an annotation, with its source line.
 
     Matches bare names (`dict`, `MutableMapping`) and dotted access (`typing.Dict`,
     `collections.deque`, `collections.abc.MutableMapping`), descends through nesting
     (`Mapping[str, list[int]]`, `tuple[set[int], ...]`) and string forward references.
+    Each name carries its own line so a violation in a multi-line annotation is reported
+    where the name sits -- not on the annotation's first line -- and a `# mutable-ok` on
+    that line suppresses it.
     """
     for node in ast.walk(annotation):
         if isinstance(node, ast.Name) and node.id in MUTABLE_COLLECTIONS:
-            yield node.id
+            yield MutableRef(node.id, node.lineno)
         elif isinstance(node, ast.Attribute) and node.attr in MUTABLE_COLLECTIONS:
-            yield node.attr
+            yield MutableRef(node.attr, node.lineno)
         elif isinstance(node, ast.Constant):
             value: object = node.value  # forward references arrive as string constants
             if isinstance(value, str):
@@ -225,7 +233,9 @@ def mutable_names_in(annotation: ast.expr) -> Iterator[str]:
                     inner = ast.parse(value, mode="eval").body
                 except SyntaxError:
                     continue
-                yield from mutable_names_in(inner)
+                # The inner parse numbers lines from 1 inside the string, so anchor every
+                # name it yields to the forward-ref string's own line in the file.
+                yield from (MutableRef(ref.name, node.lineno) for ref in mutable_names_in(inner))
  
  
 def _mutable_ann(path: Path, line: int, name: str, where: str) -> Violation:
@@ -240,11 +250,15 @@ def _mutable_ann(path: Path, line: int, name: str, where: str) -> Violation:
 
 
 def _annotation_violations(
-    path: Path, annotation: ast.expr | None, line: int, where: str, ok_lines: frozenset[int]
+    path: Path, annotation: ast.expr | None, where: str, ok_lines: frozenset[int]
 ) -> Iterator[Violation]:
-    if annotation is None or line in ok_lines:
+    if annotation is None:
         return
-    yield from (_mutable_ann(path, line, name, where) for name in mutable_names_in(annotation))
+    yield from (
+        _mutable_ann(path, ref.line, ref.name, where)
+        for ref in mutable_names_in(annotation)
+        if ref.line not in ok_lines
+    )
  
  
 def _function_violations(
@@ -254,14 +268,14 @@ def _function_violations(
     args = node.args
     for arg in (*args.posonlyargs, *args.args, *args.kwonlyargs):
         yield from _annotation_violations(
-            path, arg.annotation, arg.lineno, f"parameter `{arg.arg}` of `{node.name}`", mutable_ok
+            path, arg.annotation, f"parameter `{arg.arg}` of `{node.name}`", mutable_ok
         )
 
     # *args is allowed when typed (it's just a tuple); ruff ANN002 forces the
     # annotation, so here we only add the LIT001 mutable-collection check on the element type.
     if args.vararg is not None:
         yield from _annotation_violations(
-            path, args.vararg.annotation, args.vararg.lineno, f"`*args` of `{node.name}`", mutable_ok
+            path, args.vararg.annotation, f"`*args` of `{node.name}`", mutable_ok
         )
 
     # **kwargs is banned outright (LIT008): it erases the keyword contract and forces
@@ -278,7 +292,7 @@ def _function_violations(
 
     if node.returns is not None:
         yield from _annotation_violations(
-            path, node.returns, node.returns.lineno, f"return type of `{node.name}`", mutable_ok
+            path, node.returns, f"return type of `{node.name}`", mutable_ok
         )
  
  
@@ -293,8 +307,7 @@ def iter_annotation_violations(path: Path, tree: ast.AST, comments: Comments) ->
         elif isinstance(node, ast.AnnAssign):
             target = node.target.id if isinstance(node.target, ast.Name) else "<target>"
             yield from _annotation_violations(
-                path, node.annotation, node.lineno,
-                f"the type of `{target}`", comments.mutable_ok_lines,
+                path, node.annotation, f"the type of `{target}`", comments.mutable_ok_lines,
             )
 
 

--- a/tests/test_litellm/test_check_type_discipline.py
+++ b/tests/test_litellm/test_check_type_discipline.py
@@ -25,6 +25,12 @@ def _codes(tmp_path, source):
     return [v.code for v in checker.check_file(f)]
 
 
+def _lines(tmp_path, source, code):
+    f = tmp_path / "snippet.py"
+    f.write_text(source, encoding="utf-8")
+    return sorted(v.line for v in checker.check_file(f) if v.code == code)
+
+
 # --------------------------------------------------------------------------- #
 # Comment scanning (the readline path) — LIT003 / LIT004 / LIT005
 # --------------------------------------------------------------------------- #
@@ -130,6 +136,52 @@ def test_mutable_ok_with_reason_suppresses_both_rules(tmp_path):
     codes = _codes(tmp_path, "x: dict[str, int] = {}  # mutable-ok: in-place buffer mutated hot path\n")
     assert "LIT001" not in codes
     assert "LIT002" not in codes
+
+
+def test_multiline_annotation_is_reported_at_the_name_not_the_first_line(tmp_path):
+    # The mutable name sits three lines below where the annotation opens. The violation must
+    # point at the name's own line so the message, the PR-diff gate's "introduced here" hint,
+    # and any `# mutable-ok` all land where the name actually is.
+    src = (
+        "from collections.abc import Mapping\n"  # 1
+        "def f() -> Mapping[\n"                   # 2
+        "    str,\n"                              # 3
+        "    list[int],\n"                        # 4  <- the mutable name lives here
+        "]:\n"                                    # 5
+        "    ...\n"                               # 6
+    )
+    assert _lines(tmp_path, src, "LIT001") == [4]
+
+
+def test_mutable_ok_on_the_name_line_of_a_multiline_annotation_suppresses(tmp_path):
+    # Suppression must be honored on the line carrying the mutable name, not on the
+    # annotation's opening line; the latter is where a developer would never think to put it.
+    src = (
+        "x: Mapping[\n"
+        "    str,\n"
+        "    list[int],  # mutable-ok: in-place buffer mutated on the hot path\n"
+        "] = make()\n"
+    )
+    assert "LIT001" not in _codes(tmp_path, src)
+
+
+def test_mutable_ok_on_the_opening_line_no_longer_blankets_a_later_name(tmp_path):
+    # The opening line carries the suppression but the mutable name is two lines down, so the
+    # name is still flagged: suppression is per-name-line, never a blanket over the whole span.
+    src = (
+        "x: dict[  # mutable-ok: only meant to cover this line\n"
+        "    str,\n"
+        "    list[int],\n"
+        "] = make()\n"
+    )
+    assert _lines(tmp_path, src, "LIT001") == [3]
+
+
+def test_forward_ref_violation_anchors_to_the_string_line(tmp_path):
+    # A forward-ref string is parsed on its own, numbering lines from 1 inside the quotes;
+    # the violation must still report the string's line in the file, not line 1.
+    src = "a = 1\nb = 2\nx: 'dict[str, int]'\n"
+    assert _lines(tmp_path, src, "LIT001") == [3]
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Relevant issues

Surfaced by a Cursor review comment on `scripts/check_type_discipline.py` ("Multi-line LIT001 wrong line"). The concern reproduces, so this fixes it

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

LIT001 used a single anchor line (the annotation's first line) for every mutable name inside an annotation. For a multi-line return type or `x: T`, three things went wrong: the violation pointed at the wrong line, a `# mutable-ok` placed on the line that actually holds the mutable name was ignored, and the gate's "introduced on this PR" hint could miss a name added on a later line because that line never matched the reported one

Reproduced with the checker CLI on a minimal file (`/tmp/case.py`):

```python
from collections.abc import Mapping


def foo() -> Mapping[
    str,
    list[int],
]:
    ...
```

Before this change the violation was reported on line 4 (`def foo() -> Mapping[`), and a `# mutable-ok` on line 6 (the `list[int]` line) did nothing. After:

```
$ python3 scripts/check_type_discipline.py /tmp/case.py
/tmp/case.py:6: LIT001 mutable `list` in return type of `foo`: ... (suppress: `# mutable-ok: <reason>`)

1 violation(s).
```

The violation now lands on line 6 where `list` actually is. Adding the suppression on that same line clears it:

```python
    list[int],  # mutable-ok: values are internal and never escape
```

```
$ python3 scripts/check_type_discipline.py /tmp/case.py
$ echo $?
0
```

Whole-tree safety: per-rule totals are unchanged (`python3 scripts/check_type_discipline.py litellm/` still reports the same LIT001 count); 223 existing LIT001 violations simply move to their true line, and diffing the full output ignoring line numbers is identical. The budget gate counts totals, so it is unaffected and no re-baseline is needed

## Type

🐛 Bug Fix

## Changes

`mutable_names_in` now yields each mutable name together with its own AST line (`MutableRef(name, line)`) instead of a bare string, and `_annotation_violations` reports and checks suppression per name line rather than against one anchor. Forward-reference strings keep being anchored to the string's own line in the file, since the inner parse numbers lines from 1 inside the quotes

Tests in the mapped file `tests/test_litellm/test_check_type_discipline.py` cover the relocated line for both a multi-line return type and a multi-line `x: T`, a `# mutable-ok` honored on the name line, an opening-line suppression no longer blanketing a later name, and the forward-ref anchoring. The three line/suppression tests fail against the previous logic and pass with the fix


---
_Generated by [Claude Code](https://claude.ai/code/session_01TxufQiKJsDRzjTUgk4MZtb)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-only reporting/suppression behavior change; violation counts unchanged, only line numbers move for existing LIT001 hits.
> 
> **Overview**
> **LIT001** in `check_type_discipline.py` no longer uses the annotation’s opening line for every mutable name. `mutable_names_in` now yields **`MutableRef(name, line)`** per AST node, and **`_annotation_violations`** reports violations and honors **`# mutable-ok`** on each name’s line only (not a blanket over the whole annotation).
> 
> Forward-reference string annotations anchor inner names to the quoted string’s file line. Call sites drop the redundant anchor-line argument from **`_annotation_violations`**.
> 
> Tests add **`_lines`** helper and cover multi-line return/`AnnAssign` line numbers, suppression on the name line, opening-line suppression not covering later names, and forward-ref anchoring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb14b34e00117f09030a5e409e009b0372bed126. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->