### PR TITLE
feat(ui): migrate old usage report to App Router path route

### DIFF
--- a/ui/litellm-dashboard/e2e_tests/fixtures/migratedPages.ts
+++ b/ui/litellm-dashboard/e2e_tests/fixtures/migratedPages.ts
@@ -38,6 +38,7 @@ export const MIGRATED_E2E_PAGES: Record<string, string> = {
   "logging-and-alerts": "logging-and-alerts",
   "model-hub-table": "model-hub-table",
   new_usage: "usage",
+  usage: "old-usage",
   agents: "agents",
   "router-settings": "router-settings",
   users: "users",

--- a/ui/litellm-dashboard/src/app/(dashboard)/old-usage/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/old-usage/page.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import Usage from "@/components/usage";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+
+export default function OldUsagePage() {
+  const { accessToken, token, userRole, userId: userID, premiumUser } = useAuthorized();
+  return (
+    <Usage
+      accessToken={accessToken}
+      token={token}
+      userRole={userRole}
+      userID={userID}
+      keys={null}
+      premiumUser={premiumUser}
+    />
+  );
+}

--- a/ui/litellm-dashboard/src/app/(dashboard)/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/page.tsx
@@ -8,7 +8,6 @@ import { Organization, proxyBaseUrl, getInProductNudgesCall } from "@/components
 import { CreateKeyPrefillData } from "@/components/organisms/create_key_button";
 import { fetchOrganizations } from "@/components/organizations";
 import { SurveyPrompt, SurveyModal, ClaudeCodePrompt, ClaudeCodeModal } from "@/components/survey";
-import Usage from "@/components/usage";
 import UserDashboard from "@/components/user_dashboard";
 import { useAuth } from "@/contexts/AuthContext";
 import {
@@ -287,34 +286,23 @@ function CreateKeyPageContent() {
         />
       ) : (
         <>
-          {page == "api-keys" ? (
-            <UserDashboard
-              userID={userID}
-              userRole={userRole}
-              premiumUser={premiumUser}
-              teams={teams}
-              keys={keys}
-              setUserRole={setUserRole}
-              userEmail={userEmail}
-              setUserEmail={setUserEmail}
-              setTeams={setTeams}
-              setKeys={setKeys}
-              organizations={organizations}
-              addKey={addKey}
-              createClicked={createClicked}
-              autoOpenCreate={autoOpenCreate}
-              prefillData={prefillData}
-            />
-          ) : (
-            <Usage
-              userID={userID}
-              userRole={userRole}
-              token={token}
-              accessToken={accessToken}
-              keys={keys}
-              premiumUser={premiumUser}
-            />
-          )}
+          <UserDashboard
+            userID={userID}
+            userRole={userRole}
+            premiumUser={premiumUser}
+            teams={teams}
+            keys={keys}
+            setUserRole={setUserRole}
+            userEmail={userEmail}
+            setUserEmail={setUserEmail}
+            setTeams={setTeams}
+            setKeys={setKeys}
+            organizations={organizations}
+            addKey={addKey}
+            createClicked={createClicked}
+            autoOpenCreate={autoOpenCreate}
+            prefillData={prefillData}
+          />
 
           {/* Survey Components */}
           <SurveyPrompt

--- a/ui/litellm-dashboard/src/utils/migratedPages.test.ts
+++ b/ui/litellm-dashboard/src/utils/migratedPages.test.ts
@@ -115,9 +115,16 @@ describe("migratedHref / legacyPageHref", () => {
     expect(MIGRATED_PAGES["admin-panel"]).toBe("admin-panel");
     expect(MIGRATED_PAGES["logging-and-alerts"]).toBe("logging-and-alerts");
     expect(MIGRATED_PAGES["model-hub-table"]).toBe("model-hub-table");
-    // new_usage routes to /usage; the legacy ?page=usage report keeps its switch arm.
+    // new_usage routes to /usage; the legacy ?page=usage report routes to /old-usage (asserted below).
     expect(MIGRATED_PAGES.new_usage).toBe("usage");
-    expect(MIGRATED_PAGES.usage).toBeUndefined();
+  });
+
+  it("maps the legacy usage report id to the old-usage route and builds its redirect href", async () => {
+    vi.doMock("@/components/networking", () => ({ serverRootPath: "/" }));
+    const { MIGRATED_PAGES, migratedHref } = await import("./migratedPages");
+
+    expect(MIGRATED_PAGES.usage).toBe("old-usage");
+    expect(migratedHref(MIGRATED_PAGES.usage)).toBe("/ui/old-usage");
   });
 
   it("maps the agents and router-settings ids to their routes", async () => {

--- a/ui/litellm-dashboard/src/utils/migratedPages.ts
+++ b/ui/litellm-dashboard/src/utils/migratedPages.ts
@@ -39,8 +39,9 @@ export const MIGRATED_PAGES: Record<string, string> = {
   "admin-panel": "admin-panel",
   "logging-and-alerts": "logging-and-alerts",
   "model-hub-table": "model-hub-table",
-  // The modern usage dashboard; the old ?page=usage report stays on the legacy switch.
+  // The modern usage dashboard; the legacy ?page=usage report routes to /old-usage.
   new_usage: "usage",
+  usage: "old-usage",
   agents: "agents",
   "router-settings": "router-settings",
   users: "users",


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Refs LIT-3687

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

UI routing change, no backend component. To verify locally against the built dashboard or the proxy that serves it:

1. Click "Old Usage" in the left sidebar (under Experimental) and confirm the URL becomes `/ui/old-usage` (not `/ui/?page=usage`) and the usage report renders
2. Reload `/ui/old-usage` directly and confirm it still renders (no 404)
3. Open an old bookmark `/ui/?page=usage` and confirm it redirects to `/ui/old-usage`
4. Confirm the modern "Usage" dashboard is unaffected at `/ui/usage`

## Type

🧹 Refactoring

## Changes

Continues the App Router migration by cutting the legacy "Old Usage" report (`?page=usage`, the item under the Experimental section of the sidebar) over from the `?page=` switch in `(dashboard)/page.tsx` to a path route at `(dashboard)/old-usage/page.tsx`. The segment is `old-usage` rather than `usage` because the modern usage dashboard (`new_usage`) already owns `/usage`. Adding the `usage -> old-usage` entry to `MIGRATED_PAGES` repoints the sidebar item and redirects existing `?page=usage` deep links, the same mechanism every migrated page uses.

The report was the switch's catch-all `else` branch, so migrating it out requires choosing a new fallback. I collapsed the now-redundant explicit `api-keys` arm into the `else`, making the main dashboard (`UserDashboard`) the default branch. Behavior for `?page=api-keys` is unchanged; the only difference is that unrecognized `?page=` values now land on the dashboard instead of the Old Usage report, which is the sensible default.

The new route sources identity from `useAuthorized()` and passes `keys={null}`. The Usage page uses `keys` only to populate a key-filter dropdown, and the legacy page read the parent's `keys` state, which was already empty on direct navigation to `?page=usage`; this preserves that behavior rather than wiring a paginated key fetch into a deprecated report. Added a unit test asserting the `usage -> old-usage` mapping and its redirect href, and the e2e migration fixture entry so the navigation smoke covers it.

Note for sequencing: this touches the same `page.tsx` switch as the in-flight models (#30677) and pass-through (#30692) PRs, so whichever merges later will need a small conflict resolution in that block.

