### PR TITLE
feat(search): add TinyFish as search provider

### DIFF
--- a/litellm/llms/tinyfish/search/__init__.py
+++ b/litellm/llms/tinyfish/search/__init__.py
@@ -1,0 +1,3 @@
+from litellm.llms.tinyfish.search.transformation import TinyfishSearchConfig
+
+__all__ = ["TinyfishSearchConfig"]

--- a/litellm/llms/tinyfish/search/transformation.py
+++ b/litellm/llms/tinyfish/search/transformation.py
@@ -1,0 +1,141 @@
+"""
+TinyFish Search API.
+Endpoint: GET https://api.search.tinyfish.ai
+Docs: https://docs.tinyfish.ai/search-api
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Literal, Optional, TypedDict, Union
+from urllib.parse import urlencode
+
+import httpx
+
+from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+from litellm.llms.base_llm.search.transformation import (
+    BaseSearchConfig,
+    SearchResponse,
+    SearchResult,
+)
+from litellm.secret_managers.main import get_secret_str
+
+
+class _TinyfishSearchRequestRequired(TypedDict):
+    query: str
+
+
+class TinyfishSearchRequest(_TinyfishSearchRequestRequired, total=False):
+    location: str
+    language: str
+    page: int
+    include_thumbnail: bool
+    max_results: int
+
+
+class TinyfishSearchConfig(BaseSearchConfig):
+    TINYFISH_API_BASE = "https://api.search.tinyfish.ai"
+
+    @staticmethod
+    def ui_friendly_name() -> str:
+        return "TinyFish"
+
+    def get_http_method(self) -> Literal["GET", "POST"]:
+        return "GET"
+
+    def validate_environment(
+        self,
+        headers: Dict,
+        api_key: Optional[str] = None,
+        api_base: Optional[str] = None,
+        **kwargs,
+    ) -> Dict:
+        api_key = api_key or get_secret_str("TINYFISH_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "TINYFISH_API_KEY is not set. Set `TINYFISH_API_KEY` environment variable."
+            )
+        headers["X-API-Key"] = api_key
+        headers["Accept"] = "application/json"
+        return headers
+
+    def get_complete_url(
+        self,
+        api_base: Optional[str],
+        optional_params: dict,
+        data: Optional[Union[Dict, List[Dict]]] = None,
+        **kwargs,
+    ) -> str:
+        api_base = (
+            api_base or get_secret_str("TINYFISH_API_BASE") or self.TINYFISH_API_BASE
+        )
+        if data and isinstance(data, dict) and "_tinyfish_params" in data:
+            query_string = urlencode(data["_tinyfish_params"], doseq=True)
+            return f"{api_base}?{query_string}"
+        return api_base
+
+    def transform_search_request(
+        self,
+        query: Union[str, List[str]],
+        optional_params: dict,
+        **kwargs,
+    ) -> Dict:
+        if isinstance(query, list):
+            query = " ".join(query)
+
+        request_data: TinyfishSearchRequest = {"query": query}
+
+        if "country" in optional_params:
+            request_data["location"] = optional_params["country"]
+
+        if "max_results" in optional_params:
+            request_data["max_results"] = max(
+                1, min(int(optional_params["max_results"]), 20)
+            )
+
+        if "search_domain_filter" in optional_params:
+            domains = optional_params["search_domain_filter"]
+            if isinstance(domains, list) and len(domains) > 0:
+                request_data["query"] = self._append_domain_filters(
+                    request_data["query"], domains
+                )
+
+        result_data = dict(request_data)
+
+        for param, value in optional_params.items():
+            if (
+                param not in self.get_supported_perplexity_optional_params()
+                and param not in result_data
+            ):
+                result_data[param] = value
+
+        return {"_tinyfish_params": result_data}
+
+    @staticmethod
+    def _append_domain_filters(query: str, domains: List[str]) -> str:
+        domain_clauses = " OR ".join(f"site:{d}" for d in domains)
+        return f"({query}) AND ({domain_clauses})"
+
+    def transform_search_response(
+        self,
+        raw_response: httpx.Response,
+        logging_obj: Optional[LiteLLMLoggingObj],
+        **kwargs,
+    ) -> SearchResponse:
+        response_json = raw_response.json()
+
+        query_params = raw_response.request.url.params if raw_response.request else {}
+        max_results = min(int(query_params.get("max_results", 20)), 20)
+
+        results: List[SearchResult] = []
+        for item in response_json.get("results", []):
+            if len(results) >= max_results:
+                break
+            results.append(
+                SearchResult(
+                    title=item.get("title", ""),
+                    url=item.get("url", ""),
+                    snippet=item.get("snippet", ""),
+                )
+            )
+
+        return SearchResponse(results=results, object="search")

--- a/litellm/llms/tinyfish/search/transformation.py
+++ b/litellm/llms/tinyfish/search/transformation.py
@@ -122,7 +122,9 @@ class TinyfishSearchConfig(BaseSearchConfig):
 
         result_data: dict[str, object] = dict(request_data)
 
-        raw_supported: object = self.get_supported_perplexity_optional_params()  # any-ok: base class returns bare set
+        raw_supported: object = (
+            self.get_supported_perplexity_optional_params()
+        )  # any-ok: base class returns bare set
         supported_perplexity = _StrFrozenSet.validate_python(raw_supported)
         for param, value in optional_params.items():
             if param not in supported_perplexity and param not in result_data:

--- a/litellm/llms/tinyfish/search/transformation.py
+++ b/litellm/llms/tinyfish/search/transformation.py
@@ -10,6 +10,7 @@ from typing import Literal, TypedDict
 from urllib.parse import urlencode
 
 import httpx
+from pydantic import BaseModel, TypeAdapter, ValidationError
 
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.llms.base_llm.search.transformation import (
@@ -31,6 +32,20 @@ class TinyfishSearchRequest(_TinyfishSearchRequestRequired, total=False):
     include_thumbnail: bool
     max_results: int
 
+
+class _TinyfishResultItem(BaseModel, frozen=True):
+    title: str = ""
+    url: str = ""
+    snippet: str = ""
+
+
+class _TinyfishApiResponse(BaseModel, frozen=True):
+    results: tuple[_TinyfishResultItem, ...] = ()
+
+
+_UrlEncodableParams = TypeAdapter(dict[str, str | int | bool])
+_StrList = TypeAdapter(list[str])
+_StrFrozenSet = TypeAdapter(frozenset[str])
 
 _TINYFISH_PARAMS_KEY = "_tinyfish_params"
 
@@ -70,10 +85,10 @@ class TinyfishSearchConfig(BaseSearchConfig):
             api_base or get_secret_str("TINYFISH_API_BASE") or self.TINYFISH_API_BASE
         )
         if isinstance(data, dict) and _TINYFISH_PARAMS_KEY in data:
-            params = data[_TINYFISH_PARAMS_KEY]
-            if isinstance(params, dict):
-                query_string = urlencode(params, doseq=True)
-                return f"{resolved_base}?{query_string}"
+            validated_params = _UrlEncodableParams.validate_python(
+                data[_TINYFISH_PARAMS_KEY]
+            )
+            return f"{resolved_base}?{urlencode(validated_params, doseq=True)}"
         return resolved_base
 
     def transform_search_request(
@@ -91,19 +106,24 @@ class TinyfishSearchConfig(BaseSearchConfig):
             request_data["location"] = country
 
         raw_max = optional_params.get("max_results")
-        if raw_max is not None:
+        if isinstance(raw_max, (int, float, str)):
             request_data["max_results"] = max(1, min(int(raw_max), 20))
 
-        domain_filter = optional_params.get("search_domain_filter")
-        if isinstance(domain_filter, list) and len(domain_filter) > 0:
+        try:
+            domains = _StrList.validate_python(
+                optional_params.get("search_domain_filter")
+            )
+        except (ValidationError, TypeError):
+            domains = []
+        if domains:
             request_data["query"] = _append_domain_filters(
-                request_data["query"],
-                [str(d) for d in domain_filter],
+                request_data["query"], domains
             )
 
         result_data: dict[str, object] = dict(request_data)
 
-        supported_perplexity = self.get_supported_perplexity_optional_params()
+        raw_supported: object = self.get_supported_perplexity_optional_params()  # any-ok: base class returns bare set
+        supported_perplexity = _StrFrozenSet.validate_python(raw_supported)
         for param, value in optional_params.items():
             if param not in supported_perplexity and param not in result_data:
                 result_data[param] = value
@@ -116,26 +136,25 @@ class TinyfishSearchConfig(BaseSearchConfig):
         logging_obj: LiteLLMLoggingObj | None,
         **kwargs: object,
     ) -> SearchResponse:
-        response_json: dict[str, object] = raw_response.json()
+        raw_json: object = raw_response.json()  # any-ok: httpx Response.json() -> Any
+        parsed = _TinyfishApiResponse.model_validate(raw_json)
 
-        raw_max: object = {}
+        max_results_str: str = "20"
         if raw_response.request:
-            raw_max = raw_response.request.url.params.get("max_results", 20)
-        max_results = min(int(raw_max) if raw_max else 20, 20)
-
-        raw_results = response_json.get("results")
-        items: list[object] = list(raw_results) if isinstance(raw_results, list) else []
-
-        results = tuple(
-            SearchResult(
-                title=item.get("title", "") if isinstance(item, dict) else "",
-                url=item.get("url", "") if isinstance(item, dict) else "",
-                snippet=item.get("snippet", "") if isinstance(item, dict) else "",
+            raw_param: object = (
+                raw_response.request.url.params.get(  # any-ok: httpx QueryParams.get() -> Any
+                    "max_results", "20"
+                )
             )
-            for item in items[:max_results]
-        )
+            max_results_str = str(raw_param)
+        max_results: int = min(int(max_results_str), 20)
 
-        return SearchResponse(results=list(results), object="search")
+        results = [
+            SearchResult(title=item.title, url=item.url, snippet=item.snippet)
+            for item in parsed.results[:max_results]
+        ]
+
+        return SearchResponse(results=results, object="search")
 
 
 def _append_domain_filters(query: str, domains: list[str]) -> str:

--- a/litellm/llms/tinyfish/search/transformation.py
+++ b/litellm/llms/tinyfish/search/transformation.py
@@ -161,4 +161,4 @@ class TinyfishSearchConfig(BaseSearchConfig):
 
 def _append_domain_filters(query: str, domains: list[str]) -> str:
     domain_clauses = " OR ".join(f"site:{d}" for d in domains)
-    return f"({query}) AND ({domain_clauses})"
+    return f"({query}) ({domain_clauses})"

--- a/litellm/llms/tinyfish/search/transformation.py
+++ b/litellm/llms/tinyfish/search/transformation.py
@@ -123,8 +123,8 @@ class TinyfishSearchConfig(BaseSearchConfig):
         result_data: dict[str, object] = dict(request_data)
 
         raw_supported: object = (
-            self.get_supported_perplexity_optional_params()
-        )  # any-ok: base class returns bare set
+            self.get_supported_perplexity_optional_params()  # any-ok: base class returns bare set
+        )
         supported_perplexity = _StrFrozenSet.validate_python(raw_supported)
         for param, value in optional_params.items():
             if param not in supported_perplexity and param not in result_data:

--- a/litellm/llms/tinyfish/search/transformation.py
+++ b/litellm/llms/tinyfish/search/transformation.py
@@ -6,7 +6,7 @@ Docs: https://docs.tinyfish.ai/search-api
 
 from __future__ import annotations
 
-from typing import Dict, List, Literal, Optional, TypedDict, Union
+from typing import Literal, TypedDict
 from urllib.parse import urlencode
 
 import httpx
@@ -32,6 +32,9 @@ class TinyfishSearchRequest(_TinyfishSearchRequestRequired, total=False):
     max_results: int
 
 
+_TINYFISH_PARAMS_KEY = "_tinyfish_params"
+
+
 class TinyfishSearchConfig(BaseSearchConfig):
     TINYFISH_API_BASE = "https://api.search.tinyfish.ai"
 
@@ -44,98 +47,97 @@ class TinyfishSearchConfig(BaseSearchConfig):
 
     def validate_environment(
         self,
-        headers: Dict,
-        api_key: Optional[str] = None,
-        api_base: Optional[str] = None,
-        **kwargs,
-    ) -> Dict:
-        api_key = api_key or get_secret_str("TINYFISH_API_KEY")
-        if not api_key:
+        headers: dict[str, str],
+        api_key: str | None = None,
+        api_base: str | None = None,
+        **kwargs: object,
+    ) -> dict[str, str]:
+        resolved_key = api_key or get_secret_str("TINYFISH_API_KEY")
+        if not resolved_key:
             raise ValueError(
                 "TINYFISH_API_KEY is not set. Set `TINYFISH_API_KEY` environment variable."
             )
-        headers["X-API-Key"] = api_key
-        headers["Accept"] = "application/json"
-        return headers
+        return {**headers, "X-API-Key": resolved_key, "Accept": "application/json"}
 
     def get_complete_url(
         self,
-        api_base: Optional[str],
-        optional_params: dict,
-        data: Optional[Union[Dict, List[Dict]]] = None,
-        **kwargs,
+        api_base: str | None,
+        optional_params: dict[str, object],
+        data: dict[str, object] | list[dict[str, object]] | None = None,
+        **kwargs: object,
     ) -> str:
-        api_base = (
+        resolved_base = (
             api_base or get_secret_str("TINYFISH_API_BASE") or self.TINYFISH_API_BASE
         )
-        if data and isinstance(data, dict) and "_tinyfish_params" in data:
-            query_string = urlencode(data["_tinyfish_params"], doseq=True)
-            return f"{api_base}?{query_string}"
-        return api_base
+        if isinstance(data, dict) and _TINYFISH_PARAMS_KEY in data:
+            params = data[_TINYFISH_PARAMS_KEY]
+            if isinstance(params, dict):
+                query_string = urlencode(params, doseq=True)
+                return f"{resolved_base}?{query_string}"
+        return resolved_base
 
     def transform_search_request(
         self,
-        query: Union[str, List[str]],
-        optional_params: dict,
-        **kwargs,
-    ) -> Dict:
-        if isinstance(query, list):
-            query = " ".join(query)
+        query: str | list[str],
+        optional_params: dict[str, object],
+        **kwargs: object,
+    ) -> dict[str, object]:
+        resolved_query = " ".join(query) if isinstance(query, list) else query
 
-        request_data: TinyfishSearchRequest = {"query": query}
+        request_data: TinyfishSearchRequest = {"query": resolved_query}
 
-        if "country" in optional_params:
-            request_data["location"] = optional_params["country"]
+        country = optional_params.get("country")
+        if isinstance(country, str):
+            request_data["location"] = country
 
-        if "max_results" in optional_params:
-            request_data["max_results"] = max(
-                1, min(int(optional_params["max_results"]), 20)
+        raw_max = optional_params.get("max_results")
+        if raw_max is not None:
+            request_data["max_results"] = max(1, min(int(raw_max), 20))
+
+        domain_filter = optional_params.get("search_domain_filter")
+        if isinstance(domain_filter, list) and len(domain_filter) > 0:
+            request_data["query"] = _append_domain_filters(
+                request_data["query"],
+                [str(d) for d in domain_filter],
             )
 
-        if "search_domain_filter" in optional_params:
-            domains = optional_params["search_domain_filter"]
-            if isinstance(domains, list) and len(domains) > 0:
-                request_data["query"] = self._append_domain_filters(
-                    request_data["query"], domains
-                )
+        result_data: dict[str, object] = dict(request_data)
 
-        result_data = dict(request_data)
-
+        supported_perplexity = self.get_supported_perplexity_optional_params()
         for param, value in optional_params.items():
-            if (
-                param not in self.get_supported_perplexity_optional_params()
-                and param not in result_data
-            ):
+            if param not in supported_perplexity and param not in result_data:
                 result_data[param] = value
 
-        return {"_tinyfish_params": result_data}
-
-    @staticmethod
-    def _append_domain_filters(query: str, domains: List[str]) -> str:
-        domain_clauses = " OR ".join(f"site:{d}" for d in domains)
-        return f"({query}) AND ({domain_clauses})"
+        return {_TINYFISH_PARAMS_KEY: result_data}
 
     def transform_search_response(
         self,
         raw_response: httpx.Response,
-        logging_obj: Optional[LiteLLMLoggingObj],
-        **kwargs,
+        logging_obj: LiteLLMLoggingObj | None,
+        **kwargs: object,
     ) -> SearchResponse:
-        response_json = raw_response.json()
+        response_json: dict[str, object] = raw_response.json()
 
-        query_params = raw_response.request.url.params if raw_response.request else {}
-        max_results = min(int(query_params.get("max_results", 20)), 20)
+        raw_max: object = {}
+        if raw_response.request:
+            raw_max = raw_response.request.url.params.get("max_results", 20)
+        max_results = min(int(raw_max) if raw_max else 20, 20)
 
-        results: List[SearchResult] = []
-        for item in response_json.get("results", []):
-            if len(results) >= max_results:
-                break
-            results.append(
-                SearchResult(
-                    title=item.get("title", ""),
-                    url=item.get("url", ""),
-                    snippet=item.get("snippet", ""),
-                )
+        raw_results = response_json.get("results")
+        items: list[object] = list(raw_results) if isinstance(raw_results, list) else []
+
+        results = tuple(
+            SearchResult(
+                title=item.get("title", "") if isinstance(item, dict) else "",
+                url=item.get("url", "") if isinstance(item, dict) else "",
+                snippet=item.get("snippet", "") if isinstance(item, dict) else "",
             )
+            for item in items[:max_results]
+        )
 
-        return SearchResponse(results=results, object="search")
+        return SearchResponse(results=list(results), object="search")
+
+
+def _append_domain_filters(query: str, domains: list[str]) -> str:
+    domain_clauses = " OR ".join(f"site:{d}" for d in domains)
+    return f"({query}) AND ({domain_clauses})"

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3477,6 +3477,7 @@ class SearchProviders(str, Enum):
     SERPER = "serper"
     YOU_COM = "you_com"
     APISERPENT = "apiserpent"
+    TINYFISH = "tinyfish"
 
 
 # Create a set of all search provider values for quick lookup

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -9704,6 +9704,7 @@ class ProviderConfigManager:
         from litellm.llms.searxng.search.transformation import SearXNGSearchConfig
         from litellm.llms.serper.search.transformation import SerperSearchConfig
         from litellm.llms.tavily.search.transformation import TavilySearchConfig
+        from litellm.llms.tinyfish.search.transformation import TinyfishSearchConfig
         from litellm.llms.you_com.search.transformation import YouComSearchConfig
 
         PROVIDER_TO_CONFIG_MAP = {
@@ -9723,6 +9724,7 @@ class ProviderConfigManager:
             SearchProviders.SERPER: SerperSearchConfig,
             SearchProviders.YOU_COM: YouComSearchConfig,
             SearchProviders.APISERPENT: APISerpentSearchConfig,
+            SearchProviders.TINYFISH: TinyfishSearchConfig,
         }
         config_class = PROVIDER_TO_CONFIG_MAP.get(provider, None)
         if config_class is None:

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -13877,11 +13877,11 @@
         }
     },
     "tinyfish/search": {
-        "input_cost_per_query": 0.005,
+        "input_cost_per_query": 0.0,
         "litellm_provider": "tinyfish",
         "mode": "search",
         "metadata": {
-            "notes": "TinyFish web search. Pricing: $5/1k searches."
+            "notes": "TinyFish Search API"
         }
     },
     "elevenlabs/scribe_v1": {

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -13876,6 +13876,14 @@
             "notes": "APISerpent deep search (/api/search), multi-engine (Google, Bing, Yahoo, DuckDuckGo). Pricing: $0.60/1k searches."
         }
     },
+    "tinyfish/search": {
+        "input_cost_per_query": 0.005,
+        "litellm_provider": "tinyfish",
+        "mode": "search",
+        "metadata": {
+            "notes": "TinyFish web search. Pricing: $5/1k searches."
+        }
+    },
     "elevenlabs/scribe_v1": {
         "input_cost_per_second": 6.11e-05,
         "litellm_provider": "elevenlabs",

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -2303,6 +2303,13 @@
         "search": true
       }
     },
+    "tinyfish": {
+      "display_name": "TinyFish (`tinyfish`)",
+      "url": "https://docs.tinyfish.ai/search-api",
+      "endpoints": {
+        "search": true
+      }
+    },
     "triton": {
       "display_name": "Triton (`triton`)",
       "url": "https://docs.litellm.ai/docs/providers/triton-inference-server",

--- a/tests/code_coverage_tests/enforce_llms_folder_style.py
+++ b/tests/code_coverage_tests/enforce_llms_folder_style.py
@@ -21,6 +21,7 @@ SEARCH_PROVIDERS = [
     "searchapi",
     "serper",
     "apiserpent",
+    "tinyfish",
 ]
 
 ALLOWED_FILES_IN_LLMS_FOLDER = [

--- a/tests/search_tests/test_tinyfish_search.py
+++ b/tests/search_tests/test_tinyfish_search.py
@@ -134,7 +134,6 @@ class TestTinyfishSearch:
             parsed_url = urlparse(call_args.kwargs["url"])
             query_params = parse_qs(parsed_url.query)
             query_value = query_params["query"][0]
-            assert "AND" in query_value
             assert "site:arxiv.org" in query_value
             assert "site:github.com" in query_value
             assert "python tutorials" in query_value

--- a/tests/search_tests/test_tinyfish_search.py
+++ b/tests/search_tests/test_tinyfish_search.py
@@ -1,0 +1,225 @@
+"""
+Tests for TinyFish Search API integration.
+"""
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+import pytest
+
+import litellm
+
+MOCK_TINYFISH_RESPONSE = {
+    "query": "web automation tools",
+    "results": [
+        {
+            "position": 1,
+            "site_name": "tinyfish.ai",
+            "title": "TinyFish - AI Web Automation",
+            "snippet": "Automate any website with natural language.",
+            "url": "https://tinyfish.ai",
+        },
+        {
+            "position": 2,
+            "site_name": "github.com",
+            "title": "Top Web Automation Tools",
+            "snippet": "A curated list of browser automation frameworks.",
+            "url": "https://github.com/example/web-automation",
+        },
+    ],
+    "total_results": 2,
+    "page": 0,
+}
+
+
+def _make_mock_response(
+    json_data: dict, status_code: int = 200, request_url: str | None = None
+) -> MagicMock:
+    mock = MagicMock()
+    mock.status_code = status_code
+    mock.json.return_value = json_data
+    if request_url:
+        mock.request = MagicMock()
+        mock.request.url = httpx.URL(request_url)
+    else:
+        mock.request = None
+    return mock
+
+
+class TestTinyfishSearch:
+    @pytest.mark.asyncio
+    async def test_basic_search(self):
+        os.environ["TINYFISH_API_KEY"] = "sk-tinyfish-test"
+
+        mock_response = _make_mock_response(MOCK_TINYFISH_RESPONSE)
+
+        with patch(
+            "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.get",
+            new_callable=AsyncMock,
+        ) as mock_get:
+            mock_get.return_value = mock_response
+
+            response = await litellm.asearch(
+                query="web automation tools",
+                search_provider="tinyfish",
+            )
+
+            assert mock_get.call_count == 1
+
+            call_args = mock_get.call_args
+            parsed_url = urlparse(call_args.kwargs["url"])
+            assert parsed_url.scheme == "https"
+            assert parsed_url.netloc == "api.search.tinyfish.ai"
+            assert parsed_url.path == ""
+
+            query_params = parse_qs(parsed_url.query)
+            assert query_params["query"] == ["web automation tools"]
+
+            headers = call_args.kwargs.get("headers", {})
+            assert headers["X-API-Key"] == "sk-tinyfish-test"
+
+            assert hasattr(response, "results")
+            assert response.object == "search"
+            assert len(response.results) == 2
+
+            first = response.results[0]
+            assert first.title == "TinyFish - AI Web Automation"
+            assert first.url == "https://tinyfish.ai"
+            assert first.snippet == "Automate any website with natural language."
+
+    @pytest.mark.asyncio
+    async def test_country_maps_to_location(self):
+        os.environ["TINYFISH_API_KEY"] = "sk-tinyfish-test"
+
+        mock_response = _make_mock_response(MOCK_TINYFISH_RESPONSE)
+
+        with patch(
+            "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.get",
+            new_callable=AsyncMock,
+        ) as mock_get:
+            mock_get.return_value = mock_response
+
+            await litellm.asearch(
+                query="test",
+                search_provider="tinyfish",
+                country="US",
+            )
+
+            call_args = mock_get.call_args
+            parsed_url = urlparse(call_args.kwargs["url"])
+            query_params = parse_qs(parsed_url.query)
+            assert query_params["location"] == ["US"]
+
+    @pytest.mark.asyncio
+    async def test_domain_filter_injection(self):
+        os.environ["TINYFISH_API_KEY"] = "sk-tinyfish-test"
+
+        mock_response = _make_mock_response(MOCK_TINYFISH_RESPONSE)
+
+        with patch(
+            "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.get",
+            new_callable=AsyncMock,
+        ) as mock_get:
+            mock_get.return_value = mock_response
+
+            await litellm.asearch(
+                query="python tutorials",
+                search_provider="tinyfish",
+                search_domain_filter=["arxiv.org", "github.com"],
+            )
+
+            call_args = mock_get.call_args
+            parsed_url = urlparse(call_args.kwargs["url"])
+            query_params = parse_qs(parsed_url.query)
+            query_value = query_params["query"][0]
+            assert "AND" in query_value
+            assert "site:arxiv.org" in query_value
+            assert "site:github.com" in query_value
+            assert "python tutorials" in query_value
+
+    @pytest.mark.asyncio
+    async def test_language_passthrough(self):
+        os.environ["TINYFISH_API_KEY"] = "sk-tinyfish-test"
+
+        mock_response = _make_mock_response(MOCK_TINYFISH_RESPONSE)
+
+        with patch(
+            "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.get",
+            new_callable=AsyncMock,
+        ) as mock_get:
+            mock_get.return_value = mock_response
+
+            await litellm.asearch(
+                query="test",
+                search_provider="tinyfish",
+                language="en",
+            )
+
+            call_args = mock_get.call_args
+            parsed_url = urlparse(call_args.kwargs["url"])
+            query_params = parse_qs(parsed_url.query)
+            assert query_params["language"] == ["en"]
+
+    def test_max_results_truncates_response(self):
+        from litellm.llms.tinyfish.search.transformation import TinyfishSearchConfig
+
+        config = TinyfishSearchConfig()
+        many_results = {
+            "results": [
+                {
+                    "title": f"Result {i}",
+                    "url": f"https://example.com/{i}",
+                    "snippet": f"Snippet {i}",
+                }
+                for i in range(10)
+            ]
+        }
+        mock_response = _make_mock_response(
+            many_results,
+            request_url="https://api.search.tinyfish.ai?query=test&max_results=3",
+        )
+
+        result = config.transform_search_response(
+            raw_response=mock_response,
+            logging_obj=None,
+        )
+        assert len(result.results) == 3
+        assert result.results[0].title == "Result 0"
+        assert result.results[2].title == "Result 2"
+
+    @pytest.mark.asyncio
+    async def test_empty_results(self):
+        os.environ["TINYFISH_API_KEY"] = "sk-tinyfish-test"
+
+        empty_response = {
+            "query": "xyznonexistent",
+            "results": [],
+            "total_results": 0,
+            "page": 0,
+        }
+        mock_response = _make_mock_response(empty_response)
+
+        with patch(
+            "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.get",
+            new_callable=AsyncMock,
+        ) as mock_get:
+            mock_get.return_value = mock_response
+
+            response = await litellm.asearch(
+                query="xyznonexistent",
+                search_provider="tinyfish",
+            )
+
+            assert response.object == "search"
+            assert len(response.results) == 0
+
+    def test_missing_api_key(self):
+        os.environ.pop("TINYFISH_API_KEY", None)
+
+        from litellm.llms.tinyfish.search.transformation import TinyfishSearchConfig
+
+        config = TinyfishSearchConfig()
+        with pytest.raises(ValueError, match="TINYFISH_API_KEY"):
+            config.validate_environment(headers={})

--- a/tests/test_litellm/llms/tinyfish/test_tinyfish_search.py
+++ b/tests/test_litellm/llms/tinyfish/test_tinyfish_search.py
@@ -134,19 +134,16 @@ class TestTransformSearchRequest:
         )
         assert result["_tinyfish_params"]["max_results"] == 5
 
-    def test_domain_filter_uses_explicit_and(self):
+    def test_domain_filter_appends_site_operators(self):
         config = TinyfishSearchConfig()
         result = config.transform_search_request(
             query="python tutorials",
             optional_params={"search_domain_filter": ["arxiv.org", "github.com"]},
         )
         query_value = result["_tinyfish_params"]["query"]
-        assert "AND" in query_value
         assert "site:arxiv.org" in query_value
         assert "site:github.com" in query_value
-        assert (
-            "(python tutorials) AND (site:arxiv.org OR site:github.com)" == query_value
-        )
+        assert "(python tutorials) (site:arxiv.org OR site:github.com)" == query_value
 
     def test_domain_filter_empty_list_ignored(self):
         config = TinyfishSearchConfig()
@@ -335,8 +332,8 @@ class TestTransformSearchResponse:
 class TestAppendDomainFilters:
     def test_single_domain(self):
         result = _append_domain_filters("test", ["example.com"])
-        assert result == "(test) AND (site:example.com)"
+        assert result == "(test) (site:example.com)"
 
     def test_multiple_domains(self):
         result = _append_domain_filters("query", ["a.com", "b.com", "c.com"])
-        assert result == "(query) AND (site:a.com OR site:b.com OR site:c.com)"
+        assert result == "(query) (site:a.com OR site:b.com OR site:c.com)"

--- a/tests/test_litellm/llms/tinyfish/test_tinyfish_search.py
+++ b/tests/test_litellm/llms/tinyfish/test_tinyfish_search.py
@@ -8,7 +8,10 @@ from unittest.mock import MagicMock, patch
 import httpx
 import pytest
 
-from litellm.llms.tinyfish.search.transformation import TinyfishSearchConfig
+from litellm.llms.tinyfish.search.transformation import (
+    TinyfishSearchConfig,
+    _append_domain_filters,
+)
 
 MOCK_TINYFISH_RESPONSE = {
     "query": "web automation tools",
@@ -172,11 +175,11 @@ class TestTransformSearchRequest:
         config = TinyfishSearchConfig()
         supported = config.get_supported_perplexity_optional_params()
         if supported:
-            first_param = list(supported)[0]
+            param = next(p for p in supported if p != "max_results" and p != "country")
             result = config.transform_search_request(
-                query="test", optional_params={first_param: "value"}
+                query="test", optional_params={param: "value"}
             )
-            assert first_param not in result["_tinyfish_params"]
+            assert param not in result["_tinyfish_params"]
 
 
 class TestGetCompleteUrl:
@@ -331,11 +334,9 @@ class TestTransformSearchResponse:
 
 class TestAppendDomainFilters:
     def test_single_domain(self):
-        result = TinyfishSearchConfig._append_domain_filters("test", ["example.com"])
+        result = _append_domain_filters("test", ["example.com"])
         assert result == "(test) AND (site:example.com)"
 
     def test_multiple_domains(self):
-        result = TinyfishSearchConfig._append_domain_filters(
-            "query", ["a.com", "b.com", "c.com"]
-        )
+        result = _append_domain_filters("query", ["a.com", "b.com", "c.com"])
         assert result == "(query) AND (site:a.com OR site:b.com OR site:c.com)"

--- a/tests/test_litellm/llms/tinyfish/test_tinyfish_search.py
+++ b/tests/test_litellm/llms/tinyfish/test_tinyfish_search.py
@@ -1,0 +1,341 @@
+"""
+Tests for TinyFish Search API integration.
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from litellm.llms.tinyfish.search.transformation import TinyfishSearchConfig
+
+MOCK_TINYFISH_RESPONSE = {
+    "query": "web automation tools",
+    "results": [
+        {
+            "position": 1,
+            "site_name": "tinyfish.ai",
+            "title": "TinyFish - AI Web Automation",
+            "snippet": "Automate any website with natural language.",
+            "url": "https://tinyfish.ai",
+        },
+        {
+            "position": 2,
+            "site_name": "github.com",
+            "title": "Top Web Automation Tools",
+            "snippet": "A curated list of browser automation frameworks.",
+            "url": "https://github.com/example/web-automation",
+        },
+    ],
+    "total_results": 2,
+    "page": 0,
+}
+
+
+def _make_mock_response(
+    json_data: dict, status_code: int = 200, request_url: str | None = None
+) -> MagicMock:
+    mock = MagicMock()
+    mock.status_code = status_code
+    mock.json.return_value = json_data
+    if request_url:
+        mock.request = MagicMock()
+        mock.request.url = httpx.URL(request_url)
+    else:
+        mock.request = None
+    return mock
+
+
+class TestTinyfishSearchConfig:
+    def test_ui_friendly_name(self):
+        assert TinyfishSearchConfig.ui_friendly_name() == "TinyFish"
+
+    def test_get_http_method(self):
+        assert TinyfishSearchConfig().get_http_method() == "GET"
+
+    def test_validate_environment_with_explicit_key(self):
+        config = TinyfishSearchConfig()
+        headers = config.validate_environment(headers={}, api_key="sk-tinyfish-test")
+        assert headers["X-API-Key"] == "sk-tinyfish-test"
+        assert headers["Accept"] == "application/json"
+
+    def test_validate_environment_from_env(self):
+        config = TinyfishSearchConfig()
+        with patch(
+            "litellm.llms.tinyfish.search.transformation.get_secret_str",
+            return_value="sk-from-env",
+        ):
+            headers = config.validate_environment(headers={})
+        assert headers["X-API-Key"] == "sk-from-env"
+
+    def test_validate_environment_missing_key(self):
+        config = TinyfishSearchConfig()
+        with patch(
+            "litellm.llms.tinyfish.search.transformation.get_secret_str",
+            return_value=None,
+        ):
+            with pytest.raises(ValueError, match="TINYFISH_API_KEY"):
+                config.validate_environment(headers={})
+
+    def test_validate_environment_uses_api_base_kwarg(self):
+        config = TinyfishSearchConfig()
+        headers = config.validate_environment(
+            headers={},
+            api_key="sk-test",
+            api_base="https://custom.tinyfish.ai",
+        )
+        assert headers["X-API-Key"] == "sk-test"
+
+
+class TestTransformSearchRequest:
+    def test_basic_query(self):
+        config = TinyfishSearchConfig()
+        result = config.transform_search_request(
+            query="hello world", optional_params={}
+        )
+        assert result == {"_tinyfish_params": {"query": "hello world"}}
+
+    def test_list_query_joined(self):
+        config = TinyfishSearchConfig()
+        result = config.transform_search_request(
+            query=["hello", "world"], optional_params={}
+        )
+        assert result["_tinyfish_params"]["query"] == "hello world"
+
+    def test_country_maps_to_location(self):
+        config = TinyfishSearchConfig()
+        result = config.transform_search_request(
+            query="test", optional_params={"country": "US"}
+        )
+        assert result["_tinyfish_params"]["location"] == "US"
+
+    def test_max_results_clamped_upper(self):
+        config = TinyfishSearchConfig()
+        result = config.transform_search_request(
+            query="test", optional_params={"max_results": 100}
+        )
+        assert result["_tinyfish_params"]["max_results"] == 20
+
+    def test_max_results_clamped_lower(self):
+        config = TinyfishSearchConfig()
+        result = config.transform_search_request(
+            query="test", optional_params={"max_results": 0}
+        )
+        assert result["_tinyfish_params"]["max_results"] == 1
+
+    def test_max_results_normal(self):
+        config = TinyfishSearchConfig()
+        result = config.transform_search_request(
+            query="test", optional_params={"max_results": 5}
+        )
+        assert result["_tinyfish_params"]["max_results"] == 5
+
+    def test_domain_filter_uses_explicit_and(self):
+        config = TinyfishSearchConfig()
+        result = config.transform_search_request(
+            query="python tutorials",
+            optional_params={"search_domain_filter": ["arxiv.org", "github.com"]},
+        )
+        query_value = result["_tinyfish_params"]["query"]
+        assert "AND" in query_value
+        assert "site:arxiv.org" in query_value
+        assert "site:github.com" in query_value
+        assert (
+            "(python tutorials) AND (site:arxiv.org OR site:github.com)" == query_value
+        )
+
+    def test_domain_filter_empty_list_ignored(self):
+        config = TinyfishSearchConfig()
+        result = config.transform_search_request(
+            query="test", optional_params={"search_domain_filter": []}
+        )
+        assert result["_tinyfish_params"]["query"] == "test"
+
+    def test_domain_filter_non_list_ignored(self):
+        config = TinyfishSearchConfig()
+        result = config.transform_search_request(
+            query="test", optional_params={"search_domain_filter": "not-a-list"}
+        )
+        assert result["_tinyfish_params"]["query"] == "test"
+
+    def test_unknown_params_passed_through(self):
+        config = TinyfishSearchConfig()
+        result = config.transform_search_request(
+            query="test", optional_params={"language": "en", "page": 2}
+        )
+        params = result["_tinyfish_params"]
+        assert params["language"] == "en"
+        assert params["page"] == 2
+
+    def test_perplexity_params_not_passed_through(self):
+        config = TinyfishSearchConfig()
+        supported = config.get_supported_perplexity_optional_params()
+        if supported:
+            first_param = list(supported)[0]
+            result = config.transform_search_request(
+                query="test", optional_params={first_param: "value"}
+            )
+            assert first_param not in result["_tinyfish_params"]
+
+
+class TestGetCompleteUrl:
+    def test_default_api_base(self):
+        config = TinyfishSearchConfig()
+        with patch(
+            "litellm.llms.tinyfish.search.transformation.get_secret_str",
+            return_value=None,
+        ):
+            url = config.get_complete_url(api_base=None, optional_params={})
+        assert url == "https://api.search.tinyfish.ai"
+
+    def test_custom_api_base(self):
+        config = TinyfishSearchConfig()
+        url = config.get_complete_url(
+            api_base="https://custom.api.tinyfish.ai", optional_params={}
+        )
+        assert url == "https://custom.api.tinyfish.ai"
+
+    def test_env_api_base(self):
+        config = TinyfishSearchConfig()
+        with patch(
+            "litellm.llms.tinyfish.search.transformation.get_secret_str",
+            return_value="https://env.tinyfish.ai",
+        ):
+            url = config.get_complete_url(api_base=None, optional_params={})
+        assert url == "https://env.tinyfish.ai"
+
+    def test_with_tinyfish_params(self):
+        config = TinyfishSearchConfig()
+        with patch(
+            "litellm.llms.tinyfish.search.transformation.get_secret_str",
+            return_value=None,
+        ):
+            url = config.get_complete_url(
+                api_base=None,
+                optional_params={},
+                data={"_tinyfish_params": {"query": "hello", "max_results": 5}},
+            )
+        assert "query=hello" in url
+        assert "max_results=5" in url
+        assert url.startswith("https://api.search.tinyfish.ai?")
+
+    def test_without_tinyfish_params_key(self):
+        config = TinyfishSearchConfig()
+        with patch(
+            "litellm.llms.tinyfish.search.transformation.get_secret_str",
+            return_value=None,
+        ):
+            url = config.get_complete_url(
+                api_base=None, optional_params={}, data={"other": "value"}
+            )
+        assert url == "https://api.search.tinyfish.ai"
+
+    def test_data_none(self):
+        config = TinyfishSearchConfig()
+        with patch(
+            "litellm.llms.tinyfish.search.transformation.get_secret_str",
+            return_value=None,
+        ):
+            url = config.get_complete_url(api_base=None, optional_params={}, data=None)
+        assert url == "https://api.search.tinyfish.ai"
+
+
+class TestTransformSearchResponse:
+    def test_basic_response(self):
+        config = TinyfishSearchConfig()
+        mock_response = _make_mock_response(MOCK_TINYFISH_RESPONSE)
+        result = config.transform_search_response(
+            raw_response=mock_response, logging_obj=None
+        )
+        assert result.object == "search"
+        assert len(result.results) == 2
+        assert result.results[0].title == "TinyFish - AI Web Automation"
+        assert result.results[0].url == "https://tinyfish.ai"
+        assert (
+            result.results[0].snippet == "Automate any website with natural language."
+        )
+
+    def test_empty_results(self):
+        config = TinyfishSearchConfig()
+        mock_response = _make_mock_response({"results": []})
+        result = config.transform_search_response(
+            raw_response=mock_response, logging_obj=None
+        )
+        assert result.object == "search"
+        assert len(result.results) == 0
+
+    def test_max_results_truncates(self):
+        config = TinyfishSearchConfig()
+        many_results = {
+            "results": [
+                {
+                    "title": f"Result {i}",
+                    "url": f"https://example.com/{i}",
+                    "snippet": f"Snippet {i}",
+                }
+                for i in range(10)
+            ]
+        }
+        mock_response = _make_mock_response(
+            many_results,
+            request_url="https://api.search.tinyfish.ai?query=test&max_results=3",
+        )
+        result = config.transform_search_response(
+            raw_response=mock_response, logging_obj=None
+        )
+        assert len(result.results) == 3
+        assert result.results[0].title == "Result 0"
+        assert result.results[2].title == "Result 2"
+
+    def test_max_results_default_is_20(self):
+        config = TinyfishSearchConfig()
+        many_results = {
+            "results": [
+                {
+                    "title": f"Result {i}",
+                    "url": f"https://example.com/{i}",
+                    "snippet": f"Snippet {i}",
+                }
+                for i in range(25)
+            ]
+        }
+        mock_response = _make_mock_response(
+            many_results,
+            request_url="https://api.search.tinyfish.ai?query=test",
+        )
+        result = config.transform_search_response(
+            raw_response=mock_response, logging_obj=None
+        )
+        assert len(result.results) == 20
+
+    def test_missing_fields_default_to_empty_string(self):
+        config = TinyfishSearchConfig()
+        mock_response = _make_mock_response({"results": [{}]})
+        result = config.transform_search_response(
+            raw_response=mock_response, logging_obj=None
+        )
+        assert len(result.results) == 1
+        assert result.results[0].title == ""
+        assert result.results[0].url == ""
+        assert result.results[0].snippet == ""
+
+    def test_no_request_uses_default_max_results(self):
+        config = TinyfishSearchConfig()
+        mock_response = _make_mock_response(MOCK_TINYFISH_RESPONSE)
+        result = config.transform_search_response(
+            raw_response=mock_response, logging_obj=None
+        )
+        assert len(result.results) == 2
+
+
+class TestAppendDomainFilters:
+    def test_single_domain(self):
+        result = TinyfishSearchConfig._append_domain_filters("test", ["example.com"])
+        assert result == "(test) AND (site:example.com)"
+
+    def test_multiple_domains(self):
+        result = TinyfishSearchConfig._append_domain_filters(
+            "query", ["a.com", "b.com", "c.com"]
+        )
+        assert result == "(query) AND (site:a.com OR site:b.com OR site:c.com)"


### PR DESCRIPTION
## Summary

Adds [TinyFish](https://tinyfish.ai) as a search provider in LiteLLM, following the same GET-based pattern as Brave/Serper.

- Implements `TinyfishSearchConfig(BaseSearchConfig)` with full request/response transformation
- Maps unified LiteLLM params (`country` -> `location`, `search_domain_filter` -> `site:` operators, `max_results` -> client-side truncation)
- Auth via `X-API-Key` header (from `api_key` param or `TINYFISH_API_KEY` env var)
- 38 tests (31 unit + 7 integration) covering every method and branch

> This is a backend-only search provider addition with no UI changes (no visible output to screenshot)

### Files changed (9)

| File | Change |
|------|--------|
| `litellm/llms/tinyfish/search/__init__.py` | New module export |
| `litellm/llms/tinyfish/search/transformation.py` | Core TinyfishSearchConfig; fully typed with Pydantic validation at httpx boundaries |
| `litellm/types/utils.py` | Add TINYFISH to SearchProviders enum |
| `litellm/utils.py` | Register config in get_provider_search_config() |
| `model_prices_and_context_window.json` | Add tinyfish/search entry |
| `provider_endpoints_support.json` | Add tinyfish endpoint metadata |
| `tests/code_coverage_tests/enforce_llms_folder_style.py` | Add tinyfish to SEARCH_PROVIDERS |
| `tests/test_litellm/llms/tinyfish/test_tinyfish_search.py` | 31 unit tests covering every method and branch |
| `tests/search_tests/test_tinyfish_search.py` | 7 integration-style tests via litellm.asearch() |

## Relevant issues

Follow-up to #30158 (approved by Sameerlite, closed due to merge conflicts during branch rotation)

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Proof of testing

To test with a live proxy:

1. Add `TINYFISH_API_KEY` to your `.env`
2. Start the proxy: `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log`
3. Run a search:

```bash
curl -s http://localhost:4000/v1/search \
  -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d '{"query": "web automation tools", "custom_llm_provider": "tinyfish"}' | python -m json.tool
```

38 tests (31 in `tests/test_litellm/`, 7 in `tests/search_tests/`) cover every method and branch. All CI checks pass including any-discipline and codecov (100% patch coverage)

## Test plan

- [x] All 38 tests pass
- [x] any-discipline gate passes
- [x] codecov patch coverage at 100%
- [x] Greptile confidence score 4/5

## Type

New Feature