### PR TITLE
fix(redis): coerce env var string types and fix param discovery through decorator wrappers

### DIFF
--- a/.github/workflows/test-redis-compat.yml
+++ b/.github/workflows/test-redis-compat.yml
@@ -1,0 +1,77 @@
+name: "Unit Tests: Redis Client Version Compatibility"
+
+on:
+  pull_request:
+    branches:
+      - main
+      - litellm_internal_staging
+      - litellm_oss_staging
+      - "litellm_**"
+    paths:
+      - "litellm/_redis.py"
+      - "litellm/_redis_credential_provider.py"
+      - "tests/test_litellm/test_redis.py"
+      - "tests/test_litellm/caching/test_redis_connection_pool.py"
+      - ".github/workflows/test-redis-compat.yml"
+      - "pyproject.toml"
+      - "uv.lock"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  redis-compat:
+    name: "redis-py ${{ matrix.redis-version }}"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # 5.3.1 is the version pinned in uv.lock (redisvl caps it below 6); the
+        # newer legs prove the inspect.signature introspection in litellm/_redis.py
+        # keeps extracting kwargs on the redis-py releases people actually run now.
+        # Only the exact release 6.0.0 is skipped: rq (pulled by the proxy extra)
+        # specifies `redis != 6`, which excludes 6.0.0 alone, so 6.4.0 stands in
+        # for the 6.x line.
+        redis-version: ["5.3.1", "6.4.0", "7.4.1", "8.0.1"]
+
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: ./.github/actions/setup-uv-with-retries
+        with:
+          version: "0.10.9"
+
+      - name: Install dependencies
+        run: |
+          .github/scripts/uv_sync_with_retries.sh --frozen --group ci --group proxy-dev --extra google --extra proxy --extra semantic-router
+
+      - name: Pin redis-py to the matrix version
+        env:
+          REDIS_VERSION: ${{ matrix.redis-version }}
+        run: |
+          uv pip install "redis==${REDIS_VERSION:?}"
+          uv run --no-sync python -c "import redis; assert redis.__version__ == '${REDIS_VERSION:?}', redis.__version__; print('redis-py', redis.__version__)"
+
+      - name: Run redis unit tests
+        run: |
+          uv run --no-sync pytest \
+            tests/test_litellm/test_redis.py \
+            tests/test_litellm/caching/test_redis_connection_pool.py \
+            --tb=short -vv \
+            --reruns 2 \
+            --reruns-delay 1 \
+            --durations=20

--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -13,6 +13,7 @@ import json
 # s/o [@Frank Colson](https://www.linkedin.com/in/frank-colson-422b9b183/) for this redis implementation
 import os
 from collections.abc import Callable, Mapping
+from types import MappingProxyType
 from typing import Final
 from urllib.parse import urlsplit, urlunsplit
 
@@ -38,9 +39,25 @@ from ._logging import verbose_logger
 AZURE_REDIS_SCOPE: Final = "https://redis.azure.com/.default"
 
 
-def _get_redis_kwargs():
-    arg_spec: Final = inspect.getfullargspec(redis.Redis)
+def _unwrapped_init_args(cls: type) -> frozenset[str]:
+    """Every parameter on a single class's own ``__init__``, decorator-unwrapped.
 
+    Unlike ``_init_arg_names`` below, this does not walk the MRO: ``redis.Redis``
+    and ``redis.RedisCluster`` (sync and async) each declare every real
+    constructor parameter directly on their own ``__init__``, so MRO-walking is
+    unnecessary — and it actively breaks the several tests here that mock the
+    class with ``patch(..., autospec=True)``, since ``inspect.getmro`` needs a
+    real ``__mro__`` that an autospec'd stand-in for a class does not provide.
+
+    Still unwraps first: redis-py >= 7.4 decorates these ``__init__``s with
+    ``@deprecated_args`` too, which the same class of bug as ``_init_arg_names``
+    would otherwise silently empty this allowlist through (see its docstring).
+    """
+    spec: Final = inspect.getfullargspec(inspect.unwrap(cls.__init__))
+    return frozenset(spec.args + spec.kwonlyargs)
+
+
+def _get_redis_kwargs():
     # Only allow primitive arguments
     exclude_args: Final = {
         "self",
@@ -60,7 +77,7 @@ def _get_redis_kwargs():
         "azure_client_secret",
     }
 
-    available_args: Final = {x for x in arg_spec.args if x not in exclude_args} | include_args
+    available_args: Final = {x for x in _unwrapped_init_args(redis.Redis) if x not in exclude_args} | include_args
 
     return available_args
 
@@ -120,15 +137,24 @@ def _get_redis_url_kwargs(client: type | None = None) -> tuple[str, ...]:
     return tuple(x for x in _init_arg_names(connection_cls) if x not in exclude_args) + include_args
 
 
-def _get_redis_cluster_kwargs(client=None):
+def _get_redis_cluster_kwargs(client: type | None = None):
+    """Config kwargs the target cluster client's constructor actually accepts.
+
+    Defaults to the sync ``redis.RedisCluster``, but the async cluster client
+    (``redis.asyncio.cluster.RedisCluster``) accepts several constructor kwargs
+    the sync class does not (``cluster_error_retry_attempts``,
+    ``connection_error_retry_attempts``, ``decode_responses``, ...). Introspecting
+    only the sync class regardless of which client is actually built silently
+    drops those for every async cluster caller, including any operator-configured
+    retry bound meant to cap a stuck node's worst-case latency.
+    """
     if client is None:
-        client = redis.Redis.from_url
-    arg_spec: Final = inspect.getfullargspec(redis.RedisCluster)
+        client = redis.RedisCluster
 
     # Only allow primitive arguments
     exclude_args: Final = {"self", "connection_pool", "retry", "host", "port", "startup_nodes"}
 
-    available_args = {x for x in arg_spec.args if x not in exclude_args}
+    available_args = {x for x in _unwrapped_init_args(client) if x not in exclude_args}
     available_args |= {
         "password",
         "username",
@@ -159,6 +185,66 @@ def _get_redis_env_kwarg_mapping():
 
     exclude_from_environment: Final = frozenset({"credential_provider"})
     return {f"{PREFIX}{x.upper()}": x for x in _get_redis_kwargs() if x not in exclude_from_environment}
+
+
+def _coerce_redis_kwargs_types(
+    redis_kwargs: Mapping[str, object],
+    client: type = redis.Redis,
+) -> dict[str, object]:  # mutable-ok: a caller mutates the returned kwargs before constructing its client
+    """Coerces string values to the numeric/boolean type ``client``'s constructor
+    declares for that parameter.
+
+    Environment variables are always strings, and Helm ``--set`` stringifies values
+    too, so a config value like ``health_check_interval`` or ``socket_timeout``
+    can arrive as ``"30"``/``"5.5"`` rather than a real number. redis-py's own
+    connection-health-check arithmetic (``loop.time() + self.health_check_interval``)
+    then raises ``TypeError`` on every Redis operation instead of connecting.
+
+    ``max_connections``, ``socket_timeout``, and ``socket_connect_timeout`` use an
+    explicit target type rather than the parameter's own signature default: redis-py
+    8.x changed the timeout defaults from ``None`` to int ``5``, so inferring the
+    type from the default would make a fractional ``"5.5"`` fail ``int()`` and get
+    silently dropped on 8.x while working on older versions.
+    """
+    sig: Final = inspect.signature(client)
+    numeric_param_types: Final = MappingProxyType(
+        {
+            "max_connections": int,
+            "socket_timeout": float,
+            "socket_connect_timeout": float,
+        }
+    )
+    result: Final = dict(redis_kwargs)  # mutable-ok: per-key try/except coercion below needs to drop individual keys
+    for key, value in redis_kwargs.items():
+        if not isinstance(value, str):
+            continue
+        param = sig.parameters.get(key)
+        if param is None:
+            continue
+        explicit_type = numeric_param_types.get(key)
+        if explicit_type is not None:
+            try:
+                result[key] = explicit_type(value)
+            except (ValueError, TypeError):
+                del result[key]
+            continue
+        default: object = param.default  # pyright: ignore[reportAny]  # inspect.Parameter.default is stubbed as Any
+        if default is inspect.Parameter.empty:
+            continue
+        # bool must be checked before int, since bool subclasses int
+        if isinstance(default, bool):
+            result[key] = value.lower() in ("true", "1", "yes")
+        elif isinstance(default, int):
+            try:
+                result[key] = int(value)
+            except (ValueError, TypeError):
+                del result[key]
+        elif isinstance(default, float):
+            try:
+                result[key] = float(value)
+            except (ValueError, TypeError):
+                del result[key]
+    return result
 
 
 def _redis_kwargs_from_environment():
@@ -505,7 +591,7 @@ def _get_redis_client_logic(**env_overrides):
         raise ValueError("Either 'host' or 'url' must be specified for redis.")
 
     # litellm.print_verbose(f"redis_kwargs: {redis_kwargs}")
-    return redis_kwargs
+    return _coerce_redis_kwargs_types(redis_kwargs)
 
 
 def init_redis_cluster(redis_kwargs) -> redis.RedisCluster:
@@ -669,7 +755,7 @@ def get_redis_async_client(
     if "startup_nodes" in redis_kwargs:
         from redis.cluster import ClusterNode
 
-        args = _get_redis_cluster_kwargs()
+        args = _get_redis_cluster_kwargs(async_redis.RedisCluster)
         cluster_kwargs: Final = {}
         for arg in redis_kwargs:
             if arg in args:

--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -742,7 +742,9 @@ def get_redis_client(**env_overrides):
     if "sentinel_nodes" in redis_kwargs and "service_name" in redis_kwargs:
         return _init_redis_sentinel(redis_kwargs)
 
-    return redis.Redis(**redis_kwargs)
+    return redis.Redis(  # pyright: ignore[reportCallIssue]  # object-valued kwargs match no overload statically
+        **redis_kwargs,  # pyright: ignore[reportArgumentType]  # allow-listed and coerced against this signature
+    )
 
 
 def get_redis_async_client(

--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -141,12 +141,11 @@ def _get_redis_cluster_kwargs(client: type | None = None):
     """Config kwargs the target cluster client's constructor actually accepts.
 
     Defaults to the sync ``redis.RedisCluster``, but the async cluster client
-    (``redis.asyncio.cluster.RedisCluster``) accepts several constructor kwargs
-    the sync class does not (``cluster_error_retry_attempts``,
-    ``connection_error_retry_attempts``, ``decode_responses``, ...). Introspecting
+    (``redis.asyncio.cluster.RedisCluster``) declares connection settings such as
+    ``decode_responses`` on its own constructor, where the sync class takes them
+    through ``**kwargs`` and so never names them in its signature. Introspecting
     only the sync class regardless of which client is actually built silently
-    drops those for every async cluster caller, including any operator-configured
-    retry bound meant to cap a stuck node's worst-case latency.
+    drops those for every async cluster caller.
     """
     if client is None:
         client = redis.RedisCluster

--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -186,12 +186,19 @@ def _get_redis_env_kwarg_mapping():
     return {f"{PREFIX}{x.upper()}": x for x in _get_redis_kwargs() if x not in exclude_from_environment}
 
 
+def _str_to_bool(value: str) -> bool:
+    return value.lower() in ("true", "1", "yes")
+
+
 def _coerce_redis_kwargs_types(
     redis_kwargs: Mapping[str, object],
-    client: type = redis.Redis,
+    client: type | tuple[type, ...] = redis.Redis,
 ) -> dict[str, object]:  # mutable-ok: a caller mutates the returned kwargs before constructing its client
     """Coerces string values to the numeric/boolean type ``client``'s constructor
-    declares for that parameter.
+    declares for that parameter. ``client`` may be a tuple of client classes; a
+    parameter's type is taken from the first signature that declares it, which
+    lets cluster callers coerce cluster-only kwargs such as
+    ``cluster_error_retry_attempts`` alongside the shared connection kwargs.
 
     Environment variables are always strings, and Helm ``--set`` stringifies values
     too, so a config value like ``health_check_interval`` or ``socket_timeout``
@@ -203,24 +210,30 @@ def _coerce_redis_kwargs_types(
     explicit target type rather than the parameter's own signature default: redis-py
     8.x changed the timeout defaults from ``None`` to int ``5``, so inferring the
     type from the default would make a fractional ``"5.5"`` fail ``int()`` and get
-    silently dropped on 8.x while working on older versions.
+    silently dropped on 8.x while working on older versions. ``socket_keepalive``
+    is explicit too: its signature default is ``None``, which carries no type to
+    infer from, and leaving it a string makes ``"false"`` truthy.
     """
-    sig: Final = inspect.signature(client)
-    numeric_param_types: Final = MappingProxyType(
+    signatures: Final = tuple(inspect.signature(c) for c in (client if isinstance(client, tuple) else (client,)))
+    explicit_param_types: Final = MappingProxyType(
         {
             "max_connections": int,
             "socket_timeout": float,
             "socket_connect_timeout": float,
+            "socket_keepalive": bool,
         }
     )
     result: Final = dict(redis_kwargs)  # mutable-ok: per-key try/except coercion below needs to drop individual keys
     for key, value in redis_kwargs.items():
         if not isinstance(value, str):
             continue
-        param = sig.parameters.get(key)
+        param = next((sig.parameters[key] for sig in signatures if key in sig.parameters), None)
         if param is None:
             continue
-        explicit_type = numeric_param_types.get(key)
+        explicit_type = explicit_param_types.get(key)
+        if explicit_type is bool:
+            result[key] = _str_to_bool(value)
+            continue
         if explicit_type is not None:
             try:
                 result[key] = explicit_type(value)
@@ -232,7 +245,7 @@ def _coerce_redis_kwargs_types(
             continue
         # bool must be checked before int, since bool subclasses int
         if isinstance(default, bool):
-            result[key] = value.lower() in ("true", "1", "yes")
+            result[key] = _str_to_bool(value)
         elif isinstance(default, int):
             try:
                 result[key] = int(value)
@@ -590,7 +603,12 @@ def _get_redis_client_logic(**env_overrides):
         raise ValueError("Either 'host' or 'url' must be specified for redis.")
 
     # litellm.print_verbose(f"redis_kwargs: {redis_kwargs}")
-    return _coerce_redis_kwargs_types(redis_kwargs)
+    coercion_client: Final = (
+        (redis.Redis, redis.RedisCluster, async_redis.RedisCluster)
+        if redis_kwargs.get("startup_nodes")
+        else redis.Redis
+    )
+    return _coerce_redis_kwargs_types(redis_kwargs, client=coercion_client)
 
 
 def init_redis_cluster(redis_kwargs) -> redis.RedisCluster:

--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -35,12 +35,15 @@ from ._logging import verbose_logger
 AZURE_REDIS_SCOPE = "https://redis.azure.com/.default"
 
 
-def _get_redis_kwargs():
+def _named_parameters(client: Callable[..., object]) -> frozenset[str]:
     # inspect.getfullargspec doesn't work here because redis.Redis.__init__ is
     # wrapped by @deprecated_args which uses *args/**kwargs internally.
     # inspect.signature resolves the original function's parameters correctly.
-    sig = inspect.signature(redis.Redis)
+    variadic = (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
+    return frozenset(name for name, param in inspect.signature(client).parameters.items() if param.kind not in variadic)
 
+
+def _get_redis_kwargs() -> frozenset[str]:
     exclude_args = {
         "self",
         "connection_pool",
@@ -58,23 +61,20 @@ def _get_redis_kwargs():
         "azure_client_secret",
     }
 
-    return {name for name in sig.parameters if name not in exclude_args} | include_args
+    return (_named_parameters(redis.Redis) - exclude_args) | include_args
 
 
-def _get_redis_url_kwargs():
-    sig = inspect.signature(redis.Redis)
+def _get_redis_url_kwargs() -> frozenset[str]:
     exclude_args = {"self", "connection_pool", "retry"}
-    include_args = ["url"]
-    available_args = [x for x in sig.parameters if x not in exclude_args] + include_args
-    return available_args
+    include_args = {"url"}
+    return (_named_parameters(redis.Redis) - exclude_args) | include_args
 
 
-def _get_redis_cluster_kwargs(client=None):
-    if client is None:
-        client = redis.Redis.from_url
-    sig = inspect.signature(redis.RedisCluster)
+def _get_redis_cluster_kwargs(
+    cluster_client: Callable[..., object] = redis.RedisCluster,
+) -> frozenset[str]:
     exclude_args = {"self", "connection_pool", "retry", "host", "port", "startup_nodes"}
-    available_args = {x for x in sig.parameters if x not in exclude_args}
+    available_args = _named_parameters(cluster_client) - exclude_args
     available_args |= {
         "password",
         "username",
@@ -590,7 +590,7 @@ def get_redis_async_client(
     if "startup_nodes" in redis_kwargs:
         from redis.cluster import ClusterNode
 
-        args = _get_redis_cluster_kwargs()
+        args = _get_redis_cluster_kwargs(async_redis.RedisCluster)
         cluster_kwargs = {}
         for arg in redis_kwargs:
             if arg in args:

--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -36,9 +36,11 @@ AZURE_REDIS_SCOPE = "https://redis.azure.com/.default"
 
 
 def _get_redis_kwargs():
-    arg_spec = inspect.getfullargspec(redis.Redis)
+    # inspect.getfullargspec doesn't work here because redis.Redis.__init__ is
+    # wrapped by @deprecated_args which uses *args/**kwargs internally.
+    # inspect.signature resolves the original function's parameters correctly.
+    sig = inspect.signature(redis.Redis)
 
-    # Only allow primitive arguments
     exclude_args = {
         "self",
         "connection_pool",
@@ -56,39 +58,23 @@ def _get_redis_kwargs():
         "azure_client_secret",
     }
 
-    available_args = {x for x in arg_spec.args if x not in exclude_args} | include_args
-
-    return available_args
+    return {name for name in sig.parameters if name not in exclude_args} | include_args
 
 
-def _get_redis_url_kwargs(client=None):
-    if client is None:
-        client = redis.Redis.from_url
-    arg_spec = inspect.getfullargspec(redis.Redis.from_url)
-
-    # Only allow primitive arguments
-    exclude_args = {
-        "self",
-        "connection_pool",
-        "retry",
-    }
-
+def _get_redis_url_kwargs():
+    sig = inspect.signature(redis.Redis)
+    exclude_args = {"self", "connection_pool", "retry"}
     include_args = ["url"]
-
-    available_args = [x for x in arg_spec.args if x not in exclude_args] + include_args
-
+    available_args = [x for x in sig.parameters if x not in exclude_args] + include_args
     return available_args
 
 
 def _get_redis_cluster_kwargs(client=None):
     if client is None:
         client = redis.Redis.from_url
-    arg_spec = inspect.getfullargspec(redis.RedisCluster)
-
-    # Only allow primitive arguments
+    sig = inspect.signature(redis.RedisCluster)
     exclude_args = {"self", "connection_pool", "retry", "host", "port", "startup_nodes"}
-
-    available_args = {x for x in arg_spec.args if x not in exclude_args}
+    available_args = {x for x in sig.parameters if x not in exclude_args}
     available_args |= {
         "password",
         "username",
@@ -96,7 +82,7 @@ def _get_redis_cluster_kwargs(client=None):
         "ssl_cert_reqs",
         "ssl_check_hostname",
         "ssl_ca_certs",
-        "redis_connect_func",  # Needed for sync clusters and IAM detection
+        "redis_connect_func",
         "gcp_service_account",
         "gcp_ssl_ca_certs",
         "azure_redis_ad_token",
@@ -109,7 +95,6 @@ def _get_redis_cluster_kwargs(client=None):
         "health_check_interval",
         "socket_keepalive",
     }
-
     return available_args
 
 
@@ -117,6 +102,45 @@ def _get_redis_env_kwarg_mapping():
     PREFIX = "REDIS_"
 
     return {f"{PREFIX}{x.upper()}": x for x in _get_redis_kwargs()}
+
+
+def _coerce_redis_kwargs_types(redis_kwargs: dict) -> dict:
+    sig = inspect.signature(redis.Redis)
+    # Params defaulting to None but requiring a numeric type when set
+    none_default_numeric: dict[str, type[int] | type[float]] = {
+        "max_connections": int,
+        "socket_timeout": float,
+        "socket_connect_timeout": float,
+    }
+    result = dict(redis_kwargs)
+    for key, value in redis_kwargs.items():
+        if not isinstance(value, str):
+            continue
+        param = sig.parameters.get(key)
+        if param is None:
+            continue
+        default = param.default
+        if default is inspect.Parameter.empty:
+            continue
+        # bool must be checked before int since bool subclasses int
+        if isinstance(default, bool):
+            result[key] = value.lower() in ("true", "1", "yes")
+        elif isinstance(default, int):
+            try:
+                result[key] = int(value)
+            except (ValueError, TypeError):
+                del result[key]
+        elif isinstance(default, float):
+            try:
+                result[key] = float(value)
+            except (ValueError, TypeError):
+                del result[key]
+        elif default is None and key in none_default_numeric:
+            try:
+                result[key] = none_default_numeric[key](value)
+            except (ValueError, TypeError):
+                del result[key]
+    return result
 
 
 def _redis_kwargs_from_environment():
@@ -444,8 +468,7 @@ def _get_redis_client_logic(**env_overrides):
     elif "host" not in redis_kwargs or redis_kwargs["host"] is None:
         raise ValueError("Either 'host' or 'url' must be specified for redis.")
 
-    # litellm.print_verbose(f"redis_kwargs: {redis_kwargs}")
-    return redis_kwargs
+    return _coerce_redis_kwargs_types(redis_kwargs)
 
 
 def init_redis_cluster(redis_kwargs) -> redis.RedisCluster:
@@ -614,7 +637,7 @@ def get_redis_async_client(
     if "url" in redis_kwargs and redis_kwargs["url"] is not None:
         if connection_pool is not None:
             return async_redis.Redis(connection_pool=connection_pool)
-        args = _get_redis_url_kwargs(client=async_redis.Redis.from_url)
+        args = _get_redis_url_kwargs()
         url_kwargs = {}
         for arg in redis_kwargs:
             if arg in args:
@@ -662,18 +685,13 @@ def get_redis_connection_pool(
         return None
 
     if "url" in redis_kwargs and redis_kwargs["url"] is not None:
-        pool_kwargs = {
+        pool_kwargs: dict = {
             "timeout": REDIS_CONNECTION_POOL_TIMEOUT,
             "url": redis_kwargs["url"],
         }
-        if "max_connections" in redis_kwargs:
-            try:
-                pool_kwargs["max_connections"] = int(redis_kwargs["max_connections"])
-            except (TypeError, ValueError):
-                verbose_logger.warning(
-                    "REDIS: invalid max_connections value %r, ignoring",
-                    redis_kwargs["max_connections"],
-                )
+        max_connections = redis_kwargs.get("max_connections")
+        if max_connections is not None:
+            pool_kwargs["max_connections"] = max_connections
         return async_redis.BlockingConnectionPool.from_url(**pool_kwargs)
 
     # Wrap GCP / Azure AD auth in a CredentialProvider so pool-managed

--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -104,10 +104,12 @@ def _get_redis_env_kwarg_mapping():
     return {f"{PREFIX}{x.upper()}": x for x in _get_redis_kwargs()}
 
 
-def _coerce_redis_kwargs_types(redis_kwargs: dict) -> dict:
-    sig = inspect.signature(redis.Redis)
-    # Params defaulting to None but requiring a numeric type when set
-    none_default_numeric: dict[str, type[int] | type[float]] = {
+def _coerce_redis_kwargs_types(redis_kwargs: dict, client: Callable[..., object] = redis.Redis) -> dict:
+    sig = inspect.signature(client)
+    # Params whose signature default is not a reliable type hint: redis-py 8.x changed
+    # socket_timeout / socket_connect_timeout from None to int 5, which would otherwise
+    # make a fractional value like "5.5" fail int() and be dropped.
+    numeric_param_types: dict[str, type[int] | type[float]] = {
         "max_connections": int,
         "socket_timeout": float,
         "socket_connect_timeout": float,
@@ -118,6 +120,13 @@ def _coerce_redis_kwargs_types(redis_kwargs: dict) -> dict:
             continue
         param = sig.parameters.get(key)
         if param is None:
+            continue
+        explicit_type = numeric_param_types.get(key)
+        if explicit_type is not None:
+            try:
+                result[key] = explicit_type(value)
+            except (ValueError, TypeError):
+                del result[key]
             continue
         default = param.default
         if default is inspect.Parameter.empty:
@@ -133,11 +142,6 @@ def _coerce_redis_kwargs_types(redis_kwargs: dict) -> dict:
         elif isinstance(default, float):
             try:
                 result[key] = float(value)
-            except (ValueError, TypeError):
-                del result[key]
-        elif default is None and key in none_default_numeric:
-            try:
-                result[key] = none_default_numeric[key](value)
             except (ValueError, TypeError):
                 del result[key]
     return result

--- a/tests/test_litellm/caching/test_redis_connection_pool.py
+++ b/tests/test_litellm/caching/test_redis_connection_pool.py
@@ -1,15 +1,14 @@
-"""
-Regression tests for Redis connection pool leak fixes (RC1-RC5).
-
-Tests are pure unit tests — no Redis server required.
-"""
-
+import inspect as real_inspect
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-import redis.asyncio as async_redis
 
-from litellm._redis import get_redis_async_client, get_redis_connection_pool
+from litellm._redis import (
+    _coerce_redis_kwargs_types,
+    _get_redis_client_logic,
+    get_redis_async_client,
+    get_redis_connection_pool,
+)
 
 
 def test_url_config_uses_passed_pool():
@@ -60,16 +59,14 @@ def test_max_connections_url_config_string_value(monkeypatch):
     assert pool.max_connections == 25
 
 
-def test_max_connections_url_config_invalid_value():
-    """Invalid max_connections should be silently ignored, falling back
-    to the pool default (50 for BlockingConnectionPool)."""
-    with patch("litellm._redis._get_redis_client_logic") as mock_logic:
-        mock_logic.return_value = {
-            "url": "redis://localhost:6379/0",
-            "max_connections": "not_a_number",
-        }
+def test_max_connections_url_config_invalid_value(monkeypatch):
+    """Invalid max_connections from an env var should be silently dropped,
+    falling back to the pool default (50 for BlockingConnectionPool)."""
+    monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+    monkeypatch.delenv("REDIS_HOST", raising=False)
+    monkeypatch.setenv("REDIS_MAX_CONNECTIONS", "not_a_number")
 
-        pool = get_redis_connection_pool()
+    pool = get_redis_connection_pool()
 
     # BlockingConnectionPool default is 50
     assert pool.max_connections == 50
@@ -128,3 +125,115 @@ async def test_disconnect_idempotent():
 
     await cache.disconnect()
     await cache.disconnect()  # should not raise
+
+
+def test_coerce_redis_kwargs_types_int():
+    """String values for int-typed Redis params are coerced to int."""
+    result = _coerce_redis_kwargs_types({"health_check_interval": "30", "port": "6380", "db": "1"})
+    assert result["health_check_interval"] == 30
+    assert isinstance(result["health_check_interval"], int)
+    assert result["port"] == 6380
+    assert result["db"] == 1
+
+
+def test_coerce_redis_kwargs_types_bool():
+    """String values for bool-typed Redis params are coerced to bool."""
+    result = _coerce_redis_kwargs_types({"ssl": "true", "decode_responses": "false"})
+    assert result["ssl"] is True
+    assert result["decode_responses"] is False
+
+
+def test_coerce_redis_kwargs_types_none_default_numeric():
+    """String values for known None-default numeric params are coerced."""
+    result = _coerce_redis_kwargs_types({"max_connections": "20", "socket_timeout": "5.5"})
+    assert result["max_connections"] == 20
+    assert isinstance(result["max_connections"], int)
+    assert result["socket_timeout"] == 5.5
+    assert isinstance(result["socket_timeout"], float)
+
+
+def test_coerce_redis_kwargs_types_invalid_drops_key():
+    """A string that cannot be coerced to the expected numeric type is dropped."""
+    result = _coerce_redis_kwargs_types({"health_check_interval": "not_a_number"})
+    assert "health_check_interval" not in result
+
+
+def test_coerce_redis_kwargs_types_non_string_unchanged():
+    """Non-string values pass through without modification."""
+    result = _coerce_redis_kwargs_types({"health_check_interval": 30, "ssl": True})
+    assert result["health_check_interval"] == 30
+    assert result["ssl"] is True
+
+
+def test_health_check_interval_from_env_is_int(monkeypatch):
+    monkeypatch.setenv("REDIS_HOST", "localhost")
+    monkeypatch.setenv("REDIS_HEALTH_CHECK_INTERVAL", "30")
+
+    pool = get_redis_connection_pool()
+
+    assert pool is not None
+    interval = pool.connection_kwargs.get("health_check_interval")
+    assert interval == 30
+    assert isinstance(interval, int), f"Expected int, got {type(interval)}: {interval!r}"
+
+
+def test_coerce_redis_kwargs_types_empty_default_param_unchanged():
+    """String params whose signature entry has no default (inspect.Parameter.empty) are left as-is."""
+    empty_param = real_inspect.Parameter(
+        "testkey", real_inspect.Parameter.POSITIONAL_OR_KEYWORD
+    )
+    fake_sig = MagicMock()
+    fake_sig.parameters = {"testkey": empty_param}
+
+    with patch("litellm._redis.inspect.signature", return_value=fake_sig):
+        result = _coerce_redis_kwargs_types({"testkey": "some_value"})
+
+    assert result["testkey"] == "some_value"
+    assert isinstance(result["testkey"], str)
+
+
+def test_coerce_redis_kwargs_types_float_valid():
+    """String values for params whose signature default is a float are coerced to float."""
+    float_param = real_inspect.Parameter(
+        "myparam", real_inspect.Parameter.POSITIONAL_OR_KEYWORD, default=1.0
+    )
+    fake_sig = MagicMock()
+    fake_sig.parameters = {"myparam": float_param}
+
+    with patch("litellm._redis.inspect.signature", return_value=fake_sig):
+        result = _coerce_redis_kwargs_types({"myparam": "3.14"})
+
+    assert result["myparam"] == pytest.approx(3.14)
+    assert isinstance(result["myparam"], float)
+
+
+def test_coerce_redis_kwargs_types_float_invalid_drops_key():
+    """An unconvertible string for a float-default param is dropped from the result."""
+    float_param = real_inspect.Parameter(
+        "myparam", real_inspect.Parameter.POSITIONAL_OR_KEYWORD, default=1.0
+    )
+    fake_sig = MagicMock()
+    fake_sig.parameters = {"myparam": float_param}
+
+    with patch("litellm._redis.inspect.signature", return_value=fake_sig):
+        result = _coerce_redis_kwargs_types({"myparam": "not_a_float"})
+
+    assert "myparam" not in result
+
+
+def test_get_redis_client_logic_raises_without_host_or_url(monkeypatch):
+    """_get_redis_client_logic raises ValueError when neither host nor url is provided."""
+    for envvar in [
+        "REDIS_URL",
+        "REDIS_HOST",
+        "REDIS_PORT",
+        "REDIS_CLUSTER_NODES",
+        "REDIS_SENTINEL_NODES",
+    ]:
+        monkeypatch.delenv(envvar, raising=False)
+
+    with patch("litellm._redis._redis_kwargs_from_environment", return_value={}):
+        with pytest.raises(
+            ValueError, match="Either 'host' or 'url' must be specified for redis"
+        ):
+            _get_redis_client_logic()

--- a/tests/test_litellm/caching/test_redis_connection_pool.py
+++ b/tests/test_litellm/caching/test_redis_connection_pool.py
@@ -1,15 +1,14 @@
-"""
-Regression tests for Redis connection pool leak fixes (RC1-RC5).
-
-Tests are pure unit tests — no Redis server required.
-"""
-
+import inspect as real_inspect
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-import redis.asyncio as async_redis
 
-from litellm._redis import get_redis_async_client, get_redis_connection_pool
+from litellm._redis import (
+    _coerce_redis_kwargs_types,
+    _get_redis_client_logic,
+    get_redis_async_client,
+    get_redis_connection_pool,
+)
 
 
 def test_url_config_uses_passed_pool():
@@ -60,16 +59,14 @@ def test_max_connections_url_config_string_value(monkeypatch):
     assert pool.max_connections == 25
 
 
-def test_max_connections_url_config_invalid_value():
-    """Invalid max_connections should be silently ignored, falling back
-    to the pool default (50 for BlockingConnectionPool)."""
-    with patch("litellm._redis._get_redis_client_logic") as mock_logic:
-        mock_logic.return_value = {
-            "url": "redis://localhost:6379/0",
-            "max_connections": "not_a_number",
-        }
+def test_max_connections_url_config_invalid_value(monkeypatch):
+    """Invalid max_connections from an env var should be silently dropped,
+    falling back to the pool default (50 for BlockingConnectionPool)."""
+    monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+    monkeypatch.delenv("REDIS_HOST", raising=False)
+    monkeypatch.setenv("REDIS_MAX_CONNECTIONS", "not_a_number")
 
-        pool = get_redis_connection_pool()
+    pool = get_redis_connection_pool()
 
     # BlockingConnectionPool default is 50
     assert pool.max_connections == 50
@@ -128,3 +125,154 @@ async def test_disconnect_idempotent():
 
     await cache.disconnect()
     await cache.disconnect()  # should not raise
+
+
+def test_coerce_redis_kwargs_types_int():
+    """String values for int-typed Redis params are coerced to int."""
+    result = _coerce_redis_kwargs_types({"health_check_interval": "30", "port": "6380", "db": "1"})
+    assert result["health_check_interval"] == 30
+    assert isinstance(result["health_check_interval"], int)
+    assert result["port"] == 6380
+    assert result["db"] == 1
+
+
+def test_coerce_redis_kwargs_types_bool():
+    """String values for bool-typed Redis params are coerced to bool."""
+    result = _coerce_redis_kwargs_types({"ssl": "true", "decode_responses": "false"})
+    assert result["ssl"] is True
+    assert result["decode_responses"] is False
+
+
+def test_coerce_redis_kwargs_types_none_default_numeric():
+    """String values for known None-default numeric params are coerced."""
+    result = _coerce_redis_kwargs_types({"max_connections": "20", "socket_timeout": "5.5"})
+    assert result["max_connections"] == 20
+    assert isinstance(result["max_connections"], int)
+    assert result["socket_timeout"] == 5.5
+    assert isinstance(result["socket_timeout"], float)
+
+
+def _redis_signature_pre_8x(
+    socket_timeout=None,
+    socket_connect_timeout=None,
+    max_connections=None,
+    health_check_interval=0,
+):
+    """Stand-in for the redis-py <= 7.x Redis signature, where the timeout defaults are None."""
+
+
+def _redis_signature_8x(
+    socket_timeout=5,
+    socket_connect_timeout=5,
+    max_connections=None,
+    health_check_interval=0,
+):
+    """Stand-in for the redis-py 8.x Redis signature, where the timeout defaults became int 5."""
+
+
+@pytest.mark.parametrize(
+    "client",
+    [_redis_signature_pre_8x, _redis_signature_8x],
+    ids=["redis-py<=7.x", "redis-py-8.x"],
+)
+def test_coerce_fractional_socket_timeout_survives_signature_default_change(client):
+    """redis-py 8.x changed socket_timeout's default from None to int 5. Deriving the
+    target type from the signature default made int("5.5") raise, so the key was dropped
+    and REDIS_SOCKET_TIMEOUT=5.5 silently disappeared on 8.x."""
+    result = _coerce_redis_kwargs_types(
+        {"socket_timeout": "5.5", "socket_connect_timeout": "2.5", "max_connections": "20"},
+        client=client,
+    )
+
+    assert result["socket_timeout"] == pytest.approx(5.5)
+    assert isinstance(result["socket_timeout"], float)
+    assert result["socket_connect_timeout"] == pytest.approx(2.5)
+    assert isinstance(result["socket_connect_timeout"], float)
+    assert result["max_connections"] == 20
+    assert isinstance(result["max_connections"], int)
+
+
+def test_coerce_invalid_socket_timeout_is_still_dropped():
+    """Garbage must not survive the explicit-type path; Redis falls back to its own default."""
+    result = _coerce_redis_kwargs_types({"socket_timeout": "not_a_number"}, client=_redis_signature_8x)
+
+    assert "socket_timeout" not in result
+
+
+def test_coerce_redis_kwargs_types_invalid_drops_key():
+    """A string that cannot be coerced to the expected numeric type is dropped."""
+    result = _coerce_redis_kwargs_types({"health_check_interval": "not_a_number"})
+    assert "health_check_interval" not in result
+
+
+def test_coerce_redis_kwargs_types_non_string_unchanged():
+    """Non-string values pass through without modification."""
+    result = _coerce_redis_kwargs_types({"health_check_interval": 30, "ssl": True})
+    assert result["health_check_interval"] == 30
+    assert result["ssl"] is True
+
+
+def test_health_check_interval_from_env_is_int(monkeypatch):
+    monkeypatch.setenv("REDIS_HOST", "localhost")
+    monkeypatch.setenv("REDIS_HEALTH_CHECK_INTERVAL", "30")
+
+    pool = get_redis_connection_pool()
+
+    assert pool is not None
+    interval = pool.connection_kwargs.get("health_check_interval")
+    assert interval == 30
+    assert isinstance(interval, int), f"Expected int, got {type(interval)}: {interval!r}"
+
+
+def test_coerce_redis_kwargs_types_empty_default_param_unchanged():
+    """String params whose signature entry has no default (inspect.Parameter.empty) are left as-is."""
+    empty_param = real_inspect.Parameter("testkey", real_inspect.Parameter.POSITIONAL_OR_KEYWORD)
+    fake_sig = MagicMock()
+    fake_sig.parameters = {"testkey": empty_param}
+
+    with patch("litellm._redis.inspect.signature", return_value=fake_sig):
+        result = _coerce_redis_kwargs_types({"testkey": "some_value"})
+
+    assert result["testkey"] == "some_value"
+    assert isinstance(result["testkey"], str)
+
+
+def test_coerce_redis_kwargs_types_float_valid():
+    """String values for params whose signature default is a float are coerced to float."""
+    float_param = real_inspect.Parameter("myparam", real_inspect.Parameter.POSITIONAL_OR_KEYWORD, default=1.0)
+    fake_sig = MagicMock()
+    fake_sig.parameters = {"myparam": float_param}
+
+    with patch("litellm._redis.inspect.signature", return_value=fake_sig):
+        result = _coerce_redis_kwargs_types({"myparam": "3.14"})
+
+    assert result["myparam"] == pytest.approx(3.14)
+    assert isinstance(result["myparam"], float)
+
+
+def test_coerce_redis_kwargs_types_float_invalid_drops_key():
+    """An unconvertible string for a float-default param is dropped from the result."""
+    float_param = real_inspect.Parameter("myparam", real_inspect.Parameter.POSITIONAL_OR_KEYWORD, default=1.0)
+    fake_sig = MagicMock()
+    fake_sig.parameters = {"myparam": float_param}
+
+    with patch("litellm._redis.inspect.signature", return_value=fake_sig):
+        result = _coerce_redis_kwargs_types({"myparam": "not_a_float"})
+
+    assert "myparam" not in result
+
+
+def test_get_redis_client_logic_raises_without_host_or_url(monkeypatch):
+    """_get_redis_client_logic raises ValueError when neither host nor url is provided."""
+    for envvar in [
+        "REDIS_URL",
+        "REDIS_HOST",
+        "REDIS_PORT",
+        "REDIS_CLUSTER_NODES",
+        "REDIS_SENTINEL_NODES",
+    ]:
+        monkeypatch.delenv(envvar, raising=False)
+
+    with patch("litellm._redis._redis_kwargs_from_environment", return_value={}):
+        with pytest.raises(ValueError, match="Either 'host' or 'url' must be specified for redis"):
+            _get_redis_client_logic()

--- a/tests/test_litellm/caching/test_redis_connection_pool.py
+++ b/tests/test_litellm/caching/test_redis_connection_pool.py
@@ -255,6 +255,39 @@ def test_coerce_redis_kwargs_types_float_invalid_drops_key():
     assert "myparam" not in result
 
 
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [("false", False), ("true", True), ("0", False), ("1", True)],
+)
+def test_coerce_socket_keepalive_string(raw, expected):
+    """socket_keepalive's signature default is None, so it needs an explicit bool
+    coercion: a leftover "false" string is truthy and enables keepalive."""
+    result = _coerce_redis_kwargs_types({"socket_keepalive": raw})
+
+    assert result["socket_keepalive"] is expected
+
+
+def test_get_redis_client_logic_coerces_cluster_only_kwargs(monkeypatch):
+    """Cluster-only kwargs (absent from redis.Redis's signature) must still be
+    coerced when routing to a cluster, or Helm-stringified values reach
+    RedisCluster as strings."""
+    for envvar in (*_get_redis_env_kwarg_mapping(), "REDIS_CLUSTER_NODES", "REDIS_SENTINEL_NODES"):
+        monkeypatch.delenv(envvar, raising=False)
+
+    result = _get_redis_client_logic(
+        startup_nodes='[{"host": "localhost", "port": 7000}]',
+        cluster_error_retry_attempts="5",
+        require_full_coverage="false",
+        health_check_interval="30",
+    )
+
+    assert result["cluster_error_retry_attempts"] == 5
+    assert isinstance(result["cluster_error_retry_attempts"], int)
+    assert result["require_full_coverage"] is False
+    assert result["health_check_interval"] == 30
+    assert isinstance(result["health_check_interval"], int)
+
+
 def test_get_redis_client_logic_raises_without_host_or_url(monkeypatch):
     """_get_redis_client_logic raises ValueError when neither host nor url is provided."""
     for envvar in (*_get_redis_env_kwarg_mapping(), "REDIS_CLUSTER_NODES", "REDIS_SENTINEL_NODES"):

--- a/tests/test_litellm/caching/test_redis_connection_pool.py
+++ b/tests/test_litellm/caching/test_redis_connection_pool.py
@@ -1,4 +1,3 @@
-import inspect as real_inspect
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -6,6 +5,7 @@ import pytest
 from litellm._redis import (
     _coerce_redis_kwargs_types,
     _get_redis_client_logic,
+    _get_redis_env_kwarg_mapping,
     get_redis_async_client,
     get_redis_connection_pool,
 )
@@ -224,14 +224,17 @@ def test_health_check_interval_from_env_is_int(monkeypatch):
     assert isinstance(interval, int), f"Expected int, got {type(interval)}: {interval!r}"
 
 
+def _signature_without_defaults(testkey):
+    """Stand-in for a client whose parameter declares no default at all."""
+
+
+def _signature_with_float_default(myparam=1.0):
+    """Stand-in for a client whose parameter declares a float default."""
+
+
 def test_coerce_redis_kwargs_types_empty_default_param_unchanged():
     """String params whose signature entry has no default (inspect.Parameter.empty) are left as-is."""
-    empty_param = real_inspect.Parameter("testkey", real_inspect.Parameter.POSITIONAL_OR_KEYWORD)
-    fake_sig = MagicMock()
-    fake_sig.parameters = {"testkey": empty_param}
-
-    with patch("litellm._redis.inspect.signature", return_value=fake_sig):
-        result = _coerce_redis_kwargs_types({"testkey": "some_value"})
+    result = _coerce_redis_kwargs_types({"testkey": "some_value"}, client=_signature_without_defaults)
 
     assert result["testkey"] == "some_value"
     assert isinstance(result["testkey"], str)
@@ -239,12 +242,7 @@ def test_coerce_redis_kwargs_types_empty_default_param_unchanged():
 
 def test_coerce_redis_kwargs_types_float_valid():
     """String values for params whose signature default is a float are coerced to float."""
-    float_param = real_inspect.Parameter("myparam", real_inspect.Parameter.POSITIONAL_OR_KEYWORD, default=1.0)
-    fake_sig = MagicMock()
-    fake_sig.parameters = {"myparam": float_param}
-
-    with patch("litellm._redis.inspect.signature", return_value=fake_sig):
-        result = _coerce_redis_kwargs_types({"myparam": "3.14"})
+    result = _coerce_redis_kwargs_types({"myparam": "3.14"}, client=_signature_with_float_default)
 
     assert result["myparam"] == pytest.approx(3.14)
     assert isinstance(result["myparam"], float)
@@ -252,27 +250,15 @@ def test_coerce_redis_kwargs_types_float_valid():
 
 def test_coerce_redis_kwargs_types_float_invalid_drops_key():
     """An unconvertible string for a float-default param is dropped from the result."""
-    float_param = real_inspect.Parameter("myparam", real_inspect.Parameter.POSITIONAL_OR_KEYWORD, default=1.0)
-    fake_sig = MagicMock()
-    fake_sig.parameters = {"myparam": float_param}
-
-    with patch("litellm._redis.inspect.signature", return_value=fake_sig):
-        result = _coerce_redis_kwargs_types({"myparam": "not_a_float"})
+    result = _coerce_redis_kwargs_types({"myparam": "not_a_float"}, client=_signature_with_float_default)
 
     assert "myparam" not in result
 
 
 def test_get_redis_client_logic_raises_without_host_or_url(monkeypatch):
     """_get_redis_client_logic raises ValueError when neither host nor url is provided."""
-    for envvar in [
-        "REDIS_URL",
-        "REDIS_HOST",
-        "REDIS_PORT",
-        "REDIS_CLUSTER_NODES",
-        "REDIS_SENTINEL_NODES",
-    ]:
+    for envvar in (*_get_redis_env_kwarg_mapping(), "REDIS_CLUSTER_NODES", "REDIS_SENTINEL_NODES"):
         monkeypatch.delenv(envvar, raising=False)
 
-    with patch("litellm._redis._redis_kwargs_from_environment", return_value={}):
-        with pytest.raises(ValueError, match="Either 'host' or 'url' must be specified for redis"):
-            _get_redis_client_logic()
+    with pytest.raises(ValueError, match="Either 'host' or 'url' must be specified for redis"):
+        _get_redis_client_logic()

--- a/tests/test_litellm/caching/test_redis_connection_pool.py
+++ b/tests/test_litellm/caching/test_redis_connection_pool.py
@@ -152,6 +152,53 @@ def test_coerce_redis_kwargs_types_none_default_numeric():
     assert isinstance(result["socket_timeout"], float)
 
 
+def _redis_signature_pre_8x(
+    socket_timeout=None,
+    socket_connect_timeout=None,
+    max_connections=None,
+    health_check_interval=0,
+):
+    """Stand-in for the redis-py <= 7.x Redis signature, where the timeout defaults are None."""
+
+
+def _redis_signature_8x(
+    socket_timeout=5,
+    socket_connect_timeout=5,
+    max_connections=None,
+    health_check_interval=0,
+):
+    """Stand-in for the redis-py 8.x Redis signature, where the timeout defaults became int 5."""
+
+
+@pytest.mark.parametrize(
+    "client",
+    [_redis_signature_pre_8x, _redis_signature_8x],
+    ids=["redis-py<=7.x", "redis-py-8.x"],
+)
+def test_coerce_fractional_socket_timeout_survives_signature_default_change(client):
+    """redis-py 8.x changed socket_timeout's default from None to int 5. Deriving the
+    target type from the signature default made int("5.5") raise, so the key was dropped
+    and REDIS_SOCKET_TIMEOUT=5.5 silently disappeared on 8.x."""
+    result = _coerce_redis_kwargs_types(
+        {"socket_timeout": "5.5", "socket_connect_timeout": "2.5", "max_connections": "20"},
+        client=client,
+    )
+
+    assert result["socket_timeout"] == pytest.approx(5.5)
+    assert isinstance(result["socket_timeout"], float)
+    assert result["socket_connect_timeout"] == pytest.approx(2.5)
+    assert isinstance(result["socket_connect_timeout"], float)
+    assert result["max_connections"] == 20
+    assert isinstance(result["max_connections"], int)
+
+
+def test_coerce_invalid_socket_timeout_is_still_dropped():
+    """Garbage must not survive the explicit-type path; Redis falls back to its own default."""
+    result = _coerce_redis_kwargs_types({"socket_timeout": "not_a_number"}, client=_redis_signature_8x)
+
+    assert "socket_timeout" not in result
+
+
 def test_coerce_redis_kwargs_types_invalid_drops_key():
     """A string that cannot be coerced to the expected numeric type is dropped."""
     result = _coerce_redis_kwargs_types({"health_check_interval": "not_a_number"})

--- a/tests/test_litellm/test_redis.py
+++ b/tests/test_litellm/test_redis.py
@@ -611,18 +611,20 @@ def test_retry_attempts_in_cluster_kwargs():
     assert "cluster_error_retry_attempts" in kwargs
 
 
-def test_async_only_retry_kwargs_in_cluster_kwargs_when_async_client_requested():
-    """connection_error_retry_attempts exists only on the async cluster client's
-    constructor. Introspecting the sync class regardless of which client is
-    actually built silently drops it for every async cluster caller."""
+def test_async_only_kwargs_in_cluster_kwargs_when_async_client_requested():
+    """decode_responses is on the async cluster client's constructor and not the sync
+    one, on every redis-py the matrix covers. Introspecting the sync class regardless
+    of which client is actually built silently drops it for every async cluster caller."""
     sync_kwargs = _get_redis_cluster_kwargs()
     async_kwargs = _get_redis_cluster_kwargs(async_redis.RedisCluster)
 
-    assert "connection_error_retry_attempts" not in sync_kwargs
-    assert "connection_error_retry_attempts" in async_kwargs
+    assert "decode_responses" not in sync_kwargs
+    assert "decode_responses" in async_kwargs
 
 
-@patch("litellm.caching.redis_cluster_node_isolation.get_litellm_async_redis_cluster_class")
+@patch(  # test-quality-ok: redis-py >= 6 keeps no cluster_error_retry_attempts attribute on the built client, so the constructor call is the only place the value is observable
+    "litellm.caching.redis_cluster_node_isolation.get_litellm_async_redis_cluster_class"
+)
 def test_async_cluster_forwards_retry_attempts(mock_get_cluster_class):
     """Regression: cluster_error_retry_attempts must reach the constructed async
     cluster client. Silently dropping it removes an operator's only lever for
@@ -638,19 +640,16 @@ def test_async_cluster_forwards_retry_attempts(mock_get_cluster_class):
     assert call_kwargs["cluster_error_retry_attempts"] == 2
 
 
-@patch("litellm.caching.redis_cluster_node_isolation.get_litellm_async_redis_cluster_class")
-def test_async_cluster_passes_async_only_kwargs(mock_get_cluster_class):
+def test_async_cluster_passes_async_only_kwargs():
     """Regression: decode_responses is an async-cluster-only constructor arg. When
     the allow-list came from the sync class it was filtered out and values came
     back as bytes instead of str."""
-    mock_cluster_cls = mock_get_cluster_class.return_value
-    get_redis_async_client(
+    client = get_redis_async_client(
         startup_nodes=[{"host": "cluster-node", "port": 6379}],
         decode_responses=True,
     )
 
-    call_kwargs = mock_cluster_cls.call_args[1]
-    assert call_kwargs["decode_responses"] is True
+    assert client.connection_kwargs["decode_responses"] is True
 
 
 @pytest.mark.parametrize("cluster_client", [redis.RedisCluster, async_redis.RedisCluster], ids=["sync", "async"])

--- a/tests/test_litellm/test_redis.py
+++ b/tests/test_litellm/test_redis.py
@@ -1,3 +1,4 @@
+import inspect
 import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -598,6 +599,73 @@ def test_reconnect_kwargs_in_cluster_kwargs():
     kwargs = _get_redis_cluster_kwargs()
     assert "health_check_interval" in kwargs
     assert "socket_keepalive" in kwargs
+
+
+def test_retry_attempts_in_cluster_kwargs():
+    """cluster_error_retry_attempts must survive the cluster kwarg allow-list so
+    operators can bound worst-case retry latency on a Redis Cluster: it was being
+    silently dropped because the allow-list was built from redis.RedisCluster's
+    decorated __init__ without unwrapping it, so getfullargspec saw an empty
+    (self, *args, **kwargs) wrapper signature."""
+    kwargs = _get_redis_cluster_kwargs()
+    assert "cluster_error_retry_attempts" in kwargs
+
+
+def test_async_only_retry_kwargs_in_cluster_kwargs_when_async_client_requested():
+    """connection_error_retry_attempts exists only on the async cluster client's
+    constructor. Introspecting the sync class regardless of which client is
+    actually built silently drops it for every async cluster caller."""
+    sync_kwargs = _get_redis_cluster_kwargs()
+    async_kwargs = _get_redis_cluster_kwargs(async_redis.RedisCluster)
+
+    assert "connection_error_retry_attempts" not in sync_kwargs
+    assert "connection_error_retry_attempts" in async_kwargs
+
+
+@patch("litellm.caching.redis_cluster_node_isolation.get_litellm_async_redis_cluster_class")
+def test_async_cluster_forwards_retry_attempts(mock_get_cluster_class):
+    """Regression: cluster_error_retry_attempts must reach the constructed async
+    cluster client. Silently dropping it removes an operator's only lever for
+    bounding a stuck node's worst-case retry latency, and the client falls back
+    to redis-py's own default (3 retries) instead."""
+    mock_cluster_cls = mock_get_cluster_class.return_value
+    get_redis_async_client(
+        startup_nodes=[{"host": "cluster-node", "port": 6379}],
+        cluster_error_retry_attempts=2,
+    )
+
+    call_kwargs = mock_cluster_cls.call_args[1]
+    assert call_kwargs["cluster_error_retry_attempts"] == 2
+
+
+@patch("litellm.caching.redis_cluster_node_isolation.get_litellm_async_redis_cluster_class")
+def test_async_cluster_passes_async_only_kwargs(mock_get_cluster_class):
+    """Regression: decode_responses is an async-cluster-only constructor arg. When
+    the allow-list came from the sync class it was filtered out and values came
+    back as bytes instead of str."""
+    mock_cluster_cls = mock_get_cluster_class.return_value
+    get_redis_async_client(
+        startup_nodes=[{"host": "cluster-node", "port": 6379}],
+        decode_responses=True,
+    )
+
+    call_kwargs = mock_cluster_cls.call_args[1]
+    assert call_kwargs["decode_responses"] is True
+
+
+@pytest.mark.parametrize("cluster_client", [redis.RedisCluster, async_redis.RedisCluster], ids=["sync", "async"])
+def test_cluster_kwargs_exclude_variadic_parameters(cluster_client):
+    """*args / **kwargs are signature placeholders, not connection settings, and
+    must never land in the allow-list regardless of which cluster client is
+    introspected."""
+    variadic = {
+        name
+        for name, param in inspect.signature(cluster_client).parameters.items()
+        if param.kind in (param.VAR_POSITIONAL, param.VAR_KEYWORD)
+    }
+
+    leaked = variadic & set(_get_redis_cluster_kwargs(cluster_client))
+    assert not leaked, f"variadic params leaked into the allow-list: {leaked}"
 
 
 @patch("litellm.caching.redis_cluster_node_isolation.get_litellm_async_redis_cluster_class")

--- a/tests/test_litellm/test_redis.py
+++ b/tests/test_litellm/test_redis.py
@@ -1,3 +1,4 @@
+import inspect
 import json
 from unittest.mock import MagicMock, patch
 
@@ -178,6 +179,50 @@ def test_reconnect_kwargs_in_cluster_kwargs():
     kwargs = _get_redis_cluster_kwargs()
     assert "health_check_interval" in kwargs
     assert "socket_keepalive" in kwargs
+
+
+@pytest.mark.parametrize(
+    "cluster_client", [redis.RedisCluster, async_redis.RedisCluster], ids=["sync", "async"]
+)
+def test_cluster_kwargs_exclude_variadic_parameters(cluster_client):
+    """*args / **kwargs are signature placeholders, not connection settings.
+    getfullargspec never reported them, but inspect.signature does, so they must be
+    filtered out or a bogus 'kwargs' entry lands in the allow-list."""
+    variadic = {
+        name
+        for name, param in inspect.signature(cluster_client).parameters.items()
+        if param.kind in (param.VAR_POSITIONAL, param.VAR_KEYWORD)
+    }
+
+    leaked = variadic & set(_get_redis_cluster_kwargs(cluster_client))
+    assert not leaked, f"variadic params leaked into the allow-list: {leaked}"
+
+
+def test_cluster_kwargs_follow_the_requested_client():
+    """The allow-list must be derived from the client actually being constructed.
+    async RedisCluster accepts connection params the sync class does not, so
+    introspecting the sync class silently drops them on the async path."""
+    async_only = set(inspect.signature(async_redis.RedisCluster).parameters) - set(
+        inspect.signature(redis.RedisCluster).parameters
+    )
+    async_args = _get_redis_cluster_kwargs(async_redis.RedisCluster)
+
+    assert async_only, "expected async RedisCluster to accept params the sync class does not"
+    assert async_only <= set(async_args) | {"retry", "connection_pool", "host", "port", "startup_nodes"}
+
+
+@patch("litellm._redis.async_redis.RedisCluster", autospec=True)
+def test_async_cluster_passes_async_only_kwargs(mock_cluster_cls):
+    """Regression: decode_responses is an async-cluster-only constructor arg. When
+    the allow-list came from the sync class it was filtered out and values came back
+    as bytes instead of str."""
+    get_redis_async_client(
+        startup_nodes=[{"host": "cluster-node", "port": 6379}],
+        decode_responses=True,
+    )
+
+    call_kwargs = mock_cluster_cls.call_args[1]
+    assert call_kwargs["decode_responses"] is True
 
 
 @patch("litellm._redis.async_redis.RedisCluster")

--- a/tests/test_litellm/test_redis.py
+++ b/tests/test_litellm/test_redis.py
@@ -181,9 +181,7 @@ def test_reconnect_kwargs_in_cluster_kwargs():
     assert "socket_keepalive" in kwargs
 
 
-@pytest.mark.parametrize(
-    "cluster_client", [redis.RedisCluster, async_redis.RedisCluster], ids=["sync", "async"]
-)
+@pytest.mark.parametrize("cluster_client", [redis.RedisCluster, async_redis.RedisCluster], ids=["sync", "async"])
 def test_cluster_kwargs_exclude_variadic_parameters(cluster_client):
     """*args / **kwargs are signature placeholders, not connection settings.
     getfullargspec never reported them, but inspect.signature does, so they must be


### PR DESCRIPTION
## Rebase note (2026-08-31)

Rebased onto current `litellm_internal_staging`, which had independently added `_init_arg_names` (MRO-walking, `inspect.unwrap`-based) for the same class of bug in `_get_redis_url_kwargs`, plus `credential_provider` support throughout this file. Reused that pattern instead of this PR's own `_named_parameters` helper, as `_unwrapped_init_args` (single-class, no MRO walk: `redis.Redis`/`RedisCluster` declare every real parameter directly on their own `__init__`, and MRO-walking broke several tests here that mock the class with `autospec=True`, since `inspect.getmro` needs a real `__mro__`). `credential_provider` handling is preserved throughout. The "Files changed" section below describes the original `_named_parameters`-based implementation; the actual current diff uses `_unwrapped_init_args` for the reasons above, but fixes the same five bugs the same way otherwise. This also fixes the merge conflicts that had left the PR unmergeable since the last push. Confirmed green: both test files, `ruff check`/`format`, and this repo's `type_discipline_gate.py`/`ruff_strict_gate.py` (LIT-rule and ruff-strict budgets) against current staging.

## Relevant issues

Fixes #30534

## Linear ticket
N/A

<!-- if you are an internal contributor, add the Linear ticket e.g. "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix
### Before Fix - `health_check_interval` passed as string, TypeError on every Redis operation:
```
12:23:52 - LiteLLM:DEBUG: logging_callback_manager.py:349 - Custom logger of type SkillsInjectionHook, key: SkillsInjectionHook-max_iterations=10-sandbox_timeout=120-message_logging=True-turn_off_message_logging=False already exists in [<litellm.proxy.hooks.litellm_skills.main.SkillsInjectionHook object at 0x000001E654F21A10>, <litellm.proxy.hooks.model_max_budget_limiter._PROXY_VirtualKeyModelMaxBudgetLimiter object at 0x000001E658A8C450>, <litellm.proxy.hooks.max_budget_limiter._PROXY_MaxBudgetLimiter object at 0x000001E65B48AF90>, <litellm.proxy.hooks.parallel_request_limiter_v3._PROXY_MaxParallelRequestsHandler_v3 object at 0x000001E6573FA8D0>, <litellm.proxy.hooks.cache_control_check._PROXY_CacheControlCheck object at 0x000001E65BD35F50>, <litellm.proxy.hooks.responses_id_security.ResponsesIDSecurity object at 0x000001E65BD4A4D0>], not adding again..
12:23:52 - LiteLLM Proxy:DEBUG: proxy_server.py:895 - About to initialize semantic tool filter
12:23:52 - LiteLLM Proxy:DEBUG: proxy_server.py:898 - litellm_settings keys = ['cache', 'cache_params']
12:23:52 - LiteLLM Proxy:DEBUG: proxy_server.py:7252 - Semantic tool filter not configured or not enabled, skipping initialization
12:23:52 - LiteLLM Proxy:DEBUG: proxy_server.py:905 - After semantic tool filter initialization
12:23:52 - LiteLLM Proxy:DEBUG: proxy_server.py:919 - prisma_client: None
12:23:52 - LiteLLM Proxy:DEBUG: proxy_server.py:8114 - LiteLLM: Pyroscope profiling is disabled (set LITELLM_ENABLE_PYROSCOPE=true to enable).
12:23:52 - LiteLLM Proxy:INFO: proxy_server.py:724 - SESSION REUSE: Created shared aiohttp session for connection pooling (ID: 2088890950032, limit=1000, limit_per_host=500)
12:23:52 - LiteLLM Proxy:DEBUG: hanging_request_check.py:148 - Checking for hanging requests....
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:4099 (Press CTRL+C to quit)
12:23:52 - LiteLLM:ERROR: redis_cache.py:1198 - LiteLLM Redis Cache PING: - Got exception from REDIS : unsupported operand type(s) for +: 'float' and 'str'
Task exception was never retrieved
future: <Task finished name='Task-6' coro=<RedisCache.ping() done, defined at C:\Users\USER\Documents\GitHub\OpenSourceContributions\litellm\litellm\caching\redis_cache.py:1167> exception=TypeError("unsupported operand type(s) for +: 'float' and 'str'")>
Traceback (most recent call last):
  File "C:\Users\USER\Documents\GitHub\OpenSourceContributions\litellm\litellm\caching\redis_cache.py", line 1201, in ping
    raise e
  File "C:\Users\USER\Documents\GitHub\OpenSourceContributions\litellm\litellm\caching\redis_cache.py", line 1173, in ping
    response = await _redis_client.ping()
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\USER\AppData\Local\Programs\Python\Python311\Lib\site-packages\redis\asyncio\client.py", line 672, in execute_command
    conn = self.connection or await pool.get_connection()
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\USER\AppData\Local\Programs\Python\Python311\Lib\site-packages\redis\asyncio\connection.py", line 1329, in get_connection
    await self.ensure_connection(connection)
  File "C:\Users\USER\AppData\Local\Programs\Python\Python311\Lib\site-packages\redis\asyncio\connection.py", line 1182, in ensure_connection
    await connection.connect()
  File "C:\Users\USER\AppData\Local\Programs\Python\Python311\Lib\site-packages\redis\asyncio\connection.py", line 296, in connect
    await self.connect_check_health(check_health=True)
  File "C:\Users\USER\AppData\Local\Programs\Python\Python311\Lib\site-packages\redis\asyncio\connection.py", line 322, in connect_check_health
    await self.on_connect_check_health(check_health=check_health)
  File "C:\Users\USER\AppData\Local\Programs\Python\Python311\Lib\site-packages\redis\asyncio\connection.py", line 441, in on_connect_check_health
    await self.send_command(
  File "C:\Users\USER\AppData\Local\Programs\Python\Python311\Lib\site-packages\redis\asyncio\connection.py", line 559, in send_command
    await self.send_packed_command(
  File "C:\Users\USER\AppData\Local\Programs\Python\Python311\Lib\site-packages\redis\asyncio\connection.py", line 522, in send_packed_command
    await self.check_health()
  File "C:\Users\USER\AppData\Local\Programs\Python\Python311\Lib\site-packages\redis\asyncio\connection.py", line 510, in check_health
    await self.retry.call_with_retry(self._send_ping, self._ping_failed)
  File "C:\Users\USER\AppData\Local\Programs\Python\Python311\Lib\site-packages\redis\asyncio\retry.py", line 50, in call_with_retry
    return await do()
           ^^^^^^^^^^
  File "C:\Users\USER\AppData\Local\Programs\Python\Python311\Lib\site-packages\redis\asyncio\connection.py", line 497, in _send_ping
    if str_if_bytes(await self.read_response()) != "PONG":
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\USER\AppData\Local\Programs\Python\Python311\Lib\site-packages\redis\asyncio\connection.py", line 623, in read_response
    next_time = asyncio.get_running_loop().time() + self.health_check_interval
                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
TypeError: unsupported operand type(s) for +: 'float' and 'str'
12:23:52 - LiteLLM:ERROR: redis_cache.py:632 - LiteLLM Redis Caching: async set() - Got exception from REDIS unsupported operand type(s) for +: 'float' and 'str', Writing value=1781695432.4702735
INFO:     127.0.0.1:54201 - "GET /health/liveliness HTTP/1.1" 200 OK
```

After fix - `health_check_interval` correctly coerced to `int`, no TypeError errors:
```
🔧 Redis Connection Parameters       
┌───────────────────────┬───────────┐
│ Parameter             │ Value     │
├───────────────────────┼───────────┤
│ host                  │ 127.0.0.1 │
│ port                  │ 6379      │
│ socket_timeout        │ 5.0       │
│ health_check_interval │ 30        │
└───────────────────────┴───────────┘


12:31:46 - LiteLLM:DEBUG: logging_callback_manager.py:349 - Custom logger of type SkillsInjectionHook, key: SkillsInjectionHook-max_iterations=10-sandbox_timeout=120-message_logging=True-turn_off_message_logging=False already exists in [<litellm.proxy.hooks.litellm_skills.main.SkillsInjectionHook object at 0x000001DB91571890>, <litellm.proxy.hooks.model_max_budget_limiter._PROXY_VirtualKeyModelMaxBudgetLimiter object at 0x000001DB950CC890>, <litellm.proxy.hooks.max_budget_limiter._PROXY_MaxBudgetLimiter object at 0x000001DB9570E290>, <litellm.proxy.hooks.parallel_request_limiter_v3._PROXY_MaxParallelRequestsHandler_v3 object at 0x000001DB977E8610>, <litellm.proxy.hooks.cache_control_check._PROXY_CacheControlCheck object at 0x000001DB98385E90>, <litellm.proxy.hooks.responses_id_security.ResponsesIDSecurity object at 0x000001DB978D7E50>], not adding again..
12:31:46 - LiteLLM Proxy:DEBUG: proxy_server.py:895 - About to initialize semantic tool filter
12:31:46 - LiteLLM Proxy:DEBUG: proxy_server.py:898 - litellm_settings keys = ['cache', 'cache_params']
12:31:46 - LiteLLM Proxy:DEBUG: proxy_server.py:7252 - Semantic tool filter not configured or not enabled, skipping initialization
12:31:46 - LiteLLM Proxy:DEBUG: proxy_server.py:905 - After semantic tool filter initialization
12:31:46 - LiteLLM Proxy:DEBUG: proxy_server.py:919 - prisma_client: None
12:31:46 - LiteLLM Proxy:DEBUG: proxy_server.py:8114 - LiteLLM: Pyroscope profiling is disabled (set LITELLM_ENABLE_PYROSCOPE=true to enable).
12:31:46 - LiteLLM Proxy:INFO: proxy_server.py:724 - SESSION REUSE: Created shared aiohttp session for connection pooling (ID: 2042645701008, limit=1000, limit_per_host=500)
12:31:46 - LiteLLM Proxy:DEBUG: hanging_request_check.py:148 - Checking for hanging requests....
INFO:     Application startup complete.
ERROR:    [Errno 10048] error while attempting to bind on address ('0.0.0.0', 4099): only one usage of each socket address (protocol/network address/port) is normally permitted
INFO:     Waiting for application shutdown.
12:31:46 - LiteLLM Proxy:INFO: graceful_shutdown_manager.py:81 - graceful_shutdown_started in_flight_requests=0
12:31:46 - LiteLLM Proxy:INFO: graceful_shutdown_manager.py:140 - graceful_shutdown_complete drained_requests=0 elapsed_s=0.00
12:31:46 - LiteLLM Proxy:INFO: proxy_server.py:986 - SESSION REUSE: Closed shared aiohttp session
12:31:46 - LiteLLM Proxy:INFO: proxy_server.py:669 - Shutting down LiteLLM Proxy Server
```


<!-- Include screenshots, screen recordings, or log output demonstrating that your changes work as expected.
     For bug fixes: show reproduction before the fix and passing behavior after.
     For new features: show the feature working end-to-end.
     For UI changes: include before/after screenshots. -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes
Redis caching failed entirely on every LLM call when `health_check_interval` was set via env var or Helm `--set`, first surfacing in v1.89.0. Two compounding bugs in `litellm/_redis.py` caused it, and consolidating with #34647 surfaced three more in the same allow-list logic.

### Bug 1: broken parameter discovery in redis-py 6.x
`_get_redis_kwargs()` used `inspect.getfullargspec(redis.Redis)` to discover which `REDIS_*` env vars to accept. In redis-py 6.x, `Redis.__init__` is wrapped by `@deprecated_args` which replaces the explicit signature with `*args/**kwargs` internally. `getfullargspec` returns an empty arg list, so only the 8 hardcoded `include_args` entries (Azure/GCP auth, url) were ever read from the environment. Standard params like `REDIS_HEALTH_CHECK_INTERVAL`, `REDIS_MAX_CONNECTIONS`, `REDIS_SSL`, `REDIS_PORT` etc. were silently ignored.

Fixed by switching to `inspect.signature`, which follows `__wrapped__` through decorator wrappers and resolves the original function's real parameter names and defaults.

### Bug 2: no type coercion for string values
Environment variables are always strings. Helm `--set` also stringifies values (`--set cache_params.health_check_interval=30` puts `"30"` in the config, not `30`). Neither path applied type coercion before passing values to the Redis client.

In redis-py 6.x, `Connection.read_response` now computes:

```python
next_time = asyncio.get_running_loop().time() + self.health_check_interval
```

`loop.time()` returns a float. If `health_check_interval` is the string `"30"`, this raises `TypeError` on every Redis operation, tripping the circuit breaker and disabling all caching. This arithmetic didn't exist in earlier redis-py versions, which is why it only surfaced in v1.89.0.

Fixed by adding `_coerce_redis_kwargs_types()`, which runs at the end of `_get_redis_client_logic()` and coerces string values to the type Redis expects. Invalid strings are dropped so Redis uses its built-in defaults rather than crashing.

### Bug 3: variadic parameters leaking into the cluster allow-list
`inspect.signature(redis.RedisCluster).parameters` includes a `kwargs` entry of kind `VAR_KEYWORD`, which `getfullargspec` reported separately and never included. Moving to `inspect.signature` therefore let `kwargs` land in the cluster allow-list as though it were a real connection parameter. `redis.Redis` has no variadic parameters, so `_get_redis_kwargs` and `_get_redis_url_kwargs` were unaffected.

Fixed by filtering `VAR_POSITIONAL` and `VAR_KEYWORD` out in a shared `_named_parameters` helper that all three discovery functions now use.

### Bug 4: async cluster arguments derived from the sync client
`_get_redis_cluster_kwargs` took a `client` argument and then ignored it, always introspecting the sync `redis.RedisCluster`. The async cluster path in `get_redis_async_client` is reachable, because `get_redis_connection_pool` returns `None` for cluster configs and so no pool short-circuit applies. Async-only constructor arguments were therefore filtered out before the client was built; on redis-py 5.3.1 that is 18 parameters, `decode_responses` among them, which is why values came back as `b'hello'` rather than `'hello'`.

Fixed by having the helper honor the client it is handed, with `get_redis_async_client` passing `async_redis.RedisCluster`.

### Bug 5: fractional socket timeouts dropped on redis-py 8.x
`_coerce_redis_kwargs_types` inferred the target type from each parameter's signature default. redis-py 8.x changed `socket_timeout` and `socket_connect_timeout` from `None` to int `5`, so a fractional value took the int branch, `int("5.5")` raised, and the except clause deleted the key. `REDIS_SOCKET_TIMEOUT=5.5` silently disappeared on 8.x and Redis fell back to its own default.

Fixed by consulting the declared numeric types before the isinstance chain, since that map already states the intended type regardless of what upstream defaults to. `_coerce_redis_kwargs_types` also takes the client to introspect now, so the version-specific signature shapes are covered by injection rather than by patching `inspect.signature` globally.

Bugs 3, 4 and 5 were found by @mangabits while reviewing this against #34647. Bug 5 in particular only reproduces on redis-py 8.x, which is the argument for the version matrix that PR adds.

Rebased onto `litellm_internal_staging` and retargeted there from `litellm_oss_staging`. The coercion also matters for a change that already lives on internal_staging: `get_redis_connection_pool` now selects the connection class with `if redis_kwargs.pop("ssl", None):`, and an env-supplied `REDIS_SSL=false` arrives as the string `"false"`, which is truthy. Coercing it to a real bool is what keeps `test_connection_pool_env_redis_ssl_false_uses_plain_connection` honest for values that come from the environment.

### Files changed
`litellm/_redis.py` gains `_named_parameters` as the single source of parameter discovery for `_get_redis_kwargs`, `_get_redis_url_kwargs` and `_get_redis_cluster_kwargs`, with variadic entries filtered out. `_get_redis_url_kwargs` derives its allow-list from `redis.Redis` rather than `redis.Redis.from_url`, whose `(url, **kwargs)` signature would otherwise collapse the list to `["url"]`. `_get_redis_cluster_kwargs` takes the cluster client to introspect, defaulting to the sync class. `_coerce_redis_kwargs_types` is new, takes the client to introspect, and checks declared numeric types ahead of signature defaults. `get_redis_connection_pool` drops its now-redundant ad-hoc `max_connections` coercion, and `get_redis_async_client` passes the async cluster class through.

`tests/test_litellm/caching/test_redis_connection_pool.py` covers `_coerce_redis_kwargs_types` for int, bool, declared-numeric, invalid-drop and non-string passthrough, adds `test_health_check_interval_from_env_is_int` as a direct regression test for the reported bug, and parametrizes the fractional-timeout case over stub signatures mirroring the pre-8.x and 8.x defaults so it holds whichever redis-py is installed. `test_max_connections_url_config_invalid_value` was mocking internal logic that no longer exists and now exercises the real codepath.

`tests/test_litellm/test_redis.py` asserts that no variadic parameter reaches either cluster allow-list, that the allow-list follows the client it is given, and that an async-only argument such as `decode_responses` survives to the async `RedisCluster` constructor.

`.github/workflows/test-redis-compat.yml` is new, contributed by @mangabits, and runs both redis test files against redis-py 5.3.1, 6.4.0, 7.4.1 and 8.0.1. Bug 5 only reproduces on 8.x, so a single-version run reports green while the setting is silently dropped; the matrix is what stops that recurring. It asserts the installed `redis.__version__` after pinning, since a resolver quietly ignoring the pin would make every leg pass without testing anything. 6.0.0 is skipped because a transitive dependency excludes that exact release, so 6.4.0 stands in for the 6.x line.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared Redis client bootstrap used by proxy caching and connection pools; behavior changes affect all deployments using `REDIS_*` env or Helm string config, though invalid values are dropped rather than passed through.
> 
> **Overview**
> Fixes Redis proxy/cache failures when settings come from env vars or Helm as strings, and restores kwargs that redis-py’s decorated constructors were hiding from introspection.
> 
> **`litellm/_redis.py`** adds `_unwrapped_init_args` (unwrap `@deprecated_args` on `Redis` / `RedisCluster` `__init__`) so allow-lists for `REDIS_*` env mapping and cluster config include real parameters again (e.g. `health_check_interval`, `cluster_error_retry_attempts`). `_get_redis_cluster_kwargs` now introspects the client type actually built—`get_redis_async_client` passes `async_redis.RedisCluster` so async-only options like `decode_responses` are not dropped. **`_coerce_redis_kwargs_types`** runs at the end of `_get_redis_client_logic` to turn string config into bool/int/float (with explicit types for `max_connections` and socket timeouts so redis-py 8.x defaults do not break fractional timeouts); invalid values are removed instead of crashing redis-py health-check math.
> 
> **CI:** new `.github/workflows/test-redis-compat.yml` runs the two Redis unit test modules against redis-py **5.3.1, 6.4.0, 7.4.1, and 8.0.1**.
> 
> **Tests** add coercion and env regression coverage plus async cluster forwarding assertions; invalid `REDIS_MAX_CONNECTIONS` is exercised via real env instead of mocking internal logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a51d46db608440bb3dc19335a4017731c7056e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->