### PR TITLE
ci: run a local fake OpenAI endpoint instead of the shared Railway mock

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,26 @@ commands:
             done
             echo "record/replay proxy did not become ready" >&2
             exit 1
+  start_fake_openai_endpoint:
+    description: "Start the canned OpenAI mock (tests/_fake_openai_endpoint_server.py) on host port 8190 and wait until healthy. Models whose api_base points here (via FAKE_OPENAI_API_BASE) get well-formed chat/text/embedding responses with realistic usage, so the E2E run neither pays for nor depends on the live provider. A request whose model is '429' returns HTTP 429 for rate-limit/cooldown tests. Run after uv deps are synced."
+    steps:
+      - run:
+          name: Start fake OpenAI endpoint
+          background: true
+          command: |
+            uv run --no-sync python tests/_fake_openai_endpoint_server.py --host 0.0.0.0 --port 8190
+      - run:
+          name: Wait for fake OpenAI endpoint
+          command: |
+            for i in $(seq 1 30); do
+              if curl -sf http://localhost:8190/health >/dev/null 2>&1; then
+                echo "fake OpenAI endpoint is up"
+                exit 0
+              fi
+              sleep 1
+            done
+            echo "fake OpenAI endpoint did not become ready" >&2
+            exit 1
   setup_litellm_enterprise_pip:
     steps:
       - run:
@@ -594,6 +614,8 @@ jobs:
     working_directory: ~/project
     resource_class: large
     parallelism: 4
+    environment:
+      FAKE_OPENAI_API_BASE: http://127.0.0.1:8190
     steps:
       - checkout
       - setup_google_dns
@@ -609,6 +631,7 @@ jobs:
           paths:
             - ~/.cache/uv
           key: v1-uv-cache-{{ checksum "uv.lock" }}
+      - start_fake_openai_endpoint
       # Run pytest and generate JUnit XML report
       - setup_litellm_enterprise_pip
       - run:
@@ -1549,6 +1572,7 @@ jobs:
           name: Install Dependencies
           command: |
             uv sync --frozen --all-groups --all-extras --python 3.12
+      - start_fake_openai_endpoint
       - start_postgres:
           db_name: litellm_test
       - attach_workspace:
@@ -1586,6 +1610,7 @@ jobs:
               -e DATABASE_URL="postgresql://postgres:postgres@host.docker.internal:5432/litellm_test" \
               -e DEFAULT_NUM_WORKERS_LITELLM_PROXY=1 \
               -e DISABLE_SCHEMA_UPDATE="True" \
+              -e FAKE_OPENAI_API_BASE=http://host.docker.internal:8190 \
               --name my-app \
               --add-host=host.docker.internal:host-gateway \
               -v $(pwd)/litellm/proxy/example_config_yaml/bad_schema.prisma:/app/schema.prisma \
@@ -1648,6 +1673,7 @@ jobs:
             zstd -d litellm-docker-database.tar.zst --stdout | docker load
             docker tag litellm-docker-database:ci my-app:latest
       - start_openai_record_replay_proxy
+      - start_fake_openai_endpoint
       - run:
           name: Run Docker container
           command: |
@@ -1655,6 +1681,7 @@ jobs:
               -p 4000:4000 \
               -e DATABASE_URL=postgresql://postgres:postgres@host.docker.internal:5432/circle_test \
               -e USE_PRISMA_MIGRATE=True \
+              -e FAKE_OPENAI_API_BASE=http://host.docker.internal:8190 \
               -e AZURE_API_KEY=$AZURE_API_KEY \
               -e REDIS_HOST=$REDIS_HOST \
               -e REDIS_PASSWORD=$REDIS_PASSWORD \
@@ -1817,6 +1844,7 @@ jobs:
             zstd -d litellm-docker-database.tar.zst --stdout | docker load
             docker images | grep litellm-docker-database
       - start_openai_record_replay_proxy
+      - start_fake_openai_endpoint
       - run:
           name: Run Docker container
           # intentionally give bad redis credentials here
@@ -1830,6 +1858,7 @@ jobs:
               -e REDIS_PORT=$REDIS_PORT \
               -e LITELLM_MASTER_KEY="sk-1234" \
               -e OPENAI_API_KEY=$OPENAI_API_KEY \
+              -e FAKE_OPENAI_API_BASE=http://host.docker.internal:8190 \
               -e LITELLM_LICENSE=$LITELLM_LICENSE \
               -e OTEL_EXPORTER="in_memory" \
               -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
@@ -1889,6 +1918,7 @@ jobs:
               -e REDIS_PORT=$REDIS_PORT \
               -e LITELLM_MASTER_KEY="sk-1234" \
               -e OPENAI_API_KEY=$OPENAI_API_KEY \
+              -e FAKE_OPENAI_API_BASE=http://host.docker.internal:8190 \
               -e LITELLM_LICENSE="bad-license" \
               --add-host host.docker.internal:host-gateway \
               --name my-app-3 \
@@ -1938,6 +1968,7 @@ jobs:
             uv sync --frozen --all-groups --all-extras --python 3.12
       - start_postgres
       - start_redis
+      - start_fake_openai_endpoint
       - attach_workspace:
           at: ~/project
       - run:
@@ -1961,6 +1992,7 @@ jobs:
               -e REDIS_PORT=6379 \
               -e LITELLM_MASTER_KEY="sk-1234" \
               -e OPENAI_API_KEY=$OPENAI_API_KEY \
+              -e FAKE_OPENAI_API_BASE=http://host.docker.internal:8190 \
               -e LITELLM_LICENSE=$LITELLM_LICENSE \
               -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
               -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
@@ -2020,6 +2052,7 @@ jobs:
           command: |
             uv sync --frozen --all-groups --all-extras --python 3.12
       - start_postgres
+      - start_fake_openai_endpoint
       - attach_workspace:
           at: ~/project
       - run:
@@ -2039,6 +2072,7 @@ jobs:
               -e REDIS_PASSWORD=$REDIS_PASSWORD \
               -e REDIS_PORT=$REDIS_PORT \
               -e LITELLM_MASTER_KEY="sk-1234" \
+              -e FAKE_OPENAI_API_BASE=http://host.docker.internal:8190 \
               -e LITELLM_LICENSE=$LITELLM_LICENSE \
               -e USE_DDTRACE=True \
               -e DD_API_KEY=$DD_API_KEY \
@@ -2060,6 +2094,7 @@ jobs:
               -e REDIS_PASSWORD=$REDIS_PASSWORD \
               -e REDIS_PORT=$REDIS_PORT \
               -e LITELLM_MASTER_KEY="sk-1234" \
+              -e FAKE_OPENAI_API_BASE=http://host.docker.internal:8190 \
               -e LITELLM_LICENSE=$LITELLM_LICENSE \
               -e USE_DDTRACE=True \
               -e DD_API_KEY=$DD_API_KEY \
@@ -2112,6 +2147,7 @@ jobs:
           command: |
             uv sync --frozen --all-groups --all-extras --python 3.12
       - start_postgres
+      - start_fake_openai_endpoint
       - attach_workspace:
           at: ~/project
       - run:
@@ -2129,6 +2165,7 @@ jobs:
               -e DATABASE_URL=postgresql://postgres:postgres@host.docker.internal:5432/circle_test \
               -e STORE_MODEL_IN_DB="True" \
               -e LITELLM_MASTER_KEY="sk-1234" \
+              -e FAKE_OPENAI_API_BASE=http://host.docker.internal:8190 \
               -e LITELLM_LICENSE=$LITELLM_LICENSE \
               --add-host host.docker.internal:host-gateway \
               --name my-app \
@@ -2187,6 +2224,7 @@ jobs:
           command: |
             docker build -t my-app:latest -f docker/build_from_pip/Dockerfile.build_from_pip .
       - start_postgres
+      - start_fake_openai_endpoint
       - run:
           name: Run Docker container
           # intentionally give bad redis credentials here
@@ -2200,6 +2238,7 @@ jobs:
               -e REDIS_PORT=$REDIS_PORT \
               -e LITELLM_MASTER_KEY="sk-1234" \
               -e OPENAI_API_KEY=$OPENAI_API_KEY \
+              -e FAKE_OPENAI_API_BASE=http://host.docker.internal:8190 \
               -e LITELLM_LICENSE=$LITELLM_LICENSE \
               -e OTEL_EXPORTER="in_memory" \
               -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \

--- a/docker/build_from_pip/litellm_config.yaml
+++ b/docker/build_from_pip/litellm_config.yaml
@@ -3,7 +3,7 @@ model_list:
     litellm_params:
       model: openai/fake
       api_key: fake-key
-      api_base: https://exampleopenaiendpoint-production.up.railway.app/
+      api_base: os.environ/FAKE_OPENAI_API_BASE
 
 general_settings:    
     alerting: ["slack"]

--- a/litellm/proxy/example_config_yaml/disable_schema_update.yaml
+++ b/litellm/proxy/example_config_yaml/disable_schema_update.yaml
@@ -3,12 +3,12 @@ model_list:
     litellm_params:
       model: openai/fake
       api_key: fake-key
-      api_base: https://exampleopenaiendpoint-production.up.railway.app/
+      api_base: os.environ/FAKE_OPENAI_API_BASE
   - model_name: gpt-4
     litellm_params:
       model: openai/gpt-4
       api_key: fake-key
-      api_base: https://exampleopenaiendpoint-production.up.railway.app/
+      api_base: os.environ/FAKE_OPENAI_API_BASE
 
 litellm_settings:
   callbacks: ["gcs_bucket"]

--- a/litellm/proxy/example_config_yaml/enterprise_config.yaml
+++ b/litellm/proxy/example_config_yaml/enterprise_config.yaml
@@ -3,7 +3,7 @@ model_list:
    litellm_params:
      model: openai/fake
      api_key: fake-key
-     api_base: https://exampleopenaiendpoint-production.up.railway.app/
+     api_base: os.environ/FAKE_OPENAI_API_BASE
      tags: ["teamA"]
    model_info:
      id: "team-a-model"

--- a/litellm/proxy/example_config_yaml/multi_instance_simple_config.yaml
+++ b/litellm/proxy/example_config_yaml/multi_instance_simple_config.yaml
@@ -3,7 +3,7 @@ model_list:
     litellm_params:
       model: openai/my-fake-model
       api_key: my-fake-key
-      api_base: https://exampleopenaiendpoint-production.up.railway.app/
+      api_base: os.environ/FAKE_OPENAI_API_BASE
 
 litellm_settings:
   cache: True

--- a/litellm/proxy/example_config_yaml/otel_test_config.yaml
+++ b/litellm/proxy/example_config_yaml/otel_test_config.yaml
@@ -3,7 +3,7 @@ model_list:
    litellm_params:
      model: openai/gpt-5-mini
      api_key: fake-key
-     api_base: https://exampleopenaiendpoint-production.up.railway.app/
+     api_base: os.environ/FAKE_OPENAI_API_BASE
      tags: ["teamA"]
    model_info:
      id: "team-a-model"
@@ -11,7 +11,7 @@ model_list:
    litellm_params:
      model: openai/gpt-5-mini
      api_key: fake-key
-     api_base: https://exampleopenaiendpoint-production.up.railway.app/
+     api_base: os.environ/FAKE_OPENAI_API_BASE
      tags: ["teamB"]
    model_info:
      id: "team-b-model"
@@ -24,7 +24,7 @@ model_list:
    litellm_params:
      model: openai/429
      api_key: fake-key
-     api_base: https://exampleopenaiendpoint-production.up.railway.app
+     api_base: os.environ/FAKE_OPENAI_API_BASE
  - model_name: llava-hf
    litellm_params:
      model: openai/llava-hf/llava-v1.6-vicuna-7b-hf
@@ -35,12 +35,12 @@ model_list:
  - model_name: bedrock/*
    litellm_params:
      model:  bedrock/*
-     api_base: https://exampleopenaiendpoint-production.up.railway.app/
+     api_base: os.environ/FAKE_OPENAI_API_BASE
  - model_name: openai/*
    litellm_params:
      model: openai/*
      api_key: os.environ/OPENAI_API_KEY
-     api_base: https://exampleopenaiendpoint-production.up.railway.app/
+     api_base: os.environ/FAKE_OPENAI_API_BASE
 
 
 litellm_settings:

--- a/litellm/proxy/example_config_yaml/spend_tracking_config.yaml
+++ b/litellm/proxy/example_config_yaml/spend_tracking_config.yaml
@@ -3,7 +3,7 @@ model_list:
     litellm_params:
       model: openai/gpt-5-mini
       api_key: fake-key
-      api_base: https://exampleopenaiendpoint-production.up.railway.app/
+      api_base: os.environ/FAKE_OPENAI_API_BASE
 
 general_settings:
   use_redis_transaction_buffer: true

--- a/litellm/proxy/example_config_yaml/store_model_db_config.yaml
+++ b/litellm/proxy/example_config_yaml/store_model_db_config.yaml
@@ -3,7 +3,7 @@ model_list:
     litellm_params:
       model: openai/my-fake-model
       api_key: my-fake-key
-      api_base: https://exampleopenaiendpoint-production.up.railway.app/
+      api_base: os.environ/FAKE_OPENAI_API_BASE
 
 general_settings:
   store_model_in_db: true

--- a/proxy_server_config.yaml
+++ b/proxy_server_config.yaml
@@ -64,39 +64,39 @@ model_list:
     litellm_params:
       model: openai/gpt-5-mini
       api_key: fake-key
-      api_base: https://exampleopenaiendpoint-production.up.railway.app/
+      api_base: os.environ/FAKE_OPENAI_API_BASE
   - model_name: fake-openai-endpoint-2
     litellm_params:
       model: openai/my-fake-model
       api_key: my-fake-key
-      api_base: https://exampleopenaiendpoint-production.up.railway.app/
+      api_base: os.environ/FAKE_OPENAI_API_BASE
       stream_timeout: 0.001
       rpm: 1
   - model_name: fake-openai-endpoint-3
     litellm_params:
       model: openai/my-fake-model
       api_key: my-fake-key
-      api_base: https://exampleopenaiendpoint-production.up.railway.app/
+      api_base: os.environ/FAKE_OPENAI_API_BASE
       stream_timeout: 0.001
       rpm: 1000
   - model_name: fake-openai-endpoint-4
     litellm_params:
       model: openai/my-fake-model
       api_key: my-fake-key
-      api_base: https://exampleopenaiendpoint-production.up.railway.app/
+      api_base: os.environ/FAKE_OPENAI_API_BASE
       num_retries: 50
   - model_name: fake-openai-endpoint-3
     litellm_params:
       model: openai/my-fake-model-2
       api_key: my-fake-key
-      api_base: https://exampleopenaiendpoint-production.up.railway.app/
+      api_base: os.environ/FAKE_OPENAI_API_BASE
       stream_timeout: 0.001
       rpm: 1000
   - model_name: bad-model
     litellm_params:
       model: openai/bad-model
       api_key: os.environ/OPENAI_API_KEY
-      api_base: https://exampleopenaiendpoint-production.up.railway.app/
+      api_base: os.environ/FAKE_OPENAI_API_BASE
       mock_timeout: True
       timeout: 60
       rpm: 1000
@@ -106,7 +106,7 @@ model_list:
     litellm_params:
       model: openai/bad-model
       api_key: os.environ/OPENAI_API_KEY
-      api_base: https://exampleopenaiendpoint-production.up.railway.app/
+      api_base: os.environ/FAKE_OPENAI_API_BASE
       rpm: 1000
     model_info:
       health_check_timeout: 1
@@ -148,7 +148,7 @@ model_list:
     litellm_params:
       model: openai/my-fake-model
       api_key: my-fake-key
-      api_base: https://exampleopenaiendpoint-production.up.railway.app/
+      api_base: os.environ/FAKE_OPENAI_API_BASE
       timeout: 1
   - model_name: badly-configured-openai-endpoint
     litellm_params:

--- a/tests/_fake_openai_endpoint_server.py
+++ b/tests/_fake_openai_endpoint_server.py
@@ -1,0 +1,239 @@
+"""Canned OpenAI-shaped mock server for the CI proxy E2Es.
+
+Several CI jobs run the litellm proxy (often in its own Docker container) against
+a model whose ``api_base`` is a fake OpenAI endpoint that returns canned
+responses, so the run costs nothing and does not depend on a real provider. That
+endpoint used to be a single shared deployment; when it went down every one of
+those jobs failed with ``404 Application not found`` even though nothing in the
+PR was broken.
+
+This process is the local stand-in. A model points its ``api_base`` here and
+gets back a well-formed chat/text/embedding response with realistic ``usage`` so
+cost tracking and spend accounting still exercise their real code paths. The one
+behavioral special case mirrors the old hosted mock: a request whose ``model``
+is ``429`` returns HTTP 429 so rate-limit and cooldown tests still have
+something to trip on.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import uuid
+from typing import AsyncIterator, Final
+
+import uvicorn
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse, PlainTextResponse, Response, StreamingResponse
+from starlette.routing import Route
+
+_CANNED_CONTENT: Final = "Hello! This is a mock response from the fake OpenAI endpoint."
+_RATE_LIMIT_MODEL: Final = "429"
+_PROMPT_TOKENS: Final = 20
+_COMPLETION_TOKENS: Final = 20
+
+
+def _usage() -> dict[str, int]:
+    return {
+        "prompt_tokens": _PROMPT_TOKENS,
+        "completion_tokens": _COMPLETION_TOKENS,
+        "total_tokens": _PROMPT_TOKENS + _COMPLETION_TOKENS,
+    }
+
+
+def _requested_model(body: dict[str, object]) -> str:
+    model = body.get("model")
+    return model if isinstance(model, str) else "mock-model"
+
+
+def _wants_stream(body: dict[str, object]) -> bool:
+    return body.get("stream") is True
+
+
+def _wants_stream_usage(body: dict[str, object]) -> bool:
+    options = body.get("stream_options")
+    return isinstance(options, dict) and options.get("include_usage") is True
+
+
+async def _parse_body(request: Request) -> dict[str, object]:
+    raw = await request.body()
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except ValueError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _rate_limit_response(model: str) -> JSONResponse:
+    return JSONResponse(
+        status_code=429,
+        content={
+            "error": {
+                "message": f"Rate limit reached for model `{model}` (mock).",
+                "type": "rate_limit_error",
+                "code": "429",
+            }
+        },
+    )
+
+
+def _chat_completion_body(model: str) -> dict[str, object]:
+    return {
+        "id": f"chatcmpl-{uuid.uuid4().hex[:24]}",
+        "object": "chat.completion",
+        "created": int(time.time()),
+        "model": model,
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": _CANNED_CONTENT},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": _usage(),
+    }
+
+
+async def _chat_completion_stream(model: str, with_usage: bool) -> AsyncIterator[str]:
+    response_id = f"chatcmpl-{uuid.uuid4().hex[:24]}"
+    created = int(time.time())
+
+    def chunk(delta: dict[str, object], finish_reason: str | None) -> dict[str, object]:
+        return {
+            "id": response_id,
+            "object": "chat.completion.chunk",
+            "created": created,
+            "model": model,
+            "choices": [{"index": 0, "delta": delta, "finish_reason": finish_reason}],
+        }
+
+    yield f"data: {json.dumps(chunk({'role': 'assistant', 'content': _CANNED_CONTENT}, None))}\n\n"
+    yield f"data: {json.dumps(chunk({}, 'stop'))}\n\n"
+    if with_usage:
+        final = chunk({}, None) | {"choices": [], "usage": _usage()}
+        yield f"data: {json.dumps(final)}\n\n"
+    yield "data: [DONE]\n\n"
+
+
+async def chat_completions(request: Request) -> Response:
+    body = await _parse_body(request)
+    model = _requested_model(body)
+    if model == _RATE_LIMIT_MODEL:
+        return _rate_limit_response(model)
+    if _wants_stream(body):
+        return StreamingResponse(
+            _chat_completion_stream(model, _wants_stream_usage(body)),
+            media_type="text/event-stream",
+        )
+    return JSONResponse(_chat_completion_body(model))
+
+
+def _text_completion_body(model: str) -> dict[str, object]:
+    return {
+        "id": f"cmpl-{uuid.uuid4().hex[:24]}",
+        "object": "text_completion",
+        "created": int(time.time()),
+        "model": model,
+        "choices": [
+            {
+                "text": _CANNED_CONTENT,
+                "index": 0,
+                "logprobs": None,
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": _usage(),
+    }
+
+
+async def _text_completion_stream(model: str, with_usage: bool) -> AsyncIterator[str]:
+    response_id = f"cmpl-{uuid.uuid4().hex[:24]}"
+    created = int(time.time())
+
+    def chunk(text: str, finish_reason: str | None) -> dict[str, object]:
+        return {
+            "id": response_id,
+            "object": "text_completion",
+            "created": created,
+            "model": model,
+            "choices": [{"text": text, "index": 0, "logprobs": None, "finish_reason": finish_reason}],
+        }
+
+    yield f"data: {json.dumps(chunk(_CANNED_CONTENT, None))}\n\n"
+    yield f"data: {json.dumps(chunk('', 'stop'))}\n\n"
+    if with_usage:
+        final = chunk("", None) | {"choices": [], "usage": _usage()}
+        yield f"data: {json.dumps(final)}\n\n"
+    yield "data: [DONE]\n\n"
+
+
+async def completions(request: Request) -> Response:
+    body = await _parse_body(request)
+    model = _requested_model(body)
+    if model == _RATE_LIMIT_MODEL:
+        return _rate_limit_response(model)
+    if _wants_stream(body):
+        return StreamingResponse(
+            _text_completion_stream(model, _wants_stream_usage(body)),
+            media_type="text/event-stream",
+        )
+    return JSONResponse(_text_completion_body(model))
+
+
+async def embeddings(request: Request) -> Response:
+    body = await _parse_body(request)
+    raw_input = body.get("input", "")
+    count = len(raw_input) if isinstance(raw_input, list) else 1
+    return JSONResponse(
+        {
+            "object": "list",
+            "data": [{"object": "embedding", "index": i, "embedding": [0.0] * 1536} for i in range(max(count, 1))],
+            "model": _requested_model(body),
+            "usage": {"prompt_tokens": 5, "total_tokens": 5},
+        }
+    )
+
+
+async def list_models(_request: Request) -> Response:
+    return JSONResponse(
+        {
+            "object": "list",
+            "data": [
+                {"id": "fake", "object": "model", "owned_by": "mock"},
+                {"id": "my-fake-model", "object": "model", "owned_by": "mock"},
+            ],
+        }
+    )
+
+
+async def health(_request: Request) -> Response:
+    return PlainTextResponse("ok")
+
+
+app = Starlette(
+    routes=[
+        Route("/health", health, methods=["GET"]),
+        Route("/", health, methods=["GET"]),
+        Route("/chat/completions", chat_completions, methods=["POST"]),
+        Route("/v1/chat/completions", chat_completions, methods=["POST"]),
+        Route("/completions", completions, methods=["POST"]),
+        Route("/v1/completions", completions, methods=["POST"]),
+        Route("/embeddings", embeddings, methods=["POST"]),
+        Route("/v1/embeddings", embeddings, methods=["POST"]),
+        Route("/models", list_models, methods=["GET"]),
+        Route("/v1/models", list_models, methods=["GET"]),
+    ]
+)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--port", type=int, default=8190)
+    args = parser.parse_args()
+    uvicorn.run(app, host=args.host, port=args.port)

--- a/tests/local_testing/test_router.py
+++ b/tests/local_testing/test_router.py
@@ -1639,7 +1639,10 @@ async def test_router_text_completion_client():
                 "litellm_params": {
                     "model": "text-completion-openai/gpt-3.5-turbo-instruct",
                     "api_key": os.getenv("OPENAI_API_KEY", None),
-                    "api_base": "https://exampleopenaiendpoint-production.up.railway.app/",
+                    "api_base": os.getenv(
+                        "FAKE_OPENAI_API_BASE",
+                        "https://exampleopenaiendpoint-production.up.railway.app/",
+                    ),
                 },
             }
         ]


### PR DESCRIPTION
## Relevant issues

Several CI jobs run the proxy against a model whose `api_base` is a shared "fake OpenAI endpoint" hosted on Railway (`exampleopenaiendpoint-production.up.railway.app`) so the E2E runs get canned responses without paying for or depending on a live provider. When that single deployment goes down, every one of those jobs fails with `404 Application not found` even though nothing in the PR is broken; the whole repo is coupled to the uptime of one free external service. We hit exactly this on #30690, where the same outage reddened a batch of unrelated jobs.

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

The new server stands in for the live endpoint; here it is serving the shapes the E2Es rely on (run `uv run --no-sync python tests/_fake_openai_endpoint_server.py --port 8190` first):

```
$ curl -s http://127.0.0.1:8190/health
ok

$ curl -s -X POST http://127.0.0.1:8190/v1/chat/completions \
    -H 'Content-Type: application/json' \
    -d '{"model":"gpt-5-mini","messages":[{"role":"user","content":"hi"}]}'
{"id":"chatcmpl-...","object":"chat.completion","model":"gpt-5-mini","choices":[{"index":0,"message":{"role":"assistant","content":"Hello! This is a mock response from the fake OpenAI endpoint."},"finish_reason":"stop"}],"usage":{"prompt_tokens":20,"completion_tokens":20,"total_tokens":40}}

$ curl -s -o /dev/null -w 'HTTP %{http_code}\n' -X POST http://127.0.0.1:8190/v1/chat/completions \
    -H 'Content-Type: application/json' \
    -d '{"model":"429","messages":[{"role":"user","content":"hi"}]}'
HTTP 429

$ curl -s -N -X POST http://127.0.0.1:8190/v1/completions \
    -H 'Content-Type: application/json' \
    -d '{"model":"x","stream":true,"stream_options":{"include_usage":true},"prompt":"hi"}'
data: {"id":"cmpl-...","object":"text_completion","choices":[{"text":"Hello! ...","index":0,"logprobs":null,"finish_reason":null}]}
data: {"id":"cmpl-...","object":"text_completion","choices":[{"text":"","index":0,"logprobs":null,"finish_reason":"stop"}]}
data: {"id":"cmpl-...","object":"text_completion","choices":[],"usage":{"prompt_tokens":20,"completion_tokens":20,"total_tokens":40}}
data: [DONE]
```

The real end-to-end proof is the CI run itself: the eight affected jobs should pass with the live Railway endpoint completely out of the loop. Branch-creation and last-commit CI links go in the section above once they finish.

## Type

🚄 Infrastructure

## Changes

Adds `tests/_fake_openai_endpoint_server.py`, a small canned-response OpenAI-shaped server (Starlette) covering chat completions, text completions, embeddings, streaming with optional usage chunks, and the one behavioral special case the old hosted mock had: a request whose `model` is `429` returns HTTP 429 so rate-limit and cooldown tests still trip. Usage is non-zero and self-consistent (`20`/`20`/`40`) so spend and cost-tracking code paths run for real; the spend-accuracy E2E derives its expected total from each response's own usage, so the absolute numbers don't need to match the old endpoint.

Adds a reusable `start_fake_openai_endpoint` CircleCI command that launches the server on host port 8190 and waits until healthy, then wires it into the eight jobs that depended on the Railway endpoint: `build_and_test`, `litellm_router_testing`, `db_migration_disable_update_check`, `proxy_logging_guardrails_model_info_tests`, `proxy_spend_accuracy_tests`, `proxy_multi_instance_tests`, `proxy_store_model_in_db_tests`, and `proxy_build_from_pip_tests`. Machine-executor jobs reach it from their proxy container via `FAKE_OPENAI_API_BASE=http://host.docker.internal:8190`; the docker-executor `litellm_router_testing` job runs it in-container and points at `http://127.0.0.1:8190`. The example configs those jobs mount now resolve `api_base` from `os.environ/FAKE_OPENAI_API_BASE` instead of hardcoding the Railway URL.

Two things are deliberately left alone. The intentionally malformed fallback URL in `proxy_server_config.yaml` (`...railway.appxxxx/`) stays as-is so the fallback test still has a failing upstream to fall back from. And nothing here touches the record/replay (VCR) proxy on port 8090 or its redis cassette store; the fake endpoint is a separate process on 8190 that real-provider traffic never reaches, so the cassettes can't be affected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI wiring, test fixtures, and example configs; production proxy behavior is unchanged unless operators set `FAKE_OPENAI_API_BASE`.
> 
> **Overview**
> Replaces the shared Railway fake OpenAI host with a **job-local mock** so proxy E2E and router tests no longer fail when that external service is down.
> 
> Adds `tests/_fake_openai_endpoint_server.py` (Starlette on port **8190**) with canned chat/text/embedding responses, streaming + usage, and **HTTP 429** when `model` is `429`. CircleCI gets a reusable **`start_fake_openai_endpoint`** step; eight jobs start it and set **`FAKE_OPENAI_API_BASE`** (`127.0.0.1:8190` in-container, `host.docker.internal:8190` for proxy Docker runs).
> 
> CI example configs and `proxy_server_config.yaml` switch fake-model **`api_base`** from the Railway URL to **`os.environ/FAKE_OPENAI_API_BASE`**. `test_router_text_completion_client` reads the same env with the old URL as fallback. The deliberately broken Railway URL for fallback testing is **unchanged**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afd66a579b86977b1f975ace22e60ac42ffe6eb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->