### PR TITLE
fix(anthropic): drop non-serializable callback metadata from /v1/messages body

### DIFF
--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -231,6 +231,35 @@ def _has_pre_call_deployment_hook(logging_obj: Any) -> bool:
     return False
 
 
+def _is_json_serializable(value: object) -> bool:
+    try:
+        json.dumps(value)
+        return True
+    except (TypeError, ValueError):
+        return False
+
+
+def dumps_anthropic_messages_request_body(request_body: dict[str, object]) -> str:
+    """Serialize the /v1/messages body, dropping non-serializable values that a
+    callback added to metadata after validation (e.g. a Sentry span); those
+    belong in logs, not on the wire."""
+    try:
+        return json.dumps(request_body)
+    except (TypeError, ValueError):
+        metadata = request_body.get("metadata")
+        if not isinstance(metadata, dict):
+            raise
+        typed_metadata = cast(dict[str, object], metadata)
+        serializable_metadata = {key: value for key, value in typed_metadata.items() if _is_json_serializable(value)}
+        dropped = sorted(typed_metadata.keys() - serializable_metadata.keys())
+        if dropped:
+            verbose_logger.debug(
+                "Anthropic /v1/messages: dropped non-serializable metadata key(s) %s",
+                dropped,
+            )
+        return json.dumps({**request_body, "metadata": serializable_metadata})
+
+
 class BaseLLMHTTPHandler:
     async def _make_common_async_call(
         self,
@@ -1888,7 +1917,7 @@ class BaseLLMHTTPHandler:
                 response = await async_httpx_client.post(
                     url=request_url,
                     headers=headers,
-                    data=signed_json_body or json.dumps(request_body),
+                    data=signed_json_body or dumps_anthropic_messages_request_body(request_body),
                     stream=stream or False,
                     logging_obj=logging_obj,
                 )
@@ -2043,15 +2072,11 @@ class BaseLLMHTTPHandler:
             model=model,
         )
 
-        # The request body was serialized once for the pre-call log input and
-        # again for the wire (json.dumps is O(payload), large for long-context
-        # Claude Code history). Serialize once and reuse for both. Only when
-        # the provider didn't sign the request (sign_request no-op for the
-        # native anthropic path -> signed_json_body is None); signed providers
-        # (e.g. Bedrock) keep their signed body untouched. The HTTP-error
-        # retry path mutates + re-signs the body, so it still re-serializes
-        # internally -- this only deduplicates the success path.
-        request_body_json = json.dumps(request_body)
+        # json.dumps is O(payload) and costly for long Claude Code histories,
+        # so serialize once here for the pre-call log and reuse it for the wire
+        # on the unsigned path (native anthropic -> signed_json_body is None).
+        # Signed providers (e.g. Bedrock) send their own signed body instead.
+        request_body_json = dumps_anthropic_messages_request_body(request_body)
 
         logging_obj.pre_call(
             input=[{"role": "user", "content": request_body_json}],

--- a/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
@@ -22,6 +22,7 @@ from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler, HTTPHandler
 from litellm.llms.custom_httpx.llm_http_handler import (
     BaseLLMHTTPHandler,
     _google_genai_streaming_hidden_params,
+    dumps_anthropic_messages_request_body,
 )
 from litellm.types.llms.openai import ResponsesAPIResponse
 from litellm.types.router import GenericLiteLLMParams
@@ -1837,3 +1838,185 @@ async def test_alist_input_items_surfaces_upstream_error_status():
         )
 
     assert excinfo.value.status_code == 404
+
+
+class _SentrySpanStub:
+    """Stand-in for sentry_sdk's Transaction/Span, which is not JSON serializable."""
+
+    def __repr__(self) -> str:
+        return "<Transaction stub>"
+
+
+@pytest.mark.asyncio
+async def test_async_post_anthropic_messages_strips_non_serializable_metadata():
+    """Regression for #30662: a callback injects a non-serializable value into
+    metadata after validation; the body builder must drop it rather than crash
+    the outbound serialization, and must not ship it to Anthropic."""
+    handler = BaseLLMHTTPHandler()
+
+    captured = {}
+
+    async def fake_post(*args, **kwargs):
+        captured["data"] = kwargs.get("data")
+        response = Mock()
+        response.status_code = 200
+        response.headers = {}
+        response.raise_for_status = Mock()
+        return response
+
+    mock_client = Mock()
+    mock_client.post = AsyncMock(side_effect=fake_post)
+
+    provider_config = Mock()
+    provider_config.max_retry_on_anthropic_messages_http_error = 1
+
+    request_body = {
+        "model": "claude-3-5-sonnet-latest",
+        "messages": [{"role": "user", "content": "hi"}],
+        "max_tokens": 16,
+        "metadata": {"user_id": "my-org", "_sentry_span": _SentrySpanStub()},
+    }
+
+    await handler._async_post_anthropic_messages_with_http_error_retry(
+        async_httpx_client=mock_client,
+        request_url="https://api.anthropic.com/v1/messages",
+        headers={},
+        signed_json_body=None,  # native anthropic path -> body is json.dumps'd here
+        request_body=request_body,
+        stream=False,
+        logging_obj=Mock(),
+        provider_config=provider_config,
+        litellm_params=GenericLiteLLMParams(),
+        api_key="sk-ant-test",
+        model="claude-3-5-sonnet-latest",
+    )
+
+    sent = json.loads(captured["data"])
+    assert sent["metadata"] == {"user_id": "my-org"}
+    assert sent["messages"] == [{"role": "user", "content": "hi"}]
+    assert sent["max_tokens"] == 16
+
+
+@pytest.mark.asyncio
+async def test_async_anthropic_messages_handler_strips_non_serializable_metadata_on_wire():
+    """The success-path serialization in async_anthropic_messages_handler (the
+    second #30662 call site, run on every request) also drops callback-injected
+    non-serializable metadata rather than crashing."""
+    handler = BaseLLMHTTPHandler()
+
+    provider_config = Mock()
+    provider_config.validate_anthropic_messages_environment = Mock(
+        return_value=({"x-api-key": "k"}, "https://api.anthropic.com")
+    )
+    provider_config.transform_anthropic_messages_request = Mock(
+        return_value={
+            "model": "claude-3-5-sonnet-latest",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 16,
+            "metadata": {"user_id": "my-org", "_sentry_span": _SentrySpanStub()},
+        }
+    )
+    provider_config.get_complete_url = Mock(
+        return_value="https://api.anthropic.com/v1/messages"
+    )
+    # Unsigned (native anthropic): the success path serializes via the helper.
+    provider_config.sign_request = Mock(return_value=({"x-api-key": "k"}, None))
+    provider_config.max_retry_on_anthropic_messages_http_error = 1
+    provider_config.transform_anthropic_messages_response = Mock(
+        return_value={"id": "m"}
+    )
+
+    captured = {}
+
+    async def fake_post(*args, **kwargs):
+        captured["data"] = kwargs.get("data")
+        response = Mock()
+        response.status_code = 200
+        response.headers = {}
+        response.raise_for_status = Mock()
+        return response
+
+    client = AsyncHTTPHandler()
+    logging_obj = Mock()
+    logging_obj.model_call_details = {}
+
+    with (
+        patch.object(client, "post", side_effect=fake_post),
+        patch(
+            "litellm.litellm_core_utils.get_provider_specific_headers.ProviderSpecificHeaderUtils.get_provider_specific_headers",
+            return_value=None,
+        ),
+    ):
+        try:
+            await handler.async_anthropic_messages_handler(
+                model="claude-3-5-sonnet-latest",
+                messages=[{"role": "user", "content": "hi"}],
+                anthropic_messages_provider_config=provider_config,
+                anthropic_messages_optional_request_params={},
+                custom_llm_provider="anthropic",
+                litellm_params=GenericLiteLLMParams(),
+                logging_obj=logging_obj,
+                client=client,
+                stream=False,
+            )
+        except Exception:
+            # Response transform / hooks run after the body is on the wire;
+            # the assertion target is the captured outbound body.
+            pass
+
+    assert "data" in captured  # serialization reached the wire, did not crash
+    sent = json.loads(captured["data"])
+    assert sent["metadata"] == {"user_id": "my-org"}
+    assert "_sentry_span" not in sent["metadata"]
+
+
+def test_dumps_anthropic_messages_request_body_drops_non_serializable_metadata():
+    """The dropped value must not reach the wire, the validated metadata must
+    survive, and the caller's request_body must not be mutated."""
+    request_body = {
+        "model": "claude-3-5-sonnet-latest",
+        "max_tokens": 16,
+        "metadata": {"user_id": "my-org", "_sentry_span": _SentrySpanStub()},
+    }
+
+    sent = json.loads(dumps_anthropic_messages_request_body(request_body))
+
+    assert sent["metadata"] == {"user_id": "my-org"}
+    assert sent["max_tokens"] == 16
+    assert "_sentry_span" in request_body["metadata"]  # original untouched
+
+
+def test_dumps_anthropic_messages_request_body_passthrough_when_serializable():
+    """A fully serializable body round-trips unchanged, metadata intact."""
+    request_body = {
+        "model": "claude-3-5-sonnet-latest",
+        "max_tokens": 16,
+        "metadata": {"user_id": "my-org"},
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+
+    assert (
+        json.loads(dumps_anthropic_messages_request_body(request_body)) == request_body
+    )
+
+
+def test_dumps_anthropic_messages_request_body_reraises_non_metadata():
+    """A non-serializable value outside metadata is a real bug, not callback
+    noise; surface it instead of silently dropping request content. Covers both
+    a missing metadata key (re-raise guard) and a present, already-clean
+    metadata dict (the stripped body still fails to serialize)."""
+    no_metadata = {
+        "model": "claude-3-5-sonnet-latest",
+        "max_tokens": 16,
+        "messages": [{"role": "user", "content": _SentrySpanStub()}],
+    }
+    clean_metadata = {
+        "model": "claude-3-5-sonnet-latest",
+        "max_tokens": 16,
+        "metadata": {"user_id": "my-org"},
+        "messages": [{"role": "user", "content": _SentrySpanStub()}],
+    }
+
+    for body in (no_metadata, clean_metadata):
+        with pytest.raises(TypeError):
+            dumps_anthropic_messages_request_body(body)


### PR DESCRIPTION
## Relevant issues

Fixes #30662

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

The documented crash reproduces in the `>=1.0.0,<1.82.7` range; it is confirmed against an installed 1.81.9, where serializing the outbound `/v1/messages` body fails with `TypeError: Object of type ... is not JSON serializable` at `data=signed_json_body or json.dumps(request_body)` before the request is sent. On current main the same callback-injected span lands in `litellm_params["metadata"]`, which a perf-driven serialization reordering (#28289) happens to decouple from the wire body, so the crash is masked rather than fixed. This PR makes the body builder drop non-serializable metadata regardless of that incidental ordering.

Verified locally against the real Anthropic API (real spend) with a Sentry-style input-callback active that injects a live span into metadata exactly as `sentry_sdk`'s `LiteLLMIntegration` does. A `claude-haiku-4-5` `/v1/messages` call returned a normal response, and at the serialization boundary a span-polluted body raises under a bare `json.dumps` while `dumps_anthropic_messages_request_body` drops `_sentry_span` and keeps `user_id`:

```
== fix behavior on a span-polluted /v1/messages body ==
bare json.dumps -> TypeError: Object of type FakeSentrySpan is not JSON serializable
dumps_anthropic_messages_request_body -> {"model": "claude-haiku-4-5", "messages": [{"role": "user", "content": "hi"}], "max_tokens": 16, "metadata": {"user_id": "my-org"}}
== real Anthropic /v1/messages call, Sentry-style callback active ==
response id: msg_01Pj6UgQopTV1GtMQVhkJmxK
stop_reason: end_turn
content: [{'type': 'text', 'text': 'Hello'}]
usage: {'input_tokens': 14, 'output_tokens': 4, ...}
```

To reproduce against a live proxy:

1. Start the proxy

```
python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log
```

2. Hit the passthrough with caller metadata

```
curl -s http://localhost:4000/v1/messages \
  -H "Content-Type: application/json" \
  -H "x-api-key: sk-1234" \
  -d '{
    "model": "anthropic-haiku-4-5",
    "max_tokens": 16,
    "metadata": {"user_id": "my-org"},
    "messages": [{"role": "user", "content": "say hi in one word"}]
  }' | jq .
```

Expect a normal `message` response (HTTP 200), with the outbound body carrying `"metadata": {"user_id": "my-org"}` and no serialization error.

## Type

🐛 Bug Fix

## Changes

Added `dumps_anthropic_messages_request_body`, used at both points where the Anthropic `/v1/messages` request body is serialized (`async_anthropic_messages_handler` and the HTTP-error retry helper). It serializes normally on the happy path and, only when serialization fails, drops the non-serializable entries from `metadata` (where input-callbacks such as Sentry's `LiteLLMIntegration` stash a live `Span` under `_sentry_span`) and reserializes; dropped keys are named in a debug log so the drop is diagnosable rather than invisible. A non-serializable value anywhere other than `metadata` still raises, so genuine request-construction bugs are not masked.

Tests in `tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py` cover both serialization call sites end to end (the retry helper and the success path through `async_anthropic_messages_handler`), the helper's drop-and-preserve behavior plus caller-dict immutability, a fully-serializable passthrough, and the re-raise for non-`metadata` values across both the guard branch and the recovery branch.
