### PR TITLE
fix(pod_lock): release cron lock by matching async_set_cache JSON encoding

### DIFF
--- a/litellm/proxy/db/db_transaction_queue/pod_lock_manager.py
+++ b/litellm/proxy/db/db_transaction_queue/pod_lock_manager.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 from litellm._uuid import uuid
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -167,8 +168,11 @@ end
                     self._release_lock_script = script_register(
                         self._COMPARE_AND_DELETE_LOCK_SCRIPT
                     )
+                # acquire_lock stores the pod_id via async_set_cache, which
+                # JSON-encodes the value; compare against the same encoding so
+                # the Lua equality check matches and the lock is released
                 result = await self._release_lock_script(
-                    keys=[lock_key], args=[self.pod_id]
+                    keys=[lock_key], args=[json.dumps(self.pod_id)]
                 )
                 return int(result or 0)
             except Exception:

--- a/tests/test_litellm/proxy/db/db_transaction_queue/test_pod_lock_manager.py
+++ b/tests/test_litellm/proxy/db/db_transaction_queue/test_pod_lock_manager.py
@@ -327,7 +327,7 @@ async def test_release_lock_uses_atomic_compare_delete_script_when_available(
         PodLockManager._COMPARE_AND_DELETE_LOCK_SCRIPT
     )
     script_callable.assert_called_once_with(
-        keys=[lock_key], args=[pod_lock_manager.pod_id]
+        keys=[lock_key], args=[json.dumps(pod_lock_manager.pod_id)]
     )
     mock_redis.async_get_cache.assert_not_called()
     mock_redis.async_delete_cache.assert_not_called()
@@ -362,6 +362,78 @@ async def test_release_lock_lua_path_emits_released_event(pod_lock_manager, mock
     mock_emit.assert_called_once_with(
         cronjob_id="test_job", pod_id=pod_lock_manager.pod_id
     )
+
+
+class FakeRedisLockStore:
+    """
+    Minimal stand-in that mirrors how RedisCache actually stores values:
+    async_set_cache JSON-encodes the value, and the compare-and-delete Lua
+    script compares against the raw stored bytes. This is what exposes the
+    quoted-vs-raw mismatch that a value-agnostic mock cannot catch.
+    """
+
+    def __init__(self):
+        self.store: dict = {}
+
+    async def async_set_cache(self, key, value, nx=False, ttl=None, **kwargs):
+        if nx and key in self.store:
+            return None
+        self.store[key] = json.dumps(value)
+        return True
+
+    async def async_get_cache(self, key, **kwargs):
+        raw = self.store.get(key)
+        return json.loads(raw) if raw is not None else None
+
+    async def async_delete_cache(self, key, **kwargs):
+        return 1 if self.store.pop(key, None) is not None else 0
+
+    def async_register_script(self, script):
+        async def _run(keys, args):
+            key = keys[0]
+            if self.store.get(key) == args[0]:
+                del self.store[key]
+                return 1
+            return 0
+
+        return _run
+
+
+@pytest.mark.asyncio
+async def test_release_lock_deletes_lock_held_by_same_pod():
+    """
+    Regression: acquire_lock stores the pod_id JSON-encoded, so release_lock's
+    Lua compare-and-delete must use the same encoding or the comparison never
+    matches and the lock leaks until its TTL expires (stalling the spend-update
+    drain and growing the Redis transaction buffers).
+    """
+    redis = FakeRedisLockStore()
+    pod = PodLockManager(redis_cache=redis)
+    lock_key = PodLockManager.get_redis_lock_key("db_spend_update_job")
+
+    acquired = await pod.acquire_lock(cronjob_id="db_spend_update_job")
+    assert acquired is True
+    assert lock_key in redis.store
+
+    await pod.release_lock(cronjob_id="db_spend_update_job")
+    assert lock_key not in redis.store
+
+
+@pytest.mark.asyncio
+async def test_release_lock_preserves_lock_held_by_other_pod():
+    """
+    A pod must not release a lock currently held by a different pod, even with
+    the encoding fix in place.
+    """
+    redis = FakeRedisLockStore()
+    holder = PodLockManager(redis_cache=redis)
+    other = PodLockManager(redis_cache=redis)
+    lock_key = PodLockManager.get_redis_lock_key("db_spend_update_job")
+
+    assert await holder.acquire_lock(cronjob_id="db_spend_update_job") is True
+
+    await other.release_lock(cronjob_id="db_spend_update_job")
+    assert redis.store.get(lock_key) == json.dumps(holder.pod_id)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Relevant issues

Redis memory grows significantly after upgrading to v1.84.1; the largest offenders are the spend update buffers (`litellm_daily_tag_spend_update_buffer`, `litellm_daily_team_spend_update_buffer`, `litellm_daily_end_user_spend_update_buffer`)

Internal discussion: https://berriaillm.slack.com/archives/C09F56F8G31/p1781663517667329?thread_ts=1780766536.521459&cid=C09F56F8G31

## Linear ticket

Resolves LIT-3562

## Root cause

`PodLockManager.acquire_lock` stores the pod id through `RedisCache.async_set_cache`, which JSON-encodes every value (`json.dumps(value)`), so Redis holds the quoted string `"<pod_id>"`. `release_lock` runs an atomic Lua compare-and-delete that compared the value against the raw `self.pod_id`. `"<pod_id>" == <pod_id>` is never true, so the script returned 0 and the lock was never deleted; it only cleared once the TTL expired.

This was introduced in #24466 (re-land of the atomic compare-and-delete release), which shipped in v1.84.1. Before that, release used GET + DEL through `async_get_cache`, which JSON-decodes the value back to the raw id, so the comparison matched. That lines up with the report that v1.83.7 is fine and v1.84.1 is not.

While a single leader pod holds the unreleasable lock it keeps re-acquiring it (the "already holds the lock" branch reads through `async_get_cache` and matches), so it still drains. The damage shows up when that leader restarts or is rescheduled: the stale lock lingers for the whole TTL window and no other pod can take it, so nothing drains the `litellm_daily_*_spend_update_buffer` lists while every pod keeps pushing into them. At high request volume with routine pod restarts that is the unbounded Redis growth in the ticket.

## Fix

Compare against `json.dumps(self.pod_id)` in the Lua args so the release matches the value `async_set_cache` actually stored. The GET + DEL fallback already round-trips through `async_get_cache` and is unchanged.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit` for the touched path (`test_pod_lock_manager.py`, 17 passed)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Verified against a live proxy on `localhost:4000` (`use_redis_transaction_buffer: true`, `proxy_batch_write_at: 5`) backed by a real Postgres and a real Redis. The sandbox has no outbound LLM provider credentials, so spend was generated with `mock_response` to exercise the real `db_spend_update_job` -> `PodLockManager` acquire/release path; the lock release behavior under test is provider independent.

Drive spend and watch the lock key:

```
for i in 1 2 3 4 5; do
  curl -s http://localhost:4000/v1/chat/completions \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"model":"mock-gpt","messages":[{"role":"user","content":"verify '"$i"'"}]}' -o /dev/null -w "req $i -> HTTP %{http_code}\n"
done
for t in $(seq 1 10); do
  printf "GET=%s TTL=%s\n" "$(redis-cli GET cronjob_lock:db_spend_update_job)" "$(redis-cli TTL cronjob_lock:db_spend_update_job)"
  sleep 1
done
```

Before the fix (lock stuck, value is JSON-quoted, TTL counts down and never clears):

```
GET="9a199b7b-59d5-42bf-bfc4-c5f30f8b540e" TTL=59
GET="9a199b7b-59d5-42bf-bfc4-c5f30f8b540e" TTL=58
GET="9a199b7b-59d5-42bf-bfc4-c5f30f8b540e" TTL=57
...
GET="9a199b7b-59d5-42bf-bfc4-c5f30f8b540e" TTL=44

# proxy log
successfully released Redis lock: 0
failed to release Redis lock:     6
already holds the Redis lock:     4   (same pod monopolizing the lock)
```

After the fix (lock is released every drain cycle; key absent between cycles, TTL=-2):

```
GET= TTL=-2
GET= TTL=-2
...

# proxy log
Pod ... successfully acquired Redis lock for cronjob_id=db_spend_update_job
Pod ... successfully released Redis lock for cronjob_id=db_spend_update_job
successfully released Redis lock: 5
failed to release Redis lock:     0
```

Buffers stay drained after the fix:

```
litellm_daily_tag_spend_update_buffer         LLEN=0
litellm_daily_team_spend_update_buffer        LLEN=0
litellm_spend_update_buffer                   LLEN=0
```

Regression test confirmation (fails on the old `args=[self.pod_id]`, passes with the fix): `test_release_lock_deletes_lock_held_by_same_pod` drives the real `PodLockManager` against a Redis fake that mirrors `async_set_cache`'s `json.dumps` storage, so a value-agnostic mock can no longer hide the quoted-vs-raw mismatch.

## Type

Bug Fix

## Changes

`litellm/proxy/db/db_transaction_queue/pod_lock_manager.py`: compare the Lua release arg against `json.dumps(self.pod_id)` to match the stored value.

`tests/test_litellm/proxy/db/db_transaction_queue/test_pod_lock_manager.py`: add `test_release_lock_deletes_lock_held_by_same_pod` and `test_release_lock_preserves_lock_held_by_other_pod` exercising real acquire/release encoding through a `json.dumps`-faithful Redis fake, and update the existing Lua-args assertion to the JSON-encoded value.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmfNR17UHeQcEJk1Rnzf2J)_