### PR TITLE
fix(proxy): back spend counter with router Redis so multi-pod key budgets are enforced

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -2064,6 +2064,34 @@ async def get_current_spend(counter_key: str, fallback_spend: float) -> float:
     return fallback_spend
 
 
+def attach_shared_spend_counter_redis(
+    spend_counter_cache: DualCache,
+    router: Optional[Router],
+) -> None:
+    """
+    Back the cross-process spend counter with Redis when one is available.
+
+    Budget enforcement reads and writes spend_counter_cache. If it stays
+    in-memory each worker/replica enforces budgets against its own counter
+    while the database aggregates spend from all of them, so keys exceed their
+    limit cluster-wide. litellm_settings.cache already wires Redis here, but a
+    deployment that configures Redis only via router_settings would otherwise
+    leave the counter in-memory; adopt the router's Redis in that case.
+    attach_redis_cache is a no-op when a backend was already wired.
+    """
+    if router is not None and router.cache.redis_cache is not None:
+        spend_counter_cache.attach_redis_cache(router.cache.redis_cache)
+    if spend_counter_cache.redis_cache is None:
+        verbose_proxy_logger.warning(
+            "spend_counter_cache has no Redis backend: virtual-key, team, and "
+            "user budget enforcement is per-process (in-memory). In multi-worker "
+            "or multi-replica deployments this lets budgets be exceeded because "
+            "each process tracks spend independently. Configure Redis via "
+            "litellm_settings.cache or router_settings to enable cross-process "
+            "budget enforcement."
+        )
+
+
 async def increment_spend_counters(
     token: Optional[str],
     team_id: Optional[str],
@@ -4599,6 +4627,10 @@ class ProxyConfig:
 
         if redis_usage_cache is not None and router.cache.redis_cache is None:
             router._update_redis_cache(cache=redis_usage_cache)
+
+        attach_shared_spend_counter_redis(
+            spend_counter_cache=spend_counter_cache, router=router
+        )
 
         # Guardrail settings
         guardrails_v2: Optional[List[Dict]] = None

--- a/tests/test_litellm/proxy/proxy_server/test_spend_counters.py
+++ b/tests/test_litellm/proxy/proxy_server/test_spend_counters.py
@@ -26,6 +26,8 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 import litellm.proxy.proxy_server as ps
+from litellm.caching.dual_cache import DualCache
+from litellm.caching.redis_cache import RedisCache
 
 from .conftest import normalize
 
@@ -816,3 +818,53 @@ async def test_update_cache_user_cache_failure_invalid_state_is_swallowed(monkey
     )
 
     assert result is None
+
+
+def test_attach_shared_spend_counter_redis_adopts_router_redis():
+    """Multi-replica budget enforcement (LIT-3772): when Redis is configured
+    only on the router (router_settings), the in-memory-only spend counter must
+    adopt the router's Redis so spend is shared across processes."""
+    spend_counter_cache = DualCache()
+    assert spend_counter_cache.redis_cache is None
+
+    router_redis = MagicMock(spec=RedisCache)
+    router = MagicMock()
+    router.cache = DualCache()
+    router.cache.redis_cache = router_redis
+
+    ps.attach_shared_spend_counter_redis(
+        spend_counter_cache=spend_counter_cache, router=router
+    )
+
+    assert spend_counter_cache.redis_cache is router_redis
+
+
+def test_attach_shared_spend_counter_redis_preserves_existing_backend():
+    """A Redis backend already wired from litellm_settings.cache must not be
+    clobbered by the router adoption."""
+    existing = MagicMock(spec=RedisCache)
+    spend_counter_cache = DualCache()
+    spend_counter_cache.redis_cache = existing
+
+    router = MagicMock()
+    router.cache = DualCache()
+    router.cache.redis_cache = MagicMock(spec=RedisCache)
+
+    ps.attach_shared_spend_counter_redis(
+        spend_counter_cache=spend_counter_cache, router=router
+    )
+
+    assert spend_counter_cache.redis_cache is existing
+
+
+def test_attach_shared_spend_counter_redis_noop_without_any_redis():
+    spend_counter_cache = DualCache()
+    router = MagicMock()
+    router.cache = DualCache()
+    router.cache.redis_cache = None
+
+    ps.attach_shared_spend_counter_redis(
+        spend_counter_cache=spend_counter_cache, router=router
+    )
+
+    assert spend_counter_cache.redis_cache is None


### PR DESCRIPTION
## Relevant issues

Resolves LIT-3772

## Linear ticket

https://linear.app/litellm-ai/issue/LIT-3772/virtual-key-spend-limits-are-not-being-enforced

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

Virtual-key, team, and user budget enforcement reads and writes a cross-process spend counter (`spend_counter_cache`). That counter is only given a Redis backend when Redis is configured through `litellm_settings.cache`. A deployment that configures Redis only via `router_settings` (a common setup for cross-pod cooldowns and routing) leaves the spend counter in-memory, so every worker and replica enforces budgets against its own private counter while the database aggregates spend from all of them. Keys then run well past their `max_budget` cluster-wide, which matches the report here where a key exceeded its limit by hundreds of dollars and overspend recurred for months.

The startup sync was one-directional; the proxy pushed its Redis into the router (`proxy_server.py`) but never adopted the router's Redis when the proxy itself had none. This PR adds `attach_shared_spend_counter_redis`, which adopts the router's Redis for the spend counter when no cache-level Redis is present, and warns at startup when the counter is left in-memory so the per-process limitation is visible to operators. `attach_redis_cache` is idempotent, so a backend already wired from `litellm_settings.cache` is preserved and not clobbered.

The single-process path was already correct (the optimistic reservation plus the read-time counter handle concurrency); the gap was specifically that the shared counter had no shared store in multi-worker and multi-replica deployments configured this way, so the symptom was intermittent and depended on how requests spread across processes.

## Screenshots / Proof of Fix

Reproduced on a live proxy running two uvicorn workers (standing in for two replicas), with Redis configured only through `router_settings` and no `litellm_settings.cache`, a shared Postgres, and real `gpt-4o-mini` traffic. A virtual key was created with `max_budget` of $0.003 and hit with 180 concurrent chat-completion requests.

config.yaml (note: Redis is only under `router_settings`)

```yaml
model_list:
  - model_name: gpt-4o-mini
    litellm_params:
      model: openai/gpt-4o-mini
      api_key: os.environ/OPENAI_API_KEY

router_settings:
  redis_host: 127.0.0.1
  redis_port: 6380

general_settings:
  master_key: os.environ/LITELLM_MASTER_KEY
```

launch (two workers):

```bash
python litellm/proxy/proxy_cli.py --config /tmp/litfix/config.yaml --port 4001 --num_workers 2 --use_v2_migration_resolver
```

create the key and drive load:

```bash
KEY=$(curl -s -X POST http://127.0.0.1:4001/key/generate \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" \
  -d '{"max_budget":0.003,"models":["gpt-4o-mini"]}' | python3 -c "import sys,json;print(json.load(sys.stdin)['key'])")

# fire 180 concurrent chat-completion requests against $KEY, then read /key/info
seq 180 | xargs -P 16 -I{} curl -s -o /dev/null -w "%{http_code}\n" \
  -X POST http://127.0.0.1:4001/v1/chat/completions \
  -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
  -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Write two sentences about the ocean."}],"max_tokens":120}' \
  | sort | uniq -c

curl -s "http://127.0.0.1:4001/key/info?key=$KEY" -H "Authorization: Bearer $LITELLM_MASTER_KEY"
```

Before the fix (spend counter stays in-memory per worker):

```
# request status codes across the run
 156 200
  24 429

# /key/info
spend=$0.005129  max_budget=$0.003   ->  1.7x over budget
# requests kept returning 200 even while the key was already over budget
# redis: no spend:key:* counter exists
$ redis-cli --scan --pattern '*spend:key*'
(empty)
```

After the fix (spend counter adopts the router's Redis, shared across workers):

```
# request status codes across the run
  89 200
  91 429

# /key/info
spend=$0.002822  max_budget=$0.003   ->  0.94x, under budget
# requests are rejected with HTTP 429 once the budget is reached
# redis: a single shared counter is present and read by both workers
$ redis-cli --scan --pattern '*spend:key*'
spend:key:d0bb31a82362f914e90bdaf20c9346d8e76d3be13ad515e3c2a90ea81a62f884
```

Unit coverage in `tests/test_litellm/proxy/proxy_server/test_spend_counters.py` pins the wiring: the counter adopts the router's Redis when it has none, a backend already wired from `litellm_settings.cache` is preserved, and it stays in-memory (with the warning) when no Redis exists anywhere. Each test fails if the adoption is removed.
