### PR TITLE
fix(proxy): expose model_group_alias entries in /model/info

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -12948,9 +12948,16 @@ async def model_info_v1(
     # model_name to the alias and skips hidden (dict-style `hidden: true`)
     # entries; deep-copy so the downstream enrich/translate steps never mutate
     # the shared router deployment records.
+    #
+    # Like any model group, an alias backed by several deployments expands to one
+    # row per backing deployment -- this is the same per-deployment granularity
+    # /model/info already uses for non-alias groups, and it lets the access
+    # filters below keep exactly the deployments the caller can reach. The
+    # base_model_names guard only skips aliases whose name collides with a real
+    # model_list model_name, so an alias never double-lists an existing entry.
     base_model_names = {model.get("model_name") for model in all_models}
     all_models.extend(
-        copy.deepcopy(dict(alias_deployment))
+        copy.deepcopy(alias_deployment)
         for alias_deployment in llm_router.get_model_list_from_model_alias()
         if alias_deployment.get("model_name") not in base_model_names
     )

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -12940,6 +12940,21 @@ async def model_info_v1(
     # use internal routing keys (model_name_{team_id}_{uuid}) and were omitted
     # when v1 resolved models only via public model_name strings.
     all_models: List[dict] = copy.deepcopy(llm_router.model_list)
+
+    # Aliases declared under router_settings.model_group_alias are not stored in
+    # llm_router.model_list, so listing model_list alone dropped them here even
+    # though /models exposes them (#5524). Expand non-hidden aliases so both
+    # endpoints agree. get_model_list_from_model_alias() already overrides
+    # model_name to the alias and skips hidden (dict-style `hidden: true`)
+    # entries; deep-copy so the downstream enrich/translate steps never mutate
+    # the shared router deployment records.
+    base_model_names = {model.get("model_name") for model in all_models}
+    all_models.extend(
+        copy.deepcopy(dict(alias_deployment))
+        for alias_deployment in llm_router.get_model_list_from_model_alias()
+        if alias_deployment.get("model_name") not in base_model_names
+    )
+
     allowed_model_names = _get_v1_model_info_allowed_model_names(
         user_api_key_dict=user_api_key_dict,
         llm_router=llm_router,

--- a/tests/proxy_unit_tests/test_proxy_server.py
+++ b/tests/proxy_unit_tests/test_proxy_server.py
@@ -2087,27 +2087,21 @@ async def test_gemini_pass_through_endpoint():
 
 @pytest.mark.parametrize("hidden", [True, False])
 @pytest.mark.asyncio
-@pytest.mark.skip(reason="Requires reliable external DB connection (prisma).")
-async def test_proxy_model_group_alias_checks(prisma_client, hidden):
+async def test_proxy_model_group_alias_checks(hidden):
     """
     Check if model group alias is returned on
 
     `/v1/models`
     `/v1/model/info`
     `/v1/model_group/info`
+
+    Runs without a DB connection: `prisma_client` is set to None so the
+    handlers exercise the in-memory router path only (see #30589).
     """
-    import json
-
-    from fastapi import HTTPException, Request, Response
-    from starlette.datastructures import URL
-
     from litellm.proxy.proxy_server import model_group_info, model_info_v1, model_list
 
-    setattr(litellm.proxy.proxy_server, "prisma_client", prisma_client)
+    setattr(litellm.proxy.proxy_server, "prisma_client", None)
     setattr(litellm.proxy.proxy_server, "master_key", "sk-1234")
-    await litellm.proxy.proxy_server.prisma_client.connect()
-
-    proxy_config = getattr(litellm.proxy.proxy_server, "proxy_config")
 
     _model_list = [
         {
@@ -2122,9 +2116,6 @@ async def test_proxy_model_group_alias_checks(prisma_client, hidden):
     )
     setattr(litellm.proxy.proxy_server, "llm_router", router)
     setattr(litellm.proxy.proxy_server, "llm_model_list", _model_list)
-
-    request = Request(scope={"type": "http", "method": "POST", "headers": {}})
-    request._url = URL(url="/v1/models")
 
     resp = await model_list(
         user_api_key_dict=UserAPIKeyAuth(models=[]),

--- a/tests/proxy_unit_tests/test_proxy_server.py
+++ b/tests/proxy_unit_tests/test_proxy_server.py
@@ -2159,6 +2159,40 @@ async def test_proxy_model_group_alias_checks(hidden):
 
 
 @pytest.mark.asyncio
+async def test_model_info_expands_alias_per_backing_deployment():
+    """A model_group_alias backed by a multi-deployment group expands to one
+
+    `/v1/model/info` row per backing deployment -- the same per-deployment
+    granularity the endpoint already uses for non-alias groups -- so the alias
+    name is never dropped just because one backing deployment is filtered out.
+    See #30589.
+    """
+    from litellm.proxy.proxy_server import model_info_v1
+
+    setattr(litellm.proxy.proxy_server, "prisma_client", None)
+    setattr(litellm.proxy.proxy_server, "master_key", "sk-1234")
+
+    _model_list = [
+        {"model_name": "gpt-3.5-turbo", "litellm_params": {"model": "gpt-3.5-turbo"}},
+        {"model_name": "gpt-3.5-turbo", "litellm_params": {"model": "gpt-3.5-turbo"}},
+    ]
+    router = litellm.Router(
+        model_list=_model_list,
+        model_group_alias={"gpt-4": {"model": "gpt-3.5-turbo", "hidden": False}},
+    )
+    setattr(litellm.proxy.proxy_server, "llm_router", router)
+    setattr(litellm.proxy.proxy_server, "llm_model_list", _model_list)
+
+    resp = await model_info_v1(user_api_key_dict=UserAPIKeyAuth(models=[]))
+    names = [item["model_name"] for item in resp["data"]]
+
+    # alias mirrors the backing group: one row per deployment, same as the
+    # real group it points at -- and never collides with a real model_name.
+    assert names.count("gpt-4") == 2
+    assert names.count("gpt-3.5-turbo") == 2
+
+
+@pytest.mark.asyncio
 @pytest.mark.skip(reason="Requires reliable external DB connection (prisma).")
 async def test_proxy_model_group_info_rerank(prisma_client):
     """


### PR DESCRIPTION
## Summary

`/model/info` only returned deployments from `llm_router.model_list`, so model names declared under `router_settings.model_group_alias` were missing — even though `/models` lists them (added in #5524). On a proxy with 82 aliases, `/models` returns all of them while `/model/info` drops exactly those 82, so dashboards/SDK pickers that read `/model/info` can't discover alias metadata.

## Fix

After building the deployment list from `model_list`, expand non-hidden aliases through the existing `Router.get_model_list_from_model_alias()` helper. That helper already overrides `model_name` to the alias and skips hidden (`hidden: true`) entries, so the aliases flow through the same allow-list / team-access / enrichment pipeline as regular deployments. Aliases are deep-copied so the downstream enrich/translate steps don't mutate the shared router records, and any alias whose name already exists in `model_list` is skipped to avoid duplicates.

## Test

Revived `test_proxy_model_group_alias_checks`, which was skipped because it required a live DB. It now runs against the in-memory router with `prisma_client=None` and asserts, for both the hidden and visible cases, that the alias appears in `/models`, `/model/info`, and `/model_group/info` (and stays out when hidden).

Closes #30589

## Type
🐛 Bug Fix

## Changes
- `litellm/proxy/proxy_server.py`: expand non-hidden `model_group_alias` entries in `model_info_v1`
- `tests/proxy_unit_tests/test_proxy_server.py`: un-skip and de-DB the alias coverage test