### PR TITLE
fix: ensure checks show gemini-3-flash-preview supports responseJsonS…

### DIFF
--- a/litellm/llms/vertex_ai/common_utils.py
+++ b/litellm/llms/vertex_ai/common_utils.py
@@ -271,7 +271,7 @@ def supports_response_json_schema(model: str) -> bool:
 
     # Gemini 2.0+ and 2.5+ models support responseJsonSchema
     # Pattern matches: gemini-2.0-*, gemini-2.5-*, gemini-3-*, etc.
-    gemini_2_plus_pattern = re.compile(r"gemini-([2-9]|[1-9]\d+)\.")
+    gemini_2_plus_pattern = re.compile(r"gemini-(?:[2-9]|[1-9]\d+)(?:\.|\-)")
 
     return bool(gemini_2_plus_pattern.search(model_lower))
 

--- a/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
@@ -17,6 +17,7 @@ from litellm.llms.vertex_ai.common_utils import (
     get_vertex_project_id_from_url,
     pop_vertex_request_labels,
     set_schema_property_ordering,
+    supports_response_json_schema,
     vertex_request_labels_from_litellm_params,
 )
 
@@ -148,6 +149,23 @@ async def test_get_supports_system_message():
         model="random-model-name", custom_llm_provider="vertex_ai"
     )
     assert result == False
+
+
+@pytest.mark.parametrize(
+    "model, expected",
+    [
+        ("gemini-2.0-flash", True),
+        ("gemini-1.5-pro", False),
+        ("random-model-name", False),
+        ("gemini-3-flash-preview", True),
+        ("gemini-123-pro", True),
+        ("vertex_ai/gemini-3.1-pro-preview", True),
+    ],
+)
+async def test_supports_response_json_schema(model: str, expected: bool):
+    """Test supports_response_json_schema correctly detects Gemini 2.0+ model names"""
+
+    assert supports_response_json_schema(model) == expected
 
 
 def test_set_schema_property_ordering_with_excessive_nesting():
@@ -1526,11 +1544,7 @@ def test_vertex_request_labels_from_litellm_params_extracts_requester_metadata()
 
 
 def test_vertex_request_labels_from_litellm_params_accepts_litellm_metadata():
-    lp = {
-        "litellm_metadata": {
-            "requester_metadata": {"team": "platform", "count": 3}
-        }
-    }
+    lp = {"litellm_metadata": {"requester_metadata": {"team": "platform", "count": 3}}}
     assert vertex_request_labels_from_litellm_params(lp) == {"team": "platform"}
 
 

--- a/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
@@ -162,7 +162,7 @@ async def test_get_supports_system_message():
         ("vertex_ai/gemini-3.1-pro-preview", True),
     ],
 )
-async def test_supports_response_json_schema(model: str, expected: bool):
+def test_supports_response_json_schema(model: str, expected: bool):
     """Test supports_response_json_schema correctly detects Gemini 2.0+ model names"""
 
     assert supports_response_json_schema(model) == expected


### PR DESCRIPTION
…chema.

## Relevant issues
- Couldn't find a related issue.

## Linear ticket
- No related ticket.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or log output demonstrating that your changes work as expected.
     For bug fixes: show reproduction before the fix and passing behavior after.
     For new features: show the feature working end-to-end.
     For UI changes: include before/after screenshots. -->
- See the Bug Impact Example section below for reproduction and proof of fix.

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->
🐛 Bug Fix

## Changes

### Background
- Gemini models support structured outputs using two configurations: `responseSchema` and `responseJsonSchema`. The former is used by legacy models and does not support the full JSON Schema specification. The latter does support the full JSON Schema specification.
- The gemini-2.0 generation introduced `responseJsonSchema`. All older generations use `responseSchema`.

### The Bug
- The [`supports_response_json_schema`](https://github.com/clpatterson/litellm/blob/litellm_internal_staging/litellm/llms/vertex_ai/common_utils.py#L251) function is used to check if a gemini model supports `responseJsonSchema`. If a model is older than the gemini-2.0 generation, the function returns false, `responseJsonSchema`, is not supported.
- This function contains a bug in the regex pattern used to detect model generation numbers to determine is a model supports `responseJsonSchema`.
- The bug causes a false negative for `gemini-3-flash-preview`, a model that supports `responseJsonSchema`.

### Bug Impact Example
`gemini-3-*` was misclassified as a legacy model, so litellm stripped `additionalProperties` (not supported by legacy `responseSchema` configuration)  from the schema and any `dict[str, str]` map field came back empty.

```python
import os
import litellm
from pydantic import BaseModel, Field

class ResearchResult(BaseModel):
    topic: str
    # dict[str, str] -> {"type": "object", "additionalProperties": {"type": "string"}}
    research_sources: dict[str, str] = Field(
        description="map of source URL -> one-sentence description"
    )

response = litellm.completion(
    model="gemini/gemini-3-flash-preview",
    api_key=os.environ["GEMINI_API_KEY"],
    messages=[{"role": "user", "content": (
        "Give me three reputable sources about the James Webb Space Telescope. "
        "Put them in research_sources as a map from each source URL to a "
        "one-sentence description of what it covers."
    )}],
    response_format=ResearchResult,
)
print(response.choices[0].message.content)
```

Before the fix, `research_sources` is always empty:

```json
{"topic": "James Webb Space Telescope", "research_sources": {}}
```

After the fix, the map is populated (real API response):

```json
{
  "topic": "James Webb Space Telescope",
  "research_sources": {
    "https://webb.nasa.gov/": "Official NASA mission site with updates, specs, and imagery.",
    "https://esawebb.org/": "ESA's portal highlighting Europe's contributions and discoveries.",
    "https://www.stsci.edu/jwst/": "Space Telescope Science Institute technical and operational resources."
  }
}
```

### The Fix
- The regex pattern in `supports_response_json_schema` now correctly matches `gemini-3-*`. The previous pattern assumed that each model name contains a generation number and point release number separated by a period (i.e. `gemini-2.5-*`) but did not support model names where only a generation number is provided (i.e. `gemini-3-flash-preview`).
- Test coverage was added for `supports_response_json_schema`.
