### PR TITLE
fix(proxy): include model group aliases in v1 model info

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -12943,7 +12943,6 @@ async def model_info_v1(
     alias_models = copy.deepcopy(llm_router.get_model_list_from_model_alias())
     all_models.extend(alias_models)
 
-
     allowed_model_names = _get_v1_model_info_allowed_model_names(
         user_api_key_dict=user_api_key_dict,
         llm_router=llm_router,

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -12939,7 +12939,11 @@ async def model_info_v1(
     # expanded model names from get_complete_model_list(). Team-scoped rows
     # use internal routing keys (model_name_{team_id}_{uuid}) and were omitted
     # when v1 resolved models only via public model_name strings.
-    all_models: List[dict] = copy.deepcopy(llm_router.get_model_list() or [])
+    all_models: List[dict] = copy.deepcopy(llm_router.model_list)
+    alias_models = copy.deepcopy(llm_router.get_model_list_from_model_alias())
+    all_models.extend(alias_models)
+
+
     allowed_model_names = _get_v1_model_info_allowed_model_names(
         user_api_key_dict=user_api_key_dict,
         llm_router=llm_router,

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -12939,7 +12939,7 @@ async def model_info_v1(
     # expanded model names from get_complete_model_list(). Team-scoped rows
     # use internal routing keys (model_name_{team_id}_{uuid}) and were omitted
     # when v1 resolved models only via public model_name strings.
-    all_models: List[dict] = copy.deepcopy(llm_router.model_list)
+    all_models: List[dict] = copy.deepcopy(llm_router.get_model_list() or [])
     allowed_model_names = _get_v1_model_info_allowed_model_names(
         user_api_key_dict=user_api_key_dict,
         llm_router=llm_router,

--- a/tests/proxy_unit_tests/test_proxy_server.py
+++ b/tests/proxy_unit_tests/test_proxy_server.py
@@ -2087,6 +2087,48 @@ async def test_gemini_pass_through_endpoint():
 
 @pytest.mark.parametrize("hidden", [True, False])
 @pytest.mark.asyncio
+async def test_model_info_alias_without_prisma(hidden):
+    from litellm.proxy.proxy_server import model_info_v1
+
+    _model_list = [
+        {
+            "model_name": "gpt-3.5-turbo",
+            "litellm_params": {"model": "gpt-3.5-turbo"},
+        }
+    ]
+
+    model_alias = "gpt-4"
+
+    router = litellm.Router(
+        model_list=_model_list,
+        model_group_alias={
+            model_alias: {
+                "model": "gpt-3.5-turbo",
+                "hidden": hidden,
+            }
+        },
+    )
+
+    setattr(litellm.proxy.proxy_server, "llm_router", router)
+    setattr(litellm.proxy.proxy_server, "llm_model_list", _model_list)
+    setattr(litellm.proxy.proxy_server, "prisma_client", None)
+
+    resp = await model_info_v1(
+        user_api_key_dict=UserAPIKeyAuth(models=[]),
+    )
+
+    models = resp["data"]
+
+    alias_found = any(
+        m["model_name"] == model_alias
+        for m in models
+    )
+
+    assert alias_found is (not hidden)
+
+    
+@pytest.mark.parametrize("hidden", [True, False])
+@pytest.mark.asyncio
 @pytest.mark.skip(reason="Requires reliable external DB connection (prisma).")
 async def test_proxy_model_group_alias_checks(prisma_client, hidden):
     """


### PR DESCRIPTION
## Relevant issues

Fixes  #30589 

/v1/model/info did not include models exposed through model_group_alias because it was reading directly from llm_router.model_list, which excludes alias-backed models.

## Linear ticket


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

<img width="1920" height="599" alt="Screenshot 2026-06-17 125022" src="https://github.com/user-attachments/assets/435511be-80c2-4db1-953c-f7d14a5edfb6" />


## Type

🐛 Bug Fix
✅ Test

## Changes

## Summary 

/v1/model/info was building its response from llm_router.model_list which excludes models defined through model_group_alias.

This change updates the endpoint to use llm_router.get_model_list(), ensuring alias-backed models are included in the response while continuing to respect hidden aliases.

## Code Changes

- Updated `model_info_v1` to use:

  `copy.deepcopy(llm_router.get_model_list() or [])`

  instead of:

  `copy.deepcopy(llm_router.model_list)`

- Added regression test:
  `test_model_info_alias_without_prisma`


## Testing 

### Verified with:

```bash
python -m pytest tests/proxy_unit_tests/test_proxy_server.py \
-k model_info_alias_without_prisma -vv
```


### Results:
- test_model_info_alias_without_prisma[False] ✅
- test_model_info_alias_without_prisma[True] ✅

The new test confirms that:
- visible aliases appear in /v1/model/info
- hidden aliases remain excluded