### PR TITLE
feat(posthog): surface Anthropic prompt-cache token counts in StandardLoggingPayload and $ai_generation events

### DIFF
--- a/litellm/integrations/posthog.py
+++ b/litellm/integrations/posthog.py
@@ -229,6 +229,12 @@ class PostHogLogger(CustomBatchLogger):
             properties["$ai_output_tokens"] = self._safe_get(
                 standard_logging_object, "completion_tokens", 0
             )
+        cache_read = self._safe_get(standard_logging_object, "cache_read_input_tokens", 0) or 0
+        cache_creation = self._safe_get(standard_logging_object, "cache_creation_input_tokens", 0) or 0
+        if cache_read:
+            properties["$ai_cache_read_input_tokens"] = cache_read
+        if cache_creation:
+            properties["$ai_cache_creation_input_tokens"] = cache_creation
 
         # Cost and performance
         response_cost = self._safe_get(standard_logging_object, "response_cost")

--- a/litellm/integrations/posthog.py
+++ b/litellm/integrations/posthog.py
@@ -229,8 +229,12 @@ class PostHogLogger(CustomBatchLogger):
             properties["$ai_output_tokens"] = self._safe_get(
                 standard_logging_object, "completion_tokens", 0
             )
-        cache_read = self._safe_get(standard_logging_object, "cache_read_input_tokens", 0) or 0
-        cache_creation = self._safe_get(standard_logging_object, "cache_creation_input_tokens", 0) or 0
+        cache_read = self._safe_get(
+            standard_logging_object, "cache_read_input_tokens", 0
+        )
+        cache_creation = self._safe_get(
+            standard_logging_object, "cache_creation_input_tokens", 0
+        )
         if cache_read:
             properties["$ai_cache_read_input_tokens"] = cache_read
         if cache_creation:

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -5172,35 +5172,65 @@ class StandardLoggingPayloadSetup:
         Like get_usage_from_response_obj but returns a plain dict, skipping
         the Pydantic Usage construction on the hot path.
         """
-        _empty: dict = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+        _empty: dict = {
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "total_tokens": 0,
+            "cache_read_input_tokens": 0,
+            "cache_creation_input_tokens": 0,
+        }
         if combined_usage_object is not None:
-            d = combined_usage_object.model_dump()
-            d["cache_read_input_tokens"] = combined_usage_object._cache_read_input_tokens
-            d["cache_creation_input_tokens"] = combined_usage_object._cache_creation_input_tokens
-            return d
+            return StandardLoggingPayloadSetup._inject_cache_tokens(
+                combined_usage_object.model_dump(), combined_usage_object
+            )
         if not response_obj:
             return _empty
         _raw = response_obj.get("usage", None)
         if _raw is None:
             return _empty
         if isinstance(_raw, ResponseAPIUsage):
-            return ResponseAPILoggingUtils._transform_response_api_usage_to_chat_usage(
+            usage = ResponseAPILoggingUtils._transform_response_api_usage_to_chat_usage(
                 _raw
-            ).model_dump()
+            )
+            return StandardLoggingPayloadSetup._inject_cache_tokens(
+                usage.model_dump(), usage
+            )
         if isinstance(_raw, dict):
             if ResponseAPILoggingUtils._is_response_api_usage(_raw):
-                return (
-                    ResponseAPILoggingUtils._transform_response_api_usage_to_chat_usage(
-                        _raw
-                    ).model_dump()
+                usage = ResponseAPILoggingUtils._transform_response_api_usage_to_chat_usage(
+                    _raw
+                )
+                return StandardLoggingPayloadSetup._inject_cache_tokens(
+                    usage.model_dump(), usage
                 )
             return _raw
         if isinstance(_raw, Usage):
-            d = _raw.model_dump()
-            d["cache_read_input_tokens"] = _raw._cache_read_input_tokens
-            d["cache_creation_input_tokens"] = _raw._cache_creation_input_tokens
-            return d
+            return StandardLoggingPayloadSetup._inject_cache_tokens(
+                _raw.model_dump(), _raw
+            )
         return _empty
+
+    @staticmethod
+    def _inject_cache_tokens(d: dict, usage: Usage) -> dict:
+        """Inject cache token counts into a usage dict produced by model_dump().
+
+        Pydantic PrivateAttr fields are excluded from model_dump(), so
+        _cache_read_input_tokens and _cache_creation_input_tokens must be
+        read directly from the Usage instance.
+
+        cache_read_input_tokens sources (in priority order):
+          1. usage._cache_read_input_tokens — set by Anthropic and Bedrock
+          2. prompt_tokens_details.cached_tokens — set by OpenAI, Gemini, DeepSeek
+
+        cache_creation_input_tokens: Anthropic and Bedrock only via private attr.
+        """
+        ptd = d.get("prompt_tokens_details") or {}
+        ptd_cached = (ptd.get("cached_tokens") or 0) if isinstance(ptd, dict) else 0
+        d["cache_read_input_tokens"] = (
+            getattr(usage, "_cache_read_input_tokens", 0) or ptd_cached
+        )
+        d["cache_creation_input_tokens"] = getattr(usage, "_cache_creation_input_tokens", 0) or 0
+        return d
 
     @staticmethod
     def get_model_cost_information(

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -5197,8 +5197,10 @@ class StandardLoggingPayloadSetup:
             )
         if isinstance(_raw, dict):
             if ResponseAPILoggingUtils._is_response_api_usage(_raw):
-                usage = ResponseAPILoggingUtils._transform_response_api_usage_to_chat_usage(
-                    _raw
+                usage = (
+                    ResponseAPILoggingUtils._transform_response_api_usage_to_chat_usage(
+                        _raw
+                    )
                 )
                 return StandardLoggingPayloadSetup._inject_cache_tokens(
                     usage.model_dump(), usage
@@ -5223,13 +5225,23 @@ class StandardLoggingPayloadSetup:
           2. prompt_tokens_details.cached_tokens — set by OpenAI, Gemini, DeepSeek
 
         cache_creation_input_tokens: Anthropic and Bedrock only via private attr.
+
+        Reads prompt_tokens_details off the Usage object (not ``d``) so the
+        result is correct regardless of what the caller passes as ``d``.
+        prompt_tokens_details may be a Pydantic wrapper (attribute access) or a
+        dict, so tolerate both.
         """
-        ptd = d.get("prompt_tokens_details") or {}
-        ptd_cached = (ptd.get("cached_tokens") or 0) if isinstance(ptd, dict) else 0
+        ptd = getattr(usage, "prompt_tokens_details", None)
+        if isinstance(ptd, dict):
+            ptd_cached = ptd.get("cached_tokens") or 0
+        else:
+            ptd_cached = getattr(ptd, "cached_tokens", 0) or 0
         d["cache_read_input_tokens"] = (
             getattr(usage, "_cache_read_input_tokens", 0) or ptd_cached
         )
-        d["cache_creation_input_tokens"] = getattr(usage, "_cache_creation_input_tokens", 0) or 0
+        d["cache_creation_input_tokens"] = (
+            getattr(usage, "_cache_creation_input_tokens", 0) or 0
+        )
         return d
 
     @staticmethod
@@ -5927,7 +5939,9 @@ def get_standard_logging_object_payload(
             prompt_tokens=usage_dict.get("prompt_tokens", 0),
             completion_tokens=usage_dict.get("completion_tokens", 0),
             cache_read_input_tokens=usage_dict.get("cache_read_input_tokens", 0),
-            cache_creation_input_tokens=usage_dict.get("cache_creation_input_tokens", 0),
+            cache_creation_input_tokens=usage_dict.get(
+                "cache_creation_input_tokens", 0
+            ),
             request_tags=request_tags,
             end_user=end_user_id or "",
             api_base=StandardLoggingPayloadSetup.strip_trailing_slash(

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -5174,7 +5174,10 @@ class StandardLoggingPayloadSetup:
         """
         _empty: dict = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
         if combined_usage_object is not None:
-            return combined_usage_object.model_dump()
+            d = combined_usage_object.model_dump()
+            d["cache_read_input_tokens"] = combined_usage_object._cache_read_input_tokens
+            d["cache_creation_input_tokens"] = combined_usage_object._cache_creation_input_tokens
+            return d
         if not response_obj:
             return _empty
         _raw = response_obj.get("usage", None)
@@ -5193,7 +5196,10 @@ class StandardLoggingPayloadSetup:
                 )
             return _raw
         if isinstance(_raw, Usage):
-            return _raw.model_dump()
+            d = _raw.model_dump()
+            d["cache_read_input_tokens"] = _raw._cache_read_input_tokens
+            d["cache_creation_input_tokens"] = _raw._cache_creation_input_tokens
+            return d
         return _empty
 
     @staticmethod
@@ -5890,6 +5896,8 @@ def get_standard_logging_object_payload(
             total_tokens=usage_dict.get("total_tokens", 0),
             prompt_tokens=usage_dict.get("prompt_tokens", 0),
             completion_tokens=usage_dict.get("completion_tokens", 0),
+            cache_read_input_tokens=usage_dict.get("cache_read_input_tokens", 0),
+            cache_creation_input_tokens=usage_dict.get("cache_creation_input_tokens", 0),
             request_tags=request_tags,
             end_user=end_user_id or "",
             api_base=StandardLoggingPayloadSetup.strip_trailing_slash(

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -2979,6 +2979,8 @@ class StandardLoggingPayload(TypedDict):
     total_tokens: int
     prompt_tokens: int
     completion_tokens: int
+    cache_read_input_tokens: int
+    cache_creation_input_tokens: int
     startTime: float  # Note: making this camelCase was a mistake, everything should be snake case
     endTime: float
     completionStartTime: float

--- a/tests/logging_callback_tests/test_posthog.py
+++ b/tests/logging_callback_tests/test_posthog.py
@@ -569,3 +569,40 @@ async def test_sync_callback_not_affected_by_atexit():
             assert (
                 callback_invoked_immediately
             ), "Sync callback should be invoked immediately"
+
+
+@pytest.mark.asyncio
+async def test_cache_tokens_emitted_when_nonzero():
+    """$ai_cache_read_input_tokens / $ai_cache_creation_input_tokens are
+    conditionally emitted — only when the corresponding field is non-zero."""
+    from create_mock_standard_logging_payload import create_standard_logging_payload
+
+    posthog_logger = PostHogLogger()
+    standard_payload = create_standard_logging_payload()
+    standard_payload["cache_read_input_tokens"] = 500
+    standard_payload["cache_creation_input_tokens"] = 100
+    kwargs = {"standard_logging_object": standard_payload}
+
+    event_payload = posthog_logger.create_posthog_event_payload(kwargs)
+    props = event_payload["properties"]
+
+    assert props["$ai_cache_read_input_tokens"] == 500
+    assert props["$ai_cache_creation_input_tokens"] == 100
+
+
+@pytest.mark.asyncio
+async def test_cache_tokens_absent_when_zero():
+    """Cache token fields must not be emitted when the value is 0 —
+    keeps PostHog events clean for non-caching providers."""
+    from create_mock_standard_logging_payload import create_standard_logging_payload
+
+    posthog_logger = PostHogLogger()
+    standard_payload = create_standard_logging_payload()
+    # Both default to 0; confirm they are not forwarded to PostHog.
+    kwargs = {"standard_logging_object": standard_payload}
+
+    event_payload = posthog_logger.create_posthog_event_payload(kwargs)
+    props = event_payload["properties"]
+
+    assert "$ai_cache_read_input_tokens" not in props
+    assert "$ai_cache_creation_input_tokens" not in props

--- a/tests/logging_callback_tests/test_standard_logging_payload.py
+++ b/tests/logging_callback_tests/test_standard_logging_payload.py
@@ -1105,8 +1105,12 @@ def test_merge_litellm_metadata_bedrock_passthrough_scenario():
 
 # --- cache token tests ---
 
-def _make_usage(cache_read: int = 0, cache_creation: int = 0, ptd_cached: int = 0) -> Usage:
+
+def _make_usage(
+    cache_read: int = 0, cache_creation: int = 0, ptd_cached: int = 0
+) -> Usage:
     from litellm.types.utils import PromptTokensDetailsWrapper
+
     u = Usage(prompt_tokens=100, completion_tokens=50, total_tokens=150)
     u._cache_read_input_tokens = cache_read
     u._cache_creation_input_tokens = cache_creation
@@ -1154,3 +1158,29 @@ def test_get_usage_as_dict_from_response_obj():
     d = StandardLoggingPayloadSetup.get_usage_as_dict(response_obj={"usage": usage})
     assert d["cache_read_input_tokens"] == 300
     assert d["cache_creation_input_tokens"] == 100
+
+
+def test_inject_cache_tokens_prefers_private_attr_then_prompt_tokens_details():
+    """Direct coverage for the _inject_cache_tokens helper: the private
+    Anthropic/Bedrock attrs win, with a prompt_tokens_details.cached_tokens
+    fallback for OpenAI/Gemini/DeepSeek."""
+    from litellm.types.utils import PromptTokensDetailsWrapper
+
+    # Private attrs present → used directly.
+    anthropic = Usage(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+    anthropic._cache_read_input_tokens = 200
+    anthropic._cache_creation_input_tokens = 500
+    d = StandardLoggingPayloadSetup._inject_cache_tokens({}, anthropic)
+    assert d["cache_read_input_tokens"] == 200
+    assert d["cache_creation_input_tokens"] == 500
+
+    # No private attr → fall back to prompt_tokens_details.cached_tokens.
+    openai = Usage(
+        prompt_tokens=10,
+        completion_tokens=5,
+        total_tokens=15,
+        prompt_tokens_details=PromptTokensDetailsWrapper(cached_tokens=80),
+    )
+    d = StandardLoggingPayloadSetup._inject_cache_tokens({}, openai)
+    assert d["cache_read_input_tokens"] == 80
+    assert d["cache_creation_input_tokens"] == 0

--- a/tests/logging_callback_tests/test_standard_logging_payload.py
+++ b/tests/logging_callback_tests/test_standard_logging_payload.py
@@ -1184,3 +1184,19 @@ def test_inject_cache_tokens_prefers_private_attr_then_prompt_tokens_details():
     d = StandardLoggingPayloadSetup._inject_cache_tokens({}, openai)
     assert d["cache_read_input_tokens"] == 80
     assert d["cache_creation_input_tokens"] == 0
+
+
+def test_inject_cache_tokens_prompt_tokens_details_as_dict():
+    """_inject_cache_tokens must handle prompt_tokens_details as a plain dict
+    (the branch distinct from the PromptTokensDetailsWrapper object path)."""
+    from litellm.litellm_core_utils.litellm_logging import StandardLoggingPayloadSetup
+    from litellm.types.utils import Usage
+
+    # Construct a Usage where prompt_tokens_details is stored as a dict.
+    usage = Usage(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+    # Directly set a dict to exercise the isinstance(ptd, dict) branch.
+    object.__setattr__(usage, "prompt_tokens_details", {"cached_tokens": 42})
+
+    d = StandardLoggingPayloadSetup._inject_cache_tokens({}, usage)
+    assert d["cache_read_input_tokens"] == 42
+    assert d["cache_creation_input_tokens"] == 0

--- a/tests/logging_callback_tests/test_standard_logging_payload.py
+++ b/tests/logging_callback_tests/test_standard_logging_payload.py
@@ -1101,3 +1101,56 @@ def test_merge_litellm_metadata_bedrock_passthrough_scenario():
 
     # Verify total number of fields (9 user fields + 4 model fields = 13)
     assert len(result) == 13
+
+
+# --- cache token tests ---
+
+def _make_usage(cache_read: int = 0, cache_creation: int = 0, ptd_cached: int = 0) -> Usage:
+    from litellm.types.utils import PromptTokensDetailsWrapper
+    u = Usage(prompt_tokens=100, completion_tokens=50, total_tokens=150)
+    u._cache_read_input_tokens = cache_read
+    u._cache_creation_input_tokens = cache_creation
+    if ptd_cached:
+        u.prompt_tokens_details = PromptTokensDetailsWrapper(cached_tokens=ptd_cached)
+    return u
+
+
+def test_get_usage_as_dict_cache_tokens_from_private_attrs():
+    usage = _make_usage(cache_read=1000, cache_creation=500)
+    d = StandardLoggingPayloadSetup.get_usage_as_dict(
+        response_obj=None, combined_usage_object=usage
+    )
+    assert d["cache_read_input_tokens"] == 1000
+    assert d["cache_creation_input_tokens"] == 500
+
+
+def test_get_usage_as_dict_cache_read_falls_back_to_prompt_tokens_details():
+    # OpenAI / Gemini / DeepSeek set ptd.cached_tokens but not the private attr
+    usage = _make_usage(cache_read=0, cache_creation=0, ptd_cached=800)
+    d = StandardLoggingPayloadSetup.get_usage_as_dict(
+        response_obj=None, combined_usage_object=usage
+    )
+    assert d["cache_read_input_tokens"] == 800
+    assert d["cache_creation_input_tokens"] == 0
+
+
+def test_get_usage_as_dict_private_attr_wins_over_ptd():
+    # When both are set, private attr takes priority
+    usage = _make_usage(cache_read=600, cache_creation=200, ptd_cached=800)
+    d = StandardLoggingPayloadSetup.get_usage_as_dict(
+        response_obj=None, combined_usage_object=usage
+    )
+    assert d["cache_read_input_tokens"] == 600
+
+
+def test_get_usage_as_dict_empty_when_no_usage():
+    d = StandardLoggingPayloadSetup.get_usage_as_dict(response_obj=None)
+    assert d["cache_read_input_tokens"] == 0
+    assert d["cache_creation_input_tokens"] == 0
+
+
+def test_get_usage_as_dict_from_response_obj():
+    usage = _make_usage(cache_read=300, cache_creation=100)
+    d = StandardLoggingPayloadSetup.get_usage_as_dict(response_obj={"usage": usage})
+    assert d["cache_read_input_tokens"] == 300
+    assert d["cache_creation_input_tokens"] == 100

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -1726,11 +1726,23 @@ def test_get_usage_as_dict():
 
     # Test case 1: None response_obj returns empty usage dict
     result = StandardLoggingPayloadSetup.get_usage_as_dict(response_obj=None)
-    assert result == {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+    assert result == {
+        "prompt_tokens": 0,
+        "completion_tokens": 0,
+        "total_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "cache_creation_input_tokens": 0,
+    }
 
     # Test case 2: Empty response_obj returns empty usage dict
     result = StandardLoggingPayloadSetup.get_usage_as_dict(response_obj={})
-    assert result == {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+    assert result == {
+        "prompt_tokens": 0,
+        "completion_tokens": 0,
+        "total_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "cache_creation_input_tokens": 0,
+    }
 
     # Test case 3: combined_usage_object takes priority
     combined = Usage(prompt_tokens=10, completion_tokens=5, total_tokens=15)
@@ -1752,7 +1764,13 @@ def test_get_usage_as_dict():
     result = StandardLoggingPayloadSetup.get_usage_as_dict(
         response_obj={"id": "resp-1", "choices": []}
     )
-    assert result == {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+    assert result == {
+        "prompt_tokens": 0,
+        "completion_tokens": 0,
+        "total_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "cache_creation_input_tokens": 0,
+    }
 
 
 def test_append_system_prompt_messages():


### PR DESCRIPTION
## Summary

Anthropic's prompt-caching API returns `cache_read_input_tokens` and `cache_creation_input_tokens` in the usage block. LiteLLM parses these correctly into `Usage._cache_read_input_tokens` / `_cache_creation_input_tokens` (Pydantic `PrivateAttr`), but they are currently invisible to all logging callbacks because:

1. `Usage.model_dump()` does not serialise `PrivateAttr` fields
2. `get_usage_as_dict` returns only what `model_dump()` produces
3. `StandardLoggingPayload` has no `cache_read_input_tokens` / `cache_creation_input_tokens` fields
4. `PostHogLogger._create_posthog_properties` therefore cannot emit `$ai_cache_read_input_tokens` / `$ai_cache_creation_input_tokens`

## Changes

**`litellm/litellm_core_utils/litellm_logging.py`** — `get_usage_as_dict`  
After calling `.model_dump()` on a `Usage` instance (both the `combined_usage_object` path and the `_raw` path), copy the two private attrs into the returned dict.

**`litellm/types/utils.py`** — `StandardLoggingPayload`  
Add `cache_read_input_tokens: int` and `cache_creation_input_tokens: int` after `completion_tokens`. Populated from `usage_dict` in `get_standard_logging_object_payload` (defaults to 0, matching existing token field behaviour).

**`litellm/integrations/posthog.py`** — `_create_posthog_properties`  
Read the two new fields from `standard_logging_object` and emit `$ai_cache_read_input_tokens` / `$ai_cache_creation_input_tokens` when non-zero.

## Why this matters

Without this fix, users running Anthropic with prompt caching enabled (either via explicit `cache_control` breakpoints or Anthropic's automatic caching) have no way to observe cache effectiveness through any LiteLLM logging callback. The fields exist on the `Usage` object but are effectively invisible at the logging layer.

## Test plan

- [ ] Direct Anthropic call with a long system prompt: `$ai_cache_read_input_tokens` appears on second request, `$ai_cache_creation_input_tokens` on first
- [ ] Non-Anthropic providers: both fields absent (default 0, not emitted)
- [ ] `get_usage_as_dict` unit test: `Usage` with non-zero private attrs returns correct dict