### PR TITLE
fix(sdk): type suppress debug info setting

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -413,7 +413,7 @@ anthropic_beta_headers_url: str = os.getenv(
     "LITELLM_ANTHROPIC_BETA_HEADERS_URL",
     "https://raw.githubusercontent.com/BerriAI/litellm/main/litellm/anthropic_beta_headers_config.json",
 )
-suppress_debug_info = False
+suppress_debug_info: bool = False
 dynamodb_table_name: Optional[str] = None
 s3_callback_params: Optional[Dict] = None
 s3_audit_callback_params: Optional[Dict] = None

--- a/tests/test_litellm/test_litellm_init.py
+++ b/tests/test_litellm/test_litellm_init.py
@@ -1,0 +1,5 @@
+import litellm
+
+
+def test_suppress_debug_info_has_bool_type_annotation() -> None:
+    assert litellm.__annotations__.get("suppress_debug_info") == "bool"


### PR DESCRIPTION
## Relevant issues

Fixes #30523

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Focused regression test:

```shell
.venv/bin/python -m pytest tests/test_litellm/test_litellm_init.py -q
1 passed, 2 warnings in 0.07s
```

Formatting check:

```shell
.venv/bin/python -m black --check litellm/__init__.py tests/test_litellm/test_litellm_init.py
2 files would be left unchanged.
```

`make test-unit` was not run locally because `uv` is not installed in this environment.

## Type

Bug Fix
Test

## Changes

Adds a `bool` annotation to `litellm.suppress_debug_info` so type checkers treat reassignment to `True` as valid. Adds a focused regression test for the exported module annotation.
