### PR TITLE
fix(key management): /key/list exact user_id/key_alias match by default (cross-user key disclosure)

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -5145,7 +5145,7 @@ async def list_keys(
     size: int = Query(10, description="Page size", ge=1, le=100),
     user_id: Optional[str] = Query(
         None,
-        description="Filter keys by user ID. Supports partial matching (substring, case-insensitive).",
+        description="Filter keys by user ID. Exact match by default; set substring_matching=true (admin only) for case-insensitive substring matching.",
     ),
     team_id: Optional[str] = Query(None, description="Filter keys by team ID"),
     organization_id: Optional[str] = Query(
@@ -5154,7 +5154,7 @@ async def list_keys(
     key_hash: Optional[str] = Query(None, description="Filter keys by key hash"),
     key_alias: Optional[str] = Query(
         None,
-        description="Filter keys by key alias. Supports partial matching (substring, case-insensitive).",
+        description="Filter keys by key alias. Exact match by default; set substring_matching=true (admin only) for case-insensitive substring matching.",
     ),
     return_full_object: bool = Query(False, description="Return full key object"),
     include_team_keys: bool = Query(
@@ -5177,6 +5177,10 @@ async def list_keys(
     project_id: Optional[str] = Query(None, description="Filter keys by project ID"),
     access_group_id: Optional[str] = Query(
         None, description="Filter keys by access group ID"
+    ),
+    substring_matching: bool = Query(
+        False,
+        description="If true (proxy admins only), match user_id/key_alias as case-insensitive substrings instead of exact values. Defaults to false: /key/list matched these exactly before substring search was added, and an exact user_id/key_alias filter must never return another user's keys.",
     ),
 ) -> KeyListResponseObject:
     """
@@ -5259,12 +5263,21 @@ async def list_keys(
         else:
             admin_team_ids = None
 
-        use_substring_matching = user_api_key_dict.user_role in [
+        is_proxy_admin = user_api_key_dict.user_role in [
             LitellmUserRoles.PROXY_ADMIN.value,
             LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY.value,
         ]
 
-        if not user_id and not use_substring_matching:
+        # Substring matching is opt-in (admin-only). /key/list matched user_id and
+        # key_alias exactly before substring search was added; auto-applying a
+        # substring match to every admin call broke that contract and let a caller
+        # passing an exact user_id (e.g. an integration scoping to one user with an
+        # admin key) receive other users' keys (user_id="alice" -> "alice2"). Exact
+        # by default restores the prior behavior; the dashboard opts in explicitly.
+        use_substring_matching = substring_matching and is_proxy_admin
+
+        # Admins may omit user_id to list all keys; non-admins are scoped to self.
+        if not user_id and not is_proxy_admin:
             user_id = user_api_key_dict.user_id
 
         response = await _list_key_helper(

--- a/tests/proxy_behavior/management/test_key_list.py
+++ b/tests/proxy_behavior/management/test_key_list.py
@@ -81,8 +81,11 @@ async def _list_hashes(proxy_client, caller_cleartext: str, query: str) -> set:
 
 
 async def test_key_list_admin_key_alias_substring_match(proxy_client, scratch, world):
-    """A PROXY_ADMIN's key_alias filter is a case-insensitive substring match;
-    a narrower fragment selects the subset whose alias contains it."""
+    """A PROXY_ADMIN's key_alias filter is a case-insensitive substring match
+    when substring_matching=true is requested (the dashboard search box); a
+    narrower fragment selects the subset whose alias contains it. Substring
+    matching is opt-in: without the flag the filter is exact (see
+    test_key_list_admin_key_alias_exact_without_substring_flag)."""
     admin = world.keys[Actor.PROXY_ADMIN]
     a = await create_scratch_key(
         proxy_client,
@@ -101,14 +104,44 @@ async def test_key_list_admin_key_alias_substring_match(proxy_client, scratch, w
     seeded = {hash_token(a), hash_token(b)}
 
     broad = await _list_hashes(
-        proxy_client, admin.cleartext, f"key_alias={scratch.prefix}-sub"
+        proxy_client,
+        admin.cleartext,
+        f"key_alias={scratch.prefix}-sub&substring_matching=true",
     )
     assert broad & seeded == seeded
 
     narrow = await _list_hashes(
-        proxy_client, admin.cleartext, f"key_alias={scratch.prefix}-sub-a"
+        proxy_client,
+        admin.cleartext,
+        f"key_alias={scratch.prefix}-sub-a&substring_matching=true",
     )
     assert narrow & seeded == {hash_token(a)}
+
+
+async def test_key_list_admin_key_alias_exact_without_substring_flag(
+    proxy_client, scratch, world
+):
+    """Regression guard for the prior exact-match contract: without
+    substring_matching, even a PROXY_ADMIN's key_alias filter is exact, so a
+    fragment of a seeded alias does not select it."""
+    admin = world.keys[Actor.PROXY_ADMIN]
+    full_alias = f"{scratch.prefix}-exactflag"
+    key = await create_scratch_key(
+        proxy_client,
+        admin.cleartext,
+        scratch.prefix,
+        user_id=admin.user_id,
+        key_alias=full_alias,
+    )
+    key_hash = hash_token(key)
+
+    exact = await _list_hashes(proxy_client, admin.cleartext, f"key_alias={full_alias}")
+    assert key_hash in exact
+
+    fragment = await _list_hashes(
+        proxy_client, admin.cleartext, f"key_alias={scratch.prefix}-exactfla"
+    )
+    assert key_hash not in fragment
 
 
 async def test_key_list_non_admin_key_alias_is_exact_match(

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -12448,3 +12448,80 @@ async def test_build_model_max_budget_usage_provider_prefix_cache_fallback():
 
     assert result["openai/gpt-4o"]["current_spend"] == 0.55
     assert mock_user_api_key_cache.async_get_cache.await_count == 2
+
+
+def test_list_keys_substring_matching_param_defaults_to_false():
+    """Regression guard: /key/list matched user_id/key_alias exactly before
+    substring search was added (commit 33bd570d5e). The substring_matching query
+    param must default to False so an absent param yields exact matching."""
+    import inspect
+
+    param = inspect.signature(list_keys).parameters["substring_matching"]
+    assert getattr(param.default, "default", param.default) is False
+
+
+async def _list_keys_capture_helper_kwargs(user_api_key_dict, **list_kwargs):
+    from unittest.mock import Mock, patch
+
+    from litellm.proxy._types import LiteLLM_UserTable
+
+    mock_user_info = LiteLLM_UserTable(
+        user_id=user_api_key_dict.user_id,
+        user_email="u@example.com",
+        teams=[],
+        organization_memberships=[],
+    )
+    helper = AsyncMock(
+        return_value={"keys": [], "total_count": 0, "current_page": 1, "total_pages": 0}
+    )
+    with patch("litellm.proxy.proxy_server.prisma_client", AsyncMock()):
+        with patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints.validate_key_list_check",
+            return_value=mock_user_info,
+        ):
+            with patch(
+                "litellm.proxy.management_endpoints.key_management_endpoints._list_key_helper",
+                helper,
+            ):
+                await list_keys(
+                    request=Mock(),
+                    user_api_key_dict=user_api_key_dict,
+                    status=None,
+                    **list_kwargs,
+                )
+    return helper.call_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_list_keys_admin_exact_by_default():
+    """Security regression: an admin calling /key/list with an exact user_id and
+    no substring_matching flag must get exact matching, so an integration scoping
+    to one user with an admin key never receives other users' keys."""
+    admin = UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin-1")
+    kwargs = await _list_keys_capture_helper_kwargs(
+        admin, user_id="alice", substring_matching=False
+    )
+    assert kwargs["user_id"] == "alice"
+    assert kwargs["use_substring_matching"] is False
+
+
+@pytest.mark.asyncio
+async def test_list_keys_admin_substring_opt_in():
+    """An admin may opt back into substring matching (dashboard search)."""
+    admin = UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin-1")
+    kwargs = await _list_keys_capture_helper_kwargs(
+        admin, user_id="alice", substring_matching=True
+    )
+    assert kwargs["use_substring_matching"] is True
+
+
+@pytest.mark.asyncio
+async def test_list_keys_non_admin_cannot_opt_into_substring():
+    """substring_matching is admin-only: a non-admin requesting it still gets
+    exact matching, scoped to their own user_id."""
+    user = UserAPIKeyAuth(user_role=LitellmUserRoles.INTERNAL_USER, user_id="alice")
+    kwargs = await _list_keys_capture_helper_kwargs(
+        user, user_id=None, substring_matching=True
+    )
+    assert kwargs["use_substring_matching"] is False
+    assert kwargs["user_id"] == "alice"

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/keys/useKeys.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/keys/useKeys.test.ts
@@ -215,7 +215,7 @@ describe("useKeys", () => {
     expect(result.current.error).toBeNull();
     expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(mockFetch).toHaveBeenCalledWith(
-      "/key/list?page=1&size=10&return_full_object=true&include_team_keys=true&include_created_by_keys=true",
+      "/key/list?page=1&size=10&return_full_object=true&include_team_keys=true&include_created_by_keys=true&substring_matching=true",
       {
         method: "GET",
         headers: {
@@ -252,7 +252,7 @@ describe("useKeys", () => {
     expect(result.current.data).toBeUndefined();
     expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(mockFetch).toHaveBeenCalledWith(
-      "/key/list?page=1&size=10&return_full_object=true&include_team_keys=true&include_created_by_keys=true",
+      "/key/list?page=1&size=10&return_full_object=true&include_team_keys=true&include_created_by_keys=true&substring_matching=true",
       {
         method: "GET",
         headers: {
@@ -305,7 +305,7 @@ describe("useKeys", () => {
     });
 
     expect(mockFetch).toHaveBeenCalledWith(
-      `/key/list?page=${page}&size=${pageSize}&return_full_object=true&include_team_keys=true&include_created_by_keys=true`,
+      `/key/list?page=${page}&size=${pageSize}&return_full_object=true&include_team_keys=true&include_created_by_keys=true&substring_matching=true`,
       {
         method: "GET",
         headers: {
@@ -339,7 +339,7 @@ describe("useKeys", () => {
 
     expect(result.current.data).toEqual(emptyResponse);
     expect(mockFetch).toHaveBeenCalledWith(
-      "/key/list?page=1&size=10&return_full_object=true&include_team_keys=true&include_created_by_keys=true",
+      "/key/list?page=1&size=10&return_full_object=true&include_team_keys=true&include_created_by_keys=true&substring_matching=true",
       {
         method: "GET",
         headers: {
@@ -388,7 +388,7 @@ describe("useKeys", () => {
 
     expect(result.current.data).toEqual(paginatedResponse);
     expect(mockFetch).toHaveBeenCalledWith(
-      "/key/list?page=2&size=10&return_full_object=true&include_team_keys=true&include_created_by_keys=true",
+      "/key/list?page=2&size=10&return_full_object=true&include_team_keys=true&include_created_by_keys=true&substring_matching=true",
       {
         method: "GET",
         headers: {
@@ -518,7 +518,7 @@ describe("useDeletedKeys", () => {
     expect(result.current.error).toBeNull();
     expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(mockFetch).toHaveBeenCalledWith(
-      "/key/list?page=1&size=10&status=deleted&return_full_object=true&include_team_keys=true&include_created_by_keys=true",
+      "/key/list?page=1&size=10&status=deleted&return_full_object=true&include_team_keys=true&include_created_by_keys=true&substring_matching=true",
       {
         method: "GET",
         headers: {
@@ -575,7 +575,7 @@ describe("useDeletedKeys", () => {
     expect(result.current.data).toBeUndefined();
     expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(mockFetch).toHaveBeenCalledWith(
-      "/key/list?page=1&size=10&status=deleted&return_full_object=true&include_team_keys=true&include_created_by_keys=true",
+      "/key/list?page=1&size=10&status=deleted&return_full_object=true&include_team_keys=true&include_created_by_keys=true&substring_matching=true",
       {
         method: "GET",
         headers: {
@@ -628,7 +628,7 @@ describe("useDeletedKeys", () => {
     });
 
     expect(mockFetch).toHaveBeenCalledWith(
-      `/key/list?page=${page}&size=${pageSize}&status=deleted&return_full_object=true&include_team_keys=true&include_created_by_keys=true`,
+      `/key/list?page=${page}&size=${pageSize}&status=deleted&return_full_object=true&include_team_keys=true&include_created_by_keys=true&substring_matching=true`,
       {
         method: "GET",
         headers: {
@@ -662,7 +662,7 @@ describe("useDeletedKeys", () => {
 
     expect(result.current.data).toEqual(emptyResponse);
     expect(mockFetch).toHaveBeenCalledWith(
-      "/key/list?page=1&size=10&status=deleted&return_full_object=true&include_team_keys=true&include_created_by_keys=true",
+      "/key/list?page=1&size=10&status=deleted&return_full_object=true&include_team_keys=true&include_created_by_keys=true&substring_matching=true",
       {
         method: "GET",
         headers: {
@@ -711,7 +711,7 @@ describe("useDeletedKeys", () => {
 
     expect(result.current.data).toEqual(paginatedResponse);
     expect(mockFetch).toHaveBeenCalledWith(
-      "/key/list?page=2&size=10&status=deleted&return_full_object=true&include_team_keys=true&include_created_by_keys=true",
+      "/key/list?page=2&size=10&status=deleted&return_full_object=true&include_team_keys=true&include_created_by_keys=true&substring_matching=true",
       {
         method: "GET",
         headers: {

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/keys/useKeys.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/keys/useKeys.ts
@@ -62,6 +62,9 @@ const keyListCall = async (accessToken: string, page: number, pageSize: number, 
         return_full_object: "true",
         include_team_keys: "true",
         include_created_by_keys: "true",
+        // Opt into substring matching so the admin key-list search box keeps
+        // matching partial user_id/key_alias. /key/list is exact by default.
+        substring_matching: "true",
       })
         .filter(([, value]) => value !== undefined && value !== null)
         .map(([key, value]) => [key, String(value)]),

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -2453,6 +2453,9 @@ export const keyListCall = async (
         return_full_object: "true",
         include_team_keys: "true",
         include_created_by_keys: "true",
+        // /key/list is exact by default; opt in so the key-list search box keeps
+        // matching partial user_id/key_alias.
+        substring_matching: "true",
       },
     });
   } catch (error) {

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -41425,7 +41425,7 @@ export interface operations {
                 page?: number;
                 /** @description Page size */
                 size?: number;
-                /** @description Filter keys by user ID. Supports partial matching (substring, case-insensitive). */
+                /** @description Filter keys by user ID. Exact match by default; set substring_matching=true (admin only) for case-insensitive substring matching. */
                 user_id?: string | null;
                 /** @description Filter keys by team ID */
                 team_id?: string | null;
@@ -41433,7 +41433,7 @@ export interface operations {
                 organization_id?: string | null;
                 /** @description Filter keys by key hash */
                 key_hash?: string | null;
-                /** @description Filter keys by key alias. Supports partial matching (substring, case-insensitive). */
+                /** @description Filter keys by key alias. Exact match by default; set substring_matching=true (admin only) for case-insensitive substring matching. */
                 key_alias?: string | null;
                 /** @description Return full key object */
                 return_full_object?: boolean;
@@ -41453,6 +41453,8 @@ export interface operations {
                 project_id?: string | null;
                 /** @description Filter keys by access group ID */
                 access_group_id?: string | null;
+                /** @description If true (proxy admins only), match user_id/key_alias as case-insensitive substrings instead of exact values. Defaults to false: /key/list matched these exactly before substring search was added, and an exact user_id/key_alias filter must never return another user's keys. */
+                substring_matching?: boolean;
             };
             header?: never;
             path?: never;


### PR DESCRIPTION
## Title
fix(key management): `/key/list` exact `user_id`/`key_alias` match by default (cross-user key disclosure)

## Relevant issues
Cross-user API key disclosure via `/key/list`.

## Summary

`/key/list` performs a **case-insensitive substring (`contains`) match** on `user_id` and `key_alias` whenever the caller is a proxy admin. Any caller that authenticates with an admin key and passes an **exact** `user_id` as an access filter therefore receives **other users' keys**.

Example: `GET /key/list?user_id=alice` returns keys for `alice`, `alice2`, `alice-test`, and anyone else whose `user_id` contains `alice`. This is a cross-user key disclosure for any integration that uses an admin key to scope `/key/list` to a single user.

### Root cause
In `list_keys`, substring matching was derived purely from the caller's role with no opt-out:
```python
use_substring_matching = user_api_key_dict.user_role in [PROXY_ADMIN, PROXY_ADMIN_VIEW_ONLY]
```
`_build_key_filter_conditions` then applied `{"contains": user_id, "mode": "insensitive"}`.

### Fix
- Add an explicit, admin-only `substring_matching: bool = Query(False)` parameter.
- `use_substring_matching = substring_matching and is_proxy_admin` — **exact match by default**.
- Preserve the admin "list all keys" behavior (omitting `user_id`) by gating it on the admin **role**, not on the substring flag.

The admin UI search box can continue to use partial matching by passing `substring_matching=true`.

## Type
🐛 Bug Fix / 🔒 Security

## Changes
- `litellm/proxy/management_endpoints/key_management_endpoints.py`: new `substring_matching` query param; exact-by-default gating; preserve admin list-all.
- Tests: `_build_key_filter_conditions` exact-by-default + opt-in `contains`; `list_keys` exact-by-default, opt-in substring, default `False`, and non-admin path.

## Testing
`pytest tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py -k "list_keys or substring or build_key_filter_conditions_user_id"` → 18 passed locally.
