### PR TITLE
fix(audio): don't override explicit response_format with verbose_json

### DIFF
--- a/litellm/llms/openai/transcriptions/whisper_transformation.py
+++ b/litellm/llms/openai/transcriptions/whisper_transformation.py
@@ -107,9 +107,7 @@ class OpenAIWhisperAudioTranscriptionConfig(BaseAudioTranscriptionConfig):
         """
         data = {"model": model, "file": audio_file, **optional_params}
 
-        if "response_format" not in data or (
-            data["response_format"] == "text" or data["response_format"] == "json"
-        ):
+        if "response_format" not in data:
             data["response_format"] = (
                 "verbose_json"  # ensures 'duration' is received - used for cost calculation
             )

--- a/litellm/llms/openai/transcriptions/whisper_transformation.py
+++ b/litellm/llms/openai/transcriptions/whisper_transformation.py
@@ -1,3 +1,4 @@
+import json
 from typing import List, Optional, Union
 
 from httpx import Headers, Response
@@ -131,10 +132,8 @@ class OpenAIWhisperAudioTranscriptionConfig(BaseAudioTranscriptionConfig):
     ) -> TranscriptionResponse:
         try:
             raw_response_json = raw_response.json()
-        except Exception as e:
-            raise ValueError(
-                f"Error transforming response to json: {str(e)}\nResponse: {raw_response.text}"
-            )
+        except json.JSONDecodeError:
+            return TranscriptionResponse(text=raw_response.text)
 
         if any(
             key in raw_response_json

--- a/litellm/llms/openai/transcriptions/whisper_transformation.py
+++ b/litellm/llms/openai/transcriptions/whisper_transformation.py
@@ -133,7 +133,7 @@ class OpenAIWhisperAudioTranscriptionConfig(BaseAudioTranscriptionConfig):
         try:
             raw_response_json = raw_response.json()
         except json.JSONDecodeError:
-            content_type = raw_response.headers.get("content-type", "")
+            content_type = raw_response.headers.get("content-type", "").lower()
             if "application/json" in content_type:
                 raise
             return TranscriptionResponse(text=raw_response.text)

--- a/litellm/llms/openai/transcriptions/whisper_transformation.py
+++ b/litellm/llms/openai/transcriptions/whisper_transformation.py
@@ -133,6 +133,9 @@ class OpenAIWhisperAudioTranscriptionConfig(BaseAudioTranscriptionConfig):
         try:
             raw_response_json = raw_response.json()
         except json.JSONDecodeError:
+            content_type = raw_response.headers.get("content-type", "")
+            if "application/json" in content_type:
+                raise
             return TranscriptionResponse(text=raw_response.text)
 
         if any(

--- a/tests/test_litellm/llms/openai/transcriptions/test_whisper_transformation.py
+++ b/tests/test_litellm/llms/openai/transcriptions/test_whisper_transformation.py
@@ -7,6 +7,8 @@ import io
 import json
 from unittest.mock import MagicMock
 
+import pytest
+
 from litellm.llms.openai.transcriptions.whisper_transformation import (
     OpenAIWhisperAudioTranscriptionConfig,
 )
@@ -47,8 +49,9 @@ class TestWhisperTransformRequestResponseFormat:
 
 
 class TestWhisperTransformResponse:
-    def _make_response(self, *, text: str, is_json: bool):
+    def _make_response(self, *, text: str, content_type: str, is_json: bool):
         mock = MagicMock()
+        mock.headers = {"content-type": content_type}
         if is_json:
             mock.json.return_value = {"text": text}
         else:
@@ -60,7 +63,9 @@ class TestWhisperTransformResponse:
         """JSON body (verbose_json or json format) is parsed into TranscriptionResponse."""
         config = OpenAIWhisperAudioTranscriptionConfig()
         result = config.transform_audio_transcription_response(
-            self._make_response(text="Hello world", is_json=True)
+            self._make_response(
+                text="Hello world", content_type="application/json", is_json=True
+            )
         )
         assert result.text == "Hello world"
 
@@ -68,6 +73,22 @@ class TestWhisperTransformResponse:
         """Plain-text body (response_format=text) is returned as TranscriptionResponse without error."""
         config = OpenAIWhisperAudioTranscriptionConfig()
         result = config.transform_audio_transcription_response(
-            self._make_response(text="Four score and seven years ago", is_json=False)
+            self._make_response(
+                text="Four score and seven years ago",
+                content_type="text/plain",
+                is_json=False,
+            )
         )
         assert result.text == "Four score and seven years ago"
+
+    def test_malformed_json_body_with_json_content_type_raises(self):
+        """A non-JSON body labelled application/json is a genuine upstream error, not a transcription."""
+        config = OpenAIWhisperAudioTranscriptionConfig()
+        with pytest.raises(json.JSONDecodeError):
+            config.transform_audio_transcription_response(
+                self._make_response(
+                    text="<html>502 Bad Gateway</html>",
+                    content_type="application/json",
+                    is_json=False,
+                )
+            )

--- a/tests/test_litellm/llms/openai/transcriptions/test_whisper_transformation.py
+++ b/tests/test_litellm/llms/openai/transcriptions/test_whisper_transformation.py
@@ -92,3 +92,15 @@ class TestWhisperTransformResponse:
                     is_json=False,
                 )
             )
+
+    def test_json_content_type_match_is_case_insensitive(self):
+        """Media types are case-insensitive (RFC 7231), so a mixed-case application/json still re-raises."""
+        config = OpenAIWhisperAudioTranscriptionConfig()
+        with pytest.raises(json.JSONDecodeError):
+            config.transform_audio_transcription_response(
+                self._make_response(
+                    text="<html>502 Bad Gateway</html>",
+                    content_type="Application/JSON; charset=utf-8",
+                    is_json=False,
+                )
+            )

--- a/tests/test_litellm/llms/openai/transcriptions/test_whisper_transformation.py
+++ b/tests/test_litellm/llms/openai/transcriptions/test_whisper_transformation.py
@@ -1,8 +1,11 @@
 """
-Tests for OpenAIWhisperAudioTranscriptionConfig.transform_audio_transcription_request.
+Tests for OpenAIWhisperAudioTranscriptionConfig.transform_audio_transcription_request
+and transform_audio_transcription_response.
 """
 
 import io
+import json
+from unittest.mock import MagicMock
 
 from litellm.llms.openai.transcriptions.whisper_transformation import (
     OpenAIWhisperAudioTranscriptionConfig,
@@ -41,3 +44,30 @@ class TestWhisperTransformRequestResponseFormat:
         """verbose_json explicitly set by the caller stays as-is."""
         data = self._transform({"response_format": "verbose_json"})
         assert data["response_format"] == "verbose_json"
+
+
+class TestWhisperTransformResponse:
+    def _make_response(self, *, text: str, is_json: bool):
+        mock = MagicMock()
+        if is_json:
+            mock.json.return_value = {"text": text}
+        else:
+            mock.json.side_effect = json.JSONDecodeError("", "", 0)
+            mock.text = text
+        return mock
+
+    def test_parses_json_response(self):
+        """JSON body (verbose_json or json format) is parsed into TranscriptionResponse."""
+        config = OpenAIWhisperAudioTranscriptionConfig()
+        result = config.transform_audio_transcription_response(
+            self._make_response(text="Hello world", is_json=True)
+        )
+        assert result.text == "Hello world"
+
+    def test_parses_plain_text_response(self):
+        """Plain-text body (response_format=text) is returned as TranscriptionResponse without error."""
+        config = OpenAIWhisperAudioTranscriptionConfig()
+        result = config.transform_audio_transcription_response(
+            self._make_response(text="Four score and seven years ago", is_json=False)
+        )
+        assert result.text == "Four score and seven years ago"

--- a/tests/test_litellm/llms/openai/transcriptions/test_whisper_transformation.py
+++ b/tests/test_litellm/llms/openai/transcriptions/test_whisper_transformation.py
@@ -1,0 +1,43 @@
+"""
+Tests for OpenAIWhisperAudioTranscriptionConfig.transform_audio_transcription_request.
+"""
+
+import io
+
+from litellm.llms.openai.transcriptions.whisper_transformation import (
+    OpenAIWhisperAudioTranscriptionConfig,
+)
+
+
+class TestWhisperTransformRequestResponseFormat:
+    def _transform(self, optional_params: dict) -> dict:
+        config = OpenAIWhisperAudioTranscriptionConfig()
+        audio_file = io.BytesIO(b"fake audio")
+        audio_file.name = "test.wav"
+        result = config.transform_audio_transcription_request(
+            model="whisper-1",
+            audio_file=audio_file,
+            optional_params=optional_params,
+            litellm_params={},
+        )
+        return result.data
+
+    def test_defaults_to_verbose_json_when_unset(self):
+        """When response_format is not specified, default to verbose_json for cost calculation."""
+        data = self._transform({})
+        assert data["response_format"] == "verbose_json"
+
+    def test_respects_explicit_json(self):
+        """When response_format='json' is set, do not override to verbose_json."""
+        data = self._transform({"response_format": "json"})
+        assert data["response_format"] == "json"
+
+    def test_respects_explicit_text(self):
+        """When response_format='text' is set, do not override to verbose_json."""
+        data = self._transform({"response_format": "text"})
+        assert data["response_format"] == "text"
+
+    def test_preserves_verbose_json_when_set(self):
+        """verbose_json explicitly set by the caller stays as-is."""
+        data = self._transform({"response_format": "verbose_json"})
+        assert data["response_format"] == "verbose_json"


### PR DESCRIPTION
## Relevant issues

Internal-branch copy of #30077 so CircleCI can run against the fix (CircleCI does not run on fork PRs). Original author: @cohml

## Root cause

`OpenAIWhisperAudioTranscriptionConfig.transform_audio_transcription_request()` overrides any caller-supplied `response_format` of `"json"` or `"text"` to `"verbose_json"`, even when the value was set explicitly. The override exists to ensure `duration` comes back for cost calculation. However, the `openai/` provider prefix is the documented convention for any OpenAI-compatible endpoint reached via a custom `api_base`, not just OpenAI itself. Endpoints reached that way may not implement `verbose_json` (Cohere's transcription API is one example), so the silent upgrade produces a 400 even when the caller requested a format the endpoint does support.

A second issue surfaces once the explicit format is honored: `transform_audio_transcription_response()` calls `raw_response.json()` and raises a `ValueError` on failure, so `response_format=text` (a plain-text body) blows up instead of being returned.

## Fix

Only default to `verbose_json` when `response_format` has not been set by the caller; when an explicit value is present, forward it unchanged. Cost calculation is unaffected because the fallback path in `main.py` already computes `duration` from file size when `response.duration` is absent.

For the response side, `json()` is still attempted first, so the common JSON path is unchanged. When it fails, the body is returned as a plain-text `TranscriptionResponse` only if the response is not labelled `application/json`; a body that fails to parse yet declares `application/json` is re-raised as a genuine upstream error rather than being silently turned into a transcription of garbled bytes. The `Content-Type` comparison is case-insensitive (media types are case-insensitive per RFC 7231). This keeps `response_format=text` (a `text/plain` body) working while not masking malformed JSON for `json`/`verbose_json` callers.

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Start a local proxy with an `openai/`-prefixed model pointing at a custom api_base that does not support `verbose_json`:

```yaml
model_list:
  - model_name: cohere-transcribe
    litellm_params:
      model: openai/cohere-transcribe-03-2026
      api_key:
      api_base: https://model-q41o2dyq.api.baseten.co/environments/production/sync/v1
    model_info:
      mode: audio_transcription
```

Before this fix, passing `response_format=json` still produces a 400 because the transformation silently upgrades it to `verbose_json`:

```shell
curl -X POST http://localhost:4000/audio/transcriptions \
  -H "Authorization: Bearer sk-1234" \
  -F "model=cohere-transcribe" \
  -F "file=@audio.wav" \
  -F "response_format=json"

-> 400 {"error": {"message": "litellm.BadRequestError: OpenAIException - Currently do not support verbose_json for cohere-transcribe-03-2026 ..."}}
```

After the fix, the explicit json is forwarded and the transcription succeeds:

```shell
curl -X POST http://localhost:4000/audio/transcriptions \
  -H "Authorization: Bearer sk-1234" \
  -F "model=cohere-transcribe" \
  -F "file=@audio.wav" \
  -F "response_format=json"

-> 200 {"text": "..."}
```

## Type

🐛 Bug Fix

## Changes

`OpenAIWhisperAudioTranscriptionConfig.transform_audio_transcription_request()` in `litellm/llms/openai/transcriptions/whisper_transformation.py` guarded the `verbose_json` default with `or (data["response_format"] == "text" or data["response_format"] == "json")`, so an explicit `response_format="json"` was silently promoted to `verbose_json`. The guard is narrowed to a plain `if "response_format" not in data` check; callers who do not set a format still get `verbose_json` as the default (preserving the duration-for-cost-calculation path), while explicit values are forwarded unchanged.

`transform_audio_transcription_response()` attempts `json()` first; on `json.JSONDecodeError` it consults the response `Content-Type` (lower-cased for case-insensitive matching). A non-JSON body labelled `application/json` is re-raised (genuine upstream error), while any other non-JSON body (the `response_format=text` / `text/plain` case) is returned as `TranscriptionResponse(text=raw_response.text)`.

`tests/test_litellm/llms/openai/transcriptions/test_whisper_transformation.py` covers the request cases (unset defaults to `verbose_json`, explicit `json`, explicit `text`, explicit `verbose_json`) and the response cases (JSON body parsed, plain-text body returned, malformed body declared `application/json` re-raised, and a mixed-case `Application/JSON` body re-raised to lock in the case-insensitive match).