### PR TITLE
fix(redis): coerce env var string types and fix param discovery through decorator wrappers

### DIFF
--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -32,9 +32,11 @@ AZURE_REDIS_SCOPE = "https://redis.azure.com/.default"
 
 
 def _get_redis_kwargs():
-    arg_spec = inspect.getfullargspec(redis.Redis)
+    # inspect.getfullargspec doesn't work here because redis.Redis.__init__ is
+    # wrapped by @deprecated_args which uses *args/**kwargs internally.
+    # inspect.signature resolves the original function's parameters correctly.
+    sig = inspect.signature(redis.Redis)
 
-    # Only allow primitive arguments
     exclude_args = {
         "self",
         "connection_pool",
@@ -52,9 +54,7 @@ def _get_redis_kwargs():
         "azure_client_secret",
     }
 
-    available_args = {x for x in arg_spec.args if x not in exclude_args} | include_args
-
-    return available_args
+    return {name for name in sig.parameters if name not in exclude_args} | include_args
 
 
 def _get_redis_url_kwargs(client=None):
@@ -111,6 +111,45 @@ def _get_redis_env_kwarg_mapping():
     PREFIX = "REDIS_"
 
     return {f"{PREFIX}{x.upper()}": x for x in _get_redis_kwargs()}
+
+
+def _coerce_redis_kwargs_types(redis_kwargs: dict) -> dict:
+    sig = inspect.signature(redis.Redis)
+    # Params defaulting to None but requiring a numeric type when set
+    none_default_numeric: dict[str, type[int] | type[float]] = {
+        "max_connections": int,
+        "socket_timeout": float,
+        "socket_connect_timeout": float,
+    }
+    result = dict(redis_kwargs)
+    for key, value in redis_kwargs.items():
+        if not isinstance(value, str):
+            continue
+        param = sig.parameters.get(key)
+        if param is None:
+            continue
+        default = param.default
+        if default is inspect.Parameter.empty:
+            continue
+        # bool must be checked before int since bool subclasses int
+        if isinstance(default, bool):
+            result[key] = value.lower() in ("true", "1", "yes")
+        elif isinstance(default, int):
+            try:
+                result[key] = int(value)
+            except (ValueError, TypeError):
+                del result[key]
+        elif isinstance(default, float):
+            try:
+                result[key] = float(value)
+            except (ValueError, TypeError):
+                del result[key]
+        elif default is None and key in none_default_numeric:
+            try:
+                result[key] = none_default_numeric[key](value)
+            except (ValueError, TypeError):
+                del result[key]
+    return result
 
 
 def _redis_kwargs_from_environment():
@@ -449,8 +488,7 @@ def _get_redis_client_logic(**env_overrides):  # noqa: PLR0915
     elif "host" not in redis_kwargs or redis_kwargs["host"] is None:
         raise ValueError("Either 'host' or 'url' must be specified for redis.")
 
-    # litellm.print_verbose(f"redis_kwargs: {redis_kwargs}")
-    return redis_kwargs
+    return _coerce_redis_kwargs_types(redis_kwargs)
 
 
 def init_redis_cluster(redis_kwargs) -> redis.RedisCluster:
@@ -669,18 +707,13 @@ def get_redis_connection_pool(
         return None
 
     if "url" in redis_kwargs and redis_kwargs["url"] is not None:
-        pool_kwargs = {
+        pool_kwargs: dict = {
             "timeout": REDIS_CONNECTION_POOL_TIMEOUT,
             "url": redis_kwargs["url"],
         }
-        if "max_connections" in redis_kwargs:
-            try:
-                pool_kwargs["max_connections"] = int(redis_kwargs["max_connections"])
-            except (TypeError, ValueError):
-                verbose_logger.warning(
-                    "REDIS: invalid max_connections value %r, ignoring",
-                    redis_kwargs["max_connections"],
-                )
+        max_connections = redis_kwargs.get("max_connections")
+        if max_connections is not None:
+            pool_kwargs["max_connections"] = max_connections
         return async_redis.BlockingConnectionPool.from_url(**pool_kwargs)
 
     # Wrap GCP / Azure AD auth in a CredentialProvider so pool-managed

--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -60,31 +60,19 @@ def _get_redis_kwargs():
 def _get_redis_url_kwargs(client=None):
     if client is None:
         client = redis.Redis.from_url
-    arg_spec = inspect.getfullargspec(redis.Redis.from_url)
-
-    # Only allow primitive arguments
-    exclude_args = {
-        "self",
-        "connection_pool",
-        "retry",
-    }
-
+    sig = inspect.signature(redis.Redis)
+    exclude_args = {"self", "connection_pool", "retry"}
     include_args = ["url"]
-
-    available_args = [x for x in arg_spec.args if x not in exclude_args] + include_args
-
+    available_args = [x for x in sig.parameters if x not in exclude_args] + include_args
     return available_args
 
 
 def _get_redis_cluster_kwargs(client=None):
     if client is None:
         client = redis.Redis.from_url
-    arg_spec = inspect.getfullargspec(redis.RedisCluster)
-
-    # Only allow primitive arguments
+    sig = inspect.signature(redis.RedisCluster)
     exclude_args = {"self", "connection_pool", "retry", "host", "port", "startup_nodes"}
-
-    available_args = {x for x in arg_spec.args if x not in exclude_args}
+    available_args = {x for x in sig.parameters if x not in exclude_args}
     available_args |= {
         "password",
         "username",
@@ -92,7 +80,7 @@ def _get_redis_cluster_kwargs(client=None):
         "ssl_cert_reqs",
         "ssl_check_hostname",
         "ssl_ca_certs",
-        "redis_connect_func",  # Needed for sync clusters and IAM detection
+        "redis_connect_func",
         "gcp_service_account",
         "gcp_ssl_ca_certs",
         "azure_redis_ad_token",
@@ -103,7 +91,6 @@ def _get_redis_cluster_kwargs(client=None):
         "socket_timeout",
         "socket_connect_timeout",
     }
-
     return available_args
 
 

--- a/tests/test_litellm/caching/test_redis_connection_pool.py
+++ b/tests/test_litellm/caching/test_redis_connection_pool.py
@@ -1,9 +1,3 @@
-"""
-Regression tests for Redis connection pool leak fixes (RC1-RC5).
-
-Tests are pure unit tests — no Redis server required.
-"""
-
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest

--- a/tests/test_litellm/caching/test_redis_connection_pool.py
+++ b/tests/test_litellm/caching/test_redis_connection_pool.py
@@ -7,9 +7,12 @@ Tests are pure unit tests — no Redis server required.
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-import redis.asyncio as async_redis
 
-from litellm._redis import get_redis_async_client, get_redis_connection_pool
+from litellm._redis import (
+    _coerce_redis_kwargs_types,
+    get_redis_async_client,
+    get_redis_connection_pool,
+)
 
 
 def test_url_config_uses_passed_pool():
@@ -60,16 +63,14 @@ def test_max_connections_url_config_string_value(monkeypatch):
     assert pool.max_connections == 25
 
 
-def test_max_connections_url_config_invalid_value():
-    """Invalid max_connections should be silently ignored, falling back
-    to the pool default (50 for BlockingConnectionPool)."""
-    with patch("litellm._redis._get_redis_client_logic") as mock_logic:
-        mock_logic.return_value = {
-            "url": "redis://localhost:6379/0",
-            "max_connections": "not_a_number",
-        }
+def test_max_connections_url_config_invalid_value(monkeypatch):
+    """Invalid max_connections from an env var should be silently dropped,
+    falling back to the pool default (50 for BlockingConnectionPool)."""
+    monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+    monkeypatch.delenv("REDIS_HOST", raising=False)
+    monkeypatch.setenv("REDIS_MAX_CONNECTIONS", "not_a_number")
 
-        pool = get_redis_connection_pool()
+    pool = get_redis_connection_pool()
 
     # BlockingConnectionPool default is 50
     assert pool.max_connections == 50
@@ -128,3 +129,56 @@ async def test_disconnect_idempotent():
 
     await cache.disconnect()
     await cache.disconnect()  # should not raise
+
+
+def test_coerce_redis_kwargs_types_int():
+    """String values for int-typed Redis params are coerced to int."""
+    result = _coerce_redis_kwargs_types({"health_check_interval": "30", "port": "6380", "db": "1"})
+    assert result["health_check_interval"] == 30
+    assert isinstance(result["health_check_interval"], int)
+    assert result["port"] == 6380
+    assert result["db"] == 1
+
+
+def test_coerce_redis_kwargs_types_bool():
+    """String values for bool-typed Redis params are coerced to bool."""
+    result = _coerce_redis_kwargs_types({"ssl": "true", "decode_responses": "false"})
+    assert result["ssl"] is True
+    assert result["decode_responses"] is False
+
+
+def test_coerce_redis_kwargs_types_none_default_numeric():
+    """String values for known None-default numeric params are coerced."""
+    result = _coerce_redis_kwargs_types({"max_connections": "20", "socket_timeout": "5.5"})
+    assert result["max_connections"] == 20
+    assert isinstance(result["max_connections"], int)
+    assert result["socket_timeout"] == 5.5
+    assert isinstance(result["socket_timeout"], float)
+
+
+def test_coerce_redis_kwargs_types_invalid_drops_key():
+    """A string that cannot be coerced to the expected numeric type is dropped."""
+    result = _coerce_redis_kwargs_types({"health_check_interval": "not_a_number"})
+    assert "health_check_interval" not in result
+
+
+def test_coerce_redis_kwargs_types_non_string_unchanged():
+    """Non-string values pass through without modification."""
+    result = _coerce_redis_kwargs_types({"health_check_interval": 30, "ssl": True})
+    assert result["health_check_interval"] == 30
+    assert result["ssl"] is True
+
+
+def test_health_check_interval_from_env_is_int(monkeypatch):
+    """REDIS_HEALTH_CHECK_INTERVAL set as string env var must produce an int
+    on the Redis connection, so Redis can do float + int arithmetic for health checks."""
+    monkeypatch.setenv("REDIS_HOST", "localhost")
+    monkeypatch.setenv("REDIS_HEALTH_CHECK_INTERVAL", "30")
+
+    with patch("litellm._redis.get_redis_client"):
+        pool = get_redis_connection_pool()
+
+    assert pool is not None
+    interval = pool.connection_kwargs.get("health_check_interval")
+    assert interval == 30
+    assert isinstance(interval, int), f"Expected int, got {type(interval)}: {interval!r}"


### PR DESCRIPTION

## Relevant issues

Fixes #30534

## Linear ticket
N/A

<!-- if you are an internal contributor, add the Linear ticket e.g. "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix
### Before Fix - `health_check_interval` passed as string, TypeError on every Redis operation:
```
12:23:52 - LiteLLM:DEBUG: logging_callback_manager.py:349 - Custom logger of type SkillsInjectionHook, key: SkillsInjectionHook-max_iterations=10-sandbox_timeout=120-message_logging=True-turn_off_message_logging=False already exists in [<litellm.proxy.hooks.litellm_skills.main.SkillsInjectionHook object at 0x000001E654F21A10>, <litellm.proxy.hooks.model_max_budget_limiter._PROXY_VirtualKeyModelMaxBudgetLimiter object at 0x000001E658A8C450>, <litellm.proxy.hooks.max_budget_limiter._PROXY_MaxBudgetLimiter object at 0x000001E65B48AF90>, <litellm.proxy.hooks.parallel_request_limiter_v3._PROXY_MaxParallelRequestsHandler_v3 object at 0x000001E6573FA8D0>, <litellm.proxy.hooks.cache_control_check._PROXY_CacheControlCheck object at 0x000001E65BD35F50>, <litellm.proxy.hooks.responses_id_security.ResponsesIDSecurity object at 0x000001E65BD4A4D0>], not adding again..
12:23:52 - LiteLLM Proxy:DEBUG: proxy_server.py:895 - About to initialize semantic tool filter
12:23:52 - LiteLLM Proxy:DEBUG: proxy_server.py:898 - litellm_settings keys = ['cache', 'cache_params']
12:23:52 - LiteLLM Proxy:DEBUG: proxy_server.py:7252 - Semantic tool filter not configured or not enabled, skipping initialization
12:23:52 - LiteLLM Proxy:DEBUG: proxy_server.py:905 - After semantic tool filter initialization
12:23:52 - LiteLLM Proxy:DEBUG: proxy_server.py:919 - prisma_client: None
12:23:52 - LiteLLM Proxy:DEBUG: proxy_server.py:8114 - LiteLLM: Pyroscope profiling is disabled (set LITELLM_ENABLE_PYROSCOPE=true to enable).
12:23:52 - LiteLLM Proxy:INFO: proxy_server.py:724 - SESSION REUSE: Created shared aiohttp session for connection pooling (ID: 2088890950032, limit=1000, limit_per_host=500)
12:23:52 - LiteLLM Proxy:DEBUG: hanging_request_check.py:148 - Checking for hanging requests....
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:4099 (Press CTRL+C to quit)
12:23:52 - LiteLLM:ERROR: redis_cache.py:1198 - LiteLLM Redis Cache PING: - Got exception from REDIS : unsupported operand type(s) for +: 'float' and 'str'
Task exception was never retrieved
future: <Task finished name='Task-6' coro=<RedisCache.ping() done, defined at C:\Users\USER\Documents\GitHub\OpenSourceContributions\litellm\litellm\caching\redis_cache.py:1167> exception=TypeError("unsupported operand type(s) for +: 'float' and 'str'")>
Traceback (most recent call last):
  File "C:\Users\USER\Documents\GitHub\OpenSourceContributions\litellm\litellm\caching\redis_cache.py", line 1201, in ping
    raise e
  File "C:\Users\USER\Documents\GitHub\OpenSourceContributions\litellm\litellm\caching\redis_cache.py", line 1173, in ping
    response = await _redis_client.ping()
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\USER\AppData\Local\Programs\Python\Python311\Lib\site-packages\redis\asyncio\client.py", line 672, in execute_command
    conn = self.connection or await pool.get_connection()
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\USER\AppData\Local\Programs\Python\Python311\Lib\site-packages\redis\asyncio\connection.py", line 1329, in get_connection
    await self.ensure_connection(connection)
  File "C:\Users\USER\AppData\Local\Programs\Python\Python311\Lib\site-packages\redis\asyncio\connection.py", line 1182, in ensure_connection
    await connection.connect()
  File "C:\Users\USER\AppData\Local\Programs\Python\Python311\Lib\site-packages\redis\asyncio\connection.py", line 296, in connect
    await self.connect_check_health(check_health=True)
  File "C:\Users\USER\AppData\Local\Programs\Python\Python311\Lib\site-packages\redis\asyncio\connection.py", line 322, in connect_check_health
    await self.on_connect_check_health(check_health=check_health)
  File "C:\Users\USER\AppData\Local\Programs\Python\Python311\Lib\site-packages\redis\asyncio\connection.py", line 441, in on_connect_check_health
    await self.send_command(
  File "C:\Users\USER\AppData\Local\Programs\Python\Python311\Lib\site-packages\redis\asyncio\connection.py", line 559, in send_command
    await self.send_packed_command(
  File "C:\Users\USER\AppData\Local\Programs\Python\Python311\Lib\site-packages\redis\asyncio\connection.py", line 522, in send_packed_command
    await self.check_health()
  File "C:\Users\USER\AppData\Local\Programs\Python\Python311\Lib\site-packages\redis\asyncio\connection.py", line 510, in check_health
    await self.retry.call_with_retry(self._send_ping, self._ping_failed)
  File "C:\Users\USER\AppData\Local\Programs\Python\Python311\Lib\site-packages\redis\asyncio\retry.py", line 50, in call_with_retry
    return await do()
           ^^^^^^^^^^
  File "C:\Users\USER\AppData\Local\Programs\Python\Python311\Lib\site-packages\redis\asyncio\connection.py", line 497, in _send_ping
    if str_if_bytes(await self.read_response()) != "PONG":
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\USER\AppData\Local\Programs\Python\Python311\Lib\site-packages\redis\asyncio\connection.py", line 623, in read_response
    next_time = asyncio.get_running_loop().time() + self.health_check_interval
                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
TypeError: unsupported operand type(s) for +: 'float' and 'str'
12:23:52 - LiteLLM:ERROR: redis_cache.py:632 - LiteLLM Redis Caching: async set() - Got exception from REDIS unsupported operand type(s) for +: 'float' and 'str', Writing value=1781695432.4702735
INFO:     127.0.0.1:54201 - "GET /health/liveliness HTTP/1.1" 200 OK
```

After fix - `health_check_interval` correctly coerced to `int`, no TypeError errors:
```
🔧 Redis Connection Parameters       
┌───────────────────────┬───────────┐
│ Parameter             │ Value     │
├───────────────────────┼───────────┤
│ host                  │ 127.0.0.1 │
│ port                  │ 6379      │
│ socket_timeout        │ 5.0       │
│ health_check_interval │ 30        │
└───────────────────────┴───────────┘


12:31:46 - LiteLLM:DEBUG: logging_callback_manager.py:349 - Custom logger of type SkillsInjectionHook, key: SkillsInjectionHook-max_iterations=10-sandbox_timeout=120-message_logging=True-turn_off_message_logging=False already exists in [<litellm.proxy.hooks.litellm_skills.main.SkillsInjectionHook object at 0x000001DB91571890>, <litellm.proxy.hooks.model_max_budget_limiter._PROXY_VirtualKeyModelMaxBudgetLimiter object at 0x000001DB950CC890>, <litellm.proxy.hooks.max_budget_limiter._PROXY_MaxBudgetLimiter object at 0x000001DB9570E290>, <litellm.proxy.hooks.parallel_request_limiter_v3._PROXY_MaxParallelRequestsHandler_v3 object at 0x000001DB977E8610>, <litellm.proxy.hooks.cache_control_check._PROXY_CacheControlCheck object at 0x000001DB98385E90>, <litellm.proxy.hooks.responses_id_security.ResponsesIDSecurity object at 0x000001DB978D7E50>], not adding again..
12:31:46 - LiteLLM Proxy:DEBUG: proxy_server.py:895 - About to initialize semantic tool filter
12:31:46 - LiteLLM Proxy:DEBUG: proxy_server.py:898 - litellm_settings keys = ['cache', 'cache_params']
12:31:46 - LiteLLM Proxy:DEBUG: proxy_server.py:7252 - Semantic tool filter not configured or not enabled, skipping initialization
12:31:46 - LiteLLM Proxy:DEBUG: proxy_server.py:905 - After semantic tool filter initialization
12:31:46 - LiteLLM Proxy:DEBUG: proxy_server.py:919 - prisma_client: None
12:31:46 - LiteLLM Proxy:DEBUG: proxy_server.py:8114 - LiteLLM: Pyroscope profiling is disabled (set LITELLM_ENABLE_PYROSCOPE=true to enable).
12:31:46 - LiteLLM Proxy:INFO: proxy_server.py:724 - SESSION REUSE: Created shared aiohttp session for connection pooling (ID: 2042645701008, limit=1000, limit_per_host=500)
12:31:46 - LiteLLM Proxy:DEBUG: hanging_request_check.py:148 - Checking for hanging requests....
INFO:     Application startup complete.
ERROR:    [Errno 10048] error while attempting to bind on address ('0.0.0.0', 4099): only one usage of each socket address (protocol/network address/port) is normally permitted
INFO:     Waiting for application shutdown.
12:31:46 - LiteLLM Proxy:INFO: graceful_shutdown_manager.py:81 - graceful_shutdown_started in_flight_requests=0
12:31:46 - LiteLLM Proxy:INFO: graceful_shutdown_manager.py:140 - graceful_shutdown_complete drained_requests=0 elapsed_s=0.00
12:31:46 - LiteLLM Proxy:INFO: proxy_server.py:986 - SESSION REUSE: Closed shared aiohttp session
12:31:46 - LiteLLM Proxy:INFO: proxy_server.py:669 - Shutting down LiteLLM Proxy Server
```


<!-- Include screenshots, screen recordings, or log output demonstrating that your changes work as expected.
     For bug fixes: show reproduction before the fix and passing behavior after.
     For new features: show the feature working end-to-end.
     For UI changes: include before/after screenshots. -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes
Two compounding bugs in `litellm/_redis.py` caused Redis caching to fail entirely on every LLM call when `health_check_interval` was set via env var or Helm `--set`, first surfacing in v1.89.0.

### Bug 1: broken parameter discovery in redis-py 6.x
`_get_redis_kwargs()` used `inspect.getfullargspec(redis.Redis)` to discover which `REDIS_*` env vars to accept. In redis-py 6.x, `Redis.__init__` is wrapped by `@deprecated_args` which replaces the explicit signature with `*args/**kwargs` internally. `getfullargspec` returns an empty arg list, so only the 8 hardcoded `include_args` entries (Azure/GCP auth, url) were ever read from the environment. Standard params like `REDIS_HEALTH_CHECK_INTERVAL`, `REDIS_MAX_CONNECTIONS`, `REDIS_SSL`, `REDIS_PORT` etc. were silently ignored.

Fixed by switching to `inspect.signature` which correctly follows `__wrapped__` through decorator wrappers and resolves the original function's real parameter names and defaults.

### Bug 2: no type coercion for string values
Environment variables are always strings. Helm `--set` also stringifies values (`--set cache_params.health_check_interval=30` puts `"30"` in the config, not `30`). Neither path applied type coercion before passing values to the Redis client.

In redis-py 6.x, `Connection.read_response` now computes:

```python
next_time = asyncio.get_running_loop().time() + self.health_check_interval
```
`loop.time()` returns a float. If `health_check_interval` is the string `"30"`, this raises `TypeError` on every Redis operation, tripping the circuit breaker and disabling all caching. This arithmetic didn't exist in earlier redis-py versions, which is why it only surfaced in v1.89.0.

Fixed by adding `_coerce_redis_kwargs_types()` which runs at the end of `_get_redis_client_logic()` and uses the Redis signature's default values to determine expected types and coerce accordingly. Invalid strings are dropped so Redis uses its built-in defaults rather than crashing.

### Files changed:
`litellm/_redis.py`:
- `_get_redis_kwargs()`: switched from `inspect.getfullargspec` to `inspect.signature`
- Added `_coerce_redis_kwargs_types()`: coerces string env var values to correct types using Redis signature defaults
- `get_redis_connection_pool()`: removed now-redundant ad-hoc `max_connections` int coercion

`tests/test_litellm/caching/test_redis_connection_pool.py`:

- Added 5 unit tests for `_coerce_redis_kwargs_types` covering int, bool, None-default numeric, invalid drop, and non-string passthrough
- Added `test_health_check_interval_from_env_is_int`: direct regression test for the reported bug
- Fixed `test_max_connections_url_config_invalid_value`: was mocking internal logic that no longer exists; updated to use real codepath
