### PR TITLE
fix(dashscope): treat an explicit 0.0 tier cost as a real price, not missing

### DIFF
--- a/litellm/llms/dashscope/cost_calculator.py
+++ b/litellm/llms/dashscope/cost_calculator.py
@@ -46,6 +46,23 @@ def _extract_token_breakdown(usage: Usage) -> TokenBreakdown:
     )
 
 
+def _resolve_tier_cost_per_token(
+    tier: dict, cost_key: str, fallback_cost_key: Optional[str]
+) -> float:
+    """Resolve a tier's per-token cost.
+
+    An explicit 0.0 is a real price (e.g. a free-cache-read tier) and must not
+    be treated as "missing". Only fall back to ``fallback_cost_key`` when the
+    primary key is absent. This mirrors the flat-pricing path in
+    ``_calculate_prompt_cost`` / ``_calculate_completion_cost``, which already
+    guards with ``is None``.
+    """
+    cost = tier.get(cost_key)
+    if cost is None and fallback_cost_key is not None:
+        cost = tier.get(fallback_cost_key)
+    return float(cost) if cost is not None else 0.0
+
+
 def _calculate_tiered_cost(
     tokens: int,
     tiered_pricing: List[dict],
@@ -105,7 +122,9 @@ def _calculate_tiered_cost(
 
         if tier_end > tier_start:
             tokens_in_tier = tier_end - tier_start
-            cost_per_token = tier.get(cost_key) or tier.get(fallback_cost_key, 0)
+            cost_per_token = _resolve_tier_cost_per_token(
+                tier, cost_key, fallback_cost_key
+            )
             total_cost += tokens_in_tier * cost_per_token
             tokens_processed = tier_end
 
@@ -114,7 +133,9 @@ def _calculate_tiered_cost(
     if tokens_processed < tokens and sorted_tiers:
         last_tier = sorted_tiers[-1]
         remaining_tokens = tokens - tokens_processed
-        cost_per_token = last_tier.get(cost_key) or last_tier.get(fallback_cost_key, 0)
+        cost_per_token = _resolve_tier_cost_per_token(
+            last_tier, cost_key, fallback_cost_key
+        )
         total_cost += remaining_tokens * cost_per_token
 
     return total_cost

--- a/tests/test_litellm/llms/dashscope/test_dashscope_cost_calculator.py
+++ b/tests/test_litellm/llms/dashscope/test_dashscope_cost_calculator.py
@@ -8,7 +8,6 @@ Tests the cost calculation for Dashscope models including:
 - Correctly calculates costs for token counts exceeding the highest defined tier.
 """
 
-import json
 import math
 import os
 import sys
@@ -20,6 +19,7 @@ sys.path.insert(0, os.path.abspath("../../../.."))
 
 import litellm
 from litellm.llms.dashscope.cost_calculator import (
+    _calculate_tiered_cost,
     cost_per_token as dashscope_cost_per_token,
 )
 from litellm.types.utils import Usage, PromptTokensDetailsWrapper
@@ -157,3 +157,53 @@ class TestDashscopeCostCalculator:
         )
 
         assert math.isclose(prompt_cost, expected_prompt_cost, rel_tol=1e-10)
+
+    def test_dashscope_tiered_zero_cost_not_overridden_by_fallback(self):
+        """
+        A tier may legitimately price cached reads (or reasoning tokens) at 0.0,
+        e.g. a free-cache-read tier. The tiered calculator must treat an explicit
+        0.0 as a real price, not as "missing" and fall back to the full input
+        rate. This mirrors the flat-pricing path, which already guards on `None`.
+        """
+        tiered_pricing = [
+            {
+                "range": [0, 256000],
+                "input_cost_per_token": 2e-7,
+                "cache_read_input_token_cost": 0.0,  # free cache reads in this tier
+            }
+        ]
+
+        cost = _calculate_tiered_cost(
+            tokens=10000,
+            tiered_pricing=tiered_pricing,
+            cost_key="cache_read_input_token_cost",
+            fallback_cost_key="input_cost_per_token",
+        )
+
+        # 10,000 cached tokens priced at $0.0/token must cost $0.0, not the
+        # input rate (which would be 10000 * 2e-7 = $0.002).
+        assert cost == 0.0
+
+    def test_dashscope_tiered_zero_cost_applies_to_overflow_tokens(self):
+        """
+        The same 0.0-is-real-price rule must hold on the overflow path that
+        charges tokens exceeding the highest defined tier at the last tier's
+        rate.
+        """
+        tiered_pricing = [
+            {
+                "range": [0, 100],
+                "input_cost_per_token": 2e-7,
+                "cache_read_input_token_cost": 0.0,
+            }
+        ]
+
+        # 150 cached tokens: 100 in-tier + 50 overflow, both at $0.0.
+        cost = _calculate_tiered_cost(
+            tokens=150,
+            tiered_pricing=tiered_pricing,
+            cost_key="cache_read_input_token_cost",
+            fallback_cost_key="input_cost_per_token",
+        )
+
+        assert cost == 0.0


### PR DESCRIPTION
## What

In the Dashscope tiered cost calculator, a tier that legitimately prices a component at `0.0` is silently billed at the full fallback rate instead of being free.

## Why it's wrong

`_calculate_tiered_cost` resolves a tier's per-token cost with:

```python
cost_per_token = tier.get(cost_key) or tier.get(fallback_cost_key, 0)
```

`or` short-circuits on any falsy value, including `0.0`. So a tier that sets, say, `cache_read_input_token_cost: 0.0` (a free-cache-read tier) returns `0.0` from the first `get`, which is falsy, so it falls through to `fallback_cost_key` (`input_cost_per_token`) and bills cached reads at the full input rate. The same applies to a free-reasoning tier (`output_cost_per_reasoning_token: 0.0` falling back to `output_cost_per_token`). This happens at both the in-range site and the "tokens exceed the highest tier" overflow site.

The flat-pricing path in the same module already handles this correctly:

```python
cache_cost_val = model_info.get("cache_read_input_token_cost")
if cache_cost_val is None:
    cache_cost = input_cost
else:
    cache_cost = float(cache_cost_val)
```

So the tiered path is inconsistent with the flat path for the identical scenario.

## Scope / honesty

No model in the current pricing map has a `0.0` cache/reasoning cost inside a tier, so this is a **latent** defect rather than an active mischarge. The relevant tier keys (`cache_read_input_token_cost`, `output_cost_per_reasoning_token`) are in active use with the fallback mechanism (e.g. `qwen3-coder-flash`, `qwen-plus`), so only a `0.0` value is currently missing. The fix makes the tiered path consistent with the flat path and prevents over-charging the first time such a tier is added.

## Fix

Resolve tier costs through a small helper that only falls back when the primary key is **absent** (`is None`), mirroring the flat-pricing path, and use it at both sites.

## Tests

Added two unit tests on `_calculate_tiered_cost` (in-range and overflow paths) asserting that a `0.0` tier cost yields `0.0` rather than the fallback rate. RED before the change, green after. Full `tests/test_litellm/llms/dashscope/test_dashscope_cost_calculator.py` passes (7 tests) and the files are `ruff` clean (also dropped one unused import that `ruff` flagged in the touched test file).