### PR TITLE
fix(health): correct bedrock embedding health checks

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -7434,22 +7434,7 @@ def speech(
 
 async def ahealth_check(
     model_params: dict,
-    mode: Optional[
-        Literal[
-            "chat",
-            "completion",
-            "embedding",
-            "audio_speech",
-            "audio_transcription",
-            "image_generation",
-            "video_generation",
-            "batch",
-            "rerank",
-            "realtime",
-            "responses",
-            "ocr",
-        ]
-    ] = "chat",
+    mode: str | None = "chat",
     prompt: Optional[str] = None,
     input: Optional[List] = None,
 ):

--- a/litellm/proxy/health_check.py
+++ b/litellm/proxy/health_check.py
@@ -73,7 +73,7 @@ def _resolve_health_check_mode(
 
 
 def _should_inject_health_check_max_tokens(
-    model_info: Mapping[str, object], litellm_params: Mapping[str, object]
+    model_info: Mapping[str, object], mode: str | None
 ) -> bool:
     """
     Whether the health-check probe should include `max_tokens`.
@@ -86,7 +86,6 @@ def _should_inject_health_check_max_tokens(
     explicit = model_info.get("health_check_supports_max_tokens")
     if explicit is not None:
         return bool(explicit)
-    mode = _resolve_health_check_mode(model_info, litellm_params)
     return (mode or "chat") in _MAX_TOKEN_SUPPORT_MODES
 
 
@@ -454,9 +453,12 @@ def _update_litellm_params_for_health_check(
     - updates the `voice` param with the `health_check_voice` for `audio_speech` mode if it exists Doc: https://docs.litellm.ai/docs/proxy/health#text-to-speech-models
     - for Bedrock models with region routing (bedrock/region/model), strips the litellm routing prefix but preserves the model ID, and pins `custom_llm_provider` to `bedrock` (only when the deployment hasn't already set one, so an explicit `bedrock_converse` survives) so the bare model id still resolves to the provider (e.g. cross-region ids like `us.cohere.embed-v4:0`)
     """
+    mode = _resolve_health_check_mode(
+        model_info, litellm_params  # any-ok: untyped router config dict
+    )
     litellm_params["messages"] = _get_random_llm_message()
     if _should_inject_health_check_max_tokens(
-        model_info, litellm_params  # any-ok: untyped router config dict
+        model_info, mode  # any-ok: untyped router config dict
     ):
         _resolved_max_tokens = _resolve_health_check_max_tokens(
             model_info, litellm_params
@@ -465,7 +467,7 @@ def _update_litellm_params_for_health_check(
             litellm_params["max_tokens"] = _resolved_max_tokens
 
     # Per-model reasoning effort for health checks only (e.g. reasoning_effort=none).
-    if model_info.get("mode", None) in _HEALTH_CHECK_MODES_SUPPORTING_REASONING_EFFORT:
+    if mode in _HEALTH_CHECK_MODES_SUPPORTING_REASONING_EFFORT:
         _hc_reasoning_effort = model_info.get("health_check_reasoning_effort", None)
         if _hc_reasoning_effort is not None:
             litellm_params["reasoning_effort"] = _hc_reasoning_effort
@@ -473,7 +475,7 @@ def _update_litellm_params_for_health_check(
     _health_check_model = model_info.get("health_check_model", None)
     if _health_check_model is not None:
         litellm_params["model"] = _health_check_model
-    if model_info.get("mode", None) == "audio_speech":
+    if mode == "audio_speech":
         litellm_params["voice"] = model_info.get("health_check_voice", "alloy")
 
     # Handle Bedrock region routing format: bedrock/region/model

--- a/litellm/proxy/health_check.py
+++ b/litellm/proxy/health_check.py
@@ -6,6 +6,7 @@ import random
 import sys
 import threading
 import time
+from collections.abc import Mapping
 from typing import List, Optional
 
 import litellm
@@ -42,23 +43,51 @@ MINIMAL_DISPLAY_PARAMS = ["model", "mode_error"]
 # endpoints that reject unknown fields with 400 "Unknown parameter:
 # 'max_tokens'". Allow-list so new modes are safe by default.
 # Per-deployment override: `model_info.health_check_supports_max_tokens`.
-_MAX_TOKEN_SUPPORT_MODES: frozenset = frozenset({"chat", "completion", "responses"})
+_MAX_TOKEN_SUPPORT_MODES: frozenset[str] = frozenset(
+    {"chat", "completion", "responses"}
+)
 
 
-def _should_inject_health_check_max_tokens(model_info: dict) -> bool:
+def _resolve_health_check_mode(
+    model_info: Mapping[str, object], litellm_params: Mapping[str, object]
+) -> str | None:
+    """
+    Effective mode for a deployment's health-check probe.
+
+    Prefers operator-set `model_info.mode`; otherwise resolves it from the model
+    cost map, which understands `bedrock/` and cross-region inference-profile
+    prefixes (`us.`, `eu.`, `apac.`). Without this, non-chat Bedrock deployments
+    (e.g. embeddings) are probed as chat, so `max_tokens` is injected and the
+    request 400s on "extraneous key [max_tokens]".
+    """
+    explicit_mode = model_info.get("mode")
+    if isinstance(explicit_mode, str):
+        return explicit_mode
+    model = litellm_params.get("model")
+    if not isinstance(model, str):
+        return None
+    try:
+        return litellm.get_model_info(model=model).get("mode")
+    except Exception:
+        return None
+
+
+def _should_inject_health_check_max_tokens(
+    model_info: Mapping[str, object], litellm_params: Mapping[str, object]
+) -> bool:
     """
     Whether the health-check probe should include `max_tokens`.
 
     Order:
       1. `model_info.health_check_supports_max_tokens` (operator override).
-      2. `_MAX_TOKEN_SUPPORT_MODES`. Missing `mode` is treated as `chat`
+      2. `_MAX_TOKEN_SUPPORT_MODES`. An unresolvable mode is treated as `chat`
          for backward compatibility.
     """
     explicit = model_info.get("health_check_supports_max_tokens")
     if explicit is not None:
         return bool(explicit)
-    mode = model_info.get("mode") or "chat"
-    return mode in _MAX_TOKEN_SUPPORT_MODES
+    mode = _resolve_health_check_mode(model_info, litellm_params)
+    return (mode or "chat") in _MAX_TOKEN_SUPPORT_MODES
 
 
 # Health-check modes that forward `reasoning_effort` to the provider (chat-style calls).
@@ -165,7 +194,9 @@ async def run_with_timeout(task, timeout):
 async def _run_model_health_check(model: dict):
     litellm_params = model["litellm_params"]
     model_info = model.get("model_info", {})
-    mode = model_info.get("mode", None)
+    mode = _resolve_health_check_mode(
+        model_info, litellm_params  # any-ok: untyped router config dict
+    )
     litellm_params = _update_litellm_params_for_health_check(model_info, litellm_params)
     timeout = model_info.get("health_check_timeout") or HEALTH_CHECK_TIMEOUT_SECONDS
 
@@ -421,10 +452,12 @@ def _update_litellm_params_for_health_check(
       reject unknown fields with 400 "Unknown parameter: 'max_tokens'".
     - updates the `model` param with the `health_check_model` if it exists Doc: https://docs.litellm.ai/docs/proxy/health#wildcard-routes
     - updates the `voice` param with the `health_check_voice` for `audio_speech` mode if it exists Doc: https://docs.litellm.ai/docs/proxy/health#text-to-speech-models
-    - for Bedrock models with region routing (bedrock/region/model), strips the litellm routing prefix but preserves the model ID
+    - for Bedrock models with region routing (bedrock/region/model), strips the litellm routing prefix but preserves the model ID, and pins `custom_llm_provider` to `bedrock` so the bare model id still resolves to the provider (e.g. cross-region ids like `us.cohere.embed-v4:0`)
     """
     litellm_params["messages"] = _get_random_llm_message()
-    if _should_inject_health_check_max_tokens(model_info):
+    if _should_inject_health_check_max_tokens(
+        model_info, litellm_params  # any-ok: untyped router config dict
+    ):
         _resolved_max_tokens = _resolve_health_check_max_tokens(
             model_info, litellm_params
         )
@@ -477,6 +510,7 @@ def _update_litellm_params_for_health_check(
 
         model = "/".join(filtered_parts)
         litellm_params["model"] = model
+        litellm_params["custom_llm_provider"] = "bedrock"  # any-ok: untyped router dict
 
     return litellm_params
 

--- a/litellm/proxy/health_check.py
+++ b/litellm/proxy/health_check.py
@@ -452,7 +452,7 @@ def _update_litellm_params_for_health_check(
       reject unknown fields with 400 "Unknown parameter: 'max_tokens'".
     - updates the `model` param with the `health_check_model` if it exists Doc: https://docs.litellm.ai/docs/proxy/health#wildcard-routes
     - updates the `voice` param with the `health_check_voice` for `audio_speech` mode if it exists Doc: https://docs.litellm.ai/docs/proxy/health#text-to-speech-models
-    - for Bedrock models with region routing (bedrock/region/model), strips the litellm routing prefix but preserves the model ID, and pins `custom_llm_provider` to `bedrock` so the bare model id still resolves to the provider (e.g. cross-region ids like `us.cohere.embed-v4:0`)
+    - for Bedrock models with region routing (bedrock/region/model), strips the litellm routing prefix but preserves the model ID, and pins `custom_llm_provider` to `bedrock` (only when the deployment hasn't already set one, so an explicit `bedrock_converse` survives) so the bare model id still resolves to the provider (e.g. cross-region ids like `us.cohere.embed-v4:0`)
     """
     litellm_params["messages"] = _get_random_llm_message()
     if _should_inject_health_check_max_tokens(
@@ -510,7 +510,10 @@ def _update_litellm_params_for_health_check(
 
         model = "/".join(filtered_parts)
         litellm_params["model"] = model
-        litellm_params["custom_llm_provider"] = "bedrock"  # any-ok: untyped router dict
+        if not litellm_params.get("custom_llm_provider"):  # any-ok: untyped router dict
+            litellm_params["custom_llm_provider"] = (  # any-ok: untyped router dict
+                "bedrock"
+            )
 
     return litellm_params
 

--- a/tests/test_litellm/proxy/test_health_check_max_tokens.py
+++ b/tests/test_litellm/proxy/test_health_check_max_tokens.py
@@ -454,3 +454,22 @@ def test_bedrock_chat_without_mode_still_injects_max_tokens_and_pins_provider():
     assert updated["max_tokens"] == 5
     assert updated["custom_llm_provider"] == "bedrock"
     assert updated["model"] == "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+
+
+def test_bedrock_prefix_strip_preserves_explicit_custom_llm_provider():
+    """An operator-set provider (e.g. bedrock_converse) must survive the prefix strip.
+
+    The pin only fills in a provider when the deployment left it blank; it must
+    not clobber a more specific one, otherwise a converse deployment would be
+    probed against the Invoke endpoint and report a spurious failure.
+    """
+    updated = _update_litellm_params_for_health_check(
+        {},
+        {
+            "model": "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
+            "custom_llm_provider": "bedrock_converse",
+        },
+    )
+
+    assert updated["custom_llm_provider"] == "bedrock_converse"
+    assert updated["model"] == "us.anthropic.claude-haiku-4-5-20251001-v1:0"

--- a/tests/test_litellm/proxy/test_health_check_max_tokens.py
+++ b/tests/test_litellm/proxy/test_health_check_max_tokens.py
@@ -6,6 +6,7 @@ from litellm.litellm_core_utils.health_check_helpers import HealthCheckHelpers
 from litellm.proxy import health_check as hc_module
 from litellm.proxy.health_check import (
     _resolve_health_check_max_tokens,
+    _resolve_health_check_mode,
     _update_litellm_params_for_health_check,
 )
 
@@ -391,3 +392,65 @@ def test_update_litellm_params_health_check_reasoning_effort():
         model_info, {"model": "openai/gpt-4o", "api_key": "x"}
     )
     assert "reasoning_effort" not in out
+
+
+# ---------------------------------------------------------------------------
+# Bedrock embedding deployments declared without an explicit `model_info.mode`.
+#
+# The health-check builder used to treat a missing mode as `chat`, so it
+# injected `max_tokens` into the embedding probe. Bedrock embeddings reject it
+# with 400 "extraneous key [max_tokens]". It also stripped the `bedrock/`
+# routing prefix without pinning the provider, so a cross-region id like
+# `us.cohere.embed-v4:0` failed downstream with "LLM Provider NOT provided".
+# Mode is now resolved from the model cost map (which understands `bedrock/`
+# and `us.`/`eu.`/`apac.` prefixes) and the provider is pinned to `bedrock`.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "deployment_model, expected_request_model",
+    [
+        ("bedrock/amazon.titan-embed-text-v2:0", "amazon.titan-embed-text-v2:0"),
+        ("bedrock/us.cohere.embed-v4:0", "us.cohere.embed-v4:0"),
+    ],
+)
+def test_bedrock_embedding_without_explicit_mode_skips_max_tokens(
+    deployment_model, expected_request_model
+):
+    """Embedding mode auto-detected from model cost map -> no max_tokens, provider pinned."""
+    assert _resolve_health_check_mode({}, {"model": deployment_model}) == "embedding"
+
+    updated = _update_litellm_params_for_health_check({}, {"model": deployment_model})
+
+    assert "max_tokens" not in updated
+    assert updated["custom_llm_provider"] == "bedrock"
+    assert updated["model"] == expected_request_model
+
+
+def test_resolve_health_check_mode_prefers_explicit_model_info_mode():
+    """An operator-set mode wins over model-cost lookup."""
+    assert (
+        _resolve_health_check_mode(
+            {"mode": "chat"}, {"model": "bedrock/amazon.titan-embed-text-v2:0"}
+        )
+        == "chat"
+    )
+
+
+def test_resolve_health_check_mode_unknown_model_returns_none():
+    assert (
+        _resolve_health_check_mode({}, {"model": "bedrock/not-a-real-model-xyz"})
+        is None
+    )
+    assert _resolve_health_check_mode({}, {}) is None
+
+
+def test_bedrock_chat_without_mode_still_injects_max_tokens_and_pins_provider():
+    """Regression guard: chat-style Bedrock deployments keep max_tokens and get the provider pin."""
+    updated = _update_litellm_params_for_health_check(
+        {}, {"model": "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0"}
+    )
+
+    assert updated["max_tokens"] == 5
+    assert updated["custom_llm_provider"] == "bedrock"
+    assert updated["model"] == "us.anthropic.claude-haiku-4-5-20251001-v1:0"

--- a/tests/test_litellm/proxy/test_health_check_max_tokens.py
+++ b/tests/test_litellm/proxy/test_health_check_max_tokens.py
@@ -473,3 +473,29 @@ def test_bedrock_prefix_strip_preserves_explicit_custom_llm_provider():
 
     assert updated["custom_llm_provider"] == "bedrock_converse"
     assert updated["model"] == "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+
+
+@pytest.mark.asyncio
+async def test_run_model_health_check_threads_resolved_mode_to_ahealth_check():
+    """The resolved mode must reach `ahealth_check`, not just the params builder.
+
+    A Bedrock embedding deployment declared without an explicit `model_info.mode`
+    has to be probed with `mode="embedding"` so the call routes to the embedding
+    handler; if the resolution were dropped it would fall back to `chat`. This
+    also guards that the embedding params (no `max_tokens`, provider pinned) are
+    the ones actually handed to the probe.
+    """
+    fake_ahealth_check = AsyncMock(return_value={})
+    model = {
+        "litellm_params": {"model": "bedrock/amazon.titan-embed-text-v2:0"},
+        "model_info": {},
+    }
+
+    with patch.object(hc_module.litellm, "ahealth_check", fake_ahealth_check):
+        await hc_module._run_model_health_check(model)
+
+    assert fake_ahealth_check.call_args.kwargs["mode"] == "embedding"
+    probed_params = fake_ahealth_check.call_args.args[0]
+    assert "max_tokens" not in probed_params
+    assert probed_params["custom_llm_provider"] == "bedrock"
+    assert probed_params["model"] == "amazon.titan-embed-text-v2:0"

--- a/tests/test_litellm/proxy/test_health_check_max_tokens.py
+++ b/tests/test_litellm/proxy/test_health_check_max_tokens.py
@@ -499,3 +499,21 @@ async def test_run_model_health_check_threads_resolved_mode_to_ahealth_check():
     assert "max_tokens" not in probed_params
     assert probed_params["custom_llm_provider"] == "bedrock"
     assert probed_params["model"] == "amazon.titan-embed-text-v2:0"
+
+
+def test_autodetected_embedding_skips_reasoning_effort():
+    """reasoning_effort must not leak into an embedding probe whose mode is auto-detected.
+
+    Same bug class as the max_tokens fix: with no explicit `model_info.mode`, the
+    reasoning-effort gate used to read the raw (missing) mode and treat it as
+    chat-like, so a configured `health_check_reasoning_effort` was injected into a
+    Bedrock embedding probe, which embeddings reject as an unknown field. The mode
+    is now resolved from the cost map, so embeddings are excluded.
+    """
+    updated = _update_litellm_params_for_health_check(
+        {"health_check_reasoning_effort": "low"},
+        {"model": "bedrock/amazon.titan-embed-text-v2:0"},
+    )
+
+    assert "reasoning_effort" not in updated
+    assert "max_tokens" not in updated


### PR DESCRIPTION
## Relevant issues

Customer thread (ticket #4474) reporting two Bedrock embedding setup errors that have no PR yet. The Bedrock Mantle config/auth part of the same thread already shipped via #29490, #30083, #30163, #30426 and #29788; this PR covers the two embedding bugs that were left unaddressed.

## Linear ticket

LIT-3747

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## What was broken

A Bedrock embedding deployment configured the natural way, without an explicit `model_info.mode`, failed its health check for two independent reasons.

First, the health-check builder treated a missing mode as `chat` and injected `max_tokens` into the probe. Bedrock embeddings reject unknown fields, so `bedrock/amazon.titan-embed-text-v2:0` came back `400 "Malformed input request: extraneous key [max_tokens]"`, and `drop_params` did not help because the param is injected by the health-check builder rather than mapped through provider drop logic. The only workaround was setting `model_info: {mode: embedding}` by hand.

Second, the Bedrock rewrite strips the `bedrock/` routing prefix but did not record the provider, so a cross-region inference-profile id like `bedrock/us.cohere.embed-v4:0` became the bare `us.cohere.embed-v4:0` and `ahealth_check`'s `get_llm_provider` raised `litellm.BadRequestError: LLM Provider NOT provided` (the `us.` prefix keeps it out of `bedrock_embedding_models`).

## Changes

`litellm/proxy/health_check.py` now resolves a deployment's effective mode from the model cost map before deciding whether to inject `max_tokens`. `litellm.get_model_info` already understands the `bedrock/` and `us.`/`eu.`/`apac.` prefixes, so titan and cohere both resolve to `embedding` and the probe no longer carries `max_tokens`. That same resolved mode now also gates the `reasoning_effort` and `audio_speech` `voice` injections, so an embedding deployment auto-detected without an explicit `model_info.mode` no longer picks up a configured `reasoning_effort` that the embeddings endpoint would reject. When the rewrite strips `bedrock/`, it pins `custom_llm_provider` to `bedrock` only when the deployment hasn't already set one, so a bare cross-region id still resolves to the provider while an explicit `custom_llm_provider: bedrock_converse` survives untouched. `litellm.ahealth_check`'s `mode` parameter is widened from a strict `Literal` to `Optional[str]` (it only uses the value as a handler key and already tolerates arbitrary modes), so the resolved embedding mode flows through and routes the probe to the embedding handler.

## Screenshots / Proof of Fix

I could not exercise this against live AWS Bedrock from the sandbox (no Bedrock credentials), so here is the runbook to capture the proof against a real account.

1. Add to `litellm/proxy/dev_config.yaml`:

```yaml
model_list:
  - model_name: titan-embed-text-v2
    litellm_params:
      model: bedrock/amazon.titan-embed-text-v2:0
      aws_region_name: us-east-1
  - model_name: cohere-embed
    litellm_params:
      model: bedrock/us.cohere.embed-v4:0
      aws_region_name: us-east-1
```

2. Start the proxy:

```bash
python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log
```

3. Hit the health endpoint and confirm both deployments are healthy (before this change they showed up under `unhealthy_endpoints` with the two errors above):

```bash
curl -s -H "Authorization: Bearer $LITELLM_MASTER_KEY" http://localhost:4000/health | jq '.healthy_endpoints, .unhealthy_endpoints'
```

4. Or in the UI, go to http://localhost:4000/ui/?page=models, click "Health Status" / run a health check on both deployments, and confirm both are green.

## Type

🐛 Bug Fix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to proxy health-check param building and a typing widen on `ahealth_check`; behavior change is intentional for Bedrock embeddings with backward-compatible fallback when mode is unknown.
> 
> **Overview**
> Fixes proxy health checks for **Bedrock embedding** deployments that omit `model_info.mode`.
> 
> **Mode resolution:** Adds `_resolve_health_check_mode`, which uses `model_info.mode` when set, otherwise `litellm.get_model_info` (handles `bedrock/` and cross-region `us.`/`eu.`/`apac.` ids). That resolved mode drives `max_tokens` injection, `reasoning_effort`, audio/voice handling, and the `mode` passed into `ahealth_check`—so embeddings are no longer probed as chat with `max_tokens` or stray `reasoning_effort`.
> 
> **Bedrock routing:** After stripping `bedrock/` (and region segments) from the model id, the builder sets `custom_llm_provider` to `bedrock` only when unset, so bare ids like `us.cohere.embed-v4:0` still resolve while explicit `bedrock_converse` is preserved.
> 
> **API typing:** `ahealth_check`'s `mode` is relaxed from a strict `Literal` to `Optional[str]` so resolved modes (e.g. `embedding`) flow through.
> 
> Tests cover Titan/Cohere embedding paths, explicit mode override, chat regression, provider pin vs preserve, and threading mode into `ahealth_check`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66692e2f6bea0e8c4529ebcc2b543a0b24af85c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
