### PR TITLE
fix(opentelemetry): trace MCP tool calls without dropping the tool output

### DIFF
--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -208,7 +208,12 @@ def _response_obj_as_mapping(response_obj: Optional[Any]) -> Optional[Dict[str, 
     if callable(model_dump):
         try:
             dumped = model_dump()
-        except Exception:
+        except Exception as e:
+            verbose_logger.debug(
+                "OpenTelemetry: failed to coerce response_obj of type %s via model_dump: %s",
+                type(response_obj).__name__,
+                e,
+            )
             return None
         if isinstance(dumped, dict):
             return dumped

--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -190,7 +190,7 @@ def _normalize_team_metadata_keys(value: Any) -> List[str]:
     return [str(item).strip() for item in value if str(item).strip()]
 
 
-def _response_obj_as_mapping(response_obj: Optional[Any]) -> Optional[Dict[str, Any]]:
+def _response_obj_as_mapping(response_obj: Optional[Any]) -> Optional[Any]:
     """Return a dict view of ``response_obj`` for the OTEL attribute writers.
 
     Chat-completions and Responses-API responses already behave like dicts.
@@ -199,6 +199,10 @@ def _response_obj_as_mapping(response_obj: Optional[Any]) -> Optional[Dict[str, 
     ``set_attributes`` raises ``AttributeError`` and the span loses its output
     attributes (issue #30651). ``model_dump`` is the documented way to
     flatten a Pydantic ``BaseModel`` to a dict.
+
+    The return is typed ``Optional[Any]`` rather than ``Optional[Dict[str, Any]]``
+    so downstream ``response_obj.get(...)`` calls keep their pre-existing mypy
+    semantics (which assume an ``Any``-typed value, not an Optional one).
     """
     if response_obj is None:
         return None

--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -31,6 +31,7 @@ from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 from litellm.secret_managers.main import get_secret_bool, str_to_bool
 from litellm.types.services import ServiceLoggerPayload
 from litellm.types.utils import (
+    CallTypes,
     ChatCompletionMessageToolCall,
     CostBreakdown,
     Function,
@@ -187,6 +188,31 @@ def _normalize_team_metadata_keys(value: Any) -> List[str]:
     if isinstance(value, str):
         return [item.strip() for item in value.split(",") if item.strip()]
     return [str(item).strip() for item in value if str(item).strip()]
+
+
+def _response_obj_as_mapping(response_obj: Optional[Any]) -> Optional[Dict[str, Any]]:
+    """Return a dict view of ``response_obj`` for the OTEL attribute writers.
+
+    Chat-completions and Responses-API responses already behave like dicts.
+    MCP tool calls pass ``mcp.types.CallToolResult`` (a Pydantic model with no
+    ``.get``); without coercion every ``response_obj.get(...)`` in
+    ``set_attributes`` raises ``AttributeError`` and the span loses its output
+    attributes (issue #30651). ``model_dump`` is the documented way to
+    flatten a Pydantic ``BaseModel`` to a dict.
+    """
+    if response_obj is None:
+        return None
+    if isinstance(response_obj, dict):
+        return response_obj
+    model_dump = getattr(response_obj, "model_dump", None)
+    if callable(model_dump):
+        try:
+            dumped = model_dump()
+        except Exception:
+            return None
+        if isinstance(dumped, dict):
+            return dumped
+    return None
 
 
 @dataclass
@@ -1461,6 +1487,7 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
         return attrs
 
     def _record_metrics(self, kwargs, response_obj, start_time, end_time):
+        response_obj = _response_obj_as_mapping(response_obj)
         duration_s = (end_time - start_time).total_seconds()
         params = kwargs.get("litellm_params") or {}
         provider = params.get("custom_llm_provider", "Unknown")
@@ -2233,6 +2260,8 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
             if standard_logging_payload is None:
                 raise ValueError("standard_logging_object not found in kwargs")
 
+            response_obj = _response_obj_as_mapping(response_obj)
+
             # https://github.com/open-telemetry/semantic-conventions/blob/main/model/registry/gen-ai.yaml
             # Following Conventions here: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/llm-spans.md
             #############################################
@@ -2574,6 +2603,34 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
                             key=SpanAttributes.GEN_AI_RESPONSE_FINISH_REASONS.value,
                             value=safe_dumps([status]),
                         )
+
+                elif (
+                    standard_logging_payload.get("call_type")
+                    == CallTypes.call_mcp_tool.value
+                ):
+                    # mcp.types.CallToolResult (dict-coerced above): captures
+                    # the tool output that the chat / responses branches miss.
+                    content = response_obj.get("content")
+                    if content is not None:
+                        self.safe_set_attribute(
+                            span=span,
+                            key=SpanAttributes.GEN_AI_OUTPUT_MESSAGES.value,
+                            value=safe_dumps(content),
+                        )
+                    structured = response_obj.get("structuredContent")
+                    if structured is not None:
+                        self.safe_set_attribute(
+                            span=span,
+                            key="gen_ai.mcp.tool_call.structured_content",
+                            value=safe_dumps(structured),
+                        )
+                    self.safe_set_attribute(
+                        span=span,
+                        key=SpanAttributes.GEN_AI_RESPONSE_FINISH_REASONS.value,
+                        value=safe_dumps(
+                            ["error"] if response_obj.get("isError") else ["stop"]
+                        ),
+                    )
 
         except Exception as e:
             self.handle_callback_failure(

--- a/tests/test_litellm/integrations/test_opentelemetry.py
+++ b/tests/test_litellm/integrations/test_opentelemetry.py
@@ -417,9 +417,7 @@ class TestOpenTelemetryMCPToolCall(unittest.TestCase):
         mock_span = MagicMock()
         result = CallToolResult(content=[TextContent(type="text", text="20")])
 
-        with patch(
-            "litellm.integrations.opentelemetry.verbose_logger"
-        ) as mock_logger:
+        with patch("litellm.integrations.opentelemetry.verbose_logger") as mock_logger:
             otel.set_attributes(
                 span=mock_span, kwargs=self._mcp_kwargs(), response_obj=result
             )

--- a/tests/test_litellm/integrations/test_opentelemetry.py
+++ b/tests/test_litellm/integrations/test_opentelemetry.py
@@ -385,6 +385,104 @@ class TestOpenTelemetryCostBreakdown(unittest.TestCase):
         assert ("gen_ai.cost.original_cost", 0.004) not in call_args_list
 
 
+class TestOpenTelemetryMCPToolCall(unittest.TestCase):
+    """Regression coverage for issue #30651.
+
+    MCP tool calls hand ``set_attributes`` an ``mcp.types.CallToolResult``
+    (a Pydantic model with no ``.get``). Before the fix every
+    ``response_obj.get(...)`` in ``set_attributes`` raised ``AttributeError``,
+    the span lost every output attribute, and ``verbose_logger`` filled with
+    "OpenTelemetry logging error in set_attributes" lines.
+    """
+
+    def _mcp_kwargs(self):
+        return {
+            "model": "mcp-tool-call",
+            "optional_params": {},
+            "litellm_params": {"custom_llm_provider": "litellm_mcp"},
+            "standard_logging_object": {
+                "id": "test-id",
+                "call_type": "call_mcp_tool",
+                "metadata": {},
+            },
+        }
+
+    def test_set_attributes_does_not_raise_on_pydantic_call_tool_result(self):
+        try:
+            from mcp.types import CallToolResult, TextContent
+        except ImportError:
+            self.skipTest("mcp not installed")
+
+        otel = OpenTelemetry()
+        mock_span = MagicMock()
+        result = CallToolResult(content=[TextContent(type="text", text="20")])
+
+        with patch(
+            "litellm.integrations.opentelemetry.verbose_logger"
+        ) as mock_logger:
+            otel.set_attributes(
+                span=mock_span, kwargs=self._mcp_kwargs(), response_obj=result
+            )
+
+        # The pre-fix failure mode was the exception being caught and logged
+        # via ``verbose_logger.exception`` after the AttributeError fired; if
+        # ``exception`` is ever called we have regressed.
+        assert not mock_logger.exception.called, (
+            "set_attributes raised on a Pydantic CallToolResult: "
+            f"{mock_logger.exception.call_args}"
+        )
+
+    def test_set_attributes_writes_tool_output_for_mcp_call_tool_result(self):
+        try:
+            from mcp.types import CallToolResult, TextContent
+        except ImportError:
+            self.skipTest("mcp not installed")
+
+        otel = OpenTelemetry()
+        mock_span = MagicMock()
+        result = CallToolResult(
+            content=[TextContent(type="text", text="20")],
+            isError=False,
+        )
+
+        otel.set_attributes(
+            span=mock_span, kwargs=self._mcp_kwargs(), response_obj=result
+        )
+
+        recorded = {
+            call.args[0]: call.args[1]
+            for call in mock_span.set_attribute.call_args_list
+        }
+
+        assert "gen_ai.output.messages" in recorded
+        output_payload = json.loads(recorded["gen_ai.output.messages"])
+        assert output_payload[0].get("text") == "20"
+        assert json.loads(recorded["gen_ai.response.finish_reasons"]) == ["stop"]
+
+    def test_set_attributes_marks_failed_mcp_call_with_error_finish_reason(self):
+        try:
+            from mcp.types import CallToolResult, TextContent
+        except ImportError:
+            self.skipTest("mcp not installed")
+
+        otel = OpenTelemetry()
+        mock_span = MagicMock()
+        result = CallToolResult(
+            content=[TextContent(type="text", text="boom")],
+            isError=True,
+        )
+
+        otel.set_attributes(
+            span=mock_span, kwargs=self._mcp_kwargs(), response_obj=result
+        )
+
+        recorded = {
+            call.args[0]: call.args[1]
+            for call in mock_span.set_attribute.call_args_list
+        }
+        assert json.loads(recorded["gen_ai.response.finish_reasons"]) == ["error"]
+
+
 class TestOpenTelemetryProviderInitialization(unittest.TestCase):
     """Test suite for verifying provider initialization respects existing providers"""
 


### PR DESCRIPTION
## Relevant issues

Closes #30651.

## Linear ticket

n/a

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes the OTEL integration test file (247 passed, 0 failed); the broader `make test-unit` requires deps I cannot fully install on macOS Python 3.14, so I ran the affected suite against Python 3.13 with `pytest tests/test_litellm/integrations/test_opentelemetry.py`
- [x] My PR's scope is as isolated as possible; it only solves issue #30651
- [ ] Greptile confidence score >= 4/5 (will request via `@greptileai` after this PR opens)

## CI

- [ ] Branch creation CI run
- [ ] CI run for the last commit
- [ ] Merge / cherry-pick CI run

## Screenshots / Proof of Fix

The reporter's in-process repro from the issue exits cleanly on this branch with the tool output written to the span instead of the OTEL handler swallowing an AttributeError.

```python
import asyncio
from datetime import datetime
import litellm
from litellm.integrations.opentelemetry import OpenTelemetry, OpenTelemetryConfig
from litellm.types.utils import CallTypes, StandardLoggingMCPToolCall
from litellm.utils import Rules, function_setup
from mcp.types import CallToolResult, TextContent

otel = OpenTelemetry(config=OpenTelemetryConfig(exporter="console"))
litellm.callbacks = [otel]; litellm._async_success_callback = []
result = CallToolResult(content=[TextContent(type="text", text="20")])

async def main():
    start = datetime.now()
    lo, _ = function_setup(
        original_function="call_mcp_tool",
        rules_obj=Rules(),
        start_time=start,
        litellm_call_id="x",
    )
    lo.model_call_details["mcp_tool_call_metadata"] = StandardLoggingMCPToolCall(
        name="add", arguments={"a": 12, "b": 8}
    )
    lo.call_type = CallTypes.call_mcp_tool.value
    await lo.async_success_handler(result=result, start_time=start, end_time=datetime.now())

asyncio.run(main())
```

Pre-fix: stderr emits `OpenTelemetry logging error in set_attributes ... 'CallToolResult' object has no attribute 'get'` and the exported span carries `metadata.mcp_tool_call_metadata` (input) with no `gen_ai.output.messages` (output).

Post-fix: no error in stderr; the exported span carries `metadata.mcp_tool_call_metadata` plus `gen_ai.output.messages = [{"type": "text", "text": "20"}]` and `gen_ai.response.finish_reasons = ["stop"]`.

## Type

Bug Fix

## Changes

Two changes to `litellm/integrations/opentelemetry.py`. First, a module-level `_response_obj_as_mapping(response_obj)` helper returns the dict view that the OTEL attribute writers assume. It passes `dict` through unchanged, calls `.model_dump()` on a Pydantic model, and returns `None` otherwise. It is called at the top of `set_attributes` and `_record_metrics`, so every existing `response_obj.get(...)` call site keeps working for dict callers and stops raising `AttributeError` for MCP callers without rewriting the per-attribute logic.

Second, a new MCP branch sits alongside the existing chat-completions and Responses-API output branches inside `set_attributes`. It triggers when `standard_logging_payload["call_type"]` is `call_mcp_tool`, writes the `CallToolResult.content` into `gen_ai.output.messages`, writes any `structuredContent` into `gen_ai.mcp.tool_call.structured_content`, and stamps `gen_ai.response.finish_reasons` as `["error"]` when `isError` is true and `["stop"]` otherwise. The chat and Responses-API branches are not touched.

Regression coverage lives in a new `TestOpenTelemetryMCPToolCall` test class in `tests/test_litellm/integrations/test_opentelemetry.py`. One test asserts `verbose_logger.exception` is never called (the pre-fix failure signature), a second asserts the success path writes the tool output into `gen_ai.output.messages` with `finish_reasons = ["stop"]`, and a third asserts the `isError=True` path writes `finish_reasons = ["error"]`. All three skip cleanly if the `mcp` extra is not installed in the test environment.
