### PR TITLE
fix(security): validate resolved model in /realtime/client_secrets for non-transcription sessions

### DIFF
--- a/litellm/proxy/realtime_endpoints/endpoints.py
+++ b/litellm/proxy/realtime_endpoints/endpoints.py
@@ -130,6 +130,12 @@ async def _prepare_client_secret_session(
     session_model = req.session.model if req.session else None
     model: str = session_model or req.model or _DEFAULT_REALTIME_MODEL
     if session_type != "transcription":
+        await can_key_call_resolved_model(
+            model=model,
+            valid_token=user_api_key_dict,
+            llm_model_list=llm_model_list,
+            llm_router=llm_router,
+        )
         return model, session_data, session_type
 
     transcription_model_candidates = _transcription_model_candidates_from_session(

--- a/tests/test_litellm/proxy/realtime_endpoints/test_realtime_webrtc_endpoints.py
+++ b/tests/test_litellm/proxy/realtime_endpoints/test_realtime_webrtc_endpoints.py
@@ -902,6 +902,109 @@ def test_session_type_coerced_for_unknown_value():
 
 
 @pytest.mark.asyncio
+async def test_client_secrets_realtime_default_model_blocked_when_not_in_key_scope(
+    proxy_app,
+):
+    """
+    Regression: omitting both model and session.model must NOT bypass the authz
+    check. The endpoint defaults to gpt-4o-realtime-preview; a key that cannot
+    reach that model must receive 403.
+    """
+    proxy_app.dependency_overrides[user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_id="test-user",
+        models=["some-other-model"],
+    )
+    try:
+        client = TestClient(proxy_app, raise_server_exceptions=False)
+        with (
+            patch("litellm.proxy.proxy_server.route_request") as mock_route_request,
+            patch("litellm.proxy.proxy_server.proxy_logging_obj") as mock_logging,
+        ):
+            mock_logging.post_call_failure_hook = AsyncMock()
+
+            response = client.post(
+                "/v1/realtime/client_secrets",
+                headers={"Authorization": "Bearer sk-test-master-key"},
+                json={},
+            )
+
+        assert response.status_code == 403
+        assert "gpt-4o-realtime-preview" in response.text
+        mock_route_request.assert_not_called()
+    finally:
+        proxy_app.dependency_overrides.pop(user_api_key_auth, None)
+
+
+@pytest.mark.asyncio
+async def test_client_secrets_realtime_explicit_model_blocked_when_not_in_key_scope(
+    proxy_app,
+):
+    """An explicit model not in the key's allowed list must also be rejected."""
+    proxy_app.dependency_overrides[user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_id="test-user",
+        models=["gpt-4o-realtime-preview"],
+    )
+    try:
+        client = TestClient(proxy_app, raise_server_exceptions=False)
+        with (
+            patch("litellm.proxy.proxy_server.route_request") as mock_route_request,
+            patch("litellm.proxy.proxy_server.proxy_logging_obj") as mock_logging,
+        ):
+            mock_logging.post_call_failure_hook = AsyncMock()
+
+            response = client.post(
+                "/v1/realtime/client_secrets",
+                headers={"Authorization": "Bearer sk-test-master-key"},
+                json={"model": "gpt-4o-realtime-mini"},
+            )
+
+        assert response.status_code == 403
+        assert "gpt-4o-realtime-mini" in response.text
+        mock_route_request.assert_not_called()
+    finally:
+        proxy_app.dependency_overrides.pop(user_api_key_auth, None)
+
+
+@pytest.mark.asyncio
+async def test_client_secrets_realtime_default_model_allowed_when_in_key_scope(
+    proxy_app,
+    mock_route_request_client_secrets,
+    mock_add_litellm_data,
+    mock_pre_call_hook,
+):
+    """Omitting model should succeed when the default (gpt-4o-realtime-preview) is in scope."""
+    proxy_app.dependency_overrides[user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_id="test-user",
+        models=["gpt-4o-realtime-preview"],
+    )
+    try:
+        client = TestClient(proxy_app)
+        with (
+            patch(
+                "litellm.proxy.proxy_server.route_request",
+                side_effect=mock_route_request_client_secrets,
+            ),
+            patch(
+                "litellm.proxy.proxy_server.add_litellm_data_to_request",
+                side_effect=mock_add_litellm_data,
+            ),
+            patch("litellm.proxy.proxy_server.proxy_logging_obj") as mock_logging,
+        ):
+            mock_logging.pre_call_hook = AsyncMock(side_effect=mock_pre_call_hook)
+            mock_logging.post_call_failure_hook = AsyncMock()
+
+            response = client.post(
+                "/v1/realtime/client_secrets",
+                headers={"Authorization": "Bearer sk-test-master-key"},
+                json={},
+            )
+
+        assert response.status_code == 200
+    finally:
+        proxy_app.dependency_overrides.pop(user_api_key_auth, None)
+
+
+@pytest.mark.asyncio
 async def test_transcription_sessions_returns_upstream_error_verbatim(
     proxy_app,
     mock_add_litellm_data,


### PR DESCRIPTION
## Relevant issues

Addresses Veria finding on PR #30637.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Screenshots / Proof of Fix

The vulnerability: POST `/v1/realtime/client_secrets` with an empty body (no `model`, no `session.model`) would resolve to `gpt-4o-realtime-preview` without calling `can_key_call_resolved_model`. Any authenticated key could reach that model regardless of its `models` allowlist.

The transcription path inside `_prepare_client_secret_session` already called `can_key_call_resolved_model`; the realtime path returned early before that check.

Fix: call `can_key_call_resolved_model` for the resolved model in the non-transcription branch before returning.

Regression tests added to `test_realtime_webrtc_endpoints.py`:
- a restricted key (models=["some-other-model"]) gets 403 when no model is provided
- a restricted key gets 403 when an explicit model outside its scope is provided
- a key with gpt-4o-realtime-preview in scope succeeds with no model provided

## Type

🐛 Bug Fix

## Changes

`litellm/proxy/realtime_endpoints/endpoints.py`: add `can_key_call_resolved_model` call in `_prepare_client_secret_session` for the realtime (non-transcription) branch.