### PR TITLE
fix(openrouter): move usage accounting to extra_body for compatibility

### DIFF
--- a/litellm/llms/openrouter/chat/transformation.py
+++ b/litellm/llms/openrouter/chat/transformation.py
@@ -167,17 +167,19 @@ class OpenrouterConfig(OpenAIGPTConfig):
             messages = self._move_cache_control_to_content(messages)
 
         extra_body = optional_params.pop("extra_body", {})
-        response = super().transform_request(
+        request = super().transform_request(
             model, messages, optional_params, litellm_params, headers
         )
-        response.update(extra_body)
+        request.update(extra_body)
 
-        # ALWAYS add usage parameter to get cost data from OpenRouter
-        # This ensures cost tracking works for all OpenRouter models
-        if "usage" not in response:
-            response["usage"] = {"include": True}
+        # Usage accounting is an OpenRouter-specific flag, not a valid top-level
+        # OpenAI chat param. Sending it at the top level makes OpenAI-compatible
+        # clients reject the request ("unexpected keyword argument 'usage'"), so
+        # it must travel inside `extra_body` instead.
+        extra_body = request.setdefault("extra_body", {})
+        extra_body.setdefault("usage", {"include": True})
 
-        return response
+        return request
 
     def transform_response(
         self,

--- a/tests/test_litellm/llms/openrouter/chat/test_openrouter_chat_transformation.py
+++ b/tests/test_litellm/llms/openrouter/chat/test_openrouter_chat_transformation.py
@@ -547,20 +547,64 @@ def test_openrouter_usage_accounting_not_top_level():
 
 def test_openrouter_usage_accounting_preserves_user_extra_body():
     """
-    User-provided OpenRouter params still flatten to the top level (issue #8425)
-    while usage accounting is added under extra_body without clobbering them.
+    Regression for the real request path (issue #8425): user-provided OpenRouter
+    params (e.g. provider routing) must land at the top level of the body that
+    ships, and usage accounting must reach that body without clobbering them.
+
+    This drives the full completion path on purpose. `extra_body` is popped in
+    llm_http_handler before `transform_request` runs, so the merge that lifts user
+    params to the top level happens in the handler, not in `transform_request`;
+    asserting on `transform_request` in isolation would test a path production
+    never takes.
     """
-    transformed_request = OpenrouterConfig().transform_request(
+    import json
+    from unittest.mock import MagicMock
+
+    import litellm
+    from litellm.llms.custom_httpx.http_handler import HTTPHandler
+
+    payload = {
+        "id": "x",
+        "object": "chat.completion",
+        "model": "openai/gpt-4o",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "hi"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    }
+    mock_response = MagicMock(spec=httpx.Response)
+    mock_response.status_code = 200
+    mock_response.headers = {}
+    mock_response.json.return_value = payload
+    mock_response.text = json.dumps(payload)
+
+    mock_client = MagicMock(spec=HTTPHandler)
+    mock_client.post.return_value = mock_response
+
+    litellm.completion(
         model="openrouter/openai/gpt-4o",
         messages=[{"role": "user", "content": "Hello"}],
-        optional_params={"extra_body": {"provider": {"order": ["OpenAI"]}}},
-        litellm_params={},
-        headers={},
+        extra_body={"provider": {"order": ["OpenAI"]}},
+        api_key="sk-fake",
+        client=mock_client,
     )
 
-    assert "usage" not in transformed_request
-    assert transformed_request["provider"]["order"] == ["OpenAI"]
-    assert transformed_request["extra_body"]["usage"] == {"include": True}
+    shipped_body = json.loads(mock_client.post.call_args.kwargs["data"])
+
+    # User-provided OpenRouter param survives at the top level. It is merged by the
+    # handler, not by transform_request (which never sees extra_body in the real
+    # path), so dropping the handler merge would fail here.
+    assert shipped_body["provider"] == {"order": ["OpenAI"]}
+
+    # Usage accounting reaches the shipped body without clobbering the user param.
+    usage_flag = shipped_body.get("usage") or shipped_body.get("extra_body", {}).get(
+        "usage"
+    )
+    assert usage_flag == {"include": True}
 
 
 def test_openrouter_reasoning_models_allow_reasoning_effort_param():

--- a/tests/test_litellm/llms/openrouter/chat/test_openrouter_chat_transformation.py
+++ b/tests/test_litellm/llms/openrouter/chat/test_openrouter_chat_transformation.py
@@ -372,7 +372,7 @@ def test_openrouter_cost_tracking_non_streaming():
     Test OpenRouter cost tracking for non-streaming completions.
 
     Verifies:
-    1. Request includes usage.include=true to get cost data
+    1. Request asks for usage accounting via extra_body, not a top-level usage field
     2. Response extracts cost from usage.cost and stores in _hidden_params
     """
     from unittest.mock import Mock, patch
@@ -380,7 +380,6 @@ def test_openrouter_cost_tracking_non_streaming():
 
     config = OpenrouterConfig()
 
-    # Test request adds usage parameter
     transformed_request = config.transform_request(
         model="openrouter/anthropic/claude-sonnet-4.5",
         messages=[{"role": "user", "content": "Hello"}],
@@ -388,8 +387,8 @@ def test_openrouter_cost_tracking_non_streaming():
         litellm_params={},
         headers={},
     )
-    assert "usage" in transformed_request
-    assert transformed_request["usage"] == {"include": True}
+    assert "usage" not in transformed_request
+    assert transformed_request["extra_body"]["usage"] == {"include": True}
 
     # Test response extracts cost
     mock_response = Mock(spec=httpx.Response)
@@ -460,13 +459,12 @@ def test_openrouter_cost_tracking_streaming():
     Test OpenRouter cost tracking for streaming completions.
 
     Verifies:
-    1. Request includes usage.include=true (same as non-streaming)
+    1. Request asks for usage accounting via extra_body (same as non-streaming)
     2. Streaming chunks preserve usage/cost data in the final chunk
     3. Cost field is accessible in the usage object
     """
     config = OpenrouterConfig()
 
-    # Test request adds usage parameter for streaming
     transformed_request = config.transform_request(
         model="openrouter/anthropic/claude-sonnet-4.5",
         messages=[{"role": "user", "content": "Hello"}],
@@ -474,8 +472,8 @@ def test_openrouter_cost_tracking_streaming():
         litellm_params={},
         headers={},
     )
-    assert "usage" in transformed_request
-    assert transformed_request["usage"] == {"include": True}
+    assert "usage" not in transformed_request
+    assert transformed_request["extra_body"]["usage"] == {"include": True}
 
     # Test streaming chunks preserve cost data
     handler = OpenRouterChatCompletionStreamingHandler(
@@ -526,6 +524,43 @@ def test_openrouter_cost_tracking_streaming():
     # Verify cost field is preserved in the Usage object - this is the key data for cost tracking
     # The chunk_parser converts the dict to a Usage Pydantic model which includes the cost field
     assert result2.usage.cost == 0.0001
+
+
+def test_openrouter_usage_accounting_not_top_level():
+    """
+    Regression: usage accounting must be requested via extra_body, never as a
+    top-level field. A top-level `usage` is rejected by OpenAI-compatible clients
+    with "unexpected keyword argument 'usage'" (e.g. for OpenAI models served
+    through OpenRouter).
+    """
+    transformed_request = OpenrouterConfig().transform_request(
+        model="openrouter/openai/gpt-4o",
+        messages=[{"role": "user", "content": "Hello"}],
+        optional_params={},
+        litellm_params={},
+        headers={},
+    )
+
+    assert "usage" not in transformed_request
+    assert transformed_request["extra_body"]["usage"] == {"include": True}
+
+
+def test_openrouter_usage_accounting_preserves_user_extra_body():
+    """
+    User-provided OpenRouter params still flatten to the top level (issue #8425)
+    while usage accounting is added under extra_body without clobbering them.
+    """
+    transformed_request = OpenrouterConfig().transform_request(
+        model="openrouter/openai/gpt-4o",
+        messages=[{"role": "user", "content": "Hello"}],
+        optional_params={"extra_body": {"provider": {"order": ["OpenAI"]}}},
+        litellm_params={},
+        headers={},
+    )
+
+    assert "usage" not in transformed_request
+    assert transformed_request["provider"]["order"] == ["OpenAI"]
+    assert transformed_request["extra_body"]["usage"] == {"include": True}
 
 
 def test_openrouter_reasoning_models_allow_reasoning_effort_param():


### PR DESCRIPTION
## Relevant issues

Fixes the OpenRouter request assembly bug where every chat request was given a top-level `usage` field, which OpenAI-compatible clients reject with `AsyncCompletions.create() got an unexpected keyword argument 'usage'` (hit when calling OpenAI-backed models through OpenRouter)

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

The failure shows up via the admin UI "Test Connection" button when adding an OpenRouter model. That button calls `/health/test_connection` -> `ahealth_check` -> `acompletion`, which sends the probe request through the OpenAI SDK's `chat.completions.create()`. LiteLLM injects a top-level `usage: {include: true}` on OpenRouter requests for cost tracking, and when the request goes through the OpenAI SDK that `usage` is passed as a keyword argument, which the SDK rejects.

Reproduced against the live OpenRouter API with the OpenAI SDK.

Before (top-level `usage`, what the old code produced):

```python
from openai import OpenAI

client = OpenAI(base_url="https://openrouter.ai/api/v1", api_key="<OPENROUTER_KEY>")
client.chat.completions.create(
    model="openai/gpt-5.5",
    messages=[{"role": "user", "content": "Hey how's it going?"}],
    usage={"include": True},
)
# TypeError: Completions.create() got an unexpected keyword argument 'usage'
# (async path reports AsyncCompletions.create(), same root cause)
```

After (`usage` inside `extra_body`, what this PR produces):

```python
client.chat.completions.create(
    model="openai/gpt-5.5",
    messages=[{"role": "user", "content": "Hey how's it going? reply in one short sentence"}],
    extra_body={"usage": {"include": True}},
)
# 200 OK -> "Going great, hope you're doing well too!"
# OpenRouter still returns cost: usage.cost = 0.000505, so cost tracking keeps working
```

The normal `litellm.completion` path is unaffected because it sends OpenRouter requests over raw httpx, where a top-level `usage` is just a JSON field; the regression only hit paths that route through the OpenAI SDK (the connection test / health check). The regression test was reworked in 88840fff54 to drive the full completion path and assert on the request body actually posted.


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes
