### PR TITLE
feat: add Azure passwordless datastore auth

### DIFF
--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -20,6 +20,7 @@ import redis  # type: ignore
 import redis.asyncio as async_redis  # type: ignore
 
 from litellm import get_secret, get_secret_str
+from litellm.secret_managers.main import str_to_bool
 from litellm._redis_credential_provider import (
     AzureADCredentialProvider,
     GCPIAMCredentialProvider,
@@ -35,6 +36,14 @@ from litellm.litellm_core_utils.sensitive_data_masker import SensitiveDataMasker
 from ._logging import verbose_logger
 
 AZURE_REDIS_SCOPE: Final = "https://redis.azure.com/.default"
+
+
+def _is_ssl_enabled(ssl: object) -> bool:
+    if isinstance(ssl, bool):
+        return ssl
+    if isinstance(ssl, str):
+        return str_to_bool(ssl) is True
+    return False
 
 
 def _get_redis_kwargs():
@@ -472,7 +481,7 @@ def _get_redis_client_logic(**env_overrides):
                 and _parsed_redis_url.hostname is not None
             )
             if _parsed_redis_url is not None
-            else redis_kwargs.get("ssl") is True
+            else _is_ssl_enabled(redis_kwargs.get("ssl"))
         )
         if not _uses_tls:
             raise ValueError("Redis IAM authentication requires TLS")

--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -12,7 +12,7 @@ import json
 
 # s/o [@Frank Colson](https://www.linkedin.com/in/frank-colson-422b9b183/) for this redis implementation
 import os
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from typing import Final
 from urllib.parse import urlparse
 
@@ -326,23 +326,25 @@ def create_azure_ad_redis_connect_func(
     return ad_connect
 
 
-def _get_azure_ad_redis_username(redis_kwargs: dict) -> str | None:
-    username = redis_kwargs.get("username") or os.environ.get("REDIS_USERNAME")
+def _get_azure_ad_redis_username(redis_kwargs: Mapping[str, object]) -> str | None:
+    username: Final = redis_kwargs.get("username") or os.environ.get("REDIS_USERNAME")
     return str(username) if username is not None else None
 
 
 def _get_credential_provider_from_connect_func(
     redis_connect_func: Callable | None,
-    redis_kwargs: dict,
-):
+    redis_kwargs: Mapping[str, object],
+) -> GCPIAMCredentialProvider | AzureADCredentialProvider | None:
     if redis_connect_func is None:
         return None
-    connect_func_attrs = getattr(redis_connect_func, "__dict__", {})
-    if "_gcp_service_account" in connect_func_attrs and "_azure_credential" in connect_func_attrs:
+    connect_func_attrs: Final[frozenset[str]] = frozenset(getattr(redis_connect_func, "__dict__", ()))
+    has_gcp: Final = "_gcp_service_account" in connect_func_attrs
+    has_azure: Final = "_azure_credential" in connect_func_attrs
+    if has_gcp and has_azure:
         raise ValueError("redis_connect_func cannot define both GCP and Azure credentials")
-    if "_gcp_service_account" in connect_func_attrs:
+    if has_gcp:
         return GCPIAMCredentialProvider(redis_connect_func._gcp_service_account)
-    if "_azure_credential" in connect_func_attrs:
+    if has_azure:
         return AzureADCredentialProvider(
             redis_connect_func._azure_credential,
             username=_get_azure_ad_redis_username(redis_kwargs),
@@ -462,8 +464,15 @@ def _get_redis_client_logic(**env_overrides):
     _redis_url: Final = redis_kwargs.get("url")
     _uses_url: Final = "startup_nodes" not in redis_kwargs and _redis_url is not None
     if _credential_provider is not None or _azure_ad_enabled:
+        _parsed_redis_url: Final = urlparse(str(_redis_url)) if _uses_url else None
         _uses_tls: Final = (
-            urlparse(str(_redis_url)).scheme == "rediss" if _uses_url else redis_kwargs.get("ssl") is True
+            (
+                str(_redis_url).startswith("rediss://")
+                and _parsed_redis_url.scheme == "rediss"
+                and _parsed_redis_url.hostname is not None
+            )
+            if _parsed_redis_url is not None
+            else redis_kwargs.get("ssl") is True
         )
         if not _uses_tls:
             raise ValueError("Redis IAM authentication requires TLS")

--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -14,6 +14,7 @@ import json
 import os
 from collections.abc import Callable
 from typing import Final
+from urllib.parse import urlparse
 
 import redis  # type: ignore
 import redis.asyncio as async_redis  # type: ignore
@@ -228,6 +229,7 @@ def _build_azure_credential(
     _client_id: Final = azure_client_id or os.environ.get("AZURE_CLIENT_ID")
     _tenant_id: Final = azure_tenant_id or os.environ.get("AZURE_TENANT_ID")
     _client_secret: Final = azure_client_secret or os.environ.get("AZURE_CLIENT_SECRET")
+    _federated_token_file: Final = os.environ.get("AZURE_FEDERATED_TOKEN_FILE")
 
     if _client_id and _tenant_id and _client_secret:
         return ClientSecretCredential(
@@ -235,6 +237,8 @@ def _build_azure_credential(
             tenant_id=_tenant_id,
             client_secret=_client_secret,
         )
+    elif _federated_token_file:
+        return DefaultAzureCredential()
     elif _client_id:
         return ManagedIdentityCredential(client_id=_client_id)
     else:
@@ -267,6 +271,7 @@ def create_azure_ad_redis_connect_func(
     azure_client_id: str | None = None,
     azure_tenant_id: str | None = None,
     azure_client_secret: str | None = None,
+    username: str | None = None,
 ) -> Callable:
     """
     Creates a custom Redis connection function for Azure AD authentication.
@@ -295,9 +300,9 @@ def create_azure_ad_redis_connect_func(
 
         # Only include username when explicitly set — sending AUTH "" <token>
         # is invalid for most ACL-configured Azure Redis instances.
-        username: Final = os.environ.get("REDIS_USERNAME", "")
-        if username:
-            auth_args = (username, access_token)
+        redis_username: Final = username or os.environ.get("REDIS_USERNAME", "")
+        if redis_username:
+            auth_args = (redis_username, access_token)
         else:
             auth_args = (access_token,)
 
@@ -319,6 +324,30 @@ def create_azure_ad_redis_connect_func(
     # credential closure already holds them.
     ad_connect._azure_credential = credential  # type: ignore[attr-defined]
     return ad_connect
+
+
+def _get_azure_ad_redis_username(redis_kwargs: dict) -> str | None:
+    username = redis_kwargs.get("username") or os.environ.get("REDIS_USERNAME")
+    return str(username) if username is not None else None
+
+
+def _get_credential_provider_from_connect_func(
+    redis_connect_func: Callable | None,
+    redis_kwargs: dict,
+):
+    if redis_connect_func is None:
+        return None
+    connect_func_attrs = getattr(redis_connect_func, "__dict__", {})
+    if "_gcp_service_account" in connect_func_attrs and "_azure_credential" in connect_func_attrs:
+        raise ValueError("redis_connect_func cannot define both GCP and Azure credentials")
+    if "_gcp_service_account" in connect_func_attrs:
+        return GCPIAMCredentialProvider(redis_connect_func._gcp_service_account)
+    if "_azure_credential" in connect_func_attrs:
+        return AzureADCredentialProvider(
+            redis_connect_func._azure_credential,
+            username=_get_azure_ad_redis_username(redis_kwargs),
+        )
+    return None
 
 
 def get_redis_url_from_environment():
@@ -427,6 +456,18 @@ def _get_redis_client_logic(**env_overrides):
 
     _azure_ad_enabled: Final = _azure_redis_ad_token is not None and str(_azure_redis_ad_token).lower() == "true"
 
+    _credential_provider: Final = _get_credential_provider_from_connect_func(
+        redis_kwargs.get("redis_connect_func"), redis_kwargs
+    )
+    _redis_url: Final = redis_kwargs.get("url")
+    _uses_url: Final = "startup_nodes" not in redis_kwargs and _redis_url is not None
+    if _credential_provider is not None or _azure_ad_enabled:
+        _uses_tls: Final = (
+            urlparse(str(_redis_url)).scheme == "rediss" if _uses_url else redis_kwargs.get("ssl") is True
+        )
+        if not _uses_tls:
+            raise ValueError("Redis IAM authentication requires TLS")
+
     if _azure_ad_enabled and _gcp_service_account is not None:
         verbose_logger.warning(
             "Both GCP IAM (gcp_service_account) and Azure AD (azure_redis_ad_token) are configured for Redis. "
@@ -443,6 +484,7 @@ def _get_redis_client_logic(**env_overrides):
             azure_client_id=_azure_client_id,
             azure_tenant_id=_azure_tenant_id,
             azure_client_secret=_azure_client_secret,
+            username=_get_azure_ad_redis_username(redis_kwargs),
         )
         # Marker for async paths to detect Azure AD auth. The live credential
         # object is attached separately as `_azure_credential` by
@@ -575,6 +617,11 @@ def get_redis_client(**env_overrides):
         return init_redis_cluster(redis_kwargs)
 
     if "url" in redis_kwargs and redis_kwargs["url"] is not None:
+        redis_connect_func: Final = redis_kwargs.pop("redis_connect_func", None)
+        credential_provider: Final = _get_credential_provider_from_connect_func(redis_connect_func, redis_kwargs)
+        if credential_provider is not None:
+            redis_kwargs["credential_provider"] = credential_provider
+
         args: Final = _get_redis_url_kwargs()
         url_kwargs: Final = {}
         for arg in redis_kwargs:
@@ -606,21 +653,16 @@ def get_redis_async_client(
                 cluster_kwargs[arg] = redis_kwargs[arg]
 
         # Handle GCP IAM authentication for async clusters
-        redis_connect_func = cluster_kwargs.pop("redis_connect_func", None)
+        cluster_connect_func: Final = cluster_kwargs.pop("redis_connect_func", None)
 
         # Use a CredentialProvider so the IAM token is regenerated on every new
         # connection — mirrors the sync path where redis_connect_func is invoked
         # per connection.  Without this, the token would expire after ~1 hour.
-        if redis_connect_func and hasattr(redis_connect_func, "_gcp_service_account"):
-            cluster_kwargs["credential_provider"] = GCPIAMCredentialProvider(redis_connect_func._gcp_service_account)
-        # Handle Azure AD authentication for async clusters via CredentialProvider
-        # so the credential's internal cache + silent refresh runs per connection
-        # (mirrors GCP IAM above; avoids static-token-baked-in-pool expiry).
-        elif redis_connect_func and hasattr(redis_connect_func, "_azure_credential"):
-            cluster_kwargs["credential_provider"] = AzureADCredentialProvider(
-                redis_connect_func._azure_credential,
-                username=os.environ.get("REDIS_USERNAME") or None,
-            )
+        cluster_credential_provider: Final = _get_credential_provider_from_connect_func(
+            cluster_connect_func, redis_kwargs
+        )
+        if cluster_credential_provider is not None:
+            cluster_kwargs["credential_provider"] = cluster_credential_provider
 
         new_startup_nodes: Final[list[ClusterNode]] = []
 
@@ -646,6 +688,10 @@ def get_redis_async_client(
     if "url" in redis_kwargs and redis_kwargs["url"] is not None:
         if connection_pool is not None:
             return async_redis.Redis(connection_pool=connection_pool)
+        url_connect_func: Final = redis_kwargs.pop("redis_connect_func", None)
+        url_credential_provider: Final = _get_credential_provider_from_connect_func(url_connect_func, redis_kwargs)
+        if url_credential_provider is not None:
+            redis_kwargs["credential_provider"] = url_credential_provider
         args = _get_redis_url_kwargs(client=async_redis.Redis)
         url_kwargs: Final = {}
         for arg in redis_kwargs:
@@ -665,14 +711,10 @@ def get_redis_async_client(
     # Redis client. The async client doesn't support redis_connect_func, but it
     # does honour credential_provider — which is called per connection, so the
     # underlying SDK can refresh tokens silently before they expire.
-    redis_connect_func = redis_kwargs.pop("redis_connect_func", None)
-    if redis_connect_func and hasattr(redis_connect_func, "_azure_credential"):
-        redis_kwargs["credential_provider"] = AzureADCredentialProvider(
-            redis_connect_func._azure_credential,
-            username=os.environ.get("REDIS_USERNAME") or None,
-        )
-    elif redis_connect_func and hasattr(redis_connect_func, "_gcp_service_account"):
-        redis_kwargs["credential_provider"] = GCPIAMCredentialProvider(redis_connect_func._gcp_service_account)
+    redis_connect_func: Final = redis_kwargs.pop("redis_connect_func", None)
+    credential_provider: Final = _get_credential_provider_from_connect_func(redis_connect_func, redis_kwargs)
+    if credential_provider is not None:
+        redis_kwargs["credential_provider"] = credential_provider
 
     _pretty_print_redis_config(redis_kwargs=redis_kwargs)
 
@@ -694,10 +736,14 @@ def get_redis_connection_pool(
         return None
 
     if "url" in redis_kwargs and redis_kwargs["url"] is not None:
+        url_connect_func: Final = redis_kwargs.pop("redis_connect_func", None)
+        url_credential_provider: Final = _get_credential_provider_from_connect_func(url_connect_func, redis_kwargs)
         allowed_args: Final = _get_redis_url_kwargs(client=async_redis.Redis)
         pool_kwargs: Final = {k: v for k, v in redis_kwargs.items() if k in allowed_args and k != "max_connections"}
         pool_kwargs["timeout"] = REDIS_CONNECTION_POOL_TIMEOUT
         pool_kwargs["url"] = redis_kwargs["url"]
+        if url_credential_provider is not None:
+            pool_kwargs["credential_provider"] = url_credential_provider
         if "max_connections" in redis_kwargs:
             try:
                 pool_kwargs["max_connections"] = int(redis_kwargs["max_connections"])
@@ -712,13 +758,9 @@ def get_redis_connection_pool(
     # connections re-fetch tokens via the SDK's internal cache + silent refresh
     # rather than reusing a single token captured at pool creation.
     redis_connect_func: Final = redis_kwargs.pop("redis_connect_func", None)
-    if redis_connect_func and hasattr(redis_connect_func, "_azure_credential"):
-        redis_kwargs["credential_provider"] = AzureADCredentialProvider(
-            redis_connect_func._azure_credential,
-            username=os.environ.get("REDIS_USERNAME") or None,
-        )
-    elif redis_connect_func and hasattr(redis_connect_func, "_gcp_service_account"):
-        redis_kwargs["credential_provider"] = GCPIAMCredentialProvider(redis_connect_func._gcp_service_account)
+    credential_provider: Final = _get_credential_provider_from_connect_func(redis_connect_func, redis_kwargs)
+    if credential_provider is not None:
+        redis_kwargs["credential_provider"] = credential_provider
 
     if redis_kwargs.pop("ssl", None):
         redis_kwargs["connection_class"] = async_redis.SSLConnection

--- a/litellm/proxy/auth/azure_postgres_token.py
+++ b/litellm/proxy/auth/azure_postgres_token.py
@@ -1,0 +1,56 @@
+import os
+from typing import Any
+from urllib.parse import quote
+
+AZURE_POSTGRES_SCOPE = "https://ossrdbms-aad.database.windows.net/.default"
+
+
+def _build_azure_postgres_credential(
+    azure_client_id: str | None = None,
+    azure_tenant_id: str | None = None,
+    azure_client_secret: str | None = None,
+) -> Any:
+    try:
+        from azure.identity import (
+            ClientSecretCredential,
+            DefaultAzureCredential,
+            ManagedIdentityCredential,
+        )
+    except ImportError:
+        raise ImportError(
+            "azure-identity is required for Azure PostgreSQL passwordless auth. "
+            "Install it with: pip install azure-identity"
+        )
+
+    _client_id = azure_client_id or os.environ.get("AZURE_CLIENT_ID")
+    _tenant_id = azure_tenant_id or os.environ.get("AZURE_TENANT_ID")
+    _client_secret = azure_client_secret or os.environ.get("AZURE_CLIENT_SECRET")
+    _federated_token_file = os.environ.get("AZURE_FEDERATED_TOKEN_FILE")
+
+    if _client_id and _tenant_id and _client_secret:
+        return ClientSecretCredential(
+            client_id=_client_id,
+            tenant_id=_tenant_id,
+            client_secret=_client_secret,
+        )
+    if _federated_token_file:
+        return DefaultAzureCredential()
+    if _client_id:
+        return ManagedIdentityCredential(client_id=_client_id)
+    return DefaultAzureCredential()
+
+
+def generate_azure_postgres_auth_token(
+    credential: Any | None = None,
+    azure_client_id: str | None = None,
+    azure_tenant_id: str | None = None,
+    azure_client_secret: str | None = None,
+) -> str:
+    if credential is None:
+        credential = _build_azure_postgres_credential(
+            azure_client_id=azure_client_id,
+            azure_tenant_id=azure_tenant_id,
+            azure_client_secret=azure_client_secret,
+        )
+
+    return quote(credential.get_token(AZURE_POSTGRES_SCOPE).token, safe="")

--- a/litellm/proxy/auth/azure_postgres_token.py
+++ b/litellm/proxy/auth/azure_postgres_token.py
@@ -1,15 +1,24 @@
 import os
-from typing import Any
+from typing import Final, Protocol
 from urllib.parse import quote
 
-AZURE_POSTGRES_SCOPE = "https://ossrdbms-aad.database.windows.net/.default"
+AZURE_POSTGRES_SCOPE: Final = "https://ossrdbms-aad.database.windows.net/.default"
+
+
+class _AccessToken(Protocol):
+    @property
+    def token(self) -> str: ...
+
+
+class _TokenCredential(Protocol):
+    def get_token(self, *scopes: str) -> _AccessToken: ...
 
 
 def _build_azure_postgres_credential(
     azure_client_id: str | None = None,
     azure_tenant_id: str | None = None,
     azure_client_secret: str | None = None,
-) -> Any:
+) -> _TokenCredential:
     try:
         from azure.identity import (
             ClientSecretCredential,
@@ -22,10 +31,10 @@ def _build_azure_postgres_credential(
             "Install it with: pip install azure-identity"
         )
 
-    _client_id = azure_client_id or os.environ.get("AZURE_CLIENT_ID")
-    _tenant_id = azure_tenant_id or os.environ.get("AZURE_TENANT_ID")
-    _client_secret = azure_client_secret or os.environ.get("AZURE_CLIENT_SECRET")
-    _federated_token_file = os.environ.get("AZURE_FEDERATED_TOKEN_FILE")
+    _client_id: Final = azure_client_id or os.environ.get("AZURE_CLIENT_ID")
+    _tenant_id: Final = azure_tenant_id or os.environ.get("AZURE_TENANT_ID")
+    _client_secret: Final = azure_client_secret or os.environ.get("AZURE_CLIENT_SECRET")
+    _federated_token_file: Final = os.environ.get("AZURE_FEDERATED_TOKEN_FILE")
 
     if _client_id and _tenant_id and _client_secret:
         return ClientSecretCredential(
@@ -41,16 +50,15 @@ def _build_azure_postgres_credential(
 
 
 def generate_azure_postgres_auth_token(
-    credential: Any | None = None,
+    credential: _TokenCredential | None = None,
     azure_client_id: str | None = None,
     azure_tenant_id: str | None = None,
     azure_client_secret: str | None = None,
 ) -> str:
-    if credential is None:
-        credential = _build_azure_postgres_credential(
-            azure_client_id=azure_client_id,
-            azure_tenant_id=azure_tenant_id,
-            azure_client_secret=azure_client_secret,
-        )
+    _credential: Final = credential or _build_azure_postgres_credential(
+        azure_client_id=azure_client_id,
+        azure_tenant_id=azure_tenant_id,
+        azure_client_secret=azure_client_secret,
+    )
 
-    return quote(credential.get_token(AZURE_POSTGRES_SCOPE).token, safe="")
+    return quote(_credential.get_token(AZURE_POSTGRES_SCOPE).token, safe="")

--- a/litellm/proxy/db/prisma_client.py
+++ b/litellm/proxy/db/prisma_client.py
@@ -220,7 +220,7 @@ def _parse_jwt_expiration_claim(token: str) -> datetime | None:
             return None
         return datetime.utcfromtimestamp(int(exp))
     except (OSError, OverflowError, TypeError, ValueError) as e:
-        verbose_proxy_logger.debug(f"Failed to parse JWT token expiration: {e}")
+        verbose_proxy_logger.debug("Failed to parse JWT token expiration: %s", e)
         return None
 
 

--- a/litellm/proxy/db/prisma_client.py
+++ b/litellm/proxy/db/prisma_client.py
@@ -3,6 +3,8 @@ This file contains the PrismaWrapper class, which is used to wrap the Prisma cli
 """
 
 import asyncio
+import base64
+import json
 import os
 import random
 import signal
@@ -17,6 +19,8 @@ from typing import Any, Final, Protocol
 
 from litellm._logging import verbose_proxy_logger
 from litellm.secret_managers.main import str_to_bool
+
+AZURE_POSTGRESQL_AUTH_MARKER_ENV = "_LITELLM_AZURE_POSTGRESQL_AUTH"
 
 
 @dataclass(frozen=True)
@@ -169,6 +173,57 @@ def parse_iam_endpoint_from_url(url: str) -> IAMEndpoint:
     )
 
 
+def get_database_auth_endpoint_from_env() -> IAMEndpoint:
+    return IAMEndpoint(
+        host=os.getenv("DATABASE_HOST") or "",
+        port=os.getenv("DATABASE_PORT", "5432"),
+        user=os.getenv("DATABASE_USER") or "",
+        name=os.getenv("DATABASE_NAME") or "",
+        schema=os.getenv("DATABASE_SCHEMA"),
+    )
+
+
+def build_database_token_auth_url(
+    endpoint: IAMEndpoint,
+    *,
+    azure_postgresql_auth: bool = False,
+) -> str:
+    if azure_postgresql_auth:
+        from litellm.proxy.auth.azure_postgres_token import (
+            generate_azure_postgres_auth_token,
+        )
+
+        return (
+            f"{endpoint.build_url(generate_azure_postgres_auth_token())}"
+            f"{'&' if endpoint.schema else '?'}sslmode=require&sslaccept=strict"
+        )
+
+    from litellm.proxy.auth.rds_iam_token import generate_iam_auth_token
+
+    token = generate_iam_auth_token(db_host=endpoint.host, db_port=endpoint.port, db_user=endpoint.user)
+    return endpoint.build_url(token)
+
+
+def _parse_jwt_expiration_claim(token: str) -> datetime | None:
+    try:
+        parts = token.split(".")
+        if len(parts) < 2:
+            return None
+        payload = parts[1]
+        padding = "=" * (-len(payload) % 4)
+        decoded = base64.urlsafe_b64decode(f"{payload}{padding}")
+        claims = json.loads(decoded)
+        if not isinstance(claims, dict):
+            return None
+        exp = claims.get("exp")
+        if exp is None:
+            return None
+        return datetime.utcfromtimestamp(int(exp))
+    except (OSError, OverflowError, TypeError, ValueError) as e:
+        verbose_proxy_logger.debug(f"Failed to parse JWT token expiration: {e}")
+        return None
+
+
 class PrismaWrapper:
     """
     Wrapper around Prisma client that handles RDS IAM token authentication.
@@ -200,9 +255,11 @@ class PrismaWrapper:
         iam_endpoint: IAMEndpoint | None = None,
         recreate_uses_datasource: bool = False,
         log_prefix: str = "",
+        azure_postgresql_auth: bool = False,
     ):
         self._original_prisma = original_prisma
         self.iam_token_db_auth = iam_token_db_auth
+        self._azure_postgresql_auth = azure_postgresql_auth
 
         # Per-connection knobs so the same wrapper can be used for the writer
         # (defaults: DATABASE_URL env, IAM endpoint from DATABASE_HOST/etc.,
@@ -240,6 +297,11 @@ class PrismaWrapper:
         self._expected_engine_deaths: set[int] = set()
         self._engine_generation: int = 0
         self.on_engine_replaced: Callable[[], None] | None = None
+
+    def _token_auth_log_name(self) -> str:
+        if self._azure_postgresql_auth:
+            return "Azure PostgreSQL Entra token"
+        return "RDS IAM token"
 
     @staticmethod
     def _read_engine(prisma_client: _PrismaClient) -> _PrismaEngine:
@@ -379,27 +441,33 @@ class PrismaWrapper:
         if token is None:
             return None
 
-        try:
-            # Token format: ...?X-Amz-Date=YYYYMMDDTHHMMSSZ&X-Amz-Expires=900&...
-            if "?" not in token:
-                return None
+        # Token format: ...?X-Amz-Date=YYYYMMDDTHHMMSSZ&X-Amz-Expires=900&...
+        if "?" in token:
+            try:
+                query_string: Final = token.split("?", 1)[1]
+                params: Final = urllib.parse.parse_qs(query_string)
 
-            query_string: Final = token.split("?", 1)[1]
-            params: Final = urllib.parse.parse_qs(query_string)
+                expires_str: Final = params.get("X-Amz-Expires", [None])[0]
+                date_str: Final = params.get("X-Amz-Date", [None])[0]
 
-            expires_str: Final = params.get("X-Amz-Expires", [None])[0]
-            date_str: Final = params.get("X-Amz-Date", [None])[0]
+                if expires_str and date_str:
+                    token_created: Final = datetime.strptime(date_str, "%Y%m%dT%H%M%SZ")
+                    expires_in: Final = int(expires_str)
 
-            if not expires_str or not date_str:
-                return None
+                    return token_created + timedelta(seconds=expires_in)
+            except Exception as e:
+                verbose_proxy_logger.debug("Failed to parse token expiration: %s", e)
 
-            token_created: Final = datetime.strptime(date_str, "%Y%m%dT%H%M%SZ")
-            expires_in: Final = int(expires_str)
+        return self._parse_jwt_token_expiration(token)
 
-            return token_created + timedelta(seconds=expires_in)
-        except Exception as e:
-            verbose_proxy_logger.debug("Failed to parse token expiration: %s", e)
-            return None
+    def _parse_jwt_token_expiration(self, token: str) -> datetime | None:
+        """Parse the exp claim from JWT-shaped database auth tokens.
+
+        Azure PostgreSQL Entra access tokens are JWTs. The token was already
+        accepted from Azure Identity, so this only decodes the payload locally
+        to schedule refresh; it does not validate trust.
+        """
+        return _parse_jwt_expiration_claim(token)
 
     def _calculate_seconds_until_refresh(self) -> float:
         """
@@ -461,27 +529,12 @@ class PrismaWrapper:
         if not self.iam_token_db_auth:
             return None
 
-        from litellm.proxy.auth.rds_iam_token import generate_iam_auth_token
-
         if self._iam_endpoint is not None:
-            endpoint: Final = self._iam_endpoint
-            token = generate_iam_auth_token(db_host=endpoint.host, db_port=endpoint.port, db_user=endpoint.user)
-            _db_url = endpoint.build_url(token)
+            endpoint = self._iam_endpoint
         else:
-            db_host: Final = os.getenv("DATABASE_HOST")
-            # Default to the Postgres standard port; passing None to
-            # `generate_iam_auth_token` makes botocore embed the literal
-            # string "None" in the presigned URL, which then fails to parse.
-            db_port: Final = os.getenv("DATABASE_PORT", "5432")
-            db_user: Final = os.getenv("DATABASE_USER")
-            db_name: Final = os.getenv("DATABASE_NAME")
-            db_schema: Final = os.getenv("DATABASE_SCHEMA")
+            endpoint = get_database_auth_endpoint_from_env()
 
-            token = generate_iam_auth_token(db_host=db_host, db_port=db_port, db_user=db_user)
-
-            _db_url = f"postgresql://{db_user}:{token}@{db_host}:{db_port}/{db_name}"
-            if db_schema:
-                _db_url += f"?schema={db_schema}"
+        _db_url: Final = build_database_token_auth_url(endpoint, azure_postgresql_auth=self._azure_postgresql_auth)
 
         os.environ[self._db_url_env_var] = _db_url
         return _db_url
@@ -640,8 +693,9 @@ class PrismaWrapper:
 
         self._token_refresh_task = asyncio.create_task(self._token_refresh_loop())
         verbose_proxy_logger.info(
-            "%sStarted RDS IAM token proactive refresh background task",
+            "%sStarted %s proactive refresh background task",
             self._log_prefix,
+            self._token_auth_log_name(),
         )
 
     async def stop_token_refresh_task(self) -> None:
@@ -659,7 +713,11 @@ class PrismaWrapper:
         except asyncio.CancelledError:
             pass
         self._token_refresh_task = None
-        verbose_proxy_logger.info("%sStopped RDS IAM token refresh background task", self._log_prefix)
+        verbose_proxy_logger.info(
+            "%sStopped %s refresh background task",
+            self._log_prefix,
+            self._token_auth_log_name(),
+        )
 
     async def _token_refresh_loop(self) -> None:
         """
@@ -670,8 +728,9 @@ class PrismaWrapper:
         This is more efficient than polling, requiring only 1 wake-up per token cycle.
         """
         verbose_proxy_logger.info(
-            "%sRDS IAM token refresh loop started. Tokens will be refreshed %ss before expiration.",
+            "%s%s refresh loop started. Tokens will be refreshed %ss before expiration.",
             self._log_prefix,
+            self._token_auth_log_name(),
             self.TOKEN_REFRESH_BUFFER_SECONDS,
         )
 
@@ -682,22 +741,31 @@ class PrismaWrapper:
 
                 if sleep_seconds > 0:
                     verbose_proxy_logger.info(
-                        f"{self._log_prefix}RDS IAM token refresh scheduled in "
+                        f"{self._log_prefix}{self._token_auth_log_name()} refresh scheduled in "
                         f"{sleep_seconds:.0f} seconds ({sleep_seconds / 60:.1f} minutes)"
                     )
                     await asyncio.sleep(sleep_seconds)
 
                 # Refresh the token
-                verbose_proxy_logger.info("%sProactively refreshing RDS IAM token...", self._log_prefix)
+                verbose_proxy_logger.info(
+                    "%sProactively refreshing %s...",
+                    self._log_prefix,
+                    self._token_auth_log_name(),
+                )
                 await self._safe_refresh_token()
 
             except asyncio.CancelledError:
-                verbose_proxy_logger.info("%sRDS IAM token refresh loop cancelled", self._log_prefix)
+                verbose_proxy_logger.info(
+                    "%s%s refresh loop cancelled",
+                    self._log_prefix,
+                    self._token_auth_log_name(),
+                )
                 break
             except Exception as e:
                 verbose_proxy_logger.error(
-                    "%sError in RDS IAM token refresh loop: %s. Retrying in %ss...",
+                    "%sError in %s refresh loop: %s. Retrying in %ss...",
                     self._log_prefix,
+                    self._token_auth_log_name(),
                     e,
                     self.FALLBACK_REFRESH_INTERVAL_SECONDS,
                 )
@@ -740,13 +808,15 @@ class PrismaWrapper:
                     raise
                 self._last_refresh_time = datetime.utcnow()
                 verbose_proxy_logger.info(
-                    "%sRDS IAM token refreshed successfully. New token valid for ~15 minutes.",
+                    "%s%s refreshed successfully.",
                     self._log_prefix,
+                    self._token_auth_log_name(),
                 )
             else:
                 verbose_proxy_logger.error(
-                    "%sFailed to generate new RDS IAM token during proactive refresh",
+                    "%sFailed to generate new %s during proactive refresh",
                     self._log_prefix,
+                    self._token_auth_log_name(),
                 )
 
     def _token_refresh_not_needed(self, token_url: str | None) -> bool:
@@ -800,10 +870,11 @@ class PrismaWrapper:
 
                 if running_loop is not None:
                     verbose_proxy_logger.warning(
-                        "%sRDS IAM token expired in __getattr__ — proactive refresh "
+                        "%s%s expired in __getattr__ — proactive refresh "
                         "may have failed. Scheduling async refresh; the current "
                         "request may fail and be retried with the fresh token.",
                         self._log_prefix,
+                        self._token_auth_log_name(),
                     )
                     # Non-blocking: schedule the locked refresh on the
                     # running loop. The reconnection lock inside
@@ -811,9 +882,10 @@ class PrismaWrapper:
                     running_loop.create_task(self._safe_refresh_token())
                 else:
                     verbose_proxy_logger.warning(
-                        "%sRDS IAM token expired in __getattr__ — proactive refresh "
+                        "%s%s expired in __getattr__ — proactive refresh "
                         "may have failed. Triggering synchronous fallback refresh...",
                         self._log_prefix,
+                        self._token_auth_log_name(),
                     )
                     new_db_url: Final = self.get_rds_iam_token()
                     if new_db_url:

--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -791,6 +791,12 @@ class ProxyInitializationHelpers:
     help="Connects to RDS DB with IAM token",
 )
 @click.option(
+    "--azure_postgresql_auth",
+    default=False,
+    is_flag=True,
+    help="Connects to Azure PostgreSQL with Microsoft Entra token auth",
+)
+@click.option(
     "--num_requests",
     default=10,
     type=int,
@@ -950,6 +956,7 @@ def run_server(
     granian_threads,
     test_async,
     iam_token_db_auth,
+    azure_postgresql_auth,
     num_requests,
     use_queue,
     health,
@@ -1081,29 +1088,21 @@ def run_server(
         general_settings = {}
         ### GET DB TOKEN FOR IAM AUTH ###
 
-        if iam_token_db_auth or get_secret_bool("IAM_TOKEN_DB_AUTH"):
-            from litellm.proxy.auth.rds_iam_token import generate_iam_auth_token
+        if azure_postgresql_auth or iam_token_db_auth or get_secret_bool("IAM_TOKEN_DB_AUTH"):
+            from litellm.proxy.db.prisma_client import (
+                AZURE_POSTGRESQL_AUTH_MARKER_ENV,
+                build_database_token_auth_url,
+                get_database_auth_endpoint_from_env,
+            )
 
-            db_host: Final = os.getenv("DATABASE_HOST")
-            # Default to the Postgres standard port. Without a default,
-            # `db_port=None` flows into `boto.generate_db_auth_token(Port=None)`
-            # and botocore stringifies it to `"None"` while building the
-            # presigned URL, which then blows up with `ValueError: Port could
-            # not be cast to integer value as 'None'` during signing.
-            db_port: Final = os.getenv("DATABASE_PORT", "5432")
-            db_user: Final = os.getenv("DATABASE_USER")
-            db_name: Final = os.getenv("DATABASE_NAME")
-            db_schema: Final = os.getenv("DATABASE_SCHEMA")
-
-            token: Final = generate_iam_auth_token(db_host=db_host, db_port=db_port, db_user=db_user)
-
-            # print(f"token: {token}")
-            _db_url = f"postgresql://{db_user}:{token}@{db_host}:{db_port}/{db_name}"
-            if db_schema:
-                _db_url += f"?schema={db_schema}"
-
+            _db_url: Final = build_database_token_auth_url(
+                get_database_auth_endpoint_from_env(),
+                azure_postgresql_auth=azure_postgresql_auth,
+            )
             os.environ["DATABASE_URL"] = _db_url
             os.environ["IAM_TOKEN_DB_AUTH"] = "True"
+            if azure_postgresql_auth:
+                os.environ[AZURE_POSTGRESQL_AUTH_MARKER_ENV] = "True"
 
         ### DECRYPT ENV VAR ###
 

--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -1103,6 +1103,8 @@ def run_server(
             os.environ["IAM_TOKEN_DB_AUTH"] = "True"
             if azure_postgresql_auth:
                 os.environ[AZURE_POSTGRESQL_AUTH_MARKER_ENV] = "True"
+            else:
+                os.environ.pop(AZURE_POSTGRESQL_AUTH_MARKER_ENV, None)
 
         ### DECRYPT ENV VAR ###
 

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -114,7 +114,9 @@ from litellm.proxy.db.exception_handler import (
 )
 from litellm.proxy.db.log_db_metrics import log_db_metrics
 from litellm.proxy.db.prisma_client import (
+    AZURE_POSTGRESQL_AUTH_MARKER_ENV,
     PrismaWrapper,
+    build_database_token_auth_url,
     parse_iam_endpoint_from_url,
 )
 from litellm.proxy.db.routing_prisma_wrapper import RoutingPrismaWrapper
@@ -3006,6 +3008,7 @@ class PrismaClient:
         ## init logging object
         self.proxy_logging_obj = proxy_logging_obj
         self.iam_token_db_auth: bool | None = str_to_bool(os.getenv("IAM_TOKEN_DB_AUTH"))
+        azure_postgresql_auth: Final = str_to_bool(os.getenv(AZURE_POSTGRESQL_AUTH_MARKER_ENV)) is True
         verbose_proxy_logger.debug("Creating Prisma Client..")
         try:
             from prisma import Prisma  # type: ignore
@@ -3015,6 +3018,7 @@ class PrismaClient:
             verbose_proxy_logger.error("Please run 'prisma generate' to generate the Prisma client.")
             raise Exception("Unable to find Prisma binaries. Please run 'prisma generate' first.")
         iam_flag: Final = self.iam_token_db_auth if self.iam_token_db_auth is not None else False
+        token_auth_enabled: Final = bool(iam_flag or azure_postgresql_auth)
         # When read-replica routing is on, tag log lines with [writer]/[reader]
         # so the two wrappers' interleaved IAM refresh logs can be told apart.
         # Single-DB deployments get an empty prefix (logs unchanged).
@@ -3023,14 +3027,16 @@ class PrismaClient:
         if http_client is not None:
             writer_wrapper = PrismaWrapper(
                 original_prisma=Prisma(http=http_client),
-                iam_token_db_auth=iam_flag,
+                iam_token_db_auth=token_auth_enabled,
                 log_prefix=writer_log_prefix,
+                azure_postgresql_auth=azure_postgresql_auth,
             )
         else:
             writer_wrapper = PrismaWrapper(
                 original_prisma=Prisma(),
-                iam_token_db_auth=iam_flag,
+                iam_token_db_auth=token_auth_enabled,
                 log_prefix=writer_log_prefix,
+                azure_postgresql_auth=azure_postgresql_auth,
             )
 
         # Optional read-replica routing. When DATABASE_URL_READ_REPLICA is set,
@@ -3045,7 +3051,9 @@ class PrismaClient:
                 # the same cadence as the writer. We parse the static endpoint
                 # pieces (host/port/user/db) once from the reader URL — only
                 # the IAM token rotates after that.
-                reader_iam_endpoint: Final = parse_iam_endpoint_from_url(read_replica_url) if iam_flag else None
+                reader_iam_endpoint: Final = (
+                    parse_iam_endpoint_from_url(read_replica_url) if token_auth_enabled else None
+                )
                 # Mint a fresh IAM token for the reader BEFORE constructing the
                 # Prisma client. Mirrors what `proxy_cli.py` already does for
                 # the writer (proxy_cli.py:812-832) — without this, the reader
@@ -3054,17 +3062,11 @@ class PrismaClient:
                 # to the synchronous fallback path in
                 # `PrismaWrapper.__getattr__`, which deadlocks the event loop
                 # and times out after 30s.
-                if iam_flag and reader_iam_endpoint is not None:
-                    from litellm.proxy.auth.rds_iam_token import (
-                        generate_iam_auth_token,
+                if token_auth_enabled and reader_iam_endpoint is not None:
+                    read_replica_url = build_database_token_auth_url(
+                        reader_iam_endpoint,
+                        azure_postgresql_auth=azure_postgresql_auth,
                     )
-
-                    reader_token: Final = generate_iam_auth_token(
-                        db_host=reader_iam_endpoint.host,
-                        db_port=reader_iam_endpoint.port,
-                        db_user=reader_iam_endpoint.user,
-                    )
-                    read_replica_url = reader_iam_endpoint.build_url(reader_token)
                     os.environ["DATABASE_URL_READ_REPLICA"] = read_replica_url
                 reader_kwargs: Final[dict[str, Any]] = {"datasource": {"url": read_replica_url}}
                 if http_client is not None:
@@ -3073,16 +3075,17 @@ class PrismaClient:
                     reader_prisma = Prisma(**reader_kwargs)
                 reader_wrapper: Final = PrismaWrapper(
                     original_prisma=reader_prisma,
-                    iam_token_db_auth=iam_flag,
+                    iam_token_db_auth=token_auth_enabled,
                     db_url_env_var="DATABASE_URL_READ_REPLICA",
                     iam_endpoint=reader_iam_endpoint,
                     recreate_uses_datasource=True,
                     log_prefix="[reader]",
+                    azure_postgresql_auth=azure_postgresql_auth,
                 )
                 self.db = RoutingPrismaWrapper(writer=writer_wrapper, reader=reader_wrapper)
                 verbose_proxy_logger.info(
                     "PrismaClient: read-replica routing enabled via DATABASE_URL_READ_REPLICA"
-                    + (" (with IAM token auto-refresh)" if iam_flag else "")
+                    + (" (with token auto-refresh)" if token_auth_enabled else "")
                 )
             except Exception as e:
                 # Reader is opt-in; never let its construction fail proxy

--- a/tests/azure_workload_identity_e2e.sh
+++ b/tests/azure_workload_identity_e2e.sh
@@ -1,0 +1,590 @@
+#!/usr/bin/env bash
+# Reproduce LiteLLM Azure PostgreSQL and Redis authentication from a real AKS
+# Workload Identity. This creates billable resources and deletes them by default.
+set -Eeuo pipefail
+
+[[ "${AZURE_WI_E2E_ACK:-}" == "YES" ]] || {
+  echo "Set AZURE_WI_E2E_ACK=YES to acknowledge temporary Azure charges." >&2
+  exit 2
+}
+
+POST_PR_COMMENT="${POST_PR_COMMENT:-0}"
+PR_NUMBER="${PR_NUMBER:-}"
+if [[ "$POST_PR_COMMENT" == "1" && -z "$PR_NUMBER" ]]; then
+  PR_NUMBER=30633
+fi
+if [[ "$POST_PR_COMMENT" == "1" && "${KEEP_RESOURCES:-0}" == "1" ]]; then
+  echo "POST_PR_COMMENT=1 requires default cleanup; unset KEEP_RESOURCES." >&2
+  exit 2
+fi
+
+for command_name in az git kubectl docker curl jq openssl rg tar; do
+  command -v "$command_name" >/dev/null 2>&1 || {
+    echo "Missing required command: $command_name" >&2
+    exit 2
+  }
+done
+docker buildx version >/dev/null 2>&1 || {
+  echo "Missing required Docker Buildx plugin." >&2
+  exit 2
+}
+if [[ -n "$PR_NUMBER" || "$POST_PR_COMMENT" == "1" ]]; then
+  command -v gh >/dev/null 2>&1 || {
+    echo "Missing required command for PR verification/publication: gh" >&2
+    exit 2
+  }
+fi
+
+SUBSCRIPTION_ID="${AZURE_SUBSCRIPTION_ID:-$(az account show --query id -o tsv)}"
+TENANT_ID="$(az account show --query tenantId -o tsv)"
+LOCATION="${AZURE_LOCATION:-westeurope}"
+AKS_NODE_VM_SIZE="${AKS_NODE_VM_SIZE:-Standard_B2s}"
+GIT_SHA="$(git rev-parse HEAD)"
+SUFFIX="$(openssl rand -hex 4 | tr '[:upper:]' '[:lower:]')"
+PREFIX="litellm-wi-e2e-${SUFFIX}"
+RESOURCE_GROUP="$PREFIX"
+NODE_RESOURCE_GROUP="${PREFIX}-nodes"
+ACR_NAME="litellmwi${SUFFIX}"
+AKS_NAME="${PREFIX}-aks"
+IDENTITY_NAME="${PREFIX}-id"
+POSTGRES_NAME="${PREFIX}-pg"
+REDIS_NAME="${PREFIX}-redis"
+NAMESPACE="litellm-wi-proof"
+SERVICE_ACCOUNT="litellm-wi"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/litellm-wi-e2e.XXXXXX")"
+EVIDENCE_FILE="${EVIDENCE_FILE:-${TMPDIR:-/tmp}/${PREFIX}-evidence.md}"
+CLEANUP_STARTED=0
+CLEANUP_OK=0
+RUN_SUCCEEDED=0
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+retry_postgres_busy() {
+  postgres_attempt=1
+  while ! "$@" 2>"$TMP_DIR/postgres-operation.err"; do
+    if ! rg -q 'ServerIsBusy|AnotherOperationInProgress' "$TMP_DIR/postgres-operation.err" || \
+      [[ "$postgres_attempt" -ge 30 ]]; then
+      sed -n '1,20p' "$TMP_DIR/postgres-operation.err" >&2
+      return 1
+    fi
+    sleep 10
+    postgres_attempt=$((postgres_attempt + 1))
+  done
+}
+
+group_exists() {
+  [[ "$(az group exists --name "$1" 2>/dev/null)" == "true" ]]
+}
+
+cleanup_resources() {
+  [[ "$CLEANUP_STARTED" == "0" ]] || return 0
+  CLEANUP_STARTED=1
+  trap '' INT TERM
+  set +e
+
+  if [[ "${KEEP_RESOURCES:-0}" == "1" ]]; then
+    {
+      echo
+      echo "## Cleanup"
+      echo
+      echo "- Resources retained by KEEP_RESOURCES=1: true"
+      echo "- Delete with: \`az group delete -g $RESOURCE_GROUP -y\`"
+    } >>"$EVIDENCE_FILE"
+    echo "WARNING: Resources retained and may incur charges." >&2
+    echo "Delete with: az group delete -g $RESOURCE_GROUP -y" >&2
+    trap 'exit 130' INT
+    trap 'exit 143' TERM
+    return 0
+  fi
+
+  if group_exists "$RESOURCE_GROUP"; then
+    az group delete --name "$RESOURCE_GROUP" --yes --no-wait --only-show-errors
+    az group wait --name "$RESOURCE_GROUP" --deleted --interval 20 --timeout 1800
+  fi
+  if group_exists "$NODE_RESOURCE_GROUP"; then
+    az group delete --name "$NODE_RESOURCE_GROUP" --yes --no-wait --only-show-errors
+    az group wait --name "$NODE_RESOURCE_GROUP" --deleted --interval 20 --timeout 1800
+  fi
+
+  parent_exists="$(az group exists --name "$RESOURCE_GROUP" 2>/dev/null)"
+  node_exists="$(az group exists --name "$NODE_RESOURCE_GROUP" 2>/dev/null)"
+  {
+    echo
+    echo "## Cleanup"
+    echo
+    echo "- Parent resource group exists: $parent_exists"
+    echo "- AKS node resource group exists: $node_exists"
+  } >>"$EVIDENCE_FILE"
+  if [[ "$parent_exists" == "false" && "$node_exists" == "false" ]]; then
+    CLEANUP_OK=1
+  fi
+  set -e
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
+}
+
+on_exit() {
+  exit_code=$?
+  trap - EXIT
+  cleanup_resources
+  if [[ "$RUN_SUCCEEDED" == "1" ]]; then
+    rm -rf "$TMP_DIR"
+  else
+    echo "Failure artifacts preserved in: $TMP_DIR" >&2
+  fi
+  echo "Sanitized evidence: $EVIDENCE_FILE" >&2
+  exit "$exit_code"
+}
+trap on_exit EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+: >"$EVIDENCE_FILE"
+chmod 600 "$EVIDENCE_FILE"
+
+az account set --subscription "$SUBSCRIPTION_ID"
+[[ "$(az account show --query state -o tsv)" == "Enabled" ]] || die "Azure subscription is not enabled."
+[[ "$(az account show --query tenantId -o tsv)" == "$TENANT_ID" ]] || die "Azure tenant changed during preflight."
+[[ -z "$(git status --porcelain)" ]] || die "Worktree must be clean so the image exactly matches Git HEAD."
+if [[ -n "$PR_NUMBER" ]]; then
+  PR_HEAD="$(gh pr view "$PR_NUMBER" --repo BerriAI/litellm --json headRefOid --jq .headRefOid)"
+  [[ "$PR_HEAD" == "$GIT_SHA" ]] || die "Git HEAD does not match PR #$PR_NUMBER head."
+fi
+
+CREATOR="$(az account show --query user.name -o tsv)"
+CREATED_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "Resource group: $RESOURCE_GROUP"
+echo "Emergency cleanup: az group delete -g $RESOURCE_GROUP -y"
+echo "Evidence file: $EVIDENCE_FILE"
+
+for provider in Microsoft.Cache Microsoft.ContainerRegistry Microsoft.ContainerService Microsoft.DBforPostgreSQL Microsoft.ManagedIdentity Microsoft.Network; do
+  az provider register --namespace "$provider" --wait --only-show-errors
+done
+
+az group create --name "$RESOURCE_GROUP" --location "$LOCATION" \
+  --tags purpose=litellm-workload-identity-e2e git_sha="$GIT_SHA" creator="$CREATOR" created_utc="$CREATED_UTC" \
+  --only-show-errors >/dev/null
+az acr create --resource-group "$RESOURCE_GROUP" --name "$ACR_NAME" --sku Basic \
+  --admin-enabled false --only-show-errors >/dev/null
+az identity create --resource-group "$RESOURCE_GROUP" --name "$IDENTITY_NAME" \
+  --location "$LOCATION" --only-show-errors >/dev/null
+IDENTITY_CLIENT_ID="$(az identity show -g "$RESOURCE_GROUP" -n "$IDENTITY_NAME" --query clientId -o tsv)"
+IDENTITY_PRINCIPAL_ID="$(az identity show -g "$RESOURCE_GROUP" -n "$IDENTITY_NAME" --query principalId -o tsv)"
+
+az aks create --resource-group "$RESOURCE_GROUP" --name "$AKS_NAME" --location "$LOCATION" \
+  --tier free --node-count 1 --node-vm-size "$AKS_NODE_VM_SIZE" \
+  --enable-oidc-issuer --enable-workload-identity \
+  --node-resource-group "$NODE_RESOURCE_GROUP" --attach-acr "$ACR_NAME" \
+  --no-ssh-key --only-show-errors >/dev/null
+az aks get-credentials --resource-group "$RESOURCE_GROUP" --name "$AKS_NAME" \
+  --overwrite-existing --only-show-errors
+OIDC_ENABLED="$(az aks show -g "$RESOURCE_GROUP" -n "$AKS_NAME" --query oidcIssuerProfile.enabled -o tsv)"
+WORKLOAD_IDENTITY_ENABLED="$(az aks show -g "$RESOURCE_GROUP" -n "$AKS_NAME" --query securityProfile.workloadIdentity.enabled -o tsv)"
+OIDC_ISSUER="$(az aks show -g "$RESOURCE_GROUP" -n "$AKS_NAME" --query oidcIssuerProfile.issuerUrl -o tsv)"
+[[ "$OIDC_ENABLED" == "true" && "$WORKLOAD_IDENTITY_ENABLED" == "true" ]] || die "AKS identity features are not enabled."
+
+ADMIN_OBJECT_ID="$(az ad signed-in-user show --query id -o tsv)"
+ADMIN_DISPLAY_NAME="$(az ad signed-in-user show --query userPrincipalName -o tsv)"
+PUBLIC_IP="$(curl -fsS https://api.ipify.org)"
+[[ "$PUBLIC_IP" =~ ^[0-9a-fA-F:.]+$ ]] || die "Could not resolve the operator public IP."
+
+POSTGRES_BODY="$(jq -cn --arg location "$LOCATION" --arg tenant "$TENANT_ID" \
+  '{location:$location,sku:{name:"Standard_B1ms",tier:"Burstable"},properties:{version:"16",storage:{storageSizeGB:32},authConfig:{activeDirectoryAuth:"Enabled",passwordAuth:"Disabled",tenantId:$tenant},network:{publicNetworkAccess:"Enabled"}}}')"
+az rest --method put \
+  --url "https://management.azure.com/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.DBforPostgreSQL/flexibleServers/$POSTGRES_NAME?api-version=2024-08-01" \
+  --body "$POSTGRES_BODY" --only-show-errors >/dev/null
+unset POSTGRES_BODY
+az resource wait --resource-group "$RESOURCE_GROUP" --name "$POSTGRES_NAME" \
+  --resource-type Microsoft.DBforPostgreSQL/flexibleServers \
+  --custom "properties.state=='Ready'" --interval 20 --timeout 1800 --only-show-errors
+retry_postgres_busy az rest --method patch \
+  --url "https://management.azure.com/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.DBforPostgreSQL/flexibleServers/$POSTGRES_NAME?api-version=2024-08-01" \
+  --body '{"properties":{"network":{"publicNetworkAccess":"Enabled"}}}' --only-show-errors >/dev/null
+az resource wait --resource-group "$RESOURCE_GROUP" --name "$POSTGRES_NAME" \
+  --resource-type Microsoft.DBforPostgreSQL/flexibleServers \
+  --custom "properties.state=='Ready' && properties.network.publicNetworkAccess=='Enabled'" \
+  --interval 20 --timeout 1800 --only-show-errors
+retry_postgres_busy az postgres flexible-server firewall-rule create --resource-group "$RESOURCE_GROUP" \
+  --server-name "$POSTGRES_NAME" --name operator-bootstrap \
+  --start-ip-address "$PUBLIC_IP" --end-ip-address "$PUBLIC_IP" --only-show-errors >/dev/null
+
+ADMIN_BODY="$(jq -cn --arg name "$ADMIN_DISPLAY_NAME" --arg tenant "$TENANT_ID" \
+  '{properties:{principalName:$name,principalType:"User",tenantId:$tenant}}')"
+retry_postgres_busy az rest --method put \
+  --url "https://management.azure.com/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.DBforPostgreSQL/flexibleServers/$POSTGRES_NAME/administrators/$ADMIN_OBJECT_ID?api-version=2024-08-01" \
+  --body "$ADMIN_BODY" --only-show-errors >/dev/null
+unset ADMIN_BODY
+POSTGRES_HOST="$(az postgres flexible-server show -g "$RESOURCE_GROUP" -n "$POSTGRES_NAME" --query fullyQualifiedDomainName -o tsv)"
+POSTGRES_AUTH="$(az postgres flexible-server show -g "$RESOURCE_GROUP" -n "$POSTGRES_NAME" -o json)"
+jq -e '.authConfig.activeDirectoryAuth == "Enabled" and .authConfig.passwordAuth == "Disabled"' \
+  <<<"$POSTGRES_AUTH" >/dev/null || die "PostgreSQL is not Entra-only."
+
+printf '%s\n' '{"aad-enabled":"true"}' >"$TMP_DIR/redis-configuration.json"
+az redis create --resource-group "$RESOURCE_GROUP" --name "$REDIS_NAME" --location "$LOCATION" \
+  --sku Basic --vm-size c0 --minimum-tls-version 1.2 \
+  --disable-access-keys true --redis-configuration "@$TMP_DIR/redis-configuration.json" \
+  --only-show-errors >/dev/null
+REDIS_JSON="$(az redis show -g "$RESOURCE_GROUP" -n "$REDIS_NAME" -o json)"
+REDIS_HOST="$(jq -r '.hostName' <<<"$REDIS_JSON")"
+jq -e '((.redisConfiguration.aadEnabled // .redisConfiguration["aad-enabled"]) | tostring | ascii_downcase) == "true"
+  and .disableAccessKeyAuthentication == true
+  and .enableNonSslPort == false
+  and .minimumTlsVersion == "1.2"' <<<"$REDIS_JSON" >/dev/null || die "Redis security settings are incorrect."
+
+az identity federated-credential create --resource-group "$RESOURCE_GROUP" \
+  --identity-name "$IDENTITY_NAME" --name litellm --issuer "$OIDC_ISSUER" \
+  --subject "system:serviceaccount:$NAMESPACE:$SERVICE_ACCOUNT" \
+  --audiences api://AzureADTokenExchange --only-show-errors >/dev/null
+
+kubectl create namespace "$NAMESPACE"
+kubectl create serviceaccount "$SERVICE_ACCOUNT" --namespace "$NAMESPACE"
+kubectl annotate serviceaccount "$SERVICE_ACCOUNT" --namespace "$NAMESPACE" \
+  "azure.workload.identity/client-id=$IDENTITY_CLIENT_ID"
+SA_CLIENT_ID="$(kubectl get serviceaccount "$SERVICE_ACCOUNT" -n "$NAMESPACE" \
+  -o jsonpath='{.metadata.annotations.azure\.workload\.identity/client-id}')"
+[[ "$SA_CLIENT_ID" == "$IDENTITY_CLIENT_ID" ]] || die "Service-account client ID annotation does not match."
+
+FEDERATION_JSON="$(az identity federated-credential show -g "$RESOURCE_GROUP" \
+  --identity-name "$IDENTITY_NAME" -n litellm -o json)"
+jq -e --arg subject "system:serviceaccount:$NAMESPACE:$SERVICE_ACCOUNT" \
+  '.subject == $subject and (.audiences | index("api://AzureADTokenExchange") != null)' \
+  <<<"$FEDERATION_JSON" >/dev/null || die "Federated credential does not match the service account."
+
+POSTGRES_ADMIN_TOKEN="$(az account get-access-token --resource-type oss-rdbms --query accessToken -o tsv)"
+printf '%s\n' "SELECT * FROM pgaadauth_create_principal_with_oid(:'identity_name', :'principal_id', 'service', false, false);" | \
+  PGPASSWORD="$POSTGRES_ADMIN_TOKEN" docker run --rm -i -e PGPASSWORD postgres:16-alpine \
+  psql "host=$POSTGRES_HOST port=5432 dbname=postgres user=$ADMIN_DISPLAY_NAME sslmode=require" \
+  --set=ON_ERROR_STOP=1 --set=identity_name="$IDENTITY_NAME" \
+  --set=principal_id="$IDENTITY_PRINCIPAL_ID" \
+  >/dev/null
+printf '%s\n' 'CREATE DATABASE litellm OWNER :"identity_name";' | \
+  PGPASSWORD="$POSTGRES_ADMIN_TOKEN" docker run --rm -i -e PGPASSWORD postgres:16-alpine \
+  psql "host=$POSTGRES_HOST port=5432 dbname=postgres user=$ADMIN_DISPLAY_NAME sslmode=require" \
+  --set=ON_ERROR_STOP=1 --set=identity_name="$IDENTITY_NAME" \
+  >/dev/null
+PG_PRINCIPAL_COUNT="$(printf '%s\n' "SELECT count(*) FROM pg_roles WHERE rolname = :'identity_name';" | \
+  PGPASSWORD="$POSTGRES_ADMIN_TOKEN" docker run --rm -i -e PGPASSWORD postgres:16-alpine \
+  psql "host=$POSTGRES_HOST port=5432 dbname=postgres user=$ADMIN_DISPLAY_NAME sslmode=require" \
+  --tuples-only --no-align --set=ON_ERROR_STOP=1 --set=identity_name="$IDENTITY_NAME" \
+  )"
+printf 'GRANT USAGE, CREATE ON SCHEMA public TO :"identity_name";\n' |
+  PGPASSWORD="$POSTGRES_ADMIN_TOKEN" docker run --rm -i -e PGPASSWORD postgres:16-alpine \
+  psql "host=$POSTGRES_HOST port=5432 user=$ADMIN_DISPLAY_NAME dbname=litellm sslmode=require" \
+  --set=ON_ERROR_STOP=1 --set=identity_name="$IDENTITY_NAME" \
+  >/dev/null
+unset POSTGRES_ADMIN_TOKEN PGPASSWORD
+[[ "$PG_PRINCIPAL_COUNT" == "1" ]] || die "PostgreSQL managed-identity principal was not created."
+
+AKS_OUTBOUND_IP_ID="$(az aks show -g "$RESOURCE_GROUP" -n "$AKS_NAME" \
+  --query 'networkProfile.loadBalancerProfile.effectiveOutboundIPs[0].id' -o tsv)"
+AKS_OUTBOUND_IP="$(az network public-ip show --ids "$AKS_OUTBOUND_IP_ID" --query ipAddress -o tsv)"
+az postgres flexible-server firewall-rule create --resource-group "$RESOURCE_GROUP" \
+  --server-name "$POSTGRES_NAME" --name aks-outbound \
+  --start-ip-address "$AKS_OUTBOUND_IP" --end-ip-address "$AKS_OUTBOUND_IP" \
+  --only-show-errors >/dev/null
+OPERATOR_FIREWALL_RULES="$(az postgres flexible-server firewall-rule list -g "$RESOURCE_GROUP" \
+  --server-name "$POSTGRES_NAME" --query "[?startIpAddress=='$PUBLIC_IP'].name" -o tsv)"
+while IFS= read -r firewall_rule; do
+  [[ -n "$firewall_rule" ]] || continue
+  az postgres flexible-server firewall-rule delete -g "$RESOURCE_GROUP" --server-name "$POSTGRES_NAME" \
+    --name "$firewall_rule" --yes --only-show-errors >/dev/null
+done <<<"$OPERATOR_FIREWALL_RULES"
+OPERATOR_FIREWALL_RULES="$(az postgres flexible-server firewall-rule list -g "$RESOURCE_GROUP" \
+  --server-name "$POSTGRES_NAME" --query "[?startIpAddress=='$PUBLIC_IP'].name" -o tsv)"
+[[ -z "$OPERATOR_FIREWALL_RULES" ]] || die "The operator PostgreSQL firewall rule was not removed."
+unset OPERATOR_FIREWALL_RULES
+
+az redis access-policy-assignment create --resource-group "$RESOURCE_GROUP" \
+  --name "$REDIS_NAME" --object-id "$IDENTITY_PRINCIPAL_ID" \
+  --object-id-alias "$IDENTITY_PRINCIPAL_ID" --access-policy-name "Data Contributor" \
+  --policy-assignment-name litellm-workload-identity --only-show-errors >/dev/null
+REDIS_POLICY_JSON="$(az redis access-policy-assignment show -g "$RESOURCE_GROUP" -n "$REDIS_NAME" \
+  --policy-assignment-name litellm-workload-identity -o json)"
+jq -e --arg object_id "$IDENTITY_PRINCIPAL_ID" \
+  '.objectId == $object_id and .objectIdAlias == $object_id and .accessPolicyName == "Data Contributor"' \
+  <<<"$REDIS_POLICY_JSON" >/dev/null || die "Redis access policy does not match the managed identity."
+
+IMAGE_TAG="wi-e2e-${GIT_SHA}"
+ACR_LOGIN_SERVER="$(az acr show -g "$RESOURCE_GROUP" -n "$ACR_NAME" --query loginServer -o tsv)"
+az acr login --name "$ACR_NAME" --only-show-errors >/dev/null
+mkdir "$TMP_DIR/build-context"
+git archive HEAD | tar -x -C "$TMP_DIR/build-context"
+docker buildx build --platform linux/amd64 --file "$TMP_DIR/build-context/gateway/Dockerfile" \
+  --tag "${ACR_LOGIN_SERVER}/litellm:$IMAGE_TAG" --push "$TMP_DIR/build-context"
+IMAGE_DIGEST="$(az acr repository show -n "$ACR_NAME" --image "litellm:$IMAGE_TAG" --query digest -o tsv)"
+[[ "$IMAGE_DIGEST" == sha256:* ]] || die "ACR did not return an immutable digest."
+IMAGE_REFERENCE="${ACR_LOGIN_SERVER}/litellm@${IMAGE_DIGEST}"
+
+cat >"$TMP_DIR/proxy.yaml" <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: litellm-config
+  namespace: $NAMESPACE
+data:
+  config.yaml: |
+    model_list: []
+    litellm_settings:
+      telemetry: false
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: litellm-postgres-proof
+  namespace: $NAMESPACE
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: litellm-postgres-proof
+  template:
+    metadata:
+      labels:
+        app: litellm-postgres-proof
+        azure.workload.identity/use: "true"
+    spec:
+      serviceAccountName: $SERVICE_ACCOUNT
+      containers:
+        - name: litellm
+          image: $IMAGE_REFERENCE
+          imagePullPolicy: IfNotPresent
+          command: ["/app/.venv/bin/litellm"]
+          args: ["--config", "/config/config.yaml", "--port", "4000", "--azure_postgresql_auth", "--enforce_prisma_migration_check"]
+          ports:
+            - name: http
+              containerPort: 4000
+          readinessProbe:
+            httpGet:
+              path: /health/readiness
+              port: http
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 120
+          env:
+            - name: LITELLM_LOG
+              value: INFO
+            - name: DATABASE_HOST
+              value: $POSTGRES_HOST
+            - name: DATABASE_PORT
+              value: "5432"
+            - name: DATABASE_USER
+              value: $IDENTITY_NAME
+            - name: DATABASE_NAME
+              value: litellm
+            - name: STORE_MODEL_IN_DB
+              value: "True"
+          volumeMounts:
+            - name: config
+              mountPath: /config
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: litellm-config
+EOF
+kubectl apply -f "$TMP_DIR/proxy.yaml"
+kubectl rollout status deployment/litellm-postgres-proof -n "$NAMESPACE" --timeout=15m
+PROXY_POD="$(kubectl get pods -n "$NAMESPACE" -l app=litellm-postgres-proof \
+  -o jsonpath='{.items[0].metadata.name}')"
+POD_IMAGE_ID="$(kubectl get pod "$PROXY_POD" -n "$NAMESPACE" \
+  -o jsonpath='{.status.containerStatuses[0].imageID}')"
+[[ "$POD_IMAGE_ID" == *"$IMAGE_DIGEST"* ]] || die "Running proxy image does not match the ACR digest."
+
+kubectl exec -n "$NAMESPACE" "$PROXY_POD" -- python -c \
+  'import json,os; required=("AZURE_CLIENT_ID","AZURE_TENANT_ID","AZURE_FEDERATED_TOKEN_FILE"); forbidden=("AZURE_CLIENT_SECRET","DATABASE_PASSWORD","DATABASE_URL","REDIS_PASSWORD"); print(json.dumps({"present":[x for x in required if x in os.environ],"absent":[x for x in forbidden if x not in os.environ]},sort_keys=True))' \
+  >"$TMP_DIR/proxy-env.json"
+jq -e '.present == ["AZURE_CLIENT_ID","AZURE_TENANT_ID","AZURE_FEDERATED_TOKEN_FILE"]
+  and .absent == ["AZURE_CLIENT_SECRET","DATABASE_PASSWORD","DATABASE_URL","REDIS_PASSWORD"]' \
+  "$TMP_DIR/proxy-env.json" >/dev/null || die "Proxy pod credential environment is incorrect."
+
+READINESS_HTTP="$(kubectl exec -n "$NAMESPACE" "$PROXY_POD" -- python -c \
+  'import pathlib,urllib.request; r=urllib.request.urlopen("http://127.0.0.1:4000/health/readiness",timeout=20); pathlib.Path("/tmp/readiness.json").write_bytes(r.read()); print(r.status)' | tr -d '\r')"
+[[ "$READINESS_HTTP" == "200" ]] || die "Proxy readiness did not return HTTP 200."
+kubectl cp "$NAMESPACE/$PROXY_POD:/tmp/readiness.json" "$TMP_DIR/readiness.json" >/dev/null
+kubectl logs -n "$NAMESPACE" "$PROXY_POD" >"$TMP_DIR/proxy.log"
+rg -q 'Azure PostgreSQL Entra token refresh loop started' "$TMP_DIR/proxy.log" || die "PostgreSQL token refresh loop did not start."
+rg -q 'Azure PostgreSQL Entra token refresh scheduled in' "$TMP_DIR/proxy.log" || die "PostgreSQL token refresh was not scheduled."
+rg -q 'Started Azure PostgreSQL Entra token proactive refresh background task' "$TMP_DIR/proxy.log" || \
+  die "PostgreSQL proactive token refresh task did not start."
+jq -e '.status == "healthy" and .db == "connected"' "$TMP_DIR/readiness.json" >/dev/null || \
+  die "Proxy readiness does not report a connected database."
+
+cat >"$TMP_DIR/redis-job.yaml" <<EOF
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: litellm-redis-proof
+  namespace: $NAMESPACE
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        app: litellm-redis-proof
+        azure.workload.identity/use: "true"
+    spec:
+      restartPolicy: Never
+      serviceAccountName: $SERVICE_ACCOUNT
+      containers:
+        - name: proof
+          image: $IMAGE_REFERENCE
+          imagePullPolicy: IfNotPresent
+          command: ["python", "-c"]
+          args:
+            - |
+              import asyncio
+              import json
+              import os
+              import uuid
+              from litellm._redis import get_redis_async_client, get_redis_client, get_redis_connection_pool
+
+              async def main():
+                  required = ("AZURE_CLIENT_ID", "AZURE_TENANT_ID", "AZURE_FEDERATED_TOKEN_FILE")
+                  forbidden = ("AZURE_CLIENT_SECRET", "REDIS_PASSWORD")
+                  assert all(name in os.environ for name in required)
+                  assert all(name not in os.environ for name in forbidden)
+                  key = f"litellm:wi-proof:{uuid.uuid4().hex}"
+                  kwargs = {
+                      "url": os.environ["REDIS_URL"],
+                      "username": os.environ["REDIS_USERNAME"],
+                      "azure_redis_ad_token": True,
+                  }
+                  sync_client = get_redis_client(**kwargs)
+                  assert sync_client.ping() is True
+                  pool = get_redis_connection_pool(**kwargs)
+                  assert pool is not None
+                  client = get_redis_async_client(connection_pool=pool, **kwargs)
+                  assert await client.ping() is True
+                  assert await client.set(key, "ok", ex=60) is True
+                  assert await client.get(key) == b"ok"
+                  assert await client.delete(key) == 1
+                  assert await client.get(key) is None
+                  print(json.dumps({"async_pool_ping": True, "credential_source": "AKS Workload Identity", "set_get_delete": True, "sync_ping": True}, sort_keys=True))
+                  await client.aclose()
+                  await pool.disconnect()
+                  sync_client.close()
+
+              asyncio.run(main())
+          env:
+            - name: REDIS_URL
+              value: rediss://$REDIS_HOST:6380/0
+            - name: REDIS_USERNAME
+              value: $IDENTITY_PRINCIPAL_ID
+            - name: REDIS_AZURE_AD_TOKEN
+              value: "true"
+            - name: REDIS_SOCKET_TIMEOUT
+              value: "10"
+EOF
+
+REDIS_RESULT=""
+attempt=1
+while [[ "$attempt" -le 10 ]]; do
+  kubectl delete job litellm-redis-proof -n "$NAMESPACE" --ignore-not-found --wait=true >/dev/null
+  kubectl apply -f "$TMP_DIR/redis-job.yaml" >/dev/null
+  if kubectl wait job/litellm-redis-proof -n "$NAMESPACE" --for=condition=complete --timeout=5m >/dev/null 2>&1; then
+    kubectl logs job/litellm-redis-proof -n "$NAMESPACE" >"$TMP_DIR/redis.log"
+    REDIS_RESULT="$(rg '^\{"async_pool_ping": true, "credential_source": "AKS Workload Identity", "set_get_delete": true, "sync_ping": true\}$' \
+      "$TMP_DIR/redis.log" | tail -n 1)"
+    [[ -n "$REDIS_RESULT" ]] || die "Redis proof completed without the expected result."
+    break
+  fi
+  kubectl logs job/litellm-redis-proof -n "$NAMESPACE" >"$TMP_DIR/redis.log" 2>&1 || true
+  if ! rg -qi 'WRONGPASS|NOAUTH|access.?policy|not authorized|authentication' "$TMP_DIR/redis.log"; then
+    die "Redis proof failed for a non-propagation reason; see $TMP_DIR/redis.log"
+  fi
+  if [[ "$attempt" == "10" ]]; then
+    die "Redis access policy did not propagate after ten attempts."
+  fi
+  echo "Redis identity access is still propagating (attempt $attempt/10)."
+  sleep 30
+  attempt=$((attempt + 1))
+done
+
+REDIS_POD="$(kubectl get pods -n "$NAMESPACE" -l job-name=litellm-redis-proof \
+  -o jsonpath='{.items[0].metadata.name}')"
+REDIS_IMAGE_ID="$(kubectl get pod "$REDIS_POD" -n "$NAMESPACE" \
+  -o jsonpath='{.status.containerStatuses[0].imageID}')"
+[[ "$REDIS_IMAGE_ID" == *"$IMAGE_DIGEST"* ]] || die "Running Redis proof image does not match the ACR digest."
+REDIS_EXIT_CODE="$(kubectl get pod "$REDIS_POD" -n "$NAMESPACE" \
+  -o jsonpath='{.status.containerStatuses[0].state.terminated.exitCode}')"
+[[ "$REDIS_EXIT_CODE" == "0" ]] || die "Redis proof container did not exit successfully."
+
+FORBIDDEN_ENV_NAMES="$(kubectl get deployment litellm-postgres-proof -n "$NAMESPACE" -o json | \
+  jq -r '[.spec.template.spec.containers[].env[]?.name] | map(select(. == "AZURE_CLIENT_SECRET" or . == "DATABASE_PASSWORD" or . == "DATABASE_URL" or . == "REDIS_PASSWORD")) | length')"
+[[ "$FORBIDDEN_ENV_NAMES" == "0" ]] || die "A forbidden credential variable exists in the proxy specification."
+
+cat >"$EVIDENCE_FILE" <<EOF
+# Azure Workload Identity live proof
+
+- Git/PR head SHA: \`$GIT_SHA\`
+- Immutable image digest: \`$IMAGE_DIGEST\`
+- Proxy pod digest matches: true
+- Redis job digest matches: true
+- AKS OIDC issuer enabled: $OIDC_ENABLED
+- AKS Workload Identity enabled: $WORKLOAD_IDENTITY_ENABLED
+- Federated subject: \`system:serviceaccount:$NAMESPACE:$SERVICE_ACCOUNT\`
+- Federated audience: \`api://AzureADTokenExchange\`
+- Service-account client-ID annotation matches: true
+- Injected variable names present: \`AZURE_CLIENT_ID\`, \`AZURE_TENANT_ID\`, \`AZURE_FEDERATED_TOKEN_FILE\`
+- Forbidden variable names absent: \`AZURE_CLIENT_SECRET\`, \`DATABASE_PASSWORD\`, \`DATABASE_URL\`, \`REDIS_PASSWORD\`
+
+## PostgreSQL
+
+- SKU/storage: Burstable Standard_B1ms / 32 GiB
+- Microsoft Entra authentication enabled: true
+- Password authentication disabled: true
+- Managed-identity database principal exists: true
+- Readiness HTTP status: $READINESS_HTTP
+- Readiness status: healthy
+- Database status: connected
+- Prisma migration success enforced: true
+- Token refresh loop started: true
+- Token refresh scheduled: true
+- Proactive token refresh background task started: true
+- No inference request made.
+
+## Redis
+
+- SKU: Azure Cache for Redis Basic C0
+- Microsoft Entra authentication enabled: true
+- Access-key authentication disabled: true
+- Non-TLS port disabled: true
+- Minimum TLS version: 1.2
+- Access policy: Data Contributor
+- Object-ID alias matches managed identity principal: true
+- Job condition: Complete
+- Container exit code: $REDIS_EXIT_CODE
+- Production routes: sync URL client and async URL connection pool
+- Result: \`$REDIS_RESULT\`
+- Proof key deleted: true
+- No inference request made.
+EOF
+
+SECRET_PATTERN='eyJ[A-Za-z0-9_-]+\.|password[=:][^[:space:]<]+|postgresql://[^[:space:]<]+:[^@[:space:]<]+@|client_secret[=:][^[:space:]<]+|refresh_token[=:][^[:space:]<]+|access_token[=:][^[:space:]<]+'
+if rg -qi "$SECRET_PATTERN" "$EVIDENCE_FILE" "$TMP_DIR/proxy.log" "$TMP_DIR/redis.log" >/dev/null; then
+  die "Potential secret found; evidence will not be published."
+fi
+
+cleanup_resources
+if [[ "${KEEP_RESOURCES:-0}" != "1" && "$CLEANUP_OK" != "1" ]]; then
+  die "Azure cleanup could not be confirmed."
+fi
+if rg -qi "$SECRET_PATTERN" "$EVIDENCE_FILE" >/dev/null; then
+  die "Potential secret found after cleanup; evidence will not be published."
+fi
+
+if [[ "$POST_PR_COMMENT" == "1" ]]; then
+  PR_HEAD="$(gh pr view "$PR_NUMBER" --repo BerriAI/litellm --json headRefOid --jq .headRefOid)"
+  [[ "$PR_HEAD" == "$GIT_SHA" ]] || die "PR #$PR_NUMBER advanced during the live proof; evidence was not published."
+  gh pr comment "$PR_NUMBER" --repo BerriAI/litellm --body-file "$EVIDENCE_FILE"
+  gh pr comment "$PR_NUMBER" --repo BerriAI/litellm \
+    --body "@greptileai please re-review commit $GIT_SHA and update the confidence score."
+fi
+
+RUN_SUCCEEDED=1
+echo "PostgreSQL and Redis Workload Identity proofs passed."
+echo "Sanitized evidence: $EVIDENCE_FILE"

--- a/tests/proxy_unit_tests/test_aproxy_startup.py
+++ b/tests/proxy_unit_tests/test_aproxy_startup.py
@@ -1,26 +1,24 @@
 # What this tests
 ## This tests the proxy server startup
-import sys, os, json
-import traceback
+import json
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
 from dotenv import load_dotenv
 
 load_dotenv()
-import os, io
 
 # this file is to test litellm/proxy
 
 sys.path.insert(
     0, os.path.abspath("../..")
 )  # Adds the parent directory to the system path
-import pytest, logging, asyncio
+import pytest
+
 import litellm
 from litellm.proxy.proxy_server import (
-    router,
-    save_worker_config,
-    initialize,
     proxy_startup_event,
-    llm_model_list,
-    proxy_shutdown_event,
 )
 
 
@@ -94,3 +92,71 @@ async def test_proxy_gunicorn_startup_config_dict():
 
 
 # test_proxy_gunicorn_startup()
+
+
+def test_proxy_cli_azure_postgresql_auth_sets_token_database_url(monkeypatch):
+    from litellm.proxy.db.prisma_client import (
+        AZURE_POSTGRESQL_AUTH_MARKER_ENV,
+        IAMEndpoint,
+    )
+    from litellm.proxy.proxy_cli import run_server
+
+    endpoint = IAMEndpoint(
+        host="server.postgres.database.azure.com",
+        port="5432",
+        user="managed-identity",
+        name="litellm",
+    )
+    token_url = (
+        "postgresql://managed-identity:token@"
+        "server.postgres.database.azure.com:5432/litellm"
+    )
+    mock_proxy_module = MagicMock(
+        app=MagicMock(),
+        ProxyConfig=MagicMock(),
+        KeyManagementSettings=MagicMock(),
+        save_worker_config=MagicMock(),
+    )
+
+    for key in (
+        "DATABASE_URL",
+        "DIRECT_URL",
+        "IAM_TOKEN_DB_AUTH",
+        AZURE_POSTGRESQL_AUTH_MARKER_ENV,
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    with (
+        patch.dict(
+            "sys.modules",
+            {
+                "proxy_server": mock_proxy_module,
+                "litellm.proxy.proxy_server": mock_proxy_module,
+            },
+        ),
+        patch("subprocess.run", return_value=MagicMock(returncode=0)),
+        patch("atexit.register"),
+        patch(
+            "litellm.proxy.db.prisma_client.get_database_auth_endpoint_from_env",
+            return_value=endpoint,
+        ) as mock_get_endpoint,
+        patch(
+            "litellm.proxy.db.prisma_client.build_database_token_auth_url",
+            return_value=token_url,
+        ) as mock_build_url,
+        patch(
+            "litellm.proxy.db.prisma_client.should_update_prisma_schema",
+            return_value=False,
+        ),
+        patch("litellm.proxy.db.check_migration.check_prisma_schema_diff"),
+    ):
+        run_server.main(
+            ["--local", "--skip_server_startup", "--azure_postgresql_auth"],
+            standalone_mode=False,
+        )
+
+    assert os.environ["DATABASE_URL"].startswith(token_url)
+    assert os.environ["IAM_TOKEN_DB_AUTH"] == "True"
+    assert os.environ[AZURE_POSTGRESQL_AUTH_MARKER_ENV] == "True"
+    mock_get_endpoint.assert_called_once()
+    mock_build_url.assert_called_once_with(endpoint, azure_postgresql_auth=True)

--- a/tests/test_litellm/proxy/db/test_rds_iam_token_expiry.py
+++ b/tests/test_litellm/proxy/db/test_rds_iam_token_expiry.py
@@ -14,12 +14,118 @@ Run these tests:
 """
 
 import asyncio
+import builtins
 import os
+import sys
+import types
 import urllib.parse
 from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+
+def test_init_rds_client_does_not_import_secret_manager(monkeypatch):
+    from litellm.proxy.auth.rds_iam_token import init_rds_client
+
+    fake_boto3 = types.SimpleNamespace(
+        session=types.SimpleNamespace(Config=MagicMock()),
+        client=MagicMock(return_value="rds-client"),
+    )
+    real_import = builtins.__import__
+
+    def fail_on_secret_manager_import(name, *args, **kwargs):
+        if name == "litellm.secret_managers.main":
+            raise AssertionError("rds_iam_token must not import secret_managers.main")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setenv("AWS_REGION_NAME", "us-east-1")
+    monkeypatch.setitem(sys.modules, "boto3", fake_boto3)
+    monkeypatch.setattr(builtins, "__import__", fail_on_secret_manager_import)
+
+    assert init_rds_client() == "rds-client"
+
+
+def test_init_rds_client_resolves_region_and_oidc_with_get_secret(monkeypatch):
+    import litellm
+    from litellm.proxy.auth.rds_iam_token import init_rds_client
+
+    fake_sts = MagicMock()
+    fake_sts.assume_role_with_web_identity.return_value = {
+        "Credentials": {
+            "AccessKeyId": "access-key",
+            "SecretAccessKey": "secret-key",
+            "SessionToken": "session-token",
+        }
+    }
+    rds_client = object()
+
+    def fake_boto_client(service_name, **kwargs):
+        if service_name == "sts":
+            return fake_sts
+        if service_name == "rds":
+            fake_boto_client.rds_kwargs = kwargs
+            return rds_client
+        raise AssertionError(service_name)
+
+    fake_boto_client.rds_kwargs = {}
+    fake_boto3 = types.SimpleNamespace(
+        session=types.SimpleNamespace(Config=MagicMock()),
+        client=MagicMock(side_effect=fake_boto_client),
+    )
+
+    def fake_get_secret(secret_name, default_value=None):
+        return {
+            "AWS_REGION_NAME": "us-east-1",
+            "AWS_REGION": None,
+            "oidc/google/audience": "oidc-token",
+        }.get(secret_name, default_value)
+
+    monkeypatch.delenv("AWS_REGION_NAME", raising=False)
+    monkeypatch.delenv("AWS_REGION", raising=False)
+    monkeypatch.setattr(litellm, "get_secret", fake_get_secret)
+    monkeypatch.setitem(sys.modules, "boto3", fake_boto3)
+
+    assert (
+        init_rds_client(
+            aws_role_name="arn:aws:iam::123:role/rds",
+            aws_session_name="litellm",
+            aws_web_identity_token="oidc/google/audience",
+        )
+        is rds_client
+    )
+    fake_sts.assume_role_with_web_identity.assert_called_once_with(
+        RoleArn="arn:aws:iam::123:role/rds",
+        RoleSessionName="litellm",
+        WebIdentityToken="oidc-token",
+        DurationSeconds=3600,
+    )
+    assert fake_boto_client.rds_kwargs["region_name"] == "us-east-1"
+
+
+def test_init_rds_client_resolves_os_environ_parameter(monkeypatch):
+    from litellm.proxy.auth.rds_iam_token import init_rds_client
+
+    rds_client = object()
+    fake_boto3 = types.SimpleNamespace(
+        session=types.SimpleNamespace(Config=MagicMock()),
+        client=MagicMock(return_value=rds_client),
+    )
+
+    monkeypatch.setenv("AWS_REGION_NAME", "us-east-1")
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "env-access-key")
+    monkeypatch.setitem(sys.modules, "boto3", fake_boto3)
+
+    assert (
+        init_rds_client(aws_access_key_id="os.environ/AWS_ACCESS_KEY_ID") is rds_client
+    )
+    fake_boto3.client.assert_called_once_with(
+        service_name="rds",
+        region_name="us-east-1",
+        aws_access_key_id="env-access-key",
+        aws_secret_access_key=None,
+        config=fake_boto3.session.Config.return_value,
+    )
 
 
 class TestPrismaWrapperTokenRefresh:

--- a/tests/test_litellm/proxy/db/test_rds_iam_token_expiry.py
+++ b/tests/test_litellm/proxy/db/test_rds_iam_token_expiry.py
@@ -14,7 +14,6 @@ Run these tests:
 """
 
 import asyncio
-import builtins
 import os
 import sys
 import types
@@ -25,29 +24,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
-def test_init_rds_client_does_not_import_secret_manager(monkeypatch):
-    from litellm.proxy.auth.rds_iam_token import init_rds_client
-
-    fake_boto3 = types.SimpleNamespace(
-        session=types.SimpleNamespace(Config=MagicMock()),
-        client=MagicMock(return_value="rds-client"),
-    )
-    real_import = builtins.__import__
-
-    def fail_on_secret_manager_import(name, *args, **kwargs):
-        if name == "litellm.secret_managers.main":
-            raise AssertionError("rds_iam_token must not import secret_managers.main")
-        return real_import(name, *args, **kwargs)
-
-    monkeypatch.setenv("AWS_REGION_NAME", "us-east-1")
-    monkeypatch.setitem(sys.modules, "boto3", fake_boto3)
-    monkeypatch.setattr(builtins, "__import__", fail_on_secret_manager_import)
-
-    assert init_rds_client() == "rds-client"
-
-
 def test_init_rds_client_resolves_region_and_oidc_with_get_secret(monkeypatch):
-    import litellm
+    import litellm.secret_managers.main
     from litellm.proxy.auth.rds_iam_token import init_rds_client
 
     fake_sts = MagicMock()
@@ -83,7 +61,7 @@ def test_init_rds_client_resolves_region_and_oidc_with_get_secret(monkeypatch):
 
     monkeypatch.delenv("AWS_REGION_NAME", raising=False)
     monkeypatch.delenv("AWS_REGION", raising=False)
-    monkeypatch.setattr(litellm, "get_secret", fake_get_secret)
+    monkeypatch.setattr(litellm.secret_managers.main, "get_secret", fake_get_secret)
     monkeypatch.setitem(sys.modules, "boto3", fake_boto3)
 
     assert (
@@ -116,9 +94,7 @@ def test_init_rds_client_resolves_os_environ_parameter(monkeypatch):
     monkeypatch.setenv("AWS_ACCESS_KEY_ID", "env-access-key")
     monkeypatch.setitem(sys.modules, "boto3", fake_boto3)
 
-    assert (
-        init_rds_client(aws_access_key_id="os.environ/AWS_ACCESS_KEY_ID") is rds_client
-    )
+    assert init_rds_client(aws_access_key_id="os.environ/AWS_ACCESS_KEY_ID") is rds_client
     fake_boto3.client.assert_called_once_with(
         service_name="rds",
         region_name="us-east-1",
@@ -151,9 +127,7 @@ class TestPrismaWrapperTokenRefresh:
     def _set_database_url_with_token(self, expires_in_seconds: int = 900):
         """Set DATABASE_URL with a mock token."""
         token = self._generate_mock_token(expires_in_seconds)
-        os.environ["DATABASE_URL"] = (
-            f"postgresql://test_user:{token}@test-host:5432/test_db"
-        )
+        os.environ["DATABASE_URL"] = f"postgresql://test_user:{token}@test-host:5432/test_db"
 
     @pytest.mark.asyncio
     async def test_is_token_expired_fresh(self, setup_env):
@@ -179,9 +153,7 @@ class TestPrismaWrapperTokenRefresh:
         # Create an expired token
         old_date = datetime.utcnow() - timedelta(seconds=901)
         date_str = old_date.strftime("%Y%m%dT%H%M%SZ")
-        token = (
-            f"mock-token?X-Amz-Date={date_str}&X-Amz-Expires=900&X-Amz-Signature=abc"
-        )
+        token = f"mock-token?X-Amz-Date={date_str}&X-Amz-Expires=900&X-Amz-Signature=abc"
         encoded_token = urllib.parse.quote(token, safe="")
         db_url = f"postgresql://test_user:{encoded_token}@test-host:5432/test_db"
 
@@ -316,9 +288,7 @@ async def demonstrate_fix():
     date_str = now.strftime("%Y%m%dT%H%M%SZ")
     token = f"mock-token?X-Amz-Date={date_str}&X-Amz-Expires=10&X-Amz-Signature=abc123"
     encoded_token = urllib.parse.quote(token, safe="")
-    os.environ["DATABASE_URL"] = (
-        f"postgresql://iam_user:{encoded_token}@mock-rds:5432/litellm"
-    )
+    os.environ["DATABASE_URL"] = f"postgresql://iam_user:{encoded_token}@mock-rds:5432/litellm"
 
     # Create mock prisma client
     mock_prisma = MagicMock()

--- a/tests/test_litellm/proxy/db/test_routing_prisma_wrapper.py
+++ b/tests/test_litellm/proxy/db/test_routing_prisma_wrapper.py
@@ -569,6 +569,25 @@ async def test_iam_refresh_logs_carry_log_prefix(caplog):
     )
 
 
+@pytest.mark.asyncio
+async def test_iam_refresh_loop_logs_refresh_and_cancellation(caplog):
+    from litellm.proxy.db.prisma_client import PrismaWrapper
+
+    wrapper = PrismaWrapper(
+        original_prisma=MagicMock(),
+        iam_token_db_auth=True,
+    )
+    wrapper._calculate_seconds_until_refresh = MagicMock(return_value=0)
+    wrapper._safe_refresh_token = AsyncMock(side_effect=asyncio.CancelledError)
+
+    with caplog.at_level(logging.INFO, logger="LiteLLM Proxy"):
+        await wrapper._token_refresh_loop()
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert "Proactively refreshing RDS IAM token..." in messages
+    assert "RDS IAM token refresh loop cancelled" in messages
+
+
 def test_get_rds_iam_token_returns_none_when_iam_disabled():
     """`get_rds_iam_token` short-circuits to None when iam_token_db_auth is
     False — covers the early-return guard at the top of the method."""
@@ -756,6 +775,366 @@ def test_reader_iam_refresh_uses_parsed_endpoint(monkeypatch):
     # The reader updates its OWN env var; writer's DATABASE_URL is left alone.
     assert os.environ["DATABASE_URL_READ_REPLICA"] == new_url
     assert os.environ["DATABASE_URL"] == "writer-url-untouched"
+
+
+def test_azure_postgres_token_helper_uses_entra_scope(monkeypatch):
+    """Azure PostgreSQL passwordless auth must request the Azure Database for
+    PostgreSQL scope and URL-encode the access token before placing it in a
+    Postgres URL password slot."""
+    from litellm.proxy.auth.azure_postgres_token import (
+        AZURE_POSTGRES_SCOPE,
+        generate_azure_postgres_auth_token,
+    )
+
+    captured: Dict[str, Any] = {}
+
+    class FakeCredential:
+        def get_token(self, scope: str):
+            captured["scope"] = scope
+            return type(
+                "Token",
+                (),
+                {"token": "raw/token?with&chars=1"},
+            )()
+
+    token = generate_azure_postgres_auth_token(credential=FakeCredential())
+
+    assert captured["scope"] == AZURE_POSTGRES_SCOPE
+    assert token == "raw%2Ftoken%3Fwith%26chars%3D1"
+
+
+def test_azure_postgres_workload_identity_uses_default_credential(monkeypatch):
+    from litellm.proxy.auth.azure_postgres_token import (
+        _build_azure_postgres_credential,
+    )
+
+    default_credential = object()
+    mock_azure_identity = MagicMock()
+    mock_azure_identity.DefaultAzureCredential = MagicMock(
+        return_value=default_credential
+    )
+    mock_azure_identity.ClientSecretCredential = MagicMock()
+    mock_azure_identity.ManagedIdentityCredential = MagicMock()
+    monkeypatch.setenv("AZURE_CLIENT_ID", "client-id")
+    monkeypatch.setenv("AZURE_TENANT_ID", "tenant-id")
+    monkeypatch.setenv("AZURE_FEDERATED_TOKEN_FILE", "/var/run/token")
+    monkeypatch.delenv("AZURE_CLIENT_SECRET", raising=False)
+
+    with patch.dict(
+        "sys.modules", {"azure.identity": mock_azure_identity, "azure": MagicMock()}
+    ):
+        credential = _build_azure_postgres_credential()
+
+    assert credential is default_credential
+    mock_azure_identity.DefaultAzureCredential.assert_called_once_with()
+    mock_azure_identity.ManagedIdentityCredential.assert_not_called()
+
+
+def test_azure_postgres_service_principal_uses_client_secret_credential(
+    monkeypatch,
+):
+    from litellm.proxy.auth.azure_postgres_token import (
+        _build_azure_postgres_credential,
+    )
+
+    client_secret_credential = object()
+    mock_azure_identity = MagicMock()
+    mock_azure_identity.ClientSecretCredential = MagicMock(
+        return_value=client_secret_credential
+    )
+    mock_azure_identity.DefaultAzureCredential = MagicMock()
+    mock_azure_identity.ManagedIdentityCredential = MagicMock()
+    monkeypatch.delenv("AZURE_FEDERATED_TOKEN_FILE", raising=False)
+
+    with patch.dict(
+        "sys.modules", {"azure.identity": mock_azure_identity, "azure": MagicMock()}
+    ):
+        credential = _build_azure_postgres_credential(
+            azure_client_id="client-id",
+            azure_tenant_id="tenant-id",
+            azure_client_secret="client-secret",
+        )
+
+    assert credential is client_secret_credential
+    mock_azure_identity.ClientSecretCredential.assert_called_once_with(
+        client_id="client-id",
+        tenant_id="tenant-id",
+        client_secret="client-secret",
+    )
+    mock_azure_identity.DefaultAzureCredential.assert_not_called()
+    mock_azure_identity.ManagedIdentityCredential.assert_not_called()
+
+
+def test_azure_postgres_managed_identity_uses_client_id(monkeypatch):
+    from litellm.proxy.auth.azure_postgres_token import (
+        _build_azure_postgres_credential,
+    )
+
+    managed_identity_credential = object()
+    mock_azure_identity = MagicMock()
+    mock_azure_identity.ClientSecretCredential = MagicMock()
+    mock_azure_identity.DefaultAzureCredential = MagicMock()
+    mock_azure_identity.ManagedIdentityCredential = MagicMock(
+        return_value=managed_identity_credential
+    )
+    monkeypatch.delenv("AZURE_CLIENT_SECRET", raising=False)
+    monkeypatch.delenv("AZURE_FEDERATED_TOKEN_FILE", raising=False)
+    monkeypatch.delenv("AZURE_TENANT_ID", raising=False)
+
+    with patch.dict(
+        "sys.modules", {"azure.identity": mock_azure_identity, "azure": MagicMock()}
+    ):
+        credential = _build_azure_postgres_credential(
+            azure_client_id="managed-client-id"
+        )
+
+    assert credential is managed_identity_credential
+    mock_azure_identity.ManagedIdentityCredential.assert_called_once_with(
+        client_id="managed-client-id"
+    )
+    mock_azure_identity.ClientSecretCredential.assert_not_called()
+    mock_azure_identity.DefaultAzureCredential.assert_not_called()
+
+
+def test_generate_azure_postgres_auth_token_builds_default_credential(
+    monkeypatch,
+):
+    from litellm.proxy.auth.azure_postgres_token import (
+        AZURE_POSTGRES_SCOPE,
+        generate_azure_postgres_auth_token,
+    )
+
+    default_credential = MagicMock()
+    default_credential.get_token.return_value.token = "raw/default token"
+    mock_azure_identity = MagicMock()
+    mock_azure_identity.ClientSecretCredential = MagicMock()
+    mock_azure_identity.DefaultAzureCredential = MagicMock(
+        return_value=default_credential
+    )
+    mock_azure_identity.ManagedIdentityCredential = MagicMock()
+    monkeypatch.delenv("AZURE_CLIENT_ID", raising=False)
+    monkeypatch.delenv("AZURE_TENANT_ID", raising=False)
+    monkeypatch.delenv("AZURE_CLIENT_SECRET", raising=False)
+    monkeypatch.delenv("AZURE_FEDERATED_TOKEN_FILE", raising=False)
+
+    with patch.dict(
+        "sys.modules", {"azure.identity": mock_azure_identity, "azure": MagicMock()}
+    ):
+        token = generate_azure_postgres_auth_token()
+
+    assert token == "raw%2Fdefault%20token"
+    mock_azure_identity.DefaultAzureCredential.assert_called_once_with()
+    default_credential.get_token.assert_called_once_with(AZURE_POSTGRES_SCOPE)
+
+
+def test_azure_postgres_auth_requires_azure_identity(monkeypatch):
+    import builtins
+
+    from litellm.proxy.auth.azure_postgres_token import (
+        _build_azure_postgres_credential,
+    )
+
+    real_import = builtins.__import__
+
+    def fail_azure_identity_import(name, *args, **kwargs):
+        if name == "azure.identity":
+            raise ImportError("missing azure.identity")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fail_azure_identity_import)
+
+    with pytest.raises(ImportError, match="azure-identity is required"):
+        _build_azure_postgres_credential()
+
+
+@pytest.mark.parametrize(
+    ("schema", "expected_url"),
+    (
+        (
+            "public",
+            "postgresql://u:TOKEN@h:5432/db?schema=public&sslmode=require&sslaccept=strict",
+        ),
+        (None, "postgresql://u:TOKEN@h:5432/db?sslmode=require&sslaccept=strict"),
+    ),
+)
+def test_build_database_token_auth_url_requires_strict_tls_for_azure(
+    monkeypatch, schema, expected_url
+):
+    from litellm.proxy.db.prisma_client import (
+        IAMEndpoint,
+        build_database_token_auth_url,
+    )
+
+    fake_module = MagicMock()
+    fake_module.generate_azure_postgres_auth_token.return_value = "TOKEN"
+    monkeypatch.setitem(
+        sys.modules, "litellm.proxy.auth.azure_postgres_token", fake_module
+    )
+
+    url = build_database_token_auth_url(
+        IAMEndpoint(host="h", port="5432", user="u", name="db", schema=schema),
+        azure_postgresql_auth=True,
+    )
+
+    assert url == expected_url
+
+
+def test_writer_get_azure_postgres_token_uses_database_env_vars(
+    monkeypatch, unset_database_url
+):
+    """Writer Azure passwordless auth reads the same DATABASE_HOST/PORT/USER/NAME
+    env vars as the existing RDS IAM path, but mints an Entra token instead of
+    an AWS presigned token."""
+    from litellm.proxy.db.prisma_client import PrismaWrapper
+
+    monkeypatch.setenv("DATABASE_HOST", "server.postgres.database.azure.com")
+    monkeypatch.setenv("DATABASE_PORT", "5432")
+    monkeypatch.setenv("DATABASE_USER", "managed-identity-name")
+    monkeypatch.setenv("DATABASE_NAME", "litellm")
+    monkeypatch.setenv("DATABASE_SCHEMA", "public")
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+
+    fake_module = MagicMock()
+    fake_module.generate_azure_postgres_auth_token.return_value = "AZURE%2FTOKEN"
+    monkeypatch.setitem(
+        sys.modules, "litellm.proxy.auth.azure_postgres_token", fake_module
+    )
+
+    writer = PrismaWrapper(
+        original_prisma=MagicMock(),
+        iam_token_db_auth=True,
+        azure_postgresql_auth=True,
+    )
+
+    new_url = writer.get_rds_iam_token()
+
+    assert new_url == (
+        "postgresql://managed-identity-name:AZURE%2FTOKEN@"
+        "server.postgres.database.azure.com:5432/litellm?"
+        "schema=public&sslmode=require&sslaccept=strict"
+    )
+    assert os.environ["DATABASE_URL"] == new_url
+    fake_module.generate_azure_postgres_auth_token.assert_called_once()
+
+
+def test_azure_postgres_jwt_expiration_is_used_for_refresh_timing():
+    """Azure PostgreSQL tokens are JWTs; the wrapper should read exp so the
+    existing proactive refresh loop can schedule before token expiry."""
+    from datetime import datetime
+
+    from litellm.proxy.db.prisma_client import PrismaWrapper
+
+    exp = 1893456000
+    token = "eyJhbGciOiJub25lIn0.eyJleHAiOjE4OTM0NTYwMDB9.signature"
+    wrapper = PrismaWrapper(
+        original_prisma=MagicMock(),
+        iam_token_db_auth=True,
+        azure_postgresql_auth=True,
+    )
+
+    assert wrapper._parse_token_expiration(token) == datetime.utcfromtimestamp(exp)
+
+
+def test_azure_postgres_token_auth_log_name():
+    from litellm.proxy.db.prisma_client import PrismaWrapper
+
+    wrapper = PrismaWrapper(
+        original_prisma=MagicMock(),
+        iam_token_db_auth=True,
+        azure_postgresql_auth=True,
+    )
+
+    assert wrapper._token_auth_log_name() == "Azure PostgreSQL Entra token"
+
+
+def test_jwt_expiration_parse_returns_none_without_exp():
+    from litellm.proxy.db.prisma_client import _parse_jwt_expiration_claim
+
+    assert _parse_jwt_expiration_claim("header.e30.signature") is None
+
+
+def test_jwt_expiration_parse_returns_none_for_non_object_payload():
+    from litellm.proxy.db.prisma_client import _parse_jwt_expiration_claim
+
+    assert _parse_jwt_expiration_claim("header.W10.signature") is None
+
+
+def test_jwt_expiration_parse_returns_none_for_invalid_payload():
+    from litellm.proxy.db.prisma_client import _parse_jwt_expiration_claim
+
+    assert _parse_jwt_expiration_claim("header.invalid-payload.signature") is None
+
+
+def test_rds_token_expiration_parse_returns_none_for_invalid_query():
+    from litellm.proxy.db.prisma_client import PrismaWrapper
+
+    wrapper = PrismaWrapper(
+        original_prisma=MagicMock(),
+        iam_token_db_auth=True,
+    )
+
+    assert (
+        wrapper._parse_token_expiration("token?X-Amz-Date=not-a-date&X-Amz-Expires=900")
+        is None
+    )
+
+
+def test_prisma_client_uses_azure_marker_not_jwt_shape(monkeypatch):
+    import urllib.parse
+
+    from litellm.proxy.db.prisma_client import (
+        AZURE_POSTGRESQL_AUTH_MARKER_ENV,
+        PrismaWrapper,
+    )
+    from litellm.proxy.db.routing_prisma_wrapper import RoutingPrismaWrapper
+
+    token = "eyJhbGciOiJub25lIn0.eyJleHAiOjE4OTM0NTYwMDB9.signature"
+    jwt_url = (
+        "postgresql://managed-identity:"
+        f"{urllib.parse.quote(token, safe='')}@server.postgres.database.azure.com:5432/litellm"
+    )
+
+    class FakePrisma:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        async def connect(self):
+            return None
+
+    fake_module = MagicMock()
+    fake_module.Prisma = FakePrisma
+    monkeypatch.setitem(sys.modules, "prisma", fake_module)
+    monkeypatch.delenv("IAM_TOKEN_DB_AUTH", raising=False)
+    monkeypatch.delenv("DATABASE_URL_READ_REPLICA", raising=False)
+    monkeypatch.delenv(AZURE_POSTGRESQL_AUTH_MARKER_ENV, raising=False)
+
+    from litellm.proxy.utils import PrismaClient
+
+    client = PrismaClient(database_url=jwt_url, proxy_logging_obj=MagicMock())
+    assert isinstance(client.db, PrismaWrapper)
+    assert client.db.iam_token_db_auth is False
+    assert client.db._azure_postgresql_auth is False
+
+    monkeypatch.setenv(AZURE_POSTGRESQL_AUTH_MARKER_ENV, "True")
+    replica_url = (
+        "postgresql://reader@server-replica.postgres.database.azure.com:5432/litellm"
+    )
+    refreshed_url = replica_url.replace("reader@", "reader:token@")
+    monkeypatch.setenv("DATABASE_URL_READ_REPLICA", replica_url)
+
+    with patch(
+        "litellm.proxy.utils.build_database_token_auth_url",
+        return_value=refreshed_url,
+    ):
+        client = PrismaClient(database_url=jwt_url, proxy_logging_obj=MagicMock())
+
+    assert isinstance(client.db, RoutingPrismaWrapper)
+    assert client.db.reader.iam_token_db_auth is True
+    assert client.db.reader._azure_postgresql_auth is True
+    assert client.db.reader._original_prisma.kwargs == {
+        "datasource": {"url": refreshed_url}
+    }
+    assert os.environ["DATABASE_URL_READ_REPLICA"] == refreshed_url
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/test_proxy_cli.py
+++ b/tests/test_litellm/proxy/test_proxy_cli.py
@@ -1899,6 +1899,85 @@ class TestRunServerDbSetup:
     @patch("litellm.proxy.db.prisma_client.PrismaManager.setup_database")
     @patch("litellm.proxy.db.check_migration.check_prisma_schema_diff")
     @patch("litellm.proxy.db.prisma_client.should_update_prisma_schema")
+    def test_rds_iam_auth_clears_stale_azure_marker(
+        self,
+        mock_should_update_schema,
+        mock_check_schema_diff,
+        mock_setup_database,
+        mock_atexit_register,
+        mock_subprocess_run,
+    ):
+        from litellm.proxy.db.prisma_client import (
+            AZURE_POSTGRESQL_AUTH_MARKER_ENV,
+            IAMEndpoint,
+        )
+        from litellm.proxy.proxy_cli import run_server
+
+        mock_subprocess_run.return_value = MagicMock(returncode=0)
+        mock_should_update_schema.return_value = True
+        mock_setup_database.return_value = True
+
+        endpoint = IAMEndpoint(
+            host="db.example.rds.amazonaws.com",
+            port="5432",
+            user="litellm",
+            name="litellm",
+        )
+        mock_proxy_module = MagicMock(
+            app=MagicMock(),
+            ProxyConfig=MagicMock(),
+            KeyManagementSettings=MagicMock(),
+            save_worker_config=MagicMock(),
+        )
+        stale_env = {
+            **{
+                k: v
+                for k, v in os.environ.items()
+                if k not in ("DATABASE_URL", "DIRECT_URL", "IAM_TOKEN_DB_AUTH")
+            },
+            AZURE_POSTGRESQL_AUTH_MARKER_ENV: "True",
+        }
+
+        with (
+            patch.dict(os.environ, stale_env, clear=True),
+            patch.dict(
+                "sys.modules",
+                {
+                    "proxy_server": mock_proxy_module,
+                    "litellm.proxy.proxy_server": mock_proxy_module,
+                },
+            ),
+            patch(
+                "litellm.proxy.proxy_cli.ProxyInitializationHelpers._get_default_unvicorn_init_args"
+            ) as mock_get_args,
+            patch(
+                "litellm.proxy.db.prisma_client.get_database_auth_endpoint_from_env",
+                return_value=endpoint,
+            ),
+            patch(
+                "litellm.proxy.db.prisma_client.build_database_token_auth_url",
+                return_value="postgresql://litellm:token@db.example.rds.amazonaws.com:5432/litellm",
+            ),
+        ):
+            mock_get_args.return_value = {
+                "app": "litellm.proxy.proxy_server:app",
+                "host": "localhost",
+                "port": 8000,
+            }
+
+            run_server.main(
+                ["--local", "--skip_server_startup", "--iam_token_db_auth"],
+                standalone_mode=False,
+            )
+
+            assert os.environ["IAM_TOKEN_DB_AUTH"] == "True"
+            assert AZURE_POSTGRESQL_AUTH_MARKER_ENV not in os.environ
+
+    @patch("subprocess.run")
+    @patch("atexit.register")
+    @patch("litellm.proxy.db.prisma_client.PrismaManager.setup_database")
+    @patch("litellm.proxy.db.check_migration.check_prisma_schema_diff")
+    @patch("litellm.proxy.db.prisma_client.should_update_prisma_schema")
     def test_startup_fails_when_db_setup_fails(
         self,
         mock_should_update_schema,

--- a/tests/test_litellm/proxy/test_proxy_cli.py
+++ b/tests/test_litellm/proxy/test_proxy_cli.py
@@ -6,14 +6,12 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import click
-import fastapi
 import pytest
 
 sys.path.insert(
     0, os.path.abspath("../../..")
 )  # Adds the parent directory to the system-path
 
-import builtins
 import types
 import urllib.parse as urlparse
 
@@ -1553,8 +1551,6 @@ class TestProxyInitializationHelpers:
     @patch("builtins.print")
     def test_run_server_no_config_passed(self, mock_print, mock_uvicorn_run):
         """Test that run_server properly handles the case when no config is passed"""
-        import asyncio
-
         from click.testing import CliRunner
 
         from litellm.proxy.proxy_cli import run_server
@@ -1806,6 +1802,97 @@ class TestRunServerDbSetup:
             mock_setup_database.assert_called_with(
                 use_migrate=False, use_v2_resolver=False
             )
+
+    @patch("subprocess.run")
+    @patch("atexit.register")
+    @patch("litellm.proxy.db.prisma_client.PrismaManager.setup_database")
+    @patch("litellm.proxy.db.check_migration.check_prisma_schema_diff")
+    @patch("litellm.proxy.db.prisma_client.should_update_prisma_schema")
+    def test_azure_postgresql_auth_builds_token_database_url(
+        self,
+        mock_should_update_schema,
+        mock_check_schema_diff,
+        mock_setup_database,
+        mock_atexit_register,
+        mock_subprocess_run,
+    ):
+        from litellm.proxy.db.prisma_client import (
+            AZURE_POSTGRESQL_AUTH_MARKER_ENV,
+            IAMEndpoint,
+        )
+        from litellm.proxy.proxy_cli import run_server
+
+        mock_subprocess_run.return_value = MagicMock(returncode=0)
+        mock_should_update_schema.return_value = True
+        mock_setup_database.return_value = True
+
+        endpoint = IAMEndpoint(
+            host="server.postgres.database.azure.com",
+            port="5432",
+            user="managed-identity",
+            name="litellm",
+        )
+        mock_proxy_module = MagicMock(
+            app=MagicMock(),
+            ProxyConfig=MagicMock(),
+            KeyManagementSettings=MagicMock(),
+            save_worker_config=MagicMock(),
+        )
+        clean_env = {
+            k: v
+            for k, v in os.environ.items()
+            if k
+            not in (
+                "DATABASE_URL",
+                "DIRECT_URL",
+                "IAM_TOKEN_DB_AUTH",
+                AZURE_POSTGRESQL_AUTH_MARKER_ENV,
+            )
+        }
+
+        with (
+            patch.dict(os.environ, clean_env, clear=True),
+            patch.dict(
+                "sys.modules",
+                {
+                    "proxy_server": mock_proxy_module,
+                    "litellm.proxy.proxy_server": mock_proxy_module,
+                },
+            ),
+            patch(
+                "litellm.proxy.proxy_cli.ProxyInitializationHelpers._get_default_unvicorn_init_args"
+            ) as mock_get_args,
+            patch(
+                "litellm.proxy.db.prisma_client.get_database_auth_endpoint_from_env",
+                return_value=endpoint,
+            ) as mock_get_endpoint,
+            patch(
+                "litellm.proxy.db.prisma_client.build_database_token_auth_url",
+                return_value=(
+                    "postgresql://managed-identity:token@"
+                    "server.postgres.database.azure.com:5432/litellm"
+                ),
+            ) as mock_build_url,
+        ):
+            mock_get_args.return_value = {
+                "app": "litellm.proxy.proxy_server:app",
+                "host": "localhost",
+                "port": 8000,
+            }
+
+            run_server.main(
+                ["--local", "--skip_server_startup", "--azure_postgresql_auth"],
+                standalone_mode=False,
+            )
+
+            assert os.environ["IAM_TOKEN_DB_AUTH"] == "True"
+            assert os.environ[AZURE_POSTGRESQL_AUTH_MARKER_ENV] == "True"
+            assert os.environ["DATABASE_URL"].startswith(
+                "postgresql://managed-identity:token@"
+            )
+
+        mock_get_endpoint.assert_called_once()
+        mock_build_url.assert_called_once_with(endpoint, azure_postgresql_auth=True)
 
     @patch("subprocess.run")
     @patch("atexit.register")

--- a/tests/test_litellm/test_redis.py
+++ b/tests/test_litellm/test_redis.py
@@ -6,7 +6,10 @@ import redis
 import redis.asyncio as async_redis
 
 from litellm._redis import (
+    _get_credential_provider_from_connect_func,
+    _get_redis_client_logic,
     _get_redis_cluster_kwargs,
+    create_azure_ad_redis_connect_func,
     get_redis_async_client,
     get_redis_client,
     get_redis_connection_pool,
@@ -14,6 +17,7 @@ from litellm._redis import (
 )
 from litellm.constants import REDIS_CLUSTER_HEALTH_CHECK_INTERVAL
 from litellm._redis_credential_provider import (
+    AzureADCredentialProvider,
     GCPIAMCredentialProvider,
     _token_cache,
 )
@@ -25,6 +29,41 @@ def clear_gcp_iam_token_cache():
     _token_cache.clear()
     yield
     _token_cache.clear()
+
+
+def _mock_azure_identity(mock_credential):
+    mock_azure_identity = MagicMock()
+    mock_azure_identity.DefaultAzureCredential = MagicMock(return_value=mock_credential)
+    mock_azure_identity.ClientSecretCredential = MagicMock(return_value=mock_credential)
+    mock_azure_identity.ManagedIdentityCredential = MagicMock(
+        return_value=mock_credential
+    )
+    return mock_azure_identity
+
+
+def test_azure_redis_workload_identity_uses_default_credential(monkeypatch):
+    from litellm._redis import _build_azure_credential
+
+    default_credential = object()
+    mock_azure_identity = MagicMock()
+    mock_azure_identity.DefaultAzureCredential = MagicMock(
+        return_value=default_credential
+    )
+    mock_azure_identity.ClientSecretCredential = MagicMock()
+    mock_azure_identity.ManagedIdentityCredential = MagicMock()
+    monkeypatch.setenv("AZURE_CLIENT_ID", "client-id")
+    monkeypatch.setenv("AZURE_TENANT_ID", "tenant-id")
+    monkeypatch.setenv("AZURE_FEDERATED_TOKEN_FILE", "/var/run/token")
+    monkeypatch.delenv("AZURE_CLIENT_SECRET", raising=False)
+
+    with patch.dict(
+        "sys.modules", {"azure.identity": mock_azure_identity, "azure": MagicMock()}
+    ):
+        credential = _build_azure_credential()
+
+    assert credential is default_credential
+    mock_azure_identity.DefaultAzureCredential.assert_called_once_with()
+    mock_azure_identity.ManagedIdentityCredential.assert_not_called()
 
 
 def test_get_redis_url_from_environment_single_url(monkeypatch):
@@ -383,6 +422,267 @@ def test_get_redis_async_client_gcp_cluster_uses_credential_provider():
     assert (
         "password" not in cluster_call_kwargs
     ), "async GCP cluster must not use a static password (expires after 1h)"
+
+
+def test_redis_connect_func_rejects_mixed_credential_markers():
+    mock_connect_func = MagicMock()
+    mock_connect_func._gcp_service_account = "service-account"
+    mock_connect_func._azure_credential = MagicMock()
+
+    with pytest.raises(ValueError, match="both GCP and Azure"):
+        _get_credential_provider_from_connect_func(mock_connect_func, {})
+
+
+def test_redis_connect_func_without_markers_has_no_credential_provider():
+    assert _get_credential_provider_from_connect_func(lambda _: None, {}) is None
+
+
+def test_redis_connect_func_conflict_precedes_tls_validation():
+    mock_connect_func = MagicMock()
+    mock_connect_func._gcp_service_account = "service-account"
+    mock_connect_func._azure_credential = MagicMock()
+
+    with pytest.raises(ValueError, match="both GCP and Azure"):
+        get_redis_client(
+            url="redis://plain-redis.example.com:6379",
+            redis_connect_func=mock_connect_func,
+        )
+
+
+@pytest.mark.parametrize(
+    "client_factory",
+    [get_redis_client, get_redis_async_client, get_redis_connection_pool],
+)
+@pytest.mark.parametrize(
+    "iam_kwargs",
+    [
+        {"gcp_service_account": "projects/-/serviceAccounts/test@example.com"},
+        {"azure_redis_ad_token": "true"},
+    ],
+)
+@pytest.mark.parametrize(
+    "target_kwargs",
+    [
+        {"url": "redis://plain-redis.example.com:6379"},
+        {"url": "ReDiSs://secure-redis.example.com:6380"},
+        {"url": "rediss://"},
+        {"host": "plain-redis.example.com", "port": 6379},
+        {"host": "plain-redis.example.com", "port": 6379, "ssl": False},
+    ],
+)
+def test_redis_iam_requires_tls(client_factory, iam_kwargs, target_kwargs):
+    with pytest.raises(ValueError, match="Redis IAM authentication requires TLS"):
+        client_factory(**target_kwargs, **iam_kwargs)
+
+
+@pytest.mark.parametrize(
+    "redis_kwargs",
+    [
+        {
+            "url": "rediss://secure-redis.example.com:6380",
+            "gcp_service_account": "projects/-/serviceAccounts/test@example.com",
+        },
+        {
+            "host": "secure-redis.example.com",
+            "port": 6380,
+            "ssl": True,
+            "gcp_service_account": "projects/-/serviceAccounts/test@example.com",
+        },
+        {
+            "url": "redis://plain-redis.example.com:6379",
+            "password": "password",
+        },
+    ],
+)
+def test_redis_tls_validation_accepts_valid_configuration(redis_kwargs):
+    _get_redis_client_logic(**redis_kwargs)
+
+
+@pytest.mark.parametrize("client_factory", [get_redis_client, get_redis_async_client])
+def test_redis_iam_cluster_requires_ssl_when_explicit_url_is_present(client_factory):
+    startup_nodes = [{"host": "cluster-node.example.com", "port": 6380}]
+
+    with pytest.raises(ValueError, match="Redis IAM authentication requires TLS"):
+        client_factory(
+            url="rediss://fallback.example.com:6380",
+            startup_nodes=startup_nodes,
+            gcp_service_account="projects/-/serviceAccounts/test@example.com",
+        )
+
+
+@pytest.mark.parametrize("client_factory", [get_redis_client, get_redis_async_client])
+def test_redis_iam_cluster_requires_ssl_when_url_and_nodes_are_from_environment(
+    client_factory, monkeypatch
+):
+    monkeypatch.setenv("REDIS_URL", "rediss://fallback.example.com:6380")
+    monkeypatch.setenv(
+        "REDIS_CLUSTER_NODES",
+        json.dumps([{"host": "cluster-node.example.com", "port": 6380}]),
+    )
+    monkeypatch.setenv(
+        "REDIS_GCP_SERVICE_ACCOUNT",
+        "projects/-/serviceAccounts/test@example.com",
+    )
+    monkeypatch.delenv("REDIS_SSL", raising=False)
+
+    with pytest.raises(ValueError, match="Redis IAM authentication requires TLS"):
+        client_factory()
+
+
+def test_azure_ad_connect_func_sends_username_auth_argument():
+    mock_credential = MagicMock()
+    mock_credential.get_token.return_value.token = "access-token"
+    mock_azure_identity = _mock_azure_identity(mock_credential)
+
+    with patch.dict(
+        "sys.modules", {"azure.identity": mock_azure_identity, "azure": MagicMock()}
+    ):
+        connect_func = create_azure_ad_redis_connect_func(username="redis-user")
+
+    connection = MagicMock()
+    connection.read_response.return_value = b"OK"
+
+    connect_func(connection)
+
+    connection.send_command.assert_called_once_with(
+        "AUTH", "redis-user", "access-token", check_health=False
+    )
+
+
+def test_sync_url_client_azure_ad_auth_uses_credential_provider(monkeypatch):
+    """URL-based Azure Redis clients must keep token auth instead of filtering
+    it out before Redis.from_url."""
+    mock_credential = MagicMock()
+    mock_azure_identity = _mock_azure_identity(mock_credential)
+    monkeypatch.setenv("REDIS_USERNAME", "managed-identity-object-id")
+
+    with (
+        patch.dict(
+            "sys.modules", {"azure.identity": mock_azure_identity, "azure": MagicMock()}
+        ),
+        patch("litellm._redis.redis.Redis.from_url") as mock_from_url,
+    ):
+        get_redis_client(
+            url="rediss://cache.redis.cache.windows.net:6380",
+            azure_redis_ad_token="true",
+            ssl=True,
+        )
+
+    call_kwargs = mock_from_url.call_args.kwargs
+    assert call_kwargs["url"] == "rediss://cache.redis.cache.windows.net:6380"
+    assert isinstance(call_kwargs["credential_provider"], AzureADCredentialProvider)
+    assert "redis_connect_func" not in call_kwargs
+    assert call_kwargs["credential_provider"].get_credentials() == (
+        "managed-identity-object-id",
+        mock_credential.get_token.return_value.token,
+    )
+
+
+def test_async_url_client_azure_ad_auth_uses_credential_provider(monkeypatch):
+    mock_credential = MagicMock()
+    mock_azure_identity = _mock_azure_identity(mock_credential)
+    monkeypatch.setenv("REDIS_USERNAME", "managed-identity-object-id")
+
+    with (
+        patch.dict(
+            "sys.modules", {"azure.identity": mock_azure_identity, "azure": MagicMock()}
+        ),
+        patch("litellm._redis.async_redis.Redis.from_url") as mock_from_url,
+    ):
+        get_redis_async_client(
+            url="rediss://cache.redis.cache.windows.net:6380",
+            azure_redis_ad_token="true",
+            ssl=True,
+        )
+
+    call_kwargs = mock_from_url.call_args.kwargs
+    assert isinstance(call_kwargs["credential_provider"], AzureADCredentialProvider)
+    assert call_kwargs["credential_provider"].get_credentials() == (
+        "managed-identity-object-id",
+        mock_credential.get_token.return_value.token,
+    )
+
+
+def test_async_client_azure_ad_auth_uses_credential_provider(monkeypatch):
+    mock_credential = MagicMock()
+    mock_azure_identity = _mock_azure_identity(mock_credential)
+    monkeypatch.setenv("REDIS_USERNAME", "managed-identity-object-id")
+
+    with (
+        patch.dict(
+            "sys.modules", {"azure.identity": mock_azure_identity, "azure": MagicMock()}
+        ),
+        patch("litellm._redis.async_redis.Redis") as mock_redis,
+    ):
+        get_redis_async_client(
+            host="cache.redis.cache.windows.net",
+            port=6380,
+            azure_redis_ad_token="true",
+            ssl=True,
+        )
+
+    call_kwargs = mock_redis.call_args.kwargs
+    assert isinstance(call_kwargs["credential_provider"], AzureADCredentialProvider)
+    assert call_kwargs["credential_provider"].get_credentials() == (
+        "managed-identity-object-id",
+        mock_credential.get_token.return_value.token,
+    )
+
+
+def test_connection_pool_url_azure_ad_auth_uses_credential_provider(monkeypatch):
+    """Connection pools built from Redis URLs need Azure AD credential_provider
+    too, otherwise pooled connections authenticate with no token."""
+    mock_credential = MagicMock()
+    mock_azure_identity = _mock_azure_identity(mock_credential)
+    monkeypatch.setenv("REDIS_USERNAME", "managed-identity-object-id")
+
+    with (
+        patch.dict(
+            "sys.modules", {"azure.identity": mock_azure_identity, "azure": MagicMock()}
+        ),
+        patch(
+            "litellm._redis.async_redis.BlockingConnectionPool.from_url"
+        ) as mock_from_url,
+    ):
+        get_redis_connection_pool(
+            url="rediss://cache.redis.cache.windows.net:6380",
+            azure_redis_ad_token="true",
+            ssl=True,
+        )
+
+    call_kwargs = mock_from_url.call_args.kwargs
+    assert call_kwargs["url"] == "rediss://cache.redis.cache.windows.net:6380"
+    assert isinstance(call_kwargs["credential_provider"], AzureADCredentialProvider)
+    assert call_kwargs["credential_provider"].get_credentials() == (
+        "managed-identity-object-id",
+        mock_credential.get_token.return_value.token,
+    )
+
+
+def test_connection_pool_azure_ad_auth_uses_credential_provider(monkeypatch):
+    mock_credential = MagicMock()
+    mock_azure_identity = _mock_azure_identity(mock_credential)
+    monkeypatch.setenv("REDIS_USERNAME", "managed-identity-object-id")
+
+    with (
+        patch.dict(
+            "sys.modules", {"azure.identity": mock_azure_identity, "azure": MagicMock()}
+        ),
+        patch("litellm._redis.async_redis.BlockingConnectionPool") as mock_pool,
+    ):
+        get_redis_connection_pool(
+            host="cache.redis.cache.windows.net",
+            port=6380,
+            azure_redis_ad_token="true",
+            ssl=True,
+        )
+
+    call_kwargs = mock_pool.call_args.kwargs
+    assert isinstance(call_kwargs["credential_provider"], AzureADCredentialProvider)
+    assert call_kwargs["credential_provider"].get_credentials() == (
+        "managed-identity-object-id",
+        mock_credential.get_token.return_value.token,
+    )
 
 
 @patch("litellm._redis.init_redis_cluster")

--- a/tests/test_litellm/test_redis.py
+++ b/tests/test_litellm/test_redis.py
@@ -498,6 +498,27 @@ def test_redis_tls_validation_accepts_valid_configuration(redis_kwargs):
     _get_redis_client_logic(**redis_kwargs)
 
 
+@pytest.mark.parametrize("ssl_value", ["true", "True", " TRUE "])
+def test_redis_iam_accepts_string_ssl_flag(ssl_value):
+    _get_redis_client_logic(
+        host="secure-redis.example.com",
+        port=6380,
+        ssl=ssl_value,
+        gcp_service_account="projects/-/serviceAccounts/test@example.com",
+    )
+
+
+@pytest.mark.parametrize("ssl_value", ["false", "no", ""])
+def test_redis_iam_rejects_non_true_string_ssl_flag(ssl_value):
+    with pytest.raises(ValueError, match="Redis IAM authentication requires TLS"):
+        _get_redis_client_logic(
+            host="plain-redis.example.com",
+            port=6379,
+            ssl=ssl_value,
+            gcp_service_account="projects/-/serviceAccounts/test@example.com",
+        )
+
+
 @pytest.mark.parametrize("client_factory", [get_redis_client, get_redis_async_client])
 def test_redis_iam_cluster_requires_ssl_when_explicit_url_is_present(client_factory):
     startup_nodes = [{"host": "cluster-node.example.com", "port": 6380}]


### PR DESCRIPTION
## Summary
- add Azure PostgreSQL Entra token support for proxy database auth
- pass Azure AD Redis credential providers through URL and pool based clients
- share token auth URL construction across writer, reader, and CLI startup paths
- trim unused PostgreSQL token expiry metadata and rely on JWT exp parsing

## Why
Azure passwordless deployments need rotating Entra tokens for PostgreSQL, and Redis URL/pool clients need credential providers instead of filtered-out custom auth.

## Validation
- `111 passed` — Redis, Prisma routing, Azure PostgreSQL, RDS IAM, and proxy CLI regression suite
- `1 passed` — proxy startup wiring for `--azure_postgresql_auth`
- Ruff format check and Ruff lint pass on all changed production Python files
- `git diff --check` passes

### Live Azure Workload Identity proof

Tested exact commit `b15fbaa9db20f346c73c66cadc5f68df76fa22e8` in West Europe using AKS Workload Identity and Azure Database for PostgreSQL Flexible Server.

- pod image digest matched the ACR digest
- AKS OIDC issuer and Workload Identity were enabled
- the service account injected `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_FEDERATED_TOKEN_FILE`
- `AZURE_CLIENT_SECRET`, `DATABASE_URL`, and `DATABASE_PASSWORD` were absent from the pod specification
- LiteLLM logged `Azure PostgreSQL Entra token refresh loop started` and a scheduled refresh
- `/health/readiness` returned HTTP 200 with `{"status":"healthy","db":"connected"}`
- no inference request was made
- the resource group and AKS node resource group were deleted and verified absent

Full sanitized command evidence: https://github.com/BerriAI/litellm/pull/30633#issuecomment-5026763557

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches database and Redis authentication, token refresh, and TLS enforcement for IAM-style credentials. Misconfiguration could break proxy DB connectivity or Redis auth.
> 
> **Overview**
> Adds passwordless **Azure PostgreSQL Entra** auth on the same Prisma token-refresh path used for RDS IAM. `--azure_postgresql_auth` mints rotating Entra tokens (including AKS Workload Identity via `AZURE_FEDERATED_TOKEN_FILE`), requires TLS, and schedules refresh from JWT `exp`. Writer, reader replica, and CLI startup now share `build_database_token_auth_url`.
> 
> Redis Azure AD / GCP IAM auth now keeps a `credential_provider` on **URL and connection-pool** clients instead of dropping `redis_connect_func`. IAM Redis connections must use TLS. Azure Redis username is taken from kwargs or `REDIS_USERNAME`, and mixed GCP/Azure connect-func markers are rejected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 634ac83abf212a2b0a43c8a3e3525e8ea8c0117c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->