### PR TITLE
fix(otel): handle MCP CallToolResult in set_attributes

### DIFF
--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -2231,6 +2231,22 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
                     value=optional_params.get("user"),
                 )
 
+            # ``response_obj`` is normally a dict-like ModelResponse, but some
+            # call types pass a non-dict object that has no ``.get`` -- e.g. an
+            # MCP tool call, where it is a Pydantic ``CallToolResult``. Without
+            # coalescing, the first ``.get`` below raises AttributeError, which
+            # is swallowed and silently drops every response attribute (model,
+            # usage, messages, tool output) from the span.
+            # See https://github.com/BerriAI/litellm/issues/30651
+            mcp_tool_result: Optional[Any] = None
+            if response_obj is not None and not hasattr(response_obj, "get"):
+                # Keep the original result so its content can be recorded later,
+                # only when message-content capture is enabled (see below).
+                mcp_tool_result = response_obj
+                # Reuse the file's canonical normalizer (handles pydantic
+                # model_dump); falls back to {} so the .get() accessors are safe.
+                response_obj = self._to_dict(response_obj) or {}
+
             # The unique identifier for the LLM call.
             # Completions have a provider response ID (e.g. "chatcmpl-xxx"),
             # but Embeddings and Image-gen responses do not.  Fall back to
@@ -2288,6 +2304,18 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
 
             if not self._capture_in_span():
                 return
+
+            # Record the tool-call result content (e.g. an MCP CallToolResult)
+            # so tool output is not missing from the span. Extraction runs here,
+            # inside the content-capture gate, not before it. See issue #30651.
+            if mcp_tool_result is not None:
+                tool_output = self._extract_tool_result_output(mcp_tool_result)
+                if tool_output is not None:
+                    self.safe_set_attribute(
+                        span=span,
+                        key="gen_ai.tool.output",
+                        value=tool_output,
+                    )
 
             if optional_params.get("tools"):
                 tools = optional_params["tools"]
@@ -2459,6 +2487,20 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
             return str(value)
         except Exception:
             return ""
+
+    @staticmethod
+    def _extract_tool_result_output(response_obj: Any) -> Optional[str]:
+        """Extract text from a tool-call result (e.g. an MCP ``CallToolResult``).
+
+        ``CallToolResult.content`` is a list of content blocks; join the text of
+        any text blocks so the tool output can be recorded on the span. Returns
+        ``None`` when there is no text content.
+        """
+        content = getattr(response_obj, "content", None)
+        if not isinstance(content, list):
+            return None
+        texts = [item.text for item in content if isinstance(getattr(item, "text", None), str)]
+        return "\n".join(texts) if texts else None
 
     def safe_set_attribute(self, span: Span, key: str, value: Any):
         """

--- a/tests/test_litellm/integrations/test_otel_mcp_tool_result.py
+++ b/tests/test_litellm/integrations/test_otel_mcp_tool_result.py
@@ -1,0 +1,86 @@
+"""Regression tests for the OTEL callback crashing on MCP tool-call results.
+
+When an MCP tool call is traced (call_type ``call_mcp_tool``), ``response_obj``
+is a Pydantic ``mcp.types.CallToolResult``, which has no ``.get()``.
+``set_attributes`` assumed a dict and raised
+``AttributeError: 'CallToolResult' object has no attribute 'get'``, which the
+outer try/except swallowed, so the span silently lost every response attribute
+and the tool output. See https://github.com/BerriAI/litellm/issues/30651
+"""
+
+from unittest.mock import MagicMock
+
+from mcp.types import CallToolResult, TextContent
+
+from litellm.integrations.opentelemetry import OpenTelemetry
+
+
+def _span_attrs(mock_span):
+    return {c.args[0]: c.args[1] for c in mock_span.set_attribute.call_args_list}
+
+
+def _kwargs():
+    return {
+        "optional_params": {},
+        "litellm_params": {},
+        "standard_logging_object": {
+            "metadata": {},
+            "call_type": "call_mcp_tool",
+            "id": "resp-1",
+            "litellm_call_id": "call-1",
+        },
+    }
+
+
+def test_set_attributes_handles_mcp_call_tool_result():
+    """A CallToolResult response must not crash set_attributes, and its output
+    must be captured rather than silently dropped."""
+    otel = OpenTelemetry()
+    otel._capture_in_span = lambda: True  # enable content capture for tool output
+    span = MagicMock()
+    response_obj = CallToolResult(content=[TextContent(type="text", text="20")], isError=False)
+
+    otel.set_attributes(span, _kwargs(), response_obj)
+
+    attrs = _span_attrs(span)
+    # Crash fix: execution got past the `.get("id")` line, so the response id
+    # (falling back to the standard-logging-object id) is set on the span.
+    # Before the fix this attribute is never set because the AttributeError is
+    # raised first and swallowed.
+    assert attrs.get("gen_ai.response.id") == "resp-1"
+    # Tool output content is captured instead of being dropped.
+    assert attrs.get("gen_ai.tool.output") == "20"
+
+
+def test_set_attributes_non_dict_without_model_dump_does_not_crash():
+    """A non-dict response object lacking both .get and .model_dump must
+    coalesce to {} rather than crash; response id still falls back to the
+    standard-logging-object id."""
+    otel = OpenTelemetry()
+    otel._capture_in_span = lambda: True
+    span = MagicMock()
+
+    otel.set_attributes(span, _kwargs(), object())
+
+    attrs = _span_attrs(span)
+    assert attrs.get("gen_ai.response.id") == "resp-1"
+    # No content to record, so the tool-output attribute is not set.
+    assert "gen_ai.tool.output" not in attrs
+
+
+def test_extract_tool_result_output():
+    result = CallToolResult(content=[TextContent(type="text", text="hello")], isError=False)
+    assert OpenTelemetry._extract_tool_result_output(result) == "hello"
+
+    # Multiple text blocks are joined with newlines.
+    multi = CallToolResult(
+        content=[
+            TextContent(type="text", text="line1"),
+            TextContent(type="text", text="line2"),
+        ],
+        isError=False,
+    )
+    assert OpenTelemetry._extract_tool_result_output(multi) == "line1\nline2"
+
+    # No text content -> None (nothing to record).
+    assert OpenTelemetry._extract_tool_result_output(object()) is None


### PR DESCRIPTION
## Description

When an MCP tool call is traced with `callbacks: ["otel"]`, the `response_obj` passed to `OpenTelemetry.set_attributes` is a Pydantic `mcp.types.CallToolResult`, which has no `.get()`. The method assumes a dict, so `response_obj.get("id")` raises:

```
AttributeError: 'CallToolResult' object has no attribute 'get'
```

The outer `try/except` swallows it, so the span is emitted with input metadata only and every response attribute (model, usage, response id, messages, tool output) is silently dropped.

Fixes #30651

## Changes

- `set_attributes`: if `response_obj` has no `.get` (e.g. an MCP `CallToolResult`), coalesce it to a dict via `model_dump()` before the dict-style accessors. The guard is on the absence of `.get`, so the normal dict-like `ModelResponse` path is unchanged (it keeps `.get`, so the branch never triggers for it).
- Capture the tool-result content into `gen_ai.tool.output` (gated behind content capture, consistent with the other content attributes), so MCP tool output is no longer missing from the span.

## Testing

Added `tests/test_litellm/integrations/test_otel_mcp_tool_result.py`:

- `test_set_attributes_handles_mcp_call_tool_result`: a `CallToolResult` response no longer crashes `set_attributes`; the response id and `gen_ai.tool.output` are set on the span. This fails on current `main` (only `gen_ai.system`, `llm.is_streaming`, `llm.request.type` get set before the swallowed `AttributeError`) and passes with the fix.
- `test_extract_tool_result_output`: unit test for the content-extraction helper.

Also verified directly that the normal `ModelResponse` path is unaffected (its live id/model are still recorded; it is not rewritten via `model_dump`).
