### PR TITLE
test(pass_through): harden vertex spendlog poll against transient empty reads

### DIFF
--- a/tests/pass_through_tests/test_vertex_ai.py
+++ b/tests/pass_through_tests/test_vertex_ai.py
@@ -126,15 +126,21 @@ async def test_basic_vertex_ai_pass_through_with_spendlog():
 
     print("response", response)
 
-    # Poll for spend update instead of fixed sleep - spend logging is async/batched
-    max_wait = 120  # total seconds to wait
+    # Spend logging is async/batched and can lag under CI load, so poll instead of
+    # sleeping a fixed amount. A transient empty read is skipped, not counted as 0.0
+    # spend, which would spuriously fail the assertion on an otherwise-billed call.
+    max_wait = 240  # total seconds to wait
     poll_interval = 10  # seconds between checks
     elapsed = 0
     spend_after = spend_before
     while elapsed < max_wait:
         await asyncio.sleep(poll_interval)
         elapsed += poll_interval
-        spend_after = await call_spend_logs_endpoint() or 0.0
+        latest_spend = await call_spend_logs_endpoint()
+        if latest_spend is None:
+            print(f"spend logs unavailable (elapsed={elapsed}s), retrying")
+            continue
+        spend_after = latest_spend
         print(f"spend_after (elapsed={elapsed}s)", spend_after)
         if spend_after > spend_before:
             break


### PR DESCRIPTION
## Relevant issues

`test_basic_vertex_ai_pass_through_with_spendlog` is the most persistent flake on `litellm_internal_staging` CI. It failed in CircleCI pipelines 82155, 82196, 82209, and 82230 (the `proxy_pass_through_endpoint_tests` suite) with `AssertionError: Spend should be greater than before after 120s`.

## Linear ticket

N/A

## Root cause

The test does a live Vertex AI pass-through call and then polls `/global/spend/logs` for up to 120s, asserting `spend_after > spend_before`. Spend logging is async and batched, so under CI load the call's cost sometimes had not been aggregated within the 120s window, which surfaced as `spend_before == spend_after` (for example `0.063 > 0.063`). In one run (#82155) the assertion failed with `spend_after: 0.0`: the final poll's `call_spend_logs_endpoint()` returned `None` (a transient empty/non-200 read), and `await call_spend_logs_endpoint() or 0.0` recorded that momentary hiccup as zero spend even though earlier the call had been billed.

## Fix

Widen the poll window to 240s so batched spend logging has more headroom to flush, and skip a transient empty read (`None`) instead of coercing it to `0.0`, so a momentary endpoint blip on the last poll no longer clobbers a billed reading. The `spend_after > spend_before` assertion is unchanged, so a genuinely unbilled call still fails the test; this only removes the false negatives. In the common case the loop still breaks early as soon as spend grows, so green runs are not slowed.

## Pre-Submission checklist

- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have added meaningful tests
- [ ] My PR passes all unit tests on `make test-unit`
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

This is a test-infra hardening change to an existing live-API e2e test; there is no product code change, so no separate regression test is added. The guarantee under test (an identical billed pass-through call must move recorded spend) is preserved by the unchanged assertion.

## Screenshots / Proof of Fix

This change only affects timing/resilience of a live Vertex pass-through e2e test, so the proof is the run itself going green on the `proxy_pass_through_endpoint_tests` suite. The before-state is the recurring `Spend should be greater than before after 120s` failures linked above; the after-state is the same suite passing on this branch's CI run.

## Type

✅ Test

## Changes

`tests/pass_through_tests/test_vertex_ai.py`: in `test_basic_vertex_ai_pass_through_with_spendlog`, raise the spend-log poll window from 120s to 240s and `continue` past a `None` reading rather than treating it as `0.0` spend.