### PR TITLE
docs(guardrails): fix broken guardrails docs link in ibm_guardrails README

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/ibm_guardrails/README.md
+++ b/litellm/proxy/guardrails/guardrail_hooks/ibm_guardrails/README.md
@@ -177,7 +177,7 @@ Message 1:
 
 - [IBM FMS Guardrails Documentation](https://github.com/foundation-model-stack/fms-guardrails-orchestr8)
 - [Detector API Gist](https://gist.github.com/RobGeada/fa886a6c723f06dee6becb583566d748)
-- [LiteLLM Guardrails Documentation](https://docs.litellm.ai/docs/proxy/guardrails)
+- [LiteLLM Guardrails Documentation](https://docs.litellm.ai/docs/proxy/guardrails/quick_start)
 
 ## Environment Variables
 


### PR DESCRIPTION
## Summary

`litellm/proxy/guardrails/guardrail_hooks/ibm_guardrails/README.md` links to `https://docs.litellm.ai/docs/proxy/guardrails`, which 404s. The litellm docs site restructured the guardrails guide to live at `/docs/proxy/guardrails/quick_start`.

## Fix

```diff
-- [LiteLLM Guardrails Documentation](https://docs.litellm.ai/docs/proxy/guardrails)
++ [LiteLLM Guardrails Documentation](https://docs.litellm.ai/docs/proxy/guardrails/quick_start)
```

## Verification

- Old URL: 404.
- New URL: 200.

## Note

This is a separate file from the litellm PR #30530 (which is still open and fixes a different set of broken links in the top-level README and enterprise README). No file overlap.