### PR TITLE
fix(cost): stop non-string service_tier from silently dropping cost tracking

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -1227,10 +1227,14 @@ def completion_cost(
         if service_tier is None and optional_params is not None:
             service_tier = optional_params.get("service_tier")
 
-        # "auto" is a routing preference, not a billable tier: the provider picks
-        # the tier and reports the one actually served on the response/usage, so
-        # defer to that instead of pricing the request-level "auto" as standard
-        if service_tier is not None and service_tier.lower() == ServiceTier.AUTO.value:
+        # A request-level service_tier only prices the request when it is a
+        # concrete billable tier string. "auto" is a routing preference and any
+        # non-string value is not a billable tier, so defer to the tier the
+        # provider reports on the response/usage instead of crashing or mispricing
+        if (
+            not isinstance(service_tier, str)
+            or service_tier.lower() == ServiceTier.AUTO.value
+        ):
             service_tier = None
 
         # Extract service_tier from completion_response if not provided

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -2233,6 +2233,58 @@ def test_completion_cost_anthropic_auto_tier_uses_served_priority_rate():
     assert cost == pytest.approx(expected_priority)
 
 
+def test_completion_cost_non_string_service_tier_defers_to_served_tier():
+    """
+    Regression: a non-string request-level ``service_tier`` (reachable via
+    ``allowed_openai_params``/``drop_params``) must not crash cost tracking.
+
+    Before the fix, ``completion_cost`` called ``service_tier.lower()`` on the
+    request-level value, so a dict raised ``AttributeError``. ``_response_cost_calculator``
+    swallowed it and reported ``response_cost=None``, silently dropping the cost.
+    The non-string preference must be ignored so pricing defers to the tier the
+    provider actually served on the response usage.
+    """
+    from litellm import completion_cost
+    from litellm.llms.anthropic.chat.transformation import AnthropicConfig
+
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+
+    model = "claude-test-non-string-tier-cost-model"
+    litellm.register_model(
+        model_cost={
+            model: {
+                "input_cost_per_token": 3e-6,
+                "output_cost_per_token": 15e-6,
+                "input_cost_per_token_priority": 6e-6,
+                "output_cost_per_token_priority": 30e-6,
+                "litellm_provider": "anthropic",
+                "max_tokens": 8192,
+            }
+        }
+    )
+
+    usage = AnthropicConfig().calculate_usage(
+        usage_object={
+            "input_tokens": 1000,
+            "output_tokens": 500,
+            "service_tier": "priority",
+        },
+        reasoning_content=None,
+    )
+    response = ModelResponse(usage=usage, model=model)
+
+    cost = completion_cost(
+        completion_response=response,
+        model=model,
+        custom_llm_provider="anthropic",
+        optional_params={"service_tier": {"name": "auto"}},
+    )
+
+    expected_priority = 1000 * 6e-6 + 500 * 30e-6
+    assert cost == pytest.approx(expected_priority)
+
+
 def test_anthropic_cost_per_token_prices_cache_at_served_tier_with_multiplier():
     """
     Regression for the cache/tier interaction in the Anthropic geo/speed path.


### PR DESCRIPTION
## Relevant issues

Follow-up to #30558, which introduced the request-level `service_tier` "auto" handling in `completion_cost`.

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## What's wrong

`completion_cost` reads `service_tier` from the request `optional_params` and calls `service_tier.lower()` on it (`cost_calculator.py:1233`, added by #30558). That assumes a string. A non-string value (dict/int/list), reachable when a caller forces `service_tier` through `allowed_openai_params`/`drop_params`, hits `.lower()` and raises `AttributeError`. `_response_cost_calculator` (`litellm_logging.py`) swallows the error, logs only at debug, and returns `None`, so the request's cost is silently dropped. Normal string callers and the response-usage path (always string-or-null) are unaffected.

The obvious one-liner (`isinstance` guard at line 1233) is not enough: a surviving dict would crash again downstream in `_get_service_tier_cost_key` (`llm_cost_calc/utils.py:187`), which also calls `.lower()`. So a request-level `service_tier` is only meaningful for pricing when it is a concrete billable tier string; any non-string value is coerced to `None` and pricing defers to the tier the provider reports on the response usage, exactly the way `"auto"` already does.

## Type

🐛 Bug Fix

## Changes

`cost_calculator.py`: the request-level `service_tier` guard now treats any non-string value the same as `"auto"`, coercing it to `None` so it neither crashes nor misprices, and the served tier on the response wins.

Added `test_completion_cost_non_string_service_tier_defers_to_served_tier`, which drives a dict `service_tier` through `completion_cost` against a model with priority rates and a usage that reports the served `priority` tier. It raises `AttributeError` on the pre-fix code and prices at the served priority rate after the fix.

## Screenshots / Proof of Fix

To be added with a live proxy run.