### PR TITLE
fix(perplexity): bill search queries at the per-request price, not 1/1000 of it

### DIFF
--- a/litellm/llms/perplexity/cost_calculator.py
+++ b/litellm/llms/perplexity/cost_calculator.py
@@ -98,10 +98,11 @@ def cost_per_token(model: str, usage: Usage) -> Tuple[float, float]:
     if num_search_queries > 0 and search_cost_value is not None:
         # Handle both dict and float formats
         if isinstance(search_cost_value, dict):
-            # Use the "low" size as default - tests expect 0.005 / 1000
-            search_cost_per_query = (
-                _safe_float_cast(search_cost_value.get("search_context_size_low", 0))
-                / 1000
+            # search_context_cost_per_query stores the per-request price in USD
+            # (e.g. sonar low = $0.005/request). Use it directly, matching the
+            # gemini cost calculator which reads the same field per request.
+            search_cost_per_query = _safe_float_cast(
+                search_cost_value.get("search_context_size_low", 0)
             )
         else:
             search_cost_per_query = _safe_float_cast(search_cost_value)

--- a/tests/test_litellm/llms/perplexity/test_perplexity_cost_calculator.py
+++ b/tests/test_litellm/llms/perplexity/test_perplexity_cost_calculator.py
@@ -9,7 +9,7 @@ import json
 import math
 import os
 import sys
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -120,10 +120,10 @@ class TestPerplexityCostCalculator:
         # Expected costs:
         # Input: 100 tokens * $2e-6 = $0.0002
         # Output: 50 tokens * $8e-6 = $0.0004
-        # Search: 3 queries * ($0.005 / 1000) = $0.000015
-        # Total completion cost: $0.000415
+        # Search: 3 queries * $0.005 per request = $0.015
+        # Total completion cost: $0.0154
         expected_prompt_cost = 100 * 2e-6
-        expected_completion_cost = (50 * 8e-6) + (3 / 1000 * 0.005)
+        expected_completion_cost = (50 * 8e-6) + (3 * 0.005)
 
         assert math.isclose(prompt_cost, expected_prompt_cost, rel_tol=1e-6)
         assert math.isclose(completion_cost, expected_completion_cost, rel_tol=1e-6)
@@ -195,10 +195,10 @@ class TestPerplexityCostCalculator:
         # Total prompt cost                        = $0.00026
         # Output (text): (50 - 15) tokens  * $8e-6 = $0.00028
         # Reasoning:      15 tokens        * $3e-6 = $0.000045
-        # Search:          2 queries * ($0.005 / 1000) = $0.00001
-        # Total completion cost                    = $0.000335
+        # Search:          2 queries * $0.005 per request = $0.01
+        # Total completion cost                    = $0.010325
         expected_prompt_cost = (100 * 2e-6) + (30 * 2e-6)
-        expected_completion_cost = ((50 - 15) * 8e-6) + (15 * 3e-6) + (2 / 1000 * 0.005)
+        expected_completion_cost = ((50 - 15) * 8e-6) + (15 * 3e-6) + (2 * 0.005)
 
         assert math.isclose(prompt_cost, expected_prompt_cost, rel_tol=1e-6)
         assert math.isclose(completion_cost, expected_completion_cost, rel_tol=1e-6)
@@ -311,7 +311,7 @@ class TestPerplexityCostCalculator:
         # Calculate expected total cost (reasoning is a subset of completion_tokens)
         expected_prompt_cost = (100 * 2e-6) + (15 * 2e-6)  # Input + citation
         expected_completion_cost = (
-            ((50 - 10) * 8e-6) + (10 * 3e-6) + (1 / 1000 * 0.005)
+            ((50 - 10) * 8e-6) + (10 * 3e-6) + (1 * 0.005)
         )  # Output (text) + reasoning + search
         expected_total = expected_prompt_cost + expected_completion_cost
 
@@ -361,7 +361,7 @@ class TestPerplexityCostCalculator:
         expected_completion_cost = (
             ((50 - reasoning_tokens) * 8e-6)
             + (reasoning_tokens * 3e-6)
-            + (search_queries / 1000 * 0.005)
+            + (search_queries * 0.005)
         )
 
         assert math.isclose(prompt_cost, expected_prompt_cost, rel_tol=1e-6)

--- a/tests/test_litellm/llms/perplexity/test_perplexity_integration.py
+++ b/tests/test_litellm/llms/perplexity/test_perplexity_integration.py
@@ -9,7 +9,6 @@ import json
 import math
 import os
 import sys
-from unittest.mock import Mock, patch
 
 import pytest
 

--- a/tests/test_litellm/llms/perplexity/test_perplexity_integration.py
+++ b/tests/test_litellm/llms/perplexity/test_perplexity_integration.py
@@ -106,8 +106,8 @@ class TestPerplexityIntegration:
 
         expected_prompt_cost = (100 * 2e-6) + (citation_tokens * 2e-6)
         expected_completion_cost = (
-            ((50 - 10) * 8e-6) + (10 * 3e-6) + (2 / 1000 * 0.005)
-        )
+            ((50 - 10) * 8e-6) + (10 * 3e-6) + (2 * 0.005)
+        )  # Output (text) + reasoning + search
         expected_total = expected_prompt_cost + expected_completion_cost
 
         assert math.isclose(total_cost, expected_total, rel_tol=1e-6)
@@ -152,8 +152,8 @@ class TestPerplexityIntegration:
 
         expected_prompt_cost = (200 * 2e-6) + (40 * 2e-6)
         expected_completion_cost = (
-            ((100 - 25) * 8e-6) + (25 * 3e-6) + (3 / 1000 * 0.005)
-        )
+            ((100 - 25) * 8e-6) + (25 * 3e-6) + (3 * 0.005)
+        )  # Output (text) + reasoning + search
 
         assert math.isclose(prompt_cost, expected_prompt_cost, rel_tol=1e-6)
         assert math.isclose(completion_cost_val, expected_completion_cost, rel_tol=1e-6)
@@ -262,9 +262,9 @@ class TestPerplexityIntegration:
 
         expected_prompt_cost = (50000 * 2e-6) + (5000 * 2e-6)
         expected_completion_cost = (
-            ((25000 - 10000) * 8e-6) + (10000 * 3e-6) + (100 / 1000 * 0.005)
-        )
-        expected_total = expected_prompt_cost + expected_completion_cost
+            ((25000 - 10000) * 8e-6) + (10000 * 3e-6) + (100 * 0.005)
+        )  # $0.65
+        expected_total = expected_prompt_cost + expected_completion_cost  # $0.76
 
         assert math.isclose(total_cost, expected_total, rel_tol=1e-6)
         assert total_cost > 0.25
@@ -326,7 +326,7 @@ class TestPerplexityIntegration:
 
         # Should calculate costs correctly
         expected_prompt_cost = (100 * 2e-6) + (10 * 2e-6)
-        expected_completion_cost = (50 * 8e-6) + (1 / 1000 * 0.005)
+        expected_completion_cost = (50 * 8e-6) + (1 * 0.005)
 
         assert math.isclose(prompt_cost, expected_prompt_cost, rel_tol=1e-6)
         assert math.isclose(completion_cost_val, expected_completion_cost, rel_tol=1e-6)


### PR DESCRIPTION
## What

The Perplexity fallback cost calculator (`litellm/llms/perplexity/cost_calculator.py`) divides `search_context_cost_per_query` by 1000 before billing search queries. That field stores the **per-request price in USD**, so the division understates search cost by **1000x**.

## Why it's wrong

The shipped pricing map stores per-request dollars, e.g. sonar:

```json
"search_context_cost_per_query": {
    "search_context_size_low": 0.005,
    "search_context_size_medium": 0.008,
    "search_context_size_high": 0.012
}
```

These match Perplexity's published pricing of $5 / $8 / $12 per 1,000 requests, expressed per request. The gemini cost calculator (`litellm/llms/gemini/cost_calculator.py`) reads the **same** field and bills it per request with no division - its docstring calls it "the per-request cost". Perplexity is the only adapter that divides.

The buggy `/1000` only affects the manual fallback path (when the API does not return a pre-computed `usage.cost`).

Reproduction against the real function and the shipped pricing map:

```python
import os; os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
from litellm.types.utils import Usage, PromptTokensDetailsWrapper
from litellm.llms.perplexity.cost_calculator import cost_per_token

usage = Usage(prompt_tokens=100, completion_tokens=50, total_tokens=150,
              prompt_tokens_details=PromptTokensDetailsWrapper(web_search_requests=10))
_, completion_cost = cost_per_token(model="sonar", usage=usage)
# search component (completion_cost minus 50 * output_cost_per_token):
#   before: $0.00005   (10 queries)
#   after:  $0.05      (10 * $0.005)
```

## Fix

Use the per-request value directly, matching the gemini calculator.

## Tests

The existing search-cost tests had encoded the `/1000` factor in their expected values (one even carried the comment `tests expect 0.005 / 1000`). Updated those expectations to the correct per-request amounts. All 61 tests in `tests/test_litellm/llms/perplexity/test_perplexity_cost_calculator.py` pass, and the file is `ruff` clean (also dropped one unused import that `ruff` flagged in the touched test file).