### PR TITLE
ci(windows): pin uv to Python 3.11 so it ignores the preinstalled 3.14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,6 +188,8 @@ jobs:
       name: win/default
       shell: powershell.exe
     working_directory: ~/project
+    environment:
+      UV_PYTHON: "3.11"
     steps:
       - checkout
       - run:
@@ -220,7 +222,7 @@ jobs:
             if (-not (Select-String -Path $PROFILE -SimpleMatch $uvBin -Quiet)) {
               Add-Content -Path $PROFILE -Value "`$env:Path = `"$uvBin;`$env:Path`""
             }
-            uv sync --frozen --group dev --python (Get-Command python).Source
+            uv sync --frozen --group dev --python 3.11
       - run:
           name: Run Windows-specific test
           command: |


### PR DESCRIPTION
## Relevant issues

The `using_litellm_on_windows` job fails intermittently on the dependency install:

```
Using CPython 3.14.5 interpreter at: C:\Python314\python.exe
error: The requested interpreter resolved to Python 3.14.5, which is
incompatible with the project's Python requirement: `>=3.10, <3.14`
```

The job installs Python 3.11.0 via choco, then picks the interpreter for uv with `(Get-Command python).Source`. The `win/default` image ships Python 3.14.5 preinstalled at `C:\Python314`, and the dependency-install step runs in a fresh shell where the machine PATH ordering between the preinstalled 3.14 and the choco-installed 3.11 is not guaranteed. When `Get-Command python` lands on 3.14, uv aborts because the project requires `>=3.10, <3.14`.

This is luck-of-the-draw, not a code change: the same config passes on adjacent commits and on staging when PATH happens to surface `C:\Python311` first. Recent evidence is a staging run that resolved `C:\Python311\python.exe` and passed minutes before a branch run that resolved `C:\Python314\python.exe` and failed, both on identical config.

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

Note on tests: this is a CI-config-only change; the regression coverage is the Windows job itself, which now selects the interpreter by version request instead of by PATH order

## Screenshots / Proof of Fix

The fix stops trusting PATH order and tells uv to select Python by version, so it resolves the 3.11 interpreter and ignores the preinstalled 3.14 regardless of ordering. `UV_PYTHON: "3.11"` is set at the job level so every uv invocation (sync, plus the `uv venv` and `uv build` in the wheel-guard step, which carries the same latent flake) targets 3.11.

Before: the failing run resolved `C:\Python314\python.exe` and aborted at dependency install with the error above.

After: this branch's `using_litellm_on_windows` run resolves `C:\Python311\python.exe` and goes green:

```
Using CPython 3.11.0 interpreter at: C:\Python311\python.exe
Installed 143 packages in 6.06s
```

Run: https://app.circleci.com/pipelines/github/BerriAI/litellm/82399/workflows/6dbb878b-9706-4468-9cba-694f10459f3c/jobs/1850713

## Type

🚄 Infrastructure
🐛 Bug Fix

## Changes

In `using_litellm_on_windows`, set `UV_PYTHON: "3.11"` at the job level and change the sync from `--python (Get-Command python).Source` to `--python 3.11`. uv treats `--python 3.11` as a version request and selects the choco-installed 3.11 interpreter, so the image's preinstalled 3.14 no longer wins on PATH