### PR TITLE
feat: plugin architecture — toggle between AI Gateway and external plugins

### DIFF
--- a/backend/routes/allowlist.py
+++ b/backend/routes/allowlist.py
@@ -120,6 +120,9 @@ BACKEND_PATH_PREFIXES: tuple[str, ...] = (
     "/robots.txt",
     # Health (k8s probes)
     "/health",
+    # Plugin system
+    "/api/plugins",
+    "/plugin-proxy/",
 )
 
 BACKEND_EXACT_PATHS: frozenset[str] = frozenset(

--- a/litellm/proxy/plugin_routes.py
+++ b/litellm/proxy/plugin_routes.py
@@ -1,0 +1,102 @@
+"""
+Plugin proxy routes for litellm.
+
+Enables external services (e.g. litellm-agent-platform) to register as plugins
+and be proxied through the litellm proxy server.
+
+Config (in litellm config.yaml general_settings):
+  plugins:
+    - name: litellm-platform-plugin
+      url: "http://localhost:3210"
+      display_name: "Agent Control Plane"
+"""
+
+import httpx
+from fastapi import APIRouter, Request, Response
+from fastapi.responses import StreamingResponse
+import asyncio
+
+router = APIRouter()
+
+# In-memory plugin registry — populated from general_settings at startup
+_plugin_registry: dict[str, dict] = {}
+
+
+def register_plugins_from_config(general_settings: dict) -> None:
+    """Call at startup to load plugin config from general_settings."""
+    plugins = general_settings.get("plugins", [])
+    for plugin in plugins:
+        name = plugin.get("name")
+        if name:
+            _plugin_registry[name] = plugin
+
+
+@router.get("/api/plugins", tags=["plugins"])
+async def list_plugins(request: Request) -> list[dict]:
+    """Return registered plugins for UI discovery.
+
+    plugin_key is only returned to authenticated requests (Authorization header present).
+    """
+    authed = bool(request.headers.get("Authorization") or request.cookies.get("token"))
+    result = []
+    for name, plugin in _plugin_registry.items():
+        entry: dict = {
+            "name": name,
+            "display_name": plugin.get("display_name", name),
+            "url": plugin.get("url", ""),
+        }
+        if authed and plugin.get("plugin_key"):
+            entry["plugin_key"] = plugin["plugin_key"]
+        result.append(entry)
+    return result
+
+
+@router.api_route(
+    "/plugin-proxy/{plugin_name}/{path:path}",
+    methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"],
+    tags=["plugins"],
+    include_in_schema=False,
+)
+async def plugin_proxy(plugin_name: str, path: str, request: Request) -> Response:
+    """Reverse-proxy any request to the registered plugin's backend."""
+    plugin = _plugin_registry.get(plugin_name)
+    if not plugin:
+        return Response(
+            content=f"Plugin '{plugin_name}' not registered",
+            status_code=404,
+        )
+
+    target_url = f"{plugin['url'].rstrip('/')}/{path}"
+    query = request.url.query
+    if query:
+        target_url = f"{target_url}?{query}"
+
+    body = await request.body()
+
+    # Forward headers, strip hop-by-hop
+    forward_headers = {
+        k: v
+        for k, v in request.headers.items()
+        if k.lower() not in {"host", "connection", "transfer-encoding", "te", "trailers", "upgrade"}
+    }
+
+    async with httpx.AsyncClient(timeout=60.0) as client:
+        try:
+            resp = await client.request(
+                method=request.method,
+                url=target_url,
+                headers=forward_headers,
+                content=body,
+                follow_redirects=True,
+            )
+        except httpx.ConnectError:
+            return Response(
+                content=f"Cannot connect to plugin '{plugin_name}' at {plugin['url']}",
+                status_code=502,
+            )
+
+    return Response(
+        content=resp.content,
+        status_code=resp.status_code,
+        headers=dict(resp.headers),
+    )

--- a/litellm/proxy/plugin_routes.py
+++ b/litellm/proxy/plugin_routes.py
@@ -33,7 +33,7 @@ def register_plugins_from_config(general_settings: dict) -> None:
             _plugin_registry[name] = plugin
 
 
-@router.get("/api/plugins", tags=["plugins"])
+@router.get("/api/plugins", tags=["plugins"], include_in_schema=False)
 async def list_plugins(
     user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
 ) -> list:

--- a/litellm/proxy/plugin_routes.py
+++ b/litellm/proxy/plugin_routes.py
@@ -25,9 +25,13 @@ _plugin_registry: dict = {}
 
 
 def register_plugins_from_config(general_settings: dict) -> None:
-    """Call at startup to load plugin config from general_settings."""
-    plugins = general_settings.get("plugins", [])
-    for plugin in plugins:
+    """Replace the plugin registry from general_settings.
+
+    Replaces (not merges) so plugins removed from config are immediately
+    unreachable without requiring a process restart.
+    """
+    _plugin_registry.clear()
+    for plugin in general_settings.get("plugins", []):
         name = plugin.get("name")
         if name:
             _plugin_registry[name] = plugin

--- a/litellm/proxy/plugin_routes.py
+++ b/litellm/proxy/plugin_routes.py
@@ -39,8 +39,10 @@ async def list_plugins(
 ) -> list:
     """Return registered plugins for authenticated UI callers.
 
-    plugin_key is only returned to callers with a valid litellm token.
+    plugin_key is only returned to proxy admins — not to regular users —
+    so plugin credentials cannot be extracted by non-admin callers.
     """
+    is_admin = getattr(user_api_key_dict, "user_role", None) == "proxy_admin"
     result = []
     for name, plugin in _plugin_registry.items():
         entry: dict = {
@@ -48,7 +50,7 @@ async def list_plugins(
             "display_name": plugin.get("display_name", name),
             "url": plugin.get("url", ""),
         }
-        if plugin.get("plugin_key"):
+        if is_admin and plugin.get("plugin_key"):
             entry["plugin_key"] = plugin["plugin_key"]
         result.append(entry)
     return result

--- a/litellm/proxy/plugin_routes.py
+++ b/litellm/proxy/plugin_routes.py
@@ -33,7 +33,7 @@ def register_plugins_from_config(general_settings: dict) -> None:
             _plugin_registry[name] = plugin
 
 
-@router.get("/api/plugins", tags=["plugins"], include_in_schema=False)
+@router.get("/api/plugins", tags=["plugins"])
 async def list_plugins(
     user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
 ) -> list:

--- a/litellm/proxy/plugin_routes.py
+++ b/litellm/proxy/plugin_routes.py
@@ -6,14 +6,16 @@ the litellm proxy server.
 
 Config (in litellm config.yaml general_settings):
   plugins:
-    - name: agent-control-plane
+    - name: my-plugin
       url: "http://localhost:3210"
-      display_name: "Agent Control Plane"
+      display_name: "My Plugin"
       plugin_key: "sk-..."   # optional: plugin's own auth key
 """
 
-from fastapi import APIRouter, Request, Response
+from fastapi import APIRouter, Depends, Request, Response
 
+from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 from litellm.llms.custom_httpx.http_handler import get_async_httpx_client
 
 router = APIRouter()
@@ -32,12 +34,13 @@ def register_plugins_from_config(general_settings: dict) -> None:
 
 
 @router.get("/api/plugins", tags=["plugins"])
-async def list_plugins(request: Request) -> list:
-    """Return registered plugins for UI discovery.
+async def list_plugins(
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+) -> list:
+    """Return registered plugins for authenticated UI callers.
 
-    plugin_key is only returned to authenticated requests.
+    plugin_key is only returned to callers with a valid litellm token.
     """
-    authed = bool(request.headers.get("Authorization") or request.cookies.get("token"))
     result = []
     for name, plugin in _plugin_registry.items():
         entry: dict = {
@@ -45,7 +48,7 @@ async def list_plugins(request: Request) -> list:
             "display_name": plugin.get("display_name", name),
             "url": plugin.get("url", ""),
         }
-        if authed and plugin.get("plugin_key"):
+        if plugin.get("plugin_key"):
             entry["plugin_key"] = plugin["plugin_key"]
         result.append(entry)
     return result
@@ -57,8 +60,13 @@ async def list_plugins(request: Request) -> list:
     tags=["plugins"],
     include_in_schema=False,
 )
-async def plugin_proxy(plugin_name: str, path: str, request: Request) -> Response:
-    """Reverse-proxy any request to the registered plugin's backend."""
+async def plugin_proxy(
+    plugin_name: str,
+    path: str,
+    request: Request,
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+) -> Response:
+    """Authenticated reverse-proxy to a registered plugin backend."""
     plugin = _plugin_registry.get(plugin_name)
     if not plugin:
         return Response(

--- a/litellm/proxy/plugin_routes.py
+++ b/litellm/proxy/plugin_routes.py
@@ -1,25 +1,25 @@
 """
 Plugin proxy routes for litellm.
 
-Enables external services (e.g. litellm-agent-platform) to register as plugins
-and be proxied through the litellm proxy server.
+Enables external services to register as plugins and be proxied through
+the litellm proxy server.
 
 Config (in litellm config.yaml general_settings):
   plugins:
-    - name: litellm-platform-plugin
+    - name: agent-control-plane
       url: "http://localhost:3210"
       display_name: "Agent Control Plane"
+      plugin_key: "sk-..."   # optional: plugin's own auth key
 """
 
-import httpx
 from fastapi import APIRouter, Request, Response
-from fastapi.responses import StreamingResponse
-import asyncio
+
+from litellm.llms.custom_httpx.http_handler import get_async_httpx_client
 
 router = APIRouter()
 
 # In-memory plugin registry — populated from general_settings at startup
-_plugin_registry: dict[str, dict] = {}
+_plugin_registry: dict = {}
 
 
 def register_plugins_from_config(general_settings: dict) -> None:
@@ -32,10 +32,10 @@ def register_plugins_from_config(general_settings: dict) -> None:
 
 
 @router.get("/api/plugins", tags=["plugins"])
-async def list_plugins(request: Request) -> list[dict]:
+async def list_plugins(request: Request) -> list:
     """Return registered plugins for UI discovery.
 
-    plugin_key is only returned to authenticated requests (Authorization header present).
+    plugin_key is only returned to authenticated requests.
     """
     authed = bool(request.headers.get("Authorization") or request.cookies.get("token"))
     result = []
@@ -73,27 +73,34 @@ async def plugin_proxy(plugin_name: str, path: str, request: Request) -> Respons
 
     body = await request.body()
 
-    # Forward headers, strip hop-by-hop
     forward_headers = {
         k: v
         for k, v in request.headers.items()
-        if k.lower() not in {"host", "connection", "transfer-encoding", "te", "trailers", "upgrade"}
+        if k.lower()
+        not in {
+            "host",
+            "connection",
+            "transfer-encoding",
+            "te",
+            "trailers",
+            "upgrade",
+        }
     }
 
-    async with httpx.AsyncClient(timeout=60.0) as client:
-        try:
-            resp = await client.request(
-                method=request.method,
-                url=target_url,
-                headers=forward_headers,
-                content=body,
-                follow_redirects=True,
-            )
-        except httpx.ConnectError:
-            return Response(
-                content=f"Cannot connect to plugin '{plugin_name}' at {plugin['url']}",
-                status_code=502,
-            )
+    handler = get_async_httpx_client(llm_provider=None)
+    try:
+        req = handler.client.build_request(
+            method=request.method,
+            url=target_url,
+            headers=forward_headers,
+            content=body,
+        )
+        resp = await handler.client.send(req, follow_redirects=True)
+    except Exception:
+        return Response(
+            content=f"Cannot connect to plugin '{plugin_name}' at {plugin['url']}",
+            status_code=502,
+        )
 
     return Response(
         content=resp.content,

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -418,6 +418,7 @@ from litellm.proxy.management_endpoints.workflow_management_endpoints import (
 )
 from litellm.proxy.management_helpers.audit_logs import create_audit_log_for_update
 from litellm.proxy.memory.memory_endpoints import router as memory_router
+from litellm.proxy.plugin_routes import router as plugin_router, register_plugins_from_config
 from litellm.proxy.middleware.in_flight_requests_middleware import (
     InFlightRequestsMiddleware,
 )
@@ -4295,6 +4296,8 @@ class ProxyConfig:
             load_from_azure_key_vault(use_azure_key_vault=use_azure_key_vault)
             ### ALERTING ###
             self._load_alerting_settings(general_settings=general_settings)
+            ### PLUGINS ###
+            register_plugins_from_config(general_settings)
             ### CONNECT TO DATABASE ###
             database_url = general_settings.get("database_url", None)
             if database_url and database_url.startswith("os.environ/"):
@@ -16173,6 +16176,7 @@ app.include_router(model_access_group_management_router)
 app.include_router(tag_management_router)
 app.include_router(workflow_management_router)
 app.include_router(memory_router)
+app.include_router(plugin_router)
 app.include_router(cost_tracking_settings_router)
 app.include_router(router_settings_router)
 app.include_router(fallback_management_router)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -418,7 +418,10 @@ from litellm.proxy.management_endpoints.workflow_management_endpoints import (
 )
 from litellm.proxy.management_helpers.audit_logs import create_audit_log_for_update
 from litellm.proxy.memory.memory_endpoints import router as memory_router
-from litellm.proxy.plugin_routes import router as plugin_router, register_plugins_from_config
+from litellm.proxy.plugin_routes import (
+    router as plugin_router,
+    register_plugins_from_config,
+)
 from litellm.proxy.middleware.in_flight_requests_middleware import (
     InFlightRequestsMiddleware,
 )
@@ -2839,9 +2842,11 @@ def run_ollama_serve():
         with open(os.devnull, "w") as devnull:
             subprocess.Popen(command, stdout=devnull, stderr=devnull)
     except Exception as e:
-        verbose_proxy_logger.debug(f"""
+        verbose_proxy_logger.debug(
+            f"""
             LiteLLM Warning: proxy started with `ollama` model\n`ollama serve` failed with Exception{e}. \nEnsure you run `ollama serve`
-        """)
+        """
+        )
 
 
 def _get_process_rss_mb() -> Optional[float]:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -2842,11 +2842,9 @@ def run_ollama_serve():
         with open(os.devnull, "w") as devnull:
             subprocess.Popen(command, stdout=devnull, stderr=devnull)
     except Exception as e:
-        verbose_proxy_logger.debug(
-            f"""
+        verbose_proxy_logger.debug(f"""
             LiteLLM Warning: proxy started with `ollama` model\n`ollama serve` failed with Exception{e}. \nEnsure you run `ollama serve`
-        """
-        )
+        """)
 
 
 def _get_process_rss_mb() -> Optional[float]:

--- a/ui/litellm-dashboard/package-lock.json
+++ b/ui/litellm-dashboard/package-lock.json
@@ -89,7 +89,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -2049,7 +2048,6 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -2071,7 +2069,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -2081,14 +2078,12 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -2262,7 +2257,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -2276,7 +2270,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -2286,7 +2279,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -2593,7 +2585,7 @@
       "version": "1.58.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.1.tgz",
       "integrity": "sha512-6LdVIUERWxQMmUSSQi0I53GgCBYgM2RpGngCPY7hSeju+VrKjq3lvs7HpJoPbDiY5QM5EYRtRX5fvrinnMAz3w==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.58.1"
@@ -3666,14 +3658,12 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.2.48",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.48.tgz",
       "integrity": "sha512-qboRCl6Ie70DQQG9hhNREz81jqC1cs9EVNcjQ1AU+jH6NFfSAhVVbrrY/+nSF+Bsk4AOwm9Qa61InvMCyV+H3w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -3715,7 +3705,6 @@
       "version": "0.26.0",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.26.0.tgz",
       "integrity": "sha512-WFHp9YUJQ6CKshqoC37iOlHnQSmxNc795UhB26CyBBttrN9svdIrUjl/NjnNmfcwtncN0h/0PPAFWv9ovP8mLA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/unist": {
@@ -4605,14 +4594,12 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -4626,7 +4613,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -4639,7 +4625,6 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -5002,7 +4987,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5028,7 +5012,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -5144,7 +5127,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -5275,7 +5257,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
@@ -5300,7 +5281,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -5383,7 +5363,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -5451,7 +5430,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "cssesc": "bin/cssesc"
@@ -5865,14 +5843,12 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/doctrine": {
@@ -6774,7 +6750,6 @@
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
       "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -6807,7 +6782,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -6845,7 +6819,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -6985,7 +6958,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -7146,7 +7118,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -7674,7 +7645,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -7727,7 +7697,6 @@
       "version": "2.16.2",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
       "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.3"
@@ -7788,7 +7757,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7834,7 +7802,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -7883,7 +7850,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -8160,7 +8126,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -8472,7 +8438,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
       "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -8485,7 +8450,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
@@ -8939,7 +8903,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -9512,7 +9475,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -9526,7 +9488,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -9641,7 +9602,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0",
@@ -9854,7 +9814,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -9873,7 +9832,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -10270,7 +10228,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-scurry": {
@@ -10317,7 +10274,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -10330,7 +10286,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10340,7 +10295,6 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
       "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -10350,7 +10304,7 @@
       "version": "1.58.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.1.tgz",
       "integrity": "sha512-+2uTZHxSCcxjvGc5C891LrS1/NlxglGxzrC4seZiVjcYVQfUa87wBL6rTDqzGjuoWNjnBzRqKmF6zRYGMvQUaQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.58.1"
@@ -10369,7 +10323,7 @@
       "version": "1.58.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.1.tgz",
       "integrity": "sha512-bcWzOaTxcW+VOOGBCQgnaKToLJ65d6AqfLVKEWvexyS3AS6rbXl+xdpYRMGSRBClPvyj44njOWoxjNdL/H9UNg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -10430,7 +10384,6 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
       "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
@@ -10448,7 +10401,6 @@
       "version": "1.22.12",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
       "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -10470,7 +10422,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
       "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -10496,7 +10447,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
       "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -10539,7 +10489,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
       "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -10565,7 +10514,6 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -10579,7 +10527,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/prelude-ls": {
@@ -10686,7 +10633,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -11513,7 +11459,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
@@ -11523,7 +11468,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
@@ -11536,7 +11480,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -11878,7 +11821,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -11934,7 +11876,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -12575,7 +12516,6 @@
       "version": "3.35.1",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
       "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -12611,7 +12551,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -12647,7 +12586,6 @@
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
@@ -12685,7 +12623,6 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -12702,7 +12639,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -12715,7 +12651,6 @@
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
@@ -12725,7 +12660,6 @@
       "version": "1.22.12",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
       "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -12762,7 +12696,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0"
@@ -12772,7 +12705,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
@@ -12814,7 +12746,6 @@
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
       "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -12881,7 +12812,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -12975,7 +12905,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/tsconfig-paths": {
@@ -13105,7 +13034,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -13347,7 +13276,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/uuid": {
@@ -13801,7 +13729,7 @@
       "version": "8.20.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
       "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -13886,7 +13814,7 @@
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/ui/litellm-dashboard/package-lock.json
+++ b/ui/litellm-dashboard/package-lock.json
@@ -89,6 +89,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -2048,6 +2049,7 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -2069,6 +2071,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -2078,12 +2081,14 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -2257,6 +2262,7 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -2270,6 +2276,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -2279,6 +2286,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -2585,7 +2593,7 @@
       "version": "1.58.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.1.tgz",
       "integrity": "sha512-6LdVIUERWxQMmUSSQi0I53GgCBYgM2RpGngCPY7hSeju+VrKjq3lvs7HpJoPbDiY5QM5EYRtRX5fvrinnMAz3w==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.58.1"
@@ -3658,12 +3666,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.2.48",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.48.tgz",
       "integrity": "sha512-qboRCl6Ie70DQQG9hhNREz81jqC1cs9EVNcjQ1AU+jH6NFfSAhVVbrrY/+nSF+Bsk4AOwm9Qa61InvMCyV+H3w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -3705,6 +3715,7 @@
       "version": "0.26.0",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.26.0.tgz",
       "integrity": "sha512-WFHp9YUJQ6CKshqoC37iOlHnQSmxNc795UhB26CyBBttrN9svdIrUjl/NjnNmfcwtncN0h/0PPAFWv9ovP8mLA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/unist": {
@@ -4594,12 +4605,14 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -4613,6 +4626,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -4625,6 +4639,7 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -4987,6 +5002,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5012,6 +5028,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -5127,6 +5144,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -5257,6 +5275,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
@@ -5281,6 +5300,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -5363,6 +5383,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -5430,6 +5451,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "cssesc": "bin/cssesc"
@@ -5843,12 +5865,14 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/doctrine": {
@@ -6750,6 +6774,7 @@
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
       "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -6782,6 +6807,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -6819,6 +6845,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -6958,6 +6985,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -7118,6 +7146,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -7645,6 +7674,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -7697,6 +7727,7 @@
       "version": "2.16.2",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
       "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.3"
@@ -7757,6 +7788,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7802,6 +7834,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -7850,6 +7883,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -8126,7 +8160,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -8438,6 +8472,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
       "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -8450,6 +8485,7 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
@@ -8903,6 +8939,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -9475,6 +9512,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -9488,6 +9526,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -9602,6 +9641,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0",
@@ -9814,6 +9854,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -9832,6 +9873,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -10228,6 +10270,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-scurry": {
@@ -10274,6 +10317,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -10286,6 +10330,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10295,6 +10340,7 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
       "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -10304,7 +10350,7 @@
       "version": "1.58.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.1.tgz",
       "integrity": "sha512-+2uTZHxSCcxjvGc5C891LrS1/NlxglGxzrC4seZiVjcYVQfUa87wBL6rTDqzGjuoWNjnBzRqKmF6zRYGMvQUaQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.58.1"
@@ -10323,7 +10369,7 @@
       "version": "1.58.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.1.tgz",
       "integrity": "sha512-bcWzOaTxcW+VOOGBCQgnaKToLJ65d6AqfLVKEWvexyS3AS6rbXl+xdpYRMGSRBClPvyj44njOWoxjNdL/H9UNg==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -10384,6 +10430,7 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
       "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
@@ -10401,6 +10448,7 @@
       "version": "1.22.12",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
       "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -10422,6 +10470,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
       "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -10447,6 +10496,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
       "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -10489,6 +10539,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
       "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -10514,6 +10565,7 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -10527,6 +10579,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/prelude-ls": {
@@ -10633,6 +10686,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -11459,6 +11513,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
@@ -11468,6 +11523,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
@@ -11480,6 +11536,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -11821,6 +11878,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -11876,6 +11934,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -12516,6 +12575,7 @@
       "version": "3.35.1",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
       "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -12551,6 +12611,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -12586,6 +12647,7 @@
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
@@ -12623,6 +12685,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -12639,6 +12702,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -12651,6 +12715,7 @@
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
@@ -12660,6 +12725,7 @@
       "version": "1.22.12",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
       "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -12696,6 +12762,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0"
@@ -12705,6 +12772,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
@@ -12746,6 +12814,7 @@
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
       "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -12812,6 +12881,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -12905,6 +12975,7 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/tsconfig-paths": {
@@ -13034,7 +13105,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -13276,6 +13347,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/uuid": {
@@ -13729,7 +13801,7 @@
       "version": "8.20.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
       "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -13814,7 +13886,7 @@
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/ui/litellm-dashboard/src/app/(dashboard)/layout.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/layout.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { Suspense, useState } from "react";
+import React, { Suspense, useState, useRef, useEffect } from "react";
 import Navbar from "@/components/navbar";
 import LoadingScreen from "@/components/common_components/LoadingScreen";
 import { ThemeProvider } from "@/contexts/ThemeContext";
@@ -14,6 +14,22 @@ import { PluginModeProvider, usePluginMode } from "@/contexts/PluginModeContext"
 function AgentControlPlaneView() {
   const { agentPlatformUrl, agentPlatformPath } = usePluginMode();
   const { accessToken } = useAuth();
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+
+  // Send auth token via postMessage after iframe loads — avoids exposing the
+  // token in the URL (browser history, server logs, Referer headers).
+  useEffect(() => {
+    const iframe = iframeRef.current;
+    if (!iframe || !accessToken || !agentPlatformUrl) return;
+    const send = () => {
+      iframe.contentWindow?.postMessage(
+        { type: "litellm-auth", token: accessToken },
+        agentPlatformUrl, // targetOrigin — only the configured plugin receives this
+      );
+    };
+    iframe.addEventListener("load", send);
+    return () => iframe.removeEventListener("load", send);
+  }, [accessToken, agentPlatformUrl]);
 
   if (!agentPlatformUrl) {
     return (
@@ -26,14 +42,10 @@ function AgentControlPlaneView() {
     );
   }
 
-  // Pass the user's litellm virtual key — LAP validates it against litellm's /key/info.
-  // This propagates litellm's user hierarchy (role, team, budget) into the agent control plane.
-  const params = accessToken ? `?token=${encodeURIComponent(accessToken)}` : "";
-  const iframeSrc = `${agentPlatformUrl}${agentPlatformPath}${params}`;
-
   return (
     <iframe
-      src={iframeSrc}
+      ref={iframeRef}
+      src={`${agentPlatformUrl}${agentPlatformPath}`}
       style={{
         width: "100%",
         height: "100%",

--- a/ui/litellm-dashboard/src/app/(dashboard)/layout.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/layout.tsx
@@ -9,6 +9,43 @@ import SidebarProvider from "@/app/(dashboard)/components/SidebarProvider";
 import { useRouter, useSearchParams, usePathname } from "next/navigation";
 import { DebugWarningBanner } from "@/components/DebugWarningBanner";
 import { MIGRATED_PAGES, migratedHref, legacyPageHref, legacyKeyForPathname } from "@/utils/migratedPages";
+import { PluginModeProvider, usePluginMode } from "@/contexts/PluginModeContext";
+
+function AgentControlPlaneView() {
+  const { agentPlatformUrl, agentPlatformPath } = usePluginMode();
+  const { accessToken } = useAuth();
+
+  if (!agentPlatformUrl) {
+    return (
+      <div className="flex flex-1 items-center justify-center text-gray-500">
+        <div className="text-center">
+          <p className="text-lg font-medium mb-2">Agent Control Plane</p>
+          <p className="text-sm">Configure agent platform URL in settings</p>
+        </div>
+      </div>
+    );
+  }
+
+  // Pass the user's litellm virtual key — LAP validates it against litellm's /key/info.
+  // This propagates litellm's user hierarchy (role, team, budget) into the agent control plane.
+  const params = accessToken ? `?token=${encodeURIComponent(accessToken)}` : "";
+  const iframeSrc = `${agentPlatformUrl}${agentPlatformPath}${params}`;
+
+  return (
+    <iframe
+      src={iframeSrc}
+      style={{
+        width: "100%",
+        height: "100%",
+        border: "none",
+        flex: 1,
+        minHeight: "calc(100vh - 56px)",
+      }}
+      title="Agent Control Plane"
+      allow="clipboard-read; clipboard-write"
+    />
+  );
+}
 
 function DashboardShell({ children }: { children: React.ReactNode }) {
   const router = useRouter();
@@ -16,6 +53,7 @@ function DashboardShell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const { accessToken } = useAuth();
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const { mode } = usePluginMode();
 
   const page = legacyKeyForPathname(pathname) || searchParams.get("page") || "api-keys";
 
@@ -37,7 +75,13 @@ function DashboardShell({ children }: { children: React.ReactNode }) {
         <div className="mt-2">
           <SidebarProvider setPage={navigateToPage} defaultSelectedKey={page} sidebarCollapsed={sidebarCollapsed} />
         </div>
-        <main className="flex-1">{children}</main>
+        {mode === "litellm-platform-plugin" ? (
+          <div className="flex-1 flex">
+            <AgentControlPlaneView />
+          </div>
+        ) : (
+          <main className="flex-1">{children}</main>
+        )}
       </div>
     </div>
   );
@@ -62,7 +106,9 @@ function LayoutContent({ children }: { children: React.ReactNode }) {
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
     <Suspense fallback={<LoadingScreen />}>
-      <LayoutContent>{children}</LayoutContent>
+      <PluginModeProvider>
+        <LayoutContent>{children}</LayoutContent>
+      </PluginModeProvider>
     </Suspense>
   );
 }

--- a/ui/litellm-dashboard/src/components/AdminPanel.tsx
+++ b/ui/litellm-dashboard/src/components/AdminPanel.tsx
@@ -25,6 +25,7 @@ import LoggingSettings from "./Settings/AdminSettings/LoggingSettings/LoggingSet
 import SSOSettings from "./Settings/AdminSettings/SSOSettings/SSOSettings";
 import UISettings from "./Settings/AdminSettings/UISettings/UISettings";
 import HashicorpVault from "./Settings/AdminSettings/HashicorpVault/HashicorpVault";
+import PluginSettings from "./Settings/AdminSettings/PluginSettings/PluginSettings";
 import SSOModals from "./SSOModals";
 import UIAccessControlForm from "./UIAccessControlForm";
 
@@ -372,6 +373,11 @@ const AdminPanel: React.FC<AdminPanelProps> = ({ proxySettings }) => {
       key: "hashicorp-vault",
       label: "Hashicorp Vault",
       children: <HashicorpVault />,
+    },
+    {
+      key: "plugins",
+      label: "Plugins",
+      children: <PluginSettings />,
     },
   ];
 

--- a/ui/litellm-dashboard/src/components/Settings/AdminSettings/PluginSettings/PluginSettings.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/AdminSettings/PluginSettings/PluginSettings.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Button, Card, Form, Input, Modal, Space, Table, Typography } from "antd";
+import { DeleteOutlined, EditOutlined, PlusOutlined } from "@ant-design/icons";
+import { getConfigFieldSetting, updateConfigFieldSetting } from "@/components/networking";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+
+const { Title, Text, Paragraph } = Typography;
+
+interface Plugin {
+  name: string;
+  display_name: string;
+  url: string;
+  plugin_key?: string;
+}
+
+export default function PluginSettings() {
+  const { accessToken } = useAuthorized();
+  const [plugins, setPlugins] = useState<Plugin[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [editingIndex, setEditingIndex] = useState<number | null>(null);
+  const [form] = Form.useForm<Plugin>();
+
+  useEffect(() => {
+    if (!accessToken) return;
+    getConfigFieldSetting(accessToken, "plugins")
+      .then((data) => {
+        const val = data?.field_value;
+        setPlugins(Array.isArray(val) ? val : []);
+      })
+      .catch(() => setPlugins([]))
+      .finally(() => setLoading(false));
+  }, [accessToken]);
+
+  const save = async (updated: Plugin[]) => {
+    if (!accessToken) return;
+    setSaving(true);
+    try {
+      await updateConfigFieldSetting(accessToken, "plugins", updated);
+      setPlugins(updated);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const openAdd = () => {
+    setEditingIndex(null);
+    form.resetFields();
+    setModalOpen(true);
+  };
+
+  const openEdit = (idx: number) => {
+    setEditingIndex(idx);
+    form.setFieldsValue(plugins[idx]);
+    setModalOpen(true);
+  };
+
+  const handleDelete = (idx: number) => {
+    const updated = plugins.filter((_, i) => i !== idx);
+    save(updated);
+  };
+
+  const handleOk = async () => {
+    const values = await form.validateFields();
+    const updated =
+      editingIndex !== null
+        ? plugins.map((p, i) => (i === editingIndex ? values : p))
+        : [...plugins, values];
+    await save(updated);
+    setModalOpen(false);
+  };
+
+  const columns = [
+    {
+      title: "Name",
+      dataIndex: "name",
+      key: "name",
+      render: (v: string) => <Text code>{v}</Text>,
+    },
+    { title: "Display Name", dataIndex: "display_name", key: "display_name" },
+    {
+      title: "URL",
+      dataIndex: "url",
+      key: "url",
+      render: (v: string) => (
+        <a href={v} target="_blank" rel="noopener noreferrer">
+          {v}
+        </a>
+      ),
+    },
+    {
+      title: "Plugin Key",
+      dataIndex: "plugin_key",
+      key: "plugin_key",
+      render: (v?: string) => (v ? <Text code>{"•".repeat(8)}</Text> : <Text type="secondary">—</Text>),
+    },
+    {
+      title: "Actions",
+      key: "actions",
+      render: (_: unknown, __: Plugin, idx: number) => (
+        <Space>
+          <Button icon={<EditOutlined />} size="small" onClick={() => openEdit(idx)} />
+          <Button icon={<DeleteOutlined />} size="small" danger onClick={() => handleDelete(idx)} />
+        </Space>
+      ),
+    },
+  ];
+
+  return (
+    <Card>
+      <Title level={4}>Plugins</Title>
+      <Paragraph>
+        Register external services as plugins. Once added, users can toggle to the plugin from the
+        mode switcher in the top-left of the sidebar.
+      </Paragraph>
+      <Paragraph type="secondary" style={{ fontSize: 12 }}>
+        Each plugin must expose <Text code>GET /api/plugin-manifest</Text> returning nav items and
+        capabilities.
+      </Paragraph>
+
+      <Button
+        type="primary"
+        icon={<PlusOutlined />}
+        onClick={openAdd}
+        style={{ marginBottom: 16 }}
+      >
+        Add Plugin
+      </Button>
+
+      <Table
+        dataSource={plugins}
+        columns={columns}
+        rowKey="name"
+        loading={loading}
+        pagination={false}
+        size="small"
+      />
+
+      <Modal
+        title={editingIndex !== null ? "Edit Plugin" : "Add Plugin"}
+        open={modalOpen}
+        onOk={handleOk}
+        onCancel={() => setModalOpen(false)}
+        confirmLoading={saving}
+        okText="Save"
+      >
+        <Form form={form} layout="vertical" style={{ marginTop: 16 }}>
+          <Form.Item
+            name="name"
+            label="Name (identifier)"
+            rules={[{ required: true, message: "Required" }]}
+            extra="Used in URLs and config. No spaces. E.g. litellm-platform-plugin"
+          >
+            <Input placeholder="litellm-platform-plugin" />
+          </Form.Item>
+          <Form.Item
+            name="display_name"
+            label="Display Name"
+            rules={[{ required: true, message: "Required" }]}
+          >
+            <Input placeholder="Agent Control Plane" />
+          </Form.Item>
+          <Form.Item
+            name="url"
+            label="URL"
+            rules={[{ required: true, message: "Required" }, { type: "url", message: "Must be a valid URL" }]}
+            extra="Base URL of the plugin service"
+          >
+            <Input placeholder="https://your-plugin.example.com" />
+          </Form.Item>
+          <Form.Item
+            name="plugin_key"
+            label="Plugin Key"
+            extra="The plugin's own auth key. Passed as ?token= so users don't need to log in separately."
+          >
+            <Input.Password placeholder="sk-..." />
+          </Form.Item>
+        </Form>
+      </Modal>
+    </Card>
+  );
+}

--- a/ui/litellm-dashboard/src/components/Settings/AdminSettings/PluginSettings/PluginSettings.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/AdminSettings/PluginSettings/PluginSettings.tsx
@@ -66,9 +66,7 @@ export default function PluginSettings() {
   const handleOk = async () => {
     const values = await form.validateFields();
     const updated =
-      editingIndex !== null
-        ? plugins.map((p, i) => (i === editingIndex ? values : p))
-        : [...plugins, values];
+      editingIndex !== null ? plugins.map((p, i) => (i === editingIndex ? values : p)) : [...plugins, values];
     await save(updated);
     setModalOpen(false);
   };
@@ -113,31 +111,18 @@ export default function PluginSettings() {
     <Card>
       <Title level={4}>Plugins</Title>
       <Paragraph>
-        Register external services as plugins. Once added, users can toggle to the plugin from the
-        mode switcher in the top-left of the sidebar.
+        Register external services as plugins. Once added, users can toggle to the plugin from the mode switcher in the
+        top-left of the sidebar.
       </Paragraph>
       <Paragraph type="secondary" style={{ fontSize: 12 }}>
-        Each plugin must expose <Text code>GET /api/plugin-manifest</Text> returning nav items and
-        capabilities.
+        Each plugin must expose <Text code>GET /api/plugin-manifest</Text> returning nav items and capabilities.
       </Paragraph>
 
-      <Button
-        type="primary"
-        icon={<PlusOutlined />}
-        onClick={openAdd}
-        style={{ marginBottom: 16 }}
-      >
+      <Button type="primary" icon={<PlusOutlined />} onClick={openAdd} style={{ marginBottom: 16 }}>
         Add Plugin
       </Button>
 
-      <Table
-        dataSource={plugins}
-        columns={columns}
-        rowKey="name"
-        loading={loading}
-        pagination={false}
-        size="small"
-      />
+      <Table dataSource={plugins} columns={columns} rowKey="name" loading={loading} pagination={false} size="small" />
 
       <Modal
         title={editingIndex !== null ? "Edit Plugin" : "Add Plugin"}
@@ -156,17 +141,16 @@ export default function PluginSettings() {
           >
             <Input placeholder="litellm-platform-plugin" />
           </Form.Item>
-          <Form.Item
-            name="display_name"
-            label="Display Name"
-            rules={[{ required: true, message: "Required" }]}
-          >
+          <Form.Item name="display_name" label="Display Name" rules={[{ required: true, message: "Required" }]}>
             <Input placeholder="Agent Control Plane" />
           </Form.Item>
           <Form.Item
             name="url"
             label="URL"
-            rules={[{ required: true, message: "Required" }, { type: "url", message: "Must be a valid URL" }]}
+            rules={[
+              { required: true, message: "Required" },
+              { type: "url", message: "Must be a valid URL" },
+            ]}
             extra="Base URL of the plugin service"
           >
             <Input placeholder="https://your-plugin.example.com" />

--- a/ui/litellm-dashboard/src/components/leftnav.tsx
+++ b/ui/litellm-dashboard/src/components/leftnav.tsx
@@ -1,6 +1,7 @@
 import { useOrganizations } from "@/app/(dashboard)/hooks/organizations/useOrganizations";
 import { useTeams } from "@/app/(dashboard)/hooks/teams/useTeams";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+import { usePluginMode, type PluginMode } from "@/contexts/PluginModeContext";
 import {
   ApiOutlined,
   ApartmentOutlined,
@@ -11,26 +12,33 @@ import {
   BgColorsOutlined,
   BlockOutlined,
   BookOutlined,
+  ClockCircleOutlined,
   CreditCardOutlined,
   DatabaseOutlined,
   ExperimentOutlined,
   ExportOutlined,
   FileTextOutlined,
   FolderOutlined,
+  InboxOutlined,
   KeyOutlined,
   LineChartOutlined,
+  LockOutlined,
+  MessageOutlined,
   PlayCircleOutlined,
+  PlusSquareOutlined,
   RobotOutlined,
   SafetyOutlined,
   SearchOutlined,
   SettingOutlined,
+  SwapOutlined,
   TagsOutlined,
   TeamOutlined,
+  ThunderboltOutlined,
   ToolOutlined,
   UserOutlined,
 } from "@ant-design/icons";
 import type { MenuProps } from "antd";
-import { ConfigProvider, Layout, Menu } from "antd";
+import { ConfigProvider, Layout, Menu, Select } from "antd";
 import { useMemo } from "react";
 import {
   all_admin_roles,
@@ -406,6 +414,7 @@ const Sidebar: React.FC<SidebarProps> = ({
   const { userId, accessToken, userRole } = useAuthorized();
   const { data: organizations } = useOrganizations();
   const { data: teams } = useTeams();
+  const { mode, setMode, setAgentPlatformPath } = usePluginMode();
 
   // Check if user is an org_admin
   const isOrgAdmin = useMemo(() => {
@@ -596,6 +605,41 @@ const Sidebar: React.FC<SidebarProps> = ({
     return items;
   };
 
+  // Build ACP menu items (no role filtering needed — simpler)
+  const buildAcpMenuItems = (): MenuProps["items"] => {
+    const items: MenuProps["items"] = [];
+    agentControlPlaneMenuGroups.forEach((group) => {
+      items.push({
+        type: "group",
+        label: collapsed ? null : (
+          <span
+            style={{
+              fontSize: "10px",
+              fontWeight: 600,
+              color: "#6b7280",
+              letterSpacing: "0.05em",
+              padding: "12px 0 4px 12px",
+              display: "block",
+              marginBottom: "2px",
+            }}
+          >
+            {group.groupLabel}
+          </span>
+        ),
+        children: group.items.map((item) => ({
+          key: item.key,
+          icon: item.icon,
+          label: item.label,
+          onClick: () => {
+            const path = acpPagePaths[item.page] ?? "/sessions";
+            setAgentPlatformPath(path);
+          },
+        })),
+      });
+    });
+    return items;
+  };
+
   // Find selected menu key
   const findMenuItemKey = (page: string): string => {
     for (const group of menuGroups) {
@@ -612,6 +656,11 @@ const Sidebar: React.FC<SidebarProps> = ({
 
   const selectedMenuKey = findMenuItemKey(defaultSelectedKey);
 
+  const modeOptions = [
+    { value: "ai-gateway" as PluginMode, label: "AI Gateway" },
+    { value: "litellm-platform-plugin" as PluginMode, label: "Agent Control Plane" },
+  ];
+
   return (
     <Layout>
       <Sider
@@ -626,6 +675,44 @@ const Sidebar: React.FC<SidebarProps> = ({
           position: "relative",
         }}
       >
+        {/* Product/Mode Switcher */}
+        <div
+          style={{
+            padding: collapsed ? "8px 4px" : "10px 12px 6px 12px",
+            borderBottom: "1px solid #f0f0f0",
+            marginBottom: "4px",
+          }}
+        >
+          {collapsed ? (
+            <div
+              title={mode === "ai-gateway" ? "AI Gateway" : "Agent Control Plane"}
+              style={{
+                display: "flex",
+                justifyContent: "center",
+                cursor: "pointer",
+                padding: "4px",
+                borderRadius: "6px",
+                background: "#f5f5f5",
+              }}
+              onClick={() => setMode(mode === "ai-gateway" ? "litellm-platform-plugin" : "ai-gateway")}
+            >
+              <SwapOutlined style={{ fontSize: 16, color: "#6b7280" }} />
+            </div>
+          ) : (
+            <Select
+              value={mode}
+              onChange={(val) => setMode(val as PluginMode)}
+              options={modeOptions}
+              size="small"
+              style={{ width: "100%" }}
+              suffixIcon={<SwapOutlined />}
+              styles={{
+                popup: { root: { minWidth: 180 } },
+              }}
+            />
+          )}
+        </div>
+
         <ConfigProvider
           theme={{
             components: {
@@ -643,22 +730,41 @@ const Sidebar: React.FC<SidebarProps> = ({
             },
           }}
         >
-          <Menu
-            mode="inline"
-            selectedKeys={[selectedMenuKey]}
-            defaultOpenKeys={[]}
-            inlineCollapsed={collapsed}
-            className="custom-sidebar-menu"
-            style={{
-              borderRight: 0,
-              backgroundColor: "transparent",
-              fontSize: "13px",
-              paddingTop: "4px",
-            }}
-            items={buildMenuItems()}
-          />
+          {mode === "ai-gateway" ? (
+            <Menu
+              mode="inline"
+              selectedKeys={[selectedMenuKey]}
+              defaultOpenKeys={[]}
+              inlineCollapsed={collapsed}
+              className="custom-sidebar-menu"
+              style={{
+                borderRight: 0,
+                backgroundColor: "transparent",
+                fontSize: "13px",
+                paddingTop: "4px",
+              }}
+              items={buildMenuItems()}
+            />
+          ) : (
+            <Menu
+              mode="inline"
+              selectedKeys={[]}
+              defaultOpenKeys={["AGENT CONTROL PLANE", "INFRASTRUCTURE"]}
+              inlineCollapsed={collapsed}
+              className="custom-sidebar-menu"
+              style={{
+                borderRight: 0,
+                backgroundColor: "transparent",
+                fontSize: "13px",
+                paddingTop: "4px",
+              }}
+              items={buildAcpMenuItems()}
+            />
+          )}
         </ConfigProvider>
-        {isAdminRole(userRole) && !collapsed && <UsageIndicator accessToken={accessToken} width={220} />}
+        {isAdminRole(userRole) && !collapsed && mode === "ai-gateway" && (
+          <UsageIndicator accessToken={accessToken} width={220} />
+        )}
       </Sider>
     </Layout>
   );
@@ -668,3 +774,98 @@ export default Sidebar;
 
 // Also export menuGroups for advanced use cases
 export { menuGroups };
+
+// Agent Control Plane nav groups
+export const agentControlPlaneMenuGroups: MenuGroup[] = [
+  {
+    groupLabel: "AGENT CONTROL PLANE",
+    items: [
+      {
+        key: "acp-sessions",
+        page: "acp-sessions",
+        label: "Sessions",
+        icon: <MessageOutlined />,
+      },
+      {
+        key: "acp-agents",
+        page: "acp-agents",
+        label: "Agents",
+        icon: <RobotOutlined />,
+      },
+      {
+        key: "acp-routines",
+        page: "acp-routines",
+        label: "Routines",
+        icon: <ClockCircleOutlined />,
+      },
+      {
+        key: "acp-inbox",
+        page: "acp-inbox",
+        label: "Inbox",
+        icon: <InboxOutlined />,
+      },
+      {
+        key: "acp-skills",
+        page: "acp-skills",
+        label: "Skills",
+        icon: <ThunderboltOutlined />,
+      },
+      {
+        key: "acp-rules",
+        page: "acp-rules",
+        label: "Rules",
+        icon: <SafetyOutlined />,
+      },
+      {
+        key: "acp-vault",
+        page: "acp-vault",
+        label: "Vault",
+        icon: <LockOutlined />,
+      },
+      {
+        key: "acp-integrations",
+        page: "acp-integrations",
+        label: "Integrations",
+        icon: <PlusSquareOutlined />,
+      },
+    ],
+  },
+  {
+    groupLabel: "INFRASTRUCTURE",
+    items: [
+      {
+        key: "acp-runtimes",
+        page: "acp-runtimes",
+        label: "Agent Runtimes",
+        icon: <ToolOutlined />,
+      },
+      {
+        key: "acp-mcp-servers",
+        page: "acp-mcp-servers",
+        label: "MCP Servers",
+        icon: <ApiOutlined />,
+      },
+      {
+        key: "acp-providers",
+        page: "acp-providers",
+        label: "LLM Providers",
+        icon: <DatabaseOutlined />,
+      },
+    ],
+  },
+];
+
+// Page to agent platform path mapping
+const acpPagePaths: Record<string, string> = {
+  "acp-sessions": "/sessions",
+  "acp-agents": "/agents",
+  "acp-routines": "/routines",
+  "acp-inbox": "/inbox",
+  "acp-skills": "/skills",
+  "acp-rules": "/rules",
+  "acp-vault": "/vault",
+  "acp-integrations": "/integrations",
+  "acp-runtimes": "/runtimes",
+  "acp-mcp-servers": "/mcp-servers",
+  "acp-providers": "/providers",
+};

--- a/ui/litellm-dashboard/src/contexts/PluginModeContext.tsx
+++ b/ui/litellm-dashboard/src/contexts/PluginModeContext.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import React, { createContext, useContext, useState, useEffect } from "react";
+import { getProxyBaseUrl } from "@/components/networking";
+
+export type PluginMode = "ai-gateway" | "litellm-platform-plugin";
+
+export interface PluginNavItem {
+  key: string;
+  label: string;
+  icon?: string;
+  path: string;
+  badge?: boolean;
+}
+
+export interface Plugin {
+  name: string;
+  display_name: string;
+  url: string;
+  plugin_key?: string;
+  nav_items: PluginNavItem[];
+  capabilities: string[];
+}
+
+interface PluginModeContextValue {
+  mode: PluginMode;
+  setMode: (mode: PluginMode) => void;
+  pluginKey: string | null;
+  agentPlatformUrl: string;
+  agentPlatformPath: string;
+  setAgentPlatformPath: (path: string) => void;
+}
+
+const PluginModeContext = createContext<PluginModeContextValue>({
+  mode: "ai-gateway",
+  setMode: () => {},
+  pluginKey: null,
+  agentPlatformUrl: "",
+  agentPlatformPath: "/sessions",
+  setAgentPlatformPath: () => {},
+});
+
+const STORAGE_KEY = "litellm_plugin_mode";
+
+export function PluginModeProvider({ children }: { children: React.ReactNode }) {
+  const [mode, setModeState] = useState<PluginMode>("ai-gateway");
+  const [pluginKey, setPluginKey] = useState<string | null>(null);
+  const [agentPlatformUrl, setAgentPlatformUrl] = useState<string>("");
+  const [agentPlatformPath, setAgentPlatformPath] = useState<string>("/sessions");
+
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY) as PluginMode | null;
+    if (stored === "litellm-platform-plugin" || stored === "ai-gateway") {
+      setModeState(stored);
+    }
+
+    // Fetch plugin registry to get plugin_key and url
+    const base = getProxyBaseUrl() ?? "";
+    fetch(`${base}/api/plugins`, {
+      credentials: "include",
+      headers: { Authorization: `Bearer ${document.cookie.match(/token=([^;]+)/)?.[1] ?? ""}` },
+    })
+      .then((r) => r.json())
+      .then((plugins: Plugin[]) => {
+        const lap = plugins.find((p) => p.name === "litellm-platform-plugin");
+        if (lap) {
+          setAgentPlatformUrl(lap.url);
+          if (lap.plugin_key) setPluginKey(lap.plugin_key);
+        }
+      })
+      .catch(() => {});
+  }, []);
+
+  const setMode = (m: PluginMode) => {
+    setModeState(m);
+    localStorage.setItem(STORAGE_KEY, m);
+  };
+
+  return (
+    <PluginModeContext.Provider value={{ mode, setMode, pluginKey, agentPlatformUrl, agentPlatformPath, setAgentPlatformPath }}>
+      {children}
+    </PluginModeContext.Provider>
+  );
+}
+
+export function usePluginMode() {
+  return useContext(PluginModeContext);
+}

--- a/ui/litellm-dashboard/src/contexts/PluginModeContext.tsx
+++ b/ui/litellm-dashboard/src/contexts/PluginModeContext.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { createContext, useContext, useState, useEffect } from "react";
-import { getProxyBaseUrl } from "@/components/networking";
+import { createApiClient } from "@/lib/http/client";
 
 export type PluginMode = "ai-gateway" | "litellm-platform-plugin";
 
@@ -41,26 +41,25 @@ const PluginModeContext = createContext<PluginModeContextValue>({
 });
 
 const STORAGE_KEY = "litellm_plugin_mode";
+const pluginApiClient = createApiClient({});
+
+function readStoredMode(): PluginMode {
+  if (typeof window === "undefined") return "ai-gateway";
+  const stored = localStorage.getItem(STORAGE_KEY) as PluginMode | null;
+  return stored === "litellm-platform-plugin" || stored === "ai-gateway" ? stored : "ai-gateway";
+}
 
 export function PluginModeProvider({ children }: { children: React.ReactNode }) {
-  const [mode, setModeState] = useState<PluginMode>("ai-gateway");
+  // Lazy initializer reads localStorage once — no setState in effect
+  const [mode, setModeState] = useState<PluginMode>(readStoredMode);
   const [pluginKey, setPluginKey] = useState<string | null>(null);
   const [agentPlatformUrl, setAgentPlatformUrl] = useState<string>("");
   const [agentPlatformPath, setAgentPlatformPath] = useState<string>("/sessions");
 
   useEffect(() => {
-    const stored = localStorage.getItem(STORAGE_KEY) as PluginMode | null;
-    if (stored === "litellm-platform-plugin" || stored === "ai-gateway") {
-      setModeState(stored);
-    }
-
-    // Fetch plugin registry to get plugin_key and url
-    const base = getProxyBaseUrl() ?? "";
-    fetch(`${base}/api/plugins`, {
-      credentials: "include",
-      headers: { Authorization: `Bearer ${document.cookie.match(/token=([^;]+)/)?.[1] ?? ""}` },
-    })
-      .then((r) => r.json())
+    const token = document.cookie.match(/token=([^;]+)/)?.[1] ?? localStorage.getItem("token") ?? "";
+    pluginApiClient
+      .get("/api/plugins", { accessToken: token })
       .then((plugins: Plugin[]) => {
         const lap = plugins.find((p) => p.name === "litellm-platform-plugin");
         if (lap) {
@@ -77,7 +76,16 @@ export function PluginModeProvider({ children }: { children: React.ReactNode }) 
   };
 
   return (
-    <PluginModeContext.Provider value={{ mode, setMode, pluginKey, agentPlatformUrl, agentPlatformPath, setAgentPlatformPath }}>
+    <PluginModeContext.Provider
+      value={{
+        mode,
+        setMode,
+        pluginKey,
+        agentPlatformUrl,
+        agentPlatformPath,
+        setAgentPlatformPath,
+      }}
+    >
       {children}
     </PluginModeContext.Provider>
   );

--- a/ui/litellm-dashboard/src/contexts/PluginModeContext.tsx
+++ b/ui/litellm-dashboard/src/contexts/PluginModeContext.tsx
@@ -2,6 +2,7 @@
 
 import React, { createContext, useContext, useState, useEffect } from "react";
 import { createApiClient } from "@/lib/http/client";
+import { getProxyBaseUrl } from "@/components/networking";
 
 export type PluginMode = "ai-gateway" | "litellm-platform-plugin";
 
@@ -41,7 +42,7 @@ const PluginModeContext = createContext<PluginModeContextValue>({
 });
 
 const STORAGE_KEY = "litellm_plugin_mode";
-const pluginApiClient = createApiClient({});
+const pluginApiClient = createApiClient({ getBaseUrl: () => getProxyBaseUrl() ?? "" });
 
 function readStoredMode(): PluginMode {
   if (typeof window === "undefined") return "ai-gateway";

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -44442,250 +44442,6 @@ export interface operations {
             };
         };
     };
-    list_plugins_api_plugins_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown[];
-                };
-            };
-        };
-    };
-    plugin_proxy_plugin_proxy__plugin_name___path__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                plugin_name: string;
-                path: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    plugin_proxy_plugin_proxy__plugin_name___path__put: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                plugin_name: string;
-                path: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    plugin_proxy_plugin_proxy__plugin_name___path__post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                plugin_name: string;
-                path: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    plugin_proxy_plugin_proxy__plugin_name___path__delete: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                plugin_name: string;
-                path: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    plugin_proxy_plugin_proxy__plugin_name___path__options: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                plugin_name: string;
-                path: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    plugin_proxy_plugin_proxy__plugin_name___path__head: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                plugin_name: string;
-                path: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    plugin_proxy_plugin_proxy__plugin_name___path__patch: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                plugin_name: string;
-                path: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
     organization_member_add_organization_member_add_post: {
         parameters: {
             query?: never;
@@ -54027,6 +53783,250 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["MemoryDeleteResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_plugins_api_plugins_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown[];
+                };
+            };
+        };
+    };
+    plugin_proxy_plugin_proxy__plugin_name___path__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                plugin_name: string;
+                path: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    plugin_proxy_plugin_proxy__plugin_name___path__put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                plugin_name: string;
+                path: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    plugin_proxy_plugin_proxy__plugin_name___path__post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                plugin_name: string;
+                path: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    plugin_proxy_plugin_proxy__plugin_name___path__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                plugin_name: string;
+                path: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    plugin_proxy_plugin_proxy__plugin_name___path__options: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                plugin_name: string;
+                path: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    plugin_proxy_plugin_proxy__plugin_name___path__head: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                plugin_name: string;
+                path: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    plugin_proxy_plugin_proxy__plugin_name___path__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                plugin_name: string;
+                path: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
                 };
             };
             /** @description Validation Error */

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -33583,6 +33583,26 @@ export interface operations {
             };
         };
     };
+    list_plugins_api_plugins_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown[];
+                };
+            };
+        };
+    };
     apply_guardrail_apply_guardrail_post: {
         parameters: {
             query?: never;
@@ -44647,6 +44667,230 @@ export interface operations {
             };
         };
     };
+    plugin_proxy_plugin_proxy__plugin_name___path__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                plugin_name: string;
+                path: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    plugin_proxy_plugin_proxy__plugin_name___path__put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                plugin_name: string;
+                path: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    plugin_proxy_plugin_proxy__plugin_name___path__post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                plugin_name: string;
+                path: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    plugin_proxy_plugin_proxy__plugin_name___path__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                plugin_name: string;
+                path: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    plugin_proxy_plugin_proxy__plugin_name___path__options: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                plugin_name: string;
+                path: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    plugin_proxy_plugin_proxy__plugin_name___path__head: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                plugin_name: string;
+                path: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    plugin_proxy_plugin_proxy__plugin_name___path__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                plugin_name: string;
+                path: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     create_policy_attachment_policies_attachments_post: {
         parameters: {
             query?: never;
@@ -53783,250 +54027,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["MemoryDeleteResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    list_plugins_api_plugins_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown[];
-                };
-            };
-        };
-    };
-    plugin_proxy_plugin_proxy__plugin_name___path__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                plugin_name: string;
-                path: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    plugin_proxy_plugin_proxy__plugin_name___path__put: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                plugin_name: string;
-                path: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    plugin_proxy_plugin_proxy__plugin_name___path__post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                plugin_name: string;
-                path: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    plugin_proxy_plugin_proxy__plugin_name___path__delete: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                plugin_name: string;
-                path: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    plugin_proxy_plugin_proxy__plugin_name___path__options: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                plugin_name: string;
-                path: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    plugin_proxy_plugin_proxy__plugin_name___path__head: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                plugin_name: string;
-                path: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    plugin_proxy_plugin_proxy__plugin_name___path__patch: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                plugin_name: string;
-                path: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
                 };
             };
             /** @description Validation Error */

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -526,7 +526,8 @@ export interface paths {
          * List Plugins
          * @description Return registered plugins for authenticated UI callers.
          *
-         *     plugin_key is only returned to callers with a valid litellm token.
+         *     plugin_key is only returned to proxy admins — not to regular users —
+         *     so plugin credentials cannot be extracted by non-admin callers.
          */
         get: operations["list_plugins_api_plugins_get"];
         put?: never;

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -524,9 +524,9 @@ export interface paths {
         };
         /**
          * List Plugins
-         * @description Return registered plugins for UI discovery.
+         * @description Return registered plugins for authenticated UI callers.
          *
-         *     plugin_key is only returned to authenticated requests.
+         *     plugin_key is only returned to callers with a valid litellm token.
          */
         get: operations["list_plugins_api_plugins_get"];
         put?: never;
@@ -8898,37 +8898,37 @@ export interface paths {
         };
         /**
          * Plugin Proxy
-         * @description Reverse-proxy any request to the registered plugin's backend.
+         * @description Authenticated reverse-proxy to a registered plugin backend.
          */
         get: operations["plugin_proxy_plugin_proxy__plugin_name___path__get"];
         /**
          * Plugin Proxy
-         * @description Reverse-proxy any request to the registered plugin's backend.
+         * @description Authenticated reverse-proxy to a registered plugin backend.
          */
         put: operations["plugin_proxy_plugin_proxy__plugin_name___path__put"];
         /**
          * Plugin Proxy
-         * @description Reverse-proxy any request to the registered plugin's backend.
+         * @description Authenticated reverse-proxy to a registered plugin backend.
          */
         post: operations["plugin_proxy_plugin_proxy__plugin_name___path__post"];
         /**
          * Plugin Proxy
-         * @description Reverse-proxy any request to the registered plugin's backend.
+         * @description Authenticated reverse-proxy to a registered plugin backend.
          */
         delete: operations["plugin_proxy_plugin_proxy__plugin_name___path__delete"];
         /**
          * Plugin Proxy
-         * @description Reverse-proxy any request to the registered plugin's backend.
+         * @description Authenticated reverse-proxy to a registered plugin backend.
          */
         options: operations["plugin_proxy_plugin_proxy__plugin_name___path__options"];
         /**
          * Plugin Proxy
-         * @description Reverse-proxy any request to the registered plugin's backend.
+         * @description Authenticated reverse-proxy to a registered plugin backend.
          */
         head: operations["plugin_proxy_plugin_proxy__plugin_name___path__head"];
         /**
          * Plugin Proxy
-         * @description Reverse-proxy any request to the registered plugin's backend.
+         * @description Authenticated reverse-proxy to a registered plugin backend.
          */
         patch: operations["plugin_proxy_plugin_proxy__plugin_name___path__patch"];
         trace?: never;

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -674,6 +674,60 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/audit": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Audit Logs
+         * @description Get all audit logs with filtering and pagination.
+         *
+         *     Returns a paginated response of audit logs matching the specified filters.
+         *
+         *     Note: object_team_id and object_key_hash use Prisma JSON path filtering,
+         *     which requires PostgreSQL.
+         */
+        get: operations["get_audit_logs_audit_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/audit/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Audit Log By Id
+         * @description Get detailed information about a specific audit log entry by its ID.
+         *
+         *     Args:
+         *         id (str): The unique identifier of the audit log entry
+         *
+         *     Returns:
+         *         AuditLogResponse: Detailed information about the audit log entry
+         *
+         *     Raises:
+         *         HTTPException: If the audit log is not found or if there's a database connection error
+         */
+        get: operations["get_audit_log_by_id_audit__id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/azure/{endpoint}": {
         parameters: {
             query?: never;
@@ -3032,6 +3086,50 @@ export interface paths {
         put?: never;
         /** Delete Allowed Ip */
         post: operations["delete_allowed_ip_delete_allowed_ip_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/email/event_settings": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Email Event Settings
+         * @description Get all email event settings
+         */
+        get: operations["get_email_event_settings_email_event_settings_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Update Event Settings
+         * @description Update the settings for email events
+         */
+        patch: operations["update_event_settings_email_event_settings_patch"];
+        trace?: never;
+    };
+    "/email/event_settings/reset": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Reset Event Settings
+         * @description Reset all email event settings to default (new user invitations on, virtual key creation off)
+         */
+        post: operations["reset_event_settings_email_event_settings_reset_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -9752,6 +9850,240 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/project/delete": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Delete Project
+         * @description Delete projects
+         *
+         *     Parameters:
+         *     - project_ids: *List[str]* - List of project ids to delete
+         *
+         *     Example:
+         *     ```bash
+         *     curl --location --request DELETE 'http://0.0.0.0:4000/project/delete' \
+         *     --header 'Authorization: Bearer sk-1234' \
+         *     --header 'Content-Type: application/json' \
+         *     --data '{
+         *         "project_ids": ["project-123", "project-456"]
+         *     }'
+         *     ```
+         */
+        delete: operations["delete_project_project_delete_delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/project/info": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Project Info
+         * @description Get information about a specific project
+         *
+         *     Parameters:
+         *     - project_id: *str* - The project id to fetch info for
+         *
+         *     Example:
+         *     ```bash
+         *     curl --location 'http://0.0.0.0:4000/project/info?project_id=project-123' \
+         *     --header 'Authorization: Bearer sk-1234'
+         *     ```
+         */
+        get: operations["project_info_project_info_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/project/list": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Projects
+         * @description List all projects that the user has access to
+         *
+         *     Example:
+         *     ```bash
+         *     curl --location 'http://0.0.0.0:4000/project/list' \
+         *     --header 'Authorization: Bearer sk-1234'
+         *     ```
+         */
+        get: operations["list_projects_project_list_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/project/new": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * New Project
+         * @description Create a new project. Projects sit between teams and keys in the hierarchy.
+         *
+         *     Only admins or team admins can create projects.
+         *
+         *     # Parameters
+         *
+         *     - project_alias: *Optional[str]* - The name of the project.
+         *     - description: *Optional[str]* - Description of the project's purpose and use case.
+         *     - team_id: *str* - The team id that this project belongs to. Required.
+         *     - models: *List* - The models the project has access to.
+         *     - budget_id: *Optional[str]* - The id for a budget (tpm/rpm/max budget) for the project.
+         *     ### IF NO BUDGET ID - CREATE ONE WITH THESE PARAMS ###
+         *     - max_budget: *Optional[float]* - Max budget for project
+         *     - tpm_limit: *Optional[int]* - Max tpm limit for project
+         *     - rpm_limit: *Optional[int]* - Max rpm limit for project
+         *     - max_parallel_requests: *Optional[int]* - Max parallel requests for project
+         *     - soft_budget: *Optional[float]* - Get a slack alert when this soft budget is reached. Don't block requests.
+         *     - model_max_budget: *Optional[dict]* - Max budget for a specific model. Example: {"gpt-4": 100.0, "gpt-3.5-turbo": 50.0}
+         *     - model_rpm_limit: *Optional[dict]* - RPM limits per model. Example: {"gpt-4": 1000, "gpt-3.5-turbo": 5000}
+         *     - model_tpm_limit: *Optional[dict]* - TPM limits per model. Example: {"gpt-4": 50000, "gpt-3.5-turbo": 100000}
+         *     - budget_duration: *Optional[str]* - Frequency of reseting project budget
+         *     - metadata: *Optional[dict]* - Metadata for project, store information for project. Example metadata - {"use_case_id": "SNOW-12345", "responsible_ai_id": "RAI-67890"}
+         *     - tags: *Optional[list]* - Tags for the project. Example: ["production", "api"]
+         *     - blocked: *bool* - Flag indicating if the project is blocked or not - will stop all calls from keys with this project_id.
+         *     - object_permission: Optional[LiteLLM_ObjectPermissionBase] - project-specific object permission. Example - {"vector_stores": ["vector_store_1", "vector_store_2"]}. IF null or {} then no object permission.
+         *
+         *     Example 1: Create new project **without** a budget_id, with model-specific limits
+         *
+         *     ```bash
+         *     curl --location 'http://0.0.0.0:4000/project/new' \
+         *     --header 'Authorization: Bearer sk-1234' \
+         *     --header 'Content-Type: application/json' \
+         *     --data '{
+         *         "project_alias": "flight-search-assistant",
+         *         "description": "AI-powered flight search and booking assistant",
+         *         "team_id": "team-123",
+         *         "models": ["gpt-4", "gpt-3.5-turbo"],
+         *         "max_budget": 100,
+         *         "model_rpm_limit": {
+         *             "gpt-4": 1000,
+         *             "gpt-3.5-turbo": 5000
+         *         },
+         *         "model_tpm_limit": {
+         *             "gpt-4": 50000,
+         *             "gpt-3.5-turbo": 100000
+         *         },
+         *         "metadata": {
+         *             "use_case_id": "SNOW-12345",
+         *             "responsible_ai_id": "RAI-67890"
+         *         }
+         *     }'
+         *     ```
+         *
+         *     Example 2: Create new project **with** a budget_id
+         *
+         *     ```bash
+         *     curl --location 'http://0.0.0.0:4000/project/new' \
+         *     --header 'Authorization: Bearer sk-1234' \
+         *     --header 'Content-Type: application/json' \
+         *     --data '{
+         *         "project_alias": "hotel-recommendations",
+         *         "description": "Personalized hotel recommendation engine",
+         *         "team_id": "team-123",
+         *         "models": ["claude-3-sonnet"],
+         *         "budget_id": "428eeaa8-f3ac-4e85-a8fb-7dc8d7aa8689",
+         *         "metadata": {
+         *             "use_case_id": "SNOW-54321"
+         *         }
+         *     }'
+         *     ```
+         */
+        post: operations["new_project_project_new_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/project/update": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Update Project
+         * @description Update a project
+         *
+         *     Parameters:
+         *     - project_id: *str* - The project id to update. Required.
+         *     - project_alias: *Optional[str]* - Updated name for the project
+         *     - description: *Optional[str]* - Updated description for the project
+         *     - team_id: *Optional[str]* - Updated team_id for the project
+         *     - metadata: *Optional[dict]* - Updated metadata for project
+         *     - models: *Optional[list]* - Updated list of models for the project
+         *     - blocked: *Optional[bool]* - Updated blocked status
+         *     - max_budget: *Optional[float]* - Updated max budget
+         *     - tpm_limit: *Optional[int]* - Updated tpm limit
+         *     - rpm_limit: *Optional[int]* - Updated rpm limit
+         *     - model_rpm_limit: *Optional[dict]* - Updated RPM limits per model
+         *     - model_tpm_limit: *Optional[dict]* - Updated TPM limits per model
+         *     - budget_duration: *Optional[str]* - Updated budget duration
+         *     - tags: *Optional[list]* - Updated list of tags for the project
+         *     - object_permission: Optional[LiteLLM_ObjectPermissionBase] - Updated object permission
+         *
+         *     Example:
+         *     ```bash
+         *     curl --location 'http://0.0.0.0:4000/project/update' \
+         *     --header 'Authorization: Bearer sk-1234' \
+         *     --header 'Content-Type: application/json' \
+         *     --data '{
+         *         "project_id": "project-123",
+         *         "description": "Updated flight search system with enhanced capabilities",
+         *         "max_budget": 200,
+         *         "model_rpm_limit": {
+         *             "gpt-4": 2000,
+         *             "gpt-3.5-turbo": 10000
+         *         },
+         *         "metadata": {
+         *             "use_case_id": "SNOW-12345",
+         *             "status": "active"
+         *         }
+         *     }'
+         *     ```
+         */
+        post: operations["update_project_project_update_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/prompts": {
         parameters: {
             query?: never;
@@ -10786,6 +11118,27 @@ export interface paths {
          * @description List input items for a response.
          */
         get: operations["get_response_input_items_responses__response_id__input_items_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/robots.txt": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Robots
+         * @description Block all web crawlers from indexing the proxy server endpoints
+         *     This is useful for ensuring that the API endpoints aren't indexed by search engines
+         */
+        get: operations["get_robots_robots_txt_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -13825,6 +14178,26 @@ export interface paths {
          *     }
          */
         get: operations["ui_get_available_role_user_available_roles_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/user/available_users": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Available Enterprise Users
+         * @description For keys with `max_users` set, return the list of users that are allowed to use the key.
+         */
+        get: operations["available_enterprise_users_user_available_users_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -20090,6 +20463,37 @@ export interface components {
              */
             unnamed_teams_count: number;
         };
+        /**
+         * AuditLogResponse
+         * @description Response model for a single audit log entry
+         */
+        AuditLogResponse: {
+            /** Action */
+            action: string;
+            /** Before Value */
+            before_value?: {
+                [key: string]: unknown;
+            } | null;
+            /** Changed By */
+            changed_by: string;
+            /** Changed By Api Key */
+            changed_by_api_key: string;
+            /** Id */
+            id: string;
+            /** Object Id */
+            object_id: string;
+            /** Table Name */
+            table_name: string;
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at: string;
+            /** Updated Values */
+            updated_values?: {
+                [key: string]: unknown;
+            } | null;
+        };
         /** BaseLitellmParams */
         "BaseLitellmParams-Input": {
             /**
@@ -22504,6 +22908,14 @@ export interface components {
             organization_ids: string[];
         };
         /**
+         * DeleteProjectRequest
+         * @description Request model for DELETE /project/delete
+         */
+        DeleteProjectRequest: {
+            /** Project Ids */
+            project_ids: string[];
+        };
+        /**
          * DeleteSkillResponse
          * @description Response from deleting a skill
          */
@@ -22616,6 +23028,27 @@ export interface components {
             user_table_name: string;
             /** Write Capacity Units */
             write_capacity_units?: number | null;
+        };
+        /**
+         * EmailEvent
+         * @enum {string}
+         */
+        EmailEvent: "Virtual Key Created" | "New User Invitation" | "Virtual Key Rotated" | "Soft Budget Crossed" | "Max Budget Alert";
+        /** EmailEventSettings */
+        EmailEventSettings: {
+            /** Enabled */
+            enabled: boolean;
+            event: components["schemas"]["EmailEvent"];
+        };
+        /** EmailEventSettingsResponse */
+        EmailEventSettingsResponse: {
+            /** Settings */
+            settings: components["schemas"]["EmailEventSettings"][];
+        };
+        /** EmailEventSettingsUpdateRequest */
+        EmailEventSettingsUpdateRequest: {
+            /** Settings */
+            settings: components["schemas"]["EmailEventSettings"][];
         };
         /** EmbeddingRequest */
         EmbeddingRequest: {
@@ -24887,6 +25320,65 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /**
+         * LiteLLM_ProjectTable
+         * @description Database model representation for project
+         */
+        LiteLLM_ProjectTable: {
+            /**
+             * Blocked
+             * @default false
+             */
+            blocked: boolean;
+            /** Budget Id */
+            budget_id?: string | null;
+            /** Created At */
+            created_at?: string | null;
+            /** Created By */
+            created_by?: string | null;
+            /** Description */
+            description?: string | null;
+            litellm_budget_table?: components["schemas"]["LiteLLM_BudgetTable"] | null;
+            /** Metadata */
+            metadata?: {
+                [key: string]: unknown;
+            } | null;
+            /** Model Rpm Limit */
+            model_rpm_limit?: {
+                [key: string]: unknown;
+            } | null;
+            /** Model Spend */
+            model_spend?: {
+                [key: string]: unknown;
+            } | null;
+            /** Model Tpm Limit */
+            model_tpm_limit?: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Models
+             * @default []
+             */
+            models: string[];
+            object_permission?: components["schemas"]["LiteLLM_ObjectPermissionTable"] | null;
+            /** Object Permission Id */
+            object_permission_id?: string | null;
+            /** Project Alias */
+            project_alias?: string | null;
+            /** Project Id */
+            project_id: string;
+            /**
+             * Spend
+             * @default 0
+             */
+            spend: number;
+            /** Team Id */
+            team_id?: string | null;
+            /** Updated At */
+            updated_at?: string | null;
+            /** Updated By */
+            updated_by?: string | null;
+        };
         /** LiteLLM_ProxyModelTable */
         LiteLLM_ProxyModelTable: {
             /**
@@ -26899,6 +27391,134 @@ export interface components {
             /** Users */
             users?: components["schemas"]["LiteLLM_UserTable"][] | null;
         };
+        /**
+         * NewProjectRequest
+         * @description Request model for POST /project/new
+         */
+        NewProjectRequest: {
+            /** Allowed Models */
+            allowed_models?: string[] | null;
+            /**
+             * Blocked
+             * @default false
+             */
+            blocked: boolean;
+            /** Budget Duration */
+            budget_duration?: string | null;
+            /** Budget Id */
+            budget_id?: string | null;
+            /** Description */
+            description?: string | null;
+            /** Guardrails */
+            guardrails?: string[] | null;
+            /** Max Budget */
+            max_budget?: number | null;
+            /** Max Parallel Requests */
+            max_parallel_requests?: number | null;
+            /** Metadata */
+            metadata?: {
+                [key: string]: unknown;
+            } | null;
+            /** Model Max Budget */
+            model_max_budget?: {
+                [key: string]: unknown;
+            } | null;
+            /** Model Rpm Limit */
+            model_rpm_limit?: {
+                [key: string]: unknown;
+            } | null;
+            /** Model Tpm Limit */
+            model_tpm_limit?: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Models
+             * @default []
+             */
+            models: string[];
+            object_permission?: components["schemas"]["LiteLLM_ObjectPermissionBase"] | null;
+            /** Policies */
+            policies?: string[] | null;
+            /** Project Alias */
+            project_alias?: string | null;
+            /** Project Id */
+            project_id?: string | null;
+            /** Rpm Limit */
+            rpm_limit?: number | null;
+            /** Soft Budget */
+            soft_budget?: number | null;
+            /** Tags */
+            tags?: string[] | null;
+            /** Team Id */
+            team_id: string;
+            /** Tpm Limit */
+            tpm_limit?: number | null;
+        };
+        /**
+         * NewProjectResponse
+         * @description Response model for POST /project/new
+         */
+        NewProjectResponse: {
+            /**
+             * Blocked
+             * @default false
+             */
+            blocked: boolean;
+            /** Budget Id */
+            budget_id?: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /** Created By */
+            created_by?: string | null;
+            /** Description */
+            description?: string | null;
+            litellm_budget_table?: components["schemas"]["LiteLLM_BudgetTable"] | null;
+            /** Metadata */
+            metadata?: {
+                [key: string]: unknown;
+            } | null;
+            /** Model Rpm Limit */
+            model_rpm_limit?: {
+                [key: string]: unknown;
+            } | null;
+            /** Model Spend */
+            model_spend?: {
+                [key: string]: unknown;
+            } | null;
+            /** Model Tpm Limit */
+            model_tpm_limit?: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Models
+             * @default []
+             */
+            models: string[];
+            object_permission?: components["schemas"]["LiteLLM_ObjectPermissionTable"] | null;
+            /** Object Permission Id */
+            object_permission_id?: string | null;
+            /** Project Alias */
+            project_alias?: string | null;
+            /** Project Id */
+            project_id: string;
+            /**
+             * Spend
+             * @default 0
+             */
+            spend: number;
+            /** Team Id */
+            team_id?: string | null;
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at: string;
+            /** Updated By */
+            updated_by?: string | null;
+        };
         /** NewTeamRequest */
         NewTeamRequest: {
             /** Access Group Ids */
@@ -27407,6 +28027,34 @@ export interface components {
         OrganizationRequest: {
             /** Organizations */
             organizations: string[];
+        };
+        /**
+         * PaginatedAuditLogResponse
+         * @description Response model for paginated audit logs
+         */
+        PaginatedAuditLogResponse: {
+            /** Audit Logs */
+            audit_logs: components["schemas"]["AuditLogResponse"][];
+            /**
+             * Page
+             * @description Current page number
+             */
+            page: number;
+            /**
+             * Page Size
+             * @description Number of items per page
+             */
+            page_size: number;
+            /**
+             * Total
+             * @description Total number of audit logs matching the filters
+             */
+            total: number;
+            /**
+             * Total Pages
+             * @description Total number of pages
+             */
+            total_pages: number;
         };
         /** PassThroughEndpointResponse */
         PassThroughEndpointResponse: {
@@ -30859,6 +31507,63 @@ export interface components {
             model_names?: string[] | null;
         };
         /**
+         * UpdateProjectRequest
+         * @description Request model for POST /project/update
+         */
+        UpdateProjectRequest: {
+            /** Allowed Models */
+            allowed_models?: string[] | null;
+            /** Blocked */
+            blocked?: boolean | null;
+            /** Budget Duration */
+            budget_duration?: string | null;
+            /** Budget Id */
+            budget_id?: string | null;
+            /** Description */
+            description?: string | null;
+            /** Guardrails */
+            guardrails?: string[] | null;
+            /** Max Budget */
+            max_budget?: number | null;
+            /** Max Parallel Requests */
+            max_parallel_requests?: number | null;
+            /** Metadata */
+            metadata?: {
+                [key: string]: unknown;
+            } | null;
+            /** Model Max Budget */
+            model_max_budget?: {
+                [key: string]: unknown;
+            } | null;
+            /** Model Rpm Limit */
+            model_rpm_limit?: {
+                [key: string]: unknown;
+            } | null;
+            /** Model Tpm Limit */
+            model_tpm_limit?: {
+                [key: string]: unknown;
+            } | null;
+            /** Models */
+            models?: string[] | null;
+            object_permission?: components["schemas"]["LiteLLM_ObjectPermissionBase"] | null;
+            /** Policies */
+            policies?: string[] | null;
+            /** Project Alias */
+            project_alias?: string | null;
+            /** Project Id */
+            project_id: string;
+            /** Rpm Limit */
+            rpm_limit?: number | null;
+            /** Soft Budget */
+            soft_budget?: number | null;
+            /** Tags */
+            tags?: string[] | null;
+            /** Team Id */
+            team_id?: string | null;
+            /** Tpm Limit */
+            tpm_limit?: number | null;
+        };
+        /**
          * UpdatePublicModelGroupsRequest
          * @description Request model for updating public model groups
          */
@@ -33227,6 +33932,105 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
                 };
+            };
+        };
+    };
+    get_audit_logs_audit_get: {
+        parameters: {
+            query?: {
+                page?: number;
+                page_size?: number;
+                /** @description Filter by user or system that performed the action */
+                changed_by?: string | null;
+                /** @description Filter by API key hash that performed the action */
+                changed_by_api_key?: string | null;
+                /** @description Filter by action type (create, update, delete) */
+                action?: string | null;
+                /** @description Filter by table name that was modified */
+                table_name?: string | null;
+                /** @description Filter by ID of the object that was modified */
+                object_id?: string | null;
+                /** @description Filter logs after this date */
+                start_date?: string | null;
+                /** @description Filter logs before this date */
+                end_date?: string | null;
+                /** @description Filter by team_id present in before_value or updated_values JSON (PostgreSQL only) */
+                object_team_id?: string | null;
+                /** @description Filter by token (key hash) present in before_value or updated_values JSON (PostgreSQL only) */
+                object_key_hash?: string | null;
+                /** @description Column to sort by (e.g. 'updated_at', 'action', 'table_name') */
+                sort_by?: string | null;
+                /** @description Sort order ('asc' or 'desc') */
+                sort_order?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PaginatedAuditLogResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_audit_log_by_id_audit__id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuditLogResponse"];
+                };
+            };
+            /** @description Audit log not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+            /** @description Database connection error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };
@@ -36699,6 +37503,79 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_email_event_settings_email_event_settings_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EmailEventSettingsResponse"];
+                };
+            };
+        };
+    };
+    update_event_settings_email_event_settings_patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["EmailEventSettingsUpdateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    reset_event_settings_email_event_settings_reset_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
                 };
             };
         };
@@ -44885,6 +45762,156 @@ export interface operations {
             };
         };
     };
+    delete_project_project_delete_delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["DeleteProjectRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LiteLLM_ProjectTable"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    project_info_project_info_get: {
+        parameters: {
+            query: {
+                project_id: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LiteLLM_ProjectTable"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_projects_project_list_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LiteLLM_ProjectTable"][];
+                };
+            };
+        };
+    };
+    new_project_project_new_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["NewProjectRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NewProjectResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_project_project_update_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateProjectRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LiteLLM_ProjectTable"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     create_prompt_prompts_post: {
         parameters: {
             query?: never;
@@ -45799,6 +46826,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_robots_robots_txt_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
                 };
             };
         };
@@ -49388,6 +50435,26 @@ export interface operations {
         };
     };
     ui_get_available_role_user_available_roles_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    available_enterprise_users_user_available_users_get: {
         parameters: {
             query?: never;
             header?: never;

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -436,26 +436,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/alerting/settings": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Alerting Settings
-         * @description Return the configurable alerting param, description, and current value
-         */
-        get: operations["alerting_settings_alerting_settings_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/anthropic/{endpoint}": {
         parameters: {
             query?: never;
@@ -509,28 +489,6 @@ export interface paths {
          *     It exists to prevent 404 errors from Claude Code clients that send telemetry.
          */
         post: operations["event_logging_batch_api_event_logging_batch_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/plugins": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List Plugins
-         * @description Return registered plugins for authenticated UI callers.
-         *
-         *     plugin_key is only returned to callers with a valid litellm token.
-         */
-        get: operations["list_plugins_api_plugins_get"];
-        put?: never;
-        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -1812,26 +1770,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/config/callback/delete": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Delete Callback
-         * @description Delete specific logging callback from configuration.
-         */
-        post: operations["delete_callback_config_callback_delete_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/config/cost_discount_config": {
         parameters: {
             query?: never;
@@ -1913,83 +1851,6 @@ export interface paths {
         patch: operations["update_cost_margin_config_config_cost_margin_config_patch"];
         trace?: never;
     };
-    "/config/field/delete": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Delete Config General Settings
-         * @description Delete the db value of this field in litellm general settings. Resets it to it's initial default value on litellm.
-         */
-        post: operations["delete_config_general_settings_config_field_delete_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/config/field/info": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Config General Settings */
-        get: operations["get_config_general_settings_config_field_info_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/config/field/update": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Update Config General Settings
-         * @description Update a specific field in litellm general settings
-         */
-        post: operations["update_config_general_settings_config_field_update_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/config/list": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Config List
-         * @description List the available fields + current values for a given type of setting (currently just 'general_settings'user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),)
-         */
-        get: operations["get_config_list_config_list_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/config/pass_through_endpoint": {
         parameters: {
             query?: never;
@@ -2058,64 +1919,6 @@ export interface paths {
          * @description Update a pass-through endpoint by ID.
          */
         post: operations["update_pass_through_endpoints_config_pass_through_endpoint__endpoint_id__post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/config/update": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Update Config
-         * @description For Admin UI - allows admin to update config via UI.
-         *
-         *     Writes only the sections present in the request body to LiteLLM_Config rows
-         *     (one row per top-level section). Sections the caller did not send are left
-         *     untouched — this endpoint never persists pre-existing YAML values to DB as
-         *     a side effect of an unrelated update.
-         */
-        post: operations["update_config_config_update_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/config/yaml": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Config Yaml Endpoint
-         * @description This is a mock endpoint, to show what you can set in config.yaml details in the Swagger UI.
-         *
-         *     Parameters:
-         *
-         *     The config.yaml object has the following attributes:
-         *     - **model_list**: *Optional[List[ModelParams]]* - A list of supported models on the server, along with model-specific configurations. ModelParams includes "model_name" (name of the model), "litellm_params" (litellm-specific parameters for the model), and "model_info" (additional info about the model such as id, mode, cost per token, etc).
-         *
-         *     - **litellm_settings**: *Optional[dict]*: Settings for the litellm module. You can specify multiple properties like "drop_params", "set_verbose", "api_base", "cache".
-         *
-         *     - **general_settings**: *Optional[ConfigGeneralSettings]*: General settings for the server like "completion_model" (default model for chat completion calls), "use_azure_key_vault" (option to load keys from azure key vault), "master_key" (key required for all calls to proxy), and others.
-         *
-         *     Please, refer to each class's description for a better understanding of the specific attributes within them.
-         *
-         *     Note: This is a mock endpoint primarily meant for demonstration purposes, and does not actually provide or change any configurations.
-         */
-        get: operations["config_yaml_endpoint_config_yaml_get"];
-        put?: never;
-        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -2961,120 +2764,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/debug/memory/details": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Memory Details
-         * @description Get detailed memory diagnostics for deep debugging.
-         *
-         *     Returns:
-         *     - worker_pid: Process ID
-         *     - process_memory: RAM usage, virtual memory, file handles, threads
-         *     - garbage_collector: GC thresholds, counts, collection history
-         *     - objects: Total tracked objects and top object types
-         *     - uncollectable: Objects that can't be garbage collected (potential leaks)
-         *     - cache_memory: Memory usage of user_api_key, router, and logging caches
-         *     - router_memory: Memory usage of router components (model_list, deployment_names, etc.)
-         *
-         *     Query Parameters:
-         *     - top_n: Number of top object types to return (default: 20)
-         *     - include_process_info: Include process-level memory info using psutil (default: true)
-         *
-         *     Example usage:
-         *     curl "http://localhost:4000/debug/memory/details?top_n=30" -H "Authorization: Bearer sk-1234"
-         *
-         *     All memory sizes are reported in both bytes and MB.
-         */
-        get: operations["get_memory_details_debug_memory_details_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/debug/memory/gc/configure": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Configure Gc Thresholds Endpoint
-         * @description Configure Python garbage collection thresholds.
-         *
-         *     Lower thresholds mean more frequent GC cycles (less memory, more CPU overhead).
-         *     Higher thresholds mean less frequent GC cycles (more memory, less CPU overhead).
-         *
-         *     Returns:
-         *     - message: Confirmation message
-         *     - previous_thresholds: Old threshold values
-         *     - new_thresholds: New threshold values
-         *     - objects_awaiting_collection: Current object count in gen-0
-         *     - tip: Hint about when next collection will occur
-         *
-         *     Query Parameters:
-         *     - generation_0: Number of allocations before gen-0 collection (default: 700)
-         *     - generation_1: Number of gen-0 collections before gen-1 collection (default: 10)
-         *     - generation_2: Number of gen-1 collections before gen-2 collection (default: 10)
-         *
-         *     Example for more aggressive collection:
-         *     curl -X POST "http://localhost:4000/debug/memory/gc/configure?generation_0=500" -H "Authorization: Bearer sk-1234"
-         *
-         *     Example for less aggressive collection:
-         *     curl -X POST "http://localhost:4000/debug/memory/gc/configure?generation_0=1000" -H "Authorization: Bearer sk-1234"
-         *
-         *     Monitor memory usage with GET /debug/memory/summary after changes.
-         */
-        post: operations["configure_gc_thresholds_endpoint_debug_memory_gc_configure_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/debug/memory/summary": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Memory Summary
-         * @description Get simplified memory usage summary for the proxy.
-         *
-         *     Returns:
-         *     - worker_pid: Process ID
-         *     - status: Overall health based on memory usage
-         *     - memory: Process memory usage and RAM info
-         *     - caches: Cache item counts and descriptions
-         *     - garbage_collector: GC status and pending object counts
-         *
-         *     Example usage:
-         *     curl http://localhost:4000/debug/memory/summary -H "Authorization: Bearer sk-1234"
-         *
-         *     For detailed analysis, call GET /debug/memory/details
-         *     For cache management, use the cache management endpoints
-         */
-        get: operations["get_memory_summary_debug_memory_summary_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/delete/allowed_ip": {
         parameters: {
             query?: never;
@@ -3160,312 +2849,6 @@ export interface paths {
          *     ```
          */
         post: operations["embeddings_embeddings_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/end_user/block": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Block User
-         * @description [BETA] Reject calls with this end-user id
-         *
-         *     Parameters:
-         *     - user_ids (List[str], required): The unique `user_id`s for the users to block
-         *
-         *         (any /chat/completion call with this user={end-user-id} param, will be rejected.)
-         *
-         *         ```
-         *         curl -X POST "http://0.0.0.0:8000/user/block"
-         *         -H "Authorization: Bearer sk-1234"
-         *         -d '{
-         *         "user_ids": [<user_id>, ...]
-         *         }'
-         *         ```
-         */
-        post: operations["block_user_end_user_block_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/end_user/daily/activity": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Customer Daily Activity
-         * @description Get daily activity for specific organizations or all accessible organizations.
-         */
-        get: operations["get_customer_daily_activity_end_user_daily_activity_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/end_user/delete": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Delete End User
-         * @description Delete multiple end-users.
-         *
-         *     Parameters:
-         *     - user_ids (List[str], required): The unique `user_id`s for the users to delete
-         *
-         *     Example curl:
-         *     ```
-         *     curl --location 'http://0.0.0.0:4000/customer/delete'         --header 'Authorization: Bearer sk-1234'         --header 'Content-Type: application/json'         --data '{
-         *             "user_ids" :["ishaan-jaff-5"]
-         *     }'
-         *
-         *     See below for all params
-         *     ```
-         */
-        post: operations["delete_end_user_end_user_delete_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/end_user/info": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * End User Info
-         * @description Get information about an end-user. An `end_user` is a customer (external user) of the proxy.
-         *
-         *     Parameters:
-         *     - end_user_id (str, required): The unique identifier for the end-user
-         *
-         *     Example curl:
-         *     ```
-         *     curl -X GET 'http://localhost:4000/customer/info?end_user_id=test-litellm-user-4'         -H 'Authorization: Bearer sk-1234'
-         *     ```
-         */
-        get: operations["end_user_info_end_user_info_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/end_user/list": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List End User
-         * @description [Admin-only] List all available customers
-         *
-         *     Example curl:
-         *     ```
-         *     curl --location --request GET 'http://0.0.0.0:4000/customer/list'         --header 'Authorization: Bearer sk-1234'
-         *     ```
-         */
-        get: operations["list_end_user_end_user_list_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/end_user/new": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * New End User
-         * @description Allow creating a new Customer
-         *
-         *
-         *     Parameters:
-         *     - user_id: str - The unique identifier for the user.
-         *     - alias: Optional[str] - A human-friendly alias for the user.
-         *     - blocked: bool - Flag to allow or disallow requests for this end-user. Default is False.
-         *     - max_budget: Optional[float] - The maximum budget allocated to the user. Either 'max_budget' or 'budget_id' should be provided, not both.
-         *     - budget_id: Optional[str] - The identifier for an existing budget allocated to the user. Either 'max_budget' or 'budget_id' should be provided, not both.
-         *     - allowed_model_region: Optional[Union[Literal["eu"], Literal["us"]]] - Require all user requests to use models in this specific region.
-         *     - default_model: Optional[str] - If no equivalent model in the allowed region, default all requests to this model.
-         *     - metadata: Optional[dict] = Metadata for customer, store information for customer. Example metadata = {"data_training_opt_out": True}
-         *     - budget_duration: Optional[str] - Budget is reset at the end of specified duration. If not set, budget is never reset. You can set duration as seconds ("30s"), minutes ("30m"), hours ("30h"), days ("30d").
-         *     - tpm_limit: Optional[int] - [Not Implemented Yet] Specify tpm limit for a given customer (Tokens per minute)
-         *     - rpm_limit: Optional[int] - [Not Implemented Yet] Specify rpm limit for a given customer (Requests per minute)
-         *     - model_max_budget: Optional[dict] - [Not Implemented Yet] Specify max budget for a given model. Example: {"openai/gpt-4o-mini": {"max_budget": 100.0, "budget_duration": "1d"}}
-         *     - max_parallel_requests: Optional[int] - [Not Implemented Yet] Specify max parallel requests for a given customer.
-         *     - soft_budget: Optional[float] - [Not Implemented Yet] Get alerts when customer crosses given budget, doesn't block requests.
-         *     - spend: Optional[float] - Specify initial spend for a given customer.
-         *     - budget_reset_at: Optional[str] - Specify the date and time when the budget should be reset.
-         *     - object_permission: Optional[LiteLLM_ObjectPermissionBase] - Customer-specific object permissions to control access to resources.
-         *         Supported fields:
-         *         * mcp_servers: List[str] - List of allowed MCP server IDs
-         *         * mcp_access_groups: List[str] - List of MCP access group names
-         *         * mcp_tool_permissions: Dict[str, List[str]] - Map of server ID to allowed tool names (e.g., {"server_1": ["tool_a", "tool_b"]})
-         *         * vector_stores: List[str] - List of allowed vector store IDs
-         *         * agents: List[str] - List of allowed agent IDs
-         *         * agent_access_groups: List[str] - List of agent access group names
-         *         Example: {"mcp_servers": ["server_1", "server_2"], "vector_stores": ["vector_store_1"], "agents": ["agent_1"]}
-         *         IF null or {} then no object-level restrictions apply.
-         *
-         *
-         *     - Allow specifying allowed regions
-         *     - Allow specifying default model
-         *
-         *     Example curl:
-         *     ```
-         *     curl --location 'http://0.0.0.0:4000/customer/new'         --header 'Authorization: Bearer sk-1234'         --header 'Content-Type: application/json'         --data '{
-         *             "user_id" : "ishaan-jaff-3",
-         *             "allowed_region": "eu",
-         *             "budget_id": "free_tier",
-         *             "default_model": "azure/gpt-3.5-turbo-eu"
-         *         }'
-         *
-         *     # With object permissions
-         *     curl -L -X POST 'http://localhost:4000/customer/new'         -H 'Authorization: Bearer sk-1234'         -H 'Content-Type: application/json'         -d '{
-         *             "user_id": "user_1",
-         *             "object_permission": {
-         *               "mcp_servers": ["server_1"],
-         *               "mcp_access_groups": ["public_group"],
-         *               "vector_stores": ["vector_store_1"]
-         *             }
-         *           }'
-         *
-         *         # return end-user object
-         *     ```
-         *
-         *     NOTE: This used to be called `/end_user/new`, we will still be maintaining compatibility for /end_user/XXX for these endpoints
-         */
-        post: operations["new_end_user_end_user_new_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/end_user/unblock": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Unblock User
-         * @description [BETA] Unblock calls with this user id
-         *
-         *     Example
-         *     ```
-         *     curl -X POST "http://0.0.0.0:8000/user/unblock"
-         *     -H "Authorization: Bearer sk-1234"
-         *     -d '{
-         *     "user_ids": [<user_id>, ...]
-         *     }'
-         *     ```
-         */
-        post: operations["unblock_user_end_user_unblock_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/end_user/update": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Update End User
-         * @description Example curl
-         *
-         *     Parameters:
-         *     - user_id: str
-         *     - alias: Optional[str] = None  # human-friendly alias
-         *     - blocked: bool = False  # allow/disallow requests for this end-user
-         *     - max_budget: Optional[float] = None
-         *     - budget_id: Optional[str] = None  # give either a budget_id or max_budget
-         *     - allowed_model_region: Optional[AllowedModelRegion] = (
-         *         None  # require all user requests to use models in this specific region
-         *     )
-         *     - default_model: Optional[str] = (
-         *         None  # if no equivalent model in allowed region - default all requests to this model
-         *     )
-         *     - object_permission: Optional[LiteLLM_ObjectPermissionBase] - Customer-specific object permissions to control access to resources.
-         *         Supported fields:
-         *         * mcp_servers: List[str] - List of allowed MCP server IDs
-         *         * mcp_access_groups: List[str] - List of MCP access group names
-         *         * mcp_tool_permissions: Dict[str, List[str]] - Map of server ID to allowed tool names
-         *         * vector_stores: List[str] - List of allowed vector store IDs
-         *         * agents: List[str] - List of allowed agent IDs
-         *         * agent_access_groups: List[str] - List of agent access group names
-         *         Example: {"mcp_servers": ["server_1"], "vector_stores": ["vector_store_1"]}
-         *         IF null or {} then no object-level restrictions apply.
-         *
-         *     Example curl:
-         *     ```
-         *     curl --location 'http://0.0.0.0:4000/customer/update'     --header 'Authorization: Bearer sk-1234'     --header 'Content-Type: application/json'     --data '{
-         *         "user_id": "test-litellm-user-4",
-         *         "budget_id": "paid_tier"
-         *     }'
-         *
-         *     # Updating object permissions
-         *     curl -L -X POST 'http://localhost:4000/customer/update'     --header 'Authorization: Bearer sk-1234'     --header 'Content-Type: application/json'     --data '{
-         *         "user_id": "user_1",
-         *         "object_permission": {
-         *           "mcp_servers": ["server_3"],
-         *           "vector_stores": ["vector_store_2", "vector_store_3"]
-         *         }
-         *       }'
-         *
-         *     See below for all params
-         *     ```
-         */
-        post: operations["update_end_user_end_user_update_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -3621,28 +3004,6 @@ export interface paths {
          *     - `content_policy`: Fallbacks specifically for content policy violations
          */
         post: operations["create_fallback_fallback_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/fallback/login": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Fallback Login
-         * @description Create Proxy API Keys using Google Workspace SSO. Requires setting PROXY_BASE_URL in .env
-         *     PROXY_BASE_URL should be the your deployed proxy endpoint, e.g. PROXY_BASE_URL="https://litellm-production-7002.up.railway.app/"
-         *     Example:
-         */
-        get: operations["fallback_login_fallback_login_get"];
-        put?: never;
-        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -3935,44 +3296,6 @@ export interface paths {
         patch: operations["gemini_proxy_route_gemini__endpoint__patch"];
         trace?: never;
     };
-    "/get/allowed_ips": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Allowed Ips */
-        get: operations["get_allowed_ips_get_allowed_ips_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/get/config/callbacks": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Config
-         * @description For Admin UI - allows admin to view config via UI
-         *     # return the callbacks and the env variables for the callback
-         */
-        get: operations["get_config_get_config_callbacks_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/get/default_team_settings": {
         parameters: {
             query?: never;
@@ -4102,508 +3425,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/get_favicon": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Favicon
-         * @description Get custom favicon for the admin UI.
-         */
-        get: operations["get_favicon_get_favicon_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/get_image": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Image
-         * @description Get logo to show on admin UI
-         */
-        get: operations["get_image_get_image_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/get_logo_url": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Logo Url
-         * @description Get the current logo URL from environment.
-         *
-         *     Only HTTP(S) URLs are returned — those are intended to be loaded
-         *     directly by the browser from a public/internal CDN. Local file
-         *     paths set via ``UI_LOGO_PATH`` are NOT returned: they are admin-
-         *     only filesystem details, the dashboard falls back to ``/get_image``
-         *     which serves the file only when it is a supported image. Without
-         *     this filter, the unauthenticated endpoint would disclose internal
-         *     hostnames or filesystem paths to any caller.
-         */
-        get: operations["get_logo_url_get_logo_url_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/global/activity": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Global Activity
-         * @description Get number of API Requests, total tokens through proxy
-         *
-         *     {
-         *         "daily_data": [
-         *                 const chartdata = [
-         *                 {
-         *                 date: 'Jan 22',
-         *                 api_requests: 10,
-         *                 total_tokens: 2000
-         *                 },
-         *                 {
-         *                 date: 'Jan 23',
-         *                 api_requests: 10,
-         *                 total_tokens: 12
-         *                 },
-         *         ],
-         *         "sum_api_requests": 20,
-         *         "sum_total_tokens": 2012
-         *     }
-         */
-        get: operations["get_global_activity_global_activity_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/global/activity/cache_hits": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Global Activity
-         * @description Get number of cache hits, vs misses
-         *
-         *     {
-         *         "daily_data": [
-         *                 const chartdata = [
-         *                 {
-         *                     date: 'Jan 22',
-         *                     cache_hits: 10,
-         *                     llm_api_calls: 2000
-         *                 },
-         *                 {
-         *                     date: 'Jan 23',
-         *                     cache_hits: 10,
-         *                     llm_api_calls: 12
-         *                 },
-         *         ],
-         *         "sum_cache_hits": 20,
-         *         "sum_llm_api_calls": 2012
-         *     }
-         */
-        get: operations["get_global_activity_global_activity_cache_hits_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/global/activity/exceptions": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Global Activity Exceptions
-         * @description Get number of API Requests, total tokens through proxy
-         *
-         *     {
-         *         "daily_data": [
-         *                 const chartdata = [
-         *                 {
-         *                 date: 'Jan 22',
-         *                 num_rate_limit_exceptions: 10,
-         *                 },
-         *                 {
-         *                 date: 'Jan 23',
-         *                 num_rate_limit_exceptions: 10,
-         *                 },
-         *         ],
-         *         "sum_api_exceptions": 20,
-         *     }
-         */
-        get: operations["get_global_activity_exceptions_global_activity_exceptions_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/global/activity/exceptions/deployment": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Global Activity Exceptions Per Deployment
-         * @description Get number of 429 errors - Grouped by deployment
-         *
-         *     [
-         *         {
-         *             "deployment": "https://azure-us-east-1.openai.azure.com/",
-         *             "daily_data": [
-         *                     const chartdata = [
-         *                     {
-         *                     date: 'Jan 22',
-         *                     num_rate_limit_exceptions: 10
-         *                     },
-         *                     {
-         *                     date: 'Jan 23',
-         *                     num_rate_limit_exceptions: 12
-         *                     },
-         *             ],
-         *             "sum_num_rate_limit_exceptions": 20,
-         *
-         *         },
-         *         {
-         *             "deployment": "https://azure-us-east-1.openai.azure.com/",
-         *             "daily_data": [
-         *                     const chartdata = [
-         *                     {
-         *                     date: 'Jan 22',
-         *                     num_rate_limit_exceptions: 10,
-         *                     },
-         *                     {
-         *                     date: 'Jan 23',
-         *                     num_rate_limit_exceptions: 12
-         *                     },
-         *             ],
-         *             "sum_num_rate_limit_exceptions": 20,
-         *
-         *         },
-         *     ]
-         */
-        get: operations["get_global_activity_exceptions_per_deployment_global_activity_exceptions_deployment_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/global/activity/model": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Global Activity Model
-         * @description Get number of API Requests, total tokens through proxy - Grouped by MODEL
-         *
-         *     [
-         *         {
-         *             "model": "gpt-4",
-         *             "daily_data": [
-         *                     const chartdata = [
-         *                     {
-         *                     date: 'Jan 22',
-         *                     api_requests: 10,
-         *                     total_tokens: 2000
-         *                     },
-         *                     {
-         *                     date: 'Jan 23',
-         *                     api_requests: 10,
-         *                     total_tokens: 12
-         *                     },
-         *             ],
-         *             "sum_api_requests": 20,
-         *             "sum_total_tokens": 2012
-         *
-         *         },
-         *         {
-         *             "model": "azure/gpt-4-turbo",
-         *             "daily_data": [
-         *                     const chartdata = [
-         *                     {
-         *                     date: 'Jan 22',
-         *                     api_requests: 10,
-         *                     total_tokens: 2000
-         *                     },
-         *                     {
-         *                     date: 'Jan 23',
-         *                     api_requests: 10,
-         *                     total_tokens: 12
-         *                     },
-         *             ],
-         *             "sum_api_requests": 20,
-         *             "sum_total_tokens": 2012
-         *
-         *         },
-         *     ]
-         */
-        get: operations["get_global_activity_model_global_activity_model_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/global/all_end_users": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Global View All End Users
-         * @description [BETA] This is a beta endpoint. It will change.
-         *
-         *     Use this to just get all the unique `end_users`
-         */
-        get: operations["global_view_all_end_users_global_all_end_users_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/global/spend": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Global Spend
-         * @description [BETA] This is a beta endpoint. It will change.
-         *
-         *     View total spend across all proxy keys
-         */
-        get: operations["global_spend_global_spend_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/global/spend/all_tag_names": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Global Get All Tag Names */
-        get: operations["global_get_all_tag_names_global_spend_all_tag_names_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/global/spend/end_users": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Global Spend End Users
-         * @description [BETA] This is a beta endpoint. It will change.
-         *
-         *     Use this to get the top 'n' keys with the highest spend, ordered by spend.
-         */
-        post: operations["global_spend_end_users_global_spend_end_users_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/global/spend/keys": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Global Spend Keys
-         * @description [BETA] This is a beta endpoint. It will change.
-         *
-         *     Use this to get the top 'n' keys with the highest spend, ordered by spend.
-         */
-        get: operations["global_spend_keys_global_spend_keys_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/global/spend/logs": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Global Spend Logs
-         * @description [BETA] This is a beta endpoint. It will change.
-         *
-         *     Use this to get global spend (spend per day for last 30d). Admin-only endpoint
-         *
-         *     More efficient implementation of /spend/logs, by creating a view over the spend logs table.
-         */
-        get: operations["global_spend_logs_global_spend_logs_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/global/spend/models": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Global Spend Models
-         * @description [BETA] This is a beta endpoint. It will change.
-         *
-         *     Use this to get the top 'n' models with the highest spend, ordered by spend.
-         */
-        get: operations["global_spend_models_global_spend_models_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/global/spend/provider": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Global Spend Provider
-         * @description Get breakdown of spend per provider
-         *     [
-         *         {
-         *             "provider": "Azure OpenAI",
-         *             "spend": 20
-         *         },
-         *         {
-         *             "provider": "OpenAI",
-         *             "spend": 10
-         *         },
-         *         {
-         *             "provider": "VertexAI",
-         *             "spend": 30
-         *         }
-         *     ]
-         */
-        get: operations["get_global_spend_provider_global_spend_provider_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/global/spend/refresh": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Global Spend Refresh
-         * @description ADMIN ONLY / MASTER KEY Only Endpoint
-         *
-         *     Globally refresh spend MonthlyGlobalSpend view
-         */
-        post: operations["global_spend_refresh_global_spend_refresh_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/global/spend/report": {
         parameters: {
             query?: never;
@@ -4698,28 +3519,6 @@ export interface paths {
          *     ```
          */
         get: operations["global_view_spend_tags_global_spend_tags_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/global/spend/teams": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Global Spend Per Team
-         * @description [BETA] This is a beta endpoint. It will change.
-         *
-         *     Use this to get daily spend, grouped by `team_id` and `date`
-         */
-        get: operations["global_spend_per_team_global_spend_teams_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -6061,111 +4860,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/invitation/delete": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Invitation Delete
-         * @description Delete invitation link
-         *
-         *     ```
-         *     curl -X POST 'http://localhost:4000/invitation/delete'         -H 'Content-Type: application/json'         -d '{
-         *             "invitation_id": "1234" // 👈 id of invitation in 'LiteLLM_InvitationTable'
-         *         }'
-         *     ```
-         */
-        post: operations["invitation_delete_invitation_delete_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/invitation/info": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Invitation Info
-         * @description Allow admin to create invite links, to onboard new users to Admin UI.
-         *
-         *     ```
-         *     curl -X POST 'http://localhost:4000/invitation/new'         -H 'Content-Type: application/json'         -d '{
-         *             "user_id": "1234" // 👈 id of user in 'LiteLLM_UserTable'
-         *         }'
-         *     ```
-         */
-        get: operations["invitation_info_invitation_info_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/invitation/new": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * New Invitation
-         * @description Allow admin to create invite links, to onboard new users to Admin UI.
-         *
-         *     ```
-         *     curl -X POST 'http://localhost:4000/invitation/new'         -H 'Content-Type: application/json'         -d '{
-         *             "user_id": "1234" // 👈 id of user in 'LiteLLM_UserTable'
-         *         }'
-         *     ```
-         */
-        post: operations["new_invitation_invitation_new_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/invitation/update": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Invitation Update
-         * @description Update when invitation is accepted
-         *
-         *     ```
-         *     curl -X POST 'http://localhost:4000/invitation/update'         -H 'Content-Type: application/json'         -d '{
-         *             "invitation_id": "1234" // 👈 id of invitation in 'LiteLLM_InvitationTable'
-         *             "is_accepted": True // when invitation is accepted
-         *         }'
-         *     ```
-         */
-        post: operations["invitation_update_invitation_update_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/jwt/key/mapping/delete": {
         parameters: {
             query?: never;
@@ -7006,23 +5700,6 @@ export interface paths {
         patch: operations["langfuse_proxy_route_langfuse__endpoint__patch"];
         trace?: never;
     };
-    "/lazy/warm/{name}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Warm */
-        post: operations["warm_lazy_warm__name__post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/litellm/.well-known/litellm-ui-config": {
         parameters: {
             query?: never;
@@ -7034,23 +5711,6 @@ export interface paths {
         get: operations["get_ui_config_litellm__well_known_litellm_ui_config_get"];
         put?: never;
         post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/login": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Login */
-        post: operations["login_login_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -7154,52 +5814,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/memory-usage-in-mem-cache": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Memory Usage In Mem Cache
-         * @description 1. user_api_key_cache
-         *     2. router_cache
-         *     3. proxy_logging_cache
-         *     4. internal_usage_cache
-         */
-        get: operations["memory_usage_in_mem_cache_memory_usage_in_mem_cache_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/memory-usage-in-mem-cache-items": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Memory Usage In Mem Cache Items
-         * @description 1. user_api_key_cache
-         *     2. router_cache
-         *     3. proxy_logging_cache
-         *     4. internal_usage_cache
-         */
-        get: operations["memory_usage_in_mem_cache_items_memory_usage_in_mem_cache_items_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/milvus/{endpoint}": {
         parameters: {
             query?: never;
@@ -7272,58 +5886,6 @@ export interface paths {
         patch: operations["mistral_proxy_route_mistral__endpoint__patch"];
         trace?: never;
     };
-    "/model/block": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Block Model
-         * @description Block a DB-stored model deployment from serving requests.
-         *
-         *     Parameters:
-         *     - model_id: str - The model deployment id to block.
-         */
-        post: operations["block_model_model_block_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/model/cost_map/source": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Model Cost Map Source
-         * @description ADMIN ONLY / MASTER KEY Only Endpoint
-         *
-         *     Returns information about where the current model cost/pricing data was loaded from.
-         *
-         *     Response fields:
-         *     - source: "local" (bundled backup) or "remote" (fetched from URL)
-         *     - url: the remote URL that was attempted (null when env-forced local)
-         *     - is_env_forced: true if LITELLM_LOCAL_MODEL_COST_MAP=True forced local usage
-         *     - fallback_reason: human-readable reason why remote failed (null on success)
-         *     - model_count: number of models in the currently loaded cost map
-         */
-        get: operations["get_model_cost_map_source_model_cost_map_source_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/model/delete": {
         parameters: {
             query?: never;
@@ -7360,11 +5922,6 @@ export interface paths {
          *
          *         - When litellm_model_id is passed, it will return the info for that specific model
          *         - When litellm_model_id is not passed, it will return the info for all models
-         *         - include_team_models: When true, filter to deployments the caller can use (same as /v2/model/info).
-         *         - teamId: Filter to models accessible by the given team.
-         *
-         *     Each model in the list response includes `model_info.access_via_team_ids` and
-         *     `model_info.direct_access` when the proxy database is connected.
          *
          *     Returns:
          *         Returns a dictionary containing information about each model.
@@ -7398,66 +5955,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/model/metrics": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Model Metrics
-         * @description View number of requests & avg latency per model on config.yaml
-         */
-        get: operations["model_metrics_model_metrics_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/model/metrics/exceptions": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Model Metrics Exceptions
-         * @description View number of failed requests per model on config.yaml
-         */
-        get: operations["model_metrics_exceptions_model_metrics_exceptions_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/model/metrics/slow_responses": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Model Metrics Slow Responses
-         * @description View number of hanging requests per model_group
-         */
-        get: operations["model_metrics_slow_responses_model_metrics_slow_responses_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/model/new": {
         parameters: {
             query?: never;
@@ -7472,69 +5969,6 @@ export interface paths {
          * @description Allows adding new models to the model list in the config.yaml
          */
         post: operations["add_new_model_model_new_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/model/settings": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Model Settings
-         * @description Returns provider name, description, and required parameters for each provider
-         */
-        get: operations["model_settings_model_settings_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/model/streaming_metrics": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Model Streaming Metrics
-         * @description View time to first token for models in spend logs
-         */
-        get: operations["model_streaming_metrics_model_streaming_metrics_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/model/unblock": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Unblock Model
-         * @description Unblock a DB-stored model deployment so it can serve requests again.
-         *
-         *     Parameters:
-         *     - model_id: str - The model deployment id to unblock.
-         */
-        post: operations["unblock_model_model_unblock_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -7814,15 +6248,6 @@ export interface paths {
          *     - scope: Optional scope parameter. Currently only accepts "expand".
          *              When scope=expand is passed, proxy admins, team admins, and org admins
          *              will receive all proxy models as if they are a proxy admin.
-         *     - healthy_only: When true, hide models whose backing deployments are all marked
-         *                     unhealthy by background health checks. Requires
-         *                     `background_health_checks: true` in general_settings; without
-         *                     health state the listing is returned unfiltered (fail open).
-         *                     Models expanded from wildcard routes (e.g. `openai/*`) are not
-         *                     filtered, and nothing is hidden when `allowed_fails_policy` is
-         *                     configured (cooldown remains the sole exclusion mechanism).
-         *                     Hiding is presentation-only: a hidden model can still be
-         *                     called directly.
          */
         get: operations["model_list_models_get"];
         put?: never;
@@ -7849,10 +6274,6 @@ export interface paths {
          *
          *     Follows OpenAI API specification for individual model retrieval.
          *     https://platform.openai.com/docs/api-reference/models/retrieve
-         *
-         *     Query parameters mirror `/v1/models` so the same caller context (team
-         *     scoping, health filtering, paused deployments) drives both endpoints; the
-         *     listing's public id must resolve to the same internal deployment here.
          */
         get: operations["model_info_models__model_id__get"];
         put?: never;
@@ -7984,58 +6405,6 @@ export interface paths {
          *     ```
          */
         post: operations["ocr_ocr_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/onboarding/claim_token": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Claim Onboarding Link
-         * @description Special route. Allows UI link share user to update their password.
-         *
-         *     - Get the invite link
-         *     - Validate it's still 'valid'
-         *     - Check if user within initial session (prevents abuse)
-         *     - Get user from db
-         *     - Update user password
-         *
-         *     This route can only update user password.
-         */
-        post: operations["claim_onboarding_link_onboarding_claim_token_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/onboarding/get_token": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Onboarding
-         * @description - Get the invite link
-         *     - Validate it's still 'valid'
-         *     - Return a short-lived onboarding token
-         *     - Get user from db
-         *     - Pass in user_email if set
-         */
-        get: operations["onboarding_onboarding_get_token_get"];
-        put?: never;
-        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -8968,67 +7337,6 @@ export interface paths {
          * @description Update an organization
          */
         patch: operations["update_organization_organization_update_patch"];
-        trace?: never;
-    };
-    "/otel-spans": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Otel Spans */
-        get: operations["get_otel_spans_otel_spans_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/plugin-proxy/{plugin_name}/{path}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Plugin Proxy
-         * @description Authenticated reverse-proxy to a registered plugin backend.
-         */
-        get: operations["plugin_proxy_plugin_proxy__plugin_name___path__get"];
-        /**
-         * Plugin Proxy
-         * @description Authenticated reverse-proxy to a registered plugin backend.
-         */
-        put: operations["plugin_proxy_plugin_proxy__plugin_name___path__put"];
-        /**
-         * Plugin Proxy
-         * @description Authenticated reverse-proxy to a registered plugin backend.
-         */
-        post: operations["plugin_proxy_plugin_proxy__plugin_name___path__post"];
-        /**
-         * Plugin Proxy
-         * @description Authenticated reverse-proxy to a registered plugin backend.
-         */
-        delete: operations["plugin_proxy_plugin_proxy__plugin_name___path__delete"];
-        /**
-         * Plugin Proxy
-         * @description Authenticated reverse-proxy to a registered plugin backend.
-         */
-        options: operations["plugin_proxy_plugin_proxy__plugin_name___path__options"];
-        /**
-         * Plugin Proxy
-         * @description Authenticated reverse-proxy to a registered plugin backend.
-         */
-        head: operations["plugin_proxy_plugin_proxy__plugin_name___path__head"];
-        /**
-         * Plugin Proxy
-         * @description Authenticated reverse-proxy to a registered plugin backend.
-         */
-        patch: operations["plugin_proxy_plugin_proxy__plugin_name___path__patch"];
         trace?: never;
     };
     "/policies": {
@@ -10704,23 +9012,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/queue/chat/completions": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Async Queue Request */
-        post: operations["async_queue_request_queue_chat_completions_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/rag/ingest": {
         parameters: {
             query?: never;
@@ -10881,52 +9172,6 @@ export interface paths {
         put?: never;
         /** Create Realtime Client Secret */
         post: operations["create_realtime_client_secret_realtime_client_secrets_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/reload/anthropic_beta_headers": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Reload Anthropic Beta Headers
-         * @description ADMIN ONLY / MASTER KEY Only Endpoint
-         *
-         *     Manually reload the Anthropic beta headers configuration from the remote source.
-         *     This will fetch fresh configuration from the anthropic_beta_headers_config.json file.
-         */
-        post: operations["reload_anthropic_beta_headers_reload_anthropic_beta_headers_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/reload/model_cost_map": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Reload Model Cost Map
-         * @description ADMIN ONLY / MASTER KEY Only Endpoint
-         *
-         *     Manually reload the model cost map from the remote source.
-         *     This will fetch fresh pricing data from the model_prices_and_context_window.json file.
-         */
-        post: operations["reload_model_cost_map_reload_model_cost_map_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -11214,108 +9459,6 @@ export interface paths {
          * @description Get a list of available routes in the FastAPI application.
          */
         get: operations["get_routes_routes_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/schedule/anthropic_beta_headers_reload": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Schedule Anthropic Beta Headers Reload
-         * @description ADMIN ONLY / MASTER KEY Only Endpoint
-         *
-         *     Schedule periodic reload of the Anthropic beta headers configuration.
-         *     This will create a background job that reloads the configuration every specified hours.
-         */
-        post: operations["schedule_anthropic_beta_headers_reload_schedule_anthropic_beta_headers_reload_post"];
-        /**
-         * Cancel Anthropic Beta Headers Reload
-         * @description ADMIN ONLY / MASTER KEY Only Endpoint
-         *
-         *     Cancel the scheduled periodic reload of the Anthropic beta headers configuration.
-         */
-        delete: operations["cancel_anthropic_beta_headers_reload_schedule_anthropic_beta_headers_reload_delete"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/schedule/anthropic_beta_headers_reload/status": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Anthropic Beta Headers Reload Status
-         * @description ADMIN ONLY / MASTER KEY Only Endpoint
-         *
-         *     Get the status of the scheduled Anthropic beta headers reload job.
-         */
-        get: operations["get_anthropic_beta_headers_reload_status_schedule_anthropic_beta_headers_reload_status_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/schedule/model_cost_map_reload": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Schedule Model Cost Map Reload
-         * @description ADMIN ONLY / MASTER KEY Only Endpoint
-         *
-         *     Schedule periodic reload of the model cost map.
-         *     This will create a background job that reloads the model cost map every specified hours.
-         */
-        post: operations["schedule_model_cost_map_reload_schedule_model_cost_map_reload_post"];
-        /**
-         * Cancel Model Cost Map Reload
-         * @description ADMIN ONLY / MASTER KEY Only Endpoint
-         *
-         *     Cancel the scheduled periodic reload of the model cost map.
-         */
-        delete: operations["cancel_model_cost_map_reload_schedule_model_cost_map_reload_delete"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/schedule/model_cost_map_reload/status": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Model Cost Map Reload Status
-         * @description ADMIN ONLY / MASTER KEY Only Endpoint
-         *
-         *     Get the status of the scheduled model cost map reload job.
-         */
-        get: operations["get_model_cost_map_reload_status_schedule_model_cost_map_reload_status_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -12179,38 +10322,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/spend/keys": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Spend Key Fn
-         * @description View keys created, ordered by spend.
-         *
-         *     - Admin callers (PROXY_ADMIN / PROXY_ADMIN_VIEW_ONLY) see every key in
-         *       the database.
-         *     - All other callers (INTERNAL_USER / INTERNAL_USER_VIEW_ONLY, etc.) are
-         *       scoped to keys they own (``user_id == caller``). A caller with no
-         *       ``user_id`` has no scope and receives an empty list rather than the
-         *       full table.
-         *
-         *     Example Request:
-         *     ```
-         *     curl -X GET "http://0.0.0.0:8000/spend/keys" -H "Authorization: Bearer sk-1234"
-         *     ```
-         */
-        get: operations["spend_key_fn_spend_keys_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/spend/logs": {
         parameters: {
             query?: never;
@@ -12255,86 +10366,6 @@ export interface paths {
          *     ```
          */
         get: operations["view_spend_logs_spend_logs_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/spend/logs/session/ui": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Ui View Session Spend Logs
-         * @description Get paginated spend logs for a particular session.
-         *
-         *     Returns:
-         *         {
-         *             "data": List[LiteLLM_SpendLogs],
-         *             "total": int,
-         *             "page": int,
-         *             "page_size": int,
-         *             "total_pages": int,
-         *         }
-         */
-        get: operations["ui_view_session_spend_logs_spend_logs_session_ui_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/spend/logs/ui": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Ui View Spend Logs
-         * @description View spend logs with pagination support.
-         *     Available at both `/spend/logs/v2` (public API) and `/spend/logs/ui` (internal UI).
-         *
-         *     Returns paginated response with data, total, page, page_size, and total_pages.
-         *
-         *     Example:
-         *     ```
-         *     curl -X GET "http://0.0.0.0:8000/spend/logs/v2?start_date=2025-11-25%2000:00:00&end_date=2025-11-26%2023:59:59&page=1&page_size=50" -H "Authorization: Bearer sk-1234"
-         *     ```
-         */
-        get: operations["ui_view_spend_logs_spend_logs_ui_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/spend/logs/ui/{request_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Ui View Request Response For Request Id
-         * @description View request / response for a specific request_id
-         *
-         *     - goes through all callbacks, checks if any of them have a @property -> has_request_response_payload
-         *     - if so, it will return the request and response payload
-         */
-        get: operations["ui_view_request_response_for_request_id_spend_logs_ui__request_id__get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -12393,208 +10424,6 @@ export interface paths {
          *     ```
          */
         get: operations["view_spend_tags_spend_tags_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/spend/users": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Spend User Fn
-         * @description View users created, ordered by spend.
-         *
-         *     - Admin callers (PROXY_ADMIN / PROXY_ADMIN_VIEW_ONLY) see every user, or
-         *       a specific user when ``user_id`` is supplied.
-         *     - All other callers may only read their own row. If they supply a
-         *       ``user_id`` query parameter that does not match their authenticated
-         *       ``user_id`` the request is rejected with HTTP 403; supplying their
-         *       own id (or none at all) returns just their row. A caller with no
-         *       ``user_id`` on their key has no scope and receives an empty list
-         *       rather than the full table.
-         *
-         *     Example Request:
-         *     ```
-         *     curl -X GET "http://0.0.0.0:8000/spend/users" -H "Authorization: Bearer sk-1234"
-         *     ```
-         *
-         *     View User Table row for user_id
-         *     ```
-         *     curl -X GET "http://0.0.0.0:8000/spend/users?user_id=1234" -H "Authorization: Bearer sk-1234"
-         *     ```
-         */
-        get: operations["spend_user_fn_spend_users_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/sso/callback": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Auth Callback
-         * @description Verify login
-         */
-        get: operations["auth_callback_sso_callback_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/sso/cli/complete/{login_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Cli Sso Complete */
-        post: operations["cli_sso_complete_sso_cli_complete__login_id__post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/sso/cli/poll/{key_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Cli Poll Key
-         * @description CLI polling endpoint - retrieves session from cache and generates JWT.
-         *
-         *     Flow:
-         *     1. First poll (no team_id): Returns teams list without generating JWT
-         *     2. Second poll (with team_id): Generates JWT with selected team and deletes session
-         *
-         *     Args:
-         *         key_id: The CLI login session ID
-         *         team_id: Optional team ID to assign to the JWT. If provided, must be one of user's teams.
-         */
-        get: operations["cli_poll_key_sso_cli_poll__key_id__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/sso/cli/start": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Cli Sso Start */
-        post: operations["cli_sso_start_sso_cli_start_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/sso/debug/callback": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Debug Sso Callback
-         * @description Returns the OpenID object returned by the SSO provider
-         */
-        get: operations["debug_sso_callback_sso_debug_callback_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/sso/debug/login": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Debug Sso Login
-         * @description Create Proxy API Keys using Google Workspace SSO. Requires setting PROXY_BASE_URL in .env
-         *     PROXY_BASE_URL should be the your deployed proxy endpoint, e.g. PROXY_BASE_URL="https://litellm-production-7002.up.railway.app/"
-         *     Example:
-         */
-        get: operations["debug_sso_login_sso_debug_login_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/sso/get/ui_settings": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Ui Settings */
-        get: operations["get_ui_settings_sso_get_ui_settings_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/sso/key/generate": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Google Login
-         * @description Create Proxy API Keys using Google Workspace SSO. Requires setting PROXY_BASE_URL in .env
-         *     PROXY_BASE_URL should be the your deployed proxy endpoint, e.g. PROXY_BASE_URL="https://litellm-production-7002.up.railway.app/"
-         *     Example:
-         */
-        get: operations["google_login_sso_key_generate_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -13135,36 +10964,6 @@ export interface paths {
          *     ```
          */
         post: operations["delete_team_team_delete_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/team/filter/ui": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Ui View Teams
-         * @description [PROXY-ADMIN ONLY] Filter teams based on partial match of team_id or team_alias with pagination.
-         *
-         *     Args:
-         *         user_id (Optional[str]): Partial user ID to search for
-         *         user_email (Optional[str]): Partial email to search for
-         *         page (int): Page number for pagination (starts at 1)
-         *         page_size (int): Number of items per page (max 100)
-         *         user_api_key_dict (UserAPIKeyAuth): User authentication information
-         *
-         *     Returns:
-         *         List[LiteLLM_SpendLogs]: Paginated list of matching user records
-         */
-        get: operations["ui_view_teams_team_filter_ui_get"];
-        put?: never;
-        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -14160,32 +11959,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/user/available_roles": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Ui Get Available Role
-         * @description Endpoint used by Admin UI to show all available roles to assign a user
-         *     return {
-         *         "proxy_admin": {
-         *             "description": "Proxy Admin role",
-         *             "ui_label": "Admin"
-         *         }
-         *     }
-         */
-        get: operations["ui_get_available_role_user_available_roles_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/user/available_users": {
         parameters: {
             query?: never;
@@ -14349,36 +12122,6 @@ export interface paths {
          *     - user_ids: List[str] - The list of user id's to be deleted.
          */
         post: operations["delete_user_user_delete_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/user/filter/ui": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Ui View Users
-         * @description Filter users based on partial match of user_id or email with pagination.
-         *
-         *     Behaviour depends on the ``scope_user_search_to_org`` UI-setting flag
-         *     (stored in the ``litellm_uisettings`` table):
-         *
-         *     * **Flag OFF (default):** any authenticated user can search all users.
-         *     * **Flag ON:**
-         *       - Proxy admins see all users.
-         *       - Org admins see only users in their org(s).
-         *       - Team admins for an org-bound team see users in that org.
-         *       - Others receive a 403.
-         */
-        get: operations["ui_view_users_user_filter_ui_get"];
-        put?: never;
-        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -16640,11 +14383,6 @@ export interface paths {
          *
          *         - When litellm_model_id is passed, it will return the info for that specific model
          *         - When litellm_model_id is not passed, it will return the info for all models
-         *         - include_team_models: When true, filter to deployments the caller can use (same as /v2/model/info).
-         *         - teamId: Filter to models accessible by the given team.
-         *
-         *     Each model in the list response includes `model_info.access_via_team_ids` and
-         *     `model_info.direct_access` when the proxy database is connected.
          *
          *     Returns:
          *         Returns a dictionary containing information about each model.
@@ -16698,15 +14436,6 @@ export interface paths {
          *     - scope: Optional scope parameter. Currently only accepts "expand".
          *              When scope=expand is passed, proxy admins, team admins, and org admins
          *              will receive all proxy models as if they are a proxy admin.
-         *     - healthy_only: When true, hide models whose backing deployments are all marked
-         *                     unhealthy by background health checks. Requires
-         *                     `background_health_checks: true` in general_settings; without
-         *                     health state the listing is returned unfiltered (fail open).
-         *                     Models expanded from wildcard routes (e.g. `openai/*`) are not
-         *                     filtered, and nothing is hidden when `allowed_fails_policy` is
-         *                     configured (cooldown remains the sole exclusion mechanism).
-         *                     Hiding is presentation-only: a hidden model can still be
-         *                     called directly.
          */
         get: operations["model_list_v1_models_get"];
         put?: never;
@@ -16733,10 +14462,6 @@ export interface paths {
          *
          *     Follows OpenAI API specification for individual model retrieval.
          *     https://platform.openai.com/docs/api-reference/models/retrieve
-         *
-         *     Query parameters mirror `/v1/models` so the same caller context (team
-         *     scoping, health filtering, paused deployments) drives both endpoints; the
-         *     listing's public id must resolve to the same internal deployment here.
          */
         get: operations["model_info_v1_models__model_id__get"];
         put?: never;
@@ -18531,117 +16256,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v2/key/info": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Info Key Fn V2
-         * @description Retrieve information about a list of keys.
-         *
-         *     **New endpoint**. Currently admin only.
-         *     Parameters:
-         *         keys: Optional[list] = body parameter representing the key(s) in the request
-         *         user_api_key_dict: UserAPIKeyAuth = Dependency representing the user's API key
-         *     Returns:
-         *         Dict containing the key and its associated information
-         *
-         *     Example Curl:
-         *     ```
-         *     curl -X GET "http://0.0.0.0:4000/key/info"     -H "Authorization: Bearer sk-1234"     -d {"keys": ["sk-1", "sk-2", "sk-3"]}
-         *     ```
-         */
-        post: operations["info_key_fn_v2_v2_key_info_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v2/login": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Login V2 */
-        post: operations["login_v2_v2_login_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v2/model/info": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Model Info V2
-         * @description Paginated model metadata for proxy deployments (pricing, provider, team access).
-         *
-         *     Returns configured router deployments with enriched `model_info` (costs, provider,
-         *     context window, etc.). Sensitive fields such as API keys and api_base are omitted.
-         *
-         *     Query parameters:
-         *         model: Filter to a single public `model_name`.
-         *         user_models_only: When true, only return models created by the calling user.
-         *         include_team_models: When true, populate `access_via_team_ids` and `direct_access`
-         *             on each model and filter to deployments the caller can use.
-         *         page / size: Pagination controls (defaults: page=1, size=50).
-         *         search: Case-insensitive partial match on model name or team public name.
-         *         modelId: Return a single deployment by LiteLLM model id.
-         *         teamId: Filter to models with direct access or team membership for this team id.
-         *         sortBy / sortOrder: Sort by model_name, created_at, updated_at, costs, or status.
-         *
-         *     Example request:
-         *     ```
-         *     curl -X GET 'http://localhost:4000/v2/model/info?include_team_models=true&page=1&size=50' \
-         *     --header 'Authorization: Bearer sk-1234'
-         *     ```
-         *
-         *     Example response:
-         *     ```json
-         *     {
-         *         "data": [
-         *             {
-         *                 "model_name": "gpt-4",
-         *                 "litellm_params": {"model": "openai/gpt-4.1"},
-         *                 "model_info": {
-         *                     "id": "abc123",
-         *                     "litellm_provider": "openai",
-         *                     "access_via_team_ids": ["team-1"],
-         *                     "direct_access": true
-         *                 }
-         *             }
-         *         ],
-         *         "total_count": 1,
-         *         "current_page": 1,
-         *         "total_pages": 1,
-         *         "size": 50
-         *     }
-         *     ```
-         */
-        get: operations["model_info_v2_v2_model_info_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/v2/rerank": {
         parameters: {
             query?: never;
@@ -18728,40 +16342,6 @@ export interface paths {
         get: operations["user_info_v2_v2_user_info_get"];
         put?: never;
         post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v3/login": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Login V3 */
-        post: operations["login_v3_v3_login_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v3/login/exchange": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Login V3 Exchange */
-        post: operations["login_v3_exchange_v3_login_exchange_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -19170,52 +16750,6 @@ export interface paths {
         options?: never;
         head?: never;
         patch?: never;
-        trace?: never;
-    };
-    "/vertex-ai/{endpoint}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Vertex Proxy Route
-         * @description Call LiteLLM proxy via Vertex AI SDK.
-         *
-         *     [Docs](https://docs.litellm.ai/docs/pass_through/vertex_ai)
-         */
-        get: operations["vertex_proxy_route_vertex_ai__endpoint__get_2"];
-        /**
-         * Vertex Proxy Route
-         * @description Call LiteLLM proxy via Vertex AI SDK.
-         *
-         *     [Docs](https://docs.litellm.ai/docs/pass_through/vertex_ai)
-         */
-        put: operations["vertex_proxy_route_vertex_ai__endpoint__put_2"];
-        /**
-         * Vertex Proxy Route
-         * @description Call LiteLLM proxy via Vertex AI SDK.
-         *
-         *     [Docs](https://docs.litellm.ai/docs/pass_through/vertex_ai)
-         */
-        post: operations["vertex_proxy_route_vertex_ai__endpoint__post_2"];
-        /**
-         * Vertex Proxy Route
-         * @description Call LiteLLM proxy via Vertex AI SDK.
-         *
-         *     [Docs](https://docs.litellm.ai/docs/pass_through/vertex_ai)
-         */
-        delete: operations["vertex_proxy_route_vertex_ai__endpoint__delete_2"];
-        options?: never;
-        head?: never;
-        /**
-         * Vertex Proxy Route
-         * @description Call LiteLLM proxy via Vertex AI SDK.
-         *
-         *     [Docs](https://docs.litellm.ai/docs/pass_through/vertex_ai)
-         */
-        patch: operations["vertex_proxy_route_vertex_ai__endpoint__patch_2"];
         trace?: never;
     };
     "/vertex_ai/discovery/{endpoint}": {
@@ -20385,12 +17919,6 @@ export interface components {
             /** Tags */
             tags?: string[];
         };
-        /**
-         * AlertType
-         * @description Enum for alert types and management event types
-         * @enum {string}
-         */
-        AlertType: "llm_exceptions" | "llm_too_slow" | "llm_requests_hanging" | "budget_alerts" | "spend_reports" | "failed_tracking_spend" | "db_exceptions" | "daily_reports" | "cooldown_deployment" | "new_model_added" | "outage_alerts" | "region_outage_alerts" | "fallback_reports" | "new_virtual_key_created" | "virtual_key_updated" | "virtual_key_deleted" | "new_team_created" | "team_updated" | "team_deleted" | "new_internal_user_created" | "internal_user_updated" | "internal_user_deleted";
         /** AllowedVectorStoreIndexItem */
         AllowedVectorStoreIndexItem: {
             /** Index Name */
@@ -20851,11 +18379,6 @@ export interface components {
             /** Key */
             key: string;
         };
-        /** BlockModelRequest */
-        BlockModelRequest: {
-            /** Model Id */
-            model_id: string;
-        };
         /** BlockTeamRequest */
         BlockTeamRequest: {
             /** Team Id */
@@ -20902,18 +18425,12 @@ export interface components {
         };
         /** Body_audio_transcriptions_audio_transcriptions_post */
         Body_audio_transcriptions_audio_transcriptions_post: {
-            /**
-             * File
-             * Format: binary
-             */
+            /** File */
             file: string;
         };
         /** Body_audio_transcriptions_v1_audio_transcriptions_post */
         Body_audio_transcriptions_v1_audio_transcriptions_post: {
-            /**
-             * File
-             * Format: binary
-             */
+            /** File */
             file: string;
         };
         /** Body_convert_prompt_file_to_json_utils_dotprompt_json_converter_post */
@@ -20931,10 +18448,7 @@ export interface components {
              * @default openai
              */
             custom_llm_provider: string;
-            /**
-             * File
-             * Format: binary
-             */
+            /** File */
             file: string;
             /** Litellm Metadata */
             litellm_metadata?: string | null;
@@ -20958,10 +18472,7 @@ export interface components {
              * @default openai
              */
             custom_llm_provider: string;
-            /**
-             * File
-             * Format: binary
-             */
+            /** File */
             file: string;
             /** Litellm Metadata */
             litellm_metadata?: string | null;
@@ -20985,10 +18496,7 @@ export interface components {
              * @default openai
              */
             custom_llm_provider: string;
-            /**
-             * File
-             * Format: binary
-             */
+            /** File */
             file: string;
             /** Litellm Metadata */
             litellm_metadata?: string | null;
@@ -21009,34 +18517,34 @@ export interface components {
         Body_image_edit_api_images_edits_post: {
             /** Image */
             image?: string[] | null;
-            /** Image Array */
-            image_array?: string[] | null;
+            /** Image[] */
+            "image[]"?: string[] | null;
             /** Mask */
             mask?: string[] | null;
-            /** Mask Array */
-            mask_array?: string[] | null;
+            /** Mask[] */
+            "mask[]"?: string[] | null;
         };
         /** Body_image_edit_api_openai_deployments__model__images_edits_post */
         Body_image_edit_api_openai_deployments__model__images_edits_post: {
             /** Image */
             image?: string[] | null;
-            /** Image Array */
-            image_array?: string[] | null;
+            /** Image[] */
+            "image[]"?: string[] | null;
             /** Mask */
             mask?: string[] | null;
-            /** Mask Array */
-            mask_array?: string[] | null;
+            /** Mask[] */
+            "mask[]"?: string[] | null;
         };
         /** Body_image_edit_api_v1_images_edits_post */
         Body_image_edit_api_v1_images_edits_post: {
             /** Image */
             image?: string[] | null;
-            /** Image Array */
-            image_array?: string[] | null;
+            /** Image[] */
+            "image[]"?: string[] | null;
             /** Mask */
             mask?: string[] | null;
-            /** Mask Array */
-            mask_array?: string[] | null;
+            /** Mask[] */
+            "mask[]"?: string[] | null;
         };
         /** Body_test_model_connection_health_test_connection_post */
         Body_test_model_connection_health_test_connection_post: {
@@ -21063,30 +18571,21 @@ export interface components {
         };
         /** Body_upload_logo_upload_logo_post */
         Body_upload_logo_upload_logo_post: {
-            /**
-             * File
-             * Format: binary
-             */
+            /** File */
             file: string;
         };
         /** Body_video_create_character_v1_videos_characters_post */
         Body_video_create_character_v1_videos_characters_post: {
             /** Name */
             name: string;
-            /**
-             * Video
-             * Format: binary
-             */
+            /** Video */
             video: string;
         };
         /** Body_video_create_character_videos_characters_post */
         Body_video_create_character_videos_characters_post: {
             /** Name */
             name: string;
-            /**
-             * Video
-             * Format: binary
-             */
+            /** Video */
             video: string;
         };
         /** Body_video_generation_v1_videos_post */
@@ -21463,11 +18962,6 @@ export interface components {
          * @enum {string}
          */
         CallTypes: "embedding" | "aembedding" | "completion" | "acompletion" | "atext_completion" | "text_completion" | "image_generation" | "aimage_generation" | "image_edit" | "aimage_edit" | "moderation" | "amoderation" | "atranscription" | "transcription" | "aspeech" | "speech" | "rerank" | "arerank" | "search" | "asearch" | "_arealtime" | "_aresponses_websocket" | "create_batch" | "acreate_batch" | "aretrieve_batch" | "retrieve_batch" | "acancel_batch" | "cancel_batch" | "pass_through_endpoint" | "anthropic_messages" | "get_assistants" | "aget_assistants" | "create_assistants" | "acreate_assistants" | "delete_assistant" | "adelete_assistant" | "acreate_thread" | "create_thread" | "aget_thread" | "get_thread" | "a_add_message" | "add_message" | "aget_messages" | "get_messages" | "arun_thread" | "run_thread" | "arun_thread_stream" | "run_thread_stream" | "afile_retrieve" | "file_retrieve" | "afile_delete" | "file_delete" | "afile_list" | "file_list" | "acreate_file" | "create_file" | "afile_content" | "file_content" | "create_fine_tuning_job" | "acreate_fine_tuning_job" | "create_video" | "acreate_video" | "avideo_retrieve" | "video_retrieve" | "avideo_content" | "video_content" | "video_remix" | "avideo_remix" | "video_list" | "avideo_list" | "video_retrieve_job" | "avideo_retrieve_job" | "video_delete" | "avideo_delete" | "video_create_character" | "avideo_create_character" | "video_get_character" | "avideo_get_character" | "video_edit" | "avideo_edit" | "video_extension" | "avideo_extension" | "vector_store_file_create" | "avector_store_file_create" | "vector_store_file_list" | "avector_store_file_list" | "vector_store_file_retrieve" | "avector_store_file_retrieve" | "vector_store_file_content" | "avector_store_file_content" | "vector_store_file_update" | "avector_store_file_update" | "vector_store_file_delete" | "avector_store_file_delete" | "vector_store_create" | "avector_store_create" | "vector_store_search" | "avector_store_search" | "create_container" | "acreate_container" | "list_containers" | "alist_containers" | "retrieve_container" | "aretrieve_container" | "delete_container" | "adelete_container" | "list_container_files" | "alist_container_files" | "upload_container_file" | "aupload_container_file" | "acancel_fine_tuning_job" | "cancel_fine_tuning_job" | "alist_fine_tuning_jobs" | "list_fine_tuning_jobs" | "aretrieve_fine_tuning_job" | "retrieve_fine_tuning_job" | "responses" | "aresponses" | "alist_input_items" | "llm_passthrough_route" | "allm_passthrough_route" | "generate_content" | "agenerate_content" | "generate_content_stream" | "agenerate_content_stream" | "ocr" | "aocr" | "call_mcp_tool" | "list_mcp_tools" | "asend_message" | "send_message" | "acreate_skill";
-        /** CallbackDelete */
-        CallbackDelete: {
-            /** Callback Name */
-            callback_name: string;
-        };
         /** CallbacksByType */
         CallbacksByType: {
             /** Failure */
@@ -22087,326 +19581,6 @@ export interface components {
             /** Regulation */
             regulation: string;
         };
-        /** ConfigFieldDelete */
-        ConfigFieldDelete: {
-            /**
-             * Config Type
-             * @constant
-             */
-            config_type: "general_settings";
-            /** Field Name */
-            field_name: string;
-        };
-        /** ConfigFieldInfo */
-        ConfigFieldInfo: {
-            /** Field Name */
-            field_name: string;
-            /** Field Value */
-            field_value: unknown;
-        };
-        /** ConfigFieldUpdate */
-        ConfigFieldUpdate: {
-            /**
-             * Config Type
-             * @constant
-             */
-            config_type: "general_settings";
-            /** Field Name */
-            field_name: string;
-            /** Field Value */
-            field_value: unknown;
-        };
-        /**
-         * ConfigGeneralSettings
-         * @description Documents all the fields supported by `general_settings` in config.yaml
-         */
-        ConfigGeneralSettings: {
-            /**
-             * Alert To Webhook Url
-             * @description Mapping of alert type to webhook url. e.g. `alert_to_webhook_url: {'budget_alerts': 'https://nothooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX'}`
-             */
-            alert_to_webhook_url?: {
-                [key: string]: unknown;
-            } | null;
-            /**
-             * Alert Types
-             * @description List of alerting types. By default it is all alerts
-             */
-            alert_types?: components["schemas"]["AlertType"][] | null;
-            /**
-             * Alerting
-             * @description List of alerting integrations. Today, just slack - `alerting: ['slack']`
-             */
-            alerting?: unknown[] | null;
-            /**
-             * Alerting Args
-             * @description Controllable params for slack alerting - e.g. ttl in cache.
-             */
-            alerting_args?: {
-                [key: string]: unknown;
-            } | null;
-            /**
-             * Alerting Threshold
-             * @description sends alerts if requests hang for 5min+
-             */
-            alerting_threshold?: number | null;
-            /**
-             * Allow Cli Sso Verification Uri Complete
-             * @description opt-in to RFC 8628 verification_uri_complete for the CLI SSO device flow, pre-filling the user_code in the browser. Off by default; intended for same-host clients where the device that starts the flow and the browser run on the same machine
-             */
-            allow_cli_sso_verification_uri_complete?: boolean | null;
-            /**
-             * Allowed Routes
-             * @description Proxy API Endpoints you want users to be able to access
-             */
-            allowed_routes?: unknown[] | null;
-            /**
-             * Background Health Checks
-             * @description run health checks in background
-             */
-            background_health_checks?: boolean | null;
-            /**
-             * Cancel On Disconnect
-             * @description cancel the in-flight upstream LLM request (non-streaming) when the client disconnects, freeing backend capacity (e.g. a vLLM GPU slot); the request is logged as a 499 failure
-             */
-            cancel_on_disconnect?: boolean | null;
-            /**
-             * Completion Model
-             * @description proxy level default model for all chat completion calls
-             */
-            completion_model?: string | null;
-            /**
-             * Custom Auth
-             * @description override user_api_key_auth with your own auth script - https://docs.litellm.ai/docs/proxy/virtual_keys#custom-auth
-             */
-            custom_auth?: string | null;
-            /** @description custom args for instantiating dynamodb client - e.g. billing provision */
-            database_args?: components["schemas"]["DynamoDBArgs"] | null;
-            /**
-             * Database Connect Timeout
-             * @description Prisma `connect_timeout` URL param (seconds). Bounds how long the engine waits to establish a new connection before failing. Defaults to Prisma's built-in value when unset.
-             */
-            database_connect_timeout?: number | null;
-            /**
-             * Database Connection Pool Limit
-             * @description default connection pool for prisma client connecting to postgres db
-             * @default 10
-             */
-            database_connection_pool_limit: number | null;
-            /**
-             * Database Connection Timeout
-             * @description default timeout for a connection to the database
-             * @default 60
-             */
-            database_connection_timeout: number | null;
-            /**
-             * Database Disable Prepared Statements
-             * @description Disable server-side prepared statements by setting Prisma's `pgbouncer=true` URL param. Use this for pgbouncer transaction-pooling deployments, or to prevent the 'cached plan must not change result type' error that pooled connections hit during rolling schema migrations. An explicit `pgbouncer` in `database_extra_connection_params` takes precedence.
-             */
-            database_disable_prepared_statements?: boolean | null;
-            /**
-             * Database Extra Connection Params
-             * @description Escape hatch: extra key/value pairs appended verbatim to the Prisma DATABASE_URL / DIRECT_URL query string (e.g. `sslmode`, `pgbouncer`, `statement_cache_size`). Keys here override any default LiteLLM sets.
-             */
-            database_extra_connection_params?: {
-                [key: string]: unknown;
-            } | null;
-            /**
-             * Database Socket Timeout
-             * @description Prisma `socket_timeout` URL param (seconds). When set, an idle/slow connection that has not produced data within this window is closed. This is the main knob for capping idle DB connections from LiteLLM.
-             */
-            database_socket_timeout?: number | null;
-            /**
-             * Database Type
-             * @description to use dynamodb instead of postgres db
-             */
-            database_type?: "dynamo_db" | null;
-            /**
-             * Database Url
-             * @description connect to a postgres db - needed for generating temporary keys + tracking spend / key
-             */
-            database_url?: string | null;
-            /**
-             * Disable Budget Reservation
-             * @description If True, disables the optimistic per-request budget reservation introduced in v1.84.0. WARNING: This weakens hard budget enforcement. Without the reservation, a burst of concurrent requests from a single key can each pass the read-time spend check before any of them is charged, allowing a configured budget to be exceeded under high concurrency. Budgets are still evaluated on every request at read time, so an already-exhausted budget is still rejected. Enable only if your deployment is experiencing phantom BudgetExceededError responses caused by leaked reservations (see GitHub issue #27639). A proxy-level WARNING is logged on every request while this flag is active as a reminder that hard enforcement is relaxed.
-             */
-            disable_budget_reservation?: boolean | null;
-            /**
-             * Enable Public Model Hub
-             * @description Public model hub for users to see what models they have access to, supported openai params, etc.
-             * @default false
-             */
-            enable_public_model_hub: boolean;
-            /**
-             * Forward Client Headers To Llm Api
-             * @description If True, forwards client headers (e.g. Authorization) to the LLM API. Required for Claude Code with Max subscription.
-             */
-            forward_client_headers_to_llm_api?: boolean | null;
-            /**
-             * Global Max Parallel Requests
-             * @description global max parallel requests to allow for a proxy instance.
-             */
-            global_max_parallel_requests?: number | null;
-            /**
-             * Health Check Concurrency
-             * @description limit concurrent health checks per cycle; when unset, health checks run without a concurrency cap
-             */
-            health_check_concurrency?: number | null;
-            /**
-             * Health Check Interval
-             * @description background health check interval in seconds
-             * @default 300
-             */
-            health_check_interval: number;
-            /**
-             * Health Check Skip Disabled Background Models
-             * @description When true, deployments with model_info.disable_background_health_check are skipped for on-demand GET /health as well as the background health loop.
-             * @default false
-             */
-            health_check_skip_disabled_background_models: boolean;
-            /**
-             * Infer Model From Keys
-             * @description for `/models` endpoint, infers available model based on environment keys (e.g. OPENAI_API_KEY)
-             */
-            infer_model_from_keys?: boolean | null;
-            /** @description key manager to load keys from / decrypt keys with */
-            key_management_system?: components["schemas"]["KeyManagementSystem"] | null;
-            /**
-             * Master Key
-             * @description require a key for all calls to proxy
-             */
-            master_key?: string | null;
-            /**
-             * Max Parallel Requests
-             * @description maximum parallel requests for each api key
-             */
-            max_parallel_requests?: number | null;
-            /**
-             * Max Request Size Mb
-             * @description max request size in MB, if a request is larger than this size it will be rejected
-             */
-            max_request_size_mb?: number | null;
-            /**
-             * Max Response Size Mb
-             * @description max response size in MB, if a response is larger than this size it will be rejected
-             */
-            max_response_size_mb?: number | null;
-            /**
-             * Maximum Spend Logs Retention Period
-             * @description Maximum retention period for spend logs (e.g., '7d' for 7 days). Logs older than this will be deleted.
-             */
-            maximum_spend_logs_retention_period?: string | null;
-            /**
-             * Mcp Internal Ip Ranges
-             * @description Custom CIDR ranges that define internal/private networks for MCP access control. When set, only these ranges are treated as internal. Defaults to RFC 1918 private ranges (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 127.0.0.0/8).
-             */
-            mcp_internal_ip_ranges?: string[] | null;
-            /**
-             * Mcp Required Fields
-             * @description List of MCP server fields that must be filled in for a submission to pass standards checks (e.g. ['description', 'source_url', 'alias']).
-             */
-            mcp_required_fields?: string[] | null;
-            /**
-             * Mcp Trusted Proxy Ranges
-             * @description CIDR ranges of trusted reverse proxies. When set, X-Forwarded-For and X-Forwarded-* origin headers are only trusted from these IPs.
-             */
-            mcp_trusted_proxy_ranges?: string[] | null;
-            /**
-             * Otel
-             * @description [BETA] OpenTelemetry support - this might change, use with caution.
-             */
-            otel?: boolean | null;
-            /**
-             * Pass Through Endpoints
-             * @description Set-up pass-through endpoints for provider-specific endpoints. Docs - https://docs.litellm.ai/docs/proxy/pass_through
-             */
-            pass_through_endpoints?: components["schemas"]["PassThroughGenericEndpoint"][] | null;
-            /**
-             * Pass Through Request Timeout
-             * @description Default upstream request timeout in seconds for native and custom pass-through endpoints that use pass_through_request. Defaults to 600 when unset.
-             */
-            pass_through_request_timeout?: number | null;
-            /**
-             * Reject Clientside Metadata Tags
-             * @description When set to True, rejects requests that contain client-side 'metadata.tags' to prevent users from influencing budgets by sending different tags. Tags can only be inherited from the API key metadata.
-             */
-            reject_clientside_metadata_tags?: boolean | null;
-            /**
-             * Store Model In Db
-             * @description If True, models and config are stored in and loaded from the database. Default is False.
-             */
-            store_model_in_db?: boolean | null;
-            /**
-             * Store Prompts In Spend Logs
-             * @description If True, stores request messages and responses in spend logs. Default is False.
-             */
-            store_prompts_in_spend_logs?: boolean | null;
-            /**
-             * Supported Db Objects
-             * @description Fine-grained control over which object types to load from the database when store_model_in_db is True. Available types: 'models', 'mcp', 'guardrails', 'vector_stores', 'pass_through_endpoints', 'prompts', 'model_cost_map', 'tools', 'config_overrides'. If not set, all objects are loaded (default behavior).
-             */
-            supported_db_objects?: components["schemas"]["SupportedDBObjectType"][] | null;
-            /**
-             * Trusted Proxy Ranges
-             * @description CIDR ranges of trusted reverse proxies allowed to provide identity headers for header-based auth paths such as enable_oauth2_proxy_auth and custom_ui_sso_sign_in_handler.
-             */
-            trusted_proxy_ranges?: string[] | null;
-            /**
-             * Ui Access Mode
-             * @description Control access to the Proxy UI
-             * @default all
-             */
-            ui_access_mode: ("admin_only" | "all") | null;
-            /**
-             * Use Azure Key Vault
-             * @description load keys from azure key vault
-             */
-            use_azure_key_vault?: boolean | null;
-            /**
-             * Use Google Kms
-             * @description decrypt keys with google kms
-             */
-            use_google_kms?: boolean | null;
-            /**
-             * Use Spend Logs Partitioning
-             * @description If True and LiteLLM_SpendLogs has been converted to a range-partitioned table (db_scripts/partition_spend_logs.sql), retention cleanup drops expired partitions instead of deleting rows, and pre-creates upcoming partitions. Default is False.
-             */
-            use_spend_logs_partitioning?: boolean | null;
-            /** User Header Mappings */
-            user_header_mappings?: components["schemas"]["UserHeaderMapping"][] | null;
-            /**
-             * User Header Name
-             * @description [DEPRECATED] Use 'user_header_mappings' instead. When set, the header value is treated as the end user id unless overridden by user_header_mappings.
-             */
-            user_header_name?: string | null;
-            /**
-             * User Mcp Management Mode
-             * @description Controls how non-admin users interact with MCP servers in the dashboard. 'restricted' shows only accessible servers, 'view_all' lists every server in read-only mode.
-             */
-            user_mcp_management_mode?: ("restricted" | "view_all") | null;
-        };
-        /** ConfigList */
-        ConfigList: {
-            /** Field Default Value */
-            field_default_value: unknown;
-            /** Field Description */
-            field_description: string;
-            /** Field Name */
-            field_name: string;
-            /** Field Type */
-            field_type: string;
-            /** Field Value */
-            field_value: unknown;
-            /** Nested Fields */
-            nested_fields?: components["schemas"]["FieldDetail"][] | null;
-            /**
-             * Premium Field
-             * @default false
-             */
-            premium_field: boolean;
-            /** Stored In Db */
-            stored_in_db: boolean | null;
-        };
         /**
          * ConfigOverrideSettingsResponse
          * @description Response model for config override settings GET endpoints.
@@ -22431,34 +19605,6 @@ export interface components {
             values: {
                 [key: string]: unknown;
             };
-        };
-        /**
-         * ConfigYAML
-         * @description Documents all the fields supported by the config.yaml
-         */
-        ConfigYAML: {
-            /**
-             * Environment Variables
-             * @description Object to pass in additional environment variables via POST request
-             */
-            environment_variables?: {
-                [key: string]: unknown;
-            } | null;
-            general_settings?: components["schemas"]["ConfigGeneralSettings"] | null;
-            /**
-             * Litellm Settings
-             * @description litellm Module settings. See __init__.py for all, example litellm.drop_params=True, litellm.set_verbose=True, litellm.api_base, litellm.cache
-             */
-            litellm_settings?: {
-                [key: string]: unknown;
-            } | null;
-            /**
-             * Model List
-             * @description List of supported models on the server, with model-specific configs
-             */
-            model_list?: components["schemas"]["ModelParams"][] | null;
-            /** @description litellm router object settings. See router.py __init__ for all, example router.num_retries=5, router.timeout=5, router.max_retries=5, router.retry_after=5 */
-            router_settings?: components["schemas"]["UpdateRouterConfig"] | null;
         };
         /** ConfigurableClientsideParamsCustomAuth */
         "ConfigurableClientsideParamsCustomAuth-Input": {
@@ -22941,7 +20087,7 @@ export interface components {
         /** Deployment */
         Deployment: {
             litellm_params: components["schemas"]["LiteLLM_Params"];
-            model_info: components["schemas"]["litellm__types__router__ModelInfo"];
+            model_info: components["schemas"]["ModelInfo"];
             /** Model Name */
             model_name: string;
         } & {
@@ -22974,60 +20120,6 @@ export interface components {
              * @constant
              */
             type: "text";
-        };
-        /** DynamoDBArgs */
-        DynamoDBArgs: {
-            /** Assume Role Aws Role Name */
-            assume_role_aws_role_name?: string | null;
-            /** Assume Role Aws Session Name */
-            assume_role_aws_session_name?: string | null;
-            /** Aws Duration Seconds */
-            aws_duration_seconds?: number | null;
-            /** Aws Policy */
-            aws_policy?: string | null;
-            /** Aws Policy Arns */
-            aws_policy_arns?: string[] | null;
-            /** Aws Provider Id */
-            aws_provider_id?: string | null;
-            /** Aws Role Name */
-            aws_role_name?: string | null;
-            /** Aws Session Name */
-            aws_session_name?: string | null;
-            /** Aws Web Identity Token */
-            aws_web_identity_token?: string | null;
-            /**
-             * Billing Mode
-             * @enum {string}
-             */
-            billing_mode: "PROVISIONED_THROUGHPUT" | "PAY_PER_REQUEST";
-            /**
-             * Config Table Name
-             * @default LiteLLM_Config
-             */
-            config_table_name: string;
-            /**
-             * Key Table Name
-             * @default LiteLLM_VerificationToken
-             */
-            key_table_name: string;
-            /** Read Capacity Units */
-            read_capacity_units?: number | null;
-            /** Region Name */
-            region_name: string;
-            /**
-             * Spend Table Name
-             * @default LiteLLM_SpendLogs
-             */
-            spend_table_name: string;
-            /** Ssl Verify */
-            ssl_verify?: boolean | null;
-            /**
-             * User Table Name
-             * @default LiteLLM_UserTable
-             */
-            user_table_name: string;
-            /** Write Capacity Units */
-            write_capacity_units?: number | null;
         };
         /**
          * EmailEvent
@@ -23301,19 +20393,6 @@ export interface components {
              * @description The model name
              */
             model: string;
-        };
-        /** FieldDetail */
-        FieldDetail: {
-            /** Field Default Value */
-            field_default_value?: unknown;
-            /** Field Description */
-            field_description: string;
-            /** Field Name */
-            field_name: string;
-            /** Field Type */
-            field_type: string;
-            /** Stored In Db */
-            stored_in_db: boolean | null;
         };
         /** FunctionCall */
         FunctionCall: {
@@ -23649,15 +20728,6 @@ export interface components {
              */
             team_member_permissions: string[] | null;
         };
-        /** GlobalEndUsersSpend */
-        GlobalEndUsersSpend: {
-            /** Api Key */
-            api_key?: string | null;
-            /** Endtime */
-            endTime?: string | null;
-            /** Starttime */
-            startTime?: string | null;
-        };
         /**
          * GraySwanGuardrailConfigModelOptionalParams
          * @description Optional parameters for the Gray Swan guardrail.
@@ -23970,62 +21040,6 @@ export interface components {
                 [key: string]: unknown;
             };
         };
-        /** InvitationClaim */
-        InvitationClaim: {
-            /** Invitation Link */
-            invitation_link: string;
-            /** Password */
-            password: string;
-            /** User Id */
-            user_id: string;
-        };
-        /** InvitationDelete */
-        InvitationDelete: {
-            /** Invitation Id */
-            invitation_id: string;
-        };
-        /** InvitationModel */
-        InvitationModel: {
-            /** Accepted At */
-            accepted_at: string | null;
-            /**
-             * Created At
-             * Format: date-time
-             */
-            created_at: string;
-            /** Created By */
-            created_by: string;
-            /**
-             * Expires At
-             * Format: date-time
-             */
-            expires_at: string;
-            /** Id */
-            id: string;
-            /** Is Accepted */
-            is_accepted: boolean;
-            /**
-             * Updated At
-             * Format: date-time
-             */
-            updated_at: string;
-            /** Updated By */
-            updated_by: string;
-            /** User Id */
-            user_id: string;
-        };
-        /** InvitationNew */
-        InvitationNew: {
-            /** User Id */
-            user_id: string;
-        };
-        /** InvitationUpdate */
-        InvitationUpdate: {
-            /** Invitation Id */
-            invitation_id: string;
-            /** Is Accepted */
-            is_accepted: boolean;
-        };
         /** JWTKeyMappingResponse */
         JWTKeyMappingResponse: {
             /**
@@ -24079,11 +21093,6 @@ export interface components {
          * @enum {string}
          */
         KeyManagementRoutes: "/key/generate" | "/key/update" | "/key/delete" | "/key/regenerate" | "/key/service-account/generate" | "/key/{key_id}/regenerate" | "/key/block" | "/key/unblock" | "/key/bulk_update" | "/team/key/bulk_update" | "/key/{key_id}/reset_spend" | "/key/access_group_assignment" | "/key/info" | "/key/health" | "/key/list" | "/key/aliases" | "/team/daily/activity" | "/spend/logs" | "/spend/logs/v2";
-        /**
-         * KeyManagementSystem
-         * @enum {string}
-         */
-        KeyManagementSystem: "google_kms" | "azure_key_vault" | "aws_secret_manager" | "google_secret_manager" | "hashicorp_vault" | "cyberark" | "local" | "aws_kms" | "custom";
         /**
          * KeyMetadata
          * @description Metadata for a key
@@ -24355,7 +21364,8 @@ export interface components {
         };
         /**
          * LiteLLM_DeletedTeamTable
-         * @description Audit record for deleted teams; mirrors the team plus deletion metadata.
+         * @description Recording of deleted teams for audit purposes. Mirrors LiteLLM_TeamTable
+         *     plus metadata captured at deletion time.
          */
         LiteLLM_DeletedTeamTable: {
             /** Access Group Ids */
@@ -24365,11 +21375,6 @@ export interface components {
              * @default []
              */
             admins: unknown[];
-            /**
-             * Allow Team Guardrail Config
-             * @default false
-             */
-            allow_team_guardrail_config: boolean | null;
             /**
              * Blocked
              * @default false
@@ -24417,20 +21422,6 @@ export interface components {
             /** Model Id */
             model_id?: number | null;
             /**
-             * Model Max Budget
-             * @default {}
-             */
-            model_max_budget: {
-                [key: string]: unknown;
-            } | null;
-            /**
-             * Model Spend
-             * @default {}
-             */
-            model_spend: {
-                [key: string]: unknown;
-            } | null;
-            /**
              * Models
              * @default []
              */
@@ -24440,8 +21431,6 @@ export interface components {
             object_permission_id?: string | null;
             /** Organization Id */
             organization_id?: string | null;
-            /** Policies */
-            policies?: string[] | null;
             /** Router Settings */
             router_settings?: {
                 [key: string]: unknown;
@@ -24465,7 +21454,8 @@ export interface components {
         };
         /**
          * LiteLLM_DeletedVerificationToken
-         * @description Audit record for deleted keys; mirrors the token plus deletion metadata.
+         * @description Recording of deleted keys for audit purposes. Mirrors LiteLLM_VerificationToken
+         *     plus metadata captured at deletion time.
          */
         LiteLLM_DeletedVerificationToken: {
             /** Access Group Ids */
@@ -24498,8 +21488,6 @@ export interface components {
             blocked?: boolean | null;
             /** Budget Duration */
             budget_duration?: string | null;
-            /** Budget Id */
-            budget_id?: string | null;
             /** Budget Limits */
             budget_limits?: {
                 [key: string]: unknown;
@@ -24878,9 +21866,9 @@ export interface components {
             /** Id */
             id?: number | null;
             /** Model Aliases */
-            model_aliases?: string | {
+            model_aliases?: {
                 [key: string]: unknown;
-            } | null;
+            } | string | null;
             team?: components["schemas"]["LiteLLM_TeamTable"] | null;
             /** Updated By */
             updated_by: string;
@@ -24946,11 +21934,6 @@ export interface components {
             } | null;
             /** Mcp Toolsets */
             mcp_toolsets?: string[] | null;
-            /**
-             * Models
-             * @default []
-             */
-            models: string[] | null;
             /** Object Permission Id */
             object_permission_id: string;
             /**
@@ -24966,7 +21949,7 @@ export interface components {
         };
         /**
          * LiteLLM_OrganizationMembershipTable
-         * @description Tracks which organizations a user belongs to and their spend within it.
+         * @description This is the table that track what organizations a user belongs to and users spend within the organization
          */
         LiteLLM_OrganizationMembershipTable: {
             /** Budget Id */
@@ -25022,17 +22005,7 @@ export interface components {
             metadata?: {
                 [key: string]: unknown;
             } | null;
-            /**
-             * Model Spend
-             * @default {}
-             */
-            model_spend: {
-                [key: string]: unknown;
-            } | null;
-            /**
-             * Models
-             * @default []
-             */
+            /** Models */
             models: string[];
             object_permission?: components["schemas"]["LiteLLM_ObjectPermissionTable"] | null;
             /** Object Permission Id */
@@ -25088,16 +22061,12 @@ export interface components {
             auto_router_embedding_model?: string | null;
             /** Aws Access Key Id */
             aws_access_key_id?: string | null;
-            /** Aws Bedrock Project Id */
-            aws_bedrock_project_id?: string | null;
             /** Aws Bedrock Runtime Endpoint */
             aws_bedrock_runtime_endpoint?: string | null;
             /** Aws Region Name */
             aws_region_name?: string | null;
             /** Aws Secret Access Key */
             aws_secret_access_key?: string | null;
-            /** Azure Ad Token */
-            azure_ad_token?: string | null;
             /** Budget Duration */
             budget_duration?: string | null;
             /** Cache Creation Input Audio Token Cost */
@@ -25114,10 +22083,6 @@ export interface components {
             cache_read_input_token_cost?: number | null;
             /** Cache Read Input Token Cost Above 200K Tokens */
             cache_read_input_token_cost_above_200k_tokens?: number | null;
-            /** Cache Read Input Token Cost Above 200K Tokens Priority */
-            cache_read_input_token_cost_above_200k_tokens_priority?: number | null;
-            /** Cache Read Input Token Cost Above 272K Tokens Priority */
-            cache_read_input_token_cost_above_272k_tokens_priority?: number | null;
             /** Cache Read Input Token Cost Flex */
             cache_read_input_token_cost_flex?: number | null;
             /** Cache Read Input Token Cost Priority */
@@ -25166,10 +22131,6 @@ export interface components {
             input_cost_per_token_above_128k_tokens?: number | null;
             /** Input Cost Per Token Above 200K Tokens */
             input_cost_per_token_above_200k_tokens?: number | null;
-            /** Input Cost Per Token Above 200K Tokens Priority */
-            input_cost_per_token_above_200k_tokens_priority?: number | null;
-            /** Input Cost Per Token Above 272K Tokens Priority */
-            input_cost_per_token_above_272k_tokens_priority?: number | null;
             /** Input Cost Per Token Batches */
             input_cost_per_token_batches?: number | null;
             /** Input Cost Per Token Cache Hit */
@@ -25243,10 +22204,6 @@ export interface components {
             output_cost_per_token_above_128k_tokens?: number | null;
             /** Output Cost Per Token Above 200K Tokens */
             output_cost_per_token_above_200k_tokens?: number | null;
-            /** Output Cost Per Token Above 200K Tokens Priority */
-            output_cost_per_token_above_200k_tokens_priority?: number | null;
-            /** Output Cost Per Token Above 272K Tokens Priority */
-            output_cost_per_token_above_272k_tokens_priority?: number | null;
             /** Output Cost Per Token Batches */
             output_cost_per_token_batches?: number | null;
             /** Output Cost Per Token Flex */
@@ -25274,7 +22231,7 @@ export interface components {
                 [key: string]: unknown;
             } | null;
             /** Stream Timeout */
-            stream_timeout?: number | string | null;
+            stream_timeout?: string | number | null;
             /** Tag Regex */
             tag_regex?: string[] | null;
             /** Tags */
@@ -25299,12 +22256,6 @@ export interface components {
              * @default false
              */
             use_litellm_proxy: boolean | null;
-            /**
-             * Use Xai Oauth
-             * @description Use stored xAI OAuth credentials when no xAI API key is configured.
-             * @default false
-             */
-            use_xai_oauth: boolean | null;
             /** Vector Store Id */
             vector_store_id?: string | null;
             /** Vertex Credentials */
@@ -25335,7 +22286,7 @@ export interface components {
             /** Created At */
             created_at?: string | null;
             /** Created By */
-            created_by?: string | null;
+            created_by: string;
             /** Description */
             description?: string | null;
             litellm_budget_table?: components["schemas"]["LiteLLM_BudgetTable"] | null;
@@ -25377,35 +22328,7 @@ export interface components {
             /** Updated At */
             updated_at?: string | null;
             /** Updated By */
-            updated_by?: string | null;
-        };
-        /** LiteLLM_ProxyModelTable */
-        LiteLLM_ProxyModelTable: {
-            /**
-             * Blocked
-             * @default false
-             */
-            blocked: boolean;
-            /** Created At */
-            created_at?: string | null;
-            /** Created By */
-            created_by?: string | null;
-            /** Litellm Params */
-            litellm_params: {
-                [key: string]: unknown;
-            };
-            /** Model Id */
-            model_id: string;
-            /** Model Info */
-            model_info?: {
-                [key: string]: unknown;
-            } | null;
-            /** Model Name */
-            model_name: string;
-            /** Updated At */
-            updated_at?: string | null;
-            /** Updated By */
-            updated_by?: string | null;
+            updated_by: string;
         };
         /** LiteLLM_SpendLogs */
         LiteLLM_SpendLogs: {
@@ -25510,11 +22433,6 @@ export interface components {
              */
             admins: unknown[];
             /**
-             * Allow Team Guardrail Config
-             * @default false
-             */
-            allow_team_guardrail_config: boolean | null;
-            /**
              * Blocked
              * @default false
              */
@@ -25551,20 +22469,6 @@ export interface components {
             /** Model Id */
             model_id?: number | null;
             /**
-             * Model Max Budget
-             * @default {}
-             */
-            model_max_budget: {
-                [key: string]: unknown;
-            } | null;
-            /**
-             * Model Spend
-             * @default {}
-             */
-            model_spend: {
-                [key: string]: unknown;
-            } | null;
-            /**
              * Models
              * @default []
              */
@@ -25574,8 +22478,6 @@ export interface components {
             object_permission_id?: string | null;
             /** Organization Id */
             organization_id?: string | null;
-            /** Policies */
-            policies?: string[] | null;
             /** Router Settings */
             router_settings?: {
                 [key: string]: unknown;
@@ -25647,11 +22549,6 @@ export interface components {
         };
         /** LiteLLM_UserTable */
         LiteLLM_UserTable: {
-            /**
-             * Allowed Cache Controls
-             * @default []
-             */
-            allowed_cache_controls: string[];
             /** Budget Duration */
             budget_duration?: string | null;
             /** Budget Reset At */
@@ -25660,8 +22557,6 @@ export interface components {
             created_at?: string | null;
             /** Max Budget */
             max_budget?: number | null;
-            /** Max Parallel Requests */
-            max_parallel_requests?: number | null;
             /** Metadata */
             metadata?: {
                 [key: string]: unknown;
@@ -25686,17 +22581,8 @@ export interface components {
              */
             models: unknown[];
             object_permission?: components["schemas"]["LiteLLM_ObjectPermissionTable"] | null;
-            /** Object Permission Id */
-            object_permission_id?: string | null;
-            /** Organization Id */
-            organization_id?: string | null;
             /** Organization Memberships */
             organization_memberships?: components["schemas"]["LiteLLM_OrganizationMembershipTable"][] | null;
-            /**
-             * Policies
-             * @default []
-             */
-            policies: string[];
             /** Rpm Limit */
             rpm_limit?: number | null;
             /**
@@ -25706,8 +22592,6 @@ export interface components {
             spend: number;
             /** Sso User Id */
             sso_user_id?: string | null;
-            /** Team Id */
-            team_id?: string | null;
             /**
              * Teams
              * @default []
@@ -25726,20 +22610,8 @@ export interface components {
             /** User Role */
             user_role?: string | null;
         };
-        /** LiteLLM_UserTableFiltered */
-        LiteLLM_UserTableFiltered: {
-            /** User Email */
-            user_email?: string | null;
-            /** User Id */
-            user_id: string;
-        };
         /** LiteLLM_UserTableWithKeyCount */
         LiteLLM_UserTableWithKeyCount: {
-            /**
-             * Allowed Cache Controls
-             * @default []
-             */
-            allowed_cache_controls: string[];
             /** Budget Duration */
             budget_duration?: string | null;
             /** Budget Reset At */
@@ -25753,8 +22625,6 @@ export interface components {
             key_count: number;
             /** Max Budget */
             max_budget?: number | null;
-            /** Max Parallel Requests */
-            max_parallel_requests?: number | null;
             /** Metadata */
             metadata?: {
                 [key: string]: unknown;
@@ -25779,17 +22649,8 @@ export interface components {
              */
             models: unknown[];
             object_permission?: components["schemas"]["LiteLLM_ObjectPermissionTable"] | null;
-            /** Object Permission Id */
-            object_permission_id?: string | null;
-            /** Organization Id */
-            organization_id?: string | null;
             /** Organization Memberships */
             organization_memberships?: components["schemas"]["LiteLLM_OrganizationMembershipTable"][] | null;
-            /**
-             * Policies
-             * @default []
-             */
-            policies: string[];
             /** Rpm Limit */
             rpm_limit?: number | null;
             /**
@@ -25799,8 +22660,6 @@ export interface components {
             spend: number;
             /** Sso User Id */
             sso_user_id?: string | null;
-            /** Team Id */
-            team_id?: string | null;
             /**
              * Teams
              * @default []
@@ -25851,8 +22710,6 @@ export interface components {
             blocked?: boolean | null;
             /** Budget Duration */
             budget_duration?: string | null;
-            /** Budget Id */
-            budget_id?: string | null;
             /** Budget Limits */
             budget_limits?: {
                 [key: string]: unknown;
@@ -27053,20 +23910,40 @@ export interface components {
             /** Tpm */
             tpm?: number | null;
         };
+        /** ModelInfo */
+        ModelInfo: {
+            /** Base Model */
+            base_model?: string | null;
+            /** Blocked */
+            blocked?: boolean | null;
+            /** Created At */
+            created_at?: string | null;
+            /** Created By */
+            created_by?: string | null;
+            /**
+             * Db Model
+             * @default false
+             */
+            db_model: boolean;
+            /** Id */
+            id: string | null;
+            /** Team Id */
+            team_id?: string | null;
+            /** Team Public Model Name */
+            team_public_model_name?: string | null;
+            /** Tier */
+            tier?: ("free" | "paid") | null;
+            /** Updated At */
+            updated_at?: string | null;
+            /** Updated By */
+            updated_by?: string | null;
+        } & {
+            [key: string]: unknown;
+        };
         /** ModelInfoDelete */
         ModelInfoDelete: {
             /** Id */
             id: string;
-        };
-        /** ModelParams */
-        ModelParams: {
-            /** Litellm Params */
-            litellm_params: {
-                [key: string]: unknown;
-            };
-            model_info: components["schemas"]["litellm__proxy___types__ModelInfo"];
-            /** Model Name */
-            model_name: string;
         };
         /** ModelResponse */
         ModelResponse: {
@@ -27357,17 +24234,7 @@ export interface components {
             metadata?: {
                 [key: string]: unknown;
             } | null;
-            /**
-             * Model Spend
-             * @default {}
-             */
-            model_spend: {
-                [key: string]: unknown;
-            } | null;
-            /**
-             * Models
-             * @default []
-             */
+            /** Models */
             models: string[];
             object_permission?: components["schemas"]["LiteLLM_ObjectPermissionTable"] | null;
             /** Object Permission Id */
@@ -27472,7 +24339,7 @@ export interface components {
              */
             created_at: string;
             /** Created By */
-            created_by?: string | null;
+            created_by: string;
             /** Description */
             description?: string | null;
             litellm_budget_table?: components["schemas"]["LiteLLM_BudgetTable"] | null;
@@ -27517,7 +24384,7 @@ export interface components {
              */
             updated_at: string;
             /** Updated By */
-            updated_by?: string | null;
+            updated_by: string;
         };
         /** NewTeamRequest */
         NewTeamRequest: {
@@ -28130,11 +24997,6 @@ export interface components {
              * @description The URL to which requests for this path should be forwarded.
              */
             target: string;
-            /**
-             * Timeout
-             * @description Upstream request timeout in seconds for this pass-through endpoint. If unset, uses general_settings.pass_through_request_timeout (default 600).
-             */
-            timeout?: number | null;
         };
         /**
          * PassThroughGuardrailSettings
@@ -30269,13 +27131,6 @@ export interface components {
             /** Model */
             model?: string | null;
         };
-        /**
-         * SupportedDBObjectType
-         * @description Supported database object types for fine-grained DB storage control.
-         *     Use in general_settings.supported_db_objects to specify which objects to load from DB.
-         * @enum {string}
-         */
-        SupportedDBObjectType: "models" | "mcp" | "guardrails" | "policies" | "vector_stores" | "pass_through_endpoints" | "prompts" | "model_cost_map" | "tools" | "config_overrides";
         /** SupportedEndpoint */
         SupportedEndpoint: {
             /** Endpoint */
@@ -30418,11 +27273,6 @@ export interface components {
              */
             admins: unknown[];
             /**
-             * Allow Team Guardrail Config
-             * @default false
-             */
-            allow_team_guardrail_config: boolean | null;
-            /**
              * Blocked
              * @default false
              */
@@ -30459,20 +27309,6 @@ export interface components {
             /** Model Id */
             model_id?: number | null;
             /**
-             * Model Max Budget
-             * @default {}
-             */
-            model_max_budget: {
-                [key: string]: unknown;
-            } | null;
-            /**
-             * Model Spend
-             * @default {}
-             */
-            model_spend: {
-                [key: string]: unknown;
-            } | null;
-            /**
              * Models
              * @default []
              */
@@ -30482,8 +27318,6 @@ export interface components {
             object_permission_id?: string | null;
             /** Organization Id */
             organization_id?: string | null;
-            /** Policies */
-            policies?: string[] | null;
             /** Router Settings */
             router_settings?: {
                 [key: string]: unknown;
@@ -30527,11 +27361,6 @@ export interface components {
              * @default []
              */
             admins: unknown[];
-            /**
-             * Allow Team Guardrail Config
-             * @default false
-             */
-            allow_team_guardrail_config: boolean | null;
             /**
              * Blocked
              * @default false
@@ -30579,20 +27408,6 @@ export interface components {
             /** Model Id */
             model_id?: number | null;
             /**
-             * Model Max Budget
-             * @default {}
-             */
-            model_max_budget: {
-                [key: string]: unknown;
-            } | null;
-            /**
-             * Model Spend
-             * @default {}
-             */
-            model_spend: {
-                [key: string]: unknown;
-            } | null;
-            /**
              * Models
              * @default []
              */
@@ -30602,8 +27417,6 @@ export interface components {
             object_permission_id?: string | null;
             /** Organization Id */
             organization_id?: string | null;
-            /** Policies */
-            policies?: string[] | null;
             /** Router Settings */
             router_settings?: {
                 [key: string]: unknown;
@@ -30761,11 +27574,6 @@ export interface components {
              * @description List of models this team member can access. Pass an empty list to remove per-member model restrictions.
              */
             allowed_models?: string[] | null;
-            /**
-             * Budget Duration
-             * @description Duration after which this team member's budget resets (e.g. '1h', '24h', '7d', '30d'). If not set, the budget never resets.
-             */
-            budget_duration?: string | null;
             /** Max Budget In Team */
             max_budget_in_team?: number | null;
             /** Role */
@@ -30791,8 +27599,6 @@ export interface components {
         TeamMemberUpdateResponse: {
             /** Allowed Models */
             allowed_models?: string[] | null;
-            /** Budget Duration */
-            budget_duration?: string | null;
             /** Max Budget In Team */
             max_budget_in_team?: number | null;
             /** Rpm Limit */
@@ -31218,11 +28024,6 @@ export interface components {
             admin_ui_disabled: boolean;
             /** Auto Redirect To Sso */
             auto_redirect_to_sso: boolean;
-            /**
-             * Hide Default Credentials Hint
-             * @default false
-             */
-            hide_default_credentials_hint: boolean;
             /**
              * Is Control Plane
              * @default false
@@ -32099,8 +28900,6 @@ export interface components {
             blocked?: boolean | null;
             /** Budget Duration */
             budget_duration?: string | null;
-            /** Budget Id */
-            budget_id?: string | null;
             /** Budget Limits */
             budget_limits?: {
                 [key: string]: unknown;
@@ -32320,19 +29119,6 @@ export interface components {
             /** User Tpm Limit */
             user_tpm_limit?: number | null;
         };
-        /**
-         * UserHeaderMapping
-         * @description Map an incoming HTTP header to a LiteLLM user role.
-         */
-        UserHeaderMapping: {
-            /** Header Name */
-            header_name: string;
-            /**
-             * Litellm User Role
-             * @enum {string}
-             */
-            litellm_user_role: "internal_user" | "customer";
-        };
         /** UserInfoResponse */
         UserInfoResponse: {
             /** Keys */
@@ -32430,6 +29216,10 @@ export interface components {
         };
         /** ValidationError */
         ValidationError: {
+            /** Context */
+            ctx?: Record<string, never>;
+            /** Input */
+            input?: unknown;
             /** Location */
             loc: (string | number)[];
             /** Message */
@@ -32653,68 +29443,12 @@ export interface components {
             /** Status */
             status?: ("pending" | "running" | "paused" | "completed" | "failed") | null;
         };
-        /** ModelInfo */
-        litellm__proxy___types__ModelInfo: {
-            /** Base Model */
-            base_model: ("gpt-4-1106-preview" | "gpt-4-32k" | "gpt-4" | "gpt-3.5-turbo-16k" | "gpt-3.5-turbo" | "text-embedding-ada-002") | null;
-            /** Id */
-            id: string | null;
-            /**
-             * Input Cost Per Token
-             * @default 0
-             */
-            input_cost_per_token: number | null;
-            /**
-             * Max Tokens
-             * @default 2048
-             */
-            max_tokens: number | null;
-            /** Mode */
-            mode: ("embedding" | "chat" | "completion") | null;
-            /**
-             * Output Cost Per Token
-             * @default 0
-             */
-            output_cost_per_token: number | null;
-        } & {
-            [key: string]: unknown;
-        };
-        /** ModelInfo */
-        litellm__types__router__ModelInfo: {
-            /** Base Model */
-            base_model?: string | null;
-            /** Blocked */
-            blocked?: boolean | null;
-            /** Created At */
-            created_at?: string | null;
-            /** Created By */
-            created_by?: string | null;
-            /**
-             * Db Model
-             * @default false
-             */
-            db_model: boolean;
-            /** Id */
-            id: string | null;
-            /** Team Id */
-            team_id?: string | null;
-            /** Team Public Model Name */
-            team_public_model_name?: string | null;
-            /** Tier */
-            tier?: ("free" | "paid") | null;
-            /** Updated At */
-            updated_at?: string | null;
-            /** Updated By */
-            updated_by?: string | null;
-        } & {
-            [key: string]: unknown;
-        };
         /** updateDeployment */
         updateDeployment: {
             /** Blocked */
             blocked?: boolean | null;
             litellm_params?: components["schemas"]["updateLiteLLMParams"] | null;
-            model_info?: components["schemas"]["litellm__types__router__ModelInfo"] | null;
+            model_info?: components["schemas"]["ModelInfo"] | null;
             /** Model Name */
             model_name?: string | null;
         };
@@ -32742,16 +29476,12 @@ export interface components {
             auto_router_embedding_model?: string | null;
             /** Aws Access Key Id */
             aws_access_key_id?: string | null;
-            /** Aws Bedrock Project Id */
-            aws_bedrock_project_id?: string | null;
             /** Aws Bedrock Runtime Endpoint */
             aws_bedrock_runtime_endpoint?: string | null;
             /** Aws Region Name */
             aws_region_name?: string | null;
             /** Aws Secret Access Key */
             aws_secret_access_key?: string | null;
-            /** Azure Ad Token */
-            azure_ad_token?: string | null;
             /** Budget Duration */
             budget_duration?: string | null;
             /** Cache Creation Input Audio Token Cost */
@@ -32768,10 +29498,6 @@ export interface components {
             cache_read_input_token_cost?: number | null;
             /** Cache Read Input Token Cost Above 200K Tokens */
             cache_read_input_token_cost_above_200k_tokens?: number | null;
-            /** Cache Read Input Token Cost Above 200K Tokens Priority */
-            cache_read_input_token_cost_above_200k_tokens_priority?: number | null;
-            /** Cache Read Input Token Cost Above 272K Tokens Priority */
-            cache_read_input_token_cost_above_272k_tokens_priority?: number | null;
             /** Cache Read Input Token Cost Flex */
             cache_read_input_token_cost_flex?: number | null;
             /** Cache Read Input Token Cost Priority */
@@ -32820,10 +29546,6 @@ export interface components {
             input_cost_per_token_above_128k_tokens?: number | null;
             /** Input Cost Per Token Above 200K Tokens */
             input_cost_per_token_above_200k_tokens?: number | null;
-            /** Input Cost Per Token Above 200K Tokens Priority */
-            input_cost_per_token_above_200k_tokens_priority?: number | null;
-            /** Input Cost Per Token Above 272K Tokens Priority */
-            input_cost_per_token_above_272k_tokens_priority?: number | null;
             /** Input Cost Per Token Batches */
             input_cost_per_token_batches?: number | null;
             /** Input Cost Per Token Cache Hit */
@@ -32897,10 +29619,6 @@ export interface components {
             output_cost_per_token_above_128k_tokens?: number | null;
             /** Output Cost Per Token Above 200K Tokens */
             output_cost_per_token_above_200k_tokens?: number | null;
-            /** Output Cost Per Token Above 200K Tokens Priority */
-            output_cost_per_token_above_200k_tokens_priority?: number | null;
-            /** Output Cost Per Token Above 272K Tokens Priority */
-            output_cost_per_token_above_272k_tokens_priority?: number | null;
             /** Output Cost Per Token Batches */
             output_cost_per_token_batches?: number | null;
             /** Output Cost Per Token Flex */
@@ -32928,7 +29646,7 @@ export interface components {
                 [key: string]: unknown;
             } | null;
             /** Stream Timeout */
-            stream_timeout?: number | string | null;
+            stream_timeout?: string | number | null;
             /** Tag Regex */
             tag_regex?: string[] | null;
             /** Tags */
@@ -32953,12 +29671,6 @@ export interface components {
              * @default false
              */
             use_litellm_proxy: boolean | null;
-            /**
-             * Use Xai Oauth
-             * @description Use stored xAI OAuth credentials when no xAI API key is configured.
-             * @default false
-             */
-            use_xai_oauth: boolean | null;
             /** Vector Store Id */
             vector_store_id?: string | null;
             /** Vertex Credentials */
@@ -33408,26 +30120,6 @@ export interface operations {
             };
         };
     };
-    alerting_settings_alerting_settings_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
     anthropic_proxy_route_anthropic__endpoint__get: {
         parameters: {
             query?: never;
@@ -33599,26 +30291,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
-                };
-            };
-        };
-    };
-    list_plugins_api_plugins_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown[];
                 };
             };
         };
@@ -35854,39 +32526,6 @@ export interface operations {
             };
         };
     };
-    delete_callback_config_callback_delete_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["CallbackDelete"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
     get_cost_discount_config_config_cost_discount_config_get: {
         parameters: {
             query?: never;
@@ -35986,134 +32625,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    delete_config_general_settings_config_field_delete_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ConfigFieldDelete"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_config_general_settings_config_field_info_get: {
-        parameters: {
-            query: {
-                field_name: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ConfigFieldInfo"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    update_config_general_settings_config_field_update_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ConfigFieldUpdate"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_config_list_config_list_get: {
-        parameters: {
-            query: {
-                config_type: "general_settings";
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ConfigList"][];
                 };
             };
             /** @description Validation Error */
@@ -36268,72 +32779,6 @@ export interface operations {
         requestBody: {
             content: {
                 "application/json": components["schemas"]["PassThroughGenericEndpoint"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    update_config_config_update_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ConfigYAML"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    config_yaml_endpoint_config_yaml_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ConfigYAML"];
             };
         };
         responses: {
@@ -37378,102 +33823,6 @@ export interface operations {
             };
         };
     };
-    get_memory_details_debug_memory_details_get: {
-        parameters: {
-            query?: {
-                /** @description Number of top object types to return */
-                top_n?: number;
-                /** @description Include process memory info */
-                include_process_info?: boolean;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    configure_gc_thresholds_endpoint_debug_memory_gc_configure_post: {
-        parameters: {
-            query?: {
-                /** @description Generation 0 threshold (default: 700) */
-                generation_0?: number;
-                /** @description Generation 1 threshold (default: 10) */
-                generation_1?: number;
-                /** @description Generation 2 threshold (default: 10) */
-                generation_2?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_memory_summary_debug_memory_summary_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
-                };
-            };
-        };
-    };
     delete_allowed_ip_delete_allowed_ip_post: {
         parameters: {
             query?: never;
@@ -37657,261 +34006,6 @@ export interface operations {
                      */
                     user?: string | null;
                 };
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    block_user_end_user_block_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["BlockUsers"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_customer_daily_activity_end_user_daily_activity_get: {
-        parameters: {
-            query?: {
-                end_user_ids?: string | null;
-                start_date?: string | null;
-                end_date?: string | null;
-                model?: string | null;
-                api_key?: string | null;
-                page?: number;
-                page_size?: number;
-                exclude_end_user_ids?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    delete_end_user_end_user_delete_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["DeleteCustomerRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    end_user_info_end_user_info_get: {
-        parameters: {
-            query: {
-                /** @description End User ID in the request parameters */
-                end_user_id: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    list_end_user_end_user_list_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    new_end_user_end_user_new_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["NewCustomerRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    unblock_user_end_user_unblock_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["BlockUsers"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    update_end_user_end_user_update_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["UpdateCustomerRequest"];
             };
         };
         responses: {
@@ -38457,26 +34551,6 @@ export interface operations {
             };
         };
     };
-    fallback_login_fallback_login_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
     get_fallback_fallback__model__get: {
         parameters: {
             query?: {
@@ -38997,46 +35071,6 @@ export interface operations {
             };
         };
     };
-    get_allowed_ips_get_allowed_ips_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    get_config_get_config_callbacks_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
     get_default_team_settings_get_default_team_settings_get: {
         parameters: {
             query?: never;
@@ -39157,483 +35191,6 @@ export interface operations {
             };
         };
     };
-    get_favicon_get_favicon_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    get_image_get_image_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    get_logo_url_get_logo_url_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    get_global_activity_global_activity_get: {
-        parameters: {
-            query?: {
-                /** @description Time from which to start viewing spend */
-                start_date?: string | null;
-                /** @description Time till which to view spend */
-                end_date?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["LiteLLM_SpendLogs"][];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_global_activity_global_activity_cache_hits_get: {
-        parameters: {
-            query?: {
-                /** @description Time from which to start viewing spend */
-                start_date?: string | null;
-                /** @description Time till which to view spend */
-                end_date?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["LiteLLM_SpendLogs"][];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_global_activity_exceptions_global_activity_exceptions_get: {
-        parameters: {
-            query: {
-                /** @description Filter by model group */
-                model_group: string;
-                /** @description Time from which to start viewing spend */
-                start_date?: string | null;
-                /** @description Time till which to view spend */
-                end_date?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["LiteLLM_SpendLogs"][];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_global_activity_exceptions_per_deployment_global_activity_exceptions_deployment_get: {
-        parameters: {
-            query: {
-                /** @description Filter by model group */
-                model_group: string;
-                /** @description Time from which to start viewing spend */
-                start_date?: string | null;
-                /** @description Time till which to view spend */
-                end_date?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["LiteLLM_SpendLogs"][];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_global_activity_model_global_activity_model_get: {
-        parameters: {
-            query?: {
-                /** @description Time from which to start viewing spend */
-                start_date?: string | null;
-                /** @description Time till which to view spend */
-                end_date?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["LiteLLM_SpendLogs"][];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    global_view_all_end_users_global_all_end_users_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    global_spend_global_spend_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    global_get_all_tag_names_global_spend_all_tag_names_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["LiteLLM_SpendLogs"][];
-                };
-            };
-        };
-    };
-    global_spend_end_users_global_spend_end_users_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: {
-            content: {
-                "application/json": components["schemas"]["GlobalEndUsersSpend"] | null;
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    global_spend_keys_global_spend_keys_get: {
-        parameters: {
-            query?: {
-                /** @description Number of keys to get. Will return Top 'n' keys. */
-                limit?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    global_spend_logs_global_spend_logs_get: {
-        parameters: {
-            query?: {
-                /** @description API Key to get global spend (spend per day for last 30d). Admin-only endpoint */
-                api_key?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    global_spend_models_global_spend_models_get: {
-        parameters: {
-            query?: {
-                /** @description Number of models to get. Will return Top 'n' models. */
-                limit?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_global_spend_provider_global_spend_provider_get: {
-        parameters: {
-            query?: {
-                /** @description Time from which to start viewing spend */
-                start_date?: string | null;
-                /** @description Time till which to view spend */
-                end_date?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["LiteLLM_SpendLogs"][];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    global_spend_refresh_global_spend_refresh_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
     get_global_spend_report_global_spend_report_get: {
         parameters: {
             query?: {
@@ -39730,26 +35287,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    global_spend_per_team_global_spend_teams_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
                 };
             };
         };
@@ -40722,7 +36259,7 @@ export interface operations {
         parameters: {
             query: {
                 /** @description Specify the service being hit. */
-                service: ("slack_budget_alerts" | "langfuse" | "langfuse_otel" | "slack" | "openmeter" | "webhook" | "email" | "braintrust" | "datadog" | "datadog_llm_observability" | "generic_api" | "arize" | "galileo" | "newrelic" | "sqs") | string;
+                service: ("slack_budget_alerts" | "langfuse" | "langfuse_otel" | "slack" | "openmeter" | "webhook" | "email" | "braintrust" | "datadog" | "datadog_llm_observability" | "generic_api" | "arize" | "sqs") | string;
             };
             header?: never;
             path?: never;
@@ -40989,136 +36526,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    invitation_delete_invitation_delete_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["InvitationDelete"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["InvitationModel"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    invitation_info_invitation_info_get: {
-        parameters: {
-            query: {
-                invitation_id: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["InvitationModel"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    new_invitation_invitation_new_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["InvitationNew"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["InvitationModel"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    invitation_update_invitation_update_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["InvitationUpdate"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["InvitationModel"];
                 };
             };
             /** @description Validation Error */
@@ -41973,37 +37380,6 @@ export interface operations {
             };
         };
     };
-    warm_lazy_warm__name__post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                name: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
     get_ui_config_litellm__well_known_litellm_ui_config_get: {
         parameters: {
             query?: never;
@@ -42020,26 +37396,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["UiDiscoveryEndpoints"];
-                };
-            };
-        };
-    };
-    login_login_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
                 };
             };
         };
@@ -42160,46 +37516,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    memory_usage_in_mem_cache_memory_usage_in_mem_cache_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    memory_usage_in_mem_cache_items_memory_usage_in_mem_cache_items_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
                 };
             };
         };
@@ -42514,62 +37830,6 @@ export interface operations {
             };
         };
     };
-    block_model_model_block_post: {
-        parameters: {
-            query?: never;
-            header?: {
-                /** @description The litellm-changed-by header enables tracking of actions performed by authorized users on behalf of other users, providing an audit trail for accountability */
-                "litellm-changed-by"?: string | null;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["BlockModelRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["LiteLLM_ProxyModelTable"] | null;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_model_cost_map_source_model_cost_map_source_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
     delete_model_model_delete_post: {
         parameters: {
             query?: never;
@@ -42607,115 +37867,6 @@ export interface operations {
         parameters: {
             query?: {
                 litellm_model_id?: string | null;
-                /** @description When true, filter to deployments the caller can use via direct access or team membership. */
-                include_team_models?: boolean | null;
-                /** @description Filter models by team ID. Returns models with direct_access=True or teamId in access_via_team_ids */
-                teamId?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    model_metrics_model_metrics_get: {
-        parameters: {
-            query?: {
-                _selected_model_group?: string | null;
-                startTime?: string | null;
-                endTime?: string | null;
-                api_key?: string | null;
-                customer?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    model_metrics_exceptions_model_metrics_exceptions_get: {
-        parameters: {
-            query?: {
-                _selected_model_group?: string | null;
-                startTime?: string | null;
-                endTime?: string | null;
-                api_key?: string | null;
-                customer?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    model_metrics_slow_responses_model_metrics_slow_responses_get: {
-        parameters: {
-            query?: {
-                _selected_model_group?: string | null;
-                startTime?: string | null;
-                endTime?: string | null;
-                api_key?: string | null;
-                customer?: string | null;
             };
             header?: never;
             path?: never;
@@ -42763,95 +37914,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    model_settings_model_settings_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    model_streaming_metrics_model_streaming_metrics_get: {
-        parameters: {
-            query?: {
-                _selected_model_group?: string | null;
-                startTime?: string | null;
-                endTime?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    unblock_model_model_unblock_post: {
-        parameters: {
-            query?: never;
-            header?: {
-                /** @description The litellm-changed-by header enables tracking of actions performed by authorized users on behalf of other users, providing an audit trail for accountability */
-                "litellm-changed-by"?: string | null;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["BlockModelRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["LiteLLM_ProxyModelTable"] | null;
                 };
             };
             /** @description Validation Error */
@@ -43040,7 +38102,6 @@ export interface operations {
                 include_metadata?: boolean | null;
                 fallback_type?: string | null;
                 scope?: string | null;
-                healthy_only?: boolean | null;
             };
             header?: never;
             path?: never;
@@ -43070,10 +38131,7 @@ export interface operations {
     };
     model_info_models__model_id__get: {
         parameters: {
-            query?: {
-                team_id?: string | null;
-                healthy_only?: boolean | null;
-            };
+            query?: never;
             header?: never;
             path: {
                 model_id: string;
@@ -43231,70 +38289,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
-                };
-            };
-        };
-    };
-    claim_onboarding_link_onboarding_claim_token_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["InvitationClaim"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    onboarding_onboarding_get_token_get: {
-        parameters: {
-            query: {
-                invite_link: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };
@@ -43543,17 +38537,7 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /**
-             * @description Unified rate-limit error.
-             *
-             *         Every rate-limit condition surfaced by litellm — whether it originated from
-             *         an upstream LLM provider, a vendor batch endpoint, or one of litellm's own
-             *         proxy-side limiters (parallel-requests, dynamic-rate, batch-rate, budget,
-             *         max-iterations, etc.) — is raised as an instance of this class.
-             *
-             *         The :attr:`category` attribute lets callers distinguish the source. See
-             *         :class:`RateLimitErrorCategory` for the available values.
-             */
+            /** @description RateLimitError */
             429: {
                 headers: {
                     [name: string]: unknown;
@@ -43783,11 +38767,7 @@ export interface operations {
     };
     websocket_realtime_websocket_endpoint_get_3: {
         parameters: {
-            query?: {
-                model?: string;
-                intent?: string;
-                guardrails?: string;
-            };
+            query?: never;
             header?: never;
             path?: never;
             cookie?: never;
@@ -44634,250 +39614,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["LiteLLM_OrganizationTableWithMembers"];
-                };
-            };
-        };
-    };
-    get_otel_spans_otel_spans_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    plugin_proxy_plugin_proxy__plugin_name___path__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                plugin_name: string;
-                path: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    plugin_proxy_plugin_proxy__plugin_name___path__put: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                plugin_name: string;
-                path: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    plugin_proxy_plugin_proxy__plugin_name___path__post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                plugin_name: string;
-                path: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    plugin_proxy_plugin_proxy__plugin_name___path__delete: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                plugin_name: string;
-                path: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    plugin_proxy_plugin_proxy__plugin_name___path__options: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                plugin_name: string;
-                path: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    plugin_proxy_plugin_proxy__plugin_name___path__head: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                plugin_name: string;
-                path: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    plugin_proxy_plugin_proxy__plugin_name___path__patch: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                plugin_name: string;
-                path: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };
@@ -46453,37 +41189,6 @@ export interface operations {
             };
         };
     };
-    async_queue_request_queue_chat_completions_post: {
-        parameters: {
-            query?: {
-                model?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
     rag_ingest_rag_ingest_post: {
         parameters: {
             query?: never;
@@ -46526,11 +41231,7 @@ export interface operations {
     };
     websocket_realtime_websocket_endpoint_get: {
         parameters: {
-            query?: {
-                model?: string;
-                intent?: string;
-                guardrails?: string;
-            };
+            query?: never;
             header?: never;
             path?: never;
             cookie?: never;
@@ -46586,46 +41287,6 @@ export interface operations {
             };
         };
     };
-    reload_anthropic_beta_headers_reload_anthropic_beta_headers_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    reload_model_cost_map_reload_model_cost_map_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
     rerank_rerank_post: {
         parameters: {
             query?: never;
@@ -46648,9 +41309,7 @@ export interface operations {
     };
     websocket_responses_websocket_endpoint_get: {
         parameters: {
-            query?: {
-                model?: string;
-            };
+            query?: never;
             header?: never;
             path?: never;
             cookie?: never;
@@ -46891,148 +41550,6 @@ export interface operations {
         };
     };
     get_routes_routes_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    schedule_anthropic_beta_headers_reload_schedule_anthropic_beta_headers_reload_post: {
-        parameters: {
-            query: {
-                hours: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    cancel_anthropic_beta_headers_reload_schedule_anthropic_beta_headers_reload_delete: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    get_anthropic_beta_headers_reload_status_schedule_anthropic_beta_headers_reload_status_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    schedule_model_cost_map_reload_schedule_model_cost_map_reload_post: {
-        parameters: {
-            query: {
-                hours: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    cancel_model_cost_map_reload_schedule_model_cost_map_reload_delete: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    get_model_cost_map_reload_status_schedule_model_cost_map_reload_status_get: {
         parameters: {
             query?: never;
             header?: never;
@@ -48000,26 +42517,6 @@ export interface operations {
             };
         };
     };
-    spend_key_fn_spend_keys_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
     view_spend_logs_spend_logs_get: {
         parameters: {
             query?: {
@@ -48049,148 +42546,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["LiteLLM_SpendLogs"][];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    ui_view_session_spend_logs_spend_logs_session_ui_get: {
-        parameters: {
-            query: {
-                /** @description Get all spend logs for a particular session */
-                session_id: string;
-                /** @description Page number for pagination */
-                page?: number;
-                /** @description Number of items per page */
-                page_size?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["LiteLLM_SpendLogs"][];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    ui_view_spend_logs_spend_logs_ui_get: {
-        parameters: {
-            query?: {
-                /** @description Get spend logs based on api key */
-                api_key?: string | null;
-                /** @description Get spend logs based on user_id */
-                user_id?: string | null;
-                /** @description request_id to get spend logs for specific request_id */
-                request_id?: string | null;
-                /** @description Filter spend logs by team_id */
-                team_id?: string | null;
-                /** @description Filter logs with spend greater than or equal to this value */
-                min_spend?: number | null;
-                /** @description Filter logs with spend less than or equal to this value */
-                max_spend?: number | null;
-                /** @description Time from which to start viewing key spend */
-                start_date?: string | null;
-                /** @description Time till which to view key spend */
-                end_date?: string | null;
-                /** @description Page number for pagination */
-                page?: number;
-                /** @description Number of items per page */
-                page_size?: number;
-                /** @description Filter logs by status (e.g., success, failure) */
-                status_filter?: string | null;
-                /** @description Filter logs by model */
-                model?: string | null;
-                /** @description Filter logs by model ID (litellm model deployment id) */
-                model_id?: string | null;
-                /** @description Filter logs by model group */
-                model_group?: string | null;
-                /** @description Filter logs by key alias */
-                key_alias?: string | null;
-                /** @description Filter logs by end user */
-                end_user?: string | null;
-                /** @description Filter logs by error code (e.g., '404', '500') */
-                error_code?: string | null;
-                /** @description Filter logs by error message (partial string match) */
-                error_message?: string | null;
-                /** @description Sort logs by field: spend, total_tokens, startTime, endTime, request_duration_ms, model, or ttft_ms */
-                sort_by?: string;
-                /** @description Sort order: asc or desc */
-                sort_order?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["LiteLLM_SpendLogs"][];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    ui_view_request_response_for_request_id_spend_logs_ui__request_id__get: {
-        parameters: {
-            query?: {
-                /** @description Time from which to start viewing key spend */
-                start_date?: string | null;
-                /** @description Time till which to view key spend */
-                end_date?: string | null;
-            };
-            header?: never;
-            path: {
-                request_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
                 };
             };
             /** @description Validation Error */
@@ -48297,250 +42652,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["LiteLLM_SpendLogs"][];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    spend_user_fn_spend_users_get: {
-        parameters: {
-            query?: {
-                /** @description Get User Table row for user_id */
-                user_id?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    auth_callback_sso_callback_get: {
-        parameters: {
-            query?: {
-                state?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    cli_sso_complete_sso_cli_complete__login_id__post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                login_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    cli_poll_key_sso_cli_poll__key_id__get: {
-        parameters: {
-            query?: {
-                team_id?: string | null;
-            };
-            header?: {
-                "x-litellm-cli-poll-secret"?: string | null;
-            };
-            path: {
-                key_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    cli_sso_start_sso_cli_start_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    debug_sso_callback_sso_debug_callback_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    debug_sso_login_sso_debug_login_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    get_ui_settings_sso_get_ui_settings_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    google_login_sso_key_generate_get: {
-        parameters: {
-            query?: {
-                source?: string | null;
-                key?: string | null;
-                existing_key?: string | null;
-                return_to?: string | null;
-                user_code?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
                 };
             };
             /** @description Validation Error */
@@ -49133,44 +43244,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    ui_view_teams_team_filter_ui_get: {
-        parameters: {
-            query?: {
-                /** @description Team ID in the request parameters */
-                team_id?: string | null;
-                /** @description Team alias in the request parameters */
-                team_alias?: string | null;
-                /** @description Page number for pagination */
-                page?: number;
-                /** @description Number of items per page */
-                page_size?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["LiteLLM_TeamTable"][];
                 };
             };
             /** @description Validation Error */
@@ -50434,26 +44507,6 @@ export interface operations {
             };
         };
     };
-    ui_get_available_role_user_available_roles_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
     available_enterprise_users_user_available_users_get: {
         parameters: {
             query?: never;
@@ -50621,46 +44674,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    ui_view_users_user_filter_ui_get: {
-        parameters: {
-            query?: {
-                /** @description User ID in the request parameters */
-                user_id?: string | null;
-                /** @description User email in the request parameters */
-                user_email?: string | null;
-                /** @description Team ID — used when a team admin searches for users to add to their team */
-                team_id?: string | null;
-                /** @description Page number for pagination */
-                page?: number;
-                /** @description Number of items per page */
-                page_size?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["LiteLLM_UserTableFiltered"][];
                 };
             };
             /** @description Validation Error */
@@ -54114,10 +48127,6 @@ export interface operations {
         parameters: {
             query?: {
                 litellm_model_id?: string | null;
-                /** @description When true, filter to deployments the caller can use via direct access or team membership. */
-                include_team_models?: boolean | null;
-                /** @description Filter models by team ID. Returns models with direct_access=True or teamId in access_via_team_ids */
-                teamId?: string | null;
             };
             header?: never;
             path?: never;
@@ -54155,7 +48164,6 @@ export interface operations {
                 include_metadata?: boolean | null;
                 fallback_type?: string | null;
                 scope?: string | null;
-                healthy_only?: boolean | null;
             };
             header?: never;
             path?: never;
@@ -54185,10 +48193,7 @@ export interface operations {
     };
     model_info_v1_models__model_id__get: {
         parameters: {
-            query?: {
-                team_id?: string | null;
-                healthy_only?: boolean | null;
-            };
+            query?: never;
             header?: never;
             path: {
                 model_id: string;
@@ -54299,11 +48304,7 @@ export interface operations {
     };
     websocket_realtime_websocket_endpoint_get_2: {
         parameters: {
-            query?: {
-                model?: string;
-                intent?: string;
-                guardrails?: string;
-            };
+            query?: never;
             header?: never;
             path?: never;
             cookie?: never;
@@ -54381,9 +48382,7 @@ export interface operations {
     };
     websocket_responses_websocket_endpoint_get_2: {
         parameters: {
-            query?: {
-                model?: string;
-            };
+            query?: never;
             header?: never;
             path?: never;
             cookie?: never;
@@ -56430,110 +50429,6 @@ export interface operations {
             };
         };
     };
-    info_key_fn_v2_v2_key_info_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: {
-            content: {
-                "application/json": components["schemas"]["KeyRequest"] | null;
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    login_v2_v2_login_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    model_info_v2_v2_model_info_get: {
-        parameters: {
-            query?: {
-                /** @description Specify the model name (optional) */
-                model?: string | null;
-                /** @description Only return models added by this user */
-                user_models_only?: boolean | null;
-                /** @description Return all models across all teams user is in. */
-                include_team_models?: boolean | null;
-                debug?: boolean | null;
-                /** @description Page number */
-                page?: number;
-                /** @description Page size */
-                size?: number;
-                /** @description Search model names (case-insensitive partial match) */
-                search?: string | null;
-                /** @description Search for a specific model by its unique ID */
-                modelId?: string | null;
-                /** @description Filter models by team ID. Returns models with direct_access=True or teamId in access_via_team_ids */
-                teamId?: string | null;
-                /** @description Field to sort by. Options: model_name, created_at, updated_at, costs, status */
-                sortBy?: string | null;
-                /** @description Sort order. Options: asc, desc */
-                sortOrder?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
     rerank_v2_rerank_post: {
         parameters: {
             query?: never;
@@ -56632,46 +50527,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    login_v3_v3_login_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    login_v3_exchange_v3_login_exchange_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
                 };
             };
         };
@@ -57380,161 +51235,6 @@ export interface operations {
             };
         };
     };
-    vertex_proxy_route_vertex_ai__endpoint__get_2: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                endpoint: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    vertex_proxy_route_vertex_ai__endpoint__put_2: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                endpoint: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    vertex_proxy_route_vertex_ai__endpoint__post_2: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                endpoint: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    vertex_proxy_route_vertex_ai__endpoint__delete_2: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                endpoint: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    vertex_proxy_route_vertex_ai__endpoint__patch_2: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                endpoint: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
     vertex_discovery_proxy_route_vertex_ai_discovery__endpoint__get: {
         parameters: {
             query?: never;
@@ -57692,11 +51392,7 @@ export interface operations {
     };
     websocket_vertex_ai_live_passthrough_endpoint: {
         parameters: {
-            query?: {
-                model?: string;
-                vertex_project?: string;
-                vertex_location?: string;
-            };
+            query?: never;
             header?: never;
             path?: never;
             cookie?: never;

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -515,6 +515,28 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/plugins": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Plugins
+         * @description Return registered plugins for UI discovery.
+         *
+         *     plugin_key is only returned to authenticated requests.
+         */
+        get: operations["list_plugins_api_plugins_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/apply_guardrail": {
         parameters: {
             query?: never;
@@ -646,60 +668,6 @@ export interface paths {
          *     https://platform.openai.com/docs/api-reference/audio/createTranscription?lang=curl
          */
         post: operations["audio_transcriptions_audio_transcriptions_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/audit": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Audit Logs
-         * @description Get all audit logs with filtering and pagination.
-         *
-         *     Returns a paginated response of audit logs matching the specified filters.
-         *
-         *     Note: object_team_id and object_key_hash use Prisma JSON path filtering,
-         *     which requires PostgreSQL.
-         */
-        get: operations["get_audit_logs_audit_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/audit/{id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Audit Log By Id
-         * @description Get detailed information about a specific audit log entry by its ID.
-         *
-         *     Args:
-         *         id (str): The unique identifier of the audit log entry
-         *
-         *     Returns:
-         *         AuditLogResponse: Detailed information about the audit log entry
-         *
-         *     Raises:
-         *         HTTPException: If the audit log is not found or if there's a database connection error
-         */
-        get: operations["get_audit_log_by_id_audit__id__get"];
-        put?: never;
-        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -3064,50 +3032,6 @@ export interface paths {
         put?: never;
         /** Delete Allowed Ip */
         post: operations["delete_allowed_ip_delete_allowed_ip_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/email/event_settings": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Email Event Settings
-         * @description Get all email event settings
-         */
-        get: operations["get_email_event_settings_email_event_settings_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        /**
-         * Update Event Settings
-         * @description Update the settings for email events
-         */
-        patch: operations["update_event_settings_email_event_settings_patch"];
-        trace?: never;
-    };
-    "/email/event_settings/reset": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Reset Event Settings
-         * @description Reset all email event settings to default (new user invitations on, virtual key creation off)
-         */
-        post: operations["reset_event_settings_email_event_settings_reset_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -8965,6 +8889,50 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/plugin-proxy/{plugin_name}/{path}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Plugin Proxy
+         * @description Reverse-proxy any request to the registered plugin's backend.
+         */
+        get: operations["plugin_proxy_plugin_proxy__plugin_name___path__get"];
+        /**
+         * Plugin Proxy
+         * @description Reverse-proxy any request to the registered plugin's backend.
+         */
+        put: operations["plugin_proxy_plugin_proxy__plugin_name___path__put"];
+        /**
+         * Plugin Proxy
+         * @description Reverse-proxy any request to the registered plugin's backend.
+         */
+        post: operations["plugin_proxy_plugin_proxy__plugin_name___path__post"];
+        /**
+         * Plugin Proxy
+         * @description Reverse-proxy any request to the registered plugin's backend.
+         */
+        delete: operations["plugin_proxy_plugin_proxy__plugin_name___path__delete"];
+        /**
+         * Plugin Proxy
+         * @description Reverse-proxy any request to the registered plugin's backend.
+         */
+        options: operations["plugin_proxy_plugin_proxy__plugin_name___path__options"];
+        /**
+         * Plugin Proxy
+         * @description Reverse-proxy any request to the registered plugin's backend.
+         */
+        head: operations["plugin_proxy_plugin_proxy__plugin_name___path__head"];
+        /**
+         * Plugin Proxy
+         * @description Reverse-proxy any request to the registered plugin's backend.
+         */
+        patch: operations["plugin_proxy_plugin_proxy__plugin_name___path__patch"];
+        trace?: never;
+    };
     "/policies": {
         parameters: {
             query?: never;
@@ -9778,240 +9746,6 @@ export interface paths {
          *     ```
          */
         post: operations["validate_policy_policy_validate_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/project/delete": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        /**
-         * Delete Project
-         * @description Delete projects
-         *
-         *     Parameters:
-         *     - project_ids: *List[str]* - List of project ids to delete
-         *
-         *     Example:
-         *     ```bash
-         *     curl --location --request DELETE 'http://0.0.0.0:4000/project/delete' \
-         *     --header 'Authorization: Bearer sk-1234' \
-         *     --header 'Content-Type: application/json' \
-         *     --data '{
-         *         "project_ids": ["project-123", "project-456"]
-         *     }'
-         *     ```
-         */
-        delete: operations["delete_project_project_delete_delete"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/project/info": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Project Info
-         * @description Get information about a specific project
-         *
-         *     Parameters:
-         *     - project_id: *str* - The project id to fetch info for
-         *
-         *     Example:
-         *     ```bash
-         *     curl --location 'http://0.0.0.0:4000/project/info?project_id=project-123' \
-         *     --header 'Authorization: Bearer sk-1234'
-         *     ```
-         */
-        get: operations["project_info_project_info_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/project/list": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List Projects
-         * @description List all projects that the user has access to
-         *
-         *     Example:
-         *     ```bash
-         *     curl --location 'http://0.0.0.0:4000/project/list' \
-         *     --header 'Authorization: Bearer sk-1234'
-         *     ```
-         */
-        get: operations["list_projects_project_list_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/project/new": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * New Project
-         * @description Create a new project. Projects sit between teams and keys in the hierarchy.
-         *
-         *     Only admins or team admins can create projects.
-         *
-         *     # Parameters
-         *
-         *     - project_alias: *Optional[str]* - The name of the project.
-         *     - description: *Optional[str]* - Description of the project's purpose and use case.
-         *     - team_id: *str* - The team id that this project belongs to. Required.
-         *     - models: *List* - The models the project has access to.
-         *     - budget_id: *Optional[str]* - The id for a budget (tpm/rpm/max budget) for the project.
-         *     ### IF NO BUDGET ID - CREATE ONE WITH THESE PARAMS ###
-         *     - max_budget: *Optional[float]* - Max budget for project
-         *     - tpm_limit: *Optional[int]* - Max tpm limit for project
-         *     - rpm_limit: *Optional[int]* - Max rpm limit for project
-         *     - max_parallel_requests: *Optional[int]* - Max parallel requests for project
-         *     - soft_budget: *Optional[float]* - Get a slack alert when this soft budget is reached. Don't block requests.
-         *     - model_max_budget: *Optional[dict]* - Max budget for a specific model. Example: {"gpt-4": 100.0, "gpt-3.5-turbo": 50.0}
-         *     - model_rpm_limit: *Optional[dict]* - RPM limits per model. Example: {"gpt-4": 1000, "gpt-3.5-turbo": 5000}
-         *     - model_tpm_limit: *Optional[dict]* - TPM limits per model. Example: {"gpt-4": 50000, "gpt-3.5-turbo": 100000}
-         *     - budget_duration: *Optional[str]* - Frequency of reseting project budget
-         *     - metadata: *Optional[dict]* - Metadata for project, store information for project. Example metadata - {"use_case_id": "SNOW-12345", "responsible_ai_id": "RAI-67890"}
-         *     - tags: *Optional[list]* - Tags for the project. Example: ["production", "api"]
-         *     - blocked: *bool* - Flag indicating if the project is blocked or not - will stop all calls from keys with this project_id.
-         *     - object_permission: Optional[LiteLLM_ObjectPermissionBase] - project-specific object permission. Example - {"vector_stores": ["vector_store_1", "vector_store_2"]}. IF null or {} then no object permission.
-         *
-         *     Example 1: Create new project **without** a budget_id, with model-specific limits
-         *
-         *     ```bash
-         *     curl --location 'http://0.0.0.0:4000/project/new' \
-         *     --header 'Authorization: Bearer sk-1234' \
-         *     --header 'Content-Type: application/json' \
-         *     --data '{
-         *         "project_alias": "flight-search-assistant",
-         *         "description": "AI-powered flight search and booking assistant",
-         *         "team_id": "team-123",
-         *         "models": ["gpt-4", "gpt-3.5-turbo"],
-         *         "max_budget": 100,
-         *         "model_rpm_limit": {
-         *             "gpt-4": 1000,
-         *             "gpt-3.5-turbo": 5000
-         *         },
-         *         "model_tpm_limit": {
-         *             "gpt-4": 50000,
-         *             "gpt-3.5-turbo": 100000
-         *         },
-         *         "metadata": {
-         *             "use_case_id": "SNOW-12345",
-         *             "responsible_ai_id": "RAI-67890"
-         *         }
-         *     }'
-         *     ```
-         *
-         *     Example 2: Create new project **with** a budget_id
-         *
-         *     ```bash
-         *     curl --location 'http://0.0.0.0:4000/project/new' \
-         *     --header 'Authorization: Bearer sk-1234' \
-         *     --header 'Content-Type: application/json' \
-         *     --data '{
-         *         "project_alias": "hotel-recommendations",
-         *         "description": "Personalized hotel recommendation engine",
-         *         "team_id": "team-123",
-         *         "models": ["claude-3-sonnet"],
-         *         "budget_id": "428eeaa8-f3ac-4e85-a8fb-7dc8d7aa8689",
-         *         "metadata": {
-         *             "use_case_id": "SNOW-54321"
-         *         }
-         *     }'
-         *     ```
-         */
-        post: operations["new_project_project_new_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/project/update": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Update Project
-         * @description Update a project
-         *
-         *     Parameters:
-         *     - project_id: *str* - The project id to update. Required.
-         *     - project_alias: *Optional[str]* - Updated name for the project
-         *     - description: *Optional[str]* - Updated description for the project
-         *     - team_id: *Optional[str]* - Updated team_id for the project
-         *     - metadata: *Optional[dict]* - Updated metadata for project
-         *     - models: *Optional[list]* - Updated list of models for the project
-         *     - blocked: *Optional[bool]* - Updated blocked status
-         *     - max_budget: *Optional[float]* - Updated max budget
-         *     - tpm_limit: *Optional[int]* - Updated tpm limit
-         *     - rpm_limit: *Optional[int]* - Updated rpm limit
-         *     - model_rpm_limit: *Optional[dict]* - Updated RPM limits per model
-         *     - model_tpm_limit: *Optional[dict]* - Updated TPM limits per model
-         *     - budget_duration: *Optional[str]* - Updated budget duration
-         *     - tags: *Optional[list]* - Updated list of tags for the project
-         *     - object_permission: Optional[LiteLLM_ObjectPermissionBase] - Updated object permission
-         *
-         *     Example:
-         *     ```bash
-         *     curl --location 'http://0.0.0.0:4000/project/update' \
-         *     --header 'Authorization: Bearer sk-1234' \
-         *     --header 'Content-Type: application/json' \
-         *     --data '{
-         *         "project_id": "project-123",
-         *         "description": "Updated flight search system with enhanced capabilities",
-         *         "max_budget": 200,
-         *         "model_rpm_limit": {
-         *             "gpt-4": 2000,
-         *             "gpt-3.5-turbo": 10000
-         *         },
-         *         "metadata": {
-         *             "use_case_id": "SNOW-12345",
-         *             "status": "active"
-         *         }
-         *     }'
-         *     ```
-         */
-        post: operations["update_project_project_update_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -11052,27 +10786,6 @@ export interface paths {
          * @description List input items for a response.
          */
         get: operations["get_response_input_items_responses__response_id__input_items_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/robots.txt": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Robots
-         * @description Block all web crawlers from indexing the proxy server endpoints
-         *     This is useful for ensuring that the API endpoints aren't indexed by search engines
-         */
-        get: operations["get_robots_robots_txt_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -14112,26 +13825,6 @@ export interface paths {
          *     }
          */
         get: operations["ui_get_available_role_user_available_roles_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/user/available_users": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Available Enterprise Users
-         * @description For keys with `max_users` set, return the list of users that are allowed to use the key.
-         */
-        get: operations["available_enterprise_users_user_available_users_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -20397,37 +20090,6 @@ export interface components {
              */
             unnamed_teams_count: number;
         };
-        /**
-         * AuditLogResponse
-         * @description Response model for a single audit log entry
-         */
-        AuditLogResponse: {
-            /** Action */
-            action: string;
-            /** Before Value */
-            before_value?: {
-                [key: string]: unknown;
-            } | null;
-            /** Changed By */
-            changed_by: string;
-            /** Changed By Api Key */
-            changed_by_api_key: string;
-            /** Id */
-            id: string;
-            /** Object Id */
-            object_id: string;
-            /** Table Name */
-            table_name: string;
-            /**
-             * Updated At
-             * Format: date-time
-             */
-            updated_at: string;
-            /** Updated Values */
-            updated_values?: {
-                [key: string]: unknown;
-            } | null;
-        };
         /** BaseLitellmParams */
         "BaseLitellmParams-Input": {
             /**
@@ -20836,12 +20498,18 @@ export interface components {
         };
         /** Body_audio_transcriptions_audio_transcriptions_post */
         Body_audio_transcriptions_audio_transcriptions_post: {
-            /** File */
+            /**
+             * File
+             * Format: binary
+             */
             file: string;
         };
         /** Body_audio_transcriptions_v1_audio_transcriptions_post */
         Body_audio_transcriptions_v1_audio_transcriptions_post: {
-            /** File */
+            /**
+             * File
+             * Format: binary
+             */
             file: string;
         };
         /** Body_convert_prompt_file_to_json_utils_dotprompt_json_converter_post */
@@ -20859,7 +20527,10 @@ export interface components {
              * @default openai
              */
             custom_llm_provider: string;
-            /** File */
+            /**
+             * File
+             * Format: binary
+             */
             file: string;
             /** Litellm Metadata */
             litellm_metadata?: string | null;
@@ -20883,7 +20554,10 @@ export interface components {
              * @default openai
              */
             custom_llm_provider: string;
-            /** File */
+            /**
+             * File
+             * Format: binary
+             */
             file: string;
             /** Litellm Metadata */
             litellm_metadata?: string | null;
@@ -20907,7 +20581,10 @@ export interface components {
              * @default openai
              */
             custom_llm_provider: string;
-            /** File */
+            /**
+             * File
+             * Format: binary
+             */
             file: string;
             /** Litellm Metadata */
             litellm_metadata?: string | null;
@@ -20928,34 +20605,34 @@ export interface components {
         Body_image_edit_api_images_edits_post: {
             /** Image */
             image?: string[] | null;
-            /** Image[] */
-            "image[]"?: string[] | null;
+            /** Image Array */
+            image_array?: string[] | null;
             /** Mask */
             mask?: string[] | null;
-            /** Mask[] */
-            "mask[]"?: string[] | null;
+            /** Mask Array */
+            mask_array?: string[] | null;
         };
         /** Body_image_edit_api_openai_deployments__model__images_edits_post */
         Body_image_edit_api_openai_deployments__model__images_edits_post: {
             /** Image */
             image?: string[] | null;
-            /** Image[] */
-            "image[]"?: string[] | null;
+            /** Image Array */
+            image_array?: string[] | null;
             /** Mask */
             mask?: string[] | null;
-            /** Mask[] */
-            "mask[]"?: string[] | null;
+            /** Mask Array */
+            mask_array?: string[] | null;
         };
         /** Body_image_edit_api_v1_images_edits_post */
         Body_image_edit_api_v1_images_edits_post: {
             /** Image */
             image?: string[] | null;
-            /** Image[] */
-            "image[]"?: string[] | null;
+            /** Image Array */
+            image_array?: string[] | null;
             /** Mask */
             mask?: string[] | null;
-            /** Mask[] */
-            "mask[]"?: string[] | null;
+            /** Mask Array */
+            mask_array?: string[] | null;
         };
         /** Body_test_model_connection_health_test_connection_post */
         Body_test_model_connection_health_test_connection_post: {
@@ -20982,21 +20659,30 @@ export interface components {
         };
         /** Body_upload_logo_upload_logo_post */
         Body_upload_logo_upload_logo_post: {
-            /** File */
+            /**
+             * File
+             * Format: binary
+             */
             file: string;
         };
         /** Body_video_create_character_v1_videos_characters_post */
         Body_video_create_character_v1_videos_characters_post: {
             /** Name */
             name: string;
-            /** Video */
+            /**
+             * Video
+             * Format: binary
+             */
             video: string;
         };
         /** Body_video_create_character_videos_characters_post */
         Body_video_create_character_videos_characters_post: {
             /** Name */
             name: string;
-            /** Video */
+            /**
+             * Video
+             * Format: binary
+             */
             video: string;
         };
         /** Body_video_generation_v1_videos_post */
@@ -22818,14 +22504,6 @@ export interface components {
             organization_ids: string[];
         };
         /**
-         * DeleteProjectRequest
-         * @description Request model for DELETE /project/delete
-         */
-        DeleteProjectRequest: {
-            /** Project Ids */
-            project_ids: string[];
-        };
-        /**
          * DeleteSkillResponse
          * @description Response from deleting a skill
          */
@@ -22938,27 +22616,6 @@ export interface components {
             user_table_name: string;
             /** Write Capacity Units */
             write_capacity_units?: number | null;
-        };
-        /**
-         * EmailEvent
-         * @enum {string}
-         */
-        EmailEvent: "Virtual Key Created" | "New User Invitation" | "Virtual Key Rotated" | "Soft Budget Crossed" | "Max Budget Alert";
-        /** EmailEventSettings */
-        EmailEventSettings: {
-            /** Enabled */
-            enabled: boolean;
-            event: components["schemas"]["EmailEvent"];
-        };
-        /** EmailEventSettingsResponse */
-        EmailEventSettingsResponse: {
-            /** Settings */
-            settings: components["schemas"]["EmailEventSettings"][];
-        };
-        /** EmailEventSettingsUpdateRequest */
-        EmailEventSettingsUpdateRequest: {
-            /** Settings */
-            settings: components["schemas"]["EmailEventSettings"][];
         };
         /** EmbeddingRequest */
         EmbeddingRequest: {
@@ -25230,65 +24887,6 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
-        /**
-         * LiteLLM_ProjectTable
-         * @description Database model representation for project
-         */
-        LiteLLM_ProjectTable: {
-            /**
-             * Blocked
-             * @default false
-             */
-            blocked: boolean;
-            /** Budget Id */
-            budget_id?: string | null;
-            /** Created At */
-            created_at?: string | null;
-            /** Created By */
-            created_by?: string | null;
-            /** Description */
-            description?: string | null;
-            litellm_budget_table?: components["schemas"]["LiteLLM_BudgetTable"] | null;
-            /** Metadata */
-            metadata?: {
-                [key: string]: unknown;
-            } | null;
-            /** Model Rpm Limit */
-            model_rpm_limit?: {
-                [key: string]: unknown;
-            } | null;
-            /** Model Spend */
-            model_spend?: {
-                [key: string]: unknown;
-            } | null;
-            /** Model Tpm Limit */
-            model_tpm_limit?: {
-                [key: string]: unknown;
-            } | null;
-            /**
-             * Models
-             * @default []
-             */
-            models: string[];
-            object_permission?: components["schemas"]["LiteLLM_ObjectPermissionTable"] | null;
-            /** Object Permission Id */
-            object_permission_id?: string | null;
-            /** Project Alias */
-            project_alias?: string | null;
-            /** Project Id */
-            project_id: string;
-            /**
-             * Spend
-             * @default 0
-             */
-            spend: number;
-            /** Team Id */
-            team_id?: string | null;
-            /** Updated At */
-            updated_at?: string | null;
-            /** Updated By */
-            updated_by?: string | null;
-        };
         /** LiteLLM_ProxyModelTable */
         LiteLLM_ProxyModelTable: {
             /**
@@ -27301,134 +26899,6 @@ export interface components {
             /** Users */
             users?: components["schemas"]["LiteLLM_UserTable"][] | null;
         };
-        /**
-         * NewProjectRequest
-         * @description Request model for POST /project/new
-         */
-        NewProjectRequest: {
-            /** Allowed Models */
-            allowed_models?: string[] | null;
-            /**
-             * Blocked
-             * @default false
-             */
-            blocked: boolean;
-            /** Budget Duration */
-            budget_duration?: string | null;
-            /** Budget Id */
-            budget_id?: string | null;
-            /** Description */
-            description?: string | null;
-            /** Guardrails */
-            guardrails?: string[] | null;
-            /** Max Budget */
-            max_budget?: number | null;
-            /** Max Parallel Requests */
-            max_parallel_requests?: number | null;
-            /** Metadata */
-            metadata?: {
-                [key: string]: unknown;
-            } | null;
-            /** Model Max Budget */
-            model_max_budget?: {
-                [key: string]: unknown;
-            } | null;
-            /** Model Rpm Limit */
-            model_rpm_limit?: {
-                [key: string]: unknown;
-            } | null;
-            /** Model Tpm Limit */
-            model_tpm_limit?: {
-                [key: string]: unknown;
-            } | null;
-            /**
-             * Models
-             * @default []
-             */
-            models: string[];
-            object_permission?: components["schemas"]["LiteLLM_ObjectPermissionBase"] | null;
-            /** Policies */
-            policies?: string[] | null;
-            /** Project Alias */
-            project_alias?: string | null;
-            /** Project Id */
-            project_id?: string | null;
-            /** Rpm Limit */
-            rpm_limit?: number | null;
-            /** Soft Budget */
-            soft_budget?: number | null;
-            /** Tags */
-            tags?: string[] | null;
-            /** Team Id */
-            team_id: string;
-            /** Tpm Limit */
-            tpm_limit?: number | null;
-        };
-        /**
-         * NewProjectResponse
-         * @description Response model for POST /project/new
-         */
-        NewProjectResponse: {
-            /**
-             * Blocked
-             * @default false
-             */
-            blocked: boolean;
-            /** Budget Id */
-            budget_id?: string | null;
-            /**
-             * Created At
-             * Format: date-time
-             */
-            created_at: string;
-            /** Created By */
-            created_by?: string | null;
-            /** Description */
-            description?: string | null;
-            litellm_budget_table?: components["schemas"]["LiteLLM_BudgetTable"] | null;
-            /** Metadata */
-            metadata?: {
-                [key: string]: unknown;
-            } | null;
-            /** Model Rpm Limit */
-            model_rpm_limit?: {
-                [key: string]: unknown;
-            } | null;
-            /** Model Spend */
-            model_spend?: {
-                [key: string]: unknown;
-            } | null;
-            /** Model Tpm Limit */
-            model_tpm_limit?: {
-                [key: string]: unknown;
-            } | null;
-            /**
-             * Models
-             * @default []
-             */
-            models: string[];
-            object_permission?: components["schemas"]["LiteLLM_ObjectPermissionTable"] | null;
-            /** Object Permission Id */
-            object_permission_id?: string | null;
-            /** Project Alias */
-            project_alias?: string | null;
-            /** Project Id */
-            project_id: string;
-            /**
-             * Spend
-             * @default 0
-             */
-            spend: number;
-            /** Team Id */
-            team_id?: string | null;
-            /**
-             * Updated At
-             * Format: date-time
-             */
-            updated_at: string;
-            /** Updated By */
-            updated_by?: string | null;
-        };
         /** NewTeamRequest */
         NewTeamRequest: {
             /** Access Group Ids */
@@ -27937,34 +27407,6 @@ export interface components {
         OrganizationRequest: {
             /** Organizations */
             organizations: string[];
-        };
-        /**
-         * PaginatedAuditLogResponse
-         * @description Response model for paginated audit logs
-         */
-        PaginatedAuditLogResponse: {
-            /** Audit Logs */
-            audit_logs: components["schemas"]["AuditLogResponse"][];
-            /**
-             * Page
-             * @description Current page number
-             */
-            page: number;
-            /**
-             * Page Size
-             * @description Number of items per page
-             */
-            page_size: number;
-            /**
-             * Total
-             * @description Total number of audit logs matching the filters
-             */
-            total: number;
-            /**
-             * Total Pages
-             * @description Total number of pages
-             */
-            total_pages: number;
         };
         /** PassThroughEndpointResponse */
         PassThroughEndpointResponse: {
@@ -31417,63 +30859,6 @@ export interface components {
             model_names?: string[] | null;
         };
         /**
-         * UpdateProjectRequest
-         * @description Request model for POST /project/update
-         */
-        UpdateProjectRequest: {
-            /** Allowed Models */
-            allowed_models?: string[] | null;
-            /** Blocked */
-            blocked?: boolean | null;
-            /** Budget Duration */
-            budget_duration?: string | null;
-            /** Budget Id */
-            budget_id?: string | null;
-            /** Description */
-            description?: string | null;
-            /** Guardrails */
-            guardrails?: string[] | null;
-            /** Max Budget */
-            max_budget?: number | null;
-            /** Max Parallel Requests */
-            max_parallel_requests?: number | null;
-            /** Metadata */
-            metadata?: {
-                [key: string]: unknown;
-            } | null;
-            /** Model Max Budget */
-            model_max_budget?: {
-                [key: string]: unknown;
-            } | null;
-            /** Model Rpm Limit */
-            model_rpm_limit?: {
-                [key: string]: unknown;
-            } | null;
-            /** Model Tpm Limit */
-            model_tpm_limit?: {
-                [key: string]: unknown;
-            } | null;
-            /** Models */
-            models?: string[] | null;
-            object_permission?: components["schemas"]["LiteLLM_ObjectPermissionBase"] | null;
-            /** Policies */
-            policies?: string[] | null;
-            /** Project Alias */
-            project_alias?: string | null;
-            /** Project Id */
-            project_id: string;
-            /** Rpm Limit */
-            rpm_limit?: number | null;
-            /** Soft Budget */
-            soft_budget?: number | null;
-            /** Tags */
-            tags?: string[] | null;
-            /** Team Id */
-            team_id?: string | null;
-            /** Tpm Limit */
-            tpm_limit?: number | null;
-        };
-        /**
          * UpdatePublicModelGroupsRequest
          * @description Request model for updating public model groups
          */
@@ -32340,10 +31725,6 @@ export interface components {
         };
         /** ValidationError */
         ValidationError: {
-            /** Context */
-            ctx?: Record<string, never>;
-            /** Input */
-            input?: unknown;
             /** Location */
             loc: (string | number)[];
             /** Message */
@@ -33517,6 +32898,26 @@ export interface operations {
             };
         };
     };
+    list_plugins_api_plugins_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown[];
+                };
+            };
+        };
+    };
     apply_guardrail_apply_guardrail_post: {
         parameters: {
             query?: never;
@@ -33826,105 +33227,6 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
                 };
-            };
-        };
-    };
-    get_audit_logs_audit_get: {
-        parameters: {
-            query?: {
-                page?: number;
-                page_size?: number;
-                /** @description Filter by user or system that performed the action */
-                changed_by?: string | null;
-                /** @description Filter by API key hash that performed the action */
-                changed_by_api_key?: string | null;
-                /** @description Filter by action type (create, update, delete) */
-                action?: string | null;
-                /** @description Filter by table name that was modified */
-                table_name?: string | null;
-                /** @description Filter by ID of the object that was modified */
-                object_id?: string | null;
-                /** @description Filter logs after this date */
-                start_date?: string | null;
-                /** @description Filter logs before this date */
-                end_date?: string | null;
-                /** @description Filter by team_id present in before_value or updated_values JSON (PostgreSQL only) */
-                object_team_id?: string | null;
-                /** @description Filter by token (key hash) present in before_value or updated_values JSON (PostgreSQL only) */
-                object_key_hash?: string | null;
-                /** @description Column to sort by (e.g. 'updated_at', 'action', 'table_name') */
-                sort_by?: string | null;
-                /** @description Sort order ('asc' or 'desc') */
-                sort_order?: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PaginatedAuditLogResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_audit_log_by_id_audit__id__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AuditLogResponse"];
-                };
-            };
-            /** @description Audit log not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-            /** @description Database connection error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
             };
         };
     };
@@ -37397,79 +36699,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_email_event_settings_email_event_settings_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["EmailEventSettingsResponse"];
-                };
-            };
-        };
-    };
-    update_event_settings_email_event_settings_patch: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["EmailEventSettingsUpdateRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    reset_event_settings_email_event_settings_reset_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
                 };
             };
         };
@@ -43677,7 +42906,11 @@ export interface operations {
     };
     websocket_realtime_websocket_endpoint_get_3: {
         parameters: {
-            query?: never;
+            query?: {
+                model?: string;
+                intent?: string;
+                guardrails?: string;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -44544,6 +43777,230 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+        };
+    };
+    plugin_proxy_plugin_proxy__plugin_name___path__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                plugin_name: string;
+                path: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    plugin_proxy_plugin_proxy__plugin_name___path__put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                plugin_name: string;
+                path: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    plugin_proxy_plugin_proxy__plugin_name___path__post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                plugin_name: string;
+                path: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    plugin_proxy_plugin_proxy__plugin_name___path__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                plugin_name: string;
+                path: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    plugin_proxy_plugin_proxy__plugin_name___path__options: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                plugin_name: string;
+                path: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    plugin_proxy_plugin_proxy__plugin_name___path__head: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                plugin_name: string;
+                path: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    plugin_proxy_plugin_proxy__plugin_name___path__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                plugin_name: string;
+                path: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };
@@ -45428,156 +44885,6 @@ export interface operations {
             };
         };
     };
-    delete_project_project_delete_delete: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["DeleteProjectRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["LiteLLM_ProjectTable"][];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    project_info_project_info_get: {
-        parameters: {
-            query: {
-                project_id: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["LiteLLM_ProjectTable"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    list_projects_project_list_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["LiteLLM_ProjectTable"][];
-                };
-            };
-        };
-    };
-    new_project_project_new_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["NewProjectRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["NewProjectResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    update_project_project_update_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["UpdateProjectRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["LiteLLM_ProjectTable"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
     create_prompt_prompts_post: {
         parameters: {
             query?: never;
@@ -46192,7 +45499,11 @@ export interface operations {
     };
     websocket_realtime_websocket_endpoint_get: {
         parameters: {
-            query?: never;
+            query?: {
+                model?: string;
+                intent?: string;
+                guardrails?: string;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -46310,7 +45621,9 @@ export interface operations {
     };
     websocket_responses_websocket_endpoint_get: {
         parameters: {
-            query?: never;
+            query?: {
+                model?: string;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -46486,26 +45799,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_robots_robots_txt_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
                 };
             };
         };
@@ -50095,26 +49388,6 @@ export interface operations {
         };
     };
     ui_get_available_role_user_available_roles_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    available_enterprise_users_user_available_users_get: {
         parameters: {
             query?: never;
             header?: never;
@@ -53959,7 +53232,11 @@ export interface operations {
     };
     websocket_realtime_websocket_endpoint_get_2: {
         parameters: {
-            query?: never;
+            query?: {
+                model?: string;
+                intent?: string;
+                guardrails?: string;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -54037,7 +53314,9 @@ export interface operations {
     };
     websocket_responses_websocket_endpoint_get_2: {
         parameters: {
-            query?: never;
+            query?: {
+                model?: string;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -57346,7 +56625,11 @@ export interface operations {
     };
     websocket_vertex_ai_live_passthrough_endpoint: {
         parameters: {
-            query?: never;
+            query?: {
+                model?: string;
+                vertex_project?: string;
+                vertex_location?: string;
+            };
             header?: never;
             path?: never;
             cookie?: never;

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -44634,39 +44634,6 @@ export interface operations {
             };
         };
     };
-    create_policy_policies_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["PolicyCreateRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PolicyDBResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
     plugin_proxy_plugin_proxy__plugin_name___path__get: {
         parameters: {
             query?: never;
@@ -44878,6 +44845,39 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_policy_policies_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PolicyCreateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PolicyDBResponse"];
                 };
             };
             /** @description Validation Error */

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -436,6 +436,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/alerting/settings": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Alerting Settings
+         * @description Return the configurable alerting param, description, and current value
+         */
+        get: operations["alerting_settings_alerting_settings_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/anthropic/{endpoint}": {
         parameters: {
             query?: never;
@@ -489,6 +509,28 @@ export interface paths {
          *     It exists to prevent 404 errors from Claude Code clients that send telemetry.
          */
         post: operations["event_logging_batch_api_event_logging_batch_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/plugins": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Plugins
+         * @description Return registered plugins for authenticated UI callers.
+         *
+         *     plugin_key is only returned to callers with a valid litellm token.
+         */
+        get: operations["list_plugins_api_plugins_get"];
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -1770,6 +1812,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/config/callback/delete": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Delete Callback
+         * @description Delete specific logging callback from configuration.
+         */
+        post: operations["delete_callback_config_callback_delete_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/config/cost_discount_config": {
         parameters: {
             query?: never;
@@ -1851,6 +1913,83 @@ export interface paths {
         patch: operations["update_cost_margin_config_config_cost_margin_config_patch"];
         trace?: never;
     };
+    "/config/field/delete": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Delete Config General Settings
+         * @description Delete the db value of this field in litellm general settings. Resets it to it's initial default value on litellm.
+         */
+        post: operations["delete_config_general_settings_config_field_delete_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/config/field/info": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Config General Settings */
+        get: operations["get_config_general_settings_config_field_info_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/config/field/update": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Update Config General Settings
+         * @description Update a specific field in litellm general settings
+         */
+        post: operations["update_config_general_settings_config_field_update_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/config/list": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Config List
+         * @description List the available fields + current values for a given type of setting (currently just 'general_settings'user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),)
+         */
+        get: operations["get_config_list_config_list_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/config/pass_through_endpoint": {
         parameters: {
             query?: never;
@@ -1919,6 +2058,64 @@ export interface paths {
          * @description Update a pass-through endpoint by ID.
          */
         post: operations["update_pass_through_endpoints_config_pass_through_endpoint__endpoint_id__post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/config/update": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Update Config
+         * @description For Admin UI - allows admin to update config via UI.
+         *
+         *     Writes only the sections present in the request body to LiteLLM_Config rows
+         *     (one row per top-level section). Sections the caller did not send are left
+         *     untouched — this endpoint never persists pre-existing YAML values to DB as
+         *     a side effect of an unrelated update.
+         */
+        post: operations["update_config_config_update_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/config/yaml": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Config Yaml Endpoint
+         * @description This is a mock endpoint, to show what you can set in config.yaml details in the Swagger UI.
+         *
+         *     Parameters:
+         *
+         *     The config.yaml object has the following attributes:
+         *     - **model_list**: *Optional[List[ModelParams]]* - A list of supported models on the server, along with model-specific configurations. ModelParams includes "model_name" (name of the model), "litellm_params" (litellm-specific parameters for the model), and "model_info" (additional info about the model such as id, mode, cost per token, etc).
+         *
+         *     - **litellm_settings**: *Optional[dict]*: Settings for the litellm module. You can specify multiple properties like "drop_params", "set_verbose", "api_base", "cache".
+         *
+         *     - **general_settings**: *Optional[ConfigGeneralSettings]*: General settings for the server like "completion_model" (default model for chat completion calls), "use_azure_key_vault" (option to load keys from azure key vault), "master_key" (key required for all calls to proxy), and others.
+         *
+         *     Please, refer to each class's description for a better understanding of the specific attributes within them.
+         *
+         *     Note: This is a mock endpoint primarily meant for demonstration purposes, and does not actually provide or change any configurations.
+         */
+        get: operations["config_yaml_endpoint_config_yaml_get"];
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -2764,6 +2961,120 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/debug/memory/details": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Memory Details
+         * @description Get detailed memory diagnostics for deep debugging.
+         *
+         *     Returns:
+         *     - worker_pid: Process ID
+         *     - process_memory: RAM usage, virtual memory, file handles, threads
+         *     - garbage_collector: GC thresholds, counts, collection history
+         *     - objects: Total tracked objects and top object types
+         *     - uncollectable: Objects that can't be garbage collected (potential leaks)
+         *     - cache_memory: Memory usage of user_api_key, router, and logging caches
+         *     - router_memory: Memory usage of router components (model_list, deployment_names, etc.)
+         *
+         *     Query Parameters:
+         *     - top_n: Number of top object types to return (default: 20)
+         *     - include_process_info: Include process-level memory info using psutil (default: true)
+         *
+         *     Example usage:
+         *     curl "http://localhost:4000/debug/memory/details?top_n=30" -H "Authorization: Bearer sk-1234"
+         *
+         *     All memory sizes are reported in both bytes and MB.
+         */
+        get: operations["get_memory_details_debug_memory_details_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/debug/memory/gc/configure": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Configure Gc Thresholds Endpoint
+         * @description Configure Python garbage collection thresholds.
+         *
+         *     Lower thresholds mean more frequent GC cycles (less memory, more CPU overhead).
+         *     Higher thresholds mean less frequent GC cycles (more memory, less CPU overhead).
+         *
+         *     Returns:
+         *     - message: Confirmation message
+         *     - previous_thresholds: Old threshold values
+         *     - new_thresholds: New threshold values
+         *     - objects_awaiting_collection: Current object count in gen-0
+         *     - tip: Hint about when next collection will occur
+         *
+         *     Query Parameters:
+         *     - generation_0: Number of allocations before gen-0 collection (default: 700)
+         *     - generation_1: Number of gen-0 collections before gen-1 collection (default: 10)
+         *     - generation_2: Number of gen-1 collections before gen-2 collection (default: 10)
+         *
+         *     Example for more aggressive collection:
+         *     curl -X POST "http://localhost:4000/debug/memory/gc/configure?generation_0=500" -H "Authorization: Bearer sk-1234"
+         *
+         *     Example for less aggressive collection:
+         *     curl -X POST "http://localhost:4000/debug/memory/gc/configure?generation_0=1000" -H "Authorization: Bearer sk-1234"
+         *
+         *     Monitor memory usage with GET /debug/memory/summary after changes.
+         */
+        post: operations["configure_gc_thresholds_endpoint_debug_memory_gc_configure_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/debug/memory/summary": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Memory Summary
+         * @description Get simplified memory usage summary for the proxy.
+         *
+         *     Returns:
+         *     - worker_pid: Process ID
+         *     - status: Overall health based on memory usage
+         *     - memory: Process memory usage and RAM info
+         *     - caches: Cache item counts and descriptions
+         *     - garbage_collector: GC status and pending object counts
+         *
+         *     Example usage:
+         *     curl http://localhost:4000/debug/memory/summary -H "Authorization: Bearer sk-1234"
+         *
+         *     For detailed analysis, call GET /debug/memory/details
+         *     For cache management, use the cache management endpoints
+         */
+        get: operations["get_memory_summary_debug_memory_summary_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/delete/allowed_ip": {
         parameters: {
             query?: never;
@@ -2849,6 +3160,312 @@ export interface paths {
          *     ```
          */
         post: operations["embeddings_embeddings_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/end_user/block": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Block User
+         * @description [BETA] Reject calls with this end-user id
+         *
+         *     Parameters:
+         *     - user_ids (List[str], required): The unique `user_id`s for the users to block
+         *
+         *         (any /chat/completion call with this user={end-user-id} param, will be rejected.)
+         *
+         *         ```
+         *         curl -X POST "http://0.0.0.0:8000/user/block"
+         *         -H "Authorization: Bearer sk-1234"
+         *         -d '{
+         *         "user_ids": [<user_id>, ...]
+         *         }'
+         *         ```
+         */
+        post: operations["block_user_end_user_block_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/end_user/daily/activity": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Customer Daily Activity
+         * @description Get daily activity for specific organizations or all accessible organizations.
+         */
+        get: operations["get_customer_daily_activity_end_user_daily_activity_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/end_user/delete": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Delete End User
+         * @description Delete multiple end-users.
+         *
+         *     Parameters:
+         *     - user_ids (List[str], required): The unique `user_id`s for the users to delete
+         *
+         *     Example curl:
+         *     ```
+         *     curl --location 'http://0.0.0.0:4000/customer/delete'         --header 'Authorization: Bearer sk-1234'         --header 'Content-Type: application/json'         --data '{
+         *             "user_ids" :["ishaan-jaff-5"]
+         *     }'
+         *
+         *     See below for all params
+         *     ```
+         */
+        post: operations["delete_end_user_end_user_delete_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/end_user/info": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * End User Info
+         * @description Get information about an end-user. An `end_user` is a customer (external user) of the proxy.
+         *
+         *     Parameters:
+         *     - end_user_id (str, required): The unique identifier for the end-user
+         *
+         *     Example curl:
+         *     ```
+         *     curl -X GET 'http://localhost:4000/customer/info?end_user_id=test-litellm-user-4'         -H 'Authorization: Bearer sk-1234'
+         *     ```
+         */
+        get: operations["end_user_info_end_user_info_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/end_user/list": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List End User
+         * @description [Admin-only] List all available customers
+         *
+         *     Example curl:
+         *     ```
+         *     curl --location --request GET 'http://0.0.0.0:4000/customer/list'         --header 'Authorization: Bearer sk-1234'
+         *     ```
+         */
+        get: operations["list_end_user_end_user_list_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/end_user/new": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * New End User
+         * @description Allow creating a new Customer
+         *
+         *
+         *     Parameters:
+         *     - user_id: str - The unique identifier for the user.
+         *     - alias: Optional[str] - A human-friendly alias for the user.
+         *     - blocked: bool - Flag to allow or disallow requests for this end-user. Default is False.
+         *     - max_budget: Optional[float] - The maximum budget allocated to the user. Either 'max_budget' or 'budget_id' should be provided, not both.
+         *     - budget_id: Optional[str] - The identifier for an existing budget allocated to the user. Either 'max_budget' or 'budget_id' should be provided, not both.
+         *     - allowed_model_region: Optional[Union[Literal["eu"], Literal["us"]]] - Require all user requests to use models in this specific region.
+         *     - default_model: Optional[str] - If no equivalent model in the allowed region, default all requests to this model.
+         *     - metadata: Optional[dict] = Metadata for customer, store information for customer. Example metadata = {"data_training_opt_out": True}
+         *     - budget_duration: Optional[str] - Budget is reset at the end of specified duration. If not set, budget is never reset. You can set duration as seconds ("30s"), minutes ("30m"), hours ("30h"), days ("30d").
+         *     - tpm_limit: Optional[int] - [Not Implemented Yet] Specify tpm limit for a given customer (Tokens per minute)
+         *     - rpm_limit: Optional[int] - [Not Implemented Yet] Specify rpm limit for a given customer (Requests per minute)
+         *     - model_max_budget: Optional[dict] - [Not Implemented Yet] Specify max budget for a given model. Example: {"openai/gpt-4o-mini": {"max_budget": 100.0, "budget_duration": "1d"}}
+         *     - max_parallel_requests: Optional[int] - [Not Implemented Yet] Specify max parallel requests for a given customer.
+         *     - soft_budget: Optional[float] - [Not Implemented Yet] Get alerts when customer crosses given budget, doesn't block requests.
+         *     - spend: Optional[float] - Specify initial spend for a given customer.
+         *     - budget_reset_at: Optional[str] - Specify the date and time when the budget should be reset.
+         *     - object_permission: Optional[LiteLLM_ObjectPermissionBase] - Customer-specific object permissions to control access to resources.
+         *         Supported fields:
+         *         * mcp_servers: List[str] - List of allowed MCP server IDs
+         *         * mcp_access_groups: List[str] - List of MCP access group names
+         *         * mcp_tool_permissions: Dict[str, List[str]] - Map of server ID to allowed tool names (e.g., {"server_1": ["tool_a", "tool_b"]})
+         *         * vector_stores: List[str] - List of allowed vector store IDs
+         *         * agents: List[str] - List of allowed agent IDs
+         *         * agent_access_groups: List[str] - List of agent access group names
+         *         Example: {"mcp_servers": ["server_1", "server_2"], "vector_stores": ["vector_store_1"], "agents": ["agent_1"]}
+         *         IF null or {} then no object-level restrictions apply.
+         *
+         *
+         *     - Allow specifying allowed regions
+         *     - Allow specifying default model
+         *
+         *     Example curl:
+         *     ```
+         *     curl --location 'http://0.0.0.0:4000/customer/new'         --header 'Authorization: Bearer sk-1234'         --header 'Content-Type: application/json'         --data '{
+         *             "user_id" : "ishaan-jaff-3",
+         *             "allowed_region": "eu",
+         *             "budget_id": "free_tier",
+         *             "default_model": "azure/gpt-3.5-turbo-eu"
+         *         }'
+         *
+         *     # With object permissions
+         *     curl -L -X POST 'http://localhost:4000/customer/new'         -H 'Authorization: Bearer sk-1234'         -H 'Content-Type: application/json'         -d '{
+         *             "user_id": "user_1",
+         *             "object_permission": {
+         *               "mcp_servers": ["server_1"],
+         *               "mcp_access_groups": ["public_group"],
+         *               "vector_stores": ["vector_store_1"]
+         *             }
+         *           }'
+         *
+         *         # return end-user object
+         *     ```
+         *
+         *     NOTE: This used to be called `/end_user/new`, we will still be maintaining compatibility for /end_user/XXX for these endpoints
+         */
+        post: operations["new_end_user_end_user_new_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/end_user/unblock": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Unblock User
+         * @description [BETA] Unblock calls with this user id
+         *
+         *     Example
+         *     ```
+         *     curl -X POST "http://0.0.0.0:8000/user/unblock"
+         *     -H "Authorization: Bearer sk-1234"
+         *     -d '{
+         *     "user_ids": [<user_id>, ...]
+         *     }'
+         *     ```
+         */
+        post: operations["unblock_user_end_user_unblock_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/end_user/update": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Update End User
+         * @description Example curl
+         *
+         *     Parameters:
+         *     - user_id: str
+         *     - alias: Optional[str] = None  # human-friendly alias
+         *     - blocked: bool = False  # allow/disallow requests for this end-user
+         *     - max_budget: Optional[float] = None
+         *     - budget_id: Optional[str] = None  # give either a budget_id or max_budget
+         *     - allowed_model_region: Optional[AllowedModelRegion] = (
+         *         None  # require all user requests to use models in this specific region
+         *     )
+         *     - default_model: Optional[str] = (
+         *         None  # if no equivalent model in allowed region - default all requests to this model
+         *     )
+         *     - object_permission: Optional[LiteLLM_ObjectPermissionBase] - Customer-specific object permissions to control access to resources.
+         *         Supported fields:
+         *         * mcp_servers: List[str] - List of allowed MCP server IDs
+         *         * mcp_access_groups: List[str] - List of MCP access group names
+         *         * mcp_tool_permissions: Dict[str, List[str]] - Map of server ID to allowed tool names
+         *         * vector_stores: List[str] - List of allowed vector store IDs
+         *         * agents: List[str] - List of allowed agent IDs
+         *         * agent_access_groups: List[str] - List of agent access group names
+         *         Example: {"mcp_servers": ["server_1"], "vector_stores": ["vector_store_1"]}
+         *         IF null or {} then no object-level restrictions apply.
+         *
+         *     Example curl:
+         *     ```
+         *     curl --location 'http://0.0.0.0:4000/customer/update'     --header 'Authorization: Bearer sk-1234'     --header 'Content-Type: application/json'     --data '{
+         *         "user_id": "test-litellm-user-4",
+         *         "budget_id": "paid_tier"
+         *     }'
+         *
+         *     # Updating object permissions
+         *     curl -L -X POST 'http://localhost:4000/customer/update'     --header 'Authorization: Bearer sk-1234'     --header 'Content-Type: application/json'     --data '{
+         *         "user_id": "user_1",
+         *         "object_permission": {
+         *           "mcp_servers": ["server_3"],
+         *           "vector_stores": ["vector_store_2", "vector_store_3"]
+         *         }
+         *       }'
+         *
+         *     See below for all params
+         *     ```
+         */
+        post: operations["update_end_user_end_user_update_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -3004,6 +3621,28 @@ export interface paths {
          *     - `content_policy`: Fallbacks specifically for content policy violations
          */
         post: operations["create_fallback_fallback_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/fallback/login": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Fallback Login
+         * @description Create Proxy API Keys using Google Workspace SSO. Requires setting PROXY_BASE_URL in .env
+         *     PROXY_BASE_URL should be the your deployed proxy endpoint, e.g. PROXY_BASE_URL="https://litellm-production-7002.up.railway.app/"
+         *     Example:
+         */
+        get: operations["fallback_login_fallback_login_get"];
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -3296,6 +3935,44 @@ export interface paths {
         patch: operations["gemini_proxy_route_gemini__endpoint__patch"];
         trace?: never;
     };
+    "/get/allowed_ips": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Allowed Ips */
+        get: operations["get_allowed_ips_get_allowed_ips_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/get/config/callbacks": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Config
+         * @description For Admin UI - allows admin to view config via UI
+         *     # return the callbacks and the env variables for the callback
+         */
+        get: operations["get_config_get_config_callbacks_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/get/default_team_settings": {
         parameters: {
             query?: never;
@@ -3425,6 +4102,508 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/get_favicon": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Favicon
+         * @description Get custom favicon for the admin UI.
+         */
+        get: operations["get_favicon_get_favicon_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/get_image": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Image
+         * @description Get logo to show on admin UI
+         */
+        get: operations["get_image_get_image_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/get_logo_url": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Logo Url
+         * @description Get the current logo URL from environment.
+         *
+         *     Only HTTP(S) URLs are returned — those are intended to be loaded
+         *     directly by the browser from a public/internal CDN. Local file
+         *     paths set via ``UI_LOGO_PATH`` are NOT returned: they are admin-
+         *     only filesystem details, the dashboard falls back to ``/get_image``
+         *     which serves the file only when it is a supported image. Without
+         *     this filter, the unauthenticated endpoint would disclose internal
+         *     hostnames or filesystem paths to any caller.
+         */
+        get: operations["get_logo_url_get_logo_url_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/global/activity": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Global Activity
+         * @description Get number of API Requests, total tokens through proxy
+         *
+         *     {
+         *         "daily_data": [
+         *                 const chartdata = [
+         *                 {
+         *                 date: 'Jan 22',
+         *                 api_requests: 10,
+         *                 total_tokens: 2000
+         *                 },
+         *                 {
+         *                 date: 'Jan 23',
+         *                 api_requests: 10,
+         *                 total_tokens: 12
+         *                 },
+         *         ],
+         *         "sum_api_requests": 20,
+         *         "sum_total_tokens": 2012
+         *     }
+         */
+        get: operations["get_global_activity_global_activity_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/global/activity/cache_hits": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Global Activity
+         * @description Get number of cache hits, vs misses
+         *
+         *     {
+         *         "daily_data": [
+         *                 const chartdata = [
+         *                 {
+         *                     date: 'Jan 22',
+         *                     cache_hits: 10,
+         *                     llm_api_calls: 2000
+         *                 },
+         *                 {
+         *                     date: 'Jan 23',
+         *                     cache_hits: 10,
+         *                     llm_api_calls: 12
+         *                 },
+         *         ],
+         *         "sum_cache_hits": 20,
+         *         "sum_llm_api_calls": 2012
+         *     }
+         */
+        get: operations["get_global_activity_global_activity_cache_hits_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/global/activity/exceptions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Global Activity Exceptions
+         * @description Get number of API Requests, total tokens through proxy
+         *
+         *     {
+         *         "daily_data": [
+         *                 const chartdata = [
+         *                 {
+         *                 date: 'Jan 22',
+         *                 num_rate_limit_exceptions: 10,
+         *                 },
+         *                 {
+         *                 date: 'Jan 23',
+         *                 num_rate_limit_exceptions: 10,
+         *                 },
+         *         ],
+         *         "sum_api_exceptions": 20,
+         *     }
+         */
+        get: operations["get_global_activity_exceptions_global_activity_exceptions_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/global/activity/exceptions/deployment": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Global Activity Exceptions Per Deployment
+         * @description Get number of 429 errors - Grouped by deployment
+         *
+         *     [
+         *         {
+         *             "deployment": "https://azure-us-east-1.openai.azure.com/",
+         *             "daily_data": [
+         *                     const chartdata = [
+         *                     {
+         *                     date: 'Jan 22',
+         *                     num_rate_limit_exceptions: 10
+         *                     },
+         *                     {
+         *                     date: 'Jan 23',
+         *                     num_rate_limit_exceptions: 12
+         *                     },
+         *             ],
+         *             "sum_num_rate_limit_exceptions": 20,
+         *
+         *         },
+         *         {
+         *             "deployment": "https://azure-us-east-1.openai.azure.com/",
+         *             "daily_data": [
+         *                     const chartdata = [
+         *                     {
+         *                     date: 'Jan 22',
+         *                     num_rate_limit_exceptions: 10,
+         *                     },
+         *                     {
+         *                     date: 'Jan 23',
+         *                     num_rate_limit_exceptions: 12
+         *                     },
+         *             ],
+         *             "sum_num_rate_limit_exceptions": 20,
+         *
+         *         },
+         *     ]
+         */
+        get: operations["get_global_activity_exceptions_per_deployment_global_activity_exceptions_deployment_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/global/activity/model": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Global Activity Model
+         * @description Get number of API Requests, total tokens through proxy - Grouped by MODEL
+         *
+         *     [
+         *         {
+         *             "model": "gpt-4",
+         *             "daily_data": [
+         *                     const chartdata = [
+         *                     {
+         *                     date: 'Jan 22',
+         *                     api_requests: 10,
+         *                     total_tokens: 2000
+         *                     },
+         *                     {
+         *                     date: 'Jan 23',
+         *                     api_requests: 10,
+         *                     total_tokens: 12
+         *                     },
+         *             ],
+         *             "sum_api_requests": 20,
+         *             "sum_total_tokens": 2012
+         *
+         *         },
+         *         {
+         *             "model": "azure/gpt-4-turbo",
+         *             "daily_data": [
+         *                     const chartdata = [
+         *                     {
+         *                     date: 'Jan 22',
+         *                     api_requests: 10,
+         *                     total_tokens: 2000
+         *                     },
+         *                     {
+         *                     date: 'Jan 23',
+         *                     api_requests: 10,
+         *                     total_tokens: 12
+         *                     },
+         *             ],
+         *             "sum_api_requests": 20,
+         *             "sum_total_tokens": 2012
+         *
+         *         },
+         *     ]
+         */
+        get: operations["get_global_activity_model_global_activity_model_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/global/all_end_users": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Global View All End Users
+         * @description [BETA] This is a beta endpoint. It will change.
+         *
+         *     Use this to just get all the unique `end_users`
+         */
+        get: operations["global_view_all_end_users_global_all_end_users_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/global/spend": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Global Spend
+         * @description [BETA] This is a beta endpoint. It will change.
+         *
+         *     View total spend across all proxy keys
+         */
+        get: operations["global_spend_global_spend_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/global/spend/all_tag_names": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Global Get All Tag Names */
+        get: operations["global_get_all_tag_names_global_spend_all_tag_names_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/global/spend/end_users": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Global Spend End Users
+         * @description [BETA] This is a beta endpoint. It will change.
+         *
+         *     Use this to get the top 'n' keys with the highest spend, ordered by spend.
+         */
+        post: operations["global_spend_end_users_global_spend_end_users_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/global/spend/keys": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Global Spend Keys
+         * @description [BETA] This is a beta endpoint. It will change.
+         *
+         *     Use this to get the top 'n' keys with the highest spend, ordered by spend.
+         */
+        get: operations["global_spend_keys_global_spend_keys_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/global/spend/logs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Global Spend Logs
+         * @description [BETA] This is a beta endpoint. It will change.
+         *
+         *     Use this to get global spend (spend per day for last 30d). Admin-only endpoint
+         *
+         *     More efficient implementation of /spend/logs, by creating a view over the spend logs table.
+         */
+        get: operations["global_spend_logs_global_spend_logs_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/global/spend/models": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Global Spend Models
+         * @description [BETA] This is a beta endpoint. It will change.
+         *
+         *     Use this to get the top 'n' models with the highest spend, ordered by spend.
+         */
+        get: operations["global_spend_models_global_spend_models_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/global/spend/provider": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Global Spend Provider
+         * @description Get breakdown of spend per provider
+         *     [
+         *         {
+         *             "provider": "Azure OpenAI",
+         *             "spend": 20
+         *         },
+         *         {
+         *             "provider": "OpenAI",
+         *             "spend": 10
+         *         },
+         *         {
+         *             "provider": "VertexAI",
+         *             "spend": 30
+         *         }
+         *     ]
+         */
+        get: operations["get_global_spend_provider_global_spend_provider_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/global/spend/refresh": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Global Spend Refresh
+         * @description ADMIN ONLY / MASTER KEY Only Endpoint
+         *
+         *     Globally refresh spend MonthlyGlobalSpend view
+         */
+        post: operations["global_spend_refresh_global_spend_refresh_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/global/spend/report": {
         parameters: {
             query?: never;
@@ -3519,6 +4698,28 @@ export interface paths {
          *     ```
          */
         get: operations["global_view_spend_tags_global_spend_tags_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/global/spend/teams": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Global Spend Per Team
+         * @description [BETA] This is a beta endpoint. It will change.
+         *
+         *     Use this to get daily spend, grouped by `team_id` and `date`
+         */
+        get: operations["global_spend_per_team_global_spend_teams_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -4860,6 +6061,111 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/invitation/delete": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Invitation Delete
+         * @description Delete invitation link
+         *
+         *     ```
+         *     curl -X POST 'http://localhost:4000/invitation/delete'         -H 'Content-Type: application/json'         -d '{
+         *             "invitation_id": "1234" // 👈 id of invitation in 'LiteLLM_InvitationTable'
+         *         }'
+         *     ```
+         */
+        post: operations["invitation_delete_invitation_delete_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/invitation/info": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Invitation Info
+         * @description Allow admin to create invite links, to onboard new users to Admin UI.
+         *
+         *     ```
+         *     curl -X POST 'http://localhost:4000/invitation/new'         -H 'Content-Type: application/json'         -d '{
+         *             "user_id": "1234" // 👈 id of user in 'LiteLLM_UserTable'
+         *         }'
+         *     ```
+         */
+        get: operations["invitation_info_invitation_info_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/invitation/new": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * New Invitation
+         * @description Allow admin to create invite links, to onboard new users to Admin UI.
+         *
+         *     ```
+         *     curl -X POST 'http://localhost:4000/invitation/new'         -H 'Content-Type: application/json'         -d '{
+         *             "user_id": "1234" // 👈 id of user in 'LiteLLM_UserTable'
+         *         }'
+         *     ```
+         */
+        post: operations["new_invitation_invitation_new_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/invitation/update": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Invitation Update
+         * @description Update when invitation is accepted
+         *
+         *     ```
+         *     curl -X POST 'http://localhost:4000/invitation/update'         -H 'Content-Type: application/json'         -d '{
+         *             "invitation_id": "1234" // 👈 id of invitation in 'LiteLLM_InvitationTable'
+         *             "is_accepted": True // when invitation is accepted
+         *         }'
+         *     ```
+         */
+        post: operations["invitation_update_invitation_update_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/jwt/key/mapping/delete": {
         parameters: {
             query?: never;
@@ -5700,6 +7006,23 @@ export interface paths {
         patch: operations["langfuse_proxy_route_langfuse__endpoint__patch"];
         trace?: never;
     };
+    "/lazy/warm/{name}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Warm */
+        post: operations["warm_lazy_warm__name__post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/litellm/.well-known/litellm-ui-config": {
         parameters: {
             query?: never;
@@ -5711,6 +7034,23 @@ export interface paths {
         get: operations["get_ui_config_litellm__well_known_litellm_ui_config_get"];
         put?: never;
         post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/login": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Login */
+        post: operations["login_login_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -5814,6 +7154,52 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/memory-usage-in-mem-cache": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Memory Usage In Mem Cache
+         * @description 1. user_api_key_cache
+         *     2. router_cache
+         *     3. proxy_logging_cache
+         *     4. internal_usage_cache
+         */
+        get: operations["memory_usage_in_mem_cache_memory_usage_in_mem_cache_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/memory-usage-in-mem-cache-items": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Memory Usage In Mem Cache Items
+         * @description 1. user_api_key_cache
+         *     2. router_cache
+         *     3. proxy_logging_cache
+         *     4. internal_usage_cache
+         */
+        get: operations["memory_usage_in_mem_cache_items_memory_usage_in_mem_cache_items_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/milvus/{endpoint}": {
         parameters: {
             query?: never;
@@ -5886,6 +7272,58 @@ export interface paths {
         patch: operations["mistral_proxy_route_mistral__endpoint__patch"];
         trace?: never;
     };
+    "/model/block": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Block Model
+         * @description Block a DB-stored model deployment from serving requests.
+         *
+         *     Parameters:
+         *     - model_id: str - The model deployment id to block.
+         */
+        post: operations["block_model_model_block_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/model/cost_map/source": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Model Cost Map Source
+         * @description ADMIN ONLY / MASTER KEY Only Endpoint
+         *
+         *     Returns information about where the current model cost/pricing data was loaded from.
+         *
+         *     Response fields:
+         *     - source: "local" (bundled backup) or "remote" (fetched from URL)
+         *     - url: the remote URL that was attempted (null when env-forced local)
+         *     - is_env_forced: true if LITELLM_LOCAL_MODEL_COST_MAP=True forced local usage
+         *     - fallback_reason: human-readable reason why remote failed (null on success)
+         *     - model_count: number of models in the currently loaded cost map
+         */
+        get: operations["get_model_cost_map_source_model_cost_map_source_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/model/delete": {
         parameters: {
             query?: never;
@@ -5922,6 +7360,11 @@ export interface paths {
          *
          *         - When litellm_model_id is passed, it will return the info for that specific model
          *         - When litellm_model_id is not passed, it will return the info for all models
+         *         - include_team_models: When true, filter to deployments the caller can use (same as /v2/model/info).
+         *         - teamId: Filter to models accessible by the given team.
+         *
+         *     Each model in the list response includes `model_info.access_via_team_ids` and
+         *     `model_info.direct_access` when the proxy database is connected.
          *
          *     Returns:
          *         Returns a dictionary containing information about each model.
@@ -5955,6 +7398,66 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/model/metrics": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Model Metrics
+         * @description View number of requests & avg latency per model on config.yaml
+         */
+        get: operations["model_metrics_model_metrics_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/model/metrics/exceptions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Model Metrics Exceptions
+         * @description View number of failed requests per model on config.yaml
+         */
+        get: operations["model_metrics_exceptions_model_metrics_exceptions_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/model/metrics/slow_responses": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Model Metrics Slow Responses
+         * @description View number of hanging requests per model_group
+         */
+        get: operations["model_metrics_slow_responses_model_metrics_slow_responses_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/model/new": {
         parameters: {
             query?: never;
@@ -5969,6 +7472,69 @@ export interface paths {
          * @description Allows adding new models to the model list in the config.yaml
          */
         post: operations["add_new_model_model_new_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/model/settings": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Model Settings
+         * @description Returns provider name, description, and required parameters for each provider
+         */
+        get: operations["model_settings_model_settings_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/model/streaming_metrics": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Model Streaming Metrics
+         * @description View time to first token for models in spend logs
+         */
+        get: operations["model_streaming_metrics_model_streaming_metrics_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/model/unblock": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Unblock Model
+         * @description Unblock a DB-stored model deployment so it can serve requests again.
+         *
+         *     Parameters:
+         *     - model_id: str - The model deployment id to unblock.
+         */
+        post: operations["unblock_model_model_unblock_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -6248,6 +7814,15 @@ export interface paths {
          *     - scope: Optional scope parameter. Currently only accepts "expand".
          *              When scope=expand is passed, proxy admins, team admins, and org admins
          *              will receive all proxy models as if they are a proxy admin.
+         *     - healthy_only: When true, hide models whose backing deployments are all marked
+         *                     unhealthy by background health checks. Requires
+         *                     `background_health_checks: true` in general_settings; without
+         *                     health state the listing is returned unfiltered (fail open).
+         *                     Models expanded from wildcard routes (e.g. `openai/*`) are not
+         *                     filtered, and nothing is hidden when `allowed_fails_policy` is
+         *                     configured (cooldown remains the sole exclusion mechanism).
+         *                     Hiding is presentation-only: a hidden model can still be
+         *                     called directly.
          */
         get: operations["model_list_models_get"];
         put?: never;
@@ -6274,6 +7849,10 @@ export interface paths {
          *
          *     Follows OpenAI API specification for individual model retrieval.
          *     https://platform.openai.com/docs/api-reference/models/retrieve
+         *
+         *     Query parameters mirror `/v1/models` so the same caller context (team
+         *     scoping, health filtering, paused deployments) drives both endpoints; the
+         *     listing's public id must resolve to the same internal deployment here.
          */
         get: operations["model_info_models__model_id__get"];
         put?: never;
@@ -6405,6 +7984,58 @@ export interface paths {
          *     ```
          */
         post: operations["ocr_ocr_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/onboarding/claim_token": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Claim Onboarding Link
+         * @description Special route. Allows UI link share user to update their password.
+         *
+         *     - Get the invite link
+         *     - Validate it's still 'valid'
+         *     - Check if user within initial session (prevents abuse)
+         *     - Get user from db
+         *     - Update user password
+         *
+         *     This route can only update user password.
+         */
+        post: operations["claim_onboarding_link_onboarding_claim_token_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/onboarding/get_token": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Onboarding
+         * @description - Get the invite link
+         *     - Validate it's still 'valid'
+         *     - Return a short-lived onboarding token
+         *     - Get user from db
+         *     - Pass in user_email if set
+         */
+        get: operations["onboarding_onboarding_get_token_get"];
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -7337,6 +8968,67 @@ export interface paths {
          * @description Update an organization
          */
         patch: operations["update_organization_organization_update_patch"];
+        trace?: never;
+    };
+    "/otel-spans": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Otel Spans */
+        get: operations["get_otel_spans_otel_spans_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/plugin-proxy/{plugin_name}/{path}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Plugin Proxy
+         * @description Authenticated reverse-proxy to a registered plugin backend.
+         */
+        get: operations["plugin_proxy_plugin_proxy__plugin_name___path__get"];
+        /**
+         * Plugin Proxy
+         * @description Authenticated reverse-proxy to a registered plugin backend.
+         */
+        put: operations["plugin_proxy_plugin_proxy__plugin_name___path__put"];
+        /**
+         * Plugin Proxy
+         * @description Authenticated reverse-proxy to a registered plugin backend.
+         */
+        post: operations["plugin_proxy_plugin_proxy__plugin_name___path__post"];
+        /**
+         * Plugin Proxy
+         * @description Authenticated reverse-proxy to a registered plugin backend.
+         */
+        delete: operations["plugin_proxy_plugin_proxy__plugin_name___path__delete"];
+        /**
+         * Plugin Proxy
+         * @description Authenticated reverse-proxy to a registered plugin backend.
+         */
+        options: operations["plugin_proxy_plugin_proxy__plugin_name___path__options"];
+        /**
+         * Plugin Proxy
+         * @description Authenticated reverse-proxy to a registered plugin backend.
+         */
+        head: operations["plugin_proxy_plugin_proxy__plugin_name___path__head"];
+        /**
+         * Plugin Proxy
+         * @description Authenticated reverse-proxy to a registered plugin backend.
+         */
+        patch: operations["plugin_proxy_plugin_proxy__plugin_name___path__patch"];
         trace?: never;
     };
     "/policies": {
@@ -9012,6 +10704,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/queue/chat/completions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Async Queue Request */
+        post: operations["async_queue_request_queue_chat_completions_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/rag/ingest": {
         parameters: {
             query?: never;
@@ -9172,6 +10881,52 @@ export interface paths {
         put?: never;
         /** Create Realtime Client Secret */
         post: operations["create_realtime_client_secret_realtime_client_secrets_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/reload/anthropic_beta_headers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Reload Anthropic Beta Headers
+         * @description ADMIN ONLY / MASTER KEY Only Endpoint
+         *
+         *     Manually reload the Anthropic beta headers configuration from the remote source.
+         *     This will fetch fresh configuration from the anthropic_beta_headers_config.json file.
+         */
+        post: operations["reload_anthropic_beta_headers_reload_anthropic_beta_headers_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/reload/model_cost_map": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Reload Model Cost Map
+         * @description ADMIN ONLY / MASTER KEY Only Endpoint
+         *
+         *     Manually reload the model cost map from the remote source.
+         *     This will fetch fresh pricing data from the model_prices_and_context_window.json file.
+         */
+        post: operations["reload_model_cost_map_reload_model_cost_map_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -9459,6 +11214,108 @@ export interface paths {
          * @description Get a list of available routes in the FastAPI application.
          */
         get: operations["get_routes_routes_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/schedule/anthropic_beta_headers_reload": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Schedule Anthropic Beta Headers Reload
+         * @description ADMIN ONLY / MASTER KEY Only Endpoint
+         *
+         *     Schedule periodic reload of the Anthropic beta headers configuration.
+         *     This will create a background job that reloads the configuration every specified hours.
+         */
+        post: operations["schedule_anthropic_beta_headers_reload_schedule_anthropic_beta_headers_reload_post"];
+        /**
+         * Cancel Anthropic Beta Headers Reload
+         * @description ADMIN ONLY / MASTER KEY Only Endpoint
+         *
+         *     Cancel the scheduled periodic reload of the Anthropic beta headers configuration.
+         */
+        delete: operations["cancel_anthropic_beta_headers_reload_schedule_anthropic_beta_headers_reload_delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/schedule/anthropic_beta_headers_reload/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Anthropic Beta Headers Reload Status
+         * @description ADMIN ONLY / MASTER KEY Only Endpoint
+         *
+         *     Get the status of the scheduled Anthropic beta headers reload job.
+         */
+        get: operations["get_anthropic_beta_headers_reload_status_schedule_anthropic_beta_headers_reload_status_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/schedule/model_cost_map_reload": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Schedule Model Cost Map Reload
+         * @description ADMIN ONLY / MASTER KEY Only Endpoint
+         *
+         *     Schedule periodic reload of the model cost map.
+         *     This will create a background job that reloads the model cost map every specified hours.
+         */
+        post: operations["schedule_model_cost_map_reload_schedule_model_cost_map_reload_post"];
+        /**
+         * Cancel Model Cost Map Reload
+         * @description ADMIN ONLY / MASTER KEY Only Endpoint
+         *
+         *     Cancel the scheduled periodic reload of the model cost map.
+         */
+        delete: operations["cancel_model_cost_map_reload_schedule_model_cost_map_reload_delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/schedule/model_cost_map_reload/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Model Cost Map Reload Status
+         * @description ADMIN ONLY / MASTER KEY Only Endpoint
+         *
+         *     Get the status of the scheduled model cost map reload job.
+         */
+        get: operations["get_model_cost_map_reload_status_schedule_model_cost_map_reload_status_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -10322,6 +12179,38 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/spend/keys": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Spend Key Fn
+         * @description View keys created, ordered by spend.
+         *
+         *     - Admin callers (PROXY_ADMIN / PROXY_ADMIN_VIEW_ONLY) see every key in
+         *       the database.
+         *     - All other callers (INTERNAL_USER / INTERNAL_USER_VIEW_ONLY, etc.) are
+         *       scoped to keys they own (``user_id == caller``). A caller with no
+         *       ``user_id`` has no scope and receives an empty list rather than the
+         *       full table.
+         *
+         *     Example Request:
+         *     ```
+         *     curl -X GET "http://0.0.0.0:8000/spend/keys" -H "Authorization: Bearer sk-1234"
+         *     ```
+         */
+        get: operations["spend_key_fn_spend_keys_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/spend/logs": {
         parameters: {
             query?: never;
@@ -10366,6 +12255,86 @@ export interface paths {
          *     ```
          */
         get: operations["view_spend_logs_spend_logs_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/spend/logs/session/ui": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Ui View Session Spend Logs
+         * @description Get paginated spend logs for a particular session.
+         *
+         *     Returns:
+         *         {
+         *             "data": List[LiteLLM_SpendLogs],
+         *             "total": int,
+         *             "page": int,
+         *             "page_size": int,
+         *             "total_pages": int,
+         *         }
+         */
+        get: operations["ui_view_session_spend_logs_spend_logs_session_ui_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/spend/logs/ui": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Ui View Spend Logs
+         * @description View spend logs with pagination support.
+         *     Available at both `/spend/logs/v2` (public API) and `/spend/logs/ui` (internal UI).
+         *
+         *     Returns paginated response with data, total, page, page_size, and total_pages.
+         *
+         *     Example:
+         *     ```
+         *     curl -X GET "http://0.0.0.0:8000/spend/logs/v2?start_date=2025-11-25%2000:00:00&end_date=2025-11-26%2023:59:59&page=1&page_size=50" -H "Authorization: Bearer sk-1234"
+         *     ```
+         */
+        get: operations["ui_view_spend_logs_spend_logs_ui_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/spend/logs/ui/{request_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Ui View Request Response For Request Id
+         * @description View request / response for a specific request_id
+         *
+         *     - goes through all callbacks, checks if any of them have a @property -> has_request_response_payload
+         *     - if so, it will return the request and response payload
+         */
+        get: operations["ui_view_request_response_for_request_id_spend_logs_ui__request_id__get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -10424,6 +12393,208 @@ export interface paths {
          *     ```
          */
         get: operations["view_spend_tags_spend_tags_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/spend/users": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Spend User Fn
+         * @description View users created, ordered by spend.
+         *
+         *     - Admin callers (PROXY_ADMIN / PROXY_ADMIN_VIEW_ONLY) see every user, or
+         *       a specific user when ``user_id`` is supplied.
+         *     - All other callers may only read their own row. If they supply a
+         *       ``user_id`` query parameter that does not match their authenticated
+         *       ``user_id`` the request is rejected with HTTP 403; supplying their
+         *       own id (or none at all) returns just their row. A caller with no
+         *       ``user_id`` on their key has no scope and receives an empty list
+         *       rather than the full table.
+         *
+         *     Example Request:
+         *     ```
+         *     curl -X GET "http://0.0.0.0:8000/spend/users" -H "Authorization: Bearer sk-1234"
+         *     ```
+         *
+         *     View User Table row for user_id
+         *     ```
+         *     curl -X GET "http://0.0.0.0:8000/spend/users?user_id=1234" -H "Authorization: Bearer sk-1234"
+         *     ```
+         */
+        get: operations["spend_user_fn_spend_users_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/sso/callback": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Auth Callback
+         * @description Verify login
+         */
+        get: operations["auth_callback_sso_callback_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/sso/cli/complete/{login_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Cli Sso Complete */
+        post: operations["cli_sso_complete_sso_cli_complete__login_id__post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/sso/cli/poll/{key_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Cli Poll Key
+         * @description CLI polling endpoint - retrieves session from cache and generates JWT.
+         *
+         *     Flow:
+         *     1. First poll (no team_id): Returns teams list without generating JWT
+         *     2. Second poll (with team_id): Generates JWT with selected team and deletes session
+         *
+         *     Args:
+         *         key_id: The CLI login session ID
+         *         team_id: Optional team ID to assign to the JWT. If provided, must be one of user's teams.
+         */
+        get: operations["cli_poll_key_sso_cli_poll__key_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/sso/cli/start": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Cli Sso Start */
+        post: operations["cli_sso_start_sso_cli_start_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/sso/debug/callback": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Debug Sso Callback
+         * @description Returns the OpenID object returned by the SSO provider
+         */
+        get: operations["debug_sso_callback_sso_debug_callback_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/sso/debug/login": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Debug Sso Login
+         * @description Create Proxy API Keys using Google Workspace SSO. Requires setting PROXY_BASE_URL in .env
+         *     PROXY_BASE_URL should be the your deployed proxy endpoint, e.g. PROXY_BASE_URL="https://litellm-production-7002.up.railway.app/"
+         *     Example:
+         */
+        get: operations["debug_sso_login_sso_debug_login_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/sso/get/ui_settings": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Ui Settings */
+        get: operations["get_ui_settings_sso_get_ui_settings_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/sso/key/generate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Google Login
+         * @description Create Proxy API Keys using Google Workspace SSO. Requires setting PROXY_BASE_URL in .env
+         *     PROXY_BASE_URL should be the your deployed proxy endpoint, e.g. PROXY_BASE_URL="https://litellm-production-7002.up.railway.app/"
+         *     Example:
+         */
+        get: operations["google_login_sso_key_generate_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -10964,6 +13135,36 @@ export interface paths {
          *     ```
          */
         post: operations["delete_team_team_delete_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/team/filter/ui": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Ui View Teams
+         * @description [PROXY-ADMIN ONLY] Filter teams based on partial match of team_id or team_alias with pagination.
+         *
+         *     Args:
+         *         user_id (Optional[str]): Partial user ID to search for
+         *         user_email (Optional[str]): Partial email to search for
+         *         page (int): Page number for pagination (starts at 1)
+         *         page_size (int): Number of items per page (max 100)
+         *         user_api_key_dict (UserAPIKeyAuth): User authentication information
+         *
+         *     Returns:
+         *         List[LiteLLM_SpendLogs]: Paginated list of matching user records
+         */
+        get: operations["ui_view_teams_team_filter_ui_get"];
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -11959,6 +14160,32 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/user/available_roles": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Ui Get Available Role
+         * @description Endpoint used by Admin UI to show all available roles to assign a user
+         *     return {
+         *         "proxy_admin": {
+         *             "description": "Proxy Admin role",
+         *             "ui_label": "Admin"
+         *         }
+         *     }
+         */
+        get: operations["ui_get_available_role_user_available_roles_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/user/available_users": {
         parameters: {
             query?: never;
@@ -12122,6 +14349,36 @@ export interface paths {
          *     - user_ids: List[str] - The list of user id's to be deleted.
          */
         post: operations["delete_user_user_delete_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/user/filter/ui": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Ui View Users
+         * @description Filter users based on partial match of user_id or email with pagination.
+         *
+         *     Behaviour depends on the ``scope_user_search_to_org`` UI-setting flag
+         *     (stored in the ``litellm_uisettings`` table):
+         *
+         *     * **Flag OFF (default):** any authenticated user can search all users.
+         *     * **Flag ON:**
+         *       - Proxy admins see all users.
+         *       - Org admins see only users in their org(s).
+         *       - Team admins for an org-bound team see users in that org.
+         *       - Others receive a 403.
+         */
+        get: operations["ui_view_users_user_filter_ui_get"];
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -14383,6 +16640,11 @@ export interface paths {
          *
          *         - When litellm_model_id is passed, it will return the info for that specific model
          *         - When litellm_model_id is not passed, it will return the info for all models
+         *         - include_team_models: When true, filter to deployments the caller can use (same as /v2/model/info).
+         *         - teamId: Filter to models accessible by the given team.
+         *
+         *     Each model in the list response includes `model_info.access_via_team_ids` and
+         *     `model_info.direct_access` when the proxy database is connected.
          *
          *     Returns:
          *         Returns a dictionary containing information about each model.
@@ -14436,6 +16698,15 @@ export interface paths {
          *     - scope: Optional scope parameter. Currently only accepts "expand".
          *              When scope=expand is passed, proxy admins, team admins, and org admins
          *              will receive all proxy models as if they are a proxy admin.
+         *     - healthy_only: When true, hide models whose backing deployments are all marked
+         *                     unhealthy by background health checks. Requires
+         *                     `background_health_checks: true` in general_settings; without
+         *                     health state the listing is returned unfiltered (fail open).
+         *                     Models expanded from wildcard routes (e.g. `openai/*`) are not
+         *                     filtered, and nothing is hidden when `allowed_fails_policy` is
+         *                     configured (cooldown remains the sole exclusion mechanism).
+         *                     Hiding is presentation-only: a hidden model can still be
+         *                     called directly.
          */
         get: operations["model_list_v1_models_get"];
         put?: never;
@@ -14462,6 +16733,10 @@ export interface paths {
          *
          *     Follows OpenAI API specification for individual model retrieval.
          *     https://platform.openai.com/docs/api-reference/models/retrieve
+         *
+         *     Query parameters mirror `/v1/models` so the same caller context (team
+         *     scoping, health filtering, paused deployments) drives both endpoints; the
+         *     listing's public id must resolve to the same internal deployment here.
          */
         get: operations["model_info_v1_models__model_id__get"];
         put?: never;
@@ -16256,6 +18531,117 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v2/key/info": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Info Key Fn V2
+         * @description Retrieve information about a list of keys.
+         *
+         *     **New endpoint**. Currently admin only.
+         *     Parameters:
+         *         keys: Optional[list] = body parameter representing the key(s) in the request
+         *         user_api_key_dict: UserAPIKeyAuth = Dependency representing the user's API key
+         *     Returns:
+         *         Dict containing the key and its associated information
+         *
+         *     Example Curl:
+         *     ```
+         *     curl -X GET "http://0.0.0.0:4000/key/info"     -H "Authorization: Bearer sk-1234"     -d {"keys": ["sk-1", "sk-2", "sk-3"]}
+         *     ```
+         */
+        post: operations["info_key_fn_v2_v2_key_info_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v2/login": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Login V2 */
+        post: operations["login_v2_v2_login_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v2/model/info": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Model Info V2
+         * @description Paginated model metadata for proxy deployments (pricing, provider, team access).
+         *
+         *     Returns configured router deployments with enriched `model_info` (costs, provider,
+         *     context window, etc.). Sensitive fields such as API keys and api_base are omitted.
+         *
+         *     Query parameters:
+         *         model: Filter to a single public `model_name`.
+         *         user_models_only: When true, only return models created by the calling user.
+         *         include_team_models: When true, populate `access_via_team_ids` and `direct_access`
+         *             on each model and filter to deployments the caller can use.
+         *         page / size: Pagination controls (defaults: page=1, size=50).
+         *         search: Case-insensitive partial match on model name or team public name.
+         *         modelId: Return a single deployment by LiteLLM model id.
+         *         teamId: Filter to models with direct access or team membership for this team id.
+         *         sortBy / sortOrder: Sort by model_name, created_at, updated_at, costs, or status.
+         *
+         *     Example request:
+         *     ```
+         *     curl -X GET 'http://localhost:4000/v2/model/info?include_team_models=true&page=1&size=50' \
+         *     --header 'Authorization: Bearer sk-1234'
+         *     ```
+         *
+         *     Example response:
+         *     ```json
+         *     {
+         *         "data": [
+         *             {
+         *                 "model_name": "gpt-4",
+         *                 "litellm_params": {"model": "openai/gpt-4.1"},
+         *                 "model_info": {
+         *                     "id": "abc123",
+         *                     "litellm_provider": "openai",
+         *                     "access_via_team_ids": ["team-1"],
+         *                     "direct_access": true
+         *                 }
+         *             }
+         *         ],
+         *         "total_count": 1,
+         *         "current_page": 1,
+         *         "total_pages": 1,
+         *         "size": 50
+         *     }
+         *     ```
+         */
+        get: operations["model_info_v2_v2_model_info_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v2/rerank": {
         parameters: {
             query?: never;
@@ -16342,6 +18728,40 @@ export interface paths {
         get: operations["user_info_v2_v2_user_info_get"];
         put?: never;
         post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v3/login": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Login V3 */
+        post: operations["login_v3_v3_login_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v3/login/exchange": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Login V3 Exchange */
+        post: operations["login_v3_exchange_v3_login_exchange_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -16750,6 +19170,52 @@ export interface paths {
         options?: never;
         head?: never;
         patch?: never;
+        trace?: never;
+    };
+    "/vertex-ai/{endpoint}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Vertex Proxy Route
+         * @description Call LiteLLM proxy via Vertex AI SDK.
+         *
+         *     [Docs](https://docs.litellm.ai/docs/pass_through/vertex_ai)
+         */
+        get: operations["vertex_proxy_route_vertex_ai__endpoint__get_2"];
+        /**
+         * Vertex Proxy Route
+         * @description Call LiteLLM proxy via Vertex AI SDK.
+         *
+         *     [Docs](https://docs.litellm.ai/docs/pass_through/vertex_ai)
+         */
+        put: operations["vertex_proxy_route_vertex_ai__endpoint__put_2"];
+        /**
+         * Vertex Proxy Route
+         * @description Call LiteLLM proxy via Vertex AI SDK.
+         *
+         *     [Docs](https://docs.litellm.ai/docs/pass_through/vertex_ai)
+         */
+        post: operations["vertex_proxy_route_vertex_ai__endpoint__post_2"];
+        /**
+         * Vertex Proxy Route
+         * @description Call LiteLLM proxy via Vertex AI SDK.
+         *
+         *     [Docs](https://docs.litellm.ai/docs/pass_through/vertex_ai)
+         */
+        delete: operations["vertex_proxy_route_vertex_ai__endpoint__delete_2"];
+        options?: never;
+        head?: never;
+        /**
+         * Vertex Proxy Route
+         * @description Call LiteLLM proxy via Vertex AI SDK.
+         *
+         *     [Docs](https://docs.litellm.ai/docs/pass_through/vertex_ai)
+         */
+        patch: operations["vertex_proxy_route_vertex_ai__endpoint__patch_2"];
         trace?: never;
     };
     "/vertex_ai/discovery/{endpoint}": {
@@ -17919,6 +20385,12 @@ export interface components {
             /** Tags */
             tags?: string[];
         };
+        /**
+         * AlertType
+         * @description Enum for alert types and management event types
+         * @enum {string}
+         */
+        AlertType: "llm_exceptions" | "llm_too_slow" | "llm_requests_hanging" | "budget_alerts" | "spend_reports" | "failed_tracking_spend" | "db_exceptions" | "daily_reports" | "cooldown_deployment" | "new_model_added" | "outage_alerts" | "region_outage_alerts" | "fallback_reports" | "new_virtual_key_created" | "virtual_key_updated" | "virtual_key_deleted" | "new_team_created" | "team_updated" | "team_deleted" | "new_internal_user_created" | "internal_user_updated" | "internal_user_deleted";
         /** AllowedVectorStoreIndexItem */
         AllowedVectorStoreIndexItem: {
             /** Index Name */
@@ -18378,6 +20850,11 @@ export interface components {
         BlockKeyRequest: {
             /** Key */
             key: string;
+        };
+        /** BlockModelRequest */
+        BlockModelRequest: {
+            /** Model Id */
+            model_id: string;
         };
         /** BlockTeamRequest */
         BlockTeamRequest: {
@@ -18962,6 +21439,11 @@ export interface components {
          * @enum {string}
          */
         CallTypes: "embedding" | "aembedding" | "completion" | "acompletion" | "atext_completion" | "text_completion" | "image_generation" | "aimage_generation" | "image_edit" | "aimage_edit" | "moderation" | "amoderation" | "atranscription" | "transcription" | "aspeech" | "speech" | "rerank" | "arerank" | "search" | "asearch" | "_arealtime" | "_aresponses_websocket" | "create_batch" | "acreate_batch" | "aretrieve_batch" | "retrieve_batch" | "acancel_batch" | "cancel_batch" | "pass_through_endpoint" | "anthropic_messages" | "get_assistants" | "aget_assistants" | "create_assistants" | "acreate_assistants" | "delete_assistant" | "adelete_assistant" | "acreate_thread" | "create_thread" | "aget_thread" | "get_thread" | "a_add_message" | "add_message" | "aget_messages" | "get_messages" | "arun_thread" | "run_thread" | "arun_thread_stream" | "run_thread_stream" | "afile_retrieve" | "file_retrieve" | "afile_delete" | "file_delete" | "afile_list" | "file_list" | "acreate_file" | "create_file" | "afile_content" | "file_content" | "create_fine_tuning_job" | "acreate_fine_tuning_job" | "create_video" | "acreate_video" | "avideo_retrieve" | "video_retrieve" | "avideo_content" | "video_content" | "video_remix" | "avideo_remix" | "video_list" | "avideo_list" | "video_retrieve_job" | "avideo_retrieve_job" | "video_delete" | "avideo_delete" | "video_create_character" | "avideo_create_character" | "video_get_character" | "avideo_get_character" | "video_edit" | "avideo_edit" | "video_extension" | "avideo_extension" | "vector_store_file_create" | "avector_store_file_create" | "vector_store_file_list" | "avector_store_file_list" | "vector_store_file_retrieve" | "avector_store_file_retrieve" | "vector_store_file_content" | "avector_store_file_content" | "vector_store_file_update" | "avector_store_file_update" | "vector_store_file_delete" | "avector_store_file_delete" | "vector_store_create" | "avector_store_create" | "vector_store_search" | "avector_store_search" | "create_container" | "acreate_container" | "list_containers" | "alist_containers" | "retrieve_container" | "aretrieve_container" | "delete_container" | "adelete_container" | "list_container_files" | "alist_container_files" | "upload_container_file" | "aupload_container_file" | "acancel_fine_tuning_job" | "cancel_fine_tuning_job" | "alist_fine_tuning_jobs" | "list_fine_tuning_jobs" | "aretrieve_fine_tuning_job" | "retrieve_fine_tuning_job" | "responses" | "aresponses" | "alist_input_items" | "llm_passthrough_route" | "allm_passthrough_route" | "generate_content" | "agenerate_content" | "generate_content_stream" | "agenerate_content_stream" | "ocr" | "aocr" | "call_mcp_tool" | "list_mcp_tools" | "asend_message" | "send_message" | "acreate_skill";
+        /** CallbackDelete */
+        CallbackDelete: {
+            /** Callback Name */
+            callback_name: string;
+        };
         /** CallbacksByType */
         CallbacksByType: {
             /** Failure */
@@ -19581,6 +22063,326 @@ export interface components {
             /** Regulation */
             regulation: string;
         };
+        /** ConfigFieldDelete */
+        ConfigFieldDelete: {
+            /**
+             * Config Type
+             * @constant
+             */
+            config_type: "general_settings";
+            /** Field Name */
+            field_name: string;
+        };
+        /** ConfigFieldInfo */
+        ConfigFieldInfo: {
+            /** Field Name */
+            field_name: string;
+            /** Field Value */
+            field_value: unknown;
+        };
+        /** ConfigFieldUpdate */
+        ConfigFieldUpdate: {
+            /**
+             * Config Type
+             * @constant
+             */
+            config_type: "general_settings";
+            /** Field Name */
+            field_name: string;
+            /** Field Value */
+            field_value: unknown;
+        };
+        /**
+         * ConfigGeneralSettings
+         * @description Documents all the fields supported by `general_settings` in config.yaml
+         */
+        ConfigGeneralSettings: {
+            /**
+             * Alert To Webhook Url
+             * @description Mapping of alert type to webhook url. e.g. `alert_to_webhook_url: {'budget_alerts': 'https://nothooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX'}`
+             */
+            alert_to_webhook_url?: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Alert Types
+             * @description List of alerting types. By default it is all alerts
+             */
+            alert_types?: components["schemas"]["AlertType"][] | null;
+            /**
+             * Alerting
+             * @description List of alerting integrations. Today, just slack - `alerting: ['slack']`
+             */
+            alerting?: unknown[] | null;
+            /**
+             * Alerting Args
+             * @description Controllable params for slack alerting - e.g. ttl in cache.
+             */
+            alerting_args?: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Alerting Threshold
+             * @description sends alerts if requests hang for 5min+
+             */
+            alerting_threshold?: number | null;
+            /**
+             * Allow Cli Sso Verification Uri Complete
+             * @description opt-in to RFC 8628 verification_uri_complete for the CLI SSO device flow, pre-filling the user_code in the browser. Off by default; intended for same-host clients where the device that starts the flow and the browser run on the same machine
+             */
+            allow_cli_sso_verification_uri_complete?: boolean | null;
+            /**
+             * Allowed Routes
+             * @description Proxy API Endpoints you want users to be able to access
+             */
+            allowed_routes?: unknown[] | null;
+            /**
+             * Background Health Checks
+             * @description run health checks in background
+             */
+            background_health_checks?: boolean | null;
+            /**
+             * Cancel On Disconnect
+             * @description cancel the in-flight upstream LLM request (non-streaming) when the client disconnects, freeing backend capacity (e.g. a vLLM GPU slot); the request is logged as a 499 failure
+             */
+            cancel_on_disconnect?: boolean | null;
+            /**
+             * Completion Model
+             * @description proxy level default model for all chat completion calls
+             */
+            completion_model?: string | null;
+            /**
+             * Custom Auth
+             * @description override user_api_key_auth with your own auth script - https://docs.litellm.ai/docs/proxy/virtual_keys#custom-auth
+             */
+            custom_auth?: string | null;
+            /** @description custom args for instantiating dynamodb client - e.g. billing provision */
+            database_args?: components["schemas"]["DynamoDBArgs"] | null;
+            /**
+             * Database Connect Timeout
+             * @description Prisma `connect_timeout` URL param (seconds). Bounds how long the engine waits to establish a new connection before failing. Defaults to Prisma's built-in value when unset.
+             */
+            database_connect_timeout?: number | null;
+            /**
+             * Database Connection Pool Limit
+             * @description default connection pool for prisma client connecting to postgres db
+             * @default 10
+             */
+            database_connection_pool_limit: number | null;
+            /**
+             * Database Connection Timeout
+             * @description default timeout for a connection to the database
+             * @default 60
+             */
+            database_connection_timeout: number | null;
+            /**
+             * Database Disable Prepared Statements
+             * @description Disable server-side prepared statements by setting Prisma's `pgbouncer=true` URL param. Use this for pgbouncer transaction-pooling deployments, or to prevent the 'cached plan must not change result type' error that pooled connections hit during rolling schema migrations. An explicit `pgbouncer` in `database_extra_connection_params` takes precedence.
+             */
+            database_disable_prepared_statements?: boolean | null;
+            /**
+             * Database Extra Connection Params
+             * @description Escape hatch: extra key/value pairs appended verbatim to the Prisma DATABASE_URL / DIRECT_URL query string (e.g. `sslmode`, `pgbouncer`, `statement_cache_size`). Keys here override any default LiteLLM sets.
+             */
+            database_extra_connection_params?: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Database Socket Timeout
+             * @description Prisma `socket_timeout` URL param (seconds). When set, an idle/slow connection that has not produced data within this window is closed. This is the main knob for capping idle DB connections from LiteLLM.
+             */
+            database_socket_timeout?: number | null;
+            /**
+             * Database Type
+             * @description to use dynamodb instead of postgres db
+             */
+            database_type?: "dynamo_db" | null;
+            /**
+             * Database Url
+             * @description connect to a postgres db - needed for generating temporary keys + tracking spend / key
+             */
+            database_url?: string | null;
+            /**
+             * Disable Budget Reservation
+             * @description If True, disables the optimistic per-request budget reservation introduced in v1.84.0. WARNING: This weakens hard budget enforcement. Without the reservation, a burst of concurrent requests from a single key can each pass the read-time spend check before any of them is charged, allowing a configured budget to be exceeded under high concurrency. Budgets are still evaluated on every request at read time, so an already-exhausted budget is still rejected. Enable only if your deployment is experiencing phantom BudgetExceededError responses caused by leaked reservations (see GitHub issue #27639). A proxy-level WARNING is logged on every request while this flag is active as a reminder that hard enforcement is relaxed.
+             */
+            disable_budget_reservation?: boolean | null;
+            /**
+             * Enable Public Model Hub
+             * @description Public model hub for users to see what models they have access to, supported openai params, etc.
+             * @default false
+             */
+            enable_public_model_hub: boolean;
+            /**
+             * Forward Client Headers To Llm Api
+             * @description If True, forwards client headers (e.g. Authorization) to the LLM API. Required for Claude Code with Max subscription.
+             */
+            forward_client_headers_to_llm_api?: boolean | null;
+            /**
+             * Global Max Parallel Requests
+             * @description global max parallel requests to allow for a proxy instance.
+             */
+            global_max_parallel_requests?: number | null;
+            /**
+             * Health Check Concurrency
+             * @description limit concurrent health checks per cycle; when unset, health checks run without a concurrency cap
+             */
+            health_check_concurrency?: number | null;
+            /**
+             * Health Check Interval
+             * @description background health check interval in seconds
+             * @default 300
+             */
+            health_check_interval: number;
+            /**
+             * Health Check Skip Disabled Background Models
+             * @description When true, deployments with model_info.disable_background_health_check are skipped for on-demand GET /health as well as the background health loop.
+             * @default false
+             */
+            health_check_skip_disabled_background_models: boolean;
+            /**
+             * Infer Model From Keys
+             * @description for `/models` endpoint, infers available model based on environment keys (e.g. OPENAI_API_KEY)
+             */
+            infer_model_from_keys?: boolean | null;
+            /** @description key manager to load keys from / decrypt keys with */
+            key_management_system?: components["schemas"]["KeyManagementSystem"] | null;
+            /**
+             * Master Key
+             * @description require a key for all calls to proxy
+             */
+            master_key?: string | null;
+            /**
+             * Max Parallel Requests
+             * @description maximum parallel requests for each api key
+             */
+            max_parallel_requests?: number | null;
+            /**
+             * Max Request Size Mb
+             * @description max request size in MB, if a request is larger than this size it will be rejected
+             */
+            max_request_size_mb?: number | null;
+            /**
+             * Max Response Size Mb
+             * @description max response size in MB, if a response is larger than this size it will be rejected
+             */
+            max_response_size_mb?: number | null;
+            /**
+             * Maximum Spend Logs Retention Period
+             * @description Maximum retention period for spend logs (e.g., '7d' for 7 days). Logs older than this will be deleted.
+             */
+            maximum_spend_logs_retention_period?: string | null;
+            /**
+             * Mcp Internal Ip Ranges
+             * @description Custom CIDR ranges that define internal/private networks for MCP access control. When set, only these ranges are treated as internal. Defaults to RFC 1918 private ranges (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 127.0.0.0/8).
+             */
+            mcp_internal_ip_ranges?: string[] | null;
+            /**
+             * Mcp Required Fields
+             * @description List of MCP server fields that must be filled in for a submission to pass standards checks (e.g. ['description', 'source_url', 'alias']).
+             */
+            mcp_required_fields?: string[] | null;
+            /**
+             * Mcp Trusted Proxy Ranges
+             * @description CIDR ranges of trusted reverse proxies. When set, X-Forwarded-For and X-Forwarded-* origin headers are only trusted from these IPs.
+             */
+            mcp_trusted_proxy_ranges?: string[] | null;
+            /**
+             * Otel
+             * @description [BETA] OpenTelemetry support - this might change, use with caution.
+             */
+            otel?: boolean | null;
+            /**
+             * Pass Through Endpoints
+             * @description Set-up pass-through endpoints for provider-specific endpoints. Docs - https://docs.litellm.ai/docs/proxy/pass_through
+             */
+            pass_through_endpoints?: components["schemas"]["PassThroughGenericEndpoint"][] | null;
+            /**
+             * Pass Through Request Timeout
+             * @description Default upstream request timeout in seconds for native and custom pass-through endpoints that use pass_through_request. Defaults to 600 when unset.
+             */
+            pass_through_request_timeout?: number | null;
+            /**
+             * Reject Clientside Metadata Tags
+             * @description When set to True, rejects requests that contain client-side 'metadata.tags' to prevent users from influencing budgets by sending different tags. Tags can only be inherited from the API key metadata.
+             */
+            reject_clientside_metadata_tags?: boolean | null;
+            /**
+             * Store Model In Db
+             * @description If True, models and config are stored in and loaded from the database. Default is False.
+             */
+            store_model_in_db?: boolean | null;
+            /**
+             * Store Prompts In Spend Logs
+             * @description If True, stores request messages and responses in spend logs. Default is False.
+             */
+            store_prompts_in_spend_logs?: boolean | null;
+            /**
+             * Supported Db Objects
+             * @description Fine-grained control over which object types to load from the database when store_model_in_db is True. Available types: 'models', 'mcp', 'guardrails', 'vector_stores', 'pass_through_endpoints', 'prompts', 'model_cost_map', 'tools', 'config_overrides'. If not set, all objects are loaded (default behavior).
+             */
+            supported_db_objects?: components["schemas"]["SupportedDBObjectType"][] | null;
+            /**
+             * Trusted Proxy Ranges
+             * @description CIDR ranges of trusted reverse proxies allowed to provide identity headers for header-based auth paths such as enable_oauth2_proxy_auth and custom_ui_sso_sign_in_handler.
+             */
+            trusted_proxy_ranges?: string[] | null;
+            /**
+             * Ui Access Mode
+             * @description Control access to the Proxy UI
+             * @default all
+             */
+            ui_access_mode: ("admin_only" | "all") | null;
+            /**
+             * Use Azure Key Vault
+             * @description load keys from azure key vault
+             */
+            use_azure_key_vault?: boolean | null;
+            /**
+             * Use Google Kms
+             * @description decrypt keys with google kms
+             */
+            use_google_kms?: boolean | null;
+            /**
+             * Use Spend Logs Partitioning
+             * @description If True and LiteLLM_SpendLogs has been converted to a range-partitioned table (db_scripts/partition_spend_logs.sql), retention cleanup drops expired partitions instead of deleting rows, and pre-creates upcoming partitions. Default is False.
+             */
+            use_spend_logs_partitioning?: boolean | null;
+            /** User Header Mappings */
+            user_header_mappings?: components["schemas"]["UserHeaderMapping"][] | null;
+            /**
+             * User Header Name
+             * @description [DEPRECATED] Use 'user_header_mappings' instead. When set, the header value is treated as the end user id unless overridden by user_header_mappings.
+             */
+            user_header_name?: string | null;
+            /**
+             * User Mcp Management Mode
+             * @description Controls how non-admin users interact with MCP servers in the dashboard. 'restricted' shows only accessible servers, 'view_all' lists every server in read-only mode.
+             */
+            user_mcp_management_mode?: ("restricted" | "view_all") | null;
+        };
+        /** ConfigList */
+        ConfigList: {
+            /** Field Default Value */
+            field_default_value: unknown;
+            /** Field Description */
+            field_description: string;
+            /** Field Name */
+            field_name: string;
+            /** Field Type */
+            field_type: string;
+            /** Field Value */
+            field_value: unknown;
+            /** Nested Fields */
+            nested_fields?: components["schemas"]["FieldDetail"][] | null;
+            /**
+             * Premium Field
+             * @default false
+             */
+            premium_field: boolean;
+            /** Stored In Db */
+            stored_in_db: boolean | null;
+        };
         /**
          * ConfigOverrideSettingsResponse
          * @description Response model for config override settings GET endpoints.
@@ -19605,6 +22407,34 @@ export interface components {
             values: {
                 [key: string]: unknown;
             };
+        };
+        /**
+         * ConfigYAML
+         * @description Documents all the fields supported by the config.yaml
+         */
+        ConfigYAML: {
+            /**
+             * Environment Variables
+             * @description Object to pass in additional environment variables via POST request
+             */
+            environment_variables?: {
+                [key: string]: unknown;
+            } | null;
+            general_settings?: components["schemas"]["ConfigGeneralSettings"] | null;
+            /**
+             * Litellm Settings
+             * @description litellm Module settings. See __init__.py for all, example litellm.drop_params=True, litellm.set_verbose=True, litellm.api_base, litellm.cache
+             */
+            litellm_settings?: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Model List
+             * @description List of supported models on the server, with model-specific configs
+             */
+            model_list?: components["schemas"]["ModelParams"][] | null;
+            /** @description litellm router object settings. See router.py __init__ for all, example router.num_retries=5, router.timeout=5, router.max_retries=5, router.retry_after=5 */
+            router_settings?: components["schemas"]["UpdateRouterConfig"] | null;
         };
         /** ConfigurableClientsideParamsCustomAuth */
         "ConfigurableClientsideParamsCustomAuth-Input": {
@@ -20087,7 +22917,7 @@ export interface components {
         /** Deployment */
         Deployment: {
             litellm_params: components["schemas"]["LiteLLM_Params"];
-            model_info: components["schemas"]["ModelInfo"];
+            model_info: components["schemas"]["litellm__types__router__ModelInfo"];
             /** Model Name */
             model_name: string;
         } & {
@@ -20120,6 +22950,60 @@ export interface components {
              * @constant
              */
             type: "text";
+        };
+        /** DynamoDBArgs */
+        DynamoDBArgs: {
+            /** Assume Role Aws Role Name */
+            assume_role_aws_role_name?: string | null;
+            /** Assume Role Aws Session Name */
+            assume_role_aws_session_name?: string | null;
+            /** Aws Duration Seconds */
+            aws_duration_seconds?: number | null;
+            /** Aws Policy */
+            aws_policy?: string | null;
+            /** Aws Policy Arns */
+            aws_policy_arns?: string[] | null;
+            /** Aws Provider Id */
+            aws_provider_id?: string | null;
+            /** Aws Role Name */
+            aws_role_name?: string | null;
+            /** Aws Session Name */
+            aws_session_name?: string | null;
+            /** Aws Web Identity Token */
+            aws_web_identity_token?: string | null;
+            /**
+             * Billing Mode
+             * @enum {string}
+             */
+            billing_mode: "PROVISIONED_THROUGHPUT" | "PAY_PER_REQUEST";
+            /**
+             * Config Table Name
+             * @default LiteLLM_Config
+             */
+            config_table_name: string;
+            /**
+             * Key Table Name
+             * @default LiteLLM_VerificationToken
+             */
+            key_table_name: string;
+            /** Read Capacity Units */
+            read_capacity_units?: number | null;
+            /** Region Name */
+            region_name: string;
+            /**
+             * Spend Table Name
+             * @default LiteLLM_SpendLogs
+             */
+            spend_table_name: string;
+            /** Ssl Verify */
+            ssl_verify?: boolean | null;
+            /**
+             * User Table Name
+             * @default LiteLLM_UserTable
+             */
+            user_table_name: string;
+            /** Write Capacity Units */
+            write_capacity_units?: number | null;
         };
         /**
          * EmailEvent
@@ -20393,6 +23277,19 @@ export interface components {
              * @description The model name
              */
             model: string;
+        };
+        /** FieldDetail */
+        FieldDetail: {
+            /** Field Default Value */
+            field_default_value?: unknown;
+            /** Field Description */
+            field_description: string;
+            /** Field Name */
+            field_name: string;
+            /** Field Type */
+            field_type: string;
+            /** Stored In Db */
+            stored_in_db: boolean | null;
         };
         /** FunctionCall */
         FunctionCall: {
@@ -20728,6 +23625,15 @@ export interface components {
              */
             team_member_permissions: string[] | null;
         };
+        /** GlobalEndUsersSpend */
+        GlobalEndUsersSpend: {
+            /** Api Key */
+            api_key?: string | null;
+            /** Endtime */
+            endTime?: string | null;
+            /** Starttime */
+            startTime?: string | null;
+        };
         /**
          * GraySwanGuardrailConfigModelOptionalParams
          * @description Optional parameters for the Gray Swan guardrail.
@@ -21040,6 +23946,62 @@ export interface components {
                 [key: string]: unknown;
             };
         };
+        /** InvitationClaim */
+        InvitationClaim: {
+            /** Invitation Link */
+            invitation_link: string;
+            /** Password */
+            password: string;
+            /** User Id */
+            user_id: string;
+        };
+        /** InvitationDelete */
+        InvitationDelete: {
+            /** Invitation Id */
+            invitation_id: string;
+        };
+        /** InvitationModel */
+        InvitationModel: {
+            /** Accepted At */
+            accepted_at: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /** Created By */
+            created_by: string;
+            /**
+             * Expires At
+             * Format: date-time
+             */
+            expires_at: string;
+            /** Id */
+            id: string;
+            /** Is Accepted */
+            is_accepted: boolean;
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at: string;
+            /** Updated By */
+            updated_by: string;
+            /** User Id */
+            user_id: string;
+        };
+        /** InvitationNew */
+        InvitationNew: {
+            /** User Id */
+            user_id: string;
+        };
+        /** InvitationUpdate */
+        InvitationUpdate: {
+            /** Invitation Id */
+            invitation_id: string;
+            /** Is Accepted */
+            is_accepted: boolean;
+        };
         /** JWTKeyMappingResponse */
         JWTKeyMappingResponse: {
             /**
@@ -21093,6 +24055,11 @@ export interface components {
          * @enum {string}
          */
         KeyManagementRoutes: "/key/generate" | "/key/update" | "/key/delete" | "/key/regenerate" | "/key/service-account/generate" | "/key/{key_id}/regenerate" | "/key/block" | "/key/unblock" | "/key/bulk_update" | "/team/key/bulk_update" | "/key/{key_id}/reset_spend" | "/key/access_group_assignment" | "/key/info" | "/key/health" | "/key/list" | "/key/aliases" | "/team/daily/activity" | "/spend/logs" | "/spend/logs/v2";
+        /**
+         * KeyManagementSystem
+         * @enum {string}
+         */
+        KeyManagementSystem: "google_kms" | "azure_key_vault" | "aws_secret_manager" | "google_secret_manager" | "hashicorp_vault" | "cyberark" | "local" | "aws_kms" | "custom";
         /**
          * KeyMetadata
          * @description Metadata for a key
@@ -21364,8 +24331,7 @@ export interface components {
         };
         /**
          * LiteLLM_DeletedTeamTable
-         * @description Recording of deleted teams for audit purposes. Mirrors LiteLLM_TeamTable
-         *     plus metadata captured at deletion time.
+         * @description Audit record for deleted teams; mirrors the team plus deletion metadata.
          */
         LiteLLM_DeletedTeamTable: {
             /** Access Group Ids */
@@ -21375,6 +24341,11 @@ export interface components {
              * @default []
              */
             admins: unknown[];
+            /**
+             * Allow Team Guardrail Config
+             * @default false
+             */
+            allow_team_guardrail_config: boolean | null;
             /**
              * Blocked
              * @default false
@@ -21422,6 +24393,20 @@ export interface components {
             /** Model Id */
             model_id?: number | null;
             /**
+             * Model Max Budget
+             * @default {}
+             */
+            model_max_budget: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Model Spend
+             * @default {}
+             */
+            model_spend: {
+                [key: string]: unknown;
+            } | null;
+            /**
              * Models
              * @default []
              */
@@ -21431,6 +24416,8 @@ export interface components {
             object_permission_id?: string | null;
             /** Organization Id */
             organization_id?: string | null;
+            /** Policies */
+            policies?: string[] | null;
             /** Router Settings */
             router_settings?: {
                 [key: string]: unknown;
@@ -21454,8 +24441,7 @@ export interface components {
         };
         /**
          * LiteLLM_DeletedVerificationToken
-         * @description Recording of deleted keys for audit purposes. Mirrors LiteLLM_VerificationToken
-         *     plus metadata captured at deletion time.
+         * @description Audit record for deleted keys; mirrors the token plus deletion metadata.
          */
         LiteLLM_DeletedVerificationToken: {
             /** Access Group Ids */
@@ -21488,6 +24474,8 @@ export interface components {
             blocked?: boolean | null;
             /** Budget Duration */
             budget_duration?: string | null;
+            /** Budget Id */
+            budget_id?: string | null;
             /** Budget Limits */
             budget_limits?: {
                 [key: string]: unknown;
@@ -21866,9 +24854,9 @@ export interface components {
             /** Id */
             id?: number | null;
             /** Model Aliases */
-            model_aliases?: {
+            model_aliases?: string | {
                 [key: string]: unknown;
-            } | string | null;
+            } | null;
             team?: components["schemas"]["LiteLLM_TeamTable"] | null;
             /** Updated By */
             updated_by: string;
@@ -21934,6 +24922,11 @@ export interface components {
             } | null;
             /** Mcp Toolsets */
             mcp_toolsets?: string[] | null;
+            /**
+             * Models
+             * @default []
+             */
+            models: string[] | null;
             /** Object Permission Id */
             object_permission_id: string;
             /**
@@ -21949,7 +24942,7 @@ export interface components {
         };
         /**
          * LiteLLM_OrganizationMembershipTable
-         * @description This is the table that track what organizations a user belongs to and users spend within the organization
+         * @description Tracks which organizations a user belongs to and their spend within it.
          */
         LiteLLM_OrganizationMembershipTable: {
             /** Budget Id */
@@ -22005,7 +24998,17 @@ export interface components {
             metadata?: {
                 [key: string]: unknown;
             } | null;
-            /** Models */
+            /**
+             * Model Spend
+             * @default {}
+             */
+            model_spend: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Models
+             * @default []
+             */
             models: string[];
             object_permission?: components["schemas"]["LiteLLM_ObjectPermissionTable"] | null;
             /** Object Permission Id */
@@ -22061,12 +25064,16 @@ export interface components {
             auto_router_embedding_model?: string | null;
             /** Aws Access Key Id */
             aws_access_key_id?: string | null;
+            /** Aws Bedrock Project Id */
+            aws_bedrock_project_id?: string | null;
             /** Aws Bedrock Runtime Endpoint */
             aws_bedrock_runtime_endpoint?: string | null;
             /** Aws Region Name */
             aws_region_name?: string | null;
             /** Aws Secret Access Key */
             aws_secret_access_key?: string | null;
+            /** Azure Ad Token */
+            azure_ad_token?: string | null;
             /** Budget Duration */
             budget_duration?: string | null;
             /** Cache Creation Input Audio Token Cost */
@@ -22083,6 +25090,10 @@ export interface components {
             cache_read_input_token_cost?: number | null;
             /** Cache Read Input Token Cost Above 200K Tokens */
             cache_read_input_token_cost_above_200k_tokens?: number | null;
+            /** Cache Read Input Token Cost Above 200K Tokens Priority */
+            cache_read_input_token_cost_above_200k_tokens_priority?: number | null;
+            /** Cache Read Input Token Cost Above 272K Tokens Priority */
+            cache_read_input_token_cost_above_272k_tokens_priority?: number | null;
             /** Cache Read Input Token Cost Flex */
             cache_read_input_token_cost_flex?: number | null;
             /** Cache Read Input Token Cost Priority */
@@ -22131,6 +25142,10 @@ export interface components {
             input_cost_per_token_above_128k_tokens?: number | null;
             /** Input Cost Per Token Above 200K Tokens */
             input_cost_per_token_above_200k_tokens?: number | null;
+            /** Input Cost Per Token Above 200K Tokens Priority */
+            input_cost_per_token_above_200k_tokens_priority?: number | null;
+            /** Input Cost Per Token Above 272K Tokens Priority */
+            input_cost_per_token_above_272k_tokens_priority?: number | null;
             /** Input Cost Per Token Batches */
             input_cost_per_token_batches?: number | null;
             /** Input Cost Per Token Cache Hit */
@@ -22204,6 +25219,10 @@ export interface components {
             output_cost_per_token_above_128k_tokens?: number | null;
             /** Output Cost Per Token Above 200K Tokens */
             output_cost_per_token_above_200k_tokens?: number | null;
+            /** Output Cost Per Token Above 200K Tokens Priority */
+            output_cost_per_token_above_200k_tokens_priority?: number | null;
+            /** Output Cost Per Token Above 272K Tokens Priority */
+            output_cost_per_token_above_272k_tokens_priority?: number | null;
             /** Output Cost Per Token Batches */
             output_cost_per_token_batches?: number | null;
             /** Output Cost Per Token Flex */
@@ -22231,7 +25250,7 @@ export interface components {
                 [key: string]: unknown;
             } | null;
             /** Stream Timeout */
-            stream_timeout?: string | number | null;
+            stream_timeout?: number | string | null;
             /** Tag Regex */
             tag_regex?: string[] | null;
             /** Tags */
@@ -22256,6 +25275,12 @@ export interface components {
              * @default false
              */
             use_litellm_proxy: boolean | null;
+            /**
+             * Use Xai Oauth
+             * @description Use stored xAI OAuth credentials when no xAI API key is configured.
+             * @default false
+             */
+            use_xai_oauth: boolean | null;
             /** Vector Store Id */
             vector_store_id?: string | null;
             /** Vertex Credentials */
@@ -22286,7 +25311,7 @@ export interface components {
             /** Created At */
             created_at?: string | null;
             /** Created By */
-            created_by: string;
+            created_by?: string | null;
             /** Description */
             description?: string | null;
             litellm_budget_table?: components["schemas"]["LiteLLM_BudgetTable"] | null;
@@ -22328,7 +25353,35 @@ export interface components {
             /** Updated At */
             updated_at?: string | null;
             /** Updated By */
-            updated_by: string;
+            updated_by?: string | null;
+        };
+        /** LiteLLM_ProxyModelTable */
+        LiteLLM_ProxyModelTable: {
+            /**
+             * Blocked
+             * @default false
+             */
+            blocked: boolean;
+            /** Created At */
+            created_at?: string | null;
+            /** Created By */
+            created_by?: string | null;
+            /** Litellm Params */
+            litellm_params: {
+                [key: string]: unknown;
+            };
+            /** Model Id */
+            model_id: string;
+            /** Model Info */
+            model_info?: {
+                [key: string]: unknown;
+            } | null;
+            /** Model Name */
+            model_name: string;
+            /** Updated At */
+            updated_at?: string | null;
+            /** Updated By */
+            updated_by?: string | null;
         };
         /** LiteLLM_SpendLogs */
         LiteLLM_SpendLogs: {
@@ -22433,6 +25486,11 @@ export interface components {
              */
             admins: unknown[];
             /**
+             * Allow Team Guardrail Config
+             * @default false
+             */
+            allow_team_guardrail_config: boolean | null;
+            /**
              * Blocked
              * @default false
              */
@@ -22469,6 +25527,20 @@ export interface components {
             /** Model Id */
             model_id?: number | null;
             /**
+             * Model Max Budget
+             * @default {}
+             */
+            model_max_budget: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Model Spend
+             * @default {}
+             */
+            model_spend: {
+                [key: string]: unknown;
+            } | null;
+            /**
              * Models
              * @default []
              */
@@ -22478,6 +25550,8 @@ export interface components {
             object_permission_id?: string | null;
             /** Organization Id */
             organization_id?: string | null;
+            /** Policies */
+            policies?: string[] | null;
             /** Router Settings */
             router_settings?: {
                 [key: string]: unknown;
@@ -22549,6 +25623,11 @@ export interface components {
         };
         /** LiteLLM_UserTable */
         LiteLLM_UserTable: {
+            /**
+             * Allowed Cache Controls
+             * @default []
+             */
+            allowed_cache_controls: string[];
             /** Budget Duration */
             budget_duration?: string | null;
             /** Budget Reset At */
@@ -22557,6 +25636,8 @@ export interface components {
             created_at?: string | null;
             /** Max Budget */
             max_budget?: number | null;
+            /** Max Parallel Requests */
+            max_parallel_requests?: number | null;
             /** Metadata */
             metadata?: {
                 [key: string]: unknown;
@@ -22581,8 +25662,17 @@ export interface components {
              */
             models: unknown[];
             object_permission?: components["schemas"]["LiteLLM_ObjectPermissionTable"] | null;
+            /** Object Permission Id */
+            object_permission_id?: string | null;
+            /** Organization Id */
+            organization_id?: string | null;
             /** Organization Memberships */
             organization_memberships?: components["schemas"]["LiteLLM_OrganizationMembershipTable"][] | null;
+            /**
+             * Policies
+             * @default []
+             */
+            policies: string[];
             /** Rpm Limit */
             rpm_limit?: number | null;
             /**
@@ -22592,6 +25682,8 @@ export interface components {
             spend: number;
             /** Sso User Id */
             sso_user_id?: string | null;
+            /** Team Id */
+            team_id?: string | null;
             /**
              * Teams
              * @default []
@@ -22610,8 +25702,20 @@ export interface components {
             /** User Role */
             user_role?: string | null;
         };
+        /** LiteLLM_UserTableFiltered */
+        LiteLLM_UserTableFiltered: {
+            /** User Email */
+            user_email?: string | null;
+            /** User Id */
+            user_id: string;
+        };
         /** LiteLLM_UserTableWithKeyCount */
         LiteLLM_UserTableWithKeyCount: {
+            /**
+             * Allowed Cache Controls
+             * @default []
+             */
+            allowed_cache_controls: string[];
             /** Budget Duration */
             budget_duration?: string | null;
             /** Budget Reset At */
@@ -22625,6 +25729,8 @@ export interface components {
             key_count: number;
             /** Max Budget */
             max_budget?: number | null;
+            /** Max Parallel Requests */
+            max_parallel_requests?: number | null;
             /** Metadata */
             metadata?: {
                 [key: string]: unknown;
@@ -22649,8 +25755,17 @@ export interface components {
              */
             models: unknown[];
             object_permission?: components["schemas"]["LiteLLM_ObjectPermissionTable"] | null;
+            /** Object Permission Id */
+            object_permission_id?: string | null;
+            /** Organization Id */
+            organization_id?: string | null;
             /** Organization Memberships */
             organization_memberships?: components["schemas"]["LiteLLM_OrganizationMembershipTable"][] | null;
+            /**
+             * Policies
+             * @default []
+             */
+            policies: string[];
             /** Rpm Limit */
             rpm_limit?: number | null;
             /**
@@ -22660,6 +25775,8 @@ export interface components {
             spend: number;
             /** Sso User Id */
             sso_user_id?: string | null;
+            /** Team Id */
+            team_id?: string | null;
             /**
              * Teams
              * @default []
@@ -22710,6 +25827,8 @@ export interface components {
             blocked?: boolean | null;
             /** Budget Duration */
             budget_duration?: string | null;
+            /** Budget Id */
+            budget_id?: string | null;
             /** Budget Limits */
             budget_limits?: {
                 [key: string]: unknown;
@@ -23910,40 +27029,20 @@ export interface components {
             /** Tpm */
             tpm?: number | null;
         };
-        /** ModelInfo */
-        ModelInfo: {
-            /** Base Model */
-            base_model?: string | null;
-            /** Blocked */
-            blocked?: boolean | null;
-            /** Created At */
-            created_at?: string | null;
-            /** Created By */
-            created_by?: string | null;
-            /**
-             * Db Model
-             * @default false
-             */
-            db_model: boolean;
-            /** Id */
-            id: string | null;
-            /** Team Id */
-            team_id?: string | null;
-            /** Team Public Model Name */
-            team_public_model_name?: string | null;
-            /** Tier */
-            tier?: ("free" | "paid") | null;
-            /** Updated At */
-            updated_at?: string | null;
-            /** Updated By */
-            updated_by?: string | null;
-        } & {
-            [key: string]: unknown;
-        };
         /** ModelInfoDelete */
         ModelInfoDelete: {
             /** Id */
             id: string;
+        };
+        /** ModelParams */
+        ModelParams: {
+            /** Litellm Params */
+            litellm_params: {
+                [key: string]: unknown;
+            };
+            model_info: components["schemas"]["litellm__proxy___types__ModelInfo"];
+            /** Model Name */
+            model_name: string;
         };
         /** ModelResponse */
         ModelResponse: {
@@ -24234,7 +27333,17 @@ export interface components {
             metadata?: {
                 [key: string]: unknown;
             } | null;
-            /** Models */
+            /**
+             * Model Spend
+             * @default {}
+             */
+            model_spend: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Models
+             * @default []
+             */
             models: string[];
             object_permission?: components["schemas"]["LiteLLM_ObjectPermissionTable"] | null;
             /** Object Permission Id */
@@ -24339,7 +27448,7 @@ export interface components {
              */
             created_at: string;
             /** Created By */
-            created_by: string;
+            created_by?: string | null;
             /** Description */
             description?: string | null;
             litellm_budget_table?: components["schemas"]["LiteLLM_BudgetTable"] | null;
@@ -24384,7 +27493,7 @@ export interface components {
              */
             updated_at: string;
             /** Updated By */
-            updated_by: string;
+            updated_by?: string | null;
         };
         /** NewTeamRequest */
         NewTeamRequest: {
@@ -24997,6 +28106,11 @@ export interface components {
              * @description The URL to which requests for this path should be forwarded.
              */
             target: string;
+            /**
+             * Timeout
+             * @description Upstream request timeout in seconds for this pass-through endpoint. If unset, uses general_settings.pass_through_request_timeout (default 600).
+             */
+            timeout?: number | null;
         };
         /**
          * PassThroughGuardrailSettings
@@ -27131,6 +30245,13 @@ export interface components {
             /** Model */
             model?: string | null;
         };
+        /**
+         * SupportedDBObjectType
+         * @description Supported database object types for fine-grained DB storage control.
+         *     Use in general_settings.supported_db_objects to specify which objects to load from DB.
+         * @enum {string}
+         */
+        SupportedDBObjectType: "models" | "mcp" | "guardrails" | "policies" | "vector_stores" | "pass_through_endpoints" | "prompts" | "model_cost_map" | "tools" | "config_overrides";
         /** SupportedEndpoint */
         SupportedEndpoint: {
             /** Endpoint */
@@ -27273,6 +30394,11 @@ export interface components {
              */
             admins: unknown[];
             /**
+             * Allow Team Guardrail Config
+             * @default false
+             */
+            allow_team_guardrail_config: boolean | null;
+            /**
              * Blocked
              * @default false
              */
@@ -27309,6 +30435,20 @@ export interface components {
             /** Model Id */
             model_id?: number | null;
             /**
+             * Model Max Budget
+             * @default {}
+             */
+            model_max_budget: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Model Spend
+             * @default {}
+             */
+            model_spend: {
+                [key: string]: unknown;
+            } | null;
+            /**
              * Models
              * @default []
              */
@@ -27318,6 +30458,8 @@ export interface components {
             object_permission_id?: string | null;
             /** Organization Id */
             organization_id?: string | null;
+            /** Policies */
+            policies?: string[] | null;
             /** Router Settings */
             router_settings?: {
                 [key: string]: unknown;
@@ -27361,6 +30503,11 @@ export interface components {
              * @default []
              */
             admins: unknown[];
+            /**
+             * Allow Team Guardrail Config
+             * @default false
+             */
+            allow_team_guardrail_config: boolean | null;
             /**
              * Blocked
              * @default false
@@ -27408,6 +30555,20 @@ export interface components {
             /** Model Id */
             model_id?: number | null;
             /**
+             * Model Max Budget
+             * @default {}
+             */
+            model_max_budget: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Model Spend
+             * @default {}
+             */
+            model_spend: {
+                [key: string]: unknown;
+            } | null;
+            /**
              * Models
              * @default []
              */
@@ -27417,6 +30578,8 @@ export interface components {
             object_permission_id?: string | null;
             /** Organization Id */
             organization_id?: string | null;
+            /** Policies */
+            policies?: string[] | null;
             /** Router Settings */
             router_settings?: {
                 [key: string]: unknown;
@@ -27574,6 +30737,11 @@ export interface components {
              * @description List of models this team member can access. Pass an empty list to remove per-member model restrictions.
              */
             allowed_models?: string[] | null;
+            /**
+             * Budget Duration
+             * @description Duration after which this team member's budget resets (e.g. '1h', '24h', '7d', '30d'). If not set, the budget never resets.
+             */
+            budget_duration?: string | null;
             /** Max Budget In Team */
             max_budget_in_team?: number | null;
             /** Role */
@@ -27599,6 +30767,8 @@ export interface components {
         TeamMemberUpdateResponse: {
             /** Allowed Models */
             allowed_models?: string[] | null;
+            /** Budget Duration */
+            budget_duration?: string | null;
             /** Max Budget In Team */
             max_budget_in_team?: number | null;
             /** Rpm Limit */
@@ -28024,6 +31194,11 @@ export interface components {
             admin_ui_disabled: boolean;
             /** Auto Redirect To Sso */
             auto_redirect_to_sso: boolean;
+            /**
+             * Hide Default Credentials Hint
+             * @default false
+             */
+            hide_default_credentials_hint: boolean;
             /**
              * Is Control Plane
              * @default false
@@ -28900,6 +32075,8 @@ export interface components {
             blocked?: boolean | null;
             /** Budget Duration */
             budget_duration?: string | null;
+            /** Budget Id */
+            budget_id?: string | null;
             /** Budget Limits */
             budget_limits?: {
                 [key: string]: unknown;
@@ -29118,6 +32295,19 @@ export interface components {
             user_spend?: number | null;
             /** User Tpm Limit */
             user_tpm_limit?: number | null;
+        };
+        /**
+         * UserHeaderMapping
+         * @description Map an incoming HTTP header to a LiteLLM user role.
+         */
+        UserHeaderMapping: {
+            /** Header Name */
+            header_name: string;
+            /**
+             * Litellm User Role
+             * @enum {string}
+             */
+            litellm_user_role: "internal_user" | "customer";
         };
         /** UserInfoResponse */
         UserInfoResponse: {
@@ -29443,12 +32633,68 @@ export interface components {
             /** Status */
             status?: ("pending" | "running" | "paused" | "completed" | "failed") | null;
         };
+        /** ModelInfo */
+        litellm__proxy___types__ModelInfo: {
+            /** Base Model */
+            base_model: ("gpt-4-1106-preview" | "gpt-4-32k" | "gpt-4" | "gpt-3.5-turbo-16k" | "gpt-3.5-turbo" | "text-embedding-ada-002") | null;
+            /** Id */
+            id: string | null;
+            /**
+             * Input Cost Per Token
+             * @default 0
+             */
+            input_cost_per_token: number | null;
+            /**
+             * Max Tokens
+             * @default 2048
+             */
+            max_tokens: number | null;
+            /** Mode */
+            mode: ("embedding" | "chat" | "completion") | null;
+            /**
+             * Output Cost Per Token
+             * @default 0
+             */
+            output_cost_per_token: number | null;
+        } & {
+            [key: string]: unknown;
+        };
+        /** ModelInfo */
+        litellm__types__router__ModelInfo: {
+            /** Base Model */
+            base_model?: string | null;
+            /** Blocked */
+            blocked?: boolean | null;
+            /** Created At */
+            created_at?: string | null;
+            /** Created By */
+            created_by?: string | null;
+            /**
+             * Db Model
+             * @default false
+             */
+            db_model: boolean;
+            /** Id */
+            id: string | null;
+            /** Team Id */
+            team_id?: string | null;
+            /** Team Public Model Name */
+            team_public_model_name?: string | null;
+            /** Tier */
+            tier?: ("free" | "paid") | null;
+            /** Updated At */
+            updated_at?: string | null;
+            /** Updated By */
+            updated_by?: string | null;
+        } & {
+            [key: string]: unknown;
+        };
         /** updateDeployment */
         updateDeployment: {
             /** Blocked */
             blocked?: boolean | null;
             litellm_params?: components["schemas"]["updateLiteLLMParams"] | null;
-            model_info?: components["schemas"]["ModelInfo"] | null;
+            model_info?: components["schemas"]["litellm__types__router__ModelInfo"] | null;
             /** Model Name */
             model_name?: string | null;
         };
@@ -29476,12 +32722,16 @@ export interface components {
             auto_router_embedding_model?: string | null;
             /** Aws Access Key Id */
             aws_access_key_id?: string | null;
+            /** Aws Bedrock Project Id */
+            aws_bedrock_project_id?: string | null;
             /** Aws Bedrock Runtime Endpoint */
             aws_bedrock_runtime_endpoint?: string | null;
             /** Aws Region Name */
             aws_region_name?: string | null;
             /** Aws Secret Access Key */
             aws_secret_access_key?: string | null;
+            /** Azure Ad Token */
+            azure_ad_token?: string | null;
             /** Budget Duration */
             budget_duration?: string | null;
             /** Cache Creation Input Audio Token Cost */
@@ -29498,6 +32748,10 @@ export interface components {
             cache_read_input_token_cost?: number | null;
             /** Cache Read Input Token Cost Above 200K Tokens */
             cache_read_input_token_cost_above_200k_tokens?: number | null;
+            /** Cache Read Input Token Cost Above 200K Tokens Priority */
+            cache_read_input_token_cost_above_200k_tokens_priority?: number | null;
+            /** Cache Read Input Token Cost Above 272K Tokens Priority */
+            cache_read_input_token_cost_above_272k_tokens_priority?: number | null;
             /** Cache Read Input Token Cost Flex */
             cache_read_input_token_cost_flex?: number | null;
             /** Cache Read Input Token Cost Priority */
@@ -29546,6 +32800,10 @@ export interface components {
             input_cost_per_token_above_128k_tokens?: number | null;
             /** Input Cost Per Token Above 200K Tokens */
             input_cost_per_token_above_200k_tokens?: number | null;
+            /** Input Cost Per Token Above 200K Tokens Priority */
+            input_cost_per_token_above_200k_tokens_priority?: number | null;
+            /** Input Cost Per Token Above 272K Tokens Priority */
+            input_cost_per_token_above_272k_tokens_priority?: number | null;
             /** Input Cost Per Token Batches */
             input_cost_per_token_batches?: number | null;
             /** Input Cost Per Token Cache Hit */
@@ -29619,6 +32877,10 @@ export interface components {
             output_cost_per_token_above_128k_tokens?: number | null;
             /** Output Cost Per Token Above 200K Tokens */
             output_cost_per_token_above_200k_tokens?: number | null;
+            /** Output Cost Per Token Above 200K Tokens Priority */
+            output_cost_per_token_above_200k_tokens_priority?: number | null;
+            /** Output Cost Per Token Above 272K Tokens Priority */
+            output_cost_per_token_above_272k_tokens_priority?: number | null;
             /** Output Cost Per Token Batches */
             output_cost_per_token_batches?: number | null;
             /** Output Cost Per Token Flex */
@@ -29646,7 +32908,7 @@ export interface components {
                 [key: string]: unknown;
             } | null;
             /** Stream Timeout */
-            stream_timeout?: string | number | null;
+            stream_timeout?: number | string | null;
             /** Tag Regex */
             tag_regex?: string[] | null;
             /** Tags */
@@ -29671,6 +32933,12 @@ export interface components {
              * @default false
              */
             use_litellm_proxy: boolean | null;
+            /**
+             * Use Xai Oauth
+             * @description Use stored xAI OAuth credentials when no xAI API key is configured.
+             * @default false
+             */
+            use_xai_oauth: boolean | null;
             /** Vector Store Id */
             vector_store_id?: string | null;
             /** Vertex Credentials */
@@ -30116,6 +33384,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    alerting_settings_alerting_settings_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
                 };
             };
         };
@@ -32526,6 +35814,39 @@ export interface operations {
             };
         };
     };
+    delete_callback_config_callback_delete_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CallbackDelete"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     get_cost_discount_config_config_cost_discount_config_get: {
         parameters: {
             query?: never;
@@ -32625,6 +35946,134 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_config_general_settings_config_field_delete_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ConfigFieldDelete"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_config_general_settings_config_field_info_get: {
+        parameters: {
+            query: {
+                field_name: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ConfigFieldInfo"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_config_general_settings_config_field_update_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ConfigFieldUpdate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_config_list_config_list_get: {
+        parameters: {
+            query: {
+                config_type: "general_settings";
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ConfigList"][];
                 };
             };
             /** @description Validation Error */
@@ -32779,6 +36228,72 @@ export interface operations {
         requestBody: {
             content: {
                 "application/json": components["schemas"]["PassThroughGenericEndpoint"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_config_config_update_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ConfigYAML"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    config_yaml_endpoint_config_yaml_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ConfigYAML"];
             };
         };
         responses: {
@@ -33823,6 +37338,102 @@ export interface operations {
             };
         };
     };
+    get_memory_details_debug_memory_details_get: {
+        parameters: {
+            query?: {
+                /** @description Number of top object types to return */
+                top_n?: number;
+                /** @description Include process memory info */
+                include_process_info?: boolean;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    configure_gc_thresholds_endpoint_debug_memory_gc_configure_post: {
+        parameters: {
+            query?: {
+                /** @description Generation 0 threshold (default: 700) */
+                generation_0?: number;
+                /** @description Generation 1 threshold (default: 10) */
+                generation_1?: number;
+                /** @description Generation 2 threshold (default: 10) */
+                generation_2?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_memory_summary_debug_memory_summary_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+        };
+    };
     delete_allowed_ip_delete_allowed_ip_post: {
         parameters: {
             query?: never;
@@ -34006,6 +37617,261 @@ export interface operations {
                      */
                     user?: string | null;
                 };
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    block_user_end_user_block_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["BlockUsers"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_customer_daily_activity_end_user_daily_activity_get: {
+        parameters: {
+            query?: {
+                end_user_ids?: string | null;
+                start_date?: string | null;
+                end_date?: string | null;
+                model?: string | null;
+                api_key?: string | null;
+                page?: number;
+                page_size?: number;
+                exclude_end_user_ids?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_end_user_end_user_delete_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["DeleteCustomerRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    end_user_info_end_user_info_get: {
+        parameters: {
+            query: {
+                /** @description End User ID in the request parameters */
+                end_user_id: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_end_user_end_user_list_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    new_end_user_end_user_new_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["NewCustomerRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    unblock_user_end_user_unblock_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["BlockUsers"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_end_user_end_user_update_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateCustomerRequest"];
             };
         };
         responses: {
@@ -34551,6 +38417,26 @@ export interface operations {
             };
         };
     };
+    fallback_login_fallback_login_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
     get_fallback_fallback__model__get: {
         parameters: {
             query?: {
@@ -35071,6 +38957,46 @@ export interface operations {
             };
         };
     };
+    get_allowed_ips_get_allowed_ips_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    get_config_get_config_callbacks_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
     get_default_team_settings_get_default_team_settings_get: {
         parameters: {
             query?: never;
@@ -35191,6 +39117,483 @@ export interface operations {
             };
         };
     };
+    get_favicon_get_favicon_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    get_image_get_image_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    get_logo_url_get_logo_url_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    get_global_activity_global_activity_get: {
+        parameters: {
+            query?: {
+                /** @description Time from which to start viewing spend */
+                start_date?: string | null;
+                /** @description Time till which to view spend */
+                end_date?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LiteLLM_SpendLogs"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_global_activity_global_activity_cache_hits_get: {
+        parameters: {
+            query?: {
+                /** @description Time from which to start viewing spend */
+                start_date?: string | null;
+                /** @description Time till which to view spend */
+                end_date?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LiteLLM_SpendLogs"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_global_activity_exceptions_global_activity_exceptions_get: {
+        parameters: {
+            query: {
+                /** @description Filter by model group */
+                model_group: string;
+                /** @description Time from which to start viewing spend */
+                start_date?: string | null;
+                /** @description Time till which to view spend */
+                end_date?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LiteLLM_SpendLogs"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_global_activity_exceptions_per_deployment_global_activity_exceptions_deployment_get: {
+        parameters: {
+            query: {
+                /** @description Filter by model group */
+                model_group: string;
+                /** @description Time from which to start viewing spend */
+                start_date?: string | null;
+                /** @description Time till which to view spend */
+                end_date?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LiteLLM_SpendLogs"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_global_activity_model_global_activity_model_get: {
+        parameters: {
+            query?: {
+                /** @description Time from which to start viewing spend */
+                start_date?: string | null;
+                /** @description Time till which to view spend */
+                end_date?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LiteLLM_SpendLogs"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    global_view_all_end_users_global_all_end_users_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    global_spend_global_spend_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    global_get_all_tag_names_global_spend_all_tag_names_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LiteLLM_SpendLogs"][];
+                };
+            };
+        };
+    };
+    global_spend_end_users_global_spend_end_users_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["GlobalEndUsersSpend"] | null;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    global_spend_keys_global_spend_keys_get: {
+        parameters: {
+            query?: {
+                /** @description Number of keys to get. Will return Top 'n' keys. */
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    global_spend_logs_global_spend_logs_get: {
+        parameters: {
+            query?: {
+                /** @description API Key to get global spend (spend per day for last 30d). Admin-only endpoint */
+                api_key?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    global_spend_models_global_spend_models_get: {
+        parameters: {
+            query?: {
+                /** @description Number of models to get. Will return Top 'n' models. */
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_global_spend_provider_global_spend_provider_get: {
+        parameters: {
+            query?: {
+                /** @description Time from which to start viewing spend */
+                start_date?: string | null;
+                /** @description Time till which to view spend */
+                end_date?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LiteLLM_SpendLogs"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    global_spend_refresh_global_spend_refresh_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
     get_global_spend_report_global_spend_report_get: {
         parameters: {
             query?: {
@@ -35287,6 +39690,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    global_spend_per_team_global_spend_teams_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
                 };
             };
         };
@@ -36259,7 +40682,7 @@ export interface operations {
         parameters: {
             query: {
                 /** @description Specify the service being hit. */
-                service: ("slack_budget_alerts" | "langfuse" | "langfuse_otel" | "slack" | "openmeter" | "webhook" | "email" | "braintrust" | "datadog" | "datadog_llm_observability" | "generic_api" | "arize" | "sqs") | string;
+                service: ("slack_budget_alerts" | "langfuse" | "langfuse_otel" | "slack" | "openmeter" | "webhook" | "email" | "braintrust" | "datadog" | "datadog_llm_observability" | "generic_api" | "arize" | "galileo" | "newrelic" | "sqs") | string;
             };
             header?: never;
             path?: never;
@@ -36526,6 +40949,136 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    invitation_delete_invitation_delete_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["InvitationDelete"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InvitationModel"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    invitation_info_invitation_info_get: {
+        parameters: {
+            query: {
+                invitation_id: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InvitationModel"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    new_invitation_invitation_new_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["InvitationNew"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InvitationModel"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    invitation_update_invitation_update_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["InvitationUpdate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InvitationModel"];
                 };
             };
             /** @description Validation Error */
@@ -37380,6 +41933,37 @@ export interface operations {
             };
         };
     };
+    warm_lazy_warm__name__post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     get_ui_config_litellm__well_known_litellm_ui_config_get: {
         parameters: {
             query?: never;
@@ -37396,6 +41980,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["UiDiscoveryEndpoints"];
+                };
+            };
+        };
+    };
+    login_login_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
                 };
             };
         };
@@ -37516,6 +42120,46 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    memory_usage_in_mem_cache_memory_usage_in_mem_cache_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    memory_usage_in_mem_cache_items_memory_usage_in_mem_cache_items_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
                 };
             };
         };
@@ -37830,6 +42474,62 @@ export interface operations {
             };
         };
     };
+    block_model_model_block_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description The litellm-changed-by header enables tracking of actions performed by authorized users on behalf of other users, providing an audit trail for accountability */
+                "litellm-changed-by"?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["BlockModelRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LiteLLM_ProxyModelTable"] | null;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_model_cost_map_source_model_cost_map_source_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
     delete_model_model_delete_post: {
         parameters: {
             query?: never;
@@ -37867,6 +42567,115 @@ export interface operations {
         parameters: {
             query?: {
                 litellm_model_id?: string | null;
+                /** @description When true, filter to deployments the caller can use via direct access or team membership. */
+                include_team_models?: boolean | null;
+                /** @description Filter models by team ID. Returns models with direct_access=True or teamId in access_via_team_ids */
+                teamId?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    model_metrics_model_metrics_get: {
+        parameters: {
+            query?: {
+                _selected_model_group?: string | null;
+                startTime?: string | null;
+                endTime?: string | null;
+                api_key?: string | null;
+                customer?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    model_metrics_exceptions_model_metrics_exceptions_get: {
+        parameters: {
+            query?: {
+                _selected_model_group?: string | null;
+                startTime?: string | null;
+                endTime?: string | null;
+                api_key?: string | null;
+                customer?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    model_metrics_slow_responses_model_metrics_slow_responses_get: {
+        parameters: {
+            query?: {
+                _selected_model_group?: string | null;
+                startTime?: string | null;
+                endTime?: string | null;
+                api_key?: string | null;
+                customer?: string | null;
             };
             header?: never;
             path?: never;
@@ -37914,6 +42723,95 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    model_settings_model_settings_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    model_streaming_metrics_model_streaming_metrics_get: {
+        parameters: {
+            query?: {
+                _selected_model_group?: string | null;
+                startTime?: string | null;
+                endTime?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    unblock_model_model_unblock_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description The litellm-changed-by header enables tracking of actions performed by authorized users on behalf of other users, providing an audit trail for accountability */
+                "litellm-changed-by"?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["BlockModelRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LiteLLM_ProxyModelTable"] | null;
                 };
             };
             /** @description Validation Error */
@@ -38102,6 +43000,7 @@ export interface operations {
                 include_metadata?: boolean | null;
                 fallback_type?: string | null;
                 scope?: string | null;
+                healthy_only?: boolean | null;
             };
             header?: never;
             path?: never;
@@ -38131,7 +43030,10 @@ export interface operations {
     };
     model_info_models__model_id__get: {
         parameters: {
-            query?: never;
+            query?: {
+                team_id?: string | null;
+                healthy_only?: boolean | null;
+            };
             header?: never;
             path: {
                 model_id: string;
@@ -38289,6 +43191,70 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+        };
+    };
+    claim_onboarding_link_onboarding_claim_token_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["InvitationClaim"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    onboarding_onboarding_get_token_get: {
+        parameters: {
+            query: {
+                invite_link: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };
@@ -38537,7 +43503,17 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description RateLimitError */
+            /**
+             * @description Unified rate-limit error.
+             *
+             *         Every rate-limit condition surfaced by litellm — whether it originated from
+             *         an upstream LLM provider, a vendor batch endpoint, or one of litellm's own
+             *         proxy-side limiters (parallel-requests, dynamic-rate, batch-rate, budget,
+             *         max-iterations, etc.) — is raised as an instance of this class.
+             *
+             *         The :attr:`category` attribute lets callers distinguish the source. See
+             *         :class:`RateLimitErrorCategory` for the available values.
+             */
             429: {
                 headers: {
                     [name: string]: unknown;
@@ -39466,6 +44442,250 @@ export interface operations {
             };
         };
     };
+    list_plugins_api_plugins_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown[];
+                };
+            };
+        };
+    };
+    plugin_proxy_plugin_proxy__plugin_name___path__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                plugin_name: string;
+                path: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    plugin_proxy_plugin_proxy__plugin_name___path__put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                plugin_name: string;
+                path: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    plugin_proxy_plugin_proxy__plugin_name___path__post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                plugin_name: string;
+                path: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    plugin_proxy_plugin_proxy__plugin_name___path__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                plugin_name: string;
+                path: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    plugin_proxy_plugin_proxy__plugin_name___path__options: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                plugin_name: string;
+                path: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    plugin_proxy_plugin_proxy__plugin_name___path__head: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                plugin_name: string;
+                path: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    plugin_proxy_plugin_proxy__plugin_name___path__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                plugin_name: string;
+                path: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     organization_member_add_organization_member_add_post: {
         parameters: {
             query?: never;
@@ -39614,6 +44834,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["LiteLLM_OrganizationTableWithMembers"];
+                };
+            };
+        };
+    };
+    get_otel_spans_otel_spans_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
                 };
             };
         };
@@ -41189,6 +46429,37 @@ export interface operations {
             };
         };
     };
+    async_queue_request_queue_chat_completions_post: {
+        parameters: {
+            query?: {
+                model?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     rag_ingest_rag_ingest_post: {
         parameters: {
             query?: never;
@@ -41283,6 +46554,46 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["RealtimeClientSecretResponse"];
+                };
+            };
+        };
+    };
+    reload_anthropic_beta_headers_reload_anthropic_beta_headers_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    reload_model_cost_map_reload_model_cost_map_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
                 };
             };
         };
@@ -41550,6 +46861,148 @@ export interface operations {
         };
     };
     get_routes_routes_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    schedule_anthropic_beta_headers_reload_schedule_anthropic_beta_headers_reload_post: {
+        parameters: {
+            query: {
+                hours: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    cancel_anthropic_beta_headers_reload_schedule_anthropic_beta_headers_reload_delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    get_anthropic_beta_headers_reload_status_schedule_anthropic_beta_headers_reload_status_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    schedule_model_cost_map_reload_schedule_model_cost_map_reload_post: {
+        parameters: {
+            query: {
+                hours: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    cancel_model_cost_map_reload_schedule_model_cost_map_reload_delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    get_model_cost_map_reload_status_schedule_model_cost_map_reload_status_get: {
         parameters: {
             query?: never;
             header?: never;
@@ -42517,6 +47970,26 @@ export interface operations {
             };
         };
     };
+    spend_key_fn_spend_keys_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
     view_spend_logs_spend_logs_get: {
         parameters: {
             query?: {
@@ -42546,6 +48019,148 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["LiteLLM_SpendLogs"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    ui_view_session_spend_logs_spend_logs_session_ui_get: {
+        parameters: {
+            query: {
+                /** @description Get all spend logs for a particular session */
+                session_id: string;
+                /** @description Page number for pagination */
+                page?: number;
+                /** @description Number of items per page */
+                page_size?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LiteLLM_SpendLogs"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    ui_view_spend_logs_spend_logs_ui_get: {
+        parameters: {
+            query?: {
+                /** @description Get spend logs based on api key */
+                api_key?: string | null;
+                /** @description Get spend logs based on user_id */
+                user_id?: string | null;
+                /** @description request_id to get spend logs for specific request_id */
+                request_id?: string | null;
+                /** @description Filter spend logs by team_id */
+                team_id?: string | null;
+                /** @description Filter logs with spend greater than or equal to this value */
+                min_spend?: number | null;
+                /** @description Filter logs with spend less than or equal to this value */
+                max_spend?: number | null;
+                /** @description Time from which to start viewing key spend */
+                start_date?: string | null;
+                /** @description Time till which to view key spend */
+                end_date?: string | null;
+                /** @description Page number for pagination */
+                page?: number;
+                /** @description Number of items per page */
+                page_size?: number;
+                /** @description Filter logs by status (e.g., success, failure) */
+                status_filter?: string | null;
+                /** @description Filter logs by model */
+                model?: string | null;
+                /** @description Filter logs by model ID (litellm model deployment id) */
+                model_id?: string | null;
+                /** @description Filter logs by model group */
+                model_group?: string | null;
+                /** @description Filter logs by key alias */
+                key_alias?: string | null;
+                /** @description Filter logs by end user */
+                end_user?: string | null;
+                /** @description Filter logs by error code (e.g., '404', '500') */
+                error_code?: string | null;
+                /** @description Filter logs by error message (partial string match) */
+                error_message?: string | null;
+                /** @description Sort logs by field: spend, total_tokens, startTime, endTime, request_duration_ms, model, or ttft_ms */
+                sort_by?: string;
+                /** @description Sort order: asc or desc */
+                sort_order?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LiteLLM_SpendLogs"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    ui_view_request_response_for_request_id_spend_logs_ui__request_id__get: {
+        parameters: {
+            query?: {
+                /** @description Time from which to start viewing key spend */
+                start_date?: string | null;
+                /** @description Time till which to view key spend */
+                end_date?: string | null;
+            };
+            header?: never;
+            path: {
+                request_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
                 };
             };
             /** @description Validation Error */
@@ -42652,6 +48267,250 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["LiteLLM_SpendLogs"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    spend_user_fn_spend_users_get: {
+        parameters: {
+            query?: {
+                /** @description Get User Table row for user_id */
+                user_id?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    auth_callback_sso_callback_get: {
+        parameters: {
+            query?: {
+                state?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    cli_sso_complete_sso_cli_complete__login_id__post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                login_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    cli_poll_key_sso_cli_poll__key_id__get: {
+        parameters: {
+            query?: {
+                team_id?: string | null;
+            };
+            header?: {
+                "x-litellm-cli-poll-secret"?: string | null;
+            };
+            path: {
+                key_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    cli_sso_start_sso_cli_start_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    debug_sso_callback_sso_debug_callback_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    debug_sso_login_sso_debug_login_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    get_ui_settings_sso_get_ui_settings_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    google_login_sso_key_generate_get: {
+        parameters: {
+            query?: {
+                source?: string | null;
+                key?: string | null;
+                existing_key?: string | null;
+                return_to?: string | null;
+                user_code?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
                 };
             };
             /** @description Validation Error */
@@ -43244,6 +49103,44 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    ui_view_teams_team_filter_ui_get: {
+        parameters: {
+            query?: {
+                /** @description Team ID in the request parameters */
+                team_id?: string | null;
+                /** @description Team alias in the request parameters */
+                team_alias?: string | null;
+                /** @description Page number for pagination */
+                page?: number;
+                /** @description Number of items per page */
+                page_size?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LiteLLM_TeamTable"][];
                 };
             };
             /** @description Validation Error */
@@ -44507,6 +50404,26 @@ export interface operations {
             };
         };
     };
+    ui_get_available_role_user_available_roles_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
     available_enterprise_users_user_available_users_get: {
         parameters: {
             query?: never;
@@ -44674,6 +50591,46 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    ui_view_users_user_filter_ui_get: {
+        parameters: {
+            query?: {
+                /** @description User ID in the request parameters */
+                user_id?: string | null;
+                /** @description User email in the request parameters */
+                user_email?: string | null;
+                /** @description Team ID — used when a team admin searches for users to add to their team */
+                team_id?: string | null;
+                /** @description Page number for pagination */
+                page?: number;
+                /** @description Number of items per page */
+                page_size?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LiteLLM_UserTableFiltered"][];
                 };
             };
             /** @description Validation Error */
@@ -48127,6 +54084,10 @@ export interface operations {
         parameters: {
             query?: {
                 litellm_model_id?: string | null;
+                /** @description When true, filter to deployments the caller can use via direct access or team membership. */
+                include_team_models?: boolean | null;
+                /** @description Filter models by team ID. Returns models with direct_access=True or teamId in access_via_team_ids */
+                teamId?: string | null;
             };
             header?: never;
             path?: never;
@@ -48164,6 +54125,7 @@ export interface operations {
                 include_metadata?: boolean | null;
                 fallback_type?: string | null;
                 scope?: string | null;
+                healthy_only?: boolean | null;
             };
             header?: never;
             path?: never;
@@ -48193,7 +54155,10 @@ export interface operations {
     };
     model_info_v1_models__model_id__get: {
         parameters: {
-            query?: never;
+            query?: {
+                team_id?: string | null;
+                healthy_only?: boolean | null;
+            };
             header?: never;
             path: {
                 model_id: string;
@@ -50429,6 +56394,110 @@ export interface operations {
             };
         };
     };
+    info_key_fn_v2_v2_key_info_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["KeyRequest"] | null;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    login_v2_v2_login_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    model_info_v2_v2_model_info_get: {
+        parameters: {
+            query?: {
+                /** @description Specify the model name (optional) */
+                model?: string | null;
+                /** @description Only return models added by this user */
+                user_models_only?: boolean | null;
+                /** @description Return all models across all teams user is in. */
+                include_team_models?: boolean | null;
+                debug?: boolean | null;
+                /** @description Page number */
+                page?: number;
+                /** @description Page size */
+                size?: number;
+                /** @description Search model names (case-insensitive partial match) */
+                search?: string | null;
+                /** @description Search for a specific model by its unique ID */
+                modelId?: string | null;
+                /** @description Filter models by team ID. Returns models with direct_access=True or teamId in access_via_team_ids */
+                teamId?: string | null;
+                /** @description Field to sort by. Options: model_name, created_at, updated_at, costs, status */
+                sortBy?: string | null;
+                /** @description Sort order. Options: asc, desc */
+                sortOrder?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     rerank_v2_rerank_post: {
         parameters: {
             query?: never;
@@ -50527,6 +56596,46 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    login_v3_v3_login_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    login_v3_exchange_v3_login_exchange_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
                 };
             };
         };
@@ -51210,6 +57319,161 @@ export interface operations {
             header?: never;
             path: {
                 vector_store_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    vertex_proxy_route_vertex_ai__endpoint__get_2: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                endpoint: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    vertex_proxy_route_vertex_ai__endpoint__put_2: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                endpoint: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    vertex_proxy_route_vertex_ai__endpoint__post_2: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                endpoint: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    vertex_proxy_route_vertex_ai__endpoint__delete_2: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                endpoint: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    vertex_proxy_route_vertex_ai__endpoint__patch_2: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                endpoint: string;
             };
             cookie?: never;
         };


### PR DESCRIPTION
## Summary

Adds a generic plugin system so any external service can register with litellm and appear as a selectable mode in the UI alongside the AI Gateway.

**5 files changed** (2 new, 3 modified).

## What changed

### `litellm/proxy/plugin_routes.py` *(new)*
- `GET /api/plugins` — returns registered plugins from `general_settings.plugins`. Returns `plugin_key` only to authenticated requests.
- `ANY /plugin-proxy/{name}/{path}` — reverse proxies API calls to the plugin backend, enabling unified auth.

### `litellm/proxy/proxy_server.py` *(3 lines)*
- Import and register `plugin_router`
- Call `register_plugins_from_config(general_settings)` at startup

### `ui/litellm-dashboard/src/contexts/PluginModeContext.tsx` *(new)*
React context that fetches `/api/plugins` on load and persists the selected mode to `localStorage`.

### `ui/litellm-dashboard/src/components/leftnav.tsx`
Adds a mode switcher dropdown at the top of the sidebar. Selecting a plugin swaps the nav items and renders the plugin's UI.

### `ui/litellm-dashboard/src/app/(dashboard)/layout.tsx`
When mode = plugin, renders an `<iframe>` to the plugin URL. Passes `plugin_key` as `?token=` so the plugin can auto-authenticate without a separate login.

## Config

```yaml
general_settings:
  plugins:
    - name: my-plugin
      display_name: My Plugin
      url: "https://my-plugin.example.com"
      plugin_key: "sk-..."   # plugin's own auth key
```

## Plugin contract (2 requirements)

1. Entry in `general_settings.plugins`
2. `GET /api/plugin-manifest` → `{ name, display_name, nav_items[], capabilities[] }`

Adding a new plugin = config change only, no litellm code changes.

## Reference implementation

[LiteLLM-Labs/litellm-agent-control-plane](https://github.com/LiteLLM-Labs/litellm-agent-control-plane) implements the plugin contract: plugin manifest endpoint, hides its own sidebar when embedded, validates litellm virtual keys against `/key/info` for RBAC.