### PR TITLE
feat(agent-shin): gate triage on a dogfood allowlist

### DIFF
--- a/.github/scripts/agent_shin_shared.py
+++ b/.github/scripts/agent_shin_shared.py
@@ -48,6 +48,15 @@ AGENT_SHIN_DEFAULT_BOT_LOGIN = "github-actions[bot]"
 
 IMMEDIATE_CLOSE_LOGINS = frozenset({"swiftwinds"})
 
+# Dogfood rollout gate. While this set is non-empty, Agent Shin acts ONLY on
+# PRs/issues authored by these logins and skips everyone else. For an
+# allowlisted author the usual internal/external classification is bypassed, so
+# an internal account (e.g. a maintainer's own work login) still gets triaged
+# while the bot is being tested on a small set of accounts. Empty the set to
+# lift the restriction and restore full triage for the public rollout. Logins
+# are compared case-insensitively.
+ALLOWLIST_LOGINS = frozenset({"mateo-berri", "swiftwinds"})
+
 # `gh {pr,issue} list` has no "fetch everything" flag — `--limit` is the only
 # control and it defaults to 30. Pass a ceiling far above any realistic open
 # backlog (low thousands today) so gh paginates the API until the queue is

--- a/.github/scripts/close_low_quality_prs.py
+++ b/.github/scripts/close_low_quality_prs.py
@@ -49,6 +49,7 @@ from typing import Iterable
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from agent_shin_shared import (  # noqa: E402  -- sys.path adjusted above
+    ALLOWLIST_LOGINS,
     GRACE_COMMENT_MARKER,
     GRACE_PERIOD_SECONDS,
     GREPTILE_BOT_LOGINS,
@@ -338,12 +339,13 @@ def evaluate_pr(
     min_score: int,
     repo: str | None,
     optout_labels: set[str],
+    allowlist: frozenset[str] = ALLOWLIST_LOGINS,
 ) -> tuple[str, int | None, int | None]:
     """Decide what to do with `pr` on this triage run.
 
     Returns (action, score_or_none, age_days_or_none) where action is one of:
-        "skip-too-young", "skip-optout-label", "skip-internal",
-        "skip-no-greptile-score", "skip-score-ok",
+        "skip-too-young", "skip-optout-label", "skip-not-allowlisted",
+        "skip-internal", "skip-no-greptile-score", "skip-score-ok",
         "warn-grace", "skip-in-grace-period", or "close".
 
     Drafts are NOT skipped — the goal is "open PR count == PRs internal
@@ -373,9 +375,15 @@ def evaluate_pr(
     if min_age_days > 0 and age_days < min_age_days:
         return ("skip-too-young", None, age_days)
 
-    # Only auto-close external OSS contributors. Internal contributors
-    # (BerriAI org members) handle their own backlog.
-    if not is_external_pr_author(pr, repo):
+    # While the allowlist is active it is the sole author gate: only those
+    # logins are acted on and the external-only restriction is bypassed for
+    # them. Otherwise auto-close only external OSS contributors — internal
+    # contributors (BerriAI org members) handle their own backlog.
+    login = ((pr.get("author") or {}).get("login") or "").lower()
+    if allowlist:
+        if login not in allowlist:
+            return ("skip-not-allowlisted", None, age_days)
+    elif not is_external_pr_author(pr, repo):
         return ("skip-internal", None, age_days)
 
     comments = fetch_pr_comments(pr["number"], repo)
@@ -387,7 +395,6 @@ def evaluate_pr(
     if score >= min_score:
         return ("skip-score-ok", score, age_days)
 
-    login = ((pr.get("author") or {}).get("login") or "").lower()
     if login in IMMEDIATE_CLOSE_LOGINS:
         return ("close", score, age_days)
 
@@ -477,6 +484,7 @@ def main() -> int:
         "skip-in-grace-period": 0,
         "skip-too-young": 0,
         "skip-optout-label": 0,
+        "skip-not-allowlisted": 0,
         "skip-internal": 0,
         "skip-no-greptile-score": 0,
         "skip-score-ok": 0,

--- a/.github/scripts/triage_rollout_heads_up.py
+++ b/.github/scripts/triage_rollout_heads_up.py
@@ -47,6 +47,7 @@ if str(_SCRIPTS_DIR) not in sys.path:
 from _agent_shin_actions import maybe_post_comment  # noqa: E402
 from agent_shin_shared import (  # noqa: E402
     AGENT_SHIN_DEFAULT_BOT_LOGIN,
+    ALLOWLIST_LOGINS,
     list_open_items,
 )
 from triage_with_llm import (  # noqa: E402
@@ -326,6 +327,7 @@ def _process_one(
     dry_run: bool,
     judge: Any = None,
     skip_marker_check: bool = False,
+    allowlist: frozenset[str] = ALLOWLIST_LOGINS,
 ) -> dict:
     """Evaluate one PR/issue and post a heads-up if it would be auto-closed.
 
@@ -337,7 +339,11 @@ def _process_one(
 
     if (item.get("state") or "") != "open":
         return {**base, "action": "skip-not-open"}
-    if is_internal_contributor(item):
+    if allowlist:
+        login = (item.get("user") or {}).get("login") or ""
+        if login.lower() not in allowlist:
+            return {**base, "action": "skip-not-allowlisted"}
+    elif is_internal_contributor(item):
         return {**base, "action": "skip-internal-author"}
     if not skip_marker_check and _has_heads_up_marker(item):
         return {**base, "action": "skip-already-marked-in-body"}

--- a/.github/scripts/triage_with_llm.py
+++ b/.github/scripts/triage_with_llm.py
@@ -49,6 +49,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from agent_shin_shared import (  # noqa: E402  -- sys.path adjusted above
     AGENT_SHIN_DEFAULT_BOT_LOGIN,
+    ALLOWLIST_LOGINS,
     GRACE_COMMENT_MARKER,
     GRACE_PERIOD_SECONDS,
     GREPTILE_BOT_LOGINS,
@@ -1106,6 +1107,7 @@ def review_gate(
     grace_days: int = DEFAULT_GRACE_DAYS,
     min_greptile_score: int = DEFAULT_MIN_GREPTILE_SCORE,
     label: str = READY_FOR_REVIEW_LABEL,
+    allowlist: frozenset[str] = ALLOWLIST_LOGINS,
 ) -> dict:
     """Reconcile the `ready for review` label with a PR's current quality.
 
@@ -1157,7 +1159,10 @@ def review_gate(
     if state != "open":
         return {**base_result, "action": "skip-not-open"}
 
-    if is_internal_contributor(item):
+    if allowlist:
+        if login.lower() not in allowlist:
+            return {**base_result, "action": "skip-not-allowlisted"}
+    elif is_internal_contributor(item):
         return {**base_result, "action": "skip-internal-author"}
 
     # Resolve the comment list once — used for both the Greptile score and the
@@ -1304,6 +1309,7 @@ def triage(
     judge: Any = None,
     print_prompt: bool = False,
     reconsider: bool = False,
+    allowlist: frozenset[str] = ALLOWLIST_LOGINS,
 ) -> dict:
     """Triage a single PR or issue. Returns a result dict for logging/tests.
 
@@ -1360,7 +1366,10 @@ def triage(
         if state != "open":
             return {**base_result, "action": "skip-not-open"}
 
-    if is_internal_contributor(item):
+    if allowlist:
+        if login.lower() not in allowlist:
+            return {**base_result, "action": "skip-not-allowlisted"}
+    elif is_internal_contributor(item):
         return {**base_result, "action": "skip-internal-author"}
 
     # Reconsider-only guards — these run BEFORE the LLM call so a

--- a/tests/test_litellm/test_github_close_low_quality_prs.py
+++ b/tests/test_litellm/test_github_close_low_quality_prs.py
@@ -125,7 +125,7 @@ class TestEvaluatePr:
         created_days_ago: int = 10,
         is_draft: bool = False,
         labels: list[str] | None = None,
-        author_login: str = "someone",
+        author_login: str = "mateo-berri",
     ) -> dict:
         created = dt.datetime(2026, 5, 17, tzinfo=dt.timezone.utc) - dt.timedelta(
             days=created_days_ago
@@ -439,12 +439,13 @@ class TestEvaluatePr:
             lambda *a, **kw: pytest.fail("should not fetch comments for internal"),
         )
         action, score, _ = closer_module.evaluate_pr(
-            self._make_pr(created_days_ago=14),
+            self._make_pr(created_days_ago=14, author_login="krrishdholakia"),
             now=_now,
             min_age_days=7,
             min_score=4,
             repo=None,
             optout_labels=set(),
+            allowlist=frozenset(),
         )
         assert action == "skip-internal"
         assert score is None
@@ -732,3 +733,95 @@ class TestListOpenItemsNoCap:
         assert args[args.index("--limit") + 1] == str(shared.GH_LIST_ALL_LIMIT)
         # Still requests every field downstream evaluate_pr / labels logic needs.
         assert "createdAt" in args[args.index("--json") + 1]
+
+
+class TestEvaluatePrAllowlist:
+    """While the dogfood allowlist is active `evaluate_pr` only acts on the
+    named accounts and bypasses the external-only restriction for them.
+    Emptying it restores the internal-author skip."""
+
+    @pytest.fixture(autouse=True)
+    def _now(self):
+        return dt.datetime(2026, 5, 17, tzinfo=dt.timezone.utc)
+
+    def _make_pr(self, *, author_login: str, created_days_ago: int = 10) -> dict:
+        created = dt.datetime(2026, 5, 17, tzinfo=dt.timezone.utc) - dt.timedelta(
+            days=created_days_ago
+        )
+        return {
+            "number": 1,
+            "title": "PR #1",
+            "createdAt": created.isoformat().replace("+00:00", "Z"),
+            "isDraft": False,
+            "labels": [],
+            "author": {"login": author_login},
+            "url": "https://example.com/pr/1",
+        }
+
+    def test_should_skip_author_not_on_allowlist(
+        self, closer_module, _now, monkeypatch
+    ):
+        monkeypatch.setattr(
+            closer_module,
+            "fetch_pr_comments",
+            lambda *a, **kw: pytest.fail("must not fetch comments for non-allowlisted"),
+        )
+        action, score, _ = closer_module.evaluate_pr(
+            self._make_pr(author_login="random-oss-dev"),
+            now=_now,
+            min_age_days=0,
+            min_score=4,
+            repo=None,
+            optout_labels=set(),
+        )
+        assert action == "skip-not-allowlisted"
+        assert score is None
+
+    def test_should_act_on_allowlisted_internal_author(
+        self, closer_module, _now, monkeypatch
+    ):
+        monkeypatch.setattr(
+            closer_module, "is_external_pr_author", lambda pr, repo: False
+        )
+        monkeypatch.setattr(
+            closer_module,
+            "fetch_pr_comments",
+            lambda *a, **kw: [_greptile_comment("Confidence Score: 2/5")],
+        )
+        action, score, _ = closer_module.evaluate_pr(
+            self._make_pr(author_login="mateo-berri", created_days_ago=0),
+            now=_now,
+            min_age_days=0,
+            min_score=4,
+            repo=None,
+            optout_labels=set(),
+        )
+        assert action == "warn-grace"
+        assert score == 2
+
+    def test_empty_allowlist_restores_internal_skip(
+        self, closer_module, _now, monkeypatch
+    ):
+        monkeypatch.setattr(
+            closer_module, "is_external_pr_author", lambda pr, repo: False
+        )
+        monkeypatch.setattr(
+            closer_module,
+            "fetch_pr_comments",
+            lambda *a, **kw: pytest.fail("must not fetch comments for internal"),
+        )
+        action, score, _ = closer_module.evaluate_pr(
+            self._make_pr(author_login="krrishdholakia"),
+            now=_now,
+            min_age_days=0,
+            min_score=4,
+            repo=None,
+            optout_labels=set(),
+            allowlist=frozenset(),
+        )
+        assert action == "skip-internal"
+
+    def test_allowlist_constant_is_the_two_dogfood_accounts(self, closer_module):
+        assert closer_module.ALLOWLIST_LOGINS == frozenset(
+            {"mateo-berri", "swiftwinds"}
+        )

--- a/tests/test_litellm/test_github_review_gate.py
+++ b/tests/test_litellm/test_github_review_gate.py
@@ -79,7 +79,7 @@ def _make_pr(**overrides):
         "body": "some body without a linked issue or QA proof",
         "state": "open",
         "author_association": "NONE",
-        "user": {"login": "outside-dev"},
+        "user": {"login": "mateo-berri"},
         "labels": [],
         "created_at": JUST_NOW,
     }
@@ -392,7 +392,9 @@ class TestReviewGateGuards:
         pr = _make_pr(author_association="MEMBER", user={"login": "krrish"})
         monkeypatch.setattr(triage_module, "fetch_pr", lambda repo, n: pr)
         result = _gate(
-            triage_module, judge=lambda p: pytest.fail("no LLM for internal")
+            triage_module,
+            judge=lambda p: pytest.fail("no LLM for internal"),
+            allowlist=frozenset(),
         )
         assert result["action"] == "skip-internal-author"
 
@@ -464,3 +466,39 @@ class TestReviewGateGuards:
         assert r3["action"] == "labeled-ready"
         assert any(lbl["name"] == "ready for review" for lbl in state["labels"])
         assert "all clear" in state["comments"][-1]["body"].lower()
+
+
+class TestReviewGateAllowlist:
+    """While the dogfood allowlist is active it is the sole author gate:
+    only the named accounts pass, and for them the internal-author exemption
+    is bypassed. Emptying it restores the normal internal-author skip."""
+
+    def test_should_skip_author_not_on_allowlist(self, triage_module, monkeypatch):
+        pr = _make_pr(user={"login": "random-oss-dev"})
+        monkeypatch.setattr(triage_module, "fetch_pr", lambda repo, n: pr)
+        rec = _Recorder(triage_module, monkeypatch)
+        result = _gate(
+            triage_module, judge=lambda p: pytest.fail("no LLM for non-allowlisted")
+        )
+        assert result["action"] == "skip-not-allowlisted"
+        assert rec.added == [] and rec.comments == [] and rec.closed == []
+
+    def test_should_act_on_allowlisted_internal_author(
+        self, triage_module, monkeypatch
+    ):
+        pr = _make_pr(author_association="MEMBER", user={"login": "mateo-berri"})
+        monkeypatch.setattr(triage_module, "fetch_pr", lambda repo, n: pr)
+        rec = _Recorder(triage_module, monkeypatch)
+        result = _gate(triage_module, judge=_pass, greptile_score=5)
+        assert result["action"] == "labeled-ready"
+        assert rec.added == [triage_module.READY_FOR_REVIEW_LABEL]
+
+    def test_empty_allowlist_restores_internal_skip(self, triage_module, monkeypatch):
+        pr = _make_pr(author_association="MEMBER", user={"login": "krrish"})
+        monkeypatch.setattr(triage_module, "fetch_pr", lambda repo, n: pr)
+        result = _gate(
+            triage_module,
+            judge=lambda p: pytest.fail("no LLM for internal"),
+            allowlist=frozenset(),
+        )
+        assert result["action"] == "skip-internal-author"

--- a/tests/test_litellm/test_github_triage_with_llm.py
+++ b/tests/test_litellm/test_github_triage_with_llm.py
@@ -695,7 +695,7 @@ class TestTriageOrchestration:
             "body": "PR body",
             "state": "open",
             "author_association": "NONE",
-            "user": {"login": "outside-dev"},
+            "user": {"login": "mateo-berri"},
         }
         base.update(overrides)
         return base
@@ -716,6 +716,7 @@ class TestTriageOrchestration:
             close=True,
             model="m",
             judge=boom,
+            allowlist=frozenset(),
         )
         assert result["action"] == "skip-internal-author"
 
@@ -1199,6 +1200,7 @@ class TestTriageOrchestration:
             model="m",
             judge=lambda p: pytest.fail("LLM must not run for internal author"),
             reconsider=True,
+            allowlist=frozenset(),
         )
         assert result["action"] == "skip-internal-author"
 
@@ -1341,7 +1343,7 @@ class TestTriageOrchestration:
             "body": "## Repro\n```bash\ncurl ...\n```\n\nExpected X, got Y.",
             "state": "closed",
             "author_association": "NONE",
-            "user": {"login": "outside"},
+            "user": {"login": "mateo-berri"},
         }
         monkeypatch.setattr(triage_module, "fetch_issue", lambda repo, n: issue)
         self._stub_reconsider_guards(triage_module, monkeypatch)
@@ -1380,7 +1382,7 @@ class TestTriageOrchestration:
             "body": "no detail",
             "state": "open",
             "author_association": "NONE",
-            "user": {"login": "outside"},
+            "user": {"login": "mateo-berri"},
         }
         monkeypatch.setattr(triage_module, "fetch_issue", lambda repo, n: issue)
         # Grace already aged out -> close path. (Issues use the same
@@ -1658,9 +1660,10 @@ class TestTriageOrchestration:
     def test_should_not_treat_random_external_login_as_immediate_close(
         self, triage_module, monkeypatch
     ):
-        # Sanity check — the bypass must NOT fire for any login other
-        # than the explicitly-listed test accounts.
-        pr = self._make_pr(body="thin", user={"login": "random-oss-dev"})
+        # Sanity check — the immediate-close bypass must NOT fire for an
+        # allowlisted account that isn't in IMMEDIATE_CLOSE_LOGINS; it still
+        # goes through the normal grace path.
+        pr = self._make_pr(body="thin", user={"login": "mateo-berri"})
         monkeypatch.setattr(triage_module, "fetch_pr", lambda repo, n: pr)
         self._stub_grace_no_warning(triage_module, monkeypatch)
         posted = {}
@@ -1914,3 +1917,75 @@ class TestSecondsSinceLastGraceWarning:
         age = triage_module.seconds_since_last_grace_warning("o/r", 1)
         # Newer warning is 5 minutes (300s) before "now".
         assert age == 300.0
+
+
+class TestTriageAllowlist:
+    """The dogfood allowlist gates `triage`: while non-empty it is the sole
+    author filter (only the named accounts are acted on) and it bypasses the
+    internal-author exemption for them, so a maintainer can dogfood on their
+    own org account. Emptying it restores the internal-author skip."""
+
+    def _make_pr(self, **overrides):
+        base = {
+            "number": 1,
+            "title": "PR title",
+            "body": "Body with no linked issue and no QA proof.",
+            "state": "open",
+            "author_association": "NONE",
+            "user": {"login": "mateo-berri"},
+        }
+        base.update(overrides)
+        return base
+
+    def test_should_skip_author_not_on_allowlist(self, triage_module, monkeypatch):
+        pr = self._make_pr(user={"login": "random-oss-dev"})
+        monkeypatch.setattr(triage_module, "fetch_pr", lambda repo, n: pr)
+        result = triage_module.triage(
+            repo="o/r",
+            kind="pr",
+            number=1,
+            close=True,
+            model="m",
+            judge=lambda p: pytest.fail("LLM must not run for non-allowlisted author"),
+        )
+        assert result["action"] == "skip-not-allowlisted"
+
+    def test_should_act_on_allowlisted_internal_author(
+        self, triage_module, monkeypatch
+    ):
+        pr = self._make_pr(author_association="MEMBER", user={"login": "mateo-berri"})
+        monkeypatch.setattr(triage_module, "fetch_pr", lambda repo, n: pr)
+        result = triage_module.triage(
+            repo="o/r",
+            kind="pr",
+            number=1,
+            close=True,
+            model="m",
+            judge=lambda p: json.dumps(
+                {"verdict": "pass", "missing": [], "explanation": "ok"}
+            ),
+        )
+        assert result["action"] == "pass-llm"
+
+    def test_empty_allowlist_restores_internal_skip(self, triage_module, monkeypatch):
+        pr = self._make_pr(
+            author_association="MEMBER", user={"login": "krrishdholakia"}
+        )
+        monkeypatch.setattr(triage_module, "fetch_pr", lambda repo, n: pr)
+        result = triage_module.triage(
+            repo="o/r",
+            kind="pr",
+            number=1,
+            close=True,
+            model="m",
+            judge=lambda p: pytest.fail("LLM must not run for internal author"),
+            allowlist=frozenset(),
+        )
+        assert result["action"] == "skip-internal-author"
+
+    def test_allowlist_constant_is_the_two_dogfood_accounts(self, triage_module):
+        assert triage_module.ALLOWLIST_LOGINS == frozenset(
+            {"mateo-berri", "swiftwinds"}
+        )
+        for login in triage_module.ALLOWLIST_LOGINS:
+            assert login == login.lower(), login

--- a/tests/test_litellm/test_triage_rollout_heads_up.py
+++ b/tests/test_litellm/test_triage_rollout_heads_up.py
@@ -263,7 +263,7 @@ class TestProcessOne:
         install(
             {
                 "state": "open",
-                "user": {"login": "mateo-berri"},
+                "user": {"login": "krrishdholakia"},
                 "author_association": "MEMBER",
                 "body": "",
                 "labels": [],
@@ -277,6 +277,7 @@ class TestProcessOne:
             model="m",
             cutoff=dt.date(2026, 6, 1),
             dry_run=True,
+            allowlist=frozenset(),
         )
         assert r["action"] == "skip-internal-author"
         assert posts == []
@@ -286,7 +287,7 @@ class TestProcessOne:
         install(
             {
                 "state": "open",
-                "user": {"login": "outside-dev"},
+                "user": {"login": "mateo-berri"},
                 "author_association": "NONE",
                 "body": "Fixes #123 — clean fix with a passing rubric.",
                 "labels": [],
@@ -321,7 +322,7 @@ class TestProcessOne:
         install(
             {
                 "state": "open",
-                "user": {"login": "outside-dev"},
+                "user": {"login": "mateo-berri"},
                 "author_association": "NONE",
                 "body": "thin",
                 "labels": [],
@@ -362,7 +363,7 @@ class TestProcessOne:
         install(
             {
                 "state": "open",
-                "user": {"login": "outside-dev"},
+                "user": {"login": "mateo-berri"},
                 "author_association": "NONE",
                 "body": "X is broken",
                 "labels": [],
@@ -399,7 +400,7 @@ class TestProcessOne:
         install(
             {
                 "state": "open",
-                "user": {"login": "outside-dev"},
+                "user": {"login": "mateo-berri"},
                 "author_association": "NONE",
                 "body": "thin",
                 "labels": [],
@@ -428,7 +429,7 @@ class TestProcessOne:
         install(
             {
                 "state": "open",
-                "user": {"login": "outside-dev"},
+                "user": {"login": "mateo-berri"},
                 "author_association": "NONE",
                 "body": "thin",
                 "labels": [],
@@ -486,7 +487,7 @@ class TestRun:
 
         monkeypatch.setattr(heads_up_module, "_list_open_numbers", fake_list)
 
-        def make_item(login="outside-dev"):
+        def make_item(login="mateo-berri"):
             return {
                 "state": "open",
                 "user": {"login": login},


### PR DESCRIPTION
## Relevant issues

Stacks on top of #30433 (the combined Agent Shin branch). Merge this into that branch so the rollout can be dogfooded on a small set of accounts before it goes public.

## Linear ticket

## What this does

Adds `ALLOWLIST_LOGINS` to `agent_shin_shared.py`. While the set is non-empty Agent Shin acts ONLY on PRs/issues authored by those logins and skips everyone else with a `skip-not-allowlisted` action. The two accounts allowlisted for the dogfood are `mateo-berri` and `SwiftWinds`, so the bot can be exercised end-to-end on a work account and a personal account before any external contributor is touched.

The gate is applied in all four entrypoints: the LLM-judge `triage` (PR/issue/reconsider), the `review_gate` label lifecycle, the daily low-quality `evaluate_pr` sweep, and the rollout `_process_one` heads-up. State and opt-out-label checks still run first, so a closed PR or a `wip` draft is short-circuited before the allowlist is even consulted.

For an allowlisted author the usual internal/external classification is bypassed. `mateo-berri` is an org member, which Agent Shin would normally exempt, so without the bypass the work account could never be dogfooded; with it, both named accounts are fully triaged. SwiftWinds keeps its existing `IMMEDIATE_CLOSE_LOGINS` behavior (no grace window), while mateo-berri goes through the normal grace path.

Rolling out publicly later is a one-line change: empty `ALLOWLIST_LOGINS` and the normal internal/external triage is restored for everyone.

## Design notes

The allowlist is dependency-injected through an `allowlist` parameter on each entrypoint, defaulting to the module constant. Production reads the constant; tests inject `frozenset()` to exercise the post-rollout internal/external-skip paths without monkeypatching module state.

## Test plan

- [x] `tests/test_litellm/test_github_triage_with_llm.py::TestTriageAllowlist`
- [x] `tests/test_litellm/test_github_review_gate.py::TestReviewGateAllowlist`
- [x] `tests/test_litellm/test_github_close_low_quality_prs.py::TestEvaluatePrAllowlist`
- [x] heads-up `_process_one` allowlist coverage in `test_triage_rollout_heads_up.py`
- [x] Full suite for the five Agent Shin test files: 218 passed
- [x] Mutation check: emptying `ALLOWLIST_LOGINS` fails the skip-not-allowlisted, allowlisted-internal-author, and constant-pin tests across all entrypoints; the empty-allowlist post-rollout tests still pass

## Screenshots / Proof of Fix

This is `.github/` automation that only runs inside GitHub Actions and is dry-run unless `AGENT_SHIN_ENABLED=true`, so there's no live proxy path to curl. The behavioral proof is the mutation check above: with the allowlist active a non-allowlisted author resolves to `skip-not-allowlisted` while `mateo-berri` (org member) and `SwiftWinds` are acted on, and emptying the set restores the original internal/external behavior.

## Type

🆕 New Feature

## Changes

- `agent_shin_shared.py`: add `ALLOWLIST_LOGINS`
- `triage_with_llm.py`, `close_low_quality_prs.py`, `triage_rollout_heads_up.py`: apply the allowlist as the first author gate (after state/opt-out), bypassing internal/external classification for allowlisted authors, injectable via an `allowlist` parameter
- Tests: switch behavioral fixtures to an allowlisted author, inject an empty allowlist for the internal/external-skip tests, and add dedicated allowlist regression coverage per entrypoint


---
_Generated by [Claude Code](https://claude.ai/code/session_01Kp6FGi4dVCrEkEtkvpVE2h)_