### PR TITLE
feat(ui): migrate models page to App Router path route

### DIFF
--- a/ui/litellm-dashboard/e2e_tests/fixtures/migratedPages.ts
+++ b/ui/litellm-dashboard/e2e_tests/fixtures/migratedPages.ts
@@ -11,6 +11,7 @@
  * Keep this in lockstep with MIGRATED_PAGES in src/utils/migratedPages.ts.
  */
 export const MIGRATED_E2E_PAGES: Record<string, string> = {
+  models: "models-and-endpoints",
   api_ref: "api-reference",
   "llm-playground": "playground",
   projects: "projects",

--- a/ui/litellm-dashboard/e2e_tests/tests/migration/migratedPages.spec.ts
+++ b/ui/litellm-dashboard/e2e_tests/tests/migration/migratedPages.spec.ts
@@ -17,7 +17,7 @@ const ROOT = process.env.SERVER_ROOT_PATH ?? "";
 
 const esc = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 const pathRe = (segment: string) => new RegExp(`${esc(ROOT)}/ui/${esc(segment)}/?($|\\?)`);
-const legacyAnchor = (page: Page) => page.locator("a", { hasText: "Virtual Keys" });
+const legacyAnchor = (page: Page) => page.getByRole("link", { name: "Virtual Keys", exact: true });
 
 /** The dashboard shell is present (sidebar rendered); page didn't 404 / crash. */
 async function expectRendered(page: Page) {

--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/ModelsAndEndpointsView.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/ModelsAndEndpointsView.test.tsx
@@ -120,14 +120,7 @@ describe("ModelsAndEndpointsView", () => {
     const queryClient = createQueryClient();
     const { findByText } = render(
       <QueryClientProvider client={queryClient}>
-        <ModelsAndEndpointsView
-          token="123"
-          modelData={{ data: [] }}
-          keys={[]}
-          setModelData={() => {}}
-          premiumUser={false}
-          teams={[]}
-        />
+        <ModelsAndEndpointsView premiumUser={false} teams={[]} />
       </QueryClientProvider>,
     );
     expect(await findByText("Model Management", {}, { timeout: 10000 })).toBeInTheDocument();
@@ -138,14 +131,7 @@ describe("ModelsAndEndpointsView", () => {
     const queryClient = createQueryClient();
     const { findByText } = render(
       <QueryClientProvider client={queryClient}>
-        <ModelsAndEndpointsView
-          token="123"
-          modelData={{ data: [] }}
-          keys={[]}
-          setModelData={() => {}}
-          premiumUser={false}
-          teams={[]}
-        />
+        <ModelsAndEndpointsView premiumUser={false} teams={[]} />
       </QueryClientProvider>,
     );
     expect(await findByText("Missing a provider?", {}, { timeout: 10000 })).toBeInTheDocument();
@@ -156,14 +142,7 @@ describe("ModelsAndEndpointsView", () => {
     const queryClient = createQueryClient();
     const { findByText, queryByText, container } = render(
       <QueryClientProvider client={queryClient}>
-        <ModelsAndEndpointsView
-          token="123"
-          modelData={{ data: [] }}
-          keys={[]}
-          setModelData={() => {}}
-          premiumUser={false}
-          teams={[]}
-        />
+        <ModelsAndEndpointsView premiumUser={false} teams={[]} />
       </QueryClientProvider>,
     );
 
@@ -188,14 +167,7 @@ describe("ModelsAndEndpointsView", () => {
     const queryClient = createQueryClient();
     const { findByText, queryByText } = render(
       <QueryClientProvider client={queryClient}>
-        <ModelsAndEndpointsView
-          token="123"
-          modelData={{ data: [] }}
-          keys={[]}
-          setModelData={() => {}}
-          premiumUser={false}
-          teams={[]}
-        />
+        <ModelsAndEndpointsView premiumUser={false} teams={[]} />
       </QueryClientProvider>,
     );
 
@@ -228,14 +200,7 @@ describe("ModelsAndEndpointsView", () => {
     const queryClient = createQueryClient();
     const { getByRole } = render(
       <QueryClientProvider client={queryClient}>
-        <ModelsAndEndpointsView
-          token="123"
-          modelData={{ data: modelDataWithIds.data }}
-          keys={[]}
-          setModelData={() => {}}
-          premiumUser={false}
-          teams={[]}
-        />
+        <ModelsAndEndpointsView premiumUser={false} teams={[]} />
       </QueryClientProvider>,
     );
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/ModelsAndEndpointsView.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/ModelsAndEndpointsView.tsx
@@ -30,10 +30,6 @@ import TeamInfoView from "../../../components/team/TeamInfo";
 import useAuthorized from "../hooks/useAuthorized";
 
 interface ModelDashboardProps {
-  token: string | null;
-  modelData: any;
-  keys: any[] | null;
-  setModelData: any;
   premiumUser: boolean;
   teams: Team[] | null;
 }

--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/page.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import ModelsAndEndpointsView from "@/app/(dashboard)/models-and-endpoints/ModelsAndEndpointsView";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+import { useTeams } from "@/app/(dashboard)/hooks/teams/useTeams";
+
+export default function ModelsAndEndpointsPage() {
+  const { premiumUser } = useAuthorized();
+  const { data: teams } = useTeams();
+  return <ModelsAndEndpointsView premiumUser={premiumUser} teams={teams ?? null} />;
+}

--- a/ui/litellm-dashboard/src/app/(dashboard)/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import ModelsAndEndpointsView from "@/app/(dashboard)/models-and-endpoints/ModelsAndEndpointsView";
 import { teamListCall as v2TeamListCall } from "@/app/(dashboard)/hooks/teams/useTeams";
 import { useUISettings } from "@/app/(dashboard)/hooks/uiSettings/useUISettings";
 import LoadingScreen from "@/components/common_components/LoadingScreen";
@@ -34,7 +33,7 @@ function CreateKeyPageContent() {
 
   const router = useRouter();
   const searchParams = useSearchParams()!;
-  const [modelData, setModelData] = useState<any>({ data: [] });
+  const [modelData] = useState<any>({ data: [] });
   const [createClicked, setCreateClicked] = useState<boolean>(false);
 
   const { data: uiSettingsData, isLoading: uiSettingsLoading } = useUISettings();
@@ -307,15 +306,6 @@ function CreateKeyPageContent() {
               createClicked={createClicked}
               autoOpenCreate={autoOpenCreate}
               prefillData={prefillData}
-            />
-          ) : page == "models" ? (
-            <ModelsAndEndpointsView
-              token={token}
-              keys={keys}
-              modelData={modelData}
-              setModelData={setModelData}
-              premiumUser={premiumUser}
-              teams={teams}
             />
           ) : page == "pass-through-settings" ? (
             <PassThroughSettings

--- a/ui/litellm-dashboard/src/utils/migratedPages.test.ts
+++ b/ui/litellm-dashboard/src/utils/migratedPages.test.ts
@@ -48,6 +48,14 @@ describe("migratedHref / legacyPageHref", () => {
     expect(MIGRATED_PAGES["llm-playground"]).toBe("playground");
   });
 
+  it("maps the models sidebar id to the models-and-endpoints route and builds its redirect href", async () => {
+    vi.doMock("@/components/networking", () => ({ serverRootPath: "/" }));
+    const { MIGRATED_PAGES, migratedHref } = await import("./migratedPages");
+
+    expect(MIGRATED_PAGES.models).toBe("models-and-endpoints");
+    expect(migratedHref(MIGRATED_PAGES.models)).toBe("/ui/models-and-endpoints");
+  });
+
   it("maps the projects and access-groups sidebar ids to their routes", async () => {
     vi.doMock("@/components/networking", () => ({ serverRootPath: "/" }));
     const { MIGRATED_PAGES } = await import("./migratedPages");

--- a/ui/litellm-dashboard/src/utils/migratedPages.ts
+++ b/ui/litellm-dashboard/src/utils/migratedPages.ts
@@ -9,6 +9,7 @@ import { serverRootPath } from "@/components/networking";
  * legacy `?page=` URL; remove it to roll back.
  */
 export const MIGRATED_PAGES: Record<string, string> = {
+  models: "models-and-endpoints",
   api_ref: "api-reference",
   // Legacy alias: older bookmarks used the hyphenated ?page=api-reference form.
   "api-reference": "api-reference",


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Refs LIT-3687

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

This is a UI routing change with no backend component, so the proof is the rendered page reachable at its new path plus the legacy redirect. To verify locally:

1. Build and serve the dashboard, or run the proxy that serves it, then visit http://localhost:4000/ui/models-and-endpoints and confirm the Models + Endpoints page renders (Model Management header, the All Models / Add Model / Health Status tabs)
2. Click "Models" in the left sidebar and confirm the URL becomes `/ui/models-and-endpoints` (not `/ui/?page=models`)
3. Open an old bookmark http://localhost:4000/ui/?page=models and confirm it redirects to `/ui/models-and-endpoints`

## Type

🧹 Refactoring

## Changes

Continues the dashboard App Router migration by cutting the Models + Endpoints page over from the legacy `?page=models` switch in `(dashboard)/page.tsx` to a path route at `(dashboard)/models-and-endpoints/page.tsx`. Adding the `models -> models-and-endpoints` entry to `MIGRATED_PAGES` is the single switch that repoints the sidebar link and redirects existing `?page=models` deep links to `/ui/models-and-endpoints`, matching the mechanism every already-migrated page uses.

`ModelsAndEndpointsView` already pulled identity from `useAuthorized()` and its model data from `useModelsInfo()`, so the `token`, `keys`, `modelData`, and `setModelData` props it still declared were dead. I removed them from `ModelDashboardProps` (which also drops three `any`s), updated the view's test renders accordingly, and dropped the parent's now-unused `setModelData` state; `modelData` stays only because `pass-through-settings` still reads it (that page is the next migration). The new route's `page.tsx` supplies `premiumUser` from `useAuthorized()` and `teams` from `useTeams()`, the same pattern the agents route uses.

Added a unit test asserting `MIGRATED_PAGES.models` maps to `models-and-endpoints` and that `migratedHref` builds `/ui/models-and-endpoints`, and added the page to the e2e migration fixture so the sidebar/navigation smoke covers it.

