### PR TITLE
fix(anthropic): apply cache_control_injection_points on /v1/messages route

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,6 @@ curl -X POST 'http://0.0.0.0:4000/v1/chat/completions' \
 | [Galadriel (`galadriel`)](https://docs.litellm.ai/docs/providers/galadriel) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
 | [GitHub Copilot (`github_copilot`)](https://docs.litellm.ai/docs/providers/github_copilot) | ✅ | ✅ | ✅ | ✅ |  |  |  |  |  |  |
 | [GitHub Models (`github`)](https://docs.litellm.ai/docs/providers/github) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Google - PaLM](https://docs.litellm.ai/docs/providers/palm) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
 | [Google - Vertex AI (`vertex_ai`)](https://docs.litellm.ai/docs/providers/vertex) | ✅ | ✅ | ✅ | ✅ | ✅ |  |  |  |  |  |
 | [Google AI Studio - Gemini (`gemini`)](https://docs.litellm.ai/docs/providers/gemini) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
 | [GradientAI (`gradient_ai`)](https://docs.litellm.ai/docs/providers/gradient_ai) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
@@ -324,7 +323,6 @@ curl -X POST 'http://0.0.0.0:4000/v1/chat/completions' \
 | [LiteLLM Proxy (`litellm_proxy`)](https://docs.litellm.ai/docs/providers/litellm_proxy) | ✅ | ✅ | ✅ | ✅ | ✅ |  |  |  |  |  |
 | [Llamafile (`llamafile`)](https://docs.litellm.ai/docs/providers/llamafile) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
 | [LM Studio (`lm_studio`)](https://docs.litellm.ai/docs/providers/lm_studio) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Maritalk (`maritalk`)](https://docs.litellm.ai/docs/providers/maritalk) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
 | [Meta - Llama API (`meta_llama`)](https://docs.litellm.ai/docs/providers/meta_llama) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
 | [Mistral AI API (`mistral`)](https://docs.litellm.ai/docs/providers/mistral) | ✅ | ✅ | ✅ | ✅ |  |  |  |  |  |  |
 | [Moonshot (`moonshot`)](https://docs.litellm.ai/docs/providers/moonshot) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
@@ -457,7 +455,7 @@ For companies that need better security, user management and professional suppor
 [Talk to founders](https://enterprise.litellm.ai/demo)
 
 This covers:
-- ✅ **Features under the [LiteLLM Commercial License](https://docs.litellm.ai/docs/proxy/enterprise):**
+- ✅ **Features under the [LiteLLM Commercial License](https://docs.litellm.ai/docs/enterprise):**
 - ✅ **Feature Prioritization**
 - ✅ **Custom Integrations**
 - ✅ **Professional Support - Dedicated discord + slack**

--- a/enterprise/README.md
+++ b/enterprise/README.md
@@ -6,4 +6,4 @@ Code in this folder is licensed under a commercial license. Please review the [L
 
 👉 **Using in an Enterprise / Need specific features ?** Meet with us [here](https://enterprise.litellm.ai/demo?month=2024-02)
 
-See all Enterprise Features here 👉 [Docs](https://docs.litellm.ai/docs/proxy/enterprise)
+See all Enterprise Features here 👉 [Docs](https://docs.litellm.ai/docs/enterprise)

--- a/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
@@ -251,6 +251,17 @@ async def anthropic_messages(
             prompt_variables=None,
             dynamic_callback_params={},
         )
+        # The hook pops `cache_control_injection_points` from
+        # `request_kwargs` once all message-level points are consumed; if
+        # non-message points (e.g. `tool_config`) remain, the hook
+        # re-inserts the key. Sync the outer `kwargs` so stale entries
+        # don't leak downstream — see greptile P1 on #30615.
+        if "cache_control_injection_points" in request_kwargs:
+            kwargs["cache_control_injection_points"] = request_kwargs[
+                "cache_control_injection_points"
+            ]
+        else:
+            kwargs.pop("cache_control_injection_points", None)
 
     # Extract modified parameters. Pop every named param of `anthropic_messages`
     # that we may forward explicitly downstream, so we (a) honor pre-request hook

--- a/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
@@ -229,6 +229,29 @@ async def anthropic_messages(
         **kwargs,
     )
 
+    # Apply the AnthropicCacheControlHook when the deployment has
+    # `cache_control_injection_points` configured in its litellm_params.
+    # Without this call, the proxy-level cache control config is silently
+    # ignored for /v1/messages (Anthropic Messages) requests, even though
+    # it works for /chat/completions on the same deployment. The hook
+    # injects cache_control breakpoints into the messages at the
+    # configured locations so that Anthropic / Bedrock / Vertex can write
+    # the prompt cache. See #30293.
+    if request_kwargs.get("cache_control_injection_points"):
+        from litellm.integrations.anthropic_cache_control_hook import (
+            AnthropicCacheControlHook,
+        )
+
+        cache_control_hook = AnthropicCacheControlHook()
+        _, messages, request_kwargs = cache_control_hook.get_chat_completion_prompt(
+            model=model,
+            messages=messages,
+            non_default_params=request_kwargs,
+            prompt_id=None,
+            prompt_variables=None,
+            dynamic_callback_params={},
+        )
+
     # Extract modified parameters. Pop every named param of `anthropic_messages`
     # that we may forward explicitly downstream, so we (a) honor pre-request hook
     # overrides and (b) avoid duplicate-keyword conflicts when splatting `kwargs`

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
@@ -105,6 +105,66 @@ async def test_anthropic_messages_sanitizes_empty_text_blocks_before_dispatch():
     assert len(msgs[0]["content"]) == 2  # caller untouched
 
 
+@pytest.mark.asyncio
+async def test_anthropic_messages_applies_cache_control_injection_points():
+    """Regression test for #30293.
+
+    When a deployment has `cache_control_injection_points` configured in
+    its `litellm_params`, the AnthropicCacheControlHook must fire on the
+    /v1/messages (Anthropic Messages) path so that the proxy-level cache
+    breakpoints are injected into the request. Previously the hook only
+    fired for /chat/completions, so Anthropic-format clients (Anthropic
+    SDK, Claude Code) on the same deployment got no cache benefit.
+    """
+    from litellm.llms.anthropic.experimental_pass_through.messages import handler
+
+    msgs = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "Hi there."},
+        {"role": "user", "content": "Tell me a long story about caching."},
+    ]
+    captured = {}
+
+    def fake_handler(*args, **kwargs):
+        captured["messages"] = kwargs.get("messages")
+        return "stub"
+
+    fake_loop = MagicMock()
+    fake_loop.run_in_executor = lambda _e, func: _async_return(func())
+
+    with (
+        patch.object(handler, "anthropic_messages_handler", side_effect=fake_handler),
+        patch("asyncio.get_event_loop", return_value=fake_loop),
+    ):
+        await handler.anthropic_messages(
+            max_tokens=100,
+            messages=msgs,
+            model="vertex_ai/claude-opus-4-6",
+            custom_llm_provider="vertex_ai-anthropic_models",
+            api_key="k",
+            cache_control_injection_points=[
+                {"location": "message", "role": "system"},
+                {"location": "message", "index": -1},
+            ],
+        )
+
+    # The first (system) message must have cache_control injected.
+    assert captured["messages"][0].get("cache_control") == {
+        "type": "ephemeral"
+    }, "AnthropicCacheControlHook must inject cache_control on the system message"
+    # The last (user) message must have cache_control injected.
+    assert captured["messages"][-1].get("cache_control") == {
+        "type": "ephemeral"
+    }, "AnthropicCacheControlHook must inject cache_control on the last user message"
+    # The intermediate messages must be untouched (no cache_control added).
+    for msg in captured["messages"][1:-1]:
+        assert msg.get("cache_control") is None
+    # Caller's original messages must not be mutated.
+    assert msgs[0].get("cache_control") is None
+    assert msgs[-1].get("cache_control") is None
+
+
 async def _async_return(value):
     return value
 

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
@@ -165,6 +165,66 @@ async def test_anthropic_messages_applies_cache_control_injection_points():
     assert msgs[-1].get("cache_control") is None
 
 
+@pytest.mark.asyncio
+async def test_anthropic_messages_does_not_leak_cache_control_injection_points_kwarg():
+    """Regression test for the greptile P1 finding on #30615.
+
+    After the AnthropicCacheControlHook runs, `cache_control_injection_points`
+    must NOT be in the kwargs that are forwarded to the dispatch handler.
+    The hook consumes all message-level points and pops the key from
+    `request_kwargs`; if the caller's outer `kwargs` dict still has the
+    key, it will be passed downstream to anthropic_messages_handler and
+    may be re-applied or sent to the backend, leading to double-injection
+    or unexpected behavior.
+
+    The fix: after the hook call, sync the outer `kwargs` with
+    `request_kwargs` — if the hook re-inserted the key (for non-message
+    points like tool_config), keep the updated value; otherwise pop it
+    from the outer kwargs.
+    """
+    from litellm.llms.anthropic.experimental_pass_through.messages import handler
+
+    msgs = [
+        {"role": "system", "content": "s"},
+        {"role": "user", "content": "u"},
+    ]
+    captured = {}
+
+    def fake_handler(*args, **kwargs):
+        captured["kwargs"] = kwargs
+        captured["messages"] = kwargs.get("messages")
+        return "stub"
+
+    fake_loop = MagicMock()
+    fake_loop.run_in_executor = lambda _e, func: _async_return(func())
+
+    with (
+        patch.object(handler, "anthropic_messages_handler", side_effect=fake_handler),
+        patch("asyncio.get_event_loop", return_value=fake_loop),
+    ):
+        await handler.anthropic_messages(
+            max_tokens=100,
+            messages=msgs,
+            model="vertex_ai/claude-opus-4-6",
+            custom_llm_provider="vertex_ai-anthropic_models",
+            api_key="k",
+            cache_control_injection_points=[
+                {"location": "message", "role": "system"},
+            ],
+        )
+
+    # cache_control_injection_points must NOT leak into the dispatch kwargs
+    # when the hook has consumed all points. (If non-message points remained,
+    # the hook would re-insert it and we'd see it; but the test config has
+    # only message-level points, so the hook fully consumes the list.)
+    assert "cache_control_injection_points" not in captured["kwargs"], (
+        f"cache_control_injection_points leaked into dispatch kwargs: "
+        f"{captured['kwargs'].get('cache_control_injection_points')!r}. "
+        f"The hook consumes all message-level points and pops the key, "
+        f"so it must not appear in the outer kwargs after the hook runs."
+    )
+
+
 async def _async_return(value):
     return value
 


### PR DESCRIPTION
## What / Why

Fixes #30293.

When a deployment has `cache_control_injection_points` configured in its `litellm_params`, the `AnthropicCacheControlHook` correctly fires on the `/chat/completions` path and injects cache_control breakpoints into the messages — but the same hook was **never invoked for the `/v1/messages` (Anthropic Messages) path**. So Anthropic-format clients (Anthropic SDK, Claude Code, etc.) on the same deployment get no cache benefit, even though the config is in effect.

## Root cause

`litellm/llms/anthropic/experimental_pass_through/messages/handler.py` runs `_execute_pre_request_hooks` (which calls `async_pre_request_hook` on registered `CustomLogger` instances) but does not invoke the **prompt-management** hook system that `AnthropicCacheControlHook` is wired into. The hook's `get_chat_completion_prompt` method — which is the only place that injects cache_control breakpoints into messages — is therefore never called for `/v1/messages` requests.

The same hook DOES fire on the `/chat/completions` path because `litellm/main.py` calls `litellm_logging_obj.should_run_prompt_management_hooks(...) && async_get_chat_completion_prompt(...)` in the completion dispatch path.

## Fix

After `_execute_pre_request_hooks` returns, check whether the request now carries `cache_control_injection_points` (set by the router from `deployment.litellm_params` at `router.py:4746`), and if so, instantiate `AnthropicCacheControlHook` and invoke its `get_chat_completion_prompt` method. The hook mutates a deep copy of the messages and re-inserts the param (now possibly empty / reduced) into the request_kwargs dict via the existing `_execute_pre_request_hooks` return contract; the subsequent `kwargs.update(request_kwargs)` merges those changes back into the final kwargs. The fix is therefore transparent to the dispatch path and to any post-cache-control code that runs after this block.

```diff
+    # Apply the AnthropicCacheControlHook when the deployment has
+    # `cache_control_injection_points` configured in its litellm_params.
+    # Without this call, the proxy-level cache control config is silently
+    # ignored for /v1/messages (Anthropic Messages) requests, even though
+    # it works for /chat/completions on the same deployment. The hook
+    # injects cache_control breakpoints into the messages at the
+    # configured locations so that Anthropic / Bedrock / Vertex can write
+    # the prompt cache. See #30293.
+    if request_kwargs.get("cache_control_injection_points"):
+        from litellm.integrations.anthropic_cache_control_hook import (
+            AnthropicCacheControlHook,
+        )
+
+        cache_control_hook = AnthropicCacheControlHook()
+        _, messages, request_kwargs = cache_control_hook.get_chat_completion_prompt(
+            model=model,
+            messages=messages,
+            non_default_params=request_kwargs,
+            prompt_id=None,
+            prompt_variables=None,
+            dynamic_callback_params={},
+        )
```

The change is a no-op when `cache_control_injection_points` is absent: if the param is not in request_kwargs we never import the hook, never allocate the deep copy, and never run the injection loop. Existing `/chat/completions` behavior is unaffected — that path uses `async_get_chat_completion_prompt` on the LiteLLMLoggingObj in main.py, a separate code path that this change does not touch.

## Test

Adds `test_anthropic_messages_applies_cache_control_injection_points` in `tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py`. The test:
- Patches `anthropic_messages_handler` to capture the messages it sees.
- Calls `anthropic_messages` with `cache_control_injection_points` configured to inject on the system message and on the last message (`index: -1`).
- Asserts that the captured messages have `cache_control` set on those indices, that intermediate messages are untouched, and that the caller's original messages list was not mutated.

## Diff

```
litellm/llms/anthropic/experimental_pass_through/messages/handler.py       | 23 +++++++++
tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py | 60 ++++++++++++++++++++++++++++++
2 files changed, 83 insertions(+)
```