### PR TITLE
fix(proxy): prevent forwarding MCP proxy auth tokens

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
+++ b/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
@@ -160,6 +160,10 @@ class MCPRequestHandler:
                 validated_user_api_key_auth = await user_api_key_auth(
                     api_key=litellm_api_key, request=request
                 )
+                # The Authorization header was consumed as LiteLLM/proxy auth
+                # (including JWT auth). Do not also treat it as an upstream
+                # OAuth token for MCP servers.
+                oauth2_headers = {}
             except (HTTPException, ProxyException) as e:
                 # HTTPException.status_code is int; ProxyException.code is
                 # normalized to str in its __init__ but can be ``"None"`` or any

--- a/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
@@ -677,6 +677,39 @@ class TestMCPOAuth2AuthFlow:
             assert auth_result.api_key == "Bearer sk-litellm-valid-key"
             mock_auth.assert_called_once()
 
+    async def test_authorization_consumed_by_litellm_auth_is_not_forwarded(self):
+        """
+        When Authorization successfully authenticates the caller to LiteLLM,
+        it must not be reused as an upstream OAuth2 token for MCP servers.
+        """
+        scope = {
+            "type": "http",
+            "method": "POST",
+            "path": "/mcp/some_server",
+            "headers": [
+                (b"authorization", b"Bearer user-idp-jwt"),
+            ],
+        }
+
+        async def mock_user_api_key_auth(api_key, request):
+            return UserAPIKeyAuth(api_key=api_key, user_id="test-user")
+
+        with patch(
+            "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.user_api_key_auth",
+            side_effect=mock_user_api_key_auth,
+        ):
+            (
+                auth_result,
+                _,
+                _,
+                _,
+                oauth2_headers,
+                _,
+            ) = await MCPRequestHandler.process_mcp_request(scope)
+
+            assert auth_result.user_id == "test-user"
+            assert oauth2_headers == {}
+
     async def test_non_auth_http_exception_still_raises(self):
         """
         If user_api_key_auth raises a non-401/403 HTTPException (e.g., 500),


### PR DESCRIPTION
## What

Fixes #30559.

When an MCP request authenticates to LiteLLM using the `Authorization` header, that same header was still kept in `oauth2_headers` and could be forwarded to upstream MCP servers configured with `auth_type=oauth2`. This clears `oauth2_headers` after the header is successfully consumed by LiteLLM/proxy auth, while preserving the existing OAuth passthrough fallback when LiteLLM auth fails for an OAuth2 MCP target.

## Tests

- `/Users/parafee41/Desktop/开源社区/repos/litellm/.venv-pr/bin/python -m pytest tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py -k "authorization_consumed_by_litellm_auth_is_not_forwarded or litellm_key_in_authorization_backward_compat or oauth2_token_in_authorization_header_fallback or explicit_litellm_key_with_oauth2_authorization"`
- `/Users/parafee41/Desktop/开源社区/repos/litellm/.venv-pr/bin/python -m pytest tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py`
- `/Users/parafee41/Desktop/开源社区/repos/litellm/.venv-pr/bin/python -m black --check litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py`
- `git diff --check`