### PR TITLE
fix(cost): stop non-string response service_tier from dropping cost tracking

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -888,6 +888,23 @@ def _map_traffic_type_to_service_tier(traffic_type: Optional[str]) -> Optional[s
     return service_tier
 
 
+def _normalize_service_tier(service_tier: object) -> str | None:
+    """
+    Reduce a service_tier value to a concrete billable tier string or None.
+
+    "auto" is a routing preference and any non-string value is not a billable
+    tier, so both defer to standard pricing (or to the tier the provider reports
+    on the response usage) instead of crashing the downstream cost-key lookup,
+    which calls service_tier.lower()
+    """
+    if (
+        not isinstance(service_tier, str)
+        or service_tier.lower() == ServiceTier.AUTO.value
+    ):
+        return None
+    return service_tier
+
+
 def _get_usage_object(
     completion_response: Any,
 ) -> Optional[Usage]:
@@ -1227,15 +1244,7 @@ def completion_cost(
         if service_tier is None and optional_params is not None:
             service_tier = optional_params.get("service_tier")
 
-        # A request-level service_tier only prices the request when it is a
-        # concrete billable tier string. "auto" is a routing preference and any
-        # non-string value is not a billable tier, so defer to the tier the
-        # provider reports on the response/usage instead of crashing or mispricing
-        if (
-            not isinstance(service_tier, str)
-            or service_tier.lower() == ServiceTier.AUTO.value
-        ):
-            service_tier = None
+        service_tier = _normalize_service_tier(service_tier)
 
         # Extract service_tier from completion_response if not provided
         if service_tier is None and completion_response is not None:
@@ -1243,6 +1252,8 @@ def completion_cost(
                 service_tier = getattr(completion_response, "service_tier", None)
             elif isinstance(completion_response, dict):
                 service_tier = completion_response.get("service_tier")
+
+        service_tier = _normalize_service_tier(service_tier)
 
         # Extract service_tier from usage object if not provided
         if service_tier is None and cost_per_token_usage_object is not None:
@@ -1252,6 +1263,8 @@ def completion_cost(
                 )
             elif isinstance(cost_per_token_usage_object, dict):
                 service_tier = cost_per_token_usage_object.get("service_tier")
+
+        service_tier = _normalize_service_tier(service_tier)
 
         selected_model = _select_model_name_for_cost_calc(
             model=model,

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -2285,6 +2285,105 @@ def test_completion_cost_non_string_service_tier_defers_to_served_tier():
     assert cost == pytest.approx(expected_priority)
 
 
+def test_completion_cost_non_string_response_service_tier_defers_to_served_tier():
+    """
+    Regression: a non-string ``service_tier`` on the response object must not
+    crash cost tracking.
+
+    Before the fix ``completion_cost`` read the response-level value verbatim and
+    passed it to ``_get_service_tier_cost_key``, which called ``service_tier.lower()``
+    on the dict and raised ``AttributeError``. The non-string preference is not a
+    billable tier, so pricing defers to the concrete tier the provider served on
+    the usage object instead of crashing.
+    """
+    from litellm import completion_cost
+    from litellm.llms.anthropic.chat.transformation import AnthropicConfig
+
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+
+    model = "claude-test-response-non-string-tier-cost-model"
+    litellm.register_model(
+        model_cost={
+            model: {
+                "input_cost_per_token": 3e-6,
+                "output_cost_per_token": 15e-6,
+                "input_cost_per_token_priority": 6e-6,
+                "output_cost_per_token_priority": 30e-6,
+                "litellm_provider": "anthropic",
+                "max_tokens": 8192,
+            }
+        }
+    )
+
+    usage = AnthropicConfig().calculate_usage(
+        usage_object={
+            "input_tokens": 1000,
+            "output_tokens": 500,
+            "service_tier": "priority",
+        },
+        reasoning_content=None,
+    )
+    response = ModelResponse(
+        usage=usage, model=model, service_tier={"name": "priority"}
+    )
+
+    cost = completion_cost(
+        completion_response=response,
+        model=model,
+        custom_llm_provider="anthropic",
+    )
+
+    expected_priority = 1000 * 6e-6 + 500 * 30e-6
+    assert cost == pytest.approx(expected_priority)
+
+
+def test_completion_cost_non_string_usage_service_tier_prices_standard():
+    """
+    Regression: a non-string ``service_tier`` on the usage object must not crash
+    cost tracking.
+
+    The dict reaches ``completion_cost`` via the usage extraction path with no
+    concrete tier to defer to, so pricing falls back to the standard rate instead
+    of raising ``AttributeError`` in ``_get_service_tier_cost_key``.
+    """
+    from litellm import completion_cost
+
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+
+    model = "claude-test-usage-non-string-tier-cost-model"
+    litellm.register_model(
+        model_cost={
+            model: {
+                "input_cost_per_token": 3e-6,
+                "output_cost_per_token": 15e-6,
+                "input_cost_per_token_priority": 6e-6,
+                "output_cost_per_token_priority": 30e-6,
+                "litellm_provider": "anthropic",
+                "max_tokens": 8192,
+            }
+        }
+    )
+
+    usage = Usage(
+        prompt_tokens=1000,
+        completion_tokens=500,
+        total_tokens=1500,
+        service_tier={"name": "priority"},
+    )
+    response = ModelResponse(usage=usage, model=model)
+
+    cost = completion_cost(
+        completion_response=response,
+        model=model,
+        custom_llm_provider="anthropic",
+    )
+
+    expected_standard = 1000 * 3e-6 + 500 * 15e-6
+    assert cost == pytest.approx(expected_standard)
+
+
 def test_anthropic_cost_per_token_prices_cache_at_served_tier_with_multiplier():
     """
     Regression for the cache/tier interaction in the Anthropic geo/speed path.


### PR DESCRIPTION
## Relevant issues

Follow-up to #30690, which fixed the same crash on the request-level `optional_params` path. This PR closes the matching gap on the response/usage path.

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code) (ran `tests/test_litellm/test_cost_calculator.py` locally, 70 passed; relying on CI for the full suite)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

A live-proxy curl is not a realistic reproducer here. The crashing value comes from the provider on the response/usage object, and real providers always report `service_tier` as a string, so a normal request cannot drive a dict into this path the way the request-level path in #30690 could (that one was reachable from the client via `allowed_openai_params`/`drop_params`). The honest reproducer is the regression test going red without the fix and green with it.

Without the fix, both new tests raise the exact crash from `_get_service_tier_cost_key`:

```
>       if service_tier.lower() in [ServiceTier.FLEX.value, ServiceTier.PRIORITY.value]:
E       AttributeError: 'dict' object has no attribute 'lower'

litellm/litellm_core_utils/llm_cost_calc/utils.py:187: AttributeError
=========================== short test summary info ============================
FAILED tests/test_litellm/test_cost_calculator.py::test_completion_cost_non_string_response_service_tier_defers_to_served_tier
FAILED tests/test_litellm/test_cost_calculator.py::test_completion_cost_non_string_usage_service_tier_prices_standard
2 failed, 68 deselected in 0.26s
```

With the fix in place they pass, pricing at the served tier (response path) and at standard (usage path):

```
tests/test_litellm/test_cost_calculator.py ....                          [100%]
4 passed, 66 deselected in 0.15s
```

## Type

🐛 Bug Fix

## Changes

`completion_cost` reads `service_tier` from three sources in order: the request `optional_params`, the response object, then the usage object. PR #30690 added an `isinstance` guard to the first source so a non-string value coerces to `None` instead of crashing on `service_tier.lower()` deeper in `_get_service_tier_cost_key`. The response and usage sources had no such guard, so a non-string value there (for example a dict) still flowed straight into the cost-key lookup and raised `AttributeError`. `completion_cost` re-raises, so the request's cost was silently dropped.

This extracts #30690's inline guard into a small `_normalize_service_tier` helper and applies it after each of the three extractions. Normalizing per source means a non-string value from one source falls through to the next concrete tier the provider actually served, mirroring how the routing-only `"auto"` sentinel already defers, and falls back to standard pricing when no concrete tier is present. The request-side behavior from #30690 is unchanged; it now runs through the same helper.

Two regression tests cover the two newly guarded sources: a dict on the response object that defers to the served `priority` usage tier, and a dict on the usage object that prices at the standard rate. Each pins a distinct guard site, since a single scenario only exercises one of them.
