### PR TITLE
fix: prevent Anthropic tool type from leaking into OpenAI parameters schema

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -139,7 +139,9 @@ class AnthropicAdapter:
     def __init__(self) -> None:
         pass
 
-    def translate_completion_input_params(self, kwargs) -> Optional[ChatCompletionRequest]:
+    def translate_completion_input_params(
+        self, kwargs
+    ) -> Optional[ChatCompletionRequest]:
         """
         Translate Anthropic request params to OpenAI format.
 
@@ -172,19 +174,27 @@ class AnthropicAdapter:
         model = kwargs.pop("model")
         messages = kwargs.pop("messages")
         if not model:
-            raise ValueError("Bad Request: model is required for Anthropic Messages Request")
+            raise ValueError(
+                "Bad Request: model is required for Anthropic Messages Request"
+            )
         if not messages:
-            raise ValueError("Bad Request: messages is required for Anthropic Messages Request")
+            raise ValueError(
+                "Bad Request: messages is required for Anthropic Messages Request"
+            )
 
         #########################################################
         # Created Typed Request Body
         #########################################################
-        request_body = AnthropicMessagesRequest(model=model, messages=messages, **kwargs)
+        request_body = AnthropicMessagesRequest(
+            model=model, messages=messages, **kwargs
+        )
 
         (
             translated_body,
             tool_name_mapping,
-        ) = LiteLLMAnthropicMessagesAdapter().translate_anthropic_to_openai(anthropic_message_request=request_body)
+        ) = LiteLLMAnthropicMessagesAdapter().translate_anthropic_to_openai(
+            anthropic_message_request=request_body
+        )
 
         return translated_body, tool_name_mapping
 
@@ -233,9 +243,15 @@ class AnthropicAdapter:
                 the sync handler) don't get back an async iterator they
                 can't iterate without an event loop.
         """
-        applied_edits = polyfill_result.applied_edits_for_response() if polyfill_result else None
-        compaction_block = polyfill_result.compaction_block if polyfill_result is not None else None
-        iterations_usage = polyfill_result.iterations_usage if polyfill_result is not None else None
+        applied_edits = (
+            polyfill_result.applied_edits_for_response() if polyfill_result else None
+        )
+        compaction_block = (
+            polyfill_result.compaction_block if polyfill_result is not None else None
+        )
+        iterations_usage = (
+            polyfill_result.iterations_usage if polyfill_result is not None else None
+        )
         anthropic_wrapper = AnthropicStreamWrapper(
             completion_stream=completion_stream,
             model=model,
@@ -263,16 +279,26 @@ class LiteLLMAnthropicMessagesAdapter:
         """
         signature = None
 
-        if hasattr(tool_call, "provider_specific_fields") and tool_call.provider_specific_fields:
+        if (
+            hasattr(tool_call, "provider_specific_fields")
+            and tool_call.provider_specific_fields
+        ):
             if "thought_signature" in tool_call.provider_specific_fields:
                 signature = tool_call.provider_specific_fields["thought_signature"]
-        elif hasattr(tool_call.function, "provider_specific_fields") and tool_call.function.provider_specific_fields:
+        elif (
+            hasattr(tool_call.function, "provider_specific_fields")
+            and tool_call.function.provider_specific_fields
+        ):
             if "thought_signature" in tool_call.function.provider_specific_fields:
-                signature = tool_call.function.provider_specific_fields["thought_signature"]
+                signature = tool_call.function.provider_specific_fields[
+                    "thought_signature"
+                ]
 
         return signature
 
-    def _extract_signature_from_tool_use_content(self, content: Dict[str, Any]) -> Optional[str]:
+    def _extract_signature_from_tool_use_content(
+        self, content: Dict[str, Any]
+    ) -> Optional[str]:
         """
         Extract signature from a tool_use content block's provider_specific_fields.
         """
@@ -302,9 +328,18 @@ class LiteLLMAnthropicMessagesAdapter:
         """
         # TypedDict objects are dicts at runtime, so .get() works
         cache_control = (
-            source.get("cache_control") if isinstance(source, dict) else getattr(source, "cache_control", None)
+            source.get("cache_control")
+            if isinstance(source, dict)
+            else getattr(source, "cache_control", None)
         )
-        if cache_control and model and (self.is_anthropic_claude_model(model) or self.is_bedrock_arn_model(model)):
+        if (
+            cache_control
+            and model
+            and (
+                self.is_anthropic_claude_model(model)
+                or self.is_bedrock_arn_model(model)
+            )
+        ):
             # TypedDict objects support dict operations at runtime
             # Use type ignore consistent with codebase pattern (see anthropic/chat/transformation.py:432)
             if isinstance(target, dict):
@@ -344,7 +379,9 @@ class LiteLLMAnthropicMessagesAdapter:
         """
         tool_type = tool.get("type", "")
         tool_name = tool.get("name", "")
-        return (isinstance(tool_type, str) and tool_type.startswith("web_search")) or tool_name == "web_search"
+        return (
+            isinstance(tool_type, str) and tool_type.startswith("web_search")
+        ) or tool_name == "web_search"
 
     def translate_anthropic_messages_to_openai(
         self,
@@ -360,38 +397,66 @@ class LiteLLMAnthropicMessagesAdapter:
         for m in messages:
             user_message: Optional[ChatCompletionUserMessage] = None
             tool_message_list: List[ChatCompletionToolMessage] = []
-            new_user_content_list: List[Union[ChatCompletionTextObject, ChatCompletionImageObject]] = []
+            new_user_content_list: List[
+                Union[ChatCompletionTextObject, ChatCompletionImageObject]
+            ] = []
             ## USER MESSAGE ##
             if m["role"] == "user":
                 ## translate user message
                 message_content = m.get("content")
                 if message_content and isinstance(message_content, str):
-                    user_message = ChatCompletionUserMessage(role="user", content=message_content)
+                    user_message = ChatCompletionUserMessage(
+                        role="user", content=message_content
+                    )
                 elif message_content and isinstance(message_content, list):
                     for content in message_content:
                         if content.get("type") == "text":
-                            text_obj = ChatCompletionTextObject(type="text", text=content.get("text", ""))
-                            self._add_cache_control_if_applicable(content, text_obj, model)
+                            text_obj = ChatCompletionTextObject(
+                                type="text", text=content.get("text", "")
+                            )
+                            self._add_cache_control_if_applicable(
+                                content, text_obj, model
+                            )
                             new_user_content_list.append(text_obj)  # type: ignore
                         elif content.get("type") == "image":
                             # Convert Anthropic image format to OpenAI format
                             source = content.get("source", {})
-                            openai_image_url = self._translate_anthropic_image_to_openai(cast(dict, source))
+                            openai_image_url = (
+                                self._translate_anthropic_image_to_openai(
+                                    cast(dict, source)
+                                )
+                            )
 
                             if openai_image_url:
-                                image_url_obj = ChatCompletionImageUrlObject(url=openai_image_url)
-                                image_obj = ChatCompletionImageObject(type="image_url", image_url=image_url_obj)
-                                self._add_cache_control_if_applicable(content, image_obj, model)
+                                image_url_obj = ChatCompletionImageUrlObject(
+                                    url=openai_image_url
+                                )
+                                image_obj = ChatCompletionImageObject(
+                                    type="image_url", image_url=image_url_obj
+                                )
+                                self._add_cache_control_if_applicable(
+                                    content, image_obj, model
+                                )
                                 new_user_content_list.append(image_obj)  # type: ignore
                         elif content.get("type") == "document":
                             # Convert Anthropic document format (PDF, etc.) to OpenAI format
                             source = content.get("source", {})
-                            openai_image_url = self._translate_anthropic_image_to_openai(cast(dict, source))
+                            openai_image_url = (
+                                self._translate_anthropic_image_to_openai(
+                                    cast(dict, source)
+                                )
+                            )
 
                             if openai_image_url:
-                                image_url_obj = ChatCompletionImageUrlObject(url=openai_image_url)
-                                doc_obj = ChatCompletionImageObject(type="image_url", image_url=image_url_obj)
-                                self._add_cache_control_if_applicable(content, doc_obj, model)
+                                image_url_obj = ChatCompletionImageUrlObject(
+                                    url=openai_image_url
+                                )
+                                doc_obj = ChatCompletionImageObject(
+                                    type="image_url", image_url=image_url_obj
+                                )
+                                self._add_cache_control_if_applicable(
+                                    content, doc_obj, model
+                                )
                                 new_user_content_list.append(doc_obj)  # type: ignore
                         elif content.get("type") == "tool_result":
                             if "content" not in content:
@@ -400,7 +465,9 @@ class LiteLLMAnthropicMessagesAdapter:
                                     tool_call_id=content.get("tool_use_id", ""),
                                     content="",
                                 )
-                                self._add_cache_control_if_applicable(content, tool_result, model)
+                                self._add_cache_control_if_applicable(
+                                    content, tool_result, model
+                                )
                                 tool_message_list.append(tool_result)  # type: ignore[arg-type]
                             elif isinstance(content.get("content"), str):
                                 tool_result = ChatCompletionToolMessage(
@@ -408,7 +475,9 @@ class LiteLLMAnthropicMessagesAdapter:
                                     tool_call_id=content.get("tool_use_id", ""),
                                     content=str(content.get("content", "")),
                                 )
-                                self._add_cache_control_if_applicable(content, tool_result, model)
+                                self._add_cache_control_if_applicable(
+                                    content, tool_result, model
+                                )
                                 tool_message_list.append(tool_result)  # type: ignore[arg-type]
                             elif isinstance(content.get("content"), list):
                                 # Combine all content items into a single tool message
@@ -425,28 +494,41 @@ class LiteLLMAnthropicMessagesAdapter:
                                             tool_call_id=content.get("tool_use_id", ""),
                                             content=c,
                                         )
-                                        self._add_cache_control_if_applicable(content, tool_result, model)
+                                        self._add_cache_control_if_applicable(
+                                            content, tool_result, model
+                                        )
                                         tool_message_list.append(tool_result)  # type: ignore[arg-type]
                                     elif isinstance(c, dict):
                                         if c.get("type") == "text":
                                             tool_result = ChatCompletionToolMessage(
                                                 role="tool",
-                                                tool_call_id=content.get("tool_use_id", ""),
+                                                tool_call_id=content.get(
+                                                    "tool_use_id", ""
+                                                ),
                                                 content=c.get("text", ""),
                                             )
-                                            self._add_cache_control_if_applicable(content, tool_result, model)
+                                            self._add_cache_control_if_applicable(
+                                                content, tool_result, model
+                                            )
                                             tool_message_list.append(tool_result)  # type: ignore[arg-type]
                                         elif c.get("type") == "image":
                                             source = c.get("source", {})
                                             openai_image_url = (
-                                                self._translate_anthropic_image_to_openai(cast(dict, source)) or ""
+                                                self._translate_anthropic_image_to_openai(
+                                                    cast(dict, source)
+                                                )
+                                                or ""
                                             )
                                             tool_result = ChatCompletionToolMessage(
                                                 role="tool",
-                                                tool_call_id=content.get("tool_use_id", ""),
+                                                tool_call_id=content.get(
+                                                    "tool_use_id", ""
+                                                ),
                                                 content=openai_image_url,
                                             )
-                                            self._add_cache_control_if_applicable(content, tool_result, model)
+                                            self._add_cache_control_if_applicable(
+                                                content, tool_result, model
+                                            )
                                             tool_message_list.append(tool_result)  # type: ignore[arg-type]
                                 else:
                                     # For multiple content items, combine into a single tool message
@@ -459,7 +541,11 @@ class LiteLLMAnthropicMessagesAdapter:
                                     ] = []
                                     for c in content_items:
                                         if isinstance(c, str):
-                                            combined_content_parts.append(ChatCompletionTextObject(type="text", text=c))
+                                            combined_content_parts.append(
+                                                ChatCompletionTextObject(
+                                                    type="text", text=c
+                                                )
+                                            )
                                         elif isinstance(c, dict):
                                             if c.get("type") == "text":
                                                 combined_content_parts.append(
@@ -471,7 +557,10 @@ class LiteLLMAnthropicMessagesAdapter:
                                             elif c.get("type") == "image":
                                                 source = c.get("source", {})
                                                 openai_image_url = (
-                                                    self._translate_anthropic_image_to_openai(cast(dict, source)) or ""
+                                                    self._translate_anthropic_image_to_openai(
+                                                        cast(dict, source)
+                                                    )
+                                                    or ""
                                                 )
                                                 if openai_image_url:
                                                     combined_content_parts.append(
@@ -489,7 +578,9 @@ class LiteLLMAnthropicMessagesAdapter:
                                             tool_call_id=content.get("tool_use_id", ""),
                                             content=combined_content_parts,  # type: ignore
                                         )
-                                        self._add_cache_control_if_applicable(content, tool_result, model)
+                                        self._add_cache_control_if_applicable(
+                                            content, tool_result, model
+                                        )
                                         tool_message_list.append(tool_result)  # type: ignore[arg-type]
 
             if len(tool_message_list) > 0:
@@ -503,10 +594,14 @@ class LiteLLMAnthropicMessagesAdapter:
 
             ## ASSISTANT MESSAGE ##
             assistant_message_str: Optional[str] = None
-            assistant_content_list: List[Dict[str, Any]] = []  # For content blocks with cache_control
+            assistant_content_list: List[Dict[str, Any]] = (
+                []
+            )  # For content blocks with cache_control
             has_cache_control_in_text = False
             tool_calls: List[ChatCompletionAssistantToolCall] = []
-            thinking_blocks: List[Union[ChatCompletionThinkingBlock, ChatCompletionRedactedThinkingBlock]] = []
+            thinking_blocks: List[
+                Union[ChatCompletionThinkingBlock, ChatCompletionRedactedThinkingBlock]
+            ] = []
             if m["role"] == "assistant":
                 if isinstance(m.get("content"), str):
                     assistant_message_str = str(m.get("content", ""))
@@ -520,7 +615,9 @@ class LiteLLMAnthropicMessagesAdapter:
                                     "type": "text",
                                     "text": content.get("text", ""),
                                 }
-                                self._add_cache_control_if_applicable(content, text_block, model)
+                                self._add_cache_control_if_applicable(
+                                    content, text_block, model
+                                )
                                 if "cache_control" in text_block:
                                     has_cache_control_in_text = True
                                 assistant_content_list.append(text_block)
@@ -531,21 +628,32 @@ class LiteLLMAnthropicMessagesAdapter:
                                     "name": tool_name,
                                     "arguments": json.dumps(content.get("input", {})),
                                 }
-                                signature = self._extract_signature_from_tool_use_content(cast(Dict[str, Any], content))
+                                signature = (
+                                    self._extract_signature_from_tool_use_content(
+                                        cast(Dict[str, Any], content)
+                                    )
+                                )
 
                                 if signature:
                                     provider_specific_fields: Dict[str, Any] = (
-                                        function_chunk.get("provider_specific_fields") or {}
+                                        function_chunk.get("provider_specific_fields")
+                                        or {}
                                     )
-                                    provider_specific_fields["thought_signature"] = signature
-                                    function_chunk["provider_specific_fields"] = provider_specific_fields
+                                    provider_specific_fields["thought_signature"] = (
+                                        signature
+                                    )
+                                    function_chunk["provider_specific_fields"] = (
+                                        provider_specific_fields
+                                    )
 
                                 tool_call = ChatCompletionAssistantToolCall(
                                     id=content.get("id", ""),
                                     type="function",
                                     function=function_chunk,
                                 )
-                                self._add_cache_control_if_applicable(content, tool_call, model)
+                                self._add_cache_control_if_applicable(
+                                    content, tool_call, model
+                                )
                                 tool_calls.append(tool_call)
                             elif content.get("type") == "thinking":
                                 thinking_block = ChatCompletionThinkingBlock(
@@ -556,10 +664,12 @@ class LiteLLMAnthropicMessagesAdapter:
                                 )
                                 thinking_blocks.append(thinking_block)
                             elif content.get("type") == "redacted_thinking":
-                                redacted_thinking_block = ChatCompletionRedactedThinkingBlock(
-                                    type="redacted_thinking",
-                                    data=content.get("data") or "",
-                                    cache_control=content.get("cache_control", {}),
+                                redacted_thinking_block = (
+                                    ChatCompletionRedactedThinkingBlock(
+                                        type="redacted_thinking",
+                                        data=content.get("data") or "",
+                                        cache_control=content.get("cache_control", {}),
+                                    )
                                 )
                                 thinking_blocks.append(redacted_thinking_block)
 
@@ -574,14 +684,18 @@ class LiteLLMAnthropicMessagesAdapter:
                     assistant_content: Any = assistant_content_list
                 elif len(assistant_content_list) > 0 and not has_cache_control_in_text:
                     # Concatenate text blocks into string when no cache_control
-                    assistant_content = "".join(block.get("text", "") for block in assistant_content_list)
+                    assistant_content = "".join(
+                        block.get("text", "") for block in assistant_content_list
+                    )
                 else:
                     assistant_content = assistant_message_str
 
                 assistant_message = ChatCompletionAssistantMessage(
                     role="assistant",
                     content=assistant_content,
-                    thinking_blocks=(thinking_blocks if len(thinking_blocks) > 0 else None),
+                    thinking_blocks=(
+                        thinking_blocks if len(thinking_blocks) > 0 else None
+                    ),
                 )
                 if len(tool_calls) > 0:
                     assistant_message["tool_calls"] = tool_calls  # type: ignore
@@ -687,7 +801,9 @@ class LiteLLMAnthropicMessagesAdapter:
                 thinking
             )
             if reasoning_effort:
-                summary = thinking.get("summary") if isinstance(thinking, dict) else None
+                summary = (
+                    thinking.get("summary") if isinstance(thinking, dict) else None
+                )
                 auto_summary = is_reasoning_auto_summary_enabled()
                 if summary:
                     return {
@@ -717,12 +833,18 @@ class LiteLLMAnthropicMessagesAdapter:
             # Truncate tool name if it exceeds OpenAI's 64-char limit
             original_name = tool_choice.get("name", "")
             truncated_name = truncate_tool_name(original_name)
-            tc_function_param = ChatCompletionToolChoiceFunctionParam(name=truncated_name)
-            return ChatCompletionToolChoiceObjectParam(type="function", function=tc_function_param)
+            tc_function_param = ChatCompletionToolChoiceFunctionParam(
+                name=truncated_name
+            )
+            return ChatCompletionToolChoiceObjectParam(
+                type="function", function=tc_function_param
+            )
         elif tool_choice["type"] == "none":
             return "none"
         else:
-            raise ValueError("Incompatible tool choice param submitted - {}".format(tool_choice))
+            raise ValueError(
+                "Incompatible tool choice param submitted - {}".format(tool_choice)
+            )
 
     def translate_anthropic_tools_to_openai(
         self, tools: List[AllAnthropicToolsValues], model: Optional[str] = None
@@ -737,7 +859,13 @@ class LiteLLMAnthropicMessagesAdapter:
         """
         new_tools: List[ChatCompletionToolParam] = []
         tool_name_mapping: Dict[str, str] = {}
-        mapped_tool_params = ["name", "input_schema", "description", "cache_control", "type"]
+        mapped_tool_params = [
+            "name",
+            "input_schema",
+            "description",
+            "cache_control",
+            "type",
+        ]
 
         for idx, tool in enumerate(tools):
             # Check if this is an Anthropic-native tool that should be kept as-is
@@ -748,7 +876,9 @@ class LiteLLMAnthropicMessagesAdapter:
                 continue
 
             raw_name = tool.get("name")
-            if raw_name is None or (isinstance(raw_name, str) and not str(raw_name).strip()):
+            if raw_name is None or (
+                isinstance(raw_name, str) and not str(raw_name).strip()
+            ):
                 original_name = f"litellm_unnamed_tool_{idx}"
             else:
                 original_name = str(raw_name)
@@ -769,13 +899,17 @@ class LiteLLMAnthropicMessagesAdapter:
             for k, v in tool.items():
                 if k not in mapped_tool_params:  # pass additional computer kwargs
                     function_chunk.setdefault("parameters", {}).update({k: v})
-            tool_param = ChatCompletionToolParam(type="function", function=function_chunk)
+            tool_param = ChatCompletionToolParam(
+                type="function", function=function_chunk
+            )
             self._add_cache_control_if_applicable(tool, tool_param, model)
             new_tools.append(tool_param)  # type: ignore[arg-type]
 
         return new_tools, tool_name_mapping  # type: ignore[return-value]
 
-    def translate_anthropic_output_format_to_openai(self, output_format: Any) -> Optional[Dict[str, Any]]:
+    def translate_anthropic_output_format_to_openai(
+        self, output_format: Any
+    ) -> Optional[Dict[str, Any]]:
         """
         Translate Anthropic's output_format to OpenAI's response_format.
 
@@ -834,19 +968,25 @@ class LiteLLMAnthropicMessagesAdapter:
 
         # Handle array items
         if "items" in schema:
-            LiteLLMAnthropicMessagesAdapter._add_additional_properties_false(schema["items"])
+            LiteLLMAnthropicMessagesAdapter._add_additional_properties_false(
+                schema["items"]
+            )
 
         # Handle anyOf/oneOf/allOf
         for key in ("anyOf", "oneOf", "allOf"):
             if key in schema:
                 for sub_schema in schema[key]:
-                    LiteLLMAnthropicMessagesAdapter._add_additional_properties_false(sub_schema)
+                    LiteLLMAnthropicMessagesAdapter._add_additional_properties_false(
+                        sub_schema
+                    )
 
         # Handle $defs / definitions
         for key in ("$defs", "definitions"):
             if key in schema:
                 for def_schema in schema[key].values():
-                    LiteLLMAnthropicMessagesAdapter._add_additional_properties_false(def_schema)
+                    LiteLLMAnthropicMessagesAdapter._add_additional_properties_false(
+                        def_schema
+                    )
 
     def _add_system_message_to_messages(
         self,
@@ -966,7 +1106,9 @@ class LiteLLMAnthropicMessagesAdapter:
             new_kwargs["thinking"] = thinking  # type: ignore
             return
 
-        reasoning_effort = self.translate_anthropic_thinking_to_reasoning_effort(cast(Dict[str, Any], thinking))
+        reasoning_effort = self.translate_anthropic_thinking_to_reasoning_effort(
+            cast(Dict[str, Any], thinking)
+        )
         if not reasoning_effort:
             return
 
@@ -1021,7 +1163,9 @@ class LiteLLMAnthropicMessagesAdapter:
                 output_format = output_config.get("format")
         if not output_format:
             return
-        response_format = self.translate_anthropic_output_format_to_openai(output_format=output_format)
+        response_format = self.translate_anthropic_output_format_to_openai(
+            output_format=output_format
+        )
         if response_format:
             new_kwargs["response_format"] = response_format
 
@@ -1052,7 +1196,11 @@ class LiteLLMAnthropicMessagesAdapter:
         tool_name_mapping: Dict[str, str] = {}
 
         ## CONVERT ANTHROPIC MESSAGES TO OPENAI
-        messages_list: List[Union[AnthropicMessagesUserMessageParam, AnthopicMessagesAssistantMessageParam]] = cast(
+        messages_list: List[
+            Union[
+                AnthropicMessagesUserMessageParam, AnthopicMessagesAssistantMessageParam
+            ]
+        ] = cast(
             List[
                 Union[
                     AnthropicMessagesUserMessageParam,
@@ -1139,7 +1287,10 @@ class LiteLLMAnthropicMessagesAdapter:
         new_content: List[Dict[str, Any]] = []
         for choice in choices:
             # Handle thinking blocks first
-            if hasattr(choice.message, "thinking_blocks") and choice.message.thinking_blocks:
+            if (
+                hasattr(choice.message, "thinking_blocks")
+                and choice.message.thinking_blocks
+            ):
                 for thinking_block in choice.message.thinking_blocks:
                     if thinking_block.get("type") == "thinking":
                         thinking_value = thinking_block.get("thinking", "")
@@ -1147,8 +1298,16 @@ class LiteLLMAnthropicMessagesAdapter:
                         new_content.append(
                             AnthropicResponseContentBlockThinking(
                                 type="thinking",
-                                thinking=(str(thinking_value) if thinking_value is not None else ""),
-                                signature=(str(signature_value) if signature_value is not None else None),
+                                thinking=(
+                                    str(thinking_value)
+                                    if thinking_value is not None
+                                    else ""
+                                ),
+                                signature=(
+                                    str(signature_value)
+                                    if signature_value is not None
+                                    else None
+                                ),
                             ).model_dump()
                         )
                     elif thinking_block.get("type") == "redacted_thinking":
@@ -1160,7 +1319,10 @@ class LiteLLMAnthropicMessagesAdapter:
                             ).model_dump()
                         )
             # Handle reasoning_content when thinking_blocks is not present
-            elif hasattr(choice.message, "reasoning_content") and choice.message.reasoning_content:
+            elif (
+                hasattr(choice.message, "reasoning_content")
+                and choice.message.reasoning_content
+            ):
                 new_content.append(
                     AnthropicResponseContentBlockThinking(
                         type="thinking",
@@ -1172,10 +1334,15 @@ class LiteLLMAnthropicMessagesAdapter:
             # Handle text content
             if choice.message.content is not None:
                 new_content.append(
-                    AnthropicResponseContentBlockText(type="text", text=choice.message.content).model_dump()
+                    AnthropicResponseContentBlockText(
+                        type="text", text=choice.message.content
+                    ).model_dump()
                 )
             # Handle tool calls (in parallel to text content)
-            if choice.message.tool_calls is not None and len(choice.message.tool_calls) > 0:
+            if (
+                choice.message.tool_calls is not None
+                and len(choice.message.tool_calls) > 0
+            ):
                 for tool_call in choice.message.tool_calls:
                     # Extract signature from provider_specific_fields only
                     signature = self._extract_signature_from_tool_call(tool_call)
@@ -1187,7 +1354,9 @@ class LiteLLMAnthropicMessagesAdapter:
                     # Restore original tool name if it was truncated
                     truncated_name = tool_call.function.name or ""
                     original_name = (
-                        tool_name_mapping.get(truncated_name, truncated_name) if tool_name_mapping else truncated_name
+                        tool_name_mapping.get(truncated_name, truncated_name)
+                        if tool_name_mapping
+                        else truncated_name
                     )
 
                     # Strip Gemini thought-signature suffix from id (mirrors streaming
@@ -1211,12 +1380,16 @@ class LiteLLMAnthropicMessagesAdapter:
                     )
                     # Add provider_specific_fields if signature is present
                     if provider_specific_fields:
-                        tool_use_block.provider_specific_fields = provider_specific_fields
+                        tool_use_block.provider_specific_fields = (
+                            provider_specific_fields
+                        )
                     new_content.append(tool_use_block.model_dump())
 
         return new_content
 
-    def _translate_openai_finish_reason_to_anthropic(self, openai_finish_reason: str) -> AnthropicFinishReason:
+    def _translate_openai_finish_reason_to_anthropic(
+        self, openai_finish_reason: str
+    ) -> AnthropicFinishReason:
         if openai_finish_reason == "stop":
             return "end_turn"
         elif openai_finish_reason == "length":
@@ -1259,15 +1432,22 @@ class LiteLLMAnthropicMessagesAdapter:
         uncached_input_tokens = usage.prompt_tokens or 0
         cached_tokens = 0
         if hasattr(usage, "prompt_tokens_details") and usage.prompt_tokens_details:
-            cached_tokens = getattr(usage.prompt_tokens_details, "cached_tokens", 0) or 0
+            cached_tokens = (
+                getattr(usage.prompt_tokens_details, "cached_tokens", 0) or 0
+            )
             uncached_input_tokens -= cached_tokens
 
         anthropic_usage = AnthropicUsage(
             input_tokens=uncached_input_tokens,
             output_tokens=usage.completion_tokens or 0,
         )
-        if hasattr(usage, "_cache_creation_input_tokens") and usage._cache_creation_input_tokens > 0:
-            anthropic_usage["cache_creation_input_tokens"] = usage._cache_creation_input_tokens
+        if (
+            hasattr(usage, "_cache_creation_input_tokens")
+            and usage._cache_creation_input_tokens > 0
+        ):
+            anthropic_usage["cache_creation_input_tokens"] = (
+                usage._cache_creation_input_tokens
+            )
         if cached_tokens > 0:
             anthropic_usage["cache_read_input_tokens"] = cached_tokens
 
@@ -1290,9 +1470,13 @@ class LiteLLMAnthropicMessagesAdapter:
             stop_reason=anthropic_finish_reason,
         )
 
-        applied_edits = polyfill_result.applied_edits_for_response() if polyfill_result else None
+        applied_edits = (
+            polyfill_result.applied_edits_for_response() if polyfill_result else None
+        )
         if applied_edits:
-            translated_obj["context_management"] = ContextManagementResponse(applied_edits=list(applied_edits))
+            translated_obj["context_management"] = ContextManagementResponse(
+                applied_edits=list(applied_edits)
+            )
 
         return translated_obj
 
@@ -1332,7 +1516,9 @@ class LiteLLMAnthropicMessagesAdapter:
                 return "tool_use", cast("ContentBlockContentBlockDict", tool_block)
             elif choice.delta.content is not None and len(choice.delta.content) > 0:
                 return "text", TextBlock(type="text", text="")
-            elif isinstance(choice, StreamingChoices) and hasattr(choice.delta, "thinking_blocks"):
+            elif isinstance(choice, StreamingChoices) and hasattr(
+                choice.delta, "thinking_blocks"
+            ):
                 thinking_blocks = choice.delta.thinking_blocks or []
                 if len(thinking_blocks) > 0:
                     thinking_block = thinking_blocks[0]
@@ -1356,8 +1542,12 @@ class LiteLLMAnthropicMessagesAdapter:
             # ``Delta`` deletes the ``thinking_blocks`` attribute when unset, so the
             # branch above is skipped entirely; open a ``thinking`` block here so the
             # matching ``thinking_delta`` stream is not emitted into a text block.
-            elif isinstance(choice, StreamingChoices) and getattr(choice.delta, "reasoning_content", None):
-                return "thinking", ChatCompletionThinkingBlock(type="thinking", thinking="", signature="")
+            elif isinstance(choice, StreamingChoices) and getattr(
+                choice.delta, "reasoning_content", None
+            ):
+                return "thinking", ChatCompletionThinkingBlock(
+                    type="thinking", thinking="", signature=""
+                )
 
         return "text", TextBlock(type="text", text="")
 
@@ -1382,9 +1572,14 @@ class LiteLLMAnthropicMessagesAdapter:
             if choice.delta.tool_calls:
                 partial_json = ""
                 for tool in choice.delta.tool_calls:
-                    if tool.function is not None and tool.function.arguments is not None:
+                    if (
+                        tool.function is not None
+                        and tool.function.arguments is not None
+                    ):
                         partial_json = (partial_json or "") + tool.function.arguments
-            elif isinstance(choice, StreamingChoices) and hasattr(choice.delta, "thinking_blocks"):
+            elif isinstance(choice, StreamingChoices) and hasattr(
+                choice.delta, "thinking_blocks"
+            ):
                 thinking_blocks = choice.delta.thinking_blocks or []
                 if len(thinking_blocks) > 0:
                     for thinking_block in thinking_blocks:
@@ -1399,17 +1594,25 @@ class LiteLLMAnthropicMessagesAdapter:
                             reasoning_signature += signature
             # Handle reasoning_content when thinking_blocks is not present
             # This handles providers like OpenRouter that return reasoning_content
-            elif isinstance(choice, StreamingChoices) and hasattr(choice.delta, "reasoning_content"):
+            elif isinstance(choice, StreamingChoices) and hasattr(
+                choice.delta, "reasoning_content"
+            ):
                 if choice.delta.reasoning_content is not None:
                     reasoning_content += choice.delta.reasoning_content
 
         if reasoning_content and reasoning_signature:
-            raise ValueError("Both `reasoning` and `signature` in a single streaming chunk isn't supported.")
+            raise ValueError(
+                "Both `reasoning` and `signature` in a single streaming chunk isn't supported."
+            )
 
         if partial_json is not None:
-            return "input_json_delta", ContentJsonBlockDelta(type="input_json_delta", partial_json=partial_json)
+            return "input_json_delta", ContentJsonBlockDelta(
+                type="input_json_delta", partial_json=partial_json
+            )
         elif reasoning_content:
-            return "thinking_delta", ContentThinkingBlockDelta(type="thinking_delta", thinking=reasoning_content)
+            return "thinking_delta", ContentThinkingBlockDelta(
+                type="thinking_delta", thinking=reasoning_content
+            )
         elif reasoning_signature:
             return "signature_delta", ContentThinkingSignatureBlockDelta(
                 type="signature_delta", signature=reasoning_signature
@@ -1426,18 +1629,26 @@ class LiteLLMAnthropicMessagesAdapter:
         ## base case - final chunk w/ finish reason
         if response.choices[0].finish_reason is not None:
             delta = MessageDelta(
-                stop_reason=self._translate_openai_finish_reason_to_anthropic(response.choices[0].finish_reason),
+                stop_reason=self._translate_openai_finish_reason_to_anthropic(
+                    response.choices[0].finish_reason
+                ),
             )
             if getattr(response, "usage", None) is not None:
                 litellm_usage_chunk: Optional[Usage] = response.usage  # type: ignore
-            elif hasattr(response, "_hidden_params") and "usage" in response._hidden_params:
+            elif (
+                hasattr(response, "_hidden_params")
+                and "usage" in response._hidden_params
+            ):
                 litellm_usage_chunk = response._hidden_params["usage"]
             else:
                 litellm_usage_chunk = None
             if litellm_usage_chunk is not None:
                 uncached_input_tokens = litellm_usage_chunk.prompt_tokens or 0
                 cached_tokens = 0
-                if hasattr(litellm_usage_chunk, "prompt_tokens_details") and litellm_usage_chunk.prompt_tokens_details:
+                if (
+                    hasattr(litellm_usage_chunk, "prompt_tokens_details")
+                    and litellm_usage_chunk.prompt_tokens_details
+                ):
                     cached_tokens = (
                         getattr(
                             litellm_usage_chunk.prompt_tokens_details,
@@ -1456,7 +1667,9 @@ class LiteLLMAnthropicMessagesAdapter:
                     hasattr(litellm_usage_chunk, "_cache_creation_input_tokens")
                     and litellm_usage_chunk._cache_creation_input_tokens > 0
                 ):
-                    usage_delta["cache_creation_input_tokens"] = litellm_usage_chunk._cache_creation_input_tokens
+                    usage_delta["cache_creation_input_tokens"] = (
+                        litellm_usage_chunk._cache_creation_input_tokens
+                    )
                 if cached_tokens > 0:
                     usage_delta["cache_read_input_tokens"] = cached_tokens
             else:
@@ -1467,7 +1680,9 @@ class LiteLLMAnthropicMessagesAdapter:
                 usage=usage_delta,  # type: ignore
             )
             if applied_edits:
-                message_block["context_management"] = ContextManagementResponse(applied_edits=list(applied_edits))
+                message_block["context_management"] = ContextManagementResponse(
+                    applied_edits=list(applied_edits)
+                )
             return message_block
         (
             type_of_content,

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -139,9 +139,7 @@ class AnthropicAdapter:
     def __init__(self) -> None:
         pass
 
-    def translate_completion_input_params(
-        self, kwargs
-    ) -> Optional[ChatCompletionRequest]:
+    def translate_completion_input_params(self, kwargs) -> Optional[ChatCompletionRequest]:
         """
         Translate Anthropic request params to OpenAI format.
 
@@ -174,27 +172,19 @@ class AnthropicAdapter:
         model = kwargs.pop("model")
         messages = kwargs.pop("messages")
         if not model:
-            raise ValueError(
-                "Bad Request: model is required for Anthropic Messages Request"
-            )
+            raise ValueError("Bad Request: model is required for Anthropic Messages Request")
         if not messages:
-            raise ValueError(
-                "Bad Request: messages is required for Anthropic Messages Request"
-            )
+            raise ValueError("Bad Request: messages is required for Anthropic Messages Request")
 
         #########################################################
         # Created Typed Request Body
         #########################################################
-        request_body = AnthropicMessagesRequest(
-            model=model, messages=messages, **kwargs
-        )
+        request_body = AnthropicMessagesRequest(model=model, messages=messages, **kwargs)
 
         (
             translated_body,
             tool_name_mapping,
-        ) = LiteLLMAnthropicMessagesAdapter().translate_anthropic_to_openai(
-            anthropic_message_request=request_body
-        )
+        ) = LiteLLMAnthropicMessagesAdapter().translate_anthropic_to_openai(anthropic_message_request=request_body)
 
         return translated_body, tool_name_mapping
 
@@ -243,15 +233,9 @@ class AnthropicAdapter:
                 the sync handler) don't get back an async iterator they
                 can't iterate without an event loop.
         """
-        applied_edits = (
-            polyfill_result.applied_edits_for_response() if polyfill_result else None
-        )
-        compaction_block = (
-            polyfill_result.compaction_block if polyfill_result is not None else None
-        )
-        iterations_usage = (
-            polyfill_result.iterations_usage if polyfill_result is not None else None
-        )
+        applied_edits = polyfill_result.applied_edits_for_response() if polyfill_result else None
+        compaction_block = polyfill_result.compaction_block if polyfill_result is not None else None
+        iterations_usage = polyfill_result.iterations_usage if polyfill_result is not None else None
         anthropic_wrapper = AnthropicStreamWrapper(
             completion_stream=completion_stream,
             model=model,
@@ -279,26 +263,16 @@ class LiteLLMAnthropicMessagesAdapter:
         """
         signature = None
 
-        if (
-            hasattr(tool_call, "provider_specific_fields")
-            and tool_call.provider_specific_fields
-        ):
+        if hasattr(tool_call, "provider_specific_fields") and tool_call.provider_specific_fields:
             if "thought_signature" in tool_call.provider_specific_fields:
                 signature = tool_call.provider_specific_fields["thought_signature"]
-        elif (
-            hasattr(tool_call.function, "provider_specific_fields")
-            and tool_call.function.provider_specific_fields
-        ):
+        elif hasattr(tool_call.function, "provider_specific_fields") and tool_call.function.provider_specific_fields:
             if "thought_signature" in tool_call.function.provider_specific_fields:
-                signature = tool_call.function.provider_specific_fields[
-                    "thought_signature"
-                ]
+                signature = tool_call.function.provider_specific_fields["thought_signature"]
 
         return signature
 
-    def _extract_signature_from_tool_use_content(
-        self, content: Dict[str, Any]
-    ) -> Optional[str]:
+    def _extract_signature_from_tool_use_content(self, content: Dict[str, Any]) -> Optional[str]:
         """
         Extract signature from a tool_use content block's provider_specific_fields.
         """
@@ -328,18 +302,9 @@ class LiteLLMAnthropicMessagesAdapter:
         """
         # TypedDict objects are dicts at runtime, so .get() works
         cache_control = (
-            source.get("cache_control")
-            if isinstance(source, dict)
-            else getattr(source, "cache_control", None)
+            source.get("cache_control") if isinstance(source, dict) else getattr(source, "cache_control", None)
         )
-        if (
-            cache_control
-            and model
-            and (
-                self.is_anthropic_claude_model(model)
-                or self.is_bedrock_arn_model(model)
-            )
-        ):
+        if cache_control and model and (self.is_anthropic_claude_model(model) or self.is_bedrock_arn_model(model)):
             # TypedDict objects support dict operations at runtime
             # Use type ignore consistent with codebase pattern (see anthropic/chat/transformation.py:432)
             if isinstance(target, dict):
@@ -379,9 +344,7 @@ class LiteLLMAnthropicMessagesAdapter:
         """
         tool_type = tool.get("type", "")
         tool_name = tool.get("name", "")
-        return (
-            isinstance(tool_type, str) and tool_type.startswith("web_search")
-        ) or tool_name == "web_search"
+        return (isinstance(tool_type, str) and tool_type.startswith("web_search")) or tool_name == "web_search"
 
     def translate_anthropic_messages_to_openai(
         self,
@@ -397,66 +360,38 @@ class LiteLLMAnthropicMessagesAdapter:
         for m in messages:
             user_message: Optional[ChatCompletionUserMessage] = None
             tool_message_list: List[ChatCompletionToolMessage] = []
-            new_user_content_list: List[
-                Union[ChatCompletionTextObject, ChatCompletionImageObject]
-            ] = []
+            new_user_content_list: List[Union[ChatCompletionTextObject, ChatCompletionImageObject]] = []
             ## USER MESSAGE ##
             if m["role"] == "user":
                 ## translate user message
                 message_content = m.get("content")
                 if message_content and isinstance(message_content, str):
-                    user_message = ChatCompletionUserMessage(
-                        role="user", content=message_content
-                    )
+                    user_message = ChatCompletionUserMessage(role="user", content=message_content)
                 elif message_content and isinstance(message_content, list):
                     for content in message_content:
                         if content.get("type") == "text":
-                            text_obj = ChatCompletionTextObject(
-                                type="text", text=content.get("text", "")
-                            )
-                            self._add_cache_control_if_applicable(
-                                content, text_obj, model
-                            )
+                            text_obj = ChatCompletionTextObject(type="text", text=content.get("text", ""))
+                            self._add_cache_control_if_applicable(content, text_obj, model)
                             new_user_content_list.append(text_obj)  # type: ignore
                         elif content.get("type") == "image":
                             # Convert Anthropic image format to OpenAI format
                             source = content.get("source", {})
-                            openai_image_url = (
-                                self._translate_anthropic_image_to_openai(
-                                    cast(dict, source)
-                                )
-                            )
+                            openai_image_url = self._translate_anthropic_image_to_openai(cast(dict, source))
 
                             if openai_image_url:
-                                image_url_obj = ChatCompletionImageUrlObject(
-                                    url=openai_image_url
-                                )
-                                image_obj = ChatCompletionImageObject(
-                                    type="image_url", image_url=image_url_obj
-                                )
-                                self._add_cache_control_if_applicable(
-                                    content, image_obj, model
-                                )
+                                image_url_obj = ChatCompletionImageUrlObject(url=openai_image_url)
+                                image_obj = ChatCompletionImageObject(type="image_url", image_url=image_url_obj)
+                                self._add_cache_control_if_applicable(content, image_obj, model)
                                 new_user_content_list.append(image_obj)  # type: ignore
                         elif content.get("type") == "document":
                             # Convert Anthropic document format (PDF, etc.) to OpenAI format
                             source = content.get("source", {})
-                            openai_image_url = (
-                                self._translate_anthropic_image_to_openai(
-                                    cast(dict, source)
-                                )
-                            )
+                            openai_image_url = self._translate_anthropic_image_to_openai(cast(dict, source))
 
                             if openai_image_url:
-                                image_url_obj = ChatCompletionImageUrlObject(
-                                    url=openai_image_url
-                                )
-                                doc_obj = ChatCompletionImageObject(
-                                    type="image_url", image_url=image_url_obj
-                                )
-                                self._add_cache_control_if_applicable(
-                                    content, doc_obj, model
-                                )
+                                image_url_obj = ChatCompletionImageUrlObject(url=openai_image_url)
+                                doc_obj = ChatCompletionImageObject(type="image_url", image_url=image_url_obj)
+                                self._add_cache_control_if_applicable(content, doc_obj, model)
                                 new_user_content_list.append(doc_obj)  # type: ignore
                         elif content.get("type") == "tool_result":
                             if "content" not in content:
@@ -465,9 +400,7 @@ class LiteLLMAnthropicMessagesAdapter:
                                     tool_call_id=content.get("tool_use_id", ""),
                                     content="",
                                 )
-                                self._add_cache_control_if_applicable(
-                                    content, tool_result, model
-                                )
+                                self._add_cache_control_if_applicable(content, tool_result, model)
                                 tool_message_list.append(tool_result)  # type: ignore[arg-type]
                             elif isinstance(content.get("content"), str):
                                 tool_result = ChatCompletionToolMessage(
@@ -475,9 +408,7 @@ class LiteLLMAnthropicMessagesAdapter:
                                     tool_call_id=content.get("tool_use_id", ""),
                                     content=str(content.get("content", "")),
                                 )
-                                self._add_cache_control_if_applicable(
-                                    content, tool_result, model
-                                )
+                                self._add_cache_control_if_applicable(content, tool_result, model)
                                 tool_message_list.append(tool_result)  # type: ignore[arg-type]
                             elif isinstance(content.get("content"), list):
                                 # Combine all content items into a single tool message
@@ -494,41 +425,28 @@ class LiteLLMAnthropicMessagesAdapter:
                                             tool_call_id=content.get("tool_use_id", ""),
                                             content=c,
                                         )
-                                        self._add_cache_control_if_applicable(
-                                            content, tool_result, model
-                                        )
+                                        self._add_cache_control_if_applicable(content, tool_result, model)
                                         tool_message_list.append(tool_result)  # type: ignore[arg-type]
                                     elif isinstance(c, dict):
                                         if c.get("type") == "text":
                                             tool_result = ChatCompletionToolMessage(
                                                 role="tool",
-                                                tool_call_id=content.get(
-                                                    "tool_use_id", ""
-                                                ),
+                                                tool_call_id=content.get("tool_use_id", ""),
                                                 content=c.get("text", ""),
                                             )
-                                            self._add_cache_control_if_applicable(
-                                                content, tool_result, model
-                                            )
+                                            self._add_cache_control_if_applicable(content, tool_result, model)
                                             tool_message_list.append(tool_result)  # type: ignore[arg-type]
                                         elif c.get("type") == "image":
                                             source = c.get("source", {})
                                             openai_image_url = (
-                                                self._translate_anthropic_image_to_openai(
-                                                    cast(dict, source)
-                                                )
-                                                or ""
+                                                self._translate_anthropic_image_to_openai(cast(dict, source)) or ""
                                             )
                                             tool_result = ChatCompletionToolMessage(
                                                 role="tool",
-                                                tool_call_id=content.get(
-                                                    "tool_use_id", ""
-                                                ),
+                                                tool_call_id=content.get("tool_use_id", ""),
                                                 content=openai_image_url,
                                             )
-                                            self._add_cache_control_if_applicable(
-                                                content, tool_result, model
-                                            )
+                                            self._add_cache_control_if_applicable(content, tool_result, model)
                                             tool_message_list.append(tool_result)  # type: ignore[arg-type]
                                 else:
                                     # For multiple content items, combine into a single tool message
@@ -541,11 +459,7 @@ class LiteLLMAnthropicMessagesAdapter:
                                     ] = []
                                     for c in content_items:
                                         if isinstance(c, str):
-                                            combined_content_parts.append(
-                                                ChatCompletionTextObject(
-                                                    type="text", text=c
-                                                )
-                                            )
+                                            combined_content_parts.append(ChatCompletionTextObject(type="text", text=c))
                                         elif isinstance(c, dict):
                                             if c.get("type") == "text":
                                                 combined_content_parts.append(
@@ -557,10 +471,7 @@ class LiteLLMAnthropicMessagesAdapter:
                                             elif c.get("type") == "image":
                                                 source = c.get("source", {})
                                                 openai_image_url = (
-                                                    self._translate_anthropic_image_to_openai(
-                                                        cast(dict, source)
-                                                    )
-                                                    or ""
+                                                    self._translate_anthropic_image_to_openai(cast(dict, source)) or ""
                                                 )
                                                 if openai_image_url:
                                                     combined_content_parts.append(
@@ -578,9 +489,7 @@ class LiteLLMAnthropicMessagesAdapter:
                                             tool_call_id=content.get("tool_use_id", ""),
                                             content=combined_content_parts,  # type: ignore
                                         )
-                                        self._add_cache_control_if_applicable(
-                                            content, tool_result, model
-                                        )
+                                        self._add_cache_control_if_applicable(content, tool_result, model)
                                         tool_message_list.append(tool_result)  # type: ignore[arg-type]
 
             if len(tool_message_list) > 0:
@@ -594,14 +503,10 @@ class LiteLLMAnthropicMessagesAdapter:
 
             ## ASSISTANT MESSAGE ##
             assistant_message_str: Optional[str] = None
-            assistant_content_list: List[Dict[str, Any]] = (
-                []
-            )  # For content blocks with cache_control
+            assistant_content_list: List[Dict[str, Any]] = []  # For content blocks with cache_control
             has_cache_control_in_text = False
             tool_calls: List[ChatCompletionAssistantToolCall] = []
-            thinking_blocks: List[
-                Union[ChatCompletionThinkingBlock, ChatCompletionRedactedThinkingBlock]
-            ] = []
+            thinking_blocks: List[Union[ChatCompletionThinkingBlock, ChatCompletionRedactedThinkingBlock]] = []
             if m["role"] == "assistant":
                 if isinstance(m.get("content"), str):
                     assistant_message_str = str(m.get("content", ""))
@@ -615,9 +520,7 @@ class LiteLLMAnthropicMessagesAdapter:
                                     "type": "text",
                                     "text": content.get("text", ""),
                                 }
-                                self._add_cache_control_if_applicable(
-                                    content, text_block, model
-                                )
+                                self._add_cache_control_if_applicable(content, text_block, model)
                                 if "cache_control" in text_block:
                                     has_cache_control_in_text = True
                                 assistant_content_list.append(text_block)
@@ -628,32 +531,21 @@ class LiteLLMAnthropicMessagesAdapter:
                                     "name": tool_name,
                                     "arguments": json.dumps(content.get("input", {})),
                                 }
-                                signature = (
-                                    self._extract_signature_from_tool_use_content(
-                                        cast(Dict[str, Any], content)
-                                    )
-                                )
+                                signature = self._extract_signature_from_tool_use_content(cast(Dict[str, Any], content))
 
                                 if signature:
                                     provider_specific_fields: Dict[str, Any] = (
-                                        function_chunk.get("provider_specific_fields")
-                                        or {}
+                                        function_chunk.get("provider_specific_fields") or {}
                                     )
-                                    provider_specific_fields["thought_signature"] = (
-                                        signature
-                                    )
-                                    function_chunk["provider_specific_fields"] = (
-                                        provider_specific_fields
-                                    )
+                                    provider_specific_fields["thought_signature"] = signature
+                                    function_chunk["provider_specific_fields"] = provider_specific_fields
 
                                 tool_call = ChatCompletionAssistantToolCall(
                                     id=content.get("id", ""),
                                     type="function",
                                     function=function_chunk,
                                 )
-                                self._add_cache_control_if_applicable(
-                                    content, tool_call, model
-                                )
+                                self._add_cache_control_if_applicable(content, tool_call, model)
                                 tool_calls.append(tool_call)
                             elif content.get("type") == "thinking":
                                 thinking_block = ChatCompletionThinkingBlock(
@@ -664,12 +556,10 @@ class LiteLLMAnthropicMessagesAdapter:
                                 )
                                 thinking_blocks.append(thinking_block)
                             elif content.get("type") == "redacted_thinking":
-                                redacted_thinking_block = (
-                                    ChatCompletionRedactedThinkingBlock(
-                                        type="redacted_thinking",
-                                        data=content.get("data") or "",
-                                        cache_control=content.get("cache_control", {}),
-                                    )
+                                redacted_thinking_block = ChatCompletionRedactedThinkingBlock(
+                                    type="redacted_thinking",
+                                    data=content.get("data") or "",
+                                    cache_control=content.get("cache_control", {}),
                                 )
                                 thinking_blocks.append(redacted_thinking_block)
 
@@ -684,18 +574,14 @@ class LiteLLMAnthropicMessagesAdapter:
                     assistant_content: Any = assistant_content_list
                 elif len(assistant_content_list) > 0 and not has_cache_control_in_text:
                     # Concatenate text blocks into string when no cache_control
-                    assistant_content = "".join(
-                        block.get("text", "") for block in assistant_content_list
-                    )
+                    assistant_content = "".join(block.get("text", "") for block in assistant_content_list)
                 else:
                     assistant_content = assistant_message_str
 
                 assistant_message = ChatCompletionAssistantMessage(
                     role="assistant",
                     content=assistant_content,
-                    thinking_blocks=(
-                        thinking_blocks if len(thinking_blocks) > 0 else None
-                    ),
+                    thinking_blocks=(thinking_blocks if len(thinking_blocks) > 0 else None),
                 )
                 if len(tool_calls) > 0:
                     assistant_message["tool_calls"] = tool_calls  # type: ignore
@@ -801,9 +687,7 @@ class LiteLLMAnthropicMessagesAdapter:
                 thinking
             )
             if reasoning_effort:
-                summary = (
-                    thinking.get("summary") if isinstance(thinking, dict) else None
-                )
+                summary = thinking.get("summary") if isinstance(thinking, dict) else None
                 auto_summary = is_reasoning_auto_summary_enabled()
                 if summary:
                     return {
@@ -833,18 +717,12 @@ class LiteLLMAnthropicMessagesAdapter:
             # Truncate tool name if it exceeds OpenAI's 64-char limit
             original_name = tool_choice.get("name", "")
             truncated_name = truncate_tool_name(original_name)
-            tc_function_param = ChatCompletionToolChoiceFunctionParam(
-                name=truncated_name
-            )
-            return ChatCompletionToolChoiceObjectParam(
-                type="function", function=tc_function_param
-            )
+            tc_function_param = ChatCompletionToolChoiceFunctionParam(name=truncated_name)
+            return ChatCompletionToolChoiceObjectParam(type="function", function=tc_function_param)
         elif tool_choice["type"] == "none":
             return "none"
         else:
-            raise ValueError(
-                "Incompatible tool choice param submitted - {}".format(tool_choice)
-            )
+            raise ValueError("Incompatible tool choice param submitted - {}".format(tool_choice))
 
     def translate_anthropic_tools_to_openai(
         self, tools: List[AllAnthropicToolsValues], model: Optional[str] = None
@@ -859,7 +737,7 @@ class LiteLLMAnthropicMessagesAdapter:
         """
         new_tools: List[ChatCompletionToolParam] = []
         tool_name_mapping: Dict[str, str] = {}
-        mapped_tool_params = ["name", "input_schema", "description", "cache_control"]
+        mapped_tool_params = ["name", "input_schema", "description", "cache_control", "type"]
 
         for idx, tool in enumerate(tools):
             # Check if this is an Anthropic-native tool that should be kept as-is
@@ -870,9 +748,7 @@ class LiteLLMAnthropicMessagesAdapter:
                 continue
 
             raw_name = tool.get("name")
-            if raw_name is None or (
-                isinstance(raw_name, str) and not str(raw_name).strip()
-            ):
+            if raw_name is None or (isinstance(raw_name, str) and not str(raw_name).strip()):
                 original_name = f"litellm_unnamed_tool_{idx}"
             else:
                 original_name = str(raw_name)
@@ -893,17 +769,13 @@ class LiteLLMAnthropicMessagesAdapter:
             for k, v in tool.items():
                 if k not in mapped_tool_params:  # pass additional computer kwargs
                     function_chunk.setdefault("parameters", {}).update({k: v})
-            tool_param = ChatCompletionToolParam(
-                type="function", function=function_chunk
-            )
+            tool_param = ChatCompletionToolParam(type="function", function=function_chunk)
             self._add_cache_control_if_applicable(tool, tool_param, model)
             new_tools.append(tool_param)  # type: ignore[arg-type]
 
         return new_tools, tool_name_mapping  # type: ignore[return-value]
 
-    def translate_anthropic_output_format_to_openai(
-        self, output_format: Any
-    ) -> Optional[Dict[str, Any]]:
+    def translate_anthropic_output_format_to_openai(self, output_format: Any) -> Optional[Dict[str, Any]]:
         """
         Translate Anthropic's output_format to OpenAI's response_format.
 
@@ -962,25 +834,19 @@ class LiteLLMAnthropicMessagesAdapter:
 
         # Handle array items
         if "items" in schema:
-            LiteLLMAnthropicMessagesAdapter._add_additional_properties_false(
-                schema["items"]
-            )
+            LiteLLMAnthropicMessagesAdapter._add_additional_properties_false(schema["items"])
 
         # Handle anyOf/oneOf/allOf
         for key in ("anyOf", "oneOf", "allOf"):
             if key in schema:
                 for sub_schema in schema[key]:
-                    LiteLLMAnthropicMessagesAdapter._add_additional_properties_false(
-                        sub_schema
-                    )
+                    LiteLLMAnthropicMessagesAdapter._add_additional_properties_false(sub_schema)
 
         # Handle $defs / definitions
         for key in ("$defs", "definitions"):
             if key in schema:
                 for def_schema in schema[key].values():
-                    LiteLLMAnthropicMessagesAdapter._add_additional_properties_false(
-                        def_schema
-                    )
+                    LiteLLMAnthropicMessagesAdapter._add_additional_properties_false(def_schema)
 
     def _add_system_message_to_messages(
         self,
@@ -1100,9 +966,7 @@ class LiteLLMAnthropicMessagesAdapter:
             new_kwargs["thinking"] = thinking  # type: ignore
             return
 
-        reasoning_effort = self.translate_anthropic_thinking_to_reasoning_effort(
-            cast(Dict[str, Any], thinking)
-        )
+        reasoning_effort = self.translate_anthropic_thinking_to_reasoning_effort(cast(Dict[str, Any], thinking))
         if not reasoning_effort:
             return
 
@@ -1157,9 +1021,7 @@ class LiteLLMAnthropicMessagesAdapter:
                 output_format = output_config.get("format")
         if not output_format:
             return
-        response_format = self.translate_anthropic_output_format_to_openai(
-            output_format=output_format
-        )
+        response_format = self.translate_anthropic_output_format_to_openai(output_format=output_format)
         if response_format:
             new_kwargs["response_format"] = response_format
 
@@ -1190,11 +1052,7 @@ class LiteLLMAnthropicMessagesAdapter:
         tool_name_mapping: Dict[str, str] = {}
 
         ## CONVERT ANTHROPIC MESSAGES TO OPENAI
-        messages_list: List[
-            Union[
-                AnthropicMessagesUserMessageParam, AnthopicMessagesAssistantMessageParam
-            ]
-        ] = cast(
+        messages_list: List[Union[AnthropicMessagesUserMessageParam, AnthopicMessagesAssistantMessageParam]] = cast(
             List[
                 Union[
                     AnthropicMessagesUserMessageParam,
@@ -1281,10 +1139,7 @@ class LiteLLMAnthropicMessagesAdapter:
         new_content: List[Dict[str, Any]] = []
         for choice in choices:
             # Handle thinking blocks first
-            if (
-                hasattr(choice.message, "thinking_blocks")
-                and choice.message.thinking_blocks
-            ):
+            if hasattr(choice.message, "thinking_blocks") and choice.message.thinking_blocks:
                 for thinking_block in choice.message.thinking_blocks:
                     if thinking_block.get("type") == "thinking":
                         thinking_value = thinking_block.get("thinking", "")
@@ -1292,16 +1147,8 @@ class LiteLLMAnthropicMessagesAdapter:
                         new_content.append(
                             AnthropicResponseContentBlockThinking(
                                 type="thinking",
-                                thinking=(
-                                    str(thinking_value)
-                                    if thinking_value is not None
-                                    else ""
-                                ),
-                                signature=(
-                                    str(signature_value)
-                                    if signature_value is not None
-                                    else None
-                                ),
+                                thinking=(str(thinking_value) if thinking_value is not None else ""),
+                                signature=(str(signature_value) if signature_value is not None else None),
                             ).model_dump()
                         )
                     elif thinking_block.get("type") == "redacted_thinking":
@@ -1313,10 +1160,7 @@ class LiteLLMAnthropicMessagesAdapter:
                             ).model_dump()
                         )
             # Handle reasoning_content when thinking_blocks is not present
-            elif (
-                hasattr(choice.message, "reasoning_content")
-                and choice.message.reasoning_content
-            ):
+            elif hasattr(choice.message, "reasoning_content") and choice.message.reasoning_content:
                 new_content.append(
                     AnthropicResponseContentBlockThinking(
                         type="thinking",
@@ -1328,15 +1172,10 @@ class LiteLLMAnthropicMessagesAdapter:
             # Handle text content
             if choice.message.content is not None:
                 new_content.append(
-                    AnthropicResponseContentBlockText(
-                        type="text", text=choice.message.content
-                    ).model_dump()
+                    AnthropicResponseContentBlockText(type="text", text=choice.message.content).model_dump()
                 )
             # Handle tool calls (in parallel to text content)
-            if (
-                choice.message.tool_calls is not None
-                and len(choice.message.tool_calls) > 0
-            ):
+            if choice.message.tool_calls is not None and len(choice.message.tool_calls) > 0:
                 for tool_call in choice.message.tool_calls:
                     # Extract signature from provider_specific_fields only
                     signature = self._extract_signature_from_tool_call(tool_call)
@@ -1348,9 +1187,7 @@ class LiteLLMAnthropicMessagesAdapter:
                     # Restore original tool name if it was truncated
                     truncated_name = tool_call.function.name or ""
                     original_name = (
-                        tool_name_mapping.get(truncated_name, truncated_name)
-                        if tool_name_mapping
-                        else truncated_name
+                        tool_name_mapping.get(truncated_name, truncated_name) if tool_name_mapping else truncated_name
                     )
 
                     # Strip Gemini thought-signature suffix from id (mirrors streaming
@@ -1374,16 +1211,12 @@ class LiteLLMAnthropicMessagesAdapter:
                     )
                     # Add provider_specific_fields if signature is present
                     if provider_specific_fields:
-                        tool_use_block.provider_specific_fields = (
-                            provider_specific_fields
-                        )
+                        tool_use_block.provider_specific_fields = provider_specific_fields
                     new_content.append(tool_use_block.model_dump())
 
         return new_content
 
-    def _translate_openai_finish_reason_to_anthropic(
-        self, openai_finish_reason: str
-    ) -> AnthropicFinishReason:
+    def _translate_openai_finish_reason_to_anthropic(self, openai_finish_reason: str) -> AnthropicFinishReason:
         if openai_finish_reason == "stop":
             return "end_turn"
         elif openai_finish_reason == "length":
@@ -1426,22 +1259,15 @@ class LiteLLMAnthropicMessagesAdapter:
         uncached_input_tokens = usage.prompt_tokens or 0
         cached_tokens = 0
         if hasattr(usage, "prompt_tokens_details") and usage.prompt_tokens_details:
-            cached_tokens = (
-                getattr(usage.prompt_tokens_details, "cached_tokens", 0) or 0
-            )
+            cached_tokens = getattr(usage.prompt_tokens_details, "cached_tokens", 0) or 0
             uncached_input_tokens -= cached_tokens
 
         anthropic_usage = AnthropicUsage(
             input_tokens=uncached_input_tokens,
             output_tokens=usage.completion_tokens or 0,
         )
-        if (
-            hasattr(usage, "_cache_creation_input_tokens")
-            and usage._cache_creation_input_tokens > 0
-        ):
-            anthropic_usage["cache_creation_input_tokens"] = (
-                usage._cache_creation_input_tokens
-            )
+        if hasattr(usage, "_cache_creation_input_tokens") and usage._cache_creation_input_tokens > 0:
+            anthropic_usage["cache_creation_input_tokens"] = usage._cache_creation_input_tokens
         if cached_tokens > 0:
             anthropic_usage["cache_read_input_tokens"] = cached_tokens
 
@@ -1464,13 +1290,9 @@ class LiteLLMAnthropicMessagesAdapter:
             stop_reason=anthropic_finish_reason,
         )
 
-        applied_edits = (
-            polyfill_result.applied_edits_for_response() if polyfill_result else None
-        )
+        applied_edits = polyfill_result.applied_edits_for_response() if polyfill_result else None
         if applied_edits:
-            translated_obj["context_management"] = ContextManagementResponse(
-                applied_edits=list(applied_edits)
-            )
+            translated_obj["context_management"] = ContextManagementResponse(applied_edits=list(applied_edits))
 
         return translated_obj
 
@@ -1510,9 +1332,7 @@ class LiteLLMAnthropicMessagesAdapter:
                 return "tool_use", cast("ContentBlockContentBlockDict", tool_block)
             elif choice.delta.content is not None and len(choice.delta.content) > 0:
                 return "text", TextBlock(type="text", text="")
-            elif isinstance(choice, StreamingChoices) and hasattr(
-                choice.delta, "thinking_blocks"
-            ):
+            elif isinstance(choice, StreamingChoices) and hasattr(choice.delta, "thinking_blocks"):
                 thinking_blocks = choice.delta.thinking_blocks or []
                 if len(thinking_blocks) > 0:
                     thinking_block = thinking_blocks[0]
@@ -1536,12 +1356,8 @@ class LiteLLMAnthropicMessagesAdapter:
             # ``Delta`` deletes the ``thinking_blocks`` attribute when unset, so the
             # branch above is skipped entirely; open a ``thinking`` block here so the
             # matching ``thinking_delta`` stream is not emitted into a text block.
-            elif isinstance(choice, StreamingChoices) and getattr(
-                choice.delta, "reasoning_content", None
-            ):
-                return "thinking", ChatCompletionThinkingBlock(
-                    type="thinking", thinking="", signature=""
-                )
+            elif isinstance(choice, StreamingChoices) and getattr(choice.delta, "reasoning_content", None):
+                return "thinking", ChatCompletionThinkingBlock(type="thinking", thinking="", signature="")
 
         return "text", TextBlock(type="text", text="")
 
@@ -1566,14 +1382,9 @@ class LiteLLMAnthropicMessagesAdapter:
             if choice.delta.tool_calls:
                 partial_json = ""
                 for tool in choice.delta.tool_calls:
-                    if (
-                        tool.function is not None
-                        and tool.function.arguments is not None
-                    ):
+                    if tool.function is not None and tool.function.arguments is not None:
                         partial_json = (partial_json or "") + tool.function.arguments
-            elif isinstance(choice, StreamingChoices) and hasattr(
-                choice.delta, "thinking_blocks"
-            ):
+            elif isinstance(choice, StreamingChoices) and hasattr(choice.delta, "thinking_blocks"):
                 thinking_blocks = choice.delta.thinking_blocks or []
                 if len(thinking_blocks) > 0:
                     for thinking_block in thinking_blocks:
@@ -1588,25 +1399,17 @@ class LiteLLMAnthropicMessagesAdapter:
                             reasoning_signature += signature
             # Handle reasoning_content when thinking_blocks is not present
             # This handles providers like OpenRouter that return reasoning_content
-            elif isinstance(choice, StreamingChoices) and hasattr(
-                choice.delta, "reasoning_content"
-            ):
+            elif isinstance(choice, StreamingChoices) and hasattr(choice.delta, "reasoning_content"):
                 if choice.delta.reasoning_content is not None:
                     reasoning_content += choice.delta.reasoning_content
 
         if reasoning_content and reasoning_signature:
-            raise ValueError(
-                "Both `reasoning` and `signature` in a single streaming chunk isn't supported."
-            )
+            raise ValueError("Both `reasoning` and `signature` in a single streaming chunk isn't supported.")
 
         if partial_json is not None:
-            return "input_json_delta", ContentJsonBlockDelta(
-                type="input_json_delta", partial_json=partial_json
-            )
+            return "input_json_delta", ContentJsonBlockDelta(type="input_json_delta", partial_json=partial_json)
         elif reasoning_content:
-            return "thinking_delta", ContentThinkingBlockDelta(
-                type="thinking_delta", thinking=reasoning_content
-            )
+            return "thinking_delta", ContentThinkingBlockDelta(type="thinking_delta", thinking=reasoning_content)
         elif reasoning_signature:
             return "signature_delta", ContentThinkingSignatureBlockDelta(
                 type="signature_delta", signature=reasoning_signature
@@ -1623,26 +1426,18 @@ class LiteLLMAnthropicMessagesAdapter:
         ## base case - final chunk w/ finish reason
         if response.choices[0].finish_reason is not None:
             delta = MessageDelta(
-                stop_reason=self._translate_openai_finish_reason_to_anthropic(
-                    response.choices[0].finish_reason
-                ),
+                stop_reason=self._translate_openai_finish_reason_to_anthropic(response.choices[0].finish_reason),
             )
             if getattr(response, "usage", None) is not None:
                 litellm_usage_chunk: Optional[Usage] = response.usage  # type: ignore
-            elif (
-                hasattr(response, "_hidden_params")
-                and "usage" in response._hidden_params
-            ):
+            elif hasattr(response, "_hidden_params") and "usage" in response._hidden_params:
                 litellm_usage_chunk = response._hidden_params["usage"]
             else:
                 litellm_usage_chunk = None
             if litellm_usage_chunk is not None:
                 uncached_input_tokens = litellm_usage_chunk.prompt_tokens or 0
                 cached_tokens = 0
-                if (
-                    hasattr(litellm_usage_chunk, "prompt_tokens_details")
-                    and litellm_usage_chunk.prompt_tokens_details
-                ):
+                if hasattr(litellm_usage_chunk, "prompt_tokens_details") and litellm_usage_chunk.prompt_tokens_details:
                     cached_tokens = (
                         getattr(
                             litellm_usage_chunk.prompt_tokens_details,
@@ -1661,20 +1456,18 @@ class LiteLLMAnthropicMessagesAdapter:
                     hasattr(litellm_usage_chunk, "_cache_creation_input_tokens")
                     and litellm_usage_chunk._cache_creation_input_tokens > 0
                 ):
-                    usage_delta["cache_creation_input_tokens"] = (
-                        litellm_usage_chunk._cache_creation_input_tokens
-                    )
+                    usage_delta["cache_creation_input_tokens"] = litellm_usage_chunk._cache_creation_input_tokens
                 if cached_tokens > 0:
                     usage_delta["cache_read_input_tokens"] = cached_tokens
             else:
                 usage_delta = UsageDelta(input_tokens=0, output_tokens=0)
             message_block = MessageBlockDelta(
-                type="message_delta", delta=delta, usage=usage_delta  # type: ignore
+                type="message_delta",
+                delta=delta,
+                usage=usage_delta,  # type: ignore
             )
             if applied_edits:
-                message_block["context_management"] = ContextManagementResponse(
-                    applied_edits=list(applied_edits)
-                )
+                message_block["context_management"] = ContextManagementResponse(applied_edits=list(applied_edits))
             return message_block
         (
             type_of_content,

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_tool_type_leak.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_tool_type_leak.py
@@ -1,0 +1,104 @@
+"""
+Test for Anthropic tool type leakage into OpenAI parameters schema.
+
+Regression test for issue #30557:
+When an Anthropic tool has type: "custom", that top-level type was being
+merged into the OpenAI function parameters schema, overwriting parameters.type
+from "object" to "custom", causing validation errors from downstream providers.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("../../../../.."))
+
+from litellm.llms.anthropic.experimental_pass_through.adapters.transformation import (
+    LiteLLMAnthropicMessagesAdapter,
+)
+from litellm.types.llms.anthropic import AnthropicMessagesRequest
+
+
+def test_translate_anthropic_custom_tool_type_does_not_leak():
+    """
+    Anthropic tool with type: "custom" should not overwrite parameters.type.
+
+    The top-level Anthropic tool "type" field must not be merged into the
+    OpenAI function parameters schema. Parameters.type should remain "object"
+    as defined in input_schema.
+    """
+    adapter = LiteLLMAnthropicMessagesAdapter()
+
+    tools = [
+        {
+            "type": "custom",
+            "name": "get_weather",
+            "description": "Get weather information",
+            "input_schema": {
+                "type": "object",
+                "properties": {"location": {"type": "string"}},
+                "required": ["location"],
+            },
+        }
+    ]
+
+    result, _ = adapter.translate_anthropic_tools_to_openai(tools=tools, model=None)
+
+    assert len(result) == 1
+    assert result[0]["type"] == "function"
+    assert result[0]["function"]["name"] == "get_weather"
+    assert result[0]["function"]["description"] == "Get weather information"
+
+    # The bug: parameters.type was being set to "custom" instead of "object"
+    parameters = result[0]["function"]["parameters"]
+    assert parameters["type"] == "object", (
+        f"Expected parameters.type='object', got '{parameters['type']}'. "
+        "Tool top-level type leaked into parameters schema."
+    )
+    assert parameters["properties"]["location"]["type"] == "string"
+    assert parameters["required"] == ["location"]
+
+
+def test_translate_anthropic_tool_without_type_field():
+    """
+    Tools without a type field should work correctly.
+    """
+    adapter = LiteLLMAnthropicMessagesAdapter()
+
+    tools = [{"name": "calculate", "input_schema": {"type": "object", "properties": {"x": {"type": "number"}}}}]
+
+    result, _ = adapter.translate_anthropic_tools_to_openai(tools=tools, model=None)
+
+    assert len(result) == 1
+    assert result[0]["function"]["parameters"]["type"] == "object"
+
+
+def test_translate_anthropic_request_with_custom_tool():
+    """
+    End-to-end test: full Anthropic request translation with custom tool.
+
+    Reproduces the exact scenario from issue #30557.
+    """
+    adapter = LiteLLMAnthropicMessagesAdapter()
+
+    req = AnthropicMessagesRequest(
+        model="gpt-4o",
+        max_tokens=64,
+        messages=[{"role": "user", "content": "Weather in Paris?"}],
+        tools=[
+            {
+                "type": "custom",
+                "name": "get_weather",
+                "description": "Get weather",
+                "input_schema": {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]},
+            }
+        ],
+    )
+
+    body, _ = adapter.translate_anthropic_to_openai(anthropic_message_request=req)
+
+    assert "tools" in body
+    assert len(body["tools"]) == 1
+
+    tool_params = body["tools"][0]["function"]["parameters"]
+    assert tool_params["type"] == "object", f"Expected object, got {tool_params['type']}. Reproduce issue #30557."
+    assert "city" in tool_params["properties"]


### PR DESCRIPTION
## Relevant issues

Fixes #30557

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

Fixed Anthropic → OpenAI tool translation that was corrupting JSON schemas when Anthropic tools had `type: "custom"`.

### Problem

When `/v1/messages` (Anthropic Messages API) is bridged to non-Anthropic providers (openai/, hosted_vllm/, openai_like/), tools with top-level `type: "custom"` had that type value leaked into the OpenAI function `parameters` schema, overwriting the correct `parameters.type: "object"` with `parameters.type: "custom"`.

This caused validation errors from downstream providers:
- OpenAI/Azure: `'custom' is not valid under any of the given schemas`
- Bedrock: `$.type: does not have a value in the enumeration [array, boolean, integer, null, number, object, string]`

### Root cause

In `translate_anthropic_tools_to_openai()`, the loop that passes additional computer kwargs was merging every tool key not in `mapped_tool_params` into the parameters object. Since `"type"` wasn't excluded, it leaked from the top-level Anthropic tool definition into the OpenAI parameters schema.

### Solution

Added `"type"` to `mapped_tool_params` to prevent it from being merged into parameters.

**Modified file:**
- `litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py`
  - Line 862: Added `"type"` to `mapped_tool_params` list

**Test file (new):**
- `tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_tool_type_leak.py`
  - 3 regression tests covering the exact scenario from #30557
  - Verifies `parameters.type` remains `"object"` when tool has `type: "custom"`
  - Tests both direct translation and full end-to-end request translation

### Test Results

```bash
$ uv run python -m pytest tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_tool_type_leak.py -v
============================== 3 passed in 0.08s ===============================

$ uv run python -m pytest tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py::test_translate_anthropic_tools_to_openai_fills_missing_tool_name tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py::test_translate_anthropic_tools_with_long_names tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py::test_translate_anthropic_tools_mixed_names -v
============================== 3 passed in 0.12s ===============================
```

All new tests pass. Existing tool translation tests remain passing (no regression).

## Screenshots / Proof of Fix

Before fix (reproducing #30557):
```python
from litellm.llms.anthropic.experimental_pass_through.adapters.transformation import LiteLLMAnthropicMessagesAdapter
from litellm.types.llms.anthropic import AnthropicMessagesRequest

req = AnthropicMessagesRequest(
    model="gpt-4o",
    max_tokens=64,
    messages=[{"role": "user", "content": "Weather in Paris?"}],
    tools=[{
        "type": "custom",
        "name": "get_weather",
        "description": "Get weather",
        "input_schema": {"type": "object"}
    }]
)
body, _ = LiteLLMAnthropicMessagesAdapter().translate_anthropic_to_openai(anthropic_message_request=req)
print(body["tools"][0]["function"]["parameters"]["type"])
# Output: custom  ❌ (bug)
```

After fix:
```python
# Same code as above
print(body["tools"][0]["function"]["parameters"]["type"])
# Output: object  ✅ (correct)
```