### PR TITLE
fix: allowlist JWT claims in multi-issuer normalization

### DIFF
--- a/litellm/proxy/auth/handle_jwt.py
+++ b/litellm/proxy/auth/handle_jwt.py
@@ -113,6 +113,10 @@ class JWTHandler:
         LITELLM_ORG_ID_CLAIM,
         LITELLM_END_USER_ID_CLAIM,
     )
+    # Registered JWT claims (RFC 7519) that are safe to carry through issuer
+    # normalization regardless of mapping config: they identify/scope the token
+    # itself and are never trusted for authorization by LiteLLM.
+    STANDARD_JWT_CLAIMS = frozenset(("iss", "sub", "aud", "exp", "nbf", "iat", "jti"))
 
     def __init__(
         self,
@@ -941,8 +945,11 @@ class JWTHandler:
     def _apply_issuer_claim_mappings(
         self, token: dict, issuer_config: JWTIssuerConfig
     ) -> dict:
+        # Build the normalized token from standard registered claims; the
+        # issuer's mapped claims are re-added below. Unmapped claims are not
+        # carried across issuers.
         normalized: dict = {
-            k: v for k, v in token.items() if k not in self.LITELLM_INTERNAL_CLAIMS
+            k: v for k, v in token.items() if k in self.STANDARD_JWT_CLAIMS
         }
         normalized[self.LITELLM_JWT_ISSUER_CLAIM] = issuer_config.issuer
         claim_mappings = [

--- a/tests/test_litellm/proxy/auth/test_handle_jwt.py
+++ b/tests/test_litellm/proxy/auth/test_handle_jwt.py
@@ -4274,6 +4274,91 @@ async def test_multi_issuer_jwt_strips_unmapped_internal_claims(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_multi_issuer_jwt_drops_unmapped_scope_claims(
+    monkeypatch,
+):
+    """A token from a configured-but-low-trust issuer that carries a raw
+    ``scope`` claim must NOT escalate to proxy admin. The issuer config below
+    maps only an identity field, so ``scope`` is unmapped and dropped during
+    normalization; ``get_scopes``/``is_admin`` then see nothing.
+    """
+    monkeypatch.delenv("JWT_AUDIENCE", raising=False)
+    monkeypatch.delenv("JWT_PUBLIC_KEY_URL", raising=False)
+
+    issuer = "https://low-trust-issuer.example.com"
+    jwks_url = f"{issuer}/keys"
+    private_key, jwk = _get_rsa_key_and_jwk(kid="issuer-key")
+    jwt_handler = _get_jwt_handler_with_issuer_keys(
+        issuers=[
+            {
+                "issuer": issuer,
+                "jwks_url": jwks_url,
+                "audience": "expected-audience",
+                "user_id_jwt_field": "sub",
+            }
+        ],
+        keys_by_url={jwks_url: [jwk]},
+    )
+    token = _encode_rsa_jwt(
+        private_key=private_key,
+        issuer=issuer,
+        audience="expected-audience",
+        kid="issuer-key",
+        extra_claims={
+            "scope": "litellm_proxy_admin",
+            "roles": ["litellm_proxy_admin"],
+        },
+    )
+
+    claims = await jwt_handler.auth_jwt(token=token)
+
+    assert "scope" not in claims
+    assert "roles" not in claims
+    assert jwt_handler.get_scopes(token=claims) == []
+    assert jwt_handler.is_admin(scopes=jwt_handler.get_scopes(token=claims)) is False
+
+
+@pytest.mark.asyncio
+async def test_global_jwt_path_still_trusts_scope_for_admin(monkeypatch):
+    """The legacy single-issuer / global path (no ``issuers`` configured) must
+    keep honoring the ``scope`` claim as the admin field. The cross-issuer
+    allowlist only applies to issuer-scoped normalization, so this path is
+    unchanged and a token carrying the configured admin scope still maps to
+    proxy admin.
+    """
+    from litellm.caching.dual_cache import DualCache
+
+    monkeypatch.delenv("JWT_AUDIENCE", raising=False)
+    monkeypatch.delenv("JWT_ISSUER", raising=False)
+
+    jwks_url = "https://global-issuer.example.com/keys"
+    monkeypatch.setenv("JWT_PUBLIC_KEY_URL", jwks_url)
+
+    private_key, jwk = _get_rsa_key_and_jwk(kid="global-key")
+    cache = DualCache()
+    cache.set_cache(key=f"litellm_jwt_auth_keys_{jwks_url}", value=[jwk])
+
+    jwt_handler = JWTHandler()
+    jwt_handler.update_environment(
+        prisma_client=None,
+        user_api_key_cache=cache,
+        litellm_jwtauth=LiteLLM_JWTAuth(),
+    )
+    token = _encode_rsa_jwt(
+        private_key=private_key,
+        issuer="https://global-issuer.example.com",
+        audience="any-audience",
+        kid="global-key",
+        extra_claims={"scope": "litellm_proxy_admin"},
+    )
+
+    claims = await jwt_handler.auth_jwt(token=token)
+
+    assert jwt_handler.get_scopes(token=claims) == ["litellm_proxy_admin"]
+    assert jwt_handler.is_admin(scopes=jwt_handler.get_scopes(token=claims)) is True
+
+
+@pytest.mark.asyncio
 async def test_multi_issuer_jwt_does_not_emit_unscoped_global_warning(
     monkeypatch, caplog
 ):

--- a/tests/test_litellm/proxy/auth/test_handle_jwt.py
+++ b/tests/test_litellm/proxy/auth/test_handle_jwt.py
@@ -4417,3 +4417,174 @@ def test_build_decode_kwargs_warns_for_unscoped_global_fallback_in_mixed_deploym
         if "neither JWT_AUDIENCE nor JWT_ISSUER" in r.getMessage()
     ]
     assert len(matching) == 1
+
+
+@pytest.mark.asyncio
+async def test_multi_issuer_drops_unmapped_list_scope(monkeypatch):
+    """A low-trust issuer that maps only an identity field must have its raw
+    ``scope`` dropped even when ``scope`` arrives as a list rather than a
+    space-separated string. The list shape must not slip past normalization
+    into authorization."""
+    monkeypatch.delenv("JWT_AUDIENCE", raising=False)
+    monkeypatch.delenv("JWT_PUBLIC_KEY_URL", raising=False)
+
+    issuer = "https://list-scope-issuer.example.com"
+    jwks_url = f"{issuer}/keys"
+    private_key, jwk = _get_rsa_key_and_jwk(kid="issuer-key")
+    jwt_handler = _get_jwt_handler_with_issuer_keys(
+        issuers=[
+            {
+                "issuer": issuer,
+                "jwks_url": jwks_url,
+                "audience": "expected-audience",
+                "user_id_jwt_field": "sub",
+            }
+        ],
+        keys_by_url={jwks_url: [jwk]},
+    )
+    token = _encode_rsa_jwt(
+        private_key=private_key,
+        issuer=issuer,
+        audience="expected-audience",
+        kid="issuer-key",
+        extra_claims={"scope": ["litellm_proxy_admin", "openid"]},
+    )
+
+    claims = await jwt_handler.auth_jwt(token=token)
+
+    assert "scope" not in claims
+    assert jwt_handler.get_scopes(token=claims) == []
+    assert jwt_handler.is_admin(scopes=jwt_handler.get_scopes(token=claims)) is False
+
+
+@pytest.mark.asyncio
+async def test_multi_issuer_drops_nested_unmapped_claim(monkeypatch):
+    """A nested claim object the issuer does not map (e.g. a Keycloak-style
+    ``resource_access`` carrying roles) must be dropped during normalization,
+    not carried through where downstream role resolution could read it."""
+    monkeypatch.delenv("JWT_AUDIENCE", raising=False)
+    monkeypatch.delenv("JWT_PUBLIC_KEY_URL", raising=False)
+
+    issuer = "https://nested-claim-issuer.example.com"
+    jwks_url = f"{issuer}/keys"
+    private_key, jwk = _get_rsa_key_and_jwk(kid="issuer-key")
+    jwt_handler = _get_jwt_handler_with_issuer_keys(
+        issuers=[
+            {
+                "issuer": issuer,
+                "jwks_url": jwks_url,
+                "audience": "expected-audience",
+                "user_id_jwt_field": "sub",
+            }
+        ],
+        keys_by_url={jwks_url: [jwk]},
+    )
+    token = _encode_rsa_jwt(
+        private_key=private_key,
+        issuer=issuer,
+        audience="expected-audience",
+        kid="issuer-key",
+        extra_claims={
+            "resource_access": {
+                "litellm-proxy": {"roles": ["litellm_proxy_admin"]}
+            }
+        },
+    )
+
+    claims = await jwt_handler.auth_jwt(token=token)
+
+    assert "resource_access" not in claims
+
+
+@pytest.mark.asyncio
+async def test_multi_issuer_normalizes_token_without_optional_standard_claims(
+    monkeypatch,
+):
+    """Normalization must not depend on the presence of optional registered
+    claims. A valid token that omits ``exp``/``nbf``/``iat``/``jti`` must
+    normalize without error and still carry the issuer's explicitly mapped
+    identity field."""
+    monkeypatch.delenv("JWT_AUDIENCE", raising=False)
+    monkeypatch.delenv("JWT_PUBLIC_KEY_URL", raising=False)
+
+    import jwt as pyjwt
+    from cryptography.hazmat.primitives import serialization
+
+    issuer = "https://minimal-claims-issuer.example.com"
+    jwks_url = f"{issuer}/keys"
+    private_key, jwk = _get_rsa_key_and_jwk(kid="issuer-key")
+    jwt_handler = _get_jwt_handler_with_issuer_keys(
+        issuers=[
+            {
+                "issuer": issuer,
+                "jwks_url": jwks_url,
+                "audience": "expected-audience",
+                "user_email_jwt_field": "email",
+            }
+        ],
+        keys_by_url={jwks_url: [jwk]},
+    )
+
+    private_key_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    token = pyjwt.encode(
+        {
+            "sub": "test-subject",
+            "iss": issuer,
+            "aud": "expected-audience",
+            "email": "real-user@example.com",
+        },
+        private_key_pem,
+        algorithm="RS256",
+        headers={"kid": "issuer-key"},
+    )
+
+    claims = await jwt_handler.auth_jwt(token=token)
+
+    assert "exp" not in claims
+    assert "iat" not in claims
+    assert jwt_handler.get_user_email(token=claims, default_value=None) == (
+        "real-user@example.com"
+    )
+
+
+@pytest.mark.asyncio
+async def test_multi_issuer_preserves_explicitly_mapped_role_field(monkeypatch):
+    """The allowlist is permissive for fields the issuer explicitly maps: when
+    an issuer config maps a scope/role-bearing field to a team claim, that
+    mapped value must survive normalization and resolve to the team."""
+    monkeypatch.delenv("JWT_AUDIENCE", raising=False)
+    monkeypatch.delenv("JWT_PUBLIC_KEY_URL", raising=False)
+
+    issuer = "https://mapped-role-issuer.example.com"
+    jwks_url = f"{issuer}/keys"
+    private_key, jwk = _get_rsa_key_and_jwk(kid="issuer-key")
+    jwt_handler = _get_jwt_handler_with_issuer_keys(
+        issuers=[
+            {
+                "issuer": issuer,
+                "jwks_url": jwks_url,
+                "audience": "expected-audience",
+                "team_ids_jwt_field": "groups",
+            }
+        ],
+        keys_by_url={jwks_url: [jwk]},
+    )
+    token = _encode_rsa_jwt(
+        private_key=private_key,
+        issuer=issuer,
+        audience="expected-audience",
+        kid="issuer-key",
+        extra_claims={"groups": ["team-alpha", "team-beta"]},
+    )
+
+    claims = await jwt_handler.auth_jwt(token=token)
+
+    assert claims[JWTHandler.LITELLM_TEAM_IDS_CLAIM] == ["team-alpha", "team-beta"]
+    assert jwt_handler.get_team_ids_from_jwt(token=claims) == [
+        "team-alpha",
+        "team-beta",
+    ]


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-3829

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

Tightens how multi-issuer JWT auth normalizes a verified token's claims. Previously the per-issuer normalizer in `_apply_issuer_claim_mappings` carried over every claim that was not LiteLLM-internal and then layered each issuer's mapped claims on top, so claims an issuer did not explicitly map (for example `scope` or `roles`) were still passed through into the normalized token. `get_scopes` then read that raw `scope` and `is_admin` granted `PROXY_ADMIN`, which let a user authenticated through a lower-trust issuer inject an admin claim and escalate to full proxy admin.

This rebuilds the normalized token from the RFC 7519 registered claims (`iss`, `sub`, `aud`, `exp`, `nbf`, `iat`, `jti`) plus only the claims each issuer's config maps, and drops anything else. Those registered claims identify and scope the token itself and are never trusted by LiteLLM for authorization, so an injected `scope`/`roles` no longer survives normalization. The legacy single-issuer / global path is unchanged.

Regression tests in `tests/test_litellm/proxy/auth/test_handle_jwt.py` cover the multi-issuer normalization (unmapped `scope`/`roles` dropped, including list and nested shapes; explicitly mapped fields preserved; tokens without optional registered claims still normalize) and confirm the single-issuer path still honors `scope` as before. The core tests fail on the pre-fix code and pass with the fix.

## Screenshots / Proof of Fix

Live proxy (real Postgres, real RSA-signed JWTs fetched from a local JWKS endpoint over HTTP) with a single configured issuer that maps only `sub`. An attacker token from that issuer carries an injected `scope` and `roles` of `litellm_proxy_admin`; the admin-only route `GET /user/list` is the target.

Attacker token claims:

```json
{
  "iss": "http://127.0.0.1:9595",
  "aud": "litellm-proxy",
  "sub": "attacker-from-low-trust-idp",
  "scope": "litellm_proxy_admin",
  "roles": ["litellm_proxy_admin"]
}
```

Before (unfixed), the injected `scope` survives normalization and grants proxy admin:

```
# benign token (no scope) -> admin route is denied
curl -s -o /dev/null -w "HTTP %{http_code}\n" "http://localhost:4011/user/list?page=1&page_size=1" \
  -H "Authorization: Bearer $BENIGN"
HTTP 401  {"error":{"message":"Authentication Error, User doesn't exist in db. 'user_id'=attacker-from-low-trust-idp..."}}

# malicious token (injected scope=litellm_proxy_admin) -> escalated to PROXY_ADMIN
curl -s -w "HTTP %{http_code}\n" "http://localhost:4011/user/list?page=1&page_size=1" \
  -H "Authorization: Bearer $EVIL"
HTTP 200  {"users":[],"total":0,"page":1,"page_size":1,"total_pages":0}
```

After (this PR), the injected `scope` is stripped during normalization and the same token is no longer admin, identical to the benign token:

```
# benign token (no scope)
HTTP 401  {"error":{"message":"Authentication Error, User doesn't exist in db..."}}

# malicious token (injected scope=litellm_proxy_admin) -> blocked, no escalation
HTTP 401  {"error":{"message":"Authentication Error, User doesn't exist in db..."}}
```

The escalation route flips from HTTP 200 (admin granted) to HTTP 401 (blocked) with no other change, and the benign path is unaffected
