### PR TITLE
fix: select tiered token cost by numeric threshold, not key string

### DIFF
--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -191,6 +191,21 @@ def _get_service_tier_cost_key(base_key: str, service_tier: Optional[str]) -> st
     return base_key
 
 
+def _parse_above_threshold_tokens(key: str) -> float:
+    """Numeric token threshold encoded in an ``..._above_<N>[k]_tokens`` cost key.
+
+    Returns ``-inf`` for unparseable keys so they sort last and are skipped by the
+    selection loop's own error handling.
+    """
+    try:
+        threshold_str = key.split("_above_")[1].split("_tokens")[0]
+        return float(threshold_str.replace("k", "")) * (
+            1000 if "k" in threshold_str else 1
+        )
+    except (IndexError, ValueError):
+        return float("-inf")
+
+
 def _get_token_base_cost(
     model_info: ModelInfo, usage: Usage, service_tier: Optional[str] = None
 ) -> Tuple[float, float, float, float, float]:
@@ -254,18 +269,19 @@ def _get_token_base_cost(
             cache_read_cost,
         )
 
-    # Only sort the threshold keys (typically 1-2 keys instead of 66+)
+    # Sort by the parsed numeric threshold (descending), not the raw key string. A lexicographic
+    # sort orders tiers of different digit lengths wrong (e.g. "..._above_90k_tokens" would precede
+    # "..._above_128k_tokens"), so a request crossing both could be billed at the lower 90k tier
+    # instead of the highest 128k tier it actually crosses.
     threshold: Optional[float] = None
-    for key in sorted(threshold_keys, reverse=True):
+    for key in sorted(threshold_keys, key=_parse_above_threshold_tokens, reverse=True):
         value = model_info.get(key)
         if value is not None:
             try:
                 # Handle both formats: _above_128k_tokens and _above_128_tokens
+                threshold = _parse_above_threshold_tokens(key)
                 threshold_str = key.split("_above_")[1].split("_tokens")[0]
-                threshold = float(threshold_str.replace("k", "")) * (
-                    1000 if "k" in threshold_str else 1
-                )
-                if usage.prompt_tokens > threshold:
+                if threshold != float("-inf") and usage.prompt_tokens > threshold:
                     # Prefer a service_tier-specific above-threshold key when available,
                     # e.g. input_cost_per_token_priority_above_200k_tokens for Gemini
                     # ON_DEMAND_PRIORITY.  Falls back to the standard key automatically

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
@@ -35,6 +35,7 @@ sys.path.insert(
 from litellm.litellm_core_utils.llm_cost_calc.utils import (
     PromptTokensDetailsResult,
     _calculate_input_cost,
+    _get_token_base_cost,
     calculate_cache_writing_cost,
     generic_cost_per_token,
 )
@@ -829,6 +830,30 @@ def test_string_cost_values_with_threshold():
 
     assert round(prompt_cost, 12) == round(expected_prompt_cost, 12)
     assert round(completion_cost, 12) == round(expected_completion_cost, 12)
+
+
+def test_tiered_cost_selects_highest_threshold_by_numeric_order():
+    """Regression test for #30345.
+
+    Tiers must be chosen by their numeric token threshold, not by the raw key string. With tiers at
+    90k and 128k (different digit lengths), a 150k-token request crosses both and must be billed at
+    the highest tier it crosses (128k). A lexicographic sort would visit "..._above_90k_tokens"
+    first and wrongly bill at the lower 90k tier.
+    """
+    model_info = {
+        "input_cost_per_token": 1e-6,
+        "output_cost_per_token": 2e-6,
+        "input_cost_per_token_above_90k_tokens": 5e-6,
+        "input_cost_per_token_above_128k_tokens": 9e-6,
+        "output_cost_per_token_above_90k_tokens": 6e-6,
+        "output_cost_per_token_above_128k_tokens": 1e-5,
+    }
+    usage = Usage(prompt_tokens=150_000, completion_tokens=10, total_tokens=150_010)
+
+    prompt_base_cost, completion_base_cost = _get_token_base_cost(model_info, usage)[:2]
+
+    assert prompt_base_cost == 9e-6
+    assert completion_base_cost == 1e-5
 
 
 def test_calculate_cache_writing_cost():


### PR DESCRIPTION
## Relevant issues

Fixes #30345

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

`_get_token_base_cost` in `litellm/litellm_core_utils/llm_cost_calc/utils.py` chose which `input_cost_per_token_above_<N>_tokens` tier to apply by iterating `sorted(threshold_keys, reverse=True)`, which sorts the raw key strings lexicographically. When two tiers have thresholds of different digit lengths the string order diverges from the numeric order, so `..._above_90k_tokens` sorts before `..._above_128k_tokens` (because `9` > `1`). A request that crosses both boundaries matched the 90k tier first and was billed at the lower tier instead of the highest tier it actually crosses

This is latent on the bundled model map, where the surviving thresholds (128k/200k/272k) are all three digits and sort correctly, but it is reachable through a custom-registered model or any future map entry whose tiers differ in digit length

The fix sorts the threshold keys by their parsed numeric threshold via a small `_parse_above_threshold_tokens` helper. Unparseable keys return `-inf` so they sort last and are still skipped by the loop's existing error handling. Equal-digit-length tiers (128k/200k/272k) sort identically to before, so the bundled model map is unaffected

## Proof of fix

The issue's repro calls the tiered-cost helper directly with tiers at 90k and 128k and a 150k-token request, so both tiers reach the selection loop

```python
from litellm.types.utils import Usage
from litellm.litellm_core_utils.llm_cost_calc.utils import _get_token_base_cost

model_info = {
    "input_cost_per_token": 1e-6,
    "output_cost_per_token": 2e-6,
    "input_cost_per_token_above_90k_tokens": 5e-6,
    "input_cost_per_token_above_128k_tokens": 9e-6,
}
usage = Usage(prompt_tokens=150_000, completion_tokens=10, total_tokens=150_010)
print(_get_token_base_cost(model_info, usage)[0])
```

Before: `5e-06` (the lower 90k tier, because `..._above_90k_tokens` sorted first as a string)
After: `9e-06` (the 128k tier the 150k-token request actually crosses)

Added a regression test `test_tiered_cost_selects_highest_threshold_by_numeric_order` in `tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py`; it fails on the old string sort and passes with the numeric sort
