### PR TITLE
test: harden remaining pass-through CI flakes (image-gen spend poll, ruby assistants timeout)

### DIFF
--- a/tests/pass_through_tests/ruby_passthrough_tests/spec/openai_assistants_passthrough_spec.rb
+++ b/tests/pass_through_tests/ruby_passthrough_tests/spec/openai_assistants_passthrough_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe 'OpenAI Assistants Passthrough' do
   let(:client) do
     OpenAI::Client.new(
       access_token: "sk-1234",
-      uri_base: "http://0.0.0.0:4000/openai"
+      uri_base: "http://0.0.0.0:4000/openai",
+      request_timeout: 600
     )
   end
 

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -621,17 +621,23 @@ async def test_key_info_spend_values_image_generation():
         assert spend > 0
 
         # The record/replay proxy serves this identical second call from its
-        # cassette (free), but the proxy must still bill it. If the proxy's own
-        # response cache were on, the repeat would be a $0 cache hit and spend
-        # would not move, silently zeroing recorded-call spend; assert it grows.
+        # cassette (free), but the proxy must still bill it. Spend logging is
+        # async/batched, so poll for the increase rather than reading once after a
+        # fixed sleep; a spend that never grows means the repeat was not billed
+        # (e.g. the proxy response cache is on), which this still catches.
         await image_generation(session=session, key=key)
-        await asyncio.sleep(5)
-        key_info = await retry_request(
-            get_key_info, session=session, get_key=key, call_key=key
-        )
-        assert key_info["info"]["spend"] > spend, (
-            "spend did not increase on an identical repeat image call; the proxy "
-            "response cache appears to be ON, which would zero recorded-call spend"
+        spend_after = spend
+        for _ in range(12):
+            await asyncio.sleep(5)
+            key_info = await retry_request(
+                get_key_info, session=session, get_key=key, call_key=key
+            )
+            spend_after = key_info["info"]["spend"]
+            if spend_after > spend:
+                break
+        assert spend_after > spend, (
+            "spend did not increase on an identical repeat image call; the repeat "
+            "was not billed (the proxy response cache may be on)"
         )
 
 


### PR DESCRIPTION
## Relevant issues

Follow-up to #30683. That PR fixed the persistent vertex spendlog flake; this one fixes the two remaining one-off flakes seen on recent `litellm_internal_staging` CircleCI runs, each in its own commit.

## Linear ticket

N/A

## What was failing

`test_key_info_spend_values_image_generation` (build_and_test, pipeline 82282) failed with `spend did not increase on an identical repeat image call` (`assert 0.24966 > 0.24966`). The test made a second identical image call, slept a fixed 5s, then read the key's spend once. Response caching is commented out in `proxy_server_config.yaml` and no sibling `tests/test_*.py` enables it, so the likely cause is async/batched spend logging not having flushed the repeat call's cost within 5s; the job aggravates this by running every top-level test against one shared proxy under `pytest -n 4`.

The streaming example in `openai_assistants_passthrough_spec.rb` (proxy_pass_through, pipeline 82280) failed with `Net::ReadTimeout`, dying at roughly 125s. That is `ruby-openai`'s default `request_timeout` of 120s; an assistants run with the `code_interpreter` tool can occasionally take longer to start streaming back through the pass-through.

## Fix

For the image-gen test, poll the key's spend for up to 60s and break as soon as it grows instead of reading once after a fixed sleep. This removes the timing flake while preserving the canary: if the repeat were genuinely unbilled (for example the proxy response cache being on), spend never grows, the poll times out, and the assertion still fails. For the Ruby spec, raise the client `request_timeout` to 600s, matching the 600s timeout the Python pass-through e2e tests already use, so a slow-but-healthy streaming run no longer trips the default read timeout.

## Pre-Submission checklist

- [x] My PR's scope is as isolated as possible; it only solves CI flakiness, split into one commit per flake
- [ ] I have added meaningful tests
- [ ] My PR passes all unit tests on `make test-unit`
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

These are test-infra hardening changes to existing live-API e2e tests; there is no product code change, so no separate regression test is added. Both changes keep their original assertions, so a genuine regression (an unbilled repeat call, or a hung streaming run) still fails the test.

## Screenshots / Proof of Fix

The proof is the affected suites going green: `proxy_pass_through_endpoint_tests` (Ruby step) and `build_and_test` (`tests/test_keys.py`) on this branch's CI run. The before-state is the `Net::ReadTimeout` and `spend did not increase` failures linked above.

## Type

✅ Test

## Changes

`tests/test_keys.py`: in `test_key_info_spend_values_image_generation`, replace the fixed 5s sleep before the second spend read with a poll (up to 60s) that breaks once spend grows.

`tests/pass_through_tests/ruby_passthrough_tests/spec/openai_assistants_passthrough_spec.rb`: add `request_timeout: 600` to the `OpenAI::Client` used by the assistants specs.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FkUACdCoVU5fpMupSBf1YJ)_